### PR TITLE
evals: split CI gating into new evaluate-ci flag, flatten Evaluate sidebar

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1161,7 +1161,7 @@ export default function App() {
   const hostsEnabled = useFeatureFlagEnabled("hosts-enabled");
   const hostsHubFlagEnabled = isPostHogBooleanFlagOn(hostsEnabled);
   const playgroundEnabled = useFeatureFlagEnabled("playground-enabled");
-  const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-runs");
+  const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const {
     getAccessToken,

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -2556,7 +2556,7 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByTestId("playground-tab")).not.toBeInTheDocument();
   });
 
-  it("keeps Playground available when evaluate-runs is disabled", async () => {
+  it("keeps Playground available when evaluate-ci is disabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/evals");
@@ -2575,7 +2575,7 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
   });
 
-  it("waits on ci-evals while the evaluate-runs flag is still loading", async () => {
+  it("waits on ci-evals while the evaluate-ci flag is still loading", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/ci-evals");
@@ -2586,7 +2586,7 @@ describe("App hosted OAuth callback handling", () => {
     };
     mockPosthogState.featureFlags.hasLoadedFlags = false;
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "evaluate-runs"
+      flag === "evaluate-ci"
         ? evaluateRunsState.value
         : flag === "playground-enabled"
     );
@@ -2611,7 +2611,7 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByText("Loading Runs...")).not.toBeInTheDocument();
   });
 
-  it("redirects ci-evals to evals when evaluate-runs is disabled", async () => {
+  it("redirects ci-evals to evals when evaluate-ci is disabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/ci-evals");
@@ -2619,7 +2619,7 @@ describe("App hosted OAuth callback handling", () => {
 
     mockPosthogState.featureFlags.hasLoadedFlags = false;
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "evaluate-runs" ? undefined : flag === "playground-enabled"
+      flag === "evaluate-ci" ? undefined : flag === "playground-enabled"
     );
 
     render(<App />);
@@ -2639,14 +2639,14 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
   });
 
-  it("redirects nested ci-evals routes to evals when evaluate-runs is disabled", async () => {
+  it("redirects nested ci-evals routes to evals when evaluate-ci is disabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/ci-evals/suite/s_123?view=runs");
     mockHandleOAuthCallback.mockReset();
 
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "evaluate-runs" ? undefined : flag === "playground-enabled"
+      flag === "evaluate-ci" ? undefined : flag === "playground-enabled"
     );
 
     render(<App />);
@@ -2840,7 +2840,7 @@ describe("App hosted OAuth callback handling", () => {
     });
   });
 
-  it("still applies the CI billing redirect when evaluate-runs is enabled", async () => {
+  it("still applies the CI billing redirect when evaluate-ci is enabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/ci-evals");
@@ -2862,7 +2862,7 @@ describe("App hosted OAuth callback handling", () => {
     }));
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) =>
-        flag === "billing-entitlements-ui" || flag === "evaluate-runs"
+        flag === "billing-entitlements-ui" || flag === "evaluate-ci"
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "users:getCurrentUser") {

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -114,7 +114,7 @@ describe("filterByFeatureFlags", () => {
     expect(result[0].items[0].title).toBe("Plain");
   });
 
-  it("keeps Evaluate item visible when evaluate-runs is off", () => {
+  it("keeps Evaluate item visible when evaluate-ci is off", () => {
     const result = filterByFeatureFlags(
       [
         {
@@ -131,26 +131,26 @@ describe("filterByFeatureFlags", () => {
           ],
         },
       ],
-      { "evaluate-runs": false },
+      { "evaluate-ci": false },
     );
     const titles = result[0].items.map((i) => i.title);
     expect(titles).toEqual(["Views", "Evaluate"]);
   });
 
-  it("keeps Playground visible when evaluate-runs is off", () => {
+  it("renders no subnav when evaluate-ci is off (Evaluate is a flat link)", () => {
     expect(
       getEvalsSubnavItems({ evaluateRunsEnabled: false }).map(
         (item) => item.title,
       ),
-    ).toEqual(["Playground"]);
+    ).toEqual([]);
   });
 
-  it("shows Runs when evaluate-runs is on", () => {
+  it("shows Runs as the only subnav item when evaluate-ci is on", () => {
     expect(
       getEvalsSubnavItems({ evaluateRunsEnabled: true }).map(
         (item) => item.title,
       ),
-    ).toEqual(["Playground", "Runs"]);
+    ).toEqual(["Runs"]);
   });
 
   it("hides Conformance when the feature flag is off", () => {

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import { useMutation, useConvexAuth } from "convex/react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useHostList } from "@/hooks/useClients";
 import { toast } from "sonner";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
@@ -618,6 +619,8 @@ export function SuiteIterationsView({
     navigation.toSuiteOverview(suite._id);
   };
 
+  const ciEnabled = useFeatureFlagEnabled("evaluate-ci") === true;
+
   const handleOpenSuiteExport = useCallback(() => {
     setExportState({
       scope: "suite",
@@ -722,7 +725,7 @@ export function SuiteIterationsView({
             aggregate={aggregate}
             testCases={cases}
             onSetupCi={onSetupCi}
-            onOpenExportSuite={handleOpenSuiteExport}
+            onOpenExportSuite={ciEnabled ? handleOpenSuiteExport : undefined}
             readOnlyConfig={readOnlyConfig}
             hideRunActions={hideRunActions}
             unifiedSuiteDashboard={hideRunActions && !caseListInSidebar}
@@ -769,7 +772,7 @@ export function SuiteIterationsView({
                   isDirectGuest={isDirectGuest}
                   ensureServersReady={ensureServersReady}
                   projectServers={projectServers}
-                  onExportDraft={handleOpenDraftExport}
+                  onExportDraft={ciEnabled ? handleOpenDraftExport : undefined}
                   openCompareFromRoute={
                     route.type === "test-edit" && Boolean(route.openCompare)
                   }

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -751,8 +751,28 @@ export function MCPSidebar({
         </SidebarHeader>
         <SidebarContent>
           {visibleNavigationSections.map((section, sectionIndex) => {
-            const evalsEntry = section.items.find((item) => item.evalsSubnav);
-            const flatItems = section.items.filter((item) => !item.evalsSubnav);
+            const rawEvalsEntry = section.items.find((item) => item.evalsSubnav);
+            // Only render Evaluate through the SidebarEvalsNavGroup wrapper
+            // (which adds its own SidebarGroup padding) when there's actually
+            // a Runs sub-item to nest. Otherwise, fold Evaluate into flatItems
+            // so it sits flush with Views and matches sibling spacing.
+            const useEvalsSubnavWrapper =
+              !!rawEvalsEntry && evaluateRunsEnabled === true;
+            const evalsEntry = useEvalsSubnavWrapper ? rawEvalsEntry : undefined;
+            const flatItems = section.items
+              .map((item) => {
+                if (!item.evalsSubnav) return item;
+                if (useEvalsSubnavWrapper) return null;
+                const locked = playgroundEnabled !== true;
+                return {
+                  ...item,
+                  disabled: locked || item.disabled,
+                  disabledTooltip: locked
+                    ? "Coming soon. Playground is in beta."
+                    : item.disabledTooltip,
+                };
+              })
+              .filter((item): item is NavItem => item !== null);
 
             return (
               <React.Fragment key={section.id}>

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -17,7 +17,6 @@ import {
   Box,
   LayoutGrid,
   GitBranch,
-  Puzzle,
   UserPlus,
   ShieldCheck,
   Loader2,
@@ -391,9 +390,9 @@ function navigateToEvalsRunsList() {
 }
 
 type EvalsSubnavItem = {
-  title: "Playground" | "Runs";
+  title: "Runs";
   href: string;
-  icon: typeof Puzzle | typeof GitBranch;
+  icon: typeof GitBranch;
   isActive: (activeTab?: string) => boolean;
   onClick: () => void;
 };
@@ -401,27 +400,16 @@ type EvalsSubnavItem = {
 export function getEvalsSubnavItems(options: {
   evaluateRunsEnabled: boolean;
 }): EvalsSubnavItem[] {
-  const items: EvalsSubnavItem[] = [
+  if (!options.evaluateRunsEnabled) return [];
+  return [
     {
-      title: "Playground",
-      href: buildEvalsPath({ type: "list" }),
-      icon: Puzzle,
-      isActive: (activeTab) => activeTab === "evals",
-      onClick: navigateToEvalsExploreList,
-    },
-  ];
-
-  if (options.evaluateRunsEnabled) {
-    items.push({
       title: "Runs",
       href: "/ci-evals",
       icon: GitBranch,
       isActive: (activeTab) => activeTab === "ci-evals",
       onClick: navigateToEvalsRunsList,
-    });
-  }
-
-  return items;
+    },
+  ];
 }
 
 export function SidebarEvalsNavGroup({
@@ -446,6 +434,7 @@ export function SidebarEvalsNavGroup({
   const subnavItems = getEvalsSubnavItems({
     evaluateRunsEnabled: showRuns,
   });
+  const hasSubnav = subnavItems.length > 0;
 
   const parentButton = (
     <SidebarMenuButton
@@ -491,55 +480,47 @@ export function SidebarEvalsNavGroup({
                   </TooltipContent>
                 ) : null}
               </Tooltip>
+            ) : isPlaygroundLocked && !hasSubnav ? (
+              <Tooltip>
+                <TooltipTrigger asChild>{parentButton}</TooltipTrigger>
+                <TooltipContent side="right" sideOffset={6}>
+                  Coming soon. Playground is in beta.
+                </TooltipContent>
+              </Tooltip>
             ) : (
               parentButton
             )}
-            <SidebarMenuSub>
-              {subnavItems.map((item) => {
-                const ItemIcon = item.icon;
-                const isItemPlaygroundLocked =
-                  item.title === "Playground" && isPlaygroundLocked;
-                const isItemDisabled = disabled || isItemPlaygroundLocked;
+            {hasSubnav ? (
+              <SidebarMenuSub>
+                {subnavItems.map((item) => {
+                  const ItemIcon = item.icon;
+                  const isItemDisabled = disabled || isPlaygroundLocked;
 
-                const subnavButton = (
-                  <SidebarMenuSubButton
-                    isActive={!isItemDisabled && item.isActive(activeTab)}
-                    href={item.href}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      if (isItemDisabled) return;
-                      item.onClick();
-                    }}
-                    aria-disabled={isItemDisabled || undefined}
-                    className={cn(
-                      isItemDisabled &&
-                        "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground",
-                      isItemPlaygroundLocked &&
-                        "aria-disabled:pointer-events-auto",
-                      disabled && "pointer-events-none"
-                    )}
-                  >
-                    <ItemIcon className="h-4 w-4" />
-                    <span className="min-w-0 truncate">{item.title}</span>
-                  </SidebarMenuSubButton>
-                );
-
-                return (
-                  <SidebarMenuSubItem key={item.title}>
-                    {isItemPlaygroundLocked ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>{subnavButton}</TooltipTrigger>
-                        <TooltipContent side="right" sideOffset={6}>
-                          Coming soon. Playground is in beta.
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : (
-                      subnavButton
-                    )}
-                  </SidebarMenuSubItem>
-                );
-              })}
-            </SidebarMenuSub>
+                  return (
+                    <SidebarMenuSubItem key={item.title}>
+                      <SidebarMenuSubButton
+                        isActive={!isItemDisabled && item.isActive(activeTab)}
+                        href={item.href}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          if (isItemDisabled) return;
+                          item.onClick();
+                        }}
+                        aria-disabled={isItemDisabled || undefined}
+                        className={cn(
+                          isItemDisabled &&
+                            "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground",
+                          disabled && "pointer-events-none"
+                        )}
+                      >
+                        <ItemIcon className="h-4 w-4" />
+                        <span className="min-w-0 truncate">{item.title}</span>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  );
+                })}
+              </SidebarMenuSub>
+            ) : null}
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarGroupContent>
@@ -573,7 +554,7 @@ export function MCPSidebar({
   const learningFlagEnabled = useFeatureFlagEnabled("mcpjam-learning");
   const sandboxesEnabled = useFeatureFlagEnabled("sandboxes-enabled");
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
-  const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-runs");
+  const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
   const playgroundEnabled = useFeatureFlagEnabled("playground-enabled");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -297,43 +297,4 @@ describe("sidebar invite CTA", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows disabled Playground with a beta tooltip when the flag is off", () => {
-    mockFeatureFlags["playground-enabled"] = false;
-    window.history.replaceState({}, "", "/servers");
-
-    renderSidebar();
-
-    expect(screen.getByRole("button", { name: "Evaluate" })).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
-    const playground = screen.getByRole("button", { name: "Playground" });
-    expect(playground).toHaveAttribute("aria-disabled", "true");
-    expect(playground).toHaveClass("cursor-not-allowed");
-    expect(
-      screen.getByText("Coming soon. Playground is in beta."),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
-
-    fireEvent.click(playground);
-
-    expect(window.location.pathname).toBe("/servers");
-    expect(window.location.hash).toBe("");
-  });
-
-  it("enables Playground without a beta badge when the flag is on", () => {
-    mockFeatureFlags["playground-enabled"] = true;
-
-    renderSidebar();
-
-    const playground = screen
-      .getByText("Playground")
-      .closest("button") as HTMLButtonElement;
-    expect(playground).toBeInTheDocument();
-    expect(playground).not.toHaveAttribute("aria-disabled");
-    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("Coming soon. Playground is in beta."),
-    ).not.toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
## Summary

- New PostHog flag **`evaluate-ci`** (id 698338, 0% rollout) gates the CI surface: Runs sub-nav + Setup SDK buttons. Replaces all in-code references to the old `evaluate-runs` flag (the old flag in PostHog can be deleted at your convenience).
- **Evaluate sidebar collapses to a flat link** to `/evals` when `evaluate-ci` is off — clicking Evaluate goes straight to Playground. When `evaluate-ci` is on, Runs appears as the only sub-item (no more nested Playground row).
- Setup SDK buttons (suite header + test template editor) are now suppressed unless `evaluate-ci` is on. Done by withholding the `onOpenExportSuite` / `onExportDraft` callbacks at the suite-iterations-view parent — leaf components already render nothing when those props are undefined.
- `playground-enabled` continues to gate Evaluate visibility and the flask "Save as test case" / "Promote to test case" affordances; not touched.

## Net behavior right now
With `playground-enabled` at 100% / `evaluate-ci` at 0%: everyone sees a single flat **Evaluate** item that goes to Playground. No Runs, no Setup SDK buttons.

## Test plan
- [x] `mcp-sidebar-feature-flags.test.ts` updated and green (17 tests)
- [x] `suite-header.test.tsx` still green (15 tests) — onOpenExportSuite contract unchanged
- [x] `App.hosted-oauth.test.tsx` flag-key references migrated (`"evaluate-runs"` → `"evaluate-ci"`)
- [ ] Manually verify in the inspector: Evaluate is a flat link, Setup SDK is hidden on suite/test pages, flask save/promote still work
- [ ] Manually verify with `evaluate-ci` flipped on (override locally): Runs sub-item appears, Setup SDK buttons reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly feature-flag and navigation wiring; default 0% rollout hides CI/export until PostHog is configured, with no auth or data-path changes.
> 
> **Overview**
> Introduces PostHog flag **`evaluate-ci`** (replacing **`evaluate-runs`**) as the switch for CI evals: **`/ci-evals`**, Runs loading/redirects, and sidebar Runs nesting all read this flag.
> 
> **Evaluate navigation** is simplified: with **`evaluate-ci` off**, Evaluate is a **single flat link** to Playground (no Playground/Runs sub-items). With the flag **on**, only **Runs** appears under Evaluate. **`playground-enabled`** still controls whether Evaluate is locked and the beta tooltip.
> 
> **Setup SDK / export** entry points are gated at **`suite-iterations-view`**: **`onOpenExportSuite`** and **`onExportDraft`** are only passed when **`evaluate-ci`** is true, so suite header and test editor hide those actions when CI is off.
> 
> Tests and mocks are updated for the new flag key and subnav expectations; sidebar tests that asserted a nested disabled Playground row were removed in favor of the flat Evaluate behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4873c54f9eb0af228626710460ddd1b75533a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->