### PR TITLE
[Org Credits] Inspector: org-scoped credit balance, top-up, and usage UI

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -457,11 +457,11 @@ export function ChatTabV2({
   });
   const senderProfileByUserId = useMemo(
     () => buildProjectOwnerProfileByUserId(senderActiveMembers),
-    [senderActiveMembers],
+    [senderActiveMembers]
   );
   const currentUserForSender = useQuery(
     "users:getCurrentUser" as any,
-    isConvexAuthenticated ? ({} as any) : "skip",
+    isConvexAuthenticated ? ({} as any) : "skip"
   ) as { _id?: string } | undefined;
   const senderFallbackUserId =
     reactiveHistorySession?.userId ??
@@ -475,7 +475,7 @@ export function ChatTabV2({
         profileByUserId: senderProfileByUserId,
         fallbackOwnerUserId: senderFallbackUserId,
       }),
-    [senderProfileByUserId, senderFallbackUserId],
+    [senderProfileByUserId, senderFallbackUserId]
   );
   // Stamp the current user onto live outgoing prompts in shared sessions so
   // the transcript can attribute them immediately, before persistence
@@ -2773,6 +2773,7 @@ export function ChatTabV2({
           onOpenChange={handleTopupDialogOpenChange}
           chatSessionId={chatSessionId}
           lastUserMessage={pendingResendMessage}
+          organizationId={organizationId}
           source="chat_banner"
         />
       )}

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -5,7 +5,11 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { EditableText } from "@/components/ui/editable-text";
-import { Avatar, AvatarFallback, AvatarImage } from "@mcpjam/design-system/avatar";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@mcpjam/design-system/avatar";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -29,8 +33,17 @@ import {
   Users,
 } from "lucide-react";
 import { toast } from "sonner";
-import { Card, CardContent, CardHeader, CardTitle } from "@mcpjam/design-system/card";
-import { Alert, AlertDescription, AlertTitle } from "@mcpjam/design-system/alert";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@mcpjam/design-system/card";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@mcpjam/design-system/alert";
 import {
   Organization,
   OrganizationMember,
@@ -76,7 +89,6 @@ interface OrganizationsTabProps {
   onOrganizationDeleted?: (organizationId: string) => void;
 }
 
-
 interface PendingDowngradeConfirmation {
   targetPlan: "free";
   targetBillingInterval: BillingInterval | null;
@@ -110,17 +122,19 @@ function formatBillingIntervalLabel(interval: BillingInterval): string {
 
 function formatPlanDescriptor(
   plan: OrganizationPlan,
-  billingInterval: BillingInterval | null,
+  billingInterval: BillingInterval | null
 ): string {
   if (billingInterval == null) {
     return formatPlanName(plan);
   }
 
-  return `${formatPlanName(plan)} ${formatBillingIntervalLabel(billingInterval)}`;
+  return `${formatPlanName(plan)} ${formatBillingIntervalLabel(
+    billingInterval
+  )}`;
 }
 
 function getScheduledBillingChangeCancellationState(
-  billingStatus: OrganizationBillingStatus | undefined,
+  billingStatus: OrganizationBillingStatus | undefined
 ): ScheduledBillingChangeCancellationState | null {
   if (
     !billingStatus?.canManageBilling ||
@@ -152,14 +166,14 @@ function getScheduledBillingChangeCancellationState(
   }
 
   const currentIntervalLabel = formatBillingIntervalLabel(
-    currentBillingInterval,
+    currentBillingInterval
   );
   const scheduledIntervalLabel = formatBillingIntervalLabel(
-    scheduledBillingInterval,
+    scheduledBillingInterval
   );
   const currentPlanName = formatPlanName(currentPlan);
   const effectiveDate = formatBillingDate(
-    billingStatus.stripeScheduledEffectiveAt,
+    billingStatus.stripeScheduledEffectiveAt
   );
   const keepCurrentPlanLabel = `Keep ${currentPlanName} ${currentIntervalLabel} plan`;
   const effectiveDateSuffix = effectiveDate ? ` on ${effectiveDate}` : "";
@@ -247,9 +261,7 @@ export function OrganizationsTab({
             This organization may have been deleted or you don't have access to
             it.
           </p>
-          <Button onClick={() => (appNavigate("/servers"))}>
-            Go to Servers
-          </Button>
+          <Button onClick={() => appNavigate("/servers")}>Go to Servers</Button>
         </div>
       </div>
     );
@@ -268,9 +280,7 @@ export function OrganizationsTab({
             You don't have permission to view organization settings. Contact an
             admin or owner for access.
           </p>
-          <Button onClick={() => (appNavigate("/servers"))}>
-            Go to Servers
-          </Button>
+          <Button onClick={() => appNavigate("/servers")}>Go to Servers</Button>
         </div>
       </div>
     );
@@ -344,7 +354,7 @@ function OrganizationPage({
   } = useOrganizationMutations();
 
   const currentMember = activeMembers.find(
-    (m) => m.email.toLowerCase() === currentUserEmail?.toLowerCase(),
+    (m) => m.email.toLowerCase() === currentUserEmail?.toLowerCase()
   );
   const currentRole: OrganizationMembershipRole | null = currentMember
     ? resolveOrganizationRole(currentMember)
@@ -372,15 +382,15 @@ function OrganizationPage({
     cancelScheduledBillingChange,
   } = useOrganizationBilling(organization._id, { enabled: isAuthenticated });
   const billingEntitlementsUiEnabled = useFeatureFlagEnabled(
-    "billing-entitlements-ui",
+    "billing-entitlements-ui"
   );
   const billingUiEnabled = billingEntitlementsUiEnabled === true;
   const activeSection: OrganizationRouteSection =
     section === "models"
       ? "models"
       : billingUiEnabled && section === "billing"
-        ? "billing"
-        : "overview";
+      ? "billing"
+      : "overview";
   const memberInviteGate = resolveBillingGateState({
     billingUiEnabled,
     organizationId: organization._id,
@@ -397,7 +407,7 @@ function OrganizationPage({
     intent: "members",
   });
   const memberUpsellCtaLabel = getBillingUpsellCtaLabel(
-    memberInviteGate.upgradePlan,
+    memberInviteGate.upgradePlan
   );
 
   const canRemoveMember = (member: OrganizationMember): boolean => {
@@ -428,7 +438,7 @@ function OrganizationPage({
   const [inviteEmail, setInviteEmail] = useState("");
   const [isInviting, setIsInviting] = useState(false);
   const [roleUpdatingEmail, setRoleUpdatingEmail] = useState<string | null>(
-    null,
+    null
   );
   const [transferTargetMember, setTransferTargetMember] =
     useState<OrganizationMember | null>(null);
@@ -466,7 +476,7 @@ function OrganizationPage({
   };
 
   const handleLogoFileChange = async (
-    e: React.ChangeEvent<HTMLInputElement>,
+    e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -528,8 +538,7 @@ function OrganizationPage({
     }
     if (memberInviteGate.isDenied) {
       toast.error(
-        memberInviteGate.denialMessage ??
-          "Upgrade required to add more members",
+        memberInviteGate.denialMessage ?? "Upgrade required to add more members"
       );
       return;
     }
@@ -541,7 +550,7 @@ function OrganizationPage({
       });
       if (result.isPending) {
         toast.success(
-          `Invitation sent to ${inviteEmail}. They'll get access once they sign up.`,
+          `Invitation sent to ${inviteEmail}. They'll get access once they sign up.`
         );
       } else {
         toast.success(`${inviteEmail} added to the organization.`);
@@ -552,8 +561,8 @@ function OrganizationPage({
         getBillingErrorMessage(
           error,
           "Failed to invite member",
-          billingStatus?.canManageBilling ?? false,
-        ),
+          billingStatus?.canManageBilling ?? false
+        )
       );
     } finally {
       setIsInviting(false);
@@ -572,15 +581,15 @@ function OrganizationPage({
         getBillingErrorMessage(
           error,
           "Failed to remove member",
-          billingStatus?.canManageBilling ?? false,
-        ),
+          billingStatus?.canManageBilling ?? false
+        )
       );
     }
   };
 
   const handleChangeMemberRole = async (
     member: OrganizationMember,
-    role: "admin" | "member" | "guest",
+    role: "admin" | "member" | "guest"
   ) => {
     if (!isOwner) return;
 
@@ -623,7 +632,7 @@ function OrganizationPage({
       setTransferTargetMember(null);
     } catch (error) {
       toast.error(
-        (error as Error).message || "Failed to transfer organization ownership",
+        (error as Error).message || "Failed to transfer organization ownership"
       );
     } finally {
       setIsTransferringOwnership(false);
@@ -686,16 +695,16 @@ function OrganizationPage({
 
       window.open(url, "_blank", "noopener,noreferrer");
     },
-    [navigateBillingInSameTab],
+    [navigateBillingInSameTab]
   );
 
   const getBillingReturnUrl = useCallback(
     () =>
       `${window.location.origin}${buildOrganizationPath(
         organization._id,
-        "billing",
+        "billing"
       )}`,
-    [organization._id],
+    [organization._id]
   );
 
   const handleManageBilling = async () => {
@@ -704,34 +713,32 @@ function OrganizationPage({
       openBillingUrl(billingUrl);
     } catch (error) {
       toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to open billing portal",
+        error instanceof Error ? error.message : "Failed to open billing portal"
       );
     }
   };
 
   const handleChangeBillingInterval = async (
-    targetBillingInterval: BillingInterval,
+    targetBillingInterval: BillingInterval
   ) => {
     try {
       const billingUrl = await openIntervalChangePortal(
         getBillingReturnUrl(),
-        targetBillingInterval,
+        targetBillingInterval
       );
       openBillingUrl(billingUrl);
     } catch (error) {
       toast.error(
         error instanceof Error
           ? error.message
-          : "Failed to open billing interval change",
+          : "Failed to open billing interval change"
       );
     }
   };
 
   const handleDowngradePlan = async (
     targetPlan: OrganizationPlan,
-    _targetBillingInterval: BillingInterval,
+    _targetBillingInterval: BillingInterval
   ) => {
     const currentPlan = billingStatus?.plan;
 
@@ -764,7 +771,7 @@ function OrganizationPage({
       toast.error(
         error instanceof Error
           ? error.message
-          : "Failed to cancel scheduled billing change",
+          : "Failed to cancel scheduled billing change"
       );
     }
   };
@@ -780,7 +787,7 @@ function OrganizationPage({
       setPendingDowngradeConfirmation(null);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to change plan",
+        error instanceof Error ? error.message : "Failed to change plan"
       );
     }
   };
@@ -788,19 +795,19 @@ function OrganizationPage({
   const executeManualPlanChange = async (
     tier: "team",
     billingInterval: "monthly" | "annual",
-    options: CheckoutNavigationOptions = {},
+    options: CheckoutNavigationOptions = {}
   ) => {
     try {
       const result = await startPlanChange(
         getBillingReturnUrl(),
         tier,
         billingInterval,
-        { confirmPaidPlanChange: true },
+        { confirmPaidPlanChange: true }
       );
 
       if (result.kind === "updated") {
         toast.success(
-          `Plan updated to ${formatPlanName(result.subscription.plan ?? tier)}.`,
+          `Plan updated to ${formatPlanName(result.subscription.plan ?? tier)}.`
         );
         return;
       }
@@ -816,7 +823,7 @@ function OrganizationPage({
       openBillingUrl(billingUrl, options.navigation);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to change plan",
+        error instanceof Error ? error.message : "Failed to change plan"
       );
     }
   };
@@ -824,24 +831,24 @@ function OrganizationPage({
   const handlePlanChange = async (
     tier: "team",
     billingInterval: "monthly" | "annual",
-    options: CheckoutNavigationOptions = {},
+    options: CheckoutNavigationOptions = {}
   ) => {
     await executeManualPlanChange(tier, billingInterval, options);
   };
 
   const pendingDowngradeEffectiveDate = formatBillingDate(
-    billingStatus?.stripeCurrentPeriodEnd ?? null,
+    billingStatus?.stripeCurrentPeriodEnd ?? null
   );
   const pendingDowngradeTargetLabel = pendingDowngradeConfirmation
     ? formatPlanDescriptor(
         pendingDowngradeConfirmation.targetPlan,
-        pendingDowngradeConfirmation.targetBillingInterval,
+        pendingDowngradeConfirmation.targetBillingInterval
       )
     : null;
   const pendingDowngradeCurrentLabel = pendingDowngradeConfirmation
     ? formatPlanDescriptor(
         pendingDowngradeConfirmation.currentPlan,
-        pendingDowngradeConfirmation.currentBillingInterval,
+        pendingDowngradeConfirmation.currentBillingInterval
       )
     : null;
 
@@ -852,12 +859,14 @@ function OrganizationPage({
           getBillingReturnUrl(),
           tier,
           billingInterval,
-          { confirmPaidPlanChange: false },
+          { confirmPaidPlanChange: false }
         );
 
         if (result.kind === "updated") {
           toast.success(
-            `Plan updated to ${formatPlanName(result.subscription.plan ?? tier)}.`,
+            `Plan updated to ${formatPlanName(
+              result.subscription.plan ?? tier
+            )}.`
           );
           return;
         }
@@ -879,7 +888,7 @@ function OrganizationPage({
           )
         ) {
           toast.error(
-            error instanceof Error ? error.message : "Failed to change plan",
+            error instanceof Error ? error.message : "Failed to change plan"
           );
         }
         throw error;
@@ -890,7 +899,7 @@ function OrganizationPage({
       onCheckoutIntentNavigationStarted,
       openBillingUrl,
       startPlanChange,
-    ],
+    ]
   );
 
   return (
@@ -968,7 +977,7 @@ function OrganizationPage({
                 "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
                 activeSection === "overview"
                   ? "border-primary text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
+                  : "border-transparent text-muted-foreground hover:text-foreground"
               )}
             >
               General
@@ -981,7 +990,7 @@ function OrganizationPage({
                 "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
                 activeSection === "models"
                   ? "border-primary text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
+                  : "border-transparent text-muted-foreground hover:text-foreground"
               )}
             >
               Models
@@ -995,7 +1004,7 @@ function OrganizationPage({
                   "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
                   activeSection === "billing"
                     ? "border-primary text-foreground"
-                    : "border-transparent text-muted-foreground hover:text-foreground",
+                    : "border-transparent text-muted-foreground hover:text-foreground"
                 )}
               >
                 Billing
@@ -1012,8 +1021,10 @@ function OrganizationPage({
         ) : activeSection === "billing" ? (
           <>
             <OrganizationBillingSection
+              organizationId={organization._id}
               billingStatus={billingStatus}
               organizationName={organization.name}
+              canManageCredits={canEdit}
               planCatalog={planCatalog}
               isLoadingBilling={isLoadingBilling}
               isLoadingPlanCatalog={isLoadingPlanCatalog}
@@ -1080,8 +1091,8 @@ function OrganizationPage({
                     planCatalog?.plans[billingStatus.plan]?.billingModel ===
                       "per_seat" ? (
                       <p className="text-xs text-muted-foreground">
-                        Pending invites are free. You'll be billed for this
-                        seat once the invite is accepted.
+                        Pending invites are free. You'll be billed for this seat
+                        once the invite is accepted.
                       </p>
                     ) : null}
 
@@ -1403,8 +1414,8 @@ function OrganizationPage({
             >
               {isCancelingScheduledBillingChange
                 ? "Saving..."
-                : (scheduledBillingChangeCancellation?.confirmLabel ??
-                  "Keep current plan")}
+                : scheduledBillingChangeCancellation?.confirmLabel ??
+                  "Keep current plan"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -1486,8 +1497,8 @@ function OrganizationPage({
               {isStartingPlanChange || isOpeningPortal
                 ? "Saving..."
                 : pendingDowngradeConfirmation?.targetPlan === "free"
-                  ? "Open cancellation flow"
-                  : "Schedule downgrade"}
+                ? "Open cancellation flow"
+                : "Schedule downgrade"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -23,7 +23,10 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("convex/react", () => ({
-  useConvexAuth: () => ({ isAuthenticated: !!authState.user, isLoading: false }),
+  useConvexAuth: () => ({
+    isAuthenticated: !!authState.user,
+    isLoading: false,
+  }),
 }));
 
 vi.mock("@/hooks/useOrganizations", () => ({
@@ -74,11 +77,11 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.getByRole("heading", {
         name: /you've used up your free guest credits/i,
-      }),
+      })
     ).toBeInTheDocument();
     expect(screen.getByText(/15×/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^sign in$/i }),
+      screen.getByRole("button", { name: /^sign in$/i })
     ).toBeInTheDocument();
   });
 
@@ -117,13 +120,13 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.getByRole("heading", {
         name: /you've run out of free daily credits/i,
-      }),
+      })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^top up$/i }),
+      screen.getByRole("button", { name: /^buy credits$/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /bring your own key/i }),
+      screen.getByRole("button", { name: /bring your own key/i })
     ).toBeInTheDocument();
   });
 
@@ -135,7 +138,7 @@ describe("MCPJamLimitDialog", () => {
     render(<MCPJamLimitDialog />);
 
     await user.click(
-      screen.getByRole("button", { name: /bring your own key/i }),
+      screen.getByRole("button", { name: /bring your own key/i })
     );
 
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
@@ -150,9 +153,7 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(
-      screen.getByRole("button", { name: /^top up$/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
     expect(window.location.pathname).toBe("/organizations/org-active/billing");
@@ -166,12 +167,10 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(
-      screen.getByRole("button", { name: /^top up$/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     expect(window.location.pathname).toBe(
-      "/organizations/org-fallback/billing",
+      "/organizations/org-fallback/billing"
     );
     expect(window.location.search).toBe("?topup=open");
   });
@@ -182,9 +181,7 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(
-      screen.getByRole("button", { name: /^top up$/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     // Modal stays open and no nav happens — once orgs load, the user can
     // click again and be routed correctly.
@@ -200,7 +197,7 @@ describe("MCPJamLimitDialog", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("hides the Top up button when the billing-entitlements-ui flag is off", () => {
+  it("hides the Buy credits button when the billing-entitlements-ui flag is off", () => {
     billingUiFlagState = false;
     authState.user = { id: "user-1" };
     sortedOrganizationsState.push({ _id: "org-1" });
@@ -208,14 +205,14 @@ describe("MCPJamLimitDialog", () => {
     render(<MCPJamLimitDialog />);
 
     expect(
-      screen.getByRole("button", { name: /bring your own key/i }),
+      screen.getByRole("button", { name: /bring your own key/i })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /^top up$/i }),
+      screen.queryByRole("button", { name: /^buy credits$/i })
     ).not.toBeInTheDocument();
   });
 
-  it("hides the Top up button while the flag is still loading (undefined)", () => {
+  it("hides the Buy credits button while the flag is still loading (undefined)", () => {
     billingUiFlagState = undefined;
     authState.user = { id: "user-1" };
     sortedOrganizationsState.push({ _id: "org-1" });
@@ -223,7 +220,7 @@ describe("MCPJamLimitDialog", () => {
     render(<MCPJamLimitDialog />);
 
     expect(
-      screen.queryByRole("button", { name: /^top up$/i }),
+      screen.queryByRole("button", { name: /^buy credits$/i })
     ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -29,7 +29,7 @@ function consumeTopupFlag(): boolean {
     window.history.replaceState(
       null,
       "",
-      `${window.location.pathname}${nextSearch}`,
+      `${window.location.pathname}${nextSearch}`
     );
     return true;
   }
@@ -38,14 +38,18 @@ function consumeTopupFlag(): boolean {
 }
 
 interface CreditBalanceCardProps {
+  organizationId?: string | null;
+  canManageCredits?: boolean;
   /** Optional override for the chat session id used by the top-up flow. */
   chatSessionId?: string;
 }
 
 export function CreditBalanceCard({
+  organizationId,
+  canManageCredits = false,
   chatSessionId,
 }: CreditBalanceCardProps = {}) {
-  const { balance, isLoading } = useCreditBalance();
+  const { balance, isLoading } = useCreditBalance({ organizationId });
   const [isTopupOpen, setIsTopupOpen] = useState(false);
   const [topupSource, setTopupSource] =
     useState<CreditTopupSource>("billing_page");
@@ -68,10 +72,6 @@ export function CreditBalanceCard({
   };
 
   const hasPaidHistory = balance?.hasPurchaseHistory === true;
-  const paidPercentUsed =
-    balance?.paidPercentRemaining != null
-      ? 100 - balance.paidPercentRemaining
-      : 0;
 
   return (
     <Card className="border-border/60 py-6 shadow-sm">
@@ -82,56 +82,65 @@ export function CreditBalanceCard({
               Credit usage
             </p>
             <p className="mt-1 text-sm font-semibold leading-snug">
-              Your model credits
+              Organization model credits
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Credits are linked to your user, not the organization.
+              Shared credits are available to everyone in this organization.
             </p>
           </div>
-          <ErrorBoundary fallback={null}>
-            <TopupActionButton onClick={handleManualTopup} />
-          </ErrorBoundary>
+          {canManageCredits ? (
+            <ErrorBoundary fallback={null}>
+              <TopupActionButton onClick={handleManualTopup} />
+            </ErrorBoundary>
+          ) : null}
         </div>
 
-        <ErrorBoundary fallback={null}>
-          <PendingCreditTopupsBanner />
-        </ErrorBoundary>
+        {canManageCredits ? (
+          <ErrorBoundary fallback={null}>
+            <PendingCreditTopupsBanner organizationId={organizationId} />
+          </ErrorBoundary>
+        ) : null}
 
         <UsageRow
           label="Free daily credits"
           rightText={
             isLoading || !balance
               ? null
-              : `${Math.round(balance.freeDailyPercentUsed)}% used · ${formatCreditResetText(balance.freeDailyResetAt)}`
+              : `${Math.round(
+                  balance.freeDailyPercentUsed
+                )}% used · ${formatCreditResetText(balance.freeDailyResetAt)}`
           }
-          fillPercent={
-            isLoading || !balance ? 0 : balance.freeDailyPercentUsed
-          }
+          fillPercent={isLoading || !balance ? 0 : balance.freeDailyPercentUsed}
           isLoading={isLoading}
           testId="usage-daily"
         />
 
         {!isLoading && hasPaidHistory && balance && (
-          <UsageRow
-            label="Paid credits"
-            rightText={
-              balance.paidPercentRemaining != null
-                ? `${Math.round(100 - balance.paidPercentRemaining)}% used`
-                : null
-            }
-            fillPercent={paidPercentUsed}
-            isLoading={false}
-            testId="usage-paid"
-            tooltip="Used only after your free daily credits run out."
-          />
+          <div
+            className="rounded-md border border-border/60 bg-muted/20 px-3 py-2"
+            data-testid="usage-paid"
+          >
+            <p className="text-xs font-medium text-muted-foreground">
+              Shared paid credits
+            </p>
+            <p className="mt-1 text-lg font-semibold">
+              {balance.availableCredits.toLocaleString()} credits
+            </p>
+            {balance.walletLocked ? (
+              <p className="mt-1 text-xs text-destructive">
+                Credit spending is paused pending review.
+              </p>
+            ) : null}
+          </div>
         )}
       </CardContent>
-      {isTopupOpen && (
+      {isTopupOpen && canManageCredits && (
         <CreditTopupDialog
           open
           onOpenChange={setIsTopupOpen}
           chatSessionId={chatSessionId ?? ""}
           lastUserMessage=""
+          organizationId={organizationId}
           source={topupSource}
         />
       )}

--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -53,18 +53,32 @@ export function CreditBalanceCard({
   const [isTopupOpen, setIsTopupOpen] = useState(false);
   const [topupSource, setTopupSource] =
     useState<CreditTopupSource>("billing_page");
+  // Whether the user landed here from the global limit modal (`?topup=open`).
+  // Captured once on mount, then acted on once we know whether they can
+  // manage credits — `canManageCredits` can arrive a render late while the
+  // org role resolves.
+  const [arrivedFromLimitModal, setArrivedFromLimitModal] = useState(false);
 
-  // Auto-open the topup dialog when the user is redirected here from the
-  // global limit modal (`/organizations/{id}/billing?topup=open`). One-shot:
-  // the flag is consumed from the URL so a subsequent reload doesn't reopen.
-  // Source is recorded as `limit_modal` so the funnel can attribute the
-  // top-up back to the limit-hit that triggered the redirect.
+  // One-shot: consume the redirect flag from the URL so a reload doesn't
+  // reopen the dialog. Source is recorded as `limit_modal` so the funnel can
+  // attribute the top-up back to the limit-hit that triggered the redirect.
   useEffect(() => {
     if (consumeTopupFlag()) {
-      setTopupSource("limit_modal");
-      setIsTopupOpen(true);
+      setArrivedFromLimitModal(true);
     }
   }, []);
+
+  // Open the dialog only once we know the user can manage credits. A member
+  // who can't top up keeps `arrivedFromLimitModal` true and instead sees the
+  // "ask an admin" hint below — not a silent dead-end where the flag was
+  // consumed but nothing happened.
+  useEffect(() => {
+    if (arrivedFromLimitModal && canManageCredits) {
+      setTopupSource("limit_modal");
+      setIsTopupOpen(true);
+      setArrivedFromLimitModal(false);
+    }
+  }, [arrivedFromLimitModal, canManageCredits]);
 
   const handleManualTopup = () => {
     setTopupSource("billing_page");
@@ -126,13 +140,33 @@ export function CreditBalanceCard({
             <p className="mt-1 text-lg font-semibold">
               {balance.availableCredits.toLocaleString()} credits
             </p>
-            {balance.walletLocked ? (
-              <p className="mt-1 text-xs text-destructive">
-                Credit spending is paused pending review.
-              </p>
-            ) : null}
           </div>
         )}
+
+        {/* Wallet-lock notice is independent of purchase history: a wallet can
+            be locked (chargeback/dispute) with no completed purchase on
+            record, and that's exactly when the user needs to know spending is
+            paused. Gating it on hasPaidHistory would hide it in that case. */}
+        {!isLoading && balance?.walletLocked ? (
+          <p
+            className="text-xs text-destructive"
+            data-testid="usage-wallet-locked"
+          >
+            Credit spending is paused pending review.
+          </p>
+        ) : null}
+
+        {/* A member routed here from the limit modal who can't manage credits
+            would otherwise hit a silent dead-end (no dialog opens). Tell them
+            how to proceed instead. */}
+        {!isLoading && arrivedFromLimitModal && !canManageCredits ? (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="usage-ask-admin"
+          >
+            Ask an organization admin to add shared credits.
+          </p>
+        ) : null}
       </CardContent>
       {isTopupOpen && canManageCredits && (
         <CreditTopupDialog

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -21,6 +21,7 @@ interface CreditTopupDialogProps {
   onOpenChange: (open: boolean) => void;
   chatSessionId: string;
   lastUserMessage: string;
+  organizationId?: string | null;
   /** Surface the user came from. Forwarded to telemetry events. */
   source: CreditTopupSource;
 }
@@ -30,35 +31,38 @@ export function CreditTopupDialog({
   onOpenChange,
   chatSessionId,
   lastUserMessage,
+  organizationId,
   source,
 }: CreditTopupDialogProps) {
   const { presets, presetsLoading, startCheckout, isStartingCheckout } =
     useCreditTopup();
-  const [selectedAmountCents, setSelectedAmountCents] = useState<number | null>(
-    null,
+  const [selectedPackageId, setSelectedPackageId] = useState<string | null>(
+    null
   );
 
   useEffect(() => {
     if (!open) {
-      setSelectedAmountCents(null);
+      setSelectedPackageId(null);
     }
   }, [open]);
 
   useEffect(() => {
-    if (open && presets && selectedAmountCents === null) {
-      setSelectedAmountCents(presets[0]?.amountCents ?? null);
+    if (open && presets && selectedPackageId === null) {
+      setSelectedPackageId(presets[0]?.packageId ?? null);
     }
-  }, [open, presets, selectedAmountCents]);
+  }, [open, presets, selectedPackageId]);
 
   const selectedPreset: CreditTopupPreset | undefined = presets?.find(
-    (preset) => preset.amountCents === selectedAmountCents,
+    (preset) => preset.packageId === selectedPackageId
   );
 
   const handleConfirm = async () => {
-    if (!selectedPreset) return;
+    if (!selectedPreset || !organizationId) return;
     try {
       await startCheckout({
-        amountCents: selectedPreset.amountCents,
+        organizationId,
+        packageId: selectedPreset.packageId,
+        priceCents: selectedPreset.priceCents,
         chatSessionId,
         lastUserMessage,
         source,
@@ -79,10 +83,10 @@ export function CreditTopupDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Top up to keep chatting</DialogTitle>
+          <DialogTitle>Buy credits to keep chatting</DialogTitle>
           <DialogDescription>
-            Add credit to your account so you can keep using MCPJam models
-            without waiting for your free daily credits to reset.
+            Add credits to your organization so the team can keep using MCPJam
+            models without waiting for your free daily credits to reset.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-4">
@@ -92,27 +96,39 @@ export function CreditTopupDialog({
             </div>
           ) : !presets || presets.length === 0 ? (
             <div className="text-sm text-muted-foreground">
-              Top-up amounts are unavailable right now. Please try again later.
+              Credit packages are unavailable right now. Please try again later.
             </div>
           ) : (
             <div className="grid grid-cols-3 gap-2" role="radiogroup">
               {presets.map((preset) => {
-                const isSelected = preset.amountCents === selectedAmountCents;
+                const isSelected = preset.packageId === selectedPackageId;
+                const creditsAmount = preset.displayCredits.replace(
+                  /\s*credits\s*$/i,
+                  ""
+                );
                 return (
                   <button
-                    key={preset.amountCents}
+                    key={preset.packageId}
                     type="button"
                     role="radio"
                     aria-checked={isSelected}
-                    onClick={() => setSelectedAmountCents(preset.amountCents)}
+                    onClick={() => setSelectedPackageId(preset.packageId)}
                     className={cn(
                       "flex flex-col items-center justify-center rounded-md border px-3 py-3 text-sm font-medium transition-colors",
                       isSelected
                         ? "border-primary bg-primary/10 text-foreground"
-                        : "border-border hover:border-foreground/40",
+                        : "border-border hover:border-foreground/40"
                     )}
                   >
-                    <span className="text-base">{preset.amountUsd}</span>
+                    <span className="text-lg font-semibold leading-tight">
+                      {creditsAmount}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      credits
+                    </span>
+                    <span className="mt-0.5 text-xs text-muted-foreground">
+                      {preset.displayPrice}
+                    </span>
                   </button>
                 );
               })}
@@ -131,13 +147,13 @@ export function CreditTopupDialog({
           <Button
             type="button"
             onClick={handleConfirm}
-            disabled={!selectedPreset || isStartingCheckout}
+            disabled={!selectedPreset || !organizationId || isStartingCheckout}
           >
             {isStartingCheckout
               ? "Redirecting…"
               : selectedPreset
-                ? `Continue with ${selectedPreset.amountUsd}`
-                : "Continue"}
+              ? `Continue with ${selectedPreset.displayPrice}`
+              : "Continue"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
@@ -47,13 +47,21 @@ function bucketEntryCount(count: number): string {
   return "20+";
 }
 
-export function PaymentsHistorySection() {
+export function PaymentsHistorySection({
+  organizationId,
+  canViewHistory = false,
+}: {
+  organizationId?: string | null;
+  canViewHistory?: boolean;
+}) {
   // Hooks must be called unconditionally before any early-return — flag check
   // happens after. PostHog's `useFeatureFlagEnabled` can return `undefined`
   // during bootstrap; treat anything other than `true` as off so we don't
   // flash content before the flag resolves.
   const flagEnabled = useFeatureFlagEnabled("billing-entitlements-ui");
-  const { entries, isLoading } = usePaymentsHistory();
+  const { entries, isLoading } = usePaymentsHistory(
+    canViewHistory ? organizationId : null
+  );
   const posthog = usePostHog();
   const viewedRef = useRef(false);
 
@@ -76,7 +84,7 @@ export function PaymentsHistorySection() {
     });
   }, [flagEnabled, isLoading, posthog, safeEntries]);
 
-  if (flagEnabled !== true) return null;
+  if (flagEnabled !== true || !canViewHistory) return null;
 
   return (
     <Card className="border-border/60 py-6 shadow-sm">
@@ -108,6 +116,7 @@ function PaymentsTable({ entries }: { entries: PaymentHistoryEntry[] }) {
             <TableRow>
               <TableHead>Date</TableHead>
               <TableHead>Amount</TableHead>
+              <TableHead>Credits</TableHead>
               <TableHead>Status</TableHead>
               <TableHead className="text-right">Receipt</TableHead>
             </TableRow>
@@ -119,7 +128,10 @@ function PaymentsTable({ entries }: { entries: PaymentHistoryEntry[] }) {
                   {formatDate(entry.occurredAt)}
                 </TableCell>
                 <TableCell className="whitespace-nowrap text-sm tabular-nums">
-                  {formatUsd(entry.paidAmountCents)}
+                  {formatUsd(entry.pricePaidCents)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-sm">
+                  {entry.displayCredits}
                 </TableCell>
                 <TableCell>
                   <StatusBadge entry={entry} />
@@ -148,8 +160,11 @@ function MobileRow({ entry }: { entry: PaymentHistoryEntry }) {
       <div className="flex items-center justify-between text-sm">
         <span>{formatDate(entry.occurredAt)}</span>
         <span className="tabular-nums font-medium">
-          {formatUsd(entry.paidAmountCents)}
+          {formatUsd(entry.pricePaidCents)}
         </span>
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {entry.displayCredits}
       </div>
       <div className="flex items-center justify-between">
         <StatusBadge entry={entry} />
@@ -187,9 +202,9 @@ function StatusBadge({ entry }: { entry: PaymentHistoryEntry }) {
     const isPartial = status === "partially_refunded";
     // Hover detail like "$3 of $5 refunded" when we know the reversed amount.
     const detail =
-      typeof entry.reversedAmountCents === "number"
-        ? `${formatUsd(entry.reversedAmountCents)} of ${formatUsd(
-            entry.paidAmountCents,
+      typeof entry.reversedPaidCents === "number"
+        ? `${formatUsd(entry.reversedPaidCents)} of ${formatUsd(
+            entry.pricePaidCents
           )} refunded`
         : undefined;
     return (
@@ -226,7 +241,7 @@ function ReceiptCell({ entry }: { entry: PaymentHistoryEntry }) {
   if (entry.receiptUrl) {
     const ageDays = Math.max(
       0,
-      Math.round((Date.now() - entry.occurredAt) / (24 * 60 * 60 * 1000)),
+      Math.round((Date.now() - entry.occurredAt) / (24 * 60 * 60 * 1000))
     );
     return (
       <a
@@ -236,7 +251,7 @@ function ReceiptCell({ entry }: { entry: PaymentHistoryEntry }) {
         referrerPolicy="no-referrer"
         data-ph-no-capture
         aria-label={`View receipt for ${formatDate(
-          entry.occurredAt,
+          entry.occurredAt
         )} payment (opens in new tab)`}
         className="inline-flex items-center gap-1 text-sm text-primary underline-offset-4 hover:underline"
         onClick={() => {

--- a/mcpjam-inspector/client/src/components/billing/PendingCreditTopupsBanner.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PendingCreditTopupsBanner.tsx
@@ -8,13 +8,17 @@ const formatUsd = (cents: number): string => {
   return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
 };
 
-/** Renders a small notice for any in-flight or recently-failed credit top-up. */
-export function PendingCreditTopupsBanner() {
-  const { pending, failed } = usePendingCreditTopups();
+/** Renders a small notice for any in-flight or recently-failed credit purchase. */
+export function PendingCreditTopupsBanner({
+  organizationId,
+}: {
+  organizationId?: string | null;
+}) {
+  const { pending, failed } = usePendingCreditTopups(organizationId);
 
   const pendingTotalCents = useMemo(
-    () => (pending ?? []).reduce((sum, t) => sum + t.amountCents, 0),
-    [pending],
+    () => (pending ?? []).reduce((sum, t) => sum + t.pricePaidCents, 0),
+    [pending]
   );
 
   if (!pending && !failed) return null;
@@ -51,8 +55,8 @@ function PendingNotice({ totalAmountCents, count }: PendingNoticeProps) {
   const amountLabel = formatUsd(totalAmountCents);
   const headline =
     count === 1
-      ? `Top-up of ${amountLabel} is pending`
-      : `${count} top-ups (${amountLabel} total) are pending`;
+      ? `Credit purchase of ${amountLabel} is pending`
+      : `${count} credit purchases (${amountLabel} total) are pending`;
   return (
     <div
       role="status"
@@ -85,7 +89,8 @@ function FailedNotice({ topup }: FailedNoticeProps) {
       <CircleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
       <div className="space-y-0.5">
         <p className="font-medium">
-          Top-up of {formatUsd(topup.amountCents)} could not be completed
+          Credit purchase of {formatUsd(topup.pricePaidCents)} could not be
+          completed
         </p>
         <p className="text-destructive/80">
           Your payment was declined or returned. No credits were granted —

--- a/mcpjam-inspector/client/src/components/billing/TopupActionButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/TopupActionButton.tsx
@@ -6,9 +6,9 @@ interface TopupActionButtonProps {
 }
 
 /**
- * Renders the "Top up" button only when the topup preset endpoint has
+ * Renders the "Buy credits" button only when the credit package endpoint has
  * resolved with at least one preset. Avoids the dead-end UX where clicking
- * the button opens a dialog that immediately shows "Top-up amounts are
+ * the button opens a dialog that immediately shows "Credit packages are
  * unavailable right now" because the backend is missing the function.
  *
  * Wrap this in an `<ErrorBoundary fallback={null}>` at the call site so a
@@ -20,7 +20,7 @@ export function TopupActionButton({ onClick }: TopupActionButtonProps) {
   if (!presets || presets.length === 0) return null;
   return (
     <Button type="button" size="sm" onClick={onClick}>
-      Top up
+      Buy credits
     </Button>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -107,7 +107,7 @@ describe("CreditBalanceCard", () => {
     expect(paidRow.textContent ?? "").not.toMatch(/\$/);
   });
 
-  it("shows the org wallet lock state on the paid-credits row", () => {
+  it("shows the org wallet lock state independent of the paid-credits row", () => {
     balanceState = {
       availableCredits: -500,
       hasPurchaseHistory: true,
@@ -119,7 +119,29 @@ describe("CreditBalanceCard", () => {
 
     const paidRow = screen.getByTestId("usage-paid");
     expect(paidRow).toHaveTextContent(/-500 credits/);
-    expect(paidRow).toHaveTextContent(/paused pending review/);
+    // The lock notice lives in its own block, not inside the paid row.
+    expect(screen.getByTestId("usage-wallet-locked")).toHaveTextContent(
+      /paused pending review/
+    );
+  });
+
+  it("surfaces the wallet lock notice even with no purchase history", () => {
+    // A wallet can be locked (chargeback/dispute) before/without any completed
+    // purchase. Gating the notice on purchase history would hide it exactly
+    // when the user needs to know spending is paused.
+    balanceState = {
+      availableCredits: 0,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 0,
+      freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+      walletLocked: true,
+    };
+    render(<CreditBalanceCard />);
+
+    expect(screen.queryByTestId("usage-paid")).toBeNull();
+    expect(screen.getByTestId("usage-wallet-locked")).toHaveTextContent(
+      /paused pending review/
+    );
   });
 
   it("does NOT expose a tooltip trigger on the daily-limit row (no ambiguity to explain there)", () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -6,10 +6,11 @@ import { CreditBalanceCard } from "../CreditBalanceCard";
 
 let balanceState:
   | {
-      paidPercentRemaining: number | null;
+      availableCredits: number;
       hasPurchaseHistory: boolean;
       freeDailyPercentUsed: number;
       freeDailyResetAt: number;
+      walletLocked: boolean;
     }
   | undefined = undefined;
 let isLoadingState = false;
@@ -23,9 +24,7 @@ vi.mock("@/hooks/useCreditBalance", () => ({
 
 vi.mock("@/components/billing/CreditTopupDialog", () => ({
   CreditTopupDialog: ({ open, source }: { open: boolean; source: string }) =>
-    open ? (
-      <div data-testid="topup-dialog" data-source={source} />
-    ) : null,
+    open ? <div data-testid="topup-dialog" data-source={source} /> : null,
 }));
 
 // Stub the gated button so existing tests don't need to set up the preset
@@ -33,7 +32,7 @@ vi.mock("@/components/billing/CreditTopupDialog", () => ({
 vi.mock("@/components/billing/TopupActionButton", () => ({
   TopupActionButton: ({ onClick }: { onClick: () => void }) => (
     <button type="button" onClick={onClick}>
-      Top up
+      Buy credits
     </button>
   ),
 }));
@@ -47,10 +46,11 @@ vi.mock("@/components/billing/PendingCreditTopupsBanner", () => ({
 describe("CreditBalanceCard", () => {
   beforeEach(() => {
     balanceState = {
-      paidPercentRemaining: null,
+      availableCredits: 0,
       hasPurchaseHistory: false,
       freeDailyPercentUsed: 0,
       freeDailyResetAt: Date.now() + 11 * 60 * 60 * 1000,
+      walletLocked: false,
     };
     isLoadingState = false;
     window.location.hash = "";
@@ -68,10 +68,11 @@ describe("CreditBalanceCard", () => {
 
   it("renders the daily-limit row without surfacing any dollar value", () => {
     balanceState = {
-      paidPercentRemaining: null,
+      availableCredits: 0,
       hasPurchaseHistory: false,
       freeDailyPercentUsed: 9,
       freeDailyResetAt: Date.now() + 11 * 60 * 60 * 1000,
+      walletLocked: false,
     };
     render(<CreditBalanceCard />);
 
@@ -87,56 +88,54 @@ describe("CreditBalanceCard", () => {
     expect(screen.queryByTestId("usage-paid")).not.toBeInTheDocument();
   });
 
-  it("renders the paid-credits row as a bare percent, with no dollar value", () => {
-    // 32% remaining = 68% used. The bar's right-text is "X% used".
+  it("renders the paid-credits row as org credits, with no dollar value", () => {
     balanceState = {
-      paidPercentRemaining: 32,
+      availableCredits: 1200,
       hasPurchaseHistory: true,
       freeDailyPercentUsed: 100,
       freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+      walletLocked: false,
     };
     render(<CreditBalanceCard />);
 
     const paidRow = screen.getByTestId("usage-paid");
-    expect(paidRow).toHaveTextContent(/68% used/);
+    expect(paidRow).toHaveTextContent(/Shared paid credits/);
+    expect(paidRow).toHaveTextContent(/1,200 credits/);
     // Regression guard: the paid-credits row must NEVER surface a dollar
-    // amount. Pairing a $ with a percent invites the user to compute a
-    // wrong remaining-dollars value, and any credited-domain dollar
-    // exposes the take rate when the user knows what they paid.
+    // amount. Credits are the user-facing unit; internal pricing/margin math
+    // stays off the wire.
     expect(paidRow.textContent ?? "").not.toMatch(/\$/);
   });
 
-  it("exposes a tooltip trigger on the paid-credits row explaining consumption order", () => {
+  it("shows the org wallet lock state on the paid-credits row", () => {
     balanceState = {
-      paidPercentRemaining: 50,
+      availableCredits: -500,
       hasPurchaseHistory: true,
       freeDailyPercentUsed: 0,
       freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+      walletLocked: true,
     };
     render(<CreditBalanceCard />);
 
     const paidRow = screen.getByTestId("usage-paid");
-    // Keyboard- and screen-reader-accessible info button.
-    const infoButton = within(paidRow).getByRole("button", {
-      name: /About Paid credits/i,
-    });
-    expect(infoButton).toBeInTheDocument();
+    expect(paidRow).toHaveTextContent(/-500 credits/);
+    expect(paidRow).toHaveTextContent(/paused pending review/);
   });
 
   it("does NOT expose a tooltip trigger on the daily-limit row (no ambiguity to explain there)", () => {
     render(<CreditBalanceCard />);
     const dailyRow = screen.getByTestId("usage-daily");
     expect(
-      within(dailyRow).queryByRole("button", { name: /About/i }),
+      within(dailyRow).queryByRole("button", { name: /About/i })
     ).not.toBeInTheDocument();
   });
 
   it("opens the top-up dialog when the Top up button is clicked", async () => {
     const user = userEvent.setup();
-    render(<CreditBalanceCard />);
+    render(<CreditBalanceCard organizationId="org-1" canManageCredits />);
 
     expect(screen.queryByTestId("topup-dialog")).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /Top up/i }));
+    await user.click(screen.getByRole("button", { name: /Buy credits/i }));
     const dialog = screen.getByTestId("topup-dialog");
     expect(dialog).toBeInTheDocument();
     expect(dialog.getAttribute("data-source")).toBe("billing_page");
@@ -146,9 +145,9 @@ describe("CreditBalanceCard", () => {
     window.history.replaceState(
       {},
       "",
-      "/organizations/org-1/billing?topup=open",
+      "/organizations/org-1/billing?topup=open"
     );
-    render(<CreditBalanceCard />);
+    render(<CreditBalanceCard organizationId="org-1" canManageCredits />);
 
     const dialog = screen.getByTestId("topup-dialog");
     expect(dialog).toBeInTheDocument();
@@ -165,11 +164,13 @@ describe("CreditBalanceCard", () => {
     expect(screen.queryByTestId("topup-dialog")).not.toBeInTheDocument();
   });
 
-  it("clarifies that credits are user-scoped, not org-scoped", () => {
+  it("clarifies that credits are organization-scoped", () => {
     render(<CreditBalanceCard />);
-    expect(screen.getByText(/Your model credits/)).toBeInTheDocument();
+    expect(screen.getByText(/Organization model credits/)).toBeInTheDocument();
     expect(
-      screen.getByText(/Credits are linked to your user, not the organization/),
+      screen.getByText(
+        /Shared credits are available to everyone in this organization/
+      )
     ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -6,10 +6,14 @@ import { CreditTopupDialog } from "../CreditTopupDialog";
 
 const startCheckoutMock = vi.fn();
 
-let presetsState: Array<{
-  amountCents: number;
-  amountUsd: string;
-}> | undefined = undefined;
+let presetsState:
+  | Array<{
+      packageId: string;
+      priceCents: number;
+      displayPrice: string;
+      displayCredits: string;
+    }>
+  | undefined = undefined;
 let presetsLoadingState = false;
 let isStartingCheckoutState = false;
 
@@ -28,9 +32,24 @@ vi.mock("sonner", () => ({
 }));
 
 const DEFAULT_PRESETS = [
-  { amountCents: 500, amountUsd: "$5" },
-  { amountCents: 1000, amountUsd: "$10" },
-  { amountCents: 2000, amountUsd: "$20" },
+  {
+    packageId: "credits_500",
+    priceCents: 500,
+    displayPrice: "$5",
+    displayCredits: "500 credits",
+  },
+  {
+    packageId: "credits_1000",
+    priceCents: 1000,
+    displayPrice: "$10",
+    displayCredits: "1,000 credits",
+  },
+  {
+    packageId: "credits_2000",
+    priceCents: 2000,
+    displayPrice: "$20",
+    displayCredits: "2,000 credits",
+  },
 ];
 
 describe("CreditTopupDialog", () => {
@@ -48,13 +67,20 @@ describe("CreditTopupDialog", () => {
         onOpenChange={vi.fn()}
         chatSessionId="chat-1"
         lastUserMessage="hello"
+        organizationId="org-1"
         source="chat_banner"
-      />,
+      />
     );
 
-    expect(screen.getByRole("radio", { name: "$5" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "$10" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "$20" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: /500.*\$5/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: /1,000.*\$10/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: /2,000.*\$20/ })
+    ).toBeInTheDocument();
   });
 
   it("auto-selects the first preset without surfacing fee or credited dollar amounts", () => {
@@ -64,20 +90,26 @@ describe("CreditTopupDialog", () => {
         onOpenChange={vi.fn()}
         chatSessionId="chat-1"
         lastUserMessage="hello"
+        organizationId="org-1"
         source="chat_banner"
-      />,
+      />
     );
 
-    expect(screen.getByRole("radio", { name: "$5" })).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
+    expect(
+      screen.getByRole("radio", { name: /500.*\$5/ })
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByText(/Add credits to your organization/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/team can keep using MCPJam models/)
+    ).toBeInTheDocument();
     // The processing-fee disclaimer was removed so users can't back-compute
     // the take rate.
     expect(
       screen.queryByText(
-        /A portion of your payment covers payment processing and platform fees/,
-      ),
+        /A portion of your payment covers payment processing and platform fees/
+      )
     ).not.toBeInTheDocument();
     // Guard against regressions that surface a "credited" / "you'll receive
     // $X.XX" dollar value (which would leak the take rate).
@@ -85,7 +117,7 @@ describe("CreditTopupDialog", () => {
     expect(screen.queryByText(/in model credit/)).not.toBeInTheDocument();
   });
 
-  it("calls startCheckout with the selected amount and chat context", async () => {
+  it("calls startCheckout with the selected package, org, and chat context", async () => {
     const user = userEvent.setup();
     render(
       <CreditTopupDialog
@@ -93,23 +125,28 @@ describe("CreditTopupDialog", () => {
         onOpenChange={vi.fn()}
         chatSessionId="chat-1"
         lastUserMessage="please continue"
+        organizationId="org-1"
         source="chat_banner"
-      />,
+      />
     );
 
-    await user.click(screen.getByRole("radio", { name: "$10" }));
     await user.click(
-      screen.getByRole("button", { name: /Continue with \$10/ }),
+      screen.getByRole("radio", { name: /1,000.*\$10/ })
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Continue with \$10/ })
     );
 
     expect(startCheckoutMock).toHaveBeenCalledTimes(1);
     expect(startCheckoutMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        amountCents: 1000,
+        organizationId: "org-1",
+        packageId: "credits_1000",
+        priceCents: 1000,
         chatSessionId: "chat-1",
         lastUserMessage: "please continue",
         source: "chat_banner",
-      }),
+      })
     );
   });
 
@@ -121,19 +158,22 @@ describe("CreditTopupDialog", () => {
         onOpenChange={vi.fn()}
         chatSessionId="chat-1"
         lastUserMessage=""
+        organizationId="org-1"
         source="billing_page"
-      />,
+      />
     );
 
-    await user.click(screen.getByRole("radio", { name: "$10" }));
     await user.click(
-      screen.getByRole("button", { name: /Continue with \$10/ }),
+      screen.getByRole("radio", { name: /1,000.*\$10/ })
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Continue with \$10/ })
     );
 
     expect(startCheckoutMock).toHaveBeenCalledWith(
       expect.objectContaining({
         returnUrl: window.location.href,
-      }),
+      })
     );
   });
 
@@ -146,8 +186,9 @@ describe("CreditTopupDialog", () => {
         onOpenChange={onOpenChange}
         chatSessionId="chat-1"
         lastUserMessage="hello"
+        organizationId="org-1"
         source="chat_banner"
-      />,
+      />
     );
 
     await user.click(screen.getByRole("button", { name: "Cancel" }));
@@ -163,13 +204,14 @@ describe("CreditTopupDialog", () => {
         onOpenChange={vi.fn()}
         chatSessionId="chat-1"
         lastUserMessage="hello"
+        organizationId="org-1"
         source="chat_banner"
-      />,
+      />
     );
 
     expect(screen.getByText(/Loading amounts/)).toBeInTheDocument();
     expect(
-      screen.queryByRole("radio", { name: "$5" }),
+      screen.queryByRole("radio", { name: /500.*\$5/ })
     ).not.toBeInTheDocument();
   });
 
@@ -182,12 +224,13 @@ describe("CreditTopupDialog", () => {
         onOpenChange={vi.fn()}
         chatSessionId="chat-1"
         lastUserMessage="hello"
+        organizationId="org-1"
         source="chat_banner"
-      />,
+      />
     );
 
     expect(
-      screen.getByText(/Top-up amounts are unavailable/),
+      screen.getByText(/Credit packages are unavailable/)
     ).toBeInTheDocument();
   });
 
@@ -199,13 +242,28 @@ describe("CreditTopupDialog", () => {
         onOpenChange={vi.fn()}
         chatSessionId="chat-1"
         lastUserMessage="hello"
+        organizationId="org-1"
         source="chat_banner"
-      />,
+      />
     );
 
     expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Redirecting/ })).toBeDisabled();
+  });
+
+  it("disables checkout when no organization is available", () => {
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        source="chat_banner"
+      />
+    );
+
     expect(
-      screen.getByRole("button", { name: /Redirecting/ }),
+      screen.getByRole("button", { name: /Continue with \$5/ })
     ).toBeDisabled();
   });
 });

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
@@ -28,16 +28,17 @@ vi.mock("posthog-js/react", () => ({
 }));
 
 function makeEntry(
-  overrides: Partial<PaymentHistoryEntry> & { id: string },
+  overrides: Partial<PaymentHistoryEntry> & { id: string }
 ): PaymentHistoryEntry {
   return {
     id: overrides.id,
     sessionId: overrides.sessionId ?? `cs_${overrides.id}`,
-    paidAmountCents: overrides.paidAmountCents ?? 1000,
+    pricePaidCents: overrides.pricePaidCents ?? 1000,
+    displayCredits: overrides.displayCredits ?? "1,000 credits",
     status: overrides.status ?? "succeeded",
     occurredAt: overrides.occurredAt ?? Date.now(),
-    ...(overrides.reversedAmountCents !== undefined
-      ? { reversedAmountCents: overrides.reversedAmountCents }
+    ...(overrides.reversedPaidCents !== undefined
+      ? { reversedPaidCents: overrides.reversedPaidCents }
       : {}),
     ...(overrides.receiptUrl !== undefined
       ? { receiptUrl: overrides.receiptUrl }
@@ -69,10 +70,12 @@ describe("PaymentsHistorySection", () => {
     it("renders nothing and fires no telemetry when the flag is off", () => {
       flagState = false;
       hookState = populated;
-      const { container } = render(<PaymentsHistorySection />);
+      const { container } = render(
+        <PaymentsHistorySection organizationId="org-1" canViewHistory />
+      );
       expect(container.firstChild).toBeNull();
       const calls = captureMock.mock.calls.filter(
-        (c) => c[0] === "credit_topup_history_viewed",
+        (c) => c[0] === "credit_topup_history_viewed"
       );
       expect(calls).toHaveLength(0);
     });
@@ -80,10 +83,12 @@ describe("PaymentsHistorySection", () => {
     it("renders nothing and fires no telemetry while the flag is undefined (bootstrap)", () => {
       flagState = undefined;
       hookState = populated;
-      const { container } = render(<PaymentsHistorySection />);
+      const { container } = render(
+        <PaymentsHistorySection organizationId="org-1" canViewHistory />
+      );
       expect(container.firstChild).toBeNull();
       const calls = captureMock.mock.calls.filter(
-        (c) => c[0] === "credit_topup_history_viewed",
+        (c) => c[0] === "credit_topup_history_viewed"
       );
       expect(calls).toHaveLength(0);
     });
@@ -91,9 +96,9 @@ describe("PaymentsHistorySection", () => {
 
   describe("loading + empty states", () => {
     it("renders loading skeletons while the query is in flight", () => {
-      render(<PaymentsHistorySection />);
+      render(<PaymentsHistorySection organizationId="org-1" canViewHistory />);
       expect(
-        screen.getByTestId("payments-history-loading"),
+        screen.getByTestId("payments-history-loading")
       ).toBeInTheDocument();
     });
 
@@ -106,7 +111,7 @@ describe("PaymentsHistorySection", () => {
         isLoading: false,
         isAuthenticated: true,
       };
-      render(<PaymentsHistorySection />);
+      render(<PaymentsHistorySection organizationId="org-1" canViewHistory />);
       const empty = screen.getByTestId("payments-history-empty");
       expect(empty).toHaveTextContent(/No payments yet/);
       expect(within(empty).queryByRole("button")).not.toBeInTheDocument();
@@ -118,7 +123,8 @@ describe("PaymentsHistorySection", () => {
       makeEntry({
         id: "1",
         sessionId: "cs_succeeded_with_link",
-        paidAmountCents: 2500,
+        pricePaidCents: 2500,
+        displayCredits: "2,500 credits",
         status: "succeeded",
         receiptUrl: "https://pay.stripe.com/receipts/abc",
         occurredAt: Date.UTC(2026, 4, 22),
@@ -126,21 +132,24 @@ describe("PaymentsHistorySection", () => {
       makeEntry({
         id: "2",
         sessionId: "cs_legacy_succeeded",
-        paidAmountCents: 1000,
+        pricePaidCents: 1000,
+        displayCredits: "1,000 credits",
         status: "succeeded",
         occurredAt: Date.UTC(2026, 4, 14),
       }),
       makeEntry({
         id: "3",
         sessionId: "cs_pending",
-        paidAmountCents: 5000,
+        pricePaidCents: 5000,
+        displayCredits: "5,000 credits",
         status: "pending",
         occurredAt: Date.UTC(2026, 4, 10),
       }),
       makeEntry({
         id: "4",
         sessionId: "cs_failed",
-        paidAmountCents: 2500,
+        pricePaidCents: 2500,
+        displayCredits: "2,500 credits",
         status: "failed",
         occurredAt: Date.UTC(2026, 4, 3),
       }),
@@ -155,14 +164,14 @@ describe("PaymentsHistorySection", () => {
     });
 
     it("renders one row per entry with status-appropriate receipt copy", () => {
-      render(<PaymentsHistorySection />);
+      render(<PaymentsHistorySection organizationId="org-1" canViewHistory />);
       // Each entry is rendered TWICE: once in the desktop table (sm+) and
       // once in the mobile stacked layout (<sm). Tailwind hides one via CSS
       // but jsdom doesn't apply CSS visibility, so getAllBy* returns both
       // copies. We assert the doubled count to lock in the dual-render.
       // Succeeded + URL → "View receipt" (1 entry × 2 layouts = 2 links)
       expect(
-        screen.getAllByRole("link", { name: /View receipt/ }),
+        screen.getAllByRole("link", { name: /View receipt/ })
       ).toHaveLength(2);
       // Succeeded + no URL → "Not available"
       expect(screen.getAllByText(/Not available/)).toHaveLength(2);
@@ -173,11 +182,11 @@ describe("PaymentsHistorySection", () => {
     });
 
     it("renders the receipt link with full safety attributes", () => {
-      render(<PaymentsHistorySection />);
+      render(<PaymentsHistorySection organizationId="org-1" canViewHistory />);
       const link = screen.getAllByRole("link", { name: /View receipt/ })[0];
       expect(link).toHaveAttribute(
         "href",
-        "https://pay.stripe.com/receipts/abc",
+        "https://pay.stripe.com/receipts/abc"
       );
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
@@ -187,11 +196,11 @@ describe("PaymentsHistorySection", () => {
     });
 
     it("fires credit_topup_receipt_opened on receipt click (no URL prop, no status prop)", async () => {
-      render(<PaymentsHistorySection />);
+      render(<PaymentsHistorySection organizationId="org-1" canViewHistory />);
       const link = screen.getAllByRole("link", { name: /View receipt/ })[0];
       await userEvent.click(link);
       const call = captureMock.mock.calls.find(
-        (c) => c[0] === "credit_topup_receipt_opened",
+        (c) => c[0] === "credit_topup_receipt_opened"
       );
       expect(call).toBeDefined();
       const props = call?.[1] as Record<string, unknown>;
@@ -202,9 +211,9 @@ describe("PaymentsHistorySection", () => {
     });
 
     it("fires credit_topup_history_viewed once with bucketed entry_count", () => {
-      render(<PaymentsHistorySection />);
+      render(<PaymentsHistorySection organizationId="org-1" canViewHistory />);
       const calls = captureMock.mock.calls.filter(
-        (c) => c[0] === "credit_topup_history_viewed",
+        (c) => c[0] === "credit_topup_history_viewed"
       );
       expect(calls).toHaveLength(1);
       const props = calls[0][1] as Record<string, unknown>;
@@ -219,9 +228,9 @@ describe("PaymentsHistorySection", () => {
         isLoading: false,
         isAuthenticated: true,
       };
-      render(<PaymentsHistorySection />);
+      render(<PaymentsHistorySection organizationId="org-1" canViewHistory />);
       const calls = captureMock.mock.calls.filter(
-        (c) => c[0] === "credit_topup_history_viewed",
+        (c) => c[0] === "credit_topup_history_viewed"
       );
       expect(calls).toHaveLength(0);
     });
@@ -237,7 +246,7 @@ describe("PaymentsHistorySection", () => {
         isLoading: false,
         isAuthenticated: true,
       };
-      render(<PaymentsHistorySection />);
+      render(<PaymentsHistorySection organizationId="org-1" canViewHistory />);
     }
 
     it("renders a Refunded badge for a fully refunded payment", () => {
@@ -245,9 +254,9 @@ describe("PaymentsHistorySection", () => {
         makeEntry({
           id: "r1",
           status: "refunded",
-          paidAmountCents: 500,
-          reversedAmountCents: 500,
-        }),
+          pricePaidCents: 500,
+          reversedPaidCents: 500,
+        })
       );
       expect(screen.getAllByText("Refunded")).toHaveLength(2);
       // Must not also read as Succeeded.
@@ -259,9 +268,9 @@ describe("PaymentsHistorySection", () => {
         makeEntry({
           id: "r2",
           status: "partially_refunded",
-          paidAmountCents: 2500,
-          reversedAmountCents: 1000,
-        }),
+          pricePaidCents: 2500,
+          reversedPaidCents: 1000,
+        })
       );
       const badges = screen.getAllByText("Partially refunded");
       expect(badges).toHaveLength(2);
@@ -274,9 +283,9 @@ describe("PaymentsHistorySection", () => {
         makeEntry({
           id: "r3",
           status: "disputed",
-          paidAmountCents: 500,
-          reversedAmountCents: 500,
-        }),
+          pricePaidCents: 500,
+          reversedPaidCents: 500,
+        })
       );
       expect(screen.getAllByText("Disputed")).toHaveLength(2);
       expect(screen.queryByText("Succeeded")).not.toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PendingCreditTopupsBanner.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PendingCreditTopupsBanner.test.tsx
@@ -20,12 +20,13 @@ vi.mock("@/hooks/usePendingCreditTopups", () => ({
 }));
 
 function makeTopup(
-  overrides: Partial<PendingCreditTopup> & { id: string },
+  overrides: Partial<PendingCreditTopup> & { id: string }
 ): PendingCreditTopup {
   return {
     id: overrides.id,
     stripeSessionId: overrides.stripeSessionId ?? `cs_${overrides.id}`,
-    amountCents: overrides.amountCents ?? 1000,
+    pricePaidCents: overrides.pricePaidCents ?? 1000,
+    displayCredits: overrides.displayCredits ?? "1,000 credits",
     status: overrides.status ?? "pending",
     createdAt: overrides.createdAt ?? Date.now(),
     updatedAt: overrides.updatedAt ?? Date.now(),
@@ -44,7 +45,9 @@ describe("PendingCreditTopupsBanner", () => {
   });
 
   it("renders nothing while the query is loading (no flash of empty UI)", () => {
-    const { container } = render(<PendingCreditTopupsBanner />);
+    const { container } = render(
+      <PendingCreditTopupsBanner organizationId="org-1" />
+    );
     expect(container.firstChild).toBeNull();
   });
 
@@ -56,12 +59,14 @@ describe("PendingCreditTopupsBanner", () => {
       isLoading: false,
       isAuthenticated: true,
     };
-    const { container } = render(<PendingCreditTopupsBanner />);
+    const { container } = render(
+      <PendingCreditTopupsBanner organizationId="org-1" />
+    );
     expect(container.firstChild).toBeNull();
   });
 
   it("renders a single pending notice with the dollar amount", () => {
-    const pending = [makeTopup({ id: "p1", amountCents: 1000 })];
+    const pending = [makeTopup({ id: "p1", pricePaidCents: 1000 })];
     hookState = {
       topups: pending,
       pending,
@@ -69,17 +74,17 @@ describe("PendingCreditTopupsBanner", () => {
       isLoading: false,
       isAuthenticated: true,
     };
-    render(<PendingCreditTopupsBanner />);
+    render(<PendingCreditTopupsBanner organizationId="org-1" />);
 
     const notice = screen.getByTestId("pending-credit-topups-pending");
-    expect(notice).toHaveTextContent(/Top-up of \$10 is pending/);
+    expect(notice).toHaveTextContent(/Credit purchase of \$10 is pending/);
     expect(notice).toHaveTextContent(/1–5 business days/);
   });
 
-  it("aggregates multiple pending top-ups into one notice with a total", () => {
+  it("aggregates multiple pending credit purchases into one notice with a total", () => {
     const pending = [
-      makeTopup({ id: "p1", amountCents: 500 }),
-      makeTopup({ id: "p2", amountCents: 2500 }),
+      makeTopup({ id: "p1", pricePaidCents: 500 }),
+      makeTopup({ id: "p2", pricePaidCents: 2500 }),
     ];
     hookState = {
       topups: pending,
@@ -88,16 +93,18 @@ describe("PendingCreditTopupsBanner", () => {
       isLoading: false,
       isAuthenticated: true,
     };
-    render(<PendingCreditTopupsBanner />);
+    render(<PendingCreditTopupsBanner organizationId="org-1" />);
 
     const notice = screen.getByTestId("pending-credit-topups-pending");
-    expect(notice).toHaveTextContent(/2 top-ups \(\$30 total\) are pending/);
+    expect(notice).toHaveTextContent(
+      /2 credit purchases \(\$30 total\) are pending/
+    );
   });
 
-  it("renders a failed notice per failed top-up", () => {
+  it("renders a failed notice per failed credit purchase", () => {
     const failed = [
-      makeTopup({ id: "f1", amountCents: 1000, status: "failed" }),
-      makeTopup({ id: "f2", amountCents: 2000, status: "failed" }),
+      makeTopup({ id: "f1", pricePaidCents: 1000, status: "failed" }),
+      makeTopup({ id: "f2", pricePaidCents: 2000, status: "failed" }),
     ];
     hookState = {
       topups: failed,
@@ -106,22 +113,22 @@ describe("PendingCreditTopupsBanner", () => {
       isLoading: false,
       isAuthenticated: true,
     };
-    render(<PendingCreditTopupsBanner />);
+    render(<PendingCreditTopupsBanner organizationId="org-1" />);
 
     const failedNotices = screen.getAllByTestId("pending-credit-topups-failed");
     expect(failedNotices).toHaveLength(2);
     expect(failedNotices[0]).toHaveTextContent(
-      /Top-up of \$10 could not be completed/,
+      /Credit purchase of \$10 could not be completed/
     );
     expect(failedNotices[1]).toHaveTextContent(
-      /Top-up of \$20 could not be completed/,
+      /Credit purchase of \$20 could not be completed/
     );
   });
 
   it("renders both pending and failed notices when both exist", () => {
-    const pending = [makeTopup({ id: "p1", amountCents: 1000 })];
+    const pending = [makeTopup({ id: "p1", pricePaidCents: 1000 })];
     const failed = [
-      makeTopup({ id: "f1", amountCents: 500, status: "failed" }),
+      makeTopup({ id: "f1", pricePaidCents: 500, status: "failed" }),
     ];
     hookState = {
       topups: [...pending, ...failed],
@@ -130,22 +137,22 @@ describe("PendingCreditTopupsBanner", () => {
       isLoading: false,
       isAuthenticated: true,
     };
-    render(<PendingCreditTopupsBanner />);
+    render(<PendingCreditTopupsBanner organizationId="org-1" />);
 
     expect(
-      screen.getByTestId("pending-credit-topups-pending"),
+      screen.getByTestId("pending-credit-topups-pending")
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("pending-credit-topups-failed"),
+      screen.getByTestId("pending-credit-topups-failed")
     ).toBeInTheDocument();
   });
 
   it("never surfaces the take-rate-derived credited amount", () => {
     // Regression guard mirroring the backend wire-rule: the banner reads
-    // only `amountCents`. Even if a future server change accidentally
+    // only `pricePaidCents`. Even if a future server change accidentally
     // shipped `creditedCents` and the loose-shape normalizer kept it, it
     // must never render here.
-    const pending = [makeTopup({ id: "p1", amountCents: 1000 })];
+    const pending = [makeTopup({ id: "p1", pricePaidCents: 1000 })];
     hookState = {
       topups: pending,
       pending,
@@ -153,7 +160,7 @@ describe("PendingCreditTopupsBanner", () => {
       isLoading: false,
       isAuthenticated: true,
     };
-    render(<PendingCreditTopupsBanner />);
+    render(<PendingCreditTopupsBanner organizationId="org-1" />);
     const notice = screen.getByTestId("pending-credit-topups-pending");
     // The only dollar value should be $10. No $9.45, $9.50, etc. that could
     // hint at the post-take-rate credited amount.

--- a/mcpjam-inspector/client/src/components/billing/__tests__/TopupActionButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/TopupActionButton.test.tsx
@@ -4,7 +4,14 @@ import userEvent from "@testing-library/user-event";
 
 import { TopupActionButton } from "../TopupActionButton";
 
-let presetsState: Array<{ amountCents: number; amountUsd: string }> | undefined;
+let presetsState:
+  | Array<{
+      packageId: string;
+      priceCents: number;
+      displayPrice: string;
+      displayCredits: string;
+    }>
+  | undefined;
 
 vi.mock("@/hooks/useCreditTopup", () => ({
   useCreditTopupPresets: () => ({
@@ -16,15 +23,32 @@ vi.mock("@/hooks/useCreditTopup", () => ({
 describe("TopupActionButton", () => {
   beforeEach(() => {
     presetsState = [
-      { amountCents: 500, amountUsd: "$5" },
-      { amountCents: 1000, amountUsd: "$10" },
-      { amountCents: 2000, amountUsd: "$20" },
+      {
+        packageId: "credits_500",
+        priceCents: 500,
+        displayPrice: "$5",
+        displayCredits: "500 credits",
+      },
+      {
+        packageId: "credits_1000",
+        priceCents: 1000,
+        displayPrice: "$10",
+        displayCredits: "1,000 credits",
+      },
+      {
+        packageId: "credits_2000",
+        priceCents: 2000,
+        displayPrice: "$20",
+        displayCredits: "2,000 credits",
+      },
     ];
   });
 
-  it("renders the Top up button when presets are available", () => {
+  it("renders the Buy credits button when presets are available", () => {
     render(<TopupActionButton onClick={vi.fn()} />);
-    expect(screen.getByRole("button", { name: "Top up" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Buy credits" })
+    ).toBeInTheDocument();
   });
 
   it("renders nothing while presets are loading", () => {
@@ -43,7 +67,7 @@ describe("TopupActionButton", () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
     render(<TopupActionButton onClick={onClick} />);
-    await user.click(screen.getByRole("button", { name: "Top up" }));
+    await user.click(screen.getByRole("button", { name: "Buy credits" }));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/client/src/components/billing/__tests__/TopupGatedErrorBox.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/TopupGatedErrorBox.test.tsx
@@ -3,7 +3,14 @@ import { render, screen } from "@testing-library/react";
 
 import { TopupGatedErrorBox } from "../TopupGatedErrorBox";
 
-let presetsState: Array<{ amountCents: number; amountUsd: string }> | undefined;
+let presetsState:
+  | Array<{
+      packageId: string;
+      priceCents: number;
+      displayPrice: string;
+      displayCredits: string;
+    }>
+  | undefined;
 let presetsLoadingState: boolean;
 let presetQueryShouldThrow = false;
 
@@ -22,7 +29,7 @@ vi.mock("@/hooks/useCreditTopup", () => ({
     }
     if (presetQueryShouldThrow) {
       throw new Error(
-        "Could not find public function for 'billing:getCreditTopupPresets'",
+        "Could not find public function for 'billing:getCreditTopupPresets'"
       );
     }
     return { presets: presetsState, isLoading: presetsLoadingState };
@@ -44,66 +51,69 @@ const RATE_LIMIT_PROPS = {
 describe("TopupGatedErrorBox", () => {
   beforeEach(() => {
     presetsState = [
-      { amountCents: 500, amountUsd: "$5" },
-      { amountCents: 1000, amountUsd: "$10" },
-      { amountCents: 2000, amountUsd: "$20" },
+      {
+        packageId: "credits_500",
+        priceCents: 500,
+        displayPrice: "$5",
+        displayCredits: "500 credits",
+      },
+      {
+        packageId: "credits_1000",
+        priceCents: 1000,
+        displayPrice: "$10",
+        displayCredits: "1,000 credits",
+      },
+      {
+        packageId: "credits_2000",
+        priceCents: 2000,
+        displayPrice: "$20",
+        displayCredits: "2,000 credits",
+      },
     ];
     presetsLoadingState = false;
     presetQueryShouldThrow = false;
   });
 
-  it("does not render the Top up CTA when canTopUp is false", () => {
+  it("does not render the Buy credits CTA when canTopUp is false", () => {
     render(
       <TopupGatedErrorBox
         {...RATE_LIMIT_PROPS}
         canTopUp={false}
         onTopUp={vi.fn()}
-      />,
+      />
     );
     expect(
-      screen.queryByRole("button", { name: /Top up to keep chatting/ }),
+      screen.queryByRole("button", { name: /Buy credits to keep chatting/ })
     ).not.toBeInTheDocument();
   });
 
-  it("renders the Top up CTA when canTopUp is true and presets are available", () => {
+  it("renders the Buy credits CTA when canTopUp is true and presets are available", () => {
     render(
-      <TopupGatedErrorBox
-        {...RATE_LIMIT_PROPS}
-        canTopUp
-        onTopUp={vi.fn()}
-      />,
+      <TopupGatedErrorBox {...RATE_LIMIT_PROPS} canTopUp onTopUp={vi.fn()} />
     );
     expect(
-      screen.getByRole("button", { name: /Top up to keep chatting/ }),
+      screen.getByRole("button", { name: /Buy credits to keep chatting/ })
     ).toBeInTheDocument();
   });
 
-  it("hides the Top up CTA when canTopUp is true but presets are empty", () => {
+  it("hides the Buy credits CTA when canTopUp is true but presets are empty", () => {
     presetsState = [];
     render(
-      <TopupGatedErrorBox
-        {...RATE_LIMIT_PROPS}
-        canTopUp
-        onTopUp={vi.fn()}
-      />,
+      <TopupGatedErrorBox {...RATE_LIMIT_PROPS} canTopUp onTopUp={vi.fn()} />
     );
     expect(
-      screen.queryByRole("button", { name: /Top up to keep chatting/ }),
+      screen.queryByRole("button", { name: /Buy credits to keep chatting/ })
     ).not.toBeInTheDocument();
   });
 
-  it("hides the Top up CTA while presets are still loading", () => {
+  it("hides the Buy credits CTA while presets are still loading", () => {
     presetsState = undefined;
     presetsLoadingState = true;
     render(
-      <TopupGatedErrorBox
-        {...RATE_LIMIT_PROPS}
-        canTopUp
-        onTopUp={vi.fn()}
-      />,
+      <TopupGatedErrorBox {...RATE_LIMIT_PROPS} canTopUp onTopUp={vi.fn()} />
     );
     expect(
-      screen.queryByRole("button", { name: /Top up to keep chatting/ }),
+      screen.queryByRole("button", { name: /Buy credits to keep chatting/ })
     ).not.toBeInTheDocument();
   });
 
@@ -112,19 +122,15 @@ describe("TopupGatedErrorBox", () => {
     // Suppress React's expected error log noise from the boundary catch.
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     render(
-      <TopupGatedErrorBox
-        {...RATE_LIMIT_PROPS}
-        canTopUp
-        onTopUp={vi.fn()}
-      />,
+      <TopupGatedErrorBox {...RATE_LIMIT_PROPS} canTopUp onTopUp={vi.fn()} />
     );
     expect(
-      screen.queryByRole("button", { name: /Top up to keep chatting/ }),
+      screen.queryByRole("button", { name: /Buy credits to keep chatting/ })
     ).not.toBeInTheDocument();
     // The error copy is still rendered so the user understands what
     // happened, just without the gated Top-up CTA.
     expect(
-      screen.getAllByText(/Provider unavailable/).length,
+      screen.getAllByText(/Provider unavailable/).length
     ).toBeGreaterThanOrEqual(1);
     errorSpy.mockRestore();
   });

--- a/mcpjam-inspector/client/src/components/chat-v2/error.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/error.tsx
@@ -121,8 +121,8 @@ export function ErrorBox({
   const errorLabel = isMCPJamModelLimit
     ? "Free daily credits used up"
     : isPlatformError
-      ? "MCPJam platform issue"
-      : "An error occurred";
+    ? "MCPJam platform issue"
+    : "An error occurred";
   const errorPrefix = isMCPJamModelLimit ? `${errorLabel}.` : `${errorLabel}:`;
 
   if (isWalletLocked) {
@@ -139,8 +139,7 @@ export function ErrorBox({
               Account under review
             </p>
             <p className="text-sm leading-6 opacity-90">
-              We&apos;ve paused this account while a recent payment is
-              reviewed.{" "}
+              We&apos;ve paused this account while a recent payment is reviewed.{" "}
               <a
                 className="underline hover:no-underline"
                 href="mailto:founders@mcpjam.com?subject=MCPJam%20Account%20Review"
@@ -166,18 +165,15 @@ export function ErrorBox({
     // Another credit-funded chat is still in flight server-side. Short
     // wait, then retry — render a transient-feeling banner with a retry
     // button. Top-up doesn't help here; just wait it out.
-    const retrySeconds = Math.max(
-      1,
-      Math.ceil((retryAfterMs ?? 0) / 1000),
-    );
+    const retrySeconds = Math.max(1, Math.ceil((retryAfterMs ?? 0) / 1000));
     return (
       <div className="flex flex-col gap-2 border rounded p-3 border-border bg-muted/40 text-foreground">
         <div className="flex items-start gap-3">
           <CircleAlert className="h-4 w-4 flex-shrink-0 text-muted-foreground mt-0.5" />
           <div className="min-w-0 flex-1">
             <p className="text-xs leading-5">
-              Another credit-funded chat is finishing. Retry in{" "}
-              {retrySeconds} second{retrySeconds === 1 ? "" : "s"}.
+              Another credit-funded chat is finishing. Retry in {retrySeconds}{" "}
+              second{retrySeconds === 1 ? "" : "s"}.
             </p>
           </div>
           <div className="ml-auto flex flex-shrink-0 flex-wrap items-center gap-2">
@@ -231,7 +227,7 @@ export function ErrorBox({
         <div className="ml-auto flex flex-shrink-0 flex-wrap items-center gap-2">
           {canTopUp && onTopUp && (
             <Button type="button" onClick={onTopUp}>
-              Top up to keep chatting
+              Buy credits to keep chatting
             </Button>
           )}
           {isRetryable && onRetry && (
@@ -261,7 +257,7 @@ export function ErrorBox({
           <CollapsibleTrigger
             className={cn(
               "flex items-center gap-1.5 text-xs transition-colors",
-              triggerClasses,
+              triggerClasses
             )}
           >
             <span>More details</span>
@@ -275,7 +271,7 @@ export function ErrorBox({
             <div
               className={cn(
                 "rounded border bg-background/50 p-2",
-                borderClasses,
+                borderClasses
               )}
             >
               {errorDetailsJson ? (
@@ -289,7 +285,7 @@ export function ErrorBox({
                 <pre
                   className={cn(
                     "text-xs font-mono whitespace-pre-wrap overflow-x-auto",
-                    preClasses,
+                    preClasses
                   )}
                 >
                   {errorDetails}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -94,8 +94,8 @@ export function MCPJamLimitDialog() {
               <DialogTitle>You've used up your free guest credits.</DialogTitle>
               <DialogDescription>
                 Sign in to get{" "}
-                <strong className="text-foreground font-medium">15×</strong>{" "}
-                the free credits.
+                <strong className="text-foreground font-medium">15×</strong> the
+                free credits.
               </DialogDescription>
             </DialogHeader>
             <Button onClick={() => signIn()} className="w-full">
@@ -116,7 +116,7 @@ export function MCPJamLimitDialog() {
               <DialogTitle>You've run out of free daily credits</DialogTitle>
               <DialogDescription>
                 {billingUiEnabled
-                  ? "Top up or bring your own key to keep chatting on MCPJam's models without waiting for tomorrow's reset."
+                  ? "Buy credits or bring your own key to keep chatting on MCPJam's models without waiting for tomorrow's reset."
                   : "Bring your own key to keep chatting on MCPJam's models without waiting for tomorrow's reset."}
               </DialogDescription>
             </DialogHeader>
@@ -126,7 +126,7 @@ export function MCPJamLimitDialog() {
               </Button>
               {billingUiEnabled && (
                 <Button type="button" onClick={handleTopUp}>
-                  Top up
+                  Buy credits
                 </Button>
               )}
             </DialogFooter>

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -66,11 +66,11 @@ function getPlanColumnCta(params: {
   isBillingActionPending: boolean;
   onDowngradePlan: (
     plan: OrganizationPlan,
-    billingInterval: BillingInterval,
+    billingInterval: BillingInterval
   ) => void;
   onStartPlanChange: (
     plan: "team",
-    billingInterval: BillingInterval,
+    billingInterval: BillingInterval
   ) => Promise<void>;
   billingInterval: BillingInterval;
 }): {
@@ -142,7 +142,7 @@ function getPlanColumnCta(params: {
 function formatCurrency(
   amount: number,
   currency: string,
-  maximumFractionDigits: number,
+  maximumFractionDigits: number
 ): string {
   return new Intl.NumberFormat(undefined, {
     style: "currency",
@@ -161,7 +161,7 @@ function formatBillingDate(timestampMs: number): string {
 }
 
 function getDeferredTrialBillingCopy(
-  billingStatus: OrganizationBillingStatus | undefined,
+  billingStatus: OrganizationBillingStatus | undefined
 ): string | null {
   const deferredTrialBillingStartsAt =
     billingStatus?.deferredTrialBillingStartsAt;
@@ -170,7 +170,7 @@ function getDeferredTrialBillingCopy(
   }
 
   return `$0 today. First bill charged in advance on ${formatBillingDate(
-    deferredTrialBillingStartsAt,
+    deferredTrialBillingStartsAt
   )}.`;
 }
 
@@ -179,7 +179,7 @@ function formatPlanPriceLabel(
   _plan: OrganizationPlan,
   amountInCents: number | null,
   currency: string,
-  interval: BillingInterval,
+  interval: BillingInterval
 ): string {
   if (amountInCents == null) {
     return interval === "annual" ? "Custom annual" : "Custom pricing";
@@ -189,13 +189,17 @@ function formatPlanPriceLabel(
     return `${formatCurrency(amountInCents / 100, currency, 0)}/seat/mo`;
   }
   const monthlyEquivalentDollars = amountInCents / 12 / 100;
-  return `${formatCurrency(Math.round(monthlyEquivalentDollars), currency, 0)}/seat/mo`;
+  return `${formatCurrency(
+    Math.round(monthlyEquivalentDollars),
+    currency,
+    0
+  )}/seat/mo`;
 }
 
 function formatPerSeatCadence(
   plan: OrganizationPlan,
   entry: PlanCatalog["plans"][OrganizationPlan],
-  interval: BillingInterval,
+  interval: BillingInterval
 ): string {
   if (plan === "free") {
     return "No credit card required";
@@ -218,8 +222,8 @@ function PlanPriceDisplay({ label }: { label: string }) {
   const suffix = label.endsWith(PER_SEAT_MO_SUFFIX)
     ? PER_SEAT_MO_SUFFIX
     : label.endsWith(PER_MO_SUFFIX)
-      ? PER_MO_SUFFIX
-      : null;
+    ? PER_MO_SUFFIX
+    : null;
   const amount = suffix ? label.slice(0, -suffix.length) : label;
 
   return (
@@ -358,7 +362,7 @@ function ComparePlanMatrixCell({ cell }: { cell: ComparePlanCell }) {
     <span
       className={cn(
         "block w-full text-center text-sm text-muted-foreground",
-        cell.emphasize && "font-semibold text-foreground",
+        cell.emphasize && "font-semibold text-foreground"
       )}
     >
       {cell.text}
@@ -387,7 +391,7 @@ function BillingIntervalToggle({
           "inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2 py-1.5 text-sm font-medium transition-colors sm:gap-2 sm:px-3",
           billingInterval === "annual"
             ? "bg-background text-foreground shadow-sm"
-            : "text-muted-foreground",
+            : "text-muted-foreground"
         )}
         onClick={() => onBillingIntervalChange("annual")}
       >
@@ -405,7 +409,7 @@ function BillingIntervalToggle({
           "shrink-0 whitespace-nowrap rounded-md px-2 py-1.5 text-sm font-medium transition-colors sm:px-3",
           billingInterval === "monthly"
             ? "bg-background text-foreground shadow-sm"
-            : "text-muted-foreground",
+            : "text-muted-foreground"
         )}
         onClick={() => onBillingIntervalChange("monthly")}
       >
@@ -416,8 +420,10 @@ function BillingIntervalToggle({
 }
 
 interface OrganizationBillingSectionProps {
+  organizationId: string;
   billingStatus: OrganizationBillingStatus | undefined;
   organizationName: string;
+  canManageCredits: boolean;
   planCatalog: PlanCatalog | undefined;
   isLoadingBilling: boolean;
   isLoadingPlanCatalog: boolean;
@@ -426,23 +432,25 @@ interface OrganizationBillingSectionProps {
   isOpeningPortal: boolean;
   onDowngradePlan: (
     plan: OrganizationPlan,
-    billingInterval: BillingInterval,
+    billingInterval: BillingInterval
   ) => Promise<void>;
   onStartPlanChange: (
     plan: "team",
-    billingInterval: BillingInterval,
+    billingInterval: BillingInterval
   ) => Promise<void>;
   onStartAutoPlanChange?: (
     plan: "team",
-    billingInterval: BillingInterval,
+    billingInterval: BillingInterval
   ) => Promise<void>;
   checkoutIntent?: CheckoutIntentWithOrganization | null;
   onCheckoutIntentConsumed?: () => void;
 }
 
 export function OrganizationBillingSection({
+  organizationId,
   billingStatus,
   organizationName,
+  canManageCredits,
   planCatalog,
   isLoadingBilling,
   isLoadingPlanCatalog,
@@ -514,7 +522,7 @@ export function OrganizationBillingSection({
           toast.error(
             !billingStatus.canManageBilling
               ? "Only organization owners can start checkout."
-              : "Checkout isn't available in this environment.",
+              : "Checkout isn't available in this environment."
           );
           onCheckoutIntentConsumed?.();
         }
@@ -523,7 +531,7 @@ export function OrganizationBillingSection({
 
       const intentGuard = guardCheckoutIntentAgainstBillingStatus(
         billingStatus,
-        checkoutIntent.plan,
+        checkoutIntent.plan
       );
       if (!intentGuard.proceed) {
         if (!cancelled && autoCheckoutStartedForKeyRef.current !== intentKey) {
@@ -548,7 +556,7 @@ export function OrganizationBillingSection({
       try {
         await (onStartAutoPlanChange ?? onStartPlanChange)(
           checkoutIntent.plan,
-          checkoutIntent.interval,
+          checkoutIntent.interval
         );
         if (!cancelled) {
           onCheckoutIntentConsumed?.();
@@ -666,11 +674,17 @@ export function OrganizationBillingSection({
       </Dialog>
 
       <ErrorBoundary fallback={null}>
-        <CreditBalanceCard />
+        <CreditBalanceCard
+          organizationId={organizationId}
+          canManageCredits={canManageCredits}
+        />
       </ErrorBoundary>
 
       <ErrorBoundary fallback={null}>
-        <PaymentsHistorySection />
+        <PaymentsHistorySection
+          organizationId={organizationId}
+          canViewHistory={canManageCredits}
+        />
       </ErrorBoundary>
 
       {checkoutIntent ? (
@@ -783,27 +797,23 @@ export function OrganizationBillingSection({
                             : getDisplayPriceCentsForPlan(
                                 plan,
                                 billingInterval,
-                                entry,
+                                entry
                               );
                         const priceLabel = isEnterprisePlan
                           ? "Custom"
                           : plan === "free"
-                            ? "$0"
-                            : formatPlanPriceLabel(
-                                plan,
-                                displayCents,
-                                planCatalog.currency,
-                                billingInterval,
-                              );
+                          ? "$0"
+                          : formatPlanPriceLabel(
+                              plan,
+                              displayCents,
+                              planCatalog.currency,
+                              billingInterval
+                            );
                         const priceSubtext = isEnterprisePlan
                           ? formatPerSeatCadence(plan, entry, billingInterval)
                           : plan === "free"
-                            ? "No credit card required"
-                            : formatPerSeatCadence(
-                                plan,
-                                entry,
-                                billingInterval,
-                              );
+                          ? "No credit card required"
+                          : formatPerSeatCadence(plan, entry, billingInterval);
                         const cta = getPlanColumnCta({
                           plan,
                           currentPlan,
@@ -813,11 +823,11 @@ export function OrganizationBillingSection({
                           isBillingActionPending,
                           onDowngradePlan: (
                             targetPlan,
-                            targetBillingInterval,
+                            targetBillingInterval
                           ) =>
                             void onDowngradePlan(
                               targetPlan,
-                              targetBillingInterval,
+                              targetBillingInterval
                             ),
                           onStartPlanChange,
                           billingInterval,
@@ -826,7 +836,7 @@ export function OrganizationBillingSection({
                           pendingPlanChangeTarget === plan &&
                           (cta.label === "Upgrade" ||
                             cta.label === "Downgrade") &&
-                          (plan === "team");
+                          plan === "team";
                         const showCtaSpinner = showPlanChangeSpinner;
                         const isPopular = plan === POPULAR_PLAN;
                         const showDeferredTrialBillingCopy =
@@ -834,14 +844,14 @@ export function OrganizationBillingSection({
                           cta.label === "Upgrade" &&
                           !cta.disabled &&
                           !cta.tooltip &&
-                          (plan === "team");
+                          plan === "team";
                         return (
                           <TableHead
                             key={plan}
                             className={cn(
                               "h-full min-h-0 whitespace-normal px-3 pt-5 pb-4 text-center align-top",
                               isPopular &&
-                                "border-x border-primary/35 bg-primary/[0.06]",
+                                "border-x border-primary/35 bg-primary/[0.06]"
                             )}
                           >
                             <div className="mx-auto flex h-full min-h-[11rem] w-full max-w-[13rem] flex-col">
@@ -963,7 +973,7 @@ export function OrganizationBillingSection({
                                     className={cn(
                                       "max-w-[13rem] whitespace-normal px-3 py-3 text-center align-middle text-sm",
                                       isPopular &&
-                                        "border-x border-primary/35 bg-primary/[0.06]",
+                                        "border-x border-primary/35 bg-primary/[0.06]"
                                     )}
                                   >
                                     <ComparePlanMatrixCell cell={cells[i]!} />

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
@@ -4,10 +4,11 @@ import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
 
 let balanceState:
   | {
-      paidPercentRemaining: number | null;
+      availableCredits: number;
       hasPurchaseHistory: boolean;
       freeDailyPercentUsed: number;
       freeDailyResetAt: number;
+      walletLocked: boolean;
     }
   | undefined;
 let isLoadingState = false;
@@ -26,10 +27,11 @@ describe("SidebarCreditUsage", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-03T12:00:00Z"));
     balanceState = {
-      paidPercentRemaining: null,
+      availableCredits: 0,
       hasPurchaseHistory: false,
       freeDailyPercentUsed: 12,
       freeDailyResetAt: Date.now() + 3 * 60 * 60 * 1000,
+      walletLocked: false,
     };
     isLoadingState = false;
     hasWorkOsUserState = true;
@@ -47,17 +49,16 @@ describe("SidebarCreditUsage", () => {
     expect(dailyRow).toHaveTextContent("Free daily credits");
     expect(dailyRow).toHaveTextContent("12%");
     expect(dailyRow).toHaveTextContent("resets in 3h");
-    expect(
-      screen.queryByText(/15× the credits/i)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/15× the credits/i)).not.toBeInTheDocument();
   });
 
   it("keeps the sidebar strip focused on daily limits for paid users", () => {
     balanceState = {
-      paidPercentRemaining: 25,
+      availableCredits: 750,
       hasPurchaseHistory: true,
       freeDailyPercentUsed: 40,
       freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+      walletLocked: false,
     };
 
     render(<SidebarCreditUsage />);
@@ -68,10 +69,11 @@ describe("SidebarCreditUsage", () => {
 
   it("shows paid credits in the full account-menu variant", () => {
     balanceState = {
-      paidPercentRemaining: 25,
+      availableCredits: 750,
       hasPurchaseHistory: true,
       freeDailyPercentUsed: 40,
       freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+      walletLocked: false,
     };
 
     render(<SidebarCreditUsage variant="full" />);
@@ -81,12 +83,11 @@ describe("SidebarCreditUsage", () => {
       "40% used"
     );
     const paidRow = screen.getByTestId("sidebar-usage-paid");
-    expect(paidRow).toHaveTextContent("Paid credits");
-    expect(paidRow).toHaveTextContent("75% used");
+    expect(paidRow).toHaveTextContent("Shared paid credits");
+    expect(paidRow).toHaveTextContent("750");
+    expect(paidRow).toHaveTextContent("shared credits");
     expect(paidRow.textContent ?? "").not.toMatch(/\$/);
-    expect(
-      screen.queryByText(/15× the credits/i)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/15× the credits/i)).not.toBeInTheDocument();
   });
 
   it("does not render when there is no balance to show", () => {
@@ -101,10 +102,11 @@ describe("SidebarCreditUsage", () => {
 
   it("renders guest balance data with a sign-in upgrade hint", () => {
     balanceState = {
-      paidPercentRemaining: null,
+      availableCredits: 0,
       hasPurchaseHistory: false,
       freeDailyPercentUsed: 65,
       freeDailyResetAt: Date.now() + 2 * 60 * 60 * 1000,
+      walletLocked: false,
     };
     hasWorkOsUserState = false;
 
@@ -112,9 +114,7 @@ describe("SidebarCreditUsage", () => {
 
     const dailyRow = screen.getByTestId("sidebar-usage-daily");
     expect(screen.getByTestId("sidebar-credit-usage")).toBeInTheDocument();
-    expect(dailyRow).toHaveTextContent(
-      "Sign in for 15× the credits"
-    );
+    expect(dailyRow).toHaveTextContent("Sign in for 15× the credits");
     expect(dailyRow).toHaveTextContent("Free daily credits");
     expect(dailyRow).toHaveTextContent("65%");
     expect(dailyRow).toHaveTextContent("resets in 2h");
@@ -140,21 +140,20 @@ describe("SidebarCreditUsage", () => {
     // wrapper is now a div with role=button, leaving the tooltip trigger as
     // the only real <button> in the row.
     balanceState = {
-      paidPercentRemaining: 40,
+      availableCredits: 600,
       hasPurchaseHistory: true,
       freeDailyPercentUsed: 10,
       freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+      walletLocked: false,
     };
-    render(
-      <SidebarCreditUsage variant="full" onClick={() => undefined} />,
-    );
+    render(<SidebarCreditUsage variant="full" onClick={() => undefined} />);
     const wrapper = screen.getByTestId("sidebar-credit-usage");
     // Wrapper is NOT a real <button>
     expect(wrapper.tagName).toBe("DIV");
     expect(wrapper).toHaveAttribute("role", "button");
     // Tooltip trigger inside it is still a real focusable button
     const tooltipTrigger = screen.getByRole("button", {
-      name: /About Paid credits/i,
+      name: /About Shared paid credits/i,
     });
     expect(tooltipTrigger.tagName).toBe("BUTTON");
   });
@@ -166,15 +165,16 @@ describe("SidebarCreditUsage", () => {
     const { default: userEvent } = await import("@testing-library/user-event");
     const onWrapperClick = vi.fn();
     balanceState = {
-      paidPercentRemaining: 40,
+      availableCredits: 600,
       hasPurchaseHistory: true,
       freeDailyPercentUsed: 10,
       freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+      walletLocked: false,
     };
     render(<SidebarCreditUsage variant="full" onClick={onWrapperClick} />);
 
     const tooltipTrigger = screen.getByRole("button", {
-      name: /About Paid credits/i,
+      name: /About Shared paid credits/i,
     });
 
     vi.useRealTimers();

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 
 interface SidebarCreditUsageProps {
   className?: string;
+  organizationId?: string | null;
   includeGuests?: boolean;
   variant?: "strip" | "full";
   onClick?: () => void;
@@ -19,11 +20,13 @@ interface SidebarCreditUsageProps {
 
 export function SidebarCreditUsage({
   className,
+  organizationId,
   includeGuests = false,
   variant = "strip",
   onClick,
 }: SidebarCreditUsageProps = {}) {
   const { balance, isLoading, hasWorkOsUser } = useCreditBalance({
+    organizationId,
     includeGuests,
   });
 
@@ -37,10 +40,6 @@ export function SidebarCreditUsage({
   const resetText = balance
     ? formatCreditResetText(balance.freeDailyResetAt)
     : null;
-  const paidPercentUsed =
-    balance?.paidPercentRemaining != null
-      ? Math.round(100 - balance.paidPercentRemaining)
-      : 0;
   const hasPaidHistory = balance?.hasPurchaseHistory === true;
   const showGuestUpgradeHint =
     variant === "strip" && includeGuests && !hasWorkOsUser && !isLoading;
@@ -73,10 +72,10 @@ export function SidebarCreditUsage({
         />
         {variant === "full" && !isLoading && hasPaidHistory && balance ? (
           <SidebarUsageRow
-            label="Paid credits"
-            percentText={`${paidPercentUsed}% used`}
-            helperText={null}
-            fillPercent={paidPercentUsed}
+            label="Shared paid credits"
+            percentText={`${balance.availableCredits.toLocaleString()}`}
+            helperText="shared credits"
+            fillPercent={0}
             isLoading={false}
             testId="sidebar-usage-paid"
             tooltip="Used only after your free daily credits run out."

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -75,10 +75,13 @@ export function SidebarCreditUsage({
             label="Shared paid credits"
             percentText={`${balance.availableCredits.toLocaleString()}`}
             helperText="shared credits"
+            // Absolute credit count, not a percentage — render no progress
+            // bar (a permanently 0%-filled bar reads as a bug).
+            showBar={false}
             fillPercent={0}
             isLoading={false}
             testId="sidebar-usage-paid"
-            tooltip="Used only after your free daily credits run out."
+            tooltip="Shared across your organization. Spent after the free daily credits run out."
           />
         ) : null}
       </div>
@@ -131,6 +134,8 @@ interface SidebarUsageRowProps {
   fillPercent: number;
   isLoading: boolean;
   testId: string;
+  /** Render the progress bar. Off for absolute counts with no denominator. */
+  showBar?: boolean;
   /** Optional explainer surfaced via an info icon next to the label. */
   tooltip?: string;
 }
@@ -143,6 +148,7 @@ function SidebarUsageRow({
   fillPercent,
   isLoading,
   testId,
+  showBar = true,
   tooltip,
 }: SidebarUsageRowProps) {
   return (
@@ -179,11 +185,13 @@ function SidebarUsageRow({
           {isLoading ? <Skeleton className="h-3 w-12" /> : percentText}
         </span>
       </div>
-      {isLoading ? (
-        <Skeleton className="h-1.5 w-full rounded-full" />
-      ) : (
-        <Progress className="h-1.5 bg-primary/15" value={fillPercent} />
-      )}
+      {showBar ? (
+        isLoading ? (
+          <Skeleton className="h-1.5 w-full rounded-full" />
+        ) : (
+          <Progress className="h-1.5 bg-primary/15" value={fillPercent} />
+        )
+      ) : null}
       {helperText && !isLoading ? (
         <span className="truncate text-[10px] leading-none text-muted-foreground">
           {helperText}

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -10,7 +10,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@mcpjam/design-system/dropdown-menu";
-import { Avatar, AvatarFallback, AvatarImage } from "@mcpjam/design-system/avatar";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@mcpjam/design-system/avatar";
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -190,9 +194,7 @@ export function SidebarUser({
                   </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">
-                    {displayName}
-                  </span>
+                  <span className="truncate font-semibold">{displayName}</span>
                   <span className="truncate text-xs text-muted-foreground">
                     {email}
                   </span>
@@ -201,8 +203,11 @@ export function SidebarUser({
             </DropdownMenuLabel>
             <SidebarCreditUsage
               className="px-1 pb-1"
+              organizationId={activeOrganizationId}
               variant="full"
-              onClick={canNavigateToBilling ? handleCreditUsageClick : undefined}
+              onClick={
+                canNavigateToBilling ? handleCreditUsageClick : undefined
+              }
             />
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
@@ -32,10 +32,11 @@ describe("useCreditBalance", () => {
     mocks.workosAuth.user = null;
     mocks.workosAuth.isLoading = false;
     mocks.queryResult = {
-      paidPercentRemaining: null,
+      availableCredits: 0,
       hasPurchaseHistory: false,
       freeDailyPercentUsed: 65,
       freeDailyResetAt: 1_777_777_777_000,
+      walletLocked: false,
     };
     mocks.useQuery.mockImplementation((_name: unknown, args: unknown) =>
       args === "skip" ? undefined : mocks.queryResult
@@ -57,7 +58,7 @@ describe("useCreditBalance", () => {
     expect(result.current.hasWorkOsUser).toBe(false);
   });
 
-  it("fetches guest balances when includeGuests is enabled", () => {
+  it("fetches guest balances when includeGuests is enabled without an org", () => {
     mocks.convexAuth.isAuthenticated = true;
 
     const { result } = renderHook(() =>
@@ -66,25 +67,43 @@ describe("useCreditBalance", () => {
 
     expect(mocks.useQuery).toHaveBeenCalledWith("billing:getCreditBalance", {});
     expect(result.current.balance).toEqual({
-      paidPercentRemaining: null,
+      availableCredits: 0,
       hasPurchaseHistory: false,
       freeDailyPercentUsed: 65,
       freeDailyResetAt: 1_777_777_777_000,
+      walletLocked: false,
     });
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.hasWorkOsUser).toBe(false);
   });
 
-  it("fetches signed-in balances without includeGuests", () => {
+  it("fetches signed-in org balances without includeGuests", () => {
+    mocks.convexAuth.isAuthenticated = true;
+    mocks.workosAuth.user = { id: "user_123" };
+
+    const { result } = renderHook(() =>
+      useCreditBalance({ organizationId: "org-1" })
+    );
+
+    expect(mocks.useQuery).toHaveBeenCalledWith("billing:getCreditBalance", {
+      organizationId: "org-1",
+    });
+    expect(result.current.balance?.freeDailyPercentUsed).toBe(65);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.hasWorkOsUser).toBe(true);
+  });
+
+  it("skips signed-in fetches until an organization is selected", () => {
     mocks.convexAuth.isAuthenticated = true;
     mocks.workosAuth.user = { id: "user_123" };
 
     const { result } = renderHook(() => useCreditBalance());
 
-    expect(mocks.useQuery).toHaveBeenCalledWith("billing:getCreditBalance", {});
-    expect(result.current.balance?.freeDailyPercentUsed).toBe(65);
-    expect(result.current.isAuthenticated).toBe(true);
-    expect(result.current.hasWorkOsUser).toBe(true);
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      "billing:getCreditBalance",
+      "skip"
+    );
+    expect(result.current.balance).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePaymentsHistory.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePaymentsHistory.test.ts
@@ -11,7 +11,8 @@ let queryReturn: unknown = undefined;
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => convexAuth,
-  useQuery: (..._args: unknown[]) => queryReturn,
+  useQuery: (_name: unknown, args: unknown) =>
+    args === "skip" ? undefined : queryReturn,
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -20,6 +21,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 
 // Import AFTER mocks are set up.
 import { usePaymentsHistory } from "../usePaymentsHistory";
+
+// Billing is org-scoped, so the query only fires once an org is selected.
+const ORG_ID = "org_test";
 
 describe("usePaymentsHistory", () => {
   beforeEach(() => {
@@ -31,7 +35,7 @@ describe("usePaymentsHistory", () => {
   describe("auth gating", () => {
     it("returns isLoading=true and entries=undefined while convex auth is loading", () => {
       convexAuth = { isAuthenticated: false, isLoading: true };
-      const { result } = renderHook(() => usePaymentsHistory());
+      const { result } = renderHook(() => usePaymentsHistory(ORG_ID));
       expect(result.current.isLoading).toBe(true);
       expect(result.current.entries).toBeUndefined();
     });
@@ -39,8 +43,15 @@ describe("usePaymentsHistory", () => {
     it("returns isLoading=false and entries=undefined when unauthenticated (query is skipped)", () => {
       convexAuth = { isAuthenticated: false, isLoading: false };
       workOsAuth = { user: null, isLoading: false };
-      const { result } = renderHook(() => usePaymentsHistory());
+      const { result } = renderHook(() => usePaymentsHistory(ORG_ID));
       // Query is skipped so we don't wait on a response.
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.entries).toBeUndefined();
+    });
+
+    it("skips the query until an organization is selected", () => {
+      const { result } = renderHook(() => usePaymentsHistory());
+      // No org id -> query is skipped -> entries undefined, not loading.
       expect(result.current.isLoading).toBe(false);
       expect(result.current.entries).toBeUndefined();
     });
@@ -53,19 +64,21 @@ describe("usePaymentsHistory", () => {
           {
             id: "row_1",
             sessionId: "cs_1",
-            paidAmountCents: 2500,
+            pricePaidCents: 2500,
+            displayCredits: "2,500 credits",
             status: "succeeded",
             occurredAt: 100,
             receiptUrl: "https://pay.stripe.com/receipts/abc",
           },
         ],
       };
-      const { result } = renderHook(() => usePaymentsHistory());
+      const { result } = renderHook(() => usePaymentsHistory(ORG_ID));
       expect(result.current.entries).toHaveLength(1);
       expect(result.current.entries?.[0]).toEqual({
         id: "row_1",
         sessionId: "cs_1",
-        paidAmountCents: 2500,
+        pricePaidCents: 2500,
+        displayCredits: "2,500 credits",
         status: "succeeded",
         occurredAt: 100,
         receiptUrl: "https://pay.stripe.com/receipts/abc",
@@ -77,12 +90,13 @@ describe("usePaymentsHistory", () => {
         {
           id: "row_2",
           sessionId: "cs_2",
-          paidAmountCents: 1000,
+          pricePaidCents: 1000,
+          displayCredits: "1,000 credits",
           status: "pending",
           occurredAt: 200,
         },
       ];
-      const { result } = renderHook(() => usePaymentsHistory());
+      const { result } = renderHook(() => usePaymentsHistory(ORG_ID));
       expect(result.current.entries).toHaveLength(1);
       expect(result.current.entries?.[0].status).toBe("pending");
       expect(result.current.entries?.[0].receiptUrl).toBeUndefined();
@@ -91,19 +105,40 @@ describe("usePaymentsHistory", () => {
     it("drops malformed rows but keeps valid neighbors", () => {
       queryReturn = {
         items: [
-          { id: "good", sessionId: "cs_good", paidAmountCents: 100, status: "failed", occurredAt: 1 },
-          { id: 123, sessionId: "cs_bad", paidAmountCents: 100, status: "failed", occurredAt: 1 },
-          { id: "no_status", sessionId: "cs_n", paidAmountCents: 100, status: "weird", occurredAt: 1 },
+          {
+            id: "good",
+            sessionId: "cs_good",
+            pricePaidCents: 100,
+            displayCredits: "100 credits",
+            status: "failed",
+            occurredAt: 1,
+          },
+          {
+            id: 123,
+            sessionId: "cs_bad",
+            pricePaidCents: 100,
+            displayCredits: "100 credits",
+            status: "failed",
+            occurredAt: 1,
+          },
+          {
+            id: "no_status",
+            sessionId: "cs_n",
+            pricePaidCents: 100,
+            displayCredits: "100 credits",
+            status: "weird",
+            occurredAt: 1,
+          },
         ],
       };
-      const { result } = renderHook(() => usePaymentsHistory());
+      const { result } = renderHook(() => usePaymentsHistory(ORG_ID));
       expect(result.current.entries).toHaveLength(1);
       expect(result.current.entries?.[0].id).toBe("good");
     });
 
     it("returns undefined when raw is not an array or envelope", () => {
       queryReturn = "not an array";
-      const { result } = renderHook(() => usePaymentsHistory());
+      const { result } = renderHook(() => usePaymentsHistory(ORG_ID));
       expect(result.current.entries).toBeUndefined();
     });
 
@@ -113,14 +148,15 @@ describe("usePaymentsHistory", () => {
           {
             id: "row",
             sessionId: "cs_e",
-            paidAmountCents: 100,
+            pricePaidCents: 100,
+            displayCredits: "100 credits",
             status: "succeeded",
             occurredAt: 1,
             receiptUrl: "",
           },
         ],
       };
-      const { result } = renderHook(() => usePaymentsHistory());
+      const { result } = renderHook(() => usePaymentsHistory(ORG_ID));
       expect(result.current.entries?.[0].receiptUrl).toBeUndefined();
     });
   });

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -3,12 +3,8 @@ import { useConvexAuth, useQuery } from "convex/react";
 import { useMemo } from "react";
 
 export interface CreditBalanceState {
-  /**
-   * 0-100. Percent of the user's credited pool still remaining. The bar
-   * renders `100 - paidPercentRemaining` as "% used". Backend computes
-   * the percent so the inspector never sees the dollar denominator.
-   */
-  paidPercentRemaining: number | null;
+  /** Shared credits currently available to the organization. */
+  availableCredits: number;
   /**
    * Whether the user has ever topped up. Used to gate paid-bar
    * visibility. Boolean-only — we deliberately don't expose the
@@ -23,6 +19,8 @@ export interface CreditBalanceState {
   freeDailyPercentUsed: number;
   /** Epoch ms when the daily bucket resets. */
   freeDailyResetAt: number;
+  /** Whether org credit spending is paused for manual review. */
+  walletLocked: boolean;
 }
 
 const clampPercent = (value: unknown): number => {
@@ -32,56 +30,43 @@ const clampPercent = (value: unknown): number => {
   return value;
 };
 
-const optionalPercent = (value: unknown): number | null => {
-  if (value == null) return null;
-  return clampPercent(value);
-};
-
 const optionalNumber = (value: unknown, fallback = 0): number =>
   typeof value === "number" && Number.isFinite(value) ? value : fallback;
 
 const normalizeBalance = (raw: unknown): CreditBalanceState | undefined => {
   if (!raw || typeof raw !== "object") return undefined;
   const r = raw as Record<string, unknown>;
-  // Accept either an explicit `hasPurchaseHistory: boolean` (preferred, new
-  // backend shape) or fall back to the legacy `lifetimePurchasedCents > 0`
-  // signal. Either is enough to know the user has topped up at least once.
-  // We DO NOT store the dollar value, so the inspector can't accidentally
-  // surface it.
-  const hasPurchaseHistory =
-    r.hasPurchaseHistory === true ||
-    (typeof r.lifetimePurchasedCents === "number" &&
-      Number.isFinite(r.lifetimePurchasedCents) &&
-      r.lifetimePurchasedCents > 0);
   return {
-    paidPercentRemaining: optionalPercent(r.paidPercentRemaining),
-    hasPurchaseHistory,
+    availableCredits: optionalNumber(r.availableCredits),
+    hasPurchaseHistory: r.hasPurchaseHistory === true,
     freeDailyPercentUsed: clampPercent(r.freeDailyPercentUsed),
     freeDailyResetAt: optionalNumber(r.freeDailyResetAt),
+    walletLocked: r.walletLocked === true,
   };
 };
 
 interface UseCreditBalanceOptions {
+  organizationId?: string | null;
   includeGuests?: boolean;
 }
 
 export function useCreditBalance({
+  organizationId,
   includeGuests = false,
 }: UseCreditBalanceOptions = {}) {
-  const {
-    isAuthenticated: hasConvexIdentity,
-    isLoading: isConvexAuthLoading,
-  } = useConvexAuth();
+  const { isAuthenticated: hasConvexIdentity, isLoading: isConvexAuthLoading } =
+    useConvexAuth();
   const { user, isLoading: isWorkOsLoading } = useAuth();
   const hasWorkOsUser = !!user;
   const isAuthLoading = isConvexAuthLoading || isWorkOsLoading;
   const shouldFetchBalance =
     !isAuthLoading &&
     hasConvexIdentity &&
-    (hasWorkOsUser || includeGuests);
+    (hasWorkOsUser ? !!organizationId : includeGuests);
+  const queryArgs = organizationId ? { organizationId } : {};
   const raw = useQuery(
     "billing:getCreditBalance" as any,
-    shouldFetchBalance ? ({} as any) : "skip"
+    shouldFetchBalance ? (queryArgs as any) : "skip"
   ) as unknown | undefined;
   // Memoize on the raw query reference. Convex returns a stable reference
   // when the underlying data is unchanged, so the normalized object stays

--- a/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
@@ -3,8 +3,10 @@ import { useCallback, useMemo, useState } from "react";
 import { usePostHog } from "posthog-js/react";
 
 export interface CreditTopupPreset {
-  amountCents: number;
-  amountUsd: string;
+  packageId: string;
+  priceCents: number;
+  displayPrice: string;
+  displayCredits: string;
 }
 
 export interface PendingTopupContext {
@@ -25,18 +27,14 @@ const PENDING_TTL_MS = 10 * 60 * 1000;
 const ALLOWED_CHECKOUT_URL_PREFIX = "https://checkout.stripe.com/";
 
 export function isAllowedCheckoutUrl(url: unknown): url is string {
-  return (
-    typeof url === "string" && url.startsWith(ALLOWED_CHECKOUT_URL_PREFIX)
-  );
+  return typeof url === "string" && url.startsWith(ALLOWED_CHECKOUT_URL_PREFIX);
 }
 
-const formatUsd = (cents: number) => {
-  const dollars = cents / 100;
-  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
-};
-
 interface RawPreset {
-  amountCents?: unknown;
+  packageId?: unknown;
+  priceCents?: unknown;
+  displayPrice?: unknown;
+  displayCredits?: unknown;
 }
 
 const normalizePresets = (raw: unknown): CreditTopupPreset[] | undefined => {
@@ -56,10 +54,19 @@ const normalizePresets = (raw: unknown): CreditTopupPreset[] | undefined => {
   if (!Array.isArray(items)) return undefined;
   const presets: CreditTopupPreset[] = [];
   for (const item of items as RawPreset[]) {
-    if (typeof item?.amountCents !== "number") continue;
+    if (
+      typeof item?.packageId !== "string" ||
+      typeof item.priceCents !== "number" ||
+      typeof item.displayPrice !== "string" ||
+      typeof item.displayCredits !== "string"
+    ) {
+      continue;
+    }
     presets.push({
-      amountCents: item.amountCents,
-      amountUsd: formatUsd(item.amountCents),
+      packageId: item.packageId,
+      priceCents: item.priceCents,
+      displayPrice: item.displayPrice,
+      displayCredits: item.displayCredits,
     });
   }
   return presets.length > 0 ? presets : undefined;
@@ -147,13 +154,12 @@ export function peekPendingTopup(): PendingTopupContext | null {
  * on `credit_topup_*` PostHog events so the funnel can be split between
  * the chat-banner CTA and the billing-page Top up button.
  */
-export type CreditTopupSource =
-  | "chat_banner"
-  | "billing_page"
-  | "limit_modal";
+export type CreditTopupSource = "chat_banner" | "billing_page" | "limit_modal";
 
 interface StartCheckoutInput {
-  amountCents: number;
+  organizationId: string;
+  packageId: string;
+  priceCents: number;
   chatSessionId: string;
   lastUserMessage: string;
   returnUrl?: string;
@@ -165,13 +171,14 @@ export interface UseCreditTopupPresetsOptions {
   skip?: boolean;
 }
 
-export function useCreditTopupPresets(
-  options?: UseCreditTopupPresetsOptions,
-): { presets: CreditTopupPreset[] | undefined; isLoading: boolean } {
+export function useCreditTopupPresets(options?: UseCreditTopupPresetsOptions): {
+  presets: CreditTopupPreset[] | undefined;
+  isLoading: boolean;
+} {
   const skip = options?.skip === true;
   const presetsRaw = useQuery(
     "billing:getCreditTopupPresets" as any,
-    skip ? "skip" : (undefined as any),
+    skip ? "skip" : (undefined as any)
   ) as unknown | undefined;
   // Memoize on the raw query reference. Convex returns a stable reference
   // when the underlying data is unchanged, so the normalized array stays
@@ -187,7 +194,7 @@ export function useCreditTopup() {
   const posthog = usePostHog();
 
   const createCheckoutSession = useAction(
-    "billing:createCreditCheckoutSession" as any,
+    "billing:createCreditCheckoutSession" as any
   );
 
   const [isStartingCheckout, setIsStartingCheckout] = useState(false);
@@ -195,7 +202,9 @@ export function useCreditTopup() {
 
   const startCheckout = useCallback(
     async ({
-      amountCents,
+      organizationId,
+      packageId,
+      priceCents,
       chatSessionId,
       lastUserMessage,
       returnUrl,
@@ -204,7 +213,8 @@ export function useCreditTopup() {
       setIsStartingCheckout(true);
       setError(null);
       posthog?.capture("credit_topup_checkout_started", {
-        amount_cents: amountCents,
+        package_id: packageId,
+        price_cents: priceCents,
         source,
       });
       stashPendingTopup({ chatSessionId, message: lastUserMessage });
@@ -215,7 +225,8 @@ export function useCreditTopup() {
         "action_threw";
       try {
         const result = (await createCheckoutSession({
-          amountCents,
+          organizationId,
+          packageId,
           ...(returnUrl ? { returnUrl } : {}),
         } as any)) as { checkoutUrl?: string } | null;
         const checkoutUrl = result?.checkoutUrl;
@@ -232,7 +243,8 @@ export function useCreditTopup() {
         window.location.assign(checkoutUrl);
       } catch (err) {
         posthog?.capture("credit_topup_checkout_failed", {
-          amount_cents: amountCents,
+          package_id: packageId,
+          price_cents: priceCents,
           error_kind: errorKind,
           source,
         });
@@ -246,7 +258,7 @@ export function useCreditTopup() {
         setIsStartingCheckout(false);
       }
     },
-    [createCheckoutSession, posthog],
+    [createCheckoutSession, posthog]
   );
 
   return {

--- a/mcpjam-inspector/client/src/hooks/usePaymentsHistory.ts
+++ b/mcpjam-inspector/client/src/hooks/usePaymentsHistory.ts
@@ -13,9 +13,10 @@ export type PaymentHistoryStatus =
 export interface PaymentHistoryEntry {
   id: string;
   sessionId: string;
-  paidAmountCents: number;
+  pricePaidCents: number;
+  displayCredits: string;
   /** Paid cents handed back when refunded/charged back. Reversed rows only. */
-  reversedAmountCents?: number;
+  reversedPaidCents?: number;
   status: PaymentHistoryStatus;
   occurredAt: number;
   receiptUrl?: string;
@@ -24,8 +25,9 @@ export interface PaymentHistoryEntry {
 interface RawEntry {
   id?: unknown;
   sessionId?: unknown;
-  paidAmountCents?: unknown;
-  reversedAmountCents?: unknown;
+  pricePaidCents?: unknown;
+  displayCredits?: unknown;
+  reversedPaidCents?: unknown;
   status?: unknown;
   occurredAt?: unknown;
   receiptUrl?: unknown;
@@ -59,7 +61,8 @@ const normalize = (raw: unknown): PaymentHistoryEntry[] | undefined => {
     if (
       typeof item?.id !== "string" ||
       typeof item.sessionId !== "string" ||
-      typeof item.paidAmountCents !== "number" ||
+      typeof item.pricePaidCents !== "number" ||
+      typeof item.displayCredits !== "string" ||
       !isValidStatus(item.status) ||
       typeof item.occurredAt !== "number"
     ) {
@@ -68,11 +71,12 @@ const normalize = (raw: unknown): PaymentHistoryEntry[] | undefined => {
     out.push({
       id: item.id,
       sessionId: item.sessionId,
-      paidAmountCents: item.paidAmountCents,
+      pricePaidCents: item.pricePaidCents,
+      displayCredits: item.displayCredits,
       status: item.status,
       occurredAt: item.occurredAt,
-      ...(typeof item.reversedAmountCents === "number"
-        ? { reversedAmountCents: item.reversedAmountCents }
+      ...(typeof item.reversedPaidCents === "number"
+        ? { reversedPaidCents: item.reversedPaidCents }
         : {}),
       ...(typeof item.receiptUrl === "string" && item.receiptUrl.length > 0
         ? { receiptUrl: item.receiptUrl }
@@ -88,17 +92,20 @@ export interface UsePaymentsHistoryResult {
   isAuthenticated: boolean;
 }
 
-export function usePaymentsHistory(): UsePaymentsHistoryResult {
+export function usePaymentsHistory(
+  organizationId?: string | null
+): UsePaymentsHistoryResult {
   const { isAuthenticated: hasConvexIdentity, isLoading: isConvexAuthLoading } =
     useConvexAuth();
   const { user, isLoading: isWorkOsLoading } = useAuth();
   const hasWorkOsUser = !!user;
   const isAuthLoading = isConvexAuthLoading || isWorkOsLoading;
-  const shouldFetch = !isAuthLoading && hasConvexIdentity && hasWorkOsUser;
+  const shouldFetch =
+    !isAuthLoading && hasConvexIdentity && hasWorkOsUser && !!organizationId;
 
   const raw = useQuery(
-    "billing/creditHistory:listTopupHistoryForCurrentUser" as any,
-    shouldFetch ? ({} as any) : "skip",
+    "billing/creditHistory:listTopupHistoryForOrganization" as any,
+    shouldFetch ? ({ organizationId } as any) : "skip"
   ) as unknown | undefined;
 
   // Stable reference: Convex returns the same object when nothing has

--- a/mcpjam-inspector/client/src/hooks/usePendingCreditTopups.ts
+++ b/mcpjam-inspector/client/src/hooks/usePendingCreditTopups.ts
@@ -7,7 +7,8 @@ export type PendingCreditTopupStatus = "pending" | "failed";
 export interface PendingCreditTopup {
   id: string;
   stripeSessionId: string;
-  amountCents: number;
+  pricePaidCents: number;
+  displayCredits: string;
   status: PendingCreditTopupStatus;
   createdAt: number;
   updatedAt: number;
@@ -16,7 +17,8 @@ export interface PendingCreditTopup {
 interface RawPendingTopup {
   id?: unknown;
   stripeSessionId?: unknown;
-  amountCents?: unknown;
+  pricePaidCents?: unknown;
+  displayCredits?: unknown;
   status?: unknown;
   createdAt?: unknown;
   updatedAt?: unknown;
@@ -25,19 +27,12 @@ interface RawPendingTopup {
 const isValidStatus = (value: unknown): value is PendingCreditTopupStatus =>
   value === "pending" || value === "failed";
 
-const normalizePending = (
-  raw: unknown,
-): PendingCreditTopup[] | undefined => {
+const normalizePending = (raw: unknown): PendingCreditTopup[] | undefined => {
   // Accept either a bare array or `{ items: [...] }`. Matches the loose-shape
   // convention used by useCreditTopup / useCreditBalance so the backend can
   // evolve without forcing a coordinated inspector PR.
   let items: unknown = raw;
-  if (
-    raw &&
-    typeof raw === "object" &&
-    !Array.isArray(raw) &&
-    "items" in raw
-  ) {
+  if (raw && typeof raw === "object" && !Array.isArray(raw) && "items" in raw) {
     items = (raw as { items?: unknown }).items;
   }
   if (!Array.isArray(items)) return undefined;
@@ -47,7 +42,8 @@ const normalizePending = (
     if (
       typeof item?.id !== "string" ||
       typeof item.stripeSessionId !== "string" ||
-      typeof item.amountCents !== "number" ||
+      typeof item.pricePaidCents !== "number" ||
+      typeof item.displayCredits !== "string" ||
       !isValidStatus(item.status) ||
       typeof item.createdAt !== "number" ||
       typeof item.updatedAt !== "number"
@@ -57,7 +53,8 @@ const normalizePending = (
     out.push({
       id: item.id,
       stripeSessionId: item.stripeSessionId,
-      amountCents: item.amountCents,
+      pricePaidCents: item.pricePaidCents,
+      displayCredits: item.displayCredits,
       status: item.status,
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
@@ -76,20 +73,20 @@ export interface UsePendingCreditTopupsResult {
   isAuthenticated: boolean;
 }
 
-export function usePendingCreditTopups(): UsePendingCreditTopupsResult {
-  const {
-    isAuthenticated: hasConvexIdentity,
-    isLoading: isConvexAuthLoading,
-  } = useConvexAuth();
+export function usePendingCreditTopups(
+  organizationId?: string | null
+): UsePendingCreditTopupsResult {
+  const { isAuthenticated: hasConvexIdentity, isLoading: isConvexAuthLoading } =
+    useConvexAuth();
   const { user, isLoading: isWorkOsLoading } = useAuth();
   const hasWorkOsUser = !!user;
   const isAuthLoading = isConvexAuthLoading || isWorkOsLoading;
   const shouldFetch =
-    !isAuthLoading && hasConvexIdentity && hasWorkOsUser;
+    !isAuthLoading && hasConvexIdentity && hasWorkOsUser && !!organizationId;
 
   const raw = useQuery(
-    "billing/pendingCreditTopups:listForCurrentUser" as any,
-    shouldFetch ? ({} as any) : "skip",
+    "billing/pendingCreditTopups:listForOrganization" as any,
+    shouldFetch ? ({ organizationId } as any) : "skip"
   ) as unknown | undefined;
 
   // Stable reference: Convex returns the same object when nothing has
@@ -98,11 +95,11 @@ export function usePendingCreditTopups(): UsePendingCreditTopupsResult {
 
   const pending = useMemo(
     () => topups?.filter((t) => t.status === "pending"),
-    [topups],
+    [topups]
   );
   const failed = useMemo(
     () => topups?.filter((t) => t.status === "failed"),
-    [topups],
+    [topups]
   );
 
   const isLoading = isAuthLoading || (shouldFetch && raw === undefined);


### PR DESCRIPTION
## Summary

Updates the billing UI to read **per-organization** credits instead of per-user. Balance, top-up, payment history, and pending-top-up hooks now take the active `organizationId`, and the user-facing unit is "credits". Pairs with the backend change of the same name.

## Changes

- `useCreditBalance` / `useCreditTopup` / `usePaymentsHistory` / `usePendingCreditTopups`: org-scoped; skip the query until an organization is selected.
- Credit balance card and sidebar usage: show shared organization credits; the wallet-lock notice now renders independently of purchase history (so a locked wallet with no completed purchase still shows it); the paid-credits row no longer renders an always-empty progress bar.
- Top-up dialog and checkout require an organization.
- A member redirected from the daily-limit modal who can't manage credits now sees an "ask an admin" hint instead of a dialog that never opens.

## Verification

- Component and hook tests updated and passing.
- Requires the paired backend change (org-scoped credit balance / top-up endpoints).
