### PR TITLE
Fix reveal headers auth preservation

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -149,7 +149,7 @@ describe("useServerForm", () => {
     );
   });
 
-  it("sends a replacement header patch after stored headers are revealed", async () => {
+  it("keeps revealed Bearer Authorization as a custom header without changing auth type", async () => {
     const server = {
       name: "Revealed header server",
       config: {
@@ -173,7 +173,57 @@ describe("useServerForm", () => {
         Authorization: "Bearer old-token",
         "X-Api-Key": "secret",
       });
-      result.current.setBearerToken("new-token");
+    });
+
+    expect(result.current.authType).toBe("none");
+    expect(result.current.bearerToken).toBe("");
+    expect(result.current.customHeaders).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "Authorization",
+          value: "Bearer old-token",
+        }),
+        expect.objectContaining({ key: "X-Api-Key", value: "secret" }),
+      ])
+    );
+    expect(result.current.validateForm()).toBeNull();
+    expect(result.current.buildFormData()).toMatchObject({
+      headers: {
+        Authorization: "Bearer old-token",
+        "X-Api-Key": "secret",
+      },
+    });
+    expect(result.current.buildFormData().secretPatch?.headers).toBeUndefined();
+  });
+
+  it("sends a replacement header patch after revealed headers are edited", async () => {
+    const server = {
+      name: "Edited revealed header server",
+      config: {
+        url: "https://example.com/mcp",
+      },
+      hasHeaders: true,
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+      enabled: true,
+    } as any;
+
+    const { result } = renderHook(() => useServerForm(server));
+
+    await waitFor(() => {
+      expect(result.current.hasStoredHeaders).toBe(true);
+    });
+
+    act(() => {
+      result.current.revealStoredHeaders({
+        Authorization: "Bearer old-token",
+        "X-Api-Key": "secret",
+      });
+    });
+
+    act(() => {
+      result.current.updateCustomHeader(0, "value", "Bearer new-token");
     });
 
     expect(result.current.validateForm()).toBeNull();
@@ -216,7 +266,10 @@ describe("useServerForm", () => {
     expect(result.current.authType).toBe("none");
     expect(result.current.customHeaders).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ key: "Authorization", value: "Basic abc123" }),
+        expect.objectContaining({
+          key: "Authorization",
+          value: "Basic abc123",
+        }),
         expect.objectContaining({ key: "X-Api-Key", value: "secret" }),
       ])
     );

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -554,19 +554,9 @@ export function useServerForm(
     headers: Record<string, string> | null | undefined
   ) => {
     const nextHeaders = headers ?? {};
-    const authorization = getAuthorizationHeaderValue(nextHeaders);
-    const nextCustomHeaders = Object.entries(nextHeaders)
-      .filter(([key]) => !isAuthorizationHeader(key))
-      .map(([key, value]) => createHeaderEntry(key, String(value)));
-    const isBearerAuthorization =
-      authorization?.toLowerCase().startsWith("bearer ") === true;
-    if (isBearerAuthorization) {
-      setAuthType("bearer");
-      setBearerToken(authorization!.slice("bearer ".length));
-      setShowAuthSettings(true);
-    } else if (authorization) {
-      nextCustomHeaders.push(createHeaderEntry("Authorization", authorization));
-    }
+    const nextCustomHeaders = Object.entries(nextHeaders).map(([key, value]) =>
+      createHeaderEntry(key, String(value))
+    );
     setCustomHeaders(nextCustomHeaders);
     setHasStoredHeaders(false);
     setHeadersRevealed(true);
@@ -575,12 +565,6 @@ export function useServerForm(
     if (initialValues.current) {
       initialValues.current = {
         ...initialValues.current,
-        authType: isBearerAuthorization
-          ? "bearer"
-          : initialValues.current.authType,
-        bearerToken: isBearerAuthorization
-          ? authorization!.slice("bearer ".length)
-          : initialValues.current.bearerToken,
         hasStoredHeaders: false,
         customHeaders: nextCustomHeaders.map(({ key, value }) => ({
           key,


### PR DESCRIPTION
### Motivation
- Revealing stored HTTP headers incorrectly converted `Authorization: Bearer …` into the form's bearer auth mode, changing `authType` and `bearerToken` and risking accidental auth mutations when users simply reveal headers.

### Description
- Update `revealStoredHeaders` in `client/src/components/connection/hooks/use-server-form.ts` to restore revealed headers into the custom headers list without switching the form to bearer auth or mutating `bearerToken`.
- Remove logic that parsed `Authorization: Bearer …` into the form auth state and adjust the `initialValues` snapshot to reflect the preserved custom headers instead.
- Add/modify tests in `client/src/components/connection/hooks/__tests__/use-server-form.test.ts` to cover that revealing preserved a Bearer `Authorization` header as a normal custom header and that editing revealed headers produces a `secretPatch` replacement as expected.

### Testing
- Ran `npm test -- --run client/src/components/connection/hooks/__tests__/use-server-form.test.ts` and the targeted Vitest suite passed (`19 tests` all green).
- Ran `npm run typecheck:client` and TypeScript typechecking completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b94507c6c832bb956c4b3a6f8a4c3)