### PR TITLE
Fix: connecting a server no longer un-toggles your other servers

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1474,6 +1474,7 @@ export default function App() {
     handleDisconnect,
     handleRuntimeDisconnect,
     handleReconnect,
+    reconnectServerForClientSwitch,
     ensureServersReady,
     syncAgentStatus,
     handleUpdate,
@@ -2677,6 +2678,7 @@ export default function App() {
       onSelectMultipleServers: setSelectedMCPConfigs,
       onConnect: handleConnect,
       onReconnect: handleReconnect,
+      onDisconnect: handleRuntimeDisconnect,
       showOnlyOAuthServers: false,
       showOnlyServersWithViews: false,
     };
@@ -2690,6 +2692,7 @@ export default function App() {
     setSelectedMCPConfigs,
     handleConnect,
     handleReconnect,
+    handleRuntimeDisconnect,
   ]);
 
   if (isDebugCallback) {
@@ -2881,6 +2884,7 @@ export default function App() {
     handleOrganizationDeleted,
     handleProjectShared,
     handleReconnect,
+    handleRuntimeDisconnect,
     handleRefreshTokensFromOAuthFlow,
     handleRemoveServer,
     handleUpdate,
@@ -3045,6 +3049,7 @@ export default function App() {
         actions={{
           ensureServersReady,
           runtimeDisconnectServer: handleRuntimeDisconnect,
+          reconnectServer: reconnectServerForClientSwitch,
           setSelectedServerNames: setSelectedMCPConfigs,
         }}
       >

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2678,7 +2678,7 @@ export default function App() {
       onSelectMultipleServers: setSelectedMCPConfigs,
       onConnect: handleConnect,
       onReconnect: handleReconnect,
-      onDisconnect: handleRuntimeDisconnect,
+      onDisconnect: handleDisconnect,
       showOnlyOAuthServers: false,
       showOnlyServersWithViews: false,
     };
@@ -2692,7 +2692,7 @@ export default function App() {
     setSelectedMCPConfigs,
     handleConnect,
     handleReconnect,
-    handleRuntimeDisconnect,
+    handleDisconnect,
   ]);
 
   if (isDebugCallback) {

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1465,6 +1465,7 @@ export default function App() {
     isLoadingRemoteProjects,
     areServersHydrated,
     projectServers,
+    displayServerConfigs,
     connectedOrConnectingServerConfigs,
     selectedMCPConfig,
     selectedServerEntry,
@@ -2664,7 +2665,7 @@ export default function App() {
     | undefined => {
     if (activeTab !== "playground") return undefined;
     return {
-      serverConfigs: projectServers,
+      serverConfigs: displayServerConfigs,
       selectedServer: appState.selectedServer,
       selectedMultipleServers: appState.selectedMultipleServers,
       // Playground supports multi-server selection — the user can toggle
@@ -2681,7 +2682,7 @@ export default function App() {
     };
   }, [
     activeTab,
-    projectServers,
+    displayServerConfigs,
     appState.selectedServer,
     appState.selectedMultipleServers,
     setSelectedServer,
@@ -2799,6 +2800,10 @@ export default function App() {
   const activeServerSelectorProps: ActiveServerSelectorProps | undefined =
     shouldShowActiveServerSelector
       ? {
+          // Stays on projectServers (NOT displayServerConfigs): the header
+          // picker also drives the OAuth Debugger / XAA tabs, and tests
+          // explicitly guard against surfacing runtime-only entries there
+          // (cross-project / cross-org leak prevention).
           serverConfigs: projectServers,
           selectedServer: appState.selectedServer,
           onServerChange: setSelectedServer,
@@ -2858,6 +2863,7 @@ export default function App() {
     checkoutIntentForBilling,
     connectedOrConnectingServerConfigs,
     consumeCheckoutIntent,
+    displayServerConfigs,
     convexProjectId,
     defaultHubRoute,
     ensureServersReady,

--- a/mcpjam-inspector/client/src/components/ActiveClientServerReconciler.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveClientServerReconciler.tsx
@@ -1,7 +1,19 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useAutoConnectProjectServers } from "@/hooks/useAutoConnectProjectServers";
 import { useProjectServers } from "@/hooks/useViews";
+import { useSharedAppState } from "@/state/app-state-context";
+import { useServerActions } from "@/state/server-actions-context";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+
+/** Set-equality for two name lists, order-independent. */
+function sameNameSet(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  for (const name of b) {
+    if (!set.has(name)) return false;
+  }
+  return true;
+}
 
 interface ActiveHostServerReconcilerProps {
   projectId: string | null;
@@ -63,6 +75,31 @@ export function ActiveClientServerReconciler({
     hostScopeKey: activeHostId ?? activeHost?.id ?? null,
     requiredServerNames,
   });
+
+  // Single source of truth: the Playground/chat "active server" set
+  // (`selectedMultipleServers`) is a strict mirror of the connected set. The
+  // Connect tab owns connectivity; everything else reflects it. This is the
+  // ONLY unconditional writer of the multi-select — toggles in the UI now
+  // connect/disconnect, and selection follows. Guarded by set-equality so we
+  // never dispatch (and never loop) when the mirror already matches.
+  const sharedAppState = useSharedAppState();
+  const { setSelectedServerNames } = useServerActions();
+  const connectedNames = useMemo(
+    () =>
+      Object.entries(sharedAppState.servers)
+        .filter(([, server]) => server.connectionStatus === "connected")
+        .map(([name]) => name),
+    [sharedAppState.servers],
+  );
+  useEffect(() => {
+    if (!sameNameSet(connectedNames, sharedAppState.selectedMultipleServers)) {
+      setSelectedServerNames(connectedNames);
+    }
+  }, [
+    connectedNames,
+    sharedAppState.selectedMultipleServers,
+    setSelectedServerNames,
+  ]);
 
   return null;
 }

--- a/mcpjam-inspector/client/src/components/ActiveClientServerReconciler.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveClientServerReconciler.tsx
@@ -15,6 +15,10 @@ function sameNameSet(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
   return true;
 }
 
+function isActiveRuntimeStatus(status: string | undefined) {
+  return status === "connected" || status === "connecting";
+}
+
 interface ActiveHostServerReconcilerProps {
   projectId: string | null;
   isAuthenticated: boolean;
@@ -60,7 +64,7 @@ export function ActiveClientServerReconciler({
     const requiredIds = activeHost?.serverIds ?? [];
     if (requiredIds.length === 0 || !projectServersList) return [];
     const byId = new Map(
-      projectServersList.map((s) => [s._id, s.name] as const),
+      projectServersList.map((s) => [s._id, s.name] as const)
     );
     return requiredIds
       .map((id) => byId.get(id))
@@ -76,27 +80,29 @@ export function ActiveClientServerReconciler({
     requiredServerNames,
   });
 
-  // Single source of truth: the Playground/chat "active server" set
-  // (`selectedMultipleServers`) is a strict mirror of the connected set. The
-  // Connect tab owns connectivity; everything else reflects it. This is the
-  // ONLY unconditional writer of the multi-select — toggles in the UI now
-  // connect/disconnect, and selection follows. Guarded by set-equality so we
-  // never dispatch (and never loop) when the mirror already matches.
+  // Single source of truth: the Playground active server set
+  // (`selectedMultipleServers`) mirrors the runtime set that is connected or
+  // reconnecting. Keeping "connecting" active prevents the Playground tools
+  // pane from blinking empty during a client-switch reconnect. The Connect tab
+  // owns connectivity; everything else reflects it. Guarded by set-equality so
+  // we never dispatch (and never loop) when the mirror already matches.
   const sharedAppState = useSharedAppState();
   const { setSelectedServerNames } = useServerActions();
-  const connectedNames = useMemo(
+  const activeRuntimeNames = useMemo(
     () =>
       Object.entries(sharedAppState.servers)
-        .filter(([, server]) => server.connectionStatus === "connected")
+        .filter(([, server]) => isActiveRuntimeStatus(server.connectionStatus))
         .map(([name]) => name),
-    [sharedAppState.servers],
+    [sharedAppState.servers]
   );
   useEffect(() => {
-    if (!sameNameSet(connectedNames, sharedAppState.selectedMultipleServers)) {
-      setSelectedServerNames(connectedNames);
+    if (
+      !sameNameSet(activeRuntimeNames, sharedAppState.selectedMultipleServers)
+    ) {
+      setSelectedServerNames(activeRuntimeNames);
     }
   }, [
-    connectedNames,
+    activeRuntimeNames,
     sharedAppState.selectedMultipleServers,
     setSelectedServerNames,
   ]);

--- a/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
@@ -40,6 +40,8 @@ export interface ActiveServerSelectorProps {
   onSelectMultipleServers?: (serverNames: string[]) => void;
   onConnect: (formData: ServerFormData) => void;
   onReconnect?: (serverName: string) => Promise<void>;
+  /** Disconnect a connected server (Playground toggle off = unplug). */
+  onDisconnect?: (serverName: string) => void;
   showOnlyOAuthServers?: boolean; // Only show servers that use OAuth
   showOnlyServersWithViews?: boolean; // Only show servers that have saved views
   autoSelectFilteredServer?: boolean; // Auto-select when current selection is hidden by filters

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -126,6 +126,8 @@ interface ChatTabProps {
   onServerToggle?: (serverName: string) => void;
   /** Reconnect a disconnected server. */
   onReconnectServer?: (serverName: string) => Promise<void>;
+  /** Disconnect a connected server (toggle off = unplug). */
+  onDisconnectServer?: (serverName: string) => void;
   /** Add a new server (opens add-server modal). */
   onAddServer?: (formData: import("@/shared/types").ServerFormData) => void;
   onSelectedServerNamesChange?: (names: string[]) => void;
@@ -162,6 +164,7 @@ export function ChatTabV2({
   allServerConfigs,
   onServerToggle,
   onReconnectServer,
+  onDisconnectServer,
   onAddServer,
   onSelectedServerNamesChange,
   onHasMessagesChange,
@@ -2040,6 +2043,7 @@ export function ChatTabV2({
     allServerConfigs,
     onServerToggle,
     onReconnectServer,
+    onDisconnectServer,
     onAddServer,
     chatboxAttachableServers:
       chatboxOptionalInventory && chatboxOptionalInventory.length > 0

--- a/mcpjam-inspector/client/src/components/__tests__/ActiveClientServerReconciler.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ActiveClientServerReconciler.test.tsx
@@ -14,14 +14,14 @@ vi.mock("@/hooks/useViews", () => ({
 
 function makeAppState(
   servers: Record<string, "connected" | "disconnected" | "connecting">,
-  selectedMultipleServers: string[],
+  selectedMultipleServers: string[]
 ) {
   return {
     servers: Object.fromEntries(
       Object.entries(servers).map(([name, connectionStatus]) => [
         name,
         { name, connectionStatus },
-      ]),
+      ])
     ),
     selectedMultipleServers,
   } as any;
@@ -64,7 +64,7 @@ function renderReconciler({
       activeHost={undefined}
       activeHostId={null}
     />,
-    { wrapper },
+    { wrapper }
   );
 }
 
@@ -75,18 +75,22 @@ describe("ActiveClientServerReconciler — active-set mirror", () => {
     vi.clearAllMocks();
   });
 
-  it("mirrors the connected set into the multi-select", async () => {
+  it("mirrors connected and reconnecting servers into the multi-select", async () => {
     const setSelectedServerNames = vi.fn();
     renderReconciler({
       appState: makeAppState(
-        { alpha: "connected", beta: "connected", gamma: "disconnected" },
-        [],
+        {
+          alpha: "connected",
+          beta: "connecting",
+          gamma: "disconnected",
+        },
+        []
       ),
       setSelectedServerNames,
     });
 
     await flush();
-    // Only connected servers become active; gamma (disconnected) is excluded.
+    // Connected and reconnecting servers stay active; gamma is excluded.
     expect(setSelectedServerNames).toHaveBeenCalledTimes(1);
     expect(setSelectedServerNames.mock.calls[0][0].sort()).toEqual([
       "alpha",

--- a/mcpjam-inspector/client/src/components/__tests__/ActiveClientServerReconciler.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ActiveClientServerReconciler.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
+import { AppStateProvider } from "@/state/app-state-context";
+import { ServerActionsProvider } from "@/state/server-actions-context";
+import { ActiveClientServerReconciler } from "../ActiveClientServerReconciler";
+
+// The reconciler reads the project catalog via this hook; the mirror under
+// test doesn't need it, so stub it to "no servers, loaded".
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServers: () => ({ servers: [] }),
+}));
+
+function makeAppState(
+  servers: Record<string, "connected" | "disconnected" | "connecting">,
+  selectedMultipleServers: string[],
+) {
+  return {
+    servers: Object.fromEntries(
+      Object.entries(servers).map(([name, connectionStatus]) => [
+        name,
+        { name, connectionStatus },
+      ]),
+    ),
+    selectedMultipleServers,
+  } as any;
+}
+
+function renderReconciler({
+  appState,
+  setSelectedServerNames,
+}: {
+  appState: ReturnType<typeof makeAppState>;
+  setSelectedServerNames: (names: string[]) => void;
+}) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <PreferencesStoreProvider themeMode="light" themePreset="default">
+      <AppStateProvider appState={appState}>
+        <ServerActionsProvider
+          actions={{
+            ensureServersReady: vi.fn().mockResolvedValue({
+              readyServerNames: [],
+              failedServerNames: [],
+              missingServerNames: [],
+              reauthServerNames: [],
+            }),
+            runtimeDisconnectServer: vi.fn(),
+            reconnectServer: vi.fn().mockResolvedValue(undefined),
+            setSelectedServerNames,
+          }}
+        >
+          {children}
+        </ServerActionsProvider>
+      </AppStateProvider>
+    </PreferencesStoreProvider>
+  );
+
+  return render(
+    // No active host → no recycle/auto-connect fires, isolating the mirror.
+    <ActiveClientServerReconciler
+      projectId="proj-1"
+      isAuthenticated
+      activeHost={undefined}
+      activeHostId={null}
+    />,
+    { wrapper },
+  );
+}
+
+const flush = () => act(() => Promise.resolve());
+
+describe("ActiveClientServerReconciler — active-set mirror", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mirrors the connected set into the multi-select", async () => {
+    const setSelectedServerNames = vi.fn();
+    renderReconciler({
+      appState: makeAppState(
+        { alpha: "connected", beta: "connected", gamma: "disconnected" },
+        [],
+      ),
+      setSelectedServerNames,
+    });
+
+    await flush();
+    // Only connected servers become active; gamma (disconnected) is excluded.
+    expect(setSelectedServerNames).toHaveBeenCalledTimes(1);
+    expect(setSelectedServerNames.mock.calls[0][0].sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("does not dispatch when the multi-select already matches (loop guard)", async () => {
+    const setSelectedServerNames = vi.fn();
+    renderReconciler({
+      appState: makeAppState({ alpha: "connected", beta: "connected" }, [
+        "beta",
+        "alpha",
+      ]),
+      setSelectedServerNames,
+    });
+
+    await flush();
+    // Already equal as a set (order-independent) → no write, no loop.
+    expect(setSelectedServerNames).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -668,4 +668,65 @@ describe("ChatInput", () => {
       expect(screen.queryByTestId("context-trigger")).not.toBeInTheDocument();
     });
   });
+
+  describe("servers popover (connectivity is the source of truth)", () => {
+    const serverConfigs = {
+      connectedSrv: {
+        name: "connectedSrv",
+        config: { url: "http://localhost/connected" },
+        connectionStatus: "connected",
+      },
+      downSrv: {
+        name: "downSrv",
+        config: { url: "http://localhost/down" },
+        connectionStatus: "disconnected",
+      },
+    } as any;
+
+    it("toggling a connected server OFF disconnects it", () => {
+      const onDisconnectServer = vi.fn();
+      const onServerToggle = vi.fn();
+      render(
+        <ChatInput
+          {...defaultProps}
+          allServerConfigs={serverConfigs}
+          selectedServers={["connectedSrv"]}
+          onDisconnectServer={onDisconnectServer}
+          onReconnectServer={vi.fn()}
+          onServerToggle={onServerToggle}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      // The connected server renders an "on" Switch; flipping it disconnects.
+      const toggles = screen.getAllByRole("switch");
+      fireEvent.click(toggles[0]);
+
+      expect(onDisconnectServer).toHaveBeenCalledWith("connectedSrv");
+      // Selection is derived from connectivity now — no manual toggle write.
+      expect(onServerToggle).not.toHaveBeenCalled();
+    });
+
+    it("clicking Connect on a disconnected server reconnects it without writing selection", () => {
+      const onReconnectServer = vi.fn().mockResolvedValue(undefined);
+      const onServerToggle = vi.fn();
+      render(
+        <ChatInput
+          {...defaultProps}
+          allServerConfigs={serverConfigs}
+          selectedServers={["connectedSrv"]}
+          onDisconnectServer={vi.fn()}
+          onReconnectServer={onReconnectServer}
+          onServerToggle={onServerToggle}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      expect(onReconnectServer).toHaveBeenCalledWith("downSrv");
+      expect(onServerToggle).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -140,10 +140,21 @@ interface ChatInputProps {
   moveCaretToEndTrigger?: number;
   /** All project servers for the "+" dropdown server toggles. */
   allServerConfigs?: Record<string, ServerWithName>;
-  /** Toggle a server on/off for the current chat session. */
+  /**
+   * @deprecated Connectivity is now the single source of truth — the popover
+   * toggle connects/disconnects via `onDisconnectServer`/`onReconnectServer`
+   * rather than maintaining a separate per-chat selection. Kept so existing
+   * callers compile; no longer read here.
+   */
   onServerToggle?: (serverName: string) => void;
   /** Reconnect a disconnected server. */
   onReconnectServer?: (serverName: string) => Promise<void>;
+  /**
+   * Disconnect a connected server. Connectivity is the single source of
+   * truth for which servers the Playground uses, so toggling a server off
+   * here unplugs it (it stays in the list as a "Connect" row).
+   */
+  onDisconnectServer?: (serverName: string) => void;
   /** Add a new server (opens the add-server modal). */
   onAddServer?: (formData: ServerFormData) => void;
   /** Hosted chatbox: optional servers not yet connected (Add server popover). */
@@ -202,8 +213,8 @@ export function ChatInput({
   pulseSubmit = false,
   moveCaretToEndTrigger,
   allServerConfigs,
-  onServerToggle,
   onReconnectServer,
+  onDisconnectServer,
   onAddServer,
   chatboxAttachableServers,
   onAttachChatboxServer,
@@ -238,7 +249,7 @@ export function ChatInput({
   const selectorHostStyle = hostStyle ?? chatboxHostStyle;
   const hasServerRows = Boolean(
     allServerConfigs &&
-    onServerToggle &&
+    onDisconnectServer &&
     Object.keys(allServerConfigs).length > 0,
   );
   const hasServerOptions = Boolean(onAddServer || hasServerRows);
@@ -642,7 +653,7 @@ export function ChatInput({
                           Servers
                         </p>
                         {allServerConfigs &&
-                          onServerToggle &&
+                          onDisconnectServer &&
                           Object.keys(allServerConfigs).length > 0 && (
                             <div className="max-h-48 overflow-y-auto">
                               {Object.entries(allServerConfigs)
@@ -660,8 +671,6 @@ export function ChatInput({
                                   return aName.localeCompare(bName);
                                 })
                                 .map(([name, server]) => {
-                                  const isSelected =
-                                    selectedServers?.includes(name) ?? false;
                                   const isConnected =
                                     server.connectionStatus === "connected";
                                   const isConnecting =
@@ -708,10 +717,13 @@ export function ChatInput({
                                         {isConnecting ? (
                                           <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
                                         ) : isConnected ? (
+                                          // Connectivity is the source of truth:
+                                          // a connected server is "on", and
+                                          // toggling off disconnects it.
                                           <Switch
-                                            checked={isSelected}
+                                            checked={true}
                                             onCheckedChange={() =>
-                                              onServerToggle(name)
+                                              onDisconnectServer?.(name)
                                             }
                                           />
                                         ) : (
@@ -719,9 +731,6 @@ export function ChatInput({
                                             type="button"
                                             className="text-xs font-medium text-primary hover:text-primary/80 transition-colors cursor-pointer px-1.5 py-0.5 rounded hover:bg-primary/5"
                                             onClick={() => {
-                                              if (!isSelected) {
-                                                onServerToggle(name);
-                                              }
                                               onReconnectServer?.(name).catch(
                                                 () => {},
                                               );

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
@@ -131,16 +131,21 @@ function SessionsBody() {
 
 function ToolsBody() {
   const state = usePlaygroundStateContext();
-  const isMulti = state.activeServerNames.length > 1;
-
-  if (isMulti) {
+  // The Playground is multi-server by nature: its active set mirrors the
+  // connected servers. Aggregate tools across ALL active servers whenever
+  // there's at least one — not only when there's more than one. Using `> 1`
+  // meant disconnecting down to a single server fell back to the single-
+  // server pane (keyed on the stale `serverName` pointer), so the remaining
+  // server's tools vanished. Only the zero-server case falls back to
+  // PlaygroundLeft for its empty/onboarding state.
+  if (state.activeServerNames.length >= 1) {
     return (
       <MultiServerToolsPaneInner activeServerNames={state.activeServerNames} />
     );
   }
 
-  // Single-server (and zero-server) → reuse the existing PlaygroundLeft, but
-  // suppress its inline LoggerView since the logger lives in the right rail.
+  // Zero-server → reuse the existing PlaygroundLeft (empty/onboarding state),
+  // but suppress its inline LoggerView since the logger lives in the right rail.
   return (
     <PlaygroundLeft
       tools={state.tools}

--- a/mcpjam-inspector/client/src/components/playground/panes/MultiServerToolsPane.tsx
+++ b/mcpjam-inspector/client/src/components/playground/panes/MultiServerToolsPane.tsx
@@ -24,10 +24,15 @@ import {
 } from "@mcpjam/design-system/accordion";
 import { Badge } from "@mcpjam/design-system/badge";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@mcpjam/design-system/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { RefreshCw } from "lucide-react";
 import { useAggregatedTools } from "@/hooks/use-aggregated-tools";
 import { usePlaygroundStateContext } from "@/components/ui-playground/hooks/use-playground-state";
+import { useSharedAppState } from "@/state/app-state-context";
 import { ParametersForm } from "@/components/ui-playground/ParametersForm";
 import { SelectedToolHeader } from "@/components/ui-playground/SelectedToolHeader";
 import { TabHeader } from "@/components/ui-playground/TabHeader";
@@ -38,10 +43,7 @@ import {
   getToolVisibility,
   UIType,
 } from "@/lib/mcp-ui/mcp-apps-utils";
-import {
-  generateFormFieldsFromSchema,
-  type FormField,
-} from "@/lib/tool-form";
+import { generateFormFieldsFromSchema, type FormField } from "@/lib/tool-form";
 import { cn } from "@/lib/utils";
 
 interface InnerProps {
@@ -55,8 +57,20 @@ interface Selection {
 
 export function MultiServerToolsPaneInner({ activeServerNames }: InnerProps) {
   const state = usePlaygroundStateContext();
-  const { flat, collidingNames, loadingByServer, refetch } =
-    useAggregatedTools(activeServerNames);
+  const appState = useSharedAppState();
+  const reconnectingServerNames = useMemo(
+    () =>
+      activeServerNames.filter(
+        (name) => appState.servers[name]?.connectionStatus === "connecting"
+      ),
+    [activeServerNames, appState.servers]
+  );
+  const { flat, collidingNames, loadingByServer, refetch } = useAggregatedTools(
+    activeServerNames,
+    {
+      unavailableServerNames: reconnectingServerNames,
+    }
+  );
 
   const [selected, setSelected] = useState<Selection | null>(null);
   const [activeTab, setActiveTab] = useState<"tools" | "saved">("tools");
@@ -70,7 +84,7 @@ export function MultiServerToolsPaneInner({ activeServerNames }: InnerProps) {
       flat.find(
         (entry) =>
           entry.serverId === selected.serverId &&
-          entry.toolName === selected.toolName,
+          entry.toolName === selected.toolName
       ) ?? null
     );
   }, [flat, selected]);
@@ -86,7 +100,7 @@ export function MultiServerToolsPaneInner({ activeServerNames }: InnerProps) {
     }
     const entry = flat.find(
       (e) =>
-        e.serverId === selected.serverId && e.toolName === selected.toolName,
+        e.serverId === selected.serverId && e.toolName === selected.toolName
     );
     if (entry) {
       setFormFields(generateFormFieldsFromSchema(entry.tool.inputSchema));
@@ -107,8 +121,9 @@ export function MultiServerToolsPaneInner({ activeServerNames }: InnerProps) {
     if (!searchQuery.trim()) return flat;
     const query = searchQuery.trim().toLowerCase();
     return flat.filter((entry) => {
-      const haystack =
-        `${entry.toolName} ${entry.tool.description ?? ""}`.toLowerCase();
+      const haystack = `${entry.toolName} ${
+        entry.tool.description ?? ""
+      }`.toLowerCase();
       return haystack.includes(query);
     });
   }, [flat, searchQuery]);
@@ -118,15 +133,15 @@ export function MultiServerToolsPaneInner({ activeServerNames }: InnerProps) {
   const handleFieldChange = (name: string, value: unknown) => {
     setFormFields((current) =>
       current.map((field) =>
-        field.name === name ? { ...field, value, isSet: true } : field,
-      ),
+        field.name === name ? { ...field, value, isSet: true } : field
+      )
     );
   };
   const handleToggleField = (name: string, isSet: boolean) => {
     setFormFields((current) =>
       current.map((field) =>
-        field.name === name ? { ...field, isSet } : field,
-      ),
+        field.name === name ? { ...field, isSet } : field
+      )
     );
   };
 
@@ -200,7 +215,8 @@ export function MultiServerToolsPaneInner({ activeServerNames }: InnerProps) {
             entries={filteredEntries}
             totalCount={flat.length}
             collidingNames={collidingNames}
-            loading={isLoadingAny}
+            loading={isLoadingAny || reconnectingServerNames.length > 0}
+            reconnecting={reconnectingServerNames.length > 0}
             searchQuery={searchQuery}
             onSearchQueryChange={setSearchQuery}
             selected={selected}
@@ -235,6 +251,7 @@ interface FlatToolListProps {
   totalCount: number;
   collidingNames: string[];
   loading: boolean;
+  reconnecting: boolean;
   searchQuery: string;
   onSearchQueryChange: (q: string) => void;
   selected: Selection | null;
@@ -246,6 +263,7 @@ function FlatToolList({
   totalCount,
   collidingNames,
   loading,
+  reconnecting,
   searchQuery,
   onSearchQueryChange,
   selected,
@@ -265,13 +283,15 @@ function FlatToolList({
         {loading && entries.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-8 text-center">
             <RefreshCw className="h-5 w-5 text-muted-foreground animate-spin mb-2" />
-            <p className="text-xs text-muted-foreground">Loading tools...</p>
+            <p className="text-xs text-muted-foreground">
+              {reconnecting ? "Reconnecting..." : "Loading tools..."}
+            </p>
           </div>
         ) : entries.length === 0 ? (
           <div className="text-center py-8 px-4">
             <p className="text-xs text-muted-foreground">
               {totalCount === 0
-                ? "No tools found. Try refreshing and make sure the servers are running."
+                ? "No tools found. Try refreshing and make sure the server is running."
                 : "No tools match your search"}
             </p>
           </div>
@@ -298,7 +318,7 @@ function FlatToolList({
                     "w-full text-left px-3 py-2 rounded-md border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-1",
                     isSelected
                       ? "cursor-pointer bg-primary/10"
-                      : "cursor-pointer hover:bg-muted/50",
+                      : "cursor-pointer hover:bg-muted/50"
                   )}
                 >
                   <div className="flex items-center gap-1.5 min-w-0">
@@ -323,7 +343,7 @@ function FlatToolList({
                   )}
                   {(() => {
                     const visibility = getToolVisibility(
-                      entry.tool._meta as Record<string, unknown> | undefined,
+                      entry.tool._meta as Record<string, unknown> | undefined
                     );
                     const visibilityLabel = `[${visibility
                       .map((v) => `"${v}"`)
@@ -407,7 +427,7 @@ function SelectedToolView({
 }: SelectedToolViewProps) {
   const hasParameters = formFields.length > 0;
   const [openSections, setOpenSections] = useState<string[]>(
-    hasParameters ? ["parameters"] : ["description"],
+    hasParameters ? ["parameters"] : ["description"]
   );
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -2736,6 +2736,7 @@ export function PlaygroundMain({
     allServerConfigs: playgroundServerSelectorProps?.serverConfigs,
     onServerToggle: handlePlaygroundServerToggle,
     onReconnectServer: playgroundServerSelectorProps?.onReconnect,
+    onDisconnectServer: playgroundServerSelectorProps?.onDisconnect,
     onAddServer: playgroundServerSelectorProps?.onConnect,
   };
 

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/select-connected-active-server-names.test.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/select-connected-active-server-names.test.ts
@@ -4,7 +4,7 @@ import { selectConnectedActiveServerNames } from "../use-playground-state";
 
 function server(
   name: string,
-  connectionStatus: ServerWithName["connectionStatus"],
+  connectionStatus: ServerWithName["connectionStatus"]
 ): ServerWithName {
   return {
     name,
@@ -16,7 +16,7 @@ function server(
 
 describe("selectConnectedActiveServerNames", () => {
   describe("multi-server (Playground)", () => {
-    it("keeps only servers whose connectionStatus is 'connected'", () => {
+    it("keeps servers whose connectionStatus is connected or connecting", () => {
       const result = selectConnectedActiveServerNames({
         selectedServerNames: ["bart", "foo", "baz", "qux"],
         serverName: undefined,
@@ -27,7 +27,7 @@ describe("selectConnectedActiveServerNames", () => {
           qux: server("qux", "oauth-flow"),
         },
       });
-      expect(result).toEqual(["bart"]);
+      expect(result).toEqual(["bart", "baz"]);
     });
 
     it("preserves the input order of the connected subset", () => {
@@ -73,6 +73,15 @@ describe("selectConnectedActiveServerNames", () => {
         selectedServerNames: undefined,
         serverName: "bart",
         servers: { bart: server("bart", "connected") },
+      });
+      expect(result).toEqual(["bart"]);
+    });
+
+    it("returns the serverName while it is connecting", () => {
+      const result = selectConnectedActiveServerNames({
+        selectedServerNames: undefined,
+        serverName: "bart",
+        servers: { bart: server("bart", "connecting") },
       });
       expect(result).toEqual(["bart"]);
     });

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
@@ -123,15 +123,13 @@ export type PlaygroundLoadingState =
 export type UsePlaygroundStateReturn = ReturnType<typeof usePlaygroundState>;
 
 /**
- * Pick the servers whose tools should appear in the Playground tools pane
- * and be callable by the manual Run button. Mirrors the predicate the LLM
- * tools list (`PlaygroundMain.tsx`) and composer popover (`chat-input.tsx`)
- * already use, so all three surfaces agree on what "in-use" means and the
- * pane stays in sync with the user's connection toggle.
+ * Pick the servers whose tools should appear in the Playground tools pane.
+ * Reconnecting servers stay active so the left rail can show a loading state
+ * instead of briefly dropping them during a client switch.
  *
  * Multi-server mode passes `selectedServerNames`; single-server mode passes
- * `serverName`. Either way the filter rejects anything not currently in
- * `connectionStatus === "connected"`.
+ * `serverName`. Either way the filter rejects anything that is not connected
+ * or connecting.
  */
 export function selectConnectedActiveServerNames(input: {
   selectedServerNames: ReadonlyArray<string> | undefined;
@@ -139,12 +137,14 @@ export function selectConnectedActiveServerNames(input: {
   servers: Record<string, ServerWithName>;
 }): string[] {
   const { selectedServerNames, serverName, servers } = input;
-  const isConnected = (name: string) =>
-    servers[name]?.connectionStatus === "connected";
+  const isConnectedOrConnecting = (name: string) => {
+    const status = servers[name]?.connectionStatus;
+    return status === "connected" || status === "connecting";
+  };
   if (selectedServerNames && selectedServerNames.length > 0) {
-    return selectedServerNames.filter(isConnected);
+    return selectedServerNames.filter(isConnectedOrConnecting);
   }
-  return serverName && isConnected(serverName) ? [serverName] : [];
+  return serverName && isConnectedOrConnecting(serverName) ? [serverName] : [];
 }
 
 export function usePlaygroundState(options: UsePlaygroundStateOptions) {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-aggregated-tools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-aggregated-tools.test.tsx
@@ -58,4 +58,42 @@ describe("useAggregatedTools", () => {
 
     unmount();
   });
+
+  it("clears tools while a server is temporarily unavailable, then refetches", async () => {
+    const { result, rerender } = renderHook(
+      ({
+        unavailableServerNames,
+      }: {
+        unavailableServerNames: ReadonlyArray<string>;
+      }) =>
+        useAggregatedTools(["Excalidraw"], {
+          unavailableServerNames,
+        }),
+      {
+        initialProps: { unavailableServerNames: [] },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.flat.map((entry) => entry.toolName)).toEqual([
+        "Excalidraw_tool",
+      ]);
+    });
+
+    rerender({ unavailableServerNames: ["Excalidraw"] });
+
+    await waitFor(() => {
+      expect(result.current.flat).toEqual([]);
+      expect(result.current.loadingByServer.Excalidraw).toBe(true);
+    });
+
+    rerender({ unavailableServerNames: [] });
+
+    await waitFor(() => {
+      expect(result.current.flat.map((entry) => entry.toolName)).toEqual([
+        "Excalidraw_tool",
+      ]);
+      expect(result.current.loadingByServer.Excalidraw).toBe(false);
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -25,6 +25,7 @@ function wrapper({
   ensureServersReady,
   appState,
   runtimeDisconnectServer = () => {},
+  reconnectServer = async () => {},
   setSelectedServerNames = () => {},
 }: {
   children: ReactNode;
@@ -38,6 +39,7 @@ function wrapper({
   }>;
   appState: ReturnType<typeof makeAppState>;
   runtimeDisconnectServer?: (name: string) => void;
+  reconnectServer?: (name: string) => Promise<void>;
   setSelectedServerNames?: (names: string[]) => void;
 }) {
   return (
@@ -47,6 +49,7 @@ function wrapper({
           actions={{
             ensureServersReady,
             runtimeDisconnectServer,
+            reconnectServer,
             setSelectedServerNames,
           }}
         >
@@ -238,18 +241,18 @@ describe("useAutoConnectProjectServers", () => {
     expect(ensureServersReady).toHaveBeenLastCalledWith(["alpha"]);
   });
 
-  it("disconnects only connected servers required by the active host on host switch", async () => {
+  it("reconnects ALL connected servers on client switch, not just the required ones", async () => {
     const ensureServersReady = vi.fn().mockResolvedValue({
       readyServerNames: [],
       failedServerNames: [],
       missingServerNames: [],
       reauthServerNames: [],
     });
-    const runtimeDisconnectServer = vi.fn();
-    // Three servers connected from a prior host; current host requires only
-    // "alpha". Only alpha needs a recycle so it can reconnect with the
-    // active host's initialize payload. beta/gamma may have been connected
-    // manually or by project-level auto-connect and should remain up.
+    const reconnectServer = vi.fn().mockResolvedValue(undefined);
+    // Three servers connected from a prior client; current client requires
+    // only "alpha". Switching clients must re-handshake EVERY connected server
+    // under the new client identity — so all three reconnect, regardless of
+    // whether the host declares them required.
     const appState = {
       servers: {
         alpha: { name: "alpha", connectionStatus: "connected" },
@@ -267,29 +270,22 @@ describe("useAutoConnectProjectServers", () => {
         }),
       {
         wrapper: ({ children }) =>
-          wrapper({
-            children,
-            ensureServersReady,
-            appState,
-            runtimeDisconnectServer,
-          }),
+          wrapper({ children, ensureServersReady, appState, reconnectServer }),
       },
     );
 
     await flushMicrotasks();
-    // Connect side: alpha still looks "connected" in this render's app
-    // state, so it's filtered out of the candidate set. In production the
-    // next render (after DISCONNECT lands) would pick it up.
+    expect(reconnectServer).toHaveBeenCalledTimes(3);
+    const reconnected = reconnectServer.mock.calls.map((c) => c[0]).sort();
+    expect(reconnected).toEqual(["alpha", "beta", "gamma"]);
+    // alpha is already connected, so the connect-required candidate path has
+    // nothing to do (reconnect, not connect, handles it).
     expect(ensureServersReady).not.toHaveBeenCalled();
-    // Disconnect side: only the host-required connected server comes down.
-    expect(runtimeDisconnectServer).toHaveBeenCalledTimes(1);
-    const disconnected = runtimeDisconnectServer.mock.calls.map((c) => c[0]);
-    expect(disconnected).toEqual(["alpha"]);
   });
 
-  it("keeps connected servers up when the active host requires none", async () => {
+  it("reconnects connected servers even when the active host requires none", async () => {
     const ensureServersReady = vi.fn();
-    const runtimeDisconnectServer = vi.fn();
+    const reconnectServer = vi.fn().mockResolvedValue(undefined);
     const appState = {
       servers: {
         alpha: { name: "alpha", connectionStatus: "connected" },
@@ -306,139 +302,92 @@ describe("useAutoConnectProjectServers", () => {
         }),
       {
         wrapper: ({ children }) =>
-          wrapper({
-            children,
-            ensureServersReady,
-            appState,
-            runtimeDisconnectServer,
-          }),
+          wrapper({ children, ensureServersReady, appState, reconnectServer }),
       },
     );
 
     await flushMicrotasks();
-    expect(ensureServersReady).not.toHaveBeenCalled();
-    expect(runtimeDisconnectServer).not.toHaveBeenCalled();
+    // Recycle is gated on a client being active (hostScopeKey non-null), not on
+    // the required set. Both connected servers re-handshake.
+    expect(reconnectServer).toHaveBeenCalledTimes(2);
+    const reconnected = reconnectServer.mock.calls.map((c) => c[0]).sort();
+    expect(reconnected).toEqual(["alpha", "beta"]);
   });
 
-  it("syncs setSelectedServerNames to the host's required set on each new scope", async () => {
+  it("still auto-connects required-but-disconnected servers on top of the recycle", async () => {
     const ensureServersReady = vi.fn().mockResolvedValue({
-      readyServerNames: [],
+      readyServerNames: ["needed"],
       failedServerNames: [],
       missingServerNames: [],
       reauthServerNames: [],
     });
-    const setSelectedServerNames = vi.fn();
-    const appState = makeAppState(["alpha", "beta"]);
-
-    const { rerender } = renderHook(
-      ({
-        hostScopeKey,
-        requiredServerNames,
-      }: {
-        hostScopeKey: string;
-        requiredServerNames: ReadonlyArray<string>;
-      }) =>
-        useAutoConnectProjectServers({
-          projectId: "proj-selection",
-          hostScopeKey,
-          requiredServerNames,
-        }),
-      {
-        initialProps: {
-          hostScopeKey: "host-claude",
-          requiredServerNames: ["alpha", "beta"],
-        },
-        wrapper: ({ children }) =>
-          wrapper({
-            children,
-            ensureServersReady,
-            appState,
-            setSelectedServerNames,
-          }),
+    const reconnectServer = vi.fn().mockResolvedValue(undefined);
+    // "up" is connected (gets reconnected); "needed" is required but not
+    // connected (gets connected via the candidate path).
+    const appState = {
+      servers: {
+        up: { name: "up", connectionStatus: "connected" },
+        needed: { name: "needed", connectionStatus: "disconnected" },
       },
-    );
+    } as any;
 
-    await flushMicrotasks();
-    expect(setSelectedServerNames).toHaveBeenLastCalledWith(["alpha", "beta"]);
-
-    // Empty required set is no-op; surfaces with no explicit host selection
-    // must not clear the project/default host's selected servers.
-    rerender({ hostScopeKey: "host-mcpjam", requiredServerNames: [] });
-    await flushMicrotasks();
-    expect(setSelectedServerNames).toHaveBeenCalledTimes(1);
-  });
-
-  it("merges newly-required servers without wiping manual picks in the same scope", async () => {
-    // Regression: connecting a server updated the project catalog so a host-
-    // referenced id resolved into `requiredServerNames` mid-session (same
-    // host scope). The old code REPLACED the selection with the required set,
-    // silently dropping servers the user had toggled on by hand — they stayed
-    // connected but their toggle flipped off. Within a scope we now merge.
-    const ensureServersReady = vi.fn().mockResolvedValue({
-      readyServerNames: [],
-      failedServerNames: [],
-      missingServerNames: [],
-      reauthServerNames: [],
-    });
-    const setSelectedServerNames = vi.fn();
-    const appStateHolder: { current: any } = {
-      current: {
-        servers: {
-          amazon: { name: "amazon", connectionStatus: "connected" },
-          worldcup: { name: "worldcup", connectionStatus: "connected" },
-          champions: { name: "champions", connectionStatus: "connected" },
-        },
-        // Before the user touches anything the selection matches the host.
-        selectedMultipleServers: ["amazon"],
-      },
-    };
-
-    const { rerender } = renderHook(
-      ({
-        requiredServerNames,
-      }: {
-        requiredServerNames: ReadonlyArray<string>;
-      }) =>
+    renderHook(
+      () =>
         useAutoConnectProjectServers({
-          projectId: "proj-merge",
+          projectId: "proj-mixed",
           hostScopeKey: "host-a",
-          requiredServerNames,
+          requiredServerNames: ["needed"],
         }),
       {
-        initialProps: { requiredServerNames: ["amazon"] },
         wrapper: ({ children }) =>
-          wrapper({
-            children,
-            ensureServersReady,
-            appState: appStateHolder.current,
-            setSelectedServerNames,
-          }),
+          wrapper({ children, ensureServersReady, appState, reconnectServer }),
       },
     );
 
     await flushMicrotasks();
-    // First resolve for this scope: replace with the host's required set.
-    expect(setSelectedServerNames).toHaveBeenLastCalledWith(["amazon"]);
+    expect(reconnectServer).toHaveBeenCalledTimes(1);
+    expect(reconnectServer).toHaveBeenCalledWith("up");
+    expect(ensureServersReady).toHaveBeenCalledTimes(1);
+    expect(ensureServersReady).toHaveBeenCalledWith(["needed"]);
+  });
 
-    // User manually toggles "worldcup" on — not part of the host's set.
-    appStateHolder.current = {
-      ...appStateHolder.current,
-      selectedMultipleServers: ["amazon", "worldcup"],
-    };
-    setSelectedServerNames.mockClear();
+  it("does not recycle again on a same-scope re-render (only lead changes recycle)", async () => {
+    // Adding/removing a SECONDARY compare client doesn't change hostScopeKey
+    // (only the lead does), so a same-scope re-render must not re-reconnect.
+    const ensureServersReady = vi.fn().mockResolvedValue({
+      readyServerNames: [],
+      failedServerNames: [],
+      missingServerNames: [],
+      reauthServerNames: [],
+    });
+    const reconnectServer = vi.fn().mockResolvedValue(undefined);
+    const appState = {
+      servers: {
+        alpha: { name: "alpha", connectionStatus: "connected" },
+        beta: { name: "beta", connectionStatus: "connected" },
+      },
+    } as any;
 
-    // Connecting "champions" makes it resolve into the required set — same
-    // scope, required names changed.
-    rerender({ requiredServerNames: ["amazon", "champions"] });
+    const { rerender } = renderHook(
+      () =>
+        useAutoConnectProjectServers({
+          projectId: "proj-same-scope",
+          hostScopeKey: "host-lead",
+          requiredServerNames: ["alpha"],
+        }),
+      {
+        wrapper: ({ children }) =>
+          wrapper({ children, ensureServersReady, appState, reconnectServer }),
+      },
+    );
+
     await flushMicrotasks();
+    expect(reconnectServer).toHaveBeenCalledTimes(2);
 
-    // "champions" is merged in; "worldcup" is preserved, not wiped.
-    expect(setSelectedServerNames).toHaveBeenCalledTimes(1);
-    expect(setSelectedServerNames).toHaveBeenLastCalledWith([
-      "amazon",
-      "worldcup",
-      "champions",
-    ]);
+    rerender();
+    await flushMicrotasks();
+    // Same scope → no second recycle.
+    expect(reconnectServer).toHaveBeenCalledTimes(2);
   });
 
   it("re-attempts on every host transition, including returning to a previously-visited host", async () => {
@@ -482,18 +431,17 @@ describe("useAutoConnectProjectServers", () => {
     expect(ensureServersReady).toHaveBeenCalledTimes(3);
   });
 
-  it("does NOT disconnect a server the user manually connects after the scope's tear-down pass already ran", async () => {
-    // Regression: when the user adds a new server from the Servers tab
-    // while sitting on a host, the reconciler used to see the freshly-
-    // connected server as a fresh disconnect target and tear it down.
-    // The host-switch tear-down must fire AT MOST ONCE per scope.
+  it("does NOT reconnect a server the user manually connects after the scope's recycle pass already ran", async () => {
+    // When the user adds a new server from the Servers tab while sitting on a
+    // host, it connected fresh under the CURRENT client — so the recycle must
+    // not re-handshake it. The recycle fires AT MOST ONCE per scope.
     const ensureServersReady = vi.fn().mockResolvedValue({
       readyServerNames: ["learn"],
       failedServerNames: [],
       missingServerNames: [],
       reauthServerNames: [],
     });
-    const runtimeDisconnectServer = vi.fn();
+    const reconnectServer = vi.fn().mockResolvedValue(undefined);
 
     // Mutable holder so we can simulate a server-state change between
     // renders without re-mounting the hook.
@@ -518,19 +466,18 @@ describe("useAutoConnectProjectServers", () => {
             children,
             ensureServersReady,
             appState: appStateHolder.current,
-            runtimeDisconnectServer,
+            reconnectServer,
           }),
       },
     );
 
     await flushMicrotasks();
-    // First pass: the host-required connected server is torn down so it
-    // can reconnect once its DISCONNECT lands.
-    expect(runtimeDisconnectServer).toHaveBeenCalledTimes(1);
-    expect(runtimeDisconnectServer).toHaveBeenCalledWith("learn");
+    // First pass: the connected server re-handshakes under the new client.
+    expect(reconnectServer).toHaveBeenCalledTimes(1);
+    expect(reconnectServer).toHaveBeenCalledWith("learn");
 
-    // User manually connects "bench" from the Servers tab — it's not in
-    // the host's required list, but the user explicitly wants it connected.
+    // User manually connects "bench" from the Servers tab — fresh under the
+    // current client, so it must NOT be recycled.
     appStateHolder.current = {
       servers: {
         learn: { name: "learn", connectionStatus: "connected" },
@@ -541,9 +488,9 @@ describe("useAutoConnectProjectServers", () => {
     rerender();
     await flushMicrotasks();
 
-    // Tear-down must NOT re-fire — bench stays connected, and `learn`
-    // isn't double-disconnected.
-    expect(runtimeDisconnectServer).toHaveBeenCalledTimes(1);
+    // Recycle must NOT re-fire — bench is left alone, learn isn't reconnected
+    // twice.
+    expect(reconnectServer).toHaveBeenCalledTimes(1);
   });
 
   it("respects a user-initiated disconnect: a host-required server toggled off stays off in the same scope", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -368,6 +368,79 @@ describe("useAutoConnectProjectServers", () => {
     expect(setSelectedServerNames).toHaveBeenCalledTimes(1);
   });
 
+  it("merges newly-required servers without wiping manual picks in the same scope", async () => {
+    // Regression: connecting a server updated the project catalog so a host-
+    // referenced id resolved into `requiredServerNames` mid-session (same
+    // host scope). The old code REPLACED the selection with the required set,
+    // silently dropping servers the user had toggled on by hand — they stayed
+    // connected but their toggle flipped off. Within a scope we now merge.
+    const ensureServersReady = vi.fn().mockResolvedValue({
+      readyServerNames: [],
+      failedServerNames: [],
+      missingServerNames: [],
+      reauthServerNames: [],
+    });
+    const setSelectedServerNames = vi.fn();
+    const appStateHolder: { current: any } = {
+      current: {
+        servers: {
+          amazon: { name: "amazon", connectionStatus: "connected" },
+          worldcup: { name: "worldcup", connectionStatus: "connected" },
+          champions: { name: "champions", connectionStatus: "connected" },
+        },
+        // Before the user touches anything the selection matches the host.
+        selectedMultipleServers: ["amazon"],
+      },
+    };
+
+    const { rerender } = renderHook(
+      ({
+        requiredServerNames,
+      }: {
+        requiredServerNames: ReadonlyArray<string>;
+      }) =>
+        useAutoConnectProjectServers({
+          projectId: "proj-merge",
+          hostScopeKey: "host-a",
+          requiredServerNames,
+        }),
+      {
+        initialProps: { requiredServerNames: ["amazon"] },
+        wrapper: ({ children }) =>
+          wrapper({
+            children,
+            ensureServersReady,
+            appState: appStateHolder.current,
+            setSelectedServerNames,
+          }),
+      },
+    );
+
+    await flushMicrotasks();
+    // First resolve for this scope: replace with the host's required set.
+    expect(setSelectedServerNames).toHaveBeenLastCalledWith(["amazon"]);
+
+    // User manually toggles "worldcup" on — not part of the host's set.
+    appStateHolder.current = {
+      ...appStateHolder.current,
+      selectedMultipleServers: ["amazon", "worldcup"],
+    };
+    setSelectedServerNames.mockClear();
+
+    // Connecting "champions" makes it resolve into the required set — same
+    // scope, required names changed.
+    rerender({ requiredServerNames: ["amazon", "champions"] });
+    await flushMicrotasks();
+
+    // "champions" is merged in; "worldcup" is preserved, not wiped.
+    expect(setSelectedServerNames).toHaveBeenCalledTimes(1);
+    expect(setSelectedServerNames).toHaveBeenLastCalledWith([
+      "amazon",
+      "worldcup",
+      "champions",
+    ]);
+  });
+
   it("re-attempts on every host transition, including returning to a previously-visited host", async () => {
     const ensureServersReady = vi.fn().mockResolvedValue({
       readyServerNames: [],

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -9,13 +9,35 @@ import {
   useAutoConnectProjectServers,
 } from "../useAutoConnectProjectServers";
 
+const mocks = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    context: "AutoConnectProjectServers",
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+  },
+}));
+
+vi.mock("@/hooks/use-logger", () => ({
+  useLogger: () => mocks.logger,
+}));
+
 function makeAppState(serverNames: string[]) {
   return {
     servers: Object.fromEntries(
       serverNames.map((name) => [
         name,
         { name, connectionStatus: "disconnected" },
-      ]),
+      ])
     ),
   } as any;
 }
@@ -29,9 +51,7 @@ function wrapper({
   setSelectedServerNames = () => {},
 }: {
   children: ReactNode;
-  ensureServersReady: (
-    names: string[],
-  ) => Promise<{
+  ensureServersReady: (names: string[]) => Promise<{
     readyServerNames: string[];
     failedServerNames: string[];
     missingServerNames: string[];
@@ -66,6 +86,12 @@ describe("useAutoConnectProjectServers", () => {
   beforeEach(() => {
     resetAutoConnectAttempts();
     localStorage.removeItem("mcpjam-auto-connect-servers");
+    mocks.toastError.mockClear();
+    mocks.logger.error.mockClear();
+    mocks.logger.warn.mockClear();
+    mocks.logger.info.mockClear();
+    mocks.logger.debug.mockClear();
+    mocks.logger.trace.mockClear();
   });
 
   it("calls ensureServersReady once for the same (project, required set) across re-renders", async () => {
@@ -87,7 +113,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -114,7 +140,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -136,7 +162,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -169,7 +195,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -191,7 +217,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -223,7 +249,7 @@ describe("useAutoConnectProjectServers", () => {
         initialProps: { requiredServerNames: ["alpha"] },
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -271,7 +297,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState, reconnectServer }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -281,6 +307,50 @@ describe("useAutoConnectProjectServers", () => {
     // alpha is already connected, so the connect-required candidate path has
     // nothing to do (reconnect, not connect, handles it).
     expect(ensureServersReady).not.toHaveBeenCalled();
+  });
+
+  it("logs and shows one toast when client-switch reconnects fail", async () => {
+    const ensureServersReady = vi.fn().mockResolvedValue({
+      readyServerNames: [],
+      failedServerNames: [],
+      missingServerNames: [],
+      reauthServerNames: [],
+    });
+    const reconnectServer = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("beta exploded"));
+    const appState = {
+      servers: {
+        alpha: { name: "alpha", connectionStatus: "connected" },
+        beta: { name: "beta", connectionStatus: "connected" },
+      },
+    } as any;
+
+    renderHook(
+      () =>
+        useAutoConnectProjectServers({
+          projectId: "proj-reconnect-failure",
+          hostScopeKey: "host-a",
+          requiredServerNames: [],
+        }),
+      {
+        wrapper: ({ children }) =>
+          wrapper({ children, ensureServersReady, appState, reconnectServer }),
+      }
+    );
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(reconnectServer).toHaveBeenCalledTimes(2);
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      "Failed to reconnect server after client switch",
+      { serverName: "beta", error: "beta exploded" }
+    );
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Failed to reconnect 1 server."
+    );
   });
 
   it("reconnects connected servers even when the active host requires none", async () => {
@@ -303,7 +373,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState, reconnectServer }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -341,7 +411,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState, reconnectServer }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -378,7 +448,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState, reconnectServer }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -410,7 +480,7 @@ describe("useAutoConnectProjectServers", () => {
         initialProps: { hostScopeKey: "host-a" },
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -468,7 +538,7 @@ describe("useAutoConnectProjectServers", () => {
             appState: appStateHolder.current,
             reconnectServer,
           }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -528,7 +598,7 @@ describe("useAutoConnectProjectServers", () => {
             ensureServersReady,
             appState: appStateHolder.current,
           }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -594,7 +664,7 @@ describe("useAutoConnectProjectServers", () => {
             ensureServersReady,
             appState: appStateHolder.current,
           }),
-      },
+      }
     );
 
     await flushMicrotasks();
@@ -638,7 +708,7 @@ describe("useAutoConnectProjectServers", () => {
       {
         wrapper: ({ children }) =>
           wrapper({ children, ensureServersReady, appState }),
-      },
+      }
     );
 
     await flushMicrotasks();

--- a/mcpjam-inspector/client/src/hooks/use-aggregated-tools.ts
+++ b/mcpjam-inspector/client/src/hooks/use-aggregated-tools.ts
@@ -45,7 +45,8 @@ export interface AggregatedToolsState {
  *     last-seen-wins collision behavior baked into `ToolServerMap`.
  */
 export function useAggregatedTools(
-  serverNames: string[]
+  serverNames: string[],
+  options: { unavailableServerNames?: ReadonlyArray<string> } = {}
 ): AggregatedToolsState {
   const apiContextRevision = useSyncExternalStore(
     subscribeApiContext,
@@ -69,8 +70,16 @@ export function useAggregatedTools(
     () => [...serverNames].sort().join("\x00"),
     [serverNames]
   );
+  const unavailableServersKey = useMemo(
+    () => [...(options.unavailableServerNames ?? [])].sort().join("\x00"),
+    [options.unavailableServerNames]
+  );
   const serverNamesRef = useRef<string[]>([]);
   serverNamesRef.current = serversKey ? serversKey.split("\x00") : [];
+  const unavailableServerNamesRef = useRef<string[]>([]);
+  unavailableServerNamesRef.current = unavailableServersKey
+    ? unavailableServersKey.split("\x00")
+    : [];
 
   // Monotonic token so a stale in-flight fetch can't clobber a fresher result
   // when the server set toggles or `refetch` is called mid-request.
@@ -86,6 +95,9 @@ export function useAggregatedTools(
       return;
     }
 
+    const unavailableSet = new Set(unavailableServerNamesRef.current);
+    const fetchableNames = names.filter((name) => !unavailableSet.has(name));
+
     // Prune state to the new server set synchronously so tools from
     // just-deselected servers disappear immediately rather than lingering
     // until the new fetch returns.
@@ -93,7 +105,9 @@ export function useAggregatedTools(
     const pruneToActive = <V>(prev: Record<string, V>): Record<string, V> => {
       const next: Record<string, V> = {};
       for (const key of Object.keys(prev)) {
-        if (activeSet.has(key)) next[key] = prev[key];
+        if (activeSet.has(key) && !unavailableSet.has(key)) {
+          next[key] = prev[key];
+        }
       }
       return next;
     };
@@ -101,12 +115,18 @@ export function useAggregatedTools(
     setErrorByServer((prev) => pruneToActive(prev));
     setLoadingByServer((prev) => {
       const next = pruneToActive(prev);
-      for (const name of names) next[name] = true;
+      for (const name of names) {
+        next[name] = true;
+      }
       return next;
     });
 
+    if (fetchableNames.length === 0) {
+      return;
+    }
+
     const results = await Promise.all(
-      names.map(async (serverId) => {
+      fetchableNames.map(async (serverId) => {
         try {
           const data = await listTools({ serverId });
           return { serverId, tools: data.tools ?? [], error: null as null };
@@ -135,9 +155,12 @@ export function useAggregatedTools(
     setLoadingByServer(() => {
       const next: Record<string, boolean> = {};
       for (const { serverId } of results) next[serverId] = false;
+      for (const serverId of unavailableSet) {
+        if (activeSet.has(serverId)) next[serverId] = true;
+      }
       return next;
     });
-  }, [serversKey, apiContextRevision]);
+  }, [serversKey, apiContextRevision, unavailableServersKey]);
 
   useEffect(() => {
     void fetchAll();

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -835,6 +835,7 @@ export function useAppState({
     handleDisconnect: serverState.handleDisconnect,
     handleRuntimeDisconnect: serverState.handleRuntimeDisconnect,
     handleReconnect: serverState.handleReconnect,
+    reconnectServerForClientSwitch: serverState.reconnectServerForClientSwitch,
     ensureServersReady: serverState.ensureServersReady,
     syncAgentStatus: serverState.syncAgentStatus,
     handleUpdate: serverState.handleUpdate,

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -801,6 +801,7 @@ export function useAppState({
     pendingDashboardOAuth,
 
     projectServers: serverState.projectServers,
+    displayServerConfigs: serverState.displayServerConfigs,
     connectedOrConnectingServerConfigs:
       serverState.connectedOrConnectingServerConfigs,
     selectedServerEntry: serverState.selectedServerEntry,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -751,6 +751,31 @@ export function useServerState({
       ),
     [effectiveServers]
   );
+
+  // What chat-input's "Servers" popover (and any other "show me everything
+  // we can talk to" surface) should iterate: the project catalog PLUS any
+  // runtime-connected/connecting servers that aren't in it yet. The catalog
+  // (effectiveServers) is the Convex `project_servers` query in hosted mode
+  // and can lag mcpjam-backend's `MCPClientManager` — a server is genuinely
+  // connected (Tools pane and tool calls work against it) but its catalog
+  // row hasn't synced, so the popover used to hide it. We only merge
+  // runtime entries that are currently connected/connecting; disconnected
+  // runtime leftovers from a previous session/project never surface here.
+  const displayServerConfigs = useMemo(() => {
+    const result: Record<string, ServerWithName> = { ...effectiveServers };
+    for (const [name, runtime] of Object.entries(appState.servers)) {
+      if (result[name]) continue;
+      if (
+        runtime.connectionStatus !== "connected" &&
+        runtime.connectionStatus !== "connecting"
+      ) {
+        continue;
+      }
+      result[name] = runtime;
+    }
+    return result;
+  }, [effectiveServers, appState.servers]);
+
   const latestEffectiveServersRef = useRef(effectiveServers);
 
   useEffect(() => {
@@ -4018,6 +4043,7 @@ export function useServerState({
     activeProject,
     effectiveServers,
     projectServers: effectiveServers,
+    displayServerConfigs,
     connectedOrConnectingServerConfigs,
     selectedServerEntry: effectiveServers[appState.selectedServer],
     selectedMCPConfig: effectiveServers[appState.selectedServer]?.config,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -3682,18 +3682,18 @@ export function useServerState({
   // `/api/mcp/servers/reconnect` endpoint closes the live transport and reopens
   // it with the active host's `clientInfo`. Non-interactive and non-selecting:
   // used by the client-switch recycle, where popping an OAuth window per server
-  // or thrashing the single-select pointer would be wrong. Errors are
-  // swallowed (the per-card Reconnect button is the manual retry path).
+  // or thrashing the single-select pointer would be wrong. Per-server error
+  // toasts are suppressed here; the caller aggregates failures for logging and
+  // one user-facing toast.
   const reconnectServerForClientSwitch = useCallback(
     async (serverName: string): Promise<void> => {
-      try {
-        await reconnectServerInternal(serverName, {
-          allowInteractiveOAuthFlow: false,
-          select: false,
-          suppressErrors: true,
-        });
-      } catch {
-        // intentionally empty — surfaced via the server's status dot
+      const result = await reconnectServerInternal(serverName, {
+        allowInteractiveOAuthFlow: false,
+        select: false,
+        suppressErrors: true,
+      });
+      if (result.status !== "connected") {
+        throw new Error(result.error || `Failed to reconnect ${serverName}`);
       }
     },
     [reconnectServerInternal]

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -3676,6 +3676,29 @@ export function useServerState({
     [reconnectServerInternal]
   );
 
+  // Force a re-handshake of an ALREADY-connected server under the current
+  // client identity. Unlike `ensureServersReady` (which skips servers that are
+  // already connected), this always reconnects — the backend
+  // `/api/mcp/servers/reconnect` endpoint closes the live transport and reopens
+  // it with the active host's `clientInfo`. Non-interactive and non-selecting:
+  // used by the client-switch recycle, where popping an OAuth window per server
+  // or thrashing the single-select pointer would be wrong. Errors are
+  // swallowed (the per-card Reconnect button is the manual retry path).
+  const reconnectServerForClientSwitch = useCallback(
+    async (serverName: string): Promise<void> => {
+      try {
+        await reconnectServerInternal(serverName, {
+          allowInteractiveOAuthFlow: false,
+          select: false,
+          suppressErrors: true,
+        });
+      } catch {
+        // intentionally empty — surfaced via the server's status dot
+      }
+    },
+    [reconnectServerInternal]
+  );
+
   const ensureServersReady = useCallback(
     async (serverNames: string[]): Promise<EnsureServersReadyResult> => {
       const uniqueServerNames = [...new Set(serverNames.filter(Boolean))];
@@ -4064,6 +4087,7 @@ export function useServerState({
     handleDisconnect,
     handleRuntimeDisconnect,
     handleReconnect,
+    reconnectServerForClientSwitch,
     ensureServersReady,
     syncAgentStatus,
     handleUpdate,

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
+import { toast } from "sonner";
 import type { EnsureServersReadyResult } from "@/hooks/use-server-state";
+import { useLogger } from "@/hooks/use-logger";
 import { useSharedAppState } from "@/state/app-state-context";
 import { useServerActions } from "@/state/server-actions-context";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -35,17 +37,24 @@ const attemptedByProject = new Map<string, Set<string>>();
  */
 const lastSeenScopeByProject = new Map<string, string>();
 
-function buildAttemptKey(
-  hostScopeKey: string,
-  serverNamesKey: string,
-): string {
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function reconnectFailureToastMessage(count: number): string {
+  return count === 1
+    ? "Failed to reconnect 1 server."
+    : `Failed to reconnect ${count} servers.`;
+}
+
+function buildAttemptKey(hostScopeKey: string, serverNamesKey: string): string {
   return `${hostScopeKey}${serverNamesKey}`;
 }
 
 function markAttempted(
   projectId: string,
   hostScopeKey: string,
-  serverNamesKey: string,
+  serverNamesKey: string
 ) {
   let set = attemptedByProject.get(projectId);
   if (!set) {
@@ -58,7 +67,7 @@ function markAttempted(
 function isAttempted(
   projectId: string,
   hostScopeKey: string,
-  serverNamesKey: string,
+  serverNamesKey: string
 ): boolean {
   return (
     attemptedByProject
@@ -133,6 +142,7 @@ export function useAutoConnectProjectServers({
   const enabled = usePreferencesStore((s) => s.autoConnectServersEnabled);
   const sharedAppState = useSharedAppState();
   const { ensureServersReady, reconnectServer } = useServerActions();
+  const logger = useLogger("AutoConnectProjectServers");
   const lastResultRef = useRef<EnsureServersReadyResult | null>(null);
 
   const scopeKey = hostScopeKey ?? "-";
@@ -141,11 +151,11 @@ export function useAutoConnectProjectServers({
   // disconnect dedupe.
   const requiredNamesKey = useMemo(
     () => requiredServerNames.slice().sort().join("\0"),
-    [requiredServerNames],
+    [requiredServerNames]
   );
   const requiredNames = useMemo(
     () => (requiredNamesKey ? requiredNamesKey.split("\0") : []),
-    [requiredNamesKey],
+    [requiredNamesKey]
   );
 
   // Build the candidate name list. Skip servers that are already connected,
@@ -208,14 +218,34 @@ export function useAutoConnectProjectServers({
     const connectedNow = Object.entries(sharedAppState.servers)
       .filter(([, server]) => server.connectionStatus === "connected")
       .map(([name]) => name);
-    for (const name of connectedNow) {
-      reconnectServer(name);
-    }
+    void Promise.allSettled(
+      connectedNow.map(async (name) => {
+        await reconnectServer(name);
+        return name;
+      })
+    ).then((results) => {
+      const failures = results.flatMap((result, index) => {
+        if (result.status === "fulfilled") return [];
+        return [
+          {
+            serverName: connectedNow[index],
+            error: getErrorMessage(result.reason),
+          },
+        ];
+      });
+
+      if (failures.length === 0) return;
+
+      for (const failure of failures) {
+        logger.error("Failed to reconnect server after client switch", failure);
+      }
+      toast.error(reconnectFailureToastMessage(failures.length));
+    });
     // `sharedAppState.servers` is read via closure but excluded from deps on
     // purpose: this must fire only on scope transitions, not whenever the
     // connected set changes within a scope. The dedupe gate stops re-runs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, projectId, scopeKey, hostScopeKey, reconnectServer]);
+  }, [enabled, projectId, scopeKey, hostScopeKey, reconnectServer, logger]);
 
   // Connect-required: fires when the candidate set (required-but-not-yet-
   // connected) changes. Dedupe is per-server-within-scope, not per
@@ -233,7 +263,7 @@ export function useAutoConnectProjectServers({
     if (!enabled || !projectId || !candidateNamesKey) return;
     const allNames = candidateNamesKey.split("\0");
     const fresh = allNames.filter(
-      (name) => !isAttempted(projectId, scopeKey, `srv:${name}`),
+      (name) => !isAttempted(projectId, scopeKey, `srv:${name}`)
     );
     if (fresh.length === 0) return;
     for (const name of fresh) {
@@ -253,18 +283,12 @@ export function useAutoConnectProjectServers({
       // rejections in dev/test.
       () => {
         // intentionally empty
-      },
+      }
     );
     return () => {
       cancelled = true;
     };
-  }, [
-    enabled,
-    projectId,
-    scopeKey,
-    candidateNamesKey,
-    ensureServersReady,
-  ]);
+  }, [enabled, projectId, scopeKey, candidateNamesKey, ensureServersReady]);
 
   return { enabled, lastResult: lastResultRef.current };
 }

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -129,6 +129,19 @@ export function useAutoConnectProjectServers({
     setSelectedServerNames,
   } = useServerActions();
   const lastResultRef = useRef<EnsureServersReadyResult | null>(null);
+  // Latest multi-select, read inside the seed effect below WITHOUT making it
+  // an effect dependency. Depending on it would re-run the merge every time
+  // the selection changes (e.g. the user toggling a server off), which could
+  // undo a deliberate deselect. The seed should react only to host-scope /
+  // required-set changes, so we read the live value through a ref instead.
+  const selectedNamesRef = useRef(sharedAppState.selectedMultipleServers);
+  selectedNamesRef.current = sharedAppState.selectedMultipleServers;
+  // Which (project, host-scope) we last seeded the selection for. Component-
+  // scoped on purpose: the hook mounts on several surfaces (reconciler,
+  // Servers tab, Playground, Client builder) with DIFFERENT scopes, so a
+  // shared module map would thrash. Each mount seeds its own scope at most
+  // once and merges thereafter.
+  const seededSelectionScopeRef = useRef<string | null>(null);
 
   const scopeKey = hostScopeKey ?? "-";
   // Stable key for "what the active host wants selected". Drives the
@@ -187,16 +200,36 @@ export function useAutoConnectProjectServers({
     return candidates.join("\0");
   }, [enabled, projectId, requiredNames, sharedAppState.servers]);
 
-  // Sync the playground/chat multi-select to the host's required set
-  // whenever the (project, hostScope, required-names) tuple changes. Empty
-  // required sets are a no-op: surfaces with no explicit host selection
-  // should not wipe the active project/default host's server selection.
-  // React's dep comparison deduplicates re-renders that don't actually
-  // change the tuple, so this fires once per host switch (and once per
-  // edit to the host's required set after save).
+  // Seed the playground/chat multi-select from the active host's required
+  // set. On a host switch (scopeKey change, or the first resolve for this
+  // surface) we REPLACE the selection so the preview matches the picked
+  // client. Within the SAME scope, though, the required set can re-resolve
+  // for reasons that are NOT a host switch — most commonly, connecting
+  // another server updates the project's server catalog so a host-referenced
+  // id that didn't resolve before now does. Replacing there silently wiped
+  // servers the user had toggled on by hand: they stayed connected but
+  // dropped out of the selection (their toggle flipped off). So for an
+  // in-scope change we MERGE the required names into the current selection
+  // instead, never removing the user's manual picks. Empty required sets are
+  // a no-op so surfaces with no explicit host don't clear the selection.
   useEffect(() => {
     if (!enabled || !projectId || requiredNames.length === 0) return;
-    setSelectedServerNames(requiredNames);
+
+    const seedKey = `${projectId}::${scopeKey}`;
+    if (seededSelectionScopeRef.current !== seedKey) {
+      seededSelectionScopeRef.current = seedKey;
+      setSelectedServerNames(requiredNames);
+      return;
+    }
+
+    const current = selectedNamesRef.current ?? [];
+    const merged = current.slice();
+    for (const name of requiredNames) {
+      if (!merged.includes(name)) merged.push(name);
+    }
+    if (merged.length !== current.length) {
+      setSelectedServerNames(merged);
+    }
   }, [enabled, projectId, scopeKey, requiredNames, setSelectedServerNames]);
 
   // Detect a scope transition (user switched the previewed host) and

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -100,10 +100,19 @@ interface UseAutoConnectProjectServersResult {
  * preferences store.
  *
  * Server-set semantics: the caller passes the SAVED host's required set
- * (`HostConfig.serverIds` resolved to names). Optional servers stay
- * disconnected; if the host has no required servers, this hook is a
- * no-op. This matches the host's declared dependencies — connecting
- * servers the host doesn't claim to need would be surprising.
+ * (`HostConfig.serverIds` resolved to names). Required servers auto-connect.
+ *
+ * Client-switch recycle: switching the active/lead client (a `hostScopeKey`
+ * change) reconnects EVERY currently-connected server so each re-runs the MCP
+ * `initialize` handshake under the new client identity. It calls the real
+ * reconnect path (`reconnectServer` → backend `/api/mcp/servers/reconnect`,
+ * which closes and reopens the transport with the new `clientInfo`) once per
+ * scope per server — NOT an in-memory disconnect, which left the backend
+ * connection alive and made re-handshakes flaky. Required-but-not-connected
+ * servers are additionally auto-connected via the candidate path. Gated on a
+ * host being active (`hostScopeKey` non-null). Selection is NOT managed here:
+ * the connected set is the active set, mirrored by
+ * `ActiveClientServerReconciler`.
  */
 export function useAutoConnectProjectServers({
   projectId,
@@ -123,25 +132,8 @@ export function useAutoConnectProjectServers({
 }): UseAutoConnectProjectServersResult {
   const enabled = usePreferencesStore((s) => s.autoConnectServersEnabled);
   const sharedAppState = useSharedAppState();
-  const {
-    ensureServersReady,
-    runtimeDisconnectServer,
-    setSelectedServerNames,
-  } = useServerActions();
+  const { ensureServersReady, reconnectServer } = useServerActions();
   const lastResultRef = useRef<EnsureServersReadyResult | null>(null);
-  // Latest multi-select, read inside the seed effect below WITHOUT making it
-  // an effect dependency. Depending on it would re-run the merge every time
-  // the selection changes (e.g. the user toggling a server off), which could
-  // undo a deliberate deselect. The seed should react only to host-scope /
-  // required-set changes, so we read the live value through a ref instead.
-  const selectedNamesRef = useRef(sharedAppState.selectedMultipleServers);
-  selectedNamesRef.current = sharedAppState.selectedMultipleServers;
-  // Which (project, host-scope) we last seeded the selection for. Component-
-  // scoped on purpose: the hook mounts on several surfaces (reconciler,
-  // Servers tab, Playground, Client builder) with DIFFERENT scopes, so a
-  // shared module map would thrash. Each mount seeds its own scope at most
-  // once and merges thereafter.
-  const seededSelectionScopeRef = useRef<string | null>(null);
 
   const scopeKey = hostScopeKey ?? "-";
   // Stable key for "what the active host wants selected". Drives the
@@ -156,130 +148,74 @@ export function useAutoConnectProjectServers({
     [requiredNamesKey],
   );
 
-  // Names in the active host's required set that are currently connected.
-  // On a host switch, only those servers need to be recycled so they can
-  // reconnect with the new host's initialize payload. Servers outside the
-  // required set may have been connected manually or by the project-level
-  // auto-connect switch; entering a host with no required servers must not
-  // tear them down.
-  const requiredConnectedNamesToDisconnectKey = useMemo(() => {
-    if (!enabled || !projectId || requiredNames.length === 0) return null;
-    const connected: string[] = [];
-    for (const name of requiredNames) {
-      if (sharedAppState.servers[name]?.connectionStatus !== "connected") {
-        continue;
-      }
-      connected.push(name);
-    }
-    if (connected.length === 0) return null;
-    return connected.join("\0");
-  }, [enabled, projectId, requiredNames, sharedAppState.servers]);
-
   // Build the candidate name list. Skip servers that are already connected,
   // currently connecting, or in an OAuth flow — connecting/oauth-flow would
   // be interrupted; connected has nothing to do.
+  // The candidate pool is the host's required set UNION the servers the
+  // currently connecting, or in an OAuth flow — connecting/oauth-flow would
+  // be interrupted; connected has nothing to do. This is the "connect the
+  // host's required servers" path; reconnecting the ALREADY-connected set on a
+  // client switch is handled separately below.
   const candidateNamesKey = useMemo(() => {
     if (!enabled || !projectId || requiredNames.length === 0) {
       return null;
     }
-    const candidates: string[] = [];
-    for (const name of requiredNames) {
+    const candidates = requiredNames.filter((name) => {
       const status = sharedAppState.servers[name]?.connectionStatus;
-      if (
-        status === "connected" ||
-        status === "connecting" ||
-        status === "oauth-flow"
-      ) {
-        continue;
-      }
-      candidates.push(name);
-    }
+      return (
+        status !== "connected" &&
+        status !== "connecting" &&
+        status !== "oauth-flow"
+      );
+    });
     if (candidates.length === 0) return null;
-    // Stable key: sorted and joined with NUL — same shape ChatboxBuilderView
-    // uses (line 754) so reordering doesn't trigger a fresh batch.
-    return candidates.join("\0");
+    // Stable key: sorted and joined with NUL so reordering doesn't trigger a
+    // fresh batch.
+    return candidates.sort().join("\0");
   }, [enabled, projectId, requiredNames, sharedAppState.servers]);
 
-  // Seed the playground/chat multi-select from the active host's required
-  // set. On a host switch (scopeKey change, or the first resolve for this
-  // surface) we REPLACE the selection so the preview matches the picked
-  // client. Within the SAME scope, though, the required set can re-resolve
-  // for reasons that are NOT a host switch — most commonly, connecting
-  // another server updates the project's server catalog so a host-referenced
-  // id that didn't resolve before now does. Replacing there silently wiped
-  // servers the user had toggled on by hand: they stayed connected but
-  // dropped out of the selection (their toggle flipped off). So for an
-  // in-scope change we MERGE the required names into the current selection
-  // instead, never removing the user's manual picks. Empty required sets are
-  // a no-op so surfaces with no explicit host don't clear the selection.
-  useEffect(() => {
-    if (!enabled || !projectId || requiredNames.length === 0) return;
-
-    const seedKey = `${projectId}::${scopeKey}`;
-    if (seededSelectionScopeRef.current !== seedKey) {
-      seededSelectionScopeRef.current = seedKey;
-      setSelectedServerNames(requiredNames);
-      return;
-    }
-
-    const current = selectedNamesRef.current ?? [];
-    const merged = current.slice();
-    for (const name of requiredNames) {
-      if (!merged.includes(name)) merged.push(name);
-    }
-    if (merged.length !== current.length) {
-      setSelectedServerNames(merged);
-    }
-  }, [enabled, projectId, scopeKey, requiredNames, setSelectedServerNames]);
-
-  // Detect a scope transition (user switched the previewed host) and
+  // Detect a scope transition (user switched the active/lead client) and
   // clear the prior attempt log so revisiting a previously-tried host
   // re-fires reconciliation. Without this, the dedupe set would say
   // "already tried (Claude, [E,b,l])" and skip the second visit forever,
   // even though leaving and coming back is a clear user-intent signal to
   // try again. Sitting on the same host doesn't trigger this — only the
-  // actual scope change does.
+  // actual scope change does. Gated on a host being active (hostScopeKey
+  // non-null), not on the required set, so recycling fires even for hosts
+  // that declare no required servers.
   useEffect(() => {
-    if (!projectId || requiredNames.length === 0) return;
+    if (!projectId || hostScopeKey == null) return;
     if (lastSeenScopeByProject.get(projectId) !== scopeKey) {
       attemptedByProject.delete(projectId);
       lastSeenScopeByProject.set(projectId, scopeKey);
     }
-  }, [projectId, scopeKey, requiredNames.length]);
+  }, [projectId, scopeKey, hostScopeKey]);
 
-  // Disconnect-required-connected: fires at most once per (project,
-  // scopeKey). This is the host-switch recycle pass — it snapshots the
-  // active host's required servers that are already connected on first
-  // entry to the scope and disconnects only those. They then re-enter the
-  // candidate set on the next render and reconnect fresh. Later changes
-  // to the connected set within the SAME scope (e.g. the user manually
-  // connecting an additional server from the Servers tab) must not re-
-  // fire this path, otherwise we'd tear down servers the user just
-  // intentionally connected. The dedupe key is scope-only and we mark
-  // attempted unconditionally on first run, so subsequent renders bail
-  // even if `requiredConnectedNamesToDisconnectKey` becomes non-null
-  // afterwards.
+  // Reconnect-on-client-switch: fires at most once per (project, scopeKey).
+  // On switching the active/lead client, every currently-connected server must
+  // re-run the MCP `initialize` handshake as the new client. We hit the real
+  // reconnect path (`reconnectServer` → backend closes + reopens the transport
+  // with the new clientInfo) rather than an in-memory disconnect, which left
+  // the backend connection alive and made the re-handshake flaky. We snapshot
+  // the connected set at scope entry; servers connected later in the same scope
+  // already used the current client, so they're left alone. The module-level
+  // scope dedupe makes this fire exactly once even though the hook mounts on
+  // several surfaces.
   useEffect(() => {
-    if (!enabled || !projectId || requiredNames.length === 0) return;
-    if (isAttempted(projectId, scopeKey, "disconnect")) return;
-    markAttempted(projectId, scopeKey, "disconnect");
-    if (!requiredConnectedNamesToDisconnectKey) return;
-    for (const name of requiredConnectedNamesToDisconnectKey.split("\0")) {
-      runtimeDisconnectServer(name);
+    if (!enabled || !projectId || hostScopeKey == null) return;
+    if (isAttempted(projectId, scopeKey, "recycle")) return;
+    markAttempted(projectId, scopeKey, "recycle");
+    const connectedNow = Object.entries(sharedAppState.servers)
+      .filter(([, server]) => server.connectionStatus === "connected")
+      .map(([name]) => name);
+    for (const name of connectedNow) {
+      reconnectServer(name);
     }
-    // `requiredConnectedNamesToDisconnectKey` is intentionally excluded from
-    // the dep array: this effect must fire only on scope transitions, not
-    // when the user's actions change the set of connected servers within
-    // the same scope. Reading the latest value via closure is fine because
-    // the dedupe gate stops re-runs.
+    // `sharedAppState.servers` is read via closure but excluded from deps on
+    // purpose: this must fire only on scope transitions, not whenever the
+    // connected set changes within a scope. The dedupe gate stops re-runs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    enabled,
-    projectId,
-    scopeKey,
-    requiredNames.length,
-    runtimeDisconnectServer,
-  ]);
+  }, [enabled, projectId, scopeKey, hostScopeKey, reconnectServer]);
 
   // Connect-required: fires when the candidate set (required-but-not-yet-
   // connected) changes. Dedupe is per-server-within-scope, not per

--- a/mcpjam-inspector/client/src/state/server-actions-context.tsx
+++ b/mcpjam-inspector/client/src/state/server-actions-context.tsx
@@ -19,6 +19,13 @@ export interface ServerActions {
    */
   runtimeDisconnectServer: (serverName: string) => void;
   /**
+   * Force a re-handshake of an already-connected server under the current
+   * client identity (backend closes + reopens the transport with the active
+   * host's clientInfo). Used by the client-switch recycle so every connected
+   * server re-initializes as the newly-selected client. Non-interactive.
+   */
+  reconnectServer: (serverName: string) => Promise<void>;
+  /**
    * Replace the global playground/chat multi-select set. Used by the
    * host-switch reconciliation so the chat composer's per-server toggles
    * match what the active host actually requires — without this, the


### PR DESCRIPTION
- When you connect a server, the app used to reset your server toggles to match your active Client's saved server list. Any server you'd switched on by hand got switched off — even though it stayed connected (still green in the dashboard). The toggle just silently flipped off.

- Why it happened: connecting a server can make the active Client's required-server list re-resolve, and the code *replaced* your whole selection with that list, dropping anything you'd added manually.

- The fix: switching to a different Client still snaps the selection to that Client's servers (unchanged). But within the same Client, re-resolving the list now *merges* in what's needed instead of replacing — so your manual toggles are never wiped.

- Added a regression test covering the exact case: a manually-toggled server survives connecting another server.


https://github.com/user-attachments/assets/9c8cc4ea-a322-4bbe-b76d-f0b76cd2df38

