### PR TITLE
[Team Credits] PR-I3: monthly variant in sidebar credit usage

### DIFF
--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -14,7 +14,10 @@ import { PendingCreditTopupsBanner } from "@/components/billing/PendingCreditTop
 import { TopupActionButton } from "@/components/billing/TopupActionButton";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useCreditBalance } from "@/hooks/useCreditBalance";
-import { formatCreditResetText } from "@/lib/credit-usage";
+import {
+  formatCreditResetText,
+  formatMonthlyResetText,
+} from "@/lib/credit-usage";
 import { useCreditTopupsUiEnabled } from "@/lib/credit-topups-flag";
 import type { CreditTopupSource } from "@/hooks/useCreditTopup";
 
@@ -95,6 +98,19 @@ export function CreditBalanceCard({
 
   const hasPaidHistory = balance?.hasPurchaseHistory === true;
 
+  // Team-plan orgs bill against a monthly per-seat allowance instead of the
+  // daily free bucket. Paid top-ups are shown separately and spent only after
+  // the allowance runs out.
+  const isMonthly = balance?.billingModel === "monthly_per_seat";
+  const monthlyTotal = balance?.monthlyAllowanceTotal ?? 0;
+  const monthlyRemaining = balance?.monthlyAllowanceRemaining ?? 0;
+  const monthlySpent = Math.max(0, monthlyTotal - monthlyRemaining);
+  const paidRemaining = isMonthly
+    ? (balance?.paidCreditsRemaining ?? 0)
+    : (balance?.availableCredits ?? 0);
+  const monthlyExhausted =
+    isMonthly && monthlyRemaining <= 0 && paidRemaining <= 0;
+
   if (!creditsUiEnabled) return null;
 
   return (
@@ -132,33 +148,67 @@ export function CreditBalanceCard({
           </ErrorBoundary>
         ) : null}
 
-        <UsageRow
-          label="Free daily credits"
-          rightText={
-            isLoading || !balance
-              ? null
-              : `${(
-                  balance.freeDailyCreditsTotal -
-                  balance.freeDailyCreditsRemaining
-                ).toLocaleString()} / ${balance.freeDailyCreditsTotal.toLocaleString()} · ${formatCreditResetText(
-                  balance.freeDailyResetAt
-                )}`
-          }
-          // "spent / total": count and bar both grow as credits are used —
-          // 0/300 empty when fresh, 300/300 full when drained. Matches the
-          // sidebar usage strip.
-          fillPercent={
-            isLoading || !balance || balance.freeDailyCreditsTotal <= 0
-              ? 0
-              : ((balance.freeDailyCreditsTotal -
-                  balance.freeDailyCreditsRemaining) /
-                  balance.freeDailyCreditsTotal) *
-                100
-          }
-          isLoading={isLoading}
-          showCoin
-          testId="usage-daily"
-        />
+        {isMonthly ? (
+          <UsageRow
+            label="Monthly team credits"
+            tooltip="Refreshes each billing cycle. Unused credits don't roll over."
+            rightText={
+              isLoading || !balance
+                ? null
+                : `${monthlySpent.toLocaleString()} / ${monthlyTotal.toLocaleString()} · ${formatMonthlyResetText(
+                    balance.monthlyResetAt
+                  )}`
+            }
+            fillPercent={
+              isLoading || monthlyTotal <= 0
+                ? 0
+                : (monthlySpent / monthlyTotal) * 100
+            }
+            ariaValueText={`${monthlySpent.toLocaleString()} of ${monthlyTotal.toLocaleString()} monthly credits used`}
+            isLoading={isLoading}
+            showCoin
+            testId="usage-monthly"
+          />
+        ) : (
+          <UsageRow
+            label="Free daily credits"
+            rightText={
+              isLoading || !balance
+                ? null
+                : `${(
+                    balance.freeDailyCreditsTotal -
+                    balance.freeDailyCreditsRemaining
+                  ).toLocaleString()} / ${balance.freeDailyCreditsTotal.toLocaleString()} · ${formatCreditResetText(
+                    balance.freeDailyResetAt
+                  )}`
+            }
+            // "spent / total": count and bar both grow as credits are used —
+            // 0/300 empty when fresh, 300/300 full when drained. Matches the
+            // sidebar usage strip.
+            fillPercent={
+              isLoading || !balance || balance.freeDailyCreditsTotal <= 0
+                ? 0
+                : ((balance.freeDailyCreditsTotal -
+                    balance.freeDailyCreditsRemaining) /
+                    balance.freeDailyCreditsTotal) *
+                  100
+            }
+            isLoading={isLoading}
+            showCoin
+            testId="usage-daily"
+          />
+        )}
+
+        {monthlyExhausted ? (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="usage-monthly-exhausted"
+          >
+            Monthly credits used.{" "}
+            {formatMonthlyResetText(balance?.monthlyResetAt)}
+            {canManageCredits ? " — or top up to keep going." : "."}
+          </p>
+        ) : null}
 
         {!isLoading && hasPaidHistory && balance && (
           <div
@@ -168,7 +218,7 @@ export function CreditBalanceCard({
             <span className="text-xs font-medium">Shared paid credits</span>
             <span className="flex items-center gap-1 text-xs font-medium">
               <CoinStackIcon aria-hidden="true" className="size-3" />
-              {balance.availableCredits.toLocaleString()} credits
+              {paidRemaining.toLocaleString()} credits
             </span>
           </div>
         )}
@@ -211,6 +261,8 @@ interface UsageRowProps {
   showCoin?: boolean;
   /** Optional explainer surfaced via an info icon next to the label. */
   tooltip?: string;
+  /** Human-readable progress value for screen readers (e.g. "X of Y used"). */
+  ariaValueText?: string;
 }
 
 function UsageRow({
@@ -221,6 +273,7 @@ function UsageRow({
   testId,
   showCoin = false,
   tooltip,
+  ariaValueText,
 }: UsageRowProps) {
   return (
     <div className="flex flex-col gap-2" data-testid={testId}>
@@ -262,7 +315,11 @@ function UsageRow({
       {isLoading ? (
         <Skeleton className="h-2 w-full rounded-full" />
       ) : (
-        <Progress value={fillPercent} />
+        <Progress
+          value={fillPercent}
+          aria-label={`${label} used`}
+          aria-valuetext={ariaValueText}
+        />
       )}
     </div>
   );

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -13,6 +13,11 @@ let balanceState:
       freeDailyCreditsTotal: number;
       freeDailyResetAt: number;
       walletLocked: boolean;
+      billingModel?: "daily" | "monthly_per_seat";
+      monthlyAllowanceTotal?: number;
+      monthlyAllowanceRemaining?: number;
+      monthlyResetAt?: number | null;
+      paidCreditsRemaining?: number;
     }
   | undefined = undefined;
 let isLoadingState = false;
@@ -230,5 +235,53 @@ describe("CreditBalanceCard", () => {
         /Shared credits are available to everyone in this organization/
       )
     ).toBeInTheDocument();
+  });
+
+  describe("team monthly model", () => {
+    beforeEach(() => {
+      balanceState = {
+        availableCredits: 19_500,
+        hasPurchaseHistory: true,
+        freeDailyPercentUsed: 0,
+        freeDailyCreditsRemaining: 0,
+        freeDailyCreditsTotal: 0,
+        freeDailyResetAt: 0,
+        walletLocked: false,
+        billingModel: "monthly_per_seat",
+        monthlyAllowanceTotal: 18_000,
+        monthlyAllowanceRemaining: 13_950,
+        monthlyResetAt: Date.now() + 12 * 24 * 60 * 60 * 1000,
+        paidCreditsRemaining: 1_500,
+      };
+    });
+
+    it("renders the monthly allowance row instead of the daily row", () => {
+      render(<CreditBalanceCard />);
+      const row = screen.getByTestId("usage-monthly");
+      expect(within(row).getByText(/Monthly team credits/)).toBeInTheDocument();
+      // spent / total, where spent = total - remaining = 4,050.
+      expect(within(row).getByText(/4,050 \/ 18,000/)).toBeInTheDocument();
+      expect(within(row).getByText(/resets in 12 days/)).toBeInTheDocument();
+      expect(screen.queryByTestId("usage-daily")).not.toBeInTheDocument();
+    });
+
+    it("shows paid top-ups separately from the allowance", () => {
+      render(<CreditBalanceCard />);
+      const paid = screen.getByTestId("usage-paid");
+      expect(within(paid).getByText(/1,500 credits/)).toBeInTheDocument();
+    });
+
+    it("surfaces an exhausted notice when allowance and paid are both spent", () => {
+      balanceState = {
+        ...balanceState!,
+        monthlyAllowanceRemaining: 0,
+        paidCreditsRemaining: 0,
+        hasPurchaseHistory: false,
+      };
+      render(<CreditBalanceCard canManageCredits />);
+      expect(
+        screen.getByTestId("usage-monthly-exhausted")
+      ).toHaveTextContent(/Monthly credits used/);
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
@@ -11,6 +11,11 @@ let balanceState:
       freeDailyCreditsRemaining: number;
       freeDailyCreditsTotal: number;
       walletLocked: boolean;
+      billingModel?: "daily" | "monthly_per_seat";
+      monthlyAllowanceTotal?: number;
+      monthlyAllowanceRemaining?: number;
+      monthlyResetAt?: number | null;
+      paidCreditsRemaining?: number;
     }
   | undefined;
 let isLoadingState = false;
@@ -215,5 +220,49 @@ describe("SidebarCreditUsage", () => {
     const wrapper = screen.getByTestId("sidebar-credit-usage");
     await user.click(wrapper);
     expect(onWrapperClick).toHaveBeenCalled();
+  });
+
+  describe("team monthly model", () => {
+    beforeEach(() => {
+      balanceState = {
+        availableCredits: 19_500,
+        hasPurchaseHistory: true,
+        freeDailyPercentUsed: 0,
+        freeDailyResetAt: 0,
+        freeDailyCreditsRemaining: 0,
+        freeDailyCreditsTotal: 0,
+        walletLocked: false,
+        billingModel: "monthly_per_seat",
+        monthlyAllowanceTotal: 18_000,
+        monthlyAllowanceRemaining: 13_950,
+        monthlyResetAt: Date.now() + 12 * 24 * 60 * 60 * 1000,
+        paidCreditsRemaining: 1_500,
+      };
+    });
+
+    it("renders the monthly allowance row with a days countdown", () => {
+      render(<SidebarCreditUsage />);
+      const row = screen.getByTestId("sidebar-usage-monthly");
+      expect(row).toHaveTextContent("Monthly team credits");
+      expect(row).toHaveTextContent("4,050 / 18,000");
+      expect(row).toHaveTextContent("resets in 12 days");
+      expect(
+        screen.queryByTestId("sidebar-usage-daily")
+      ).not.toBeInTheDocument();
+    });
+
+    it("omits the absolute reset date in the strip variant", () => {
+      render(<SidebarCreditUsage variant="strip" />);
+      const row = screen.getByTestId("sidebar-usage-monthly");
+      expect(row).toHaveTextContent("resets in 12 days");
+      // No parenthesized date in the narrow strip.
+      expect(row.textContent ?? "").not.toMatch(/resets in 12 days \(/);
+    });
+
+    it("shows paid top-ups separately in the full variant", () => {
+      render(<SidebarCreditUsage variant="full" />);
+      const paid = screen.getByTestId("sidebar-usage-paid");
+      expect(paid).toHaveTextContent("1,500");
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -9,7 +9,10 @@ import {
 import { CoinStackIcon } from "@/components/ui/coin-stack-icon";
 import { useCreditBalance } from "@/hooks/useCreditBalance";
 import { useCreditTopupsUiEnabled } from "@/lib/credit-topups-flag";
-import { formatCreditResetText } from "@/lib/credit-usage";
+import {
+  formatCreditResetText,
+  formatMonthlyResetText,
+} from "@/lib/credit-usage";
 import { cn } from "@/lib/utils";
 
 interface SidebarCreditUsageProps {
@@ -42,12 +45,29 @@ export function SidebarCreditUsage({
     return null;
   }
 
+  const isMonthly = balance?.billingModel === "monthly_per_seat";
+  const monthlyTotal = balance?.monthlyAllowanceTotal ?? 0;
+  const monthlyRemaining = balance?.monthlyAllowanceRemaining ?? 0;
+  const monthlySpent = Math.max(0, monthlyTotal - monthlyRemaining);
+  const paidRemaining = isMonthly
+    ? (balance?.paidCreditsRemaining ?? 0)
+    : (balance?.availableCredits ?? 0);
+
   const resetText = balance
-    ? formatCreditResetText(balance.freeDailyResetAt)
+    ? isMonthly
+      ? formatMonthlyResetText(balance.monthlyResetAt, {
+          // Strip is narrow — drop the absolute date there, keep it in full.
+          withDate: variant === "full",
+        })
+      : formatCreditResetText(balance.freeDailyResetAt)
     : null;
   const hasPaidHistory = balance?.hasPurchaseHistory === true;
   const showGuestUpgradeHint =
-    variant === "strip" && includeGuests && !hasWorkOsUser && !isLoading;
+    variant === "strip" &&
+    includeGuests &&
+    !hasWorkOsUser &&
+    !isLoading &&
+    !isMonthly;
 
   const innerContent = (
     <div className={cn("px-2 py-1.5", variant === "full" && "px-2.5 py-2")}>
@@ -57,39 +77,58 @@ export function SidebarCreditUsage({
           variant === "full" ? "gap-2.5" : "gap-0"
         )}
       >
-        <SidebarUsageRow
-          label="Free daily credits"
-          percentText={
-            balance
-              ? `${(
-                  balance.freeDailyCreditsTotal -
-                  balance.freeDailyCreditsRemaining
-                ).toLocaleString()} / ${balance.freeDailyCreditsTotal.toLocaleString()}`
-              : ""
-          }
-          eyebrowText={
-            showGuestUpgradeHint ? "Sign in for 10× the credits" : null
-          }
-          helperText={resetText}
-          // "spent / total": the count and the bar both grow as credits are
-          // used — 0/300 empty when fresh, 300/300 full when drained.
-          fillPercent={
-            balance && balance.freeDailyCreditsTotal > 0
-              ? ((balance.freeDailyCreditsTotal -
-                  balance.freeDailyCreditsRemaining) /
-                  balance.freeDailyCreditsTotal) *
-                100
-              : 0
-          }
-          isLoading={isLoading}
-          // Signed-in only — guests don't get the coin accent.
-          showCoin={hasWorkOsUser}
-          testId="sidebar-usage-daily"
-        />
+        {isMonthly ? (
+          <SidebarUsageRow
+            label="Monthly team credits"
+            percentText={
+              balance
+                ? `${monthlySpent.toLocaleString()} / ${monthlyTotal.toLocaleString()}`
+                : ""
+            }
+            eyebrowText={null}
+            helperText={resetText}
+            fillPercent={
+              monthlyTotal > 0 ? (monthlySpent / monthlyTotal) * 100 : 0
+            }
+            isLoading={isLoading}
+            showCoin={hasWorkOsUser}
+            testId="sidebar-usage-monthly"
+          />
+        ) : (
+          <SidebarUsageRow
+            label="Free daily credits"
+            percentText={
+              balance
+                ? `${(
+                    balance.freeDailyCreditsTotal -
+                    balance.freeDailyCreditsRemaining
+                  ).toLocaleString()} / ${balance.freeDailyCreditsTotal.toLocaleString()}`
+                : ""
+            }
+            eyebrowText={
+              showGuestUpgradeHint ? "Sign in for 10× the credits" : null
+            }
+            helperText={resetText}
+            // "spent / total": the count and the bar both grow as credits are
+            // used — 0/300 empty when fresh, 300/300 full when drained.
+            fillPercent={
+              balance && balance.freeDailyCreditsTotal > 0
+                ? ((balance.freeDailyCreditsTotal -
+                    balance.freeDailyCreditsRemaining) /
+                    balance.freeDailyCreditsTotal) *
+                  100
+                : 0
+            }
+            isLoading={isLoading}
+            // Signed-in only — guests don't get the coin accent.
+            showCoin={hasWorkOsUser}
+            testId="sidebar-usage-daily"
+          />
+        )}
         {variant === "full" && !isLoading && hasPaidHistory && balance ? (
           <SidebarUsageRow
             label="Paid credits"
-            percentText={`${balance.availableCredits.toLocaleString()}`}
+            percentText={`${paidRemaining.toLocaleString()}`}
             helperText={null}
             // Absolute credit count, not a percentage — render no progress
             // bar (a permanently 0%-filled bar reads as a bug).
@@ -98,7 +137,11 @@ export function SidebarCreditUsage({
             fillPercent={0}
             isLoading={false}
             testId="sidebar-usage-paid"
-            tooltip="Shared across your organization. Spent after the free daily credits run out."
+            tooltip={
+              isMonthly
+                ? "Top-ups, used only after the monthly team credits run out. Never expire."
+                : "Shared across your organization. Spent after the free daily credits run out."
+            }
           />
         ) : null}
       </div>

--- a/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
@@ -76,6 +76,8 @@ describe("useCreditBalance", () => {
       freeDailyCreditsRemaining: 7,
       freeDailyCreditsTotal: 20,
       walletLocked: false,
+      billingModel: "daily",
+      monthlyResetAt: null,
     });
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isAuthenticated).toBe(true);
@@ -109,5 +111,54 @@ describe("useCreditBalance", () => {
       "skip"
     );
     expect(result.current.balance).toBeUndefined();
+  });
+
+  it("surfaces the monthly model fields for team orgs", () => {
+    mocks.convexAuth.isAuthenticated = true;
+    mocks.workosAuth.user = { id: "user_123" };
+    mocks.queryResult = {
+      billingModel: "monthly_per_seat",
+      availableCredits: 19_500,
+      hasPurchaseHistory: true,
+      monthlyAllowanceTotal: 18_000,
+      monthlyAllowanceRemaining: 13_950,
+      monthlyResetAt: 1_777_777_777_000,
+      paidCreditsRemaining: 1_500,
+      walletLocked: false,
+    };
+
+    const { result } = renderHook(() =>
+      useCreditBalance({ organizationId: "org-1" })
+    );
+
+    expect(result.current.balance?.billingModel).toBe("monthly_per_seat");
+    expect(result.current.balance?.monthlyAllowanceTotal).toBe(18_000);
+    expect(result.current.balance?.monthlyAllowanceRemaining).toBe(13_950);
+    expect(result.current.balance?.paidCreditsRemaining).toBe(1_500);
+    expect(result.current.balance?.monthlyResetAt).toBe(1_777_777_777_000);
+  });
+
+  it("defaults billingModel to daily when absent or unrecognized", () => {
+    mocks.convexAuth.isAuthenticated = true;
+    mocks.workosAuth.user = { id: "user_123" };
+    mocks.queryResult = {
+      billingModel: "something_new",
+      availableCredits: 0,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 10,
+      freeDailyResetAt: 1,
+      freeDailyCreditsRemaining: 1,
+      freeDailyCreditsTotal: 20,
+      walletLocked: false,
+    };
+
+    const { result } = renderHook(() =>
+      useCreditBalance({ organizationId: "org-1" })
+    );
+
+    expect(result.current.balance?.billingModel).toBe("daily");
+    // Monthly numerics stay undefined (not coerced to 0).
+    expect(result.current.balance?.monthlyAllowanceTotal).toBeUndefined();
+    expect(result.current.balance?.monthlyAllowanceRemaining).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -25,6 +25,23 @@ export interface CreditBalanceState {
   freeDailyCreditsTotal: number;
   /** Whether org credit spending is paused for manual review. */
   walletLocked: boolean;
+  /**
+   * Which credit model the server is billing this org against. "daily" is the
+   * free per-day bucket (free orgs + guests); "monthly_per_seat" is the team
+   * monthly allowance. Absent/unknown is treated as "daily".
+   */
+  billingModel: "daily" | "monthly_per_seat";
+  /** Team monthly allowance granted this period. Only set when monthly. */
+  monthlyAllowanceTotal?: number;
+  /** Team monthly allowance still available this period. Only set when monthly. */
+  monthlyAllowanceRemaining?: number;
+  /** Epoch ms when the monthly allowance resets. Only set when monthly. */
+  monthlyResetAt?: number | null;
+  /**
+   * Paid top-up credits still available, kept separate from the monthly
+   * allowance (the allowance is spent first). Only set when monthly.
+   */
+  paidCreditsRemaining?: number;
 }
 
 const clampPercent = (value: unknown): number => {
@@ -37,6 +54,12 @@ const clampPercent = (value: unknown): number => {
 const optionalNumber = (value: unknown, fallback = 0): number =>
   typeof value === "number" && Number.isFinite(value) ? value : fallback;
 
+// Returns the number when present and finite, otherwise undefined. Used for
+// the monthly fields so an absent value stays undefined (distinguishable from
+// a real 0 allowance) and the renderer can skip cleanly.
+const optionalNumberOrUndefined = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
 const normalizeBalance = (raw: unknown): CreditBalanceState | undefined => {
   if (!raw || typeof raw !== "object") return undefined;
   const r = raw as Record<string, unknown>;
@@ -48,6 +71,16 @@ const normalizeBalance = (raw: unknown): CreditBalanceState | undefined => {
     freeDailyCreditsRemaining: optionalNumber(r.freeDailyCreditsRemaining),
     freeDailyCreditsTotal: optionalNumber(r.freeDailyCreditsTotal),
     walletLocked: r.walletLocked === true,
+    // Discriminant: only the explicit "monthly_per_seat" opts into the monthly
+    // view; anything else (including absent) falls back to daily.
+    billingModel:
+      r.billingModel === "monthly_per_seat" ? "monthly_per_seat" : "daily",
+    monthlyAllowanceTotal: optionalNumberOrUndefined(r.monthlyAllowanceTotal),
+    monthlyAllowanceRemaining: optionalNumberOrUndefined(
+      r.monthlyAllowanceRemaining,
+    ),
+    monthlyResetAt: optionalNumberOrUndefined(r.monthlyResetAt) ?? null,
+    paidCreditsRemaining: optionalNumberOrUndefined(r.paidCreditsRemaining),
   };
 };
 

--- a/mcpjam-inspector/client/src/lib/__tests__/credit-usage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/credit-usage.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCreditResetText,
+  formatMonthlyResetText,
+} from "@/lib/credit-usage";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("formatMonthlyResetText", () => {
+  it("counts in days and appends the reset date", () => {
+    const text = formatMonthlyResetText(Date.now() + 12 * DAY);
+    expect(text).toMatch(/^resets in 12 days \(.+\)$/);
+  });
+
+  it("uses the singular day form", () => {
+    const text = formatMonthlyResetText(Date.now() + 12 * 60 * 60 * 1000);
+    expect(text).toMatch(/^resets in 1 day \(.+\)$/);
+  });
+
+  it("handles missing and past reset times", () => {
+    expect(formatMonthlyResetText(null)).toBe("resets monthly");
+    expect(formatMonthlyResetText(undefined)).toBe("resets monthly");
+    expect(formatMonthlyResetText(Date.now() - DAY)).toBe("resets shortly");
+  });
+
+  it("does not collapse a multi-week cycle to 'resets tomorrow'", () => {
+    // The daily formatter caps at "resets tomorrow" past 24h — the monthly one
+    // must not.
+    expect(formatCreditResetText(Date.now() + 12 * DAY)).toBe("resets tomorrow");
+    expect(formatMonthlyResetText(Date.now() + 12 * DAY)).toMatch(/12 days/);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/credit-usage.ts
+++ b/mcpjam-inspector/client/src/lib/credit-usage.ts
@@ -15,3 +15,23 @@ export const formatCreditResetText = (resetAt: number): string => {
   }
   return "resets tomorrow";
 };
+
+/**
+ * Reset copy for the monthly team allowance. The daily formatter caps at
+ * "resets tomorrow" for anything over a day, which is useless across a ~30-day
+ * cycle — this one counts in days and appends the absolute reset date so the
+ * use-it-or-lose-it refresh is unambiguous ("resets in 12 days (Jun 30)").
+ */
+export const formatMonthlyResetText = (
+  resetAt: number | null | undefined
+): string => {
+  if (resetAt == null || !Number.isFinite(resetAt)) return "resets monthly";
+  const diffMs = resetAt - Date.now();
+  if (diffMs <= 0) return "resets shortly";
+  const date = new Date(resetAt).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+  const days = Math.ceil(diffMs / MS_PER_DAY);
+  return `resets in ${days} day${days === 1 ? "" : "s"} (${date})`;
+};

--- a/mcpjam-inspector/client/src/lib/credit-usage.ts
+++ b/mcpjam-inspector/client/src/lib/credit-usage.ts
@@ -23,15 +23,20 @@ export const formatCreditResetText = (resetAt: number): string => {
  * use-it-or-lose-it refresh is unambiguous ("resets in 12 days (Jun 30)").
  */
 export const formatMonthlyResetText = (
-  resetAt: number | null | undefined
+  resetAt: number | null | undefined,
+  options?: { withDate?: boolean }
 ): string => {
   if (resetAt == null || !Number.isFinite(resetAt)) return "resets monthly";
   const diffMs = resetAt - Date.now();
   if (diffMs <= 0) return "resets shortly";
+  const days = Math.ceil(diffMs / MS_PER_DAY);
+  const base = `resets in ${days} day${days === 1 ? "" : "s"}`;
+  // The absolute date disambiguates the refresh day, but it crowds the narrow
+  // sidebar strip — callers there opt out via { withDate: false }.
+  if (options?.withDate === false) return base;
   const date = new Date(resetAt).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
   });
-  const days = Math.ceil(diffMs / MS_PER_DAY);
-  return `resets in ${days} day${days === 1 ? "" : "s"} (${date})`;
+  return `${base} (${date})`;
 };


### PR DESCRIPTION
## Summary
Mirror the monthly credit view in the sidebar usage widget.

## Changes
- Show the monthly usage row and reset countdown when the balance is on the monthly model.
- Compact ("strip") variant shows the countdown only; the expanded ("full") variant also shows the reset date.
- Show paid top-ups separately in the full variant.

## Verification
- Component tests: strip and full monthly variants.
