### PR TITLE
Gate chatboxes on team and refresh billing table

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -767,7 +767,18 @@ export function ConformanceRoute() {
 // a host, manage its chatbox here. There is no chatbox list; the host
 // list lives in Connect.
 export function ChatboxesRoute() {
-  const { convexProjectId, isAuthenticated } = useAppRouteContext();
+  const {
+    billingUiEnabled,
+    activeTabBillingLocked,
+    activeTabBillingFeature,
+    convexProjectId,
+    isAuthenticated,
+  } = useAppRouteContext();
+
+  if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
+    return <ActiveBillingUpsellGate />;
+  }
+
   return (
     <ChatboxesTab
       projectId={convexProjectId}
@@ -2431,7 +2442,11 @@ export default function App() {
       }
     }
 
-    if (activeTabBillingLocked && activeTabBillingFeature) {
+    if (
+      activeTabBillingLocked &&
+      activeTabBillingFeature &&
+      activeTab !== "chatboxes"
+    ) {
       toast.error(
         `${formatBillingFeatureName(
           activeTabBillingFeature

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -63,7 +63,7 @@ function createPlanCatalog() {
           maxMembers: 5,
           maxProjects: 3,
           maxChatboxesPerProject: 0,
-          maxEvalRunsPerMonth: 5,
+          maxEvalRunsPerMonth: 100,
         },
         includedSeats: null,
         seatMinimum: null,
@@ -1000,12 +1000,12 @@ describe("OrganizationsTab billing", () => {
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
-    // Default interval is monthly — Team lists $38/seat/mo
-    expect(screen.getByText(/\$38/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Annual/ }));
+    // Default interval is annual — Team lists $30/seat/mo billed annually
     expect(screen.getByText(/\$30/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /^Monthly$/ }));
     expect(screen.getByText(/\$38/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Annual/ }));
+    expect(screen.getByText(/\$30/)).toBeInTheDocument();
   });
 
   it("shows deferred billing copy for active trials with enough time remaining", () => {
@@ -1118,7 +1118,7 @@ describe("OrganizationsTab billing", () => {
       expect(startPlanChange).toHaveBeenCalledWith(
         expect.stringContaining("/organizations/org-1/billing"),
         "team",
-        "monthly",
+        "annual",
         { confirmPaidPlanChange: true },
       );
     });
@@ -1495,7 +1495,7 @@ describe("OrganizationsTab billing", () => {
       ).not.toBeInTheDocument();
     });
     expect(startPlanChange).not.toHaveBeenCalled();
-    expect(screen.getByText(/\$30/)).toBeInTheDocument();
+    expect(screen.getByText(/\$38/)).toBeInTheDocument();
   });
 
   it("consumes paid deep links before subscription status catches up", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -191,6 +191,7 @@ describe("filterByFeatureFlags", () => {
             url: "#chatboxes",
             icon: FakeIcon,
             featureFlag: "sandboxes-enabled",
+            billingFeature: "chatboxes" as const,
           },
         ],
       },
@@ -204,11 +205,37 @@ describe("filterByFeatureFlags", () => {
         url: "#chatboxes",
         icon: FakeIcon,
         featureFlag: "sandboxes-enabled",
+        billingFeature: "chatboxes",
       },
     ]);
     expect(
       filterByFeatureFlags(sections, { "sandboxes-enabled": false }),
     ).toHaveLength(0);
+  });
+
+  it("marks Chatboxes disabled when billing enforcement denies chatboxes", () => {
+    const result = applyBillingGateNavState(
+      [
+        {
+          id: "connection",
+          items: [
+            {
+              title: "Chatboxes",
+              url: "/chatboxes",
+              icon: FakeIcon,
+              billingFeature: "chatboxes",
+            },
+          ],
+        },
+      ],
+      {
+        billingUiEnabled: true,
+        gateDenied: { chatboxes: true },
+        enforcementActive: true,
+      },
+    );
+
+    expect(result[0].items[0].disabled).toBe(true);
   });
 });
 

--- a/mcpjam-inspector/client/src/components/billing/BillingUpsellGate.tsx
+++ b/mcpjam-inspector/client/src/components/billing/BillingUpsellGate.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef } from "react";
 import { Button } from "@mcpjam/design-system/button";
+import { usePostHog } from "posthog-js/react";
 import type {
   BillingFeatureName,
   OrganizationPlan,
@@ -7,13 +9,14 @@ import {
   formatBillingFeatureName,
   formatPlanName,
 } from "@/lib/billing-entitlements";
+import { standardEventProps } from "@/lib/PosthogUtils";
 
 const FEATURE_DESCRIPTIONS: Partial<Record<BillingFeatureName, string>> = {
   evals:
     "Create test suites, run them in the playground, and inspect traces to validate your MCP servers.",
   cicd: "Wire eval runs into your CI/CD pipeline so regressions are caught before they ship.",
   chatboxes:
-    "Publish hosted chat experiences with a fixed model, system prompt, and server set for demos and feedback.",
+    "Share a hosted chat link for each client, manage access, and review sessions and feedback.",
 };
 
 export interface BillingUpsellGateProps {
@@ -33,6 +36,8 @@ export function BillingUpsellGate({
   canManageBilling,
   onNavigateToBilling,
 }: BillingUpsellGateProps) {
+  const posthog = usePostHog();
+  const viewedRef = useRef(false);
   const featureName = formatBillingFeatureName(feature);
   const description =
     FEATURE_DESCRIPTIONS[feature] ??
@@ -42,23 +47,44 @@ export function BillingUpsellGate({
     ? `Included in ${formatPlanName(upgradePlan)} and above.`
     : `Not included on ${currentLabel}.`;
 
+  useEffect(() => {
+    if (viewedRef.current) return;
+    viewedRef.current = true;
+    posthog?.capture("billing_upsell_gate_viewed", {
+      ...standardEventProps("billing_upsell_gate"),
+      feature,
+      current_plan: currentPlan,
+      upgrade_plan: upgradePlan,
+      can_manage_billing: canManageBilling,
+      surface: window.location.pathname,
+    });
+  }, [
+    canManageBilling,
+    currentPlan,
+    feature,
+    posthog,
+    upgradePlan,
+  ]);
+
   return (
     <div
       className="flex h-full min-h-[240px] flex-col items-center justify-center gap-4 p-8 text-center"
       data-testid="billing-upsell-gate"
     >
-      <div className="max-w-md space-y-2 rounded-md border border-border/70 p-6 text-left shadow-sm">
+      <div className="max-w-md space-y-2 rounded-md border border-border/70 p-6 text-center shadow-sm">
         <h2 className="text-lg font-semibold">{featureName}</h2>
         <p className="text-sm text-muted-foreground">{description}</p>
         <p className="text-sm text-muted-foreground">{includedLine}</p>
         {canManageBilling ? (
-          <Button
-            type="button"
-            className="mt-3 w-full sm:w-auto"
-            onClick={onNavigateToBilling}
-          >
-            Upgrade
-          </Button>
+          <div className="flex justify-center pt-1">
+            <Button
+              type="button"
+              className="mt-3 w-full sm:w-auto"
+              onClick={onNavigateToBilling}
+            >
+              Upgrade
+            </Button>
+          </div>
         ) : (
           <p className="pt-2 text-sm font-medium text-foreground">
             Ask your admin to upgrade

--- a/mcpjam-inspector/client/src/components/billing/__tests__/BillingUpsellGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/BillingUpsellGate.test.tsx
@@ -1,9 +1,51 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { BillingUpsellGate } from "../BillingUpsellGate";
 
+const captureMock = vi.fn();
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}));
+
+vi.mock("@/lib/PosthogUtils", () => ({
+  standardEventProps: (location: string) => ({
+    location,
+    platform: "web",
+    environment: "test",
+  }),
+}));
+
 describe("BillingUpsellGate", () => {
+  beforeEach(() => {
+    captureMock.mockReset();
+  });
+
+  it("captures billing_upsell_gate_viewed once on mount", () => {
+    render(
+      <BillingUpsellGate
+        feature="chatboxes"
+        currentPlan="free"
+        upgradePlan="team"
+        canManageBilling
+        onNavigateToBilling={vi.fn()}
+      />,
+    );
+
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    expect(captureMock).toHaveBeenCalledWith("billing_upsell_gate_viewed", {
+      location: "billing_upsell_gate",
+      platform: "web",
+      environment: "test",
+      feature: "chatboxes",
+      current_plan: "free",
+      upgrade_plan: "team",
+      can_manage_billing: true,
+      surface: expect.any(String),
+    });
+  });
+
   it("shows Upgrade and calls onNavigateToBilling for billing managers", async () => {
     const user = userEvent.setup();
     const onNavigate = vi.fn();
@@ -36,6 +78,11 @@ describe("BillingUpsellGate", () => {
       />,
     );
 
+    expect(
+      screen.getByText(
+        /Share a hosted chat link for each client, manage access, and review sessions and feedback/i,
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Ask your admin to upgrade/i)).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /upgrade/i }),

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -206,6 +206,7 @@ const navigationSections: NavSection[] = [
         url: "/chatboxes",
         icon: Box,
         featureFlag: "sandboxes-enabled",
+        billingFeature: "chatboxes",
       },
       {
         title: "Playground",

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -208,47 +208,31 @@ function formatPerSeatCadence(
       ? "Flat rate, billed annually"
       : "Flat rate, billed monthly";
   }
-  return interval === "annual"
-    ? "Per seat, billed annually"
-    : "Per seat, billed monthly";
+  return interval === "annual" ? "Billed annually" : "Billed monthly";
 }
 
 const PER_SEAT_MO_SUFFIX = "/seat/mo";
 const PER_MO_SUFFIX = "/mo";
 
 function PlanPriceDisplay({ label }: { label: string }) {
-  if (label.endsWith(PER_SEAT_MO_SUFFIX)) {
-    const amount = label.slice(0, -PER_SEAT_MO_SUFFIX.length);
-    return (
-      <div className="flex min-w-0 flex-wrap items-baseline gap-x-1 gap-y-0">
-        <span className="text-3xl font-semibold tabular-nums tracking-tight">
-          {amount}
-        </span>
-        <span className="text-sm font-semibold text-muted-foreground">
-          {PER_SEAT_MO_SUFFIX}
-        </span>
-      </div>
-    );
-  }
-
-  if (label.endsWith(PER_MO_SUFFIX)) {
-    const amount = label.slice(0, -PER_MO_SUFFIX.length);
-    return (
-      <div className="flex min-w-0 flex-wrap items-baseline gap-x-1 gap-y-0">
-        <span className="text-3xl font-semibold tabular-nums tracking-tight">
-          {amount}
-        </span>
-        <span className="text-sm font-semibold text-muted-foreground">
-          {PER_MO_SUFFIX}
-        </span>
-      </div>
-    );
-  }
+  const suffix = label.endsWith(PER_SEAT_MO_SUFFIX)
+    ? PER_SEAT_MO_SUFFIX
+    : label.endsWith(PER_MO_SUFFIX)
+      ? PER_MO_SUFFIX
+      : null;
+  const amount = suffix ? label.slice(0, -suffix.length) : label;
 
   return (
-    <p className="min-w-0 text-3xl font-semibold tabular-nums tracking-tight">
-      {label}
-    </p>
+    <div className="flex min-h-9 min-w-0 items-baseline justify-center gap-x-1">
+      <span className="text-3xl font-semibold tabular-nums tracking-tight">
+        {amount}
+      </span>
+      {suffix ? (
+        <span className="text-sm font-medium text-muted-foreground">
+          {suffix}
+        </span>
+      ) : null}
+    </div>
   );
 }
 
@@ -256,10 +240,11 @@ const COMPARE_PLAN_ROW_LABEL_TOOLTIPS: Record<
   string,
   { ariaLabel: string; content: string; contentClassName?: string }
 > = {
-  "Evals CI/CD runs": {
-    ariaLabel: "Included runs and overage pricing",
-    content: "Free: hard cap. Overages $0.02/run otherwise.",
-    contentClassName: "max-w-[20rem]",
+  "Eval iteration overage": {
+    ariaLabel: "Eval iteration overage pricing",
+    content:
+      "Free stops at the cap. Team can continue at $0.02 per iteration beyond the included monthly pool.",
+    contentClassName: "max-w-[22rem]",
   },
   "Triage Insights": {
     ariaLabel: "About Triage Insights",
@@ -272,41 +257,11 @@ const COMPARE_PLAN_ROW_LABEL_TOOLTIPS: Record<
       "Traces for evaluations: configured user prompts, tool execution, agent reasoning, errors, and latency breakdown for playground and CI/CD runs.",
     contentClassName: "max-w-[26rem]",
   },
-  "Chatbox traces": {
-    ariaLabel: "What are chatbox traces?",
-    content:
-      "Traces for chatboxes: testing user prompts, tool execution, agent reasoning, errors, and latency breakdown while running and sharing MCP experiences.",
-    contentClassName: "max-w-[26rem]",
-  },
-  Uptime: {
-    ariaLabel: "Included uptime and overage",
-    content:
-      "Included hours are per plan. Overage after that is billed at $0.003 per minute.",
-    contentClassName: "max-w-[20rem]",
-  },
-  "User Feedback Insights": {
-    ariaLabel: "User feedback and usage insights",
-    content:
-      "User feedback and usage insights, e.g. to inform user intent and more effective product decisions and evaluations.",
-    contentClassName: "max-w-[26rem]",
-  },
   "Insights Data Export": {
     ariaLabel: "About insights data export",
     content:
       "Export triage and evaluation insights for analysis outside MCPJam.",
     contentClassName: "max-w-[22rem]",
-  },
-  "Chatbox Insights Data Export": {
-    ariaLabel: "About chatbox insights data export",
-    content:
-      "Export chatbox user feedback and usage insights for analysis outside MCPJam.",
-    contentClassName: "max-w-[22rem]",
-  },
-  Branding: {
-    ariaLabel: "About branding",
-    content:
-      "Custom branding (e.g. logo and colors) on shared chatbox experiences.",
-    contentClassName: "max-w-[18rem]",
   },
   Projects: {
     ariaLabel: "What is a project?",
@@ -504,7 +459,7 @@ export function OrganizationBillingSection({
 
   const autoCheckoutStartedForKeyRef = useRef<string | null>(null);
   const [billingInterval, setBillingInterval] =
-    useState<BillingInterval>("monthly");
+    useState<BillingInterval>("annual");
   const [checkoutPlanNotice, setCheckoutPlanNotice] = useState<{
     reason: "already_on" | "already_higher";
     currentDisplayName: string;
@@ -519,9 +474,9 @@ export function OrganizationBillingSection({
 
   useEffect(() => {
     if (billingStatus?.billingInterval === "annual") {
-      setBillingInterval((current) =>
-        current === "monthly" ? "annual" : current,
-      );
+      setBillingInterval("annual");
+    } else if (billingStatus?.billingInterval === "monthly") {
+      setBillingInterval("monthly");
     }
   }, [billingStatus?.billingInterval]);
 
@@ -901,7 +856,7 @@ export function OrganizationBillingSection({
                                     </Badge>
                                   ) : null}
                                 </div>
-                                <div className="w-full space-y-1">
+                                <div className="w-full space-y-1 text-center">
                                   <PlanPriceDisplay label={priceLabel} />
                                   <p className="text-xs leading-snug text-muted-foreground">
                                     {priceSubtext}

--- a/mcpjam-inspector/client/src/components/organization/OrganizationCurrentPlanPanel.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationCurrentPlanPanel.tsx
@@ -359,13 +359,13 @@ export function OrganizationCurrentPlanPanel({
             <Box className="size-6 text-primary" />
           </div>
           <div className="min-w-0 space-y-1.5">
-            <p className="text-2xl font-semibold tracking-tight text-muted-foreground">
+            <p className="text-2xl font-semibold tracking-tight text-foreground">
               {isTrial
                 ? `${formatPlanName(displayPlan)} Trial`
                 : formatPlanName(displayPlan)}
             </p>
             {displayPlan === "free" && !isTrial ? (
-              <p className="text-xs text-muted-foreground/90">
+              <p className="text-sm text-muted-foreground">
                 Limited functionality
               </p>
             ) : null}

--- a/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { buildComparePlanSectionsFromCatalog } from "@/components/organization/billing-compare-view-model";
+import type { PlanCatalog } from "@/hooks/useOrganizationBilling";
+
+function createPlanCatalog(
+  maxEvalRunsPerMonth: { free: number; team: number },
+): PlanCatalog {
+  const baseEntry = {
+    prices: {
+      monthly: { amountCents: 0, stripePriceId: null },
+      annual: { amountCents: 0, stripePriceId: null },
+    },
+    billingModel: "flat" as const,
+    features: {},
+  };
+
+  return {
+    currency: "USD",
+    plans: {
+      free: {
+        ...baseEntry,
+        limits: {
+          maxMembers: 1,
+          maxProjects: 1,
+          maxServersPerProject: 3,
+          maxEvalRunsPerMonth: maxEvalRunsPerMonth.free,
+        },
+      },
+      team: {
+        ...baseEntry,
+        limits: {
+          maxMembers: 10,
+          maxProjects: 10,
+          maxServersPerProject: 10,
+          maxEvalRunsPerMonth: maxEvalRunsPerMonth.team,
+        },
+      },
+      enterprise: {
+        ...baseEntry,
+        limits: {
+          maxMembers: null,
+          maxProjects: null,
+          maxServersPerProject: null,
+          maxEvalRunsPerMonth: null,
+        },
+      },
+    },
+  };
+}
+
+function findEvalIterationCapRow(
+  sections: ReturnType<typeof buildComparePlanSectionsFromCatalog>,
+) {
+  for (const section of sections) {
+    const row = section.rows.find((r) => r.label === "Eval iteration cap");
+    if (row) return row;
+  }
+  throw new Error("Eval iteration cap row not found");
+}
+
+describe("buildComparePlanSectionsFromCatalog", () => {
+  it("keeps static eval iteration cap copy instead of catalog limits", () => {
+    const sections = buildComparePlanSectionsFromCatalog(
+      createPlanCatalog({ free: 5, team: 5000 }),
+    );
+    const row = findEvalIterationCapRow(sections);
+
+    expect(row.free).toEqual({ kind: "text", text: "100 iter. / mo" });
+    expect(row.team).toEqual({
+      kind: "text",
+      text: "5,000 iter. / mo",
+      emphasize: true,
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -5,33 +5,67 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
   it("mirrors the marketing compare table sections and row coverage", () => {
     expect(COMPARE_PLAN_MARKETING_SECTIONS.map((s) => s.title)).toEqual([
       "Organization & projects",
-      "Standard features",
       "Evaluations",
-      "Chatboxes",
       "LLM Usage",
       "Security & Compliance",
-      "Platform & Infrastructure",
       "Support",
+      "Standard features",
     ]);
+
+    expect(
+      COMPARE_PLAN_MARKETING_SECTIONS.some(
+        (s) => s.title === "Platform & Infrastructure",
+      ),
+    ).toBe(false);
+
+    expect(
+      COMPARE_PLAN_MARKETING_SECTIONS.some((s) => s.title === "Chatboxes"),
+    ).toBe(false);
 
     const rowCount = COMPARE_PLAN_MARKETING_SECTIONS.reduce(
       (n, s) => n + s.rows.length,
       0,
     );
-    expect(rowCount).toBe(35);
+    expect(rowCount).toBe(24);
+
+    const standardFeatures = COMPARE_PLAN_MARKETING_SECTIONS.find(
+      (s) => s.title === "Standard features",
+    );
+    const standardLabels = standardFeatures?.rows.map((r) => r.label) ?? [];
+    expect(standardLabels).toEqual([
+      "Playground",
+      "Visual OAuth Debugger",
+      "JSON-RPC Logger & SDK",
+      "Open Source on GitHub",
+    ]);
   });
 
   it("includes representative product and org/project cells", () => {
     const testing = COMPARE_PLAN_MARKETING_SECTIONS.find(
       (s) => s.title === "Evaluations",
     );
-    const evalsRow = testing?.rows.find((r) => r.label === "Evals CI/CD runs");
-    expect(evalsRow?.team).toEqual({
+    const iterationCapRow = testing?.rows.find(
+      (r) => r.label === "Eval iteration cap",
+    );
+    expect(iterationCapRow?.team).toEqual({
       kind: "text",
-      text: "5,000 included",
+      text: "5,000 iter. / mo",
       emphasize: true,
     });
-    expect(evalsRow?.free).toEqual({ kind: "text", text: "5 / mo" });
+    expect(iterationCapRow?.free).toEqual({
+      kind: "text",
+      text: "100 iter. / mo",
+    });
+
+    const overageRow = testing?.rows.find(
+      (r) => r.label === "Eval iteration overage",
+    );
+    expect(overageRow?.free).toEqual({ kind: "x" });
+    expect(overageRow?.team).toEqual({
+      kind: "text",
+      text: "$0.02 / iter.",
+      emphasize: true,
+    });
 
     const orgProjects = COMPARE_PLAN_MARKETING_SECTIONS.find(
       (s) => s.title === "Organization & projects",
@@ -63,6 +97,19 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
       text: "$5",
       emphasize: true,
     });
+  });
+
+  it("keeps insights data export on Enterprise only", () => {
+    const evaluations = COMPARE_PLAN_MARKETING_SECTIONS.find(
+      (s) => s.title === "Evaluations",
+    );
+    const exportRow = evaluations?.rows.find(
+      (r) => r.label === "Insights Data Export",
+    );
+
+    expect(exportRow?.free).toEqual({ kind: "x" });
+    expect(exportRow?.team).toEqual({ kind: "x" });
+    expect(exportRow?.enterprise).toEqual({ kind: "check" });
   });
 
   it("keeps audit logs positioned on Enterprise only", () => {

--- a/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
+++ b/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
@@ -9,8 +9,6 @@ import type {
   PlanCatalogEntry,
 } from "@/hooks/useOrganizationBilling";
 
-const x: ComparePlanCell = { kind: "x" };
-
 function t(text: string, emphasize?: boolean): ComparePlanCell {
   return { kind: "text", text, emphasize };
 }
@@ -44,40 +42,6 @@ function formatLimitValue(
     return t("Unlimited", emphasize);
   }
   return t(value.toLocaleString(), emphasize);
-}
-
-function formatEvalRuns(
-  plan: OrganizationPlan,
-  entry: PlanCatalogEntry,
-): ComparePlanCell {
-  if (plan === "enterprise") {
-    return t("Custom", true);
-  }
-  const value = entry.limits.maxEvalRunsPerMonth;
-  if (value == null) {
-    return t("Custom", plan === "team");
-  }
-  if (plan === "free") {
-    return t(`${value.toLocaleString()} / mo`);
-  }
-  return t(`${value.toLocaleString()} included`, plan === "team");
-}
-
-function formatDeployments(
-  plan: OrganizationPlan,
-  entry: PlanCatalogEntry,
-): ComparePlanCell {
-  if (plan === "enterprise") {
-    return t("Custom", true);
-  }
-  const value = entry.limits.maxChatboxesPerProject;
-  if (value == null) {
-    return t("Unlimited", plan === "team");
-  }
-  if (value <= 0) {
-    return x;
-  }
-  return t(value.toLocaleString(), plan === "team");
 }
 
 export function buildComparePlanSectionsFromCatalog(
@@ -120,20 +84,6 @@ export function buildComparePlanSectionsFromCatalog(
               true,
             ),
             enterprise: t("Unlimited", true),
-          };
-        case "Evals CI/CD runs":
-          return {
-            ...row,
-            free: formatEvalRuns("free", getEntry(planCatalog, "free")),
-            team: formatEvalRuns("team", getEntry(planCatalog, "team")),
-            enterprise: t("Custom", true),
-          };
-        case "Deployments":
-          return {
-            ...row,
-            free: formatDeployments("free", getEntry(planCatalog, "free")),
-            team: formatDeployments("team", getEntry(planCatalog, "team")),
-            enterprise: t("Custom", true),
           };
         default:
           return row;

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -29,7 +29,7 @@ function t(text: string, emphasize?: boolean): ComparePlanCell {
   return { kind: "text", text, emphasize };
 }
 
-/** Section order: organization & projects, standard features, evaluations, chatboxes, LLM usage, security, platform, support. */
+/** Section order: organization & projects, evaluations, LLM usage, security, support, standard features. */
 export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
   {
     title: "Organization & projects",
@@ -61,53 +61,6 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     ],
   },
   {
-    title: "Standard features",
-    rows: [
-      {
-        label: "Inspector",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Visual OAuth Debugger",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "JSON-RPC Logger & SDK",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "MCPJam Public Server Registry",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Learning Platform",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "MCP Newsletter",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Open Source on GitHub",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-    ],
-  },
-  {
     title: "Evaluations",
     rows: [
       {
@@ -132,57 +85,21 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
       {
         label: "Insights Data Export",
         free: x,
-        team: c,
+        team: x,
         enterprise: c,
       },
       {
-        label: "Evals CI/CD runs",
-        free: t("5 / mo"),
-        team: t("5,000 included", true),
-        enterprise: t("Custom", true),
-      },
-    ],
-  },
-  {
-    title: "Chatboxes",
-    rows: [
-      {
-        label: "Traces",
-        tooltipKey: "Chatbox traces",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Deployments",
-        free: x,
-        team: t("3", true),
+        label: "Eval iteration cap",
+        free: t("100 iter. / mo"),
+        team: t("5,000 iter. / mo", true),
         enterprise: t("Custom", true),
       },
       {
-        label: "Uptime",
+        label: "Eval iteration overage",
+        tooltipKey: "Eval iteration overage",
         free: x,
-        team: t("60 hrs included", true),
+        team: t("$0.02 / iter.", true),
         enterprise: t("Custom", true),
-      },
-      {
-        label: "User Feedback Insights",
-        free: x,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Insights Data Export",
-        tooltipKey: "Chatbox Insights Data Export",
-        free: x,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Branding",
-        free: x,
-        team: c,
-        enterprise: c,
       },
     ],
   },
@@ -245,29 +162,6 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     ],
   },
   {
-    title: "Platform & Infrastructure",
-    rows: [
-      {
-        label: "Hosting option",
-        free: x,
-        team: t("Cloud", true),
-        enterprise: t("Cloud, Hybrid, Self-Hosted", true),
-      },
-      {
-        label: "Infra",
-        free: x,
-        team: t("Managed by MCPJam", true),
-        enterprise: t("Cloud, Hybrid, Self-Hosted", true),
-      },
-      {
-        label: "Data location",
-        free: x,
-        team: t("MCPJam's Cloud (US or EU)", true),
-        enterprise: t("Cloud, Hybrid, Self-Hosted", true),
-      },
-    ],
-  },
-  {
     title: "Support",
     rows: [
       {
@@ -279,6 +173,35 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
       {
         label: "Priority support",
         free: x,
+        team: c,
+        enterprise: c,
+      },
+    ],
+  },
+  {
+    title: "Standard features",
+    rows: [
+      {
+        label: "Playground",
+        free: c,
+        team: c,
+        enterprise: c,
+      },
+      {
+        label: "Visual OAuth Debugger",
+        free: c,
+        team: c,
+        enterprise: c,
+      },
+      {
+        label: "JSON-RPC Logger & SDK",
+        free: c,
+        team: c,
+        enterprise: c,
+      },
+      {
+        label: "Open Source on GitHub",
+        free: c,
         team: c,
         enterprise: c,
       },

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -1,8 +1,11 @@
 import { ConvexError } from "convex/values";
 import { describe, expect, it } from "vitest";
 import {
+  BILLING_FEATURE_BY_TAB,
   getBillingErrorMessage,
   getDisplayPriceCentsForPlan,
+  getPremiumnessGateForTab,
+  getRequiredBillingFeatureForTab,
   isGateAccessDenied,
   isPremiumnessGateDeniedForShell,
 } from "../billing-entitlements";
@@ -39,6 +42,14 @@ function premiumness(
     ...overrides,
   };
 }
+
+describe("BILLING_FEATURE_BY_TAB", () => {
+  it("maps the chatboxes tab to the chatboxes premiumness feature", () => {
+    expect(BILLING_FEATURE_BY_TAB.chatboxes).toBe("chatboxes");
+    expect(getRequiredBillingFeatureForTab("chatboxes")).toBe("chatboxes");
+    expect(getPremiumnessGateForTab("chatboxes")).toBe("chatboxes");
+  });
+});
 
 describe("getBillingErrorMessage", () => {
   it("formats backend limit payloads for monthly eval runs", () => {
@@ -278,6 +289,29 @@ describe("isGateAccessDenied", () => {
         "maxProjects",
       ),
     ).toBe(true);
+  });
+
+  it("allows chatboxes for enterprise when the gate decision grants access", () => {
+    expect(
+      isGateAccessDenied(
+        premiumness({
+          plan: "enterprise",
+          effectivePlan: "enterprise",
+          gates: [
+            {
+              gateKey: "chatboxes",
+              kind: "feature",
+              scope: "organization",
+              canAccess: true,
+              shouldShowUpsell: false,
+              upgradePlan: null,
+              reason: "feature_included",
+            },
+          ],
+        }),
+        "chatboxes",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -35,6 +35,7 @@ export function getAnnualDiscountPercent(
 export const BILLING_FEATURE_BY_TAB = {
   evals: "evals",
   "ci-evals": "cicd",
+  chatboxes: "chatboxes",
 } as const satisfies Record<string, BillingFeatureName>;
 
 export function getRequiredBillingFeatureForTab(


### PR DESCRIPTION
## Summary

- Gate `/chatboxes` on the `chatboxes` premiumness feature (upsell for Free, access for Team/Enterprise); wire sidebar `billingFeature` and keep users on the route when locked.
- Update compare-plans marketing: eval iteration cap/overage rows, section reorder, annual default, pricing display fixes; use static cap copy instead of live catalog override.
- Improve `BillingUpsellGate` copy/layout and add `billing_upsell_gate_viewed` PostHog event.

## Test plan

- [ ]  Free org on `/chatboxes` sees upsell, not `ChatboxesTab`
- [ ] Team/Enterprise org can open `/chatboxes`
- [ ] Compare table shows 100 / 5,000 iter. cap for Free / Team
- [ ] `npm test -- BillingUpsellGate ChatboxesRoute billing-compare compare-plan-marketing`



### Billing table reworked

[Screen Recording 2026-05-29 at 8.27.18 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2cd0f510-14cc-4b52-bda8-6db37ef8fb5d.mov" />](https://app.graphite.com/user-attachments/video/2cd0f510-14cc-4b52-bda8-6db37ef8fb5d.mov)



### Chatboxes gated to paid plans for now simply

![Screenshot 2026-05-29 at 7.49.02 PM.png](https://app.graphite.com/user-attachments/assets/1100dd4a-cc1d-4c1b-9fac-8ca10088603c.png)