### PR TITLE
evals: surface predicate verdicts in iteration detail view

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/predicates-list.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/predicates-list.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseIterationPredicates } from "../predicates-list";
+import {
+  parseIterationPredicates,
+  summarizePredicate,
+} from "../predicates-list";
+import type { Predicate } from "@/shared/eval-matching";
 
 describe("parseIterationPredicates", () => {
   it("returns null when metadata is absent", () => {
@@ -74,5 +78,44 @@ describe("parseIterationPredicates", () => {
 
   it("returns null on an empty predicates array (nothing to render)", () => {
     expect(parseIterationPredicates({ predicates: [] })).toBeNull();
+  });
+});
+
+describe("summarizePredicate", () => {
+  it("summarizes well-formed variants", () => {
+    expect(
+      summarizePredicate({ type: "toolCalledAtLeastOnce", toolName: "search" }),
+    ).toBe('tool "search" called ≥1×');
+    expect(summarizePredicate({ type: "tokenBudgetUnder", tokens: 500 })).toBe(
+      "tokens < 500",
+    );
+    expect(
+      summarizePredicate({ type: "responseContains", needle: "refund" }),
+    ).toBe('needle "refund"');
+    expect(summarizePredicate({ type: "noToolErrors" })).toBe("no tool errors");
+  });
+
+  it("degrades to an empty summary instead of throwing on a malformed-but-typed predicate", () => {
+    // Valid `type` discriminant but the variant's payload is missing — exactly
+    // what `parseIterationPredicates` lets through (it only checks the row
+    // envelope). Field access here must not throw during render.
+    const malformed: Predicate[] = [
+      { type: "tokenBudgetUnder" } as unknown as Predicate, // missing tokens
+      { type: "responseContains" } as unknown as Predicate, // missing needle
+      { type: "responseMatches" } as unknown as Predicate, // missing pattern
+      { type: "toolCalledWith", toolName: "x" } as unknown as Predicate, // missing args
+    ];
+    for (const p of malformed) {
+      expect(() => summarizePredicate(p)).not.toThrow();
+      expect(summarizePredicate(p)).toBe("");
+    }
+  });
+
+  it("returns an empty summary for an unknown future predicate type", () => {
+    const future = {
+      type: "responseMatchesSemantically",
+    } as unknown as Predicate;
+    expect(() => summarizePredicate(future)).not.toThrow();
+    expect(summarizePredicate(future)).toBe("");
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/predicates-list.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/predicates-list.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { parseIterationPredicates } from "../predicates-list";
+
+describe("parseIterationPredicates", () => {
+  it("returns null when metadata is absent", () => {
+    expect(parseIterationPredicates(undefined)).toBeNull();
+  });
+
+  it("returns null when metadata has no `predicates` key", () => {
+    expect(parseIterationPredicates({ turnCount: 3 })).toBeNull();
+  });
+
+  it("returns null when `predicates` is not an array", () => {
+    expect(parseIterationPredicates({ predicates: "not-an-array" })).toBeNull();
+    expect(parseIterationPredicates({ predicates: { passed: true } })).toBeNull();
+  });
+
+  it("returns the rows as PredicateResult[] when well-formed", () => {
+    const parsed = parseIterationPredicates({
+      predicates: [
+        {
+          predicate: { type: "toolCalledAtLeastOnce", toolName: "search" },
+          passed: true,
+          reason: 'tool "search" called 2×',
+        },
+        {
+          predicate: { type: "tokenBudgetUnder", tokens: 500 },
+          passed: false,
+          reason: "total tokens 643 exceeds budget 500",
+        },
+      ],
+    });
+    expect(parsed).toHaveLength(2);
+    expect(parsed![0].passed).toBe(true);
+    expect(parsed![0].predicate.type).toBe("toolCalledAtLeastOnce");
+    expect(parsed![1].passed).toBe(false);
+    expect(parsed![1].reason).toContain("exceeds budget");
+  });
+
+  it("skips malformed rows (missing/wrong-typed fields) without throwing", () => {
+    const parsed = parseIterationPredicates({
+      predicates: [
+        // missing `predicate`
+        { passed: true, reason: "fine" },
+        // `passed` is not a boolean
+        {
+          predicate: { type: "noToolErrors" },
+          passed: "yes" as unknown as boolean,
+          reason: "fine",
+        },
+        // `predicate.type` missing — discriminant required
+        {
+          predicate: { toolName: "search" },
+          passed: true,
+          reason: "fine",
+        },
+        // valid — survives
+        {
+          predicate: { type: "noToolErrors" },
+          passed: true,
+          reason: "no tool errors",
+        },
+      ],
+    });
+    expect(parsed).toHaveLength(1);
+    expect(parsed![0].predicate.type).toBe("noToolErrors");
+  });
+
+  it("returns null (hide section) when every row is malformed", () => {
+    expect(
+      parseIterationPredicates({ predicates: [null, "bad", { passed: true }] }),
+    ).toBeNull();
+  });
+
+  it("returns null on an empty predicates array (nothing to render)", () => {
+    expect(parseIterationPredicates({ predicates: [] })).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/cross-host/use-cross-host-data.ts
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/use-cross-host-data.ts
@@ -53,7 +53,7 @@ export type CrossHostData = {
 };
 
 function readMetaNumber(
-  meta: Record<string, string | number | boolean> | undefined,
+  meta: Record<string, unknown> | undefined,
   key: string,
 ): number | null {
   const v = meta?.[key];
@@ -61,7 +61,7 @@ function readMetaNumber(
 }
 
 function readMetaBool(
-  meta: Record<string, string | number | boolean> | undefined,
+  meta: Record<string, unknown> | undefined,
   key: string,
 ): boolean {
   return meta?.[key] === true;

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -3,6 +3,10 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { EvalIteration, EvalCase } from "./types";
 import { evaluateToolCalls } from "@/shared/eval-matching";
 import { ToolCallDiff } from "./tool-call-diff";
+import {
+  PredicatesList,
+  parseIterationPredicates,
+} from "./predicates-list";
 import { TraceViewer } from "./trace-viewer";
 import {
   MessageSquare,
@@ -784,6 +788,19 @@ export function IterationDetails({
       )
     ) : null;
 
+  const predicates = useMemo(
+    () => parseIterationPredicates(iteration.metadata),
+    [iteration.metadata],
+  );
+  const predicatesSection = predicates ? (
+    <div className="space-y-2" data-testid="iteration-predicates-section">
+      <div className="flex items-center justify-between border-b border-border/40 pb-2">
+        <div className="text-xs font-semibold">Predicate Gate</div>
+      </div>
+      <PredicatesList predicates={predicates} />
+    </div>
+  ) : null;
+
   const traceSection = iteration.blob ? (
     <div
       className={cn(
@@ -961,10 +978,12 @@ export function IterationDetails({
         <>
           {traceSection}
           {toolCallsSection}
+          {predicatesSection}
         </>
       ) : (
         <>
           {toolCallsSection}
+          {predicatesSection}
           {traceSection}
         </>
       )}

--- a/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
@@ -122,32 +122,45 @@ function PredicateRow({ row }: { row: PredicateResult }) {
 /**
  * One-line summary of *what was asserted*, derived from the predicate fields.
  * Complements `row.reason` (which says *whether the assertion held* and why).
+ *
+ * Total by construction. `parseIterationPredicates` validates the row envelope
+ * (`passed`/`reason`/`type`) but NOT each variant's payload, so a
+ * malformed-but-typed predicate — or a predicate type newer than this build —
+ * must degrade to an empty summary rather than throw during render. The row's
+ * PASS/FAIL badge and `reason` stay visible regardless, and the `type` is
+ * already shown next to this summary, so the empty fallback loses nothing.
  */
-function summarizePredicate(predicate: Predicate): string {
-  switch (predicate.type) {
-    case "toolCalledWith": {
-      const mode = predicate.args.argumentMatching ?? "partial";
-      const minCount = predicate.minCount ?? 1;
-      const suffix = minCount > 1 ? `, ≥${minCount}×` : "";
-      return `tool "${predicate.toolName}" with ${briefArgs(predicate.args.args)} (${mode}${suffix})`;
+export function summarizePredicate(predicate: Predicate): string {
+  try {
+    switch (predicate.type) {
+      case "toolCalledWith": {
+        const mode = predicate.args.argumentMatching ?? "partial";
+        const minCount = predicate.minCount ?? 1;
+        const suffix = minCount > 1 ? `, ≥${minCount}×` : "";
+        return `tool "${predicate.toolName}" with ${briefArgs(predicate.args.args)} (${mode}${suffix})`;
+      }
+      case "toolCalledAtLeastOnce":
+        return `tool "${predicate.toolName}" called ≥1×`;
+      case "toolNeverCalled":
+        return `tool "${predicate.toolName}" never called`;
+      case "responseContains":
+        return `needle "${truncate(predicate.needle, 60)}"${
+          predicate.caseSensitive ? " (case-sensitive)" : ""
+        }`;
+      case "responseMatches":
+        return `pattern /${truncate(predicate.pattern, 60)}/`;
+      case "noToolErrors":
+        return "no tool errors";
+      case "finalAssistantMessageNonEmpty":
+        return "final assistant message non-empty";
+      case "tokenBudgetUnder":
+        return `tokens < ${predicate.tokens.toLocaleString()}`;
     }
-    case "toolCalledAtLeastOnce":
-      return `tool "${predicate.toolName}" called ≥1×`;
-    case "toolNeverCalled":
-      return `tool "${predicate.toolName}" never called`;
-    case "responseContains":
-      return `needle "${truncate(predicate.needle, 60)}"${
-        predicate.caseSensitive ? " (case-sensitive)" : ""
-      }`;
-    case "responseMatches":
-      return `pattern /${truncate(predicate.pattern, 60)}/`;
-    case "noToolErrors":
-      return "no tool errors";
-    case "finalAssistantMessageNonEmpty":
-      return "final assistant message non-empty";
-    case "tokenBudgetUnder":
-      return `tokens < ${predicate.tokens.toLocaleString()}`;
+  } catch {
+    // A row whose `type` is valid but whose payload is missing/wrong (corruption,
+    // producer bug, or schema skew) would otherwise throw on field access here.
   }
+  return "";
 }
 
 function briefArgs(args: Record<string, unknown>): string {

--- a/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
@@ -1,0 +1,175 @@
+import type { Predicate, PredicateResult } from "@/shared/eval-matching";
+import type { EvalIteration } from "./types";
+
+/**
+ * Read the persisted predicate verdicts off `iteration.metadata.predicates`,
+ * defensively. The Convex round-trip preserves shape but the type bound is
+ * `unknown`, so each row is validated before we render it — a malformed entry
+ * is skipped, not rendered with `undefined`s.
+ *
+ * Returns `null` when there is no predicate gate to render (no predicates ever
+ * authored, or every row was malformed). The caller hides the section.
+ */
+export function parseIterationPredicates(
+  metadata: EvalIteration["metadata"],
+): PredicateResult[] | null {
+  if (!metadata) return null;
+  const raw = (metadata as Record<string, unknown>).predicates;
+  if (!Array.isArray(raw)) return null;
+  const out: PredicateResult[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const row = item as Record<string, unknown>;
+    if (typeof row.passed !== "boolean") continue;
+    if (typeof row.reason !== "string") continue;
+    if (!row.predicate || typeof row.predicate !== "object") continue;
+    const predicate = row.predicate as Record<string, unknown>;
+    if (typeof predicate.type !== "string") continue;
+    out.push({
+      predicate: predicate as unknown as Predicate,
+      passed: row.passed,
+      reason: row.reason,
+    });
+  }
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Render the per-iteration predicate gate. Each row shows the authored
+ * assertion (e.g. `responseContains "refund issued"`) and the evaluator's
+ * deterministic reason (e.g. `final assistant message contains "refund
+ * issued"`). The reason string is the load-bearing diagnostic — it tells you
+ * *why* the gate decided as it did and is the property a CI gate hinges on.
+ */
+export function PredicatesList({ predicates }: { predicates: PredicateResult[] }) {
+  if (predicates.length === 0) return null;
+  const failed = predicates.filter((r) => !r.passed).length;
+  const passed = predicates.length - failed;
+  const allPassed = failed === 0;
+
+  return (
+    <div
+      role="region"
+      aria-label="Predicate gate"
+      className="space-y-2 rounded-md border border-border/40 bg-muted/10 p-3"
+    >
+      <div className="flex items-center justify-between">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Predicates
+        </div>
+        <div
+          className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${
+            allPassed
+              ? "bg-green-500/15 text-green-700 dark:text-green-300"
+              : "bg-red-500/15 text-red-700 dark:text-red-300"
+          }`}
+        >
+          {allPassed ? "PASS" : `${passed}/${predicates.length} PASSED`}
+        </div>
+      </div>
+
+      <ul className="space-y-1.5">
+        {predicates.map((row, i) => (
+          <PredicateRow key={i} row={row} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PredicateRow({ row }: { row: PredicateResult }) {
+  return (
+    <li
+      className={`rounded border p-2 ${
+        row.passed
+          ? "border-green-500/20 bg-green-500/5"
+          : "border-red-500/30 bg-red-500/5"
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        <span
+          className={`mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${
+            row.passed
+              ? "bg-green-500/15 text-green-700 dark:text-green-300"
+              : "bg-red-500/15 text-red-700 dark:text-red-300"
+          }`}
+          aria-label={row.passed ? "passed" : "failed"}
+        >
+          {row.passed ? "PASS" : "FAIL"}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+            <span className="font-mono text-xs font-medium">
+              {row.predicate.type}
+            </span>
+            <span className="truncate text-[11px] text-muted-foreground">
+              {summarizePredicate(row.predicate)}
+            </span>
+          </div>
+          <div
+            className={`mt-1 whitespace-pre-wrap break-words text-[11px] leading-tight ${
+              row.passed ? "text-muted-foreground" : "text-foreground"
+            }`}
+          >
+            {row.reason}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * One-line summary of *what was asserted*, derived from the predicate fields.
+ * Complements `row.reason` (which says *whether the assertion held* and why).
+ */
+function summarizePredicate(predicate: Predicate): string {
+  switch (predicate.type) {
+    case "toolCalledWith": {
+      const mode = predicate.args.argumentMatching ?? "partial";
+      const minCount = predicate.minCount ?? 1;
+      const suffix = minCount > 1 ? `, ≥${minCount}×` : "";
+      return `tool "${predicate.toolName}" with ${briefArgs(predicate.args.args)} (${mode}${suffix})`;
+    }
+    case "toolCalledAtLeastOnce":
+      return `tool "${predicate.toolName}" called ≥1×`;
+    case "toolNeverCalled":
+      return `tool "${predicate.toolName}" never called`;
+    case "responseContains":
+      return `needle "${truncate(predicate.needle, 60)}"${
+        predicate.caseSensitive ? " (case-sensitive)" : ""
+      }`;
+    case "responseMatches":
+      return `pattern /${truncate(predicate.pattern, 60)}/`;
+    case "noToolErrors":
+      return "no tool errors";
+    case "finalAssistantMessageNonEmpty":
+      return "final assistant message non-empty";
+    case "tokenBudgetUnder":
+      return `tokens < ${predicate.tokens.toLocaleString()}`;
+  }
+}
+
+function briefArgs(args: Record<string, unknown>): string {
+  const keys = Object.keys(args ?? {});
+  if (keys.length === 0) return "{}";
+  const shown = keys
+    .slice(0, 2)
+    .map((k) => `${k}=${previewValue(args[k])}`)
+    .join(", ");
+  const more = keys.length > 2 ? ` +${keys.length - 2}` : "";
+  return `{${shown}${more}}`;
+}
+
+function previewValue(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "—";
+  if (typeof value === "string")
+    return value.length > 20 ? `"${value.slice(0, 20)}…"` : `"${value}"`;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return Array.isArray(value) ? `[${value.length}]` : "{…}";
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -159,7 +159,13 @@ export type EvalIteration = {
   errorDetails?: string;
   resultSource?: "reported" | "derived";
   externalIterationId?: string;
-  metadata?: Record<string, string | number | boolean>;
+  // Widened to `unknown` because the backend metadata column now round-trips
+  // non-scalar entries — specifically `predicates: PredicateResult[]` from the
+  // state-based eval gate. Existing readers (turnCount, firstFailedTurnIndex,
+  // compareRunId, mismatchCount…) already runtime-check via `typeof`, so the
+  // wider type is backwards-compatible. Per-key parsers live next to their
+  // call sites; see `predicates-list.tsx` for the predicates parser.
+  metadata?: Record<string, unknown>;
   _creationTime?: number; // Convex auto field
 };
 


### PR DESCRIPTION
## Summary

- Adds a **Predicate Gate** section to the iteration detail panel that lists each `successPredicate` with its PASS/FAIL verdict, a one-line summary of *what was asserted* (e.g. `responseContains needle \"refund issued\"`, `tokens < 500`), and the evaluator's deterministic *why* string from \`metadata.predicates[].reason\`.
- Section is hidden when no predicates were authored, so every iteration without a predicate gate renders byte-for-byte identically.
- Widens \`EvalIteration.metadata\` to \`Record<string, unknown>\` so the predicates array round-trips through the type. Existing readers (\`turnCount\`, \`firstFailedTurnIndex\`, \`compareRunId\`, \`mismatchCount\`, cross-host meta flags) already runtime-check via \`typeof\`, so the change is backwards-compatible — the two narrow-typed helpers in cross-host data are widened to match.

## Why

PR #2352 wired the deterministic predicate gate end-to-end: the runner evaluates \`successPredicates[]\`, AND-combines them with the tool-call matcher in \`finalizePassedForEval\`, and persists \`{ predicate, passed, reason }[]\` to \`testIteration.metadata.predicates\` via the widened backend (mcpjam-backend#383). But until now those rows have been **invisible to humans** — a failing iteration shows only the tool-call mismatch in the detail panel. The whole reason to pick deterministic predicates over an LLM judge is the reason string; without surfacing it, the gate is a black box.

This is the smallest useful next step on the predicate workstream: pure read-side, no authoring, no new persistence. It also serves as the first real read-back of the new \`metadata.predicates\` column end-to-end.

## What this does NOT include

- **Authoring** (UI form for declaring predicates on a case): deliberately separate — needs a real design pass for the 8-variant discriminated form, and shouldn't live in the per-run match-options popover.
- **Corpus / CLI**: deferred until authoring lands.
- **Aggregate predicate stats in the matrix view**: cross-host already aggregates on \`passed\`, so it's already predicate-aware; per-predicate roll-ups would be a separate analytics PR.

## Parser is defensive

\`parseIterationPredicates\` validates each row at runtime — wrong-typed fields are skipped (not rendered with undefineds), malformed / empty / non-array \`predicates\` returns null so the section stays hidden. Six parser test cases cover the malformed-row paths.

## Testing

- New: \`predicates-list.test.ts\` — 7 parser tests (well-formed, missing key, non-array, malformed rows skipped, all-malformed returns null, empty array returns null).
- Existing: 527 client eval tests green; \`compare-playground-helpers\` and other metadata readers unaffected.
- Manual: TBD — needs a case with at least one \`successPredicate\` declared (currently only authorable via API override, since the UI authoring lives in the deferred follow-up).

## Test plan

- [ ] Trigger an eval run on a case carrying \`successPredicates\` (curl/API override) and confirm the Predicate Gate section renders with each predicate's PASS/FAIL + reason.
- [ ] Confirm an iteration WITHOUT predicates renders identically to today (no new section, no layout shift).
- [ ] Confirm a failing predicate renders with the failure reason and tinted red row.
- [ ] Confirm a passing run with all predicates passing renders the green PASS badge in the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and type widening; existing metadata readers already use runtime checks, so behavior for iterations without predicates stays unchanged.
> 
> **Overview**
> Adds a **Predicate Gate** block to the iteration detail panel when `iteration.metadata.predicates` is present, showing each assertion’s PASS/FAIL, a one-line summary via `summarizePredicate`, and the persisted evaluator **reason** string.
> 
> Introduces `predicates-list.tsx` with defensive `parseIterationPredicates` (malformed rows skipped; null hides the section) and `PredicatesList` UI. **`EvalIteration.metadata`** is widened to `Record<string, unknown>` so predicate arrays type-check; cross-host `readMetaNumber` / `readMetaBool` signatures match. Vitest coverage covers parser and summary edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625469e394986a87acf54d89dcbde0d761a00771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->