### PR TITLE
evals: align generate-tests snapshot with attachment display names + fix 502 misclassification

### DIFF
--- a/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
+import type { MCPClientManager } from "@mcpjam/sdk";
 import {
   MAX_TOTAL_LLM_CALLS,
   RunEvalsRequestSchema,
   RunTestCaseRequestSchema,
   assertSuiteRunWithinCap,
   assertTestCaseRunWithinCap,
+  buildManagerKeyToDisplayNameMap,
   filterAndRemapReplayConfigs,
+  remapSnapshotServerIdsForAttachment,
 } from "../evals";
 import { WebRouteError } from "../../web/errors";
+import { SERVER_TOOL_SNAPSHOT_VERSION } from "../../../utils/export-helpers";
 
 function buildSuiteRequest(overrides?: {
   testCount?: number;
@@ -222,6 +226,95 @@ describe("assertTestCaseRunWithinCap", () => {
     expect(() =>
       assertTestCaseRunWithinCap(req, 1, { promptTurnsLength: 999 }),
     ).not.toThrow();
+  });
+});
+
+function makeManagerStub(serverIds: string[]): MCPClientManager {
+  return { listServers: () => serverIds } as unknown as MCPClientManager;
+}
+
+describe("buildManagerKeyToDisplayNameMap", () => {
+  it("maps each manager key to its parallel display name", () => {
+    const manager = makeManagerStub(["p170sbx_convex_id"]);
+    const map = buildManagerKeyToDisplayNameMap(
+      manager,
+      ["p170sbx_convex_id"],
+      ["Excalidraw (App)"],
+    );
+    expect(map.get("p170sbx_convex_id")).toBe("Excalidraw (App)");
+  });
+
+  it("returns an empty map when serverNames is absent or length-mismatched", () => {
+    const manager = makeManagerStub(["srv_1", "srv_2"]);
+    expect(
+      buildManagerKeyToDisplayNameMap(manager, ["srv_1", "srv_2"], undefined)
+        .size,
+    ).toBe(0);
+    expect(
+      buildManagerKeyToDisplayNameMap(manager, ["srv_1", "srv_2"], ["A"]).size,
+    ).toBe(0);
+  });
+
+  it("falls back to case-insensitive manager key match", () => {
+    const manager = makeManagerStub(["Excalidraw"]);
+    const map = buildManagerKeyToDisplayNameMap(
+      manager,
+      ["EXCALIDRAW"],
+      ["Excalidraw (App)"],
+    );
+    expect(map.get("Excalidraw")).toBe("Excalidraw (App)");
+  });
+
+  it("skips entries whose manager key is not currently connected", () => {
+    const manager = makeManagerStub(["srv_present"]);
+    const map = buildManagerKeyToDisplayNameMap(
+      manager,
+      ["srv_present", "srv_disconnected"],
+      ["Present", "Missing"],
+    );
+    expect(map.size).toBe(1);
+    expect(map.get("srv_present")).toBe("Present");
+  });
+});
+
+describe("remapSnapshotServerIdsForAttachment", () => {
+  const snapshot = {
+    version: SERVER_TOOL_SNAPSHOT_VERSION,
+    capturedAt: 1_700_000_000_000,
+    servers: [
+      { serverId: "manager-key-1", tools: [] },
+      { serverId: "manager-key-2", tools: [] },
+    ],
+  };
+
+  it("rewrites snapshot.serverId from manager key to display name", () => {
+    const remapped = remapSnapshotServerIdsForAttachment(
+      snapshot,
+      new Map([
+        ["manager-key-1", "Excalidraw (App)"],
+        ["manager-key-2", "Notion"],
+      ]),
+    );
+    expect(remapped.servers.map((s) => s.serverId)).toEqual([
+      "Excalidraw (App)",
+      "Notion",
+    ]);
+  });
+
+  it("is a no-op when the map is empty (standalone path)", () => {
+    const remapped = remapSnapshotServerIdsForAttachment(snapshot, new Map());
+    expect(remapped).toBe(snapshot);
+  });
+
+  it("leaves unmapped servers untouched", () => {
+    const remapped = remapSnapshotServerIdsForAttachment(
+      snapshot,
+      new Map([["manager-key-1", "Excalidraw (App)"]]),
+    );
+    expect(remapped.servers.map((s) => s.serverId)).toEqual([
+      "Excalidraw (App)",
+      "manager-key-2",
+    ]);
   });
 });
 

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -30,7 +30,10 @@ import {
   resolveOrgModelConfig,
   type ResolvedOrgModelConfig,
 } from "../../utils/org-model-config";
-import { flattenServerToolSnapshotTools } from "../../utils/export-helpers.js";
+import {
+  flattenServerToolSnapshotTools,
+  type ServerToolSnapshot,
+} from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "../../services/evals/convex-sanitize.js";
 import { type PromptTurn } from "@/shared/prompt-turns";
 import {
@@ -311,10 +314,19 @@ export type ServerAttachmentInput = z.infer<
   typeof ServerAttachmentInputSchema
 >;
 
+// `serverNames` is the optional parallel array that pairs each `serverIds[i]`
+// (the manager key — Convex Id in hosted mode, display name in standalone)
+// with its runtime display name. The backend snapshot/attachment check is
+// keyed by display name (see `applyAttachmentScope` in
+// `convex/evalGeneration/routes.ts`), so generators must rewrite the snapshot's
+// `serverId` to the display name before forwarding. Without the parallel
+// array the rewrite is a no-op and standalone callers (where manager key ==
+// display name) continue to work unchanged.
 export const GenerateTestsRequestSchema = z.object({
   serverIds: z
     .array(z.string())
     .min(1, { message: "At least one server must be selected" }),
+  serverNames: z.array(z.string()).optional(),
   convexAuthToken: z.string(),
   projectId: z.string().min(1).optional(),
   serverAttachment: ServerAttachmentInputSchema.optional(),
@@ -326,6 +338,7 @@ export const GenerateNegativeTestsRequestSchema = z.object({
   serverIds: z
     .array(z.string())
     .min(1, { message: "At least one server must be selected" }),
+  serverNames: z.array(z.string()).optional(),
   convexAuthToken: z.string(),
   projectId: z.string().min(1).optional(),
   serverAttachment: ServerAttachmentInputSchema.optional(),
@@ -1164,6 +1177,54 @@ export async function runEvalTestCaseWithManager(
   };
 }
 
+// Map each manager key back to the runtime display name the inspector client
+// sent in `serverNames`. The map drives the snapshot rewrite below so the
+// Convex `applyAttachmentScope` set-comparison lines up with
+// `serverAttachment.resolvedServerNames` (display names) instead of the
+// manager keys (Convex Ids in hosted mode).
+export function buildManagerKeyToDisplayNameMap(
+  clientManager: MCPClientManager,
+  requestServerIds: string[],
+  requestServerNames: string[] | undefined,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  if (
+    !requestServerNames ||
+    requestServerNames.length !== requestServerIds.length
+  ) {
+    return map;
+  }
+  const available = clientManager.listServers();
+  for (let i = 0; i < requestServerIds.length; i++) {
+    const requestedId = requestServerIds[i];
+    const displayName = requestServerNames[i];
+    if (!displayName || displayName === requestedId) continue;
+    const match =
+      available.find((id) => id === requestedId) ??
+      available.find((id) => id.toLowerCase() === requestedId.toLowerCase());
+    if (!match) continue;
+    if (!map.has(match)) {
+      map.set(match, displayName);
+    }
+  }
+  return map;
+}
+
+export function remapSnapshotServerIdsForAttachment(
+  snapshot: ServerToolSnapshot,
+  managerKeyToDisplayName: Map<string, string>,
+): ServerToolSnapshot {
+  if (managerKeyToDisplayName.size === 0) return snapshot;
+  let mutated = false;
+  const servers = snapshot.servers.map((server) => {
+    const displayName = managerKeyToDisplayName.get(server.serverId);
+    if (!displayName || displayName === server.serverId) return server;
+    mutated = true;
+    return { ...server, serverId: displayName };
+  });
+  return mutated ? { ...snapshot, servers } : snapshot;
+}
+
 export async function generateEvalTestsWithManager(
   clientManager: MCPClientManager,
   request: GenerateTestsRequest,
@@ -1172,12 +1233,20 @@ export async function generateEvalTestsWithManager(
     request.serverIds,
     clientManager,
   );
-  const { toolSnapshot } = await captureToolSnapshotForEvalAuthoring(
+  const { toolSnapshot: rawSnapshot } = await captureToolSnapshotForEvalAuthoring(
     clientManager,
     resolvedServerIds,
     {
       logPrefix: "evals.generate-tests",
     },
+  );
+  const toolSnapshot = remapSnapshotServerIdsForAttachment(
+    rawSnapshot,
+    buildManagerKeyToDisplayNameMap(
+      clientManager,
+      request.serverIds,
+      request.serverNames,
+    ),
   );
   const filteredTools = flattenServerToolSnapshotTools(toolSnapshot);
 
@@ -1216,12 +1285,20 @@ export async function generateNegativeEvalTestsWithManager(
     request.serverIds,
     clientManager,
   );
-  const { toolSnapshot } = await captureToolSnapshotForEvalAuthoring(
+  const { toolSnapshot: rawSnapshot } = await captureToolSnapshotForEvalAuthoring(
     clientManager,
     resolvedServerIds,
     {
       logPrefix: "evals.generate-negative-tests",
     },
+  );
+  const toolSnapshot = remapSnapshotServerIdsForAttachment(
+    rawSnapshot,
+    buildManagerKeyToDisplayNameMap(
+      clientManager,
+      request.serverIds,
+      request.serverNames,
+    ),
   );
   const filteredTools = flattenServerToolSnapshotTools(toolSnapshot);
 

--- a/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { ErrorCode, WebRouteError, mapRuntimeError } from "../errors.js";
+
+describe("mapRuntimeError", () => {
+  it("passes WebRouteError through unchanged", () => {
+    const original = new WebRouteError(404, ErrorCode.NOT_FOUND, "missing");
+    expect(mapRuntimeError(original)).toBe(original);
+  });
+
+  it("maps timeout messages to 504", () => {
+    expect(mapRuntimeError(new Error("Request timed out")).status).toBe(504);
+    expect(mapRuntimeError(new Error("Timeout exceeded")).status).toBe(504);
+  });
+
+  it("maps ECONN* errno messages to 502", () => {
+    expect(
+      mapRuntimeError(new Error("connect ECONNREFUSED 127.0.0.1:8080")).status,
+    ).toBe(502);
+    expect(mapRuntimeError(new Error("read ECONNRESET")).status).toBe(502);
+    expect(mapRuntimeError(new Error("ECONNABORTED")).status).toBe(502);
+  });
+
+  it("maps standard connection-failure phrases to 502", () => {
+    expect(
+      mapRuntimeError(new Error("Connection refused by peer")).status,
+    ).toBe(502);
+    expect(mapRuntimeError(new Error("Connection reset")).status).toBe(502);
+    expect(
+      mapRuntimeError(new Error("Failed to connect to upstream")).status,
+    ).toBe(502);
+    expect(mapRuntimeError(new Error("fetch failed")).status).toBe(502);
+    expect(
+      mapRuntimeError(new Error("getaddrinfo ENOTFOUND example.com")).status,
+    ).toBe(502);
+    expect(mapRuntimeError(new Error("socket hang up")).status).toBe(502);
+  });
+
+  it("does NOT misclassify 'Reconnect' as 502", () => {
+    // Regression: the previous implementation matched the bare substring
+    // "connect", which caught the word "Reconnect" inside upstream errors
+    // like the eval-generation attachment guard and surfaced them as 502
+    // SERVER_UNREACHABLE.
+    const error = new Error(
+      "Tool snapshot is missing servers required by the attachment: " +
+        "Excalidraw (App). Reconnect the missing server(s) in the inspector " +
+        "and try again.",
+    );
+    const mapped = mapRuntimeError(error);
+    expect(mapped.status).toBe(500);
+    expect(mapped.code).toBe(ErrorCode.INTERNAL_ERROR);
+  });
+
+  it("falls back to 500 for unrecognized errors", () => {
+    const mapped = mapRuntimeError(new Error("Something else went wrong"));
+    expect(mapped.status).toBe(500);
+    expect(mapped.code).toBe(ErrorCode.INTERNAL_ERROR);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
@@ -36,6 +36,17 @@ describe("mapRuntimeError", () => {
     expect(mapRuntimeError(new Error("socket hang up")).status).toBe(502);
   });
 
+  it("does NOT misclassify words that merely start with 'econ' as 502", () => {
+    // Regression for code-review feedback: the errno branch was originally
+    // `\becon[a-z]*` (one `n`), which matches server/tool/case names like
+    // "Economics" and re-introduces the same kind of false 502 mapping the
+    // fix was meant to eliminate. Require the full `econn` prefix.
+    expect(
+      mapRuntimeError(new Error("Economics server returned an error")).status,
+    ).toBe(500);
+    expect(mapRuntimeError(new Error("econometric pipeline")).status).toBe(500);
+  });
+
   it("does NOT misclassify 'Reconnect' as 502", () => {
     // Regression: the previous implementation matched the bare substring
     // "connect", which caught the word "Reconnect" inside upstream errors

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -55,6 +55,24 @@ export function parseErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+// Explicit connection-error patterns. The previous implementation matched the
+// bare substring `"connect"`, which also catches the word `"Reconnect"` —
+// causing actionable upstream errors like "Reconnect the missing server(s)"
+// to surface as 502 SERVER_UNREACHABLE instead of being passed through as
+// 500/4xx. Match Node's ECONN* errno family, the standard "connection X"
+// phrases, and a few well-known fetch/socket failures.
+// Each pattern starts with `\b` so the "econn" and "connect" substrings
+// inside the word `Reconnect` don't slip through — that exact bug is what
+// caused upstream attachment errors to surface as 502 SERVER_UNREACHABLE.
+const CONNECTION_ERROR_PATTERNS: readonly RegExp[] = [
+  /\becon[a-z]*/i,
+  /\bconnection\s+(?:refused|reset|closed|timed?\s*out|aborted|error|failed)\b/i,
+  /\b(?:failed|unable)\s+to\s+connect\b/i,
+  /\bfetch\s+failed\b/i,
+  /\bsocket\s+hang\s+up\b/i,
+  /\bgetaddrinfo\b/i,
+];
+
 export function mapRuntimeError(error: unknown): WebRouteError {
   if (error instanceof WebRouteError) return error;
 
@@ -65,12 +83,7 @@ export function mapRuntimeError(error: unknown): WebRouteError {
     return new WebRouteError(504, ErrorCode.TIMEOUT, message);
   }
 
-  if (
-    lower.includes("connect") ||
-    lower.includes("connection") ||
-    lower.includes("refused") ||
-    lower.includes("econn")
-  ) {
+  if (CONNECTION_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
     return new WebRouteError(502, ErrorCode.SERVER_UNREACHABLE, message);
   }
 

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -64,8 +64,11 @@ export function parseErrorMessage(error: unknown): string {
 // Each pattern starts with `\b` so the "econn" and "connect" substrings
 // inside the word `Reconnect` don't slip through — that exact bug is what
 // caused upstream attachment errors to surface as 502 SERVER_UNREACHABLE.
+// The errno branch requires the full `econn` prefix (Node's ECONN* family)
+// rather than `econ` so server/tool names like "Economics" don't slip
+// through and re-introduce the same class of false positive.
 const CONNECTION_ERROR_PATTERNS: readonly RegExp[] = [
-  /\becon[a-z]*/i,
+  /\beconn[a-z]*/i,
   /\bconnection\s+(?:refused|reset|closed|timed?\s*out|aborted|error|failed)\b/i,
   /\b(?:failed|unable)\s+to\s+connect\b/i,
   /\bfetch\s+failed\b/i,


### PR DESCRIPTION
## Summary

Fixes two bugs that surfaced as `Request failed (502)` on `/api/web/evals/generate-tests` in prod.

- **Root cause** — hosted snapshot capture used the manager key (Convex Id) as `snapshot.servers[].serverId`, but the inspector client sent `serverAttachment.resolvedServerNames` keyed by display name. The backend's `applyAttachmentScope` (`convex/evalGeneration/routes.ts`) set-compares the two and rejected every hosted request as *"Tool snapshot is missing servers required by the attachment: `<display name>`. Reconnect the missing server(s)…"*. Threads the already-validated `serverNames` parallel array through `generateEvalTestsWithManager` / `generateNegativeEvalTestsWithManager` and rewrites snapshot serverIds to display names before forwarding to `/eval-generation/generate`. Standalone path is a no-op (no `serverNames` ⇒ empty remap), so local CLI behavior is unchanged.

- **Misleading symptom** — `mapRuntimeError` substring-matched `"connect"` and turned upstream errors mentioning *"Reconnect"* into `502 SERVER_UNREACHABLE`, which is why the prod toast read like a network failure instead of an actionable validation error. Replaced the substring matches with word-boundary regexes covering the `ECONN*` errno family, `connection refused/reset/closed/timed out/aborted/error/failed`, `failed/unable to connect`, `fetch failed`, `socket hang up`, and `getaddrinfo`.

## Test plan

- [x] `npx vitest run --project server` — 1074/1074 pass (incl. new tests).
- [x] New `server/routes/web/__tests__/errors.test.ts` — regression coverage for the *"Reconnect"* → 502 misclassification, plus the existing connection-error vocabulary.
- [x] New tests in `server/routes/shared/__tests__/evals.test.ts` for `buildManagerKeyToDisplayNameMap` (case-insensitive match, length-mismatch fallback, disconnected-key skip) and `remapSnapshotServerIdsForAttachment` (rewrite, empty-map no-op, partial rewrite).
- [ ] After merge + deploy, re-run **Excalidraw quickstart** suite on `app.mcpjam.com` and confirm the suite generates tests without the *Tool snapshot is missing servers required by the attachment* error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval test-generation wire format and global web error classification; behavior change is scoped but affects all routes using mapRuntimeError and hosted generate-tests paths.
> 
> **Overview**
> Fixes hosted **generate-tests** failures and misleading **502** responses on eval generation routes.
> 
> **Snapshot / attachment alignment:** Adds optional parallel **`serverNames`** on generate (and negative-generate) requests and rewrites captured tool snapshot **`serverId`** values from MCP manager keys (e.g. Convex ids) to runtime **display names** before calling eval generation, so Convex **`applyAttachmentScope`** matches **`serverAttachment.resolvedServerNames`**. Standalone callers without **`serverNames`** skip the remap unchanged.
> 
> **Error mapping:** Replaces broad **`connect` / `connection`** substring checks in **`mapRuntimeError`** with word-boundary regexes for real network failures (ECONN*, standard connection phrases, fetch/socket errors), so messages like *"Reconnect the missing server(s)"* no longer become **502 SERVER_UNREACHABLE**.
> 
> Adds unit tests for the new remap helpers and **`mapRuntimeError`** regressions (Reconnect, Economics/econ false positives).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb25fd30e321a554a5ff6943aff41f787d4b5e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->