### PR TITLE
ui: move Compare into Connect tabs + deep-link hosts + eval Compare button

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -49,6 +49,7 @@ import { SupportTab } from "./components/SupportTab";
 import { RegistryTab } from "./components/RegistryTab";
 import { ClientsTab } from "./components/ClientsTab";
 import { HostConfigCompareView } from "./components/clients/comparison/HostConfigCompareView";
+import { ConnectViewHeader } from "./components/clients/ConnectViewHeader";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
 import { MCPSidebar } from "./components/mcp-sidebar";
@@ -629,12 +630,39 @@ export function ClientsRoute() {
 }
 
 export function HostCompareRoute() {
-  const { convexProjectId, isAuthenticated } = useAppRouteContext();
-  return (
+  const { convexProjectId, hostsHubFlagEnabled, isAuthenticated } =
+    useAppRouteContext();
+  const [previewedHostId] = usePreviewedHostId(convexProjectId);
+  const navigate = useAppNavigate();
+
+  const compareView = (
     <HostConfigCompareView
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
     />
+  );
+
+  // Mirror the gating ClientsRoute uses: when the hosts hub is off, Compare
+  // has no peer Servers/Client tabs to switch to, so render bare.
+  if (!hostsHubFlagEnabled || !isAuthenticated) {
+    return compareView;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <ConnectViewHeader
+        value="compare"
+        previewedHostId={previewedHostId}
+        onChange={(next) => {
+          if (next === "servers") {
+            navigate(routePaths.servers);
+          } else if (next === "host" && previewedHostId) {
+            navigate(buildClientsPath(previewedHostId));
+          }
+        }}
+      />
+      <div className="min-h-0 flex-1">{compareView}</div>
+    </div>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/ClientsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ClientsTab.tsx
@@ -4,11 +4,11 @@ import { useNavigate } from "react-router";
 import { ClientBuilderView } from "./clients/ClientBuilderView";
 import { ClientsConnectAddServerSlotContext } from "./clients/ClientsConnectAddServerSlotContext";
 import { ClientsConnectViewPhaseContext } from "./clients/ClientsConnectViewPhaseContext";
+import { ConnectViewHeader } from "./clients/ConnectViewHeader";
 import { SNAPPY_RAIL } from "./clients/transition-tokens";
-import { ViewModeSelector } from "./shared/view-mode-selector";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { useHost, useHostList } from "@/hooks/useClients";
-import { routePaths } from "@/lib/app-navigation";
+import { buildHostComparePath, routePaths } from "@/lib/app-navigation";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
@@ -144,44 +144,30 @@ export function ClientsTab({
             className="absolute inset-0 flex min-h-0 flex-col bg-background text-foreground"
           >
             <ClientsConnectAddServerSlotContext.Provider value={addServerSlotEl}>
-              <div
-                className="relative shrink-0 border-b border-border/40 px-4 py-2.5 md:px-8"
-                data-testid="hosts-tab-header-chrome"
-              >
-                <div className="flex flex-col items-stretch gap-2 md:grid md:grid-cols-[1fr_auto_1fr] md:items-center md:gap-3">
-                  <div className="hidden md:block" aria-hidden="true" />
-                  <div className="flex min-w-0 justify-center">
-                    <ViewModeSelector
-                      value="servers"
-                      ariaLabel="Connect view"
-                      onChange={(next) => {
-                        // `onSelectHost` is wired to `handleSelectHost` in
-                        // ClientsRoute, which itself calls `navigate(buildHostsPath(...))`
-                        // — calling `navigate` here too pushes a duplicate
-                        // history entry, breaking the browser Back button.
-                        if (next === "host" && previewedHostId) {
-                          onSelectHost(previewedHostId);
-                        } else if (next === "servers") {
-                          navigate(routePaths.servers);
-                        }
-                      }}
-                      options={[
-                        { value: "servers", label: "Servers" },
-                        {
-                          value: "host",
-                          label: "Client",
-                          disabled: !previewedHostId,
-                        },
-                      ]}
-                    />
-                  </div>
+              <ConnectViewHeader
+                value="servers"
+                previewedHostId={previewedHostId}
+                onChange={(next) => {
+                  // `onSelectHost` is wired to `handleSelectHost` in
+                  // ClientsRoute, which itself calls `navigate(buildHostsPath(...))`
+                  // — calling `navigate` here too pushes a duplicate
+                  // history entry, breaking the browser Back button.
+                  if (next === "host" && previewedHostId) {
+                    onSelectHost(previewedHostId);
+                  } else if (next === "servers") {
+                    navigate(routePaths.servers);
+                  } else if (next === "compare") {
+                    navigate(buildHostComparePath());
+                  }
+                }}
+                rightSlot={
                   <div
                     ref={setAddServerSlotEl}
                     className="flex min-w-0 flex-wrap items-center justify-center gap-3 md:justify-end"
                     data-testid="hosts-tab-add-server-slot"
                   />
-                </div>
-              </div>
+                }
+              />
               <div
                 className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background text-foreground"
                 style={browseShellStyle}

--- a/mcpjam-inspector/client/src/components/clients/ConnectViewHeader.tsx
+++ b/mcpjam-inspector/client/src/components/clients/ConnectViewHeader.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import { ViewModeSelector } from "@/components/shared/view-mode-selector";
+
+export type ConnectViewValue = "servers" | "host" | "compare";
+
+interface ConnectViewHeaderProps {
+  value: ConnectViewValue;
+  previewedHostId: string | null;
+  onChange: (next: ConnectViewValue) => void;
+  /**
+   * Optional content placed in the third grid column (typically the
+   * Servers-view "add server" slot). Default is an empty placeholder so the
+   * centered selector stays centered.
+   */
+  rightSlot?: ReactNode;
+  testId?: string;
+}
+
+export function ConnectViewHeader({
+  value,
+  previewedHostId,
+  onChange,
+  rightSlot,
+  testId = "hosts-tab-header-chrome",
+}: ConnectViewHeaderProps) {
+  return (
+    <div
+      className="relative shrink-0 border-b border-border/40 px-4 py-2.5 md:px-8"
+      data-testid={testId}
+    >
+      <div className="flex flex-col items-stretch gap-2 md:grid md:grid-cols-[1fr_auto_1fr] md:items-center md:gap-3">
+        <div className="hidden md:block" aria-hidden="true" />
+        <div className="flex min-w-0 justify-center">
+          <ViewModeSelector
+            value={value}
+            ariaLabel="Connect view"
+            onChange={onChange}
+            options={[
+              { value: "servers", label: "Servers" },
+              {
+                value: "host",
+                label: "Client",
+                disabled: !previewedHostId,
+              },
+              { value: "compare", label: "Compare" },
+            ]}
+          />
+        </div>
+        {rightSlot ?? <div className="hidden md:block" aria-hidden="true" />}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
@@ -75,11 +75,20 @@ export function HostConfigCompareView({
   useEffect(() => {
     if (!urlConsumedRef.current) return;
     if (listLoading) return;
+    // Skip while the selection hasn't been resolved yet. The selection
+    // effect above sets `urlConsumedRef.current = true` synchronously and
+    // queues the parsed-from-URL selection, so this effect runs in the same
+    // commit with `selectedHostIds` still empty. Treating that as "default"
+    // would delete `?hosts=` before the queued state lands, clobbering the
+    // deep link. After resolve, `selectedHostIds` is always ≥ 1 (resolver
+    // falls back to all live hosts; `toggleHostCompareSelection` keeps
+    // `minSelected=1`), so an empty selection means "not yet resolved."
+    if (selectedHostIds.length === 0) return;
     const isDefault =
       selectedHostIds.length === liveHostIds.length &&
       selectedHostIds.every((id, i) => id === liveHostIds[i]);
     const current = searchParams.get(HOSTS_QUERY_PARAM);
-    if (isDefault || selectedHostIds.length === 0) {
+    if (isDefault) {
       if (current === null) return;
       const next = new URLSearchParams(searchParams);
       next.delete(HOSTS_QUERY_PARAM);

--- a/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
@@ -1,14 +1,18 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
+import { useSearchParams } from "react-router";
 import { useHost, useHostList } from "@/hooks/useClients";
 import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
 import { HostCompareSelector } from "./HostCompareSelector";
 import {
+  parseHostsParam,
   resolveInitialHostCompareSelection,
   toggleHostCompareSelection,
   writeHostCompareSelection,
 } from "./host-compare-selection";
 import { HostConfigComparisonMatrix } from "./host-config-comparison-matrix";
+
+const HOSTS_QUERY_PARAM = "hosts";
 
 interface HostConfigCompareViewProps {
   projectId: string | null;
@@ -34,6 +38,11 @@ export function HostConfigCompareView({
   >({});
   const [selectedHostIds, setSelectedHostIds] = useState<string[]>([]);
   const [divergingOnly, setDivergingOnly] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Tracks whether the initial URL-driven selection has been applied.
+  // After the first resolve, subsequent URL changes are ignored — Compare
+  // becomes the source of truth and mirrors back into the URL.
+  const urlConsumedRef = useRef(false);
 
   const liveHostIds = useMemo(
     () => hosts.map((host) => host.hostId),
@@ -42,19 +51,47 @@ export function HostConfigCompareView({
 
   useEffect(() => {
     if (listLoading) return;
+    const urlSelection = urlConsumedRef.current
+      ? null
+      : parseHostsParam(searchParams.get(HOSTS_QUERY_PARAM));
+    urlConsumedRef.current = true;
     setSelectedHostIds((previous) =>
       resolveInitialHostCompareSelection({
         projectId: projectId ?? "",
         liveHostIds,
         previousSelection: previous,
+        urlSelection,
       }),
     );
-  }, [listLoading, liveHostIds, projectId]);
+  }, [listLoading, liveHostIds, projectId, searchParams]);
 
   useEffect(() => {
     if (!projectId || selectedHostIds.length === 0) return;
     writeHostCompareSelection(projectId, selectedHostIds);
   }, [projectId, selectedHostIds]);
+
+  // Mirror selection → ?hosts=. Suppress when the selection is the default
+  // "all live hosts" (in original order) so shared links stay clean.
+  useEffect(() => {
+    if (!urlConsumedRef.current) return;
+    if (listLoading) return;
+    const isDefault =
+      selectedHostIds.length === liveHostIds.length &&
+      selectedHostIds.every((id, i) => id === liveHostIds[i]);
+    const current = searchParams.get(HOSTS_QUERY_PARAM);
+    if (isDefault || selectedHostIds.length === 0) {
+      if (current === null) return;
+      const next = new URLSearchParams(searchParams);
+      next.delete(HOSTS_QUERY_PARAM);
+      setSearchParams(next, { replace: true });
+      return;
+    }
+    const desired = selectedHostIds.join(",");
+    if (current === desired) return;
+    const next = new URLSearchParams(searchParams);
+    next.set(HOSTS_QUERY_PARAM, desired);
+    setSearchParams(next, { replace: true });
+  }, [selectedHostIds, liveHostIds, listLoading, searchParams, setSearchParams]);
 
   const reportSubject = useCallback(
     (hostId: string, subject: HostComparisonSubject) => {

--- a/mcpjam-inspector/client/src/components/clients/comparison/__tests__/host-compare-selection.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/comparison/__tests__/host-compare-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
+  parseHostsParam,
   reconcileHostCompareSelection,
   resolveInitialHostCompareSelection,
   toggleHostCompareSelection,
@@ -48,5 +49,37 @@ describe("host-compare-selection", () => {
   it("readHostCompareSelection returns null for invalid storage", () => {
     sessionStorage.setItem("host-compare-selected:proj_1", "{not-json");
     expect(readHostCompareSelection("proj_1")).toBeNull();
+  });
+
+  it("parseHostsParam splits, trims, and ignores empty entries", () => {
+    expect(parseHostsParam("a,b,c")).toEqual(["a", "b", "c"]);
+    expect(parseHostsParam(" a , ,b ")).toEqual(["a", "b"]);
+    expect(parseHostsParam("")).toBeNull();
+    expect(parseHostsParam(null)).toBeNull();
+    expect(parseHostsParam(undefined)).toBeNull();
+  });
+
+  it("resolveInitialHostCompareSelection prefers urlSelection over storage", () => {
+    writeHostCompareSelection("proj_1", ["b"]);
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: ["a", "b", "c"],
+        previousSelection: [],
+        urlSelection: ["c", "a"],
+      }),
+    ).toEqual(["c", "a"]);
+  });
+
+  it("resolveInitialHostCompareSelection falls through when urlSelection has no live hosts", () => {
+    writeHostCompareSelection("proj_1", ["b"]);
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: ["a", "b", "c"],
+        previousSelection: [],
+        urlSelection: ["dead-host"],
+      }),
+    ).toEqual(["b"]);
   });
 });

--- a/mcpjam-inspector/client/src/components/clients/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/clients/comparison/host-compare-selection.ts
@@ -49,13 +49,28 @@ export function toggleHostCompareSelection(
   return [...selectedHostIds, hostId];
 }
 
+export function parseHostsParam(raw: string | null | undefined): string[] | null {
+  if (!raw) return null;
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return parts.length > 0 ? parts : null;
+}
+
 export function resolveInitialHostCompareSelection(args: {
   projectId: string;
   liveHostIds: ReadonlyArray<string>;
   previousSelection: ReadonlyArray<string>;
+  urlSelection?: ReadonlyArray<string> | null;
 }): string[] {
   const live = new Set(args.liveHostIds);
   if (live.size === 0) return [];
+
+  if (args.urlSelection && args.urlSelection.length > 0) {
+    const fromUrl = reconcileHostCompareSelection(args.urlSelection, live);
+    if (fromUrl.length > 0) return fromUrl;
+  }
 
   const stored = readHostCompareSelection(args.projectId);
   if (stored) {

--- a/mcpjam-inspector/client/src/components/clients/redesigned/ClientBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/ClientBuilderViewRedesigned.tsx
@@ -430,11 +430,14 @@ export function ClientBuilderViewRedesigned({
                   // The URL→state sync in ClientsRoute will clear the
                   // selected host when /servers takes over.
                   navigate("/servers");
+                } else if (next === "compare") {
+                  navigate("/host-compare");
                 }
               }}
               options={[
                 { value: "servers", label: "Servers" },
                 { value: "host", label: "Client" },
+                { value: "compare", label: "Compare" },
               ]}
             />
           </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-overview-client-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-overview-client-bar.tsx
@@ -6,10 +6,19 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@mcpjam/design-system/dropdown-menu";
-import { Globe, MoreHorizontal, Plus, X } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import { GitCompare, Globe, MoreHorizontal, Plus, X } from "lucide-react";
 import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
 import { type HostListItem } from "@/hooks/useClients";
-import { navigateApp, routePaths } from "@/lib/app-navigation";
+import {
+  buildHostComparePath,
+  navigateApp,
+  routePaths,
+} from "@/lib/app-navigation";
 import { cn } from "@/lib/utils";
 import type { HostAttachmentDraft } from "./client-attachments-editor";
 import type { EvalSuite } from "./types";
@@ -124,6 +133,37 @@ export function SuiteOverviewClientBar({
         (host) => !attachments.some((a) => a.namedHostId === host.hostId),
       ),
     [projectHosts, attachments],
+  );
+
+  const canCompare = attachments.length >= 2;
+  const handleOpenCompare = () => {
+    navigateApp(
+      buildHostComparePath(attachments.map((a) => a.namedHostId)),
+    );
+  };
+  const compareButton = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {/* Span wrapper lets the tooltip surface when the button is disabled. */}
+        <span className="shrink-0">
+          <button
+            type="button"
+            className="flex h-8 shrink-0 items-center gap-1 rounded-full border border-border/60 bg-background px-2.5 text-xs font-medium text-foreground outline-none transition-colors hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:bg-background"
+            aria-label="Compare attached hosts"
+            disabled={!canCompare}
+            onClick={handleOpenCompare}
+          >
+            <GitCompare className="h-3.5 w-3.5" />
+            <span>Compare</span>
+          </button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {canCompare
+          ? "Compare attached hosts side by side"
+          : "Attach 2+ hosts to compare"}
+      </TooltipContent>
+    </Tooltip>
   );
 
   const addHostMenu = (align: "start" | "end") => (
@@ -299,6 +339,7 @@ export function SuiteOverviewClientBar({
             })}
 
             {editable ? addHostMenu("end") : null}
+            {compareButton}
           </div>
         </div>
       </div>

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -17,7 +17,6 @@ import {
   Box,
   LayoutGrid,
   GitBranch,
-  GitCompare,
   Puzzle,
   UserPlus,
   ShieldCheck,
@@ -188,15 +187,7 @@ const navigationSections: NavSection[] = [
         url: "/servers",
         icon: MCPIcon,
         featureFlag: "hosts-enabled",
-        matchTabs: ["clients"],
-      },
-      {
-        title: "Compare",
-        url: "/host-compare",
-        icon: GitCompare,
-        // Gated by the same flag as Connect — there's no useful Compare
-        // surface for users who don't have the hosts hub turned on.
-        featureFlag: "hosts-enabled",
+        matchTabs: ["clients", "host-compare"],
       },
       {
         title: "Servers",

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -60,6 +60,17 @@ export function buildClientsPath(hostId?: string | null): string {
   return `${routePaths.clients}/${encodeURIComponent(hostId)}`;
 }
 
+/** Build a path that deep-links into Compare with a pre-selected set of hosts. */
+export function buildHostComparePath(
+  hostIds?: ReadonlyArray<string> | null,
+): string {
+  if (!hostIds || hostIds.length === 0) return routePaths.hostCompare;
+  const param = hostIds.map((id) => id.trim()).filter((id) => id.length > 0);
+  if (param.length === 0) return routePaths.hostCompare;
+  const search = new URLSearchParams({ hosts: param.join(",") });
+  return `${routePaths.hostCompare}?${search.toString()}`;
+}
+
 /** Build a path for a specific organization route. */
 export function buildOrganizationPath(
   orgId: string,


### PR DESCRIPTION
## Summary

- **Compare under Connect.** Compare becomes a third tab on Connect (`Servers | Client | Compare`). Standalone sidebar entry removed; Connect's `matchTabs` extended so it stays highlighted on `/host-compare`. Route `/host-compare` is preserved, no broken links. A new `ConnectViewHeader` is shared between `ClientsTab` and `HostCompareRoute` so both render the same tab chrome.
- **Compare is deep-linkable.** Compare reads `?hosts=a,b,c` on first resolve and mirrors selection back to the URL. The URL is suppressed at the default (all live hosts) so shared links stay clean. New `buildHostComparePath` helper.
- **Compare button in the Eval Playground.** The Hosts row next to `+ Attach host` gets a `Compare` button that prefills the URL with the attached hosts' ids and navigates into Compare. Disabled with a tooltip when fewer than 2 hosts are attached.

Rationale: Connect already owns host-as-client config (the Client tab is the MCPJam host config), so Compare reads as "my client + how it stacks up to others" rather than an unrelated sibling.

## Test plan

- [ ] Sidebar: standalone Compare entry is gone; Connect is highlighted both on `/servers` and `/host-compare`.
- [ ] On `/servers`, the tab strip shows `Servers | Client | Compare`. Clicking `Compare` lands on `/host-compare` with the chrome intact and the default selection (all live hosts), no `?hosts` in the URL.
- [ ] On `/host-compare`, switching to `Servers` returns to the server list; `Client` is enabled iff a previewed host exists and navigates to that host.
- [ ] Toggle some hosts off in Compare → URL updates to `?hosts=…`; reload preserves selection; selecting all again clears `?hosts`.
- [ ] Open a link like `/host-compare?hosts=<id1>,<id2>` directly → only those hosts are selected on load.
- [ ] Eval Playground suite with <2 attached hosts: `Compare` button is disabled, tooltip reads "Attach 2+ hosts to compare".
- [ ] With 2+ attached hosts: `Compare` button navigates to Compare with exactly those hosts pre-selected.
- [ ] `npm run typecheck:client` passes; `vitest` passes (8 selection tests including 3 new url-precedence cases, plus broader evals/comparison suites — 626 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only navigation and URL/query sync for compare selection; guarded against clobbering deep links on first resolve, with unit tests for selection precedence.
> 
> **Overview**
> **Compare moves under Connect** as a third tab (`Servers | Client | Compare`) via a shared `ConnectViewHeader`, used on the servers hub and on `/host-compare` when the hosts hub is enabled. The standalone sidebar Compare entry is removed; Connect stays highlighted on `host-compare` through `matchTabs`.
> 
> **Deep linking:** Compare reads `?hosts=a,b,c` on first load (URL beats session storage), then mirrors the column selection back into the URL and drops the param when the selection is the default “all live hosts.” `buildHostComparePath` builds those links.
> 
> **Entry points:** The eval suite hosts row adds a **Compare** control (enabled with 2+ attachments) that opens Compare with attached host ids prefilled. The client builder tab strip also gains a Compare option (still a local `ViewModeSelector`, not the shared header).
> 
> Tests cover `parseHostsParam` and URL-first selection resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54f19a84444ad991cacab1e52b37b4899ec43ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->