### PR TITLE
More eval UI polish

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -50,6 +50,8 @@ import { RegistryTab } from "./components/RegistryTab";
 import { ClientsTab } from "./components/ClientsTab";
 import { HostConfigCompareView } from "./components/clients/comparison/HostConfigCompareView";
 import { ConnectViewHeader } from "./components/clients/ConnectViewHeader";
+import { motion } from "framer-motion";
+import { SNAPPY_RAIL } from "./components/clients/transition-tokens";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
 import { MCPSidebar } from "./components/mcp-sidebar";
@@ -649,7 +651,13 @@ export function HostCompareRoute() {
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <motion.div
+      key="host-compare"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={SNAPPY_RAIL}
+      className="flex h-full min-h-0 flex-col"
+    >
       <ConnectViewHeader
         value="compare"
         previewedHostId={previewedHostId}
@@ -662,7 +670,7 @@ export function HostCompareRoute() {
         }}
       />
       <div className="min-h-0 flex-1">{compareView}</div>
-    </div>
+    </motion.div>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
-import { useConvexAuth } from "convex/react";
+import { useConvex, useConvexAuth, useMutation } from "convex/react";
 import { FlaskConical, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
@@ -23,6 +23,7 @@ import { EXCALIDRAW_SERVER_NAME } from "@/lib/excalidraw-quick-connect";
 import { isQuickstartSuite } from "./evals/constants";
 import type { ServerFormData } from "@/shared/types.js";
 import { useProjectServers } from "@/hooks/useViews";
+import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { useEvalsRouteFromUrl } from "@/lib/eval-route-url";
 import { useEvalTabContext } from "@/hooks/use-eval-tab-context";
 import { useIsDirectGuest } from "@/hooks/use-is-direct-guest";
@@ -133,6 +134,7 @@ function EvalsTabContent({
     useFeatureFlagEnabled("hosts-enabled") === true && isAuthenticated;
   const route = useEvalsRouteFromUrl();
   const isDirectGuest = useIsDirectGuest({ projectId });
+  const [previewedHostId] = usePreviewedHostId(projectId ?? null);
   const {
     connectedServerNames,
     userMap,
@@ -149,6 +151,14 @@ function EvalsTabContent({
     projectId: projectId ?? null,
   });
   const mutations = useEvalMutations({ isDirectGuest });
+  const convex = useConvex();
+  const createServerAttachmentMutation = useMutation(
+    "serverAttachments:createServerAttachment" as any,
+  ) as unknown as (args: {
+    projectId: string;
+    name: string;
+    serverIds: string[];
+  }) => Promise<{ _id: string }>;
 
   const selectedSuiteId =
     route.type === "suite-overview" ||
@@ -284,23 +294,29 @@ function EvalsTabContent({
     try {
       await runExcalidrawQuickstart({
         projectId,
+        convex,
         createTestSuite: mutations.createTestSuiteMutation,
         createTestCase: mutations.createTestCaseMutation,
+        createServerAttachment: createServerAttachmentMutation,
         handleConnect,
         isExcalidrawConnected: connectedServerNames.has(EXCALIDRAW_SERVER_NAME),
         existingQuickstartSuiteId,
+        previewedHostId,
       });
     } finally {
       setIsQuickstartRunning(false);
     }
   }, [
     projectId,
+    convex,
     handleConnect,
     isQuickstartRunning,
     mutations.createTestSuiteMutation,
     mutations.createTestCaseMutation,
+    createServerAttachmentMutation,
     connectedServerNames,
     existingQuickstartSuiteId,
+    previewedHostId,
   ]);
 
   const showQuickstart = Boolean(handleConnect);

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -29,6 +29,7 @@ vi.mock("convex/react", () => ({
     isLoading: false,
   }),
   useConvex: () => ({ query: vi.fn().mockResolvedValue([]) }),
+  useMutation: () => vi.fn().mockResolvedValue({ _id: "stub-id" }),
 }));
 
 vi.mock("posthog-js", () => ({

--- a/mcpjam-inspector/client/src/components/clients/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/HostCompareSelector.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown } from "lucide-react";
+import { motion, useReducedMotion } from "framer-motion";
 import { Button } from "@mcpjam/design-system/button";
 import { Switch } from "@mcpjam/design-system/switch";
 import {
@@ -98,21 +99,28 @@ function HostCompareChip({
           subject.config.chatUiOverride,
         )
       : null;
+  const reduceMotion = useReducedMotion();
 
   return (
-    <button
+    <motion.button
       type="button"
       disabled={disabled}
       aria-pressed={selected}
       data-testid={`host-compare-chip-${host.hostId}`}
       data-selected={selected ? "true" : "false"}
       className={cn(
-        "inline-flex max-w-[180px] items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px] transition-colors",
+        "inline-flex max-w-[180px] items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px]",
+        "transition-colors duration-150",
         "disabled:cursor-not-allowed disabled:opacity-50",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
         selected
           ? "border-primary/35 bg-primary/8 text-foreground shadow-xs"
           : "border-border bg-background text-muted-foreground hover:bg-muted/40 hover:text-foreground",
       )}
+      whileHover={reduceMotion || disabled ? undefined : { scale: 1.04 }}
+      whileTap={reduceMotion || disabled ? undefined : { scale: 0.94 }}
+      animate={reduceMotion ? undefined : { y: selected ? -1 : 0 }}
+      transition={{ type: "spring", stiffness: 480, damping: 28, mass: 0.5 }}
       onClick={onToggle}
     >
       {logoSrc ? (
@@ -124,7 +132,7 @@ function HostCompareChip({
         />
       )}
       <span className="truncate">{host.name}</span>
-    </button>
+    </motion.button>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/clients/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/host-config-comparison-matrix.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { X } from "lucide-react";
+import { motion, useReducedMotion } from "framer-motion";
 import {
   Popover,
   PopoverContent,
@@ -224,10 +225,16 @@ function FieldRow({
         )}
       >
         {diverges && (
-          <span
+          <motion.span
             aria-hidden="true"
-            className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary/70"
+            className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary/70 origin-top"
             data-testid={`diverge-gutter-${field.id}`}
+            initial={{ scaleY: 0, opacity: 0 }}
+            animate={{ scaleY: 1, opacity: 1 }}
+            transition={{
+              duration: 0.45,
+              ease: [0.22, 1, 0.36, 1],
+            }}
           />
         )}
         <div className="text-[13px] font-medium text-foreground leading-tight">
@@ -413,20 +420,30 @@ function HostColumnHeader({
     subject.hostStyle,
     subject.config.chatUiOverride,
   );
+  const reduceMotion = useReducedMotion();
 
   return (
     <th className="sticky top-0 z-20 bg-card border-b border-l border-border px-4 py-4 text-left align-top">
-      <div className="flex items-start gap-2">
+      <motion.div
+        key={subject.hostId}
+        className="flex items-start gap-2"
+        initial={reduceMotion ? false : { opacity: 0, x: -6 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
+      >
         {onRemove ? (
-          <button
+          <motion.button
             type="button"
             aria-label={`Remove ${subject.hostName} from comparison`}
             data-testid={`host-compare-remove-${subject.hostId}`}
-            className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
             onClick={() => onRemove(subject.hostId)}
+            whileHover={reduceMotion ? undefined : { scale: 1.15 }}
+            whileTap={reduceMotion ? undefined : { scale: 0.85, rotate: 90 }}
+            transition={{ type: "spring", stiffness: 520, damping: 24 }}
           >
             <X className="size-3" />
-          </button>
+          </motion.button>
         ) : null}
         <img
           src={logoSrc}
@@ -436,7 +453,7 @@ function HostColumnHeader({
         <div className="min-w-0 font-medium text-[14px] truncate leading-tight" title={subject.hostName}>
           {subject.hostName}
         </div>
-      </div>
+      </motion.div>
     </th>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/__tests__/commit-detail-view-render.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/commit-detail-view-render.test.tsx
@@ -12,12 +12,6 @@ vi.mock("convex/react", () => ({
 vi.mock("../use-suite-data", () => ({
   useRunDetailData: vi.fn(() => ({
     caseGroupsForSelectedRun: [],
-    selectedRunChartData: {
-      donutData: [],
-      durationData: [],
-      tokensData: [],
-      modelData: [],
-    },
   })),
 }));
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/goal-completion-card.test.tsx
@@ -63,10 +63,9 @@ const baseProps = {
 };
 
 describe("GoalCompletionCard", () => {
-  it("labels itself advisory and offers a Run judge control before any run", () => {
+  it("offers a Run judge control before any run", () => {
     render(<GoalCompletionCard {...baseProps} onRun={vi.fn()} />);
-    expect(screen.getByText("Goal completion")).toBeInTheDocument();
-    expect(screen.getByText(/advisory · LLM judge/i)).toBeInTheDocument();
+    expect(screen.getByText("LLM as Judge")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Run judge/i })).toBeEnabled();
     expect(screen.getByText("Not run yet")).toBeInTheDocument();
   });
@@ -84,39 +83,6 @@ describe("GoalCompletionCard", () => {
     // override. This is the "re-running without re-confirming exploration
     // returns to the suite contract" property the plan requires.
     expect(onRun).toHaveBeenCalledWith({ runOverride: undefined }, false);
-  });
-
-  it("falls back to the default threshold when the field is left blank", async () => {
-    const onRun = vi.fn();
-    const user = userEvent.setup();
-    render(<GoalCompletionCard {...baseProps} onRun={onRun} />);
-
-    // Blank input must NOT send threshold 0 (which would pass every score).
-    await user.clear(screen.getByLabelText("Threshold"));
-    await user.click(screen.getByRole("button", { name: /Run judge/i }));
-
-    // Parsed 0.7 == suite-config default, so no override is sent (the
-    // backend clears any persisted override and uses the suite contract).
-    expect(onRun).toHaveBeenCalledWith({ runOverride: undefined }, false);
-  });
-
-  it("sends a runOverride when the user picks a non-default threshold", async () => {
-    const onRun = vi.fn();
-    const user = userEvent.setup();
-    render(<GoalCompletionCard {...baseProps} onRun={onRun} />);
-
-    const thresholdInput = screen.getByLabelText("Threshold");
-    await user.clear(thresholdInput);
-    await user.type(thresholdInput, "0.85");
-    await user.click(screen.getByRole("button", { name: /Run judge/i }));
-
-    // The user's value differs from the suite-config default (0.7) → the
-    // card sends a runOverride. The judge model still matches the suite
-    // default so only `threshold` flows through.
-    expect(onRun).toHaveBeenCalledWith(
-      { runOverride: { threshold: 0.85 } },
-      false,
-    );
   });
 
   it("renders per-case score, advisory verdict and reason once graded", () => {
@@ -175,7 +141,7 @@ describe("GoalCompletionCard", () => {
     render(<GoalCompletionCard {...baseProps} pending onRun={vi.fn()} />);
     expect(screen.getByRole("button", { name: /Run judge/i })).toBeDisabled();
     expect(
-      screen.getByText(/Grading final answers against expected output/i),
+      screen.getByText(/Grading final answers/i),
     ).toBeInTheDocument();
   });
 
@@ -213,7 +179,7 @@ describe("GoalCompletionCard", () => {
       />,
     );
     expect(
-      screen.getByText(/Grading final answers against expected output/i),
+      screen.getByText(/Grading final answers/i),
     ).toBeInTheDocument();
     expect(screen.getByText("Requesting…")).toBeInTheDocument();
     // Stale score / reason from the previous run must not be displayed.
@@ -237,12 +203,10 @@ describe("GoalCompletionCard", () => {
     expect(onRun).toHaveBeenCalledWith({ runOverride: undefined }, true);
   });
 
-  it("renders run controls by default when the snapshot says nothing (judge is on by default)", () => {
-    // V2 default: GOAL_COMPLETION_DEFAULTS.enabled = true. A snapshot
-    // without `judgeConfig.goalCompletion.enabled` (older runs, or a
-    // suite the owner never touched) resolves to enabled and surfaces
-    // the run controls — NOT the "Configure on suite" CTA. Cost is
-    // still gated by the explicit click + autoRun: false default.
+  it("shows run controls by default when the snapshot has no explicit enable", () => {
+    // Default-on semantics matching GOAL_COMPLETION_DEFAULTS (`enabled: true`):
+    // an unconfigured snapshot resolves to enabled and surfaces controls.
+    // Cost is gated by autoRun: false + the explicit click.
     const unconfiguredRun = makeRun({
       configSnapshot: { tests: [], environment: { servers: [] } },
     });
@@ -257,14 +221,11 @@ describe("GoalCompletionCard", () => {
       screen.getByRole("button", { name: /Run judge/i }),
     ).toBeEnabled();
     expect(
-      screen.queryByText(/Goal completion isn't enabled for this suite/i),
+      screen.queryByText(/Disabled in suite settings/i),
     ).not.toBeInTheDocument();
   });
 
-  it("hides run controls and shows a Configure-on-suite CTA only when the suite explicitly disabled the judge", () => {
-    // The CTA path is now reserved for an explicit `enabled: false` on
-    // the snapshot — the owner actively turned the judge off. Older
-    // runs without any judgeConfig get the default-on path above.
+  it("hides run controls when the snapshot explicitly disabled the judge", () => {
     const disabledRun = makeRun({
       configSnapshot: {
         tests: [],
@@ -279,14 +240,35 @@ describe("GoalCompletionCard", () => {
       screen.queryByRole("button", { name: /Run judge/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Goal completion isn't enabled for this suite/i),
+      screen.getByText(/Disabled in suite settings/i),
     ).toBeInTheDocument();
-    // CTA points at the actual UI affordance (the gear button on the suite
-    // header) — not just generic "Suite settings", which had no visible
-    // entry point in the inspector until the gear shipped.
+  });
+
+  it("re-enables run controls when the current suite is enabled, even if the snapshot disabled it", () => {
+    // Real-world fix: user ran a suite when the judge was off, then
+    // enabled it later. The snapshot says off, but currentSuiteJudgeConfig
+    // says on — let the user trigger a re-run instead of locking them out.
+    const oldRun = makeRun({
+      configSnapshot: {
+        tests: [],
+        environment: { servers: [] },
+        judgeConfig: { goalCompletion: { enabled: false } },
+      },
+    });
+    render(
+      <GoalCompletionCard
+        {...baseProps}
+        run={oldRun}
+        onRun={vi.fn()}
+        currentSuiteJudgeConfig={{ goalCompletion: { enabled: true } }}
+      />,
+    );
     expect(
-      screen.getByText(/Open suite settings.*button next to the suite name/i),
-    ).toBeInTheDocument();
+      screen.getByRole("button", { name: /Run judge/i }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByText(/Disabled in suite settings/i),
+    ).not.toBeInTheDocument();
   });
 
   it("renders a prominent override banner when the run carries a judge override", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
@@ -197,7 +197,7 @@ describe("RunDetailView", () => {
     expect(root).not.toHaveClass("overflow-hidden");
   });
 
-  it("places body KPI strip and charts below the run hero band", () => {
+  it("places body KPI strip below the run hero band and above the resizable group", () => {
     vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
       matches: query.includes("min-width: 1024px"),
       media: query,
@@ -222,9 +222,6 @@ describe("RunDetailView", () => {
       />,
     );
 
-    const durationChartHeading = screen.getByRole("heading", {
-      name: "Latency by test (p50 / p95)",
-    });
     const kpiStrip = screen.getByText("Passed").closest(".mb-4");
     expect(kpiStrip).not.toBeNull();
     const kpi = within(kpiStrip as HTMLElement);
@@ -236,27 +233,17 @@ describe("RunDetailView", () => {
 
     const runHeading = screen.getByRole("heading", { name: /Run run-1/i });
     const panelGroup = screen.getByTestId("run-detail-resizable-group");
-    const sections = Array.from(document.querySelectorAll("section"));
-    const heroIndex = sections.findIndex((section) =>
-      section.contains(runHeading),
-    );
-    const chartsIndex = sections.findIndex((section) =>
-      section.contains(durationChartHeading),
-    );
-    expect(heroIndex).toBeGreaterThanOrEqual(0);
-    expect(chartsIndex).toBeGreaterThan(heroIndex);
     expect(
-      durationChartHeading.compareDocumentPosition(panelGroup) &
+      runHeading.compareDocumentPosition(panelGroup) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
-    expect(durationChartHeading).toBeVisible();
     expect(
-      screen.getByRole("heading", { name: "Tokens by test (p50 / p95)" }),
-    ).toBeVisible();
+      screen.queryByRole("heading", { name: "Latency by test (p50 / p95)" }),
+    ).not.toBeInTheDocument();
     expect(
-      document.querySelectorAll('[data-slot="chart"]').length,
-    ).toBeGreaterThanOrEqual(2);
+      screen.queryByRole("heading", { name: "Tokens by test (p50 / p95)" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
   });
 
@@ -277,7 +264,7 @@ describe("RunDetailView", () => {
     expect(screen.queryByText(/1 passed · 0 failed · 100%/)).not.toBeInTheDocument();
   });
 
-  it("keeps run-level KPIs and bar charts visible with the iteration list in a resizable two-column layout", () => {
+  it("keeps run-level KPIs visible with the iteration list in a resizable two-column layout", () => {
     vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
       matches: query.includes("min-width: 1024px"),
       media: query,
@@ -303,12 +290,6 @@ describe("RunDetailView", () => {
     );
 
     expect(screen.getByText("Passed")).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "Latency by test (p50 / p95)" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "Tokens by test (p50 / p95)" }),
-    ).toBeInTheDocument();
     expect(screen.getByText(/Test cases/)).toBeInTheDocument();
     expect(screen.getByText("P50")).toBeInTheDocument();
     expect(screen.getByText("Fail")).toBeInTheDocument();
@@ -317,38 +298,6 @@ describe("RunDetailView", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByTestId("run-detail-resizable-panel")).toHaveLength(2);
     expect(screen.getByTestId("run-detail-resizable-handle")).toBeInTheDocument();
-  });
-
-  it("hides chart section when there is no duration or token data", () => {
-    render(
-      <RunDetailView
-        selectedRunDetails={makeRun()}
-        caseGroupsForSelectedRun={[makeIteration()]}
-        source="ui"
-        selectedRunChartData={{
-          donutData: [{ name: "passed", value: 1, fill: "green" }],
-          durationData: [],
-          tokensData: [
-            {
-              name: "x",
-              inputP50: 0,
-              outputP50: 0,
-              inputP95Tail: 0,
-              outputP95Tail: 0,
-            },
-          ],
-          modelData: [],
-        }}
-        runDetailSortBy="test"
-        onSortChange={() => {}}
-        selectedIterationId={null}
-        onSelectIteration={() => {}}
-      />,
-    );
-
-    expect(
-      screen.queryByRole("button", { name: /Duration and token charts/i }),
-    ).not.toBeInTheDocument();
   });
 
   it("does not surface per-iteration case insight captions in the run view (open a test from the list to inspect a case)", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
@@ -118,36 +118,6 @@ function makeIteration(overrides: Partial<EvalIteration> = {}): EvalIteration {
   };
 }
 
-const chartDataUsable = {
-  donutData: [{ name: "passed", value: 1, fill: "green" }],
-  durationData: [
-    {
-      name: "Short name",
-      p50Ms: 4000,
-      p95Ms: 5000,
-      p50Seconds: 4,
-      p95TailSeconds: 1,
-    },
-  ],
-  tokensData: [
-    {
-      name: "Short name",
-      inputP50: 400,
-      outputP50: 800,
-      inputP95Tail: 100,
-      outputP95Tail: 200,
-    },
-  ],
-  modelData: [],
-};
-
-const emptyChartData = {
-  donutData: [],
-  durationData: [],
-  tokensData: [],
-  modelData: [],
-};
-
 function defaultRunInsightsReturn() {
   return {
     summary: null as string | null,
@@ -183,7 +153,6 @@ describe("RunDetailView", () => {
         selectedRunDetails={makeRun()}
         caseGroupsForSelectedRun={[makeIteration()]}
         source="ui"
-        selectedRunChartData={emptyChartData}
         runDetailSortBy="test"
         onSortChange={() => {}}
         selectedIterationId={null}
@@ -214,7 +183,6 @@ describe("RunDetailView", () => {
         selectedRunDetails={makeRun()}
         caseGroupsForSelectedRun={[makeIteration()]}
         source="ui"
-        selectedRunChartData={chartDataUsable}
         runDetailSortBy="test"
         onSortChange={() => {}}
         selectedIterationId={null}
@@ -253,7 +221,6 @@ describe("RunDetailView", () => {
         selectedRunDetails={makeRun()}
         caseGroupsForSelectedRun={[makeIteration()]}
         source="ui"
-        selectedRunChartData={chartDataUsable}
         runDetailSortBy="test"
         onSortChange={() => {}}
         selectedIterationId={null}
@@ -281,7 +248,6 @@ describe("RunDetailView", () => {
         selectedRunDetails={makeRun()}
         caseGroupsForSelectedRun={[makeIteration()]}
         source="ui"
-        selectedRunChartData={chartDataUsable}
         runDetailSortBy="test"
         onSortChange={() => {}}
         selectedIterationId={null}
@@ -334,7 +300,6 @@ describe("RunDetailView", () => {
           }),
         ]}
         source="ui"
-        selectedRunChartData={emptyChartData}
         runDetailSortBy="test"
         onSortChange={() => {}}
         selectedIterationId="iter-case"
@@ -422,7 +387,6 @@ describe("RunDetailView", () => {
         })}
         caseGroupsForSelectedRun={[makeIteration()]}
         source="ui"
-        selectedRunChartData={emptyChartData}
         runDetailSortBy="test"
         onSortChange={() => {}}
         selectedIterationId={null}

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-insight-rail.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-insight-rail.test.tsx
@@ -67,7 +67,7 @@ const trendFixture = [
 ];
 
 describe("RunAccuracyHeroBand", () => {
-  it("renders large accuracy with recent run cards and delta", () => {
+  it("renders large accuracy with recent run cards (delta + compare button intentionally suppressed in the header)", () => {
     render(
       <RunAccuracyHeroBand
         run={makeRun()}
@@ -83,7 +83,10 @@ describe("RunAccuracyHeroBand", () => {
     );
 
     expect(screen.getByText("Accuracy")).toBeInTheDocument();
-    expect(screen.getByText(/-10pp vs run #1/)).toBeInTheDocument();
+    expect(screen.queryByText(/pp vs run #/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Compare to previous run/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Recent runs")).toBeInTheDocument();
     expect(
       screen.getByLabelText("Accuracy across recent suite runs"),
@@ -107,7 +110,6 @@ describe("RunAccuracyHeroBand", () => {
       />,
     );
 
-    expect(screen.getByText("Client")).toBeInTheDocument();
     expect(screen.getByText("ChatGPT")).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-master-detail.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-master-detail.test.tsx
@@ -24,7 +24,6 @@ vi.mock("../use-suite-data", () => ({
   }),
   useRunDetailData: () => ({
     caseGroupsForSelectedRun: [],
-    selectedRunChartData: [],
   }),
 }));
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -307,9 +307,6 @@ describe("TestTemplateEditor run view from route", () => {
         // "still loading" and would suppress the header row entirely.
         return null;
       }
-      if (name === "testSuites:listTestIterations" && args !== "skip") {
-        return [baseIteration];
-      }
       if (
         name === "testSuites:getTestIteration" &&
         typeof args === "object" &&
@@ -362,6 +359,7 @@ describe("TestTemplateEditor run view from route", () => {
   it("opens compare run mode when the route requests run view", async () => {
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -381,16 +379,16 @@ describe("TestTemplateEditor run view from route", () => {
       expect(screen.queryByText("No compare run yet")).not.toBeInTheDocument();
     });
 
-    expect(useQueryMock).toHaveBeenCalledWith("testSuites:listTestIterations", {
-      testCaseId: "case-1",
-      limit: 200,
-    });
     expect(
       screen.getByRole("button", { name: /retry all/i })
     ).toBeInTheDocument();
   });
 
   it("shows a loading spinner instead of config UI while route-open compare data is unresolved", async () => {
+    // Iterations are now a prop, not a query — the remaining loading gates
+    // are `testCases === undefined`, the init ref mismatch, and the route
+    // anchor iteration. Withholding `testSuites:listTestCases` drives the
+    // spinner here; once that query resolves the route can settle.
     let queriesReady = false;
     useQueryMock.mockImplementation((name: string, args: unknown) => {
       if (!queriesReady) {
@@ -418,9 +416,6 @@ describe("TestTemplateEditor run view from route", () => {
       if (name === "hostConfigsV2:getSuiteConfig") {
         return null;
       }
-      if (name === "testSuites:listTestIterations" && args !== "skip") {
-        return [baseIteration];
-      }
       if (
         name === "testSuites:getTestIteration" &&
         typeof args === "object" &&
@@ -434,6 +429,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     const view = renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -456,6 +452,7 @@ describe("TestTemplateEditor run view from route", () => {
     view.rerender(
       <PreferencesStoreProvider themeMode="light" themePreset="default">
         <TestTemplateEditor
+        suiteIterations={[baseIteration]}
           suiteId="suite-1"
           selectedTestCaseId="case-1"
           connectedServerNames={new Set(["srv"])}
@@ -508,9 +505,6 @@ describe("TestTemplateEditor run view from route", () => {
       if (name === "hostConfigsV2:getSuiteConfig") {
         return null;
       }
-      if (name === "testSuites:listTestIterations" && args !== "skip") {
-        return [newerQuickIteration, clickedIteration];
-      }
       if (
         name === "testSuites:getTestIteration" &&
         typeof args === "object" &&
@@ -526,6 +520,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[newerQuickIteration, clickedIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -552,6 +547,7 @@ describe("TestTemplateEditor run view from route", () => {
   it("renders flat User prompt / Expected tool calls for a single-turn case", async () => {
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -582,6 +578,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -659,19 +656,17 @@ describe("TestTemplateEditor run view from route", () => {
       lastMessageRun: undefined,
     };
 
-    useQueryMock.mockImplementation((name: string, args: unknown) => {
+    useQueryMock.mockImplementation((name: string) => {
       if (name === "testSuites:listTestCases") return [draftCase];
       if (name === "testSuites:getTestSuite") {
         return { _id: "suite-1", environment: { servers: ["srv"] } };
-      }
-      if (name === "testSuites:listTestIterations" && args !== "skip") {
-        return [];
       }
       return undefined;
     });
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -737,6 +732,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -797,9 +793,6 @@ describe("TestTemplateEditor run view from route", () => {
       if (name === "testSuites:getTestSuite") {
         return { _id: "suite-1", environment: { servers: ["srv"] } };
       }
-      if (name === "testSuites:listTestIterations" && args !== "skip") {
-        return [baseIteration];
-      }
       if (
         name === "testSuites:getTestIteration" &&
         typeof args === "object" &&
@@ -818,6 +811,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -889,6 +883,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -969,9 +964,6 @@ describe("TestTemplateEditor run view from route", () => {
       if (name === "hostConfigsV2:getSuiteConfig") {
         return null;
       }
-      if (name === "testSuites:listTestIterations" && args !== "skip") {
-        return [baseIteration];
-      }
       if (
         name === "testSuites:getTestIteration" &&
         typeof args === "object" &&
@@ -988,6 +980,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -1071,9 +1064,6 @@ describe("TestTemplateEditor run view from route", () => {
           hostContext: {},
         };
       }
-      if (name === "testSuites:listTestIterations" && args !== "skip") {
-        return [baseIteration];
-      }
       if (
         name === "testSuites:getTestIteration" &&
         typeof args === "object" &&
@@ -1090,6 +1080,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     const view = renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -1215,6 +1206,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -1337,6 +1329,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -1462,6 +1455,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}
@@ -1593,6 +1587,7 @@ describe("TestTemplateEditor run view from route", () => {
 
     renderWithProviders(
       <TestTemplateEditor
+        suiteIterations={[baseIteration]}
         suiteId="suite-1"
         selectedTestCaseId="case-1"
         connectedServerNames={new Set(["srv"])}

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -549,7 +549,7 @@ describe("TestTemplateEditor run view from route", () => {
     });
   });
 
-  it("renders flat User prompt / Tool triggered for a single-turn case", async () => {
+  it("renders flat User prompt / Expected tool calls for a single-turn case", async () => {
     renderWithProviders(
       <TestTemplateEditor
         suiteId="suite-1"
@@ -571,7 +571,7 @@ describe("TestTemplateEditor run view from route", () => {
       expect(screen.getByText("User prompt")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Tool triggered")).toBeInTheDocument();
+    expect(screen.getByText("Expected tool calls")).toBeInTheDocument();
     expect(screen.queryByText("Prompt steps")).not.toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
@@ -144,9 +144,6 @@ describe("TestTemplateEditor prompt validation UI", () => {
           environment: { servers: ["srv"] },
         };
       }
-      if (name === "testSuites:listTestIterations" && args !== "skip") {
-        return [baseIteration];
-      }
       if (
         name === "testSuites:getTestIteration" &&
         typeof args === "object" &&
@@ -173,6 +170,7 @@ describe("TestTemplateEditor prompt validation UI", () => {
             label: "GPT-4",
           } as any,
         ]}
+        suiteIterations={[baseIteration]}
       />,
     );
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
@@ -526,7 +526,9 @@ describe("TraceViewer", () => {
   });
 
   it("uses the shared stick-to-bottom shell in chat mode", () => {
-    render(<TraceViewer trace={simpleTextTrace} forcedViewMode="chat" />);
+    render(
+      <TraceViewer trace={simpleTextTrace} forcedViewMode="chat" fillContent />,
+    );
 
     expect(screen.getByTestId("trace-viewer-chat")).toBeInTheDocument();
     expect(screen.getByTestId("stick-to-bottom")).toBeInTheDocument();
@@ -536,7 +538,9 @@ describe("TraceViewer", () => {
   it("shows the shared scroll-to-bottom button when chat is off bottom", () => {
     mockStickToBottomContext.isAtBottom = false;
 
-    render(<TraceViewer trace={simpleTextTrace} forcedViewMode="chat" />);
+    render(
+      <TraceViewer trace={simpleTextTrace} forcedViewMode="chat" fillContent />,
+    );
 
     fireEvent.click(
       within(screen.getByTestId("stick-to-bottom")).getByRole("button"),

--- a/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Copy, Loader2, RotateCw } from "lucide-react";
+import { Copy, Loader2, RotateCw, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
 import { cn } from "@/lib/utils";
@@ -56,11 +56,9 @@ function CategoryChip({ row }: { row: TriageRow }) {
 
 function TriageRowItem({ row }: { row: TriageRow }) {
   return (
-    <li className="flex items-start gap-3 border-t border-border/40 px-3 py-2.5 pl-3.5 transition-colors first:border-t-0 hover:bg-primary/[0.03]">
+    <li className="flex items-start gap-3 px-3 py-2.5">
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-foreground">
-          {row.title}
-        </div>
+        <div className="truncate text-sm text-foreground">{row.title}</div>
         <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
           <CategoryChip row={row} />
         </div>
@@ -68,9 +66,9 @@ function TriageRowItem({ row }: { row: TriageRow }) {
       <div className="flex shrink-0 items-center gap-2">
         <Button
           type="button"
-          variant="outline"
+          variant="ghost"
           size="sm"
-          className="h-7 gap-1 text-xs"
+          className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
           title={`Copy a fix prompt for your coding agent (${row.title})`}
           aria-label={`${COPY_FIX_PROMPT_LABEL}: ${row.title}`}
           onClick={() =>
@@ -154,25 +152,16 @@ export function AiTriageCard({
   })();
 
   return (
-    <section
-      className={cn(
-        "relative rounded-xl border text-card-foreground shadow-sm",
-        "border-primary/20 bg-gradient-to-br from-primary/[0.07] via-card to-card",
-        "ring-1 ring-inset ring-primary/10",
-      )}
-    >
-      <div
-        className="pointer-events-none absolute inset-y-0 left-0 w-0.5 bg-primary/50"
-        aria-hidden
-      />
-      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-primary/10 bg-primary/[0.04] px-3 py-2.5 pl-3.5">
-        <div className="min-w-0">
-          <h2 className="text-base font-semibold tracking-tight text-foreground sm:text-lg">
-            AI Insights
-          </h2>
-          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+    <section className="rounded-lg border border-border bg-card text-card-foreground">
+      <header className="flex flex-wrap items-center justify-between gap-2 px-3 py-2.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-sm font-medium text-foreground">
+            AI insights
+          </span>
+          <span className="truncate text-sm text-muted-foreground">
             {headerSubtitle}
-          </p>
+          </span>
         </div>
         <div className="flex items-center gap-2">
           {error || failedGeneration ? (
@@ -189,9 +178,9 @@ export function AiTriageCard({
           ) : null}
           <Button
             type="button"
-            variant="outline"
+            variant="ghost"
             size="sm"
-            className="h-7 shrink-0 gap-1 text-xs"
+            className="h-7 shrink-0 gap-1 text-xs text-muted-foreground hover:text-foreground"
             disabled={!hasRows || pending}
             title={`Copy the top ${topRows.length} fix prompt${topRows.length === 1 ? "" : "s"} to paste into your coding agent`}
             aria-label={copyTopFixPromptsLabel(topRows.length)}
@@ -208,36 +197,29 @@ export function AiTriageCard({
         </div>
       </header>
 
-      <div className="border-t border-border/40 px-3 py-3 pl-3.5">
+      <div className="border-t border-border/50 px-3 py-2.5">
         <div className="flex items-baseline justify-between gap-2">
-          <span className={runDetailSectionLabelClass}>{metricLabel}</span>
-          <span className="tabular-nums">
+          <div className="flex items-baseline gap-2">
+            <span className={runDetailSectionLabelClass}>{metricLabel}</span>
+            <span
+              className={cn(
+                "text-sm tabular-nums",
+                passFailStats.total === 0
+                  ? "text-muted-foreground"
+                  : passRateColorClass(passRate),
+              )}
+            >
+              {passFailStats.total === 0 ? "—" : `${passRate}%`}
+            </span>
+          </div>
+          <span className="text-xs tabular-nums text-muted-foreground">
             {passFailStats.total === 0
               ? "No cases recorded yet"
               : `${passFailStats.passed} passed · ${passFailStats.failed} failed`}
           </span>
         </div>
-        <div className="mt-1.5">
-          <span
-            className={cn(
-              "font-metric text-xl font-semibold tabular-nums leading-none",
-              passRateColorClass(passRate),
-            )}
-          >
-            {passFailStats.total === 0 ? (
-              <span className="text-muted-foreground">—</span>
-            ) : (
-              <>
-                {passRate}
-                <span className="text-sm font-medium text-muted-foreground">
-                  %
-                </span>
-              </>
-            )}
-          </span>
-        </div>
         <div
-          className="mt-2.5 flex h-2.5 w-full overflow-hidden rounded-full bg-muted"
+          className="mt-2 flex h-1 w-full overflow-hidden rounded-full bg-muted/60"
           role="img"
           aria-label={
             passFailStats.total === 0
@@ -257,7 +239,7 @@ export function AiTriageCard({
 
       <div
         className={cn(
-          "border-t border-border/40 bg-card/40",
+          "border-t border-border/50",
           hasRows && "max-h-[min(50vh,24rem)] overflow-y-auto overscroll-y-contain",
         )}
       >
@@ -296,7 +278,7 @@ export function AiTriageCard({
           )
         ) : (
           <>
-            <ul className="divide-y divide-border/40">
+            <ul className="divide-y divide-border/50">
               {visibleRows.map((row) => (
                 <TriageRowItem key={row.id} row={row} />
               ))}
@@ -304,7 +286,7 @@ export function AiTriageCard({
             {hasMoreSuggestions ? (
               <button
                 type="button"
-                className="w-full border-t border-border/40 py-2 text-xs font-medium text-primary transition-colors hover:bg-muted/50"
+                className="w-full border-t border-border/50 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
                 aria-expanded={showAllSuggestions}
                 onClick={() => setShowAllSuggestions((v) => !v)}
               >

--- a/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
@@ -156,9 +156,7 @@ export function AiTriageCard({
       <header className="flex flex-wrap items-center justify-between gap-2 px-3 py-2.5">
         <div className="flex min-w-0 items-center gap-2">
           <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-sm font-medium text-foreground">
-            AI insights
-          </span>
+          <h3 className="text-sm font-medium text-foreground">AI insights</h3>
           <span className="truncate text-sm text-muted-foreground">
             {headerSubtitle}
           </span>

--- a/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
@@ -220,7 +220,7 @@ function CommitSuiteRunDetail({
     [suiteDetails],
   );
 
-  const { caseGroupsForSelectedRun, selectedRunChartData } = useRunDetailData(
+  const { caseGroupsForSelectedRun } = useRunDetailData(
     run._id,
     allIterations,
     runDetailSortBy,
@@ -266,7 +266,6 @@ function CommitSuiteRunDetail({
         selectedRunDetails={run}
         caseGroupsForSelectedRun={caseGroupsForSelectedRun}
         source={run.source as "ui" | "sdk" | undefined}
-        selectedRunChartData={selectedRunChartData}
         runDetailSortBy={runDetailSortBy}
         onSortChange={onSortChange}
         serverNames={run.configSnapshot?.environment?.servers ?? []}

--- a/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import { useProjectServerAttachments } from "@/hooks/useViews";
 import { useHostList } from "@/hooks/useClients";
+import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import {
   ClientAttachmentsEditor,
   type HostAttachmentDraft,
@@ -64,6 +65,9 @@ export function CreateSuiteDialog({
     isAuthenticated: isAuthenticated && shouldFetchDefaults,
     projectId: shouldFetchDefaults ? projectId : null,
   });
+  const [previewedHostId] = usePreviewedHostId(
+    shouldFetchDefaults ? projectId : null,
+  );
 
   useEffect(() => {
     if (!open) {
@@ -83,12 +87,13 @@ export function CreateSuiteDialog({
 
   useEffect(() => {
     if (!shouldFetchDefaults) return;
-    if (hostAttachments.length === 0 && hosts.length > 0) {
-      setHostAttachments([
-        { namedHostId: hosts[0].hostId, enabledOptionalServerIds: [] },
-      ]);
-    }
-  }, [shouldFetchDefaults, hostAttachments.length, hosts]);
+    if (hostAttachments.length > 0 || hosts.length === 0) return;
+    const preferred =
+      hosts.find((h) => h.hostId === previewedHostId) ?? hosts[0];
+    setHostAttachments([
+      { namedHostId: preferred.hostId, enabledOptionalServerIds: [] },
+    ]);
+  }, [shouldFetchDefaults, hostAttachments.length, hosts, previewedHostId]);
 
   const attachmentsRequired = hostsEnabled && projectId !== null;
   const hasRequiredAttachments =

--- a/mcpjam-inspector/client/src/components/evals/cross-host/cross-host-dashboard.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/cross-host-dashboard.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "../types";
 import { evalSurfaceCardClass } from "../eval-surface-chrome";
 import { CrossHostMatrix } from "./cross-host-matrix";
-import { useCrossHostData } from "./use-cross-host-data";
+import { useCrossHostData, type CellData } from "./use-cross-host-data";
 
 interface CrossHostDashboardProps {
   suite: EvalSuite;
@@ -18,6 +18,8 @@ interface CrossHostDashboardProps {
   /** Full-height matrix inside the suite dashboard By host view. */
   expanded?: boolean;
   onTestCaseClick?: (testCaseId: string) => void;
+  /** Click a matrix cell → drill into that (case, host) iteration. */
+  onCellOpen?: (cell: CellData, hostId: string, caseId: string) => void;
 }
 
 export function CrossHostDashboard({
@@ -28,6 +30,7 @@ export function CrossHostDashboard({
   onConfigureHosts,
   expanded = false,
   onTestCaseClick,
+  onCellOpen,
 }: CrossHostDashboardProps) {
   const data = useCrossHostData(suite, cases, runs, allIterations);
   const posthog = usePostHog();
@@ -126,6 +129,7 @@ export function CrossHostDashboard({
           data={data}
           expanded={expanded}
           onTestCaseClick={onTestCaseClick}
+          onCellOpen={onCellOpen}
         />
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/evals/cross-host/cross-host-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/cross-host-matrix.tsx
@@ -10,7 +10,7 @@ import {
   evalSurfaceRowHoverClass,
 } from "../eval-surface-chrome";
 import { HostCell } from "./host-cell";
-import type { CrossHostData, HostColumn } from "./use-cross-host-data";
+import type { CellData, CrossHostData, HostColumn } from "./use-cross-host-data";
 import {
   buildBaseMetricComparisons,
   formatHostFallback,
@@ -21,6 +21,12 @@ interface CrossHostMatrixProps {
   data: CrossHostData;
   expanded?: boolean;
   onTestCaseClick?: (testCaseId: string) => void;
+  /**
+   * Click a per-(case,host) cell. The cell carries the iterations that
+   * produced its aggregate; consumers route to that iteration's trace
+   * (typically the run-detail view filtered to that case).
+   */
+  onCellOpen?: (cell: CellData, hostId: string, caseId: string) => void;
 }
 
 function HostColumnHeader({ col }: { col: HostColumn }) {
@@ -51,6 +57,7 @@ export function CrossHostMatrix({
   data,
   expanded = false,
   onTestCaseClick,
+  onCellOpen,
 }: CrossHostMatrixProps) {
   const { hostColumns, caseRows, matrix } = data;
 
@@ -61,15 +68,13 @@ export function CrossHostMatrix({
           <tr className={runCaseListHeadClassName}>
             <th
               className={cn(
-                "sticky left-0 z-20 min-w-[14rem] border-b border-r border-border/60 text-left",
+                "sticky left-0 z-20 min-w-[14rem] border-b border-r border-border/60 px-4 py-2 text-left",
                 evalSurfaceHeaderClass,
-                runCaseTitleClassName,
-                "px-4 py-2.5 font-sans text-base font-semibold normal-case tracking-normal text-foreground sm:text-lg"
               )}
             >
               Case
-              <span className="ml-1.5 font-mono text-sm font-normal tabular-nums text-muted-foreground">
-                · {caseRows.length}
+              <span className="ml-1.5 font-mono tabular-nums text-muted-foreground/80">
+                {caseRows.length}
               </span>
             </th>
             {hostColumns.map((col) => (
@@ -97,54 +102,91 @@ export function CrossHostMatrix({
               <tr
                 key={row.caseId}
                 data-testid={`test-case-row-${row.caseId}`}
-                className={cn(
-                  onTestCaseClick && "cursor-pointer",
-                  onTestCaseClick && evalSurfaceRowHoverClass
-                )}
-                tabIndex={onTestCaseClick ? 0 : undefined}
-                role={onTestCaseClick ? "button" : undefined}
-                aria-label={
-                  onTestCaseClick
-                    ? `Open test case: ${row.caseTitle}`
-                    : undefined
-                }
-                onClick={onTestCaseClick ? openCase : undefined}
-                onKeyDown={
-                  onTestCaseClick
-                    ? (event) => {
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
-                          openCase();
-                        }
-                      }
-                    : undefined
-                }
               >
-                <td className="sticky left-0 z-10 border-r border-border/40 bg-inherit px-4 py-2.5 backdrop-blur-sm">
+                <td
+                  className={cn(
+                    "sticky left-0 z-10 border-r border-border/40 bg-inherit px-4 py-2.5 backdrop-blur-sm",
+                    onTestCaseClick && "cursor-pointer hover:bg-muted/40",
+                  )}
+                  tabIndex={onTestCaseClick ? 0 : undefined}
+                  role={onTestCaseClick ? "button" : undefined}
+                  aria-label={
+                    onTestCaseClick
+                      ? `Open test case: ${row.caseTitle}`
+                      : undefined
+                  }
+                  onClick={onTestCaseClick ? openCase : undefined}
+                  onKeyDown={
+                    onTestCaseClick
+                      ? (event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            openCase();
+                          }
+                        }
+                      : undefined
+                  }
+                >
                   <span
-                    className={cn(runCaseTitleClassName, "block")}
+                    className={cn(
+                      runCaseTitleClassName,
+                      "block",
+                      onTestCaseClick &&
+                        "underline decoration-dotted underline-offset-4 decoration-muted-foreground/40",
+                    )}
                     title={row.caseTitle}
                   >
                     {row.caseTitle}
                   </span>
                 </td>
-                {hostColumns.map((col) => (
-                  <td
-                    key={col.hostId}
-                    className={cn(
-                      "border-r border-border/50 align-top",
-                      evalSurfaceCellClass
-                    )}
-                  >
-                    <HostCell
-                      data={byHost?.get(col.hostId)}
-                      metricComparisons={projectComparisonsForHost(
-                        baseComparisons,
-                        col.hostId,
+                {hostColumns.map((col) => {
+                  const cell = byHost?.get(col.hostId);
+                  const cellInteractive = !!(
+                    onCellOpen &&
+                    cell &&
+                    cell.totalCount > 0
+                  );
+                  const openCell = () => {
+                    if (cell) onCellOpen?.(cell, col.hostId, row.caseId);
+                  };
+                  return (
+                    <td
+                      key={col.hostId}
+                      className={cn(
+                        "border-r border-border/50 align-top",
+                        evalSurfaceCellClass,
+                        cellInteractive &&
+                          cn("cursor-pointer", evalSurfaceRowHoverClass),
                       )}
-                    />
-                  </td>
-                ))}
+                      tabIndex={cellInteractive ? 0 : undefined}
+                      role={cellInteractive ? "button" : undefined}
+                      aria-label={
+                        cellInteractive
+                          ? `Open ${col.hostName ?? col.hostId} iteration for ${row.caseTitle}`
+                          : undefined
+                      }
+                      onClick={cellInteractive ? openCell : undefined}
+                      onKeyDown={
+                        cellInteractive
+                          ? (event) => {
+                              if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault();
+                                openCell();
+                              }
+                            }
+                          : undefined
+                      }
+                    >
+                      <HostCell
+                        data={cell}
+                        metricComparisons={projectComparisonsForHost(
+                          baseComparisons,
+                          col.hostId,
+                        )}
+                      />
+                    </td>
+                  );
+                })}
               </tr>
             );
           })}

--- a/mcpjam-inspector/client/src/components/evals/cross-host/host-cell.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/host-cell.tsx
@@ -9,7 +9,6 @@ import { computeIterationResult } from "../pass-criteria";
 import { RunCaseIterationBar } from "../run-case-list-shared";
 import type { RunCaseIterationOutcome } from "../run-case-groups";
 import { formatRunCaseLatencyMs } from "../run-case-groups";
-import { passRateColorClass } from "../suite-overview-presentation";
 import type { CellData } from "./use-cross-host-data";
 import type { EvalIteration } from "../types";
 
@@ -268,12 +267,7 @@ export function HostCell({ data, metricComparisons }: HostCellProps) {
     data.passRate !== null ? `${Math.round(data.passRate)}%` : null;
   const accuracyBadge =
     accuracyLabel != null ? (
-      <span
-        className={cn(
-          "font-mono text-xs font-semibold tabular-nums leading-none",
-          passRateColorClass(data.passRate)
-        )}
-      >
+      <span className="font-mono text-xs tabular-nums leading-none text-muted-foreground">
         {accuracyLabel}
       </span>
     ) : null;

--- a/mcpjam-inspector/client/src/components/evals/evals-empty-hero.tsx
+++ b/mcpjam-inspector/client/src/components/evals/evals-empty-hero.tsx
@@ -3,7 +3,7 @@ import { Button } from "@mcpjam/design-system/button";
 import { cn } from "@/lib/utils";
 
 const FIRST_SUITE_EMPTY_DESCRIPTION =
-  "A suite groups eval cases with the MCP servers they use. Create one, then generate cases or import a chat transcript.";
+  "A suite groups test cases with the MCP servers they use. Run it across clients to get insights into your design.";
 
 interface EvalsEmptyHeroProps {
   onCreateSuite: () => void;
@@ -47,7 +47,7 @@ export function EvalsEmptyHero({
                 {isQuickstartRunning ? (
                   <Loader2 className="size-4 animate-spin" aria-hidden />
                 ) : null}
-                Try the Excalidraw quickstart
+                Try sample suite
               </Button>
             ) : null}
           </div>
@@ -157,13 +157,13 @@ function ToolCallDiffPreview() {
         <span>2 of 3 calls matched</span>
       </div>
       <DiffPreviewRow
-        toolName="create_element"
+        toolName="create_view"
         leftArg="rectangle"
         rightArg="rectangle"
         match
       />
       <DiffPreviewRow
-        toolName="create_element"
+        toolName="create_view"
         leftArg='label: "Hi"'
         rightArg='label: "Hello"'
         match={false}

--- a/mcpjam-inspector/client/src/components/evals/evals-suite-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/evals-suite-list-sidebar.tsx
@@ -5,9 +5,9 @@ import {
   Play,
   Plus,
   Search,
+  Settings,
   SlidersHorizontal,
   Trash2,
-  Settings2,
 } from "lucide-react";
 import posthog from "posthog-js";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
@@ -291,6 +291,8 @@ function SuiteTableHeader({
       )
     : SUITE_ROW_GRID;
 
+  const showBatchBar = batchDeleteEnabled && selectedCount > 0;
+
   return (
     <div className="sticky top-0 z-[1] shrink-0 border-b border-border/40 bg-card/95 px-4 py-2 backdrop-blur-sm">
       <div className={gridClass}>
@@ -306,44 +308,45 @@ function SuiteTableHeader({
         <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
           Suite
         </span>
-        <span className="text-right text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
-          Score
-        </span>
-        <div className="flex min-w-0 items-center justify-between gap-2">
-          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
-            Last run
-          </span>
-          {batchDeleteEnabled && selectedCount > 0 ? (
-            <div className="flex shrink-0 items-center gap-1.5">
-              <span className="text-[11px] tabular-nums text-muted-foreground">
-                {selectedCount} selected
-              </span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-6 px-2 text-[11px] text-muted-foreground"
-                onClick={onClearSelection}
-                disabled={selectionBlocked}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                className={cn(
-                  "h-6 px-2 text-[11px]",
-                  EVAL_DESTRUCTIVE_BUTTON_CLASS,
-                )}
-                onClick={onDeleteSelected}
-                disabled={selectionBlocked}
-              >
-                Delete
-              </Button>
-            </div>
-          ) : null}
-        </div>
-        <span className="sr-only">Actions</span>
+        {showBatchBar ? (
+          <div className="col-span-3 flex min-w-0 items-center justify-end gap-1.5">
+            <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+              {selectedCount} selected
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 shrink-0 px-2 text-[11px] text-muted-foreground"
+              onClick={onClearSelection}
+              disabled={selectionBlocked}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              className={cn(
+                "h-6 shrink-0 px-2 text-[11px]",
+                EVAL_DESTRUCTIVE_BUTTON_CLASS,
+              )}
+              onClick={onDeleteSelected}
+              disabled={selectionBlocked}
+            >
+              Delete
+            </Button>
+          </div>
+        ) : (
+          <>
+            <span className="text-right text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+              Score
+            </span>
+            <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+              Last run
+            </span>
+            <span className="sr-only">Actions</span>
+          </>
+        )}
       </div>
     </div>
   );
@@ -513,7 +516,7 @@ function SuiteOverviewRow({
                 onEditSuite(suite._id);
               }}
             >
-              <Settings2 className="h-3.5 w-3.5" aria-hidden />
+              <Settings className="h-3.5 w-3.5" aria-hidden />
             </Button>
           ) : null}
           <Button

--- a/mcpjam-inspector/client/src/components/evals/evals-suite-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/evals-suite-list-sidebar.tsx
@@ -341,7 +341,7 @@ function SuiteTableHeader({
             <span className="text-right text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
               Score
             </span>
-            <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+            <span className="text-right text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
               Last run
             </span>
             <span className="sr-only">Actions</span>
@@ -490,7 +490,7 @@ function SuiteOverviewRow({
           type="button"
           aria-hidden
           tabIndex={-1}
-          className={cn(METRIC_CELL_CLASS, "justify-start text-left")}
+          className={cn(METRIC_CELL_CLASS, "justify-end text-right")}
           onClick={() => onSelectSuite(suite._id)}
         >
           {lastRunTimestampLabel ? (

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
-import { Loader2, RotateCw, Sparkles } from "lucide-react";
+import { Loader2, RotateCw } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
-import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import {
   Select,
@@ -12,7 +11,7 @@ import {
 } from "@mcpjam/design-system/select";
 import { cn } from "@/lib/utils";
 import type { ModelDefinition } from "@/shared/types";
-import type { EvalIteration, EvalSuiteRun } from "./types";
+import type { EvalIteration, EvalJudgeConfig, EvalSuiteRun } from "./types";
 import type { GoalCompletionRequestArgs } from "./use-goal-completion";
 
 /** Managed default judge model (mirrors GOAL_COMPLETION_MODEL in the backend). */
@@ -31,25 +30,14 @@ export interface GoalCompletionCardProps {
   failedGeneration: boolean;
   error: string | null;
   onRun: (args: GoalCompletionRequestArgs, force?: boolean) => void;
-}
-
-function clampThreshold(value: number): number {
-  if (Number.isNaN(value)) {
-    return DEFAULT_THRESHOLD;
-  }
-  return Math.min(1, Math.max(0, value));
-}
-
-/**
- * Parse the threshold input. A blank field must fall back to the default — NOT
- * `Number("") === 0`, which would pass every nonnegative score and make a run
- * look successful just because the field was left empty.
- */
-function parseThreshold(input: string): number {
-  if (input.trim() === "") {
-    return DEFAULT_THRESHOLD;
-  }
-  return clampThreshold(Number(input));
+  /**
+   * Current suite-level judge config (live, not snapshotted on the run).
+   * When the suite has the judge enabled NOW, the card lets the user re-run
+   * even on older runs whose snapshot didn't have it on. When omitted,
+   * the card falls back to the run's snapshot — older parents
+   * (e.g. commit-detail) don't need to thread suite data through.
+   */
+  currentSuiteJudgeConfig?: EvalJudgeConfig | null;
 }
 
 function formatScore(score: number): string {
@@ -88,6 +76,7 @@ export function GoalCompletionCard({
   failedGeneration,
   error,
   onRun,
+  currentSuiteJudgeConfig,
 }: GoalCompletionCardProps) {
   const completedRun = run.status === "completed";
 
@@ -102,16 +91,8 @@ export function GoalCompletionCard({
     (goalCompletion?.modelUsed && goalCompletion.modelUsed !== "n/a"
       ? goalCompletion.modelUsed
       : DEFAULT_JUDGE_MODEL);
-  const initialThreshold =
-    run.judgeConfigOverride?.goalCompletion?.threshold ??
-    run.configSnapshot?.judgeConfig?.goalCompletion?.threshold ??
-    goalCompletion?.threshold ??
-    DEFAULT_THRESHOLD;
   const [selectedModelId, setSelectedModelId] =
     useState<string>(initialModel);
-  const [thresholdInput, setThresholdInput] = useState<string>(
-    String(initialThreshold),
-  );
 
   // Always keep the managed default + the current selection selectable, even
   // before the async model catalog loads (or when BYOK has none configured).
@@ -152,14 +133,18 @@ export function GoalCompletionCard({
   const suiteConfig = run.configSnapshot?.judgeConfig?.goalCompletion;
   const suiteModel = suiteConfig?.judgeModel ?? DEFAULT_JUDGE_MODEL;
   const suiteThreshold = suiteConfig?.threshold ?? DEFAULT_THRESHOLD;
-  // Treat "no explicit choice" as enabled (matches GOAL_COMPLETION_DEFAULTS
-  // on the backend: `enabled: true`). Only an explicit `enabled: false` on
-  // the suite snapshot hides the run controls behind the "Configure on
-  // suite" CTA. This keeps the judge discoverable on every suite by default
-  // while still respecting an owner who actively turned it off.
-  // Cost remains gated by the explicit Run judge click + `autoRun: false`
-  // default — an enabled-but-un-clicked judge spends nothing.
-  const isJudgeConfigured = suiteConfig?.enabled !== false;
+  // Backend default is `enabled: true` (see GOAL_COMPLETION_DEFAULTS in
+  // convex/lib/judgeConfig.ts) — only an explicit `enabled: false` turns
+  // the judge off. The current suite config takes precedence over the
+  // snapshot when provided, so flipping the toggle on today re-opens the
+  // controls for older runs whose snapshot didn't have it set.
+  // Cost is gated by `autoRun: false` (default) + the explicit Run judge
+  // click, so an unconfigured/enabled-by-default suite still spends nothing
+  // until a click.
+  const currentSuiteGoalCompletion = currentSuiteJudgeConfig?.goalCompletion;
+  const resolvedEnabled =
+    currentSuiteGoalCompletion?.enabled ?? suiteConfig?.enabled;
+  const isJudgeConfigured = resolvedEnabled !== false;
   // The persisted run override (`run.judgeConfigOverride.goalCompletion`)
   // tells the trend story (this data point isn't graded against the suite
   // contract). Surfacing it prominently is how the comparability promise
@@ -178,24 +163,16 @@ export function GoalCompletionCard({
     overrideModel !== undefined || overrideThresholdValue !== undefined;
 
   const handleRun = (force: boolean) => {
-    // Only send a runOverride when the user's inputs DIFFER from the suite
-    // config. Otherwise pass `{}` so the backend clears any previously
-    // persisted override and grades against the suite contract — the
-    // override-clearing semantic the plan + tests require.
+    // Only send a runOverride when the user's model selection DIFFERS from the
+    // suite config. Threshold is no longer adjustable from this card — it
+    // always inherits the suite default.
     const overrideModel =
       selectedModelId && selectedModelId !== suiteModel
         ? selectedModelId
         : undefined;
-    const parsedThreshold = parseThreshold(thresholdInput);
-    const overrideThreshold =
-      parsedThreshold !== suiteThreshold ? parsedThreshold : undefined;
-    const runOverride =
-      overrideModel || overrideThreshold !== undefined
-        ? {
-            judgeModel: overrideModel,
-            threshold: overrideThreshold,
-          }
-        : undefined;
+    const runOverride = overrideModel
+      ? { judgeModel: overrideModel }
+      : undefined;
     onRun({ runOverride }, force);
   };
 
@@ -210,6 +187,7 @@ export function GoalCompletionCard({
     if (pending) return "Grading…";
     if (requested) return "Requesting…";
     if (error || failedGeneration) return "Grading failed";
+    if (!isJudgeConfigured) return "Disabled";
     if (!goalCompletion) return "Not run yet";
     if (cases.length === 0) return "Summary only";
     return `${advisoryPassed}/${cases.length} meet goal (advisory)`;
@@ -221,12 +199,8 @@ export function GoalCompletionCard({
     <section className="rounded-lg border border-border bg-card text-card-foreground">
       <header className="flex flex-wrap items-center justify-between gap-2 px-3 py-2.5">
         <div className="flex min-w-0 items-center gap-2">
-          <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
           <span className="text-sm font-medium text-foreground">
-            Goal completion
-          </span>
-          <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            advisory · LLM judge
+            LLM as Judge
           </span>
           <span className="truncate text-sm text-muted-foreground">
             {headerSubtitle}
@@ -278,25 +252,6 @@ export function GoalCompletionCard({
                 </SelectContent>
               </Select>
             </div>
-            <div className="flex w-24 flex-col gap-1">
-              <Label htmlFor="goal-threshold" className="text-xs">
-                Threshold
-              </Label>
-              <Input
-                id="goal-threshold"
-                type="number"
-                min={0}
-                max={1}
-                step={0.05}
-                value={thresholdInput}
-                onChange={(e) => setThresholdInput(e.target.value)}
-                onBlur={() =>
-                  setThresholdInput(String(parseThreshold(thresholdInput)))
-                }
-                disabled={inFlight}
-                className="h-8 text-sm"
-              />
-            </div>
             <Button
               type="button"
               size="sm"
@@ -311,25 +266,15 @@ export function GoalCompletionCard({
               // a second judge call.
               disabled={!completedRun || inFlight}
             >
-              {inFlight ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Sparkles className="h-3.5 w-3.5" />
-              )}
+              {inFlight ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
               {runLabel}
             </Button>
           </div>
 
-          <p className="px-3 pb-3 text-[11px] text-muted-foreground/70">
-            Threshold is the advisory pass cutoff (score ≥ threshold).
-            Calibrate it per suite against a labeled set — LLM-judge scores
-            are not comparable across domains.
-          </p>
-
           {hasMeaningfulOverride ? (
             <div className="mx-3 mb-3 rounded-md border border-warning/50 bg-warning/50 px-3 py-2 text-[12px]">
               <div className="font-medium text-foreground">
-                ⚙ This run used an override
+                This run used an override
               </div>
               <div className="mt-0.5 text-muted-foreground">
                 Suite default:{" "}
@@ -351,28 +296,27 @@ export function GoalCompletionCard({
           ) : null}
         </>
       ) : (
-        // Suite hasn't enabled the judge. Don't render run controls —
-        // clicking them on an unconfigured run would spend an LLM call to
-        // grade zero cases. Direct the user to the right surface instead.
-        <div className="border-t border-border/50 px-3 py-4 text-sm">
-          <p className="text-foreground/90">
-            Goal completion isn't enabled for this suite.
-          </p>
-          <p className="mt-1 text-[12px] text-muted-foreground">
-            Open suite settings (the <strong>⚙</strong> button next to the
-            suite name) and enable Goal completion under{" "}
-            <strong>Judges</strong> to start grading runs against each case's{" "}
-            <code className="font-mono text-[11px]">expectedOutput</code>.
-            Cases without an expected output are skipped (anchored-only).
-          </p>
+        // Suite explicitly disabled the judge. Don't render run controls —
+        // clicking them would spend an LLM call to grade nothing. The
+        // suite settings toggle is the path back on.
+        <div className="border-t border-border/50 px-3 py-3 text-[12px] text-muted-foreground">
+          Disabled in suite settings. Turn it on to grade this run.
         </div>
       )}
 
+      {/* Skip the bottom body band entirely in the quiet "disabled, no
+          prior result" state — the CTA above is the whole story, no need
+          for an empty bordered strip below it. */}
+      {!isJudgeConfigured &&
+      !goalCompletion &&
+      !inFlight &&
+      !error &&
+      !failedGeneration ? null : (
       <div className="border-t border-border/50">
         {inFlight ? (
           <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            Grading final answers against expected output…
+            Grading final answers…
           </div>
         ) : error ? (
           <div className="px-3 py-4 text-sm text-destructive">{error}</div>
@@ -383,14 +327,13 @@ export function GoalCompletionCard({
           </div>
         ) : !goalCompletion ? (
           <div className="px-3 py-4 text-sm text-muted-foreground">
-            Grade whether each case's final answer satisfied its expected
-            output. Pick a judge model and threshold, then run — this is
-            advisory and never changes the run's pass/fail.
+            Advisory grading against each case&apos;s objective. Never
+            changes the run&apos;s pass/fail.
           </div>
         ) : cases.length === 0 ? (
           <div className="px-3 py-4 text-sm text-muted-foreground">
-            {goalCompletion.summary?.trim() ||
-              "No anchored cases to grade (cases need an expected output)."}
+            This run wasn&apos;t graded — no completed cases were available to
+            judge. Re-run the judge to grade against the current suite config.
           </div>
         ) : (
           <>
@@ -447,6 +390,7 @@ export function GoalCompletionCard({
           </>
         )}
       </div>
+      )}
     </section>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/insight-highlight-chrome.ts
+++ b/mcpjam-inspector/client/src/components/evals/insight-highlight-chrome.ts
@@ -1,28 +1,28 @@
 import { cn } from "@/lib/utils";
 
-/** Shared visual treatment for AI insight surfaces (matches AiTriageCard). */
+/** Flat insight surface — matches eval-surface-chrome (hairline border, no gradient/ring/shadow). */
 export const insightHighlightSectionClass = cn(
-  "relative rounded-xl border text-card-foreground shadow-sm",
-  "border-primary/20 bg-gradient-to-br from-primary/[0.07] via-card to-card",
-  "ring-1 ring-inset ring-primary/10",
+  "relative rounded-2xl border border-border/50 bg-card text-card-foreground",
+  "dark:border-border/40",
 );
 
-export const insightHighlightAccentClass =
-  "pointer-events-none absolute inset-y-0 left-0 w-0.5 rounded-l-xl bg-primary/50";
+/** Accent rail removed — kept as an empty class so call sites stay stable. */
+export const insightHighlightAccentClass = "hidden";
 
 export const insightHighlightHeaderRowClass =
-  "flex items-stretch gap-0 rounded-t-xl border-b border-primary/10 bg-primary/[0.04]";
+  "flex items-stretch gap-0 rounded-t-2xl";
 
 export const insightHighlightTriggerClass =
-  "flex min-w-0 flex-1 items-center gap-2 rounded-t-xl px-3 py-2.5 pl-3.5 text-left outline-none hover:bg-primary/[0.06] focus-visible:ring-2 focus-visible:ring-ring";
+  "flex min-w-0 flex-1 items-center gap-2 rounded-t-2xl px-3 py-2.5 text-left outline-none hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring";
 
 export const insightHighlightTitleClass =
-  "text-base font-semibold tracking-tight text-foreground";
+  "text-sm font-medium text-foreground";
 
 export const insightHighlightSubtitleClass =
   "mt-0.5 truncate text-xs text-muted-foreground";
 
-export const insightHighlightBodyClass = "px-3 py-3 pl-3.5";
+export const insightHighlightBodyClass =
+  "px-3 pb-3 pt-1 border-t border-border/40 dark:border-border/30";
 
 export const insightHighlightNarrativeClass =
   "text-sm leading-relaxed text-foreground";

--- a/mcpjam-inspector/client/src/components/evals/judges-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/judges-section.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
-import { Sparkles } from "lucide-react";
-import { Input } from "@mcpjam/design-system/input";
+import { useMemo } from "react";
 import { Label } from "@mcpjam/design-system/label";
 import {
   Select,
@@ -27,7 +25,6 @@ import type { EvalJudgeConfig } from "./types";
  */
 
 const MANAGED_DEFAULT_JUDGE_MODEL = "openai/gpt-5.4-mini";
-const DEFAULT_THRESHOLD = 0.7;
 
 interface JudgesSectionProps {
   value: EvalJudgeConfig | undefined;
@@ -60,19 +57,18 @@ export function JudgesSection({
   value,
   onChange,
   availableModels,
-  title = "Judges",
-  description = "Advisory LLM-as-judge scorers that grade run results against rubric anchors. Calibrate per suite — scores aren't comparable across domains.",
+  title = "LLM as Judge",
+  description = "Advisory grading of run results against rubric anchors. Calibrate per suite — scores aren't comparable across domains.",
   chrome = "panel",
 }: JudgesSectionProps) {
   const isBare = chrome === "bare";
   const gc = value?.goalCompletion;
-  // Treat absence as "enabled" to mirror GOAL_COMPLETION_DEFAULTS
-  // (`enabled: true`). Only an explicit `enabled: false` switches the
-  // suite to off; otherwise the toggle reads as on by default so users
-  // see the configuration affordance instead of an opt-in gate.
+  // Default-on: GOAL_COMPLETION_DEFAULTS.enabled = true. Only an explicit
+  // `enabled: false` flips the toggle off, matching what the resolver
+  // does at run time. Cost stays gated by `autoRun: false` + the explicit
+  // Run judge click on the run-detail card.
   const enabled = gc?.enabled !== false;
   const judgeModel = gc?.judgeModel ?? MANAGED_DEFAULT_JUDGE_MODEL;
-  const threshold = gc?.threshold ?? DEFAULT_THRESHOLD;
   const autoRun = gc?.autoRun === true;
 
   const modelOptions = useMemo(() => {
@@ -100,50 +96,28 @@ export function JudgesSection({
     onChange(pruneEmpty(nextConfig));
   };
 
-  // The threshold field keeps a local draft so typing doesn't fight the
-  // persisted prop: `onChange` here drives an async `updateSuite`, and feeding
-  // the input straight from the round-tripped prop snaps a half-typed decimal
-  // back mid-edit. Type into the draft, commit (clamp / default) on blur, and
-  // re-sync the draft whenever the persisted value changes from elsewhere.
-  const [thresholdDraft, setThresholdDraft] = useState(String(threshold));
-  useEffect(() => {
-    setThresholdDraft(String(threshold));
-  }, [threshold]);
-
-  const commitThreshold = () => {
-    const raw = thresholdDraft.trim();
-    if (raw === "") {
-      update({ threshold: undefined });
-      return;
-    }
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed)) {
-      setThresholdDraft(String(threshold));
-      return;
-    }
-    const clamped = Math.min(1, Math.max(0, parsed));
-    update({ threshold: clamped === DEFAULT_THRESHOLD ? undefined : clamped });
-  };
-
   const body = (
     <>
-      {/* Goal Completion — V1 only judge */}
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-foreground">
-              Goal completion
-            </span>
-            {!isBare ? (
-              <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                advisory · LLM judge
+          {isBare ? (
+            // Parent `SettingsSection` already labels "LLM as Judge" and
+            // describes it; surfacing the same name + blurb here would just
+            // repeat the section header. In `panel` chrome there's no outer
+            // label, so we keep the sub-heading + description.
+            <p className="text-[12px] text-muted-foreground">
+              Grade each case&apos;s final answer against its objective.
+            </p>
+          ) : (
+            <>
+              <span className="text-sm font-medium text-foreground">
+                LLM as Judge
               </span>
-            ) : null}
-          </div>
-          <p className="mt-0.5 text-[11px] text-muted-foreground/80">
-            Grades whether each case&apos;s final answer satisfied its{" "}
-            <code className="font-mono">expectedOutput</code>.
-          </p>
+              <p className="mt-0.5 text-[11px] text-muted-foreground/80">
+                Grades each case&apos;s final answer against its objective.
+              </p>
+            </>
+          )}
         </div>
         <Switch
           checked={enabled}
@@ -154,7 +128,7 @@ export function JudgesSection({
             // the user just disabled.
             update({ enabled: checked })
           }
-          aria-label="Enable Goal Completion judge for this suite"
+          aria-label="Enable LLM as Judge for this suite"
         />
       </div>
 
@@ -190,30 +164,11 @@ export function JudgesSection({
             </SelectContent>
           </Select>
 
-          {/* Threshold + Auto-run are intentionally hidden in `bare` mode —
-              the suite settings sheet keeps Judges down to a single
-              enable-toggle + model selector. Both are still configurable
-              in the full panel chrome and persisted via the same shape. */}
+          {/* Threshold is hidden from the suite UI — runs grade against a
+              fixed default and surface only the model choice. Auto-run is
+              still configurable in the full panel chrome. */}
           {!isBare ? (
             <>
-              <Label
-                htmlFor="suite-goal-threshold"
-                className="text-sm text-muted-foreground"
-              >
-                Threshold
-              </Label>
-              <Input
-                id="suite-goal-threshold"
-                type="number"
-                min={0}
-                max={1}
-                step={0.05}
-                value={thresholdDraft}
-                onChange={(e) => setThresholdDraft(e.target.value)}
-                onBlur={commitThreshold}
-                className="h-8 w-20 text-right text-sm tabular-nums"
-              />
-
               <Label
                 htmlFor="suite-goal-auto-run"
                 className="text-sm text-muted-foreground"
@@ -226,7 +181,7 @@ export function JudgesSection({
                 onCheckedChange={(checked: boolean) =>
                   update({ autoRun: checked || undefined })
                 }
-                aria-label="Auto-run the Goal Completion judge on every new completed run"
+                aria-label="Auto-run the LLM as Judge on every new completed run"
               />
             </>
           ) : null}
@@ -249,10 +204,7 @@ export function JudgesSection({
       className="rounded-lg border border-border/40 bg-card/30 p-4 space-y-4"
     >
       <div className="space-y-1">
-        <div className="flex items-center gap-2">
-          <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
-          <h3 className="text-sm font-semibold">{title}</h3>
-        </div>
+        <h3 className="text-sm font-semibold">{title}</h3>
         {description ? (
           <p className="text-[12px] text-muted-foreground">{description}</p>
         ) : null}

--- a/mcpjam-inspector/client/src/components/evals/run-case-list-shared.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-case-list-shared.tsx
@@ -17,7 +17,7 @@ export function runCaseListRowClassName() {
 
 /** Fixed-width metric columns — shared by header labels and row cells. */
 export const runCaseMetricsRailClassName =
-  "grid w-[16.25rem] shrink-0 grid-cols-[7.5rem_3.25rem_3.25rem_2.25rem] items-center";
+  "grid w-[17.5rem] shrink-0 grid-cols-[7.5rem_3.25rem_3.25rem_3.5rem] items-center";
 
 /** Sort icon column width — aligns header control with row gutter. */
 export const runCaseListSortGutterClassName = "flex w-7 shrink-0 items-center justify-end pr-2";

--- a/mcpjam-inspector/client/src/components/evals/run-case-list-shared.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-case-list-shared.tsx
@@ -24,7 +24,7 @@ export const runCaseListSortGutterClassName = "flex w-7 shrink-0 items-center ju
 
 /** Header row — mirrors `.matrix-row.head` from evals_playground_design.html */
 export const runCaseListHeadClassName = cn(
-  "min-h-9 font-mono text-xs font-medium uppercase tracking-wide text-muted-foreground",
+  "min-h-9 text-xs font-medium uppercase tracking-wide text-muted-foreground",
   evalSurfaceHeaderClass,
 );
 
@@ -93,7 +93,7 @@ export function RunCaseIterationBar({
             key={index}
             className={cn(
               "min-h-1 min-w-0 rounded-[1px]",
-              result === "pass" && "bg-success",
+              result === "pass" && "bg-success/50",
               result === "fail" && EVAL_FAIL_BAR_CLASS,
               result === "pending" && "bg-muted-foreground/25",
               result === "cancelled" && "bg-muted-foreground/20",

--- a/mcpjam-inspector/client/src/components/evals/run-detail-insight-collapsible.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-insight-collapsible.tsx
@@ -56,7 +56,7 @@ export function RunDetailInsightCollapsible({
             transition={{ type: "spring", stiffness: 520, damping: 32 }}
           >
             <motion.span
-              className="inline-flex shrink-0 text-primary/70"
+              className="inline-flex shrink-0 text-muted-foreground"
               aria-hidden
               initial={false}
               animate={{ rotate: open ? 0 : -90 }}

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -34,16 +34,14 @@ import {
 import { RunCaseListWithSections } from "./run-case-list";
 import type { RunCaseGroup } from "./run-case-groups";
 import { groupRunIterationsByTestCase } from "./run-case-groups";
-import {
-  tokensChartDatumTotal,
-  type DurationChartDatum,
-  type TokensChartDatum,
+import type {
+  DurationChartDatum,
+  TokensChartDatum,
 } from "./run-chart-data";
 import { RunDetailKpiStrip } from "./run-detail-kpis";
 import { ClientChip } from "@/components/clients/client-chip";
 import {
   RunAccuracyHeroBand,
-  RunDetailMetricsCharts,
   RunInsightRail,
   shouldShowRunAccuracyHero,
   type RunTrendPoint,
@@ -406,13 +404,6 @@ export function RunDetailView({
     [kpiPlacement, selectedRunDetails, caseGroupsForSelectedRun, source]
   );
 
-  const hasTokenData = useMemo(
-    () =>
-      selectedRunChartData.tokensData.length > 0 &&
-      selectedRunChartData.tokensData.some((d) => tokensChartDatumTotal(d) > 0),
-    [selectedRunChartData.tokensData]
-  );
-
   const serverQualityTriage =
     selectedRunDetails.status === "completed" && !serverQualityUnavailable ? (
       <AiTriageCard
@@ -499,15 +490,6 @@ export function RunDetailView({
     />
   ) : null;
 
-  const runMetricsCharts = (
-    <RunDetailMetricsCharts
-      durationData={selectedRunChartData.durationData}
-      tokensData={selectedRunChartData.tokensData}
-      hasTokenData={hasTokenData}
-      className="mb-4"
-    />
-  );
-
   const insightRail = (
     <RunInsightRail
       triageCard={serverQualityTriage}
@@ -579,7 +561,6 @@ export function RunDetailView({
     <div className="space-y-4">
       {bodyKpiStrip}
       {accuracyHero}
-      {runMetricsCharts}
       {insightRail}
     </div>
   );
@@ -620,7 +601,6 @@ export function RunDetailView({
         <>
           {bodyKpiStrip}
           {accuracyHero}
-          {runMetricsCharts}
           {lgUp ? (
             <ResizablePanelGroup
               direction="horizontal"

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -14,7 +14,7 @@ import {
 import {
   computeIterationPassed,
 } from "./pass-criteria";
-import { EvalIteration, EvalSuiteRun } from "./types";
+import { EvalIteration, EvalJudgeConfig, EvalSuiteRun } from "./types";
 import { CiMetadataDisplay } from "./ci-metadata-display";
 import { useRunInsights } from "./use-run-insights";
 import { useServerQuality } from "./use-server-quality";
@@ -24,7 +24,7 @@ import { GoalCompletionCard } from "./goal-completion-card";
 import { useAvailableEvalModels } from "@/hooks/use-available-eval-models";
 import { useSharedAppState } from "@/state/app-state-context";
 import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
-import { ArrowLeftRight, ArrowUpDown } from "lucide-react";
+import { ArrowUpDown } from "lucide-react";
 import { getSidebarRunInsightsPassRateLabel } from "./run-header-compact-stats";
 import { RunInsightsSidebarSummary } from "./run-insights-sidebar";
 import { computeRunDashboardKpis } from "./run-detail-kpis";
@@ -117,7 +117,11 @@ interface RunDetailViewProps {
    * `body` = KPI row stays in this view (CI / commit detail).
    */
   kpiPlacement?: "header" | "body";
-  /** Previous completed run offered as the default deterministic diff base. */
+  /**
+   * Previous completed run offered as the deterministic diff base. Plumbed
+   * through to {@link RunAccuracyHeroBand} for future re-surfacing; no
+   * header UI consumes it today.
+   */
   compareBaseRun?: EvalSuiteRun | null;
   onCompareWithRun?: (baseRunId: string) => void;
   /**
@@ -135,6 +139,13 @@ interface RunDetailViewProps {
    * the default `buildEvalsPath` (`/evals/...`).
    */
   onSelectRun?: (runId: string) => void;
+  /**
+   * Current (live) suite judge config. Threaded into the goal-completion
+   * card so older runs whose snapshot doesn't reflect the current toggle
+   * state can still trigger a re-run when the suite is enabled today.
+   * Optional — CI/commit-detail parents don't have a live suite handle.
+   */
+  currentSuiteJudgeConfig?: EvalJudgeConfig | null;
 }
 
 function runDetailSortLabel(sortBy: "model" | "test" | "result"): string {
@@ -320,7 +331,6 @@ export function RunDetailView({
   selectedRunDetails,
   caseGroupsForSelectedRun,
   source,
-  selectedRunChartData,
   runDetailSortBy,
   onSortChange,
   serverNames: _serverNames = [],
@@ -341,6 +351,7 @@ export function RunDetailView({
   hostNamesById,
   runTrendData = [],
   onSelectRun,
+  currentSuiteJudgeConfig,
 }: RunDetailViewProps) {
   const handleEditTestCase =
     onEditTestCaseProp ??
@@ -439,6 +450,7 @@ export function RunDetailView({
         failedGeneration={goalCompletionFailedGeneration}
         error={goalCompletionError}
         onRun={(args, force) => requestGoalCompletion(args, force)}
+        currentSuiteJudgeConfig={currentSuiteJudgeConfig}
       />
     ) : null;
 
@@ -530,23 +542,6 @@ export function RunDetailView({
         </p>
       ) : null}
 
-      {/* When the accuracy band renders, the compare action lives in its
-          Recent runs section. This top-level button is only a fallback for
-          runs without enough data to show the band. */}
-      {compareBaseRun && onCompareWithRun && !showAccuracyHero ? (
-        <div className="mb-4 flex justify-end">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => onCompareWithRun(compareBaseRun._id)}
-            className="h-8 text-xs"
-          >
-            <ArrowLeftRight className="mr-2 h-3.5 w-3.5" aria-hidden />
-            Compare to previous run
-          </Button>
-        </div>
-      ) : null}
     </>
   );
 

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -34,10 +34,6 @@ import {
 import { RunCaseListWithSections } from "./run-case-list";
 import type { RunCaseGroup } from "./run-case-groups";
 import { groupRunIterationsByTestCase } from "./run-case-groups";
-import type {
-  DurationChartDatum,
-  TokensChartDatum,
-} from "./run-chart-data";
 import { RunDetailKpiStrip } from "./run-detail-kpis";
 import { ClientChip } from "@/components/clients/client-chip";
 import {
@@ -87,11 +83,6 @@ interface RunDetailViewProps {
   selectedRunDetails: EvalSuiteRun;
   caseGroupsForSelectedRun: EvalIteration[];
   source?: "ui" | "sdk";
-  selectedRunChartData: {
-    donutData: Array<{ name: string; value: number; fill: string }>;
-    durationData: DurationChartDatum[];
-    tokensData: TokensChartDatum[];
-  };
   runDetailSortBy: "model" | "test" | "result";
   onSortChange: (sortBy: "model" | "test" | "result") => void;
   serverNames?: string[];

--- a/mcpjam-inspector/client/src/components/evals/run-insight-rail.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-insight-rail.tsx
@@ -78,11 +78,6 @@ function RunAccuracyRunCard({
         >
           {point.runIdDisplay}
         </span>
-        {isCurrent ? (
-          <span className="shrink-0 rounded-sm bg-primary/15 px-1 text-[9px] font-semibold uppercase tracking-wide text-primary">
-            now
-          </span>
-        ) : null}
       </div>
       <span className="text-base font-semibold tabular-nums leading-tight tracking-tight text-foreground">
         {point.passRate}%

--- a/mcpjam-inspector/client/src/components/evals/run-insight-rail.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-insight-rail.tsx
@@ -1,8 +1,7 @@
 import { useMemo, type ReactNode } from "react";
-import { ArrowLeftRight } from "lucide-react";
-import { Button } from "@mcpjam/design-system/button";
+import { Badge } from "@mcpjam/design-system/badge";
 import { cn } from "@/lib/utils";
-import { formatRunId } from "./helpers";
+import { formatRelativeTime, formatRunId } from "./helpers";
 import {
   computeRunPassFailStats,
   normalizeRunPassRatePercent,
@@ -14,7 +13,6 @@ import { RunMetricsBarCharts } from "./run-metrics-bar-charts";
 import type { DurationChartDatum, TokensChartDatum } from "./run-chart-data";
 import {
   runDetailHeroStatClass,
-  runDetailMetaLabelClass,
   runDetailSectionLabelClass,
   runDetailSupportingClass,
 } from "./run-detail-typography";
@@ -131,12 +129,10 @@ function RunInsightRailCard({
 export function RunAccuracyHeroBand({
   run,
   iterations,
-  compareBaseRun,
   runTrendData,
   metricLabel,
   badgeMetricLabel = metricLabel,
   onSelectRun,
-  onCompareWithRun,
   includeRunIdentity = false,
   hideReplayLineage = false,
   runClient = null,
@@ -144,7 +140,12 @@ export function RunAccuracyHeroBand({
 }: {
   run: EvalSuiteRun;
   iterations: EvalIteration[];
-  compareBaseRun: EvalSuiteRun | null;
+  /**
+   * Previous completed run for deterministic diff context. Plumbed for
+   * future re-surfacing (matrix wiring is separate); no UI consumes it
+   * here today.
+   */
+  compareBaseRun?: EvalSuiteRun | null;
   runTrendData: RunTrendPoint[];
   metricLabel: string;
   /** Pass/fail badge copy (e.g. "Accuracy" vs "Pass Rate"). */
@@ -174,15 +175,6 @@ export function RunAccuracyHeroBand({
       : run.summary
         ? normalizeRunPassRatePercent(run.summary.passRate)
         : null;
-
-  const basePassRate = compareBaseRun?.summary
-    ? normalizeRunPassRatePercent(compareBaseRun.summary.passRate)
-    : null;
-
-  const deltaPp =
-    passRatePercent !== null && basePassRate !== null
-      ? passRatePercent - basePassRate
-      : null;
 
   const trendChips = useMemo(() => {
     if (runTrendData.length < 2) return { points: [], hiddenCount: 0 };
@@ -215,8 +207,12 @@ export function RunAccuracyHeroBand({
         }
       : undefined;
 
+  const runServers = run.configSnapshot?.environment?.servers ?? [];
+  const visibleServers = runServers.slice(0, 3);
+  const hiddenServerCount = runServers.length - visibleServers.length;
+
   const runIdentityBlock = includeRunIdentity ? (
-    <div className="flex shrink-0 flex-col gap-1 sm:max-w-[11rem]">
+    <div className="flex shrink-0 flex-col gap-1.5 sm:max-w-[16rem]">
       <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
         <h2 className="text-lg font-semibold tracking-tight">
           Run {formatRunId(run._id)}
@@ -227,18 +223,49 @@ export function RunAccuracyHeroBand({
           metricLabel={badgeMetricLabel}
         />
       </div>
-      <RunHeaderCompactStats
-        run={run}
-        variant="operational"
-        statsOverride={statsOverride}
-      />
-      {runClient ? (
-        <div className="flex flex-wrap items-center gap-2">
-          <span className={runDetailMetaLabelClass}>Client</span>
-          <ClientChip
-            name={runClient.displayName}
-            hostId={runClient.hostId}
-          />
+      <div className="flex flex-wrap items-baseline gap-x-1.5 text-xs text-muted-foreground">
+        <RunHeaderCompactStats
+          run={run}
+          variant="operational"
+          statsOverride={statsOverride}
+        />
+        {run.createdAt ? (
+          <>
+            <span aria-hidden>·</span>
+            <span
+              className="tabular-nums"
+              title={new Date(run.createdAt).toLocaleString()}
+            >
+              {formatRelativeTime(run.createdAt)}
+            </span>
+          </>
+        ) : null}
+      </div>
+      {runClient || runServers.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {runClient ? (
+            <ClientChip
+              name={runClient.displayName}
+              hostId={runClient.hostId}
+            />
+          ) : null}
+          {visibleServers.map((name) => (
+            <Badge
+              key={name}
+              variant="outline"
+              className="font-mono text-[10px] font-normal text-muted-foreground"
+            >
+              {name}
+            </Badge>
+          ))}
+          {hiddenServerCount > 0 ? (
+            <span
+              className={runDetailSupportingClass}
+              title={runServers.slice(visibleServers.length).join(", ")}
+            >
+              +{hiddenServerCount}
+            </span>
+          ) : null}
         </div>
       ) : null}
       {!hideReplayLineage && run.replayedFromRunId ? (
@@ -269,49 +296,18 @@ export function RunAccuracyHeroBand({
           %
         </span>
       </p>
-      {deltaPp !== null && compareBaseRun ? (
-        <p
-          className={cn(
-            "text-sm font-medium tabular-nums",
-            deltaPp > 0 && "text-success",
-            deltaPp < 0 && "text-muted-foreground",
-            deltaPp === 0 && "text-muted-foreground",
-          )}
-        >
-          {deltaPp > 0 ? "+" : ""}
-          {deltaPp}pp vs run #
-          {compareBaseRun.runNumber ?? formatRunId(compareBaseRun._id)}
-        </p>
-      ) : null}
     </div>
   );
 
-  const compareButton =
-    compareBaseRun && onCompareWithRun ? (
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => onCompareWithRun(compareBaseRun._id)}
-        className="h-7 shrink-0 gap-1.5 text-xs"
-      >
-        <ArrowLeftRight className="h-3.5 w-3.5" aria-hidden />
-        Compare to previous run
-      </Button>
-    ) : null;
-
   const recentRunsBlock = hasRecentRuns ? (
     <div className="flex min-w-0 flex-1 flex-col gap-2">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-baseline gap-2">
-          <p className={runDetailSectionLabelClass}>Recent runs</p>
-          {trendChips.hiddenCount > 0 ? (
-            <p className={runDetailSupportingClass}>
-              Last {RUN_TREND_CHIP_LIMIT} of {runTrendData.length}
-            </p>
-          ) : null}
-        </div>
-        {compareButton}
+      <div className="flex min-w-0 items-baseline gap-2">
+        <p className={runDetailSectionLabelClass}>Recent runs</p>
+        {trendChips.hiddenCount > 0 ? (
+          <p className={runDetailSupportingClass}>
+            Last {RUN_TREND_CHIP_LIMIT} of {runTrendData.length}
+          </p>
+        ) : null}
       </div>
       <div
         className="flex w-full min-w-0 gap-3 overflow-x-auto pb-0.5 [scrollbar-width:thin]"
@@ -336,13 +332,7 @@ export function RunAccuracyHeroBand({
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
           <div className="flex min-w-0 flex-1 flex-col gap-4 sm:flex-row sm:items-start sm:gap-4">
             {runIdentityBlock}
-            {recentRunsBlock ?? (
-              compareButton ? (
-                <div className="flex min-w-0 flex-1 items-start justify-end sm:justify-start">
-                  {compareButton}
-                </div>
-              ) : null
-            )}
+            {recentRunsBlock}
           </div>
           {accuracyBlock}
         </div>

--- a/mcpjam-inspector/client/src/components/evals/server-attachment-picker.tsx
+++ b/mcpjam-inspector/client/src/components/evals/server-attachment-picker.tsx
@@ -227,7 +227,7 @@ export function ServerAttachmentPicker({
             "flex h-8 max-w-[260px] shrink-0 items-center gap-1 rounded-full border px-2 text-foreground",
             "outline-none transition-colors",
             !value && !justCreated
-              ? "border-warning/50 bg-warning/50 hover:brightness-95"
+              ? "border-dashed border-border/60 bg-muted/30 hover:bg-muted/45"
               : "border-border/60 bg-muted/40 hover:bg-muted/60",
             disabled && "cursor-not-allowed opacity-50"
           )}

--- a/mcpjam-inspector/client/src/components/evals/suite-dashboard.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-dashboard.tsx
@@ -117,10 +117,13 @@ export function SuiteDashboard({
 
   const runsSection = (
     <SuiteRunsList
+      suite={suite}
+      cases={cases}
       runs={runs}
       allIterations={allIterations}
       suiteSource={suite.source}
       onRunClick={onRunClick}
+      onTestCaseClick={onTestCaseClick}
       userMap={userMap}
       runsLoading={runsLoading}
       hostNamesById={hostNamesById}

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -20,8 +20,8 @@ import {
   Play,
   Plus,
   RotateCw,
+  Settings,
   Sparkles,
-  Settings2,
   X,
 } from "lucide-react";
 import {
@@ -762,7 +762,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                   )
                 }
               >
-                <Settings2 className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <Settings className="h-3.5 w-3.5 shrink-0" aria-hidden />
               </Button>
             </TooltipTrigger>
             <TooltipContent

--- a/mcpjam-inspector/client/src/components/evals/suite-insights-collapsible.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-insights-collapsible.tsx
@@ -29,36 +29,16 @@ export interface SuiteInsightsCollapsibleProps {
 function runInsightsHeaderSubtitle({
   pending,
   failedGeneration,
-  summary,
   requested,
-  open,
 }: {
   pending: boolean;
   failedGeneration: boolean;
-  summary: string | null;
   requested: boolean;
-  open: boolean;
 }): string {
   if (pending) return "Generating…";
   if (failedGeneration) return "Summary unavailable";
-  // When collapsed, surface the first sentence as a one-line preview so the
-  // section header itself carries the signal — saves the user from expanding
-  // for the headline finding.
-  if (summary && !open) {
-    return firstSentence(summary);
-  }
-  if (summary) return "Compared to your previous completed run";
   if (requested) return "Requesting…";
   return "Compared to your previous completed run";
-}
-
-function firstSentence(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) return "";
-  const match = trimmed.match(/[^.!?]+[.!?]/);
-  const sentence = (match ? match[0] : trimmed).trim();
-  if (sentence.length <= 180) return sentence;
-  return `${sentence.slice(0, 177).trimEnd()}…`;
 }
 
 const RUN_INSIGHTS_FAILED_FALLBACK =
@@ -116,9 +96,7 @@ export function SuiteInsightsCollapsible({
   const headerSubtitle = runInsightsHeaderSubtitle({
     pending,
     failedGeneration,
-    summary,
     requested,
-    open,
   });
 
   // Persisted error fields land on `testSuiteRun` via PR B (judge worker).
@@ -151,7 +129,7 @@ export function SuiteInsightsCollapsible({
             transition={{ type: "spring", stiffness: 520, damping: 32 }}
           >
             <motion.span
-              className="inline-flex shrink-0 text-primary/70"
+              className="inline-flex shrink-0 text-muted-foreground"
               aria-hidden
               initial={false}
               animate={{ rotate: open ? 0 : -90 }}

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -368,7 +368,7 @@ export function SuiteIterationsView({
     aggregate
   );
 
-  const { caseGroupsForSelectedRun, selectedRunChartData } = useRunDetailData(
+  const { caseGroupsForSelectedRun } = useRunDetailData(
     selectedRunId,
     allIterations,
     effectiveRunDetailSortBy
@@ -1075,7 +1075,6 @@ export function SuiteIterationsView({
                     caseGroupsForSelectedRun={caseGroupsForSelectedRun}
                     currentSuiteJudgeConfig={suite.judgeConfig ?? null}
                     source={suite.source}
-                    selectedRunChartData={selectedRunChartData}
                     runDetailSortBy={effectiveRunDetailSortBy}
                     onSortChange={effectiveRunDetailSortChange}
                     serverNames={suite.environment?.servers || []}

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -799,16 +799,12 @@ export function SuiteIterationsView({
                     navigation.toSuiteOverview(suite._id, "test-cases")
                   }
                   onContinueInChat={onContinueInChat}
-                  onOpenLastRun={(iteration) => {
-                    if (!iteration.suiteRunId) {
-                      return;
-                    }
-                    navigation.toRunDetail(
-                      suite._id,
-                      iteration.suiteRunId,
-                      iteration._id
-                    );
-                  }}
+                  onSelectTab={(tab) =>
+                    navigation.toTestEdit(suite._id, selectedTestId, {
+                      openCompare: tab === "runs",
+                      replace: true,
+                    })
+                  }
                 />
               </motion.div>
             ) : viewMode === "test-detail" && selectedTestId ? (
@@ -1076,6 +1072,7 @@ export function SuiteIterationsView({
                   <RunDetailView
                     selectedRunDetails={selectedRunDetails}
                     caseGroupsForSelectedRun={caseGroupsForSelectedRun}
+                    currentSuiteJudgeConfig={suite.judgeConfig ?? null}
                     source={suite.source}
                     selectedRunChartData={selectedRunChartData}
                     runDetailSortBy={effectiveRunDetailSortBy}
@@ -1240,10 +1237,10 @@ export function SuiteIterationsView({
                 />
               </SettingsSection>
 
-              {/* ── Judges ───────────────────────────────────────────── */}
+              {/* ── LLM as Judge ─────────────────────────────────────── */}
               <SettingsSection
-                label="Judges"
-                hint="Advisory LLM scorers. Calibrate per suite."
+                label="LLM as Judge"
+                hint="Advisory grading against each case's objective. Calibrate per suite."
               >
                 <JudgesSection
                   chrome="bare"

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -785,6 +785,7 @@ export function SuiteIterationsView({
                   connectedServerNames={connectedServerNames}
                   projectId={projectId}
                   availableModels={availableModels}
+                  suiteIterations={allIterations}
                   isDirectGuest={isDirectGuest}
                   ensureServersReady={ensureServersReady}
                   projectServers={projectServers}

--- a/mcpjam-inspector/client/src/components/evals/suite-overview-client-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-overview-client-bar.tsx
@@ -177,7 +177,7 @@ export function SuiteOverviewClientBar({
             "flex h-8 max-w-[260px] shrink-0 items-center gap-1 rounded-full border px-2 text-foreground",
             "outline-none transition-colors",
             attachments.length === 0
-              ? "border-warning/50 bg-warning/50 hover:brightness-95"
+              ? "border-dashed border-border/60 bg-muted/30 hover:bg-muted/45"
               : "border-border/60 bg-muted/40 hover:bg-muted/60",
             !editable && "cursor-not-allowed opacity-50",
           )}

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-chart-grid.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-chart-grid.tsx
@@ -9,7 +9,6 @@ import {
 import { cn } from "@/lib/utils";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
 import type { DotProps } from "recharts";
-import { EVAL_LOW_PASS_RATE_TEXT_CLASS } from "./constants";
 import {
   evalSurfaceCardClass,
   evalSurfaceHeaderClass,
@@ -45,7 +44,10 @@ function computeTrendDelta(
   return {
     value: delta,
     label: `${delta > 0 ? "+" : ""}${delta}% vs previous`,
-    colorClass: delta > 0 ? "text-success" : EVAL_LOW_PASS_RATE_TEXT_CLASS,
+    colorClass:
+      delta > 0
+        ? "bg-success/50 text-foreground"
+        : "bg-destructive/50 text-foreground",
   };
 }
 
@@ -162,7 +164,7 @@ function TrendDeltaBadge({ delta }: { delta: TrendDelta }) {
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 text-xs font-medium tabular-nums",
+        "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-xs font-medium tabular-nums",
         delta.colorClass,
       )}
     >

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-chart-grid.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-chart-grid.tsx
@@ -35,7 +35,7 @@ function computeTrendDelta(
     return { value: null, label: "—", colorClass: "text-muted-foreground" };
   }
   if (data.length < 2) {
-    return { value: null, label: "First run", colorClass: "text-info" };
+    return { value: null, label: "First run", colorClass: "text-muted-foreground" };
   }
   const delta =
     data[data.length - 1].passRate - data[data.length - 2].passRate;

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-chart-grid.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-chart-grid.tsx
@@ -157,6 +157,8 @@ function createSparklineDot(
 }
 
 function TrendDeltaBadge({ delta }: { delta: TrendDelta }) {
+  if (delta.value === null || delta.value === 0) return null;
+
   return (
     <span
       className={cn(

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
@@ -26,9 +26,15 @@ import {
   evalSurfaceRowHoverClass,
 } from "./eval-surface-chrome";
 
-/** Shared column template: run label flexes; Acc/Dur/Time share equal width. */
+/** Shared column template: run label flexes; Acc/Dur fixed; Time + chevron share the tail. */
 const RUNS_LIST_ROW_GRID =
-  "grid w-full grid-cols-[minmax(0,1.25fr)_repeat(3,minmax(4.5rem,1fr))_1rem] items-center gap-x-4";
+  "grid w-full grid-cols-[minmax(0,1fr)_3rem_3.5rem_minmax(9.5rem,1.15fr)_0.875rem] items-center gap-x-3";
+
+const RUNS_LIST_METRIC_HEADER_CLASS =
+  "text-right text-[11px] font-medium uppercase tracking-[0.06em] tabular-nums";
+
+const RUNS_LIST_METRIC_CELL_CLASS =
+  "text-right text-xs font-mono tabular-nums text-muted-foreground";
 
 /**
  * Per-row effective pass-rate stats. Prefers the live iteration set when
@@ -224,9 +230,11 @@ export function SuiteRunsList({
         )}
       >
         <div className="min-w-0 truncate">Run</div>
-        <div className="text-right">{accuracyLabel}</div>
-        <div className="text-right">Dur</div>
-        <div className="truncate text-right">Time</div>
+        <div className={RUNS_LIST_METRIC_HEADER_CLASS}>{accuracyLabel}</div>
+        <div className={RUNS_LIST_METRIC_HEADER_CLASS}>Dur</div>
+        <div className={cn(RUNS_LIST_METRIC_HEADER_CLASS, "truncate")}>
+          Time
+        </div>
         <span aria-hidden />
       </div>
 
@@ -285,6 +293,7 @@ interface StandaloneRunRowProps {
   hostNamesById?: Map<string, string | null>;
   userMap?: Map<string, { name: string; imageUrl?: string }>;
   onRunClick: (runId: string) => void;
+  nested?: boolean;
 }
 
 function StandaloneRunRow({
@@ -293,6 +302,7 @@ function StandaloneRunRow({
   hostNamesById,
   userMap,
   onRunClick,
+  nested = false,
 }: StandaloneRunRowProps) {
   const { passRate } = computeRunEffectiveStats(run, runIterations);
 
@@ -327,7 +337,12 @@ function StandaloneRunRow({
         )}
         aria-label={`Open run ${formatRunId(run._id)}`}
       >
-        <div className="flex min-w-0 items-center gap-2">
+        <div
+          className={cn(
+            "flex min-w-0 items-center gap-2",
+            nested && "border-l border-border/50 pl-3",
+          )}
+        >
           <span className="truncate text-xs font-medium">
             Run {formatRunId(run._id)}
           </span>
@@ -357,20 +372,18 @@ function StandaloneRunRow({
             </Tooltip>
           ) : null}
         </div>
-        <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
+        <div className={RUNS_LIST_METRIC_CELL_CLASS}>
           {passRate !== null ? `${passRate}%` : "—"}
         </div>
-        <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
-          {duration}
-        </div>
+        <div className={RUNS_LIST_METRIC_CELL_CLASS}>{duration}</div>
         <div
-          className="truncate text-right text-xs tabular-nums text-muted-foreground"
+          className={cn(RUNS_LIST_METRIC_CELL_CLASS, "truncate")}
           title={formatTime(timestamp)}
         >
           {timestampLabel}
         </div>
         <ChevronRight
-          className="h-3.5 w-3.5 text-muted-foreground"
+          className="size-3.5 shrink-0 justify-self-end text-muted-foreground"
           aria-hidden
         />
       </button>
@@ -521,24 +534,24 @@ function GroupRunRows({
             {group.runs.length} hosts
           </span>
         </div>
-        <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
+        <div className={RUNS_LIST_METRIC_CELL_CLASS}>
           {meanPassRate !== null ? `${meanPassRate}%` : "—"}
         </div>
-        <div className="text-right text-xs font-mono tabular-nums text-muted-foreground">
+        <div className={RUNS_LIST_METRIC_CELL_CLASS}>
           {maxDuration !== null ? formatDuration(maxDuration) : "—"}
         </div>
         <div
-          className="truncate text-right text-xs tabular-nums text-muted-foreground"
+          className={cn(RUNS_LIST_METRIC_CELL_CLASS, "truncate")}
           title={timestampLabel}
         >
           {timestampLabel}
         </div>
-        <span aria-hidden />
+        <span aria-hidden className="size-3.5 shrink-0 justify-self-end" />
       </button>
 
       {isExpanded ? (
         <div
-          className="border-t bg-muted/10 pl-4"
+          className="border-t bg-muted/10"
           data-testid="run-group-children"
         >
           {childStats.map(({ run, iterations }) => (
@@ -549,6 +562,7 @@ function GroupRunRows({
               hostNamesById={hostNamesById}
               userMap={userMap}
               onRunClick={onRunClick}
+              nested
             />
           ))}
         </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
@@ -467,18 +467,19 @@ function GroupRunRows({
 }: GroupRunRowsProps) {
   const canRenderMatrix =
     !!suite && !!cases && !!onTestCaseClick && group.runs.length >= 2;
+  const shouldRenderMatrix = isExpanded && canRenderMatrix;
   const groupRunIds = useMemo(
     () => new Set(group.runs.map((r) => r._id)),
     [group.runs],
   );
   const groupIterations = useMemo(
     () =>
-      canRenderMatrix
+      shouldRenderMatrix
         ? allIterations.filter(
             (it) => it.suiteRunId && groupRunIds.has(it.suiteRunId),
           )
         : [],
-    [canRenderMatrix, allIterations, groupRunIds],
+    [shouldRenderMatrix, allIterations, groupRunIds],
   );
   // Per-child effective stats — same source the standalone rows use.
   const childStats = group.runs.map((run) => ({
@@ -601,7 +602,7 @@ function GroupRunRows({
               nested
             />
           ))}
-          {canRenderMatrix ? (
+          {shouldRenderMatrix ? (
             <div className="border-t border-border/40">
               <CrossHostDashboard
                 suite={suite!}

--- a/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-runs-list.tsx
@@ -19,12 +19,13 @@ import {
   formatTime,
 } from "./helpers";
 import { computeIterationResult } from "./pass-criteria";
-import type { EvalIteration, EvalSuiteRun } from "./types";
+import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
 import {
   evalSurfaceCardClass,
   evalSurfaceHeaderClass,
   evalSurfaceRowHoverClass,
 } from "./eval-surface-chrome";
+import { CrossHostDashboard } from "./cross-host/cross-host-dashboard";
 
 /** Shared column template: run label flexes; Acc/Dur fixed; Time + chevron share the tail. */
 const RUNS_LIST_ROW_GRID =
@@ -83,6 +84,13 @@ export interface SuiteRunsListProps {
    */
   hostNamesById?: Map<string, string | null>;
   className?: string;
+  /**
+   * When provided, expanding a multi-host run group renders the cross-host
+   * comparison matrix for that group's runs. Click a case row to drill in.
+   */
+  suite?: EvalSuite;
+  cases?: EvalCase[];
+  onTestCaseClick?: (testCaseId: string) => void;
 }
 
 type RunGroupNode = {
@@ -125,6 +133,9 @@ export function SuiteRunsList({
   runsLoading = false,
   hostNamesById,
   className,
+  suite,
+  cases,
+  onTestCaseClick,
 }: SuiteRunsListProps) {
   const isSdk = suiteSource === "sdk";
   const accuracyLabel = isSdk ? "Pass" : "Acc";
@@ -272,6 +283,10 @@ export function SuiteRunsList({
                 onRunClick={onRunClick}
                 isExpanded={isExpanded}
                 onToggle={() => toggleGroup(node.runGroupId)}
+                suite={suite}
+                cases={cases}
+                allIterations={allIterations}
+                onTestCaseClick={onTestCaseClick}
               />
             );
           })
@@ -399,6 +414,11 @@ interface GroupRunRowsProps {
   onRunClick: (runId: string) => void;
   isExpanded: boolean;
   onToggle: () => void;
+  /** Enables the inline cross-host matrix on expand when present. */
+  suite?: EvalSuite;
+  cases?: EvalCase[];
+  allIterations: EvalIteration[];
+  onTestCaseClick?: (testCaseId: string) => void;
 }
 
 function computeChildDuration(run: EvalSuiteRun): number | null {
@@ -440,7 +460,26 @@ function GroupRunRows({
   onRunClick,
   isExpanded,
   onToggle,
+  suite,
+  cases,
+  allIterations,
+  onTestCaseClick,
 }: GroupRunRowsProps) {
+  const canRenderMatrix =
+    !!suite && !!cases && !!onTestCaseClick && group.runs.length >= 2;
+  const groupRunIds = useMemo(
+    () => new Set(group.runs.map((r) => r._id)),
+    [group.runs],
+  );
+  const groupIterations = useMemo(
+    () =>
+      canRenderMatrix
+        ? allIterations.filter(
+            (it) => it.suiteRunId && groupRunIds.has(it.suiteRunId),
+          )
+        : [],
+    [canRenderMatrix, allIterations, groupRunIds],
+  );
   // Per-child effective stats — same source the standalone rows use.
   const childStats = group.runs.map((run) => ({
     run,
@@ -550,10 +589,7 @@ function GroupRunRows({
       </button>
 
       {isExpanded ? (
-        <div
-          className="border-t bg-muted/10"
-          data-testid="run-group-children"
-        >
+        <div className="border-t bg-muted/10" data-testid="run-group-children">
           {childStats.map(({ run, iterations }) => (
             <StandaloneRunRow
               key={run._id}
@@ -565,6 +601,22 @@ function GroupRunRows({
               nested
             />
           ))}
+          {canRenderMatrix ? (
+            <div className="border-t border-border/40">
+              <CrossHostDashboard
+                suite={suite!}
+                cases={cases!}
+                runs={group.runs}
+                allIterations={groupIterations}
+                expanded
+                onTestCaseClick={onTestCaseClick}
+                onCellOpen={(cell) => {
+                  const runId = cell.iterations[0]?.suiteRunId;
+                  if (runId) onRunClick(runId);
+                }}
+              />
+            </div>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/mcpjam-inspector/client/src/components/evals/test-case-prompt-flow.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-case-prompt-flow.tsx
@@ -308,7 +308,7 @@ export function TestCasePromptFlow({
 
                               <section className="space-y-2">
                                 <Label className="text-xs font-medium text-foreground">
-                                  Tool triggered
+                                  Expected tool calls
                                 </Label>
                                 <ExpectedToolsEditor
                                   toolCalls={turn.expectedToolCalls}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -139,10 +139,11 @@ interface TestTemplateEditorProps {
   projectId: string | null;
   availableModels: ModelDefinition[];
   onBackToList?: () => void;
-  onOpenLastRun?: (iteration: EvalIteration) => void;
   onExportDraft?: (draft: EvalExportDraftInput) => void;
   onContinueInChat?: (handoff: Omit<EvalChatHandoff, "id">) => void;
-  /** Deep link: open compare run surface once iteration data is ready (same as View results). */
+  /** Route-driven tab switch. Editor reflects {@link openCompareFromRoute} after the URL changes. */
+  onSelectTab?: (tab: "edit" | "runs") => void;
+  /** Deep link: open compare run surface once iteration data is ready (same as the Runs tab). */
   openCompareFromRoute?: boolean;
   /** Deep link: exact iteration to anchor compare hydration to. */
   openCompareIterationId?: string | null;
@@ -323,6 +324,56 @@ function readCompareRunIdFromIteration(
     : null;
 }
 
+type CaseEditorTab = "edit" | "runs";
+
+/** Underline Edit / Runs section nav: drives the URL via onSelect; mirrors the last-run status as a dot on Runs. */
+function CaseEditorTabs({
+  active,
+  onSelect,
+  runsDotClass,
+  runsAriaLabel,
+}: {
+  active: CaseEditorTab;
+  onSelect: (tab: CaseEditorTab) => void;
+  /** When provided, shown to the left of the Runs label. */
+  runsDotClass?: string;
+  runsAriaLabel?: string;
+}) {
+  const baseClass =
+    "inline-flex h-9 items-center gap-1.5 -mb-px border-b-2 px-1 text-sm font-medium transition-colors";
+  const inactiveClass =
+    "border-transparent text-muted-foreground hover:text-foreground";
+  const activeClass = "border-foreground text-foreground";
+  return (
+    <div
+      role="tablist"
+      aria-label="Case view"
+      className="flex items-center gap-6 border-b border-border/60"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active === "edit"}
+        className={cn(baseClass, active === "edit" ? activeClass : inactiveClass)}
+        onClick={() => onSelect("edit")}
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active === "runs"}
+        aria-label={runsAriaLabel}
+        className={cn(baseClass, active === "runs" ? activeClass : inactiveClass)}
+        onClick={() => onSelect("runs")}
+      >
+        Runs
+        {runsDotClass ? <span className={runsDotClass} aria-hidden /> : null}
+      </button>
+    </div>
+  );
+}
+
 export function TestTemplateEditor({
   suiteId,
   selectedTestCaseId,
@@ -330,9 +381,9 @@ export function TestTemplateEditor({
   projectId,
   availableModels,
   onBackToList,
-  onOpenLastRun,
   onExportDraft,
   onContinueInChat,
+  onSelectTab,
   openCompareFromRoute = false,
   openCompareIterationId = null,
   isDirectGuest = false,
@@ -1139,16 +1190,11 @@ export function TestTemplateEditor({
     [compareRunRecords, modelLabelByValue, selectedModelValues]
   );
 
-  const hasRunViewContent = selectedCompareRecords.some(
-    (record) =>
-      record.iteration != null ||
-      record.status === "running" ||
-      Boolean(record.error)
-  );
 
   const openRunView = useCallback(
     (source: "run_compare" | "config_toggle") => {
       setEditorMode("run");
+      onSelectTab?.("runs");
       setMobileVisibleModelValue((current) =>
         current && selectedModelValues.includes(current)
           ? current
@@ -1164,7 +1210,7 @@ export function TestTemplateEditor({
         models: selectedModelValues,
       });
     },
-    [currentTestCase?._id, selectedModelValues, suiteId]
+    [currentTestCase?._id, onSelectTab, selectedModelValues, suiteId]
   );
 
   const handleStopCompare = useCallback(() => {
@@ -1797,15 +1843,6 @@ export function TestTemplateEditor({
           ariaResults: "View results, run in progress",
           ariaOpen: "Open last run, in progress",
         };
-  const canOpenLastRun =
-    Boolean(onOpenLastRun) &&
-    Boolean(lastSavedIteration?.suiteRunId) &&
-    Boolean(lastSavedIteration?._id);
-
-  if (editorMode === "run" && isCompareRouteLoading) {
-    return compareRouteLoadingState;
-  }
-
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
       {editorMode === "config" ? (
@@ -1858,42 +1895,6 @@ export function TestTemplateEditor({
                 </div>
               </div>
               <div className="flex shrink-0 items-center gap-2">
-                {latestAvailableIteration ? (
-                  hasRunViewContent ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className={cn(
-                        "h-8 gap-1.5 px-2 text-xs",
-                        latestRunNavCue.buttonTextClass
-                      )}
-                      aria-label={latestRunNavCue.ariaResults}
-                      onClick={() => openRunView("config_toggle")}
-                    >
-                      <span className={latestRunNavCue.dotClass} aria-hidden />
-                      View results
-                    </Button>
-                  ) : canOpenLastRun ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className={cn(
-                        "h-8 gap-1.5 px-2 text-xs",
-                        latestRunNavCue.buttonTextClass
-                      )}
-                      aria-label={latestRunNavCue.ariaOpen}
-                      onClick={() =>
-                        lastSavedIteration &&
-                        onOpenLastRun?.(lastSavedIteration)
-                      }
-                    >
-                      <span className={latestRunNavCue.dotClass} aria-hidden />
-                      Open last run
-                    </Button>
-                  ) : null
-                ) : null}
                 {onExportDraft ? (
                   <Button
                     type="button"
@@ -2043,6 +2044,22 @@ export function TestTemplateEditor({
                 )}
               </div>
             </div>
+            <CaseEditorTabs
+              active="edit"
+              onSelect={(tab) => {
+                if (tab === "runs") {
+                  openRunView("config_toggle");
+                }
+              }}
+              runsDotClass={
+                latestAvailableIteration ? latestRunNavCue.dotClass : undefined
+              }
+              runsAriaLabel={
+                latestAvailableIteration
+                  ? latestRunNavCue.ariaResults
+                  : "Runs (no runs yet)"
+              }
+            />
             {runPrimaryDisabled && !isRunningCompare && runDisabledTooltip ? (
               <p
                 className="text-xs leading-snug text-muted-foreground sm:text-right"
@@ -2233,6 +2250,28 @@ export function TestTemplateEditor({
               ) : null}
             </div>
 
+            <div className="mt-3">
+              <CaseEditorTabs
+                active="runs"
+                onSelect={(tab) => {
+                  if (tab === "edit") {
+                    setEditorMode("config");
+                    onSelectTab?.("edit");
+                  }
+                }}
+                runsDotClass={
+                  latestAvailableIteration
+                    ? latestRunNavCue.dotClass
+                    : undefined
+                }
+                runsAriaLabel={
+                  latestAvailableIteration
+                    ? latestRunNavCue.ariaResults
+                    : "Runs"
+                }
+              />
+            </div>
+
             {selectedCompareRecords.length > 1 ? (
               <div className="mt-4 flex gap-2 overflow-x-auto lg:hidden">
                 {selectedCompareRecords.map((record) => (
@@ -2258,13 +2297,15 @@ export function TestTemplateEditor({
           </div>
 
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden px-4 py-4 sm:px-6">
-            {selectedCompareRecords.length === 0 ? (
+            {isCompareRouteLoading ? (
+              compareRouteLoadingState
+            ) : selectedCompareRecords.length === 0 ? (
               <div className="flex h-full min-h-[320px] items-center justify-center rounded-2xl border border-dashed border-border/60 bg-muted/10 px-6 py-10 text-center">
                 <div>
-                  <div className="text-sm font-medium">No compare run yet</div>
+                  <div className="text-sm font-medium">No runs yet</div>
                   <p className="mt-2 text-sm text-muted-foreground">
-                    Choose at least one model and run compare from the prompt
-                    editor.
+                    Switch back to Edit and click Run to create your first
+                    iteration.
                   </p>
                 </div>
               </div>

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -138,6 +138,14 @@ interface TestTemplateEditorProps {
   connectedServerNames: Set<string>;
   projectId: string | null;
   availableModels: ModelDefinition[];
+  /**
+   * Iterations for the entire suite, loaded once by the parent via
+   * `getAllTestCasesAndIterationsBySuite`. We filter to the current case
+   * locally rather than firing a per-case `listTestIterations` query —
+   * same Convex cache key as the parent means navigating into the Runs
+   * tab is a synchronous cache hit instead of a network round trip.
+   */
+  suiteIterations: EvalIteration[];
   onBackToList?: () => void;
   onExportDraft?: (draft: EvalExportDraftInput) => void;
   onContinueInChat?: (handoff: Omit<EvalChatHandoff, "id">) => void;
@@ -380,6 +388,7 @@ export function TestTemplateEditor({
   connectedServerNames,
   projectId,
   availableModels,
+  suiteIterations,
   onBackToList,
   onExportDraft,
   onContinueInChat,
@@ -474,12 +483,19 @@ export function TestTemplateEditor({
       : "skip"
   ) as EvalIteration | undefined;
 
-  const recentIterations = useQuery(
-    "testSuites:listTestIterations" as any,
-    currentTestCase?._id
-      ? ({ testCaseId: currentTestCase._id, limit: 200 } as any)
-      : "skip"
-  ) as EvalIteration[] | undefined;
+  /**
+   * Iterations belonging to the currently-selected case, filtered from the
+   * suite-wide list the parent already subscribes to. Reusing the same
+   * Convex query (cache key) means this is a synchronous derive once the
+   * parent's subscription has hydrated — no separate per-case fetch, no
+   * spinner on the Runs tab when the user drills in.
+   */
+  const recentIterations = useMemo<EvalIteration[]>(() => {
+    if (!selectedTestCaseId) return [];
+    return suiteIterations.filter(
+      (iteration) => iteration.testCaseId === selectedTestCaseId,
+    );
+  }, [suiteIterations, selectedTestCaseId]);
 
   const suite = useQuery("testSuites:getTestSuite" as any, { suiteId }) as any;
 
@@ -1778,7 +1794,6 @@ export function TestTemplateEditor({
     (testCases === undefined ||
       (currentTestCase?._id != null &&
         initializedSelectionCaseRef.current !== currentTestCase._id) ||
-      (currentTestCase?._id != null && recentIterations === undefined) ||
       (routeCompareAnchorIterationId != null &&
         routeCompareAnchorIteration === undefined));
 

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -139,11 +139,11 @@ interface TestTemplateEditorProps {
   projectId: string | null;
   availableModels: ModelDefinition[];
   /**
-   * Iterations for the entire suite, loaded once by the parent via
+   * Iterations for the entire suite, already subscribed by the parent via
    * `getAllTestCasesAndIterationsBySuite`. We filter to the current case
-   * locally rather than firing a per-case `listTestIterations` query —
-   * same Convex cache key as the parent means navigating into the Runs
-   * tab is a synchronous cache hit instead of a network round trip.
+   * locally instead of opening a second `listTestIterations` subscription
+   * for data the parent already has — one reactive subscription instead
+   * of two, and no spinner when the user drills into the Runs tab.
    */
   suiteIterations: EvalIteration[];
   onBackToList?: () => void;
@@ -483,18 +483,15 @@ export function TestTemplateEditor({
       : "skip"
   ) as EvalIteration | undefined;
 
-  /**
-   * Iterations belonging to the currently-selected case, filtered from the
-   * suite-wide list the parent already subscribes to. Reusing the same
-   * Convex query (cache key) means this is a synchronous derive once the
-   * parent's subscription has hydrated — no separate per-case fetch, no
-   * spinner on the Runs tab when the user drills in.
-   */
+  // Iterations for the currently-selected case, filtered from the suite-wide
+  // list the parent already subscribes to. Cap matches the old per-case
+  // `listTestIterations({ limit: 200 })` so downstream consumers see the same
+  // bounded slice they did before.
   const recentIterations = useMemo<EvalIteration[]>(() => {
     if (!selectedTestCaseId) return [];
-    return suiteIterations.filter(
-      (iteration) => iteration.testCaseId === selectedTestCaseId,
-    );
+    return suiteIterations
+      .filter((iteration) => iteration.testCaseId === selectedTestCaseId)
+      .slice(0, 200);
   }, [suiteIterations, selectedTestCaseId]);
 
   const suite = useQuery("testSuites:getTestSuite" as any, { suiteId }) as any;
@@ -1030,7 +1027,7 @@ export function TestTemplateEditor({
   };
 
   const latestHistoricalCompareRunId = useMemo(
-    () => resolveLatestCompareRunId(recentIterations ?? []),
+    () => resolveLatestCompareRunId(recentIterations),
     [recentIterations]
   );
   const routeCompareAnchorModelValue = useMemo(
@@ -1126,7 +1123,6 @@ export function TestTemplateEditor({
   useEffect(() => {
     if (
       !currentTestCase ||
-      !recentIterations ||
       selectedModelValues.length === 0 ||
       (routeCompareAnchorIterationId &&
         routeCompareAnchorIteration === undefined)
@@ -1819,7 +1815,7 @@ export function TestTemplateEditor({
       : "lg:grid-cols-3";
   const latestAvailableIteration =
     routeCompareAnchorIteration ??
-    recentIterations?.[0] ??
+    recentIterations[0] ??
     lastSavedIteration ??
     null;
   const latestAvailableResult = latestAvailableIteration
@@ -2152,7 +2148,7 @@ export function TestTemplateEditor({
 
             <TestCaseIterationsTable
               testCase={currentTestCase}
-              iterations={recentIterations ?? []}
+              iterations={recentIterations}
               serverNames={effectiveSuiteServers}
               label="Iteration history"
               emptyState="No iterations yet — run this case to see results here."

--- a/mcpjam-inspector/client/src/components/evals/tool-calls-diff-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/tool-calls-diff-view.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { ChevronDown, ChevronRight, ArrowRight, CheckCircle2, AlertCircle } from "lucide-react";
+import { ChevronDown, ChevronRight, CheckCircle2, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { evaluateToolCalls } from "@/shared/eval-matching";
 import type { TraceViewerEvalToolCall } from "./trace-viewer";
@@ -36,12 +36,7 @@ export function ToolCallsDiffView({
     [expected, actual, result],
   );
 
-  const mismatchRowIndices = rows
-    .map((r, i) => ({ r, i }))
-    .filter(({ r }) => r.status !== "match")
-    .map(({ i }) => i);
-  const mismatchCount = mismatchRowIndices.length;
-  const firstMismatchIndex = mismatchRowIndices[0] ?? null;
+  const mismatchCount = rows.filter((r) => r.status !== "match").length;
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
@@ -52,7 +47,6 @@ export function ToolCallsDiffView({
             mismatchCount={mismatchCount}
             expectedCount={expected.length}
             actualCount={actual.length}
-            firstMismatchIndex={firstMismatchIndex}
             isLoading={isLoading}
           />
         </div>
@@ -82,12 +76,7 @@ export function ToolCallsDiffView({
           </div>
         ) : (
           rows.map((row, idx) => (
-            <DiffRow
-              key={`pair-${idx}`}
-              row={row}
-              index={idx}
-              anchorId={anchorIdFor(idx)}
-            />
+            <DiffRow key={`pair-${idx}`} row={row} index={idx} />
           ))
         )}
       </div>
@@ -102,14 +91,12 @@ function DiffBanner({
   mismatchCount,
   expectedCount,
   actualCount,
-  firstMismatchIndex,
   isLoading,
 }: {
   passed: boolean;
   mismatchCount: number;
   expectedCount: number;
   actualCount: number;
-  firstMismatchIndex: number | null;
   isLoading: boolean;
 }) {
   if (passed && mismatchCount === 0) {
@@ -140,38 +127,21 @@ function DiffBanner({
   return (
     <div
       className={cn(
-        "flex w-full flex-wrap items-center justify-between gap-2 rounded-md border px-3 py-2 text-xs",
+        "flex w-full items-center gap-2 rounded-md border px-3 py-2 text-xs",
         "border-border/60 bg-muted/20 text-foreground",
       )}
     >
-      <div className="flex min-w-0 items-center gap-2">
-        <AlertCircle
-          className="size-3.5 shrink-0 text-muted-foreground"
-          aria-hidden
-        />
-        <span className="min-w-0">
-          <strong className="font-semibold">
-            {mismatchCount} mismatch{mismatchCount === 1 ? "" : "es"}
-          </strong>{" "}
-          across {expectedCount} expected / {actualCount} actual tool call
-          {actualCount === 1 ? "" : "s"}.
-        </span>
-      </div>
-      {firstMismatchIndex !== null ? (
-        <a
-          href={`#${anchorIdFor(firstMismatchIndex)}`}
-          className="inline-flex shrink-0 items-center gap-1 rounded border border-border/50 bg-background/60 px-2 py-0.5 text-[11px] font-medium text-foreground hover:bg-background/90"
-          onClick={(event) => {
-            event.preventDefault();
-            const el = document.getElementById(
-              anchorIdFor(firstMismatchIndex),
-            );
-            if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
-          }}
-        >
-          Jump to mismatch <ArrowRight className="size-3" aria-hidden />
-        </a>
-      ) : null}
+      <AlertCircle
+        className="size-3.5 shrink-0 text-muted-foreground"
+        aria-hidden
+      />
+      <span className="min-w-0">
+        <strong className="font-semibold">
+          {mismatchCount} mismatch{mismatchCount === 1 ? "" : "es"}
+        </strong>{" "}
+        across {expectedCount} expected / {actualCount} actual tool call
+        {actualCount === 1 ? "" : "s"}.
+      </span>
     </div>
   );
 }
@@ -191,18 +161,14 @@ interface PairedRow {
 function DiffRow({
   row,
   index,
-  anchorId,
 }: {
   row: PairedRow;
   index: number;
-  anchorId: string;
 }) {
-  // Auto-expand mismatches; collapse matches.
-  const [expanded, setExpanded] = useState(row.status !== "match");
+  const [expanded, setExpanded] = useState(true);
 
   return (
     <div
-      id={anchorId}
       className={cn(
         "rounded-md border bg-background/30",
         rowBorderClass(row.status),
@@ -367,10 +333,6 @@ function StatusPill({ status }: { status: RowStatus }) {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function anchorIdFor(index: number) {
-  return `tool-diff-row-${index}`;
-}
 
 function statusLabel(status: RowStatus): string {
   switch (status) {

--- a/mcpjam-inspector/client/src/components/evals/tool-calls-diff-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/tool-calls-diff-view.tsx
@@ -165,7 +165,8 @@ function DiffRow({
   row: PairedRow;
   index: number;
 }) {
-  const [expanded, setExpanded] = useState(true);
+  // Auto-expand mismatches; collapse matches so large traces stay light.
+  const [expanded, setExpanded] = useState(() => row.status !== "match");
 
   return (
     <div

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -677,86 +677,93 @@ export function TraceViewer({
                 "min-w-0 rounded-md border border-border/30 bg-background/50 flex flex-col",
                 fillContent
                   ? "min-h-0 flex-1 overflow-hidden"
-                  : "min-h-0 max-h-[min(70vh,36rem)] overflow-hidden",
+                  : "min-h-0",
               )}
               data-testid="trace-viewer-chat"
             >
-              <StickToBottom
-                className="relative flex min-h-0 flex-1 flex-col"
-                resize="smooth"
-                initial="smooth"
-              >
-                <div className="relative flex-1 min-h-0">
-                  <StickToBottom.Content className="flex flex-col min-h-0">
-                    {(() => {
-                      // Trace `<Thread>` mount. Wrapped in
-                      // `ActiveHostCapsResolverScope` ONLY when the
-                      // caller passed explicit host inputs
-                      // (`activeHost` or `hostStyle`). Otherwise we
-                      // render Thread directly so any outer scope from
-                      // the chat surface (ClientStyledChatTabV2 /
-                      // PlaygroundTab) flows through with the user's
-                      // saved capability edits intact. Installing an
-                      // inner scope unconditionally would shadow the
-                      // outer one with template-seed caps.
-                      const threadEl = (
-                        <Thread
-                          chatSessionId={chatSessionId}
-                          messages={adaptedTrace.messages}
-                          sendFollowUpMessage={sendFollowUpMessage}
-                          model={resolvedModel}
-                          isLoading={isLoading}
-                          toolsMetadata={toolsMetadata}
-                          toolServerMap={toolServerMap}
-                          onWidgetStateChange={onWidgetStateChange}
-                          onModelContextUpdate={onModelContextUpdate}
-                          displayMode={displayMode}
-                          onDisplayModeChange={onDisplayModeChange}
-                          enableFullscreenChatOverlay={
-                            enableFullscreenChatOverlay
-                          }
-                          fullscreenChatPlaceholder={fullscreenChatPlaceholder}
-                          fullscreenChatDisabled={fullscreenChatDisabled}
-                          fullscreenChatSendBlocked={fullscreenChatSendBlocked}
-                          onFullscreenChatStop={onFullscreenChatStop}
-                          onFullscreenChange={onFullscreenChange}
-                          onToolApprovalResponse={onToolApprovalResponse}
-                          toolRenderOverrides={adaptedTrace.toolRenderOverrides}
-                          showSaveViewButton={false}
-                          minimalMode={true}
-                          interactive={threadInteractive}
-                          reasoningDisplayMode="collapsed"
-                          focusMessageId={transcriptNavigation.focusMessageId}
-                          highlightedMessageIds={
-                            transcriptNavigation.highlightedMessageIds
-                          }
-                          navigationKey={transcriptNavigation.navigationKey}
-                          contentClassName="min-w-0 mx-auto w-full max-w-4xl space-y-8 px-4 pt-2"
-                          getMessageWrapperProps={({ message }) => {
-                            const sourceRange =
-                              adaptedTrace.uiMessageSourceRanges[message.id];
-                            return {
-                              "data-source-range": sourceRange
-                                ? `${sourceRange.startIndex}-${sourceRange.endIndex}`
-                                : undefined,
-                            };
-                          }}
-                        />
-                      );
-                      if (!shouldInstallTraceScope) return threadEl;
-                      return (
-                        <ActiveHostCapsResolverScope
-                          activeHost={activeHost ?? null}
-                          hostStyle={traceScopeHostStyle}
-                        >
-                          {threadEl}
-                        </ActiveHostCapsResolverScope>
-                      );
-                    })()}
-                  </StickToBottom.Content>
-                  <ScrollToBottomButton />
-                </div>
-              </StickToBottom>
+              {(() => {
+                // Trace `<Thread>` mount. Wrapped in
+                // `ActiveHostCapsResolverScope` ONLY when the caller
+                // passed explicit host inputs (`activeHost` or
+                // `hostStyle`). Otherwise we render Thread directly so
+                // any outer scope from the chat surface
+                // (ClientStyledChatTabV2 / PlaygroundTab) flows through
+                // with the user's saved capability edits intact.
+                // Installing an inner scope unconditionally would
+                // shadow the outer one with template-seed caps.
+                const threadEl = (
+                  <Thread
+                    chatSessionId={chatSessionId}
+                    messages={adaptedTrace.messages}
+                    sendFollowUpMessage={sendFollowUpMessage}
+                    model={resolvedModel}
+                    isLoading={isLoading}
+                    toolsMetadata={toolsMetadata}
+                    toolServerMap={toolServerMap}
+                    onWidgetStateChange={onWidgetStateChange}
+                    onModelContextUpdate={onModelContextUpdate}
+                    displayMode={displayMode}
+                    onDisplayModeChange={onDisplayModeChange}
+                    enableFullscreenChatOverlay={enableFullscreenChatOverlay}
+                    fullscreenChatPlaceholder={fullscreenChatPlaceholder}
+                    fullscreenChatDisabled={fullscreenChatDisabled}
+                    fullscreenChatSendBlocked={fullscreenChatSendBlocked}
+                    onFullscreenChatStop={onFullscreenChatStop}
+                    onFullscreenChange={onFullscreenChange}
+                    onToolApprovalResponse={onToolApprovalResponse}
+                    toolRenderOverrides={adaptedTrace.toolRenderOverrides}
+                    showSaveViewButton={false}
+                    minimalMode={true}
+                    interactive={threadInteractive}
+                    reasoningDisplayMode="collapsed"
+                    focusMessageId={transcriptNavigation.focusMessageId}
+                    highlightedMessageIds={
+                      transcriptNavigation.highlightedMessageIds
+                    }
+                    navigationKey={transcriptNavigation.navigationKey}
+                    contentClassName="min-w-0 mx-auto w-full max-w-4xl space-y-8 px-4 pt-2"
+                    getMessageWrapperProps={({ message }) => {
+                      const sourceRange =
+                        adaptedTrace.uiMessageSourceRanges[message.id];
+                      return {
+                        "data-source-range": sourceRange
+                          ? `${sourceRange.startIndex}-${sourceRange.endIndex}`
+                          : undefined,
+                      };
+                    }}
+                  />
+                );
+                const scoped = shouldInstallTraceScope ? (
+                  <ActiveHostCapsResolverScope
+                    activeHost={activeHost ?? null}
+                    hostStyle={traceScopeHostStyle}
+                  >
+                    {threadEl}
+                  </ActiveHostCapsResolverScope>
+                ) : (
+                  threadEl
+                );
+                // Live streaming (fillContent): keep StickToBottom so
+                // new messages auto-pin to the bottom inside the
+                // viewport-bounded shell. Static replay: render
+                // directly and let the surrounding page own scroll,
+                // starting from the first message.
+                if (!fillContent) return scoped;
+                return (
+                  <StickToBottom
+                    className="relative flex min-h-0 flex-1 flex-col"
+                    resize="smooth"
+                    initial="smooth"
+                  >
+                    <div className="relative flex-1 min-h-0">
+                      <StickToBottom.Content className="flex flex-col min-h-0">
+                        {scoped}
+                      </StickToBottom.Content>
+                      <ScrollToBottomButton />
+                    </div>
+                  </StickToBottom>
+                );
+              })()}
             </div>
           ))}
 

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -706,6 +706,34 @@ export function useEvalHandlers({
               ? `All ${runPlans.length} host runs started.`
               : "Eval run completed!",
           );
+
+          // Drop the user on the new run's detail page so they can see
+          // results without hunting through the runs list. Multi-host
+          // fan-outs land on the suite's runs view instead, since there
+          // are multiple sibling runs to pick from.
+          if (runPlans.length === 1) {
+            const firstSettled = settled[0];
+            const newRunId =
+              firstSettled?.status === "fulfilled"
+                ? (firstSettled.value as { runId?: unknown } | null | undefined)
+                    ?.runId
+                : undefined;
+            if (typeof newRunId === "string" && newRunId.length > 0) {
+              navigateEvalRoute(
+                {
+                  type: "run-detail",
+                  suiteId: suite._id,
+                  runId: newRunId,
+                },
+                evalsNavigationContext,
+              );
+            }
+          } else {
+            navigateEvalRoute(
+              { type: "suite-overview", suiteId: suite._id, view: "runs" },
+              evalsNavigationContext,
+            );
+          }
         } else if (failures.length < runPlans.length) {
           const failedHostNames = failures
             .map((failure) => failure.plan.hostName ?? "(unnamed host)")
@@ -738,6 +766,7 @@ export function useEvalHandlers({
       projectServers,
       getSuiteExecutionContext,
       handleReplayRun,
+      evalsNavigationContext,
     ]
   );
 

--- a/mcpjam-inspector/client/src/components/evals/use-suite-data.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-suite-data.ts
@@ -6,10 +6,7 @@ import {
   computeIterationSummary,
   getTemplateKey,
 } from "./helpers";
-import {
-  computeIterationResult,
-  computeIterationPassed,
-} from "./pass-criteria";
+import { computeIterationResult } from "./pass-criteria";
 import {
   EvalCase,
   EvalIteration,
@@ -17,8 +14,6 @@ import {
   EvalSuiteRun,
   SuiteAggregate,
 } from "./types";
-import { groupRunIterationsByTestCase } from "./run-case-groups";
-import { buildRunMetricsChartData } from "./run-chart-data";
 
 function desanitizeEvalIteration(iter: EvalIteration): EvalIteration {
   return {
@@ -476,108 +471,8 @@ export function useRunDetailData(
     return sorted.map((item) => item.iteration);
   }, [selectedRunId, iterationsForSelectedRun, runDetailSortBy]);
 
-  // Data for run detail charts
-  const selectedRunChartData = useMemo(() => {
-    if (!selectedRunId || caseGroupsForSelectedRun.length === 0) {
-      return { donutData: [], durationData: [], tokensData: [], modelData: [] };
-    }
-
-    let totalPassed = 0;
-    let totalFailed = 0;
-    let totalPending = 0;
-    let totalCancelled = 0;
-
-    const modelMap = new Map<
-      string,
-      { passed: number; failed: number; total: number; modelName: string }
-    >();
-
-    iterationsForSelectedRun.forEach((iteration) => {
-      const model = iteration.testCaseSnapshot?.model || "Unknown";
-      const modelName = iteration.testCaseSnapshot?.model || "Unknown Model";
-
-      // Only count completed iterations - exclude pending/cancelled
-      const result = computeIterationResult(iteration);
-      if (result !== "passed" && result !== "failed") {
-        return; // Skip pending/cancelled iterations
-      }
-
-      if (!modelMap.has(model)) {
-        modelMap.set(model, { passed: 0, failed: 0, total: 0, modelName });
-      }
-
-      const stats = modelMap.get(model)!;
-      stats.total += 1;
-
-      if (result === "passed") {
-        stats.passed += 1;
-      } else {
-        stats.failed += 1;
-      }
-    });
-
-    // Sort alphabetically by model name for consistent, fixed ordering
-    const modelData = Array.from(modelMap.entries())
-      .map(([_model, stats]) => ({
-        model: stats.modelName,
-        passRate:
-          stats.total > 0 ? Math.round((stats.passed / stats.total) * 100) : 0,
-        passed: stats.passed,
-        failed: stats.failed,
-        total: stats.total,
-      }))
-      .sort((a, b) => a.model.localeCompare(b.model));
-
-    caseGroupsForSelectedRun.forEach((iteration) => {
-      if (iteration.result === "pending" || iteration.status === "running")
-        totalPending++;
-      else if (iteration.result === "cancelled") totalCancelled++;
-      else if (computeIterationPassed(iteration)) totalPassed++;
-      else totalFailed++;
-    });
-
-    const runCaseGroups = groupRunIterationsByTestCase(
-      caseGroupsForSelectedRun,
-      "test",
-    );
-    const { durationData, tokensData } = buildRunMetricsChartData(runCaseGroups);
-
-    const donutData = [];
-    if (totalPassed > 0) {
-      donutData.push({
-        name: "Passed",
-        value: totalPassed,
-        fill: "hsl(142.1 76.2% 36.3%)",
-      });
-    }
-    if (totalFailed > 0) {
-      donutData.push({
-        name: "Failed",
-        value: totalFailed,
-        fill: "hsl(0 84.2% 60.2%)",
-      });
-    }
-    if (totalPending > 0) {
-      donutData.push({
-        name: "Pending",
-        value: totalPending,
-        fill: "hsl(45.4 93.4% 47.5%)",
-      });
-    }
-    if (totalCancelled > 0) {
-      donutData.push({
-        name: "Cancelled",
-        value: totalCancelled,
-        fill: "hsl(240 3.7% 15.9%)",
-      });
-    }
-
-    return { donutData, durationData, tokensData, modelData };
-  }, [selectedRunId, caseGroupsForSelectedRun, iterationsForSelectedRun]);
-
   return {
     iterationsForSelectedRun,
     caseGroupsForSelectedRun,
-    selectedRunChartData,
   };
 }

--- a/mcpjam-inspector/client/src/lib/evals/excalidraw-quickstart-cases.ts
+++ b/mcpjam-inspector/client/src/lib/evals/excalidraw-quickstart-cases.ts
@@ -6,13 +6,11 @@ const DEFAULT_MODELS: CreateEvalTestCaseInput["models"] = [
 
 /**
  * Curated case payloads used by the Evaluate empty-state quickstart against
- * the Excalidraw MCP server. `suiteId` is filled in by the caller.
- *
- * Tool names and argument shapes target the public Excalidraw MCP server at
- * https://mcp.excalidraw.com/mcp. The matcher options are intentionally
- * permissive (default partial / superset semantics) so the first run lights
- * up the diff view even if the model picks slightly different arguments —
- * the goal is to showcase what an eval looks like, not to gate.
+ * the Excalidraw MCP server (https://mcp.excalidraw.com/mcp). The server
+ * exposes `read_me`, `create_view`, `export_to_excalidraw`, plus checkpoint
+ * helpers; drawing flows through a single `create_view` call that accepts an
+ * elements array. Matchers only check tool names — arguments are left empty
+ * so the first run lights up the diff view without gating on shape choices.
  */
 export const EXCALIDRAW_QUICKSTART_CASES: Array<
   Omit<CreateEvalTestCaseInput, "suiteId">
@@ -23,15 +21,13 @@ export const EXCALIDRAW_QUICKSTART_CASES: Array<
       "Add a single rectangle labeled \"Hello\" near the center of the canvas.",
     models: DEFAULT_MODELS,
     expectedToolCalls: [
-      {
-        toolName: "create_element",
-        arguments: { type: "rectangle" },
-      },
+      { toolName: "read_me", arguments: {} },
+      { toolName: "create_view", arguments: {} },
     ],
     runs: 1,
     isNegativeTest: false,
     scenario:
-      "Smoke test: the agent should reach for the create-element tool and ask for a rectangle.",
+      "Smoke test: consult read_me on first use, then render with create_view.",
   },
   {
     title: "Sketch a two-node flow",
@@ -39,25 +35,27 @@ export const EXCALIDRAW_QUICKSTART_CASES: Array<
       "Sketch a tiny flow: a box labeled \"Start\" with an arrow pointing to a box labeled \"End\".",
     models: DEFAULT_MODELS,
     expectedToolCalls: [
-      { toolName: "create_element", arguments: { type: "rectangle" } },
-      { toolName: "create_element", arguments: { type: "rectangle" } },
-      { toolName: "create_element", arguments: { type: "arrow" } },
+      { toolName: "read_me", arguments: {} },
+      { toolName: "create_view", arguments: {} },
     ],
     runs: 1,
     isNegativeTest: false,
     scenario:
-      "Multi-step composition: two rectangles plus an arrow. Tests that the agent fans out across several tool calls.",
+      "Composition: multiple elements (two boxes + arrow) in a single create_view call.",
   },
   {
-    title: "Read the canvas",
-    query: "What's currently on the canvas? Summarize what you see.",
+    title: "Draw and share a diagram",
+    query:
+      "Draw a quick two-step flow (\"Idea\" → \"Ship\") and give me a shareable excalidraw.com link.",
     models: DEFAULT_MODELS,
     expectedToolCalls: [
-      { toolName: "read_canvas", arguments: {} },
+      { toolName: "read_me", arguments: {} },
+      { toolName: "create_view", arguments: {} },
+      { toolName: "export_to_excalidraw", arguments: {} },
     ],
     runs: 1,
     isNegativeTest: false,
     scenario:
-      "Read-side coverage: the agent should query canvas state before answering, not invent contents.",
+      "Multi-tool composition: render with create_view, then publish via export_to_excalidraw.",
   },
 ];

--- a/mcpjam-inspector/client/src/lib/evals/excalidraw-quickstart.ts
+++ b/mcpjam-inspector/client/src/lib/evals/excalidraw-quickstart.ts
@@ -1,5 +1,6 @@
 import { toast } from "sonner";
 import posthog from "posthog-js";
+import type { ConvexReactClient } from "convex/react";
 import {
   EXCALIDRAW_SERVER_CONFIG,
   EXCALIDRAW_SERVER_NAME,
@@ -10,6 +11,7 @@ import { navigatePlaygroundEvalsRoute } from "@/components/evals/create-suite-na
 import { EXCALIDRAW_QUICKSTART_CASES } from "./excalidraw-quickstart-cases";
 import type { ServerFormData } from "@/shared/types.js";
 import type { CreateEvalTestCaseInput } from "./generate-and-persist-tests";
+import type { HostAttachmentDraft } from "@/components/evals/client-attachments-editor";
 
 export const EXCALIDRAW_QUICKSTART_SUITE_NAME = "Excalidraw quickstart";
 
@@ -19,15 +21,43 @@ type CreateSuiteArgs = {
   description?: string;
   environment: { servers: string[] };
   tags?: string[];
+  serverAttachmentId?: string;
+  hostAttachments?: HostAttachmentDraft[];
 };
 
 type CreateSuiteResult = { _id: string } | null | undefined;
 
+type CreateServerAttachmentArgs = {
+  projectId: string;
+  name: string;
+  serverIds: string[];
+};
+
+type ServerAttachmentRow = {
+  _id: string;
+  name: string;
+  serverIds: string[];
+  resolvedServerNames: string[];
+};
+
+type ProjectServerRow = {
+  _id: string;
+  name: string;
+};
+
+type HostListRow = {
+  hostId: string;
+};
+
 export type RunExcalidrawQuickstartOptions = {
   projectId: string;
+  convex: ConvexReactClient;
   createTestSuite: (args: CreateSuiteArgs) => Promise<CreateSuiteResult>;
   createTestCase: (input: CreateEvalTestCaseInput) => Promise<unknown>;
-  handleConnect: (config: ServerFormData) => void;
+  createServerAttachment: (
+    args: CreateServerAttachmentArgs,
+  ) => Promise<{ _id: string }>;
+  handleConnect: (config: ServerFormData) => void | Promise<void>;
   /** True when the project already has Excalidraw attached + connected. */
   isExcalidrawConnected: boolean;
   /**
@@ -35,18 +65,115 @@ export type RunExcalidrawQuickstartOptions = {
    * quickstart is idempotent — we navigate to it instead of minting another.
    */
   existingQuickstartSuiteId: string | null;
+  /**
+   * Currently previewed host (from the overlay bar). Used as the preferred
+   * default client attachment so the quickstart suite matches whatever the
+   * user is already working with, instead of just `hosts[0]`.
+   */
+  previewedHostId: string | null;
 };
+
+const SERVER_WAIT_TIMEOUT_MS = 15_000;
+const SERVER_WAIT_INTERVAL_MS = 350;
+
+async function waitForExcalidrawServerId(
+  convex: ConvexReactClient,
+  projectId: string,
+): Promise<string | null> {
+  const deadline = Date.now() + SERVER_WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const servers = (await convex.query(
+      "servers:getProjectServers" as any,
+      { projectId } as any,
+    )) as ProjectServerRow[] | undefined;
+    const match = servers?.find((s) => s.name === EXCALIDRAW_SERVER_NAME);
+    if (match) return match._id;
+    await new Promise((resolve) =>
+      setTimeout(resolve, SERVER_WAIT_INTERVAL_MS),
+    );
+  }
+  return null;
+}
+
+const QUICKSTART_ATTACHMENT_BASE_NAME = "Excalidraw";
+
+async function resolveServerAttachmentId(
+  convex: ConvexReactClient,
+  createServerAttachment: (
+    args: CreateServerAttachmentArgs,
+  ) => Promise<{ _id: string }>,
+  projectId: string,
+  excalidrawServerId: string,
+): Promise<string> {
+  const existing = (await convex.query(
+    "serverAttachments:listServerAttachments" as any,
+    { projectId } as any,
+  )) as ServerAttachmentRow[] | undefined;
+  const rows = existing ?? [];
+
+  // Prefer an exact single-server match; that's the cleanest reuse.
+  const exact = rows.find(
+    (row) =>
+      row.serverIds.length === 1 && row.serverIds[0] === excalidrawServerId,
+  );
+  if (exact) return exact._id;
+
+  // Next-best: an attachment that at least includes our server id — the
+  // quickstart cases only call Excalidraw tools, so extra servers in the
+  // pool don't break the run.
+  const superset = rows.find((row) =>
+    row.serverIds.includes(excalidrawServerId),
+  );
+  if (superset) return superset._id;
+
+  // Backend rejects duplicate names within a project, so suffix until we
+  // find a free one. The base name is the common case; the loop only
+  // engages when a user has manually created an "Excalidraw" attachment
+  // that doesn't include the quickstart server.
+  const usedNames = new Set(rows.map((row) => row.name));
+  let name = QUICKSTART_ATTACHMENT_BASE_NAME;
+  for (let suffix = 2; usedNames.has(name); suffix += 1) {
+    name = `${QUICKSTART_ATTACHMENT_BASE_NAME} ${suffix}`;
+  }
+
+  const created = await createServerAttachment({
+    projectId,
+    name,
+    serverIds: [excalidrawServerId],
+  });
+  return created._id;
+}
+
+async function resolvePreferredHostAttachment(
+  convex: ConvexReactClient,
+  projectId: string,
+  preferredHostId: string | null,
+): Promise<HostAttachmentDraft[]> {
+  const hosts = (await convex.query(
+    "hosts:listHosts" as any,
+    { projectId } as any,
+  )) as HostListRow[] | undefined;
+  const preferred =
+    (preferredHostId
+      ? hosts?.find((h) => h.hostId === preferredHostId)
+      : undefined) ?? hosts?.[0];
+  if (!preferred) return [];
+  return [{ namedHostId: preferred.hostId, enabledOptionalServerIds: [] }];
+}
 
 export async function runExcalidrawQuickstart(
   options: RunExcalidrawQuickstartOptions,
 ): Promise<void> {
   const {
     projectId,
+    convex,
     createTestSuite,
     createTestCase,
+    createServerAttachment,
     handleConnect,
     isExcalidrawConnected,
     existingQuickstartSuiteId,
+    previewedHostId,
   } = options;
 
   posthog.capture("eval_excalidraw_quickstart_clicked", {
@@ -67,8 +194,42 @@ export async function runExcalidrawQuickstart(
   }
 
   if (!isExcalidrawConnected) {
-    handleConnect(EXCALIDRAW_SERVER_CONFIG);
+    await Promise.resolve(handleConnect(EXCALIDRAW_SERVER_CONFIG));
   }
+
+  // The Convex projectServers row lags the local connect dispatch; without
+  // an id we can't build a server attachment, so the chip would render
+  // "pick one" on the new suite. Poll until the row materializes.
+  const excalidrawServerId = await waitForExcalidrawServerId(
+    convex,
+    projectId,
+  );
+  if (!excalidrawServerId) {
+    toast.error(
+      "Could not connect to the Excalidraw server in time. Try again in a moment.",
+    );
+    return;
+  }
+
+  let serverAttachmentId: string;
+  try {
+    serverAttachmentId = await resolveServerAttachmentId(
+      convex,
+      createServerAttachment,
+      projectId,
+      excalidrawServerId,
+    );
+  } catch (error) {
+    console.error("Excalidraw quickstart: server attachment failed", error);
+    toast.error("Could not prepare the Excalidraw quickstart. Try again.");
+    return;
+  }
+
+  const hostAttachments = await resolvePreferredHostAttachment(
+    convex,
+    projectId,
+    previewedHostId,
+  );
 
   let createdSuiteId: string | null = null;
   try {
@@ -78,6 +239,8 @@ export async function runExcalidrawQuickstart(
       description: "Curated cases for the Excalidraw MCP server.",
       environment: { servers: [EXCALIDRAW_SERVER_NAME] },
       tags: [QUICKSTART_SUITE_TAG],
+      serverAttachmentId,
+      ...(hostAttachments.length > 0 ? { hostAttachments } : {}),
     });
     createdSuiteId = created?._id ?? null;
   } catch (error) {
@@ -109,11 +272,16 @@ export async function runExcalidrawQuickstart(
     suite_id: createdSuiteId,
     cases_created: createdCases,
     cases_intended: EXCALIDRAW_QUICKSTART_CASES.length,
+    has_host_attachment: hostAttachments.length > 0,
   });
 
   if (createdCases < EXCALIDRAW_QUICKSTART_CASES.length) {
     toast.warning(
       `Created ${createdCases} of ${EXCALIDRAW_QUICKSTART_CASES.length} cases. The suite is ready — you can fill in the rest manually.`,
+    );
+  } else if (hostAttachments.length === 0) {
+    toast.success(
+      "Excalidraw quickstart ready. Attach a client to run it.",
     );
   } else {
     toast.success("Excalidraw quickstart ready. Connect, then run.");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches eval run/judge UX and data wiring (live vs snapshot judge config, removed chart/compare affordances) across many components; behavior changes are mostly UI but could confuse users or miss edge cases in multi-host navigation.
> 
> **Overview**
> Broad **evals playground polish**: run detail drops latency/token charts and the “compare to previous run” / delta UI in the accuracy hero; AI triage and insight surfaces use flat card styling instead of gradient chrome. **LLM as Judge** replaces “Goal completion” / “Judges” naming, removes per-run threshold controls (suite default only), and lets users re-run on old snapshots when the **live** suite has the judge enabled via `currentSuiteJudgeConfig`.
> 
> **Test case editor** gains explicit **Edit / Runs** tabs, takes **`suiteIterations` from the parent** (one suite subscription instead of `listTestIterations` per case), and routes compare via `onSelectTab` rather than “Open last run”. **Cross-host**: matrix cells and expanded multi-host run groups open iterations; case vs cell click targets are split.
> 
> **Onboarding defaults**: Excalidraw quickstart creates/resolves **server attachments** and prefers **previewed host**; create-suite dialog does the same for host attachments. **Host compare** routes and chips pick up **framer-motion** transitions (with reduced-motion). **Trace viewer** uses stick-to-bottom only when `fillContent` (live stream); static replay scrolls with the page. Copy/empty-state and attachment-picker styling tweaks; tests updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b7438fbeace4195c33cdad5d5309df087611dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->