### PR TITLE
evals: Phase 2 — predicate authoring (inspector)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -1,0 +1,840 @@
+/**
+ * Authoring UI for the deterministic predicate gate ("Checks" in user-facing
+ * copy; `Predicate` / `predicateValidator` / `defaultPredicates` in code, per
+ * the Phase 2 plan UI-wording mapping).
+ *
+ * Two surfaces:
+ *
+ *  - {@link ChecksSection} — list editor + Add-check dropdown, used by both
+ *    the suite-edit page ("Default checks") and the case-edit form (when
+ *    mode is `replace` or `extend`).
+ *  - {@link CaseChecksSection} — case-edit wrapper around ChecksSection that
+ *    adds the 3-state inherit/replace/extend radio and the inherited-suite
+ *    summary, persisting to `testCase.predicates: { mode, list }`.
+ *
+ * The list editor itself uses {@link CheckRow} per kind. Form-boundary
+ * validation runs the SDK Zod (`predicateSchema`) — invalid rows surface an
+ * inline error and disable save up the tree.
+ */
+
+import { useId, useMemo, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { Switch } from "@mcpjam/design-system/switch";
+import { Trash2, Plus } from "lucide-react";
+import type {
+  Predicate,
+  ArgMatchMode,
+  CasePredicates,
+} from "@/shared/eval-matching";
+import { predicateSchema } from "@mcpjam/sdk/predicates";
+
+// ─── kind metadata ────────────────────────────────────────────────────────
+//
+// One source of truth for the Add-check menu + per-row label. UI wording
+// here is the user-facing "checks" vocabulary; the backend `type` discriminator
+// is unchanged (Phase 2 plan: "UI says 'checks' everywhere. Internal code keeps
+// `Predicate` … to match SDK names").
+
+type Kind = Predicate["type"];
+
+const KIND_LABELS: Record<Kind, string> = {
+  toolCalledWith: "Tool was called with…",
+  toolCalledAtLeastOnce: "Tool was called at least once",
+  toolNeverCalled: "Tool was never called",
+  firstToolWas: "First tool called was…",
+  responseContains: "Response contains…",
+  responseMatches: "Response matches regex…",
+  noToolErrors: "No tool errors",
+  finalAssistantMessageNonEmpty: "Final message non-empty",
+  tokenBudgetUnder: "Token budget under N",
+};
+
+// Order chosen so tool-call checks cluster first, then response checks, then
+// no-arg checks, then resource checks. Matches the Phase 2 plan UI listing.
+const KIND_ORDER: Kind[] = [
+  "toolCalledWith",
+  "toolCalledAtLeastOnce",
+  "toolNeverCalled",
+  "firstToolWas",
+  "responseContains",
+  "responseMatches",
+  "noToolErrors",
+  "finalAssistantMessageNonEmpty",
+  "tokenBudgetUnder",
+];
+
+/** Build a fresh, valid-by-default predicate skeleton for a newly-added row. */
+function blankPredicate(kind: Kind): Predicate {
+  switch (kind) {
+    case "toolCalledWith":
+      return { type: "toolCalledWith", toolName: "", args: { args: {} } };
+    case "toolCalledAtLeastOnce":
+      return { type: "toolCalledAtLeastOnce", toolName: "" };
+    case "toolNeverCalled":
+      return { type: "toolNeverCalled", toolName: "" };
+    case "firstToolWas":
+      return { type: "firstToolWas", toolName: "" };
+    case "responseContains":
+      return { type: "responseContains", needle: "" };
+    case "responseMatches":
+      return { type: "responseMatches", pattern: "" };
+    case "noToolErrors":
+      return { type: "noToolErrors" };
+    case "finalAssistantMessageNonEmpty":
+      return { type: "finalAssistantMessageNonEmpty" };
+    case "tokenBudgetUnder":
+      return { type: "tokenBudgetUnder", tokens: 1000 };
+  }
+}
+
+// ─── Top-level checks list editor (shared between suite + case) ───────────
+
+export interface ChecksSectionProps {
+  /** The list to render and edit. */
+  value: Predicate[];
+  onChange: (next: Predicate[]) => void;
+  /** Tools available from the suite-attached server, for the tool dropdowns. */
+  availableTools?: string[];
+  /** Header label override. */
+  title?: string;
+  /** Subtitle/explainer. */
+  description?: string;
+  /** Hide the Add-check button (used by the inherited read-only summary). */
+  readOnly?: boolean;
+}
+
+export function ChecksSection({
+  value,
+  onChange,
+  availableTools,
+  title = "Default checks",
+  description,
+  readOnly = false,
+}: ChecksSectionProps) {
+  const updateAt = (index: number, next: Predicate) => {
+    const copy = value.slice();
+    copy[index] = next;
+    onChange(copy);
+  };
+  const removeAt = (index: number) => {
+    const copy = value.slice();
+    copy.splice(index, 1);
+    onChange(copy);
+  };
+  const addOfKind = (kind: Kind) => {
+    onChange([...value, blankPredicate(kind)]);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        {description ? (
+          <p className="text-xs text-muted-foreground mt-1">{description}</p>
+        ) : null}
+      </div>
+
+      {value.length === 0 ? (
+        <div className="rounded-md border border-dashed border-border/60 bg-muted/10 p-4 text-xs text-muted-foreground">
+          No checks yet.
+          {!readOnly ? " Use Add check below to author one." : ""}
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {value.map((predicate, i) => (
+            <li key={i}>
+              <CheckRow
+                predicate={predicate}
+                onChange={readOnly ? () => {} : (next) => updateAt(i, next)}
+                onRemove={readOnly ? undefined : () => removeAt(i)}
+                availableTools={availableTools}
+                readOnly={readOnly}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!readOnly ? <AddCheckMenu onAdd={addOfKind} /> : null}
+    </div>
+  );
+}
+
+function AddCheckMenu({ onAdd }: { onAdd: (kind: Kind) => void }) {
+  // A controlled Select where picking a value fires `onAdd` and resets to
+  // the placeholder — simpler than a popover menu and reuses design-system
+  // primitives that already render correctly inside dialogs/sheets.
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex items-center gap-2">
+      <Select
+        open={open}
+        onOpenChange={setOpen}
+        value=""
+        onValueChange={(kind) => {
+          if (!kind) return;
+          onAdd(kind as Kind);
+          setOpen(false);
+        }}
+      >
+        <SelectTrigger className="h-8 w-auto gap-2 text-xs">
+          <Plus className="h-3.5 w-3.5" />
+          <SelectValue placeholder="Add check…" />
+        </SelectTrigger>
+        <SelectContent>
+          {KIND_ORDER.map((kind) => (
+            <SelectItem key={kind} value={kind} className="text-xs">
+              {KIND_LABELS[kind]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+// ─── Per-row editor (shared across kinds) ─────────────────────────────────
+
+export interface CheckRowProps {
+  predicate: Predicate;
+  onChange: (next: Predicate) => void;
+  onRemove?: () => void;
+  availableTools?: string[];
+  readOnly?: boolean;
+}
+
+export function CheckRow({
+  predicate,
+  onChange,
+  onRemove,
+  availableTools,
+  readOnly = false,
+}: CheckRowProps) {
+  // Zod-validate the current row so an in-progress edit (e.g. empty toolName,
+  // malformed args JSON) surfaces an inline error and disables Save up the
+  // tree (callers wire `isAnyCheckInvalid` into their disable state).
+  const validation = useMemo(
+    () => predicateSchema.safeParse(predicate),
+    [predicate],
+  );
+  const error = validation.success
+    ? null
+    : validation.error.issues.map((i) => i.message).join("; ");
+
+  return (
+    <div
+      className={`rounded-md border p-3 ${
+        error ? "border-red-500/40 bg-red-500/5" : "border-border/60 bg-muted/10"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0 space-y-2">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {KIND_LABELS[predicate.type]}
+          </div>
+
+          <CheckFields
+            predicate={predicate}
+            onChange={onChange}
+            availableTools={availableTools}
+            readOnly={readOnly}
+          />
+
+          {error ? (
+            <div className="text-[11px] text-red-600 dark:text-red-400">
+              {error}
+            </div>
+          ) : null}
+        </div>
+        {onRemove ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0 text-muted-foreground"
+            onClick={onRemove}
+            aria-label="Remove check"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CheckFields({
+  predicate,
+  onChange,
+  availableTools,
+  readOnly,
+}: {
+  predicate: Predicate;
+  onChange: (next: Predicate) => void;
+  availableTools?: string[];
+  readOnly: boolean;
+}) {
+  switch (predicate.type) {
+    case "toolCalledWith":
+      return (
+        <ToolCalledWithFields
+          predicate={predicate}
+          onChange={onChange}
+          availableTools={availableTools}
+          readOnly={readOnly}
+        />
+      );
+    case "toolCalledAtLeastOnce":
+    case "toolNeverCalled":
+    case "firstToolWas":
+      return (
+        <ToolNameField
+          value={predicate.toolName}
+          onChange={(toolName) =>
+            onChange({ ...predicate, toolName } as Predicate)
+          }
+          availableTools={availableTools}
+          readOnly={readOnly}
+        />
+      );
+    case "responseContains":
+      return (
+        <ResponseContainsFields
+          predicate={predicate}
+          onChange={onChange}
+          readOnly={readOnly}
+        />
+      );
+    case "responseMatches":
+      return (
+        <ResponseMatchesFields
+          predicate={predicate}
+          onChange={onChange}
+          readOnly={readOnly}
+        />
+      );
+    case "noToolErrors":
+      return (
+        <div className="text-xs text-muted-foreground">
+          Passes when no tool reported an error (neither MCP isError nor a
+          transport failure).
+        </div>
+      );
+    case "finalAssistantMessageNonEmpty":
+      return (
+        <div className="text-xs text-muted-foreground">
+          Passes when the final assistant message contains non-whitespace text.
+        </div>
+      );
+    case "tokenBudgetUnder":
+      return (
+        <TokenBudgetField
+          predicate={predicate}
+          onChange={onChange}
+          readOnly={readOnly}
+        />
+      );
+  }
+}
+
+// ─── Per-kind field components ────────────────────────────────────────────
+
+function ToolNameField({
+  value,
+  onChange,
+  availableTools,
+  readOnly,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  availableTools?: string[];
+  readOnly: boolean;
+}) {
+  const id = useId();
+  // When a suite has attached servers and we know the tool list, prefer a
+  // dropdown to prevent typos. Fall back to free text otherwise (legacy
+  // suites without an attached server, or for tools the editor doesn't
+  // know about yet).
+  const useDropdown = availableTools && availableTools.length > 0;
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="text-[11px]">
+        Tool
+      </Label>
+      {useDropdown && !readOnly ? (
+        <Select value={value || undefined} onValueChange={onChange}>
+          <SelectTrigger id={id} className="h-8 text-xs">
+            <SelectValue placeholder="Pick a tool…" />
+          </SelectTrigger>
+          <SelectContent>
+            {availableTools!.map((t) => (
+              <SelectItem key={t} value={t} className="text-xs">
+                {t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : (
+        <Input
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="e.g. search"
+          className="h-8 text-xs"
+          disabled={readOnly}
+        />
+      )}
+    </div>
+  );
+}
+
+function ToolCalledWithFields({
+  predicate,
+  onChange,
+  availableTools,
+  readOnly,
+}: {
+  predicate: Extract<Predicate, { type: "toolCalledWith" }>;
+  onChange: (next: Predicate) => void;
+  availableTools?: string[];
+  readOnly: boolean;
+}) {
+  const minCountId = useId();
+  return (
+    <div className="space-y-3">
+      <ToolNameField
+        value={predicate.toolName}
+        onChange={(toolName) => onChange({ ...predicate, toolName })}
+        availableTools={availableTools}
+        readOnly={readOnly}
+      />
+      <ArgMatcherSubform
+        value={predicate.args}
+        onChange={(args) => onChange({ ...predicate, args })}
+        readOnly={readOnly}
+      />
+      <div className="space-y-1">
+        <Label htmlFor={minCountId} className="text-[11px]">
+          Minimum matching calls (optional)
+        </Label>
+        <Input
+          id={minCountId}
+          type="number"
+          min={1}
+          step={1}
+          value={predicate.minCount ?? ""}
+          onChange={(e) => {
+            const raw = e.target.value;
+            if (raw === "") {
+              const next = { ...predicate };
+              delete next.minCount;
+              onChange(next);
+              return;
+            }
+            const n = Number(raw);
+            if (!Number.isFinite(n)) return;
+            onChange({ ...predicate, minCount: Math.floor(n) });
+          }}
+          placeholder="1"
+          className="h-8 w-32 text-xs"
+          disabled={readOnly}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Sub-form for the `toolCalledWith.args` shape: a dropdown for the
+ * argumentMatching mode and a JSON textarea for the args blob. Phase 2
+ * scope: accept JSON shape with placeholder strings as raw text. The
+ * dedicated per-leaf placeholder picker is Phase 3 (not built here).
+ */
+function ArgMatcherSubform({
+  value,
+  onChange,
+  readOnly,
+}: {
+  value: { args: Record<string, unknown>; argumentMatching?: ArgMatchMode };
+  onChange: (next: {
+    args: Record<string, unknown>;
+    argumentMatching?: ArgMatchMode;
+  }) => void;
+  readOnly: boolean;
+}) {
+  const modeId = useId();
+  const argsId = useId();
+  const mode: ArgMatchMode = value.argumentMatching ?? "partial";
+  const [draftJson, setDraftJson] = useState(() => {
+    try {
+      return JSON.stringify(value.args ?? {}, null, 2);
+    } catch {
+      return "{}";
+    }
+  });
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-2">
+      <div className="space-y-1">
+        <Label htmlFor={modeId} className="text-[11px]">
+          Argument matching
+        </Label>
+        <Select
+          value={mode}
+          onValueChange={(next) =>
+            onChange({ ...value, argumentMatching: next as ArgMatchMode })
+          }
+          disabled={readOnly}
+        >
+          <SelectTrigger id={modeId} className="h-8 w-40 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="partial" className="text-xs">
+              Partial (extras ok)
+            </SelectItem>
+            <SelectItem value="exact" className="text-xs">
+              Exact (deep equal)
+            </SelectItem>
+            <SelectItem value="ignore" className="text-xs">
+              Ignore (only tool name matters)
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor={argsId} className="text-[11px]">
+          Expected args (JSON)
+          {mode === "partial" ? (
+            <span className="ml-2 text-muted-foreground font-normal">
+              Placeholders allowed: "string", "number", "boolean", "object",
+              "array", "null", "any"
+            </span>
+          ) : null}
+        </Label>
+        <textarea
+          id={argsId}
+          className={`min-h-[80px] w-full rounded-md border bg-background p-2 font-mono text-[11px] leading-tight ${
+            jsonError ? "border-red-500/60" : "border-border/60"
+          }`}
+          value={draftJson}
+          onChange={(e) => {
+            const next = e.target.value;
+            setDraftJson(next);
+            try {
+              const parsed = JSON.parse(next);
+              if (
+                parsed === null ||
+                typeof parsed !== "object" ||
+                Array.isArray(parsed)
+              ) {
+                setJsonError("Expected a JSON object");
+                return;
+              }
+              setJsonError(null);
+              onChange({ ...value, args: parsed as Record<string, unknown> });
+            } catch (err) {
+              setJsonError(
+                err instanceof Error ? err.message : "Invalid JSON",
+              );
+            }
+          }}
+          spellCheck={false}
+          disabled={readOnly}
+        />
+        {jsonError ? (
+          <div className="text-[11px] text-red-600 dark:text-red-400">
+            {jsonError}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ResponseContainsFields({
+  predicate,
+  onChange,
+  readOnly,
+}: {
+  predicate: Extract<Predicate, { type: "responseContains" }>;
+  onChange: (next: Predicate) => void;
+  readOnly: boolean;
+}) {
+  const needleId = useId();
+  const csId = useId();
+  return (
+    <div className="space-y-2">
+      <div className="space-y-1">
+        <Label htmlFor={needleId} className="text-[11px]">
+          Needle
+        </Label>
+        <Input
+          id={needleId}
+          value={predicate.needle}
+          onChange={(e) => onChange({ ...predicate, needle: e.target.value })}
+          placeholder="e.g. refund issued"
+          className="h-8 text-xs"
+          disabled={readOnly}
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch
+          id={csId}
+          checked={predicate.caseSensitive ?? false}
+          onCheckedChange={(checked) =>
+            onChange({ ...predicate, caseSensitive: checked })
+          }
+          disabled={readOnly}
+        />
+        <Label htmlFor={csId} className="text-[11px]">
+          Case sensitive
+        </Label>
+      </div>
+    </div>
+  );
+}
+
+function ResponseMatchesFields({
+  predicate,
+  onChange,
+  readOnly,
+}: {
+  predicate: Extract<Predicate, { type: "responseMatches" }>;
+  onChange: (next: Predicate) => void;
+  readOnly: boolean;
+}) {
+  const id = useId();
+  // Live-validate the regex on input. An invalid pattern shows inline and the
+  // row-level Zod validation will also flag it (empty pattern). We don't
+  // attempt to detect ReDoS here — the evaluator has its own heuristic guard.
+  let regexError: string | null = null;
+  if (predicate.pattern) {
+    try {
+      new RegExp(predicate.pattern);
+    } catch (e) {
+      regexError = e instanceof Error ? e.message : "Invalid regex";
+    }
+  }
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="text-[11px]">
+        Regex pattern (no surrounding slashes)
+      </Label>
+      <Input
+        id={id}
+        value={predicate.pattern}
+        onChange={(e) => onChange({ ...predicate, pattern: e.target.value })}
+        placeholder="e.g. ^Order #\\d{4} confirmed$"
+        className="h-8 font-mono text-xs"
+        disabled={readOnly}
+      />
+      {regexError ? (
+        <div className="text-[11px] text-red-600 dark:text-red-400">
+          {regexError}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function TokenBudgetField({
+  predicate,
+  onChange,
+  readOnly,
+}: {
+  predicate: Extract<Predicate, { type: "tokenBudgetUnder" }>;
+  onChange: (next: Predicate) => void;
+  readOnly: boolean;
+}) {
+  const id = useId();
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="text-[11px]">
+        Max tokens (strictly under)
+      </Label>
+      <Input
+        id={id}
+        type="number"
+        min={1}
+        step={1}
+        value={predicate.tokens}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          if (!Number.isFinite(n)) return;
+          onChange({ ...predicate, tokens: Math.floor(n) });
+        }}
+        className="h-8 w-32 text-xs"
+        disabled={readOnly}
+      />
+    </div>
+  );
+}
+
+// ─── Case-edit wrapper: 3-state inherit/replace/extend ────────────────────
+
+export interface CaseChecksSectionProps {
+  /** Persisted case-level override; undefined ⇒ inherit suite defaults. */
+  value: CasePredicates | undefined;
+  onChange: (next: CasePredicates | undefined) => void;
+  /** Suite defaults to show in inherit summary and prepend in extend mode. */
+  suiteDefaults: Predicate[];
+  availableTools?: string[];
+}
+
+/**
+ * Resolve a CasePredicates view-model with a default (`inherit`) when
+ * undefined, so the 3-state radio always has a checked value to bind to.
+ */
+function resolveCaseChecks(
+  value: CasePredicates | undefined,
+): CasePredicates {
+  return value ?? { mode: "inherit", list: [] };
+}
+
+export function CaseChecksSection({
+  value,
+  onChange,
+  suiteDefaults,
+  availableTools,
+}: CaseChecksSectionProps) {
+  const resolved = resolveCaseChecks(value);
+  const mode = resolved.mode;
+
+  // When the user toggles modes, preserve a populated list so they can
+  // flip back to replace/extend without losing work (Phase 2 deliverable D).
+  // But clear list to undefined when switching to inherit AND the list is
+  // empty — avoid persisting `{ mode: "inherit", list: [] }` with stale state.
+  const setMode = (next: CasePredicates["mode"]) => {
+    if (next === "inherit" && resolved.list.length === 0) {
+      onChange(undefined);
+      return;
+    }
+    onChange({ mode: next, list: resolved.list });
+  };
+
+  const setList = (list: Predicate[]) => {
+    onChange({ mode, list });
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border bg-muted/20 p-4">
+      <div>
+        <h3 className="text-sm font-semibold text-foreground">Checks</h3>
+        <p className="text-xs text-muted-foreground mt-1">
+          Deterministic checks for this case. Inherit, replace, or extend the
+          suite&apos;s default checks.
+        </p>
+      </div>
+
+      <fieldset className="space-y-1">
+        <legend className="sr-only">Check inheritance mode</legend>
+        <RadioRow
+          name="case-checks-mode"
+          value="inherit"
+          checked={mode === "inherit"}
+          onChange={setMode}
+          label="Inherit suite defaults"
+        />
+        <RadioRow
+          name="case-checks-mode"
+          value="replace"
+          checked={mode === "replace"}
+          onChange={setMode}
+          label="Replace suite defaults"
+        />
+        <RadioRow
+          name="case-checks-mode"
+          value="extend"
+          checked={mode === "extend"}
+          onChange={setMode}
+          label="Extend suite defaults"
+        />
+      </fieldset>
+
+      {mode === "inherit" ? (
+        <div className="rounded-md border border-border/40 bg-background p-3 text-xs text-muted-foreground">
+          {suiteDefaults.length === 0
+            ? "Suite has no default checks. This case will be ungated."
+            : `${suiteDefaults.length} check${suiteDefaults.length === 1 ? "" : "s"} inherited from suite — view defaults on the suite settings page.`}
+        </div>
+      ) : null}
+
+      {mode === "extend" && suiteDefaults.length > 0 ? (
+        <div className="space-y-2 opacity-70">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Inherited from suite ({suiteDefaults.length})
+          </div>
+          <ChecksSection
+            value={suiteDefaults}
+            onChange={() => {}}
+            availableTools={availableTools}
+            title=""
+            readOnly
+          />
+        </div>
+      ) : null}
+
+      {mode === "replace" || mode === "extend" ? (
+        <ChecksSection
+          value={resolved.list}
+          onChange={setList}
+          availableTools={availableTools}
+          title={mode === "extend" ? "Additional checks for this case" : "Checks for this case"}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function RadioRow({
+  name,
+  value,
+  checked,
+  onChange,
+  label,
+}: {
+  name: string;
+  value: CasePredicates["mode"];
+  checked: boolean;
+  onChange: (next: CasePredicates["mode"]) => void;
+  label: string;
+}) {
+  const id = useId();
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        id={id}
+        type="radio"
+        name={name}
+        checked={checked}
+        onChange={() => onChange(value)}
+        className="h-3 w-3"
+      />
+      <Label htmlFor={id} className="text-xs cursor-pointer">
+        {label}
+      </Label>
+    </div>
+  );
+}
+
+// ─── Utilities ────────────────────────────────────────────────────────────
+
+/**
+ * True iff every predicate in `list` passes the SDK Zod schema. Callers
+ * (suite-edit / case-edit) thread this into Save-button disabled state so
+ * the user can't persist a malformed row.
+ */
+export function areAllChecksValid(list: Predicate[]): boolean {
+  return list.every((p) => predicateSchema.safeParse(p).success);
+}

--- a/mcpjam-inspector/client/src/components/evals/iteration-row.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-row.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import { EvalIteration, EvalCase } from "./types";
 import { evalStatusLeftBorderClasses, formatRunId } from "./helpers";
+import { parseIterationPredicates } from "./predicates-list";
 
 interface IterationRowProps {
   iteration: EvalIteration;
@@ -34,6 +35,20 @@ export function CompactIterationRow({
   const isPending = iteration.result === "pending";
 
   const actualToolCalls = iteration.actualToolCalls || [];
+
+  // X/Y checks passed badge — read from the same parsed predicate verdicts
+  // PredicatesList renders. User-facing wording is "checks"; the internal
+  // data is `metadata.predicates` (the SDK-defined PredicateResult[] shape).
+  const predicates = parseIterationPredicates(iteration.metadata);
+  const checksBadge =
+    predicates && predicates.length > 0
+      ? {
+          total: predicates.length,
+          passed: predicates.filter((p) => p.passed).length,
+        }
+      : null;
+  const allChecksPassed =
+    checksBadge !== null && checksBadge.passed === checksBadge.total;
 
   return (
     <div
@@ -72,6 +87,19 @@ export function CompactIterationRow({
           <span className="text-xs text-muted-foreground font-mono min-w-[70px] max-w-[70px] text-right">
             {durationMs !== null ? formatDuration(durationMs) : "—"}
           </span>
+          {checksBadge ? (
+            <span
+              className={cn(
+                "text-[10px] font-semibold rounded px-1.5 py-0.5 min-w-[100px] max-w-[110px] text-center",
+                allChecksPassed
+                  ? "bg-green-500/15 text-green-700 dark:text-green-300"
+                  : "bg-red-500/15 text-red-700 dark:text-red-300",
+              )}
+              title={`${checksBadge.passed} of ${checksBadge.total} deterministic checks passed`}
+            >
+              {checksBadge.passed} / {checksBadge.total} checks
+            </span>
+          ) : null}
           {isPending && (
             <div className="flex items-center min-w-[40px]">
               <Loader2 className="h-3.5 w-3.5 animate-spin text-warning" />

--- a/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
@@ -50,12 +50,12 @@ export function PredicatesList({ predicates }: { predicates: PredicateResult[] }
   return (
     <div
       role="region"
-      aria-label="Predicate gate"
+      aria-label="Checks"
       className="space-y-2 rounded-md border border-border/40 bg-muted/10 p-3"
     >
       <div className="flex items-center justify-between">
         <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Predicates
+          Checks
         </div>
         <div
           className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${
@@ -64,7 +64,9 @@ export function PredicatesList({ predicates }: { predicates: PredicateResult[] }
               : "bg-red-500/15 text-red-700 dark:text-red-300"
           }`}
         >
-          {allPassed ? "PASS" : `${passed}/${predicates.length} PASSED`}
+          {allPassed
+            ? `${predicates.length} / ${predicates.length} checks passed`
+            : `${passed} / ${predicates.length} checks passed`}
         </div>
       </div>
 
@@ -143,6 +145,8 @@ export function summarizePredicate(predicate: Predicate): string {
         return `tool "${predicate.toolName}" called ≥1×`;
       case "toolNeverCalled":
         return `tool "${predicate.toolName}" never called`;
+      case "firstToolWas":
+        return `first tool was "${predicate.toolName}"`;
       case "responseContains":
         return `needle "${truncate(predicate.needle, 60)}"${
           predicate.caseSensitive ? " (case-sensitive)" : ""

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -16,7 +16,8 @@ import { TestTemplateEditor } from "./test-template-editor";
 import { PassCriteriaSelector } from "./pass-criteria-selector";
 import { ValidatorsSection } from "./validators-section";
 import { JudgesSection } from "./judges-section";
-import type { EvalMatchOptions } from "@/shared/eval-matching";
+import { ChecksSection } from "./checks-section";
+import type { EvalMatchOptions, Predicate } from "@/shared/eval-matching";
 import { MATCH_OPTIONS_DEFAULTS } from "@/shared/eval-matching";
 import { TestCasesOverview } from "./test-cases-overview";
 import { TestCaseDetailView } from "./test-case-detail-view";
@@ -1132,6 +1133,31 @@ export function SuiteIterationsView({
                       "Failed to update default validators:",
                       error
                     );
+                  }
+                }}
+              />
+            </div>
+
+            {/* Default checks (predicate gate) — suite-level deterministic
+                checks applied to every case unless the case opts out via its
+                `predicates.mode`. Phase 2 plan: primary authoring surface. */}
+            <div className="space-y-3">
+              <ChecksSection
+                title="Default checks"
+                description="Deterministic checks applied to every case in this suite. Cases can override or extend these defaults."
+                value={suite.defaultPredicates ?? []}
+                onChange={async (next: Predicate[]) => {
+                  try {
+                    await updateSuite({
+                      suiteId: suite._id,
+                      defaultPredicates: next.length === 0 ? null : next,
+                    });
+                    toast.success("Default checks updated");
+                  } catch (error) {
+                    toast.error(
+                      getBillingErrorMessage(error, "Failed to update suite"),
+                    );
+                    console.error("Failed to update default checks:", error);
                   }
                 }}
               />

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -61,7 +61,10 @@ import { normalizeToolChoice } from "@/shared/tool-choice";
 import {
   resolveMatchOptions,
   type EvalMatchOptions,
+  type CasePredicates,
+  type Predicate,
 } from "@/shared/eval-matching";
+import { CaseChecksSection, areAllChecksValid } from "./checks-section";
 import {
   emptyHostConfigInputV2,
   hostConfigDtoToInput,
@@ -128,6 +131,8 @@ interface TestTemplate {
   promptTurns: PromptTurn[];
   advancedConfig?: Record<string, unknown>;
   matchOptions?: EvalMatchOptions;
+  /** Case-level predicate gate override; undefined ⇒ inherit suite defaults. */
+  predicates?: CasePredicates;
 }
 
 interface TestTemplateEditorProps {
@@ -522,6 +527,7 @@ export function TestTemplateEditor({
       promptTurns,
       advancedConfig: normalizeAdvancedConfig(currentTestCase.advancedConfig),
       matchOptions: currentTestCase.matchOptions,
+      predicates: currentTestCase.predicates,
     });
     setExpandedPromptTurnIds(promptTurns.map((turn) => turn.id));
     // Seed the transient picker from the persisted runs so a user who saved
@@ -652,6 +658,12 @@ export function TestTemplateEditor({
     const normalizedCurrentMatchOptions = JSON.stringify(
       normalizeForComparison(currentTestCase.matchOptions ?? null)
     );
+    const normalizedPredicates = JSON.stringify(
+      normalizeForComparison(editForm.predicates ?? null),
+    );
+    const normalizedCurrentPredicates = JSON.stringify(
+      normalizeForComparison(currentTestCase.predicates ?? null),
+    );
 
     return (
       editForm.title !== currentTestCase.title ||
@@ -660,6 +672,7 @@ export function TestTemplateEditor({
       normalizedPromptTurns !== normalizedCurrentPromptTurns ||
       normalizedAdvancedConfig !== normalizedCurrentAdvancedConfig ||
       normalizedMatchOptions !== normalizedCurrentMatchOptions ||
+      normalizedPredicates !== normalizedCurrentPredicates ||
       serverNegativeFlagMismatch
     );
   }, [editForm, currentAdvancedConfig, currentPromptTurns, currentTestCase]);
@@ -669,7 +682,13 @@ export function TestTemplateEditor({
     return validatePromptTurns(editForm.promptTurns);
   }, [editForm]);
 
-  const savePrimaryDisabled = !arePromptTurnsValid || isRunningCompare;
+  const arePredicatesValid = useMemo(() => {
+    if (!editForm?.predicates) return true;
+    return areAllChecksValid(editForm.predicates.list);
+  }, [editForm?.predicates]);
+
+  const savePrimaryDisabled =
+    !arePromptTurnsValid || !arePredicatesValid || isRunningCompare;
 
   const saveDisabledTooltip = useMemo(() => {
     if (!savePrimaryDisabled) {
@@ -825,6 +844,7 @@ export function TestTemplateEditor({
       isNegativeTest,
       advancedConfig: normalizeAdvancedConfig(form.advancedConfig),
       matchOptions: form.matchOptions,
+      predicates: form.predicates,
     };
   };
 
@@ -867,6 +887,8 @@ export function TestTemplateEditor({
         // Pass `null` (not undefined) so the mutation knows to clear a
         // previously-persisted case-level override when the user resets it.
         matchOptions: savePayload.matchOptions ?? null,
+        // Same null-clears-the-field convention for the predicate override.
+        predicates: savePayload.predicates ?? null,
       });
       toast.success("Changes saved");
     } catch (error) {
@@ -920,6 +942,7 @@ export function TestTemplateEditor({
             // null (not undefined) signals "clear" — required to wipe a
             // previously-persisted case-level matchOptions override.
             matchOptions: savePayload.matchOptions ?? null,
+            predicates: savePayload.predicates ?? null,
           }
         : {}),
       ...(modelsUnchanged ? {} : { models: nextModels }),
@@ -2089,6 +2112,19 @@ export function TestTemplateEditor({
                   }
                 />
               </div>
+            ) : null}
+
+            {editForm ? (
+              <CaseChecksSection
+                value={editForm.predicates}
+                onChange={(next: CasePredicates | undefined) =>
+                  setEditForm((current) =>
+                    current ? { ...current, predicates: next } : current,
+                  )
+                }
+                suiteDefaults={(suite?.defaultPredicates ?? []) as Predicate[]}
+                availableTools={availableTools.map((t) => t.name)}
+              />
             ) : null}
 
             {currentTestCase.lastMessageRun ? (

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -1,7 +1,11 @@
 import type { PromptTurn, PromptTurnToolCall } from "@/shared/prompt-turns";
 import type { EvalTraceBlobV1 } from "@/shared/eval-trace";
 import type { EvalStreamToolCall } from "@/shared/eval-stream-events";
-import type { EvalMatchOptions } from "@/shared/eval-matching";
+import type {
+  EvalMatchOptions,
+  Predicate,
+  CasePredicates,
+} from "@/shared/eval-matching";
 import type { TraceEnvelope, TraceMessage } from "./trace-viewer-adapter";
 
 export type EvalSuiteConfigTest = {
@@ -48,6 +52,13 @@ export type EvalSuite = {
   };
   /** Suite-level default validator options (used unless a case overrides). */
   defaultMatchOptions?: EvalMatchOptions;
+  /**
+   * Suite-level default deterministic predicate gate ("Default checks" in UI).
+   * Resolved per-case via `testCase.predicates.mode` (`inherit` ⇒ use as-is,
+   * `replace` ⇒ ignored, `extend` ⇒ prepended to case list). Snapshotted onto
+   * `testIteration.testCaseSnapshot.predicates` at run-precreate time.
+   */
+  defaultPredicates?: Predicate[];
   /**
    * Suite-level advisory judge configuration. Authoritative source for
    * judgeModel / threshold / enabled flag — runs snapshot this at
@@ -122,6 +133,13 @@ export type EvalCase = {
   advancedConfig?: Record<string, unknown>;
   /** Case-level validator override; merged on top of suite defaults. */
   matchOptions?: EvalMatchOptions;
+  /**
+   * Case-level predicate gate override. Three explicit modes (`inherit`,
+   * `replace`, `extend`) eliminate the predicates / additionalPredicates
+   * ambiguity (Phase 2 plan). `undefined` is treated as
+   * `{ mode: "inherit", list: [] }`.
+   */
+  predicates?: CasePredicates;
   /**
    * Per-case judge override. V1 carries opt-out only — no alt model or
    * threshold (see backend `convex/lib/judgeConfig.ts` for rationale).

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -36,6 +36,7 @@ import { type PromptTurn } from "@/shared/prompt-turns";
 import {
   matchOptionsSchema,
   resolveMatchOptions,
+  casePredicatesSchema,
   type MatchOptionsDTO,
 } from "@/shared/eval-matching";
 
@@ -90,6 +91,10 @@ export const RunEvalsRequestSchema = z.object({
         .passthrough()
         .optional(),
       matchOptions: matchOptionsSchema.optional(),
+      // Case-level predicate gate override; threaded through every Zod
+      // boundary on the wire so it doesn't get silently stripped
+      // (feedback_zod_strips_unthreaded_fields).
+      predicates: casePredicatesSchema.optional(),
     }),
   ),
   serverIds: z
@@ -186,6 +191,10 @@ export const RunTestCaseRequestSchema = z.object({
       // validator at authoring time and evaluated deterministically by the
       // runner (unknown types fail closed).
       successPredicates: z.array(z.any()).optional(),
+      // Case-level predicate override envelope ({ mode, list }). Threaded
+      // through every Zod boundary; the runner resolves it against the
+      // suite's `defaultPredicates` per the case mode.
+      predicates: casePredicatesSchema.optional(),
     })
     .optional(),
   /**
@@ -514,6 +523,7 @@ export async function runEvalsWithManager(
       judgeRequirement?: string;
       advancedConfig?: any;
       matchOptions?: import("@/shared/eval-matching").MatchOptionsDTO;
+      predicates?: import("@/shared/eval-matching").CasePredicates;
     }
   >();
 
@@ -532,6 +542,7 @@ export async function runEvalsWithManager(
         promptTurns: test.promptTurns,
         advancedConfig: test.advancedConfig,
         matchOptions: test.matchOptions,
+        predicates: test.predicates,
       });
     }
     testCaseMap.get(key)!.models.push({
@@ -622,6 +633,11 @@ export async function runEvalsWithManager(
             normalizeForComparison(existingTestCase.matchOptions),
           ) !==
           JSON.stringify(normalizeForComparison(testCaseData.matchOptions));
+        const predicatesChanged =
+          JSON.stringify(
+            normalizeForComparison(existingTestCase.predicates),
+          ) !==
+          JSON.stringify(normalizeForComparison(testCaseData.predicates));
 
         const hasChanges =
           modelsChanged ||
@@ -633,7 +649,8 @@ export async function runEvalsWithManager(
           promptTurnsChanged ||
           judgeRequirementChanged ||
           advancedConfigChanged ||
-          matchOptionsChanged;
+          matchOptionsChanged ||
+          predicatesChanged;
 
         if (hasChanges) {
           await convexClient.mutation("testSuites:updateTestCase" as any, {
@@ -651,6 +668,7 @@ export async function runEvalsWithManager(
               testCaseData.advancedConfig,
             ),
             matchOptions: testCaseData.matchOptions,
+            predicates: testCaseData.predicates,
           });
         }
       } else {
@@ -672,6 +690,7 @@ export async function runEvalsWithManager(
             testCaseData.advancedConfig,
           ),
           matchOptions: testCaseData.matchOptions,
+          predicates: testCaseData.predicates,
         });
       }
     }
@@ -711,6 +730,7 @@ export async function runEvalsWithManager(
         judgeRequirement: testCaseData.judgeRequirement,
         advancedConfig: sanitizeForConvexTransport(testCaseData.advancedConfig),
         matchOptions: testCaseData.matchOptions,
+        predicates: testCaseData.predicates,
       });
     }
   }

--- a/mcpjam-inspector/shared/eval-matching.ts
+++ b/mcpjam-inspector/shared/eval-matching.ts
@@ -146,6 +146,11 @@ export {
   evaluatePredicates,
   allPredicatesPassed,
   buildIterationTranscript,
+  predicateSchema,
+  predicateArraySchema,
+  argMatcherSchema,
+  casePredicatesSchema,
+  PREDICATE_PLACEHOLDER_STRINGS,
 } from "@mcpjam/sdk/predicates";
 export type {
   Predicate,
@@ -158,4 +163,6 @@ export type {
   TranscriptUsage,
   ToolErrorRecord,
   ToolErrorKind,
+  CasePredicates,
+  PredicatePlaceholder,
 } from "@mcpjam/sdk/predicates";

--- a/sdk/src/predicates/evaluate.ts
+++ b/sdk/src/predicates/evaluate.ts
@@ -214,6 +214,34 @@ export function evaluatePredicate(
         : fail(predicate, `tool "${predicate.toolName}" was never called`);
     }
 
+    case "firstToolWas": {
+      // A missing toolName would otherwise PASS any transcript whose first call
+      // happens to satisfy `undefined === undefined` after read — fail closed.
+      if (
+        typeof predicate.toolName !== "string" ||
+        predicate.toolName.length === 0
+      ) {
+        return fail(predicate, `firstToolWas requires a non-empty toolName`);
+      }
+      const first = (transcript.toolCalls ?? [])[0];
+      if (!first) {
+        return fail(
+          predicate,
+          `expected first tool "${predicate.toolName}" but no tools were called`,
+        );
+      }
+      // Hard Constraint 4 (plan): tool calls carry `.toolName`, not `.name`.
+      return first.toolName === predicate.toolName
+        ? pass(
+            predicate,
+            `first tool call was "${predicate.toolName}"`,
+          )
+        : fail(
+            predicate,
+            `expected first tool "${predicate.toolName}", got "${first.toolName}"`,
+          );
+    }
+
     case "toolNeverCalled": {
       // A missing toolName matches no calls, which would otherwise PASS the
       // forbidden-tool check — fail closed on a malformed predicate instead.

--- a/sdk/src/predicates/index.ts
+++ b/sdk/src/predicates/index.ts
@@ -27,4 +27,13 @@ export type {
   TranscriptUsage,
   ToolErrorRecord,
   ToolErrorKind,
+  CasePredicates,
+  PredicatePlaceholder,
+} from "./types.js";
+export {
+  predicateSchema,
+  predicateArraySchema,
+  argMatcherSchema,
+  casePredicatesSchema,
+  PREDICATE_PLACEHOLDER_STRINGS,
 } from "./types.js";

--- a/sdk/src/predicates/types.ts
+++ b/sdk/src/predicates/types.ts
@@ -7,7 +7,7 @@
  * the property a CI release gate requires and a stochastic LLM judge cannot
  * provide. The `serverQuality` LLM judge remains the advisory **insight** layer.
  *
- * The union is intentionally small (8 types). It grows only when a real corpus
+ * The union is intentionally small (9 types). It grows only when a real corpus
  * task demands a new one — not speculatively.
  *
  * Hosted in `@mcpjam/sdk` (browser-safe; reuses the `../matchers` argument
@@ -15,6 +15,7 @@
  * implementation.
  */
 
+import { z } from "zod";
 import type { EvalMatchOptions } from "../matchers.js";
 
 /**
@@ -56,6 +57,8 @@ export type Predicate =
   | { type: "toolCalledAtLeastOnce"; toolName: string }
   /** `toolName` was never called (forbidden tool). */
   | { type: "toolNeverCalled"; toolName: string }
+  /** The first tool call observed in the transcript was `toolName`. */
+  | { type: "firstToolWas"; toolName: string }
   /** The final assistant message contains `needle`. Case-insensitive unless `caseSensitive`. */
   | { type: "responseContains"; needle: string; caseSensitive?: boolean }
   /** The final assistant message matches the regular expression `pattern` (regex source, no flags). */
@@ -69,6 +72,106 @@ export type Predicate =
 
 /** The `type` discriminants of {@link Predicate}, for validators. */
 export type PredicateType = Predicate["type"];
+
+// ─── Zod schemas ──────────────────────────────────────────────────────────
+//
+// The predicate union is the wire shape both the inspector forms and the
+// `mcpjam eval` CLI persist into Convex. Convex has its own hand-mirrored
+// `v.union` (Hard Constraint 1: no `@mcpjam/sdk` imports in `convex/`).
+// Parity between the two is proven via the JSON fixtures in
+// `sdk/tests/fixtures/predicates-parity-fixtures.json` (and its sibling in
+// `mcpjam-backend`). Adding a 10th kind requires editing both validator files
+// and the fixtures in the same PR.
+
+/**
+ * Placeholder strings the matcher's `partial` mode treats as type checks
+ * instead of literal equality. Exposed as a Zod literal union so authoring
+ * UIs can offer them as drop-down options when constructing arg matchers.
+ *
+ * The actual leaf may also be any JSON literal (string/number/boolean/object/
+ * array/null) — that's not captured here because the args blob is
+ * `z.record(z.string(), z.unknown())` at the wire boundary.
+ */
+export const PREDICATE_PLACEHOLDER_STRINGS = [
+  "any",
+  "string",
+  "number",
+  "boolean",
+  "object",
+  "array",
+  "null",
+] as const;
+
+/** Zod schema for {@link ArgMatcher}. `args` is unrestricted JSON. */
+export const argMatcherSchema = z.object({
+  args: z.record(z.string(), z.unknown()),
+  argumentMatching: z.enum(["exact", "partial", "ignore"]).optional(),
+});
+
+/**
+ * Zod schema for {@link Predicate}. Uses `z.discriminatedUnion` on `type`
+ * so authoring-side validation surfaces a precise error (e.g. "unknown
+ * predicate type 'firstToolWass'") rather than a generic union failure.
+ */
+export const predicateSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("toolCalledWith"),
+    toolName: z.string().min(1),
+    args: argMatcherSchema,
+    minCount: z.number().int().positive().optional(),
+  }),
+  z.object({
+    type: z.literal("toolCalledAtLeastOnce"),
+    toolName: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal("toolNeverCalled"),
+    toolName: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal("firstToolWas"),
+    toolName: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal("responseContains"),
+    needle: z.string().min(1),
+    caseSensitive: z.boolean().optional(),
+  }),
+  z.object({
+    type: z.literal("responseMatches"),
+    pattern: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal("noToolErrors"),
+  }),
+  z.object({
+    type: z.literal("finalAssistantMessageNonEmpty"),
+  }),
+  z.object({
+    type: z.literal("tokenBudgetUnder"),
+    tokens: z.number().int().positive(),
+  }),
+]);
+
+/** Array of predicates — used for both suite defaults and case overrides. */
+export const predicateArraySchema = z.array(predicateSchema);
+
+/**
+ * Case-level predicate override envelope. The {@link mode} eliminates the
+ * `predicates`/`additionalPredicates` ambiguity (see plan Phase 2):
+ *
+ *   - `inherit` — effective predicates = suite defaults (`list` ignored).
+ *   - `replace` — effective predicates = `list`.
+ *   - `extend`  — effective predicates = suite defaults followed by `list`.
+ */
+export const casePredicatesSchema = z.object({
+  mode: z.enum(["inherit", "replace", "extend"]),
+  list: z.array(predicateSchema),
+});
+
+export type CasePredicates = z.infer<typeof casePredicatesSchema>;
+export type PredicatePlaceholder =
+  (typeof PREDICATE_PLACEHOLDER_STRINGS)[number];
 
 /**
  * How a tool failure surfaced. The plan requires `noToolErrors` to distinguish

--- a/sdk/tests/fixtures/predicates-parity-fixtures.json
+++ b/sdk/tests/fixtures/predicates-parity-fixtures.json
@@ -1,0 +1,235 @@
+{
+  "__readme": "Shared parity fixtures for the @mcpjam/sdk Zod `predicateSchema` (this repo: mcpjam-inspector) and the Convex hand-mirrored `predicateValidator` v.union (sibling repo: mcpjam-backend at tests/convex/fixtures/predicates-parity-fixtures.json). The two files MUST stay in sync — every accept here must parse on both sides; every reject must fail on both sides. A future PR will publish them as a shared package. When adding a new predicate kind, edit BOTH files in the SAME PR (Phase 2 plan: jaunty-wiggling-lecun.md).",
+  "accept": [
+    {
+      "label": "toolCalledWith — minimal (only required fields)",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "search",
+        "args": { "args": {} }
+      }
+    },
+    {
+      "label": "toolCalledWith — all optional fields populated",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "book_flight",
+        "args": {
+          "args": { "airline": "DL", "seat": "1A" },
+          "argumentMatching": "partial"
+        },
+        "minCount": 2
+      }
+    },
+    {
+      "label": "toolCalledWith — exact argumentMatching",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "echo",
+        "args": { "args": { "msg": "hi" }, "argumentMatching": "exact" }
+      }
+    },
+    {
+      "label": "toolCalledWith — ignore argumentMatching (args still required)",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "ping",
+        "args": { "args": {}, "argumentMatching": "ignore" }
+      }
+    },
+    {
+      "label": "toolCalledWith — partial with placeholder strings",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "fs.read",
+        "args": {
+          "args": { "path": "string", "count": "number" },
+          "argumentMatching": "partial"
+        }
+      }
+    },
+    {
+      "label": "toolCalledAtLeastOnce — minimal",
+      "value": { "type": "toolCalledAtLeastOnce", "toolName": "search" }
+    },
+    {
+      "label": "toolCalledAtLeastOnce — long tool name",
+      "value": {
+        "type": "toolCalledAtLeastOnce",
+        "toolName": "very.deeply.namespaced.tool"
+      }
+    },
+    {
+      "label": "toolNeverCalled — minimal",
+      "value": { "type": "toolNeverCalled", "toolName": "delete_account" }
+    },
+    {
+      "label": "toolNeverCalled — long tool name",
+      "value": {
+        "type": "toolNeverCalled",
+        "toolName": "admin.dangerous.purge"
+      }
+    },
+    {
+      "label": "firstToolWas — minimal",
+      "value": { "type": "firstToolWas", "toolName": "search" }
+    },
+    {
+      "label": "firstToolWas — alternate tool name",
+      "value": { "type": "firstToolWas", "toolName": "list_dir" }
+    },
+    {
+      "label": "responseContains — minimal (no caseSensitive)",
+      "value": { "type": "responseContains", "needle": "refund issued" }
+    },
+    {
+      "label": "responseContains — caseSensitive true",
+      "value": {
+        "type": "responseContains",
+        "needle": "ERROR",
+        "caseSensitive": true
+      }
+    },
+    {
+      "label": "responseMatches — minimal regex",
+      "value": { "type": "responseMatches", "pattern": "\\d+" }
+    },
+    {
+      "label": "responseMatches — anchored regex",
+      "value": { "type": "responseMatches", "pattern": "^Order #\\d{4} confirmed$" }
+    },
+    {
+      "label": "noToolErrors — no fields beyond type",
+      "value": { "type": "noToolErrors" }
+    },
+    {
+      "label": "noToolErrors — second example (still no fields)",
+      "value": { "type": "noToolErrors" }
+    },
+    {
+      "label": "finalAssistantMessageNonEmpty — no fields beyond type",
+      "value": { "type": "finalAssistantMessageNonEmpty" }
+    },
+    {
+      "label": "finalAssistantMessageNonEmpty — second example",
+      "value": { "type": "finalAssistantMessageNonEmpty" }
+    },
+    {
+      "label": "tokenBudgetUnder — minimal",
+      "value": { "type": "tokenBudgetUnder", "tokens": 1000 }
+    },
+    {
+      "label": "tokenBudgetUnder — large budget",
+      "value": { "type": "tokenBudgetUnder", "tokens": 100000 }
+    }
+  ],
+  "reject": [
+    {
+      "label": "missing type discriminator",
+      "value": { "toolName": "search" }
+    },
+    {
+      "label": "unknown predicate kind",
+      "value": { "type": "toolMaybeCalled", "toolName": "search" }
+    },
+    {
+      "label": "toolCalledWith — toolName is a number (wrong field type)",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": 42,
+        "args": { "args": {} }
+      }
+    },
+    {
+      "label": "toolCalledWith — args is missing",
+      "value": { "type": "toolCalledWith", "toolName": "search" }
+    },
+    {
+      "label": "toolCalledWith — illegal argumentMatching enum value",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "search",
+        "args": { "args": {}, "argumentMatching": "fuzzy" }
+      }
+    },
+    {
+      "label": "toolCalledWith — negative minCount",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "search",
+        "args": { "args": {} },
+        "minCount": -1
+      }
+    },
+    {
+      "label": "toolCalledWith — zero minCount (must be positive)",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "search",
+        "args": { "args": {} },
+        "minCount": 0
+      }
+    },
+    {
+      "label": "toolCalledWith — fractional minCount",
+      "value": {
+        "type": "toolCalledWith",
+        "toolName": "search",
+        "args": { "args": {} },
+        "minCount": 1.5
+      }
+    },
+    {
+      "label": "toolCalledAtLeastOnce — empty toolName",
+      "value": { "type": "toolCalledAtLeastOnce", "toolName": "" }
+    },
+    {
+      "label": "toolNeverCalled — toolName is null",
+      "value": { "type": "toolNeverCalled", "toolName": null }
+    },
+    {
+      "label": "firstToolWas — missing toolName",
+      "value": { "type": "firstToolWas" }
+    },
+    {
+      "label": "firstToolWas — empty toolName",
+      "value": { "type": "firstToolWas", "toolName": "" }
+    },
+    {
+      "label": "responseContains — empty needle",
+      "value": { "type": "responseContains", "needle": "" }
+    },
+    {
+      "label": "responseContains — caseSensitive is a string",
+      "value": {
+        "type": "responseContains",
+        "needle": "ok",
+        "caseSensitive": "yes"
+      }
+    },
+    {
+      "label": "responseMatches — empty pattern",
+      "value": { "type": "responseMatches", "pattern": "" }
+    },
+    {
+      "label": "responseMatches — non-string pattern (number)",
+      "value": { "type": "responseMatches", "pattern": 42 }
+    },
+    {
+      "label": "tokenBudgetUnder — negative tokens",
+      "value": { "type": "tokenBudgetUnder", "tokens": -1 }
+    },
+    {
+      "label": "tokenBudgetUnder — zero tokens (must be positive)",
+      "value": { "type": "tokenBudgetUnder", "tokens": 0 }
+    },
+    {
+      "label": "tokenBudgetUnder — fractional tokens",
+      "value": { "type": "tokenBudgetUnder", "tokens": 100.5 }
+    },
+    {
+      "label": "tokenBudgetUnder — tokens missing",
+      "value": { "type": "tokenBudgetUnder" }
+    }
+  ]
+}

--- a/sdk/tests/predicate-evaluate.test.ts
+++ b/sdk/tests/predicate-evaluate.test.ts
@@ -112,6 +112,48 @@ describe("evaluatePredicate — table driven", () => {
       reasonIncludes: ["never called"],
     },
 
+    // ── firstToolWas ──────────────────────────────────────────────────
+    {
+      name: "firstToolWas: first call matches passes",
+      transcript: transcript({
+        toolCalls: [
+          { toolName: "search", arguments: { q: "x" } },
+          { toolName: "book_flight", arguments: {} },
+        ],
+      }),
+      predicate: { type: "firstToolWas", toolName: "search" },
+      passed: true,
+      reasonIncludes: ["first tool call was", "search"],
+    },
+    {
+      name: "firstToolWas: different first call fails with names in reason",
+      transcript: transcript({
+        toolCalls: [
+          { toolName: "book_flight", arguments: {} },
+          { toolName: "search", arguments: {} },
+        ],
+      }),
+      predicate: { type: "firstToolWas", toolName: "search" },
+      passed: false,
+      reasonIncludes: ["search", "book_flight"],
+    },
+    {
+      name: "firstToolWas: zero tool calls fails closed",
+      transcript: transcript({ toolCalls: [] }),
+      predicate: { type: "firstToolWas", toolName: "search" },
+      passed: false,
+      reasonIncludes: ["no tools were called"],
+    },
+    {
+      name: "firstToolWas: missing toolName fails closed",
+      transcript: transcript({
+        toolCalls: [{ toolName: "search", arguments: {} }],
+      }),
+      predicate: { type: "firstToolWas" } as unknown as Predicate,
+      passed: false,
+      reasonIncludes: ["non-empty toolName"],
+    },
+
     // ── toolNeverCalled ───────────────────────────────────────────────
     {
       name: "toolNeverCalled: forbidden tool absent passes",

--- a/sdk/tests/predicates-parity.test.ts
+++ b/sdk/tests/predicates-parity.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Parity test for the predicate Zod schema vs. the hand-mirrored Convex
+ * `v.union(...)` in `mcpjam-backend/convex/lib/predicates.ts` (or wherever
+ * the backend lands it). The two validators cannot be compared directly
+ * because backend tests cannot import `@mcpjam/sdk` (Hard Constraint 1 in
+ * the Phase 2 plan: no SDK imports in `convex/`).
+ *
+ * Instead, both repos load the SAME JSON fixtures file (mirrored at
+ * `sdk/tests/fixtures/predicates-parity-fixtures.json` here and at
+ * `tests/convex/fixtures/predicates-parity-fixtures.json` in the backend
+ * repo) and each side asserts its own validator accepts every `accept`
+ * row and rejects every `reject` row. If the two ever drift, both
+ * validators will continue to agree internally but diverge from each
+ * other — the per-PR check is to keep the two fixture files in lockstep
+ * (the README key at the top of the JSON spells this out).
+ */
+
+import { describe, it, expect } from "vitest";
+import fixtures from "./fixtures/predicates-parity-fixtures.json" with { type: "json" };
+import { predicateSchema } from "../src/predicates/types";
+
+type FixtureRow = { label: string; value: unknown };
+type FixturesFile = {
+  __readme?: string;
+  accept: FixtureRow[];
+  reject: FixtureRow[];
+};
+
+const data = fixtures as FixturesFile;
+
+describe("predicate parity fixtures — Zod (@mcpjam/sdk side)", () => {
+  it("fixtures file has both accept and reject cohorts and a README", () => {
+    expect(typeof data.__readme).toBe("string");
+    expect(Array.isArray(data.accept)).toBe(true);
+    expect(Array.isArray(data.reject)).toBe(true);
+    expect(data.accept.length).toBeGreaterThan(0);
+    expect(data.reject.length).toBeGreaterThan(0);
+  });
+
+  it("covers each of the 9 predicate kinds with ≥2 accept examples", () => {
+    const kinds = [
+      "toolCalledWith",
+      "toolCalledAtLeastOnce",
+      "toolNeverCalled",
+      "firstToolWas",
+      "responseContains",
+      "responseMatches",
+      "noToolErrors",
+      "finalAssistantMessageNonEmpty",
+      "tokenBudgetUnder",
+    ];
+    for (const kind of kinds) {
+      const matching = data.accept.filter(
+        (r) =>
+          r.value &&
+          typeof r.value === "object" &&
+          (r.value as Record<string, unknown>).type === kind,
+      );
+      expect(
+        matching.length,
+        `expected ≥2 accept examples for kind "${kind}", got ${matching.length}`,
+      ).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  describe("accept[]", () => {
+    for (const row of data.accept) {
+      it(`accepts: ${row.label}`, () => {
+        const parsed = predicateSchema.safeParse(row.value);
+        if (!parsed.success) {
+          // Surface zod's error in the message for fast diagnosis.
+          throw new Error(
+            `Expected accept, got reject for "${row.label}":\n${JSON.stringify(parsed.error.issues, null, 2)}`,
+          );
+        }
+        expect(parsed.success).toBe(true);
+      });
+    }
+  });
+
+  describe("reject[]", () => {
+    for (const row of data.reject) {
+      it(`rejects: ${row.label}`, () => {
+        const parsed = predicateSchema.safeParse(row.value);
+        if (parsed.success) {
+          throw new Error(
+            `Expected reject, got accept for "${row.label}". Parsed value:\n${JSON.stringify(parsed.data, null, 2)}`,
+          );
+        }
+        expect(parsed.success).toBe(false);
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Inspector-side authoring surface for the deterministic predicate gate ("Checks" in user-facing copy; `Predicate` / `defaultPredicates` in code per the Phase 2 plan UI-wording mapping). Stacks on Phase 1 (matchOptions `maxExtraToolCalls` + `superset`).

Plan: `~/.claude/plans/jaunty-wiggling-lecun.md` (Phase 2).

## Deliverables

### SDK
- Add `firstToolWas` as the 9th predicate kind. Evaluator reads `actualToolCalls[0]?.toolName` (Hard Constraint 4).
- Add Zod `predicateSchema` (discriminated on `type`), `predicateArraySchema`, `argMatcherSchema`, `casePredicatesSchema` (`{ mode, list }`), and `PREDICATE_PLACEHOLDER_STRINGS`.
- Re-export from `@mcpjam/sdk/predicates` and the inspector `@/shared/eval-matching` boundary.
- Extend `predicate-evaluate.test.ts` with `firstToolWas` coverage (pass, mismatch, empty calls, missing toolName).

### Shared parity fixtures
- New `sdk/tests/fixtures/predicates-parity-fixtures.json` with ≥2 accept rows per kind (one minimal, one with all optional fields) and reject rows for every required error class.
- `__readme` key names the sibling backend file at `tests/convex/fixtures/predicates-parity-fixtures.json` and the lock-step requirement.
- `predicates-parity.test.ts` asserts each accept parses and each reject throws against the SDK Zod.

### Inspector UI
- New `checks-section.tsx` with `<ChecksSection>` (list editor + Add-check dropdown listing all 9 kinds with the spec UI labels) and `<CaseChecksSection>` (3-state inherit/replace/extend radio + inherited summary).
- Suite settings page: "Default checks" section persists `defaultPredicates` via `updateTestSuite`.
- Case edit form: "Checks" section persists `predicates: { mode, list }` via `updateTestCase`. Mode switches preserve list to avoid lost work; switching to `inherit` with empty list persists `undefined` (no stale empty-list).

### Result rendering
- `predicates-list.tsx` extended to cover `firstToolWas` in `summarizePredicate`. User-facing copy switched to "Checks" / "X / Y checks passed".
- `CompactIterationRow` shows inline "N / M checks" badge per iteration row.

### Wire threading
- `tests[].predicates` threaded through `RunEvalsRequestSchema`, `RunTestCaseRequestSchema.testCaseOverrides`, the in-memory test-case map, the diff-on-update path, and both `createTestCase` / `updateTestCase` mutation calls (feedback_zod_strips_unthreaded_fields).

## Out of scope (per Phase 2 instructions)
- NO `mcpjam-backend` changes — parallel PR handles that.
- NO Phase 1 work (already on `evals/phase1-sdk-and-ui`).
- NO Phase 3 (override badges, per-leaf placeholder picker).
- NO Phase 4 (dead-code cleanup).
- NO `judgeConfig` changes.

## Coordination with parallel backend PR

Depends on [MCPJam/mcpjam-backend#391](https://github.com/MCPJam/mcpjam-backend/pull/391) for full Convex round-trip of `defaultPredicates` / `predicates`. That PR must merge first. Inspector schemas are permissive enough that legacy / partial deploys won't crash (mutation calls typed `as any`). Parity fixtures must stay in lockstep with the backend fixture file until they're published as a shared package.

## Test plan
- [x] SDK predicate-evaluate.test.ts — 54 tests pass (firstToolWas coverage added).
- [x] SDK predicates-parity.test.ts — 43 tests pass.
- [x] SDK typecheck clean.
- [x] Inspector typecheck:client clean.
- [x] Inspector vitest evals + shared — 578 + 181 pass.
- [x] Inspector build succeeds.
- [ ] Manual dev-server smoke (Convex round-trip blocked on backend PR merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)