### PR TITLE
evals: allow guests to create suites and rerun

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -81,33 +81,12 @@ export function EvalsTab({
   );
 }
 
-function isGuestUnavailableError(error: Error | null): boolean {
-  return (
-    error?.message.includes("Not available for guests yet. Sign in to use this.") ??
-    false
-  );
-}
-
 function EvalTabErrorFallback({
-  error,
   onRetry,
 }: {
   error: Error | null;
   onRetry: () => void;
 }) {
-  if (isGuestUnavailableError(error)) {
-    return (
-      <div className="p-6">
-        <EmptyState
-          icon={FlaskConical}
-          title="Sign in to use Testing"
-          description="Testing suites are not available for guests yet. Sign in to create suites, view runs, and investigate cases."
-          className="h-[calc(100vh-200px)]"
-        />
-      </div>
-    );
-  }
-
   return (
     <div className="p-6">
       <EmptyState

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -288,25 +288,21 @@ describe("EvalsTab", () => {
     });
   });
 
-  it("shows a sign-in state instead of crashing when Convex rejects guest eval overview", () => {
+  it("shows the generic error fallback when the suites overview query throws", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
     try {
       mocks.useEvalQueries.mockImplementation(() => {
         throw new Error(
-          "[CONVEX Q(testSuites:getTestSuitesOverview)] [Request ID: test] Server Error\nUncaught Error: Not available for guests yet. Sign in to use this.",
+          "[CONVEX Q(testSuites:getTestSuitesOverview)] [Request ID: test] Server Error",
         );
       });
 
-      render(<EvalsTab projectId="guest-project" />);
+      render(<EvalsTab projectId="project-1" />);
 
-      expect(screen.getByText("Sign in to use Testing")).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          "Testing suites are not available for guests yet. Sign in to create suites, view runs, and investigate cases.",
-        ),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Could not load Testing")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
       expect(screen.queryByTestId("suite-sidebar")).toBeNull();
     } finally {
       consoleError.mockRestore();

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -414,7 +414,11 @@ export function useEvalHandlers({
       const replayToastId = toast.loading("Replaying run...");
 
       try {
-        const accessToken = await getAccessToken();
+        // Hosted guests have no WorkOS access token; the request still
+        // authenticates via authFetch attaching a guest bearer. Treat the
+        // LoginRequired throw as an empty token — `buildEvalConvexAuthPayload`
+        // drops it in hosted mode anyway.
+        const accessToken = await getAccessToken().catch(() => "");
         const endpoints = getEvalApiEndpoints();
         const response = await authFetch(endpoints.replayRun, {
           method: "POST",
@@ -619,7 +623,10 @@ export function useEvalHandlers({
 
       const suiteRunStartedAt = Date.now();
       try {
-        const accessToken = await getAccessToken();
+        // Hosted guests have no WorkOS access token; authFetch attaches the
+        // guest bearer instead. `mergeHostedServerBatch` strips
+        // convexAuthToken in hosted mode so an empty string is harmless.
+        const accessToken = await getAccessToken().catch(() => "");
 
         // Get pass criteria from suite's defaultPassCriteria, or fall back to latest run, or default to 100%
         const suiteDefault = suite.defaultPassCriteria?.minimumPassRate;

--- a/mcpjam-inspector/server/routes/web/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/evals.test.ts
@@ -485,7 +485,13 @@ describe("web routes — evals", () => {
     expect(streamEvalTestCaseWithManagerMock).not.toHaveBeenCalled();
   });
 
-  it("rejects direct guest full suite eval runs", async () => {
+  it("allows guests to run full eval suites", async () => {
+    runEvalsWithManagerMock.mockResolvedValueOnce({
+      success: true,
+      suiteId: "guest-suite-1",
+      runId: "guest-run-1",
+    });
+
     const { app } = createEvalsTestApp();
     const { token } = issueGuestToken();
 
@@ -493,23 +499,32 @@ describe("web routes — evals", () => {
       app,
       "/api/web/evals/run",
       {
-        serverUrl: "https://guest.example.com/mcp",
-        serverName: "Guest Server",
+        projectId: "guest-project-1",
+        serverIds: ["guest-srv-1"],
+        serverNames: ["guest-server-1"],
         suiteName: "Guest Suite",
-        tests: [],
+        tests: [
+          {
+            title: "Test",
+            query: "Hello",
+            runs: 1,
+            model: "openai/gpt-5-mini",
+            provider: "openai",
+            expectedToolCalls: [],
+          },
+        ],
       },
       token,
     );
-    const { status, data } = await expectJson<{
-      code: string;
-      message: string;
-    }>(response);
 
-    expect(status).toBe(403);
-    expect(data).toEqual({
-      code: "FEATURE_NOT_SUPPORTED",
-      message: "Not available for guests yet. Sign in to use this.",
-    });
-    expect(runEvalsWithManagerMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(runEvalsWithManagerMock).toHaveBeenCalledTimes(1);
+    expect(runEvalsWithManagerMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        projectId: "guest-project-1",
+        serverIds: ["guest-srv-1"],
+        convexAuthToken: token,
+      }),
+    );
   });
 });

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -25,8 +25,6 @@ import {
 } from "../shared/evals.js";
 
 const evals = new Hono();
-const GUEST_UNSUPPORTED_MESSAGE =
-  "Not available for guests yet. Sign in to use this.";
 
 const hostedBatchSchema = z.object({
   projectId: z.string().min(1),
@@ -102,10 +100,7 @@ evals.post("/run", async (c) =>
         ...body,
         convexAuthToken: assertBearerToken(c),
       }),
-    {
-      rpcLogs: false,
-      guestUnsupportedMessage: GUEST_UNSUPPORTED_MESSAGE,
-    },
+    { rpcLogs: false },
   ),
 );
 


### PR DESCRIPTION
## Summary

Pair to [mcpjam-backend#406](https://github.com/MCPJam/mcpjam-backend/pull/406). The backend gate on `requireEvalUserActor` is gone, so the inspector no longer needs its mirror handling.

- **`EvalsTab.tsx`**: drop the `isGuestUnavailableError` predicate and the "Sign in to use Testing" branch in `EvalTabErrorFallback`. The matched Convex error string is no longer produced.
- **`server/routes/web/evals.ts`**: remove the `guestUnsupportedMessage` option from `POST /run`. (`/generate-tests` and `/generate-negative-tests` already allow guests; other eval routes had no gate.)
- **`use-eval-handlers.ts`**: `handleRerun` and `handleReplayRun` called WorkOS `getAccessToken()` unconditionally, which throws `LoginRequiredError: No access token available` for hosted guests. The resulting token is dead-stored in hosted mode — `mergeHostedServerBatch` strips `convexAuthToken`, and `authFetch` attaches the guest bearer via `getApiAuthorizationHeader`. Tolerate the throw with `.catch(() => "")` so guests can rerun and replay.

## Tests

- Flip the EvalsTab guest-fallback test into a generic-error-fallback regression test.
- Flip the Node `/run` guest-rejection test into a guest happy-path test asserting a 200 and that `runEvalsWithManager` is invoked with the guest bearer.

## Out of scope

`isDirectGuest` plumbing in `use-eval-mutations.ts`, `use-eval-queries.ts`, `EvalTabGate.tsx`, and the child-component props chain is untouched. That hook is the local/no-project escape hatch (`useIsDirectGuest` returns false in `HOSTED_MODE`), not a hosted-guest signal — touching those branches would risk regressing the local path.

## Test plan

- [x] `npm test` against the touched files — 631 tests pass.
- [x] `npx tsc -p client --noEmit` — no new errors (existing pre-existing errors in unrelated test files only).
- [ ] After deploy, repeat the reproducer from the original bug: open `/evals` as an unauthenticated hosted guest, navigate the Excalidraw quickstart, click "Run all" — should succeed and not throw `LoginRequiredError`.
- [ ] Spot-check the rerun / replay-run / single-case run paths for guests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval execution and auth wiring for unauthenticated hosted users; mistakes could allow wrong auth on runs or break signed-in rerun paths, though scope is limited to guest token handling and one route gate.
> 
> **Overview**
> Aligns the inspector with backend eval access for **hosted guests**: full suite runs via `POST /api/web/evals/run` are no longer blocked with `FEATURE_NOT_SUPPORTED`, and the Testing tab no longer treats the old guest-only Convex error as a dedicated “Sign in to use Testing” state.
> 
> **Server:** `guestUnsupportedMessage` is removed from the `/run` handler so guest bearer tokens follow the same hosted batch path as signed-in users.
> 
> **Client:** `handleRerun` and `handleReplayRun` wrap WorkOS `getAccessToken()` with `.catch(() => "")` so hosted guests without a WorkOS session do not hit `LoginRequiredError`; `authFetch` still sends the guest bearer and hosted payloads omit the empty convex token as before.
> 
> Tests now expect a generic Testing load error on query failure and assert guests get **200** on `/run` with `runEvalsWithManager` invoked using the guest token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91aa08b80db8e79fa0fb0e24396769c83a8efc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->