### PR TITLE
chore: changeset for @mcpjam/inspector 2.8.0

### DIFF
--- a/.changeset/release-inspector-2-8-0.md
+++ b/.changeset/release-inspector-2-8-0.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Inspector updates:
+
+- Tighten request-header handling for stdio and HTTP server connections
+- Allow the HTTP transport for bring-your-own-key servers
+- Freeze the evals suite execution snapshot on a plain rerun
+- Fix a dark-mode color that fell back incorrectly in local mode
+- Billing table refresh and team-based gating updates


### PR DESCRIPTION
## TL;DR

Adds a changeset to unblock the next `release.yml` run. Batches 8 unreleased commits that landed since the 2.7.0 release.

## Changeset

- **Package:** `@mcpjam/inspector`
- **Bump:** minor — `2.7.0 → 2.8.0`
- **`sdk` / `cli`:** no bump (zero source changes since 2.7.0)

## Included commits

| SHA | Description |
|---|---|
| `bca408e` | Gate chatboxes on team and refresh billing table |
| `c11fc5c` | Tighten request-header handling for stdio and HTTP |
| `3d7d38f` | Allow HTTP transport for BYOK servers |
| `b901fe1` | Codex/CLI config active-project wiring |
| `9067128` | Fix dark-mode color falling back incorrectly |
| `3947c42` | Freeze evals suite execution snapshot on plain rerun |
| `49abfdc` | Playground refactor (internal rename) |
| `2eb179d` | Nit |

## After merge

1. `deploy-staging.yml` auto-runs on the new main SHA.
2. Wait for staging green.
3. Soundcheck → `scope=full`, `promote_production=ON`, `skip_verify=OFF` → **Run release →**