### PR TITLE
evals: Goal Completion judge panel — advisory LLM-as-judge UI (V1)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -134,4 +134,30 @@ describe("GoalCompletionCard", () => {
       screen.getByText(/Grading final answers against expected output/i),
     ).toBeInTheDocument();
   });
+
+  it("disables running once a request is in flight (no duplicate judge calls)", () => {
+    // After a click, `requested` is true before the run doc flips to pending;
+    // the button must already be disabled so a second click can't double-spend.
+    render(<GoalCompletionCard {...baseProps} requested onRun={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /Run judge/i })).toBeDisabled();
+  });
+
+  it("forces a re-request when retrying a failed run", async () => {
+    const onRun = vi.fn();
+    const user = userEvent.setup();
+    // Failed with no stored result: the main control must still pass force.
+    render(
+      <GoalCompletionCard
+        {...baseProps}
+        failedGeneration
+        goalCompletion={null}
+        onRun={onRun}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Run judge/i }));
+    expect(onRun).toHaveBeenCalledWith(
+      { judgeModel: "openai/gpt-5.4-mini", threshold: 0.7 },
+      true,
+    );
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -77,6 +77,21 @@ describe("GoalCompletionCard", () => {
     );
   });
 
+  it("falls back to the default threshold when the field is left blank", async () => {
+    const onRun = vi.fn();
+    const user = userEvent.setup();
+    render(<GoalCompletionCard {...baseProps} onRun={onRun} />);
+
+    // Blank input must NOT send threshold 0 (which would pass every score).
+    await user.clear(screen.getByLabelText("Threshold"));
+    await user.click(screen.getByRole("button", { name: /Run judge/i }));
+
+    expect(onRun).toHaveBeenCalledWith(
+      { judgeModel: "openai/gpt-5.4-mini", threshold: 0.7 },
+      false,
+    );
+  });
+
   it("renders per-case score, advisory verdict and reason once graded", () => {
     const goalCompletion: EvalSuiteRun["goalCompletion"] = {
       summary: "One case met the goal, one fell short.",

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GoalCompletionCard } from "../goal-completion-card";
+import type { EvalIteration, EvalSuiteRun } from "../types";
+
+function makeRun(overrides: Partial<EvalSuiteRun> = {}): EvalSuiteRun {
+  return {
+    _id: "run-1",
+    suiteId: "suite-1",
+    createdBy: "user",
+    runNumber: 1,
+    configRevision: "rev1",
+    configSnapshot: { tests: [], environment: { servers: [] } },
+    status: "completed",
+    createdAt: 1,
+    completedAt: 2,
+    summary: { total: 1, passed: 1, failed: 0, passRate: 1 },
+    ...overrides,
+  };
+}
+
+function makeIteration(overrides: Partial<EvalIteration> = {}): EvalIteration {
+  return {
+    _id: "iter-1",
+    createdBy: "user",
+    createdAt: 1,
+    iterationNumber: 1,
+    updatedAt: 2,
+    status: "completed",
+    result: "passed",
+    actualToolCalls: [],
+    tokensUsed: 0,
+    testCaseSnapshot: {
+      caseKey: "ck-1",
+      title: "Weather lookup",
+      query: "q",
+      provider: "openai",
+      model: "gpt",
+      expectedToolCalls: [],
+    },
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  run: makeRun(),
+  iterations: [makeIteration()],
+  goalCompletion: null,
+  availableModels: [],
+  pending: false,
+  requested: false,
+  failedGeneration: false,
+  error: null,
+  onRun: vi.fn(),
+};
+
+describe("GoalCompletionCard", () => {
+  it("labels itself advisory and offers a Run judge control before any run", () => {
+    render(<GoalCompletionCard {...baseProps} onRun={vi.fn()} />);
+    expect(screen.getByText("Goal completion")).toBeInTheDocument();
+    expect(screen.getByText(/advisory · LLM judge/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Run judge/i })).toBeEnabled();
+    expect(screen.getByText("Not run yet")).toBeInTheDocument();
+  });
+
+  it("runs the judge with the selected default model and threshold", async () => {
+    const onRun = vi.fn();
+    const user = userEvent.setup();
+    render(<GoalCompletionCard {...baseProps} onRun={onRun} />);
+
+    await user.click(screen.getByRole("button", { name: /Run judge/i }));
+
+    expect(onRun).toHaveBeenCalledWith(
+      { judgeModel: "openai/gpt-5.4-mini", threshold: 0.7 },
+      false,
+    );
+  });
+
+  it("renders per-case score, advisory verdict and reason once graded", () => {
+    const goalCompletion: EvalSuiteRun["goalCompletion"] = {
+      summary: "One case met the goal, one fell short.",
+      generatedAt: 1,
+      modelUsed: "openai/gpt-5.4-mini",
+      threshold: 0.7,
+      cases: [
+        {
+          caseKey: "ck-1",
+          score: 0.8,
+          passed: true,
+          reason: "Final answer returned the forecast.",
+          rubricHits: ["returned the forecast"],
+        },
+        {
+          caseKey: "ck-2",
+          score: 0.3,
+          passed: false,
+          reason: "Final answer omitted the temperature.",
+          rubricHits: ["missing: temperature"],
+        },
+      ],
+    };
+    render(
+      <GoalCompletionCard
+        {...baseProps}
+        goalCompletion={goalCompletion}
+        onRun={vi.fn()}
+      />,
+    );
+
+    // Joins caseKey -> human title from the iterations.
+    expect(screen.getByText("Weather lookup")).toBeInTheDocument();
+    expect(screen.getByText("80%")).toBeInTheDocument();
+    expect(screen.getByText("30%")).toBeInTheDocument();
+    expect(screen.getByText("meets goal")).toBeInTheDocument();
+    expect(screen.getByText("below threshold")).toBeInTheDocument();
+    expect(
+      screen.getByText("Final answer returned the forecast."),
+    ).toBeInTheDocument();
+    // Advisory framing is explicit.
+    expect(
+      screen.getByText(/Advisory only — the deterministic/i),
+    ).toBeInTheDocument();
+    // Re-run is offered once a result exists.
+    expect(
+      screen.getByRole("button", { name: /Re-run judge/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables running while a grade is pending", () => {
+    render(<GoalCompletionCard {...baseProps} pending onRun={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /Run judge/i })).toBeDisabled();
+    expect(
+      screen.getByText(/Grading final answers against expected output/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -257,7 +257,13 @@ describe("GoalCompletionCard", () => {
     expect(
       screen.getByText(/Goal completion isn't enabled for this suite/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Suite settings . Judges/i)).toBeInTheDocument();
+    // CTA points at the actual UI affordance (the gear button on the suite
+    // header) — not just generic "Suite settings", which had no visible
+    // entry point in the inspector until the gear shipped.
+    expect(
+      screen.getByText(/Open suite settings.*button next to the suite name/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/enable Goal completion under/i)).toBeInTheDocument();
   });
 
   it("hides run controls when the snapshot has goal completion explicitly disabled", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -64,17 +64,19 @@ describe("GoalCompletionCard", () => {
     expect(screen.getByText("Not run yet")).toBeInTheDocument();
   });
 
-  it("runs the judge with the selected default model and threshold", async () => {
+  it("runs the judge against the suite config (no override) by default", async () => {
     const onRun = vi.fn();
     const user = userEvent.setup();
     render(<GoalCompletionCard {...baseProps} onRun={onRun} />);
 
     await user.click(screen.getByRole("button", { name: /Run judge/i }));
 
-    expect(onRun).toHaveBeenCalledWith(
-      { judgeModel: "openai/gpt-5.4-mini", threshold: 0.7 },
-      false,
-    );
+    // V2 semantic: when the card's inputs equal the suite-configured values
+    // (here both fall back to managed defaults), `runOverride` is undefined
+    // and the backend explicitly clears any previously persisted run
+    // override. This is the "re-running without re-confirming exploration
+    // returns to the suite contract" property the plan requires.
+    expect(onRun).toHaveBeenCalledWith({ runOverride: undefined }, false);
   });
 
   it("falls back to the default threshold when the field is left blank", async () => {
@@ -86,8 +88,26 @@ describe("GoalCompletionCard", () => {
     await user.clear(screen.getByLabelText("Threshold"));
     await user.click(screen.getByRole("button", { name: /Run judge/i }));
 
+    // Parsed 0.7 == suite-config default, so no override is sent (the
+    // backend clears any persisted override and uses the suite contract).
+    expect(onRun).toHaveBeenCalledWith({ runOverride: undefined }, false);
+  });
+
+  it("sends a runOverride when the user picks a non-default threshold", async () => {
+    const onRun = vi.fn();
+    const user = userEvent.setup();
+    render(<GoalCompletionCard {...baseProps} onRun={onRun} />);
+
+    const thresholdInput = screen.getByLabelText("Threshold");
+    await user.clear(thresholdInput);
+    await user.type(thresholdInput, "0.85");
+    await user.click(screen.getByRole("button", { name: /Run judge/i }));
+
+    // The user's value differs from the suite-config default (0.7) → the
+    // card sends a runOverride. The judge model still matches the suite
+    // default so only `threshold` flows through.
     expect(onRun).toHaveBeenCalledWith(
-      { judgeModel: "openai/gpt-5.4-mini", threshold: 0.7 },
+      { runOverride: { threshold: 0.85 } },
       false,
     );
   });
@@ -207,9 +227,6 @@ describe("GoalCompletionCard", () => {
       />,
     );
     await user.click(screen.getByRole("button", { name: /Run judge/i }));
-    expect(onRun).toHaveBeenCalledWith(
-      { judgeModel: "openai/gpt-5.4-mini", threshold: 0.7 },
-      true,
-    );
+    expect(onRun).toHaveBeenCalledWith({ runOverride: undefined }, true);
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -144,6 +144,41 @@ describe("GoalCompletionCard", () => {
     expect(screen.getByRole("button", { name: /Run judge/i })).toBeDisabled();
   });
 
+  it("shows a grading state (not stale scores) during a re-run gap", () => {
+    // requested=true with a prior result still on the run: the card must show
+    // the in-flight state rather than the previous run's scores as if current.
+    const goalCompletion: EvalSuiteRun["goalCompletion"] = {
+      summary: "prior run",
+      generatedAt: 1,
+      modelUsed: "openai/gpt-5.4-mini",
+      threshold: 0.7,
+      cases: [
+        {
+          caseKey: "ck-1",
+          score: 0.8,
+          passed: true,
+          reason: "old reason",
+          rubricHits: [],
+        },
+      ],
+    };
+    render(
+      <GoalCompletionCard
+        {...baseProps}
+        requested
+        goalCompletion={goalCompletion}
+        onRun={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/Grading final answers against expected output/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Requesting…")).toBeInTheDocument();
+    // Stale score / reason from the previous run must not be displayed.
+    expect(screen.queryByText("80%")).not.toBeInTheDocument();
+    expect(screen.queryByText("old reason")).not.toBeInTheDocument();
+  });
+
   it("forces a re-request when retrying a failed run", async () => {
     const onRun = vi.fn();
     const user = userEvent.setup();

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -110,6 +110,8 @@ describe("GoalCompletionCard", () => {
 
     // Joins caseKey -> human title from the iterations.
     expect(screen.getByText("Weather lookup")).toBeInTheDocument();
+    // ck-2 has no matching iteration, so it falls back to the caseKey itself.
+    expect(screen.getByText("ck-2")).toBeInTheDocument();
     expect(screen.getByText("80%")).toBeInTheDocument();
     expect(screen.getByText("30%")).toBeInTheDocument();
     expect(screen.getByText("meets goal")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -11,7 +11,14 @@ function makeRun(overrides: Partial<EvalSuiteRun> = {}): EvalSuiteRun {
     createdBy: "user",
     runNumber: 1,
     configRevision: "rev1",
-    configSnapshot: { tests: [], environment: { servers: [] } },
+    // Default the snapshot to a configured judge so the card renders the
+    // run controls path (the configured behavior). Tests that want the
+    // unconfigured CTA pass a run override with `judgeConfig: undefined`.
+    configSnapshot: {
+      tests: [],
+      environment: { servers: [] },
+      judgeConfig: { goalCompletion: { enabled: true } },
+    },
     status: "completed",
     createdAt: 1,
     completedAt: 2,
@@ -228,5 +235,82 @@ describe("GoalCompletionCard", () => {
     );
     await user.click(screen.getByRole("button", { name: /Run judge/i }));
     expect(onRun).toHaveBeenCalledWith({ runOverride: undefined }, true);
+  });
+
+  it("hides run controls and shows a Configure-on-suite CTA when the snapshot doesn't enable the judge", () => {
+    // Without this gate the user could click Run judge on an unconfigured
+    // run — the backend would filter every case out and still spend an
+    // LLM call to "grade" nothing. Show the CTA instead.
+    const unconfiguredRun = makeRun({
+      configSnapshot: { tests: [], environment: { servers: [] } },
+    });
+    render(
+      <GoalCompletionCard
+        {...baseProps}
+        run={unconfiguredRun}
+        onRun={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Run judge/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Goal completion isn't enabled for this suite/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Suite settings . Judges/i)).toBeInTheDocument();
+  });
+
+  it("hides run controls when the snapshot has goal completion explicitly disabled", () => {
+    const disabledRun = makeRun({
+      configSnapshot: {
+        tests: [],
+        environment: { servers: [] },
+        judgeConfig: { goalCompletion: { enabled: false } },
+      },
+    });
+    render(
+      <GoalCompletionCard {...baseProps} run={disabledRun} onRun={vi.fn()} />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Run judge/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a prominent override banner when the run carries a judge override", () => {
+    const runWithOverride = makeRun({
+      configSnapshot: {
+        tests: [],
+        environment: { servers: [] },
+        judgeConfig: {
+          goalCompletion: {
+            enabled: true,
+            judgeModel: "openai/gpt-5.4-mini",
+            threshold: 0.7,
+          },
+        },
+      },
+      judgeConfigOverride: {
+        goalCompletion: { threshold: 0.85 },
+      },
+    });
+    render(
+      <GoalCompletionCard
+        {...baseProps}
+        run={runWithOverride}
+        onRun={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/This run used an override/i),
+    ).toBeInTheDocument();
+    // Suite default + run override are shown side-by-side so the user
+    // sees why this run's scores aren't suite-contract calibrated.
+    expect(screen.getByText(/Suite default:/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/openai\/gpt-5\.4-mini @ 0\.7/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/openai\/gpt-5\.4-mini @ 0\.85/),
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -237,10 +237,12 @@ describe("GoalCompletionCard", () => {
     expect(onRun).toHaveBeenCalledWith({ runOverride: undefined }, true);
   });
 
-  it("hides run controls and shows a Configure-on-suite CTA when the snapshot doesn't enable the judge", () => {
-    // Without this gate the user could click Run judge on an unconfigured
-    // run — the backend would filter every case out and still spend an
-    // LLM call to "grade" nothing. Show the CTA instead.
+  it("renders run controls by default when the snapshot says nothing (judge is on by default)", () => {
+    // V2 default: GOAL_COMPLETION_DEFAULTS.enabled = true. A snapshot
+    // without `judgeConfig.goalCompletion.enabled` (older runs, or a
+    // suite the owner never touched) resolves to enabled and surfaces
+    // the run controls — NOT the "Configure on suite" CTA. Cost is
+    // still gated by the explicit click + autoRun: false default.
     const unconfiguredRun = makeRun({
       configSnapshot: { tests: [], environment: { servers: [] } },
     });
@@ -252,21 +254,17 @@ describe("GoalCompletionCard", () => {
       />,
     );
     expect(
-      screen.queryByRole("button", { name: /Run judge/i }),
+      screen.getByRole("button", { name: /Run judge/i }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByText(/Goal completion isn't enabled for this suite/i),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByText(/Goal completion isn't enabled for this suite/i),
-    ).toBeInTheDocument();
-    // CTA points at the actual UI affordance (the gear button on the suite
-    // header) — not just generic "Suite settings", which had no visible
-    // entry point in the inspector until the gear shipped.
-    expect(
-      screen.getByText(/Open suite settings.*button next to the suite name/i),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/enable Goal completion under/i)).toBeInTheDocument();
   });
 
-  it("hides run controls when the snapshot has goal completion explicitly disabled", () => {
+  it("hides run controls and shows a Configure-on-suite CTA only when the suite explicitly disabled the judge", () => {
+    // The CTA path is now reserved for an explicit `enabled: false` on
+    // the snapshot — the owner actively turned the judge off. Older
+    // runs without any judgeConfig get the default-on path above.
     const disabledRun = makeRun({
       configSnapshot: {
         tests: [],
@@ -280,6 +278,15 @@ describe("GoalCompletionCard", () => {
     expect(
       screen.queryByRole("button", { name: /Run judge/i }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Goal completion isn't enabled for this suite/i),
+    ).toBeInTheDocument();
+    // CTA points at the actual UI affordance (the gear button on the suite
+    // header) — not just generic "Suite settings", which had no visible
+    // entry point in the inspector until the gear shipped.
+    expect(
+      screen.getByText(/Open suite settings.*button next to the suite name/i),
+    ).toBeInTheDocument();
   });
 
   it("renders a prominent override banner when the run carries a judge override", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
@@ -72,6 +72,11 @@ vi.mock("@/components/ui/resizable", () => ({
   ResizableHandle: () => <div data-testid="run-detail-resizable-handle" />,
 }));
 
+// The panel derives the judge's org scope from shared app state.
+vi.mock("@/state/app-state-context", () => ({
+  useSharedAppState: () => ({ projects: {}, activeProjectId: null }),
+}));
+
 function makeRun(overrides: Partial<EvalSuiteRun> = {}): EvalSuiteRun {
   return {
     _id: "run-1",

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
@@ -20,6 +20,24 @@ vi.mock("../use-server-quality", () => ({
   })),
 }));
 
+// Stub the goal-completion judge hook so the rail stays empty in view tests
+// that aren't about the judge panel. Matches the `unavailable: true` shape
+// used for useServerQuality above so callers see no rendered card.
+vi.mock("../use-goal-completion", () => ({
+  useGoalCompletion: vi.fn(() => ({
+    result: null,
+    pending: false,
+    requested: false,
+    failedGeneration: false,
+    error: null,
+    canRequest: false,
+    requestGoalCompletion: vi.fn(),
+    cancelGoalCompletion: vi.fn(),
+    summary: null,
+    unavailable: true,
+  })),
+}));
+
 import { useRunInsights } from "../use-run-insights";
 import { RunDetailView, RunIterationsSidebar } from "../run-detail-view";
 
@@ -27,6 +45,13 @@ vi.mock("convex/react", () => ({
   useMutation: () => vi.fn().mockResolvedValue(undefined),
   useQuery: () => undefined,
   useAction: () => vi.fn().mockResolvedValue(undefined),
+  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+}));
+
+// The goal-completion judge panel pulls the model catalog; stub it so the view
+// test stays isolated from the provider chain (auth / provider keys / ollama).
+vi.mock("@/hooks/use-available-eval-models", () => ({
+  useAvailableEvalModels: () => ({ availableModels: [] }),
 }));
 
 vi.mock("@/components/ui/resizable", () => ({

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-insight.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-insight.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("convex/react", () => ({
+  useMutation: () => vi.fn().mockResolvedValue(undefined),
+}));
+
+import { useInsight } from "../use-insight";
+import type { EvalSuiteRun } from "../types";
+
+type GoalRun = EvalSuiteRun & {
+  goalCompletionStatus?: "pending" | "completed" | "failed";
+  goalCompletion?: { summary: string; generatedAt: number };
+};
+
+function makeRun(over: Partial<GoalRun> = {}): GoalRun {
+  return {
+    _id: "run-1",
+    suiteId: "s",
+    createdBy: "u",
+    runNumber: 1,
+    configRevision: "r",
+    configSnapshot: { tests: [], environment: { servers: [] } },
+    status: "completed",
+    createdAt: 1,
+    ...over,
+  } as GoalRun;
+}
+
+const config = {
+  getStatus: (r: EvalSuiteRun) => (r as GoalRun).goalCompletionStatus,
+  getResult: (r: EvalSuiteRun) => (r as GoalRun).goalCompletion,
+  requestMutation: "goalCompletion:requestGoalCompletion",
+  cancelMutation: "goalCompletion:cancelGoalCompletion",
+};
+
+describe("useInsight requested lifecycle", () => {
+  it("keeps `requested` across the re-run gap, then clears when a fresh result lands", () => {
+    const prior = {
+      goalCompletionStatus: "completed" as const,
+      goalCompletion: { summary: "x", generatedAt: 100 },
+    };
+    const { result, rerender } = renderHook(
+      ({ run }) => useInsight(run, config, { autoRequest: false }),
+      { initialProps: { run: makeRun(prior) } },
+    );
+
+    expect(result.current.requested).toBe(false);
+
+    act(() => result.current.requestInsight(true));
+    expect(result.current.requested).toBe(true);
+
+    // Stale "completed" still present (same generatedAt) — must NOT clear, or a
+    // second click could fire a duplicate judge call in the click→pending gap.
+    rerender({ run: makeRun(prior) });
+    expect(result.current.requested).toBe(true);
+
+    // A fresh result lands (generatedAt advanced) even without an observed
+    // `pending` frame — the controls must not stay stuck disabled.
+    rerender({
+      run: makeRun({
+        goalCompletionStatus: "completed",
+        goalCompletion: { summary: "y", generatedAt: 200 },
+      }),
+    });
+    expect(result.current.requested).toBe(false);
+  });
+
+  it("clears `requested` once the job starts (status flips to pending)", () => {
+    const { result, rerender } = renderHook(
+      ({ run }) => useInsight(run, config, { autoRequest: false }),
+      { initialProps: { run: makeRun({ goalCompletionStatus: undefined }) } },
+    );
+
+    act(() => result.current.requestInsight(false));
+    expect(result.current.requested).toBe(true);
+
+    rerender({ run: makeRun({ goalCompletionStatus: "pending" }) });
+    expect(result.current.requested).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-insight.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-insight.test.tsx
@@ -1,9 +1,18 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 
-vi.mock("convex/react", () => ({
-  useMutation: () => vi.fn().mockResolvedValue(undefined),
+const { requestMutationMock } = vi.hoisted(() => ({
+  requestMutationMock: vi.fn(),
 }));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => requestMutationMock,
+}));
+
+beforeEach(() => {
+  requestMutationMock.mockReset();
+  requestMutationMock.mockResolvedValue(undefined);
+});
 
 import { useInsight } from "../use-insight";
 import type { EvalSuiteRun } from "../types";
@@ -77,5 +86,50 @@ describe("useInsight requested lifecycle", () => {
 
     rerender({ run: makeRun({ goalCompletionStatus: "pending" }) });
     expect(result.current.requested).toBe(false);
+  });
+
+  it("clears `requested` when a re-run ends in failure (fresh fallback result)", () => {
+    const prior = {
+      goalCompletionStatus: "completed" as const,
+      goalCompletion: { summary: "x", generatedAt: 100 },
+    };
+    const { result, rerender } = renderHook(
+      ({ run }) => useInsight(run, config, { autoRequest: false }),
+      { initialProps: { run: makeRun(prior) } },
+    );
+
+    act(() => result.current.requestInsight(true));
+    expect(result.current.requested).toBe(true);
+
+    // The judge job fails: the backend writes a fresh failed fallback (new
+    // generatedAt) alongside status "failed", so the controls must re-enable.
+    rerender({
+      run: makeRun({
+        goalCompletionStatus: "failed",
+        goalCompletion: { summary: "failed fallback", generatedAt: 200 },
+      }),
+    });
+    expect(result.current.requested).toBe(false);
+    expect(result.current.failedGeneration).toBe(true);
+  });
+
+  it("resets `unavailable` when the run changes", async () => {
+    // A run-specific failure (the backend throws "Suite run not found") matches
+    // the unavailable heuristic; it must not keep the panel hidden for later
+    // runs viewed in the same mounted hook.
+    requestMutationMock.mockRejectedValueOnce(new Error("Suite run not found"));
+    const { result, rerender } = renderHook(
+      ({ run }) => useInsight(run, config, { autoRequest: false }),
+      { initialProps: { run: makeRun({ _id: "run-1" }) } },
+    );
+
+    await act(async () => {
+      result.current.requestInsight(false);
+      await Promise.resolve();
+    });
+    expect(result.current.unavailable).toBe(true);
+
+    rerender({ run: makeRun({ _id: "run-2" }) });
+    expect(result.current.unavailable).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-insight.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-insight.test.tsx
@@ -132,4 +132,26 @@ describe("useInsight requested lifecycle", () => {
     rerender({ run: makeRun({ _id: "run-2" }) });
     expect(result.current.unavailable).toBe(false);
   });
+
+  it("keeps `unavailable` sticky across runs when the backend feature is missing", async () => {
+    // A genuine "feature missing" failure (mutation not deployed) is permanent
+    // for the session; resetting it on every run switch would re-fire a failing
+    // (auto)request and flash the panel. It must stay hidden.
+    requestMutationMock.mockRejectedValue(
+      new Error("Could not find public function for 'goalCompletion:x'"),
+    );
+    const { result, rerender } = renderHook(
+      ({ run }) => useInsight(run, config, { autoRequest: false }),
+      { initialProps: { run: makeRun({ _id: "run-1" }) } },
+    );
+
+    await act(async () => {
+      result.current.requestInsight(false);
+      await Promise.resolve();
+    });
+    expect(result.current.unavailable).toBe(true);
+
+    rerender({ run: makeRun({ _id: "run-2" }) });
+    expect(result.current.unavailable).toBe(true);
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -40,6 +40,18 @@ function clampThreshold(value: number): number {
   return Math.min(1, Math.max(0, value));
 }
 
+/**
+ * Parse the threshold input. A blank field must fall back to the default — NOT
+ * `Number("") === 0`, which would pass every nonnegative score and make a run
+ * look successful just because the field was left empty.
+ */
+function parseThreshold(input: string): number {
+  if (input.trim() === "") {
+    return DEFAULT_THRESHOLD;
+  }
+  return clampThreshold(Number(input));
+}
+
 function formatScore(score: number): string {
   return `${Math.round(clampThreshold(score) * 100)}%`;
 }
@@ -116,7 +128,7 @@ export function GoalCompletionCard({
     onRun(
       {
         judgeModel: selectedModelId || undefined,
-        threshold: clampThreshold(Number(thresholdInput)),
+        threshold: parseThreshold(thresholdInput),
       },
       force,
     );
@@ -206,7 +218,7 @@ export function GoalCompletionCard({
             value={thresholdInput}
             onChange={(e) => setThresholdInput(e.target.value)}
             onBlur={() =>
-              setThresholdInput(String(clampThreshold(Number(thresholdInput))))
+              setThresholdInput(String(parseThreshold(thresholdInput)))
             }
             disabled={inFlight}
             className="h-8 text-sm"

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -351,8 +351,9 @@ export function GoalCompletionCard({
             Goal completion isn't enabled for this suite.
           </p>
           <p className="mt-1 text-[12px] text-muted-foreground">
-            Configure it under <strong>Suite settings → Judges</strong> to
-            start grading runs against each case's{" "}
+            Open suite settings (the <strong>⚙</strong> button next to the
+            suite name) and enable Goal completion under{" "}
+            <strong>Judges</strong> to start grading runs against each case's{" "}
             <code className="font-mono text-[11px]">expectedOutput</code>.
             Cases without an expected output are skipped (anchored-only).
           </p>

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -124,11 +124,15 @@ export function GoalCompletionCard({
 
   const cases = goalCompletion?.cases ?? [];
   const advisoryPassed = cases.filter((c) => c.passed).length;
+  // Treat an in-flight request (clicked, before the run doc flips to `pending`)
+  // as a grading state, so a re-run doesn't keep showing the previous run's
+  // stale scores/counts as if they were current.
+  const inFlight = pending || requested;
 
   const headerSubtitle = (() => {
     if (pending) return "Grading…";
+    if (requested) return "Requesting…";
     if (error || failedGeneration) return "Grading failed";
-    if (!goalCompletion && requested) return "Requesting…";
     if (!goalCompletion) return "Not run yet";
     if (cases.length === 0) return "Summary only";
     return `${advisoryPassed}/${cases.length} meet goal (advisory)`;
@@ -158,7 +162,7 @@ export function GoalCompletionCard({
             size="sm"
             className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
             onClick={() => handleRun(true)}
-            disabled={!completedRun || pending || requested}
+            disabled={!completedRun || inFlight}
           >
             <RotateCw className="h-3 w-3" />
             Retry
@@ -175,7 +179,7 @@ export function GoalCompletionCard({
           <Select
             value={selectedModelId}
             onValueChange={setSelectedModelId}
-            disabled={pending}
+            disabled={inFlight}
           >
             <SelectTrigger id="goal-judge-model" className="h-8 w-full text-sm">
               <SelectValue />
@@ -204,7 +208,7 @@ export function GoalCompletionCard({
             onBlur={() =>
               setThresholdInput(String(clampThreshold(Number(thresholdInput))))
             }
-            disabled={pending}
+            disabled={inFlight}
             className="h-8 text-sm"
           />
         </div>
@@ -215,11 +219,12 @@ export function GoalCompletionCard({
           // force when re-grading an existing result OR retrying a failed run,
           // so the shared insight lifecycle re-requests instead of no-opping.
           onClick={() => handleRun(Boolean(goalCompletion) || failedGeneration)}
-          // `requested` blocks the gap between click and the run doc flipping to
-          // `pending`, so a double-click can't spend a second judge call.
-          disabled={!completedRun || pending || requested}
+          // `inFlight` (pending OR requested) blocks the gap between the click
+          // and the run doc flipping to `pending`, so a double-click can't spend
+          // a second judge call.
+          disabled={!completedRun || inFlight}
         >
-          {pending ? (
+          {inFlight ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
           ) : (
             <Sparkles className="h-3.5 w-3.5" />
@@ -235,7 +240,7 @@ export function GoalCompletionCard({
       </p>
 
       <div className="border-t border-border/50">
-        {pending ? (
+        {inFlight ? (
           <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
             Grading final answers against expected output…

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -141,13 +141,33 @@ export function GoalCompletionCard({
   // displays this read-only; the model + threshold inputs on this card now
   // populate a per-run *override* (run.judgeConfigOverride) instead of being
   // the primary config source. Suite settings is the new home for default
-  // config (see JudgesSection in suite-iterations-view.tsx). The persisted
-  // run override (run.judgeConfigOverride.goalCompletion) is consumed at
-  // initial-state seeding above; the banner that surfaces it prominently
-  // is V1.x polish.
+  // config (see JudgesSection in suite-iterations-view.tsx).
   const suiteConfig = run.configSnapshot?.judgeConfig?.goalCompletion;
   const suiteModel = suiteConfig?.judgeModel ?? DEFAULT_JUDGE_MODEL;
   const suiteThreshold = suiteConfig?.threshold ?? DEFAULT_THRESHOLD;
+  // Judge is "configured" iff the suite snapshot has `enabled: true`. When
+  // false (or absent — older runs without a snapshot), the action would
+  // short-circuit to a no-op grading anyway, so the card hides the run
+  // controls and shows a "Configure on suite" CTA instead. Without this
+  // gate, clicking Run judge on an unconfigured run spends an LLM call to
+  // grade zero cases.
+  const isJudgeConfigured = suiteConfig?.enabled === true;
+  // The persisted run override (`run.judgeConfigOverride.goalCompletion`)
+  // tells the trend story (this data point isn't graded against the suite
+  // contract). Surfacing it prominently is how the comparability promise
+  // is delivered — otherwise the persistence is invisible.
+  const runOverride = run.judgeConfigOverride?.goalCompletion;
+  const overrideModel =
+    runOverride?.judgeModel && runOverride.judgeModel !== suiteModel
+      ? runOverride.judgeModel
+      : undefined;
+  const overrideThresholdValue =
+    runOverride?.threshold !== undefined &&
+    runOverride.threshold !== suiteThreshold
+      ? runOverride.threshold
+      : undefined;
+  const hasMeaningfulOverride =
+    overrideModel !== undefined || overrideThresholdValue !== undefined;
 
   const handleRun = (force: boolean) => {
     // Only send a runOverride when the user's inputs DIFFER from the suite
@@ -219,74 +239,125 @@ export function GoalCompletionCard({
         ) : null}
       </header>
 
-      {/* Controls: judge model + threshold + run */}
-      <div className="flex flex-wrap items-end gap-3 border-t border-border/50 px-3 py-3">
-        <div className="flex min-w-[12rem] flex-1 flex-col gap-1">
-          <Label htmlFor="goal-judge-model" className="text-xs">
-            Judge model
-          </Label>
-          <Select
-            value={selectedModelId}
-            onValueChange={setSelectedModelId}
-            disabled={inFlight}
-          >
-            <SelectTrigger id="goal-judge-model" className="h-8 w-full text-sm">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {modelOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex w-24 flex-col gap-1">
-          <Label htmlFor="goal-threshold" className="text-xs">
-            Threshold
-          </Label>
-          <Input
-            id="goal-threshold"
-            type="number"
-            min={0}
-            max={1}
-            step={0.05}
-            value={thresholdInput}
-            onChange={(e) => setThresholdInput(e.target.value)}
-            onBlur={() =>
-              setThresholdInput(String(parseThreshold(thresholdInput)))
-            }
-            disabled={inFlight}
-            className="h-8 text-sm"
-          />
-        </div>
-        <Button
-          type="button"
-          size="sm"
-          className="h-8 gap-1 text-xs"
-          // force when re-grading an existing result OR retrying a failed run,
-          // so the shared insight lifecycle re-requests instead of no-opping.
-          onClick={() => handleRun(Boolean(goalCompletion) || failedGeneration)}
-          // `inFlight` (pending OR requested) blocks the gap between the click
-          // and the run doc flipping to `pending`, so a double-click can't spend
-          // a second judge call.
-          disabled={!completedRun || inFlight}
-        >
-          {inFlight ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <Sparkles className="h-3.5 w-3.5" />
-          )}
-          {runLabel}
-        </Button>
-      </div>
+      {isJudgeConfigured ? (
+        <>
+          {/* Controls: judge model + threshold + run. Only shown when the
+              suite has goal completion enabled — otherwise we render the
+              "Configure on suite" CTA below so the user can't accidentally
+              trigger a no-op grading that still spends an LLM call. */}
+          <div className="flex flex-wrap items-end gap-3 border-t border-border/50 px-3 py-3">
+            <div className="flex min-w-[12rem] flex-1 flex-col gap-1">
+              <Label htmlFor="goal-judge-model" className="text-xs">
+                Judge model
+              </Label>
+              <Select
+                value={selectedModelId}
+                onValueChange={setSelectedModelId}
+                disabled={inFlight}
+              >
+                <SelectTrigger
+                  id="goal-judge-model"
+                  className="h-8 w-full text-sm"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {modelOptions.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex w-24 flex-col gap-1">
+              <Label htmlFor="goal-threshold" className="text-xs">
+                Threshold
+              </Label>
+              <Input
+                id="goal-threshold"
+                type="number"
+                min={0}
+                max={1}
+                step={0.05}
+                value={thresholdInput}
+                onChange={(e) => setThresholdInput(e.target.value)}
+                onBlur={() =>
+                  setThresholdInput(String(parseThreshold(thresholdInput)))
+                }
+                disabled={inFlight}
+                className="h-8 text-sm"
+              />
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              className="h-8 gap-1 text-xs"
+              // force when re-grading an existing result OR retrying a failed run,
+              // so the shared insight lifecycle re-requests instead of no-opping.
+              onClick={() =>
+                handleRun(Boolean(goalCompletion) || failedGeneration)
+              }
+              // `inFlight` (pending OR requested) blocks the gap between the click
+              // and the run doc flipping to `pending`, so a double-click can't spend
+              // a second judge call.
+              disabled={!completedRun || inFlight}
+            >
+              {inFlight ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Sparkles className="h-3.5 w-3.5" />
+              )}
+              {runLabel}
+            </Button>
+          </div>
 
-      <p className="px-3 pb-3 text-[11px] text-muted-foreground/70">
-        Threshold is the advisory pass cutoff (score ≥ threshold). Calibrate it
-        per suite against a labeled set — LLM-judge scores are not comparable
-        across domains.
-      </p>
+          <p className="px-3 pb-3 text-[11px] text-muted-foreground/70">
+            Threshold is the advisory pass cutoff (score ≥ threshold).
+            Calibrate it per suite against a labeled set — LLM-judge scores
+            are not comparable across domains.
+          </p>
+
+          {hasMeaningfulOverride ? (
+            <div className="mx-3 mb-3 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[12px]">
+              <div className="font-medium text-amber-700 dark:text-amber-300">
+                ⚙ This run used an override
+              </div>
+              <div className="mt-0.5 text-muted-foreground">
+                Suite default:{" "}
+                <span className="font-mono text-foreground/80">
+                  {suiteModel} @ {suiteThreshold}
+                </span>{" "}
+                · This run:{" "}
+                <span className="font-mono text-foreground/80">
+                  {overrideModel ?? suiteModel} @{" "}
+                  {overrideThresholdValue ?? suiteThreshold}
+                </span>
+              </div>
+              <div className="mt-1 text-[11px] text-muted-foreground/80">
+                Scores from this run aren't directly comparable to the
+                suite's trend. Re-run with the override cleared to re-grade
+                against the suite contract.
+              </div>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        // Suite hasn't enabled the judge. Don't render run controls —
+        // clicking them on an unconfigured run would spend an LLM call to
+        // grade zero cases. Direct the user to the right surface instead.
+        <div className="border-t border-border/50 px-3 py-4 text-sm">
+          <p className="text-foreground/90">
+            Goal completion isn't enabled for this suite.
+          </p>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            Configure it under <strong>Suite settings → Judges</strong> to
+            start grading runs against each case's{" "}
+            <code className="font-mono text-[11px]">expectedOutput</code>.
+            Cases without an expected output are skipped (anchored-only).
+          </p>
+        </div>
+      )}
 
       <div className="border-t border-border/50">
         {inFlight ? (

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -17,6 +17,8 @@ import type { GoalCompletionRequestArgs } from "./use-goal-completion";
 
 /** Managed default judge model (mirrors GOAL_COMPLETION_MODEL in the backend). */
 const DEFAULT_JUDGE_MODEL = "openai/gpt-5.4-mini";
+// A reasonable starting cutoff only — LLM-as-judge scores aren't comparable
+// across domains, so teams should recalibrate this against a labeled set.
 const DEFAULT_THRESHOLD = 0.7;
 
 export interface GoalCompletionCardProps {
@@ -156,7 +158,7 @@ export function GoalCompletionCard({
             size="sm"
             className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
             onClick={() => handleRun(true)}
-            disabled={!completedRun || pending}
+            disabled={!completedRun || pending || requested}
           >
             <RotateCw className="h-3 w-3" />
             Retry
@@ -210,8 +212,12 @@ export function GoalCompletionCard({
           type="button"
           size="sm"
           className="h-8 gap-1 text-xs"
-          onClick={() => handleRun(Boolean(goalCompletion))}
-          disabled={!completedRun || pending}
+          // force when re-grading an existing result OR retrying a failed run,
+          // so the shared insight lifecycle re-requests instead of no-opping.
+          onClick={() => handleRun(Boolean(goalCompletion) || failedGeneration)}
+          // `requested` blocks the gap between click and the run doc flipping to
+          // `pending`, so a double-click can't spend a second judge call.
+          disabled={!completedRun || pending || requested}
         >
           {pending ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -221,6 +227,12 @@ export function GoalCompletionCard({
           {runLabel}
         </Button>
       </div>
+
+      <p className="px-3 pb-3 text-[11px] text-muted-foreground/70">
+        Threshold is the advisory pass cutoff (score ≥ threshold). Calibrate it
+        per suite against a labeled set — LLM-judge scores are not comparable
+        across domains.
+      </p>
 
       <div className="border-t border-border/50">
         {pending ? (

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -53,7 +53,14 @@ function parseThreshold(input: string): number {
 }
 
 function formatScore(score: number): string {
-  return `${Math.round(clampThreshold(score) * 100)}%`;
+  // Don't route the score through clampThreshold: its NaN→DEFAULT_THRESHOLD
+  // fallback is right for the threshold input but would render a corrupt/NaN
+  // score as "70%" (the pass cutoff). Show a neutral dash instead, and clamp
+  // finite scores into [0,1].
+  if (!Number.isFinite(score)) {
+    return "—";
+  }
+  return `${Math.round(Math.min(1, Math.max(0, score)) * 100)}%`;
 }
 
 function ScoreBadge({ passed }: { passed: boolean }) {

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -1,0 +1,306 @@
+import { useMemo, useState } from "react";
+import { Loader2, RotateCw, Sparkles } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { cn } from "@/lib/utils";
+import type { ModelDefinition } from "@/shared/types";
+import type { EvalIteration, EvalSuiteRun } from "./types";
+import type { GoalCompletionRequestArgs } from "./use-goal-completion";
+
+/** Managed default judge model (mirrors GOAL_COMPLETION_MODEL in the backend). */
+const DEFAULT_JUDGE_MODEL = "openai/gpt-5.4-mini";
+const DEFAULT_THRESHOLD = 0.7;
+
+export interface GoalCompletionCardProps {
+  run: EvalSuiteRun;
+  iterations: EvalIteration[];
+  goalCompletion: EvalSuiteRun["goalCompletion"] | null;
+  availableModels: ModelDefinition[];
+  pending: boolean;
+  requested: boolean;
+  failedGeneration: boolean;
+  error: string | null;
+  onRun: (args: GoalCompletionRequestArgs, force?: boolean) => void;
+}
+
+function clampThreshold(value: number): number {
+  if (Number.isNaN(value)) {
+    return DEFAULT_THRESHOLD;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function formatScore(score: number): string {
+  return `${Math.round(clampThreshold(score) * 100)}%`;
+}
+
+function ScoreBadge({ passed }: { passed: boolean }) {
+  return (
+    <span
+      className={cn(
+        "rounded-sm px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide",
+        passed
+          ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+          : "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+      )}
+    >
+      {passed ? "meets goal" : "below threshold"}
+    </span>
+  );
+}
+
+export function GoalCompletionCard({
+  run,
+  iterations,
+  goalCompletion,
+  availableModels,
+  pending,
+  requested,
+  failedGeneration,
+  error,
+  onRun,
+}: GoalCompletionCardProps) {
+  const completedRun = run.status === "completed";
+
+  const [selectedModelId, setSelectedModelId] = useState<string>(
+    goalCompletion?.modelUsed && goalCompletion.modelUsed !== "n/a"
+      ? goalCompletion.modelUsed
+      : DEFAULT_JUDGE_MODEL,
+  );
+  const [thresholdInput, setThresholdInput] = useState<string>(
+    String(goalCompletion?.threshold ?? DEFAULT_THRESHOLD),
+  );
+
+  // Always keep the managed default + the current selection selectable, even
+  // before the async model catalog loads (or when BYOK has none configured).
+  const modelOptions = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const model of availableModels) {
+      const id = String(model.id);
+      if (id && !map.has(id)) {
+        map.set(id, model.name ?? id);
+      }
+    }
+    if (!map.has(DEFAULT_JUDGE_MODEL)) {
+      map.set(DEFAULT_JUDGE_MODEL, DEFAULT_JUDGE_MODEL);
+    }
+    if (selectedModelId && !map.has(selectedModelId)) {
+      map.set(selectedModelId, selectedModelId);
+    }
+    return Array.from(map, ([value, label]) => ({ value, label }));
+  }, [availableModels, selectedModelId]);
+
+  const titleByCaseKey = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const iter of iterations) {
+      const caseKey = iter.testCaseSnapshot?.caseKey;
+      const title = iter.testCaseSnapshot?.title;
+      if (caseKey && title && !map.has(caseKey)) {
+        map.set(caseKey, title);
+      }
+    }
+    return map;
+  }, [iterations]);
+
+  const handleRun = (force: boolean) => {
+    onRun(
+      {
+        judgeModel: selectedModelId || undefined,
+        threshold: clampThreshold(Number(thresholdInput)),
+      },
+      force,
+    );
+  };
+
+  const cases = goalCompletion?.cases ?? [];
+  const advisoryPassed = cases.filter((c) => c.passed).length;
+
+  const headerSubtitle = (() => {
+    if (pending) return "Grading…";
+    if (error || failedGeneration) return "Grading failed";
+    if (!goalCompletion && requested) return "Requesting…";
+    if (!goalCompletion) return "Not run yet";
+    if (cases.length === 0) return "Summary only";
+    return `${advisoryPassed}/${cases.length} meet goal (advisory)`;
+  })();
+
+  const runLabel = goalCompletion ? "Re-run judge" : "Run judge";
+
+  return (
+    <section className="rounded-lg border border-border bg-card text-card-foreground">
+      <header className="flex flex-wrap items-center justify-between gap-2 px-3 py-2.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-sm font-medium text-foreground">
+            Goal completion
+          </span>
+          <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            advisory · LLM judge
+          </span>
+          <span className="truncate text-sm text-muted-foreground">
+            {headerSubtitle}
+          </span>
+        </div>
+        {error || failedGeneration ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => handleRun(true)}
+            disabled={!completedRun || pending}
+          >
+            <RotateCw className="h-3 w-3" />
+            Retry
+          </Button>
+        ) : null}
+      </header>
+
+      {/* Controls: judge model + threshold + run */}
+      <div className="flex flex-wrap items-end gap-3 border-t border-border/50 px-3 py-3">
+        <div className="flex min-w-[12rem] flex-1 flex-col gap-1">
+          <Label htmlFor="goal-judge-model" className="text-xs">
+            Judge model
+          </Label>
+          <Select
+            value={selectedModelId}
+            onValueChange={setSelectedModelId}
+            disabled={pending}
+          >
+            <SelectTrigger id="goal-judge-model" className="h-8 w-full text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {modelOptions.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex w-24 flex-col gap-1">
+          <Label htmlFor="goal-threshold" className="text-xs">
+            Threshold
+          </Label>
+          <Input
+            id="goal-threshold"
+            type="number"
+            min={0}
+            max={1}
+            step={0.05}
+            value={thresholdInput}
+            onChange={(e) => setThresholdInput(e.target.value)}
+            onBlur={() =>
+              setThresholdInput(String(clampThreshold(Number(thresholdInput))))
+            }
+            disabled={pending}
+            className="h-8 text-sm"
+          />
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 gap-1 text-xs"
+          onClick={() => handleRun(Boolean(goalCompletion))}
+          disabled={!completedRun || pending}
+        >
+          {pending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Sparkles className="h-3.5 w-3.5" />
+          )}
+          {runLabel}
+        </Button>
+      </div>
+
+      <div className="border-t border-border/50">
+        {pending ? (
+          <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Grading final answers against expected output…
+          </div>
+        ) : error ? (
+          <div className="px-3 py-4 text-sm text-destructive">{error}</div>
+        ) : failedGeneration ? (
+          <div className="px-3 py-4 text-sm text-muted-foreground">
+            We could not finish grading. Adjust the model or threshold and
+            retry.
+          </div>
+        ) : !goalCompletion ? (
+          <div className="px-3 py-4 text-sm text-muted-foreground">
+            Grade whether each case's final answer satisfied its expected
+            output. Pick a judge model and threshold, then run — this is
+            advisory and never changes the run's pass/fail.
+          </div>
+        ) : cases.length === 0 ? (
+          <div className="px-3 py-4 text-sm text-muted-foreground">
+            {goalCompletion.summary?.trim() ||
+              "No anchored cases to grade (cases need an expected output)."}
+          </div>
+        ) : (
+          <>
+            {goalCompletion.summary?.trim() ? (
+              <p className="border-b border-border/40 px-3 py-2.5 text-sm text-muted-foreground">
+                {goalCompletion.summary.trim()}
+              </p>
+            ) : null}
+            <ul className="divide-y divide-border/40">
+              {cases.map((c) => {
+                const title = titleByCaseKey.get(c.caseKey) ?? c.caseKey;
+                return (
+                  <li
+                    key={c.caseKey}
+                    className="flex items-start gap-3 px-3 py-2.5"
+                  >
+                    <span className="mt-0.5 w-10 shrink-0 text-right text-sm font-semibold tabular-nums">
+                      {formatScore(c.score)}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {title}
+                        </span>
+                        <ScoreBadge passed={c.passed} />
+                      </div>
+                      {c.reason ? (
+                        <div className="mt-0.5 text-[13px] text-muted-foreground">
+                          {c.reason}
+                        </div>
+                      ) : null}
+                      {c.rubricHits.length > 0 ? (
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {c.rubricHits.map((hit, i) => (
+                            <span
+                              key={`${c.caseKey}-hit-${i}`}
+                              className="rounded-sm bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground"
+                            >
+                              {hit}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+            <p className="px-3 py-2 text-[11px] text-muted-foreground/70">
+              Judged by {goalCompletion.modelUsed} · pass when score ≥{" "}
+              {goalCompletion.threshold}. Advisory only — the deterministic
+              tool-call verdict above is the run's pass/fail.
+            </p>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -84,13 +84,26 @@ export function GoalCompletionCard({
 }: GoalCompletionCardProps) {
   const completedRun = run.status === "completed";
 
-  const [selectedModelId, setSelectedModelId] = useState<string>(
-    goalCompletion?.modelUsed && goalCompletion.modelUsed !== "n/a"
+  // Seed inputs from (in order): persisted run override → suite snapshot →
+  // managed defaults. This way reopening a run with an override pre-populates
+  // it; reopening a run without one pre-populates suite config (so a click
+  // submits the suite default and the override field stays cleared on the
+  // backend).
+  const initialModel =
+    run.judgeConfigOverride?.goalCompletion?.judgeModel ??
+    run.configSnapshot?.judgeConfig?.goalCompletion?.judgeModel ??
+    (goalCompletion?.modelUsed && goalCompletion.modelUsed !== "n/a"
       ? goalCompletion.modelUsed
-      : DEFAULT_JUDGE_MODEL,
-  );
+      : DEFAULT_JUDGE_MODEL);
+  const initialThreshold =
+    run.judgeConfigOverride?.goalCompletion?.threshold ??
+    run.configSnapshot?.judgeConfig?.goalCompletion?.threshold ??
+    goalCompletion?.threshold ??
+    DEFAULT_THRESHOLD;
+  const [selectedModelId, setSelectedModelId] =
+    useState<string>(initialModel);
   const [thresholdInput, setThresholdInput] = useState<string>(
-    String(goalCompletion?.threshold ?? DEFAULT_THRESHOLD),
+    String(initialThreshold),
   );
 
   // Always keep the managed default + the current selection selectable, even
@@ -124,14 +137,38 @@ export function GoalCompletionCard({
     return map;
   }, [iterations]);
 
+  // Read the suite's effective config from the run's snapshot. The card
+  // displays this read-only; the model + threshold inputs on this card now
+  // populate a per-run *override* (run.judgeConfigOverride) instead of being
+  // the primary config source. Suite settings is the new home for default
+  // config (see JudgesSection in suite-iterations-view.tsx). The persisted
+  // run override (run.judgeConfigOverride.goalCompletion) is consumed at
+  // initial-state seeding above; the banner that surfaces it prominently
+  // is V1.x polish.
+  const suiteConfig = run.configSnapshot?.judgeConfig?.goalCompletion;
+  const suiteModel = suiteConfig?.judgeModel ?? DEFAULT_JUDGE_MODEL;
+  const suiteThreshold = suiteConfig?.threshold ?? DEFAULT_THRESHOLD;
+
   const handleRun = (force: boolean) => {
-    onRun(
-      {
-        judgeModel: selectedModelId || undefined,
-        threshold: parseThreshold(thresholdInput),
-      },
-      force,
-    );
+    // Only send a runOverride when the user's inputs DIFFER from the suite
+    // config. Otherwise pass `{}` so the backend clears any previously
+    // persisted override and grades against the suite contract — the
+    // override-clearing semantic the plan + tests require.
+    const overrideModel =
+      selectedModelId && selectedModelId !== suiteModel
+        ? selectedModelId
+        : undefined;
+    const parsedThreshold = parseThreshold(thresholdInput);
+    const overrideThreshold =
+      parsedThreshold !== suiteThreshold ? parsedThreshold : undefined;
+    const runOverride =
+      overrideModel || overrideThreshold !== undefined
+        ? {
+            judgeModel: overrideModel,
+            threshold: overrideThreshold,
+          }
+        : undefined;
+    onRun({ runOverride }, force);
   };
 
   const cases = goalCompletion?.cases ?? [];

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -152,13 +152,14 @@ export function GoalCompletionCard({
   const suiteConfig = run.configSnapshot?.judgeConfig?.goalCompletion;
   const suiteModel = suiteConfig?.judgeModel ?? DEFAULT_JUDGE_MODEL;
   const suiteThreshold = suiteConfig?.threshold ?? DEFAULT_THRESHOLD;
-  // Judge is "configured" iff the suite snapshot has `enabled: true`. When
-  // false (or absent — older runs without a snapshot), the action would
-  // short-circuit to a no-op grading anyway, so the card hides the run
-  // controls and shows a "Configure on suite" CTA instead. Without this
-  // gate, clicking Run judge on an unconfigured run spends an LLM call to
-  // grade zero cases.
-  const isJudgeConfigured = suiteConfig?.enabled === true;
+  // Treat "no explicit choice" as enabled (matches GOAL_COMPLETION_DEFAULTS
+  // on the backend: `enabled: true`). Only an explicit `enabled: false` on
+  // the suite snapshot hides the run controls behind the "Configure on
+  // suite" CTA. This keeps the judge discoverable on every suite by default
+  // while still respecting an owner who actively turned it off.
+  // Cost remains gated by the explicit Run judge click + `autoRun: false`
+  // default — an enabled-but-un-clicked judge spends nothing.
+  const isJudgeConfigured = suiteConfig?.enabled !== false;
   // The persisted run override (`run.judgeConfigOverride.goalCompletion`)
   // tells the trend story (this data point isn't graded against the suite
   // contract). Surfacing it prominently is how the comparability promise

--- a/mcpjam-inspector/client/src/components/evals/judges-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judges-section.tsx
@@ -233,9 +233,9 @@ export function JudgesSection({
         {enabled ? (
           <p className="text-[11px] text-muted-foreground/70">
             Runs grade against this config. Individual runs can apply a one-off
-            override via the "⚙ Override for this run" disclosure on the run
-            detail page — overrides are marked on the suite trend so
-            calibration stays comparable.
+            override from the run detail page — overridden runs show a banner
+            on the run card so their scores aren't mistaken for suite-contract
+            calibration.
           </p>
         ) : null}
       </div>

--- a/mcpjam-inspector/client/src/components/evals/judges-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judges-section.tsx
@@ -1,0 +1,200 @@
+import { useMemo } from "react";
+import { Sparkles } from "lucide-react";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { Switch } from "@mcpjam/design-system/switch";
+import type { ModelDefinition } from "@/shared/types";
+import type { EvalJudgeConfig } from "./types";
+
+/**
+ * Suite-level authoritative judge config. Mirrors the `ValidatorsSection`
+ * pattern (props: value / onChange / title / description) so the suite
+ * settings page can drop it next to ValidatorsSection. V1 carries one
+ * judge — Goal Completion — but the envelope is forward-compatible with
+ * additional judges (refusal judge, etc.) without a second pass on the
+ * surface.
+ *
+ * The card on the run-detail page reads the snapshotted suite config from
+ * `run.configSnapshot.judgeConfig` and displays it read-only; this is the
+ * one place a user can change the suite contract.
+ */
+
+const MANAGED_DEFAULT_JUDGE_MODEL = "openai/gpt-5.4-mini";
+const DEFAULT_THRESHOLD = 0.7;
+
+interface JudgesSectionProps {
+  value: EvalJudgeConfig | undefined;
+  onChange: (next: EvalJudgeConfig | undefined) => void;
+  availableModels: ModelDefinition[];
+  title?: string;
+  description?: string;
+}
+
+function pruneEmpty(value: EvalJudgeConfig): EvalJudgeConfig | undefined {
+  if (!value.goalCompletion) return undefined;
+  const gc = value.goalCompletion;
+  const hasAnyField =
+    gc.enabled !== undefined ||
+    (gc.judgeModel !== undefined && gc.judgeModel !== "") ||
+    gc.threshold !== undefined;
+  if (!hasAnyField) return undefined;
+  return { goalCompletion: gc };
+}
+
+export function JudgesSection({
+  value,
+  onChange,
+  availableModels,
+  title = "Judges",
+  description = "Advisory LLM-as-judge scorers that grade run results against rubric anchors. Calibrate per suite — scores aren't comparable across domains.",
+}: JudgesSectionProps) {
+  const gc = value?.goalCompletion;
+  const enabled = gc?.enabled === true;
+  const judgeModel = gc?.judgeModel ?? MANAGED_DEFAULT_JUDGE_MODEL;
+  const threshold = gc?.threshold ?? DEFAULT_THRESHOLD;
+
+  const modelOptions = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const model of availableModels) {
+      const id = String(model.id);
+      if (id && !map.has(id)) {
+        map.set(id, model.name ?? id);
+      }
+    }
+    // Always keep the managed default + the current selection selectable,
+    // even before the async model catalog loads.
+    if (!map.has(MANAGED_DEFAULT_JUDGE_MODEL)) {
+      map.set(MANAGED_DEFAULT_JUDGE_MODEL, MANAGED_DEFAULT_JUDGE_MODEL);
+    }
+    if (judgeModel && !map.has(judgeModel)) {
+      map.set(judgeModel, judgeModel);
+    }
+    return Array.from(map, ([id, label]) => ({ id, label }));
+  }, [availableModels, judgeModel]);
+
+  const update = (patch: Partial<NonNullable<EvalJudgeConfig["goalCompletion"]>>) => {
+    const nextGC = { ...(gc ?? {}), ...patch };
+    const nextConfig: EvalJudgeConfig = { goalCompletion: nextGC };
+    onChange(pruneEmpty(nextConfig));
+  };
+
+  return (
+    <section
+      aria-label={title}
+      className="rounded-lg border border-border/40 bg-card/30 p-4 space-y-4"
+    >
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
+          <h3 className="text-sm font-semibold">{title}</h3>
+        </div>
+        {description ? (
+          <p className="text-[12px] text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+
+      <div className="space-y-3 rounded-md border border-border/30 bg-background/60 p-3">
+        {/* Goal Completion — V1 only judge */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">Goal completion</span>
+              <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                advisory · LLM judge
+              </span>
+            </div>
+            <p className="text-[11px] text-muted-foreground/80">
+              Grades whether each case's final answer satisfied its{" "}
+              <code className="font-mono">expectedOutput</code>. Cases without
+              an expected output are skipped (anchored-only).
+            </p>
+          </div>
+          <Switch
+            checked={enabled}
+            onCheckedChange={(checked: boolean) =>
+              update({ enabled: checked || undefined })
+            }
+            aria-label="Enable Goal Completion judge for this suite"
+          />
+        </div>
+
+        {enabled ? (
+          <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+            <div className="space-y-1">
+              <Label htmlFor="suite-goal-judge-model" className="text-xs">
+                Judge model
+              </Label>
+              <Select
+                value={judgeModel}
+                onValueChange={(next) =>
+                  update({
+                    judgeModel:
+                      next === MANAGED_DEFAULT_JUDGE_MODEL ? undefined : next,
+                  })
+                }
+              >
+                <SelectTrigger
+                  id="suite-goal-judge-model"
+                  className="h-8 w-full text-sm"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {modelOptions.map((opt) => (
+                    <SelectItem key={opt.id} value={opt.id}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1 sm:w-28">
+              <Label htmlFor="suite-goal-threshold" className="text-xs">
+                Threshold
+              </Label>
+              <Input
+                id="suite-goal-threshold"
+                type="number"
+                min={0}
+                max={1}
+                step={0.05}
+                value={String(threshold)}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  if (raw.trim() === "") {
+                    update({ threshold: undefined });
+                    return;
+                  }
+                  const parsed = Number(raw);
+                  if (!Number.isFinite(parsed)) return;
+                  const clamped = Math.min(1, Math.max(0, parsed));
+                  update({
+                    threshold:
+                      clamped === DEFAULT_THRESHOLD ? undefined : clamped,
+                  });
+                }}
+                className="h-8 text-sm"
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {enabled ? (
+          <p className="text-[11px] text-muted-foreground/70">
+            Runs grade against this config. Individual runs can apply a one-off
+            override via the "⚙ Override for this run" disclosure on the run
+            detail page — overrides are marked on the suite trend so
+            calibration stays comparable.
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/judges-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judges-section.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Sparkles } from "lucide-react";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
@@ -43,7 +43,8 @@ function pruneEmpty(value: EvalJudgeConfig): EvalJudgeConfig | undefined {
   const hasAnyField =
     gc.enabled !== undefined ||
     (gc.judgeModel !== undefined && gc.judgeModel !== "") ||
-    gc.threshold !== undefined;
+    gc.threshold !== undefined ||
+    gc.autoRun !== undefined;
   if (!hasAnyField) return undefined;
   return { goalCompletion: gc };
 }
@@ -84,6 +85,31 @@ export function JudgesSection({
     const nextGC = { ...(gc ?? {}), ...patch };
     const nextConfig: EvalJudgeConfig = { goalCompletion: nextGC };
     onChange(pruneEmpty(nextConfig));
+  };
+
+  // The threshold field keeps a local draft so typing doesn't fight the
+  // persisted prop: `onChange` here drives an async `updateSuite`, and feeding
+  // the input straight from the round-tripped prop snaps a half-typed decimal
+  // back mid-edit. Type into the draft, commit (clamp / default) on blur, and
+  // re-sync the draft whenever the persisted value changes from elsewhere.
+  const [thresholdDraft, setThresholdDraft] = useState(String(threshold));
+  useEffect(() => {
+    setThresholdDraft(String(threshold));
+  }, [threshold]);
+
+  const commitThreshold = () => {
+    const raw = thresholdDraft.trim();
+    if (raw === "") {
+      update({ threshold: undefined });
+      return;
+    }
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) {
+      setThresholdDraft(String(threshold));
+      return;
+    }
+    const clamped = Math.min(1, Math.max(0, parsed));
+    update({ threshold: clamped === DEFAULT_THRESHOLD ? undefined : clamped });
   };
 
   return (
@@ -166,21 +192,9 @@ export function JudgesSection({
                 min={0}
                 max={1}
                 step={0.05}
-                value={String(threshold)}
-                onChange={(e) => {
-                  const raw = e.target.value;
-                  if (raw.trim() === "") {
-                    update({ threshold: undefined });
-                    return;
-                  }
-                  const parsed = Number(raw);
-                  if (!Number.isFinite(parsed)) return;
-                  const clamped = Math.min(1, Math.max(0, parsed));
-                  update({
-                    threshold:
-                      clamped === DEFAULT_THRESHOLD ? undefined : clamped,
-                  });
-                }}
+                value={thresholdDraft}
+                onChange={(e) => setThresholdDraft(e.target.value)}
+                onBlur={commitThreshold}
                 className="h-8 text-sm"
               />
             </div>

--- a/mcpjam-inspector/client/src/components/evals/judges-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judges-section.tsx
@@ -57,7 +57,11 @@ export function JudgesSection({
   description = "Advisory LLM-as-judge scorers that grade run results against rubric anchors. Calibrate per suite — scores aren't comparable across domains.",
 }: JudgesSectionProps) {
   const gc = value?.goalCompletion;
-  const enabled = gc?.enabled === true;
+  // Treat absence as "enabled" to mirror GOAL_COMPLETION_DEFAULTS
+  // (`enabled: true`). Only an explicit `enabled: false` switches the
+  // suite to off; otherwise the toggle reads as on by default so users
+  // see the configuration affordance instead of an opt-in gate.
+  const enabled = gc?.enabled !== false;
   const judgeModel = gc?.judgeModel ?? MANAGED_DEFAULT_JUDGE_MODEL;
   const threshold = gc?.threshold ?? DEFAULT_THRESHOLD;
   const autoRun = gc?.autoRun === true;
@@ -146,7 +150,13 @@ export function JudgesSection({
           <Switch
             checked={enabled}
             onCheckedChange={(checked: boolean) =>
-              update({ enabled: checked || undefined })
+              // Persist EXPLICIT true/false. `undefined` means "inherit the
+              // default" — which is `enabled: true` — so writing
+              // `enabled: undefined` here would silently re-enable a suite
+              // the user just disabled. Write `false` to disable, `true` to
+              // re-enable; let `pruneEmpty` decide later when to drop the
+              // record entirely.
+              update({ enabled: checked })
             }
             aria-label="Enable Goal Completion judge for this suite"
           />

--- a/mcpjam-inspector/client/src/components/evals/judges-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judges-section.tsx
@@ -59,6 +59,7 @@ export function JudgesSection({
   const enabled = gc?.enabled === true;
   const judgeModel = gc?.judgeModel ?? MANAGED_DEFAULT_JUDGE_MODEL;
   const threshold = gc?.threshold ?? DEFAULT_THRESHOLD;
+  const autoRun = gc?.autoRun === true;
 
   const modelOptions = useMemo(() => {
     const map = new Map<string, string>();
@@ -181,6 +182,35 @@ export function JudgesSection({
                   });
                 }}
                 className="h-8 text-sm"
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {enabled ? (
+          <div className="space-y-2 rounded-md border border-border/20 bg-muted/10 p-2.5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 space-y-0.5">
+                <Label
+                  htmlFor="suite-goal-auto-run"
+                  className="text-xs font-medium"
+                >
+                  Run automatically on every completed run
+                </Label>
+                <p className="text-[11px] text-muted-foreground/80">
+                  When on, the judge fires the moment each run completes — no
+                  need to click <strong>Run judge</strong> per run. Off by
+                  default so each grading is an explicit choice (each one
+                  spends an LLM call).
+                </p>
+              </div>
+              <Switch
+                id="suite-goal-auto-run"
+                checked={autoRun}
+                onCheckedChange={(checked: boolean) =>
+                  update({ autoRun: checked || undefined })
+                }
+                aria-label="Auto-run the Goal Completion judge on every new completed run"
               />
             </div>
           </div>

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -420,6 +420,9 @@ export function RunDetailView({
   const goalCompletionPanel =
     selectedRunDetails.status === "completed" && !goalCompletionUnavailable ? (
       <GoalCompletionCard
+        // Remount per run so the model/threshold inputs reset to the new run's
+        // settings instead of sticking from the previously viewed run.
+        key={selectedRunDetails._id}
         run={selectedRunDetails}
         iterations={caseGroupsForSelectedRun}
         goalCompletion={goalCompletionResult ?? null}

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -22,6 +22,7 @@ import { useGoalCompletion } from "./use-goal-completion";
 import { AiTriageCard } from "./ai-triage-card";
 import { GoalCompletionCard } from "./goal-completion-card";
 import { useAvailableEvalModels } from "@/hooks/use-available-eval-models";
+import { useSharedAppState } from "@/state/app-state-context";
 import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
 import { ArrowLeftRight, ArrowUpDown } from "lucide-react";
 import { getSidebarRunInsightsPassRateLabel } from "./run-header-compact-stats";
@@ -367,7 +368,22 @@ export function RunDetailView({
 
   // Goal-completion judge: advisory, user-triggered (no auto-request — it spends
   // an LLM call). Never changes the run's deterministic pass/fail.
-  const { availableModels } = useAvailableEvalModels();
+  // Scope the judge model catalog to the run's project org (same derivation as
+  // useEvalTabContext) so hosted/BYOK orgs see the models they configured, not
+  // just the managed defaults. Execution still runs on the managed key in V1.
+  const appState = useSharedAppState();
+  const judgeOrganizationId = useMemo(() => {
+    const projectId =
+      selectedRunDetails.projectId ?? appState.activeProjectId ?? null;
+    return projectId
+      ? (appState.projects?.[projectId]?.organizationId ?? null)
+      : null;
+  }, [
+    selectedRunDetails.projectId,
+    appState.activeProjectId,
+    appState.projects,
+  ]);
+  const { availableModels } = useAvailableEvalModels(judgeOrganizationId);
   const {
     result: goalCompletionResult,
     pending: goalCompletionPending,

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -18,7 +18,10 @@ import { EvalIteration, EvalSuiteRun } from "./types";
 import { CiMetadataDisplay } from "./ci-metadata-display";
 import { useRunInsights } from "./use-run-insights";
 import { useServerQuality } from "./use-server-quality";
+import { useGoalCompletion } from "./use-goal-completion";
 import { AiTriageCard } from "./ai-triage-card";
+import { GoalCompletionCard } from "./goal-completion-card";
+import { useAvailableEvalModels } from "@/hooks/use-available-eval-models";
 import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
 import { ArrowLeftRight, ArrowUpDown } from "lucide-react";
 import { getSidebarRunInsightsPassRateLabel } from "./run-header-compact-stats";
@@ -362,6 +365,19 @@ export function RunDetailView({
     unavailable: serverQualityUnavailable,
   } = useServerQuality(selectedRunDetails, { autoRequest: true });
 
+  // Goal-completion judge: advisory, user-triggered (no auto-request — it spends
+  // an LLM call). Never changes the run's deterministic pass/fail.
+  const { availableModels } = useAvailableEvalModels();
+  const {
+    result: goalCompletionResult,
+    pending: goalCompletionPending,
+    requested: goalCompletionRequested,
+    failedGeneration: goalCompletionFailedGeneration,
+    error: goalCompletionError,
+    requestGoalCompletion,
+    unavailable: goalCompletionUnavailable,
+  } = useGoalCompletion(selectedRunDetails);
+
   const runDashboardKpis = useMemo(
     () =>
       kpiPlacement === "body"
@@ -393,6 +409,26 @@ export function RunDetailView({
         error={serverQualityError}
         onRetry={() => requestServerQuality(true)}
         source={source}
+      />
+    ) : null;
+
+  // Show the goal-completion panel once a run completes, unless the backend
+  // mutation is unavailable (older deployment). The card itself gates on an
+  // explicit "Run judge" click, so it never auto-spends an LLM call. Rendered
+  // inside RunInsightRail next to the serverQuality triage card — the rail is
+  // the run-detail "AI insights column" and goal-completion is an AI insight.
+  const goalCompletionPanel =
+    selectedRunDetails.status === "completed" && !goalCompletionUnavailable ? (
+      <GoalCompletionCard
+        run={selectedRunDetails}
+        iterations={caseGroupsForSelectedRun}
+        goalCompletion={goalCompletionResult ?? null}
+        availableModels={availableModels}
+        pending={goalCompletionPending}
+        requested={goalCompletionRequested}
+        failedGeneration={goalCompletionFailedGeneration}
+        error={goalCompletionError}
+        onRun={(args, force) => requestGoalCompletion(args, force)}
       />
     ) : null;
 
@@ -454,7 +490,10 @@ export function RunDetailView({
   );
 
   const insightRail = (
-    <RunInsightRail triageCard={serverQualityTriage} />
+    <RunInsightRail
+      triageCard={serverQualityTriage}
+      goalCompletionCard={goalCompletionPanel}
+    />
   );
 
   const runMetadataBlock = (

--- a/mcpjam-inspector/client/src/components/evals/run-insight-rail.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-insight-rail.tsx
@@ -473,12 +473,15 @@ export function RunDetailMetricsCharts({
 /** Right column: AI insights only. */
 export function RunInsightRail({
   triageCard,
+  goalCompletionCard,
   className,
 }: {
   triageCard: ReactNode;
+  /** Advisory LLM-as-judge panel rendered below the triage card. */
+  goalCompletionCard?: ReactNode;
   className?: string;
 }) {
-  if (!triageCard) return null;
+  if (!triageCard && !goalCompletionCard) return null;
 
   return (
     <aside
@@ -488,6 +491,7 @@ export function RunInsightRail({
       )}
     >
       {triageCard}
+      {goalCompletionCard}
     </aside>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -675,48 +675,50 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                 Setup CI
               </Button>
             ) : null}
-            {!readOnlyConfig && !isEditMode ? (
-              // Gear into the suite-edit page (description / pass-fail /
-              // validators / judges). The route + handler plumbing existed
-              // since the suite-edit view shipped but no UI surface invoked
-              // it — existing suites were only reachable via the URL bar.
-              // This is the one visible entry. Hidden in edit mode (would
-              // be a self-link) and when the suite is read-only.
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="h-8 w-8 p-0"
-                    aria-label="Suite settings"
-                    onClick={() =>
-                      navigateApp(
-                        buildEvalsPath({
-                          type: "suite-edit",
-                          suiteId: suite._id,
-                        }),
-                      )
-                    }
-                  >
-                    <Settings2
-                      className="h-3.5 w-3.5 shrink-0"
-                      aria-hidden
-                    />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent
-                  variant="muted"
-                  side="bottom"
-                  align="end"
-                  sideOffset={6}
-                  className="px-2 py-1 text-[11px]"
-                >
-                  Suite settings — description, validators, judges
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
           </div>
+        ) : null}
+
+        {/* Gear into the suite-edit page (description / pass-fail /
+            validators / judges). Rendered in its OWN block — NOT inside
+            `overviewHasSuiteNav` — because that predicate only fires when
+            the cases-sidebar toggle or Setup CI is shown. Without its own
+            block the gear was invisible on every standard suite-overview
+            (the case the goal-completion CTA explicitly points at).
+            The route + handler plumbing existed since the suite-edit view
+            shipped but no UI surface invoked it — existing suites were
+            only reachable via the URL bar. Hidden in edit mode (would be
+            a self-link) and when the suite is read-only. */}
+        {!readOnlyConfig && !isEditMode ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-8 w-8 p-0"
+                aria-label="Suite settings"
+                onClick={() =>
+                  navigateApp(
+                    buildEvalsPath({
+                      type: "suite-edit",
+                      suiteId: suite._id,
+                    }),
+                  )
+                }
+              >
+                <Settings2 className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent
+              variant="muted"
+              side="bottom"
+              align="end"
+              sideOffset={6}
+              className="px-2 py-1 text-[11px]"
+            >
+              Suite settings — description, validators, judges
+            </TooltipContent>
+          </Tooltip>
         ) : null}
 
         {overviewHasCaseTools ? (

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -19,9 +19,11 @@ import {
   Play,
   Plus,
   RotateCw,
+  Settings2,
   Sparkles,
   X,
 } from "lucide-react";
+import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
 import posthog from "posthog-js";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { formatRunId, getEffectiveSuiteServers } from "./helpers";
@@ -672,6 +674,47 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                 <GitBranch className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 Setup CI
               </Button>
+            ) : null}
+            {!readOnlyConfig && !isEditMode ? (
+              // Gear into the suite-edit page (description / pass-fail /
+              // validators / judges). The route + handler plumbing existed
+              // since the suite-edit view shipped but no UI surface invoked
+              // it — existing suites were only reachable via the URL bar.
+              // This is the one visible entry. Hidden in edit mode (would
+              // be a self-link) and when the suite is read-only.
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-8 w-8 p-0"
+                    aria-label="Suite settings"
+                    onClick={() =>
+                      navigateApp(
+                        buildEvalsPath({
+                          type: "suite-edit",
+                          suiteId: suite._id,
+                        }),
+                      )
+                    }
+                  >
+                    <Settings2
+                      className="h-3.5 w-3.5 shrink-0"
+                      aria-hidden
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent
+                  variant="muted"
+                  side="bottom"
+                  align="end"
+                  sideOffset={6}
+                  className="px-2 py-1 text-[11px]"
+                >
+                  Suite settings — description, validators, judges
+                </TooltipContent>
+              </Tooltip>
             ) : null}
           </div>
         ) : null}

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -22,7 +22,10 @@ import { TestCasesOverview } from "./test-cases-overview";
 import { TestCaseDetailView } from "./test-case-detail-view";
 import { SuiteDashboard } from "./suite-dashboard";
 import { EvalExportModal } from "./eval-export-modal";
-import { SuiteExecutionConfigEditor } from "./suite-execution-config-editor";
+// SuiteExecutionConfigEditor was previously rendered on the suite settings
+// page; hidden there in the judge-config rework (see comment at the
+// removed render site). Import kept dropped to avoid an unused-symbol
+// lint and to make the removal obvious if someone reaches for it later.
 import { useSuiteData, useRunDetailData } from "./use-suite-data";
 import type {
   EvalCase,
@@ -1020,11 +1023,12 @@ export function SuiteIterationsView({
       {isEditMode && (
         <div className="flex-1 min-h-0 overflow-auto">
           <div className="p-6 max-w-5xl mx-auto space-y-8">
-            <SuiteExecutionConfigEditor
-              suite={suite}
-              availableModels={availableModels}
-              projectId={projectId}
-            />
+            {/* SuiteExecutionConfigEditor was rendered here; hidden in the
+                judge-config rework so suite settings stays focused on the
+                eval contract surfaces (description, pass-fail, validators,
+                judges). Execution config (model / system prompt /
+                temperature / host-style) is editable from its dedicated
+                surfaces elsewhere and was duplicating affordances here. */}
 
             {/* Suite Description Section */}
             <div className="space-y-3">

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -15,6 +15,7 @@ import { RunDiffView } from "./run-diff-view";
 import { TestTemplateEditor } from "./test-template-editor";
 import { PassCriteriaSelector } from "./pass-criteria-selector";
 import { ValidatorsSection } from "./validators-section";
+import { JudgesSection } from "./judges-section";
 import type { EvalMatchOptions } from "@/shared/eval-matching";
 import { MATCH_OPTIONS_DEFAULTS } from "@/shared/eval-matching";
 import { TestCasesOverview } from "./test-cases-overview";
@@ -1127,6 +1128,32 @@ export function SuiteIterationsView({
                       "Failed to update default validators:",
                       error
                     );
+                  }
+                }}
+              />
+            </div>
+
+            {/* Judges Section — suite-level authoritative judge config. The
+                run-detail card reads run.configSnapshot.judgeConfig (pinned
+                at run start) and lets a single run override via the
+                "⚙ Override for this run" disclosure; this section is the
+                canonical home for what the suite calibrates against. */}
+            <div className="space-y-3">
+              <JudgesSection
+                value={suite.judgeConfig}
+                availableModels={availableModels}
+                onChange={async (next) => {
+                  try {
+                    await updateSuite({
+                      suiteId: suite._id,
+                      judgeConfig: next ?? null,
+                    });
+                    toast.success("Judges updated");
+                  } catch (error) {
+                    toast.error(
+                      getBillingErrorMessage(error, "Failed to update suite")
+                    );
+                    console.error("Failed to update judges:", error);
                   }
                 }}
               />

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -142,6 +142,13 @@ export type EvalJudgeConfig = {
     enabled?: boolean;
     judgeModel?: string;
     threshold?: number;
+    /**
+     * When true, the judge fires automatically as each run completes
+     * (matches the dominant industry pattern — most eval platforms run
+     * scorers inline with the eval rather than on-demand). Default off
+     * so suites preserve the cost-conscious V1 behavior until they opt in.
+     */
+    autoRun?: boolean;
   };
 };
 

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -351,6 +351,28 @@ export type EvalSuiteRun = {
         | "unknown";
     }>;
   };
+  // Goal-completion judge (advisory LLM-as-judge): grades each case's final
+  // answer against its expectedOutput. Mirrors the Convex `v.object` by hand.
+  // Advisory only — never changes the run's deterministic `passed`/`result`.
+  goalCompletionJobId?: string;
+  goalCompletionStatus?: "pending" | "completed" | "failed";
+  goalCompletion?: {
+    summary: string;
+    generatedAt: number;
+    /** The judge model actually used for this run. */
+    modelUsed: string;
+    /** Per-run advisory pass threshold (`passed = score >= threshold`). */
+    threshold: number;
+    cases: Array<{
+      caseKey: string;
+      /** How fully the final answer satisfied expectedOutput, in [0,1]. */
+      score: number;
+      /** Advisory pass = score >= threshold. Does NOT gate the run. */
+      passed: boolean;
+      reason: string;
+      rubricHits: string[];
+    }>;
+  };
 };
 
 export type EvalRunNumericDiff = {

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -48,6 +48,15 @@ export type EvalSuite = {
   };
   /** Suite-level default validator options (used unless a case overrides). */
   defaultMatchOptions?: EvalMatchOptions;
+  /**
+   * Suite-level advisory judge configuration. Authoritative source for
+   * judgeModel / threshold / enabled flag — runs snapshot this at
+   * run-create time, the action reads from the snapshot, and the
+   * run-detail card displays it read-only with an explicit "override
+   * for this run" disclosure as the escape hatch. Hand-mirrors the
+   * Convex `v.object` (no codegen for backend → inspector types).
+   */
+  judgeConfig?: EvalJudgeConfig;
   _creationTime?: number; // Convex auto field
   tags?: string[];
   defaultConfig?: {
@@ -113,8 +122,42 @@ export type EvalCase = {
   advancedConfig?: Record<string, unknown>;
   /** Case-level validator override; merged on top of suite defaults. */
   matchOptions?: EvalMatchOptions;
+  /**
+   * Per-case judge override. V1 carries opt-out only — no alt model or
+   * threshold (see backend `convex/lib/judgeConfig.ts` for rationale).
+   */
+  judgeConfigOverride?: EvalJudgeConfigOverride;
   lastMessageRun?: string | null;
   _creationTime?: number; // Convex auto field
+};
+
+/**
+ * Suite-level judge config envelope. Currently carries goalCompletion only;
+ * the envelope shape is forward-compatible with additional judges (refusal
+ * judge, future serverQuality move-here, etc.) without a second pass on
+ * the type surface.
+ */
+export type EvalJudgeConfig = {
+  goalCompletion?: {
+    enabled?: boolean;
+    judgeModel?: string;
+    threshold?: number;
+  };
+};
+
+/** Per-case judge override. Opt-out only in V1. */
+export type EvalJudgeConfigOverride = {
+  goalCompletion?: {
+    enabled?: boolean;
+  };
+};
+
+/** Per-run exploration override; persists on the run for transparency. */
+export type EvalJudgeRunOverride = {
+  goalCompletion?: {
+    judgeModel?: string;
+    threshold?: number;
+  };
 };
 
 export type EvalIteration = {
@@ -250,6 +293,13 @@ export type EvalSuiteRun = {
         projectServerId?: string;
       }>;
     };
+    /**
+     * Suite-level judge config snapshotted at run-create. The run-detail
+     * card reads `modelUsed` / `threshold` from here when displaying the
+     * judge config, so a config edit after the run started doesn't
+     * silently re-render in-flight scoring with new values.
+     */
+    judgeConfig?: EvalJudgeConfig;
   };
   status: "pending" | "running" | "completed" | "failed" | "cancelled";
   summary?: EvalSuiteRunSummary;
@@ -258,6 +308,12 @@ export type EvalSuiteRun = {
   };
   /** One-off validator override applied to all iterations in this run. */
   matchOptionsOverride?: EvalMatchOptions;
+  /**
+   * Per-run judge override from the "⚙ Override for this run" disclosure.
+   * Cleared (whole field wiped) when the user re-runs the judge without
+   * re-confirming the override.
+   */
+  judgeConfigOverride?: EvalJudgeRunOverride;
   result?: "pending" | "passed" | "failed" | "cancelled";
   source?: "ui" | "sdk";
   replayedFromRunId?: string;

--- a/mcpjam-inspector/client/src/components/evals/use-goal-completion.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-goal-completion.ts
@@ -1,0 +1,58 @@
+import { useCallback } from "react";
+import { useInsight } from "./use-insight";
+import type { EvalSuiteRun } from "./types";
+
+export interface GoalCompletionRequestArgs {
+  /** User-selected judge model id. Omit to use the managed default. */
+  judgeModel?: string;
+  /** Advisory pass threshold in [0,1]. Omit to use the backend default (0.7). */
+  threshold?: number;
+}
+
+/**
+ * Request and track the Goal Completion judge (advisory LLM-as-judge that grades
+ * each case's final answer against its expectedOutput). Thin wrapper around the
+ * generic `useInsight` hook.
+ *
+ * `autoRequest: false` — this judge spends an LLM call, so it only runs when the
+ * user explicitly clicks "Run judge".
+ */
+export function useGoalCompletion(run: EvalSuiteRun | null) {
+  const hook = useInsight(
+    run,
+    {
+      getStatus: (r) => r.goalCompletionStatus,
+      getResult: (r) => r.goalCompletion,
+      requestMutation: "goalCompletion:requestGoalCompletion",
+      cancelMutation: "goalCompletion:cancelGoalCompletion",
+    },
+    { autoRequest: false },
+  );
+
+  const requestGoalCompletion = useCallback(
+    (args: GoalCompletionRequestArgs = {}, force?: boolean) => {
+      const extraArgs: Record<string, unknown> = {};
+      if (args.judgeModel) {
+        extraArgs.judgeModel = args.judgeModel;
+      }
+      if (typeof args.threshold === "number") {
+        extraArgs.threshold = args.threshold;
+      }
+      hook.requestInsight(force, extraArgs);
+    },
+    [hook],
+  );
+
+  return {
+    canRequest: hook.canRequest,
+    error: hook.error,
+    unavailable: hook.unavailable,
+    requested: hook.requested,
+    requestGoalCompletion,
+    cancelGoalCompletion: hook.cancelInsight,
+    summary: hook.summary,
+    pending: hook.pending,
+    failedGeneration: hook.failedGeneration,
+    result: hook.result,
+  };
+}

--- a/mcpjam-inspector/client/src/components/evals/use-goal-completion.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-goal-completion.ts
@@ -66,7 +66,10 @@ export function useGoalCompletion(run: EvalSuiteRun | null) {
       }
       hook.requestInsight(force, extraArgs);
     },
-    [hook],
+    // Depend on the stabilized `requestInsight` (memoized inside useInsight),
+    // not the `hook` object literal — which is recreated every render and would
+    // make this useCallback a no-op.
+    [hook.requestInsight],
   );
 
   return {

--- a/mcpjam-inspector/client/src/components/evals/use-goal-completion.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-goal-completion.ts
@@ -2,11 +2,21 @@ import { useCallback } from "react";
 import { useInsight } from "./use-insight";
 import type { EvalSuiteRun } from "./types";
 
-export interface GoalCompletionRequestArgs {
-  /** User-selected judge model id. Omit to use the managed default. */
+export interface GoalCompletionRunOverride {
+  /** Per-run model override from the "⚙ Override for this run" disclosure. */
   judgeModel?: string;
-  /** Advisory pass threshold in [0,1]. Omit to use the backend default (0.7). */
+  /** Per-run threshold override from the same disclosure. */
   threshold?: number;
+}
+
+export interface GoalCompletionRequestArgs {
+  /**
+   * Explicit per-run exploration override. Omit to clear any previously
+   * persisted run override and grade against the suite-level config — the
+   * card's default behavior. See `requestGoalCompletion` on the backend
+   * for the clear-on-omit semantic.
+   */
+  runOverride?: GoalCompletionRunOverride;
 }
 
 /**
@@ -16,6 +26,15 @@ export interface GoalCompletionRequestArgs {
  *
  * `autoRequest: false` — this judge spends an LLM call, so it only runs when the
  * user explicitly clicks "Run judge".
+ *
+ * V2 arg shape (suite-as-authoritative-config): `requestGoalCompletion(
+ * { runOverride? }, force?)`. The bare `{ judgeModel, threshold }` form is
+ * gone — those fields now live on the suite (authoring) and run.configSnapshot
+ * (snapshotted at run start). Callers passing only the override disclosure's
+ * values can omit `runOverride` entirely to grade against the suite config;
+ * the backend explicitly clears any previously persisted run override on
+ * such a call, so re-running without re-confirming exploration returns to
+ * the suite contract on its own.
  */
 export function useGoalCompletion(run: EvalSuiteRun | null) {
   const hook = useInsight(
@@ -32,11 +51,18 @@ export function useGoalCompletion(run: EvalSuiteRun | null) {
   const requestGoalCompletion = useCallback(
     (args: GoalCompletionRequestArgs = {}, force?: boolean) => {
       const extraArgs: Record<string, unknown> = {};
-      if (args.judgeModel) {
-        extraArgs.judgeModel = args.judgeModel;
-      }
-      if (typeof args.threshold === "number") {
-        extraArgs.threshold = args.threshold;
+      if (args.runOverride) {
+        // Only include keys the user actually set so the backend doesn't see
+        // `{ judgeModel: undefined }` (which would round-trip as an object with
+        // explicit undefined fields through Convex's wire serialization).
+        const cleaned: Record<string, unknown> = {};
+        if (args.runOverride.judgeModel)
+          cleaned.judgeModel = args.runOverride.judgeModel;
+        if (typeof args.runOverride.threshold === "number")
+          cleaned.threshold = args.runOverride.threshold;
+        if (Object.keys(cleaned).length > 0) {
+          extraArgs.runOverride = cleaned;
+        }
       }
       hook.requestInsight(force, extraArgs);
     },

--- a/mcpjam-inspector/client/src/components/evals/use-insight.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-insight.ts
@@ -29,7 +29,10 @@ export interface InsightHookResult<TResult> {
   failedGeneration: boolean;
   result: TResult | undefined;
   summary: string | null;
-  requestInsight: (force?: boolean) => void;
+  requestInsight: (
+    force?: boolean,
+    extraArgs?: Record<string, unknown>,
+  ) => void;
   cancelInsight: () => void;
 }
 
@@ -71,13 +74,13 @@ export function useInsight<TResult extends { summary?: string }>(
     !unavailable;
 
   const requestInsight = useCallback(
-    (force?: boolean) => {
+    (force?: boolean, extraArgs?: Record<string, unknown>) => {
       if (!run || unavailable) {
         return;
       }
       setError(null);
       setRequested(true);
-      requestMut({ suiteRunId: run._id, force } as any).catch(
+      requestMut({ suiteRunId: run._id, force, ...extraArgs } as any).catch(
         (err: unknown) => {
           setRequested(false);
           const classified = classifyInsightError(err);

--- a/mcpjam-inspector/client/src/components/evals/use-insight.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-insight.ts
@@ -36,6 +36,11 @@ export interface InsightHookResult<TResult> {
   cancelInsight: () => void;
 }
 
+/** Result freshness marker shared by every insight payload. */
+function resultGeneratedAt(result: unknown): number | undefined {
+  return (result as { generatedAt?: number } | undefined)?.generatedAt;
+}
+
 function classifyInsightError(err: unknown): {
   unavailable: boolean;
   message: string;
@@ -60,12 +65,19 @@ export function useInsight<TResult extends { summary?: string }>(
   const [requested, setRequested] = useState(false);
   const hasAutoAttemptedRef = useRef(false);
   const runIdRef = useRef<string | null>(null);
+  // The result `generatedAt` captured at request time. Lets us clear the
+  // optimistic `requested` flag the instant a NEW result lands — even when a
+  // reactive update skips an observable `pending` frame — so the controls
+  // never stay stuck disabled.
+  const latestResultStampRef = useRef<number | undefined>(undefined);
+  const requestedAtStampRef = useRef<number | undefined>(undefined);
 
   const requestMut = useMutation(config.requestMutation as any);
   const cancelMut = useMutation(config.cancelMutation as any);
 
   const status = run ? config.getStatus(run) : undefined;
   const result = run ? config.getResult(run) : undefined;
+  latestResultStampRef.current = resultGeneratedAt(result);
 
   const canRequest =
     run != null &&
@@ -79,6 +91,7 @@ export function useInsight<TResult extends { summary?: string }>(
         return;
       }
       setError(null);
+      requestedAtStampRef.current = latestResultStampRef.current;
       setRequested(true);
       requestMut({ suiteRunId: run._id, force, ...extraArgs } as any).catch(
         (err: unknown) => {
@@ -110,20 +123,26 @@ export function useInsight<TResult extends { summary?: string }>(
       setError(null);
       setRequested(false);
       hasAutoAttemptedRef.current = false;
+      requestedAtStampRef.current = undefined;
     }
   }, [runKey]);
 
   // Clear the optimistic "requested" flag once the job actually starts (status
-  // flips to `pending`); `pending` then drives the disabled state. Clearing on
-  // `completed`/`failed` instead re-enabled a re-run/retry trigger in the gap
-  // between the click and the status flip (those statuses still hold the prior
-  // result), which let a second request slip through. The request mutation's
-  // catch handles the case where the job never reaches `pending`.
+  // flips to `pending`) OR once a fresh result lands (its `generatedAt` advances
+  // past the value captured at request time). Clearing on `completed`/`failed`
+  // alone re-enabled a re-run/retry trigger in the click→`pending` gap (those
+  // statuses still hold the prior result); clearing on `pending` alone could
+  // stick if a reactive update skipped the `pending` frame. Together they keep
+  // the controls correct in both cases; the request mutation's catch covers a
+  // request that never starts.
   useEffect(() => {
-    if (status === "pending") {
+    if (
+      status === "pending" ||
+      resultGeneratedAt(result) !== requestedAtStampRef.current
+    ) {
       setRequested(false);
     }
-  }, [status, run?._id]);
+  }, [status, result, run?._id]);
 
   // Auto-request on first view of a completed run with no insight.
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/evals/use-insight.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-insight.ts
@@ -113,9 +113,14 @@ export function useInsight<TResult extends { summary?: string }>(
     }
   }, [runKey]);
 
-  // Clear optimistic "requested" flag once the server status catches up.
+  // Clear the optimistic "requested" flag once the job actually starts (status
+  // flips to `pending`); `pending` then drives the disabled state. Clearing on
+  // `completed`/`failed` instead re-enabled a re-run/retry trigger in the gap
+  // between the click and the status flip (those statuses still hold the prior
+  // result), which let a second request slip through. The request mutation's
+  // catch handles the case where the job never reaches `pending`.
   useEffect(() => {
-    if (status === "completed" || status === "failed") {
+    if (status === "pending") {
       setRequested(false);
     }
   }, [status, run?._id]);

--- a/mcpjam-inspector/client/src/components/evals/use-insight.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-insight.ts
@@ -122,19 +122,26 @@ export function useInsight<TResult extends { summary?: string }>(
       runIdRef.current = runKey;
       setError(null);
       setRequested(false);
+      // Availability is re-assessed per run: a run-specific or transient failure
+      // (e.g. "Suite run not found", a transient "Server Error") must not keep
+      // the panel hidden for every later run in the same mounted view.
+      setUnavailable(false);
       hasAutoAttemptedRef.current = false;
       requestedAtStampRef.current = undefined;
     }
   }, [runKey]);
 
-  // Clear the optimistic "requested" flag once the job actually starts (status
-  // flips to `pending`) OR once a fresh result lands (its `generatedAt` advances
-  // past the value captured at request time). Clearing on `completed`/`failed`
-  // alone re-enabled a re-run/retry trigger in the click→`pending` gap (those
-  // statuses still hold the prior result); clearing on `pending` alone could
-  // stick if a reactive update skipped the `pending` frame. Together they keep
-  // the controls correct in both cases; the request mutation's catch covers a
-  // request that never starts.
+  // Clear the optimistic "requested" flag once the job has demonstrably
+  // progressed — but NOT in the click→`pending` gap where a stale terminal
+  // result still lingers (clearing there would re-enable a re-run/retry trigger
+  // and allow a duplicate request). Progress is either:
+  //   - status flips to `pending` (job started); or
+  //   - a fresh result lands — its `generatedAt` advances past the value
+  //     captured at request time.
+  // Both completion AND failure write a fresh `generatedAt` (the failed
+  // fallback in each *Action's catch stamps Date.now()), so a re-run that ends
+  // in failure clears here too; the request mutation's catch covers a request
+  // that errors before it ever starts.
   useEffect(() => {
     if (
       status === "pending" ||

--- a/mcpjam-inspector/client/src/components/evals/use-insight.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-insight.ts
@@ -43,15 +43,21 @@ function resultGeneratedAt(result: unknown): number | undefined {
 
 function classifyInsightError(err: unknown): {
   unavailable: boolean;
+  permanent: boolean;
   message: string;
 } {
   const message = err instanceof Error ? err.message : String(err);
-  const unavailable =
+  // "Feature missing" — the backend mutation isn't deployed at all. This is
+  // permanent for the session: a Convex function-lookup failure won't change
+  // between runs, so the panel should stay hidden without re-attempting.
+  const permanent =
     message.includes("Could not find") ||
-    message.includes("not found") ||
-    message.includes("is not a function") ||
+    message.includes("is not a function");
+  const unavailable =
+    permanent ||
+    message.includes("not found") || // run-specific, e.g. "Suite run not found"
     message.includes("Server Error");
-  return { unavailable, message };
+  return { unavailable, permanent, message };
 }
 
 export function useInsight<TResult extends { summary?: string }>(
@@ -65,6 +71,11 @@ export function useInsight<TResult extends { summary?: string }>(
   const [requested, setRequested] = useState(false);
   const hasAutoAttemptedRef = useRef(false);
   const runIdRef = useRef<string | null>(null);
+  // True only when the backend feature itself is missing (mutation not
+  // deployed). Unlike a run-specific/transient failure, this is permanent for
+  // the hook's lifetime, so we keep `unavailable` sticky across run switches
+  // rather than re-attempting (and flashing the panel) on every navigation.
+  const featureMissingRef = useRef(false);
   // The result `generatedAt` captured at request time. Lets us clear the
   // optimistic `requested` flag the instant a NEW result lands — even when a
   // reactive update skips an observable `pending` frame — so the controls
@@ -98,6 +109,9 @@ export function useInsight<TResult extends { summary?: string }>(
           setRequested(false);
           const classified = classifyInsightError(err);
           if (classified.unavailable) {
+            if (classified.permanent) {
+              featureMissingRef.current = true;
+            }
             setUnavailable(true);
           } else {
             setError(classified.message);
@@ -122,10 +136,14 @@ export function useInsight<TResult extends { summary?: string }>(
       runIdRef.current = runKey;
       setError(null);
       setRequested(false);
-      // Availability is re-assessed per run: a run-specific or transient failure
-      // (e.g. "Suite run not found", a transient "Server Error") must not keep
-      // the panel hidden for every later run in the same mounted view.
-      setUnavailable(false);
+      // Re-assess availability per run for run-specific/transient failures
+      // (e.g. "Suite run not found") so one bad run doesn't hide the panel for
+      // every later run — but keep it sticky when the backend feature is
+      // genuinely missing, so an autoRequest consumer (serverQuality) doesn't
+      // re-fire a failing request and flash the panel on every navigation.
+      if (!featureMissingRef.current) {
+        setUnavailable(false);
+      }
       hasAutoAttemptedRef.current = false;
       requestedAtStampRef.current = undefined;
     }


### PR DESCRIPTION
## What

Adds the run-detail **UI panel** for the Goal Completion judge (backend: MCPJam/mcpjam-backend#384). It grades whether each eval case's **final answer** satisfied its `expectedOutput` — the "did the goal get completed" question the deterministic tool-call verdict doesn't answer — and surfaces a per-case **score + advisory verdict + reason**.

The judge model is **user-selectable per run** and there's a **threshold** knob (default `0.7`). It's **advisory**: it never changes the run's deterministic `passed`/`result` — the tool-call verdict stays the primary verdict.

## Changes

- **`use-insight.ts`** — `requestInsight` now forwards optional extra mutation args (`requestInsight(force?, extraArgs?)`). Backward-compatible: the `serverQuality` / `runInsights` callers pass nothing and are unaffected.
- **`use-goal-completion.ts`** — thin wrapper over the generic `useInsight` hook with **`autoRequest: false`** (this judge spends an LLM call, so it only runs on an explicit click), exposing `requestGoalCompletion({ judgeModel, threshold }, force)`.
- **`goal-completion-card.tsx`** — the panel:
  - **Judge-model picker** (`Select` fed by `useAvailableEvalModels()`, default `openai/gpt-5.4-mini`) + **threshold** input + **Run / Re-run judge** button.
  - Per-case rows: **score %**, an advisory **meets goal / below threshold** badge, the one-line **reason**, and **rubric hits**.
  - Labeled **"Goal completion · advisory · LLM judge"**, hidden until the run completes, with an explicit "advisory only — the deterministic tool-call verdict is the run's pass/fail" footer.
- **`run-detail-view.tsx`** — wires the panel beside the existing `serverQuality` triage card.
- **`types.ts`** — `EvalSuiteRun["goalCompletion"]`, hand-mirroring the Convex `v.object`.

## Integration

Calls the backend `goalCompletion:requestGoalCompletion` / `cancelGoalCompletion` mutations by string path through `useInsight` (same pattern as `serverQuality`). The panel only appears where the backend mutation resolves; an older deployment marks it `unavailable` and the panel is hidden.

## No runner changes

`server/services/evals-runner.ts` / `recorder.ts` are untouched — the judge reads persisted `testIteration` rows on demand.

## Tests

- `goal-completion-card.test.tsx`: advisory framing, Run-judge fires with the selected default model + threshold, per-case score/verdict/reason render once graded, controls disabled while pending.
- `run-detail-view.test.tsx`: stubs the model-catalog hook so the existing view test stays isolated from the provider chain.

Local: `tsc -p client/tsconfig.typecheck.json` clean; the evals component suite is green (incl. the new + updated tests).

> Backend (mutation contract + judge): MCPJam/mcpjam-backend#384.

https://claude.ai/code/session_01Ee1pXN8CpSik5uc1XQCRsA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee1pXN8CpSik5uc1XQCRsA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New LLM-judge flows spend API calls and depend on backend mutations; shared `useInsight` changes affect other insight panels but are backward-compatible when extra args are omitted.
> 
> **Overview**
> Adds the **Goal Completion** advisory LLM-as-judge experience end-to-end in the inspector: suite-level defaults, a run-detail panel in the insights rail, and tighter shared insight lifecycle behavior.
> 
> **Run detail:** New `GoalCompletionCard` in `RunInsightRail` (with server-quality triage). Users pick judge model/threshold and **Run / Re-run judge**; results show per-case scores, advisory pass/fail, reasons, and rubric hits without changing deterministic run pass/fail. Per-run overrides are sent only when inputs differ from the snapshotted suite config; matching values clear persisted overrides. In-flight states hide stale scores; explicit suite `enabled: false` shows a configure-on-suite CTA.
> 
> **Suite settings:** New `JudgesSection` on the suite-edit page (enable, model, threshold, optional auto-run on completed runs). Types gain `judgeConfig`, run snapshot/override fields, and `goalCompletion` on runs. Suite header gets a **gear** link to suite settings (validators/judges). `SuiteExecutionConfigEditor` is removed from that page to reduce duplication.
> 
> **Hooks:** `use-goal-completion` wraps `useInsight` with `autoRequest: false` and `runOverride` mutation args. `use-insight` forwards extra mutation args, improves `requested` clearing via `generatedAt`, and distinguishes sticky vs run-scoped `unavailable`.
> 
> **Tests:** Coverage for the card, `useInsight` lifecycle, and stubs in `run-detail-view` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64abc0faa96e945cd9d12a37904c9a964fbb6c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->