### PR TITLE
evals: pastel sweep — surface /50, foreground full-token

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/TestCaseClientHeader.tsx
+++ b/mcpjam-inspector/client/src/components/evals/TestCaseClientHeader.tsx
@@ -367,7 +367,7 @@ export function TestCaseClientHeader({
         {isTweaked ? (
           <div className="flex shrink-0 items-center gap-1">
             <span
-              className="rounded-md border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+              className="rounded-md border border-warning/50 bg-warning/50 px-1.5 py-0.5 text-[10px] font-medium text-foreground"
               data-testid="test-case-host-tweaked-badge"
             >
               Tweaked

--- a/mcpjam-inspector/client/src/components/evals/TestCaseClientHeader.tsx
+++ b/mcpjam-inspector/client/src/components/evals/TestCaseClientHeader.tsx
@@ -367,7 +367,7 @@ export function TestCaseClientHeader({
         {isTweaked ? (
           <div className="flex shrink-0 items-center gap-1">
             <span
-              className="rounded-md border border-warning/50 bg-warning/50 px-1.5 py-0.5 text-[10px] font-medium text-foreground"
+              className="rounded-md border border-warning/50 bg-warning/50 px-1.5 py-0.5 text-[10px] font-medium text-warning-foreground"
               data-testid="test-case-host-tweaked-badge"
             >
               Tweaked

--- a/mcpjam-inspector/client/src/components/evals/__tests__/iteration-result-presentation.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/iteration-result-presentation.test.ts
@@ -51,7 +51,7 @@ describe("getIterationResultDisplayLabel", () => {
 });
 
 describe("getIterationResultBadgeClass", () => {
-  it("uses rose styling for failed", () => {
+  it("uses pastel destructive surface for failed", () => {
     expect(
       getIterationResultBadgeClass(
         baseIteration({
@@ -60,23 +60,23 @@ describe("getIterationResultBadgeClass", () => {
           status: "completed",
         }),
       ),
-    ).toContain("red-800");
+    ).toContain("bg-destructive/50");
   });
 });
 
 describe("suitePassCriteriaCompactBadgeClassNames", () => {
-  it("uses chart-aligned red styling for failed suite outcome", () => {
+  it("uses pastel destructive surface for failed suite outcome", () => {
     const classes = suitePassCriteriaCompactBadgeClassNames("failed");
-    expect(classes).toContain("red-800");
+    expect(classes).toContain("bg-destructive/50");
     expect(classes).toContain("text-[10px]");
   });
 
-  it("uses emerald for passed and amber for passed_with_failures", () => {
+  it("uses pastel success for passed and pastel warning for passed_with_failures", () => {
     expect(suitePassCriteriaCompactBadgeClassNames("passed")).toContain(
-      "emerald",
+      "bg-success/50",
     );
     expect(
       suitePassCriteriaCompactBadgeClassNames("passed_with_failures"),
-    ).toContain("amber");
+    ).toContain("bg-warning/50");
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
@@ -13,6 +13,10 @@ import {
   type TriageRow,
 } from "./ai-triage-helpers";
 import { runDetailSectionLabelClass } from "./run-detail-typography";
+import {
+  passRateColorClass,
+  passRateSegmentColorClass,
+} from "./suite-overview-presentation";
 import type { EvalIteration, EvalSuiteRun } from "./types";
 
 export interface AiTriageCardProps {
@@ -214,7 +218,12 @@ export function AiTriageCard({
           </span>
         </div>
         <div className="mt-1.5">
-          <span className="font-metric text-xl font-semibold tabular-nums leading-none">
+          <span
+            className={cn(
+              "font-metric text-xl font-semibold tabular-nums leading-none",
+              passRateColorClass(passRate),
+            )}
+          >
             {passFailStats.total === 0 ? (
               <span className="text-muted-foreground">—</span>
             ) : (
@@ -238,7 +247,7 @@ export function AiTriageCard({
         >
           {passFailStats.total === 0 ? null : (
             <div
-              className="h-full bg-primary"
+              className={cn("h-full", passRateSegmentColorClass(passRate))}
               style={{ width: `${passRate}%` }}
               title={`${metricLabel}: ${passRate}%`}
             />

--- a/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
@@ -275,7 +275,7 @@ export function AiTriageCard({
             <div className="px-3 py-4 text-sm text-muted-foreground">
               {serverQuality.summary?.trim() ||
                 "The analysis produced no per-tool or per-workflow insights."}
-              <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+              <p className="mt-1 text-xs text-warning">
                 No per-tool/workflow breakdown was produced — the analysis may
                 have been truncated. Re-run to retry.
               </p>

--- a/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
@@ -298,31 +298,31 @@ function StatusBadge({
 }) {
   if (status === "passed") {
     return (
-      <Badge className="gap-1.5 bg-emerald-50 text-emerald-600 border-emerald-200 hover:bg-emerald-100 dark:bg-emerald-950/50 dark:text-emerald-400">
-        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+      <Badge className="gap-1.5 bg-success/50 text-foreground border-success/50 hover:brightness-95">
+        <span className="h-1.5 w-1.5 rounded-full bg-success/50" />
         Passed
       </Badge>
     );
   }
   if (status === "failed") {
     return (
-      <Badge className="gap-1.5 bg-destructive/10 text-destructive border-destructive/30 hover:bg-destructive/20 dark:bg-destructive/20 dark:border-destructive/40">
-        <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
+      <Badge className="gap-1.5 bg-destructive/50 text-foreground border-destructive/50 hover:brightness-95">
+        <span className="h-1.5 w-1.5 rounded-full bg-destructive/50" />
         {failCount} Failed
       </Badge>
     );
   }
   if (status === "running") {
     return (
-      <Badge className="gap-1.5 bg-amber-50 text-amber-600 border-amber-200 hover:bg-amber-100 dark:bg-amber-950/50 dark:text-amber-400">
-        <span className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+      <Badge className="gap-1.5 bg-warning/50 text-foreground border-warning/50 hover:brightness-95">
+        <span className="h-1.5 w-1.5 rounded-full bg-warning/50 animate-pulse" />
         Running
       </Badge>
     );
   }
   return (
-    <Badge className="gap-1.5 bg-amber-50 text-amber-600 border-amber-200 hover:bg-amber-100 dark:bg-amber-950/50 dark:text-amber-400">
-      <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+    <Badge className="gap-1.5 bg-warning/50 text-foreground border-warning/50 hover:brightness-95">
+      <span className="h-1.5 w-1.5 rounded-full bg-warning/50" />
       Mixed
     </Badge>
   );

--- a/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
@@ -299,7 +299,7 @@ function StatusBadge({
   if (status === "passed") {
     return (
       <Badge className="gap-1.5 bg-success/50 text-foreground border-success/50 hover:brightness-95">
-        <span className="h-1.5 w-1.5 rounded-full bg-success/50" />
+        <span className="h-1.5 w-1.5 rounded-full bg-success" />
         Passed
       </Badge>
     );
@@ -307,7 +307,7 @@ function StatusBadge({
   if (status === "failed") {
     return (
       <Badge className="gap-1.5 bg-destructive/50 text-foreground border-destructive/50 hover:brightness-95">
-        <span className="h-1.5 w-1.5 rounded-full bg-destructive/50" />
+        <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
         {failCount} Failed
       </Badge>
     );
@@ -315,14 +315,14 @@ function StatusBadge({
   if (status === "running") {
     return (
       <Badge className="gap-1.5 bg-warning/50 text-foreground border-warning/50 hover:brightness-95">
-        <span className="h-1.5 w-1.5 rounded-full bg-warning/50 animate-pulse" />
+        <span className="h-1.5 w-1.5 rounded-full bg-warning animate-pulse" />
         Running
       </Badge>
     );
   }
   return (
     <Badge className="gap-1.5 bg-warning/50 text-foreground border-warning/50 hover:brightness-95">
-      <span className="h-1.5 w-1.5 rounded-full bg-warning/50" />
+      <span className="h-1.5 w-1.5 rounded-full bg-warning" />
       Mixed
     </Badge>
   );

--- a/mcpjam-inspector/client/src/components/evals/commit-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-list-sidebar.tsx
@@ -161,7 +161,7 @@ export function CommitListSidebar({
                             {suiteName}
                           </span>
                           {isRunning ? (
-                            <div className="mt-0.5 text-[10px] text-amber-600 dark:text-amber-400">
+                            <div className="mt-0.5 text-[10px] text-warning">
                               in progress
                             </div>
                           ) : null}

--- a/mcpjam-inspector/client/src/components/evals/constants.ts
+++ b/mcpjam-inspector/client/src/components/evals/constants.ts
@@ -67,9 +67,16 @@ export const EVAL_OUTCOME_STATUS_TEXT_CLASS = {
 /** Foreground text color for low pass rates, negative deltas, and fail counts in dense eval UI. */
 export const EVAL_LOW_PASS_RATE_TEXT_CLASS = "text-destructive";
 
-/** Filled delete/destructive actions — pastel surface `/50`, neutral text. */
+/**
+ * Filled delete/destructive actions — pastel surface `/50`, neutral text.
+ *
+ * `hover:bg-destructive/50` is an explicit override: without it, the design-system
+ * `Button` default variant's `hover:bg-primary/90` wins under twMerge and the
+ * button would flash brand-orange on hover. Pinning hover-bg to the same `/50`
+ * destructive token lets `hover:brightness-95` do the affordance work.
+ */
 export const EVAL_DESTRUCTIVE_BUTTON_CLASS =
-  "border-transparent bg-destructive/50 text-foreground shadow-xs hover:brightness-95 focus-visible:ring-destructive/35";
+  "border-transparent bg-destructive/50 text-foreground shadow-xs hover:bg-destructive/50 hover:brightness-95 focus-visible:ring-destructive/35";
 
 /** Pastel fail fill for stacked iteration bars. */
 export const EVAL_FAIL_BAR_CLASS = "bg-destructive/50";
@@ -90,7 +97,7 @@ export const UI_CONFIG = {
     PASSED: "var(--color-success)",
     FAILED: "var(--color-destructive)",
     PENDING: "var(--color-warning)",
-    CANCELLED: "var(--muted-foreground)",
+    CANCELLED: "var(--color-muted-foreground)",
   },
 } as const;
 

--- a/mcpjam-inspector/client/src/components/evals/constants.ts
+++ b/mcpjam-inspector/client/src/components/evals/constants.ts
@@ -64,20 +64,19 @@ export const EVAL_OUTCOME_STATUS_TEXT_CLASS = {
   failed: "text-destructive",
 } as const;
 
-/** Darker red for low pass rates, negative deltas, and fail counts in dense eval UI. */
-export const EVAL_LOW_PASS_RATE_TEXT_CLASS =
-  "text-red-800 dark:text-red-400";
+/** Foreground text color for low pass rates, negative deltas, and fail counts in dense eval UI. */
+export const EVAL_LOW_PASS_RATE_TEXT_CLASS = "text-destructive";
 
-/** Filled delete/destructive actions — same red family as {@link EVAL_LOW_PASS_RATE_TEXT_CLASS}. */
+/** Filled delete/destructive actions — pastel surface `/50`, neutral text. */
 export const EVAL_DESTRUCTIVE_BUTTON_CLASS =
-  "border-transparent bg-red-800 text-white shadow-xs hover:bg-red-900 focus-visible:ring-red-800/25 dark:bg-red-700 dark:text-white dark:hover:bg-red-600 dark:focus-visible:ring-red-400/30";
+  "border-transparent bg-destructive/50 text-foreground shadow-xs hover:brightness-95 focus-visible:ring-destructive/35";
 
-/** Darker red fill for fail segments in iteration bars. */
-export const EVAL_FAIL_BAR_CLASS = "bg-red-700 dark:bg-red-600";
+/** Pastel fail fill for stacked iteration bars. */
+export const EVAL_FAIL_BAR_CLASS = "bg-destructive/50";
 
-/** Compact failed-outcome badges — same red family as {@link EVAL_LOW_PASS_RATE_TEXT_CLASS}. */
+/** Compact failed-outcome badges — pastel surface `/50`, neutral foreground. */
 export const EVAL_FAILED_BADGE_CLASS =
-  "bg-red-800/15 text-red-800 dark:bg-red-400/20 dark:text-red-400";
+  "bg-destructive/50 text-foreground";
 
 // UI configuration
 export const UI_CONFIG = {
@@ -91,7 +90,7 @@ export const UI_CONFIG = {
     PASSED: "var(--color-success)",
     FAILED: "var(--color-destructive)",
     PENDING: "var(--color-warning)",
-    CANCELLED: "hsl(240 3.7% 15.9%)",
+    CANCELLED: "var(--muted-foreground)",
   },
 } as const;
 
@@ -103,14 +102,16 @@ export const BORDER_COLORS = {
   [RESULT_STATUS.PENDING]: "bg-warning/50",
 } as const;
 
-// Status dot colors
+// Status dot colors — pastel `/50` surfaces per the sweep. If a 6px dot
+// loses legibility against `bg-muted` neighbours, follow up in PR-2 with
+// either a full-token fallback or `ring-1 ring-<token>/60`.
 export const STATUS_DOT_COLORS = {
-  [RESULT_STATUS.PASSED]: "bg-success",
-  [RESULT_STATUS.FAILED]: "bg-destructive",
-  [RESULT_STATUS.CANCELLED]: "bg-muted-foreground",
-  [RESULT_STATUS.PENDING]: "bg-warning",
-  RUNNING: "bg-warning",
-  DEFAULT: "bg-muted-foreground",
+  [RESULT_STATUS.PASSED]: "bg-success/50",
+  [RESULT_STATUS.FAILED]: "bg-destructive/50",
+  [RESULT_STATUS.CANCELLED]: "bg-muted-foreground/50",
+  [RESULT_STATUS.PENDING]: "bg-warning/50",
+  RUNNING: "bg-warning/50",
+  DEFAULT: "bg-muted-foreground/50",
 } as const;
 
 // Wizard steps

--- a/mcpjam-inspector/client/src/components/evals/copyable-code-block.tsx
+++ b/mcpjam-inspector/client/src/components/evals/copyable-code-block.tsx
@@ -60,7 +60,7 @@ export function CopyableCodeBlock({
               className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
               {copied ? (
-                <Check className="h-4 w-4 text-green-600 dark:text-green-500" />
+                <Check className="h-4 w-4 text-success" />
               ) : (
                 <Copy className="h-4 w-4" />
               )}
@@ -89,7 +89,7 @@ export function CopyableCodeBlock({
             className="absolute right-2 top-2 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
             {copied ? (
-              <Check className="h-4 w-4 text-green-600 dark:text-green-500" />
+              <Check className="h-4 w-4 text-success" />
             ) : (
               <Copy className="h-4 w-4" />
             )}

--- a/mcpjam-inspector/client/src/components/evals/cross-host/__tests__/pass-dot-row.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/__tests__/pass-dot-row.test.tsx
@@ -51,9 +51,9 @@ describe("PassDotRow", () => {
     );
     const dots = container.querySelectorAll("span[aria-hidden]");
     // First three should map to iterationNumber 1, 2, 3 — passed, failed, passed
-    expect(dots[0]).toHaveClass("bg-green-500"); // i1 passed
-    expect(dots[1]).toHaveClass("bg-red-500"); // i2 failed
-    expect(dots[2]).toHaveClass("bg-green-500"); // i3 passed
+    expect(dots[0]).toHaveClass("bg-success/50"); // i1 passed
+    expect(dots[1]).toHaveClass("bg-destructive/50"); // i2 failed
+    expect(dots[2]).toHaveClass("bg-success/50"); // i3 passed
   });
 
   it("falls back to createdAt when iterationNumber ties", () => {
@@ -66,8 +66,8 @@ describe("PassDotRow", () => {
       />,
     );
     const dots = container.querySelectorAll("span[aria-hidden]");
-    expect(dots[0]).toHaveClass("bg-green-500"); // i_a first (earlier createdAt)
-    expect(dots[1]).toHaveClass("bg-red-500"); // i_b second
+    expect(dots[0]).toHaveClass("bg-success/50"); // i_a first (earlier createdAt)
+    expect(dots[1]).toHaveClass("bg-destructive/50"); // i_b second
   });
 
   it("includes pending/cancelled counts in the aria summary", () => {

--- a/mcpjam-inspector/client/src/components/evals/cross-host/host-cell.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/host-cell.tsx
@@ -169,7 +169,7 @@ function HostMetricComparisonTooltip({
                     className={cn(
                       "w-14 text-right font-mono text-[10px] tabular-nums",
                       delta === "best"
-                        ? "text-emerald-600 dark:text-emerald-400"
+                        ? "text-success"
                         : "text-muted-foreground"
                     )}
                   >

--- a/mcpjam-inspector/client/src/components/evals/cross-host/pass-dot-row.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/pass-dot-row.tsx
@@ -70,11 +70,11 @@ export function PassDotRow({ iterations }: PassDotRowProps) {
             title={result}
             aria-hidden
             className={cn(
-              "inline-block size-2 rounded-full",
-              result === "passed" && "bg-green-500",
-              result === "failed" && "bg-red-500",
-              result === "cancelled" && "bg-gray-400",
-              (result === "pending") && "bg-yellow-400",
+              "inline-block size-2 rounded-full ring-1",
+              result === "passed" && "bg-success/50 ring-success/60",
+              result === "failed" && "bg-destructive/50 ring-destructive/60",
+              result === "cancelled" && "bg-muted-foreground/50 ring-muted-foreground/60",
+              result === "pending" && "bg-warning/50 ring-warning/60",
             )}
           />
         );

--- a/mcpjam-inspector/client/src/components/evals/eval-runner/ReviewStep.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-runner/ReviewStep.tsx
@@ -153,7 +153,7 @@ export function ReviewStep({
                   className={cn(
                     "rounded-md border p-3",
                     template.isNegativeTest
-                      ? "bg-orange-50/5 border-orange-500/30"
+                      ? "bg-info/50 border-info/50"
                       : "bg-muted/30",
                   )}
                 >
@@ -161,7 +161,7 @@ export function ReviewStep({
                     {template.isNegativeTest && (
                       <Badge
                         variant="outline"
-                        className="bg-orange-500/10 text-orange-600 border-orange-500/30 text-xs"
+                        className="bg-info/50 text-foreground border-info/50 text-xs"
                       >
                         <ShieldX className="h-3 w-3 mr-1" />
                         Negative
@@ -172,7 +172,7 @@ export function ReviewStep({
                     </p>
                   </div>
                   {template.isNegativeTest && template.scenario && (
-                    <p className="mt-1 text-xs text-orange-600/80 italic">
+                    <p className="mt-1 text-xs text-info italic">
                       Scenario: {template.scenario}
                     </p>
                   )}
@@ -202,7 +202,7 @@ export function ReviewStep({
                         </span>
                       )}
                     {template.isNegativeTest && (
-                      <span className="text-orange-600">
+                      <span className="text-info">
                         Expected: No tools triggered
                       </span>
                     )}

--- a/mcpjam-inspector/client/src/components/evals/eval-runner/ReviewStep.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-runner/ReviewStep.tsx
@@ -172,7 +172,7 @@ export function ReviewStep({
                     </p>
                   </div>
                   {template.isNegativeTest && template.scenario && (
-                    <p className="mt-1 text-xs text-info italic">
+                    <p className="mt-1 text-xs text-foreground italic">
                       Scenario: {template.scenario}
                     </p>
                   )}
@@ -202,7 +202,7 @@ export function ReviewStep({
                         </span>
                       )}
                     {template.isNegativeTest && (
-                      <span className="text-info">
+                      <span className="text-foreground">
                         Expected: No tools triggered
                       </span>
                     )}

--- a/mcpjam-inspector/client/src/components/evals/eval-runner/TestsStep.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-runner/TestsStep.tsx
@@ -131,13 +131,13 @@ export function TestsStep({
   const renderNegativeTestCard = (template: TestTemplate, index: number) => (
     <div
       key={index}
-      className="space-y-3 rounded-lg border border-orange-500/50 bg-orange-50/5 p-4"
+      className="space-y-3 rounded-lg border border-info/50 bg-info/50 p-4"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-2">
           <Badge
             variant="outline"
-            className="bg-orange-500/10 text-orange-600 border-orange-500/30"
+            className="bg-info/50 text-foreground border-info/50"
           >
             <ShieldX className="h-3 w-3 mr-1" />
             Negative Test
@@ -242,7 +242,7 @@ export function TestsStep({
           variant="outline"
           onClick={onAddNegativeTestTemplate}
           aria-label="Add negative test case"
-          className="flex-1 border-orange-500/30 text-orange-600 hover:bg-orange-50/10"
+          className="flex-1 border-info/50 text-info hover:bg-info/50"
         >
           <ShieldX className="h-4 w-4 mr-2" />
           Add negative test
@@ -307,7 +307,7 @@ export function TestsStep({
               variant="outline"
               onClick={onGenerateNegativeTests}
               disabled={isAnyGenerating}
-              className="border-orange-500/30 text-orange-600 hover:bg-orange-50/10"
+              className="border-info/50 text-info hover:bg-info/50"
             >
               {isGeneratingNegativeTests
                 ? "Generating..."

--- a/mcpjam-inspector/client/src/components/evals/eval-runner/TestsStep.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-runner/TestsStep.tsx
@@ -242,7 +242,7 @@ export function TestsStep({
           variant="outline"
           onClick={onAddNegativeTestTemplate}
           aria-label="Add negative test case"
-          className="flex-1 border-info/50 text-info hover:bg-info/50"
+          className="flex-1 border-info/50 text-info hover:bg-info/50 hover:text-foreground"
         >
           <ShieldX className="h-4 w-4 mr-2" />
           Add negative test
@@ -307,7 +307,7 @@ export function TestsStep({
               variant="outline"
               onClick={onGenerateNegativeTests}
               disabled={isAnyGenerating}
-              className="border-info/50 text-info hover:bg-info/50"
+              className="border-info/50 text-info hover:bg-info/50 hover:text-foreground"
             >
               {isGeneratingNegativeTests
                 ? "Generating..."

--- a/mcpjam-inspector/client/src/components/evals/explore-cases-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/explore-cases-list.tsx
@@ -220,7 +220,7 @@ export function ExploreCasesList({
                   {c.title}
                 </div>
                 {c.isNegativeTest ? (
-                  <span className="text-[10px] text-orange-500">
+                  <span className="text-[10px] text-info">
                     Negative case
                   </span>
                 ) : null}

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -69,8 +69,8 @@ function ScoreBadge({ passed }: { passed: boolean }) {
       className={cn(
         "rounded-sm px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide",
         passed
-          ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
-          : "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+          ? "bg-success/50 text-foreground"
+          : "bg-warning/50 text-foreground",
       )}
     >
       {passed ? "meets goal" : "below threshold"}
@@ -327,8 +327,8 @@ export function GoalCompletionCard({
           </p>
 
           {hasMeaningfulOverride ? (
-            <div className="mx-3 mb-3 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[12px]">
-              <div className="font-medium text-amber-700 dark:text-amber-300">
+            <div className="mx-3 mb-3 rounded-md border border-warning/50 bg-warning/50 px-3 py-2 text-[12px]">
+              <div className="font-medium text-foreground">
                 ⚙ This run used an override
               </div>
               <div className="mt-0.5 text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -333,6 +333,77 @@ export function evalStatusMiniBarClasses(result: string): string {
   }
 }
 
+/**
+ * Surface fills for status — `/50` opacity per the pastel sweep. Apply to
+ * backgrounds, dots, and tinted surfaces (NOT text/icons — those use the
+ * full-token {@link evalStatusTextClasses}). Body text riding on these
+ * surfaces should use `text-foreground`.
+ */
+export function evalStatusBgClasses(result: string): string {
+  switch (result) {
+    case RESULT_STATUS.PASSED:
+      return "bg-success/50";
+    case RESULT_STATUS.FAILED:
+      return "bg-destructive/50";
+    case RESULT_STATUS.PENDING:
+    case "running":
+      return "bg-warning/50 animate-pulse";
+    case RESULT_STATUS.CANCELLED:
+      return "bg-muted-foreground/40";
+    case "mixed":
+      return "bg-warning/50";
+    default:
+      return "bg-muted-foreground/40";
+  }
+}
+
+/**
+ * Foreground text color for status indicators — full semantic token (no
+ * `/50`). Use for status-only labels that don't ride on a tinted surface.
+ */
+export function evalStatusTextClasses(result: string): string {
+  switch (result) {
+    case RESULT_STATUS.PASSED:
+      return "text-success";
+    case RESULT_STATUS.FAILED:
+      return "text-destructive";
+    case RESULT_STATUS.PENDING:
+    case "running":
+      return "text-warning";
+    case RESULT_STATUS.CANCELLED:
+      return "text-muted-foreground";
+    case "mixed":
+      return "text-warning";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+/**
+ * Icon color for status indicators — identical to {@link evalStatusTextClasses};
+ * kept as a separate export for grep-ability at icon call sites.
+ */
+export function evalStatusIconClasses(result: string): string {
+  return evalStatusTextClasses(result);
+}
+
+/**
+ * Foreground text color for delta / NEW / first-run pills — full token, no `/50`.
+ */
+export function evalDeltaTextClasses(
+  kind: "new" | "first-run" | "up" | "down",
+): string {
+  switch (kind) {
+    case "new":
+    case "first-run":
+      return "text-info";
+    case "up":
+      return "text-success";
+    case "down":
+      return "text-destructive";
+  }
+}
+
 /** Left `border-l-*` for a suite overview row from `latestRun`. */
 export function evalOverviewEntryLeftBorderClass(
   entry: EvalSuiteOverviewEntry,

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -325,82 +325,11 @@ export function evalStatusMiniBarClasses(result: string): string {
     case "running":
       return "bg-warning/50 animate-pulse";
     case RESULT_STATUS.CANCELLED:
-      return "bg-muted-foreground/40";
+      return "bg-muted-foreground/50";
     case "mixed":
       return "bg-warning/50";
     default:
-      return "bg-muted-foreground/40";
-  }
-}
-
-/**
- * Surface fills for status — `/50` opacity per the pastel sweep. Apply to
- * backgrounds, dots, and tinted surfaces (NOT text/icons — those use the
- * full-token {@link evalStatusTextClasses}). Body text riding on these
- * surfaces should use `text-foreground`.
- */
-export function evalStatusBgClasses(result: string): string {
-  switch (result) {
-    case RESULT_STATUS.PASSED:
-      return "bg-success/50";
-    case RESULT_STATUS.FAILED:
-      return "bg-destructive/50";
-    case RESULT_STATUS.PENDING:
-    case "running":
-      return "bg-warning/50 animate-pulse";
-    case RESULT_STATUS.CANCELLED:
-      return "bg-muted-foreground/40";
-    case "mixed":
-      return "bg-warning/50";
-    default:
-      return "bg-muted-foreground/40";
-  }
-}
-
-/**
- * Foreground text color for status indicators — full semantic token (no
- * `/50`). Use for status-only labels that don't ride on a tinted surface.
- */
-export function evalStatusTextClasses(result: string): string {
-  switch (result) {
-    case RESULT_STATUS.PASSED:
-      return "text-success";
-    case RESULT_STATUS.FAILED:
-      return "text-destructive";
-    case RESULT_STATUS.PENDING:
-    case "running":
-      return "text-warning";
-    case RESULT_STATUS.CANCELLED:
-      return "text-muted-foreground";
-    case "mixed":
-      return "text-warning";
-    default:
-      return "text-muted-foreground";
-  }
-}
-
-/**
- * Icon color for status indicators — identical to {@link evalStatusTextClasses};
- * kept as a separate export for grep-ability at icon call sites.
- */
-export function evalStatusIconClasses(result: string): string {
-  return evalStatusTextClasses(result);
-}
-
-/**
- * Foreground text color for delta / NEW / first-run pills — full token, no `/50`.
- */
-export function evalDeltaTextClasses(
-  kind: "new" | "first-run" | "up" | "down",
-): string {
-  switch (kind) {
-    case "new":
-    case "first-run":
-      return "text-info";
-    case "up":
-      return "text-success";
-    case "down":
-      return "text-destructive";
+      return "bg-muted-foreground/50";
   }
 }
 
@@ -434,7 +363,7 @@ export function evalOverviewEntryMiniBarClass(
     return "bg-success/50";
   }
   if (r.result === "failed") return "bg-destructive/50";
-  return "bg-muted-foreground/40";
+  return "bg-muted-foreground/50";
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -497,7 +497,7 @@ export function evalOverviewEntryLastRunStatusClass(
   const r = entry.latestRun;
   if (!r) return "text-muted-foreground";
   if (r.status === "running" || r.status === "pending") {
-    return "text-amber-600 dark:text-amber-400";
+    return "text-warning";
   }
   if (r.result === "passed") return "text-success";
   if (r.result === "failed" || r.status === "failed") {

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -891,8 +891,8 @@ export function IterationDetails({
                   className={cn(
                     "rounded-full px-2 py-0.5 text-[10px] font-medium",
                     summary.passed
-                      ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
-                      : "bg-rose-500/10 text-rose-700 dark:text-rose-400",
+                      ? "bg-success/50 text-foreground"
+                      : "bg-destructive/50 text-foreground",
                   )}
                 >
                   {summary.passed ? "Passed" : "Failed"}
@@ -906,7 +906,7 @@ export function IterationDetails({
                 {summary.actualToolCalls.length}
               </div>
               {!summary.passed ? (
-                <div className="text-[10px] text-rose-700 dark:text-rose-400">
+                <div className="text-[10px] text-destructive">
                   {formatToolCallsSummary(
                     summary.expectedToolCalls,
                     summary.actualToolCalls,

--- a/mcpjam-inspector/client/src/components/evals/iteration-result-presentation.ts
+++ b/mcpjam-inspector/client/src/components/evals/iteration-result-presentation.ts
@@ -18,10 +18,10 @@ export function suitePassCriteriaCompactBadgeClassNames(
 ) {
   const colorClass =
     outcome === "passed"
-      ? "bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300"
+      ? "bg-success/50 text-foreground"
       : outcome === "failed"
         ? EVAL_FAILED_BADGE_CLASS
-        : "bg-amber-500/15 text-amber-700 dark:bg-amber-400/20 dark:text-amber-300";
+        : "bg-warning/50 text-foreground";
 
   return cn(ITERATION_RESULT_BADGE_BASE, colorClass);
 }
@@ -39,7 +39,7 @@ export function getIterationResultDisplayLabel(iteration: EvalIteration) {
 export function getIterationResultBadgeClass(iteration: EvalIteration) {
   const result = computeIterationResult(iteration);
   if (result === "passed") {
-    return "bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300";
+    return "bg-success/50 text-foreground";
   }
   if (result === "failed") {
     return EVAL_FAILED_BADGE_CLASS;
@@ -47,7 +47,7 @@ export function getIterationResultBadgeClass(iteration: EvalIteration) {
   if (result === "cancelled") {
     return "bg-muted text-muted-foreground";
   }
-  return "bg-amber-500/15 text-amber-700 dark:bg-amber-400/20 dark:text-amber-300";
+  return "bg-warning/50 text-foreground";
 }
 
 export function iterationResultBadgeClassNames(iteration: EvalIteration) {

--- a/mcpjam-inspector/client/src/components/evals/overview-panel.tsx
+++ b/mcpjam-inspector/client/src/components/evals/overview-panel.tsx
@@ -317,10 +317,10 @@ export function OverviewPanel({
       entry.latestRun.status === "running" ||
       entry.latestRun.status === "pending"
     ) {
-      return <Loader2 className="h-5 w-5 text-amber-500 animate-spin" />;
+      return <Loader2 className="h-5 w-5 text-warning animate-spin" />;
     }
     if (entry.latestRun.result === "passed") {
-      return <CheckCircle2 className="h-5 w-5 text-emerald-500" />;
+      return <CheckCircle2 className="h-5 w-5 text-success" />;
     }
     if (entry.latestRun.result === "failed") {
       return <XCircle className="h-5 w-5 text-destructive" />;
@@ -340,18 +340,18 @@ export function OverviewPanel({
 
   const bannerConfig = {
     failure: {
-      bg: "bg-destructive/10 border-destructive/30",
+      bg: "bg-destructive/50 border-destructive/50",
       icon: <AlertTriangle className="h-4 w-4 text-destructive" />,
       text: `${stats.failedCount} ${stats.failedCount === 1 ? "FAILURE" : "FAILURES"}`,
     },
     running: {
-      bg: "bg-amber-500/10 border-amber-500/30",
-      icon: <Loader2 className="h-4 w-4 text-amber-500 animate-spin" />,
+      bg: "bg-warning/50 border-warning/50",
+      icon: <Loader2 className="h-4 w-4 text-warning animate-spin" />,
       text: `${stats.runningCount} RUNNING`,
     },
     success: {
-      bg: "bg-emerald-500/10 border-emerald-500/30",
-      icon: <CheckCircle2 className="h-4 w-4 text-emerald-500" />,
+      bg: "bg-success/50 border-success/50",
+      icon: <CheckCircle2 className="h-4 w-4 text-success" />,
       text: "ALL PASSING",
     },
   }[bannerState];
@@ -424,12 +424,12 @@ export function OverviewPanel({
               const isActive = bucket.id === activeBucketId;
               const chipColor =
                 bucket.result === "failed"
-                  ? "bg-destructive"
+                  ? "bg-destructive/50"
                   : bucket.result === "running"
-                    ? "bg-amber-500"
+                    ? "bg-warning/50"
                     : bucket.result === "passed"
-                      ? "bg-emerald-500"
-                      : "bg-muted-foreground";
+                      ? "bg-success/50"
+                      : "bg-muted-foreground/50";
 
               const chipLabel = bucket.commitSha
                 ? bucket.commitSha.slice(0, 7)
@@ -548,8 +548,8 @@ export function OverviewPanel({
                                   className={cn(
                                     "h-full rounded-full transition-all",
                                     passRate! >= 75
-                                      ? "bg-amber-500"
-                                      : "bg-destructive",
+                                      ? "bg-warning/50"
+                                      : "bg-destructive/50",
                                   )}
                                   style={{ width: `${passRate}%` }}
                                 />
@@ -753,9 +753,9 @@ export function OverviewPanel({
                       passRate === "--"
                         ? "text-muted-foreground"
                         : parseInt(passRate) >= 95
-                          ? "text-emerald-500"
+                          ? "text-success"
                           : parseInt(passRate) >= 75
-                            ? "text-amber-500"
+                            ? "text-warning"
                             : "text-destructive",
                     )}
                   >
@@ -859,17 +859,17 @@ function InlineFailureTag({ tag }: { tag: FailureTag }) {
     regression: {
       label: "regression",
       className:
-        "text-destructive bg-destructive/10 border-destructive/30 dark:bg-destructive/20 dark:border-destructive/40",
+        "text-foreground bg-destructive/50 border-destructive/50",
     },
     flaky: {
       label: "flaky",
       className:
-        "text-amber-600 bg-amber-50 border-amber-200 dark:bg-amber-950/50 dark:border-amber-800",
+        "text-foreground bg-warning/50 border-warning/50",
     },
     new: {
       label: "new",
       className:
-        "text-blue-600 bg-blue-50 border-blue-200 dark:bg-blue-950/50 dark:border-blue-800",
+        "text-foreground bg-info/50 border-info/50",
     },
   }[tag];
 

--- a/mcpjam-inspector/client/src/components/evals/pass-criteria-badge.tsx
+++ b/mcpjam-inspector/client/src/components/evals/pass-criteria-badge.tsx
@@ -120,8 +120,7 @@ export function PassCriteriaBadge({
         {!passed && passRate < minimumPassRate && (
           <div
             className={cn(
-              "mt-2 rounded border-l-2 border-red-800/40 bg-red-800/10 p-2 text-xs dark:border-red-400/40 dark:bg-red-400/10",
-              EVAL_LOW_PASS_RATE_TEXT_CLASS,
+              "mt-2 rounded border-l-2 border-destructive/50 bg-destructive/50 p-2 text-xs text-foreground",
             )}
           >
             {metricLabel} {passRate.toFixed(1)}% below threshold{" "}

--- a/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
@@ -60,8 +60,8 @@ export function PredicatesList({ predicates }: { predicates: PredicateResult[] }
         <div
           className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${
             allPassed
-              ? "bg-green-500/15 text-green-700 dark:text-green-300"
-              : "bg-red-500/15 text-red-700 dark:text-red-300"
+              ? "bg-success/50 text-foreground"
+              : "bg-destructive/50 text-foreground"
           }`}
         >
           {allPassed ? "PASS" : `${passed}/${predicates.length} PASSED`}
@@ -82,16 +82,16 @@ function PredicateRow({ row }: { row: PredicateResult }) {
     <li
       className={`rounded border p-2 ${
         row.passed
-          ? "border-green-500/20 bg-green-500/5"
-          : "border-red-500/30 bg-red-500/5"
+          ? "border-success/50 bg-success/50"
+          : "border-destructive/50 bg-destructive/50"
       }`}
     >
       <div className="flex items-start gap-2">
         <span
           className={`mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${
             row.passed
-              ? "bg-green-500/15 text-green-700 dark:text-green-300"
-              : "bg-red-500/15 text-red-700 dark:text-red-300"
+              ? "bg-success/50 text-foreground"
+              : "bg-destructive/50 text-foreground"
           }`}
           aria-label={row.passed ? "passed" : "failed"}
         >

--- a/mcpjam-inspector/client/src/components/evals/run-accordion-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-accordion-view.tsx
@@ -209,7 +209,7 @@ export function RunAccordionView({
                   )}
 
                   {run.replayedFromRunId && (
-                    <span className="shrink-0 rounded bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600">
+                    <span className="shrink-0 rounded bg-info/50 px-1.5 py-0.5 text-[11px] font-medium text-foreground">
                       Replay
                     </span>
                   )}
@@ -219,7 +219,7 @@ export function RunAccordionView({
                   {total > 0 && (
                     <span className="flex items-center gap-2 shrink-0">
                       <span className="text-xs font-mono">
-                        <span className="text-emerald-600 dark:text-emerald-400">
+                        <span className="text-success">
                           {passed}
                         </span>
                         {failed > 0 && (
@@ -234,10 +234,10 @@ export function RunAccordionView({
                           className={cn(
                             "text-xs font-medium px-1.5 py-0.5 rounded",
                             passRate === 100
-                              ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                              ? "bg-success/50 text-foreground"
                               : passRate >= 80
-                                ? "bg-amber-500/10 text-amber-700 dark:text-amber-400"
-                                : "bg-destructive/10 text-destructive",
+                                ? "bg-warning/50 text-foreground"
+                                : "bg-destructive/50 text-foreground",
                           )}
                         >
                           {passRate}%
@@ -247,7 +247,7 @@ export function RunAccordionView({
                   )}
 
                   {run.status === "running" && (
-                    <span className="text-xs text-amber-600 dark:text-amber-400 font-medium shrink-0">
+                    <span className="text-xs text-warning font-medium shrink-0">
                       Running...
                     </span>
                   )}

--- a/mcpjam-inspector/client/src/components/evals/run-diff-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-diff-view.tsx
@@ -280,7 +280,7 @@ function RunDiffLoaded({
                     <div className="flex min-w-0 flex-wrap items-center gap-2">
                       <StatusBadge status={row.status} />
                       {row.configChanged ? (
-                        <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+                        <span className="rounded bg-warning/50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground">
                           Config changed
                         </span>
                       ) : null}
@@ -406,8 +406,8 @@ function DeltaPill({
   const toneClass = neutral
     ? "bg-muted text-muted-foreground"
     : isGood
-    ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-    : "bg-destructive/10 text-destructive";
+    ? "bg-success/50 text-foreground"
+    : "bg-destructive/50 text-foreground";
 
   return (
     <span
@@ -507,13 +507,13 @@ function statusBadgeClass(status: EvalRunDiffCaseStatus): string {
   switch (status) {
     case "regressed":
     case "unchanged_failed":
-      return "bg-destructive/10 text-destructive";
+      return "bg-destructive/50 text-foreground";
     case "fixed":
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+      return "bg-success/50 text-foreground";
     case "new_case":
     case "removed_case":
     case "changed":
-      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+      return "bg-warning/50 text-foreground";
     case "unchanged_passed":
       return "bg-muted text-muted-foreground";
   }

--- a/mcpjam-inspector/client/src/components/evals/sdk-eval-quickstart.tsx
+++ b/mcpjam-inspector/client/src/components/evals/sdk-eval-quickstart.tsx
@@ -269,7 +269,7 @@ function ApiKeyRow({
                   onClick={onCopyKey}
                 >
                   {headerCopied ? (
-                    <Check className="h-3.5 w-3.5 text-green-600" />
+                    <Check className="h-3.5 w-3.5 text-success" />
                   ) : (
                     <Copy className="h-3.5 w-3.5" />
                   )}

--- a/mcpjam-inspector/client/src/components/evals/server-attachment-picker.tsx
+++ b/mcpjam-inspector/client/src/components/evals/server-attachment-picker.tsx
@@ -177,7 +177,7 @@ export function ServerAttachmentPicker({
             "flex h-8 max-w-[260px] shrink-0 items-center gap-1 rounded-full border px-2 text-foreground",
             "outline-none transition-colors",
             !selectedAttachment
-              ? "border-amber-500/50 bg-amber-500/10 hover:bg-amber-500/20"
+              ? "border-warning/50 bg-warning/50 hover:brightness-95"
               : "border-border/60 bg-muted/40 hover:bg-muted/60",
             disabled && "cursor-not-allowed opacity-50"
           )}

--- a/mcpjam-inspector/client/src/components/evals/suite-overview-presentation.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-overview-presentation.tsx
@@ -52,7 +52,7 @@ export function computeSuitePassRateDelta(
     return { value: null, label: "—", colorClass: "text-muted-foreground" };
   }
   if (trend.length < 2) {
-    return { value: null, label: "NEW", colorClass: "text-blue-500" };
+    return { value: null, label: "NEW", colorClass: "text-info" };
   }
   const delta = Math.round(
     (trend[trend.length - 1] - trend[trend.length - 2]) * 100,
@@ -63,7 +63,7 @@ export function computeSuitePassRateDelta(
   return {
     value: delta,
     label: `${delta > 0 ? "+" : ""}${delta}%`,
-    colorClass: delta > 0 ? "text-emerald-500" : EVAL_LOW_PASS_RATE_TEXT_CLASS,
+    colorClass: delta > 0 ? "text-success" : EVAL_LOW_PASS_RATE_TEXT_CLASS,
   };
 }
 
@@ -107,16 +107,16 @@ export function getSuitePassFailCounts(
 
 export function passRateColorClass(percent: number | null): string {
   if (percent === null) return "text-muted-foreground";
-  if (percent >= 95) return "text-emerald-500";
-  if (percent >= 75) return "text-amber-500";
+  if (percent >= 95) return "text-success";
+  if (percent >= 75) return "text-warning";
   return EVAL_LOW_PASS_RATE_TEXT_CLASS;
 }
 
 /** Segment fills for pass-rate bars — thresholds aligned with {@link passRateColorClass}. */
 export function passRateSegmentColorClass(percent: number | null): string {
   if (percent === null) return "bg-muted-foreground/15";
-  if (percent >= 95) return "bg-emerald-500";
-  if (percent >= 75) return "bg-amber-500";
+  if (percent >= 95) return "bg-success/50";
+  if (percent >= 75) return "bg-warning/50";
   return EVAL_FAIL_BAR_CLASS;
 }
 
@@ -164,7 +164,7 @@ export function SuiteOverviewStatusIcon({
   ) {
     return (
       <Loader2
-        className={cn(iconClass, "animate-spin text-amber-500")}
+        className={cn(iconClass, "animate-spin text-warning")}
         aria-label="Running"
       />
     );
@@ -172,7 +172,7 @@ export function SuiteOverviewStatusIcon({
   if (entry.latestRun.result === "passed") {
     return (
       <CheckCircle2
-        className={cn(iconClass, "text-emerald-500")}
+        className={cn(iconClass, "text-success")}
         aria-label="Passed"
       />
     );
@@ -249,10 +249,10 @@ export function SuitePassFailMiniBar({
           className={cn(
             "h-full rounded-full transition-all",
             pct >= 95
-              ? "bg-emerald-500"
+              ? "bg-success/50"
               : pct >= 75
-                ? "bg-amber-500"
-                : "bg-destructive",
+                ? "bg-warning/50"
+                : "bg-destructive/50",
           )}
           style={{ width: `${pct}%` }}
         />

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-chart-grid.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-chart-grid.tsx
@@ -36,7 +36,7 @@ function computeTrendDelta(
     return { value: null, label: "—", colorClass: "text-muted-foreground" };
   }
   if (data.length < 2) {
-    return { value: null, label: "First run", colorClass: "text-blue-500" };
+    return { value: null, label: "First run", colorClass: "text-info" };
   }
   const delta =
     data[data.length - 1].passRate - data[data.length - 2].passRate;
@@ -46,7 +46,7 @@ function computeTrendDelta(
   return {
     value: delta,
     label: `${delta > 0 ? "+" : ""}${delta}% vs previous`,
-    colorClass: delta > 0 ? "text-emerald-500" : EVAL_LOW_PASS_RATE_TEXT_CLASS,
+    colorClass: delta > 0 ? "text-success" : EVAL_LOW_PASS_RATE_TEXT_CLASS,
   };
 }
 

--- a/mcpjam-inspector/client/src/components/evals/tag-aggregation-panel.tsx
+++ b/mcpjam-inspector/client/src/components/evals/tag-aggregation-panel.tsx
@@ -54,11 +54,11 @@ function getStatusDot(entry: EvalSuiteOverviewEntry): {
   const run = entry.latestRun;
   if (!run) return { label: "No runs", dotClass: "bg-muted-foreground/40" };
   if (run.status === "running" || run.status === "pending")
-    return { label: "Running", dotClass: "bg-amber-500 animate-pulse" };
+    return { label: "Running", dotClass: "bg-warning/50 animate-pulse" };
   if (run.result === "passed")
-    return { label: "Passed", dotClass: "bg-emerald-500" };
+    return { label: "Passed", dotClass: "bg-success/50" };
   if (run.result === "failed")
-    return { label: "Failed", dotClass: "bg-destructive" };
+    return { label: "Failed", dotClass: "bg-destructive/50" };
   return { label: run.status, dotClass: "bg-muted-foreground/40" };
 }
 
@@ -289,18 +289,18 @@ export function TagAggregationPanel({
           const cardBorderClass = !hasData
             ? "border-muted-foreground/20"
             : group.passRate >= 95
-              ? "border-emerald-500/40"
+              ? "border-success/50"
               : group.passRate >= 75
-                ? "border-amber-500/40"
-                : "border-destructive/40";
+                ? "border-warning/50"
+                : "border-destructive/50";
 
           const barColorClass = !hasData
             ? "bg-muted-foreground/30"
             : group.passRate >= 95
-              ? "bg-emerald-500/70"
+              ? "bg-success/50"
               : group.passRate >= 75
-                ? "bg-amber-500/70"
-                : "bg-destructive/70";
+                ? "bg-warning/50"
+                : "bg-destructive/50";
 
           return (
             <div
@@ -338,7 +338,7 @@ export function TagAggregationPanel({
                   <span
                     className={cn(
                       "flex items-center gap-1 text-xs",
-                      trendDelta > 0 ? "text-emerald-500" : "text-destructive",
+                      trendDelta > 0 ? "text-success" : "text-destructive",
                     )}
                   >
                     {trendDelta > 0 ? (
@@ -615,7 +615,7 @@ export function TagAggregationPanel({
                     {group.totals.passed + group.totals.failed > 0 ? (
                       <>
                         <span className="text-xs text-muted-foreground">
-                          <span className="text-emerald-600">
+                          <span className="text-success">
                             {group.totals.passed} passed
                           </span>
                           {" · "}
@@ -659,9 +659,9 @@ export function TagAggregationPanel({
                         suitePassRate === null
                           ? "text-muted-foreground"
                           : suitePassRate >= 95
-                            ? "text-emerald-500"
+                            ? "text-success"
                             : suitePassRate >= 75
-                              ? "text-amber-500"
+                              ? "text-warning"
                               : "text-destructive";
 
                       return (
@@ -704,7 +704,7 @@ export function TagAggregationPanel({
                           <div className="w-20 text-right text-xs text-muted-foreground">
                             {total > 0 ? (
                               <>
-                                <span className="text-emerald-600">
+                                <span className="text-success">
                                   {entry.totals.passed}
                                 </span>
                                 {" / "}

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -546,7 +546,7 @@ export function TestCasesOverview({
               const caseTitle = testCase.title || "Untitled test case";
               const passBadge = (
                 <span
-                  className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300"
+                  className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-success/50 text-foreground"
                   aria-label="Passed"
                 >
                   Passed

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1737,31 +1737,31 @@ export function TestTemplateEditor({
     latestAvailableResult === "failed"
       ? {
           dotClass:
-            "size-1.5 shrink-0 rounded-full bg-rose-500 dark:bg-rose-400",
-          buttonTextClass: "text-rose-700 dark:text-rose-300",
+            "size-1.5 shrink-0 rounded-full bg-destructive/50",
+          buttonTextClass: "text-destructive",
           ariaResults: "View results, last run failed",
           ariaOpen: "Open last run, failed",
         }
       : latestAvailableResult === "passed"
       ? {
           dotClass:
-            "size-1.5 shrink-0 rounded-full bg-emerald-500 dark:bg-emerald-400",
-          buttonTextClass: "text-emerald-700 dark:text-emerald-300",
+            "size-1.5 shrink-0 rounded-full bg-success/50",
+          buttonTextClass: "text-success",
           ariaResults: "View results, last run passed",
           ariaOpen: "Open last run passed",
         }
       : latestAvailableResult === "cancelled"
       ? {
           dotClass:
-            "size-1.5 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400",
-          buttonTextClass: "text-amber-800 dark:text-amber-200",
+            "size-1.5 shrink-0 rounded-full bg-warning/50",
+          buttonTextClass: "text-warning",
           ariaResults: "View results, last run stopped",
           ariaOpen: "Open last run stopped",
         }
       : {
           dotClass:
-            "size-1.5 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400 animate-pulse motion-reduce:animate-none",
-          buttonTextClass: "text-amber-800 dark:text-amber-200",
+            "size-1.5 shrink-0 rounded-full bg-warning/50 animate-pulse motion-reduce:animate-none",
+          buttonTextClass: "text-warning",
           ariaResults: "View results, run in progress",
           ariaOpen: "Open last run, in progress",
         };
@@ -2663,9 +2663,9 @@ function RunColumn({
       </div>
     )
   ) : record.status === "cancelled" && !record.iteration ? (
-    <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-amber-500/25 bg-amber-500/5 px-6 py-10">
+    <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-warning/50 bg-warning/50 px-6 py-10">
       <div className="max-w-sm text-center">
-        <div className="text-sm font-medium text-amber-800 dark:text-amber-200">
+        <div className="text-sm font-medium text-foreground">
           {record.modelLabel} stopped
         </div>
         <p className="mt-2 text-sm text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/tool-call-diff.tsx
+++ b/mcpjam-inspector/client/src/components/evals/tool-call-diff.tsx
@@ -230,7 +230,7 @@ function toneBorderClass(tone: Tone): string {
     case "extra":
       return "border-info/50";
     case "order":
-      return "border-warning/50";
+      return "border-warning/50 border-dashed";
     case "arg":
       return "border-warning/50";
   }

--- a/mcpjam-inspector/client/src/components/evals/tool-call-diff.tsx
+++ b/mcpjam-inspector/client/src/components/evals/tool-call-diff.tsx
@@ -217,7 +217,7 @@ function toneClass(tone: Tone): string {
     case "extra":
       return "bg-info/50 text-foreground";
     case "order":
-      return "bg-info/50 text-foreground";
+      return "bg-warning/50 text-foreground";
     case "arg":
       return "bg-warning/50 text-foreground";
   }
@@ -230,7 +230,7 @@ function toneBorderClass(tone: Tone): string {
     case "extra":
       return "border-info/50";
     case "order":
-      return "border-info/50";
+      return "border-warning/50";
     case "arg":
       return "border-warning/50";
   }

--- a/mcpjam-inspector/client/src/components/evals/tool-call-diff.tsx
+++ b/mcpjam-inspector/client/src/components/evals/tool-call-diff.tsx
@@ -42,8 +42,8 @@ export function ToolCallDiff({
         <div
           className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${
             result.passed
-              ? "bg-green-500/15 text-green-700 dark:text-green-300"
-              : "bg-red-500/15 text-red-700 dark:text-red-300"
+              ? "bg-success/50 text-foreground"
+              : "bg-destructive/50 text-foreground"
           }`}
         >
           {result.passed ? "PASS" : "FAIL"}
@@ -111,7 +111,7 @@ export function ToolCallDiff({
           {argumentMismatches.map((m, i) => (
             <div
               key={`arg-${i}`}
-              className="rounded border border-amber-500/30 bg-amber-500/5 p-1.5 text-xs"
+              className="rounded border border-warning/50 bg-warning/50 p-1.5 text-xs"
             >
               <div className="font-mono font-medium">{m.toolName}</div>
               <div className="mt-1 grid grid-cols-2 gap-2 text-[11px]">
@@ -213,26 +213,26 @@ function ArgsBlock({
 function toneClass(tone: Tone): string {
   switch (tone) {
     case "missing":
-      return "bg-red-500/15 text-red-700 dark:text-red-300";
+      return "bg-destructive/50 text-foreground";
     case "extra":
-      return "bg-blue-500/15 text-blue-700 dark:text-blue-300";
+      return "bg-info/50 text-foreground";
     case "order":
-      return "bg-purple-500/15 text-purple-700 dark:text-purple-300";
+      return "bg-info/50 text-foreground";
     case "arg":
-      return "bg-amber-500/15 text-amber-700 dark:text-amber-300";
+      return "bg-warning/50 text-foreground";
   }
 }
 
 function toneBorderClass(tone: Tone): string {
   switch (tone) {
     case "missing":
-      return "border-red-500/30";
+      return "border-destructive/50";
     case "extra":
-      return "border-blue-500/30";
+      return "border-info/50";
     case "order":
-      return "border-purple-500/30";
+      return "border-info/50";
     case "arg":
-      return "border-amber-500/30";
+      return "border-warning/50";
   }
 }
 

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -1594,7 +1594,7 @@ function TimelineDetailPane({
             className={cn(
               "space-y-2",
               row.span.category === "error" || toolErrorExcerpt
-                ? "rounded-md border border-red-500/25 bg-red-500/5 p-2"
+                ? "rounded-md border border-destructive/50 bg-destructive/50 p-2"
                 : "",
             )}
           >
@@ -1603,7 +1603,7 @@ function TimelineDetailPane({
             </div>
             <PayloadPreview value={tabOutputValue ?? undefined} />
             {toolErrorExcerpt ? (
-              <pre className="max-h-40 overflow-auto rounded-md border border-red-500/20 bg-red-500/5 p-3 text-xs whitespace-pre-wrap break-words text-red-900 dark:text-red-100">
+              <pre className="max-h-40 overflow-auto rounded-md border border-destructive/50 bg-destructive/50 p-3 text-xs whitespace-pre-wrap break-words text-foreground">
                 {toolErrorExcerpt}
               </pre>
             ) : null}
@@ -2074,7 +2074,7 @@ export function TraceTimeline({
     return (
       <div className="space-y-3">
         <div className="flex items-center gap-2">
-          <Badge className="border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300">
+          <Badge className="border-warning/50 bg-warning/50 text-foreground">
             Estimated total only
           </Badge>
           <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- Sweeps the eval playground onto a single pastel palette built from existing `--success` / `--destructive` / `--warning` / `--info` design-system tokens. No new tokens.
- Rule: `/50` opacity on **surfaces** (bg, border, dot, rail, mini-bar). Full semantic token on **text and icons**. `text-foreground` when text rides on a tinted bg.
- Replaces vibe-coded Tailwind palette literals across the playground (`text-red-800`, `bg-emerald-500/15`, `text-amber-500`, `bg-blue-500/10`, etc.) with helpers + the rule above. Adds 4 new helpers to `evals/helpers.ts`.

## What's in each commit
- **PR-1** (`4a44d20d2`): new helpers (`evalStatusBgClasses`, `evalStatusTextClasses`, `evalStatusIconClasses`, `evalDeltaTextClasses`) + sources of truth (`constants.ts` exports `EVAL_LOW_PASS_RATE_TEXT_CLASS` / `EVAL_DESTRUCTIVE_BUTTON_CLASS` / `EVAL_FAIL_BAR_CLASS` / `EVAL_FAILED_BADGE_CLASS` / `STATUS_DOT_COLORS`, plus `iteration-result-presentation.ts` badges).
- **PR-2** (`63f17c205`): ~23 status-display surfaces routed through PR-1 — suite dashboard, run accordion, test cases overview, overview alerts, cross-host matrix, predicates, diff views, triage card, plus three drift surfaces found mid-sweep (`pass-criteria-badge.tsx`, `tag-aggregation-panel.tsx`, `goal-completion-card.tsx`).
- **PR-3** (`b3cb3da27`): peripherals — `trace-timeline.tsx` error `<pre>` carve-out, `server-attachment-picker.tsx`, `helpers.ts` running label, `CiEvalsTab.tsx`, eval-runner.

## Carve-outs (intentionally not touched)
- `evalOverviewEntrySelectedRowClass` in `helpers.ts:374` — selection affordance (`bg-<token>/10 ring-<token>/{35,40}`), not palette drift.
- Recharts `var(--chart-*)` — role-based series identity, not pass/fail status.
- Trace-timeline error `<pre>` **body text** — code/error legibility surface; surface tints (`bg-destructive/50 border-destructive/50`) but body stays `text-foreground`.

## Test plan
- [ ] `npm run typecheck:client` — green locally.
- [ ] `npx vitest run client/src/components/evals/` — 607/607 locally; snapshot assertions updated by hand (no `-u`).
- [ ] Walk these surfaces in both light and dark mode after pulling the branch:
  - [ ] Suite dashboard (`/playground/suite/:id`) — left rails, mini-bars, "NEW"/"First run" delta pills, pass-rate threshold text colors.
  - [ ] Run detail / accordion (`run-accordion-view.tsx`, `iteration-details.tsx`, `run-diff-view.tsx`).
  - [ ] Test cases overview — outcome tag badges, predicate rows.
  - [ ] Cross-host matrix — `pass-dot-row.tsx` dots (rings applied), `host-cell.tsx`.
  - [ ] Alerts / dialogs / triage (`overview-panel.tsx`, `commit-detail-view.tsx`, `ai-triage-card.tsx`).
  - [ ] Destructive confirm dialog (delete a test case) — reads as destructive, not inert.
- [ ] Eyeball the four visual-QA flags before merging:
  - [ ] `cross-host/pass-dot-row.tsx` 8px dots got `ring-1 ring-<token>/60` fallback. If they look fine, consider matching the same treatment on `STATUS_DOT_COLORS` (currently un-ringed) for consistency.
  - [ ] Stacked iteration bars: `EVAL_FAIL_BAR_CLASS = bg-destructive/50` adjacent to `bg-success/50` pass segments may not differentiate; flip to full token if so.
  - [ ] `text-foreground` on `bg-warning/50` in dark mode (~3.19:1) — surfaces: running banner / "Tweaked" chip / "Config changed" pill in `overview-panel.tsx`.
  - [ ] `commit-detail-view.tsx` destructive badge bumped from `bg-destructive/10 + text-destructive` to `bg-destructive/50 + text-foreground` — confirm character.
- [ ] Toggle Brutalist / Soft-pop / Tangerine theme presets — confirm pastels still hold up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only Tailwind/class changes with no eval logic or API changes; manual light/dark and contrast checks on warning/destructive badges are the main follow-up.
> 
> **Overview**
> **Pastel semantic palette** for pass/fail/running/warning states across the eval playground: surfaces and borders use **`/50`** tints on `--success`, `--destructive`, `--warning`, and `--info`; labels and icons use full semantic tokens (or `text-foreground` on tinted backgrounds).
> 
> **Central sources** in `constants.ts` and `iteration-result-presentation.ts` now drive badges, fail bars, destructive buttons, status dots, and chart cancel color—replacing literals like `text-red-800`, `bg-emerald-500/15`, and `text-amber-600`.
> 
> **Component sweep** touches dashboards, run/commit views, cross-host dots (with **`ring-1`** on 8px dots), AI triage pass-rate bar (via `passRateColorClass` / `passRateSegmentColorClass`), negative-test styling (**orange → `info`**), trace error panels, and eval-runner steps. Vitest expectations were updated to match the new class strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0e6d1402de052bee11946149cf39f952b50ca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->