### PR TITLE
evals: tool snapshot v2 capture (mirrors backend server-inspections)

### DIFF
--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -25,6 +25,7 @@ import {
   MCP_UI_RESOURCE_MIME_TYPE,
 } from "@mcpjam/sdk/browser";
 import { Switch } from "@mcpjam/design-system/switch";
+import { hostConfigField } from "@/lib/host-config-field-schema";
 import { clientAdvertisesMcpApps, isRecord } from "@/lib/host-capabilities";
 import type { HostAttentionIssue, SandboxConfigSubKey } from "../types";
 import { useJsonDraftBuffer } from "./useJsonDraftBuffer";
@@ -46,6 +47,15 @@ interface AppsExtensionTabProps {
    * is in place end-to-end so that landing is a one-file change.
    */
   focusSubKey?: SandboxConfigSubKey;
+  /**
+   * When true, the tab renders all controls disabled. Threaded as
+   * `disabled` onto the surrounding fieldset, which bubbles to every
+   * form control inside (capability-matrix switches, sub-toggles, etc.)
+   * and as the JsonEditor's own `readOnly` prop. Phase 3 can refine
+   * individual write-only buttons if any leak through; today no caller
+   * passes `readOnly={true}` so this is a prep-only addition.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -998,6 +1008,9 @@ function OpenaiAppsCapabilityMatrix({
     });
   };
 
+  // Shared with the cross-host comparison matrix via the field schema.
+  const fInjectShim = hostConfigField("compatRuntime.openaiApps");
+
   return (
     <div className="rounded-[10px] border border-border bg-background">
       <div className="flex items-stretch border-b border-border">
@@ -1010,7 +1023,7 @@ function OpenaiAppsCapabilityMatrix({
         >
           <div className="flex flex-col gap-0.5">
             <span className="text-[12px] font-medium">
-              Inject <span className="font-mono">window.openai</span>
+              {fInjectShim.label}
             </span>
           </div>
           <ChevronDown
@@ -1024,7 +1037,7 @@ function OpenaiAppsCapabilityMatrix({
             id="apps-extension-openai-toggle"
             checked={injected}
             onCheckedChange={setInjected}
-            aria-label="Inject window.openai"
+            aria-label={fInjectShim.label}
           />
         </div>
       </div>
@@ -1856,12 +1869,14 @@ export function AppsExtensionTab({
   draft,
   onDraftChange,
   focusSubKey: _focusSubKey,
+  readOnly = false,
 }: AppsExtensionTabProps) {
   // _focusSubKey is intentionally unused — see prop doc. Destructured so
   // the prop appears in TS signature checks and the linter doesn't warn
   // about an undeclared prop on the call site.
   void _focusSubKey;
   const [jsonMode, setJsonMode] = useState<JsonEditorMode>("edit");
+  const effectiveJsonMode: JsonEditorMode = readOnly ? "view" : jsonMode;
   const { content, onRawChange } = useJsonDraftBuffer({
     draft,
     serialize: appsToJson,
@@ -1870,26 +1885,33 @@ export function AppsExtensionTab({
   });
 
   return (
-    <div className="flex h-full min-h-[480px] flex-col gap-3">
-      <OpenaiAppsCapabilityMatrix draft={draft} onDraftChange={onDraftChange} />
-      {/* Two-matrix architecture: window.openai (shim) and app.* (spec
-          bridge) are independent surfaces and never cross-gate. The
-          subtitle on each section makes this explicit so users don't
-          confuse them. */}
-      <McpAppsCapabilityMatrix draft={draft} onDraftChange={onDraftChange} />
-      <div className="min-h-0 flex-1">
-        <JsonEditor
-          rawContent={content}
-          onRawChange={onRawChange}
-          mode={jsonMode}
-          onModeChange={setJsonMode}
-          showModeToggle
-          showToolbar
-          showLineNumbers
-          autoFormatOnEdit={false}
-          height="100%"
-        />
+    // `fieldset[disabled] + display:contents` bulk-disables every form
+    // control inside without changing layout. JsonEditor gets `readOnly`
+    // threaded explicitly because its editor surface isn't a form
+    // control fieldset can reach.
+    <fieldset disabled={readOnly} className="contents">
+      <div className="flex h-full min-h-[480px] flex-col gap-3">
+        <OpenaiAppsCapabilityMatrix draft={draft} onDraftChange={onDraftChange} />
+        {/* Two-matrix architecture: window.openai (shim) and app.* (spec
+            bridge) are independent surfaces and never cross-gate. The
+            subtitle on each section makes this explicit so users don't
+            confuse them. */}
+        <McpAppsCapabilityMatrix draft={draft} onDraftChange={onDraftChange} />
+        <div className="min-h-0 flex-1">
+          <JsonEditor
+            rawContent={content}
+            onRawChange={onRawChange}
+            mode={effectiveJsonMode}
+            onModeChange={readOnly ? undefined : setJsonMode}
+            showModeToggle={!readOnly}
+            showToolbar
+            showLineNumbers
+            autoFormatOnEdit={false}
+            height="100%"
+            readOnly={readOnly}
+          />
+        </div>
       </div>
-    </div>
+    </fieldset>
   );
 }

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/BehaviorTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/BehaviorTab.tsx
@@ -16,6 +16,7 @@ import {
   DEFAULT_TEMPERATURE_V2,
   type HostConfigInputV2,
 } from "@/lib/client-config-v2";
+import { hostConfigField } from "@/lib/host-config-field-schema";
 import { SUPPORTED_MODELS } from "@/shared/types";
 import { FieldRow, FocusBlock } from "./primitives";
 import { fieldsWithIssues } from "./useClientDraftValidation";
@@ -50,12 +51,20 @@ interface BehaviorTabProps {
     updater: (prev: HostConfigInputV2) => HostConfigInputV2,
   ) => void;
   attention: ReadonlyArray<HostAttentionIssue>;
+  /**
+   * When true, all controls render disabled. Used by the attachment
+   * editor when surfacing the client's profile in a context where the
+   * user shouldn't be editing it inline (edits flow through the owning
+   * Client surface instead).
+   */
+  readOnly?: boolean;
 }
 
 export function BehaviorTab({
   draft,
   onDraftChange,
   attention,
+  readOnly = false,
 }: BehaviorTabProps) {
   const issues = fieldsWithIssues(attention, "behavior");
   const reactId = useId();
@@ -75,18 +84,31 @@ export function BehaviorTab({
   const update = (patch: Partial<HostConfigInputV2>) =>
     onDraftChange((prev) => ({ ...prev, ...patch }));
 
+  // Labels and descriptions are sourced from the shared field schema so
+  // the focus tab and the cross-host comparison matrix stay in sync.
+  // Changing a label here would otherwise drift; lookups throw on a typo
+  // so renames fail loudly at the first render.
+  const fModel = hostConfigField("modelId");
+  const fTemp = hostConfigField("temperature");
+  const fApproval = hostConfigField("requireToolApproval");
+  const fVisibility = hostConfigField("respectToolVisibility");
+  const fProgressive = hostConfigField("progressiveToolDiscovery");
+  const fSystemPrompt = hostConfigField("systemPrompt");
+
   return (
     <div className="flex flex-col gap-4">
       <FocusBlock title="Model & sampling">
         <FieldRow
-          label="Model"
+          label={fModel.label}
+          description={fModel.description}
           control={
             <select
               id={`${reactId}-model`}
               value={draft.modelId}
               onChange={(e) => update({ modelId: e.target.value })}
+              disabled={readOnly}
               className={
-                "h-8 w-[260px] rounded-md border border-input bg-background px-2 text-[12px] " +
+                "h-8 w-[260px] rounded-md border border-input bg-background px-2 text-[12px] disabled:cursor-not-allowed disabled:opacity-60 " +
                 (issues.has("modelId") ? "border-amber-500" : "")
               }
             >
@@ -106,7 +128,7 @@ export function BehaviorTab({
 
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center justify-between">
-            <span className="text-[12px] font-medium">Temperature</span>
+            <span className="text-[12px] font-medium">{fTemp.label}</span>
             <span className="font-mono text-[11px] text-muted-foreground">
               {draft.temperature.toFixed(2)}
             </span>
@@ -121,32 +143,37 @@ export function BehaviorTab({
                 temperature: values[0] ?? DEFAULT_TEMPERATURE_V2,
               })
             }
-            aria-label="Temperature"
+            aria-label={fTemp.label}
+            disabled={readOnly}
           />
         </div>
 
         <FieldRow
-          label="Require tool approval"
+          label={fApproval.label}
+          description={fApproval.description}
           control={
             <Switch
               checked={draft.requireToolApproval}
               onCheckedChange={(checked) =>
                 update({ requireToolApproval: checked })
               }
-              aria-label="Require tool approval"
+              aria-label={fApproval.label}
+              disabled={readOnly}
             />
           }
         />
 
         <FieldRow
-          label="Respect tool visibility"
+          label={fVisibility.label}
+          description={fVisibility.description}
           control={
             <Switch
               checked={draft.respectToolVisibility}
               onCheckedChange={(checked) =>
                 update({ respectToolVisibility: checked })
               }
-              aria-label="Respect tool visibility"
+              aria-label={fVisibility.label}
+              disabled={readOnly}
             />
           }
         />
@@ -154,7 +181,7 @@ export function BehaviorTab({
         <FieldRow
           label={
             <span className="inline-flex items-center gap-1.5">
-              Progressive tools
+              {fProgressive.label}
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -203,6 +230,7 @@ export function BehaviorTab({
                 });
               }}
               aria-label="Progressive MCP tool discovery"
+              disabled={readOnly}
             >
               <ToggleGroupItem value="auto" aria-label="Auto (default)">
                 Auto
@@ -217,26 +245,15 @@ export function BehaviorTab({
           }
         />
 
-        <FieldRow
-          label="Respect tool visibility"
-          control={
-            <Switch
-              checked={draft.respectToolVisibility}
-              onCheckedChange={(checked) =>
-                update({ respectToolVisibility: checked })
-              }
-              aria-label="Respect tool visibility"
-            />
-          }
-        />
       </FocusBlock>
 
-      <FocusBlock title="System prompt">
+      <FocusBlock title={fSystemPrompt.label}>
         <Textarea
           rows={10}
           value={draft.systemPrompt}
           onChange={(e) => update({ systemPrompt: e.target.value })}
           placeholder="You are a helpful assistant…"
+          readOnly={readOnly}
           className={
             issues.has("systemPrompt") ? "border-amber-500/60" : undefined
           }

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/ProtocolTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { JsonEditor, type JsonEditorMode } from "@/components/ui/json-editor";
+import { hostConfigField } from "@/lib/host-config-field-schema";
 import {
   Select,
   SelectContent,
@@ -33,6 +34,11 @@ interface ProtocolTabProps {
     updater: (prev: HostConfigInputV2) => HostConfigInputV2
   ) => void;
   attention: ReadonlyArray<HostAttentionIssue>;
+  /**
+   * When true, the protocol-version dropdown and JSON editor render
+   * non-editable. See `BehaviorTab` for the same prop on its surface.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -253,8 +259,13 @@ function applyJsonToDraft(
   };
 }
 
-export function ProtocolTab({ draft, onDraftChange }: ProtocolTabProps) {
+export function ProtocolTab({
+  draft,
+  onDraftChange,
+  readOnly = false,
+}: ProtocolTabProps) {
   const [jsonMode, setJsonMode] = useState<JsonEditorMode>("edit");
+  const effectiveJsonMode: JsonEditorMode = readOnly ? "view" : jsonMode;
   const { content, onRawChange } = useJsonDraftBuffer({
     draft,
     serialize: protocolToJson,
@@ -294,6 +305,9 @@ export function ProtocolTab({ draft, onDraftChange }: ProtocolTabProps) {
     });
   };
 
+  // Shared with the cross-host comparison matrix via the field schema.
+  const fProtocolVersion = hostConfigField("mcpProtocolVersion");
+
   return (
     <div className="flex h-full min-h-[480px] flex-col gap-3">
       {statelessMcpEnabled ? (
@@ -303,13 +317,14 @@ export function ProtocolTab({ draft, onDraftChange }: ProtocolTabProps) {
               className="text-[12px] font-medium"
               title="Latest: current stable MCP wire version (2025-11-25). 2026 RC: MCPJam's current 2026-07-28 stateless preview over Streamable HTTP POST."
             >
-              Protocol version
+              {fProtocolVersion.label}
             </span>
             <Select
               value={selectedDropdownValue}
               onValueChange={(next) => {
                 setProtocolVersion(next === "rc" ? "2026-07-28" : undefined);
               }}
+              disabled={readOnly}
             >
               <SelectTrigger className="h-9 text-xs">
                 <SelectValue placeholder="Latest" />
@@ -329,13 +344,14 @@ export function ProtocolTab({ draft, onDraftChange }: ProtocolTabProps) {
         <JsonEditor
           rawContent={content}
           onRawChange={onRawChange}
-          mode={jsonMode}
-          onModeChange={setJsonMode}
-          showModeToggle
+          mode={effectiveJsonMode}
+          onModeChange={readOnly ? undefined : setJsonMode}
+          showModeToggle={!readOnly}
           showToolbar
           showLineNumbers
           autoFormatOnEdit={false}
           height="100%"
+          readOnly={readOnly}
         />
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/schema-coupling.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/schema-coupling.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import { hostConfigField } from "@/lib/host-config-field-schema";
+import { BehaviorTab } from "../BehaviorTab";
+
+/**
+ * Coupling test: the focus tabs read their labels and descriptions from
+ * the shared `host-config-field-schema`, not inline strings. If someone
+ * renames `temperature.label` in the schema, this test fails first and
+ * the tab catches up automatically — that's the contract being asserted.
+ *
+ * BehaviorTab is the proof of the pattern (most fields per tab). The
+ * minor ProtocolTab + AppsExtensionTab couplings are covered by the
+ * schema's `hostConfigField()` throw-on-typo guard at call site.
+ */
+describe("BehaviorTab consumes labels from the shared schema", () => {
+  function renderTab() {
+    render(
+      <BehaviorTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+      />,
+    );
+  }
+
+  it("renders the schema label for `temperature`", () => {
+    renderTab();
+    const label = hostConfigField("temperature").label;
+    expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+  });
+
+  it("renders the schema label for `requireToolApproval`", () => {
+    renderTab();
+    const label = hostConfigField("requireToolApproval").label;
+    expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+  });
+
+  it("renders the schema label for `respectToolVisibility`", () => {
+    renderTab();
+    const label = hostConfigField("respectToolVisibility").label;
+    expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+  });
+
+  it("renders the schema label for `progressiveToolDiscovery`", () => {
+    renderTab();
+    const label = hostConfigField("progressiveToolDiscovery").label;
+    expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+  });
+
+  it("renders the schema label for `systemPrompt` (FocusBlock title)", () => {
+    renderTab();
+    const label = hostConfigField("systemPrompt").label;
+    expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+  });
+
+  it("renders the schema description for `requireToolApproval`", () => {
+    renderTab();
+    const desc = hostConfigField("requireToolApproval").description!;
+    expect(screen.getAllByText(desc).length).toBeGreaterThan(0);
+  });
+});

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/tabs.readOnly.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/tabs.readOnly.test.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import { BehaviorTab } from "../BehaviorTab";
+import { ProtocolTab } from "../ProtocolTab";
+import { AppsExtensionTab } from "../AppsExtensionTab";
+
+/**
+ * Phase 2 of the per-attachment-server-selection plan adds a `readOnly`
+ * prop to each Client editor tab so the new AttachmentEditor (Phase 3)
+ * can surface the host's profile without letting users edit it inline.
+ *
+ * These tests are minimal — they verify the prop is wired and the most
+ * visible control on each tab respects it. Deeper readOnly behavior
+ * (capability-matrix sub-toggles, JSON view-mode forcing) gets exercised
+ * organically by ClientFocusPanel.test.tsx and downstream callers once
+ * Phase 3 sets readOnly={true} on a real surface.
+ */
+describe("Client editor tabs — readOnly prop wiring", () => {
+  it("BehaviorTab readOnly disables the model select", () => {
+    render(
+      <BehaviorTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+        readOnly
+      />,
+    );
+    const modelSelect = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(modelSelect).toBeDisabled();
+  });
+
+  it("BehaviorTab readOnly disables the system-prompt textarea", () => {
+    render(
+      <BehaviorTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+        readOnly
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(
+      "You are a helpful assistant…",
+    ) as HTMLTextAreaElement;
+    expect(textarea).toHaveAttribute("readonly");
+  });
+
+  it("BehaviorTab readOnly disables tool-approval and visibility switches", () => {
+    render(
+      <BehaviorTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+        readOnly
+      />,
+    );
+    const approval = screen.getByRole("switch", {
+      name: /require tool approval/i,
+    });
+    const visibility = screen.getAllByRole("switch", {
+      name: /respect tool visibility/i,
+    })[0];
+    expect(approval).toBeDisabled();
+    expect(visibility).toBeDisabled();
+  });
+
+  it("BehaviorTab without readOnly leaves controls enabled (sanity check)", () => {
+    render(
+      <BehaviorTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+      />,
+    );
+    const modelSelect = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(modelSelect).not.toBeDisabled();
+  });
+
+  it("AppsExtensionTab readOnly wraps the body in a disabled fieldset", () => {
+    const { container } = render(
+      <AppsExtensionTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+        readOnly
+      />,
+    );
+    const fieldset = container.querySelector("fieldset");
+    expect(fieldset).not.toBeNull();
+    expect(fieldset).toBeDisabled();
+  });
+
+  it("AppsExtensionTab without readOnly renders an enabled fieldset", () => {
+    const { container } = render(
+      <AppsExtensionTab
+        draft={emptyHostConfigInputV2()}
+        onDraftChange={vi.fn()}
+        attention={[]}
+      />,
+    );
+    const fieldset = container.querySelector("fieldset");
+    expect(fieldset).not.toBeNull();
+    expect(fieldset).not.toBeDisabled();
+  });
+
+  it("ProtocolTab accepts the readOnly prop without throwing", () => {
+    // ProtocolTab gates Select via `disabled` and forces JsonEditor to
+    // `mode="view"` + `readOnly={true}`. Direct interaction with the
+    // CodeMirror-backed JsonEditor is brittle in JSDOM, so this test
+    // verifies the prop wiring lands cleanly without asserting on the
+    // editor's internal state.
+    expect(() =>
+      render(
+        <ProtocolTab
+          draft={emptyHostConfigInputV2()}
+          onDraftChange={vi.fn()}
+          attention={[]}
+          readOnly
+        />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/iteration-result-presentation.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/iteration-result-presentation.test.ts
@@ -65,10 +65,9 @@ describe("getIterationResultBadgeClass", () => {
 });
 
 describe("suitePassCriteriaCompactBadgeClassNames", () => {
-  it("uses high-contrast destructive styling for failed suite outcome", () => {
+  it("uses rose styling for failed suite outcome", () => {
     const classes = suitePassCriteriaCompactBadgeClassNames("failed");
-    expect(classes).toContain("text-destructive");
-    expect(classes).toContain("border-destructive");
+    expect(classes).toContain("rose");
     expect(classes).toContain("text-[10px]");
   });
 

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -14,12 +14,19 @@ import { RESULT_STATUS } from "./constants";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 
 /**
- * Union of the suite's flat `environment.servers` and every attached
- * host's resolved server names. This is what "what servers can this suite
+ * Union of the suite's flat `environment.servers`, every attached host's
+ * resolved server names, AND the suite-level standalone server
+ * attachment (when present). This is what "what servers can this suite
  * see?" means in a host-aware world — generate, rerun-eligibility, and
- * any other "does this suite have any servers?" gates should consult this
- * instead of `environment.servers` alone, otherwise host-only suites
- * (created via `hostAttachments` with no flat list) read as empty.
+ * any other "does this suite have any servers?" gates should consult
+ * this instead of `environment.servers` alone, otherwise host-only or
+ * attachment-only suites read as empty.
+ *
+ * Standalone-attachment-only case: when the suite has a `serverAttachment`
+ * the per-host attachments carry empty `resolvedServerNames` because the
+ * standalone overrides per-host server picks at run-start. We must
+ * include the standalone's names here so eligibility doesn't gate "Run
+ * all" on a falsely-empty server list.
  */
 export function getEffectiveSuiteServers(
   // Accept a structurally narrower suite than the full `EvalSuite`: some
@@ -31,15 +38,21 @@ export function getEffectiveSuiteServers(
   suite: {
     environment?: { servers?: string[] } | undefined;
     hostAttachments?: EvalSuite["hostAttachments"];
+    serverAttachment?: EvalSuite["serverAttachment"];
   },
 ): string[] {
   const flatServers = suite.environment?.servers ?? [];
-  const attachmentServers =
+  const hostAttachmentServers =
     suite.hostAttachments?.flatMap(
       (attachment) => attachment.resolvedServerNames ?? [],
     ) ?? [];
-  if (attachmentServers.length === 0) return flatServers;
-  return Array.from(new Set([...flatServers, ...attachmentServers]));
+  const standaloneServers = suite.serverAttachment?.resolvedServerNames ?? [];
+  if (hostAttachmentServers.length === 0 && standaloneServers.length === 0) {
+    return flatServers;
+  }
+  return Array.from(
+    new Set([...flatServers, ...hostAttachmentServers, ...standaloneServers]),
+  );
 }
 
 export function formatTime(ts?: number) {

--- a/mcpjam-inspector/client/src/components/evals/iteration-result-presentation.ts
+++ b/mcpjam-inspector/client/src/components/evals/iteration-result-presentation.ts
@@ -19,8 +19,7 @@ export function suitePassCriteriaCompactBadgeClassNames(
     outcome === "passed"
       ? "bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300"
       : outcome === "failed"
-        ? // Use semantic destructive tokens + border so suite outcome reads at a glance next to KPIs.
-          "border border-destructive/35 bg-destructive/10 font-bold text-destructive shadow-sm dark:border-destructive/45 dark:bg-destructive/20"
+        ? "bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300"
         : "bg-amber-500/15 text-amber-700 dark:bg-amber-400/20 dark:text-amber-300";
 
   return cn(ITERATION_RESULT_BADGE_BASE, colorClass);

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -69,6 +69,24 @@ export type EvalSuite = {
     hostName: string | null;
     resolvedServerNames: string[];
   }>;
+  /**
+   * Snapshot pointer to a `serverAttachment` row of scope 'standalone'
+   * — a named, project-scoped, frozen server selection. When present,
+   * the suite's run-time resolver uses the row's `selectedServerIds`
+   * for ALL attached hosts (bypassing per-attachment server picks).
+   * Editing the project pool does NOT propagate; to change the
+   * selection, create a new attachment and re-point the suite.
+   */
+  serverAttachmentId?: string;
+  /** Hydrated by the backend resolver when serverAttachmentId is set. */
+  serverAttachment?: EvalServerAttachment;
+};
+
+export type EvalServerAttachment = {
+  _id: string;
+  name: string;
+  serverIds: string[];
+  resolvedServerNames: string[];
 };
 
 export type EvalCase = {
@@ -285,7 +303,7 @@ export type EvalSuiteRun = {
       summary: string;
     }>;
   };
-  serverQualityJobId?: number;
+  serverQualityJobId?: string;
   serverQualityStatus?: "pending" | "completed" | "failed";
   serverQuality?: {
     summary: string;
@@ -296,6 +314,16 @@ export type EvalSuiteRun = {
       rating: "good" | "needs_improvement" | "poor";
       issues: string[];
       suggestions: string[];
+      /** Arcade pattern slug the violation maps to. Allowlist-validated server-side. */
+      patternSlug?: string;
+      /** PR-B auditability metadata (optional; populated by the judge). */
+      evidence?: string[];
+      confidence?: "low" | "medium" | "high";
+      attribution?:
+        | "server_design"
+        | "agent_behavior"
+        | "test_design"
+        | "unknown";
     }>;
     workflowInsights: Array<{
       caseKey: string;
@@ -305,8 +333,128 @@ export type EvalSuiteRun = {
       efficiency: "optimal" | "acceptable" | "inefficient" | "excessive";
       issues: string[];
       suggestions: string[];
+      /** Arcade pattern slug the violation maps to. Allowlist-validated server-side. */
+      patternSlug?: string;
+      /** PR-B auditability metadata (optional; populated by the judge). */
+      evidence?: string[];
+      confidence?: "low" | "medium" | "high";
+      attribution?:
+        | "server_design"
+        | "agent_behavior"
+        | "test_design"
+        | "unknown";
     }>;
   };
+};
+
+export type EvalRunNumericDiff = {
+  base: number | null;
+  compare: number | null;
+  delta: number | null;
+  percentDelta: number | null;
+};
+
+export type EvalRunTextPreview = {
+  text: string;
+  truncated: boolean;
+};
+
+export type EvalRunDiffCaseStatus =
+  | "unchanged_passed"
+  | "unchanged_failed"
+  | "regressed"
+  | "fixed"
+  | "new_case"
+  | "removed_case"
+  | "changed";
+
+export type EvalRunDiffSide = {
+  outcome: "passed" | "failed" | "absent";
+  iterationIds: string[];
+  representativeIterationId: string | null;
+  traceBlobIds: string[];
+  input: EvalRunTextPreview | null;
+  output: EvalRunTextPreview | null;
+  expectedToolCalls: Array<{
+    toolName: string;
+    arguments: unknown;
+  }>;
+  actualToolCalls: Array<{
+    toolName: string;
+    arguments: unknown;
+  }>;
+  error: string | null;
+  metrics: {
+    durationMs: number | null;
+    totalTokens: number | null;
+    inputTokens: number | null;
+    outputTokens: number | null;
+    cachedInputTokens: number | null;
+    reasoningTokens: number | null;
+    estimatedCostUsd: number | null;
+  };
+};
+
+export type EvalRunDiff = {
+  suite: {
+    id: string;
+    name: string;
+    source?: "ui" | "sdk";
+  };
+  baseRun: {
+    id: string;
+    runNumber: number;
+    source: "ui" | "sdk" | null;
+    framework: string | null;
+    createdAt: number;
+    completedAt: number | null;
+    result?: "pending" | "passed" | "failed" | "cancelled";
+    summary: EvalSuiteRunSummary | null;
+  };
+  compareRun: {
+    id: string;
+    runNumber: number;
+    source: "ui" | "sdk" | null;
+    framework: string | null;
+    createdAt: number;
+    completedAt: number | null;
+    result?: "pending" | "passed" | "failed" | "cancelled";
+    summary: EvalSuiteRunSummary | null;
+  };
+  metrics: {
+    startOffsetMs: EvalRunNumericDiff;
+    wallDurationMs: EvalRunNumericDiff;
+    totalTokens: EvalRunNumericDiff;
+    inputTokens: EvalRunNumericDiff;
+    outputTokens: EvalRunNumericDiff;
+    cachedInputTokens: EvalRunNumericDiff;
+    reasoningTokens: EvalRunNumericDiff;
+    estimatedCostUsd: EvalRunNumericDiff;
+  };
+  scores: {
+    passRatePercent: EvalRunNumericDiff;
+    total: EvalRunNumericDiff;
+    passed: EvalRunNumericDiff;
+    failed: EvalRunNumericDiff;
+  };
+  cases: Array<{
+    caseKey: string;
+    title: string;
+    testCaseId: string | null;
+    status: EvalRunDiffCaseStatus;
+    configChanged: boolean;
+    base: EvalRunDiffSide;
+    compare: EvalRunDiffSide;
+    metrics: {
+      durationMs: EvalRunNumericDiff;
+      totalTokens: EvalRunNumericDiff;
+      inputTokens: EvalRunNumericDiff;
+      outputTokens: EvalRunNumericDiff;
+      cachedInputTokens: EvalRunNumericDiff;
+      reasoningTokens: EvalRunNumericDiff;
+      estimatedCostUsd: EvalRunNumericDiff;
+    };
+  }>;
 };
 
 export type EvalRefinementSession = {

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -355,7 +355,13 @@ export function useEvalHandlers({
       const modelApiKeys: Record<string, string> = {};
 
       return {
-        suiteServers: normalizeSuiteServerRefs(suite.environment?.servers),
+        // Effective server list: union of legacy `environment.servers`,
+        // per-host attachment picks, AND the suite's standalone server
+        // attachment (when set). The runner fallback in
+        // `runEvals.serverIds` reads this, so an attachment-only suite
+        // would otherwise send `serverIds: []` and fail the backend's
+        // `min(1)` validation with HTTP 400.
+        suiteServers: normalizeSuiteServerRefs(getEffectiveSuiteServers(suite)),
         testCases,
         tests,
         modelApiKeys,

--- a/mcpjam-inspector/client/src/lib/__tests__/eval-route-url.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/eval-route-url.test.ts
@@ -22,7 +22,7 @@ describe("eval-route-url", () => {
       view: "runs",
     });
     expect(
-      parseEvalRouteFromUrl("/evals", "/evals/suite/s_123", "?view=runs"),
+      parseEvalRouteFromUrl("/evals", "/evals/suite/s_123", "?view=runs")
     ).toEqual({
       type: "suite-overview",
       suiteId: "s_123",
@@ -32,13 +32,20 @@ describe("eval-route-url", () => {
       parseEvalRouteFromUrl(
         "/evals",
         "/evals/suite/s_123",
-        "?view=test-cases&fromCommit=abc123",
-      ),
+        "?view=test-cases&fromCommit=abc123"
+      )
     ).toEqual({
       type: "suite-overview",
       suiteId: "s_123",
       view: "test-cases",
       fromCommit: "abc123",
+    });
+    expect(
+      parseEvalRouteFromUrl("/evals", "/evals/suite/s_123", "?view=cross-host")
+    ).toEqual({
+      type: "suite-overview",
+      suiteId: "s_123",
+      view: "cross-host",
     });
   });
 
@@ -50,14 +57,14 @@ describe("eval-route-url", () => {
         type: "suite-overview",
         suiteId: "s_abc",
         view: "executions",
-      }),
+      })
     ).toBe("/evals/suite/s_abc?view=executions");
     expect(
       buildEvalsPath({
         type: "suite-overview",
         suiteId: "s_abc",
         fromCommit: "manual-xyz",
-      }),
+      })
     ).toBe("/evals/suite/s_abc?fromCommit=manual-xyz");
   });
 
@@ -66,14 +73,27 @@ describe("eval-route-url", () => {
       parseEvalRouteFromUrl(
         "/evals",
         "/evals/suite/s_123/runs/r_456",
-        "?iteration=i_1&insights=1",
-      ),
+        "?iteration=i_1&insights=1"
+      )
     ).toEqual({
       type: "run-detail",
       suiteId: "s_123",
       runId: "r_456",
       iteration: "i_1",
       insightsFocus: true,
+    });
+    expect(
+      parseEvalRouteFromUrl(
+        "/evals",
+        "/evals/suite/s_123/runs/r_456",
+        "?compareTo=r_123"
+      )
+    ).toEqual({
+      type: "run-detail",
+      suiteId: "s_123",
+      runId: "r_456",
+      iteration: undefined,
+      compareToRunId: "r_123",
     });
   });
 
@@ -85,8 +105,11 @@ describe("eval-route-url", () => {
         runId: "r_def",
         iteration: "i_3",
         insightsFocus: true,
-      }),
-    ).toBe("/evals/suite/s_abc/runs/r_def?iteration=i_3&insights=1");
+        compareToRunId: "r_base",
+      })
+    ).toBe(
+      "/evals/suite/s_abc/runs/r_def?iteration=i_3&insights=1&compareTo=r_base"
+    );
   });
 
   it("parses test detail, test edit, and suite edit routes", () => {
@@ -94,8 +117,8 @@ describe("eval-route-url", () => {
       parseEvalRouteFromUrl(
         "/evals",
         "/evals/suite/s_123/test/t_789",
-        "?iteration=i_2",
-      ),
+        "?iteration=i_2"
+      )
     ).toEqual({
       type: "test-detail",
       suiteId: "s_123",
@@ -103,10 +126,7 @@ describe("eval-route-url", () => {
       iteration: "i_2",
     });
     expect(
-      parseEvalRouteFromUrl(
-        "/evals",
-        "/evals/suite/s_123/test/t_789/edit",
-      ),
+      parseEvalRouteFromUrl("/evals", "/evals/suite/s_123/test/t_789/edit")
     ).toEqual({
       type: "test-edit",
       suiteId: "s_123",
@@ -116,8 +136,8 @@ describe("eval-route-url", () => {
       parseEvalRouteFromUrl(
         "/evals",
         "/evals/suite/s_123/test/t_789/edit",
-        "?compare=1",
-      ),
+        "?compare=1"
+      )
     ).toEqual({
       type: "test-edit",
       suiteId: "s_123",
@@ -128,8 +148,8 @@ describe("eval-route-url", () => {
       parseEvalRouteFromUrl(
         "/evals",
         "/evals/suite/s_123/test/t_789/edit",
-        "?compare=true&iteration=i_42",
-      ),
+        "?compare=true&iteration=i_42"
+      )
     ).toEqual({
       type: "test-edit",
       suiteId: "s_123",
@@ -137,9 +157,7 @@ describe("eval-route-url", () => {
       openCompare: true,
       iteration: "i_42",
     });
-    expect(
-      parseEvalRouteFromUrl("/evals", "/evals/suite/s_123/edit"),
-    ).toEqual({
+    expect(parseEvalRouteFromUrl("/evals", "/evals/suite/s_123/edit")).toEqual({
       type: "suite-edit",
       suiteId: "s_123",
     });
@@ -153,7 +171,7 @@ describe("eval-route-url", () => {
         testId: "t_def",
         openCompare: true,
         iteration: "i_42",
-      }),
+      })
     ).toBe("/evals/suite/s_abc/test/t_def/edit?compare=1&iteration=i_42");
   });
 
@@ -162,8 +180,8 @@ describe("eval-route-url", () => {
       parseEvalRouteFromUrl(
         "/ci-evals",
         "/ci-evals/commit/abc1234567890",
-        "?suite=s_abc&iteration=i_4",
-      ),
+        "?suite=s_abc&iteration=i_4"
+      )
     ).toEqual({
       type: "commit-detail",
       commitSha: "abc1234567890",
@@ -179,7 +197,7 @@ describe("eval-route-url", () => {
         commitSha: "abc1234567890",
         suite: "s_abc",
         iteration: "i_4",
-      }),
+      })
     ).toBe("/ci-evals/commit/abc1234567890?suite=s_abc&iteration=i_4");
     expect(
       buildCiEvalsPath({
@@ -187,10 +205,8 @@ describe("eval-route-url", () => {
         suiteId: "s_abc",
         view: "test-cases",
         fromCommit: "sha9abcdef",
-      }),
-    ).toBe(
-      "/ci-evals/suite/s_abc?view=test-cases&fromCommit=sha9abcdef",
-    );
+      })
+    ).toBe("/ci-evals/suite/s_abc?view=test-cases&fromCommit=sha9abcdef");
   });
 
   it("parses ci eval suite drill-down paths", () => {
@@ -198,8 +214,8 @@ describe("eval-route-url", () => {
       parseEvalRouteFromUrl(
         "/ci-evals",
         "/ci-evals/suite/s_123/test/t_789/edit",
-        "?compare=1",
-      ),
+        "?compare=1"
+      )
     ).toEqual({
       type: "test-edit",
       suiteId: "s_123",
@@ -209,17 +225,12 @@ describe("eval-route-url", () => {
   });
 
   it("returns null outside the requested prefix", () => {
-    expect(
-      parseEvalRouteFromUrl("/ci-evals", "/evals/suite/s_123"),
-    ).toBeNull();
+    expect(parseEvalRouteFromUrl("/ci-evals", "/evals/suite/s_123")).toBeNull();
   });
 
   it("decodes path params", () => {
     expect(
-      parseEvalRouteFromUrl(
-        "/evals",
-        "/evals/suite/suite%20one/test/case%202",
-      ),
+      parseEvalRouteFromUrl("/evals", "/evals/suite/suite%20one/test/case%202")
     ).toEqual({
       type: "test-detail",
       suiteId: "suite one",

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-field-schema.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-field-schema.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+import {
+  fieldDiverges,
+  groupHostConfigFields,
+  hostConfigField,
+  HOST_CONFIG_FIELDS,
+  HOST_CONFIG_SECTIONS,
+  type HostConfigFieldDef,
+} from "@/lib/host-config-field-schema";
+
+function makeConfig(overrides: Partial<HostConfigDtoV2> = {}): HostConfigDtoV2 {
+  return {
+    id: "hc_test",
+    schemaVersion: 2,
+    hostStyle: "mcpjam",
+    modelId: "claude-sonnet-4-6",
+    systemPrompt: "You are a helpful assistant.",
+    temperature: 0.2,
+    requireToolApproval: false,
+    respectToolVisibility: true,
+    serverIds: [],
+    optionalServerIds: [],
+    connectionDefaults: { headers: {}, requestTimeout: 60_000 },
+    clientCapabilities: {},
+    hostContext: {},
+    ...overrides,
+  } as HostConfigDtoV2;
+}
+
+function fieldById(id: string): HostConfigFieldDef {
+  const f = HOST_CONFIG_FIELDS.find((x) => x.id === id);
+  if (!f) throw new Error(`field ${id} not registered`);
+  return f;
+}
+
+describe("HOST_CONFIG_SECTIONS", () => {
+  it("mirrors the three focus-dialog tabs in order", () => {
+    expect(HOST_CONFIG_SECTIONS.map((s) => s.id)).toEqual([
+      "agent",
+      "protocol",
+      "apps",
+    ]);
+  });
+});
+
+describe("HOST_CONFIG_FIELDS labels", () => {
+  it("every registered field has a non-empty user-friendly label", () => {
+    // Regression guard: focus tabs and the matrix both read `field.label`
+    // — a blank entry would render as an empty row label in both surfaces.
+    for (const f of HOST_CONFIG_FIELDS) {
+      expect(f.label, `field ${f.id} missing label`).toBeTruthy();
+      expect(f.label.length, `field ${f.id} label is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("field ids are unique (lookup by id is unambiguous)", () => {
+    const ids = HOST_CONFIG_FIELDS.map((f) => f.id);
+    const dupes = ids.filter((id, idx) => ids.indexOf(id) !== idx);
+    expect(dupes).toEqual([]);
+  });
+});
+
+describe("hostConfigField()", () => {
+  it("returns the registered definition by id", () => {
+    const f = hostConfigField("temperature");
+    expect(f.id).toBe("temperature");
+    expect(f.label).toBe("Temperature");
+  });
+
+  it("throws on an unknown id so renames fail loudly at the call site", () => {
+    expect(() => hostConfigField("does-not-exist")).toThrow(
+      /unknown field id/i,
+    );
+  });
+});
+
+describe("groupHostConfigFields", () => {
+  it("groups every field under its declared section", () => {
+    const groups = groupHostConfigFields();
+    const totalFields = groups.reduce(
+      (acc, g) => acc + g.subsections.reduce((a, s) => a + s.fields.length, 0),
+      0,
+    );
+    expect(totalFields).toBe(HOST_CONFIG_FIELDS.length);
+  });
+
+  it("preserves the order fields appear in the registry within each subsection", () => {
+    const agent = groupHostConfigFields().find((g) => g.section.id === "agent")!;
+    const modelSampling = agent.subsections.find(
+      (s) => s.label === "Model & sampling",
+    );
+    expect(modelSampling).toBeTruthy();
+    expect(modelSampling!.fields.map((f) => f.id)).toEqual([
+      "modelId",
+      "temperature",
+      "requireToolApproval",
+      "respectToolVisibility",
+      "progressiveToolDiscovery",
+    ]);
+  });
+});
+
+describe("fieldDiverges", () => {
+  it("returns false for a single host (nothing to compare)", () => {
+    expect(fieldDiverges(fieldById("modelId"), [makeConfig()])).toBe(false);
+  });
+
+  it("returns false when every host has the same scalar value", () => {
+    const a = makeConfig({ temperature: 0.2 });
+    const b = makeConfig({ temperature: 0.2 });
+    expect(fieldDiverges(fieldById("temperature"), [a, b])).toBe(false);
+  });
+
+  it("returns true when scalar values differ", () => {
+    const a = makeConfig({ temperature: 0.2 });
+    const b = makeConfig({ temperature: 0.7 });
+    expect(fieldDiverges(fieldById("temperature"), [a, b])).toBe(true);
+  });
+
+  it("treats undefined and an absent field as the same value", () => {
+    // progressiveToolDiscovery is tri-state; undefined === undefined
+    const a = makeConfig();
+    const b = makeConfig();
+    expect(fieldDiverges(fieldById("progressiveToolDiscovery"), [a, b])).toBe(
+      false,
+    );
+  });
+
+  it("treats undefined as distinct from explicit false (preserves tri-state)", () => {
+    // The matrix renders these differently (auto vs off), so the gutter
+    // must light up. Regression guard against a future canonicalizer that
+    // coerces undefined → false.
+    const auto = makeConfig({ progressiveToolDiscovery: undefined });
+    const off = makeConfig({ progressiveToolDiscovery: false });
+    expect(fieldDiverges(fieldById("progressiveToolDiscovery"), [auto, off]))
+      .toBe(true);
+  });
+
+  it("compares nested object values by stable canonical form", () => {
+    // Same keys, different declaration order — should NOT diverge.
+    const a = makeConfig({
+      connectionDefaults: {
+        headers: { "X-A": "1", "X-B": "2" },
+        requestTimeout: 60_000,
+      },
+    });
+    const b = makeConfig({
+      connectionDefaults: {
+        headers: { "X-B": "2", "X-A": "1" },
+        requestTimeout: 60_000,
+      },
+    });
+    expect(fieldDiverges(fieldById("connectionDefaults.headers"), [a, b]))
+      .toBe(false);
+  });
+
+  it("flags divergence on a nested mcpProfile field across hosts", () => {
+    const a = makeConfig({
+      mcpProfile: {
+        profileVersion: 1,
+        mcpProtocolVersion: "2025-11-25",
+      },
+    });
+    const b = makeConfig({
+      mcpProfile: {
+        profileVersion: 1,
+        mcpProtocolVersion: "2026-07-28",
+      },
+    });
+    expect(fieldDiverges(fieldById("mcpProtocolVersion"), [a, b])).toBe(true);
+  });
+
+  it("coerces respectToolVisibility undefined → true so pre-feature rows don't show as diverging from a row that explicitly set true", () => {
+    const preFeature = makeConfig({ respectToolVisibility: undefined });
+    const explicitTrue = makeConfig({ respectToolVisibility: true });
+    expect(fieldDiverges(fieldById("respectToolVisibility"), [preFeature, explicitTrue]))
+      .toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -8,10 +8,7 @@
  * (`#chatbox-slug`) are NOT app navigation and are preserved verbatim.
  */
 import { useCallback, useContext, useLayoutEffect, useState } from "react";
-import {
-  UNSAFE_LocationContext,
-  UNSAFE_NavigationContext,
-} from "react-router";
+import { UNSAFE_LocationContext, UNSAFE_NavigationContext } from "react-router";
 import { getAppRouter } from "../router-ref";
 import type { EvalRoute } from "./eval-route-types";
 import {
@@ -28,6 +25,7 @@ export const routePaths = {
   home: "/home",
   servers: "/servers",
   clients: "/clients",
+  hostCompare: "/host-compare",
   registry: "/registry",
   tools: "/tools",
   resources: "/resources",
@@ -65,7 +63,7 @@ export function buildClientsPath(hostId?: string | null): string {
 /** Build a path for a specific organization route. */
 export function buildOrganizationPath(
   orgId: string,
-  section?: OrganizationRouteSection,
+  section?: OrganizationRouteSection
 ): string {
   if (section === "billing") return `/organizations/${orgId}/billing`;
   if (section === "models") return `/organizations/${orgId}/models`;
@@ -83,7 +81,10 @@ export function buildCiEvalsPath(route: EvalRoute): string {
   return buildEvalRoutePath("/ci-evals", route);
 }
 
-function buildEvalRoutePath(prefix: "/evals" | "/ci-evals", route: EvalRoute): string {
+function buildEvalRoutePath(
+  prefix: "/evals" | "/ci-evals",
+  route: EvalRoute
+): string {
   switch (route.type) {
     case "list":
       return prefix;
@@ -94,27 +95,38 @@ function buildEvalRoutePath(prefix: "/evals" | "/ci-evals", route: EvalRoute): s
       if (route.view && route.view !== "runs") params.set("view", route.view);
       if (route.fromCommit) params.set("fromCommit", route.fromCommit);
       const query = params.toString();
-      return `${prefix}/suite/${encodeURIComponent(route.suiteId)}${query ? `?${query}` : ""}`;
+      return `${prefix}/suite/${encodeURIComponent(route.suiteId)}${
+        query ? `?${query}` : ""
+      }`;
     }
     case "run-detail": {
       const params = new URLSearchParams();
       if (route.iteration) params.set("iteration", route.iteration);
       if (route.insightsFocus) params.set("insights", "1");
+      if (route.compareToRunId) params.set("compareTo", route.compareToRunId);
       const query = params.toString();
-      return `${prefix}/suite/${encodeURIComponent(route.suiteId)}/runs/${encodeURIComponent(route.runId)}${query ? `?${query}` : ""}`;
+      return `${prefix}/suite/${encodeURIComponent(
+        route.suiteId
+      )}/runs/${encodeURIComponent(route.runId)}${query ? `?${query}` : ""}`;
     }
     case "test-detail": {
       const params = new URLSearchParams();
       if (route.iteration) params.set("iteration", route.iteration);
       const query = params.toString();
-      return `${prefix}/suite/${encodeURIComponent(route.suiteId)}/test/${encodeURIComponent(route.testId)}${query ? `?${query}` : ""}`;
+      return `${prefix}/suite/${encodeURIComponent(
+        route.suiteId
+      )}/test/${encodeURIComponent(route.testId)}${query ? `?${query}` : ""}`;
     }
     case "test-edit": {
       const params = new URLSearchParams();
       if (route.openCompare) params.set("compare", "1");
       if (route.iteration) params.set("iteration", route.iteration);
       const query = params.toString();
-      return `${prefix}/suite/${encodeURIComponent(route.suiteId)}/test/${encodeURIComponent(route.testId)}/edit${query ? `?${query}` : ""}`;
+      return `${prefix}/suite/${encodeURIComponent(
+        route.suiteId
+      )}/test/${encodeURIComponent(route.testId)}/edit${
+        query ? `?${query}` : ""
+      }`;
     }
     case "suite-edit":
       return `${prefix}/suite/${encodeURIComponent(route.suiteId)}/edit`;
@@ -124,7 +136,9 @@ function buildEvalRoutePath(prefix: "/evals" | "/ci-evals", route: EvalRoute): s
       if (route.suite) params.set("suite", route.suite);
       if (route.iteration) params.set("iteration", route.iteration);
       const query = params.toString();
-      return `/ci-evals/commit/${encodeURIComponent(route.commitSha)}${query ? `?${query}` : ""}`;
+      return `/ci-evals/commit/${encodeURIComponent(route.commitSha)}${
+        query ? `?${query}` : ""
+      }`;
     }
   }
 }
@@ -177,7 +191,7 @@ export function useAppNavigate() {
       }
       navigateApp(to, options);
     },
-    [navigator],
+    [navigator]
   );
 }
 
@@ -191,7 +205,7 @@ export function useAppNavigate() {
 export function useActiveTab(): string {
   const locationContext = useContext(UNSAFE_LocationContext);
   const [fallbackPathname, setFallbackPathname] = useState(
-    getWindowFallbackPathname,
+    getWindowFallbackPathname
   );
 
   useLayoutEffect(() => {
@@ -214,6 +228,10 @@ const KNOWN_APP_TAB_SEGMENTS = new Set<string>([
   ...HOSTED_HASH_BLOCKED_TABS,
   "chat",
   "home",
+  // Top-level cross-host config comparison surface. Distinct first segment
+  // from "clients" so the sidebar's first-segment isActive resolution
+  // doesn't light up Connect when this is the active route.
+  "host-compare",
 ]);
 
 function isSpecialEntryPathname(pathname: string): boolean {
@@ -259,8 +277,8 @@ export function useCurrentOrgRoute(): CurrentOrgRoute | null {
     sectionSegment === "billing"
       ? "billing"
       : sectionSegment === "models"
-        ? "models"
-        : "overview";
+      ? "models"
+      : "overview";
   return { orgId: decodePathSegment(orgId), orgSection };
 }
 
@@ -274,7 +292,7 @@ function decodePathSegment(segment: string): string {
 
 export function navigationTargetToPath(
   rawTarget: string,
-  fallback: string = routePaths.servers,
+  fallback: string = routePaths.servers
 ): string {
   const stripped = rawTarget.replace(/^#/, "").replace(/^\/+/, "");
   const questionIndex = stripped.indexOf("?");
@@ -311,7 +329,7 @@ export function normalizeInitialLegacyHashBookmark(): void {
 
 export function normalizeReturnTargetPath(
   target?: string | null,
-  fallback: string = routePaths.servers,
+  fallback: string = routePaths.servers
 ): string {
   const trimmed = target?.trim() ?? "";
   if (!trimmed) return fallback;

--- a/mcpjam-inspector/client/src/lib/eval-route-types.ts
+++ b/mcpjam-inspector/client/src/lib/eval-route-types.ts
@@ -1,4 +1,8 @@
-export type SuiteOverviewView = "runs" | "test-cases" | "executions";
+export type SuiteOverviewView =
+  | "runs"
+  | "test-cases"
+  | "executions"
+  | "cross-host";
 
 /**
  * Unified eval hash routes for Playground (`#/evals`) and CI/CD (`#/ci-evals`).
@@ -21,6 +25,7 @@ export type EvalRoute =
       runId: string;
       iteration?: string;
       insightsFocus?: boolean;
+      compareToRunId?: string;
     }
   | { type: "test-detail"; suiteId: string; testId: string; iteration?: string }
   | {

--- a/mcpjam-inspector/client/src/lib/eval-route-url.ts
+++ b/mcpjam-inspector/client/src/lib/eval-route-url.ts
@@ -7,7 +7,7 @@ export type EvalRoutePrefix = "/evals" | "/ci-evals";
 export function parseEvalRouteFromUrl(
   prefix: EvalRoutePrefix,
   pathname: string,
-  search = "",
+  search = ""
 ): EvalRoute | null {
   const normalizedPathname = pathname.startsWith("/")
     ? pathname
@@ -20,7 +20,7 @@ export function parseEvalRouteFromUrl(
   }
 
   const params = new URLSearchParams(
-    search.startsWith("?") ? search : search ? `?${search}` : "",
+    search.startsWith("?") ? search : search ? `?${search}` : ""
   );
   const segments = normalizedPathname.replace(/^\/+/, "").split("/");
   const routeRoot = prefix.replace(/^\/+/, "");
@@ -73,6 +73,9 @@ export function parseEvalRouteFromUrl(
       runId: decodePathSegment(rest[1]),
       iteration: params.get("iteration") || undefined,
       ...(insightsFocus ? { insightsFocus: true } : {}),
+      ...(params.get("compareTo")
+        ? { compareToRunId: params.get("compareTo") || undefined }
+        : {}),
     };
   }
 
@@ -116,7 +119,7 @@ export function useEvalRouteFromUrl(prefix: EvalRoutePrefix): EvalRoute {
 
   return useMemo(
     () => parseEvalRouteFromUrl(prefix, pathname, search) ?? { type: "list" },
-    [prefix, pathname, search],
+    [prefix, pathname, search]
   );
 }
 
@@ -129,7 +132,11 @@ export function useCiEvalsRouteFromUrl(): EvalRoute {
 }
 
 function parseSuiteOverviewView(value: string | null): SuiteOverviewView {
-  return value === "test-cases" || value === "executions" ? value : "runs";
+  return value === "test-cases" ||
+    value === "executions" ||
+    value === "cross-host"
+    ? value
+    : "runs";
 }
 
 function parseTruthyParam(value: string | null): boolean {

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -1,0 +1,538 @@
+/**
+ * Shared metadata for every user-meaningful field on `HostConfigDtoV2`.
+ *
+ * Single source of truth for the host-config comparison matrix
+ * (`/clients/compare`). Drives section order, subsection grouping, field
+ * labels, descriptions, dotted paths, and value extraction. Focus tabs
+ * (`BehaviorTab`, `ProtocolTab`, `AppsExtensionTab`) currently maintain
+ * their own labels/descriptions inline; they can adopt entries from this
+ * schema incrementally without changing their editor logic — start with
+ * the description strings, then the paths.
+ */
+
+import type {
+  HostConfigDtoV2,
+  HostStyleId,
+  McpProtocolVersion,
+} from "@/lib/client-config-v2";
+
+export type HostConfigSectionId = "agent" | "protocol" | "apps";
+
+export interface HostConfigSection {
+  id: HostConfigSectionId;
+  /** Display label — matches `client-focus-tab-defs.tsx`. */
+  label: string;
+  /** Sub-line shown next to the section title in the matrix header band. */
+  subtitle: string;
+}
+
+export const HOST_CONFIG_SECTIONS: ReadonlyArray<HostConfigSection> = [
+  {
+    id: "agent",
+    label: "Agent",
+    subtitle: "model · sampling · system prompt",
+  },
+  {
+    id: "protocol",
+    label: "MCP Protocol",
+    subtitle: "version · clientInfo · capabilities · connection",
+  },
+  {
+    id: "apps",
+    label: "Apps",
+    subtitle: "SEP-1865 advertise · compat shim · sandbox",
+  },
+];
+
+/**
+ * Discriminated render hint. The matrix translates this into a pill
+ * variant; the comparator uses it to know how to test for equality
+ * (numbers compare by ===, JSON objects compare by stable stringify).
+ */
+export type HostConfigFieldKind =
+  | { kind: "boolean" }
+  /** `true | false | undefined` where undefined = "host decides". */
+  | { kind: "tri-state" }
+  | { kind: "number" }
+  /** Number rendered as `60,000 ms`. */
+  | { kind: "duration-ms" }
+  | { kind: "enum"; options?: ReadonlyArray<string> }
+  /** Short string rendered inline. */
+  | { kind: "string" }
+  /** Long string (system prompt). Matrix shows first-line preview + char count. */
+  | { kind: "string-long" }
+  | { kind: "string-array" }
+  /** Object/Record. Matrix shows `N keys ›` summary; click to expand. */
+  | { kind: "object"; itemNoun?: string };
+
+export interface HostConfigFieldDef {
+  /** Stable id; used as React key and in tests. */
+  id: string;
+  section: HostConfigSectionId;
+  /** Within-section grouping label shown as a thin row above its fields. */
+  subsection: string;
+  /**
+   * User-friendly label. This is the primary label both the matrix and the
+   * focus tabs display to users — keep it short ("Model", "Temperature",
+   * "Require tool approval"). Source of truth: editing here updates both
+   * surfaces.
+   */
+  label: string;
+  /** Dotted path against `HostConfigDtoV2` — schema identifier for tests and tooling. */
+  path: string;
+  /** User-friendly description; one short sentence. Optional. */
+  description?: string;
+  kind: HostConfigFieldKind;
+  /**
+   * Extract the field's value from a hydrated DTO. May return `undefined`
+   * if the field is absent — the matrix renders that as `—`.
+   */
+  read: (cfg: HostConfigDtoV2) => unknown;
+}
+
+const mcpProfile = (cfg: HostConfigDtoV2) => cfg.mcpProfile;
+
+export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
+  // ============================================================
+  // Agent · Model & sampling
+  // ============================================================
+  {
+    id: "modelId",
+    section: "agent",
+    subsection: "Model & sampling",
+    label: "Model",
+    path: "modelId",
+    description: "LLM the host runs the agent on.",
+    kind: { kind: "string" },
+    read: (cfg) => cfg.modelId,
+  },
+  {
+    id: "temperature",
+    section: "agent",
+    subsection: "Model & sampling",
+    label: "Temperature",
+    path: "temperature",
+    description: "0–1 sampling temperature.",
+    kind: { kind: "number" },
+    read: (cfg) => cfg.temperature,
+  },
+  {
+    id: "requireToolApproval",
+    section: "agent",
+    subsection: "Model & sampling",
+    label: "Require tool approval",
+    path: "requireToolApproval",
+    description: "Prompts the user before each tool call.",
+    kind: { kind: "boolean" },
+    read: (cfg) => cfg.requireToolApproval,
+  },
+  {
+    id: "respectToolVisibility",
+    section: "agent",
+    subsection: "Model & sampling",
+    label: "Respect tool visibility",
+    path: "respectToolVisibility",
+    description: "SEP-1865 `_meta.ui.visibility` filter.",
+    kind: { kind: "boolean" },
+    // Pre-feature rows omit the field; `hostConfigDtoToInput` coerces it
+    // to `true`, but the raw DTO can still carry `undefined`. Coerce here
+    // so the matrix shows the resolved value, not "—".
+    read: (cfg) => cfg.respectToolVisibility ?? true,
+  },
+  {
+    id: "progressiveToolDiscovery",
+    section: "agent",
+    subsection: "Model & sampling",
+    label: "Progressive tools",
+    path: "progressiveToolDiscovery",
+    description:
+      "search_mcp_tools / load_mcp_tools meta-tools above context thresholds. Undefined = host decides.",
+    kind: { kind: "tri-state" },
+    read: (cfg) => cfg.progressiveToolDiscovery,
+  },
+
+  // ============================================================
+  // Agent · System prompt
+  // ============================================================
+  {
+    id: "systemPrompt",
+    section: "agent",
+    subsection: "System prompt",
+    label: "System prompt",
+    path: "systemPrompt",
+    description: "Verbatim system prompt sent on every turn.",
+    kind: { kind: "string-long" },
+    read: (cfg) => cfg.systemPrompt,
+  },
+
+  // ============================================================
+  // Protocol · Version
+  // ============================================================
+  {
+    id: "mcpProtocolVersion",
+    section: "protocol",
+    subsection: "Version",
+    label: "Protocol version",
+    path: "mcpProfile.mcpProtocolVersion",
+    description:
+      "Host default pin. Per-server overrides win. Undefined = SDK chooses at request time.",
+    kind: {
+      kind: "enum",
+      options: [
+        "2025-03-26",
+        "2025-06-18",
+        "2025-11-25",
+        "2026-07-28",
+      ] as ReadonlyArray<McpProtocolVersion>,
+    },
+    read: (cfg) => mcpProfile(cfg)?.mcpProtocolVersion,
+  },
+  {
+    id: "supportedProtocolVersions",
+    section: "protocol",
+    subsection: "Version",
+    label: "Supported protocol versions",
+    path: "mcpProfile.initialize.supportedProtocolVersions",
+    description: "Accept-list advertised in the initialize handshake.",
+    kind: { kind: "string-array" },
+    read: (cfg) => mcpProfile(cfg)?.initialize?.supportedProtocolVersions,
+  },
+
+  // ============================================================
+  // Protocol · clientInfo
+  // ============================================================
+  {
+    id: "clientInfo.name",
+    section: "protocol",
+    subsection: "clientInfo",
+    label: "Client name",
+    path: "mcpProfile.initialize.clientInfo.name",
+    description: "`initialize.clientInfo.name` sent to the server.",
+    kind: { kind: "string" },
+    read: (cfg) => {
+      const info = mcpProfile(cfg)?.initialize?.clientInfo;
+      return typeof info?.name === "string" ? info.name : undefined;
+    },
+  },
+  {
+    id: "clientInfo.version",
+    section: "protocol",
+    subsection: "clientInfo",
+    label: "Client version",
+    path: "mcpProfile.initialize.clientInfo.version",
+    description: "`initialize.clientInfo.version` sent to the server.",
+    kind: { kind: "string" },
+    read: (cfg) => {
+      const info = mcpProfile(cfg)?.initialize?.clientInfo;
+      return typeof info?.version === "string" ? info.version : undefined;
+    },
+  },
+
+  // ============================================================
+  // Protocol · Client capabilities advertised
+  // ============================================================
+  {
+    id: "capabilities.roots",
+    section: "protocol",
+    subsection: "Client capabilities advertised",
+    label: "Roots",
+    path: "clientCapabilities.roots",
+    description: "Filesystem roots exposed to the server.",
+    kind: { kind: "object", itemNoun: "key" },
+    read: (cfg) => cfg.clientCapabilities?.roots,
+  },
+  {
+    id: "capabilities.sampling",
+    section: "protocol",
+    subsection: "Client capabilities advertised",
+    label: "Sampling",
+    path: "clientCapabilities.sampling",
+    description: "Server-initiated LLM calls.",
+    kind: { kind: "object", itemNoun: "key" },
+    read: (cfg) => cfg.clientCapabilities?.sampling,
+  },
+  {
+    id: "capabilities.elicitation",
+    section: "protocol",
+    subsection: "Client capabilities advertised",
+    label: "Elicitation",
+    path: "clientCapabilities.elicitation",
+    description: "Mid-call structured prompts back to the user.",
+    kind: { kind: "object", itemNoun: "key" },
+    read: (cfg) => cfg.clientCapabilities?.elicitation,
+  },
+  {
+    id: "capabilities.experimental",
+    section: "protocol",
+    subsection: "Client capabilities advertised",
+    label: "Experimental",
+    path: "clientCapabilities.experimental",
+    description: "Vendor-extension capabilities.",
+    kind: { kind: "object", itemNoun: "key" },
+    read: (cfg) => cfg.clientCapabilities?.experimental,
+  },
+
+  // ============================================================
+  // Protocol · Connection defaults
+  // ============================================================
+  {
+    id: "connectionDefaults.requestTimeout",
+    section: "protocol",
+    subsection: "Connection defaults",
+    label: "Request timeout",
+    path: "connectionDefaults.requestTimeout",
+    description: "Outbound MCP request timeout.",
+    kind: { kind: "duration-ms" },
+    read: (cfg) => cfg.connectionDefaults?.requestTimeout,
+  },
+  {
+    id: "connectionDefaults.headers",
+    section: "protocol",
+    subsection: "Connection defaults",
+    label: "Default headers",
+    path: "connectionDefaults.headers",
+    description: "Default outbound headers (Authorization, etc.).",
+    kind: { kind: "object", itemNoun: "header" },
+    read: (cfg) => cfg.connectionDefaults?.headers,
+  },
+
+  // ============================================================
+  // Apps · Advertise
+  // ============================================================
+  {
+    id: "hostCapabilitiesOverride",
+    section: "apps",
+    subsection: "Advertise & capability",
+    label: "Host capabilities override",
+    path: "hostCapabilitiesOverride",
+    description:
+      "User override on SEP-1865 hostCapabilities. Absent = use the hostStyle preset.",
+    kind: { kind: "object", itemNoun: "field" },
+    read: (cfg) => cfg.hostCapabilitiesOverride,
+  },
+
+  // ============================================================
+  // Apps · OpenAI compat shim
+  // ============================================================
+  {
+    id: "compatRuntime.openaiApps",
+    section: "apps",
+    subsection: "OpenAI compat shim",
+    label: "Inject window.openai",
+    path: "mcpProfile.apps.compatRuntime.openaiApps",
+    description:
+      "Inject the `window.openai` Apps-SDK shim. Undefined = use hostStyle preset.",
+    kind: { kind: "tri-state" },
+    read: (cfg) => mcpProfile(cfg)?.apps?.compatRuntime?.openaiApps,
+  },
+  {
+    id: "compatRuntime.openaiAppsOverrides",
+    section: "apps",
+    subsection: "OpenAI compat shim",
+    label: "Shim method overrides",
+    path: "mcpProfile.apps.compatRuntime.openaiAppsOverrides",
+    description: "Sparse per-method overrides on the shim surface.",
+    kind: { kind: "object", itemNoun: "method" },
+    read: (cfg) => mcpProfile(cfg)?.apps?.compatRuntime?.openaiAppsOverrides,
+  },
+
+  // ============================================================
+  // Apps · MCP Apps spec-bridge overrides
+  // ============================================================
+  {
+    id: "mcpAppsOverrides",
+    section: "apps",
+    subsection: "MCP Apps spec bridge",
+    label: "Spec-bridge overrides",
+    path: "mcpProfile.apps.mcpAppsOverrides",
+    description: "Sparse per-dimension overrides on the SEP-1865 capability matrix.",
+    kind: { kind: "object", itemNoun: "dimension" },
+    read: (cfg) => mcpProfile(cfg)?.apps?.mcpAppsOverrides,
+  },
+  {
+    id: "uiInitialize.hostInfo",
+    section: "apps",
+    subsection: "MCP Apps spec bridge",
+    label: "ui/initialize hostInfo",
+    path: "mcpProfile.apps.uiInitialize.hostInfo",
+    description: "Override the `hostInfo` advertised in `ui/initialize`.",
+    kind: { kind: "object", itemNoun: "field" },
+    read: (cfg) => mcpProfile(cfg)?.apps?.uiInitialize?.hostInfo,
+  },
+
+  // ============================================================
+  // Apps · Sandbox
+  // ============================================================
+  {
+    id: "sandbox.csp.mode",
+    section: "apps",
+    subsection: "Sandbox",
+    label: "CSP mode",
+    path: "mcpProfile.apps.sandbox.csp.mode",
+    description: "Starting CSP baseline for app iframes.",
+    kind: {
+      kind: "enum",
+      options: ["host-default", "declared", "relaxed"] as const,
+    },
+    read: (cfg) => mcpProfile(cfg)?.apps?.sandbox?.csp?.mode,
+  },
+  {
+    id: "sandbox.permissions.mode",
+    section: "apps",
+    subsection: "Sandbox",
+    label: "Permissions mode",
+    path: "mcpProfile.apps.sandbox.permissions.mode",
+    description: "How spec permissions resolve in the iframe sandbox.",
+    kind: {
+      kind: "enum",
+      options: ["resource-declared", "deny-all", "custom"] as const,
+    },
+    read: (cfg) => mcpProfile(cfg)?.apps?.sandbox?.permissions?.mode,
+  },
+  {
+    id: "sandbox.permissions.allow",
+    section: "apps",
+    subsection: "Sandbox",
+    label: "Permissions allow-list",
+    path: "mcpProfile.apps.sandbox.permissions.allow",
+    description: "Per-permission allow flags (camera, microphone, etc.).",
+    kind: { kind: "object", itemNoun: "permission" },
+    read: (cfg) => mcpProfile(cfg)?.apps?.sandbox?.permissions?.allow,
+  },
+  {
+    id: "sandbox.sandboxAttrs",
+    section: "apps",
+    subsection: "Sandbox",
+    label: "Sandbox attrs",
+    path: "mcpProfile.apps.sandbox.sandboxAttrs",
+    description:
+      "Extra iframe `sandbox=` tokens unioned with `allow-scripts allow-same-origin`.",
+    kind: { kind: "string-array" },
+    read: (cfg) => mcpProfile(cfg)?.apps?.sandbox?.sandboxAttrs,
+  },
+  {
+    id: "sandbox.allowFeatures",
+    section: "apps",
+    subsection: "Sandbox",
+    label: "Permissions Policy features",
+    path: "mcpProfile.apps.sandbox.allowFeatures",
+    description: "Permissions Policy entries appended to the outer iframe.",
+    kind: { kind: "object", itemNoun: "feature" },
+    read: (cfg) => mcpProfile(cfg)?.apps?.sandbox?.allowFeatures,
+  },
+];
+
+// ============================================================
+// Field-id lookup (for focus tabs to consume labels/descriptions)
+// ============================================================
+
+/**
+ * Map of field id → field def for O(1) lookup. Built lazily so the array
+ * stays the canonical declaration order; the map is purely a convenience
+ * for the focus tab consumers.
+ */
+const fieldById = new Map(HOST_CONFIG_FIELDS.map((f) => [f.id, f]));
+
+/**
+ * Look up a field by id. Throws if the id isn't registered — focus tabs
+ * pass static literal ids, so a typo should fail loudly at the first
+ * render in dev rather than silently miss the rename.
+ */
+export function hostConfigField(id: string): HostConfigFieldDef {
+  const f = fieldById.get(id);
+  if (!f) {
+    throw new Error(
+      `hostConfigField: unknown field id "${id}". ` +
+        `Did you rename it in host-config-field-schema.ts without updating callers?`,
+    );
+  }
+  return f;
+}
+
+// ============================================================
+// Comparison helpers
+// ============================================================
+
+/**
+ * Stable JSON canonicalizer for equality checks. Sorts object keys
+ * recursively; arrays preserve order. Matches the backend's notion of
+ * "same config" closely enough for the matrix's diverge gutter — but is
+ * NOT the same function as `canonicalizeHostConfigV2` (we don't care
+ * about dedupe-grade canonicality here, only stable comparison).
+ */
+function stableStringify(value: unknown): string {
+  if (value === undefined) return "__undef__";
+  if (value === null) return "null";
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return `{${keys
+    .map(
+      (k) =>
+        `${JSON.stringify(k)}:${stableStringify(
+          (value as Record<string, unknown>)[k],
+        )}`,
+    )
+    .join(",")}}`;
+}
+
+/** True when at least two hosts disagree on this field's value. */
+export function fieldDiverges(
+  field: HostConfigFieldDef,
+  hosts: ReadonlyArray<HostConfigDtoV2>,
+): boolean {
+  if (hosts.length < 2) return false;
+  const first = stableStringify(field.read(hosts[0]));
+  for (let i = 1; i < hosts.length; i += 1) {
+    if (stableStringify(field.read(hosts[i])) !== first) return true;
+  }
+  return false;
+}
+
+/** Convenience: an ordered { sectionId, subsection, fields[] } grouping. */
+export interface HostConfigFieldGroup {
+  section: HostConfigSection;
+  subsections: ReadonlyArray<{
+    label: string;
+    fields: ReadonlyArray<HostConfigFieldDef>;
+  }>;
+}
+
+export function groupHostConfigFields(
+  fields: ReadonlyArray<HostConfigFieldDef> = HOST_CONFIG_FIELDS,
+): ReadonlyArray<HostConfigFieldGroup> {
+  return HOST_CONFIG_SECTIONS.map((section) => {
+    const fieldsForSection = fields.filter((f) => f.section === section.id);
+    const subsectionOrder: string[] = [];
+    const bySubsection = new Map<string, HostConfigFieldDef[]>();
+    for (const f of fieldsForSection) {
+      if (!bySubsection.has(f.subsection)) {
+        subsectionOrder.push(f.subsection);
+        bySubsection.set(f.subsection, []);
+      }
+      bySubsection.get(f.subsection)!.push(f);
+    }
+    return {
+      section,
+      subsections: subsectionOrder.map((label) => ({
+        label,
+        fields: bySubsection.get(label)!,
+      })),
+    };
+  });
+}
+
+// ============================================================
+// Comparison subject — what the matrix actually consumes
+// ============================================================
+
+export interface HostComparisonSubject {
+  hostId: string;
+  hostName: string;
+  hostStyle: HostStyleId;
+  /** Short suffix of the hostConfigId — shown as `·a3f9d2` under the name. */
+  configHashShort: string;
+  config: HostConfigDtoV2;
+}

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -10,6 +10,7 @@ export const HOSTED_SIDEBAR_ALLOWED_TABS = [
   "home",
   "clients",
   "servers",
+  "host-compare",
   "registry",
   "chatboxes",
   "playground",

--- a/mcpjam-inspector/server/routes/web/servers.ts
+++ b/mcpjam-inspector/server/routes/web/servers.ts
@@ -23,6 +23,7 @@ import {
   exportSingleServerForInspection,
   type ServerToolSnapshot,
 } from "../../utils/export-helpers.js";
+import { getInspectorClientRuntimeConfig } from "../../env.js";
 import { logger } from "../../utils/logger.js";
 
 const servers = new Hono();
@@ -67,7 +68,10 @@ async function persistHostedConnectInspection(
   c: any,
   args: { projectId: string; snapshot: ServerToolSnapshot },
 ): Promise<void> {
-  const convexUrl = process.env.CONVEX_URL;
+  // Only `CONVEX_HTTP_URL` is boot-enforced; the convex-client URL is
+  // derived from it (suffix swap) by the runtime config helper so that
+  // production env (which sets only CONVEX_HTTP_URL) works.
+  const { convexUrl } = getInspectorClientRuntimeConfig();
   if (!convexUrl) return;
   const bearer = c.req.header("authorization");
   if (!bearer) return;

--- a/mcpjam-inspector/server/routes/web/servers.ts
+++ b/mcpjam-inspector/server/routes/web/servers.ts
@@ -19,7 +19,10 @@ import {
   createHostedRpcLogCollector,
 } from "./hosted-rpc-logs.js";
 import { buildConnectSuccessEnvelope } from "../../utils/local-server-resolver.js";
-import { exportSingleServerForInspection } from "../../utils/export-helpers.js";
+import {
+  exportSingleServerForInspection,
+  type ServerToolSnapshot,
+} from "../../utils/export-helpers.js";
 import { logger } from "../../utils/logger.js";
 
 const servers = new Hono();
@@ -30,13 +33,21 @@ servers.post("/validate", async (c) =>
     projectServerSchema,
     async (manager, body) => {
       await manager.getToolsForAiSdk([body.serverId]);
-      // Fire-and-forget: persist a connect-time inspection snapshot so the
-      // backend's `serverInspections` table picks up reconnect-time changes
-      // (port of PR #1731's `use-inspection-coordinator`). Failures here
-      // never affect the validate response.
-      void recordHostedConnectInspection(c, manager, {
+      // Capture the inspection snapshot synchronously while the ephemeral
+      // manager is still live — `withManager`'s `finally` will call
+      // `disconnectAllServers()` the moment we return, which would race any
+      // `listTools` we left pending here. Only the Convex write is
+      // fire-and-forget, so persistence failures still don't affect the
+      // validate response. (Port of PR #1731's `use-inspection-coordinator`.)
+      const snapshot = await exportSingleServerForInspection(
+        manager,
+        body.serverId,
+        body.serverId,
+        { logPrefix: "hosted-connect-inspection" },
+      );
+      void persistHostedConnectInspection(c, {
         projectId: body.projectId,
-        serverId: body.serverId,
+        snapshot,
       }).catch((error) => {
         logger.debug("Failed to persist hosted connect-time inspection", {
           serverId: body.serverId,
@@ -52,26 +63,19 @@ servers.post("/validate", async (c) =>
   )
 );
 
-async function recordHostedConnectInspection(
+async function persistHostedConnectInspection(
   c: any,
-  manager: any,
-  args: { projectId: string; serverId: string },
+  args: { projectId: string; snapshot: ServerToolSnapshot },
 ): Promise<void> {
   const convexUrl = process.env.CONVEX_URL;
   if (!convexUrl) return;
   const bearer = c.req.header("authorization");
   if (!bearer) return;
-  const snapshot = await exportSingleServerForInspection(
-    manager,
-    args.serverId,
-    args.serverId,
-    { logPrefix: "hosted-connect-inspection" },
-  );
   const client = new ConvexHttpClient(convexUrl);
   client.setAuth(bearer.replace(/^Bearer\s+/i, ""));
   await client.mutation("serverInspections:recordFromConnect" as any, {
     projectId: args.projectId,
-    snapshot,
+    snapshot: args.snapshot,
   });
 }
 

--- a/mcpjam-inspector/server/routes/web/servers.ts
+++ b/mcpjam-inspector/server/routes/web/servers.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { runServerDoctor } from "@mcpjam/sdk";
+import { ConvexHttpClient } from "convex/browser";
 import { WEB_CONNECT_TIMEOUT_MS } from "../../config.js";
 import {
   mapRuntimeError,
@@ -18,6 +19,8 @@ import {
   createHostedRpcLogCollector,
 } from "./hosted-rpc-logs.js";
 import { buildConnectSuccessEnvelope } from "../../utils/local-server-resolver.js";
+import { exportSingleServerForInspection } from "../../utils/export-helpers.js";
+import { logger } from "../../utils/logger.js";
 
 const servers = new Hono();
 
@@ -27,6 +30,19 @@ servers.post("/validate", async (c) =>
     projectServerSchema,
     async (manager, body) => {
       await manager.getToolsForAiSdk([body.serverId]);
+      // Fire-and-forget: persist a connect-time inspection snapshot so the
+      // backend's `serverInspections` table picks up reconnect-time changes
+      // (port of PR #1731's `use-inspection-coordinator`). Failures here
+      // never affect the validate response.
+      void recordHostedConnectInspection(c, manager, {
+        projectId: body.projectId,
+        serverId: body.serverId,
+      }).catch((error) => {
+        logger.debug("Failed to persist hosted connect-time inspection", {
+          serverId: body.serverId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
       // Same success envelope as the local /api/mcp/connect path so the
       // inspector client's `storeInitInfo` takes one code path on both
       // surfaces and we don't drift on the success shape.
@@ -35,6 +51,29 @@ servers.post("/validate", async (c) =>
     { timeoutMs: WEB_CONNECT_TIMEOUT_MS }
   )
 );
+
+async function recordHostedConnectInspection(
+  c: any,
+  manager: any,
+  args: { projectId: string; serverId: string },
+): Promise<void> {
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl) return;
+  const bearer = c.req.header("authorization");
+  if (!bearer) return;
+  const snapshot = await exportSingleServerForInspection(
+    manager,
+    args.serverId,
+    args.serverId,
+    { logPrefix: "hosted-connect-inspection" },
+  );
+  const client = new ConvexHttpClient(convexUrl);
+  client.setAuth(bearer.replace(/^Bearer\s+/i, ""));
+  await client.mutation("serverInspections:recordFromConnect" as any, {
+    projectId: args.projectId,
+    snapshot,
+  });
+}
 
 servers.post("/check-oauth", async (c) =>
   handleRoute(c, async () => {

--- a/mcpjam-inspector/server/utils/__tests__/export-helpers.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/export-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   exportConnectedServerToolSnapshotForEvalAuthoring,
   exportServer,
   renderServerToolSnapshotSection,
+  SERVER_TOOL_SNAPSHOT_VERSION,
 } from "../export-helpers.js";
 
 function createMockManager(overrides: Record<string, any> = {}) {
@@ -207,7 +208,7 @@ describe("exportConnectedServerToolSnapshotForEvalAuthoring", () => {
     );
 
     expect(snapshot).toEqual({
-      version: 1,
+      version: SERVER_TOOL_SNAPSHOT_VERSION,
       capturedAt: expect.any(Number),
       servers: [
         {
@@ -290,6 +291,94 @@ describe("exportConnectedServerToolSnapshotForEvalAuthoring", () => {
       },
     ]);
     expect(manager.listTools).toHaveBeenCalledTimes(3);
+  });
+
+  it("strips Convex-reserved $-prefixed schema keys at every depth", async () => {
+    const manager = createMockManager({
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: "json_schema_tool",
+            description: "Carries JSON Schema keywords",
+            inputSchema: {
+              $schema: "http://json-schema.org/draft-07/schema#",
+              $id: "https://example.com/tool",
+              type: "object",
+              properties: {
+                ref: { $ref: "#/$defs/Thing" },
+                _keepMe: { type: "string" },
+              },
+              $defs: { Thing: { type: "number" } },
+            },
+            outputSchema: {
+              $schema: "http://json-schema.org/draft-07/schema#",
+              type: "string",
+            },
+            _meta: { $internal: 1, kept: true },
+          },
+        ],
+      }),
+    });
+
+    const snapshot = await exportConnectedServerToolSnapshotForEvalAuthoring(
+      manager,
+      ["srv"],
+    );
+
+    // No `$`-prefixed field name survives anywhere — Convex would otherwise
+    // reject the whole payload at the function-argument boundary.
+    expect(JSON.stringify(snapshot)).not.toContain('"$');
+
+    expect(snapshot.servers[0].tools[0]).toEqual({
+      name: "json_schema_tool",
+      description: "Carries JSON Schema keywords",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ref: {},
+          // `_`-prefixed nested keys are valid in Convex and must survive.
+          _keepMe: { type: "string" },
+        },
+      },
+      outputSchema: { type: "string" },
+      // The `$internal` key inside `_meta` is dropped; siblings are kept.
+      metadata: { kept: true },
+    });
+  });
+
+  it("captures MCP annotation hints + execution.taskSupport, dropping extras", async () => {
+    const manager = createMockManager({
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            name: "delete_thing",
+            description: "Deletes a thing",
+            inputSchema: { type: "object" },
+            annotations: {
+              readOnlyHint: false,
+              destructiveHint: true,
+              title: "Delete Thing",
+              vendorExtra: 1,
+            },
+            execution: { taskSupport: "optional", extra: "x" },
+          },
+        ],
+      }),
+    });
+
+    const snapshot = await exportConnectedServerToolSnapshotForEvalAuthoring(
+      manager,
+      ["srv"],
+    );
+
+    expect(snapshot.version).toBe(SERVER_TOOL_SNAPSHOT_VERSION);
+    const tool = snapshot.servers[0].tools[0];
+    // Only the four spec hint booleans survive — no title, no vendor extras.
+    expect(tool.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+    });
+    expect(tool.execution).toEqual({ taskSupport: "optional" });
   });
 });
 

--- a/mcpjam-inspector/server/utils/export-helpers.ts
+++ b/mcpjam-inspector/server/utils/export-helpers.ts
@@ -9,16 +9,48 @@ import { logger } from "./logger.js";
 
 type Manager = InstanceType<typeof MCPClientManager>;
 
+/**
+ * Tool-snapshot envelope version. v2 added the MCP `annotations` hint booleans
+ * and `execution.taskSupport`. Deterministic serverQuality prechecks gate
+ * annotation/execution-derived facts on `version >= 2`, so older snapshots emit
+ * no false "missing hint" findings.
+ */
+export const SERVER_TOOL_SNAPSHOT_VERSION = 2;
+
 export type ServerToolSnapshotTool = {
   name: string;
   description?: string;
   inputSchema?: unknown;
   outputSchema?: unknown;
+  metadata?: Record<string, unknown>;
+  /** MCP ToolAnnotations — only the four spec hint booleans (no `title`, which
+   * is server-controlled display text we deliberately keep out of the judge). */
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+  /** MCP Tool.execution — task-augmentation support hint. */
+  execution?: {
+    taskSupport?: "forbidden" | "optional" | "required";
+  };
+};
+
+// The server's response to MCP `initialize`. Captured alongside the tool
+// catalog so the backend's diff engine can surface protocol/capability drift
+// across reconnects.
+export type ServerToolSnapshotInitialize = {
+  protocolVersion?: string;
+  serverInfo?: { name?: string; version?: string };
+  capabilities?: Record<string, unknown>;
+  instructions?: string;
 };
 
 export type ServerToolSnapshotServer = {
   serverId: string;
   tools: ServerToolSnapshotTool[];
+  initialize?: ServerToolSnapshotInitialize;
   captureError?: string;
 };
 
@@ -259,6 +291,155 @@ export function flattenServerToolSnapshotTools(
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Convex rejects any object field name that starts with `$` (e.g. JSON
+// Schema's `$schema` / `$ref` / `$defs` / `$id`) at every nesting depth — the
+// value is invalid the instant it crosses a Convex function-argument boundary,
+// well before the backend's storage-time redaction can run. MCP tool schemas
+// routinely carry these keywords, and every consumer of these snapshots (chat
+// persist, connect inspection, eval authoring) forwards the result straight
+// into a Convex action/mutation. So strip them here at the source. The drop is
+// lossy but matches what the backend would store anyway — it mirrors
+// `sanitizeConvexReservedKeys` in convex/lib/serverToolSnapshot.ts. `_`-prefixed
+// nested keys stay (Convex only reserves `_` for top-level document fields, so
+// MCP's `_meta` survives).
+function stripConvexReservedKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripConvexReservedKeys(entry)) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      if (key.startsWith("$")) {
+        continue;
+      }
+      out[key] = stripConvexReservedKeys(entry);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+/** MCP ToolAnnotations → the four spec hint booleans only (drops `title` and
+ * any vendor extras). Returns undefined when none are present. */
+function pickToolAnnotations(
+  value: unknown,
+): ServerToolSnapshotTool["annotations"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const a = value as Record<string, unknown>;
+  const out: NonNullable<ServerToolSnapshotTool["annotations"]> = {};
+  if (typeof a.readOnlyHint === "boolean") out.readOnlyHint = a.readOnlyHint;
+  if (typeof a.destructiveHint === "boolean")
+    out.destructiveHint = a.destructiveHint;
+  if (typeof a.idempotentHint === "boolean")
+    out.idempotentHint = a.idempotentHint;
+  if (typeof a.openWorldHint === "boolean")
+    out.openWorldHint = a.openWorldHint;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** MCP Tool.execution → taskSupport enum, validated. */
+function pickToolExecution(
+  value: unknown,
+): ServerToolSnapshotTool["execution"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const ts = (value as Record<string, unknown>).taskSupport;
+  if (ts === "forbidden" || ts === "optional" || ts === "required") {
+    return { taskSupport: ts };
+  }
+  return undefined;
+}
+
+function transformToolForSnapshot(tool: any): ServerToolSnapshotTool {
+  const meta =
+    tool._meta &&
+    typeof tool._meta === "object" &&
+    !Array.isArray(tool._meta)
+      ? (tool._meta as Record<string, unknown>)
+      : undefined;
+  const annotations = pickToolAnnotations(tool.annotations);
+  const execution = pickToolExecution(tool.execution);
+  return {
+    name: tool.name,
+    ...(normalizeTrimmedString(tool.description)
+      ? { description: normalizeTrimmedString(tool.description) }
+      : {}),
+    ...(tool.inputSchema !== undefined
+      ? { inputSchema: stripConvexReservedKeys(tool.inputSchema) }
+      : {}),
+    ...(tool.outputSchema !== undefined
+      ? { outputSchema: stripConvexReservedKeys(tool.outputSchema) }
+      : {}),
+    ...(meta && Object.keys(meta).length > 0
+      ? { metadata: stripConvexReservedKeys(meta) }
+      : {}),
+    ...(annotations ? { annotations } : {}),
+    ...(execution ? { execution } : {}),
+  };
+}
+
+function readInitializeFromManager(
+  manager: Manager,
+  serverId: string,
+): ServerToolSnapshotInitialize | undefined {
+  let info: unknown;
+  try {
+    info = (manager as { getInitializationInfo?: (id: string) => unknown })
+      .getInitializationInfo?.(serverId);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(info)) {
+    return undefined;
+  }
+
+  const result: ServerToolSnapshotInitialize = {};
+
+  const protocolVersion =
+    typeof info.protocolVersion === "string"
+      ? info.protocolVersion.trim()
+      : undefined;
+  if (protocolVersion) {
+    result.protocolVersion = protocolVersion;
+  }
+
+  if (isRecord(info.serverInfo)) {
+    const name =
+      typeof info.serverInfo.name === "string"
+        ? info.serverInfo.name.trim()
+        : undefined;
+    const version =
+      typeof info.serverInfo.version === "string"
+        ? info.serverInfo.version.trim()
+        : undefined;
+    if (name || version) {
+      result.serverInfo = {
+        ...(name ? { name } : {}),
+        ...(version ? { version } : {}),
+      };
+    }
+  }
+
+  if (isRecord(info.capabilities)) {
+    result.capabilities = stripConvexReservedKeys(info.capabilities);
+  }
+
+  if (typeof info.instructions === "string" && info.instructions.trim()) {
+    result.instructions = info.instructions.trim();
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 export async function exportConnectedServerToolSnapshotForEvalAuthoring(
   manager: Manager,
   serverIds: string[],
@@ -269,22 +450,14 @@ export async function exportConnectedServerToolSnapshotForEvalAuthoring(
     [...new Set(serverIds)].map(async (serverId) => {
       try {
         const result = await manager.listTools(serverId);
-        const tools = (result?.tools ?? []).map((tool: any) => ({
-          name: tool.name,
-          ...(normalizeTrimmedString(tool.description)
-            ? { description: normalizeTrimmedString(tool.description) }
-            : {}),
-          ...(tool.inputSchema !== undefined
-            ? { inputSchema: tool.inputSchema }
-            : {}),
-          ...(tool.outputSchema !== undefined
-            ? { outputSchema: tool.outputSchema }
-            : {}),
-        }));
+        const tools = (result?.tools ?? []).map(transformToolForSnapshot);
+
+        const initialize = readInitializeFromManager(manager, serverId);
 
         return {
           serverId,
           tools: sortSnapshotTools(tools),
+          ...(initialize ? { initialize } : {}),
         } satisfies ServerToolSnapshotServer;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -305,9 +478,56 @@ export async function exportConnectedServerToolSnapshotForEvalAuthoring(
   );
 
   return {
-    version: 1,
+    version: SERVER_TOOL_SNAPSHOT_VERSION,
     capturedAt: Date.now(),
     servers: sortSnapshotServers(servers),
+  };
+}
+
+/**
+ * One-server inspection snapshot for the connect-time path.
+ *
+ * The manager is keyed by `managerKey` (display name in the connect path,
+ * Convex Id in the eval path), but the snapshot's `serverId` carries
+ * `snapshotServerId` so the backend's `normalizeId('servers', …)` resolves
+ * correctly. Always returns a valid snapshot — failures land in
+ * `captureError` rather than throwing — so callers can use this without an
+ * outer try/catch.
+ */
+export async function exportSingleServerForInspection(
+  manager: Manager,
+  managerKey: string,
+  snapshotServerId: string,
+  options?: { logPrefix?: string },
+): Promise<ServerToolSnapshot> {
+  const logPrefix = options?.logPrefix ?? "inspection";
+  let server: ServerToolSnapshotServer;
+  try {
+    const result = await manager.listTools(managerKey);
+    const tools = (result?.tools ?? []).map(transformToolForSnapshot);
+    const initialize = readInitializeFromManager(manager, managerKey);
+    server = {
+      serverId: snapshotServerId,
+      tools: sortSnapshotTools(tools),
+      ...(initialize ? { initialize } : {}),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`[${logPrefix}] Failed to capture inspection snapshot`, {
+      managerKey,
+      snapshotServerId,
+      error: message,
+    });
+    server = {
+      serverId: snapshotServerId,
+      tools: [],
+      captureError: message,
+    };
+  }
+  return {
+    version: SERVER_TOOL_SNAPSHOT_VERSION,
+    capturedAt: Date.now(),
+    servers: [server],
   };
 }
 

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -11,6 +11,8 @@ import {
   forceRefreshHostedOAuthAccessToken,
 } from "./hosted-oauth-refresh.js";
 import { logger } from "./logger.js";
+import { exportSingleServerForInspection } from "./export-helpers.js";
+import { ConvexHttpClient } from "convex/browser";
 import { setRequestLogContext } from "./request-logger.js";
 import {
   type InternalLogContext,
@@ -879,7 +881,50 @@ export async function executeLocalServerConnect(
     );
   }
 
+  // Fire-and-forget: persist an inspection snapshot for this server so the
+  // backend's `getLatestInspection` picks up reconnect-time changes (port of
+  // PR #1731's `use-inspection-coordinator`). Failures here never affect the
+  // connect response; the connect succeeded regardless.
+  void recordConnectInspection(mcpClientManager, {
+    convexBearer: bearer,
+    projectId,
+    serverConvexId: serverId,
+    managerKey: serverDisplayName,
+  }).catch((error) => {
+    logger.debug("Failed to persist connect-time inspection", {
+      serverId: serverDisplayName,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
   return c.json(
     buildConnectSuccessEnvelope(mcpClientManager, serverDisplayName)
   );
+}
+
+async function recordConnectInspection(
+  manager: MCPClientManager,
+  args: {
+    convexBearer: string | undefined;
+    projectId: string;
+    serverConvexId: string;
+    managerKey: string;
+  },
+): Promise<void> {
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl || !args.convexBearer) {
+    return;
+  }
+  const snapshot = await exportSingleServerForInspection(
+    manager,
+    args.managerKey,
+    args.serverConvexId,
+    { logPrefix: "connect-inspection" },
+  );
+  const client = new ConvexHttpClient(convexUrl);
+  client.setAuth(args.convexBearer);
+  await client.mutation("serverInspections:recordFromConnect" as any, {
+    projectId: args.projectId,
+    snapshot,
+  });
 }

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -13,6 +13,7 @@ import {
 import { logger } from "./logger.js";
 import { exportSingleServerForInspection } from "./export-helpers.js";
 import { ConvexHttpClient } from "convex/browser";
+import { getInspectorClientRuntimeConfig } from "../env.js";
 import { setRequestLogContext } from "./request-logger.js";
 import {
   type InternalLogContext,
@@ -914,7 +915,10 @@ async function persistConnectInspection(args: {
   projectId: string;
   snapshot: Awaited<ReturnType<typeof exportSingleServerForInspection>>;
 }): Promise<void> {
-  const convexUrl = process.env.CONVEX_URL;
+  // Only `CONVEX_HTTP_URL` is boot-enforced; the convex-client URL is
+  // derived from it (suffix swap) by the runtime config helper so that
+  // production env (which sets only CONVEX_HTTP_URL) works.
+  const { convexUrl } = getInspectorClientRuntimeConfig();
   if (!convexUrl || !args.convexBearer) {
     return;
   }

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -881,15 +881,22 @@ export async function executeLocalServerConnect(
     );
   }
 
-  // Fire-and-forget: persist an inspection snapshot for this server so the
-  // backend's `getLatestInspection` picks up reconnect-time changes (port of
-  // PR #1731's `use-inspection-coordinator`). Failures here never affect the
-  // connect response; the connect succeeded regardless.
-  void recordConnectInspection(mcpClientManager, {
+  // Capture the inspection snapshot synchronously so a fast follow-up
+  // disconnect/reconnect on the same server can't tear down the manager
+  // mid-`listTools`. Only the Convex write is fire-and-forget — failures
+  // there never affect the connect response (the connect succeeded
+  // regardless). Port of PR #1731's `use-inspection-coordinator`; mirrors
+  // the hosted `/web/servers/validate` path.
+  const inspectionSnapshot = await exportSingleServerForInspection(
+    mcpClientManager,
+    serverDisplayName,
+    serverId,
+    { logPrefix: "connect-inspection" },
+  );
+  void persistConnectInspection({
     convexBearer: bearer,
     projectId,
-    serverConvexId: serverId,
-    managerKey: serverDisplayName,
+    snapshot: inspectionSnapshot,
   }).catch((error) => {
     logger.debug("Failed to persist connect-time inspection", {
       serverId: serverDisplayName,
@@ -902,29 +909,19 @@ export async function executeLocalServerConnect(
   );
 }
 
-async function recordConnectInspection(
-  manager: MCPClientManager,
-  args: {
-    convexBearer: string | undefined;
-    projectId: string;
-    serverConvexId: string;
-    managerKey: string;
-  },
-): Promise<void> {
+async function persistConnectInspection(args: {
+  convexBearer: string | undefined;
+  projectId: string;
+  snapshot: Awaited<ReturnType<typeof exportSingleServerForInspection>>;
+}): Promise<void> {
   const convexUrl = process.env.CONVEX_URL;
   if (!convexUrl || !args.convexBearer) {
     return;
   }
-  const snapshot = await exportSingleServerForInspection(
-    manager,
-    args.managerKey,
-    args.serverConvexId,
-    { logPrefix: "connect-inspection" },
-  );
   const client = new ConvexHttpClient(convexUrl);
   client.setAuth(args.convexBearer);
   await client.mutation("serverInspections:recordFromConnect" as any, {
     projectId: args.projectId,
-    snapshot,
+    snapshot: args.snapshot,
   });
 }


### PR DESCRIPTION
**2/8 · base `evals/foundation`**

Server-side **tool snapshot v2** capture: normalized snapshot in `export-helpers`, wired through `local-server-resolver` + the web `servers` route into `serverInspections:recordFromConnect`. Mirrors backend **server-inspections**.

---
**Stack (bottom→top)** — splitting #2325 (Eval rework) into reviewable PRs:
1. `evals/foundation`
2. `evals/tool-snapshot-v2`
3. `evals/server-attachments`
4. `evals/ai-triage`
5. `evals/run-compare`
6. `evals/cross-host-analytics`
7. `evals/host-config-compare`
8. `evals/execution-and-routing`

Rebased onto current `main` (eval-rework was 13 commits behind; 3 overlap files 3-way merged). Each branch typechecks standalone and the full eval suite is green. Please review bottom-up; merge in order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Connect/validate paths now depend on synchronous `listTools` + optional Convex writes; snapshot normalization changes stored shape (v2) and could affect downstream quality gates that key off version or fields.
> 
> **Overview**
> **Tool snapshot v2 (server)** — Snapshots now use **`SERVER_TOOL_SNAPSHOT_VERSION` (2)** with normalized tools: strips **`$`-prefixed JSON Schema keys** so Convex accepts payloads, keeps **annotation hint booleans** and **`execution.taskSupport`**, optional **`metadata`**, and per-server **`initialize`** (protocol version, serverInfo, capabilities). **`exportSingleServerForInspection`** captures one server without throwing; eval authoring export shares the same **`transformToolForSnapshot`** path.
> 
> **Connect-time persistence** — After a successful **local MCP connect** and **hosted `/web/servers/validate`**, the server **awaits snapshot capture** while the manager is still connected, then **fire-and-forgets** `serverInspections:recordFromConnect` to Convex (auth + `CONVEX_HTTP_URL` gated).
> 
> **Eval / UI stack (same diff)** — **`getEffectiveSuiteServers`** unions **standalone `serverAttachment`** names so attachment-only suites aren’t treated as empty; run handlers send that list to the backend. Eval types gain **run diff** shapes and **server attachment** fields; routes add **`compareTo`**, **`cross-host`** suite view, and **`/host-compare`**. Client focus tabs get optional **`readOnly`**, labels from **`host-config-field-schema`**, and tests; failed suite badges switch from destructive tokens to **rose** styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be6c8ac098797c77405f493dd1b04ff428d61638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->