### PR TITLE
evals: Phase 3 — override badges + arg placeholders (inspector)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/arg-leaf-picker.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/arg-leaf-picker.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test";
+import { ArgLeafPicker } from "../arg-leaf-picker";
+
+describe("ArgLeafPicker", () => {
+  it("renders a literal input by default in partial mode", () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <ArgLeafPicker
+        value="/tmp"
+        onChange={onChange}
+        argumentMatching="partial"
+      />,
+    );
+    // Mode select shows "Literal"
+    expect(screen.getByText("Literal")).toBeInTheDocument();
+    // Literal value is rendered in the input
+    const input = screen.getByDisplayValue("/tmp") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+  });
+
+  it("recognizes a placeholder string as the placeholder mode and shows label", () => {
+    renderWithProviders(
+      <ArgLeafPicker
+        value="string"
+        onChange={() => {}}
+        argumentMatching="partial"
+      />,
+    );
+    // Placeholder mode: the literal-value input is replaced with a
+    // labelled chip. The literal input shouldn't be present at all.
+    expect(screen.queryByDisplayValue("string")).not.toBeInTheDocument();
+    // The placeholder label appears in the rendered chip (and also as
+    // the SelectValue inside the closed dropdown trigger, which Radix
+    // mirrors). At least one of the matches is visible to the user.
+    const matches = screen.getAllByText("any string");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("treats a placeholder-looking value as a literal under exact mode", () => {
+    // Under exact mode the matcher does deep equality; the literal string
+    // "string" is just data, not a type assertion. The picker must NOT
+    // render it as a placeholder.
+    renderWithProviders(
+      <ArgLeafPicker
+        value="string"
+        onChange={() => {}}
+        argumentMatching="exact"
+      />,
+    );
+    expect(screen.queryByText("any string")).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("string")).toBeInTheDocument();
+  });
+
+  it("shows an ignore-mode hint and disables the dropdown", () => {
+    renderWithProviders(
+      <ArgLeafPicker
+        value="/tmp"
+        onChange={() => {}}
+        argumentMatching="ignore"
+      />,
+    );
+    expect(
+      screen.getByText(/Arguments not compared in ignore mode/),
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/override-badge.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/override-badge.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, fireEvent } from "@/test";
+import { OverrideBadge } from "../override-badge";
+
+describe("OverrideBadge", () => {
+  it("renders 'suite default · X' chip and no reset when inheriting", () => {
+    renderWithProviders(
+      <OverrideBadge
+        isInheriting
+        suiteDefaultLabel="Strict order"
+        onReset={() => {
+          throw new Error("reset should not be wired in inherit state");
+        }}
+      />,
+    );
+    expect(
+      screen.getByTestId("override-badge-inheriting"),
+    ).toHaveTextContent(/suite default · Strict order/);
+    expect(
+      screen.queryByRole("button", { name: /reset to suite default/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders 'overriding · suite: X' chip with reset button when not inheriting", () => {
+    const onReset = vi.fn();
+    renderWithProviders(
+      <OverrideBadge
+        isInheriting={false}
+        suiteDefaultLabel="Strict order"
+        onReset={onReset}
+      />,
+    );
+    expect(
+      screen.getByTestId("override-badge-overriding"),
+    ).toHaveTextContent(/overriding · suite: Strict order/);
+    const resetBtn = screen.getByRole("button", {
+      name: /reset to suite default/i,
+    });
+    fireEvent.click(resetBtn);
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders override kind label ('replace') alongside suite reference", () => {
+    renderWithProviders(
+      <OverrideBadge
+        isInheriting={false}
+        suiteDefaultLabel="2 default checks"
+        overrideKindLabel="replace"
+        onReset={() => {}}
+      />,
+    );
+    expect(
+      screen.getByTestId("override-badge-overriding"),
+    ).toHaveTextContent(/overriding · replace \(suite: 2 default checks\)/);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/arg-leaf-picker.tsx
+++ b/mcpjam-inspector/client/src/components/evals/arg-leaf-picker.tsx
@@ -1,0 +1,342 @@
+/**
+ * Per-leaf argument value picker for the eval matcher's `partial` mode
+ * (Phase 3).
+ *
+ * Background: the matcher (Phase 1 work) interprets a small set of
+ * placeholder STRINGS at the leaves of an args blob as type assertions
+ * instead of literal-equality checks. Until Phase 3, users could author
+ * these only by typing the literal placeholder string into JSON — easy to
+ * fat-finger ("any" vs "Any" vs "anyone"). This picker surfaces them as a
+ * dropdown next to (or replacing) the literal value editor.
+ *
+ * Persisted shape unchanged: a placeholder leaf is the literal string
+ * `"string"` / `"number"` / etc. in the JSON tree; the matcher already
+ * interprets those when `argumentMatching === "partial"`. No schema
+ * change is required.
+ *
+ * Used in:
+ *   - {@link ExpectedToolsEditor} (case's `expectedToolCalls[*].arguments`)
+ *   - {@link ArgMatcherSubform} (`toolCalledWith` predicate `args.args`)
+ */
+
+import { useId } from "react";
+import { Input } from "@mcpjam/design-system/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { Switch } from "@mcpjam/design-system/switch";
+import { PREDICATE_PLACEHOLDER_STRINGS } from "@mcpjam/sdk/predicates";
+import { cn } from "@/lib/utils";
+
+/** The 7 placeholder strings interpreted by the matcher in `partial` mode. */
+export type Placeholder = (typeof PREDICATE_PLACEHOLDER_STRINGS)[number];
+
+/** Human labels — italicized in the UI to distinguish from literal values. */
+const PLACEHOLDER_LABELS: Record<Placeholder, string> = {
+  any: "any value",
+  string: "any string",
+  number: "any number",
+  boolean: "any boolean",
+  object: "any object",
+  array: "any array",
+  null: "must be null",
+};
+
+/** Set membership test that doesn't widen `value`'s type. */
+function isPlaceholder(value: unknown): value is Placeholder {
+  return (
+    typeof value === "string" &&
+    (PREDICATE_PLACEHOLDER_STRINGS as readonly string[]).includes(value)
+  );
+}
+
+/** "literal" sentinel for the dropdown control (distinct from a literal that happens to be the empty string). */
+const LITERAL_MODE = "__literal__" as const;
+type Mode = typeof LITERAL_MODE | Placeholder;
+
+interface ArgLeafPickerProps {
+  /**
+   * Current leaf value. When this is one of the 7 placeholder strings AND
+   * `mode === "partial"`, the picker renders the placeholder dropdown
+   * highlighted and hides the literal-value input.
+   */
+  value: unknown;
+  onChange: (next: unknown) => void;
+  /**
+   * Effective `argumentMatching` mode for the parent matcher. Controls
+   * which placeholder options are offered:
+   *   - `partial` — literal + 7 placeholders
+   *   - `exact`   — literal only (matcher uses deep equality; placeholders
+   *                 would silently fail to type-check)
+   *   - `ignore`  — args not compared; picker is disabled with a hint
+   */
+  argumentMatching?: "exact" | "partial" | "ignore";
+  /**
+   * Optional inferred JSON-schema type for this leaf (from the server
+   * tool's inputSchema). Used to pre-select a sensible placeholder when
+   * the user switches to a placeholder mode without choosing one yet.
+   * Not validated against — purely a UX hint.
+   */
+  inferredType?: string;
+  /**
+   * Override for the literal-value placeholder text shown in the input.
+   * Defaults to "Value".
+   */
+  inputPlaceholder?: string;
+  /**
+   * `value`-side className for layout (e.g. font-mono on the literal
+   * input). Not applied to the placeholder dropdown.
+   */
+  className?: string;
+  /** Read-only suppresses the dropdown's enabled state. */
+  disabled?: boolean;
+}
+
+/**
+ * Type-appropriate literal default for when the user toggles from
+ * placeholder → literal and there's no remembered prior literal.
+ */
+function defaultLiteralFor(inferredType: string | undefined): unknown {
+  switch (inferredType) {
+    case "number":
+    case "integer":
+      return 0;
+    case "boolean":
+      return false;
+    case "object":
+      return {};
+    case "array":
+      return [];
+    case "null":
+      return null;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Best-effort placeholder choice when the user switches a literal → a
+ * generic placeholder mode and we haven't been told which one.
+ */
+function placeholderForInferredType(
+  inferredType: string | undefined,
+): Placeholder {
+  switch (inferredType) {
+    case "string":
+      return "string";
+    case "number":
+    case "integer":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "object":
+      return "object";
+    case "array":
+      return "array";
+    case "null":
+      return "null";
+    default:
+      return "any";
+  }
+}
+
+/**
+ * Stringify a literal JSON value for the inline input. Strings are
+ * un-quoted; other JSON values are stringified so the user can edit
+ * arrays/objects/null/numbers as text without breaking the round-trip.
+ */
+function literalToString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Inverse of {@link literalToString}: try JSON-parse first (so the user
+ * can type `42`, `true`, `null`, `[1,2]`, `{}`), fall back to the raw
+ * string. Mirrors `ExpectedToolsEditor`'s historical coercion so the
+ * picker is a drop-in replacement for its existing free-text input.
+ */
+function stringToLiteral(raw: string): unknown {
+  if (raw === "") return "";
+  // Match the pre-Phase-3 heuristics so existing cases round-trip
+  // identically when the user is still typing literals.
+  if (/^-?\d+\.?\d*$/.test(raw)) {
+    const n = parseFloat(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (raw === "null") return null;
+  if (raw.startsWith("[") || raw.startsWith("{")) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      // Stay as string; the matcher will surface the type mismatch.
+      return raw;
+    }
+  }
+  return raw;
+}
+
+/**
+ * Picker for a single args-blob leaf. Renders a mode dropdown on the
+ * left and either a literal-value input or a placeholder label on the
+ * right. Designed to drop in next to the existing free-text input in
+ * {@link ExpectedToolsEditor} and to be reused in the predicate
+ * authoring UI without coordinating extra state in the parent.
+ */
+export function ArgLeafPicker({
+  value,
+  onChange,
+  argumentMatching,
+  inferredType,
+  inputPlaceholder,
+  className,
+  disabled,
+}: ArgLeafPickerProps) {
+  const inputId = useId();
+  const isIgnore = argumentMatching === "ignore";
+  const isExact = argumentMatching === "exact";
+  // partial is the default if undefined — the matcher's own default.
+  const allowPlaceholders = !isExact && !isIgnore;
+
+  const valueIsPlaceholder = allowPlaceholders && isPlaceholder(value);
+  const currentMode: Mode = valueIsPlaceholder
+    ? (value as Placeholder)
+    : LITERAL_MODE;
+
+  const setMode = (nextMode: Mode) => {
+    if (nextMode === LITERAL_MODE) {
+      // Placeholder → literal: drop a type-appropriate default rather than
+      // preserve the placeholder string. If the user wanted to write
+      // `"string"` as a literal in exact mode, they can edit the field
+      // after toggling.
+      onChange(defaultLiteralFor(inferredType));
+      return;
+    }
+    onChange(nextMode);
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-1.5 sm:flex-row sm:items-stretch",
+        className,
+      )}
+    >
+      <Select
+        value={currentMode}
+        onValueChange={(v) => setMode(v as Mode)}
+        disabled={disabled || isIgnore}
+      >
+        <SelectTrigger
+          className={cn(
+            "h-9 w-full text-xs sm:w-32 shrink-0",
+            valueIsPlaceholder &&
+              "border-primary/40 bg-primary/5 text-primary",
+          )}
+          aria-label="Argument value mode"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={LITERAL_MODE} className="text-xs">
+            Literal
+          </SelectItem>
+          {allowPlaceholders ? (
+            <>
+              {PREDICATE_PLACEHOLDER_STRINGS.map((p) => (
+                <SelectItem key={p} value={p} className="text-xs">
+                  {/* "any value" / "any string" / … */}
+                  <span className="italic text-muted-foreground">
+                    {PLACEHOLDER_LABELS[p]}
+                  </span>
+                </SelectItem>
+              ))}
+            </>
+          ) : null}
+        </SelectContent>
+      </Select>
+      <div className="min-w-0 flex-1">
+        {isIgnore ? (
+          <div className="flex h-9 items-center rounded-md border border-dashed border-border/60 bg-muted/10 px-2 text-[11px] italic text-muted-foreground">
+            Arguments not compared in ignore mode
+          </div>
+        ) : valueIsPlaceholder ? (
+          <div className="flex h-9 items-center rounded-md border border-primary/30 bg-primary/5 px-2 text-xs italic text-primary">
+            {PLACEHOLDER_LABELS[value as Placeholder]}
+          </div>
+        ) : (
+          // Literal mode: a single-line input that mirrors the historical
+          // coercion (parse numbers/booleans/null/JSON; fall back to
+          // string). Booleans get a switch when inferredType says so —
+          // small UX win, doesn't change the persisted shape.
+          <LiteralValueEditor
+            id={inputId}
+            value={value}
+            onChange={onChange}
+            inferredType={inferredType}
+            placeholder={inputPlaceholder ?? "Value"}
+            disabled={disabled}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LiteralValueEditor({
+  id,
+  value,
+  onChange,
+  inferredType,
+  placeholder,
+  disabled,
+}: {
+  id: string;
+  value: unknown;
+  onChange: (next: unknown) => void;
+  inferredType?: string;
+  placeholder: string;
+  disabled?: boolean;
+}) {
+  if (inferredType === "boolean") {
+    const bool = value === true;
+    return (
+      <div className="flex h-9 items-center gap-2 rounded-md border border-border/60 bg-background px-2">
+        <Switch
+          id={id}
+          checked={bool}
+          onCheckedChange={(checked) => onChange(checked)}
+          disabled={disabled}
+        />
+        <span className="text-xs text-muted-foreground">
+          {bool ? "true" : "false"}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <Input
+      id={id}
+      value={literalToString(value)}
+      onChange={(e) => onChange(stringToLiteral(e.target.value))}
+      placeholder={placeholder}
+      className="h-9 font-mono text-xs"
+      disabled={disabled}
+    />
+  );
+}
+
+// Public re-exports for callers that want to render placeholder labels
+// outside the picker itself (e.g. a read-only summary row).
+export { PLACEHOLDER_LABELS, isPlaceholder, placeholderForInferredType };

--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -29,13 +29,15 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { Switch } from "@mcpjam/design-system/switch";
-import { Trash2, Plus } from "lucide-react";
+import { Trash2, Plus, X } from "lucide-react";
+import { ArgLeafPicker } from "./arg-leaf-picker";
 import type {
   Predicate,
   ArgMatchMode,
   CasePredicates,
 } from "@/shared/eval-matching";
 import { predicateSchema } from "@mcpjam/sdk/predicates";
+import { OverrideBadge } from "./override-badge";
 
 // ─── kind metadata ────────────────────────────────────────────────────────
 //
@@ -453,11 +455,41 @@ function ToolCalledWithFields({
   );
 }
 
+/** True iff `v` is a nested JSON container (object or array). The
+ *  structured per-leaf editor handles only flat top-level keys; nested
+ *  shapes fall back to the raw JSON view so users can author them
+ *  without a tree-builder. */
+function isNestedContainer(v: unknown): boolean {
+  if (v === null || typeof v !== "object") return false;
+  return Array.isArray(v) || Object.keys(v as Record<string, unknown>).length > 0;
+}
+
+/** True iff every top-level value in `args` is a flat leaf (not a nested
+ *  object/array). When true, the structured editor is enabled by
+ *  default; otherwise we render the JSON view because the structured
+ *  one can't roundtrip nested shapes losslessly. */
+function argsAreFlat(args: Record<string, unknown>): boolean {
+  for (const v of Object.values(args)) {
+    if (isNestedContainer(v)) return false;
+  }
+  return true;
+}
+
 /**
- * Sub-form for the `toolCalledWith.args` shape: a dropdown for the
- * argumentMatching mode and a JSON textarea for the args blob. Phase 2
- * scope: accept JSON shape with placeholder strings as raw text. The
- * dedicated per-leaf placeholder picker is Phase 3 (not built here).
+ * Sub-form for the `toolCalledWith.args` shape. Phase 3:
+ *
+ *   - **Structured editor (default for flat args)**: one row per top-level
+ *     key, key Input + {@link ArgLeafPicker} as the value control. The
+ *     picker switches between literal and placeholder modes based on the
+ *     parent `argumentMatching` selection.
+ *   - **Raw JSON editor (fallback)**: the Phase 2 JSON textarea, used when
+ *     args contain nested objects/arrays (the structured view can't
+ *     authoring-edit those without becoming a full tree builder, which is
+ *     out of scope for V1).
+ *
+ * The persisted shape is unchanged — `value.args` remains a
+ * `Record<string, unknown>` and placeholder leaves are the literal
+ * placeholder strings the matcher already interprets.
  */
 function ArgMatcherSubform({
   value,
@@ -472,11 +504,213 @@ function ArgMatcherSubform({
   readOnly: boolean;
 }) {
   const modeId = useId();
-  const argsId = useId();
   const mode: ArgMatchMode = value.argumentMatching ?? "partial";
+
+  // The structured editor is the default surface when args are flat.
+  // If the user has authored nested args via the raw editor, we default
+  // to raw to preserve their shape. They can still toggle either way.
+  const [useRaw, setUseRaw] = useState<boolean>(
+    () => !argsAreFlat(value.args ?? {}),
+  );
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-end justify-between gap-2">
+        <div className="space-y-1">
+          <Label htmlFor={modeId} className="text-[11px]">
+            Argument matching
+          </Label>
+          <Select
+            value={mode}
+            onValueChange={(next) =>
+              onChange({ ...value, argumentMatching: next as ArgMatchMode })
+            }
+            disabled={readOnly}
+          >
+            <SelectTrigger id={modeId} className="h-8 w-40 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="partial" className="text-xs">
+                Partial (extras ok)
+              </SelectItem>
+              <SelectItem value="exact" className="text-xs">
+                Exact (deep equal)
+              </SelectItem>
+              <SelectItem value="ignore" className="text-xs">
+                Ignore (only tool name matters)
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {/* Per-row "Raw JSON" toggle so power users can author nested
+            shapes the structured editor can't express. Disabled in
+            ignore mode (args aren't compared anyway). */}
+        <div className="flex items-center gap-1.5 pb-1">
+          <Switch
+            id={`${modeId}-raw`}
+            checked={useRaw}
+            onCheckedChange={(checked) => setUseRaw(checked)}
+            disabled={readOnly || mode === "ignore"}
+            aria-label="Use raw JSON editor"
+          />
+          <Label
+            htmlFor={`${modeId}-raw`}
+            className="text-[10px] text-muted-foreground"
+          >
+            Raw JSON
+          </Label>
+        </div>
+      </div>
+      {mode === "ignore" ? (
+        <div className="rounded-md border border-dashed border-border/60 bg-muted/10 p-3 text-[11px] italic text-muted-foreground">
+          Arguments not compared in ignore mode.
+        </div>
+      ) : useRaw ? (
+        <RawArgsJsonEditor
+          value={value.args ?? {}}
+          onChange={(args) => onChange({ ...value, args })}
+          mode={mode}
+          readOnly={readOnly}
+        />
+      ) : (
+        <StructuredArgsEditor
+          value={value.args ?? {}}
+          onChange={(args) => onChange({ ...value, args })}
+          mode={mode}
+          readOnly={readOnly}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Per-leaf authoring view for flat args: list of `{ key, value }` rows
+ * where each value uses {@link ArgLeafPicker} to switch between literal
+ * and placeholder modes. Operates on the same persisted shape as the
+ * raw view.
+ */
+function StructuredArgsEditor({
+  value,
+  onChange,
+  mode,
+  readOnly,
+}: {
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  mode: ArgMatchMode;
+  readOnly: boolean;
+}) {
+  // Stable ordering for the row list: insertion order via Object.entries.
+  const entries = Object.entries(value);
+
+  const setEntry = (oldKey: string, newKey: string, newValue: unknown) => {
+    // Preserve insertion order when renaming a key; replace in place.
+    const next: Record<string, unknown> = {};
+    for (const [k, v] of entries) {
+      if (k === oldKey) next[newKey] = newValue;
+      else next[k] = v;
+    }
+    onChange(next);
+  };
+  const removeKey = (key: string) => {
+    const next: Record<string, unknown> = {};
+    for (const [k, v] of entries) if (k !== key) next[k] = v;
+    onChange(next);
+  };
+  const addEmpty = () => {
+    // Pick a fresh unique key. Don't collide with existing keys; numeric
+    // suffixes are an ergonomic default familiar from ExpectedToolsEditor.
+    let candidate = "arg";
+    let i = 1;
+    while (Object.hasOwn(value, candidate)) {
+      candidate = `arg${i++}`;
+    }
+    onChange({ ...value, [candidate]: "" });
+  };
+
+  return (
+    <div className="space-y-2">
+      {entries.length === 0 ? (
+        <div className="rounded-md border border-dashed border-border/60 bg-muted/10 p-3 text-[11px] text-muted-foreground">
+          No expected arguments. Use Add argument below.
+        </div>
+      ) : (
+        <ul className="space-y-1.5">
+          {entries.map(([key, val]) => (
+            <li
+              key={key}
+              className="flex items-start gap-1.5 rounded-md bg-background/60 p-1.5 ring-1 ring-border/30"
+            >
+              <Input
+                value={key}
+                onChange={(e) => setEntry(key, e.target.value, val)}
+                placeholder="key"
+                className="h-9 w-28 shrink-0 font-mono text-xs"
+                disabled={readOnly}
+                aria-label="Argument key"
+              />
+              <div className="min-w-0 flex-1">
+                <ArgLeafPicker
+                  value={val}
+                  onChange={(next) => setEntry(key, key, next)}
+                  argumentMatching={mode}
+                  disabled={readOnly}
+                />
+              </div>
+              {!readOnly ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                  onClick={() => removeKey(key)}
+                  aria-label={`Remove argument ${key}`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+      {!readOnly ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 text-xs text-muted-foreground hover:text-foreground"
+          onClick={addEmpty}
+        >
+          <Plus className="mr-1 h-3 w-3" />
+          Add argument
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Raw JSON authoring view, preserved from Phase 2 so users with nested
+ * args can still edit them as text. Maintained as a separate component
+ * so the structured editor doesn't have to inherit its draft-text state.
+ */
+function RawArgsJsonEditor({
+  value,
+  onChange,
+  mode,
+  readOnly,
+}: {
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  mode: ArgMatchMode;
+  readOnly: boolean;
+}) {
+  const argsId = useId();
   const [draftJson, setDraftJson] = useState(() => {
     try {
-      return JSON.stringify(value.args ?? {}, null, 2);
+      return JSON.stringify(value ?? {}, null, 2);
     } catch {
       return "{}";
     }
@@ -484,80 +718,49 @@ function ArgMatcherSubform({
   const [jsonError, setJsonError] = useState<string | null>(null);
 
   return (
-    <div className="space-y-2">
-      <div className="space-y-1">
-        <Label htmlFor={modeId} className="text-[11px]">
-          Argument matching
-        </Label>
-        <Select
-          value={mode}
-          onValueChange={(next) =>
-            onChange({ ...value, argumentMatching: next as ArgMatchMode })
-          }
-          disabled={readOnly}
-        >
-          <SelectTrigger id={modeId} className="h-8 w-40 text-xs">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="partial" className="text-xs">
-              Partial (extras ok)
-            </SelectItem>
-            <SelectItem value="exact" className="text-xs">
-              Exact (deep equal)
-            </SelectItem>
-            <SelectItem value="ignore" className="text-xs">
-              Ignore (only tool name matters)
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="space-y-1">
-        <Label htmlFor={argsId} className="text-[11px]">
-          Expected args (JSON)
-          {mode === "partial" ? (
-            <span className="ml-2 text-muted-foreground font-normal">
-              Placeholders allowed: "string", "number", "boolean", "object",
-              "array", "null", "any"
-            </span>
-          ) : null}
-        </Label>
-        <textarea
-          id={argsId}
-          className={`min-h-[80px] w-full rounded-md border bg-background p-2 font-mono text-[11px] leading-tight ${
-            jsonError ? "border-red-500/60" : "border-border/60"
-          }`}
-          value={draftJson}
-          onChange={(e) => {
-            const next = e.target.value;
-            setDraftJson(next);
-            try {
-              const parsed = JSON.parse(next);
-              if (
-                parsed === null ||
-                typeof parsed !== "object" ||
-                Array.isArray(parsed)
-              ) {
-                setJsonError("Expected a JSON object");
-                return;
-              }
-              setJsonError(null);
-              onChange({ ...value, args: parsed as Record<string, unknown> });
-            } catch (err) {
-              setJsonError(
-                err instanceof Error ? err.message : "Invalid JSON",
-              );
-            }
-          }}
-          spellCheck={false}
-          disabled={readOnly}
-        />
-        {jsonError ? (
-          <div className="text-[11px] text-red-600 dark:text-red-400">
-            {jsonError}
-          </div>
+    <div className="space-y-1">
+      <Label htmlFor={argsId} className="text-[11px]">
+        Expected args (JSON)
+        {mode === "partial" ? (
+          <span className="ml-2 text-muted-foreground font-normal">
+            Placeholders allowed: "string", "number", "boolean", "object",
+            "array", "null", "any"
+          </span>
         ) : null}
-      </div>
+      </Label>
+      <textarea
+        id={argsId}
+        className={`min-h-[80px] w-full rounded-md border bg-background p-2 font-mono text-[11px] leading-tight ${
+          jsonError ? "border-red-500/60" : "border-border/60"
+        }`}
+        value={draftJson}
+        onChange={(e) => {
+          const next = e.target.value;
+          setDraftJson(next);
+          try {
+            const parsed = JSON.parse(next);
+            if (
+              parsed === null ||
+              typeof parsed !== "object" ||
+              Array.isArray(parsed)
+            ) {
+              setJsonError("Expected a JSON object");
+              return;
+            }
+            setJsonError(null);
+            onChange(parsed as Record<string, unknown>);
+          } catch (err) {
+            setJsonError(err instanceof Error ? err.message : "Invalid JSON");
+          }
+        }}
+        spellCheck={false}
+        disabled={readOnly}
+      />
+      {jsonError ? (
+        <div className="text-[11px] text-red-600 dark:text-red-400">
+          {jsonError}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -727,10 +930,34 @@ export function CaseChecksSection({
     onChange({ mode, list });
   };
 
+  // Badge label: suite default in this surface is always "Inherit suite
+  // defaults". When the case is on `replace` or `extend`, the chip surfaces
+  // which override kind is in effect; reset writes `undefined` so the case
+  // falls back to inherit.
+  const suiteDefaultLabel =
+    suiteDefaults.length === 0
+      ? "no default checks"
+      : `${suiteDefaults.length} default check${suiteDefaults.length === 1 ? "" : "s"}`;
+  const overrideKindLabel =
+    mode === "replace"
+      ? "replace"
+      : mode === "extend"
+        ? "extend"
+        : undefined;
+  const handleResetMode = () => onChange(undefined);
+
   return (
     <div className="space-y-3 rounded-lg border bg-muted/20 p-4">
       <div>
-        <h3 className="text-sm font-semibold text-foreground">Checks</h3>
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-sm font-semibold text-foreground">Checks</h3>
+          <OverrideBadge
+            isInheriting={mode === "inherit"}
+            suiteDefaultLabel={suiteDefaultLabel}
+            overrideKindLabel={overrideKindLabel}
+            onReset={mode === "inherit" ? undefined : handleResetMode}
+          />
+        </div>
         <p className="text-xs text-muted-foreground mt-1">
           Deterministic checks for this case. Inherit, replace, or extend the
           suite&apos;s default checks.

--- a/mcpjam-inspector/client/src/components/evals/expected-tools-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/expected-tools-editor.tsx
@@ -1,9 +1,9 @@
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
-import { Textarea } from "@mcpjam/design-system/textarea";
 import { Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Combobox } from "@/components/ui/combobox";
+import { ArgLeafPicker, isPlaceholder } from "./arg-leaf-picker";
 
 type ToolCall = {
   toolName: string;
@@ -20,12 +20,24 @@ type ExpectedToolsEditorProps = {
   toolCalls: ToolCall[];
   onChange: (toolCalls: ToolCall[]) => void;
   availableTools?: AvailableTool[];
+  /**
+   * Effective `argumentMatching` mode resolved for this case (suite
+   * default merged with the case override). When `"partial"` the per-leaf
+   * picker offers the 7 placeholder strings; when `"exact"` only literal;
+   * when `"ignore"` the whole args UI is disabled with a hint.
+   *
+   * Optional so legacy call sites that haven't been updated continue to
+   * render without the picker (defaults to `"partial"`, matching the
+   * matcher's default).
+   */
+  argumentMatching?: "exact" | "partial" | "ignore";
 };
 
 export function ExpectedToolsEditor({
   toolCalls,
   onChange,
   availableTools = [],
+  argumentMatching = "partial",
 }: ExpectedToolsEditorProps) {
   const addToolCall = () => {
     onChange([...toolCalls, { toolName: "", arguments: {} }]);
@@ -103,34 +115,11 @@ export function ExpectedToolsEditor({
   const updateArgumentValue = (
     toolIndex: number,
     argKey: string,
-    value: string,
+    nextValue: unknown,
   ) => {
     const updated = [...toolCalls];
     const args = { ...(updated[toolIndex].arguments || {}) };
-
-    // Try to parse as JSON if it looks like a number, boolean, array, or object
-    let parsedValue: any = value;
-    if (value.trim() !== "") {
-      try {
-        // Check if it's a number
-        if (/^-?\d+\.?\d*$/.test(value)) {
-          parsedValue = parseFloat(value);
-        }
-        // Check if it's a boolean
-        else if (value === "true" || value === "false") {
-          parsedValue = value === "true";
-        }
-        // Check if it's JSON (array or object)
-        else if (value.startsWith("[") || value.startsWith("{")) {
-          parsedValue = JSON.parse(value);
-        }
-      } catch {
-        // If parsing fails, keep as string
-        parsedValue = value;
-      }
-    }
-
-    args[argKey] = parsedValue;
+    args[argKey] = nextValue;
     updated[toolIndex] = { ...updated[toolIndex], arguments: args };
     onChange(updated);
   };
@@ -154,7 +143,11 @@ export function ExpectedToolsEditor({
     }));
   };
 
-  const isArgumentValueInvalid = (value: any): boolean => {
+  const isArgumentValueInvalid = (value: unknown): boolean => {
+    // Placeholders are always valid in partial mode. Empty string is
+    // still treated as "user hasn't filled it in yet" — same convention
+    // as before Phase 3.
+    if (argumentMatching === "partial" && isPlaceholder(value)) return false;
     return value === "";
   };
 
@@ -273,25 +266,23 @@ export function ExpectedToolsEditor({
                         </p>
                       )}
                     </div>
-                    <div className="min-w-0 flex-[2]">
-                      <Textarea
-                        value={
-                          typeof value === "string"
-                            ? value
-                            : JSON.stringify(value)
+                    <div
+                      className={cn(
+                        "min-w-0 flex-[2] rounded-md",
+                        isArgumentValueInvalid(value) &&
+                          "ring-1 ring-destructive/45",
+                      )}
+                    >
+                      <ArgLeafPicker
+                        value={value}
+                        onChange={(next) =>
+                          updateArgumentValue(toolIndex, key, next)
                         }
-                        onChange={(e) =>
-                          updateArgumentValue(toolIndex, key, e.target.value)
-                        }
-                        placeholder={
+                        argumentMatching={argumentMatching}
+                        inferredType={argSchema?.type}
+                        inputPlaceholder={
                           argSchema?.type ? `${argSchema.type}` : "Value"
                         }
-                        className={cn(
-                          "font-mono text-sm resize-none min-h-[36px]",
-                          isArgumentValueInvalid(value) &&
-                            "border-destructive/45 focus-visible:ring-destructive/25 dark:border-destructive/55",
-                        )}
-                        rows={1}
                       />
                     </div>
                     <Button

--- a/mcpjam-inspector/client/src/components/evals/override-badge.tsx
+++ b/mcpjam-inspector/client/src/components/evals/override-badge.tsx
@@ -1,0 +1,114 @@
+/**
+ * Per-control override indicator chip + reset affordance for layered
+ * eval-config fields (Phase 3).
+ *
+ * Two states:
+ *   - "(suite default · X)" — local value is undefined/inheriting. Chip
+ *     rendered secondary/greyed; the associated input is greyed/disabled
+ *     upstream (callers thread `isInheriting` into the `disabled` prop of
+ *     their input).
+ *   - "(overriding · suite: X)" — local value differs from suite default.
+ *     Chip rendered primary/highlighted; input is editable. A small reset
+ *     button writes `undefined` (NOT the default value) so the layered
+ *     resolver continues to inherit if the suite default later changes.
+ *
+ * Shared between the case-edit form and the run popover. The suite-edit
+ * page is the source — it does not render this badge.
+ */
+
+import { RotateCcw } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { cn } from "@/lib/utils";
+
+interface OverrideBadgeProps {
+  /**
+   * True when the local layer's value is `undefined` (inheriting). When
+   * false, the local value is an explicit override.
+   *
+   * Note: this is intentionally a boolean rather than `value === undefined`
+   * because some callers (predicate-mode radio) have a 3-state semantic
+   * where "inherit" is a meaningful enum value, not absence.
+   */
+  isInheriting: boolean;
+  /**
+   * Pretty-printed suite default label, e.g. "Strict order" / "Partial" /
+   * "Unlimited" / "Replace suite defaults". Rendered after the dot.
+   */
+  suiteDefaultLabel: string;
+  /**
+   * Optional override-state label shown after "overriding · suite: …".
+   * Defaults to just the suite label. Callers can pass a custom string if
+   * the override semantic ("Replace" vs "Extend") matters.
+   */
+  overrideKindLabel?: string;
+  /**
+   * Called when the user clicks the reset affordance. Must write
+   * `undefined` (not the default) so inheritance keeps tracking the suite.
+   * If omitted, no reset button is rendered (used by read-only previews).
+   */
+  onReset?: () => void;
+}
+
+/**
+ * Inline chip rendered next to a layered control's label. Keep this
+ * component visual-only: state is computed by the caller (which already
+ * knows the resolved values and field semantics).
+ */
+export function OverrideBadge({
+  isInheriting,
+  suiteDefaultLabel,
+  overrideKindLabel,
+  onReset,
+}: OverrideBadgeProps) {
+  if (isInheriting) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 rounded-full border border-border/50 bg-muted/40",
+          "px-2 py-0.5 text-[10px] font-medium leading-none text-muted-foreground",
+        )}
+        data-testid="override-badge-inheriting"
+      >
+        suite default · {suiteDefaultLabel}
+      </span>
+    );
+  }
+
+  // Overriding state. The chip itself is the reset affordance — clicking
+  // anywhere inside it (including the icon button) reverts to inherit.
+  const label = overrideKindLabel
+    ? `overriding · ${overrideKindLabel} (suite: ${suiteDefaultLabel})`
+    : `overriding · suite: ${suiteDefaultLabel}`;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border",
+        "border-primary/40 bg-primary/10",
+        "px-2 py-0.5 text-[10px] font-medium leading-none text-primary",
+      )}
+      data-testid="override-badge-overriding"
+    >
+      <span>{label}</span>
+      {onReset ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          // Tighter than the default ghost button so the icon sits cleanly
+          // inside the chip's pill. The icon is the affordance — the chip
+          // never has a separate "Reset" label, to keep the row compact.
+          className="-mr-1 h-4 w-4 p-0 text-primary hover:bg-primary/15 hover:text-primary"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onReset();
+          }}
+          title="Reset to suite default"
+          aria-label="Reset to suite default"
+        >
+          <RotateCcw className="h-3 w-3" />
+        </Button>
+      ) : null}
+    </span>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/run-validators-popover.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-validators-popover.tsx
@@ -76,6 +76,7 @@ export function RunValidatorsPopover({
           value={runOverride}
           inheritedFrom={persisted}
           onChange={onChange}
+          showBadges
         />
       </PopoverContent>
     </Popover>

--- a/mcpjam-inspector/client/src/components/evals/test-case-prompt-flow.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-case-prompt-flow.tsx
@@ -45,6 +45,12 @@ type TestCasePromptFlowProps = {
   removePromptTurn: (index: number) => void;
   movePromptTurn: (index: number, direction: -1 | 1) => void;
   togglePromptTurnExpanded: (turnId: string) => void;
+  /**
+   * Effective `argumentMatching` mode for this case (suite default merged
+   * with the case override). Threaded through to {@link ExpectedToolsEditor}
+   * so the per-leaf placeholder picker offers the right options (Phase 3).
+   */
+  argumentMatching?: "exact" | "partial" | "ignore";
 };
 
 export function TestCasePromptFlow({
@@ -59,6 +65,7 @@ export function TestCasePromptFlow({
   removePromptTurn,
   movePromptTurn,
   togglePromptTurnExpanded,
+  argumentMatching,
 }: TestCasePromptFlowProps) {
   const multi = promptTurns.length > 1;
 
@@ -312,6 +319,7 @@ export function TestCasePromptFlow({
                                     }))
                                   }
                                   availableTools={availableTools}
+                                  argumentMatching={argumentMatching}
                                 />
                                 {toolsAttention ? (
                                   <p className="text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -2092,6 +2092,16 @@ export function TestTemplateEditor({
                   removePromptTurn={removePromptTurn}
                   movePromptTurn={movePromptTurn}
                   togglePromptTurnExpanded={togglePromptTurnExpanded}
+                  // Phase 3: thread the effective argumentMatching mode
+                  // (suite default merged with case override) so the
+                  // per-leaf placeholder picker offers the right options
+                  // and disables itself in `ignore` mode.
+                  argumentMatching={
+                    resolveMatchOptions(
+                      suite?.defaultMatchOptions,
+                      editForm.matchOptions,
+                    ).argumentMatching
+                  }
                 />
               ) : null}
             </div>
@@ -2110,6 +2120,7 @@ export function TestTemplateEditor({
                       current ? { ...current, matchOptions: next } : current
                     )
                   }
+                  showBadges
                 />
               </div>
             ) : null}

--- a/mcpjam-inspector/client/src/components/evals/validators-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/validators-section.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useId } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
@@ -12,6 +13,7 @@ import {
 import { Switch } from "@mcpjam/design-system/switch";
 import type { EvalMatchOptions } from "@/shared/eval-matching";
 import { MATCH_OPTIONS_DEFAULTS } from "@/shared/eval-matching";
+import { OverrideBadge } from "./override-badge";
 
 const ORDER_OPTIONS: Array<{
   value: Exclude<EvalMatchOptions["toolCallOrder"], undefined>;
@@ -55,6 +57,17 @@ interface ValidatorsSectionProps {
   title?: string;
   description?: string;
   density?: "default" | "compact";
+  /**
+   * When true, render per-control "(suite default · X)" or
+   * "(overriding · suite: X)" chips next to each field label, with a
+   * per-control reset affordance. Used at the case-edit and run-popover
+   * layers; the suite-edit page leaves this off because it IS the source.
+   *
+   * When true, inheriting controls are also visually greyed (the dropdown
+   * still shows the resolved value so the user sees what'll apply, but the
+   * input is disabled to reinforce that the case isn't pinning it).
+   */
+  showBadges?: boolean;
 }
 
 function pruneUndefined(
@@ -108,6 +121,39 @@ const LABELS_COMPACT = {
   args: "Args",
 } as const;
 
+// ─── Pretty-printers for badge labels ─────────────────────────────────────
+//
+// Keep these inline (rather than importing the SDK enum maps) so the chip
+// text stays consistent with the dropdown option labels above, even if the
+// SDK reshapes its internal vocabulary.
+
+function orderLabelFor(value: "ignore" | "strict" | "superset"): string {
+  return ORDER_OPTIONS.find((o) => o.value === value)?.label ?? value;
+}
+
+function argsLabelFor(value: "exact" | "partial" | "ignore"): string {
+  return ARGS_OPTIONS.find((o) => o.value === value)?.label ?? value;
+}
+
+function extrasLabelFor(cap: number | null): string {
+  if (cap === null) return "Unlimited";
+  if (cap === 0) return "0 (strict)";
+  return `${cap}`;
+}
+
+/**
+ * True iff this layer pins `maxExtraToolCalls` (directly or via the
+ * legacy `allowExtraToolCalls` shim). Used by the badge logic to
+ * distinguish inheriting from explicit.
+ */
+function isExtrasPinned(value: EvalMatchOptions | undefined): boolean {
+  if (!value) return false;
+  return (
+    value.maxExtraToolCalls !== undefined ||
+    value.allowExtraToolCalls !== undefined
+  );
+}
+
 export function ValidatorsSection({
   value,
   inheritedFrom,
@@ -115,6 +161,7 @@ export function ValidatorsSection({
   title = "Validators",
   description,
   density = "default",
+  showBadges = false,
 }: ValidatorsSectionProps) {
   const inherited = inheritedFrom ?? MATCH_OPTIONS_DEFAULTS;
   const isCompact = density === "compact";
@@ -124,6 +171,20 @@ export function ValidatorsSection({
 
   const extrasFieldId = useId();
   const extrasUnlimitedId = useId();
+
+  // Per-field inheritance state. `value?.field === undefined` is the
+  // canonical "inheriting" marker (per Phase 1 layered resolver semantics);
+  // `null` on `maxExtraToolCalls` is an explicit "unlimited" override and
+  // counts as overriding.
+  const orderInheriting = value?.toolCallOrder === undefined;
+  const extrasInheriting = !isExtrasPinned(value);
+  const argsInheriting = value?.argumentMatching === undefined;
+
+  // Inherited cap for badge labels — reuses the legacy shim so old rows
+  // surface a sensible chip.
+  const inheritedExtrasForLabel = inheritedExtrasCap(inheritedFrom);
+  const inheritedOrderForLabel = inherited.toolCallOrder;
+  const inheritedArgsForLabel = inherited.argumentMatching;
 
   const setField = <K extends keyof EvalMatchOptions>(
     field: K,
@@ -175,18 +236,52 @@ export function ValidatorsSection({
       value.allowExtraToolCalls !== undefined ||
       value.argumentMatching !== undefined);
 
+  /**
+   * Reset a single field at this layer back to inherit. Writes `undefined`
+   * (NOT the resolved default) so future suite-default changes continue to
+   * propagate through the resolver.
+   */
+  const resetField = (field: keyof EvalMatchOptions) => {
+    if (!value) return;
+    const merged: EvalMatchOptions = { ...value };
+    delete merged[field];
+    // When resetting maxExtraToolCalls, also clear any legacy field so
+    // we don't accidentally leave an old shim value behind.
+    if (field === "maxExtraToolCalls") {
+      delete merged.allowExtraToolCalls;
+    }
+    onChange(pruneUndefined(merged));
+  };
+
+  const resetExtras = () => {
+    if (!value) return;
+    const merged: EvalMatchOptions = { ...value };
+    delete merged.maxExtraToolCalls;
+    delete merged.allowExtraToolCalls;
+    onChange(pruneUndefined(merged));
+  };
+
   const renderRow = (
     label: string,
     selectId: string,
     selectedValue: string,
     onValueChange: (v: string) => void,
     options: Array<{ value: string; label: string }>,
+    badge?: ReactNode,
+    disabled?: boolean,
   ) => (
     <div className="flex items-center justify-between gap-3">
-      <Label htmlFor={selectId} className="text-sm">
-        {label}
-      </Label>
-      <Select value={selectedValue} onValueChange={onValueChange}>
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+        <Label htmlFor={selectId} className="text-sm">
+          {label}
+        </Label>
+        {badge}
+      </div>
+      <Select
+        value={selectedValue}
+        onValueChange={onValueChange}
+        disabled={disabled}
+      >
         <SelectTrigger
           id={selectId}
           className={
@@ -243,13 +338,32 @@ export function ValidatorsSection({
               v as "ignore" | "strict" | "superset",
             ),
           ORDER_OPTIONS as Array<{ value: string; label: string }>,
+          showBadges ? (
+            <OverrideBadge
+              isInheriting={orderInheriting}
+              suiteDefaultLabel={orderLabelFor(inheritedOrderForLabel)}
+              onReset={
+                orderInheriting ? undefined : () => resetField("toolCallOrder")
+              }
+            />
+          ) : undefined,
+          showBadges && orderInheriting,
         )}
         {/* Extras row: number input + Unlimited toggle. Unlimited persists
             null; toggling off persists the current number. */}
         <div className="flex items-center justify-between gap-3">
-          <Label htmlFor={extrasFieldId} className="text-sm">
-            {extrasLabel}
-          </Label>
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+            <Label htmlFor={extrasFieldId} className="text-sm">
+              {extrasLabel}
+            </Label>
+            {showBadges ? (
+              <OverrideBadge
+                isInheriting={extrasInheriting}
+                suiteDefaultLabel={extrasLabelFor(inheritedExtrasForLabel)}
+                onReset={extrasInheriting ? undefined : resetExtras}
+              />
+            ) : null}
+          </div>
           <div className="flex items-center gap-2">
             <Input
               id={extrasFieldId}
@@ -257,7 +371,7 @@ export function ValidatorsSection({
               inputMode="numeric"
               min={0}
               step={1}
-              disabled={extrasUnlimited}
+              disabled={extrasUnlimited || (showBadges && extrasInheriting)}
               value={extrasUnlimited ? "" : String(extrasNumber)}
               placeholder={extrasUnlimited ? "—" : "0"}
               onChange={(e) => {
@@ -298,6 +412,7 @@ export function ValidatorsSection({
                     setExtrasCap(0);
                   }
                 }}
+                disabled={showBadges && extrasInheriting}
                 aria-label="Allow unlimited extra tool calls"
               />
               <span>Unlimited</span>
@@ -314,6 +429,18 @@ export function ValidatorsSection({
               v as "partial" | "exact" | "ignore",
             ),
           ARGS_OPTIONS as Array<{ value: string; label: string }>,
+          showBadges ? (
+            <OverrideBadge
+              isInheriting={argsInheriting}
+              suiteDefaultLabel={argsLabelFor(inheritedArgsForLabel)}
+              onReset={
+                argsInheriting
+                  ? undefined
+                  : () => resetField("argumentMatching")
+              }
+            />
+          ) : undefined,
+          showBadges && argsInheriting,
         )}
       </div>
     </div>


### PR DESCRIPTION
Phase 3 of the eval-UI plan at `.claude/plans/jaunty-wiggling-lecun.md`, inspector-only. Stacks on top of Phase 2 (#2370); Phase 1+2 inspector and Phase 1+2 backend must merge before this lands.

## Scope

### A. Override badges (per-control)

Suite-edit page is the source — no badges. Two layers get identical chip + reset treatment:

- **Case-edit form** (`test-template-editor.tsx`)
- **Run popover** (`run-validators-popover.tsx`) — the suite-header "This run" affordance

For every layered control:

- `(suite default · X)` — local field is `undefined`; chip greyed/secondary; input greyed/disabled.
- `(overriding · suite: X)` — local field differs; chip highlighted/primary; input editable; inline reset button writes `undefined` (NOT the default value) so future suite-default changes keep propagating through the layered resolver in `convex/lib/matchOptions.ts`.

Covered controls:
- `toolCallOrder` / `maxExtraToolCalls` / `argumentMatching` (the `ValidatorsSection` trio)
- Case-level predicate-mode 3-state radio: badge surfaces `(suite default · …)` vs `(overriding · replace …)` / `(overriding · extend …)`

New shared `OverrideBadge` component renders both states; callers compute inheritance.

### B. Argument placeholder picker in `partial` mode

The SDK matcher already interprets the 7 placeholder strings (`"any"`, `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`, `"null"`) at args leaves when `argumentMatching === "partial"`. Phase 3 surfaces them as a per-leaf dropdown so users don't fat-finger the literal strings.

Two surfaces:
1. **`ExpectedToolsEditor`** (case `expectedToolCalls[*].arguments`) — per-leaf `ArgLeafPicker` replaces the bare textarea
2. **`ArgMatcherSubform`** inside `toolCalledWith` check rows — structured editor by default with a Raw JSON toggle for nested shapes

Behaviour by mode:
- `partial` — dropdown shows Literal + 7 placeholders
- `exact` — dropdown shows Literal only (matcher uses deep equality; placeholders disabled)
- `ignore` — args editor disabled with a hint

Persisted shape unchanged — a placeholder leaf is still the literal placeholder string in the JSON tree.

## Out of scope (kept clean)

- No SDK changes (verified: SDK tests pass at 1071/1071 unchanged)
- No backend / schema changes
- No Phase 4 cleanup (`perTemplateThresholds` etc.) — a separate PR will land that
- No new predicate kinds, no resolver changes, no new judge-config UI

## Files changed

- `client/src/components/evals/override-badge.tsx` (new)
- `client/src/components/evals/arg-leaf-picker.tsx` (new)
- `client/src/components/evals/validators-section.tsx` — `showBadges` prop, per-control reset, OverrideBadge wiring
- `client/src/components/evals/run-validators-popover.tsx` — `showBadges` on for run layer
- `client/src/components/evals/test-template-editor.tsx` — `showBadges` on for case-edit; threads `argumentMatching` to prompt-flow
- `client/src/components/evals/test-case-prompt-flow.tsx` — threads `argumentMatching` to `ExpectedToolsEditor`
- `client/src/components/evals/expected-tools-editor.tsx` — per-leaf `ArgLeafPicker`
- `client/src/components/evals/checks-section.tsx` — `CaseChecksSection` 3-state badge; `ArgMatcherSubform` structured editor + Raw JSON toggle
- `client/src/components/evals/__tests__/override-badge.test.tsx` (new — 3 tests)
- `client/src/components/evals/__tests__/arg-leaf-picker.test.tsx` (new — 4 tests)

## Verification

- Inspector typecheck: clean
- Inspector tests: 4865 passed | 6 skipped (up from 4858 — 7 new tests)
- SDK tests: 1071 passed (unchanged — no SDK code touched)

## Test plan

- [ ] Open a suite with `defaultMatchOptions.toolCallOrder = "strict"`; open a case. Confirm Tool order shows `(suite default · Strict order)` and is greyed.
- [ ] Change the case to `superset`. Confirm chip changes to `(overriding · suite: Strict order)`, input editable.
- [ ] Click the reset icon in the chip. Confirm chip returns to `(suite default · …)`.
- [ ] Repeat in the run popover (suite header).
- [ ] In a `toolCalledWith` check, set `argumentMatching` to `partial`, switch a leaf to `string`. Save + reopen → leaf still shows the placeholder picker.
- [ ] Flip to `exact` → placeholders disabled. Flip to `ignore` → args editor disabled with hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)