### PR TITLE
MCP worker: enforce resource audience on access tokens

### DIFF
--- a/mcp/src/auth.ts
+++ b/mcp/src/auth.ts
@@ -66,11 +66,18 @@ export async function verifyBearerToken(
   }
 
   try {
-    const { payload } = await jwtVerify(token, getJwks(issuer), { issuer });
+    const { payload } = await jwtVerify(token, getJwks(issuer), {
+      issuer,
+      audience: resourceIdentifier(origin),
+    });
     return { ok: true, verified: { token, payload } };
   } catch {
     return { ok: false, response: invalidTokenResponse(origin) };
   }
+}
+
+export function resourceIdentifier(origin: string): string {
+  return `${origin}/mcp`;
 }
 
 export const OAUTH_DISCOVERY_HEADERS = {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -2,6 +2,7 @@ import { McpJamMcpServer } from "./server.js";
 import {
   OAUTH_DISCOVERY_HEADERS,
   normalizeIssuer,
+  resourceIdentifier,
   verifyBearerToken,
 } from "./auth.js";
 
@@ -28,7 +29,7 @@ const LANDING_PAGE = `<!doctype html>
 
 function protectedResourceMetadata(origin: string, issuer: string) {
   return {
-    resource: `${origin}/mcp`,
+    resource: resourceIdentifier(origin),
     authorization_servers: [issuer],
     bearer_methods_supported: ["header"],
   };


### PR DESCRIPTION
## Summary
- `verifyBearerToken` now enforces `aud === ${origin}/mcp` in addition to `iss`, matching the [WorkOS MCP integration guide](https://workos.com/docs/authkit/connect/oauth) (`jwtVerify({ issuer, audience })`).
- New `resourceIdentifier(origin)` helper shared by `auth.ts` and `index.ts` so the enforced `aud` and the advertised `resource` in `/.well-known/oauth-protected-resource/mcp` can't drift apart.

## Why
Today (`mcp/src/auth.ts:69`) we only check the issuer. Any AuthKit-issued token for any audience would pass — e.g. a token minted for an unrelated WorkOS-Connect client could call `/mcp`. The guide explicitly pairs the `WWW-Authenticate` + resource-metadata pattern with an `aud` check; we already had the former.

## ⚠️ Required dashboard change before deploy
The audience check will reject all existing tokens unless these Resource Indicators are registered in the WorkOS dashboard first:
- production: `https://mcp.mcpjam.com/mcp`
- staging: `https://mcp-staging.mcpjam.com/mcp`

Per WorkOS: _"If you don't configure any Resource Indicators in the WorkOS Dashboard, then a default `aud` value unique to your WorkOS Environment will be used instead, with the `resource` parameter then ignored."_ So without this step, every `/mcp` request will 401 after merge → deploy.

Suggested rollout: configure dashboard → merge → deploy staging → smoke test → deploy prod.

## Test plan
- [ ] Add Resource Indicator `https://mcp-staging.mcpjam.com/mcp` in WorkOS staging
- [ ] Deploy preview worker, hit `/mcp` with a valid AuthKit token whose `aud` matches → 200
- [ ] Hit `/mcp` with a token issued for a different resource → 401 with `WWW-Authenticate: ... error="invalid_token"`
- [ ] Hit `/mcp` with no token → 401 with `WWW-Authenticate: Bearer, resource_metadata="..."`
- [ ] GET `/.well-known/oauth-protected-resource/mcp` returns `resource: "<origin>/mcp"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication acceptance criteria for all `/mcp` traffic; misconfigured WorkOS Resource Indicators or deploy order can cause widespread 401s until tokens match the new audience.
> 
> **Overview**
> **Bearer auth on `/mcp` now requires tokens whose `aud` matches the protected resource URL**, not just a valid issuer. `jwtVerify` passes `audience: resourceIdentifier(origin)` (`<origin>/mcp`), so AuthKit tokens minted for other clients/resources are rejected with the existing invalid-token 401 flow.
> 
> A shared **`resourceIdentifier(origin)`** helper is used for both verification and the `resource` field in `/.well-known/oauth-protected-resource/mcp`, so the enforced audience and advertised resource cannot diverge.
> 
> **Deploy note:** WorkOS must register matching Resource Indicators (e.g. `https://mcp-staging.mcpjam.com/mcp`) before rollout, or valid sessions may 401 until tokens are issued with the new audience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5066a237aa9bc5d99c3ac7b3654f9e213d85ff23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->