### PR TITLE
Drop unreachable rate-limit branch in useCreditTopup

### DIFF
--- a/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
@@ -238,26 +238,10 @@ export function useCreditTopup() {
         });
         clearPendingTopup();
 
-        // Re-shape known server-side rate-limit responses into a friendlier,
-        // bounded user message. The dialog's existing toast displays
-        // `error.message` verbatim, so re-throwing a sanitized Error is
-        // enough to surface the right copy without double-toasting.
-        let surfaced: unknown = err;
-        if (
-          err instanceof Error &&
-          err.message.includes("Too many top-up attempts")
-        ) {
-          surfaced = new Error(
-            "You've hit the top-up rate limit. Try again in a few minutes.",
-          );
-        }
-
         const message =
-          surfaced instanceof Error
-            ? surfaced.message
-            : "Failed to start checkout";
+          err instanceof Error ? err.message : "Failed to start checkout";
         setError(message);
-        throw surfaced;
+        throw err;
       } finally {
         setIsStartingCheckout(false);
       }


### PR DESCRIPTION
## Summary

Remove an unreachable error-handling branch in `useCreditTopup` — the
matching server response shape no longer occurs, so the conditional and the
`surfaced` variable plumbing it required are dead code.

## Changes

- `mcpjam-inspector/client/src/hooks/useCreditTopup.ts` — drop the
  conditional and inline `err` through the existing message/setError/throw
  path.

## Verification

- Client typecheck clean (`client/tsconfig.typecheck.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)