### PR TITLE
bump: replace DRAFT-2026-v1 with 2026-07-28 across SDK + inspector

### DIFF
--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/ProtocolTab.tsx
@@ -17,14 +17,14 @@ import {
 import type { HostAttentionIssue } from "../types";
 import { useJsonDraftBuffer } from "./useJsonDraftBuffer";
 
-type HostProtocolDropdownValue = "latest" | "draft";
+type HostProtocolDropdownValue = "latest" | "rc";
 
 const HOST_PROTOCOL_OPTIONS: Array<{
   value: HostProtocolDropdownValue;
   label: string;
 }> = [
-  { value: "latest", label: "Latest" },
-  { value: "draft", label: "Draft" },
+  { value: "latest", label: "Latest (2025-11-25)" },
+  { value: "rc", label: "2026 RC (2026-07-28)" },
 ];
 
 interface ProtocolTabProps {
@@ -264,8 +264,8 @@ export function ProtocolTab({ draft, onDraftChange }: ProtocolTabProps) {
   // since they route to the same code path; saving normalizes back to
   // undefined.
   const selectedDropdownValue: HostProtocolDropdownValue =
-    draft.mcpProfile?.mcpProtocolVersion === "DRAFT-2026-v1"
-      ? "draft"
+    draft.mcpProfile?.mcpProtocolVersion === "2026-07-28"
+      ? "rc"
       : "latest";
 
   // Dropdown handler. Writes through to `draft.mcpProfile.mcpProtocolVersion`
@@ -300,7 +300,7 @@ export function ProtocolTab({ draft, onDraftChange }: ProtocolTabProps) {
           <div className="flex items-center gap-3">
             <span
               className="text-[12px] font-medium"
-              title="Latest: current stable MCP wire version (whatever the SDK ships). Draft: experimental DRAFT-2026-v1 stateless transport."
+              title="Latest: current stable MCP wire version (2025-11-25). 2026 RC: 2026-07-28 stateless RC transport."
             >
               Protocol version
             </span>
@@ -308,7 +308,7 @@ export function ProtocolTab({ draft, onDraftChange }: ProtocolTabProps) {
               value={selectedDropdownValue}
               onValueChange={(next) => {
                 setProtocolVersion(
-                  next === "draft" ? "DRAFT-2026-v1" : undefined,
+                  next === "rc" ? "2026-07-28" : undefined,
                 );
               }}
             >

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -304,7 +304,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         projectId="project_123"
         hostedServerId="server_123"
-        hostDefaultMcpProtocolVersion="DRAFT-2026-v1"
+        hostDefaultMcpProtocolVersion="2026-07-28"
       />
     );
 
@@ -316,7 +316,7 @@ describe("ServerDetailModal", () => {
     expect(protocolSelect).toBeEnabled();
 
     await user.click(protocolSelect);
-    await user.click(await screen.findByRole("option", { name: "Latest" }));
+    await user.click(await screen.findByRole("option", { name: "Latest (2025-11-25)" }));
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
@@ -349,7 +349,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         projectId="project_123"
         hostedServerId="server_123"
-        hostDefaultMcpProtocolVersion="DRAFT-2026-v1"
+        hostDefaultMcpProtocolVersion="2026-07-28"
       />
     );
     const { unmount } = render(renderModal());
@@ -361,7 +361,7 @@ describe("ServerDetailModal", () => {
     expect(hostDefaultSelect).toHaveTextContent("Host default");
 
     await user.click(hostDefaultSelect);
-    await user.click(await screen.findByRole("option", { name: "Latest" }));
+    await user.click(await screen.findByRole("option", { name: "Latest (2025-11-25)" }));
 
     await waitFor(() => {
       expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
@@ -378,7 +378,7 @@ describe("ServerDetailModal", () => {
     });
     await waitFor(() => {
       expect(
-        screen.queryByRole("option", { name: "Latest" })
+        screen.queryByRole("option", { name: "Latest (2025-11-25)" })
       ).not.toBeInTheDocument();
     });
     unmount();
@@ -400,7 +400,7 @@ describe("ServerDetailModal", () => {
     );
 
     const latestSelect = getProtocolVersionCombobox();
-    expect(latestSelect).toHaveTextContent("Latest");
+    expect(latestSelect).toHaveTextContent("Latest (2025-11-25)");
 
     await user.click(latestSelect);
     await user.click(
@@ -437,7 +437,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         projectId="project_123"
         hostedServerId="server_123"
-        hostDefaultMcpProtocolVersion="DRAFT-2026-v1"
+        hostDefaultMcpProtocolVersion="2026-07-28"
       />
     );
 
@@ -445,7 +445,7 @@ describe("ServerDetailModal", () => {
       screen.getByRole("button", { name: /connection overrides/i })
     );
     const protocolSelect = getProtocolVersionCombobox();
-    expect(protocolSelect).toHaveTextContent("Latest");
+    expect(protocolSelect).toHaveTextContent("Latest (2025-11-25)");
 
     await user.click(protocolSelect);
     await user.click(

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -16,10 +16,10 @@ import type { McpProtocolVersion } from "@/lib/client-config-v2";
  *   - "inherit" → `undefined`, defers to the host default (or SDK default if
  *     no host default is set).
  *   - "latest"  → `"2025-11-25"`, explicit stable pin — overrides a
- *     host-level Draft default.
- *   - "draft"   → `"DRAFT-2026-v1"`, the stateless preview client.
+ *     host-level RC default.
+ *   - "rc"      → `"2026-07-28"`, the stateless RC preview client.
  */
-type DropdownValue = "inherit" | "latest" | "draft";
+type DropdownValue = "inherit" | "latest" | "rc";
 
 const MCP_PROTOCOL_OPTIONS: Array<{
   value: DropdownValue;
@@ -28,8 +28,8 @@ const MCP_PROTOCOL_OPTIONS: Array<{
   flagGated?: boolean;
 }> = [
   { value: "inherit", label: "Host default" },
-  { value: "latest", label: "Latest" },
-  { value: "draft", label: "Draft", flagGated: true },
+  { value: "latest", label: "Latest (2025-11-25)" },
+  { value: "rc", label: "2026 RC (2026-07-28)", flagGated: true },
 ];
 
 interface HeaderEntry {
@@ -61,7 +61,7 @@ interface AdvancedConnectionSettingsSectionProps {
   /**
    * Visibility flag for the protocol-version override row. Wired from
    * `useFeatureFlagEnabled("stateless-mcp-enabled")` at the caller. When
-   * false, the entire dropdown is hidden AND the `DRAFT-2026-v1` option
+   * false, the entire dropdown is hidden AND the `2026-07-28` RC option
    * is omitted from the option list (the RC option is the flag-gated
    * piece; stateful options are always available behind the same flag).
    * Defaults to false. Host-default JSON keeps working regardless —
@@ -120,17 +120,17 @@ export function AdvancedConnectionSettingsSection({
   const showProtocolVersionControl = showMcpProtocolVersionOverride;
   const canEditProtocolVersion =
     onMcpProtocolVersionOverrideChange !== undefined;
-  // "Draft" is Streamable HTTP POST only — picking it on stdio / sse
+  // The RC is Streamable HTTP POST only — picking it on stdio / sse
   // would fail at construction with `StatelessRequiresHttpTransport`.
   // Hide it on non-HTTP transports as the user-friendly safety net.
   const isHttp = transportKind === "http";
   const visibleOptions = MCP_PROTOCOL_OPTIONS.filter((opt) => {
-    if (opt.value === "draft" && !isHttp) return false;
+    if (opt.value === "rc" && !isHttp) return false;
     return true;
   });
   const selectedDropdownValue: DropdownValue =
-    mcpProtocolVersionOverride === "DRAFT-2026-v1"
-      ? "draft"
+    mcpProtocolVersionOverride === "2026-07-28"
+      ? "rc"
       : mcpProtocolVersionOverride === "2025-11-25"
       ? "latest"
       : "inherit";
@@ -271,17 +271,17 @@ export function AdvancedConnectionSettingsSection({
             </div>
           )}
 
-          {/* Per-server MCP protocol-version pin. Binary picker:
-              "Latest" → `undefined` (legacy adapter + SDK-chosen wire
-              version); "Draft" → `"DRAFT-2026-v1"` (stateless preview
-              client). Gated by `stateless-mcp-enabled` at the caller.
-              "Draft" is hidden on non-HTTP transports because the
-              stateless client requires Streamable HTTP. */}
+          {/* Per-server MCP protocol-version pin. Tri-state picker:
+              "Latest" → `"2025-11-25"` (legacy adapter + initialize
+              handshake); "2026 RC" → `"2026-07-28"` (stateless RC
+              preview client). Gated by `stateless-mcp-enabled` at the
+              caller. The RC option is hidden on non-HTTP transports
+              because the stateless client requires Streamable HTTP. */}
           {showProtocolVersionControl && (
             <div className="space-y-1.5">
               <label
                 className="text-xs font-medium text-foreground"
-                title="Latest: the current stable MCP wire version (whatever the SDK ships). Draft: the experimental DRAFT-2026-v1 stateless transport (HTTP only)."
+                title="Latest: the current stable MCP wire version (2025-11-25). 2026 RC: the 2026-07-28 stateless RC transport (HTTP only)."
               >
                 Protocol version
               </label>
@@ -291,8 +291,8 @@ export function AdvancedConnectionSettingsSection({
                 onValueChange={(next) => {
                   if (!onMcpProtocolVersionOverrideChange) return;
                   onMcpProtocolVersionOverrideChange(
-                    next === "draft"
-                      ? "DRAFT-2026-v1"
+                    next === "rc"
+                      ? "2026-07-28"
                       : next === "latest"
                       ? "2025-11-25"
                       : undefined

--- a/mcpjam-inspector/client/src/components/home/ProductUpdatesFeed.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdatesFeed.tsx
@@ -18,8 +18,8 @@ interface ProductUpdate {
 const UPDATES: ProductUpdate[] = [
   {
     date: "May 2026",
-    title: "Stateless MCP (DRAFT-2026-v1)",
-    body: "Configure per-server protocol mode for stateless HTTP MCP — three layers of control from org default to per-server override.",
+    title: "Stateless MCP (2026 RC, 2026-07-28)",
+    body: "Try the MCP 2026-07-28 stateless RC against your own servers — per-server protocol mode with three layers of control from org default to per-server override.",
     tag: "New",
   },
   {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-aggregated-tools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-aggregated-tools.test.tsx
@@ -46,7 +46,7 @@ describe("useAggregatedTools", () => {
         },
         mcpProtocolVersionsByServerId: {
           "server-stateful": "2025-11-25",
-          "server-stateless": "DRAFT-2026-v1",
+          "server-stateless": "2026-07-28",
         },
         getAccessToken: async () => null,
       });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
@@ -230,7 +230,7 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
   it("does not re-test a connected server on initial mount", async () => {
     const dispatch = vi.fn();
     renderRevalidationHook(dispatch, {
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
+      profile: { mcpProtocolVersion: "2026-07-28" },
       hostConfig: buildHostConfig(),
     });
 
@@ -260,7 +260,7 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
     expect(reconnectServerMock).not.toHaveBeenCalled();
 
     rerender({
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
+      profile: { mcpProtocolVersion: "2026-07-28" },
       hostConfig: buildHostConfig(),
     });
 
@@ -294,7 +294,7 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
     await flushAsyncWork(5);
 
     rerender({
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
+      profile: { mcpProtocolVersion: "2026-07-28" },
       hostConfig: buildHostConfig(),
     });
 
@@ -333,7 +333,7 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
     rerender({
       profile: undefined,
       hostConfig: buildHostConfig({
-        srv_demo: { mcpProtocolVersionOverride: "DRAFT-2026-v1" },
+        srv_demo: { mcpProtocolVersionOverride: "2026-07-28" },
       }),
     });
 
@@ -345,14 +345,14 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
   it("skips re-test when the resolved version did not change", async () => {
     const dispatch = vi.fn();
     const { rerender } = renderRevalidationHook(dispatch, {
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
+      profile: { mcpProtocolVersion: "2026-07-28" },
       hostConfig: buildHostConfig(),
     });
 
     await flushAsyncWork(5);
 
     rerender({
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
+      profile: { mcpProtocolVersion: "2026-07-28" },
       hostConfig: buildHostConfig(),
     });
 

--- a/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
@@ -391,8 +391,8 @@ describe("resolveEffectiveCompatRuntime — per-method capability matrix", () =>
 describe("resolveEffectiveMcpProtocolVersion — per-server override precedence", () => {
   test("server override wins over host default", () => {
     expect(
-      resolveEffectiveMcpProtocolVersion("DRAFT-2026-v1", "2025-11-25"),
-    ).toBe("DRAFT-2026-v1");
+      resolveEffectiveMcpProtocolVersion("2026-07-28", "2025-11-25"),
+    ).toBe("2026-07-28");
   });
 
   test("host default applies when no server override", () => {
@@ -408,12 +408,12 @@ describe("resolveEffectiveMcpProtocolVersion — per-server override precedence"
   });
 
   test("stateful server override wins over stateless host default", () => {
-    // Symmetric scenario: host pinned to DRAFT-2026-v1 globally for a
+    // Symmetric scenario: host pinned to 2026-07-28 globally for a
     // migration test, one legacy server overridden back to 2025-11-25.
     // The override must reach the connect path or the legacy server
     // will fail with -32004.
     expect(
-      resolveEffectiveMcpProtocolVersion("2025-11-25", "DRAFT-2026-v1"),
+      resolveEffectiveMcpProtocolVersion("2025-11-25", "2026-07-28"),
     ).toBe("2025-11-25");
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-web-context.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-web-context.test.ts
@@ -182,9 +182,9 @@ describe("hosted web context", () => {
       projectId: "ws_stateless",
       serverIdsByName: { stateless: "srv_stateless" },
       clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
       mcpProtocolVersionsByServerId: {
-        srv_stateless: "DRAFT-2026-v1",
+        srv_stateless: "2026-07-28",
       },
       getAccessToken: async () => null,
     });
@@ -195,8 +195,8 @@ describe("hosted web context", () => {
       serverName: "stateless",
       clientCapabilities: defaultClientCapabilities,
       clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
-      mcpProtocolVersion: "DRAFT-2026-v1",
+      supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
+      mcpProtocolVersion: "2026-07-28",
     });
   });
 
@@ -208,10 +208,10 @@ describe("hosted web context", () => {
         stateless: "srv_stateless",
       },
       clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
       mcpProtocolVersionsByServerId: {
         srv_stateful: "2025-11-25",
-        srv_stateless: "DRAFT-2026-v1",
+        srv_stateless: "2026-07-28",
       },
       getAccessToken: async () => null,
     });
@@ -222,10 +222,10 @@ describe("hosted web context", () => {
       serverNames: ["Excalidraw", "stateless"],
       clientCapabilities: defaultClientCapabilities,
       clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
       mcpProtocolVersionsByServerId: {
         srv_stateful: "2025-11-25",
-        srv_stateless: "DRAFT-2026-v1",
+        srv_stateless: "2026-07-28",
       },
     });
   });
@@ -238,10 +238,10 @@ describe("hosted web context", () => {
         stateless: "srv_stateless",
       },
       clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
       mcpProtocolVersionsByServerId: {
         srv_stateful: "2025-11-25",
-        srv_stateless: "DRAFT-2026-v1",
+        srv_stateless: "2026-07-28",
       },
       getAccessToken: async () => null,
     });
@@ -259,10 +259,10 @@ describe("hosted web context", () => {
       serverNames: ["Excalidraw", "stateless"],
       clientCapabilities: defaultClientCapabilities,
       clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
       mcpProtocolVersionsByServerId: {
         srv_stateful: "2025-11-25",
-        srv_stateless: "DRAFT-2026-v1",
+        srv_stateless: "2026-07-28",
       },
       accessScope: "chat_v2",
     });

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -106,7 +106,7 @@ export type McpProtocolVersion =
   | "2025-03-26"
   | "2025-06-18"
   | "2025-11-25"
-  | "DRAFT-2026-v1";
+  | "2026-07-28";
 
 /**
  * Resolve the effective pinned protocol version for a server connection.

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -315,9 +315,9 @@ describe("web routes — chat-v2 hosted mode", () => {
         selectedServerIds: ["server-1"],
         selectedServerNames: ["Stateless"],
         clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-        supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+        supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
         mcpProtocolVersionsByServerId: {
-          "server-1": "DRAFT-2026-v1",
+          "server-1": "2026-07-28",
         },
         chatSessionId: "chat-session-stateless",
         messages: [{ role: "user", content: "hello" }],
@@ -336,8 +336,8 @@ describe("web routes — chat-v2 hosted mode", () => {
         "server-1": expect.objectContaining({
           url: "https://server-1.example.com/mcp",
           clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-          supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
-          mcpProtocolVersion: "DRAFT-2026-v1",
+          supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
+          mcpProtocolVersion: "2026-07-28",
         }),
       },
       expect.any(Object)
@@ -355,10 +355,10 @@ describe("web routes — chat-v2 hosted mode", () => {
         selectedServerIds: ["server-stateful", "server-stateless"],
         selectedServerNames: ["Excalidraw", "stateless"],
         clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
-        supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+        supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
         mcpProtocolVersionsByServerId: {
           "server-stateful": "2025-11-25",
-          "server-stateless": "DRAFT-2026-v1",
+          "server-stateless": "2026-07-28",
         },
         chatSessionId: "chat-session-mixed",
         messages: [{ role: "user", content: "hello" }],
@@ -381,8 +381,8 @@ describe("web routes — chat-v2 hosted mode", () => {
         }),
         "server-stateless": expect.objectContaining({
           url: "https://server-stateless.example.com/mcp",
-          supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
-          mcpProtocolVersion: "DRAFT-2026-v1",
+          supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
+          mcpProtocolVersion: "2026-07-28",
         }),
       },
       expect.any(Object)

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -51,7 +51,7 @@ const mcpProtocolVersionEnum = z.enum([
   "2025-03-26",
   "2025-06-18",
   "2025-11-25",
-  "DRAFT-2026-v1",
+  "2026-07-28",
 ]);
 // Per-server `mcpProtocolVersion` map. Map entries are validated against
 // the wire-mode enum so a typo in one server's pin doesn't tank the whole
@@ -133,7 +133,7 @@ export const promptsListMultiSchema = z.object({
   // single-server calls. `clientInfo` and `supportedProtocolVersions` are
   // host-level (uniform per batch). `mcpProtocolVersionsByServerId` is
   // per-server so different servers in the batch can be on different
-  // wire modes (e.g. one pinned to DRAFT-2026-v1 stateless, others on
+  // wire modes (e.g. one pinned to 2026-07-28 stateless, others on
   // legacy 2025-11-25 negotiation).
   clientInfo: clientInfoBatchSchema,
   supportedProtocolVersions: supportedProtocolVersionsBatchSchema,
@@ -498,7 +498,7 @@ export function toHttpConfig(
     clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
     supportedProtocolVersions?: string[];
     /**
-     * Outbound wire mode (DRAFT-2026-v1 stateless preview). Forwarded
+     * Outbound wire mode (2026-07-28 stateless preview). Forwarded
      * onto `HttpServerConfig.mcpProtocolVersion` so the SDK factory branches
      * to `StatelessMcpHttpPreviewClient` when set. Without this,
      * the hosted handler dropped the pin at the route boundary and
@@ -631,7 +631,7 @@ export async function createAuthorizedManager(
      * `mcpProtocolVersion` is the batch-uniform fallback wire mode;
      * `mcpProtocolVersionsByServerId` (sibling option below) overrides
      * it per server. This lets a batch contain one server pinned to
-     * DRAFT-2026-v1 stateless alongside another on legacy
+     * 2026-07-28 stateless alongside another on legacy
      * 2025-11-25 negotiation.
      */
     initializePins?: {

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -55,7 +55,7 @@ export type ConnectionDefaults = {
    * `isStatelessProtocolVersion`), the legacy upstream `Client` +
    * initialize handshake runs with the pin in
    * `supportedProtocolVersions`. When set to a stateless version
-   * (today: `"DRAFT-2026-v1"`), the SDK routes through
+   * (today: `"2026-07-28"`), the SDK routes through
    * `StatelessMcpHttpPreviewClient` — HTTP POST only; factory throws
    * `StatelessRequiresHttpTransport` for stdio / SSE, so the resolver
    * never has to gate on transport here.

--- a/mcpjam-inspector/test-servers/stateless-mcp-server.ts
+++ b/mcpjam-inspector/test-servers/stateless-mcp-server.ts
@@ -1,5 +1,5 @@
 /**
- * Fixture HTTP server for the DRAFT-2026-v1 stateless transport preview.
+ * Fixture HTTP server for the 2026-07-28 stateless transport (RC).
  * Stands up a minimal "spec-conforming enough" target so unit + integration
  * tests can exercise `StatelessMcpHttpPreviewClient` without an
  * external dependency.
@@ -7,8 +7,9 @@
  * What it implements (per `peppy-popping-flask.md` PR2 prerequisite):
  *   - Accepts POSTs without `initialize` / `Mcp-Session-Id`.
  *   - Validates body `_meta.io.modelcontextprotocol/protocolVersion ===
- *     "DRAFT-2026-v1"` — rejects with `-32004` + `data.supported:
- *     ["DRAFT-2026-v1"]`.
+ *     "2026-07-28"` — rejects with `-32004` + `data.supported:
+ *     ["2026-07-28"]` and `data.requested: <client's value>` per
+ *     upstream `schema.ts` (`UnsupportedProtocolVersionError`).
  *   - Validates required headers match body case-insensitively
  *     (RFC 9110) — rejects with `-32001 HeaderMismatch`.
  *   - Surfaces one plain tool and one annotated tool (`x-mcp-header:
@@ -30,7 +31,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 
-const DRAFT_2026_V1 = "DRAFT-2026-v1";
+const RC_2026_07_28 = "2026-07-28";
 const PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion";
 
 export interface StatelessMcpFixtureOptions {
@@ -43,7 +44,7 @@ export interface StatelessMcpFixtureOptions {
   /**
    * Reject `server/discover` requests with `-32004 Unsupported protocol
    * version` (carrying `data.supported: ["2025-11-25"]`). Simulates a
-   * 2025-only server rejecting a DRAFT-2026-v1 client. Only the discover
+   * 2025-only server rejecting a 2026-07-28 client. Only the discover
    * request is affected; other methods still validate normally so tests
    * can exercise the negative-path probe in isolation.
    */
@@ -96,13 +97,22 @@ export function startStatelessMcpFixture(
 
     // 1. Validate _meta protocolVersion.
     const meta = (body.params?._meta ?? {}) as Record<string, unknown>;
-    if (meta[PROTOCOL_VERSION_META_KEY] !== DRAFT_2026_V1) {
+    if (meta[PROTOCOL_VERSION_META_KEY] !== RC_2026_07_28) {
+      // UnsupportedProtocolVersionError carries `{ supported, requested }`
+      // in `error.data` per upstream `schema.ts` — NOT `supportedVersions`
+      // (that field belongs to DiscoverResult).
       respondJsonRpcError(
         res,
         body.id,
         -32004,
         "Unsupported protocol version",
-        { supported: [DRAFT_2026_V1] },
+        {
+          supported: [RC_2026_07_28],
+          requested:
+            typeof meta[PROTOCOL_VERSION_META_KEY] === "string"
+              ? (meta[PROTOCOL_VERSION_META_KEY] as string)
+              : null,
+        },
         opts,
       );
       return;
@@ -122,7 +132,7 @@ export function startStatelessMcpFixture(
         body.id,
         -32004,
         "Unsupported protocol version",
-        { supported: ["2025-11-25"], requested: DRAFT_2026_V1 },
+        { supported: ["2025-11-25"], requested: RC_2026_07_28 },
         opts,
       );
       return;
@@ -130,7 +140,7 @@ export function startStatelessMcpFixture(
 
     // 2. Validate MCP-Protocol-Version header matches.
     const headerVersion = headerLookup(req, "mcp-protocol-version");
-    if (headerVersion !== DRAFT_2026_V1) {
+    if (headerVersion !== RC_2026_07_28) {
       respondJsonRpcError(
         res,
         body.id,
@@ -138,7 +148,7 @@ export function startStatelessMcpFixture(
         "HeaderMismatch",
         {
           field: "MCP-Protocol-Version",
-          expected: DRAFT_2026_V1,
+          expected: RC_2026_07_28,
           got: headerVersion ?? null,
         },
         opts,
@@ -236,15 +246,22 @@ async function dispatch(
       // `discoverThrowsUnsupportedVersion`) is handled before dispatch
       // by the outer version-validation block, so the success body here
       // is what a conforming server returns.
+      // DiscoverResult per SEP-2575 + upstream `schema.ts:585`:
+      // `supportedVersions` is plural (distinct from the `supported`
+      // singular on UnsupportedProtocolVersionError.error.data). The
+      // base Result also carries `resultType` — clients treat an absent
+      // field as "complete" but emitting it explicitly is the canonical
+      // shape the fixture should model.
       return {
-        protocolVersion: DRAFT_2026_V1,
+        resultType: "complete",
+        protocolVersion: RC_2026_07_28,
         serverInfo: { name: "stateless-mcp-fixture", version: "0.1.0" },
         capabilities: {
           tools: {},
           resources: {},
           prompts: {},
         },
-        supportedVersions: [DRAFT_2026_V1],
+        supportedVersions: [RC_2026_07_28],
       };
     case "ping":
       return {};
@@ -487,6 +504,6 @@ if (
   const port = Number(process.env.PORT ?? 4040);
   startStatelessMcpFixture(port).then(({ port: bound }) => {
     // eslint-disable-next-line no-console
-    console.log(`stateless-mcp fixture (DRAFT-2026-v1) listening on ${bound}`);
+    console.log(`stateless-mcp fixture (2026-07-28) listening on ${bound}`);
   });
 }

--- a/mcpjam-inspector/test-servers/stateless-mcp-server.ts
+++ b/mcpjam-inspector/test-servers/stateless-mcp-server.ts
@@ -251,10 +251,10 @@ async function dispatch(
       // singular on UnsupportedProtocolVersionError.error.data). The
       // base Result also carries `resultType` — clients treat an absent
       // field as "complete" but emitting it explicitly is the canonical
-      // shape the fixture should model.
+      // shape the fixture should model. Upstream has NO `protocolVersion`
+      // field on DiscoverResult — that value lives in request `_meta`.
       return {
         resultType: "complete",
-        protocolVersion: RC_2026_07_28,
         serverInfo: { name: "stateless-mcp-fixture", version: "0.1.0" },
         capabilities: {
           tools: {},

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -379,7 +379,7 @@ export class MCPClientManager {
 
   /**
    * Gets the `ManagedMcpClient` for a server — works for both the legacy
-   * adapter and the DRAFT-2026-v1 stateless preview. Use this in new
+   * adapter and the 2026-07-28 stateless preview. Use this in new
    * code instead of `getClient()`.
    */
   getManagedClient(
@@ -1404,7 +1404,7 @@ export class MCPClientManager {
       this.liveClientStates.set(serverId, state);
 
       // Auto-`setLoggingLevel("debug")` — gated on the server actually
-      // advertising the logging capability. The DRAFT-2026-v1 stateless
+      // advertising the logging capability. The 2026-07-28 stateless
       // preview synthesizes capabilities that omit `logging` (it can't
       // honor the call without an `initialize` round-trip), so firing
       // blindly would either no-op + warn or RPC-error. The adapter

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -131,7 +131,7 @@ export {
   PromptListChangedNotificationMethod,
 } from "./notification-handlers.js";
 
-// ManagedMcpClient: interface + adapters + factory for DRAFT-2026-v1
+// ManagedMcpClient: interface + adapters + factory for 2026-07-28
 // stateless preview. The manager types its client state as
 // `ManagedMcpClient` (PR3); SDK consumers that need the underlying
 // upstream `Client` keep using `getClient()`, while new consumers can
@@ -152,7 +152,7 @@ export {
 export { OfficialSdkClientAdapter } from "./official-sdk-client-adapter.js";
 export {
   StatelessMcpHttpPreviewClient,
-  STATELESS_DRAFT_2026_V1,
+  LATEST_STATELESS_PROTOCOL_VERSION,
   type StatelessMcpHttpPreviewClientOptions,
   type DiscoverResult,
 } from "./stateless-mcp-http-preview-client.js";

--- a/sdk/src/mcp-client-manager/managed-mcp-client.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client.ts
@@ -2,7 +2,7 @@
  * `ManagedMcpClient` is the surface area `MCPClientManager` calls into for
  * every server connection. It exists so the manager can swap between the
  * legacy upstream `Client` (via `OfficialSdkClientAdapter`) and the
- * stateless DRAFT-2026-v1 preview transport
+ * stateless 2026-07-28 preview transport
  * (`StatelessMcpHttpPreviewClient`) without per-call branching. Selection
  * is driven by the per-server `mcpProtocolVersion` pin (`McpProtocolVersion`
  * in `./mcp-protocol-version.ts`) — the factory uses

--- a/sdk/src/mcp-client-manager/mcp-protocol-version.ts
+++ b/sdk/src/mcp-client-manager/mcp-protocol-version.ts
@@ -9,7 +9,8 @@
  * **Validate-then-route discipline:**
  *   - Trust boundaries (Convex validator, REST input parser, UI form
  *     submit) MUST gate on `isKnownProtocolVersion(v)` first. Typo strings
- *     like `"DRAFT-2027-zzz"` fail here.
+ *     like `"DRAFT-2027-zzz"` (and the retired pre-RC placeholder
+ *     `"DRAFT-2026-v1"`) fail here.
  *   - Inside trusted code (the factory, the preview client) use
  *     `isStatelessProtocolVersion(v)` for routing. It returns true for
  *     anything not on the closed `STATEFUL_PROTOCOL_VERSIONS` set —
@@ -29,7 +30,7 @@ export const MCP_PROTOCOL_VERSIONS = [
   "2025-03-26",
   "2025-06-18",
   "2025-11-25",
-  "DRAFT-2026-v1",
+  "2026-07-28",
 ] as const;
 export type McpProtocolVersion = (typeof MCP_PROTOCOL_VERSIONS)[number];
 

--- a/sdk/src/mcp-client-manager/stateless-mcp-http-preview-client.ts
+++ b/sdk/src/mcp-client-manager/stateless-mcp-http-preview-client.ts
@@ -1,7 +1,9 @@
 /**
  * `StatelessMcpHttpPreviewClient` — own-fetch implementation of
- * `ManagedMcpClient` for the experimental DRAFT-2026-v1 stateless MCP
- * transport. Does NOT extend upstream `Client` / `Protocol` /
+ * `ManagedMcpClient` for the 2026-07-28 RC stateless MCP transport
+ * (canonical wire literal post-`a11b1550` upstream pin; the pre-RC
+ * placeholder `DRAFT-2026-v1` is retired and rejects at the trust
+ * boundary). Does NOT extend upstream `Client` / `Protocol` /
  * `Transport`; upstream's private fields and missing per-send header
  * hooks make subclassing untenable (see `upstream_v2alpha_extension_points`
  * memory entry).
@@ -36,7 +38,7 @@
  *   - `subscriptions/listen` (throws `NotYetSupportedInStateless`)
  *   - Resumption tokens (`resumptionToken` / `onresumptiontoken` throw
  *     a labeled error)
- *   - Backward-compat probes against pre-DRAFT-2026-v1 servers
+ *   - Backward-compat probes against pre-2026-07-28 servers
  */
 
 import type {
@@ -77,10 +79,12 @@ import type { McpProtocolVersion } from "./mcp-protocol-version.js";
  * Default wire literal emitted in `_meta` and the `MCP-Protocol-Version`
  * header when the constructor's `protocolVersion` option is omitted. The
  * actual literal at request time always comes from `this.protocolVersion`
- * so a server pinned to a future stateless version (e.g. the post-RC
- * finalized `2026-07-28` date) routes through the same class.
+ * so a server pinned to a future stateless version routes through the
+ * same class — the factory passes `mcpProtocolVersion` verbatim, so this
+ * default only fires for direct-instantiation callers (tests, ad-hoc
+ * clients) and tracks the current RC canonical literal.
  */
-export const STATELESS_DRAFT_2026_V1 = "DRAFT-2026-v1" as const;
+export const LATEST_STATELESS_PROTOCOL_VERSION = "2026-07-28" as const;
 
 /**
  * Capabilities the preview commits to honoring. Locked per
@@ -133,9 +137,9 @@ export interface StatelessMcpHttpPreviewClientOptions {
   /**
    * Wire literal to emit in `_meta.io.modelcontextprotocol/protocolVersion`
    * and the `MCP-Protocol-Version` header. Defaults to
-   * `STATELESS_DRAFT_2026_V1`. Parameterized so the same class serves
-   * future stateless drafts without a subclass; the factory passes the
-   * resolved `mcpProtocolVersion` here.
+   * `LATEST_STATELESS_PROTOCOL_VERSION`. Parameterized so the same class
+   * serves future stateless drafts without a subclass; the factory passes
+   * the resolved `mcpProtocolVersion` here.
    */
   protocolVersion?: McpProtocolVersion;
   /** Static headers (e.g. project-level overrides). Bearer is set via authProvider. */
@@ -290,7 +294,7 @@ export class StatelessMcpHttpPreviewClient implements ManagedMcpClient {
   constructor(opts: StatelessMcpHttpPreviewClientOptions) {
     this.url = typeof opts.url === "string" ? new URL(opts.url) : opts.url;
     this.clientInfo = opts.clientInfo;
-    this.protocolVersion = opts.protocolVersion ?? STATELESS_DRAFT_2026_V1;
+    this.protocolVersion = opts.protocolVersion ?? LATEST_STATELESS_PROTOCOL_VERSION;
     this.staticHeaders = { ...(opts.staticHeaders ?? {}) };
     this.getAccessToken = opts.getAccessToken;
     this.on401 = opts.on401;
@@ -313,7 +317,7 @@ export class StatelessMcpHttpPreviewClient implements ManagedMcpClient {
     // our `protocolVersion`. A `-32004 UnsupportedProtocolVersionError`
     // from discover propagates as a connect failure with the error
     // envelope intact — that's how the inspector surfaces "this server
-    // doesn't speak DRAFT-2026-v1" instead of a misleading "Connected".
+    // doesn't speak 2026-07-28" instead of a misleading "Connected".
     if (this.closed) {
       throw new Error("StatelessMcpHttpPreviewClient: connect() after close()");
     }
@@ -582,7 +586,7 @@ export class StatelessMcpHttpPreviewClient implements ManagedMcpClient {
     _options?: RequestOptions,
   ): Promise<void> {
     this.warn(
-      "setLoggingLevel is a no-op in the DRAFT-2026-v1 stateless preview (clientCapabilities omits logging).",
+      "setLoggingLevel is a no-op in the 2026-07-28 stateless preview (clientCapabilities omits logging).",
     );
   }
 
@@ -625,14 +629,14 @@ export class StatelessMcpHttpPreviewClient implements ManagedMcpClient {
     if (taskOpt !== undefined) {
       throw new NotYetSupportedInStateless(
         `${method} (RequestOptions.task)`,
-        "task-augmented requests require MRTR / InputRequiredResult, which is out of scope for the DRAFT-2026-v1 preview",
+        "task-augmented requests require MRTR / InputRequiredResult, which is out of scope for the 2026-07-28 preview",
       );
     }
     const relatedTaskOpt = (opts as RequestOptions).relatedTask;
     if (relatedTaskOpt !== undefined) {
       throw new NotYetSupportedInStateless(
         `${method} (RequestOptions.relatedTask)`,
-        "related-task requests require MRTR / InputRequiredResult, which is out of scope for the DRAFT-2026-v1 preview",
+        "related-task requests require MRTR / InputRequiredResult, which is out of scope for the 2026-07-28 preview",
       );
     }
 
@@ -769,7 +773,7 @@ export class StatelessMcpHttpPreviewClient implements ManagedMcpClient {
       if (seenSessionId) {
         this.nonConformingSessionIdSeen = true;
         this.warn(
-          `Server returned mcp-session-id: "${seenSessionId}" on a stateless request. Discarded. Server is non-conforming under DRAFT-2026-v1.`,
+          `Server returned mcp-session-id: "${seenSessionId}" on a stateless request. Discarded. Server is non-conforming under 2026-07-28.`,
         );
         this.onSessionIdResponse?.(seenSessionId);
       }

--- a/sdk/src/mcp-client-manager/stateless-mcp-http-preview-client.ts
+++ b/sdk/src/mcp-client-manager/stateless-mcp-http-preview-client.ts
@@ -190,20 +190,31 @@ export interface StatelessMcpHttpPreviewClientOptions {
 }
 
 /**
- * Result of `server/discover` per SEP-2575 / draft `DiscoverResult` schema.
- * Carries the negotiated `protocolVersion`, the server's `serverInfo` +
- * `capabilities` + optional `instructions`, and the full
- * `supportedVersions` list so a client can retry against a mutually
- * supported version on its own. The field name is `capabilities` (NOT
- * `serverCapabilities` — that's the pre-2026 negotiation-flow naming;
- * SEP-2575 deliberately uses `capabilities` to match the rest of the
- * draft's result shapes).
+ * Result of `server/discover` per upstream `schema.ts:585` (SEP-2575).
+ * Extends the base `Result` shape — `resultType` is required for
+ * new-spec servers; an absent field is treated as `"complete"` per
+ * `schema.ts:182-185`. Carries the server's `serverInfo` + `capabilities`
+ * + optional `instructions`, and the `supportedVersions` list (plural)
+ * so a client can retry against a mutually supported version on its
+ * own. The field name is `capabilities` (NOT `serverCapabilities` —
+ * that's the pre-2026 negotiation-flow naming; the RC deliberately uses
+ * `capabilities` to match the rest of the result shapes).
+ *
+ * Note: upstream `DiscoverResult` has NO `protocolVersion` field — the
+ * value lives in `_meta.io.modelcontextprotocol/protocolVersion` on
+ * every request body, not in the discover response. Earlier drafts of
+ * this interface fabricated one; it's been removed to align with spec.
  */
 export interface DiscoverResult {
-  protocolVersion: string;
+  /**
+   * Result envelope discriminator. Optional in the type for backward
+   * compatibility with servers that omit it (treated as `"complete"`);
+   * new-spec servers MUST emit it.
+   */
+  resultType?: "complete" | "input_required";
   serverInfo: Implementation;
   capabilities: ServerCapabilities;
-  supportedVersions?: string[];
+  supportedVersions: string[];
   instructions?: string;
 }
 

--- a/sdk/src/mcp-client-manager/tool-header-map.ts
+++ b/sdk/src/mcp-client-manager/tool-header-map.ts
@@ -1,5 +1,5 @@
 /**
- * Per-tool `Mcp-Param-*` header discovery cache for the DRAFT-2026-v1
+ * Per-tool `Mcp-Param-*` header discovery cache for the 2026-07-28
  * stateless preview. See SEP-2243 ("Header conveyance for sensitive
  * params") for the wire spec, and `peppy-popping-flask.md` PR2 for plan
  * context.
@@ -232,7 +232,7 @@ export class ToolHeaderMap {
    *   - `headers`: `{ "Mcp-Param-<Name>": <encoded value>, ... }`
    *   - `bodyArguments`: the original `args` unchanged.
    *
-   * The DRAFT-2026-v1 wire contract is **mirror, not lift**: the
+   * The 2026-07-28 wire contract is **mirror, not lift**: the
    * annotated value is sent BOTH in `params.arguments[<name>]` (the
    * normal JSON-RPC body) AND in `Mcp-Param-<HeaderName>`. The server
    * validates that the two arrived consistently and rejects with

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -188,7 +188,7 @@ async function runClientChecks(
           // follow-up.
           const managed = manager.getManagedClient(serverId);
           const reason = managed
-            ? "Client-side conformance checks are not yet wired through the DRAFT-2026-v1 stateless preview adapter."
+            ? "Client-side conformance checks are not yet wired through the 2026-07-28 stateless preview adapter."
             : "Underlying MCP client is unavailable after connect";
           if (managed) {
             return selectedClientChecks.map((check) =>

--- a/sdk/tests/StatelessMcpHttpPreviewClient.test.ts
+++ b/sdk/tests/StatelessMcpHttpPreviewClient.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for `StatelessMcpHttpPreviewClient` against an
- * in-process HTTP server that enforces the DRAFT-2026-v1 wire contract:
- *   - body `_meta.io.modelcontextprotocol/protocolVersion === "DRAFT-2026-v1"`
+ * in-process HTTP server that enforces the 2026-07-28 wire contract:
+ *   - body `_meta.io.modelcontextprotocol/protocolVersion === "2026-07-28"`
  *   - `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers match
  *     body case-insensitively (RFC 9110)
  *   - `Mcp-Param-<Name>` mirrors `params.arguments.<param>` per SEP-2243
@@ -15,7 +15,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { AddressInfo } from "node:net";
 import {
   StatelessMcpHttpPreviewClient,
-  STATELESS_DRAFT_2026_V1,
+  LATEST_STATELESS_PROTOCOL_VERSION,
   NotYetSupportedInStateless,
   type DiscoverResult,
 } from "../src/mcp-client-manager/stateless-mcp-http-preview-client.js";
@@ -59,26 +59,26 @@ async function startFixture(opts: FixtureOptions = {}): Promise<{
 
     const protoVersion =
       body?.params?._meta?.["io.modelcontextprotocol/protocolVersion"];
-    if (protoVersion !== STATELESS_DRAFT_2026_V1) {
+    if (protoVersion !== LATEST_STATELESS_PROTOCOL_VERSION) {
       return respond(res, opts, {
         jsonrpc: "2.0",
         id: body.id ?? null,
         error: {
           code: -32004,
           message: "Unsupported protocol version",
-          data: { supported: [STATELESS_DRAFT_2026_V1] },
+          data: { supported: [LATEST_STATELESS_PROTOCOL_VERSION] },
         },
       });
     }
     const headerProto = pick(req, "mcp-protocol-version");
-    if (headerProto !== STATELESS_DRAFT_2026_V1) {
+    if (headerProto !== LATEST_STATELESS_PROTOCOL_VERSION) {
       return respond(res, opts, {
         jsonrpc: "2.0",
         id: body.id,
         error: {
           code: -32001,
           message: "HeaderMismatch",
-          data: { field: "MCP-Protocol-Version", expected: STATELESS_DRAFT_2026_V1 },
+          data: { field: "MCP-Protocol-Version", expected: LATEST_STATELESS_PROTOCOL_VERSION },
         },
       });
     }
@@ -104,7 +104,7 @@ async function startFixture(opts: FixtureOptions = {}): Promise<{
           message: "Unsupported protocol version",
           data: {
             supported: ["2025-11-25"],
-            requested: STATELESS_DRAFT_2026_V1,
+            requested: LATEST_STATELESS_PROTOCOL_VERSION,
           },
         },
       });
@@ -116,14 +116,14 @@ async function startFixture(opts: FixtureOptions = {}): Promise<{
           jsonrpc: "2.0",
           id: body.id,
           result: {
-            protocolVersion: STATELESS_DRAFT_2026_V1,
+            protocolVersion: LATEST_STATELESS_PROTOCOL_VERSION,
             serverInfo: { name: "fixture-server", version: "0.1.0" },
             capabilities: {
               tools: {},
               resources: {},
               prompts: {},
             },
-            supportedVersions: [STATELESS_DRAFT_2026_V1],
+            supportedVersions: [LATEST_STATELESS_PROTOCOL_VERSION],
           } satisfies DiscoverResult,
         });
       case "tools/list":
@@ -260,7 +260,7 @@ describe("StatelessMcpHttpPreviewClient", () => {
     await fixture.close();
   });
 
-  test("listTools sends DRAFT-2026-v1 _meta and required headers, returns tools", async () => {
+  test("listTools sends 2026-07-28 _meta and required headers, returns tools", async () => {
     const result = await client.listTools();
     expect(result.tools).toHaveLength(2);
     const sent = fixture.captured[0];
@@ -268,12 +268,12 @@ describe("StatelessMcpHttpPreviewClient", () => {
     expect(
       (sent.body as { params?: { _meta?: Record<string, unknown> } }).params
         ?._meta?.["io.modelcontextprotocol/protocolVersion"],
-    ).toBe(STATELESS_DRAFT_2026_V1);
+    ).toBe(LATEST_STATELESS_PROTOCOL_VERSION);
     expect(
       (sent.body as { params?: { _meta?: Record<string, unknown> } }).params
         ?._meta?.["io.modelcontextprotocol/clientInfo"],
     ).toEqual({ name: "test-client", version: "0.0.1" });
-    expect(sent.headers["mcp-protocol-version"]).toBe(STATELESS_DRAFT_2026_V1);
+    expect(sent.headers["mcp-protocol-version"]).toBe(LATEST_STATELESS_PROTOCOL_VERSION);
     expect(sent.headers["mcp-method"]).toBe("tools/list");
   });
 
@@ -493,7 +493,7 @@ describe("StatelessMcpHttpPreviewClient", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "MCP-Protocol-Version": STATELESS_DRAFT_2026_V1,
+        "MCP-Protocol-Version": LATEST_STATELESS_PROTOCOL_VERSION,
         "Mcp-Method": "tools/call",
         "Mcp-Name": "regional-echo",
         "Mcp-Param-Region": "us-west1",
@@ -508,7 +508,7 @@ describe("StatelessMcpHttpPreviewClient", () => {
           // must reject.
           arguments: { value: "hi", region: "eu-central1" },
           _meta: {
-            "io.modelcontextprotocol/protocolVersion": STATELESS_DRAFT_2026_V1,
+            "io.modelcontextprotocol/protocolVersion": LATEST_STATELESS_PROTOCOL_VERSION,
             "io.modelcontextprotocol/clientInfo": { name: "raw", version: "0" },
             "io.modelcontextprotocol/clientCapabilities": {},
           },
@@ -551,7 +551,7 @@ describe("StatelessMcpHttpPreviewClient", () => {
     // Our locked keys still present.
     expect(
       lastBody.params._meta["io.modelcontextprotocol/protocolVersion"],
-    ).toBe(STATELESS_DRAFT_2026_V1);
+    ).toBe(LATEST_STATELESS_PROTOCOL_VERSION);
   });
 
   test("never sends Mcp-Session-Id header outbound", async () => {
@@ -660,7 +660,7 @@ describe("StatelessMcpHttpPreviewClient", () => {
       const sent = localFixture.captured[0];
       expect(sent.body.method).toBe("server/discover");
       expect(sent.headers["mcp-method"]).toBe("server/discover");
-      expect(sent.headers["mcp-protocol-version"]).toBe(STATELESS_DRAFT_2026_V1);
+      expect(sent.headers["mcp-protocol-version"]).toBe(LATEST_STATELESS_PROTOCOL_VERSION);
 
       // Capability getters now return the discover-populated values
       // instead of the permissive synthetic / undefined defaults.

--- a/sdk/tests/StatelessMcpHttpPreviewClient.test.ts
+++ b/sdk/tests/StatelessMcpHttpPreviewClient.test.ts
@@ -60,13 +60,19 @@ async function startFixture(opts: FixtureOptions = {}): Promise<{
     const protoVersion =
       body?.params?._meta?.["io.modelcontextprotocol/protocolVersion"];
     if (protoVersion !== LATEST_STATELESS_PROTOCOL_VERSION) {
+      // Upstream UnsupportedProtocolVersionError.error.data carries
+      // both `supported` AND `requested` (schema.ts:392-406). Emitting
+      // both here exercises the spec-correct envelope.
       return respond(res, opts, {
         jsonrpc: "2.0",
         id: body.id ?? null,
         error: {
           code: -32004,
           message: "Unsupported protocol version",
-          data: { supported: [LATEST_STATELESS_PROTOCOL_VERSION] },
+          data: {
+            supported: [LATEST_STATELESS_PROTOCOL_VERSION],
+            requested: typeof protoVersion === "string" ? protoVersion : null,
+          },
         },
       });
     }
@@ -112,11 +118,14 @@ async function startFixture(opts: FixtureOptions = {}): Promise<{
 
     switch (body.method) {
       case "server/discover":
+        // DiscoverResult extends Result, which requires `resultType` on
+        // new-spec servers (schema.ts:182-187). Upstream has no
+        // `protocolVersion` field — that lives in request _meta only.
         return respond(res, opts, {
           jsonrpc: "2.0",
           id: body.id,
           result: {
-            protocolVersion: LATEST_STATELESS_PROTOCOL_VERSION,
+            resultType: "complete",
             serverInfo: { name: "fixture-server", version: "0.1.0" },
             capabilities: {
               tools: {},

--- a/sdk/tests/mcp-protocol-version.test.ts
+++ b/sdk/tests/mcp-protocol-version.test.ts
@@ -22,7 +22,7 @@ describe("MCP_PROTOCOL_VERSIONS", () => {
       "2025-03-26",
       "2025-06-18",
       "2025-11-25",
-      "DRAFT-2026-v1",
+      "2026-07-28",
     ]);
   });
 });
@@ -32,7 +32,7 @@ describe("isKnownProtocolVersion (membership gate)", () => {
     "2025-03-26",
     "2025-06-18",
     "2025-11-25",
-    "DRAFT-2026-v1",
+    "2026-07-28",
   ])("accepts %s", (v) => {
     expect(isKnownProtocolVersion(v)).toBe(true);
   });
@@ -41,13 +41,17 @@ describe("isKnownProtocolVersion (membership gate)", () => {
     "",
     "legacy",
     "stateless",
-    "stateless-draft-2026-v1",
+    "stateless-2026-07-28",
     "DRAFT-2027-zzz",
     "2024-11-05",
     "2024-10-07",
-    " DRAFT-2026-v1",
-    "DRAFT-2026-v1 ",
-    "draft-2026-v1",
+    " 2026-07-28",
+    "2026-07-28 ",
+    // Regression guard: the pre-RC placeholder literal was retired on
+    // upstream's a11b1550 pin to "2026-07-28". It must NOT re-enter the
+    // accepted set; if it does, the validate-then-route discipline
+    // silently widens.
+    "DRAFT-2026-v1",
   ])("rejects %j", (v) => {
     expect(isKnownProtocolVersion(v)).toBe(false);
   });
@@ -68,8 +72,8 @@ describe("isStatelessProtocolVersion (routing predicate)", () => {
     expect(isStatelessProtocolVersion(v)).toBe(false);
   });
 
-  test("returns true for DRAFT-2026-v1", () => {
-    expect(isStatelessProtocolVersion("DRAFT-2026-v1")).toBe(true);
+  test("returns true for 2026-07-28", () => {
+    expect(isStatelessProtocolVersion("2026-07-28")).toBe(true);
   });
 
   test("returns true for unknown / typo strings — documents why membership must run first", () => {
@@ -80,5 +84,9 @@ describe("isStatelessProtocolVersion (routing predicate)", () => {
     expect(isStatelessProtocolVersion("DRAFT-2027-zzz")).toBe(true);
     expect(isStatelessProtocolVersion("stateless")).toBe(true);
     expect(isStatelessProtocolVersion("anything-not-stateful")).toBe(true);
+    // The retired placeholder routes stateless via the open predicate;
+    // it would still produce a malformed wire literal if the membership
+    // gate didn't reject it first.
+    expect(isStatelessProtocolVersion("DRAFT-2026-v1")).toBe(true);
   });
 });


### PR DESCRIPTION
Upstream modelcontextprotocol/main pinned LATEST_PROTOCOL_VERSION = "2026-07-28" today (commit a11b1550), retiring the DRAFT-2026-v1 placeholder. Without this swap, every stateless request MCPJam sends carries a wire literal real spec servers reject with -32004 UnsupportedProtocolVersionError — blocking the stateless-migration announcement.

Full swap (not dual-accept). SDK exports the renamed LATEST_STATELESS_PROTOCOL_VERSION constant (was STATELESS_DRAFT_2026_V1). The "Draft" UI option is relabeled "2026 RC (2026-07-28)". Test fixture returns spec-correct -32004 envelope (error.data.supported + requested per upstream schema.ts) and a DiscoverResult with resultType: "complete" plus supportedVersions. Two new regression-guard tests assert "DRAFT-2026-v1" rejects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the canonical stateless protocol pin on connect/chat/hosted paths; stored DRAFT-2026-v1 pins stop working without migration, and any mismatch in version enums breaks connections with -32004.
> 
> **Overview**
> Replaces the retired **`DRAFT-2026-v1`** stateless placeholder with upstream’s **`2026-07-28`** RC literal across the SDK, inspector UI, hosted API validation, and tests so stateless HTTP requests match what spec servers expect.
> 
> **SDK:** `MCP_PROTOCOL_VERSIONS` and routing now use **`2026-07-28`**; **`STATELESS_DRAFT_2026_V1`** is renamed to **`LATEST_STATELESS_PROTOCOL_VERSION`**. **`DiscoverResult`** drops the fabricated **`protocolVersion`** field and aligns with upstream (**`resultType`**, required **`supportedVersions`**). Comments and error messaging reference the RC literal.
> 
> **Inspector:** Host and per-server pickers map **`draft` → `rc`**, with labels like **Latest (2025-11-25)** and **2026 RC (2026-07-28)**; stored pins and overrides persist **`2026-07-28`**. Product copy and server route Zod enums follow the same literal.
> 
> **Fixtures/tests:** The stateless test server and integration tests emit spec-correct **`-32004`** data (**`supported`** + **`requested`**) and discover bodies with **`resultType: "complete"`**. New guards assert **`DRAFT-2026-v1`** is **not** accepted by **`isKnownProtocolVersion`**.
> 
> **Note:** This is a full swap (not dual-accept)—configs still pinned to the old literal will need re-selection unless migrated elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84991b10a1f7ed0c5536778edd0e50e9eb61ac45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->