### PR TITLE
chore: changeset for @mcpjam/inspector 2.8.1

### DIFF
--- a/.changeset/payment-history-status-badges.md
+++ b/.changeset/payment-history-status-badges.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Inspector updates:
+
+- Show refund and dispute status badges in the credit purchase history, with a hover detail for partial refunds


### PR DESCRIPTION
## Summary

- Bundles the unreleased fixes since 2.8.0 into a patch changeset so the release workflow can cut 2.8.1 ahead of the upcoming deploy.

## Included since 2.8.0

- #2323 — refund/dispute status badges in top-up payment history
- #2324 — drop unreachable rate-limit branch in `useCreditTopup` (internal cleanup; not user-visible, so not called out in the release note)

## Test plan

- [ ] CI passes
- [ ] On merge, the `version packages` PR opens with a `2.8.1` bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)