### PR TITLE
evals: host-config comparison matrix + client picker

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -48,6 +48,7 @@ import { OrganizationsTab } from "./components/OrganizationsTab";
 import { SupportTab } from "./components/SupportTab";
 import { RegistryTab } from "./components/RegistryTab";
 import { ClientsTab } from "./components/ClientsTab";
+import { HostConfigCompareView } from "./components/clients/comparison/HostConfigCompareView";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
 import { MCPSidebar } from "./components/mcp-sidebar";
@@ -439,6 +440,8 @@ function NoRouterRouteBody({ activeTab }: { activeTab: string }) {
       return <TracingRoute />;
     case "clients":
       return <ClientsRoute />;
+    case "host-compare":
+      return <HostCompareRoute />;
     case "chatboxes":
       return <ChatboxesRoute />;
     case "playground":
@@ -621,6 +624,16 @@ export function ClientsRoute() {
       selectedHostId={urlHostId ?? previewedHostId}
       onSelectHost={handleSelectHost}
       serversTabElement={<ServersTabBody />}
+    />
+  );
+}
+
+export function HostCompareRoute() {
+  const { convexProjectId, isAuthenticated } = useAppRouteContext();
+  return (
+    <HostConfigCompareView
+      projectId={convexProjectId}
+      isAuthenticated={isAuthenticated}
     />
   );
 }

--- a/mcpjam-inspector/client/src/components/clients/ClientPicker.tsx
+++ b/mcpjam-inspector/client/src/components/clients/ClientPicker.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   Select,
   SelectContent,
@@ -6,9 +7,27 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { usePostHog } from "posthog-js/react";
-import { useHostList } from "@/hooks/useClients";
+import { useHostList, type HostListItem } from "@/hooks/useClients";
 import { useConvexAuth } from "convex/react";
 import { standardEventProps } from "@/lib/PosthogUtils";
+
+/**
+ * Pure: place `priorityHostId` first if it exists in the list. The rest
+ * keeps its original order. Exported for unit-testing — Radix Select's
+ * dropdown items don't render in JSDOM until the trigger is opened, so
+ * driving the integration with `userEvent` for an ordering check is more
+ * brittle than just testing the function.
+ */
+export function orderHostsByPriority(
+  hosts: HostListItem[],
+  priorityHostId: string | undefined,
+): HostListItem[] {
+  if (!priorityHostId) return hosts;
+  const idx = hosts.findIndex((h) => h.hostId === priorityHostId);
+  if (idx <= 0) return hosts;
+  const priority = hosts[idx];
+  return [priority, ...hosts.slice(0, idx), ...hosts.slice(idx + 1)];
+}
 
 export type ClientPickerLocation =
   | "chat_tab"
@@ -25,6 +44,13 @@ interface HostPickerProps {
   includeNone?: boolean;
   noneLabel?: string;
   disabled?: boolean;
+  /**
+   * Optional host ID to float to the top of the dropdown. When unset the
+   * options render in the order `useHostList` returns. The leaf does not
+   * reach into route/app context — callers pass whatever priority signal
+   * makes sense for their surface.
+   */
+  priorityHostId?: string;
 }
 
 export function ClientPicker({
@@ -36,10 +62,16 @@ export function ClientPicker({
   includeNone = true,
   noneLabel = "Project default",
   disabled = false,
+  priorityHostId,
 }: HostPickerProps) {
   const posthog = usePostHog();
   const { isAuthenticated } = useConvexAuth();
   const { hosts, isLoading } = useHostList({ isAuthenticated, projectId });
+
+  const orderedHosts = useMemo(
+    () => orderHostsByPriority(hosts, priorityHostId),
+    [hosts, priorityHostId],
+  );
 
   const selectValue =
     value !== null ? value : includeNone ? "__none__" : undefined;
@@ -72,7 +104,7 @@ export function ClientPicker({
         {includeNone && (
           <SelectItem value="__none__">{noneLabel}</SelectItem>
         )}
-        {hosts.map((host) => (
+        {orderedHosts.map((host) => (
           <SelectItem key={host.hostId} value={host.hostId}>
             {host.name}
           </SelectItem>

--- a/mcpjam-inspector/client/src/components/clients/CreateClientDialog.tsx
+++ b/mcpjam-inspector/client/src/components/clients/CreateClientDialog.tsx
@@ -73,8 +73,14 @@ export function CreateClientDialog({
     if (!trimmed) return;
     setIsSaving(true);
     try {
-      // New hosts start with no required servers so creation never triggers
-      // an auto-connect storm; users opt servers in via the Servers tab.
+      // New hosts start with no seeded servers: keeps creation deliberate.
+      // Users opt servers in afterward via the Servers tab on the host.
+      //
+      // Historical context: this used to guard against an auto-connect
+      // storm. The current auto-connect toggle is project-scoped (see
+      // preferences-store.ts:40), so the original storm risk is gone,
+      // but the deliberate-creation framing stays.
+      //
       // Thread MCPJam's current global theme into the seed so the new
       // host opens matching the inspector chrome instead of always
       // defaulting to dark — user can still flip it later from the host

--- a/mcpjam-inspector/client/src/components/clients/__tests__/ClientPicker.priority-sort.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/__tests__/ClientPicker.priority-sort.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { orderHostsByPriority } from "@/components/clients/ClientPicker";
+import type { HostListItem } from "@/hooks/useClients";
+
+function makeHost(id: string, name: string): HostListItem {
+  return {
+    hostId: id,
+    name,
+    hostConfigId: `cfg-${id}`,
+    modelId: "m",
+    serverCount: 0,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+describe("orderHostsByPriority", () => {
+  const hosts = [
+    makeHost("h_a", "Alpha"),
+    makeHost("h_b", "Bravo"),
+    makeHost("h_c", "Charlie"),
+  ];
+
+  it("returns the input list unchanged when priorityHostId is undefined", () => {
+    expect(orderHostsByPriority(hosts, undefined)).toBe(hosts);
+  });
+
+  it("floats priorityHostId to the front; rest keeps original order", () => {
+    expect(
+      orderHostsByPriority(hosts, "h_b").map((h) => h.hostId),
+    ).toEqual(["h_b", "h_a", "h_c"]);
+  });
+
+  it("returns the input list unchanged when priorityHostId is already at index 0", () => {
+    expect(orderHostsByPriority(hosts, "h_a")).toBe(hosts);
+  });
+
+  it("returns the input list unchanged when priorityHostId is not in the list", () => {
+    expect(orderHostsByPriority(hosts, "h_unknown")).toBe(hosts);
+  });
+
+  it("handles single-element lists", () => {
+    const single = [makeHost("h_a", "Alpha")];
+    expect(orderHostsByPriority(single, "h_a")).toBe(single);
+  });
+
+  it("handles empty lists", () => {
+    expect(orderHostsByPriority([], "h_a")).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/clients/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/HostCompareSelector.tsx
@@ -1,0 +1,224 @@
+import { ChevronDown } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Switch } from "@mcpjam/design-system/switch";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@mcpjam/design-system/command";
+import { cn } from "@/lib/utils";
+import { getChatboxHostLogo } from "@/lib/chatbox-client-style";
+import type { HostListItem } from "@/hooks/useClients";
+import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
+
+const INLINE_CHIP_LIMIT = 6;
+
+interface HostCompareSelectorProps {
+  hosts: ReadonlyArray<HostListItem>;
+  selectedHostIds: ReadonlyArray<string>;
+  subjectsByHost: Readonly<Record<string, HostComparisonSubject>>;
+  onToggleHost: (hostId: string) => void;
+  divergingOnly: boolean;
+  onDivergingOnlyChange: (enabled: boolean) => void;
+  disabled?: boolean;
+}
+
+export function HostCompareSelector({
+  hosts,
+  selectedHostIds,
+  subjectsByHost,
+  onToggleHost,
+  divergingOnly,
+  onDivergingOnlyChange,
+  disabled = false,
+}: HostCompareSelectorProps) {
+  const selectedSet = new Set(selectedHostIds);
+  const inlineHosts = hosts.slice(0, INLINE_CHIP_LIMIT);
+  const overflowHosts = hosts.slice(INLINE_CHIP_LIMIT);
+
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2">
+      {inlineHosts.map((host) => (
+        <HostCompareChip
+          key={host.hostId}
+          host={host}
+          subject={subjectsByHost[host.hostId]}
+          selected={selectedSet.has(host.hostId)}
+          onToggle={() => onToggleHost(host.hostId)}
+          disabled={disabled}
+        />
+      ))}
+
+      {overflowHosts.length > 0 ? (
+        <HostCompareOverflowMenu
+          hosts={overflowHosts}
+          selectedSet={selectedSet}
+          subjectsByHost={subjectsByHost}
+          onToggleHost={onToggleHost}
+          disabled={disabled}
+        />
+      ) : null}
+
+      <label className="ml-auto flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground">
+        <Switch
+          checked={divergingOnly}
+          onCheckedChange={onDivergingOnlyChange}
+          aria-label="Show only diverging fields"
+        />
+        <span>Only diverging</span>
+      </label>
+    </div>
+  );
+}
+
+function HostCompareChip({
+  host,
+  subject,
+  selected,
+  onToggle,
+  disabled,
+}: {
+  host: HostListItem;
+  subject?: HostComparisonSubject;
+  selected: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+}) {
+  const logoSrc =
+    subject !== undefined
+      ? getChatboxHostLogo(
+          subject.hostStyle,
+          subject.config.chatUiOverride,
+        )
+      : null;
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-pressed={selected}
+      data-testid={`host-compare-chip-${host.hostId}`}
+      data-selected={selected ? "true" : "false"}
+      className={cn(
+        "inline-flex max-w-[180px] items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px] transition-colors",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        selected
+          ? "border-primary/35 bg-primary/8 text-foreground shadow-xs"
+          : "border-border bg-background text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+      )}
+      onClick={onToggle}
+    >
+      {logoSrc ? (
+        <img src={logoSrc} alt="" className="size-3.5 shrink-0 object-contain" />
+      ) : (
+        <span
+          aria-hidden
+          className="size-3.5 shrink-0 rounded-full bg-muted"
+        />
+      )}
+      <span className="truncate">{host.name}</span>
+    </button>
+  );
+}
+
+function HostCompareOverflowMenu({
+  hosts,
+  selectedSet,
+  subjectsByHost,
+  onToggleHost,
+  disabled,
+}: {
+  hosts: ReadonlyArray<HostListItem>;
+  selectedSet: ReadonlySet<string>;
+  subjectsByHost: Readonly<Record<string, HostComparisonSubject>>;
+  onToggleHost: (hostId: string) => void;
+  disabled?: boolean;
+}) {
+  const selectedOverflowCount = hosts.filter((h) =>
+    selectedSet.has(h.hostId),
+  ).length;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          className="h-7 gap-1 rounded-full px-2.5 text-[12px]"
+          data-testid="host-compare-overflow-trigger"
+        >
+          More
+          {selectedOverflowCount > 0 ? (
+            <span className="text-muted-foreground">
+              ({selectedOverflowCount})
+            </span>
+          ) : null}
+          <ChevronDown className="size-3.5 opacity-60" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[240px] p-0">
+        <Command shouldFilter>
+          <CommandInput placeholder="Search clients" />
+          <CommandList>
+            <CommandEmpty>No matching clients.</CommandEmpty>
+            {hosts.map((host) => {
+              const selected = selectedSet.has(host.hostId);
+              const subject = subjectsByHost[host.hostId];
+              const logoSrc =
+                subject !== undefined
+                  ? getChatboxHostLogo(
+                      subject.hostStyle,
+                      subject.config.chatUiOverride,
+                    )
+                  : null;
+
+              return (
+                <CommandItem
+                  key={host.hostId}
+                  value={`${host.name} ${host.hostId}`}
+                  onSelect={() => onToggleHost(host.hostId)}
+                  data-testid={`host-compare-overflow-${host.hostId}`}
+                >
+                  <span className="flex min-w-0 flex-1 items-center gap-2">
+                    {logoSrc ? (
+                      <img
+                        src={logoSrc}
+                        alt=""
+                        className="size-3.5 shrink-0 object-contain"
+                      />
+                    ) : (
+                      <span
+                        aria-hidden
+                        className="size-3.5 shrink-0 rounded-full bg-muted"
+                      />
+                    )}
+                    <span className="truncate">{host.name}</span>
+                  </span>
+                  <span
+                    className={cn(
+                      "text-[11px]",
+                      selected
+                        ? "text-foreground"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {selected ? "Shown" : "Hidden"}
+                  </span>
+                </CommandItem>
+              );
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { useHost, useHostList } from "@/hooks/useClients";
+import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
+import { HostCompareSelector } from "./HostCompareSelector";
+import {
+  resolveInitialHostCompareSelection,
+  toggleHostCompareSelection,
+  writeHostCompareSelection,
+} from "./host-compare-selection";
+import { HostConfigComparisonMatrix } from "./host-config-comparison-matrix";
+
+interface HostConfigCompareViewProps {
+  projectId: string | null;
+  isAuthenticated: boolean;
+}
+
+/**
+ * Top-level container for `/clients/compare`. Loads every host in the
+ * project, lets the user pick which ones appear as columns, and renders
+ * their hydrated `HostConfigDtoV2` side by side.
+ */
+export function HostConfigCompareView({
+  projectId,
+  isAuthenticated,
+}: HostConfigCompareViewProps) {
+  const { hosts, isLoading: listLoading } = useHostList({
+    isAuthenticated,
+    projectId,
+  });
+
+  const [subjectsByHost, setSubjectsByHost] = useState<
+    Record<string, HostComparisonSubject>
+  >({});
+  const [selectedHostIds, setSelectedHostIds] = useState<string[]>([]);
+  const [divergingOnly, setDivergingOnly] = useState(false);
+
+  const liveHostIds = useMemo(
+    () => hosts.map((host) => host.hostId),
+    [hosts],
+  );
+
+  useEffect(() => {
+    if (listLoading) return;
+    setSelectedHostIds((previous) =>
+      resolveInitialHostCompareSelection({
+        projectId: projectId ?? "",
+        liveHostIds,
+        previousSelection: previous,
+      }),
+    );
+  }, [listLoading, liveHostIds, projectId]);
+
+  useEffect(() => {
+    if (!projectId || selectedHostIds.length === 0) return;
+    writeHostCompareSelection(projectId, selectedHostIds);
+  }, [projectId, selectedHostIds]);
+
+  const reportSubject = useCallback(
+    (hostId: string, subject: HostComparisonSubject | null) => {
+      setSubjectsByHost((prev) => {
+        if (subject === null) {
+          if (!(hostId in prev)) return prev;
+          const next = { ...prev };
+          delete next[hostId];
+          return next;
+        }
+        const existing = prev[hostId];
+        if (
+          existing &&
+          existing.config === subject.config &&
+          existing.hostName === subject.hostName
+        ) {
+          return prev;
+        }
+        return { ...prev, [hostId]: subject };
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (listLoading) return;
+    const live = new Set(liveHostIds);
+    setSubjectsByHost((prev) => {
+      let mutated = false;
+      const next: typeof prev = {};
+      for (const [id, subject] of Object.entries(prev)) {
+        if (live.has(id)) next[id] = subject;
+        else mutated = true;
+      }
+      return mutated ? next : prev;
+    });
+  }, [liveHostIds, listLoading]);
+
+  const selectedHostIdSet = useMemo(
+    () => new Set(selectedHostIds),
+    [selectedHostIds],
+  );
+
+  const orderedSubjects = useMemo(() => {
+    return selectedHostIds
+      .map((hostId) => subjectsByHost[hostId])
+      .filter((subject): subject is HostComparisonSubject => subject !== undefined);
+  }, [selectedHostIds, subjectsByHost]);
+
+  const loadedSelectedCount = orderedSubjects.length;
+  const totalSelectedCount = selectedHostIds.length;
+  const allSelectedLoaded =
+    !listLoading && loadedSelectedCount === totalSelectedCount;
+
+  const handleToggleHost = useCallback((hostId: string) => {
+    setSelectedHostIds((previous) =>
+      toggleHostCompareSelection(previous, hostId),
+    );
+  }, []);
+
+  if (!projectId) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Sign in to compare your hosts.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      {selectedHostIds.map((hostId) => {
+        const host = hosts.find((entry) => entry.hostId === hostId);
+        if (!host) return null;
+        return (
+          <HostConfigFetcher
+            key={host.hostId}
+            hostId={host.hostId}
+            hostName={host.name}
+            hostConfigId={host.hostConfigId}
+            isAuthenticated={isAuthenticated}
+            onLoaded={reportSubject}
+          />
+        );
+      })}
+
+      <div className="flex-1 min-h-0 overflow-auto p-4 md:p-8">
+        {listLoading ? (
+          <LoadingState label="Loading hosts…" />
+        ) : hosts.length === 0 ? (
+          <div className="rounded-xl border border-border bg-card p-10 text-center">
+            <p className="text-sm text-muted-foreground">
+              No hosts yet. Create one from the Clients tab to populate the
+              comparison.
+            </p>
+          </div>
+        ) : (
+          <>
+            <HostCompareSelector
+              hosts={hosts}
+              selectedHostIds={selectedHostIds}
+              subjectsByHost={subjectsByHost}
+              onToggleHost={handleToggleHost}
+              divergingOnly={divergingOnly}
+              onDivergingOnlyChange={setDivergingOnly}
+              disabled={listLoading}
+            />
+
+            {totalSelectedCount === 0 ? (
+              <div className="rounded-xl border border-border bg-card p-10 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Select at least one client above to compare.
+                </p>
+              </div>
+            ) : (
+              <>
+                {!allSelectedLoaded && (
+                  <div className="mb-3 flex items-center gap-2 text-[11px] text-muted-foreground">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    Loading {loadedSelectedCount} / {totalSelectedCount} client
+                    configs…
+                  </div>
+                )}
+                <HostConfigComparisonMatrix
+                  subjects={orderedSubjects}
+                  divergingOnly={divergingOnly}
+                  onRemoveHost={
+                    selectedHostIdSet.size > 1 ? handleToggleHost : undefined
+                  }
+                />
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HostConfigFetcher({
+  hostId,
+  hostName,
+  hostConfigId,
+  isAuthenticated,
+  onLoaded,
+}: {
+  hostId: string;
+  hostName: string;
+  hostConfigId: string;
+  isAuthenticated: boolean;
+  onLoaded: (hostId: string, subject: HostComparisonSubject | null) => void;
+}) {
+  const { host } = useHost({ isAuthenticated, hostId });
+
+  useEffect(() => {
+    if (!host) {
+      onLoaded(hostId, null);
+      return;
+    }
+    onLoaded(hostId, {
+      hostId,
+      hostName: host.name ?? hostName,
+      hostStyle: host.config.hostStyle,
+      configHashShort: hostConfigId.slice(-6),
+      config: host.config,
+    });
+  }, [host, hostId, hostName, hostConfigId, onLoaded]);
+
+  return null;
+}
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <div className="flex h-full min-h-[200px] items-center justify-center text-sm text-muted-foreground">
+      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+      {label}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
@@ -57,14 +57,8 @@ export function HostConfigCompareView({
   }, [projectId, selectedHostIds]);
 
   const reportSubject = useCallback(
-    (hostId: string, subject: HostComparisonSubject | null) => {
+    (hostId: string, subject: HostComparisonSubject) => {
       setSubjectsByHost((prev) => {
-        if (subject === null) {
-          if (!(hostId in prev)) return prev;
-          const next = { ...prev };
-          delete next[hostId];
-          return next;
-        }
         const existing = prev[hostId];
         if (
           existing &&
@@ -204,15 +198,16 @@ function HostConfigFetcher({
   hostName: string;
   hostConfigId: string;
   isAuthenticated: boolean;
-  onLoaded: (hostId: string, subject: HostComparisonSubject | null) => void;
+  onLoaded: (hostId: string, subject: HostComparisonSubject) => void;
 }) {
   const { host } = useHost({ isAuthenticated, hostId });
 
   useEffect(() => {
-    if (!host) {
-      onLoaded(hostId, null);
-      return;
-    }
+    // Only publish on success. `useHost` returns null for both "loading" and
+    // "not found"; calling onLoaded(null) during loading would wipe the cached
+    // subject when a host is deselected then re-selected. Dead-host removal is
+    // handled by the liveHostIds cleanup effect above.
+    if (!host) return;
     onLoaded(hostId, {
       hostId,
       hostName: host.name ?? hostName,

--- a/mcpjam-inspector/client/src/components/clients/comparison/__tests__/HostCompareSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/__tests__/HostCompareSelector.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { HostListItem } from "@/hooks/useClients";
+import { HostCompareSelector } from "../HostCompareSelector";
+
+function makeHost(hostId: string, name: string): HostListItem {
+  return {
+    hostId,
+    name,
+    hostConfigId: `hc_${hostId}`,
+    modelId: "claude-sonnet-4-6",
+    serverCount: 0,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("HostCompareSelector", () => {
+  it("renders a chip per host and toggles selection on click", async () => {
+    const user = userEvent.setup();
+    const onToggleHost = vi.fn();
+
+    render(
+      <HostCompareSelector
+        hosts={[
+          makeHost("h_a", "Claude"),
+          makeHost("h_b", "Cursor"),
+        ]}
+        selectedHostIds={["h_a"]}
+        subjectsByHost={{}}
+        onToggleHost={onToggleHost}
+        divergingOnly={false}
+        onDivergingOnlyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("host-compare-chip-h_a")).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+    expect(screen.getByTestId("host-compare-chip-h_b")).toHaveAttribute(
+      "data-selected",
+      "false",
+    );
+
+    await user.click(screen.getByTestId("host-compare-chip-h_b"));
+    expect(onToggleHost).toHaveBeenCalledWith("h_b");
+  });
+
+  it("shows a More menu when there are more than six hosts", () => {
+    const hosts = Array.from({ length: 7 }, (_, index) =>
+      makeHost(`h_${index}`, `Host ${index}`),
+    );
+
+    render(
+      <HostCompareSelector
+        hosts={hosts}
+        selectedHostIds={hosts.map((host) => host.hostId)}
+        subjectsByHost={{}}
+        onToggleHost={vi.fn()}
+        divergingOnly={false}
+        onDivergingOnlyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("host-compare-overflow-trigger")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("host-compare-chip-h_6"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/clients/comparison/__tests__/host-compare-selection.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/comparison/__tests__/host-compare-selection.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  reconcileHostCompareSelection,
+  resolveInitialHostCompareSelection,
+  toggleHostCompareSelection,
+  writeHostCompareSelection,
+  readHostCompareSelection,
+} from "../host-compare-selection";
+
+describe("host-compare-selection", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("toggleHostCompareSelection adds and removes ids while keeping a minimum", () => {
+    expect(toggleHostCompareSelection(["a"], "b")).toEqual(["a", "b"]);
+    expect(toggleHostCompareSelection(["a", "b"], "a")).toEqual(["b"]);
+    expect(toggleHostCompareSelection(["a"], "a")).toEqual(["a"]);
+  });
+
+  it("reconcileHostCompareSelection drops deleted hosts", () => {
+    expect(
+      reconcileHostCompareSelection(["a", "b", "c"], new Set(["a", "c"])),
+    ).toEqual(["a", "c"]);
+  });
+
+  it("resolveInitialHostCompareSelection prefers stored session selection", () => {
+    writeHostCompareSelection("proj_1", ["b", "c"]);
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: ["a", "b", "c"],
+        previousSelection: ["a"],
+      }),
+    ).toEqual(["b", "c"]);
+  });
+
+  it("resolveInitialHostCompareSelection falls back to all live hosts", () => {
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: ["a", "b"],
+        previousSelection: [],
+      }),
+    ).toEqual(["a", "b"]);
+  });
+
+  it("readHostCompareSelection returns null for invalid storage", () => {
+    sessionStorage.setItem("host-compare-selected:proj_1", "{not-json");
+    expect(readHostCompareSelection("proj_1")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/clients/comparison/__tests__/host-config-comparison-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/__tests__/host-config-comparison-matrix.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
+import { HostConfigComparisonMatrix } from "../host-config-comparison-matrix";
+
+function makeConfig(overrides: Partial<HostConfigDtoV2> = {}): HostConfigDtoV2 {
+  return {
+    id: "hc_test",
+    schemaVersion: 2,
+    hostStyle: "mcpjam",
+    modelId: "claude-sonnet-4-6",
+    systemPrompt: "You are a helpful assistant.",
+    temperature: 0.2,
+    requireToolApproval: false,
+    respectToolVisibility: true,
+    serverIds: [],
+    optionalServerIds: [],
+    connectionDefaults: { headers: {}, requestTimeout: 60_000 },
+    clientCapabilities: {},
+    hostContext: {},
+    ...overrides,
+  } as HostConfigDtoV2;
+}
+
+function makeSubject(
+  hostId: string,
+  hostName: string,
+  overrides: Partial<HostConfigDtoV2> = {},
+  configHashShort?: string,
+): HostComparisonSubject {
+  return {
+    hostId,
+    hostName,
+    hostStyle: overrides.hostStyle ?? "mcpjam",
+    configHashShort: configHashShort ?? hostId.slice(-6),
+    config: makeConfig(overrides),
+  };
+}
+
+describe("HostConfigComparisonMatrix", () => {
+  it("renders the empty-state hint when no subjects are passed", () => {
+    render(<HostConfigComparisonMatrix subjects={[]} />);
+    expect(
+      screen.getByText(/No hosts to compare/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the three section bands in the canonical order", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[makeSubject("h_a3f9d2_claude", "Claude Code")]}
+      />,
+    );
+    const sections = screen.getAllByRole("columnheader", { hidden: true })
+      .map((el) => el.textContent ?? "")
+      .filter((text) =>
+        /^Agent|^MCP Protocol|^Apps/.test(text.trim()),
+      );
+    // The first three matching headers should be Agent → MCP Protocol → Apps.
+    expect(sections.length).toBeGreaterThanOrEqual(3);
+    expect(sections[0]).toMatch(/^Agent/);
+    expect(sections[1]).toMatch(/^MCP Protocol/);
+    expect(sections[2]).toMatch(/^Apps/);
+  });
+
+  it("renders a column header per subject with host name", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("h_claude_001", "Claude Code", {}, "a3f9d2"),
+          makeSubject("h_cursor_002", "Cursor", { hostStyle: "cursor" }, "1b8e44"),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("Cursor")).toBeInTheDocument();
+  });
+
+  it("paints the diverge gutter on rows whose value differs across hosts", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("h_a", "A", { temperature: 0.2 }),
+          makeSubject("h_b", "B", { temperature: 0.7 }),
+        ]}
+      />,
+    );
+    expect(screen.getByTestId("diverge-gutter-temperature")).toBeInTheDocument();
+  });
+
+  it("omits the diverge gutter on rows that agree", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("h_a", "A"),
+          makeSubject("h_b", "B"),
+        ]}
+      />,
+    );
+    expect(
+      screen.queryByTestId("diverge-gutter-temperature"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides non-diverging rows when divergingOnly is set", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("h_a", "A", { temperature: 0.2 }),
+          makeSubject("h_b", "B", { temperature: 0.7 }),
+        ]}
+        divergingOnly
+      />,
+    );
+    // temperature differs → still visible
+    expect(screen.getByTestId("diverge-gutter-temperature")).toBeInTheDocument();
+    // modelId is identical across both → row hidden
+    expect(screen.queryByText("modelId")).not.toBeInTheDocument();
+  });
+
+  it("renders boolean values as plain Yes/No text", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("h_a", "A", { requireToolApproval: true }),
+          makeSubject("h_b", "B", { requireToolApproval: false }),
+        ]}
+      />,
+    );
+    expect(screen.getAllByText("Yes").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("No").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders progressiveToolDiscovery=undefined as Auto (tri-state)", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[makeSubject("h_a", "A")]}
+      />,
+    );
+    expect(screen.getAllByText("Auto").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders column remove buttons when onRemoveHost is provided", async () => {
+    const user = userEvent.setup();
+    const onRemoveHost = vi.fn();
+
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("h_a", "A"),
+          makeSubject("h_b", "B"),
+        ]}
+        onRemoveHost={onRemoveHost}
+      />,
+    );
+
+    await user.click(screen.getByTestId("host-compare-remove-h_b"));
+    expect(onRemoveHost).toHaveBeenCalledWith("h_b");
+  });
+});

--- a/mcpjam-inspector/client/src/components/clients/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/clients/comparison/host-compare-selection.ts
@@ -1,0 +1,70 @@
+const STORAGE_PREFIX = "host-compare-selected:";
+
+export function readHostCompareSelection(projectId: string): string[] | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(`${STORAGE_PREFIX}${projectId}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter((id): id is string => typeof id === "string");
+  } catch {
+    return null;
+  }
+}
+
+export function writeHostCompareSelection(
+  projectId: string,
+  hostIds: ReadonlyArray<string>,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.setItem(
+      `${STORAGE_PREFIX}${projectId}`,
+      JSON.stringify([...hostIds]),
+    );
+  } catch {
+    // Ignore quota / private-mode failures.
+  }
+}
+
+export function reconcileHostCompareSelection(
+  hostIds: ReadonlyArray<string>,
+  liveHostIds: ReadonlySet<string>,
+): string[] {
+  return hostIds.filter((id) => liveHostIds.has(id));
+}
+
+/** Toggle one host; always keeps at least `minSelected` ids. */
+export function toggleHostCompareSelection(
+  selectedHostIds: ReadonlyArray<string>,
+  hostId: string,
+  minSelected = 1,
+): string[] {
+  const selected = selectedHostIds.includes(hostId);
+  if (selected) {
+    if (selectedHostIds.length <= minSelected) return [...selectedHostIds];
+    return selectedHostIds.filter((id) => id !== hostId);
+  }
+  return [...selectedHostIds, hostId];
+}
+
+export function resolveInitialHostCompareSelection(args: {
+  projectId: string;
+  liveHostIds: ReadonlyArray<string>;
+  previousSelection: ReadonlyArray<string>;
+}): string[] {
+  const live = new Set(args.liveHostIds);
+  if (live.size === 0) return [];
+
+  const stored = readHostCompareSelection(args.projectId);
+  if (stored) {
+    const fromStorage = reconcileHostCompareSelection(stored, live);
+    if (fromStorage.length > 0) return fromStorage;
+  }
+
+  const fromPrevious = reconcileHostCompareSelection(args.previousSelection, live);
+  if (fromPrevious.length > 0) return fromPrevious;
+
+  return [...args.liveHostIds];
+}

--- a/mcpjam-inspector/client/src/components/clients/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/host-config-comparison-matrix.tsx
@@ -1,0 +1,467 @@
+import { useMemo, useState } from "react";
+import { X } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import { cn } from "@/lib/utils";
+import { getChatboxHostLogo } from "@/lib/chatbox-client-style";
+import {
+  fieldDiverges,
+  groupHostConfigFields,
+  HOST_CONFIG_FIELDS,
+  type HostComparisonSubject,
+  type HostConfigFieldDef,
+} from "@/lib/host-config-field-schema";
+
+interface HostConfigComparisonMatrixProps {
+  subjects: ReadonlyArray<HostComparisonSubject>;
+  /** When true, hide rows whose value is identical across every host. */
+  divergingOnly?: boolean;
+  /** Remove a column; omitted when only one host remains. */
+  onRemoveHost?: (hostId: string) => void;
+}
+
+/**
+ * WPT-style host comparison surface, but caniuse semantically: every row
+ * is a hostConfig field, every column is a saved host, every cell shows
+ * the actual stored value. Sections mirror the focus-dialog tabs
+ * (Agent · MCP Protocol · Apps) via `HOST_CONFIG_SECTIONS`.
+ *
+ * Pure presentation — data fetching lives in the container.
+ */
+export function HostConfigComparisonMatrix({
+  subjects,
+  divergingOnly = false,
+  onRemoveHost,
+}: HostConfigComparisonMatrixProps) {
+  const groups = useMemo(() => groupHostConfigFields(HOST_CONFIG_FIELDS), []);
+  const configs = useMemo(() => subjects.map((s) => s.config), [subjects]);
+
+  const divergingIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const field of HOST_CONFIG_FIELDS) {
+      if (fieldDiverges(field, configs)) set.add(field.id);
+    }
+    return set;
+  }, [configs]);
+
+  if (subjects.length === 0) {
+    return (
+      <div className="flex h-full min-h-[200px] items-center justify-center text-sm text-muted-foreground">
+        No hosts to compare. Create at least one host in this project.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-auto rounded-xl border border-border bg-card">
+      <table className="w-full border-collapse text-[13px]">
+        <colgroup>
+          <col style={{ width: 300 }} />
+          {subjects.map((s) => (
+            <col key={s.hostId} style={{ width: 220 }} />
+          ))}
+        </colgroup>
+
+        <thead>
+          <tr>
+            <th className="sticky left-0 top-0 z-30 bg-card border-b border-r border-border px-5 py-4 text-left">
+              <span className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                Field
+              </span>
+            </th>
+            {subjects.map((s) => (
+              <HostColumnHeader
+                key={s.hostId}
+                subject={s}
+                onRemove={onRemoveHost}
+              />
+            ))}
+          </tr>
+        </thead>
+
+        <tbody>
+          {groups.map((group) => {
+            const visibleFieldsInGroup = group.subsections
+              .flatMap((sub) => sub.fields)
+              .filter((f) => !divergingOnly || divergingIds.has(f.id));
+            if (visibleFieldsInGroup.length === 0) return null;
+
+            const groupDivergeCount = group.subsections
+              .flatMap((sub) => sub.fields)
+              .filter((f) => divergingIds.has(f.id)).length;
+
+            return (
+              <SectionRows
+                key={group.section.id}
+                sectionLabel={group.section.label}
+                divergeCount={groupDivergeCount}
+                subsections={group.subsections}
+                subjects={subjects}
+                divergingIds={divergingIds}
+                divergingOnly={divergingOnly}
+              />
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface SectionRowsProps {
+  sectionLabel: string;
+  divergeCount: number;
+  subsections: ReadonlyArray<{
+    label: string;
+    fields: ReadonlyArray<HostConfigFieldDef>;
+  }>;
+  subjects: ReadonlyArray<HostComparisonSubject>;
+  divergingIds: ReadonlySet<string>;
+  divergingOnly: boolean;
+}
+
+function SectionRows({
+  sectionLabel,
+  divergeCount,
+  subsections,
+  subjects,
+  divergingIds,
+  divergingOnly,
+}: SectionRowsProps) {
+  const colSpan = subjects.length + 1;
+  return (
+    <>
+      <tr>
+        <th
+          colSpan={colSpan}
+          scope="colgroup"
+          className="sticky top-[64px] z-20 bg-secondary border-y border-border px-5 py-2 text-left"
+        >
+          <div className="flex items-baseline gap-3">
+            <span className="text-[15px] font-medium tracking-tight">
+              {sectionLabel}
+            </span>
+            <span className="ml-auto text-[10.5px] text-muted-foreground tabular-nums">
+              {divergeCount} diverging
+            </span>
+          </div>
+        </th>
+      </tr>
+
+      {subsections.map((sub) => {
+        const fields = sub.fields.filter(
+          (f) => !divergingOnly || divergingIds.has(f.id),
+        );
+        if (fields.length === 0) return null;
+        return (
+          <SubsectionRows
+            key={`${sectionLabel}-${sub.label}`}
+            label={sub.label}
+            fields={fields}
+            subjects={subjects}
+            divergingIds={divergingIds}
+            colSpan={colSpan}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+function SubsectionRows({
+  label,
+  fields,
+  subjects,
+  divergingIds,
+  colSpan,
+}: {
+  label: string;
+  fields: ReadonlyArray<HostConfigFieldDef>;
+  subjects: ReadonlyArray<HostComparisonSubject>;
+  divergingIds: ReadonlySet<string>;
+  colSpan: number;
+}) {
+  return (
+    <>
+      <tr>
+        <td
+          colSpan={colSpan}
+          className="px-5 pt-3 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground"
+        >
+          {label}
+        </td>
+      </tr>
+      {fields.map((field) => (
+        <FieldRow
+          key={field.id}
+          field={field}
+          subjects={subjects}
+          diverges={divergingIds.has(field.id)}
+        />
+      ))}
+    </>
+  );
+}
+
+function FieldRow({
+  field,
+  subjects,
+  diverges,
+}: {
+  field: HostConfigFieldDef;
+  subjects: ReadonlyArray<HostComparisonSubject>;
+  diverges: boolean;
+}) {
+  return (
+    <tr className="border-b border-border last:border-b-0">
+      <td
+        className={cn(
+          "sticky left-0 z-10 bg-card border-r border-border px-5 py-2.5",
+          "relative",
+        )}
+      >
+        {diverges && (
+          <span
+            aria-hidden="true"
+            className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary/70"
+            data-testid={`diverge-gutter-${field.id}`}
+          />
+        )}
+        <div className="text-[13px] font-medium text-foreground leading-tight">
+          {field.label}
+        </div>
+        {field.description && (
+          <div className="text-[11px] text-muted-foreground mt-1 leading-snug">
+            {field.description}
+          </div>
+        )}
+      </td>
+      {subjects.map((s) => (
+        <td
+          key={s.hostId}
+          className="border-l border-border px-4 py-2.5 align-top"
+        >
+          <FieldCell field={field} subject={s} />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+function FieldCell({
+  field,
+  subject,
+}: {
+  field: HostConfigFieldDef;
+  subject: HostComparisonSubject;
+}) {
+  const value = field.read(subject.config);
+  const kind = field.kind;
+
+  // Tri-state fields treat `undefined` as a meaningful value ("auto" — host
+  // decides), so we must NOT short-circuit on undefined for them. Every
+  // other kind renders absence as `—`.
+  if (value === undefined && kind.kind !== "tri-state") {
+    return <span className="text-[12px] text-muted-foreground/60">—</span>;
+  }
+
+  switch (kind.kind) {
+    case "boolean":
+      return <BooleanCellValue value={value === true} />;
+
+    case "tri-state":
+      return (
+        <TriStateCellValue
+          value={
+            value === true ? true : value === false ? false : undefined
+          }
+        />
+      );
+
+    case "number":
+      return (
+        <span className="font-mono tabular-nums text-[12.5px]">
+          {typeof value === "number" ? value.toFixed(2) : String(value)}
+        </span>
+      );
+
+    case "duration-ms": {
+      const ms = typeof value === "number" ? value : Number(value);
+      if (!Number.isFinite(ms)) {
+        return <span className="text-[12px] text-muted-foreground/60">—</span>;
+      }
+      return (
+        <span className="font-mono tabular-nums text-[12.5px]">
+          {ms.toLocaleString()} ms
+        </span>
+      );
+    }
+
+    case "enum":
+      return <span className="text-[13px] text-foreground">{String(value)}</span>;
+
+    case "string": {
+      const s = String(value);
+      if (s.length === 0) {
+        return <span className="text-[12px] text-muted-foreground/60">""</span>;
+      }
+      return <span className="font-mono text-[12px] break-all">{s}</span>;
+    }
+
+    case "string-long": {
+      const s = String(value);
+      const firstLine = s.split("\n", 1)[0] ?? "";
+      return (
+        <div className="flex flex-col gap-0.5">
+          <div className="text-[12px] truncate max-w-[200px]">
+            {firstLine || <span className="italic text-muted-foreground">empty</span>}
+          </div>
+          {s.length > 0 && (
+            <ExpandablePreview label={`view ${s.length.toLocaleString()} chars`}>
+              <pre className="whitespace-pre-wrap text-[11.5px] leading-snug font-mono max-w-[480px] max-h-[320px] overflow-auto">
+                {s}
+              </pre>
+            </ExpandablePreview>
+          )}
+        </div>
+      );
+    }
+
+    case "string-array": {
+      if (!Array.isArray(value)) return <span className="text-[12px] text-muted-foreground/60">—</span>;
+      if (value.length === 0) {
+        return <span className="text-[12px] text-muted-foreground/60">[] empty</span>;
+      }
+      return (
+        <span className="text-[13px] text-foreground leading-snug">
+          {value.join(", ")}
+        </span>
+      );
+    }
+
+    case "object": {
+      if (typeof value !== "object" || value === null) {
+        return <span className="text-[12px] text-muted-foreground/60">—</span>;
+      }
+      const keys = Object.keys(value as Record<string, unknown>);
+      const noun = kind.itemNoun ?? "key";
+      if (keys.length === 0) {
+        return (
+          <span className="font-mono text-[11px] text-muted-foreground">
+            {"{} empty"}
+          </span>
+        );
+      }
+      return (
+        <ExpandablePreview
+          label={`${keys.length} ${noun}${keys.length === 1 ? "" : "s"} ›`}
+        >
+          <pre className="whitespace-pre-wrap text-[11.5px] leading-snug font-mono max-w-[480px] max-h-[320px] overflow-auto">
+            {JSON.stringify(value, null, 2)}
+          </pre>
+        </ExpandablePreview>
+      );
+    }
+  }
+}
+
+function BooleanCellValue({ value }: { value: boolean }) {
+  return (
+    <span
+      className={cn(
+        "text-[13px]",
+        value ? "text-foreground" : "text-muted-foreground",
+      )}
+    >
+      {value ? "Yes" : "No"}
+    </span>
+  );
+}
+
+function TriStateCellValue({
+  value,
+}: {
+  value: boolean | undefined;
+}) {
+  const label =
+    value === true ? "On" : value === false ? "Off" : "Auto";
+  return (
+    <span
+      className={cn(
+        "text-[13px]",
+        value === true && "text-foreground",
+        value === false && "text-muted-foreground",
+        value === undefined && "text-muted-foreground/80",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function HostColumnHeader({
+  subject,
+  onRemove,
+}: {
+  subject: HostComparisonSubject;
+  onRemove?: (hostId: string) => void;
+}) {
+  const logoSrc = getChatboxHostLogo(
+    subject.hostStyle,
+    subject.config.chatUiOverride,
+  );
+
+  return (
+    <th className="sticky top-0 z-20 bg-card border-b border-l border-border px-4 py-4 text-left align-top">
+      <div className="flex items-start gap-2">
+        {onRemove ? (
+          <button
+            type="button"
+            aria-label={`Remove ${subject.hostName} from comparison`}
+            data-testid={`host-compare-remove-${subject.hostId}`}
+            className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={() => onRemove(subject.hostId)}
+          >
+            <X className="size-3" />
+          </button>
+        ) : null}
+        <img
+          src={logoSrc}
+          alt=""
+          className="mt-0.5 size-4 shrink-0 object-contain"
+        />
+        <div className="min-w-0 font-medium text-[14px] truncate leading-tight" title={subject.hostName}>
+          {subject.hostName}
+        </div>
+      </div>
+    </th>
+  );
+}
+
+function ExpandablePreview({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="text-left text-[11px] text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+        >
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="max-w-[520px] max-h-[400px] overflow-auto p-3">
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
**7/8 · base `evals/cross-host-analytics`**

**Host-config comparison**: comparison matrix + `HostCompareSelector`/`HostConfigCompareView`, plus `ClientPicker`/`CreateClientDialog` updates.

---
**Stack (bottom→top)** — splitting #2325 (Eval rework) into reviewable PRs:
1. `evals/foundation`
2. `evals/tool-snapshot-v2`
3. `evals/server-attachments`
4. `evals/ai-triage`
5. `evals/run-compare`
6. `evals/cross-host-analytics`
7. `evals/host-config-compare`
8. `evals/execution-and-routing`

Rebased onto current `main` (eval-rework was 13 commits behind; 3 overlap files 3-way merged). Each branch typechecks standalone and the full eval suite is green. Please review bottom-up; merge in order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only inspector UI with client-side sessionStorage; no config writes or auth changes beyond a new route.
> 
> **Overview**
> Adds a **host-config comparison** flow at the `host-compare` route: users pick project clients and see hydrated `HostConfigDtoV2` values in a side-by-side matrix (Agent / MCP Protocol / Apps), with chip selection, an **Only diverging** filter, diverge highlighting, and per-column remove. Selection is persisted in **sessionStorage** per project via `host-compare-selection` helpers.
> 
> **ClientPicker** gains optional `priorityHostId` and exported `orderHostsByPriority` so callers can float one host to the top of the dropdown. **CreateClientDialog** only updates comments around empty `serverIds` on create (behavior unchanged).
> 
> Coverage includes unit tests for priority ordering, selection reconciliation, the selector, and the comparison matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297890ac79134aecde8caa44d3ba6d849de95f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->