### PR TITLE
Remove /chat-v2 tab; retire playground-tab-enabled flag

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -22,7 +22,6 @@ import { PromptsTab } from "./components/PromptsTab";
 import { SkillsTab } from "./components/SkillsTab";
 import { LearningTab } from "./components/LearningTab";
 import { TasksTab } from "./components/TasksTab";
-import { ClientStyledChatTabV2 } from "./components/ClientStyledChatTabV2";
 import { ActiveHostCapsResolverScope } from "./contexts/active-host-client-capabilities-context";
 import type { EvalChatHandoff } from "./lib/eval-chat-handoff";
 import { EvalsTab } from "./components/EvalsTab";
@@ -49,7 +48,6 @@ import { OrganizationsTab } from "./components/OrganizationsTab";
 import { SupportTab } from "./components/SupportTab";
 import { RegistryTab } from "./components/RegistryTab";
 import { ClientsTab } from "./components/ClientsTab";
-import { ClientPicker } from "./components/clients/ClientPicker";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
 import { MCPSidebar } from "./components/mcp-sidebar";
@@ -437,8 +435,6 @@ function NoRouterRouteBody({ activeTab }: { activeTab: string }) {
       return <TracingRoute />;
     case "clients":
       return <ClientsRoute />;
-    case "chat-v2":
-      return <ChatV2Route />;
     case "chatboxes":
       return <ChatboxesRoute />;
     case "playground":
@@ -927,76 +923,6 @@ export function XAAFlowRoute() {
   );
 }
 
-export function ChatV2Route() {
-  const {
-    connectedOrConnectingServerConfigs,
-    appState,
-    activeHost,
-    activeHostId,
-    convexProjectId,
-    evalChatHandoff,
-    handleConnect,
-    handleReconnect,
-    hostsHubFlagEnabled,
-    isAuthenticated,
-    projectServers,
-    setActiveHostId,
-    setEvalChatHandoff,
-    setSelectedMCPConfigs,
-    toggleServerSelection,
-  } = useAppRouteContext();
-
-  return (
-    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-      {hostsHubFlagEnabled && isAuthenticated && convexProjectId && (
-        <div className="flex shrink-0 items-center gap-2 border-b px-4 py-2">
-          <span className="text-xs text-muted-foreground">Client:</span>
-          <div className="w-48">
-            <ClientPicker
-              projectId={convexProjectId}
-              value={activeHostId}
-              onChange={setActiveHostId}
-              location="chat_tab"
-              placeholder="Project default"
-              noneLabel="Project default"
-            />
-          </div>
-        </div>
-      )}
-      <ClientStyledChatTabV2
-        connectedOrConnectingServerConfigs={connectedOrConnectingServerConfigs}
-        selectedServerNames={appState.selectedMultipleServers}
-        allServerConfigs={projectServers}
-        onServerToggle={toggleServerSelection}
-        onReconnectServer={handleReconnect}
-        onAddServer={handleConnect}
-        onSelectedServerNamesChange={setSelectedMCPConfigs}
-        enableMultiModelChat
-        showHostStyleSelector
-        executionConfig={
-          activeHost
-            ? {
-                modelId: activeHost.modelId,
-                systemPrompt: activeHost.systemPrompt,
-                temperature: activeHost.temperature,
-                requireToolApproval: activeHost.requireToolApproval,
-                progressiveToolDiscovery: activeHost.progressiveToolDiscovery,
-                respectToolVisibility: activeHost.respectToolVisibility,
-              }
-            : undefined
-        }
-        activeHost={activeHost}
-        evalChatHandoff={evalChatHandoff}
-        onEvalChatHandoffConsumed={(id) =>
-          setEvalChatHandoff((current: EvalChatHandoff | null) =>
-            current?.id === id ? null : current
-          )
-        }
-      />
-    </div>
-  );
-}
-
 export function TracingRoute() {
   return <TracingTab />;
 }
@@ -1122,7 +1048,7 @@ export function OrganizationsRoute() {
 }
 
 export function ChatAliasRoute() {
-  return <Navigate to={routePaths.chatV2} replace />;
+  return <Navigate to={routePaths.playground} replace />;
 }
 
 export function ServersRedirectRoute() {
@@ -1179,7 +1105,6 @@ export default function App() {
   const hostsEnabled = useFeatureFlagEnabled("hosts-enabled");
   const hostsHubFlagEnabled = isPostHogBooleanFlagOn(hostsEnabled);
   const playgroundEnabled = useFeatureFlagEnabled("playground-enabled");
-  const playgroundTabEnabled = useFeatureFlagEnabled("playground-tab-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-runs");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const {
@@ -1549,7 +1474,6 @@ export default function App() {
     setSelectedServer,
     setSelectedMCPConfigs,
     toggleServerSelection,
-    setSelectedMultipleServersToAllServers,
     projects,
     activeProjectId,
     handleSwitchProject,
@@ -2118,15 +2042,6 @@ export default function App() {
     [navigateToTarget]
   );
 
-  const previousActiveTabRef = useRef(activeTab);
-  useEffect(() => {
-    const previousActiveTab = previousActiveTabRef.current;
-    if (activeTab === "chat-v2" && previousActiveTab !== "chat-v2") {
-      setSelectedMultipleServersToAllServers();
-    }
-    previousActiveTabRef.current = activeTab;
-  }, [activeTab, setSelectedMultipleServersToAllServers]);
-
   useEffect(() => {
     if (!routeOrganizationId || !hasRouteOrganization) {
       return;
@@ -2534,11 +2449,6 @@ export default function App() {
       navigateToTarget(defaultHubRoute, { replace: true });
     } else if (activeTab === "xaa-flow" && xaaEnabled !== true) {
       navigateToTarget(defaultHubRoute, { replace: true });
-    } else if (
-      activeTab === "chat-v2" &&
-      playgroundTabEnabled === true
-    ) {
-      navigateApp(routePaths.playground, { replace: true });
     }
   }, [
     conformanceEnabled,
@@ -2549,7 +2459,6 @@ export default function App() {
     evaluateRunsFlagsLoaded,
     evaluateRunsEnabled,
     xaaEnabled,
-    playgroundTabEnabled,
     isAuthenticated,
     activeTab,
     navigateToTarget,
@@ -2593,7 +2502,7 @@ export default function App() {
         ...handoff,
         id: `eval-chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       });
-      navigateApp(routePaths.chatV2);
+      navigateApp(routePaths.playground);
     },
     [setSelectedMCPConfigs]
   );
@@ -2975,7 +2884,6 @@ export default function App() {
     navigateToTarget,
     pendingDashboardOAuth,
     playgroundEnabled,
-    playgroundTabEnabled,
     playgroundServerSelectorProps,
     posthog,
     projectServers,

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -202,12 +202,6 @@ const navigationSections: NavSection[] = [
         featureFlag: "registry-enabled",
       },
       {
-        title: "Chat",
-        url: "/chat-v2",
-        icon: MessageCircle,
-        hiddenByFlag: "playground-tab-enabled",
-      },
-      {
         title: "Chatboxes",
         url: "/chatboxes",
         icon: Box,
@@ -580,7 +574,6 @@ export function MCPSidebar({
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-runs");
   const playgroundEnabled = useFeatureFlagEnabled("playground-enabled");
-  const playgroundTabEnabled = useFeatureFlagEnabled("playground-tab-enabled");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
@@ -649,7 +642,6 @@ export function MCPSidebar({
       "registry-enabled": registryEnabled === true,
       "mcpjam-conformance": conformanceEnabled === true,
       "hosts-enabled": isPostHogBooleanFlagOn(hostsEnabled) && isAuthenticated,
-      "playground-tab-enabled": playgroundTabEnabled === true,
       "home-page-enabled": homePageEnabled === true && isAuthenticated,
       xaa: xaaEnabled === true,
     }),
@@ -659,7 +651,6 @@ export function MCPSidebar({
       registryEnabled,
       conformanceEnabled,
       hostsEnabled,
-      playgroundTabEnabled,
       homePageEnabled,
       xaaEnabled,
       isAuthenticated,

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/nav-main.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/nav-main.test.tsx
@@ -173,8 +173,8 @@ describe("NavMain", () => {
             icon: FakeIcon,
           },
           {
-            title: "Chat",
-            url: "#chat-v2",
+            title: "Chatboxes",
+            url: "#chatboxes",
             icon: FakeIcon,
           },
         ]}
@@ -183,7 +183,7 @@ describe("NavMain", () => {
     );
 
     expect(screen.getByTestId("learn-more-servers")).toBeInTheDocument();
-    expect(screen.queryByTestId("learn-more-chat-v2")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("learn-more-chatboxes")).not.toBeInTheDocument();
   });
 
   it("suppresses the built-in collapsed tooltip when learn more is handling it", () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -687,12 +687,25 @@ export function PlaygroundMain({
     // already written `handoff.serverNames` into the multi-set, and the
     // handoff-consume effect (below) doesn't touch the server selection.
     // Without this guard the eval thread opens with the previewed host's
-    // server set instead of the eval's. Once consumed, the ref matches
-    // and this branch falls through normally.
+    // server set instead of the eval's.
+    //
+    // We ALSO mark `lastSeededHostRef` as committed for this (hostId,
+    // configId) — otherwise after the handoff is consumed and the parent
+    // clears `evalChatHandoff`, this effect re-runs (deps like
+    // `serversById` can hydrate later) and the reseed block fires,
+    // overwriting `handoff.serverNames` on the previewed host's required
+    // set. The eval's selection conceptually IS the seed for the
+    // current host this mount; if the user later switches hosts, the
+    // (hostId, configId) tuple changes and the reseed fires normally
+    // for the new host.
     if (
       evalChatHandoff &&
       appliedEvalChatHandoffIdRef.current !== evalChatHandoff.id
     ) {
+      lastSeededHostRef.current = {
+        hostId: previewedHostId,
+        configId: previewedHost.config.id,
+      };
       return;
     }
     const configId = previewedHost.config.id;

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -670,12 +670,29 @@ export function PlaygroundMain({
   const lastSeededHostRef = useRef<{ hostId: string; configId: string } | null>(
     null
   );
+  // Declared early so the previewed-host reseed effect can early-return
+  // while an eval-chat handoff is still pending. The handoff-consume
+  // effect that flips this ref runs later in the file.
+  const appliedEvalChatHandoffIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (!previewedHostId || !previewedHost) {
       // Clear the dedupe ref so a later return to the same (hostId, configId)
       // — after a transient host-unavailable phase or project switch — still
       // reseeds the composer instead of short-circuiting on a stale ref.
       lastSeededHostRef.current = null;
+      return;
+    }
+    // Don't reseed `selectedMultipleServers` from the previewed host while
+    // an eval-chat handoff is pending: `handleContinueEvalInChat` has
+    // already written `handoff.serverNames` into the multi-set, and the
+    // handoff-consume effect (below) doesn't touch the server selection.
+    // Without this guard the eval thread opens with the previewed host's
+    // server set instead of the eval's. Once consumed, the ref matches
+    // and this branch falls through normally.
+    if (
+      evalChatHandoff &&
+      appliedEvalChatHandoffIdRef.current !== evalChatHandoff.id
+    ) {
       return;
     }
     const configId = previewedHost.config.id;
@@ -1219,7 +1236,8 @@ export function PlaygroundMain({
 
   // Eval "Continue in chat" handoff. Mirrors ChatTabV2:1283-1340 so that the
   // handoff seeds a chat in Playground with the eval's model + messages.
-  const appliedEvalChatHandoffIdRef = useRef<string | null>(null);
+  // `appliedEvalChatHandoffIdRef` is declared earlier so the previewed-host
+  // reseed effect can gate on the handoff being pending.
   useEffect(() => {
     if (!evalChatHandoff) return;
     if (!isSessionBootstrapComplete) return;

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -261,8 +261,7 @@ interface PlaygroundMainProps {
    * When set, Playground consumes the handoff once `isSessionBootstrapComplete`
    * flips true: applies executionConfig (model, system prompt, temperature,
    * tool-approval), seeds the thread, and calls `onEvalChatHandoffConsumed`.
-   * Mirrors the ChatTabV2 behavior so eval "Continue in chat" lands here when
-   * `playground-tab-enabled` is on.
+   * Mirrors the ChatTabV2 behavior so eval "Continue in chat" lands here.
    */
   evalChatHandoff?: EvalChatHandoff | null;
   onEvalChatHandoffConsumed?: (id: string) => void;
@@ -1218,9 +1217,8 @@ export function PlaygroundMain({
     setSelectedModelIds,
   ]);
 
-  // Eval "Continue in chat" handoff. Mirrors ChatTabV2:1283-1340 so that when
-  // `playground-tab-enabled` is on (and `#chat-v2` redirects to `#playground`)
-  // the handoff still seeds a chat with the eval's model + messages.
+  // Eval "Continue in chat" handoff. Mirrors ChatTabV2:1283-1340 so that the
+  // handoff seeds a chat in Playground with the eval's model + messages.
   const appliedEvalChatHandoffIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (!evalChatHandoff) return;

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
@@ -582,9 +582,9 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         | ExecuteToolInspectorCommand
         | RenderToolResultInspectorCommand
     ) => {
-      // Accept both `app-builder` (legacy) and `playground` (transition). The
-      // `playground-tab-enabled` flag controls which surface actually mounts,
-      // so at most one consumer is alive at a time — no double-handler race.
+      // Accept both `app-builder` (legacy) and `playground` (transition). Only
+      // the Playground surface mounts now, so at most one consumer is alive at
+      // a time — no double-handler race.
       if (
         command.payload.surface !== "app-builder" &&
         command.payload.surface !== "playground"

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -823,8 +823,8 @@ export function useAppState({
     activeHostId,
     setActiveHostId,
     // Back-compat: `activeMcpProfile` was the per-call alias for
-    // `activeHost?.mcpProfile`. Surfaces that still destructure it (e.g.
-    // ChatV2Route) keep working without churn.
+    // `activeHost?.mcpProfile`. Surfaces that still destructure it keep
+    // working without churn.
     activeMcpProfile: activeHost?.mcpProfile,
 
     handleConnect: serverState.handleConnect,

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -2276,7 +2276,7 @@ export function useChatSession(
 
   // When controlled, mirror `executionConfig` fields into local state; when
   // a field is undefined, reset to the hook default rather than retaining
-  // the prior host's value (e.g. ChatV2Route passes `executionConfig`
+  // the prior host's value (e.g. ChatTabV2 callers pass `executionConfig`
   // computed from `activeHost`, which is transiently undefined during
   // project/host bootstrap). When uncontrolled (Playground), skip — the
   // caller drives these via imperative setters and would otherwise race

--- a/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
@@ -25,7 +25,7 @@ describe("pathnameToActiveTab", () => {
   });
 
   it("normalizes aliases", () => {
-    expect(pathnameToActiveTab("/chat/thread-1")).toBe("chat-v2");
+    expect(pathnameToActiveTab("/chat/thread-1")).toBe("playground");
   });
 
   it("renders special entry paths through the servers fallback", () => {
@@ -69,7 +69,7 @@ describe("path navigation compatibility helpers", () => {
     expect(navigationTargetToPath("#/evals/suite/s_1?view=test-cases")).toBe(
       "/evals/suite/s_1?view=test-cases",
     );
-    expect(navigationTargetToPath("chat")).toBe("/chat-v2");
+    expect(navigationTargetToPath("chat")).toBe("/playground");
     expect(navigationTargetToPath("not-a-tab")).toBe("/servers");
   });
 

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
@@ -11,8 +11,7 @@ import {
 
 describe("hosted-tab-policy", () => {
   it("normalizes legacy hash aliases to canonical tabs", () => {
-    expect(normalizeHostedHashTab("chat")).toBe("chat-v2");
-    expect(normalizeHostedHashTab("chat-v2")).toBe("chat-v2");
+    expect(normalizeHostedHashTab("chat")).toBe("playground");
     // "registry" is now a first-class tab, not an alias
     expect(normalizeHostedHashTab("registry")).toBe("registry");
   });
@@ -49,7 +48,7 @@ describe("hosted-tab-policy", () => {
     expect(isHostedHashTabBlocked("auth")).toBe(true);
   });
 
-  it("treats #chat as allowed after normalization to #chat-v2", () => {
+  it("treats #chat as allowed after normalization to #playground", () => {
     expect(isHostedHashTabAllowed("chat")).toBe(true);
     expect(isHostedHashTabBlocked("chat")).toBe(false);
   });

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -40,7 +40,6 @@ export const routePaths = {
   oauthFlow: "/oauth-flow",
   xaaFlow: "/xaa-flow",
   tracing: "/tracing",
-  chatV2: "/chat-v2",
   chatboxes: "/chatboxes",
   playground: "/playground",
   views: "/views",

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -1,5 +1,5 @@
 const HASH_TAB_ALIASES = {
-  chat: "chat-v2",
+  chat: "playground",
   /** Public hash slug; in-app tab id is `clients`. */
   connect: "clients",
   /** Legacy alias: `/hosts` and `#hosts` map to the renamed clients tab. */
@@ -11,7 +11,6 @@ export const HOSTED_SIDEBAR_ALLOWED_TABS = [
   "clients",
   "servers",
   "registry",
-  "chat-v2",
   "chatboxes",
   "playground",
   "views",

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -3,7 +3,6 @@ import App, {
   AuthRoute,
   ChatAliasRoute,
   ChatboxesRoute,
-  ChatV2Route,
   CiEvalsRoute,
   ConformanceRoute,
   EvalsRoute,
@@ -67,7 +66,6 @@ export function createAppRouter(): AppRouter {
         { path: "xaa-flow", element: <XAAFlowRoute /> },
         { path: "tracing", element: <TracingRoute /> },
         { path: "chat", element: <ChatAliasRoute /> },
-        { path: "chat-v2", element: <ChatV2Route /> },
         // `/chatboxes` — publish-surface tab (Publish / Sessions / Clusters)
         // for the chatbox bound 1:1 to the currently-selected host. The
         // Hosts hub at `/hosts` is the primary navigation entry; tests

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -66,6 +66,11 @@ export function createAppRouter(): AppRouter {
         { path: "xaa-flow", element: <XAAFlowRoute /> },
         { path: "tracing", element: <TracingRoute /> },
         { path: "chat", element: <ChatAliasRoute /> },
+        // Catch sub-paths like `/chat/thread-1` so old bookmarks land on
+        // Playground instead of the router's `*` catch-all (which would
+        // render ServersRoute while `pathnameToActiveTab` still resolves
+        // "chat" → "playground" — sidebar/content mismatch).
+        { path: "chat/*", element: <ChatAliasRoute /> },
         // `/chatboxes` — publish-surface tab (Publish / Sessions / Clusters)
         // for the chatbox bound 1:1 to the currently-selected host. The
         // Hosts hub at `/hosts` is the primary navigation entry; tests


### PR DESCRIPTION
## Summary

Follow-up to #2301 (App Builder removal). With Playground now the only post-connect chat destination and the `playground-tab-enabled` PostHog flag at 100%, this deletes the `/chat-v2` *tab* — route, sidebar item, `ChatV2Route` function, and the now-redundant `chat-v2 → playground` redirect — and retires the flag entirely from code.

The underlying chat composer infrastructure stays — Playground and the hosted `/chatboxes` surface both depend on it:
- `ChatTabV2.tsx`, `ClientStyledChatTabV2.tsx` — still mounted by `ChatboxChatPage`
- `client/src/components/chat-v2/` directory — shared composer (chat-input, thread, history rail, mcp-apps rendering)
- `server/routes/web/chat-v2.ts`, `server/routes/mcp/chat-v2.ts` — Playground hits these endpoints
- `ChatHistoryRail` / `ChatHistoryRow` — Playground left rail uses them

## What's in this PR

**Inspector**
- Delete `/chat-v2` route + `ChatV2Route` function in App.tsx + `case "chat-v2":` in the no-router fallback switch
- Delete "Chat" sidebar nav item
- Delete the `chat-v2 → playground` redirect + the surrounding `playgroundTabEnabled` flag read in App.tsx
- Repoint `ChatAliasRoute` (`/chat`) at `/playground` (preserves bookmarks)
- Repoint `chat: "chat-v2"` hash alias in `hosted-tab-policy.ts` to `chat: "playground"` (preserves `#chat` bookmarks); drop `"chat-v2"` from `HOSTED_SIDEBAR_ALLOWED_TABS`
- Drop `routePaths.chatV2`
- Drop all in-code readers of `playground-tab-enabled` (`useFeatureFlagEnabled` calls in App.tsx + mcp-sidebar.tsx, the `featureFlagsValue` propagation)
- Update stale comments in `PlaygroundMain.tsx` + `use-app-builder-state.ts` that referenced the flag's old gating role

**Tests**
- `nav-main.test.tsx`: drop Chat-item mock + `learn-more-chat-v2` assertion
- `app-navigation.test.ts` + `hosted-tab-policy.test.ts`: update expectations because `HASH_TAB_ALIASES.chat` now maps to `playground` instead of `chat-v2`
- `ChatTabV2.history-sync.test.tsx` / `ChatTabV2.trace-views.test.tsx` — **kept**, they exercise `ChatTabV2` which still ships

**Scope deviations from the original plan (all reasonable):**
- Deleted a dead App.tsx \`useEffect\` watching \`activeTab === \"chat-v2\"\` that called \`setSelectedMultipleServersToAllServers\` — truly dead with chat-v2 gone; Playground manages its own server selection
- Repointed eval-handoff (\`handleContinueEvalInChat\`) at \`routePaths.playground\` — \`routePaths.chatV2\` is gone
- Removed unused \`ClientPicker\` import in App.tsx (only used inside the deleted \`ChatV2Route\`)

## Post-merge ops

Delete the \`playground-tab-enabled\` flag in PostHog after one rollout window. No code reads it any more.

## Test plan

- [x] \`npm run typecheck:client\` clean
- [x] Inspector client: **353 test files / 3456 tests pass** (2 skipped, unchanged)
- [x] \`grep playground-tab-enabled client/src\` → 0 hits
- [x] \`grep chat-v2 client/src\` outside intentional surfaces (shared \`components/chat-v2/\`, \`ChatTabV2.tsx\`, \`ClientStyledChatTabV2.tsx\`, \`ChatboxChatPage.tsx\`, server endpoint paths) → 0 hits
- [ ] Manual smoke (reviewer): \`/chat-v2\` URL falls through to default servers tab; \`/chat\` bookmark lands on \`/playground\`; \`#chat\` hash lands on \`/playground\`; sidebar has no Chat entry; \`/chatboxes\` (hosted) still works (ChatboxChatPage mounts ChatTabV2 unchanged); Playground left rail still renders history

Net diff: 12 files, +19 / -127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Navigation and bookmark behavior change for users on old /chat-v2 URLs; eval handoff server-selection logic is subtle but localized to Playground.
> 
> **Overview**
> **Playground is now the sole in-app chat destination.** This PR removes the `/chat-v2` tab (`ChatV2Route`, router entry, sidebar “Chat” item, and `routePaths.chatV2`) and drops all reads of the `playground-tab-enabled` PostHog flag. Shared `ChatTabV2` / `components/chat-v2/` and hosted chatboxes are unchanged.
> 
> **Routing and bookmarks:** `/chat` and `/chat/*` redirect to `/playground`; hosted `#chat` aliases normalize to `playground`. Eval **Continue in chat** and `ChatAliasRoute` navigate to Playground. A dead effect that auto-selected all servers when entering chat-v2 is removed.
> 
> **Playground eval handoff:** `PlaygroundMain` skips previewed-host server reseeding while a pending eval handoff is in flight so eval server selection is not overwritten when host config hydrates later.
> 
> Tests and comments are updated for the new aliases; no new runtime flag gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b021b498d75c2e145f9efd501da0095d25eb6794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->