### PR TITLE
feat(evals): freeze suite execution snapshot on plain rerun

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -33,10 +33,10 @@ type SuiteExecutionConfigEditorProps = {
  *
  * Phase 3 read switch: the editor now reads + writes through the v2
  * `hostConfigsV2.{getSuiteConfig,setSuiteConfig}` API. Server selection
- * is hidden (servers come from `suite.environment`; the backend rejects
- * non-empty serverIds), but model / system prompt / temperature /
- * tool-approval / connection-defaults / capabilities / hostContext are
- * all editable through the shared ClientConfigEditor.
+ * is hidden, but preserved from the suite hostConfig while model /
+ * system prompt / temperature / tool-approval / connection-defaults /
+ * capabilities / hostContext are editable through the shared
+ * ClientConfigEditor.
  *
  * `setSuiteConfig` mirrors `{ modelId, systemPrompt, temperature }`
  * back to `suite.defaultConfig` for legacy readers (run snapshot,
@@ -51,7 +51,7 @@ export function SuiteExecutionConfigEditor({
 
   const dto = useQuery(
     "hostConfigsV2:getSuiteConfig" as any,
-    { suiteId: suite._id } as any,
+    { suiteId: suite._id } as any
   ) as HostConfigDtoV2 | null | undefined;
 
   // Phase 4: project default snapshot used by the "Reset to project
@@ -59,11 +59,11 @@ export function SuiteExecutionConfigEditor({
   // (e.g. unscoped guest suites).
   const projectDefaultDto = useQuery(
     "hostConfigsV2:getProjectDefault" as any,
-    projectId ? ({ projectId } as any) : "skip",
+    projectId ? ({ projectId } as any) : "skip"
   ) as HostConfigDtoV2 | null | undefined;
 
   const setSuiteConfig = useMutation(
-    "hostConfigsV2:setSuiteConfig" as any,
+    "hostConfigsV2:setSuiteConfig" as any
   ) as unknown as (args: {
     suiteId: string;
     input: HostConfigInputV2;
@@ -128,7 +128,7 @@ export function SuiteExecutionConfigEditor({
   const isDirty = useMemo(
     () =>
       value && baseline ? !hostConfigInputsEqual(value, baseline) : !!value,
-    [value, baseline],
+    [value, baseline]
   );
 
   if (!value) {
@@ -147,15 +147,6 @@ export function SuiteExecutionConfigEditor({
     );
   }
 
-  // setSuiteConfig refuses non-empty serverIds; if a stale v2 row
-  // somehow carried any, force them empty before saving so the
-  // backend's validator doesn't reject the otherwise-valid edit.
-  // Server selection lives on `suite.environment`.
-  const stripped: HostConfigInputV2 = {
-    ...value,
-    serverIds: [],
-    optionalServerIds: [],
-  };
   const canSave = isDirty && !hasJsonError && !isSaving && !isResetting;
 
   const handleReset = () => {
@@ -166,9 +157,9 @@ export function SuiteExecutionConfigEditor({
     if (!canSave) return;
     setIsSaving(true);
     try {
-      await setSuiteConfig({ suiteId: suite._id, input: stripped });
-      setBaseline(stripped);
-      setValue(stripped);
+      await setSuiteConfig({ suiteId: suite._id, input: value });
+      setBaseline(value);
+      setValue(value);
       toast.success("Suite execution config updated");
     } catch (err) {
       // Surface the failure to the user; do NOT rethrow. The button's
@@ -177,10 +168,7 @@ export function SuiteExecutionConfigEditor({
       // feedback. Mirrors the parent-provided onSave handler the
       // pre-Phase-3 component used.
       toast.error(
-        getBillingErrorMessage(
-          err,
-          "Failed to update suite execution config",
-        ),
+        getBillingErrorMessage(err, "Failed to update suite execution config")
       );
       console.error("Failed to update suite execution config:", err);
     } finally {
@@ -192,16 +180,16 @@ export function SuiteExecutionConfigEditor({
     if (!projectDefaultDto) return;
     setIsResetting(true);
     try {
-      // Phase 4: copy the project default into the suite-owned
-      // hostConfigId via setSuiteConfig. Server lists are forced empty
-      // since suite server selection lives on `suite.environment`. The
-      // mutation mints a new v2 row when the project-default content
-      // differs from the suite's existing row, or no-ops via dedupe
-      // when they already match.
+      // Phase 4: copy the project default execution fields into the
+      // suite-owned hostConfigId via setSuiteConfig while preserving the
+      // suite's frozen server snapshot. The mutation mints a new v2 row
+      // when the project-default content differs from the suite's
+      // existing row, or no-ops via dedupe when they already match.
       const projectDefaultInput: HostConfigInputV2 = {
         ...hostConfigDtoToInput(projectDefaultDto),
-        serverIds: [],
-        optionalServerIds: [],
+        serverIds: value.serverIds,
+        optionalServerIds: value.optionalServerIds,
+        serverConnectionOverrides: value.serverConnectionOverrides,
       };
       await setSuiteConfig({
         suiteId: suite._id,
@@ -212,10 +200,7 @@ export function SuiteExecutionConfigEditor({
       toast.success("Suite reset to project default");
     } catch (err) {
       toast.error(
-        getBillingErrorMessage(
-          err,
-          "Failed to reset suite to project default",
-        ),
+        getBillingErrorMessage(err, "Failed to reset suite to project default")
       );
       console.error("Failed to reset suite to project default:", err);
     } finally {
@@ -230,7 +215,8 @@ export function SuiteExecutionConfigEditor({
           Default Execution Config
         </h2>
         <p className="mt-1 text-xs text-muted-foreground">
-          The model and parameters all iterations in this suite inherit. Per-case{" "}
+          The model and parameters all iterations in this suite inherit.
+          Per-case{" "}
           <code className="rounded bg-muted px-1 py-0.5 text-[10px]">
             advancedConfig
           </code>{" "}

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -64,6 +64,7 @@ interface SuiteHeaderProps {
     opts?: {
       matchOptionsOverride?: EvalMatchOptions;
       iterationOverride?: number;
+      refreshSnapshot?: boolean;
     },
   ) => void;
   onReplayRun?: (suite: EvalSuite, run: EvalSuiteRun) => void;
@@ -695,6 +696,33 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                 <Code2 className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 Setup SDK
               </Button>
+            ) : null}
+
+            {!hideRunActions && !readOnlyConfig && hasServersConfigured ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 gap-1.5 text-muted-foreground"
+                      disabled={isRerunning}
+                      onClick={() =>
+                        onRerun(suite, { refreshSnapshot: true })
+                      }
+                    >
+                      <RotateCw
+                        className={`h-3.5 w-3.5 shrink-0 ${isRerunning ? "animate-spin" : ""}`}
+                        aria-hidden
+                      />
+                      Update snapshot
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent variant="muted" side="bottom" className="max-w-[16rem]">
+                  Re-saves the suite&apos;s current server list as the frozen execution snapshot and starts a run.
+                </TooltipContent>
+              </Tooltip>
             ) : null}
 
             {!hideRunActions && (replayableLatestRun || !readOnlyConfig) ? (

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -488,6 +488,13 @@ export function useEvalHandlers({
          * test in the run. Does NOT mutate persisted suite/case records.
          */
         matchOptionsOverride?: import("@/shared/eval-matching").EvalMatchOptions;
+        /**
+         * When true, re-derives suite.hostConfigId from the current server
+         * list and persists it. Without this flag, reruns leave the frozen
+         * snapshot untouched so newly connected servers cannot contaminate
+         * existing suites.
+         */
+        refreshSnapshot?: boolean;
       },
     ) => {
       if (rerunningSuiteId) return;
@@ -636,6 +643,7 @@ export function useEvalHandlers({
               suiteRerun: true,
               iterationOverride: options?.iterationOverride,
               matchOptionsOverride: options?.matchOptionsOverride,
+              refreshSnapshot: options?.refreshSnapshot,
               ...(plan.namedHostId ? { namedHostId: plan.namedHostId } : {}),
             }),
           ),

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -88,6 +88,13 @@ type RunEvalsRequest = EvalRequestWithServers & {
    * the UI makes one parallel request per host.
    */
   namedHostId?: string;
+  /**
+   * When true on a suiteRerun, explicitly re-derives suite.hostConfigId
+   * from the request's server list. Without this flag, plain reruns leave
+   * the frozen snapshot untouched so newly connected servers can't
+   * silently contaminate existing suites.
+   */
+  refreshSnapshot?: boolean;
 };
 
 type RunTestCaseRequest = EvalRequestWithServers & {

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -131,6 +131,13 @@ export const RunEvalsRequestSchema = z.object({
    * multiple host attachments, the client makes one request per host.
    */
   namedHostId: z.string().optional(),
+  /**
+   * When true on a suiteRerun, explicitly re-derives suite.hostConfigId
+   * from the request's server list and persists it. Without this flag,
+   * plain reruns leave suite.hostConfigId (and suite.environment) frozen
+   * so connecting new servers cannot silently contaminate existing suites.
+   */
+  refreshSnapshot: z.boolean().optional(),
 });
 
 export type RunEvalsRequest = z.infer<typeof RunEvalsRequestSchema>;
@@ -439,6 +446,7 @@ export async function runEvalsWithManager(
     iterationOverride,
     matchOptionsOverride,
     namedHostId,
+    refreshSnapshot,
   } = request;
 
   if (!suiteId && (!suiteName || suiteName.trim().length === 0)) {
@@ -522,11 +530,19 @@ export async function runEvalsWithManager(
   }
 
   if (resolvedSuiteId) {
+    // On a plain rerun do NOT overwrite the suite's persisted environment or
+    // hostConfigId — new connected servers would silently contaminate the
+    // frozen execution snapshot. Only update when explicitly refreshing or
+    // on first-run (non-rerun) writes.
+    const shouldUpdateSnapshot = !suiteRerun || refreshSnapshot === true;
     await convexClient.mutation("testSuites:updateTestSuite" as any, {
       suiteId: resolvedSuiteId,
       name: suiteName,
       description: suiteDescription,
-      environment: persistedEnvironment,
+      ...(shouldUpdateSnapshot ? { environment: persistedEnvironment } : {}),
+      ...(shouldUpdateSnapshot && refreshSnapshot === true
+        ? { refreshHostConfigFromEnvironment: true }
+        : {}),
     });
 
     // On a suite rerun, do NOT upsert per-case fields. The wire payload

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -128,6 +128,11 @@ export type RunEvalSuiteOptions = {
   config: {
     tests: EvalTestCase[];
     environment: {
+      /**
+       * Legacy display/compat refs. These may be friendly names, not
+       * connected server identities; preserve serverBindings with any
+       * snapshotted environment before resolving tools for execution.
+       */
       servers: string[];
       serverBindings?: Array<{
         serverName: string;

--- a/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
@@ -113,12 +113,12 @@ describe("startSuiteRunWithRecorder", () => {
         suiteId: "suite-1",
         toolSnapshot: sanitizedToolSnapshot,
         toolSnapshotDebug: sanitizedToolSnapshotDebug,
-      })
+      }),
     );
     expect(mutationMock).toHaveBeenNthCalledWith(
       2,
       "testSuites:precreateIterationsForRun",
-      { runId: "run-1" }
+      { runId: "run-1" },
     );
     expect(result).toEqual(
       expect.objectContaining({
@@ -149,19 +149,26 @@ describe("startSuiteRunWithRecorder", () => {
             servers: ["alpha"],
           },
         },
-      })
+      }),
     );
   });
 
   it("runs against the environment Convex snapshotted for the suite run", async () => {
+    const snapshotEnvironment = {
+      servers: ["friendly-server-name"],
+      serverBindings: [
+        {
+          serverName: "friendly-server-name",
+          projectServerId: "project-server-id",
+        },
+      ],
+    };
     const mutationMock = vi
       .fn()
       .mockResolvedValueOnce({
         runId: "run-1",
         configSnapshot: {
-          environment: {
-            servers: ["snapshotted-server"],
-          },
+          environment: snapshotEnvironment,
         },
         testCases: [
           {
@@ -183,8 +190,6 @@ describe("startSuiteRunWithRecorder", () => {
       serverIds: ["request-server"],
     });
 
-    expect(result.config.environment).toEqual({
-      servers: ["snapshotted-server"],
-    });
+    expect(result.config.environment).toEqual(snapshotEnvironment);
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
@@ -113,12 +113,12 @@ describe("startSuiteRunWithRecorder", () => {
         suiteId: "suite-1",
         toolSnapshot: sanitizedToolSnapshot,
         toolSnapshotDebug: sanitizedToolSnapshotDebug,
-      }),
+      })
     );
     expect(mutationMock).toHaveBeenNthCalledWith(
       2,
       "testSuites:precreateIterationsForRun",
-      { runId: "run-1" },
+      { runId: "run-1" }
     );
     expect(result).toEqual(
       expect.objectContaining({
@@ -149,7 +149,42 @@ describe("startSuiteRunWithRecorder", () => {
             servers: ["alpha"],
           },
         },
-      }),
+      })
     );
+  });
+
+  it("runs against the environment Convex snapshotted for the suite run", async () => {
+    const mutationMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        runId: "run-1",
+        configSnapshot: {
+          environment: {
+            servers: ["snapshotted-server"],
+          },
+        },
+        testCases: [
+          {
+            _id: "tc-1",
+            title: "Snapshot server",
+            query: "Use the pinned server",
+            model: "gpt-5",
+            provider: "openai",
+            runs: 1,
+            expectedToolCalls: [],
+          },
+        ],
+      })
+      .mockResolvedValueOnce(undefined);
+
+    const result = await startSuiteRunWithRecorder({
+      convexClient: { mutation: mutationMock } as any,
+      suiteId: "suite-1",
+      serverIds: ["request-server"],
+    });
+
+    expect(result.config.environment).toEqual({
+      servers: ["snapshotted-server"],
+    });
   });
 });

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -374,6 +374,16 @@ export const startSuiteRunWithRecorder = async ({
     runId,
   });
 
+  // Use the server list Convex snapshotted into the run (derived from
+  // suite.hostConfigId.serverIds when available, else suite.environment).
+  // Falling back to the raw request serverIds would diverge from the
+  // DB snapshot when the backend's hostConfig-based path picks different
+  // servers than the caller requested.
+  const snapshotServers =
+    (response?.configSnapshot as any)?.environment?.servers ??
+    serverIds ??
+    [];
+
   // Build config from test cases for backward compatibility
   const config = {
     tests: testCases.flatMap((tc: any) => {
@@ -415,7 +425,7 @@ export const startSuiteRunWithRecorder = async ({
 
       return [];
     }),
-    environment: { servers: serverIds || [] },
+    environment: { servers: snapshotServers },
   };
 
   return {

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -11,6 +11,15 @@ import { sanitizeForConvexTransport } from "./convex-sanitize.js";
 
 type IterationStatus = "completed" | "failed" | "cancelled";
 
+type SuiteRunEnvironmentSnapshot = {
+  servers: string[];
+  serverBindings?: Array<{
+    serverName: string;
+    projectServerId?: string;
+    workspaceServerId?: string;
+  }>;
+};
+
 export type SuiteRunRecorder = {
   runId: string;
   suiteId: string;
@@ -66,6 +75,19 @@ export type SuiteRunRecorder = {
 };
 
 const DEFAULT_ITERATION_STATUS: IterationStatus = "completed";
+
+function isSuiteRunEnvironmentSnapshot(
+  value: unknown,
+): value is SuiteRunEnvironmentSnapshot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const environment = value as SuiteRunEnvironmentSnapshot;
+  return (
+    Array.isArray(environment.servers) &&
+    environment.servers.every((server) => typeof server === "string")
+  );
+}
 
 export const createSuiteRunRecorder = ({
   convexClient,
@@ -374,15 +396,18 @@ export const startSuiteRunWithRecorder = async ({
     runId,
   });
 
-  // Use the server list Convex snapshotted into the run (derived from
-  // suite.hostConfigId.serverIds when available, else suite.environment).
-  // Falling back to the raw request serverIds would diverge from the
-  // DB snapshot when the backend's hostConfig-based path picks different
-  // servers than the caller requested.
-  const snapshotServers =
-    (response?.configSnapshot as any)?.environment?.servers ??
-    serverIds ??
-    [];
+  // Use the full environment Convex snapshotted into the run (derived
+  // from suite.hostConfigId.serverIds when available, else the legacy
+  // suite environment). `environment.servers` is a display/compat list;
+  // serverBindings carries the stable id mapping resolveConfiguredServerIds
+  // needs before calling getToolsForAiSdk. Falling back to the raw request
+  // refs is only for older backend responses without configSnapshot.
+  const snapshotEnvironment = isSuiteRunEnvironmentSnapshot(
+    (response?.configSnapshot as any)?.environment,
+  )
+    ? ((response?.configSnapshot as any)
+        .environment as SuiteRunEnvironmentSnapshot)
+    : { servers: serverIds ?? [] };
 
   // Build config from test cases for backward compatibility
   const config = {
@@ -425,7 +450,7 @@ export const startSuiteRunWithRecorder = async ({
 
       return [];
     }),
-    environment: { servers: snapshotServers },
+    environment: snapshotEnvironment,
   };
 
   return {


### PR DESCRIPTION
## Summary

- Plain reruns no longer overwrite `suite.environment` or `suite.hostConfigId` — newly connected servers can't silently contaminate an existing suite's frozen config
- Adds a `refreshSnapshot` flag so callers can explicitly re-derive the execution snapshot from the current server list when that's intentional
- Adds **"Update snapshot"** button to the suite overview header
- Fixes `recorder.ts` to use the server list Convex actually snapshotted (from `configSnapshot.environment`) instead of the raw request `serverIds`, so the runner always agrees with the DB

## Changes

| File | Change |
|------|--------|
| `server/routes/shared/evals.ts` | Add `refreshSnapshot` to schema; guard `updateTestSuite` call on plain rerun; pass `refreshHostConfigFromEnvironment:true` when refreshing |
| `server/services/evals/recorder.ts` | Use `configSnapshot.environment.servers` from Convex response instead of raw request `serverIds` |
| `client/src/lib/apis/evals-api.ts` | Add `refreshSnapshot?: boolean` to `RunEvalsRequest` |
| `client/src/components/evals/use-eval-handlers.ts` | Add `refreshSnapshot` to `handleRerun` options; forward in `runEvals` payload |
| `client/src/components/evals/suite-header.tsx` | Update `onRerun` signature; add "Update snapshot" button |

## Depends on

Requires the companion backend PR in `mcpjam-backend` (`feat/eval-hostconfig-snapshotting`) which adds `refreshHostConfigFromEnvironment` to `updateTestSuite` and the `configSnapshot` return from `startTestSuiteRun`.

## Test plan

- [ ] Create suite with servers A and B. Run it. Confirm run uses A and B.
- [ ] Connect server C. Plain rerun. Confirm run still uses only A and B (environment unchanged).
- [ ] Click "Update snapshot". Confirm suite hostConfig is re-derived and run starts.
- [ ] Verify no regression on new suite creation (first run still persists the environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which servers and hostConfig apply on reruns versus explicit refresh, affecting eval reproducibility; depends on backend `refreshHostConfigFromEnvironment` and `configSnapshot` from the companion PR.
> 
> **Overview**
> **Freezes eval suite execution snapshots on plain reruns** so newly connected MCP servers no longer overwrite `suite.environment` or `suite.hostConfigId` when you hit Run again.
> 
> Adds optional **`refreshSnapshot`** end-to-end (API schema, `runEvals`, `handleRerun`) and an **Update snapshot** control in the suite header that re-saves the current server list, sets `refreshHostConfigFromEnvironment` on `updateTestSuite`, and starts a run.
> 
> **`recorder.ts`** now builds run config from **`configSnapshot.environment`** (including `serverBindings`) returned by Convex instead of raw request `serverIds`, with a test covering friendly names vs stable ids.
> 
> **Suite execution config editor** stops stripping `serverIds` on save and preserves the suite's frozen server fields when resetting to project default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7620559bcfd27fe08975bb09ac547970badc04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->