### PR TITLE
evals: add PostHog events for funnel + run lifecycle

### DIFF
--- a/.changeset/evaluate-posthog-events.md
+++ b/.changeset/evaluate-posthog-events.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Inspector updates:
+
+- Add PostHog instrumentation to Evaluate covering the activation funnel and run lifecycle: `evaluate_tab_viewed`, `suite_viewed`, `eval_suite_run_completed` (with pass/fail counts and duration), `eval_generate_tests_completed` (with success flag and count), `eval_run_insights_opened`, `eval_suite_server_changed`, `eval_test_case_deleted`, and `eval_test_case_edited`

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -271,16 +271,22 @@ function EvalsTabContent({
     }
   }, [overviewQueries.isOverviewLoading, route.type, selectedSuiteEntry, selectedSuiteId]);
 
+  // Wait for auth to settle before firing view events. The parent
+  // ErrorBoundary keys on (projectId, isAuthenticated), so projectId
+  // resolving null→"x" remounts this component and would otherwise
+  // double-fire (once on the null mount, once on the resolved mount).
   useEffect(() => {
+    if (isLoading) return;
     posthog.capture("evaluate_tab_viewed", {
       location: "evals_tab",
       platform: detectPlatform(),
       environment: detectEnvironment(),
       project_id: projectId ?? null,
     });
-  }, [projectId]);
+  }, [isLoading, projectId]);
 
   useEffect(() => {
+    if (isLoading) return;
     if (!selectedSuiteId) return;
     posthog.capture("suite_viewed", {
       location: "evals_tab",
@@ -290,7 +296,7 @@ function EvalsTabContent({
       suite_id: selectedSuiteId,
       route_type: route.type,
     });
-  }, [selectedSuiteId, route.type, projectId]);
+  }, [isLoading, selectedSuiteId, route.type, projectId]);
 
   const handleOpenCreateSuite = useCallback(() => {
     navigatePlaygroundEvalsRoute({ type: "create" });

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -42,6 +42,8 @@ import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { EvalsSuiteListSidebar } from "./evals/evals-suite-list-sidebar";
 import { CreateSuiteDialog, type CreateSuitePayload } from "./evals/create-suite-dialog";
 import { useFeatureFlagEnabled } from "posthog-js/react";
+import posthog from "posthog-js";
+import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
 
@@ -268,6 +270,27 @@ function EvalsTabContent({
       navigatePlaygroundEvalsRoute({ type: "list" }, { replace: true });
     }
   }, [overviewQueries.isOverviewLoading, route.type, selectedSuiteEntry, selectedSuiteId]);
+
+  useEffect(() => {
+    posthog.capture("evaluate_tab_viewed", {
+      location: "evals_tab",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+      project_id: projectId ?? null,
+    });
+  }, [projectId]);
+
+  useEffect(() => {
+    if (!selectedSuiteId) return;
+    posthog.capture("suite_viewed", {
+      location: "evals_tab",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+      project_id: projectId ?? null,
+      suite_id: selectedSuiteId,
+      route_type: route.type,
+    });
+  }, [selectedSuiteId, route.type, projectId]);
 
   const handleOpenCreateSuite = useCallback(() => {
     navigatePlaygroundEvalsRoute({ type: "create" });

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -236,6 +236,13 @@ export function SuiteHeader(props: SuiteHeaderProps) {
           suiteId: suite._id,
           serverAttachmentId,
         });
+        posthog.capture("eval_suite_server_changed", {
+          location: "suite_header",
+          platform: detectPlatform(),
+          environment: detectEnvironment(),
+          suite_id: suite._id,
+          server_attachment_id: serverAttachmentId,
+        });
         toast.success("Server attachment updated");
       } catch (error) {
         toast.error(

--- a/mcpjam-inspector/client/src/components/evals/suite-insights-collapsible.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-insights-collapsible.tsx
@@ -1,11 +1,13 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Loader2, ChevronDown } from "lucide-react";
 import { motion, useReducedMotion } from "framer-motion";
+import posthog from "posthog-js";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@mcpjam/design-system/collapsible";
+import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import type { EvalSuiteRun } from "./types";
 import { pickLatestCompletedRun } from "./helpers";
 import { useRunInsights } from "./use-run-insights";
@@ -79,6 +81,22 @@ export function SuiteInsightsCollapsible({
   const shouldReduceMotion = useReducedMotion();
   const latestCompleted = useMemo(() => pickLatestCompletedRun(runs), [runs]);
 
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (next && !open) {
+        posthog.capture("eval_run_insights_opened", {
+          location: "suite_insights_collapsible",
+          platform: detectPlatform(),
+          environment: detectEnvironment(),
+          title,
+          run_id: latestCompleted?._id ?? null,
+        });
+      }
+      setOpen(next);
+    },
+    [latestCompleted, open, title],
+  );
+
   const {
     summary,
     pending,
@@ -112,7 +130,7 @@ export function SuiteInsightsCollapsible({
   return (
     <Collapsible
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={handleOpenChange}
       className={insightHighlightSectionClass}
     >
       <div className={insightHighlightAccentClass} aria-hidden />

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -973,7 +973,7 @@ export function TestTemplateEditor({
         environment: detectEnvironment(),
         suite_id: suiteId ?? null,
         test_case_id: currentTestCase._id,
-        num_models: selectedModelValues.length,
+        num_models: currentTestCase.models?.length ?? 0,
         num_prompt_turns: editForm.promptTurns?.length ?? 0,
         has_match_options: savePayload.matchOptions != null,
         has_predicates: savePayload.predicates != null,

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -967,6 +967,17 @@ export function TestTemplateEditor({
         // Same null-clears-the-field convention for the predicate override.
         predicates: savePayload.predicates ?? null,
       });
+      posthog.capture("eval_test_case_edited", {
+        location: "test_template_editor",
+        platform: detectPlatform(),
+        environment: detectEnvironment(),
+        suite_id: suiteId ?? null,
+        test_case_id: currentTestCase._id,
+        num_models: selectedModelValues.length,
+        num_prompt_turns: editForm.promptTurns?.length ?? 0,
+        has_match_options: savePayload.matchOptions != null,
+        has_predicates: savePayload.predicates != null,
+      });
       toast.success("Changes saved");
     } catch (error) {
       console.error("Failed to save:", error);

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -1552,6 +1552,10 @@ export function useEvalHandlers({
         }
       } catch (error) {
         console.error("Failed to generate tests:", error);
+        // Cap the raw message at 200 chars so PostHog event cardinality stays
+        // bounded when backend errors include user input or random ids.
+        const rawMessage =
+          error instanceof Error ? error.message : String(error);
         posthog.capture("eval_generate_tests_completed", {
           location: "evals_tab",
           platform: detectPlatform(),
@@ -1559,8 +1563,8 @@ export function useEvalHandlers({
           suite_id: suiteId,
           generated_count: 0,
           success: false,
-          error_message:
-            error instanceof Error ? error.message : String(error),
+          error_name: error instanceof Error ? error.name : typeof error,
+          error_message: rawMessage.slice(0, 200),
         });
         toast.error(
           getBillingErrorMessage(error, "Failed to generate test cases")

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -617,6 +617,7 @@ export function useEvalHandlers({
           : "Run started successfully! Results will appear shortly.",
       );
 
+      const suiteRunStartedAt = Date.now();
       try {
         const accessToken = await getAccessToken();
 
@@ -698,6 +699,20 @@ export function useEvalHandlers({
           num_models: executionContext.providersNeeded.size,
           minimum_pass_rate: minimumPassRate,
           num_hosts: runPlans.length,
+        });
+
+        posthog.capture("eval_suite_run_completed", {
+          location: "evals_tab",
+          platform: detectPlatform(),
+          environment: detectEnvironment(),
+          suite_id: suite._id,
+          num_test_cases: executionContext.testCases.length,
+          num_tests: executionContext.tests.length,
+          num_hosts: runPlans.length,
+          num_succeeded_hosts: runPlans.length - failures.length,
+          num_failed_hosts: failures.length,
+          all_succeeded: failures.length === 0,
+          duration_ms: Date.now() - suiteRunStartedAt,
         });
 
         if (failures.length === 0) {
@@ -1268,8 +1283,15 @@ export function useEvalHandlers({
   const directDeleteTestCase = useCallback(
     async (testCaseId: string) => {
       await mutations.deleteTestCaseMutation({ testCaseId });
+      posthog.capture("eval_test_case_deleted", {
+        location: "evals_tab_batch",
+        platform: detectPlatform(),
+        environment: detectEnvironment(),
+        suite_id: selectedSuiteId ?? null,
+        test_case_id: testCaseId,
+      });
     },
-    [mutations.deleteTestCaseMutation]
+    [mutations.deleteTestCaseMutation, selectedSuiteId]
   );
 
   // Confirm test case deletion
@@ -1281,6 +1303,13 @@ export function useEvalHandlers({
     try {
       await mutations.deleteTestCaseMutation({
         testCaseId: testCaseToDelete.id,
+      });
+      posthog.capture("eval_test_case_deleted", {
+        location: "evals_tab",
+        platform: detectPlatform(),
+        environment: detectEnvironment(),
+        suite_id: selectedSuiteId ?? null,
+        test_case_id: testCaseToDelete.id,
       });
       toast.success("Test case deleted successfully");
 
@@ -1437,6 +1466,15 @@ export function useEvalHandlers({
         });
 
         if (outcome.apiReturnedTests === 0) {
+          posthog.capture("eval_generate_tests_completed", {
+            location: "evals_tab",
+            platform: detectPlatform(),
+            environment: detectEnvironment(),
+            suite_id: suiteId,
+            generated_count: 0,
+            api_returned_tests: 0,
+            success: true,
+          });
           toast.info("No test cases were generated");
           return;
         }
@@ -1457,6 +1495,19 @@ export function useEvalHandlers({
             ),
           });
         }
+
+        posthog.capture("eval_generate_tests_completed", {
+          location: "evals_tab",
+          platform: detectPlatform(),
+          environment: detectEnvironment(),
+          suite_id: suiteId,
+          generated_count: outcome.createdCount,
+          api_returned_tests: outcome.apiReturnedTests,
+          auto_ran: Boolean(
+            shouldAutoRun && outcome.createdTestCaseIds.length > 0,
+          ),
+          success: true,
+        });
 
         if (
           shouldAutoRun &&
@@ -1501,6 +1552,16 @@ export function useEvalHandlers({
         }
       } catch (error) {
         console.error("Failed to generate tests:", error);
+        posthog.capture("eval_generate_tests_completed", {
+          location: "evals_tab",
+          platform: detectPlatform(),
+          environment: detectEnvironment(),
+          suite_id: suiteId,
+          generated_count: 0,
+          success: false,
+          error_message:
+            error instanceof Error ? error.message : String(error),
+        });
         toast.error(
           getBillingErrorMessage(error, "Failed to generate test cases")
         );


### PR DESCRIPTION
## Summary

Instruments the Evaluate flow so the activation funnel and run lifecycle become measurable:

- `evaluate_tab_viewed` and `suite_viewed` — anchors the funnel (Evaluate visit → suite open → first run → result).
- `eval_suite_run_completed` — fires at the suite-level with `num_succeeded_hosts`, `num_failed_hosts`, `all_succeeded`, and `duration_ms`. Pairs with the existing `eval_suite_run_started`.
- `eval_generate_tests_completed` — fires on success (with count) and on error (with `error_message`); covers the no-cases-returned path too.
- `eval_run_insights_opened` — fires when the Run insights collapsible expands.
- `eval_suite_server_changed` — fires when the suite header server attachment picker changes the attachment.
- `eval_test_case_deleted` — fires from both the single-delete modal path and the playground batch path.
- `eval_test_case_edited` — fires on successful save in the test template editor, with `num_models`, `num_prompt_turns`, `has_match_options`, and `has_predicates`.

All events carry the standard `location` / `platform` / `environment` props via `detectPlatform` / `detectEnvironment` from `@/lib/PosthogUtils`, matching existing Evaluate events.

Note: I considered an `eval_suite_model_changed` event but the suite header has no suite-level model picker (models are per test case) — the per-case model is already captured in `eval_test_case_run_started`/`completed`.

## Test plan
- [x] `npm run typecheck:client` passes
- [x] `npx vitest run` on `EvalsTab` + `client/src/components/evals/__tests__` — 569 tests pass
- [ ] Manually verify in dev: open Evaluate, open a suite, run all, expand Run insights, change the server attachment, delete + edit a case; confirm the new events show up in PostHog Live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are client-side analytics captures only; no auth, billing, or eval execution logic is altered beyond when events fire after successful mutations.
> 
> **Overview**
> Adds **PostHog instrumentation** across the Evaluate (Evals) UI so activation and run lifecycle can be measured in analytics, using the same `location` / `platform` / `environment` props as existing eval events.
> 
> **Funnel / navigation:** `evaluate_tab_viewed` and `suite_viewed` fire from `EvalsTab` after Convex auth finishes loading, avoiding duplicate events when `projectId` resolves and the parent `ErrorBoundary` remounts.
> 
> **Run lifecycle:** `eval_suite_run_completed` is emitted after multi-host suite reruns (host success/failure counts, `duration_ms`), complementing the existing `eval_suite_run_started`.
> 
> **Generate tests:** `eval_generate_tests_completed` covers success (including zero API results), failure (truncated `error_message` for cardinality), alongside the existing sidebar-specific event when cases are created.
> 
> **Product actions:** New events for expanding run insights, changing suite server attachment, deleting test cases (confirm + batch paths), and saving edits in the test template editor (with lightweight config metadata).
> 
> Includes a patch **changeset** for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db58e63fad703914ed4672b87a8c1b0c05e451b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->