### PR TITLE
evals: group multi-host runs in the inspector UI

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-runs-list.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-runs-list.test.tsx
@@ -10,7 +10,11 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, userEvent } from "@/test";
-import { SuiteRunsList, computeRunEffectiveStats } from "../suite-runs-list";
+import {
+  SuiteRunsList,
+  computeEffectiveRunResult,
+  computeRunEffectiveStats,
+} from "../suite-runs-list";
 import type { EvalIteration, EvalSuiteRun } from "../types";
 
 // The SuiteRunsList renders an Avatar/Tooltip from the design system; jsdom
@@ -229,6 +233,47 @@ describe("SuiteRunsList run-group rendering", () => {
     ).toBeInTheDocument();
   });
 
+  it("parent group renders failed accent when a completed child is below passCriteria even with no run.result", async () => {
+    // Regression for the cursor/codex review finding: the recorder finalizes
+    // runs as `status: completed` + `summary` without always setting
+    // `result: "failed"`. Children derive failed-ness from passRate vs
+    // passCriteria; the parent must use the same source or it would show
+    // a green border over a red child.
+    const passingChild = makeRun({
+      _id: "gfail1xx",
+      runGroupId: "g-fail",
+      namedHostId: "host-pass",
+      status: "completed",
+      result: undefined,
+      summary: { total: 2, passed: 2, failed: 0, passRate: 100 },
+      passCriteria: { minimumPassRate: 80 },
+    });
+    const failingChild = makeRun({
+      _id: "gfail2xx",
+      runGroupId: "g-fail",
+      namedHostId: "host-fail",
+      status: "completed",
+      result: undefined,
+      summary: { total: 4, passed: 1, failed: 3, passRate: 25 },
+      passCriteria: { minimumPassRate: 80 },
+    });
+
+    const { container } = renderWithProviders(
+      <SuiteRunsList
+        runs={[passingChild, failingChild]}
+        allIterations={[]}
+        onRunClick={vi.fn()}
+      />,
+    );
+
+    const parentButton = screen.getByLabelText(/Expand run group g/i);
+    // Wrapper div carries the left-border accent class.
+    const accent = parentButton.closest("[class*='border-l-2']");
+    expect(accent).not.toBeNull();
+    expect(accent!.className).toContain("border-l-destructive");
+    expect(accent!.className).not.toContain("border-l-success");
+  });
+
   it("renders a group with only one settled child as a standalone (no chevron) during the partial-fan-out gap", () => {
     // If Convex sync briefly returns only one run with a given group id,
     // showing a parent labelled "1 hosts" would look broken. The
@@ -277,5 +322,61 @@ describe("computeRunEffectiveStats", () => {
     const run = makeRun({ _id: "r3", summary: undefined });
     const stats = computeRunEffectiveStats(run, []);
     expect(stats.passRate).toBeNull();
+  });
+});
+
+describe("computeEffectiveRunResult", () => {
+  it("prefers explicit run.result when set", () => {
+    const run = makeRun({ result: "failed", status: "completed" });
+    expect(computeEffectiveRunResult(run, 100)).toBe("failed");
+  });
+
+  it("derives failed from passRate below passCriteria when result is unset", () => {
+    const run = makeRun({
+      result: undefined,
+      status: "completed",
+      passCriteria: { minimumPassRate: 80 },
+    });
+    expect(computeEffectiveRunResult(run, 25)).toBe("failed");
+  });
+
+  it("derives passed from passRate at-or-above passCriteria when result is unset", () => {
+    const run = makeRun({
+      result: undefined,
+      status: "completed",
+      passCriteria: { minimumPassRate: 80 },
+    });
+    expect(computeEffectiveRunResult(run, 80)).toBe("passed");
+  });
+
+  it("defaults minimumPassRate to 100 when passCriteria is absent", () => {
+    const run = makeRun({
+      result: undefined,
+      status: "completed",
+      passCriteria: undefined,
+    });
+    expect(computeEffectiveRunResult(run, 99)).toBe("failed");
+    expect(computeEffectiveRunResult(run, 100)).toBe("passed");
+  });
+
+  it("returns running/cancelled/pending based on status when passRate is null", () => {
+    expect(
+      computeEffectiveRunResult(
+        makeRun({ result: undefined, status: "running" }),
+        null,
+      ),
+    ).toBe("running");
+    expect(
+      computeEffectiveRunResult(
+        makeRun({ result: undefined, status: "cancelled" }),
+        null,
+      ),
+    ).toBe("cancelled");
+    expect(
+      computeEffectiveRunResult(
+        makeRun({ result: undefined, status: "completed" }),
+        null,
+      ),
+    ).toBe("pending");
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-runs-list.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-runs-list.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * suite-runs-list.tsx tests
+ *
+ * Covers V1 run-group UI behavior:
+ *  - Mixed grouped + ungrouped runs render parents + standalones.
+ *  - Parent row aggregate Acc is the mean of children's *effective* pass
+ *    rates (live-iteration-derived, not `summary`-derived).
+ *  - Single-host launches (no `runGroupId`) render ungrouped just like
+ *    legacy rows — no chevron, no aggregate row.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test";
+import { SuiteRunsList, computeRunEffectiveStats } from "../suite-runs-list";
+import type { EvalIteration, EvalSuiteRun } from "../types";
+
+// The SuiteRunsList renders an Avatar/Tooltip from the design system; jsdom
+// does not need any mocking for those — they degrade gracefully without
+// portals. ClientChip also renders fine without provider mocks.
+
+function makeRun(overrides: Partial<EvalSuiteRun>): EvalSuiteRun {
+  return {
+    _id: "run-default",
+    suiteId: "suite-1",
+    createdBy: "user-1",
+    runNumber: 1,
+    configRevision: "1",
+    configSnapshot: {
+      tests: [],
+      environment: { servers: ["server-1"] },
+    },
+    status: "completed",
+    result: "passed",
+    createdAt: 1_000,
+    completedAt: 2_000,
+    summary: { total: 0, passed: 0, failed: 0, passRate: 0 },
+    ...overrides,
+  } as EvalSuiteRun;
+}
+
+// Build an iteration shaped just enough for `computeIterationResult` to
+// short-circuit on `resultSource === "reported"` and return the recorded
+// `result`. We rely on the live-iteration path here so the test exercises
+// the same code that drives the dashboard during a streaming run.
+function makeIteration(
+  suiteRunId: string,
+  result: "passed" | "failed",
+  id: string,
+): EvalIteration {
+  return {
+    _id: id,
+    suiteRunId,
+    status: "completed",
+    result,
+    resultSource: "reported",
+    actualToolCalls: [],
+    testCaseSnapshot: { expectedToolCalls: [] },
+  } as unknown as EvalIteration;
+}
+
+describe("SuiteRunsList run-group rendering", () => {
+  it("renders one parent row per multi-run group and standalone rows for ungrouped runs", () => {
+    const runs: EvalSuiteRun[] = [
+      makeRun({
+        _id: "ga1xxxxx",
+        runGroupId: "group-a",
+        namedHostId: "host-mcpjam",
+        createdAt: 10_000,
+        completedAt: 12_000,
+      }),
+      makeRun({
+        _id: "ga2xxxxx",
+        runGroupId: "group-a",
+        namedHostId: "host-claude",
+        createdAt: 11_000,
+        completedAt: 13_000,
+      }),
+      makeRun({
+        _id: "legacy0yyyy",
+        // No runGroupId → standalone.
+        createdAt: 5_000,
+        completedAt: 6_000,
+      }),
+    ];
+
+    renderWithProviders(
+      <SuiteRunsList
+        runs={runs}
+        allIterations={[]}
+        onRunClick={vi.fn()}
+      />,
+    );
+
+    // Parent row visible.
+    expect(screen.getByText(/Run group g/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 hosts/i)).toBeInTheDocument();
+
+    // Children NOT visible until expanded — assert by run id label.
+    expect(
+      screen.queryByLabelText(/Open run ga[12]/i),
+    ).not.toBeInTheDocument();
+
+    // The legacy standalone row IS visible and looks unchanged (no
+    // chevron, opens directly on click).
+    expect(
+      screen.getByLabelText(/Open run legacy0/i),
+    ).toBeInTheDocument();
+  });
+
+  it("parent aggregate Acc equals the mean of children's effective pass rates (live-iteration source)", () => {
+    // Two grouped runs. Each has 4 iterations: host-a passes 4/4
+    // (100%), host-b passes 1/4 (25%). Mean = 62 (rounded). Crucially,
+    // both runs' `summary` is left empty so we can prove the parent is
+    // reading the live-iteration path, not run.summary.
+    const runs: EvalSuiteRun[] = [
+      makeRun({
+        _id: "run-host-a",
+        runGroupId: "g-mean",
+        namedHostId: "host-a",
+        status: "running",
+        // No summary on purpose.
+        summary: undefined,
+        createdAt: 10_000,
+        completedAt: undefined,
+      }),
+      makeRun({
+        _id: "run-host-b",
+        runGroupId: "g-mean",
+        namedHostId: "host-b",
+        status: "running",
+        summary: undefined,
+        createdAt: 10_500,
+        completedAt: undefined,
+      }),
+    ];
+
+    const iterations: EvalIteration[] = [
+      makeIteration("run-host-a", "passed", "ita1"),
+      makeIteration("run-host-a", "passed", "ita2"),
+      makeIteration("run-host-a", "passed", "ita3"),
+      makeIteration("run-host-a", "passed", "ita4"),
+      makeIteration("run-host-b", "passed", "itb1"),
+      makeIteration("run-host-b", "failed", "itb2"),
+      makeIteration("run-host-b", "failed", "itb3"),
+      makeIteration("run-host-b", "failed", "itb4"),
+    ];
+
+    // Sanity: confirm the helper agrees with what we expect for each
+    // child. This pins the source of the aggregate to the helper, not
+    // to anything that could regress to `run.summary`.
+    const aStats = computeRunEffectiveStats(
+      runs[0],
+      iterations.filter((i) => i.suiteRunId === "run-host-a"),
+    );
+    const bStats = computeRunEffectiveStats(
+      runs[1],
+      iterations.filter((i) => i.suiteRunId === "run-host-b"),
+    );
+    expect(aStats.passRate).toBe(100);
+    expect(bStats.passRate).toBe(25);
+
+    renderWithProviders(
+      <SuiteRunsList
+        runs={runs}
+        allIterations={iterations}
+        onRunClick={vi.fn()}
+      />,
+    );
+
+    // Expected mean: round((100 + 25) / 2) = 63.
+    expect(screen.getByText("63%")).toBeInTheDocument();
+  });
+
+  it("renders a single-host launch (no runGroupId) as an ungrouped standalone row identical to legacy", () => {
+    const run = makeRun({
+      _id: "solo0xxx",
+      // No runGroupId at all — this is what use-eval-handlers emits for
+      // single-host launches.
+    });
+
+    renderWithProviders(
+      <SuiteRunsList runs={[run]} allIterations={[]} onRunClick={vi.fn()} />,
+    );
+
+    // Standalone row visible.
+    expect(
+      screen.getByLabelText(/Open run solo0/i),
+    ).toBeInTheDocument();
+
+    // No parent row markers at all.
+    expect(screen.queryByText(/Run group g/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/hosts/i)).not.toBeInTheDocument();
+  });
+
+  it("expanding a group reveals its child runs", async () => {
+    const user = userEvent.setup();
+    const runs: EvalSuiteRun[] = [
+      makeRun({
+        _id: "expandAaa",
+        runGroupId: "g-expand",
+        namedHostId: "host-a",
+      }),
+      makeRun({
+        _id: "expandBbb",
+        runGroupId: "g-expand",
+        namedHostId: "host-b",
+      }),
+    ];
+
+    renderWithProviders(
+      <SuiteRunsList runs={runs} allIterations={[]} onRunClick={vi.fn()} />,
+    );
+
+    // Children hidden initially.
+    expect(
+      screen.queryByLabelText(/Open run expandA/i),
+    ).not.toBeInTheDocument();
+
+    const expander = screen.getByRole("button", {
+      name: /Expand run group g/i,
+    });
+    await user.click(expander);
+
+    // Both children now visible.
+    expect(
+      screen.getByLabelText(/Open run expandA/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Open run expandB/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a group with only one settled child as a standalone (no chevron) during the partial-fan-out gap", () => {
+    // If Convex sync briefly returns only one run with a given group id,
+    // showing a parent labelled "1 hosts" would look broken. The
+    // component degrades to a standalone row until the sibling appears.
+    const run = makeRun({
+      _id: "partial0",
+      runGroupId: "g-partial",
+      namedHostId: "host-a",
+    });
+
+    renderWithProviders(
+      <SuiteRunsList runs={[run]} allIterations={[]} onRunClick={vi.fn()} />,
+    );
+
+    expect(screen.queryByText(/Run group g/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Open run partial0/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("computeRunEffectiveStats", () => {
+  it("uses live iterations once any have terminated, ignoring run.summary", () => {
+    const run = makeRun({
+      _id: "r1",
+      // summary says 0/0 — must be overridden by live iterations.
+      summary: { total: 99, passed: 99, failed: 0, passRate: 100 },
+    });
+    const stats = computeRunEffectiveStats(run, [
+      makeIteration("r1", "passed", "a"),
+      makeIteration("r1", "failed", "b"),
+    ]);
+    expect(stats.passRate).toBe(50);
+  });
+
+  it("falls back to run.summary when no iterations are observable yet", () => {
+    const run = makeRun({
+      _id: "r2",
+      summary: { total: 4, passed: 3, failed: 1, passRate: 75 },
+    });
+    const stats = computeRunEffectiveStats(run, []);
+    expect(stats.passRate).toBe(75);
+  });
+
+  it("returns null when neither iterations nor summary are usable", () => {
+    const run = makeRun({ _id: "r3", summary: undefined });
+    const stats = computeRunEffectiveStats(run, []);
+    expect(stats.passRate).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -700,6 +700,107 @@ describe("useEvalHandlers", () => {
       const requestBody = JSON.parse(callArgs[1].body);
       expect(requestBody.runId).toBe("run-clicked");
     });
+
+    it("includes a shared runGroupId on every POST when the rerun fans out to multiple hosts", async () => {
+      const { result } = renderHook(() =>
+        useEvalHandlers({
+          ...defaultProps,
+          connectedServerNames: new Set(["server-a", "server-b"]),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-multi-host",
+          name: "Multi-host suite",
+          environment: { servers: ["server-a", "server-b"] },
+          hostAttachments: [
+            {
+              namedHostId: "host-mcpjam",
+              hostName: "MCPJam",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-a"],
+            },
+            {
+              namedHostId: "host-claude",
+              hostName: "Claude",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-b"],
+            },
+          ],
+        } as any);
+      });
+
+      // One POST per host attachment.
+      const evalRunCalls = mockAuthFetch.mock.calls.filter(
+        (call) => call[0] === "/api/mcp/evals/run",
+      );
+      expect(evalRunCalls).toHaveLength(2);
+
+      const bodies = evalRunCalls.map((call) =>
+        JSON.parse(call[1].body as string),
+      );
+      const groupIds = bodies.map((b) => b.runGroupId);
+
+      // Each body carries the same non-empty runGroupId.
+      expect(groupIds[0]).toBeTypeOf("string");
+      expect(groupIds[0]).not.toEqual("");
+      expect(groupIds[0]).toEqual(groupIds[1]);
+
+      // namedHostId is still wired through per host (sanity check that the
+      // fan-out itself works — group id rides on top of it, not replacing).
+      const hostIds = bodies.map((b) => b.namedHostId).sort();
+      expect(hostIds).toEqual(["host-claude", "host-mcpjam"]);
+    });
+
+    it("omits runGroupId on a single-host rerun so the row stays ungrouped", async () => {
+      const { result } = renderHook(() => useEvalHandlers(defaultProps));
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-single",
+          name: "Single host suite",
+          environment: { servers: ["server-1"] },
+        } as any);
+      });
+
+      const callArgs = mockAuthFetch.mock.calls[0];
+      const requestBody = JSON.parse(callArgs[1].body);
+      expect(requestBody.runGroupId).toBeUndefined();
+    });
+
+    it("omits runGroupId on a single-attachment rerun (one host attached)", async () => {
+      const { result } = renderHook(() =>
+        useEvalHandlers({
+          ...defaultProps,
+          connectedServerNames: new Set(["server-a"]),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-one-attachment",
+          name: "Single attachment suite",
+          environment: { servers: ["server-a"] },
+          hostAttachments: [
+            {
+              namedHostId: "host-mcpjam",
+              hostName: "MCPJam",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-a"],
+            },
+          ],
+        } as any);
+      });
+
+      const evalRunCalls = mockAuthFetch.mock.calls.filter(
+        (call) => call[0] === "/api/mcp/evals/run",
+      );
+      expect(evalRunCalls).toHaveLength(1);
+      const body = JSON.parse(evalRunCalls[0][1].body as string);
+      expect(body.runGroupId).toBeUndefined();
+      expect(body.namedHostId).toBe("host-mcpjam");
+    });
   });
 
   describe("handleRunTestCase", () => {

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
@@ -306,17 +306,7 @@ function StandaloneRunRow({
   const timestamp = run.completedAt ?? run.createdAt;
   const timestampLabel = formatTime(timestamp);
 
-  const runResult =
-    run.result ||
-    (run.status === "completed" && passRate !== null
-      ? passRate >= (run.passCriteria?.minimumPassRate ?? 100)
-        ? "passed"
-        : "failed"
-      : run.status === "cancelled"
-        ? "cancelled"
-        : run.status === "running"
-          ? "running"
-          : "pending");
+  const runResult = computeEffectiveRunResult(run, passRate);
 
   const creator = run.createdBy ? userMap?.get(run.createdBy) : undefined;
 
@@ -408,6 +398,27 @@ function computeChildDuration(run: EvalSuiteRun): number | null {
   return null;
 }
 
+// Effective result for a run: prefer the explicit `result` set by the recorder
+// when present, otherwise derive from live pass rate against passCriteria.
+// The recorder finalizes runs with `status: "completed"` + `summary` but does
+// not always populate `result`, so a parent that only checks `result === "failed"`
+// would render a green border over a child whose passRate is below criteria.
+export function computeEffectiveRunResult(
+  run: EvalSuiteRun,
+  passRate: number | null,
+): "passed" | "failed" | "running" | "cancelled" | "pending" {
+  if (run.result) return run.result;
+  if (run.status === "completed" && passRate !== null) {
+    return passRate >= (run.passCriteria?.minimumPassRate ?? 100)
+      ? "passed"
+      : "failed";
+  }
+  if (run.status === "cancelled") return "cancelled";
+  if (run.status === "running") return "running";
+  if (run.status === "failed") return "failed";
+  return "pending";
+}
+
 function GroupRunRows({
   group,
   iterationsByRun,
@@ -446,16 +457,19 @@ function GroupRunRows({
   const maxDuration =
     childDurations.length > 0 ? Math.max(...childDurations) : null;
 
-  // Parent status: pick the "worst" status across children so the left
-  // border accurately reflects partial failure / running state.
-  const anyRunning = group.runs.some((r) => r.status === "running");
-  const anyFailed = group.runs.some(
-    (r) => r.result === "failed" || r.status === "failed",
+  // Parent status: pick the "worst" effective status across children so the
+  // left border matches what each child row shows. Derive from the same
+  // helper the standalone rows use — checking only `run.result`/`run.status`
+  // here misses children that the recorder finalized as `status: completed`
+  // without setting `result: failed`, even though their passRate is below
+  // criteria. Order: running > failed > cancelled > pending > passed.
+  const effectiveResults = childStats.map((c) =>
+    computeEffectiveRunResult(c.run, c.stats.passRate),
   );
-  const anyCancelled = group.runs.some(
-    (r) => r.status === "cancelled" || r.result === "cancelled",
-  );
-  const allCompleted = group.runs.every((r) => r.status === "completed");
+  const anyRunning = effectiveResults.some((r) => r === "running");
+  const anyFailed = effectiveResults.some((r) => r === "failed");
+  const anyCancelled = effectiveResults.some((r) => r === "cancelled");
+  const anyPending = effectiveResults.some((r) => r === "pending");
   const groupResult: "running" | "failed" | "cancelled" | "passed" | "pending" =
     anyRunning
       ? "running"
@@ -463,9 +477,9 @@ function GroupRunRows({
         ? "failed"
         : anyCancelled
           ? "cancelled"
-          : allCompleted
-            ? "passed"
-            : "pending";
+          : anyPending
+            ? "pending"
+            : "passed";
 
   const timestampLabel = formatTime(group.latestTimestamp);
   const shortGroupId = group.runGroupId.slice(0, 8);

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { ClientChip } from "@/components/clients/client-chip";
 import { cn, getInitials } from "@/lib/utils";
 import {
@@ -30,6 +30,37 @@ import {
 const RUNS_LIST_ROW_GRID =
   "grid w-full grid-cols-[minmax(0,1.25fr)_repeat(3,minmax(4.5rem,1fr))_1rem] items-center gap-x-4";
 
+/**
+ * Per-row effective pass-rate stats. Prefers the live iteration set when
+ * any iteration has terminated; falls back to `run.summary` only when no
+ * iterations are observable yet. Exported as a tiny pure helper so the
+ * parent group row and the child rows compute aggregates from the same
+ * source — otherwise parent vs. children diverge during live updates.
+ */
+export function computeRunEffectiveStats(
+  run: EvalSuiteRun,
+  runIterations: EvalIteration[],
+): {
+  effectivePassed: number;
+  effectiveTotal: number;
+  passRate: number | null;
+} {
+  const iterationResults = runIterations.map((i) => computeIterationResult(i));
+  const passed = iterationResults.filter((r) => r === "passed").length;
+  const failed = iterationResults.filter((r) => r === "failed").length;
+  const completedTotal = passed + failed;
+  const summaryPassed = run.summary?.passed ?? 0;
+  const summaryTotal = run.summary?.total ?? 0;
+
+  const effectivePassed = completedTotal > 0 ? passed : summaryPassed;
+  const effectiveTotal = completedTotal > 0 ? completedTotal : summaryTotal;
+  const passRate =
+    effectiveTotal > 0
+      ? Math.round((effectivePassed / effectiveTotal) * 100)
+      : null;
+  return { effectivePassed, effectiveTotal, passRate };
+}
+
 export interface SuiteRunsListProps {
   runs: EvalSuiteRun[];
   allIterations: EvalIteration[];
@@ -46,6 +77,30 @@ export interface SuiteRunsListProps {
    */
   hostNamesById?: Map<string, string | null>;
   className?: string;
+}
+
+type RunGroupNode = {
+  kind: "group";
+  /** Stable key shared by all child runs (the runGroupId itself). */
+  key: string;
+  runGroupId: string;
+  runs: EvalSuiteRun[];
+  /** Latest timestamp across children (completedAt ?? createdAt). */
+  latestTimestamp: number;
+};
+
+type RunStandaloneNode = {
+  kind: "standalone";
+  /** The run id, used as a stable key. */
+  key: string;
+  run: EvalSuiteRun;
+  latestTimestamp: number;
+};
+
+type RunListNode = RunGroupNode | RunStandaloneNode;
+
+function getRunTimestamp(run: EvalSuiteRun): number {
+  return run.completedAt ?? run.createdAt ?? 0;
 }
 
 /**
@@ -79,22 +134,83 @@ export function SuiteRunsList({
     return map;
   }, [allIterations]);
 
-  const sortedRuns = useMemo(() => {
-    return [...runs].sort((a, b) => {
-      const aTime = a.completedAt ?? a.createdAt ?? 0;
-      const bTime = b.completedAt ?? b.createdAt ?? 0;
-      return bTime - aTime;
-    });
+  // Build the list of nodes — one entry per group, one per standalone
+  // run — sorted newest-first by the latest child timestamp in each
+  // group. Runs without `runGroupId` render exactly as before (no
+  // chevron, no aggregate), preserving the legacy layout.
+  const nodes = useMemo<RunListNode[]>(() => {
+    const groups = new Map<string, EvalSuiteRun[]>();
+    const standalones: EvalSuiteRun[] = [];
+    for (const run of runs) {
+      if (run.runGroupId) {
+        const existing = groups.get(run.runGroupId);
+        if (existing) existing.push(run);
+        else groups.set(run.runGroupId, [run]);
+      } else {
+        standalones.push(run);
+      }
+    }
+
+    const groupNodes: RunListNode[] = [];
+    for (const [groupId, groupRuns] of groups.entries()) {
+      // Single-member groups can happen if a multi-host POST settles with
+      // only one row visible (slow Convex sync). Render them as standalones
+      // so the user never sees an empty-looking parent during the gap.
+      if (groupRuns.length < 2) {
+        for (const run of groupRuns) {
+          standalones.push(run);
+        }
+        continue;
+      }
+      const sortedChildren = [...groupRuns].sort(
+        (a, b) => getRunTimestamp(b) - getRunTimestamp(a),
+      );
+      const latestTimestamp = sortedChildren.reduce(
+        (max, r) => Math.max(max, getRunTimestamp(r)),
+        0,
+      );
+      groupNodes.push({
+        kind: "group",
+        key: groupId,
+        runGroupId: groupId,
+        runs: sortedChildren,
+        latestTimestamp,
+      });
+    }
+
+    const standaloneNodes: RunListNode[] = standalones.map((run) => ({
+      kind: "standalone",
+      key: run._id,
+      run,
+      latestTimestamp: getRunTimestamp(run),
+    }));
+
+    return [...groupNodes, ...standaloneNodes].sort(
+      (a, b) => b.latestTimestamp - a.latestTimestamp,
+    );
   }, [runs]);
 
-  const visibleRuns = useMemo(() => {
+  // Cap by *groups* (nodes), not raw rows, so a group is never split
+  // mid-expansion. Footer count is in node terms too.
+  const visibleNodes = useMemo(() => {
     if (typeof maxVisibleRuns === "number" && maxVisibleRuns > 0) {
-      return sortedRuns.slice(0, maxVisibleRuns);
+      return nodes.slice(0, maxVisibleRuns);
     }
-    return sortedRuns;
-  }, [sortedRuns, maxVisibleRuns]);
+    return nodes;
+  }, [nodes, maxVisibleRuns]);
 
-  const hiddenRunCount = sortedRuns.length - visibleRuns.length;
+  const hiddenNodeCount = nodes.length - visibleNodes.length;
+
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleGroup = (groupId: string) =>
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
 
   return (
     <div
@@ -115,139 +231,312 @@ export function SuiteRunsList({
       </div>
 
       <div className="max-h-[520px] divide-y overflow-y-auto">
-        {runsLoading && sortedRuns.length === 0 ? (
+        {runsLoading && nodes.length === 0 ? (
           <div className="px-4 py-12 text-center text-sm text-muted-foreground">
             Loading runs…
           </div>
-        ) : sortedRuns.length === 0 ? (
+        ) : nodes.length === 0 ? (
           <div className="px-4 py-12 text-center text-sm text-muted-foreground">
             No runs yet. Run this suite to see results here.
           </div>
         ) : (
-          visibleRuns.map((run) => {
-            const runIterations = iterationsByRun.get(run._id) ?? [];
-            const iterationResults = runIterations.map((i) =>
-              computeIterationResult(i),
-            );
-            const passed = iterationResults.filter((r) => r === "passed")
-              .length;
-            const failed = iterationResults.filter((r) => r === "failed")
-              .length;
-            const completedTotal = passed + failed;
-            const summaryPassed = run.summary?.passed ?? 0;
-            const summaryTotal = run.summary?.total ?? 0;
-
-            const effectivePassed = completedTotal > 0 ? passed : summaryPassed;
-            const effectiveTotal =
-              completedTotal > 0 ? completedTotal : summaryTotal;
-            const passRate =
-              effectiveTotal > 0
-                ? Math.round((effectivePassed / effectiveTotal) * 100)
-                : null;
-
-            const duration =
-              run.completedAt && run.createdAt
-                ? formatDuration(run.completedAt - run.createdAt)
-                : run.createdAt && run.status === "running"
-                  ? formatDuration(Date.now() - run.createdAt)
-                  : "—";
-
-            const timestamp = run.completedAt ?? run.createdAt;
-            const timestampLabel = formatTime(timestamp);
-
-            const runResult =
-              run.result ||
-              (run.status === "completed" && passRate !== null
-                ? passRate >= (run.passCriteria?.minimumPassRate ?? 100)
-                  ? "passed"
-                  : "failed"
-                : run.status === "cancelled"
-                  ? "cancelled"
-                  : run.status === "running"
-                    ? "running"
-                    : "pending");
-
-            const creator = run.createdBy
-              ? userMap?.get(run.createdBy)
-              : undefined;
-
+          visibleNodes.map((node) => {
+            if (node.kind === "standalone") {
+              return (
+                <StandaloneRunRow
+                  key={node.key}
+                  run={node.run}
+                  runIterations={iterationsByRun.get(node.run._id) ?? []}
+                  hostNamesById={hostNamesById}
+                  userMap={userMap}
+                  onRunClick={onRunClick}
+                />
+              );
+            }
+            const isExpanded = expandedGroups.has(node.runGroupId);
             return (
-              <div
-                key={run._id}
-                className={cn(
-                  "relative border-l-2",
-                  evalStatusLeftBorderClasses(runResult),
-                )}
-              >
-                <button
-                  type="button"
-                  onClick={() => onRunClick(run._id)}
-                  className={cn(
-                    RUNS_LIST_ROW_GRID,
-                    "px-4 py-2.5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
-                    evalSurfaceRowHoverClass,
-                  )}
-                  aria-label={`Open run ${formatRunId(run._id)}`}
-                >
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className="truncate text-xs font-medium">
-                      Run {formatRunId(run._id)}
-                    </span>
-                    {run.namedHostId ? (
-                      <ClientChip
-                        name={
-                          hostNamesById?.get(run.namedHostId) ??
-                          formatRunId(run.namedHostId)
-                        }
-                        hostId={run.namedHostId}
-                        className="shrink-0 max-w-[140px] gap-1 border-primary/35 bg-primary/10 px-2 py-0.5 text-[10px] text-primary shadow-none"
-                      />
-                    ) : null}
-                    {creator ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Avatar className="size-5 shrink-0">
-                            <AvatarImage
-                              src={creator.imageUrl}
-                              alt={creator.name}
-                            />
-                            <AvatarFallback className="text-[9px]">
-                              {getInitials(creator.name)}
-                            </AvatarFallback>
-                          </Avatar>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p className="text-xs">{creator.name}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : null}
-                  </div>
-                  <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
-                    {passRate !== null ? `${passRate}%` : "—"}
-                  </div>
-                  <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
-                    {duration}
-                  </div>
-                  <div
-                    className="truncate text-right text-xs tabular-nums text-muted-foreground"
-                    title={timestampLabel}
-                  >
-                    {timestampLabel}
-                  </div>
-                  <ChevronRight
-                    className="h-3.5 w-3.5 text-muted-foreground"
-                    aria-hidden
-                  />
-                </button>
-              </div>
+              <GroupRunRows
+                key={node.key}
+                group={node}
+                iterationsByRun={iterationsByRun}
+                hostNamesById={hostNamesById}
+                userMap={userMap}
+                onRunClick={onRunClick}
+                isExpanded={isExpanded}
+                onToggle={() => toggleGroup(node.runGroupId)}
+              />
             );
           })
         )}
       </div>
 
-      {hiddenRunCount > 0 ? (
+      {hiddenNodeCount > 0 ? (
         <div className="shrink-0 border-t bg-muted/20 px-4 py-2 text-[11px] text-muted-foreground">
-          Showing {visibleRuns.length} of {sortedRuns.length} runs
+          Showing {visibleNodes.length} of {nodes.length} runs
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface StandaloneRunRowProps {
+  run: EvalSuiteRun;
+  runIterations: EvalIteration[];
+  hostNamesById?: Map<string, string | null>;
+  userMap?: Map<string, { name: string; imageUrl?: string }>;
+  onRunClick: (runId: string) => void;
+}
+
+function StandaloneRunRow({
+  run,
+  runIterations,
+  hostNamesById,
+  userMap,
+  onRunClick,
+}: StandaloneRunRowProps) {
+  const { passRate } = computeRunEffectiveStats(run, runIterations);
+
+  const duration =
+    run.completedAt && run.createdAt
+      ? formatDuration(run.completedAt - run.createdAt)
+      : run.createdAt && run.status === "running"
+        ? formatDuration(Date.now() - run.createdAt)
+        : "—";
+
+  const timestamp = run.completedAt ?? run.createdAt;
+  const timestampLabel = formatTime(timestamp);
+
+  const runResult =
+    run.result ||
+    (run.status === "completed" && passRate !== null
+      ? passRate >= (run.passCriteria?.minimumPassRate ?? 100)
+        ? "passed"
+        : "failed"
+      : run.status === "cancelled"
+        ? "cancelled"
+        : run.status === "running"
+          ? "running"
+          : "pending");
+
+  const creator = run.createdBy ? userMap?.get(run.createdBy) : undefined;
+
+  return (
+    <div
+      className={cn(
+        "relative border-l-2",
+        evalStatusLeftBorderClasses(runResult),
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => onRunClick(run._id)}
+        className={cn(
+          RUNS_LIST_ROW_GRID,
+          "px-4 py-2.5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
+          evalSurfaceRowHoverClass,
+        )}
+        aria-label={`Open run ${formatRunId(run._id)}`}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-xs font-medium">
+            Run {formatRunId(run._id)}
+          </span>
+          {run.namedHostId ? (
+            <ClientChip
+              name={
+                hostNamesById?.get(run.namedHostId) ??
+                formatRunId(run.namedHostId)
+              }
+              hostId={run.namedHostId}
+              className="shrink-0 max-w-[140px] gap-1 border-primary/35 bg-primary/10 px-2 py-0.5 text-[10px] text-primary shadow-none"
+            />
+          ) : null}
+          {creator ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Avatar className="size-5 shrink-0">
+                  <AvatarImage src={creator.imageUrl} alt={creator.name} />
+                  <AvatarFallback className="text-[9px]">
+                    {getInitials(creator.name)}
+                  </AvatarFallback>
+                </Avatar>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="text-xs">{creator.name}</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
+        <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
+          {passRate !== null ? `${passRate}%` : "—"}
+        </div>
+        <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
+          {duration}
+        </div>
+        <div
+          className="truncate text-right text-xs tabular-nums text-muted-foreground"
+          title={formatTime(timestamp)}
+        >
+          {timestampLabel}
+        </div>
+        <ChevronRight
+          className="h-3.5 w-3.5 text-muted-foreground"
+          aria-hidden
+        />
+      </button>
+    </div>
+  );
+}
+
+interface GroupRunRowsProps {
+  group: RunGroupNode;
+  iterationsByRun: Map<string, EvalIteration[]>;
+  hostNamesById?: Map<string, string | null>;
+  userMap?: Map<string, { name: string; imageUrl?: string }>;
+  onRunClick: (runId: string) => void;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+function computeChildDuration(run: EvalSuiteRun): number | null {
+  if (run.completedAt && run.createdAt) {
+    return Math.max(run.completedAt - run.createdAt, 0);
+  }
+  if (run.createdAt && run.status === "running") {
+    return Math.max(Date.now() - run.createdAt, 0);
+  }
+  return null;
+}
+
+function GroupRunRows({
+  group,
+  iterationsByRun,
+  hostNamesById,
+  userMap,
+  onRunClick,
+  isExpanded,
+  onToggle,
+}: GroupRunRowsProps) {
+  // Per-child effective stats — same source the standalone rows use.
+  const childStats = group.runs.map((run) => ({
+    run,
+    iterations: iterationsByRun.get(run._id) ?? [],
+    stats: computeRunEffectiveStats(
+      run,
+      iterationsByRun.get(run._id) ?? [],
+    ),
+  }));
+
+  // Mean across children's effective pass rates. Children with a null
+  // passRate (no iterations yet AND no summary) are excluded from the
+  // mean — counting them as 0 would dilute the live aggregate.
+  const childRates = childStats
+    .map((c) => c.stats.passRate)
+    .filter((p): p is number => p !== null);
+  const meanPassRate =
+    childRates.length > 0
+      ? Math.round(
+          childRates.reduce((sum, p) => sum + p, 0) / childRates.length,
+        )
+      : null;
+
+  const childDurations = childStats
+    .map((c) => computeChildDuration(c.run))
+    .filter((d): d is number => d !== null);
+  const maxDuration =
+    childDurations.length > 0 ? Math.max(...childDurations) : null;
+
+  // Parent status: pick the "worst" status across children so the left
+  // border accurately reflects partial failure / running state.
+  const anyRunning = group.runs.some((r) => r.status === "running");
+  const anyFailed = group.runs.some(
+    (r) => r.result === "failed" || r.status === "failed",
+  );
+  const anyCancelled = group.runs.some(
+    (r) => r.status === "cancelled" || r.result === "cancelled",
+  );
+  const allCompleted = group.runs.every((r) => r.status === "completed");
+  const groupResult: "running" | "failed" | "cancelled" | "passed" | "pending" =
+    anyRunning
+      ? "running"
+      : anyFailed
+        ? "failed"
+        : anyCancelled
+          ? "cancelled"
+          : allCompleted
+            ? "passed"
+            : "pending";
+
+  const timestampLabel = formatTime(group.latestTimestamp);
+  const shortGroupId = group.runGroupId.slice(0, 8);
+
+  return (
+    <div
+      className={cn(
+        "relative border-l-2",
+        evalStatusLeftBorderClasses(groupResult),
+      )}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isExpanded}
+        className={cn(
+          RUNS_LIST_ROW_GRID,
+          "px-4 py-2.5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
+          evalSurfaceRowHoverClass,
+        )}
+        aria-label={`${isExpanded ? "Collapse" : "Expand"} run group g${shortGroupId}`}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {isExpanded ? (
+            <ChevronDown
+              className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+          ) : (
+            <ChevronRight
+              className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+          )}
+          <span className="truncate text-xs font-medium">
+            Run group g{shortGroupId}
+          </span>
+          <span className="shrink-0 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+            {group.runs.length} hosts
+          </span>
+        </div>
+        <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
+          {meanPassRate !== null ? `${meanPassRate}%` : "—"}
+        </div>
+        <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
+          {maxDuration !== null ? formatDuration(maxDuration) : "—"}
+        </div>
+        <div
+          className="truncate text-right text-xs tabular-nums text-muted-foreground"
+          title={timestampLabel}
+        >
+          {timestampLabel}
+        </div>
+        <span aria-hidden />
+      </button>
+
+      {isExpanded ? (
+        <div
+          className="border-t bg-muted/10 pl-4"
+          data-testid="run-group-children"
+        >
+          {childStats.map(({ run, iterations }) => (
+            <StandaloneRunRow
+              key={run._id}
+              run={run}
+              runIterations={iterations}
+              hostNamesById={hostNamesById}
+              userMap={userMap}
+              onRunClick={onRunClick}
+            />
+          ))}
         </div>
       ) : null}
     </div>

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -287,6 +287,13 @@ export type EvalSuiteRun = {
    * "host matrix" view.
    */
   namedHostId?: string;
+  /**
+   * Client-generated UUID shared by every per-host run from the same
+   * multi-host eval launch. The UI groups runs by this id; runs without
+   * a `runGroupId` (legacy or single-host launches) render as standalone
+   * rows. Set client-side at fan-out and persisted on `testSuiteRun`.
+   */
+  runGroupId?: string;
   _creationTime?: number;
   runInsightsJobId?: number;
   runInsightsStatus?: "pending" | "completed" | "failed";

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -590,6 +590,15 @@ export function useEvalHandlers({
               },
             ];
 
+      // Generate a shared group id ONLY when the rerun fans out to more
+      // than one host. The inspector route threads this through the Zod
+      // schema → recorder → Convex mutation; every sibling run carries
+      // the same id so the UI can collapse them into a single parent
+      // row. Single-host launches stay ungrouped so legacy + single-host
+      // rows render identically.
+      const runGroupId =
+        runPlans.length > 1 ? crypto.randomUUID() : undefined;
+
       // Show toast immediately when user clicks rerun
       toast.success(
         runPlans.length > 1
@@ -651,6 +660,7 @@ export function useEvalHandlers({
               matchOptionsOverride: options?.matchOptionsOverride,
               refreshSnapshot: options?.refreshSnapshot,
               ...(plan.namedHostId ? { namedHostId: plan.namedHostId } : {}),
+              ...(runGroupId ? { runGroupId } : {}),
             }),
           ),
         );

--- a/mcpjam-inspector/client/src/components/evals/use-eval-queries.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-queries.ts
@@ -53,10 +53,14 @@ export function useEvalQueries({
     enableSuiteDetailsQuery ? ({ suiteId: selectedSuiteId } as any) : "skip"
   ) as SuiteDetailsQueryResponse | undefined;
 
+  // Raised from 20 → 100 so a multi-host run group (up to ~5 hosts in
+  // practice) is never truncated mid-group. The list consumer caps by
+  // *groups* after grouping rather than capping raw rows, so groups
+  // remain fully expandable even near the limit.
   const suiteRuns = useQuery(
     "testSuites:listTestSuiteRuns" as any,
     enableSuiteDetailsQuery
-      ? ({ suiteId: selectedSuiteId, limit: 20 } as any)
+      ? ({ suiteId: selectedSuiteId, limit: 100 } as any)
       : "skip"
   ) as EvalSuiteRun[] | undefined;
 

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -95,6 +95,13 @@ type RunEvalsRequest = EvalRequestWithServers & {
    * silently contaminate existing suites.
    */
   refreshSnapshot?: boolean;
+  /**
+   * Client-generated UUID set on every per-host POST when a multi-host
+   * eval launch fans out (N > 1). Persisted on the resulting
+   * `testSuiteRun` rows so the UI can group sibling runs into a single
+   * parent row. Absent on single-host launches and legacy runs.
+   */
+  runGroupId?: string;
 };
 
 type RunTestCaseRequest = EvalRequestWithServers & {

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -142,6 +142,17 @@ export const RunEvalsRequestSchema = z.object({
    * so connecting new servers cannot silently contaminate existing suites.
    */
   refreshSnapshot: z.boolean().optional(),
+  /**
+   * Client-generated UUID set on every per-host POST when a multi-host
+   * eval launch fans out (N > 1). Threaded into Convex `startTestSuiteRun`
+   * so the resulting `testSuiteRun` rows share a group id, which the UI
+   * uses to collapse them into a single parent row. Absent on single-host
+   * launches and on legacy runs — those render ungrouped.
+   *
+   * Must be declared explicitly on every Zod boundary in the wire path;
+   * unknown keys are stripped silently.
+   */
+  runGroupId: z.string().optional(),
 });
 
 export type RunEvalsRequest = z.infer<typeof RunEvalsRequestSchema>;
@@ -458,6 +469,7 @@ export async function runEvalsWithManager(
     matchOptionsOverride,
     namedHostId,
     refreshSnapshot,
+    runGroupId,
   } = request;
 
   if (!suiteId && (!suiteName || suiteName.trim().length === 0)) {
@@ -731,6 +743,7 @@ export async function runEvalsWithManager(
     iterationOverride,
     matchOptionsOverride,
     namedHostId,
+    runGroupId,
   });
   const suiteHostConfig =
     runHostConfigSnapshot ??

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -332,6 +332,7 @@ export const startSuiteRunWithRecorder = async ({
   iterationOverride,
   matchOptionsOverride,
   namedHostId,
+  runGroupId,
 }: {
   convexClient: ConvexHttpClient;
   suiteId: string;
@@ -370,6 +371,13 @@ export const startSuiteRunWithRecorder = async ({
    * just receives the host's servers like any other run.
    */
   namedHostId?: string;
+  /**
+   * Client-generated UUID shared by every per-host run when a multi-host
+   * eval launch fans out. Persisted on `testSuiteRun.runGroupId` so the
+   * UI can collapse sibling rows into a single group. Absent on
+   * single-host launches.
+   */
+  runGroupId?: string;
 }) => {
   const response = await convexClient.mutation(
     "testSuites:startTestSuiteRun" as any,
@@ -385,6 +393,7 @@ export const startSuiteRunWithRecorder = async ({
       iterationOverride,
       matchOptionsOverride,
       ...(namedHostId ? { namedHostId } : {}),
+      ...(runGroupId ? { runGroupId } : {}),
     },
   );
 


### PR DESCRIPTION
## Summary
- Generate `runGroupId` client-side when fanning out a multi-host eval launch
- Thread it through `RunEvalsRequestSchema` → `runEvalsWithManager` → `startSuiteRunWithRecorder` → Convex mutation
- `SuiteRunsList` groups runs by `runGroupId`; parent row shows mean Acc, max Dur
- Legacy ungrouped runs render unchanged (no chevron)

## Context
Inspector half of a UI-only V1. Companion backend PR adds `runGroupId` to the `testSuiteRun` Convex schema — that PR must land first in production. V1 derives the group entirely in the UI; no backend group query, no CI verdict aggregator (deferred per plan).

## Test plan
- [ ] Frontend grouping tests pass
- [ ] `use-eval-handlers` tests pass (UUID set when N>1, absent when N===1)
- [ ] Lint and typecheck pass
- [ ] Manual: attach 2 hosts to a suite, "Run all" → one collapsed parent row with `2 hosts`, expandable to children
- [ ] Manual: single-host launch → ungrouped row identical to today

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval run creation and list aggregation logic across client and server; behavior depends on companion Convex schema for `runGroupId`, but changes are UI-focused with backward-compatible ungrouped rows.
> 
> **Overview**
> Multi-host eval launches now share a client-generated **`runGroupId`** when fan-out spans more than one host; single-host and legacy runs omit it so rows stay flat.
> 
> **Launch path:** `handleRerun` assigns one UUID per multi-host batch and sends it on each `/api/mcp/evals/run` POST alongside `namedHostId`. The field is typed on the client API, validated in **`RunEvalsRequestSchema`**, and passed through **`startSuiteRunWithRecorder`** into Convex **`startTestSuiteRun`**.
> 
> **Runs list:** **`SuiteRunsList`** groups by `runGroupId` into expandable parent rows (mean accuracy, max duration, worst child status border). Shared helpers **`computeRunEffectiveStats`** and **`computeEffectiveRunResult`** keep parent/child metrics aligned with live iterations and pass criteria when `result` is unset. Single-member groups during slow sync render as standalones; list caps apply to groups, not raw rows. Suite run fetch limit rises **20 → 100** so groups are not truncated.
> 
> **Tests:** New **`suite-runs-list.test.tsx`** and **`use-eval-handlers`** cases cover grouping, aggregates, and `runGroupId` presence/absence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683ac3f6dd197d6ee240746a745c356f2b426af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->