### PR TITLE
[codex] add workspace release changeset

### DIFF
--- a/.changeset/inspector-evals-ui-release.md
+++ b/.changeset/inspector-evals-ui-release.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/cli": minor
+"@mcpjam/inspector": minor
+---
+
+Workspace release rollup:
+
+- Add the advisory Goal Completion judge panel for eval test-case iterations
+- Surface partial-state visibility and insight error details in eval run views


### PR DESCRIPTION
## Summary
- Add a Changesets entry for the latest workspace release rollup
- Marks @mcpjam/sdk, @mcpjam/cli, and @mcpjam/inspector for minor releases

## Validation
- npx changeset status

## Notes
This PR intentionally does not run `changeset version`; the release bot should consume the changeset and open the later version-packages PR.