### PR TITLE
evals: surface added-servers in chat-import toasts

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
@@ -294,9 +294,17 @@ export function ConvertChatSessionDialog({
         testCaseId: string;
         createdSuite?: boolean;
         updatedSuiteEnvironment?: boolean;
+        addedServers?: string[];
       };
 
-      toast.success("Chat session promoted to a test case");
+      const added = result.addedServers ?? [];
+      if (destinationMode === "existing" && added.length > 0) {
+        toast.success(
+          `Chat session promoted to a test case. Added ${added.join(", ")} to the suite.`,
+        );
+      } else {
+        toast.success("Chat session promoted to a test case");
+      }
       onOpenChange(false);
       onImported({ suiteId: result.suiteId, testCaseId: result.testCaseId });
     } catch (error) {

--- a/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
@@ -298,7 +298,11 @@ export function ConvertChatSessionDialog({
       };
 
       const added = result.addedServers ?? [];
-      if (destinationMode === "existing" && added.length > 0) {
+      if (
+        destinationMode === "existing" &&
+        result.updatedSuiteEnvironment === true &&
+        added.length > 0
+      ) {
         toast.success(
           `Chat session promoted to a test case. Added ${added.join(", ")} to the suite.`,
         );

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/save-as-test-case-action.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/save-as-test-case-action.tsx
@@ -113,7 +113,7 @@ export function SaveAsTestCaseAction({
     }
     setSubmitting(true);
     try {
-      await saveAsTestCase({
+      const result = (await saveAsTestCase({
         chatSessionId,
         promptIndex,
         projectId,
@@ -122,8 +122,15 @@ export function SaveAsTestCaseAction({
         ...(destinationMode === "existing"
           ? { destinationSuiteId: selectedSuiteId }
           : { newSuiteName: newSuiteName.trim() }),
-      });
-      toast.success("Saved as test case");
+      })) as { addedServers?: string[] } | undefined;
+      const added = result?.addedServers ?? [];
+      if (destinationMode === "existing" && added.length > 0) {
+        toast.success(
+          `Saved as test case. Added ${added.join(", ")} to the suite.`,
+        );
+      } else {
+        toast.success("Saved as test case");
+      }
       setOpen(false);
     } catch (error) {
       const message = getBillingErrorMessage(

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/save-as-test-case-action.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/save-as-test-case-action.tsx
@@ -122,9 +122,15 @@ export function SaveAsTestCaseAction({
         ...(destinationMode === "existing"
           ? { destinationSuiteId: selectedSuiteId }
           : { newSuiteName: newSuiteName.trim() }),
-      })) as { addedServers?: string[] } | undefined;
+      })) as
+        | { addedServers?: string[]; updatedSuiteEnvironment?: boolean }
+        | undefined;
       const added = result?.addedServers ?? [];
-      if (destinationMode === "existing" && added.length > 0) {
+      if (
+        destinationMode === "existing" &&
+        result?.updatedSuiteEnvironment === true &&
+        added.length > 0
+      ) {
         toast.success(
           `Saved as test case. Added ${added.join(", ")} to the suite.`,
         );


### PR DESCRIPTION
## Summary

- Capture the `addedServers` return value from `saveAsTestCaseFromChatMessage` and `importChatSessionToTestCase` actions and surface added servers in the success toast when the backend reports it mutated the suite environment.
- The save-as-test-case dialog (per user message) has no "missing servers" checkbox, so the toast is the only signal that the destination suite was extended.
- The promote-to-test-case dialog already gates the env update behind a checkbox; the toast is a transparency win there too.
- Toast is gated on `updatedSuiteEnvironment === true && addedServers.length > 0` so it only fires when the backend actually mutated the suite.

## Why

Pairs with backend PR MCPJam/mcpjam-backend#395, which now propagates added servers into the destination suite's host attachments when `updateSuiteEnvironment` is true. Without surfacing this in the UI, the user wouldn't realize their suite's server selection actually changed.

## Test plan

- [x] `npm run typecheck:client` clean
- [x] `npm test -- --run client/src/components/chat-v2` (564 passed)
- [ ] Save a chat turn into an existing suite that's missing some of the chat's servers; confirm the toast lists the added servers.
- [ ] Promote a chat session into an existing suite with the "Add the missing servers" checkbox ticked; confirm the toast lists the added servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)