### PR TITLE
Add HostConfig v2 canonicalizer, hash, and public Host builder API

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -51,6 +51,11 @@
       "types": "./dist/host-config/index.d.ts",
       "import": "./dist/host-config/index.js",
       "default": "./dist/host-config/index.js"
+    },
+    "./host-config/internal": {
+      "types": "./dist/host-config/internal.d.ts",
+      "import": "./dist/host-config/internal.js",
+      "default": "./dist/host-config/internal.js"
     }
   },
   "files": [
@@ -66,7 +71,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:packaging": "npm run build && node --input-type=module -e \"await import('@mcpjam/sdk'); await import('@mcpjam/sdk/browser'); await import('@mcpjam/sdk/worker'); await import('@mcpjam/sdk/operations'); await import('@mcpjam/sdk/skill-reference'); await import('@mcpjam/sdk/model-factory'); await import('@mcpjam/sdk/matchers'); await import('@mcpjam/sdk/predicates'); await import('@mcpjam/sdk/host-config');\"",
+    "test:packaging": "npm run build && node --input-type=module -e \"await import('@mcpjam/sdk'); await import('@mcpjam/sdk/browser'); await import('@mcpjam/sdk/worker'); await import('@mcpjam/sdk/operations'); await import('@mcpjam/sdk/skill-reference'); await import('@mcpjam/sdk/model-factory'); await import('@mcpjam/sdk/matchers'); await import('@mcpjam/sdk/predicates'); await import('@mcpjam/sdk/host-config'); await import('@mcpjam/sdk/host-config/internal');\"",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -46,6 +46,11 @@
       "types": "./dist/predicates/index.d.ts",
       "import": "./dist/predicates/index.js",
       "default": "./dist/predicates/index.js"
+    },
+    "./host-config": {
+      "types": "./dist/host-config/index.d.ts",
+      "import": "./dist/host-config/index.js",
+      "default": "./dist/host-config/index.js"
     }
   },
   "files": [
@@ -61,7 +66,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:packaging": "npm run build && node --input-type=module -e \"await import('@mcpjam/sdk'); await import('@mcpjam/sdk/browser'); await import('@mcpjam/sdk/worker'); await import('@mcpjam/sdk/operations'); await import('@mcpjam/sdk/skill-reference'); await import('@mcpjam/sdk/model-factory'); await import('@mcpjam/sdk/matchers'); await import('@mcpjam/sdk/predicates');\"",
+    "test:packaging": "npm run build && node --input-type=module -e \"await import('@mcpjam/sdk'); await import('@mcpjam/sdk/browser'); await import('@mcpjam/sdk/worker'); await import('@mcpjam/sdk/operations'); await import('@mcpjam/sdk/skill-reference'); await import('@mcpjam/sdk/model-factory'); await import('@mcpjam/sdk/matchers'); await import('@mcpjam/sdk/predicates'); await import('@mcpjam/sdk/host-config');\"",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",

--- a/sdk/scripts/gen-host-config-parity-fixture.mjs
+++ b/sdk/scripts/gen-host-config-parity-fixture.mjs
@@ -21,7 +21,7 @@ import {
   canonicalizeHostConfigV2,
   computeHostConfigHashV2,
   sha256Hex,
-} from "../dist/host-config/index.js";
+} from "../dist/host-config/internal.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const outPath = join(here, "..", "tests", "fixtures", "host-config-parity-fixtures.json");

--- a/sdk/scripts/gen-host-config-parity-fixture.mjs
+++ b/sdk/scripts/gen-host-config-parity-fixture.mjs
@@ -1,0 +1,239 @@
+/**
+ * Generate the HostConfig v2 golden-vector parity fixture.
+ *
+ * Runs a curated battery of inputs through the BUILT SDK canonicalizer + hash
+ * and writes `tests/fixtures/host-config-parity-fixtures.json`. The backend
+ * keeps a BYTE-IDENTICAL copy at
+ * `mcpjam-backend/tests/convex/fixtures/host-config-parity-fixtures.json` and
+ * asserts its own canonicalizer reproduces the same canonical JSON + sha256.
+ *
+ * Regenerate (and copy to the backend) whenever the canonicalizer changes:
+ *   npm run build && node scripts/gen-host-config-parity-fixture.mjs
+ *
+ * The top-level `__inputHash` pins the sha256 of the rows array so a partial
+ * edit to one repo's copy fails that repo's parity test loudly.
+ */
+
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  canonicalizeHostConfigV2,
+  computeHostConfigHashV2,
+  sha256Hex,
+} from "../dist/host-config/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outPath = join(here, "..", "tests", "fixtures", "host-config-parity-fixtures.json");
+
+/** Minimal valid base; spread + override per vector. */
+const base = () => ({
+  hostStyle: "claude",
+  modelId: "anthropic/claude-sonnet-4-6",
+  systemPrompt: "You are a helpful assistant.",
+  temperature: 0.7,
+  requireToolApproval: false,
+  connectionDefaults: { headers: {}, requestTimeout: 10000 },
+  clientCapabilities: {},
+  hostContext: {},
+});
+
+const inputs = [
+  { label: "base-minimal", input: base() },
+  {
+    label: "explicit-false-flags",
+    input: {
+      ...base(),
+      progressiveToolDiscovery: false,
+      respectToolVisibility: false,
+    },
+  },
+  {
+    label: "headers-and-caps-key-order",
+    input: {
+      ...base(),
+      connectionDefaults: {
+        headers: { "X-Z": "1", "A-Header": "2", "m-mid": "3" },
+        requestTimeout: 30000,
+      },
+      clientCapabilities: { zeta: true, alpha: { nested: 1, deep: 2 } },
+      hostContext: { b: 2, a: 1 },
+    },
+  },
+  {
+    label: "server-ids-unsorted-plus-overrides",
+    input: {
+      ...base(),
+      serverIds: ["srv-c", "srv-a", "srv-b"],
+      optionalServerIds: ["opt-z", "opt-a"],
+      serverConnectionOverrides: {
+        "srv-b": {
+          headersOverride: { "Z": "1", "A": "2" },
+          requestTimeoutOverride: 5000,
+          mcpProtocolVersionOverride: "2025-06-18",
+        },
+        // No-content entry is stripped during canonicalization.
+        "srv-a": {},
+      },
+    },
+  },
+  {
+    label: "mcp-profile-initialize-order-preserved",
+    input: {
+      ...base(),
+      mcpProfile: {
+        profileVersion: 1,
+        initialize: {
+          supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+          clientInfo: { version: "1.2.3", name: "mcpjam", title: "MCPJam" },
+        },
+      },
+    },
+  },
+  {
+    label: "mcp-profile-stateful-pin-derives-supported",
+    input: {
+      ...base(),
+      mcpProfile: { profileVersion: 1, mcpProtocolVersion: "2025-06-18" },
+    },
+  },
+  {
+    label: "mcp-profile-stateless-pin-no-derivation",
+    input: {
+      ...base(),
+      mcpProfile: { profileVersion: 1, mcpProtocolVersion: "2026-07-28" },
+    },
+  },
+  {
+    label: "sandbox-csp-restrictto-sorted-plus-directives",
+    input: {
+      ...base(),
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          sandbox: {
+            csp: {
+              mode: "declared",
+              restrictTo: {
+                connectDomains: ["b.example.com", "a.example.com", "b.example.com"],
+                frameDomains: ["x.example.com"],
+              },
+              cspDirectives: { "script-src": ["'wasm-unsafe-eval'", "'unsafe-eval'"] },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    label: "sandbox-permissions-allow-key-order",
+    input: {
+      ...base(),
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          sandbox: {
+            permissions: {
+              mode: "custom",
+              allow: { microphone: true, camera: false },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    label: "sandbox-allowfeatures-drops-spec-features",
+    input: {
+      ...base(),
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          sandbox: {
+            // camera/clipboard-write are spec features → dropped; fullscreen kept.
+            allowFeatures: { "camera": "*", "fullscreen": "'self'", "clipboard-write": "*" },
+          },
+        },
+      },
+    },
+  },
+  {
+    label: "compat-runtime-openai-overrides",
+    input: {
+      ...base(),
+      hostStyle: "chatgpt",
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          compatRuntime: {
+            openaiApps: true,
+            openaiAppsOverrides: {
+              requestDisplayMode: "fullscreen-only",
+              uploadFile: false,
+              callTool: true,
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    label: "mcp-apps-overrides-display-modes-reordered",
+    input: {
+      ...base(),
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          mcpAppsOverrides: {
+            availableDisplayModes: ["pip", "inline"],
+            widgetDisplayModeRequests: "user-initiated-only",
+            logging: true,
+          },
+        },
+      },
+    },
+  },
+  {
+    label: "host-capabilities-override-explicit-empty",
+    input: { ...base(), hostCapabilitiesOverride: {}, chatUiOverride: { logo: "x" } },
+  },
+  {
+    label: "adversarial-stray-deny-must-be-dropped",
+    input: {
+      ...base(),
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          sandbox: {
+            csp: {
+              mode: "declared",
+              restrictTo: { connectDomains: ["api.example.com"] },
+              // Stray legacy/foreign field — allowlist-only shape must drop it.
+              deny: { connectDomains: ["evil.example.com"] },
+            },
+            permissions: {
+              mode: "custom",
+              allow: { camera: true },
+              // Stray legacy deny[] — must be dropped.
+              deny: ["microphone"],
+            },
+          },
+        },
+      },
+    },
+  },
+];
+
+const rows = [];
+for (const { label, input } of inputs) {
+  const canonicalJson = JSON.stringify(canonicalizeHostConfigV2(input));
+  const sha256 = await computeHostConfigHashV2(input);
+  rows.push({ label, input, canonicalJson, sha256 });
+}
+
+const __inputHash = await sha256Hex(JSON.stringify(rows));
+const fixture = { __inputHash, rows };
+
+writeFileSync(outPath, JSON.stringify(fixture, null, 2) + "\n", "utf8");
+console.log(`Wrote ${rows.length} rows to ${outPath}`);
+console.log(`__inputHash: ${__inputHash}`);

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -191,22 +191,16 @@ export {
   type McpProtocolVersion,
 } from "./mcp-client-manager/mcp-protocol-version.js";
 
-// HostConfig v2 portable core (also exported from `@mcpjam/sdk/host-config`).
-// Browser-safe: pure shape + canonicalizer + Web Crypto hash, no Node deps.
+// HostConfig — the public `Host` builder (also at `@mcpjam/sdk/host-config`).
+// Browser-safe: the class wraps the pure canonicalizer + Web Crypto hash.
 // `McpProtocolVersion` is omitted here — already exported just above.
-export {
-  HOST_CONFIG_SCHEMA_VERSION_V2,
-  SEP_1865_PERMISSION_FEATURES,
-  canonicalizeHostConfigV2,
-  computeHostConfigHashV2,
-  sha256Hex,
-} from "./host-config/index.js";
+export { Host } from "./host-config/index.js";
 export type {
-  HostConfigInputV2,
-  CanonicalHostConfigV2,
-  HostConfigConnectionDefaults,
-  HostConfigMcpProfileV1,
-  HostConfigStyle,
+  HostInit,
+  HostJson,
+  HostMcp,
+  HostServerOverride,
+  HostConnectionDefaults,
   HostStyleId,
   ServerId,
   CspDomainSet,

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -190,3 +190,26 @@ export {
   isStatelessProtocolVersion,
   type McpProtocolVersion,
 } from "./mcp-client-manager/mcp-protocol-version.js";
+
+// HostConfig v2 portable core (also exported from `@mcpjam/sdk/host-config`).
+// Browser-safe: pure shape + canonicalizer + Web Crypto hash, no Node deps.
+// `McpProtocolVersion` is omitted here — already exported just above.
+export {
+  HOST_CONFIG_SCHEMA_VERSION_V2,
+  SEP_1865_PERMISSION_FEATURES,
+  canonicalizeHostConfigV2,
+  computeHostConfigHashV2,
+  sha256Hex,
+} from "./host-config/index.js";
+export type {
+  HostConfigInputV2,
+  CanonicalHostConfigV2,
+  HostConfigConnectionDefaults,
+  HostConfigMcpProfileV1,
+  HostConfigStyle,
+  HostStyleId,
+  ServerId,
+  CspDomainSet,
+  OpenAiAppsCapabilities,
+  McpAppsCapabilities,
+} from "./host-config/index.js";

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -1,0 +1,945 @@
+/**
+ * HostConfig v2 canonicalizer — pure, browser-safe, byte-stable.
+ *
+ * SOURCE OF TRUTH (hand-mirrored by `convex/lib/hostConfigV2.ts`). Stable key
+ * ordering matters for hash stability across runtimes: we JSON.stringify the
+ * canonical object; Object.keys preserves insertion order, so we build output
+ * with a fixed key order rather than spreading user input. Any behavior change
+ * here must be mirrored in the backend in lockstep and the parity fixtures
+ * regenerated (see `./types.ts` header).
+ */
+
+import {
+  isKnownProtocolVersion,
+  isStatelessProtocolVersion,
+  MCP_PROTOCOL_VERSIONS,
+  type McpProtocolVersion,
+} from "../mcp-client-manager/mcp-protocol-version.js";
+import {
+  HOST_CONFIG_SCHEMA_VERSION_V2,
+  SEP_1865_PERMISSION_FEATURES,
+  type CanonicalHostConfigV2,
+  type CspDomainSet,
+  type HostConfigInputV2,
+  type HostConfigMcpProfileV1,
+  type McpAppsCapabilities,
+  type OpenAiAppsCapabilities,
+  type ServerId,
+} from "./types.js";
+
+// Allowed keys on `openaiAppsOverrides`. Centralized so the canonicalizer's
+// typo-rejection stays in sync with the type — if you add a method to
+// `OpenAiAppsCapabilities`, add it here too.
+const OPENAI_APPS_CAPABILITY_KEYS = [
+  "callTool",
+  "sendFollowUpMessage",
+  "setWidgetState",
+  "requestDisplayMode",
+  "notifyIntrinsicHeight",
+  "openExternal",
+  "setOpenInAppUrl",
+  "requestModal",
+  "uploadFile",
+  "selectFiles",
+  "getFileDownloadUrl",
+  "requestCheckout",
+  "requestClose",
+] as const satisfies ReadonlyArray<keyof OpenAiAppsCapabilities>;
+
+const OPENAI_APPS_CAPABILITY_KEY_SET: ReadonlySet<string> = new Set(
+  OPENAI_APPS_CAPABILITY_KEYS,
+);
+
+const OPENAI_APPS_REQUEST_DISPLAY_MODE_VALUES = [
+  "all",
+  "fullscreen-only",
+  "none",
+] as const;
+
+// Allowed keys on `mcpAppsOverrides`. Centralized for typo defense.
+const MCP_APPS_CAPABILITY_KEYS = [
+  "availableDisplayModes",
+  "toolInputPartial",
+  "toolCancelled",
+  "hostContextChanged",
+  "resourceTeardown",
+  "toolInfo",
+  "openLinks",
+  "serverTools",
+  "serverResources",
+  "logging",
+  "updateModelContext",
+  "message",
+  "sandboxPermissions",
+  "cspFrameDomains",
+  "cspBaseUriDomains",
+  "resourcePrefersBorder",
+  "downloadFile",
+  "requestTeardown",
+  "widgetDisplayModeRequests",
+] as const satisfies ReadonlyArray<keyof McpAppsCapabilities>;
+
+const MCP_APPS_CAPABILITY_KEY_SET: ReadonlySet<string> = new Set(
+  MCP_APPS_CAPABILITY_KEYS,
+);
+
+const MCP_APPS_DISPLAY_MODE_VALUES = ["inline", "fullscreen", "pip"] as const;
+
+const MCP_APPS_WIDGET_DISPLAY_MODE_REQUEST_VALUES = [
+  "accept",
+  "user-initiated-only",
+  "decline",
+] as const;
+
+const MCP_APPS_DISPLAY_MODE_VALUE_SET: ReadonlySet<string> = new Set(
+  MCP_APPS_DISPLAY_MODE_VALUES,
+);
+
+function sortStringKeys<T extends Record<string, unknown>>(input: T): T {
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(input).sort()) out[k] = input[k];
+  return out as T;
+}
+
+// Deep variant: recursively sorts keys at every object level so nested
+// records hash the same regardless of original key order.
+function deepSortStringKeys<T>(input: T): T {
+  if (Array.isArray(input)) {
+    return input.map((v) => deepSortStringKeys(v)) as unknown as T;
+  }
+  if (input && typeof input === "object") {
+    const out: Record<string, unknown> = {};
+    const src = input as Record<string, unknown>;
+    for (const k of Object.keys(src).sort()) {
+      out[k] = deepSortStringKeys(src[k]);
+    }
+    return out as T;
+  }
+  return input;
+}
+
+// Plain-object guard shared by hostCapabilitiesOverride and mcpProfile.
+// Arrays/null satisfy `typeof === 'object'`; the canonicalizer is the
+// chokepoint.
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Canonicalize a CSP domain list as a SET: trim, drop empty, dedupe, sort.
+// Order has no meaning for CSP allowlists (contrast supportedProtocolVersions,
+// where order IS semantic).
+function canonicalizeCspDomainList(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(
+      "hostConfigV2: mcpProfile CSP domain list must be a string[]",
+    );
+  }
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      throw new Error(
+        "hostConfigV2: mcpProfile CSP domain list entries must be strings",
+      );
+    }
+    const trimmed = entry.trim();
+    if (trimmed === "") continue;
+    seen.add(trimmed);
+  }
+  return Array.from(seen).sort();
+}
+
+function canonicalizeCspDomainSet(value: unknown): CspDomainSet | undefined {
+  if (value === undefined) return undefined;
+  if (!isPlainObject(value)) {
+    throw new Error(
+      "hostConfigV2: mcpProfile CSP restrictTo must be a plain object",
+    );
+  }
+  const out: CspDomainSet = {};
+  const src = value as Record<string, unknown>;
+  for (const key of [
+    "connectDomains",
+    "resourceDomains",
+    "frameDomains",
+    "baseUriDomains",
+  ] as const) {
+    const canonical = canonicalizeCspDomainList(src[key]);
+    if (canonical !== undefined) out[key] = canonical;
+  }
+  // Preserve unknown keys verbatim so future CSP directive families
+  // round-trip without a schema bump. Deep-sort them for hash stability.
+  for (const key of Object.keys(src).sort()) {
+    if (
+      key === "connectDomains" ||
+      key === "resourceDomains" ||
+      key === "frameDomains" ||
+      key === "baseUriDomains"
+    ) {
+      continue;
+    }
+    (out as Record<string, unknown>)[key] = deepSortStringKeys(src[key]);
+  }
+  // Re-key in sorted order for stable JSON output.
+  const sorted: CspDomainSet = {};
+  for (const key of Object.keys(out).sort()) {
+    (sorted as Record<string, unknown>)[key] = (out as Record<string, unknown>)[
+      key
+    ];
+  }
+  return sorted;
+}
+
+// Canonicalize the inspector-only `allowFeatures` extra Permissions Policy
+// entries. Keys are kebab-case Permissions Policy tokens; values are allowlist
+// strings. The 4 spec features are silently dropped — `permissions.allow` is
+// the single source of truth for them.
+function canonicalizeAllowFeatures(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (value === undefined) return undefined;
+  if (!isPlainObject(value)) {
+    throw new Error(
+      "hostConfigV2: mcpProfile.apps.sandbox.allowFeatures must be a plain object",
+    );
+  }
+  const dropped = new Set<string>(SEP_1865_PERMISSION_FEATURES);
+  const out: Record<string, string> = {};
+  for (const k of Object.keys(value).sort()) {
+    // Strict Permissions Policy feature-name token: lowercase ASCII kebab,
+    // starting with a letter. Anything looser lets a pasted key like
+    // " camera" slip past `dropped.has(k)` and re-grant a spec feature.
+    if (!/^[a-z][a-z0-9-]*$/.test(k)) {
+      throw new Error(
+        `hostConfigV2: mcpProfile.apps.sandbox.allowFeatures key "${k}" must be a lowercase kebab-case Permissions Policy token (^[a-z][a-z0-9-]*$)`,
+      );
+    }
+    if (dropped.has(k)) continue;
+    const v = (value as Record<string, unknown>)[k];
+    if (typeof v !== "string") {
+      throw new Error(
+        `hostConfigV2: mcpProfile.apps.sandbox.allowFeatures.${k} must be a string`,
+      );
+    }
+    // Reject Permissions Policy directive separators in values (`;` iframe
+    // allow= separator, `,` HTTP header separator) — injection guard.
+    if (/[;,]/.test(v)) {
+      throw new Error(
+        `hostConfigV2: mcpProfile.apps.sandbox.allowFeatures.${k} must not contain ';' or ',' (Permissions Policy directive separators)`,
+      );
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+// Canonicalize the inspector-only `cspDirectives` per-directive
+// source-expression overrides. Rejects `;`/`,` in names and values
+// (CSP directive separators) — injection guard.
+function canonicalizeCspDirectives(
+  value: unknown,
+): Record<string, string[]> | undefined {
+  if (value === undefined) return undefined;
+  if (!isPlainObject(value)) {
+    throw new Error(
+      "hostConfigV2: mcpProfile.apps.sandbox.csp.cspDirectives must be a plain object",
+    );
+  }
+  const out: Record<string, string[]> = {};
+  for (const k of Object.keys(value).sort()) {
+    if (!/^[a-z][a-z0-9-]*$/.test(k)) {
+      throw new Error(
+        `hostConfigV2: mcpProfile.apps.sandbox.csp.cspDirectives key "${k}" must be a lowercase kebab-case CSP directive name (^[a-z][a-z0-9-]*$)`,
+      );
+    }
+    const arr = (value as Record<string, unknown>)[k];
+    if (!Array.isArray(arr)) {
+      throw new Error(
+        `hostConfigV2: mcpProfile.apps.sandbox.csp.cspDirectives.${k} must be a string[]`,
+      );
+    }
+    const seen = new Set<string>();
+    for (const entry of arr) {
+      if (typeof entry !== "string") {
+        throw new Error(
+          `hostConfigV2: mcpProfile.apps.sandbox.csp.cspDirectives.${k} entries must be strings`,
+        );
+      }
+      const trimmed = entry.trim();
+      if (trimmed === "") continue;
+      if (/[;,]/.test(trimmed)) {
+        throw new Error(
+          `hostConfigV2: mcpProfile.apps.sandbox.csp.cspDirectives.${k} entry "${trimmed}" must not contain ';' or ',' (CSP directive separators — injection guard)`,
+        );
+      }
+      seen.add(trimmed);
+    }
+    out[k] = Array.from(seen).sort();
+  }
+  return out;
+}
+
+function canonicalizeMcpProfile(
+  input: HostConfigMcpProfileV1 | undefined,
+): HostConfigMcpProfileV1 | undefined {
+  if (input === undefined) return undefined;
+  if (!isPlainObject(input)) {
+    throw new Error("hostConfigV2: mcpProfile must be a plain object");
+  }
+  // Forward-compat trip wire: a future profileVersion: 2 shape must NOT
+  // silently round-trip through a v1 reader.
+  if ((input as { profileVersion?: unknown }).profileVersion !== 1) {
+    throw new Error("hostConfigV2: mcpProfile.profileVersion must be 1");
+  }
+
+  const out: HostConfigMcpProfileV1 = { profileVersion: 1 };
+
+  // Host-default pinned MCP protocol version. Absent → SDK chooses at resolve
+  // time; we drop the field when absent so pre-feature rows hash identically.
+  if (input.mcpProtocolVersion !== undefined) {
+    if (!isKnownProtocolVersion(input.mcpProtocolVersion)) {
+      throw new Error(
+        `hostConfigV2: mcpProfile.mcpProtocolVersion must be one of ${MCP_PROTOCOL_VERSIONS.join(", ")} (got "${String(input.mcpProtocolVersion)}")`,
+      );
+    }
+    out.mcpProtocolVersion = input.mcpProtocolVersion;
+  }
+
+  if (input.initialize !== undefined) {
+    if (!isPlainObject(input.initialize)) {
+      throw new Error(
+        "hostConfigV2: mcpProfile.initialize must be a plain object",
+      );
+    }
+    const initOut: NonNullable<HostConfigMcpProfileV1["initialize"]> = {};
+
+    if (input.initialize.supportedProtocolVersions !== undefined) {
+      const versions = input.initialize.supportedProtocolVersions;
+      if (!Array.isArray(versions)) {
+        throw new Error(
+          "hostConfigV2: mcpProfile.initialize.supportedProtocolVersions must be a string[]",
+        );
+      }
+      if (versions.length === 0) {
+        throw new Error(
+          "hostConfigV2: mcpProfile.initialize.supportedProtocolVersions must be a non-empty array when set (omit the field to use SDK defaults)",
+        );
+      }
+      for (const v of versions) {
+        if (typeof v !== "string") {
+          throw new Error(
+            "hostConfigV2: mcpProfile.initialize.supportedProtocolVersions entries must be strings",
+          );
+        }
+        if (v.trim() === "") {
+          throw new Error(
+            "hostConfigV2: mcpProfile.initialize.supportedProtocolVersions entries must be non-empty strings",
+          );
+        }
+      }
+      // Order is semantic — do NOT sort or dedupe. Preserve verbatim.
+      initOut.supportedProtocolVersions = [...versions];
+    }
+
+    if (input.initialize.clientInfo !== undefined) {
+      const ci = input.initialize.clientInfo;
+      if (!isPlainObject(ci)) {
+        throw new Error(
+          "hostConfigV2: mcpProfile.initialize.clientInfo must be a plain object",
+        );
+      }
+      // Soft validation — name & version required by the MCP lifecycle spec.
+      const name = ci.name;
+      const version = ci.version;
+      if (typeof name !== "string" || name.trim() === "") {
+        throw new Error(
+          "hostConfigV2: mcpProfile.initialize.clientInfo.name must be a non-empty string",
+        );
+      }
+      if (typeof version !== "string" || version.trim() === "") {
+        throw new Error(
+          "hostConfigV2: mcpProfile.initialize.clientInfo.version must be a non-empty string",
+        );
+      }
+      initOut.clientInfo = deepSortStringKeys(ci);
+    }
+
+    // Skip empty initialize{} so absent-vs-present hashing remains honest.
+    if (Object.keys(initOut).length > 0) {
+      const sortedInit: NonNullable<HostConfigMcpProfileV1["initialize"]> = {};
+      for (const k of Object.keys(initOut).sort()) {
+        (sortedInit as Record<string, unknown>)[k] = (
+          initOut as Record<string, unknown>
+        )[k];
+      }
+      out.initialize = sortedInit;
+    }
+  }
+
+  // Cross-field rule (Option A): when `mcpProtocolVersion` pins a stateful
+  // (pre-2026) version, the legacy `initialize` handshake runs and must
+  // advertise that exact version. Derive when caller didn't set one; throw if
+  // they set both AND the pin isn't in the list. Stateless versions skip
+  // initialize entirely, so leave `supportedProtocolVersions` alone there.
+  if (
+    out.mcpProtocolVersion !== undefined &&
+    !isStatelessProtocolVersion(out.mcpProtocolVersion)
+  ) {
+    const advertised = out.initialize?.supportedProtocolVersions;
+    if (advertised === undefined) {
+      const initBase = out.initialize ?? {};
+      const initWithDerived: NonNullable<
+        HostConfigMcpProfileV1["initialize"]
+      > = {
+        ...initBase,
+        supportedProtocolVersions: [out.mcpProtocolVersion],
+      };
+      const sortedInit: NonNullable<HostConfigMcpProfileV1["initialize"]> = {};
+      for (const k of Object.keys(initWithDerived).sort()) {
+        (sortedInit as Record<string, unknown>)[k] = (
+          initWithDerived as Record<string, unknown>
+        )[k];
+      }
+      out.initialize = sortedInit;
+    } else if (!advertised.includes(out.mcpProtocolVersion)) {
+      throw new Error(
+        `hostConfigV2: ConflictingProtocolVersionPin — mcpProtocolVersion "${out.mcpProtocolVersion}" is not in initialize.supportedProtocolVersions [${advertised.join(", ")}]. Either omit one or align them.`,
+      );
+    }
+  }
+
+  if (input.apps !== undefined) {
+    if (!isPlainObject(input.apps)) {
+      throw new Error("hostConfigV2: mcpProfile.apps must be a plain object");
+    }
+    const appsOut: NonNullable<HostConfigMcpProfileV1["apps"]> = {};
+    if (input.apps.sandbox !== undefined) {
+      if (!isPlainObject(input.apps.sandbox)) {
+        throw new Error(
+          "hostConfigV2: mcpProfile.apps.sandbox must be a plain object",
+        );
+      }
+      const sandboxIn = input.apps.sandbox;
+      const sandboxOut: NonNullable<
+        NonNullable<HostConfigMcpProfileV1["apps"]>["sandbox"]
+      > = {};
+
+      if (sandboxIn.csp !== undefined) {
+        if (!isPlainObject(sandboxIn.csp)) {
+          throw new Error(
+            "hostConfigV2: mcpProfile.apps.sandbox.csp must be a plain object",
+          );
+        }
+        // Note: there is NO `csp.deny` field. SEP-1865 is allowlist-only —
+        // `restrictTo` is the entire hardening lever. The runtime CSP
+        // resolver (sdk `sandbox-policy.ts`) carries deny + a hosted clamp,
+        // but that is a different layer and never persists here. If you're
+        // tempted to add deny back, talk to whoever owns the resolver first.
+        const cspOut: NonNullable<
+          NonNullable<
+            NonNullable<HostConfigMcpProfileV1["apps"]>["sandbox"]
+          >["csp"]
+        > = {};
+        if (sandboxIn.csp.mode !== undefined) {
+          if (
+            sandboxIn.csp.mode !== "host-default" &&
+            sandboxIn.csp.mode !== "declared" &&
+            sandboxIn.csp.mode !== "relaxed"
+          ) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.sandbox.csp.mode must be 'host-default' | 'declared' | 'relaxed'",
+            );
+          }
+          cspOut.mode = sandboxIn.csp.mode;
+        }
+        const restrictTo = canonicalizeCspDomainSet(sandboxIn.csp.restrictTo);
+        if (restrictTo !== undefined) cspOut.restrictTo = restrictTo;
+        const cspDirectives = canonicalizeCspDirectives(
+          (sandboxIn.csp as { cspDirectives?: unknown }).cspDirectives,
+        );
+        if (cspDirectives !== undefined)
+          (
+            cspOut as { cspDirectives?: Record<string, string[]> }
+          ).cspDirectives = cspDirectives;
+        if (sandboxIn.csp.extensions !== undefined) {
+          if (!isPlainObject(sandboxIn.csp.extensions)) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.sandbox.csp.extensions must be a plain object",
+            );
+          }
+          cspOut.extensions = deepSortStringKeys(sandboxIn.csp.extensions);
+        }
+        // Re-key in sorted order.
+        const sortedCsp = {} as typeof cspOut;
+        for (const k of Object.keys(cspOut).sort()) {
+          (sortedCsp as Record<string, unknown>)[k] = (
+            cspOut as Record<string, unknown>
+          )[k];
+        }
+        sandboxOut.csp = sortedCsp;
+      }
+
+      if (sandboxIn.permissions !== undefined) {
+        if (!isPlainObject(sandboxIn.permissions)) {
+          throw new Error(
+            "hostConfigV2: mcpProfile.apps.sandbox.permissions must be a plain object",
+          );
+        }
+        const permsIn = sandboxIn.permissions;
+        const permsOut: NonNullable<
+          NonNullable<
+            NonNullable<HostConfigMcpProfileV1["apps"]>["sandbox"]
+          >["permissions"]
+        > = {};
+        if (permsIn.mode !== undefined) {
+          if (
+            permsIn.mode !== "resource-declared" &&
+            permsIn.mode !== "deny-all" &&
+            permsIn.mode !== "custom"
+          ) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.sandbox.permissions.mode must be 'resource-declared' | 'deny-all' | 'custom'",
+            );
+          }
+          permsOut.mode = permsIn.mode;
+        }
+        if (permsIn.allow !== undefined) {
+          if (!isPlainObject(permsIn.allow)) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.sandbox.permissions.allow must be a plain object",
+            );
+          }
+          const allowOut: Record<string, boolean> = {};
+          for (const k of Object.keys(permsIn.allow).sort()) {
+            const v = (permsIn.allow as Record<string, unknown>)[k];
+            if (typeof v !== "boolean") {
+              throw new Error(
+                `hostConfigV2: mcpProfile.apps.sandbox.permissions.allow.${k} must be a boolean`,
+              );
+            }
+            allowOut[k] = v;
+          }
+          permsOut.allow = allowOut;
+        }
+        if (permsIn.extensions !== undefined) {
+          if (!isPlainObject(permsIn.extensions)) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.sandbox.permissions.extensions must be a plain object",
+            );
+          }
+          permsOut.extensions = deepSortStringKeys(permsIn.extensions);
+        }
+        const sortedPerms = {} as typeof permsOut;
+        for (const k of Object.keys(permsOut).sort()) {
+          (sortedPerms as Record<string, unknown>)[k] = (
+            permsOut as Record<string, unknown>
+          )[k];
+        }
+        sandboxOut.permissions = sortedPerms;
+      }
+
+      if (
+        (sandboxIn as { sandboxAttrs?: unknown }).sandboxAttrs !== undefined
+      ) {
+        const sandboxAttrs = canonicalizeCspDomainList(
+          (sandboxIn as { sandboxAttrs?: unknown }).sandboxAttrs,
+        );
+        if (sandboxAttrs !== undefined) {
+          (sandboxOut as { sandboxAttrs?: string[] }).sandboxAttrs =
+            sandboxAttrs;
+        }
+      }
+
+      if (
+        (sandboxIn as { allowFeatures?: unknown }).allowFeatures !== undefined
+      ) {
+        const allowFeatures = canonicalizeAllowFeatures(
+          (sandboxIn as { allowFeatures?: unknown }).allowFeatures,
+        );
+        if (allowFeatures !== undefined) {
+          (
+            sandboxOut as { allowFeatures?: Record<string, string> }
+          ).allowFeatures = allowFeatures;
+        }
+      }
+
+      if (Object.keys(sandboxOut).length > 0) {
+        const sortedSandbox = {} as typeof sandboxOut;
+        for (const k of Object.keys(sandboxOut).sort()) {
+          (sortedSandbox as Record<string, unknown>)[k] = (
+            sandboxOut as Record<string, unknown>
+          )[k];
+        }
+        appsOut.sandbox = sortedSandbox;
+      }
+    }
+    if (input.apps.uiInitialize !== undefined) {
+      if (!isPlainObject(input.apps.uiInitialize)) {
+        throw new Error(
+          "hostConfigV2: mcpProfile.apps.uiInitialize must be a plain object",
+        );
+      }
+      const uiInitOut: NonNullable<
+        NonNullable<HostConfigMcpProfileV1["apps"]>["uiInitialize"]
+      > = {};
+      if (input.apps.uiInitialize.hostInfo !== undefined) {
+        const hi = input.apps.uiInitialize.hostInfo;
+        if (!isPlainObject(hi)) {
+          throw new Error(
+            "hostConfigV2: mcpProfile.apps.uiInitialize.hostInfo must be a plain object",
+          );
+        }
+        // Mirror the soft validation applied to initialize.clientInfo.
+        const name = (hi as Record<string, unknown>).name;
+        if (typeof name !== "string" || name.trim() === "") {
+          throw new Error(
+            "hostConfigV2: mcpProfile.apps.uiInitialize.hostInfo.name must be a non-empty string",
+          );
+        }
+        const version = (hi as Record<string, unknown>).version;
+        if (typeof version !== "string" || version.trim() === "") {
+          throw new Error(
+            "hostConfigV2: mcpProfile.apps.uiInitialize.hostInfo.version must be a non-empty string",
+          );
+        }
+        uiInitOut.hostInfo = deepSortStringKeys(hi);
+      }
+      if (Object.keys(uiInitOut).length > 0) {
+        const sortedUiInit = {} as typeof uiInitOut;
+        for (const k of Object.keys(uiInitOut).sort()) {
+          (sortedUiInit as Record<string, unknown>)[k] = (
+            uiInitOut as Record<string, unknown>
+          )[k];
+        }
+        appsOut.uiInitialize = sortedUiInit;
+      }
+    }
+    if (
+      (input.apps as { compatRuntime?: unknown }).compatRuntime !== undefined
+    ) {
+      const compatRuntimeIn = (input.apps as { compatRuntime?: unknown })
+        .compatRuntime;
+      if (!isPlainObject(compatRuntimeIn)) {
+        throw new Error(
+          "hostConfigV2: mcpProfile.apps.compatRuntime must be a plain object",
+        );
+      }
+      const compatRuntimeOut: NonNullable<
+        NonNullable<HostConfigMcpProfileV1["apps"]>["compatRuntime"]
+      > = {};
+      const compatRecord = compatRuntimeIn as Record<string, unknown>;
+      const openaiApps = compatRecord.openaiApps;
+      if (openaiApps !== undefined) {
+        if (typeof openaiApps !== "boolean") {
+          throw new Error(
+            "hostConfigV2: mcpProfile.apps.compatRuntime.openaiApps must be a boolean",
+          );
+        }
+        compatRuntimeOut.openaiApps = openaiApps;
+      }
+      const openaiAppsOverridesIn = compatRecord.openaiAppsOverrides;
+      if (openaiAppsOverridesIn !== undefined) {
+        if (!isPlainObject(openaiAppsOverridesIn)) {
+          throw new Error(
+            "hostConfigV2: mcpProfile.apps.compatRuntime.openaiAppsOverrides must be a plain object",
+          );
+        }
+        const overridesOut: OpenAiAppsCapabilities = {};
+        for (const [key, value] of Object.entries(openaiAppsOverridesIn)) {
+          if (!OPENAI_APPS_CAPABILITY_KEY_SET.has(key)) {
+            throw new Error(
+              `hostConfigV2: mcpProfile.apps.compatRuntime.openaiAppsOverrides has unknown key "${key}"`,
+            );
+          }
+          if (key === "requestDisplayMode") {
+            if (
+              typeof value !== "string" ||
+              !(
+                OPENAI_APPS_REQUEST_DISPLAY_MODE_VALUES as readonly string[]
+              ).includes(value)
+            ) {
+              throw new Error(
+                'hostConfigV2: mcpProfile.apps.compatRuntime.openaiAppsOverrides.requestDisplayMode must be "all" | "fullscreen-only" | "none"',
+              );
+            }
+            overridesOut.requestDisplayMode =
+              value as OpenAiAppsCapabilities["requestDisplayMode"];
+          } else {
+            if (typeof value !== "boolean") {
+              throw new Error(
+                `hostConfigV2: mcpProfile.apps.compatRuntime.openaiAppsOverrides.${key} must be a boolean`,
+              );
+            }
+            (overridesOut as Record<string, unknown>)[key] = value;
+          }
+        }
+        // Empty `{}` collapses to absent (same runtime behavior as absent).
+        if (Object.keys(overridesOut).length > 0) {
+          const sortedOverrides = {} as OpenAiAppsCapabilities;
+          for (const k of Object.keys(overridesOut).sort()) {
+            (sortedOverrides as Record<string, unknown>)[k] = (
+              overridesOut as Record<string, unknown>
+            )[k];
+          }
+          compatRuntimeOut.openaiAppsOverrides = sortedOverrides;
+        }
+      }
+      if (Object.keys(compatRuntimeOut).length > 0) {
+        const sortedCompat = {} as typeof compatRuntimeOut;
+        for (const k of Object.keys(compatRuntimeOut).sort()) {
+          (sortedCompat as Record<string, unknown>)[k] = (
+            compatRuntimeOut as Record<string, unknown>
+          )[k];
+        }
+        appsOut.compatRuntime = sortedCompat;
+      }
+    }
+    if (
+      (input.apps as { mcpAppsOverrides?: unknown }).mcpAppsOverrides !==
+      undefined
+    ) {
+      const mcpAppsOverridesIn = (input.apps as { mcpAppsOverrides?: unknown })
+        .mcpAppsOverrides;
+      if (!isPlainObject(mcpAppsOverridesIn)) {
+        throw new Error(
+          "hostConfigV2: mcpProfile.apps.mcpAppsOverrides must be a plain object",
+        );
+      }
+      const mcpAppsOverridesOut: McpAppsCapabilities = {};
+      for (const [key, value] of Object.entries(mcpAppsOverridesIn)) {
+        if (!MCP_APPS_CAPABILITY_KEY_SET.has(key)) {
+          throw new Error(
+            `hostConfigV2: mcpProfile.apps.mcpAppsOverrides has unknown key "${key}"`,
+          );
+        }
+        if (key === "availableDisplayModes") {
+          if (!Array.isArray(value)) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.mcpAppsOverrides.availableDisplayModes must be an array",
+            );
+          }
+          if (value.length === 0) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.mcpAppsOverrides.availableDisplayModes must contain at least one mode",
+            );
+          }
+          const seen = new Set<string>();
+          for (const entry of value) {
+            if (
+              typeof entry !== "string" ||
+              !MCP_APPS_DISPLAY_MODE_VALUE_SET.has(entry)
+            ) {
+              throw new Error(
+                'hostConfigV2: mcpProfile.apps.mcpAppsOverrides.availableDisplayModes entries must be "inline" | "fullscreen" | "pip"',
+              );
+            }
+            seen.add(entry);
+          }
+          mcpAppsOverridesOut.availableDisplayModes =
+            MCP_APPS_DISPLAY_MODE_VALUES.filter((m) =>
+              seen.has(m),
+            ) as McpAppsCapabilities["availableDisplayModes"];
+        } else if (key === "widgetDisplayModeRequests") {
+          if (
+            typeof value !== "string" ||
+            !(
+              MCP_APPS_WIDGET_DISPLAY_MODE_REQUEST_VALUES as readonly string[]
+            ).includes(value)
+          ) {
+            throw new Error(
+              'hostConfigV2: mcpProfile.apps.mcpAppsOverrides.widgetDisplayModeRequests must be "accept" | "user-initiated-only" | "decline"',
+            );
+          }
+          mcpAppsOverridesOut.widgetDisplayModeRequests =
+            value as McpAppsCapabilities["widgetDisplayModeRequests"];
+        } else {
+          if (typeof value !== "boolean") {
+            throw new Error(
+              `hostConfigV2: mcpProfile.apps.mcpAppsOverrides.${key} must be a boolean`,
+            );
+          }
+          (mcpAppsOverridesOut as Record<string, unknown>)[key] = value;
+        }
+      }
+      // Empty `{}` collapses to absent (use preset for all dimensions).
+      if (Object.keys(mcpAppsOverridesOut).length > 0) {
+        const sortedMcpApps = {} as McpAppsCapabilities;
+        for (const k of Object.keys(mcpAppsOverridesOut).sort()) {
+          (sortedMcpApps as Record<string, unknown>)[k] = (
+            mcpAppsOverridesOut as Record<string, unknown>
+          )[k];
+        }
+        appsOut.mcpAppsOverrides = sortedMcpApps;
+      }
+    }
+    if (Object.keys(appsOut).length > 0) {
+      const sortedApps = {} as typeof appsOut;
+      for (const k of Object.keys(appsOut).sort()) {
+        (sortedApps as Record<string, unknown>)[k] = (
+          appsOut as Record<string, unknown>
+        )[k];
+      }
+      out.apps = sortedApps;
+    }
+  }
+
+  if (input.extensions !== undefined) {
+    if (!isPlainObject(input.extensions)) {
+      throw new Error(
+        "hostConfigV2: mcpProfile.extensions must be a plain object",
+      );
+    }
+    out.extensions = deepSortStringKeys(input.extensions);
+  }
+
+  // Re-key the top level deterministically (profileVersion first, then sorted).
+  const sorted: HostConfigMcpProfileV1 = { profileVersion: 1 };
+  for (const k of Object.keys(out).sort()) {
+    if (k === "profileVersion") continue;
+    (sorted as Record<string, unknown>)[k] = (out as Record<string, unknown>)[
+      k
+    ];
+  }
+  return sorted;
+}
+
+// Normalize per-server connection overrides for stable hashing.
+// - Validates all keys are in serverIds ∪ optionalServerIds.
+// - Strips entries that carry no information.
+// - Returns undefined when the normalized result is empty.
+function canonicalizeServerConnectionOverrides(
+  serverIds: Array<ServerId>,
+  optionalServerIds: Array<ServerId>,
+  overrides: HostConfigInputV2["serverConnectionOverrides"],
+): CanonicalHostConfigV2["serverConnectionOverrides"] {
+  if (!overrides || Object.keys(overrides).length === 0) return undefined;
+  const allowedIds = new Set<string>([...serverIds, ...optionalServerIds]);
+  const result: Record<
+    string,
+    {
+      headersOverride?: Record<string, string>;
+      requestTimeoutOverride?: number;
+      mcpProtocolVersionOverride?: McpProtocolVersion;
+    }
+  > = {};
+  for (const [serverId, entry] of Object.entries(overrides)) {
+    if (!allowedIds.has(serverId)) {
+      throw new Error(
+        `hostConfigV2: serverConnectionOverrides key "${serverId}" is not in serverIds or optionalServerIds`,
+      );
+    }
+    if (!entry) continue;
+    const normalizedHeaders =
+      entry.headersOverride && Object.keys(entry.headersOverride).length > 0
+        ? sortStringKeys(entry.headersOverride)
+        : undefined;
+    let mcpProtocolVersionOverride: McpProtocolVersion | undefined;
+    if (entry.mcpProtocolVersionOverride !== undefined) {
+      if (!isKnownProtocolVersion(entry.mcpProtocolVersionOverride)) {
+        throw new Error(
+          `hostConfigV2: serverConnectionOverrides["${serverId}"].mcpProtocolVersionOverride must be one of ${MCP_PROTOCOL_VERSIONS.join(", ")} (got "${String(entry.mcpProtocolVersionOverride)}")`,
+        );
+      }
+      mcpProtocolVersionOverride = entry.mcpProtocolVersionOverride;
+    }
+    const hasContent =
+      normalizedHeaders !== undefined ||
+      entry.requestTimeoutOverride !== undefined ||
+      mcpProtocolVersionOverride !== undefined;
+    if (hasContent) {
+      const entryOut: {
+        headersOverride?: Record<string, string>;
+        requestTimeoutOverride?: number;
+        mcpProtocolVersionOverride?: McpProtocolVersion;
+      } = {
+        ...(normalizedHeaders !== undefined
+          ? { headersOverride: normalizedHeaders }
+          : {}),
+        ...(entry.requestTimeoutOverride !== undefined
+          ? { requestTimeoutOverride: entry.requestTimeoutOverride }
+          : {}),
+        ...(mcpProtocolVersionOverride !== undefined
+          ? { mcpProtocolVersionOverride }
+          : {}),
+      };
+      // Sort inner keys for hash stability across runtimes.
+      result[serverId] = sortStringKeys(entryOut);
+    }
+  }
+  if (Object.keys(result).length === 0) return undefined;
+  // Sort outer keys for hash stability.
+  return sortStringKeys(
+    result,
+  ) as CanonicalHostConfigV2["serverConnectionOverrides"];
+}
+
+export function canonicalizeHostConfigV2(
+  input: HostConfigInputV2,
+): CanonicalHostConfigV2 {
+  if (!Number.isFinite(input.temperature)) {
+    throw new Error("hostConfigV2: temperature must be finite");
+  }
+  if (!Number.isFinite(input.connectionDefaults.requestTimeout)) {
+    throw new Error(
+      "hostConfigV2: connectionDefaults.requestTimeout must be finite",
+    );
+  }
+  if (
+    input.hostCapabilitiesOverride !== undefined &&
+    (input.hostCapabilitiesOverride === null ||
+      typeof input.hostCapabilitiesOverride !== "object" ||
+      Array.isArray(input.hostCapabilitiesOverride))
+  ) {
+    throw new Error(
+      "hostConfigV2: hostCapabilitiesOverride must be a plain object",
+    );
+  }
+  if (
+    input.chatUiOverride !== undefined &&
+    (input.chatUiOverride === null ||
+      typeof input.chatUiOverride !== "object" ||
+      Array.isArray(input.chatUiOverride))
+  ) {
+    throw new Error("hostConfigV2: chatUiOverride must be a plain object");
+  }
+  return {
+    schemaVersion: HOST_CONFIG_SCHEMA_VERSION_V2,
+    hostStyle: input.hostStyle,
+    modelId: input.modelId,
+    systemPrompt: input.systemPrompt,
+    temperature: input.temperature,
+    requireToolApproval: input.requireToolApproval,
+    // Preserve undefined-vs-set: absent hashes byte-identically to a
+    // pre-feature row; explicit `false` writes a key and hashes distinctly.
+    progressiveToolDiscovery: input.progressiveToolDiscovery,
+    respectToolVisibility: input.respectToolVisibility,
+    // Normalize undefined → [] BEFORE sort so canonical/hash output is
+    // identical to the pre-tolerance "explicit empty array" case.
+    serverIds: [...(input.serverIds ?? [])].sort() as Array<ServerId>,
+    optionalServerIds: [...(input.optionalServerIds ?? [])].sort() as Array<
+      ServerId
+    >,
+    connectionDefaults: {
+      headers: sortStringKeys(input.connectionDefaults.headers),
+      requestTimeout: input.connectionDefaults.requestTimeout,
+    },
+    clientCapabilities: sortStringKeys(input.clientCapabilities ?? {}),
+    hostContext: sortStringKeys(input.hostContext ?? {}),
+    // Preserve undefined (omitted → dedupes with preset) vs {} (explicit empty
+    // → hashes distinctly).
+    hostCapabilitiesOverride:
+      input.hostCapabilitiesOverride === undefined
+        ? undefined
+        : deepSortStringKeys(input.hostCapabilitiesOverride),
+    chatUiOverride:
+      input.chatUiOverride === undefined
+        ? undefined
+        : deepSortStringKeys(input.chatUiOverride),
+    mcpProfile: canonicalizeMcpProfile(input.mcpProfile),
+    serverConnectionOverrides: canonicalizeServerConnectionOverrides(
+      input.serverIds ?? [],
+      input.optionalServerIds ?? [],
+      input.serverConnectionOverrides,
+    ),
+  };
+}

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -118,6 +118,10 @@ function deepSortStringKeys<T>(input: T): T {
   return input;
 }
 
+function sortUniqueServerIds(ids: Array<ServerId> | undefined): Array<ServerId> {
+  return Array.from(new Set(ids ?? [])).sort() as Array<ServerId>;
+}
+
 // Plain-object guard shared by hostCapabilitiesOverride and mcpProfile.
 // Arrays/null satisfy `typeof === 'object'`; the canonicalizer is the
 // chokepoint.
@@ -842,6 +846,14 @@ function canonicalizeServerConnectionOverrides(
       }
       mcpProtocolVersionOverride = entry.mcpProtocolVersionOverride;
     }
+    if (
+      entry.requestTimeoutOverride !== undefined &&
+      !Number.isFinite(entry.requestTimeoutOverride)
+    ) {
+      throw new Error(
+        `hostConfigV2: serverConnectionOverrides["${serverId}"].requestTimeoutOverride must be finite`,
+      );
+    }
     const hasContent =
       normalizedHeaders !== undefined ||
       entry.requestTimeoutOverride !== undefined ||
@@ -902,6 +914,8 @@ export function canonicalizeHostConfigV2(
   ) {
     throw new Error("hostConfigV2: chatUiOverride must be a plain object");
   }
+  const serverIds = sortUniqueServerIds(input.serverIds);
+  const optionalServerIds = sortUniqueServerIds(input.optionalServerIds);
   return {
     schemaVersion: HOST_CONFIG_SCHEMA_VERSION_V2,
     hostStyle: input.hostStyle,
@@ -913,12 +927,10 @@ export function canonicalizeHostConfigV2(
     // pre-feature row; explicit `false` writes a key and hashes distinctly.
     progressiveToolDiscovery: input.progressiveToolDiscovery,
     respectToolVisibility: input.respectToolVisibility,
-    // Normalize undefined → [] BEFORE sort so canonical/hash output is
-    // identical to the pre-tolerance "explicit empty array" case.
-    serverIds: [...(input.serverIds ?? [])].sort() as Array<ServerId>,
-    optionalServerIds: [...(input.optionalServerIds ?? [])].sort() as Array<
-      ServerId
-    >,
+    // Normalize undefined → [] and dedupe before sort so canonical/hash output
+    // is identical for semantically equivalent server lists.
+    serverIds,
+    optionalServerIds,
     connectionDefaults: {
       headers: sortStringKeys(input.connectionDefaults.headers),
       requestTimeout: input.connectionDefaults.requestTimeout,
@@ -937,8 +949,8 @@ export function canonicalizeHostConfigV2(
         : deepSortStringKeys(input.chatUiOverride),
     mcpProfile: canonicalizeMcpProfile(input.mcpProfile),
     serverConnectionOverrides: canonicalizeServerConnectionOverrides(
-      input.serverIds ?? [],
-      input.optionalServerIds ?? [],
+      serverIds,
+      optionalServerIds,
       input.serverConnectionOverrides,
     ),
   };

--- a/sdk/src/host-config/hash.ts
+++ b/sdk/src/host-config/hash.ts
@@ -1,0 +1,41 @@
+/**
+ * HostConfig v2 content hash — Web Crypto, ASYNC.
+ *
+ * Uses `crypto.subtle` (available in the browser, Node >= 20, and the Convex
+ * isolate), so this is the single portable hashing path. There is
+ * deliberately NO synchronous variant: the backend mirror is already async
+ * (`convex/lib/keys.ts:sha256Hex` + `computeHostConfigHashV2`), so SDK and
+ * backend stay byte-identical with zero call-site divergence. If a sync need
+ * ever arises, add an explicit `*Sync` API backed by a vendored SHA-256
+ * rather than making the default ambiguous.
+ */
+
+import { canonicalizeHostConfigV2 } from "./canonicalize.js";
+import type { HostConfigInputV2 } from "./types.js";
+
+function toHex(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let hex = "";
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return toHex(digest);
+}
+
+/**
+ * Canonicalize `input` and return the sha256 of its canonical JSON. This is
+ * the content-address used to dedupe persisted host-config rows; the backend
+ * recomputes the same value to integrity-check client-supplied configs.
+ */
+export async function computeHostConfigHashV2(
+  input: HostConfigInputV2,
+): Promise<string> {
+  return sha256Hex(JSON.stringify(canonicalizeHostConfigV2(input)));
+}

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -76,7 +76,8 @@ function hostMcpToProfile(mcp: HostMcp): HostConfigMcpProfileV1 {
  * NOT collapsed here — the canonicalizer drops empty sub-blocks on its own,
  * but the wrapper profile still appears.
  */
-function isEmptyHostMcp(mcp: HostMcp): boolean {
+function isEmptyHostMcp(mcp: HostMcp | undefined): boolean {
+  if (mcp === undefined) return true;
   return (
     mcp.protocolVersion === undefined &&
     mcp.initialize === undefined &&
@@ -494,8 +495,8 @@ export class Host {
       input.chatUiOverride = snap.chatUiOverride;
     }
     // Collapse "empty mcp": an untouched `host.mcp = {}` (the default after
-    // construction) maps to no `mcpProfile`, so a freshly-constructed host
-    // hashes identically to one with `host.mcp = undefined`.
+    // construction) maps to no `mcpProfile`, matching an explicitly cleared
+    // profile.
     if (!isEmptyHostMcp(snap.mcp)) {
       input.mcpProfile = hostMcpToProfile(snap.mcp);
     }

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -15,22 +15,26 @@
  *   })
  *   .addServer("srv_abc");
  *
- * const json = host.toJSON();     // normalized, content-addressable shape
- * const fp   = await host.hash(); // sha256 fingerprint of `json`
+ * const json = host.toJSON();     // normalized public shape (clean vocab)
+ * const fp   = await host.hash(); // sha256 fingerprint
  * ```
  *
- * Setters mutate and return `this` for chaining. `toJSON()` / `hash()` run the
- * same `canonicalizeHostConfigV2` the Convex backend mirrors, so the
- * fingerprint is identical across SDK and backend (golden-vector parity).
+ * Setters mutate and return `this` for chaining. The public surface is pure
+ * MCP vocabulary — `mcp`, `servers`, `protocolVersion`, `clientInfo`. The
+ * storage-row vocabulary (`mcpProfile`, `schemaVersion`, the canonicalizer,
+ * the hash function) never crosses this boundary: `toJSON()` projects to the
+ * public shape, and `hash()` returns an opaque fingerprint.
  *
- * Wire note (option b): the fluent API says `mcp`, but the serialized
- * `toJSON()` keeps the on-disk field name `mcpProfile` for backend
- * compatibility. Nobody outside the SDK authors against the wire field.
+ * Backend compatibility: the fingerprint is computed over the internal
+ * canonical form (which still uses `mcpProfile` on the wire), so it is
+ * byte-identical to what the Convex backend derives from the same host
+ * (golden-vector parity). That internal form is simply never surfaced.
  */
 
 import { canonicalizeHostConfigV2 } from "./canonicalize.js";
 import { computeHostConfigHashV2 } from "./hash.js";
 import type {
+  CanonicalHostConfigV2,
   HostConfigInputV2,
   HostConfigMcpProfileV1,
 } from "./types.js";
@@ -84,6 +88,71 @@ function serverOverridesToInternal(
   const out: NonNullable<HostConfigInputV2["serverConnectionOverrides"]> = {};
   for (const [id, override] of Object.entries(overrides)) {
     out[id] = serverOverrideToInternal(override);
+  }
+  return out;
+}
+
+/** Inverse of {@link hostMcpToProfile} — internal `mcpProfile` → public `mcp`. */
+function profileToHostMcp(profile: HostConfigMcpProfileV1): HostMcp {
+  const mcp: HostMcp = {};
+  if (profile.mcpProtocolVersion !== undefined) {
+    mcp.protocolVersion = profile.mcpProtocolVersion;
+  }
+  if (profile.initialize !== undefined) mcp.initialize = profile.initialize;
+  if (profile.apps !== undefined) mcp.apps = profile.apps;
+  if (profile.extensions !== undefined) mcp.extensions = profile.extensions;
+  return mcp;
+}
+
+function serverOverridesToPublic(
+  overrides: NonNullable<CanonicalHostConfigV2["serverConnectionOverrides"]>,
+): Record<string, HostServerOverride> {
+  const out: Record<string, HostServerOverride> = {};
+  for (const [id, ov] of Object.entries(overrides)) {
+    const pub: HostServerOverride = {};
+    if (ov.headersOverride !== undefined) pub.headers = ov.headersOverride;
+    if (ov.requestTimeoutOverride !== undefined) {
+      pub.requestTimeout = ov.requestTimeoutOverride;
+    }
+    if (ov.mcpProtocolVersionOverride !== undefined) {
+      pub.protocolVersion = ov.mcpProtocolVersionOverride;
+    }
+    out[id] = pub;
+  }
+  return out;
+}
+
+/**
+ * Project the internal canonical form (storage-row vocabulary: `mcpProfile`,
+ * `serverIds`, `schemaVersion`, …) onto the public `HostJson` (clean MCP
+ * vocabulary). No implementation names cross this boundary.
+ */
+function canonicalToPublic(c: CanonicalHostConfigV2): HostJson {
+  const out: HostJson = {
+    style: c.hostStyle,
+    model: c.modelId,
+    systemPrompt: c.systemPrompt,
+    temperature: c.temperature,
+    requireToolApproval: c.requireToolApproval,
+    servers: c.serverIds,
+    optionalServers: c.optionalServerIds,
+    connectionDefaults: c.connectionDefaults,
+    clientCapabilities: c.clientCapabilities,
+    hostContext: c.hostContext,
+  };
+  if (c.progressiveToolDiscovery !== undefined) {
+    out.progressiveToolDiscovery = c.progressiveToolDiscovery;
+  }
+  if (c.respectToolVisibility !== undefined) {
+    out.respectToolVisibility = c.respectToolVisibility;
+  }
+  if (c.hostCapabilitiesOverride !== undefined) {
+    out.hostCapabilitiesOverride = c.hostCapabilitiesOverride;
+  }
+  if (c.chatUiOverride !== undefined) out.chatUiOverride = c.chatUiOverride;
+  if (c.mcpProfile !== undefined) out.mcp = profileToHostMcp(c.mcpProfile);
+  if (c.serverConnectionOverrides !== undefined) {
+    out.serverOverrides = serverOverridesToPublic(c.serverConnectionOverrides);
   }
   return out;
 }
@@ -229,15 +298,21 @@ export class Host {
   }
 
   /**
-   * Serialize to the normalized, content-addressable JSON shape (the wire
-   * form, keyed by `mcpProfile`). Throws if the configuration is invalid
-   * (e.g. a non-finite temperature or a malformed MCP profile).
+   * Serialize to the normalized public `HostJson` shape (clean MCP vocabulary
+   * — `mcp`, `servers`, `style`; no `mcpProfile`/`schemaVersion`). Normalized
+   * and round-trippable: `new Host(host.toJSON())` reproduces an equivalent
+   * host with the same `hash()`. Throws if the configuration is invalid (e.g.
+   * a non-finite temperature or a malformed MCP profile).
    */
   toJSON(): HostJson {
-    return canonicalizeHostConfigV2(this.input);
+    return canonicalToPublic(canonicalizeHostConfigV2(this.input));
   }
 
-  /** sha256 fingerprint of `toJSON()` — the host's content address. */
+  /**
+   * sha256 fingerprint — the host's content address. Computed over the
+   * internal canonical form (kept stable for backend compatibility), so it is
+   * identical to the value the Convex backend derives from the same host.
+   */
   async hash(): Promise<string> {
     return computeHostConfigHashV2(this.input);
   }

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -251,25 +251,37 @@ export class Host {
     return this;
   }
 
-  /** The host's MCP settings (`protocolVersion`, `initialize`, `apps`). */
+  /**
+   * Set the host's MCP settings (`protocolVersion`, `initialize`, `apps`).
+   * **Replaces** the previous MCP block in full — calling `setMcp({ apps })`
+   * after `setMcp({ protocolVersion })` drops the protocolVersion. Pass a
+   * fully-formed `HostMcp` each time.
+   */
   setMcp(mcp: HostMcp): this {
     this.input.mcpProfile = hostMcpToProfile(structuredClone(mcp));
     return this;
   }
 
-  /** Add a required server. */
+  /**
+   * Add a required server. Appends to the list — duplicates are kept as-is
+   * (the canonicalizer sorts but does not currently dedupe, so adding the
+   * same id twice produces a distinct content hash).
+   */
   addServer(id: ServerId): this {
     (this.input.serverIds ??= []).push(id);
     return this;
   }
 
-  /** Add an optional (auto-connect-if-available) server. */
+  /** Add an optional (auto-connect-if-available) server. Same append + duplicate semantics as {@link addServer}. */
   addOptionalServer(id: ServerId): this {
     (this.input.optionalServerIds ??= []).push(id);
     return this;
   }
 
-  /** Merge connection defaults (headers and/or request timeout). */
+  /**
+   * **Merges** into existing connection defaults: only the fields you pass
+   * are updated, the others are preserved. To wipe headers, pass `{ headers: {} }`.
+   */
   setConnectionDefaults(defaults: Partial<HostConnectionDefaults>): this {
     if (defaults.headers !== undefined) {
       this.input.connectionDefaults.headers = structuredClone(defaults.headers);
@@ -280,22 +292,29 @@ export class Host {
     return this;
   }
 
+  /** **Replaces** the client-capabilities blob in full. */
   setClientCapabilities(capabilities: Record<string, unknown>): this {
     this.input.clientCapabilities = structuredClone(capabilities);
     return this;
   }
 
+  /** **Replaces** the host-context blob in full. */
   setHostContext(context: Record<string, unknown>): this {
     this.input.hostContext = structuredClone(context);
     return this;
   }
 
-  /** Override the MCP-Apps `hostCapabilities` blob. `{}` = advertise nothing. */
+  /**
+   * **Replaces** the MCP-Apps `hostCapabilities` blob in full. `{}` =
+   * advertise nothing (distinct from omitting the override, which means
+   * "use the host's default capabilities").
+   */
   setHostCapabilitiesOverride(override: Record<string, unknown>): this {
     this.input.hostCapabilitiesOverride = structuredClone(override);
     return this;
   }
 
+  /** **Replaces** the chat-UI override blob (logo, fonts, ...) in full. */
   setChatUiOverride(override: Record<string, unknown>): this {
     this.input.chatUiOverride = structuredClone(override);
     return this;

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -1,0 +1,255 @@
+/**
+ * `Host` — the public, developer-facing host configuration builder.
+ *
+ * A thin, MCP-vocabulary facade over the internal canonicalizer. You build a
+ * host, configure its MCP settings + servers, then serialize:
+ *
+ * ```ts
+ * import { Host } from "@mcpjam/sdk";
+ *
+ * const host = new Host()
+ *   .setMcp({
+ *     protocolVersion: "2025-11-25",
+ *     initialize: { clientInfo: { name: "my-app", version: "1.0" } },
+ *     apps: { sandbox: { csp: { mode: "declared" } } },
+ *   })
+ *   .addServer("srv_abc");
+ *
+ * const json = host.toJSON();     // normalized, content-addressable shape
+ * const fp   = await host.hash(); // sha256 fingerprint of `json`
+ * ```
+ *
+ * Setters mutate and return `this` for chaining. `toJSON()` / `hash()` run the
+ * same `canonicalizeHostConfigV2` the Convex backend mirrors, so the
+ * fingerprint is identical across SDK and backend (golden-vector parity).
+ *
+ * Wire note (option b): the fluent API says `mcp`, but the serialized
+ * `toJSON()` keeps the on-disk field name `mcpProfile` for backend
+ * compatibility. Nobody outside the SDK authors against the wire field.
+ */
+
+import { canonicalizeHostConfigV2 } from "./canonicalize.js";
+import { computeHostConfigHashV2 } from "./hash.js";
+import type {
+  HostConfigInputV2,
+  HostConfigMcpProfileV1,
+} from "./types.js";
+import type {
+  HostConnectionDefaults,
+  HostInit,
+  HostJson,
+  HostMcp,
+  HostServerOverride,
+  HostStyleId,
+  ServerId,
+} from "./public-types.js";
+
+const DEFAULT_STYLE: HostStyleId = "mcpjam";
+const DEFAULT_TEMPERATURE = 0.7;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
+
+/** Map the public `HostMcp` (spec vocab) to the internal `mcpProfile`. */
+function hostMcpToProfile(mcp: HostMcp): HostConfigMcpProfileV1 {
+  const profile: HostConfigMcpProfileV1 = { profileVersion: 1 };
+  if (mcp.protocolVersion !== undefined) {
+    profile.mcpProtocolVersion = mcp.protocolVersion;
+  }
+  if (mcp.initialize !== undefined) profile.initialize = mcp.initialize;
+  if (mcp.apps !== undefined) profile.apps = mcp.apps;
+  if (mcp.extensions !== undefined) profile.extensions = mcp.extensions;
+  return profile;
+}
+
+/** Map a public per-server override to the internal field names. */
+function serverOverrideToInternal(
+  override: HostServerOverride,
+): NonNullable<HostConfigInputV2["serverConnectionOverrides"]>[string] {
+  const out: NonNullable<
+    HostConfigInputV2["serverConnectionOverrides"]
+  >[string] = {};
+  if (override.headers !== undefined) out.headersOverride = override.headers;
+  if (override.requestTimeout !== undefined) {
+    out.requestTimeoutOverride = override.requestTimeout;
+  }
+  if (override.protocolVersion !== undefined) {
+    out.mcpProtocolVersionOverride = override.protocolVersion;
+  }
+  return out;
+}
+
+function serverOverridesToInternal(
+  overrides?: Record<string, HostServerOverride>,
+): HostConfigInputV2["serverConnectionOverrides"] {
+  if (!overrides) return undefined;
+  const out: NonNullable<HostConfigInputV2["serverConnectionOverrides"]> = {};
+  for (const [id, override] of Object.entries(overrides)) {
+    out[id] = serverOverrideToInternal(override);
+  }
+  return out;
+}
+
+export class Host {
+  private input: HostConfigInputV2;
+
+  constructor(init: HostInit = {}) {
+    this.input = {
+      hostStyle: init.style ?? DEFAULT_STYLE,
+      modelId: init.model ?? "",
+      systemPrompt: init.systemPrompt ?? "",
+      temperature: init.temperature ?? DEFAULT_TEMPERATURE,
+      requireToolApproval: init.requireToolApproval ?? false,
+      connectionDefaults: {
+        headers: init.connectionDefaults?.headers ?? {},
+        requestTimeout:
+          init.connectionDefaults?.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      },
+      clientCapabilities: init.clientCapabilities ?? {},
+      hostContext: init.hostContext ?? {},
+    };
+    if (init.progressiveToolDiscovery !== undefined) {
+      this.input.progressiveToolDiscovery = init.progressiveToolDiscovery;
+    }
+    if (init.respectToolVisibility !== undefined) {
+      this.input.respectToolVisibility = init.respectToolVisibility;
+    }
+    if (init.servers !== undefined) this.input.serverIds = [...init.servers];
+    if (init.optionalServers !== undefined) {
+      this.input.optionalServerIds = [...init.optionalServers];
+    }
+    if (init.hostCapabilitiesOverride !== undefined) {
+      this.input.hostCapabilitiesOverride = init.hostCapabilitiesOverride;
+    }
+    if (init.chatUiOverride !== undefined) {
+      this.input.chatUiOverride = init.chatUiOverride;
+    }
+    if (init.mcp !== undefined) {
+      this.input.mcpProfile = hostMcpToProfile(init.mcp);
+    }
+    if (init.serverOverrides !== undefined) {
+      this.input.serverConnectionOverrides = serverOverridesToInternal(
+        init.serverOverrides,
+      );
+    }
+  }
+
+  /** Host style id (pointer into the host registry). */
+  setStyle(style: HostStyleId): this {
+    this.input.hostStyle = style;
+    return this;
+  }
+
+  /** LLM model id, e.g. "anthropic/claude-sonnet-4-6". */
+  setModel(model: string): this {
+    this.input.modelId = model;
+    return this;
+  }
+
+  setSystemPrompt(systemPrompt: string): this {
+    this.input.systemPrompt = systemPrompt;
+    return this;
+  }
+
+  setTemperature(temperature: number): this {
+    this.input.temperature = temperature;
+    return this;
+  }
+
+  setRequireToolApproval(require = true): this {
+    this.input.requireToolApproval = require;
+    return this;
+  }
+
+  /** Opt into progressive MCP tool discovery (search/load meta-tools). */
+  setProgressiveToolDiscovery(enabled: boolean): this {
+    this.input.progressiveToolDiscovery = enabled;
+    return this;
+  }
+
+  /** SEP-1865 `_meta.ui.visibility` filtering. Omit to use the spec default. */
+  setRespectToolVisibility(respect: boolean): this {
+    this.input.respectToolVisibility = respect;
+    return this;
+  }
+
+  /** The host's MCP settings (`protocolVersion`, `initialize`, `apps`). */
+  setMcp(mcp: HostMcp): this {
+    this.input.mcpProfile = hostMcpToProfile(mcp);
+    return this;
+  }
+
+  /** Add a required server. */
+  addServer(id: ServerId): this {
+    (this.input.serverIds ??= []).push(id);
+    return this;
+  }
+
+  /** Add an optional (auto-connect-if-available) server. */
+  addOptionalServer(id: ServerId): this {
+    (this.input.optionalServerIds ??= []).push(id);
+    return this;
+  }
+
+  /** Merge connection defaults (headers and/or request timeout). */
+  setConnectionDefaults(defaults: Partial<HostConnectionDefaults>): this {
+    if (defaults.headers !== undefined) {
+      this.input.connectionDefaults.headers = defaults.headers;
+    }
+    if (defaults.requestTimeout !== undefined) {
+      this.input.connectionDefaults.requestTimeout = defaults.requestTimeout;
+    }
+    return this;
+  }
+
+  setClientCapabilities(capabilities: Record<string, unknown>): this {
+    this.input.clientCapabilities = capabilities;
+    return this;
+  }
+
+  setHostContext(context: Record<string, unknown>): this {
+    this.input.hostContext = context;
+    return this;
+  }
+
+  /** Override the MCP-Apps `hostCapabilities` blob. `{}` = advertise nothing. */
+  setHostCapabilitiesOverride(override: Record<string, unknown>): this {
+    this.input.hostCapabilitiesOverride = override;
+    return this;
+  }
+
+  setChatUiOverride(override: Record<string, unknown>): this {
+    this.input.chatUiOverride = override;
+    return this;
+  }
+
+  /** Set a per-server connection override (replaces any existing one). */
+  addServerOverride(id: ServerId, override: HostServerOverride): this {
+    (this.input.serverConnectionOverrides ??= {})[id] =
+      serverOverrideToInternal(override);
+    return this;
+  }
+
+  /**
+   * Serialize to the normalized, content-addressable JSON shape (the wire
+   * form, keyed by `mcpProfile`). Throws if the configuration is invalid
+   * (e.g. a non-finite temperature or a malformed MCP profile).
+   */
+  toJSON(): HostJson {
+    return canonicalizeHostConfigV2(this.input);
+  }
+
+  /** sha256 fingerprint of `toJSON()` — the host's content address. */
+  async hash(): Promise<string> {
+    return computeHostConfigHashV2(this.input);
+  }
+}
+
+export type {
+  HostInit,
+  HostJson,
+  HostMcp,
+  HostServerOverride,
+  HostConnectionDefaults,
+  HostStyleId,
+  McpProtocolVersion,
+  ServerId,
+} from "./public-types.js";

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -1,27 +1,31 @@
 /**
  * `Host` — the public, developer-facing host configuration builder.
  *
- * A thin, MCP-vocabulary facade over the internal canonicalizer. You build a
- * host, configure its MCP settings + servers, then serialize:
+ * A thin, MCP-vocabulary facade over the internal canonicalizer. Configure a
+ * host by mutating its public properties directly, then serialize:
  *
  * ```ts
  * import { Host } from "@mcpjam/sdk";
  *
- * const host = new Host()
- *   .setMcp({
- *     protocolVersion: "2025-11-25",
- *     initialize: { clientInfo: { name: "my-app", version: "1.0" } },
- *     apps: { sandbox: { csp: { mode: "declared" } } },
- *   })
- *   .addServer("srv_abc");
+ * const host = new Host({ style: "mcpjam", model: "anthropic/claude-sonnet-4-6" });
+ * host.mcp.protocolVersion = "2025-11-25";
+ * host.mcp.initialize = { clientInfo: { name: "my-app", version: "1.0" } };
+ * host.mcp.apps = { sandbox: { csp: { mode: "declared" } } };
+ * host.addServer("srv_abc");
  *
  * const json = host.toJSON(); // normalized public shape (clean vocab)
  * ```
  *
- * Setters mutate and return `this` for chaining. The public surface is pure
- * MCP vocabulary — `mcp`, `servers`, `protocolVersion`, `clientInfo`. The
- * storage-row vocabulary (`mcpProfile`, `schemaVersion`, the canonicalizer)
- * never crosses this boundary: `toJSON()` projects to the public shape.
+ * Public fields are mutable and use MCP vocabulary — `mcp`, `servers`,
+ * `clientCapabilities`, … The storage-row vocabulary (`mcpProfile`,
+ * `schemaVersion`, the canonicalizer) never crosses this boundary: input is
+ * snapshotted at `toJSON()` time and projected through the canonicalizer to
+ * the public shape.
+ *
+ * Convenience methods (`addServer`, `setServerOverride`, `clearMcp`, …) are
+ * provided where they read more naturally than raw property mutation and
+ * where enforcing invariants (e.g. server-id dedup) is helpful. All methods
+ * return `this` for chaining.
  *
  * Content-addressed storage (canonical-form hashing for backend dedupe) is a
  * first-party concern handled at the SDK↔backend boundary via
@@ -45,10 +49,10 @@ import type {
 } from "./public-types.js";
 
 // No default `style` or `model` — both are required to produce a valid host
-// and must be supplied by the caller (constructor `init` or `setStyle()` /
-// `setModel()`). The SDK deliberately refuses to pick a product-style default
-// here: an external agent author who forgets `style` should fail loudly, not
-// silently get MCPJam chrome on a Claude-style flow.
+// and must be supplied by the caller (constructor `init` or by assigning to
+// `host.style` / `host.model`). The SDK deliberately refuses to pick a
+// product-style default here: an external agent author who forgets `style`
+// should fail loudly, not silently get MCPJam chrome on a Claude-style flow.
 const DEFAULT_TEMPERATURE = 0.7;
 const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
 
@@ -62,6 +66,23 @@ function hostMcpToProfile(mcp: HostMcp): HostConfigMcpProfileV1 {
   if (mcp.apps !== undefined) profile.apps = mcp.apps;
   if (mcp.extensions !== undefined) profile.extensions = mcp.extensions;
   return profile;
+}
+
+/**
+ * True if every top-level `HostMcp` field is unset. Used to collapse the
+ * always-defined-but-untouched `host.mcp = {}` default to no `mcpProfile` in
+ * canonical, so a freshly-constructed host hashes identically to one that
+ * never touched `mcp`. Sub-object emptiness (e.g. `host.mcp.apps = {}`) is
+ * NOT collapsed here — the canonicalizer drops empty sub-blocks on its own,
+ * but the wrapper profile still appears.
+ */
+function isEmptyHostMcp(mcp: HostMcp): boolean {
+  return (
+    mcp.protocolVersion === undefined &&
+    mcp.initialize === undefined &&
+    mcp.apps === undefined &&
+    mcp.extensions === undefined
+  );
 }
 
 /** Map a public per-server override to the internal field names. */
@@ -82,9 +103,9 @@ function serverOverrideToInternal(
 }
 
 function serverOverridesToInternal(
-  overrides?: Record<string, HostServerOverride>,
+  overrides: Record<string, HostServerOverride>,
 ): HostConfigInputV2["serverConnectionOverrides"] {
-  if (!overrides) return undefined;
+  if (Object.keys(overrides).length === 0) return undefined;
   const out: NonNullable<HostConfigInputV2["serverConnectionOverrides"]> = {};
   for (const [id, override] of Object.entries(overrides)) {
     out[id] = serverOverrideToInternal(override);
@@ -157,206 +178,343 @@ function canonicalToPublic(c: CanonicalHostConfigV2): HostJson {
   return out;
 }
 
+/** Append `id` to `list` if not already present. */
+function pushUnique<T>(list: T[], id: T): void {
+  if (!list.includes(id)) list.push(id);
+}
+
+/** Remove first occurrence of `id` from `list`. */
+function removeFrom<T>(list: T[], id: T): void {
+  const i = list.indexOf(id);
+  if (i >= 0) list.splice(i, 1);
+}
+
+/** Order-preserving dedup. */
+function dedup<T>(arr: readonly T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const v of arr) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
 export class Host {
-  private input: HostConfigInputV2;
+  /**
+   * Host style id (e.g. "mcpjam", "claude", "chatgpt"). **Required** at
+   * `toJSON()` time — there is no SDK default, so an external agent author
+   * who forgets to set it gets a loud error rather than silently inheriting
+   * MCPJam product chrome on a Claude-style flow.
+   *
+   * Note: `style` is a **product knob**, not part of SEP-1865 / the MCP base
+   * spec. It selects which host-style preset (chrome, default capabilities,
+   * compat-runtime shims) the inspector applies.
+   */
+  style: HostStyleId;
+
+  /**
+   * LLM model id, e.g. `"anthropic/claude-sonnet-4-6"`. **Required** at
+   * `toJSON()` time — no SDK default.
+   */
+  model: string;
+
+  systemPrompt: string;
+  temperature: number;
+  requireToolApproval: boolean;
+
+  /** Opt into progressive MCP tool discovery (search/load meta-tools). */
+  progressiveToolDiscovery?: boolean;
+
+  /**
+   * SEP-1865 `_meta.ui.visibility` filtering. `undefined` → spec default
+   * (filter); explicit `false` → show every tool (for hosts that don't
+   * implement visibility).
+   */
+  respectToolVisibility?: boolean;
+
+  /** Required servers. Mutable — `addServer`/`removeServer` are sugar. */
+  servers: ServerId[];
+
+  /** Optional (auto-connect-if-available) servers. */
+  optionalServers: ServerId[];
+
+  connectionDefaults: HostConnectionDefaults;
+
+  /**
+   * MCP `ClientCapabilities` the inspector advertises in `initialize`.
+   * Untyped (`Record<string, unknown>`) so future spec additions and host
+   * extensions (SEP-1724) can be added without an SDK release. The MCP Apps
+   * extension lives at `clientCapabilities.extensions["io.modelcontextprotocol/ui"]`.
+   */
+  clientCapabilities: Record<string, unknown>;
+
+  /** SEP-1865 `HostContext` (theme, displayMode, …) advertised via `ui/initialize`. */
+  hostContext: Record<string, unknown>;
+
+  /**
+   * Override the SEP-1865 MCP-Apps `hostCapabilities` blob the inspector
+   * advertises in `ui/initialize`.
+   *
+   * Semantics: `undefined` = "use the host-style preset" (the inspector
+   * picks a sensible default per style). `{}` = "advertise nothing"
+   * (distinct from `undefined`; hashes distinctly). Use this to *cap* what
+   * a host advertises — e.g. force `serverTools: undefined` to block widget
+   * → server tool proxying for a hardened host.
+   */
+  hostCapabilitiesOverride?: Record<string, unknown>;
+
+  /** Override the chat-UI surface (logo, fonts, …). `undefined` vs `{}` semantics match `hostCapabilitiesOverride`. */
+  chatUiOverride?: Record<string, unknown>;
+
+  /**
+   * The host's MCP settings.
+   *
+   * Spec-aligned shape (`protocolVersion`, `initialize`, `apps`, `extensions`)
+   * is **mutable in place** — assign or mutate any leaf directly:
+   *
+   * ```ts
+   * host.mcp.protocolVersion = "2025-11-25";
+   * host.mcp.initialize = { clientInfo: { name: "my-app", version: "1.0" } };
+   * host.mcp.apps = { sandbox: { csp: { mode: "declared" } } };
+   * ```
+   *
+   * The SEP-1865 sandbox knobs at `mcp.apps.sandbox.csp` / `.permissions` are
+   * **host enforcement caps**, not capability grants to the widget. The
+   * widget *declares* what it needs via its resource metadata; the host MAY
+   * further restrict but MUST NOT loosen (`restrictTo` intersects the
+   * declared set; `mode: "declared"` honors the declared set as-is).
+   *
+   * A "freshly constructed, untouched" `host.mcp` (all fields undefined)
+   * collapses to no `mcpProfile` in canonical, so it hashes identically to
+   * `host.mcp = undefined`.
+   */
+  mcp: HostMcp;
+
+  /** Per-server connection overrides keyed by server id. */
+  serverOverrides: Record<string, HostServerOverride>;
 
   constructor(init: HostInit = {}) {
     // Defensive deep copy: a Host must be deterministic, so a caller mutating
     // the objects they passed in (mcp / capabilities / headers / overrides)
-    // must not retroactively change this host's toJSON()/hash(). Arrays were
-    // already copied; this snapshots the object-valued inputs too.
-    // structuredClone is available across the SDK's targets (browser, Node >=
-    // 20, Convex isolate).
+    // must not retroactively change this host's toJSON(). `structuredClone`
+    // is available across the SDK's targets (browser, Node >= 20, Convex).
     const cfg = structuredClone(init);
-    this.input = {
-      // `style` and `model` are required for a valid host but kept optional in
-      // `HostInit` so the setter pattern (`new Host().setStyle(...).setModel(...)`)
-      // works. Empty-string sentinels are caught by `requireConfigured()` at
-      // `toJSON()` / `hash()` time with a clear error message.
-      hostStyle: cfg.style ?? "",
-      modelId: cfg.model ?? "",
-      systemPrompt: cfg.systemPrompt ?? "",
-      temperature: cfg.temperature ?? DEFAULT_TEMPERATURE,
-      requireToolApproval: cfg.requireToolApproval ?? false,
-      connectionDefaults: {
-        headers: cfg.connectionDefaults?.headers ?? {},
-        requestTimeout:
-          cfg.connectionDefaults?.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_MS,
-      },
-      clientCapabilities: cfg.clientCapabilities ?? {},
-      hostContext: cfg.hostContext ?? {},
+
+    // `style` and `model` are kept type-optional so users can construct an
+    // empty Host and configure it imperatively. Empty-string sentinels are
+    // caught by `requireConfigured()` at `toJSON()` time with a clear error.
+    this.style = cfg.style ?? "";
+    this.model = cfg.model ?? "";
+
+    this.systemPrompt = cfg.systemPrompt ?? "";
+    this.temperature = cfg.temperature ?? DEFAULT_TEMPERATURE;
+    this.requireToolApproval = cfg.requireToolApproval ?? false;
+    this.progressiveToolDiscovery = cfg.progressiveToolDiscovery;
+    this.respectToolVisibility = cfg.respectToolVisibility;
+    this.servers = cfg.servers ? dedup(cfg.servers) : [];
+    this.optionalServers = cfg.optionalServers
+      ? dedup(cfg.optionalServers)
+      : [];
+    this.connectionDefaults = {
+      headers: cfg.connectionDefaults?.headers ?? {},
+      requestTimeout:
+        cfg.connectionDefaults?.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_MS,
     };
-    if (cfg.progressiveToolDiscovery !== undefined) {
-      this.input.progressiveToolDiscovery = cfg.progressiveToolDiscovery;
-    }
-    if (cfg.respectToolVisibility !== undefined) {
-      this.input.respectToolVisibility = cfg.respectToolVisibility;
-    }
-    if (cfg.servers !== undefined) this.input.serverIds = [...cfg.servers];
-    if (cfg.optionalServers !== undefined) {
-      this.input.optionalServerIds = [...cfg.optionalServers];
-    }
-    if (cfg.hostCapabilitiesOverride !== undefined) {
-      this.input.hostCapabilitiesOverride = cfg.hostCapabilitiesOverride;
-    }
-    if (cfg.chatUiOverride !== undefined) {
-      this.input.chatUiOverride = cfg.chatUiOverride;
-    }
-    if (cfg.mcp !== undefined) {
-      this.input.mcpProfile = hostMcpToProfile(cfg.mcp);
-    }
-    if (cfg.serverOverrides !== undefined) {
-      this.input.serverConnectionOverrides = serverOverridesToInternal(
-        cfg.serverOverrides,
-      );
-    }
+    this.clientCapabilities = cfg.clientCapabilities ?? {};
+    this.hostContext = cfg.hostContext ?? {};
+    this.hostCapabilitiesOverride = cfg.hostCapabilitiesOverride;
+    this.chatUiOverride = cfg.chatUiOverride;
+    this.mcp = cfg.mcp ?? {};
+    this.serverOverrides = cfg.serverOverrides ?? {};
   }
 
-  /** Host style id (pointer into the host registry). */
+  // ── Setters kept as fluent-chain conveniences. Direct property assignment
+  //    is equivalent (`host.style = "..."`); both are supported. ────────────
+
   setStyle(style: HostStyleId): this {
-    this.input.hostStyle = style;
+    this.style = style;
     return this;
   }
 
-  /** LLM model id, e.g. "anthropic/claude-sonnet-4-6". */
   setModel(model: string): this {
-    this.input.modelId = model;
+    this.model = model;
     return this;
   }
 
   setSystemPrompt(systemPrompt: string): this {
-    this.input.systemPrompt = systemPrompt;
+    this.systemPrompt = systemPrompt;
     return this;
   }
 
   setTemperature(temperature: number): this {
-    this.input.temperature = temperature;
+    this.temperature = temperature;
     return this;
   }
 
   setRequireToolApproval(require = true): this {
-    this.input.requireToolApproval = require;
+    this.requireToolApproval = require;
     return this;
   }
 
-  /** Opt into progressive MCP tool discovery (search/load meta-tools). */
   setProgressiveToolDiscovery(enabled: boolean): this {
-    this.input.progressiveToolDiscovery = enabled;
+    this.progressiveToolDiscovery = enabled;
     return this;
   }
 
-  /** SEP-1865 `_meta.ui.visibility` filtering. Omit to use the spec default. */
   setRespectToolVisibility(respect: boolean): this {
-    this.input.respectToolVisibility = respect;
+    this.respectToolVisibility = respect;
     return this;
   }
 
-  /**
-   * Set the host's MCP settings (`protocolVersion`, `initialize`, `apps`).
-   * **Replaces** the previous MCP block in full — calling `setMcp({ apps })`
-   * after `setMcp({ protocolVersion })` drops the protocolVersion. Pass a
-   * fully-formed `HostMcp` each time.
-   */
-  setMcp(mcp: HostMcp): this {
-    this.input.mcpProfile = hostMcpToProfile(structuredClone(mcp));
-    return this;
-  }
+  // ── Server list mutations (deduped). ──────────────────────────────────────
 
-  /**
-   * Add a required server. Appends to the list — duplicates are kept as-is
-   * (the canonicalizer sorts but does not currently dedupe, so adding the
-   * same id twice produces a distinct content hash).
-   */
+  /** Append a required server; no-op if `id` is already in the list. */
   addServer(id: ServerId): this {
-    (this.input.serverIds ??= []).push(id);
+    pushUnique(this.servers, id);
     return this;
   }
 
-  /** Add an optional (auto-connect-if-available) server. Same append + duplicate semantics as {@link addServer}. */
+  /** Remove a required server; no-op if absent. */
+  removeServer(id: ServerId): this {
+    removeFrom(this.servers, id);
+    return this;
+  }
+
+  /** Append an optional (auto-connect-if-available) server; deduped. */
   addOptionalServer(id: ServerId): this {
-    (this.input.optionalServerIds ??= []).push(id);
+    pushUnique(this.optionalServers, id);
     return this;
   }
+
+  removeOptionalServer(id: ServerId): this {
+    removeFrom(this.optionalServers, id);
+    return this;
+  }
+
+  // ── Per-server connection overrides. ──────────────────────────────────────
 
   /**
-   * **Merges** into existing connection defaults: only the fields you pass
-   * are updated, the others are preserved. To wipe headers, pass `{ headers: {} }`.
+   * Replace the per-server override for `id`. Passing an empty `{}` is
+   * preserved here but stripped from the canonical output (an override with
+   * no fields adds no information).
    */
-  setConnectionDefaults(defaults: Partial<HostConnectionDefaults>): this {
-    if (defaults.headers !== undefined) {
-      this.input.connectionDefaults.headers = structuredClone(defaults.headers);
-    }
-    if (defaults.requestTimeout !== undefined) {
-      this.input.connectionDefaults.requestTimeout = defaults.requestTimeout;
-    }
+  setServerOverride(id: ServerId, override: HostServerOverride): this {
+    this.serverOverrides[id] = structuredClone(override);
     return this;
   }
 
-  /** **Replaces** the client-capabilities blob in full. */
-  setClientCapabilities(capabilities: Record<string, unknown>): this {
-    this.input.clientCapabilities = structuredClone(capabilities);
+  removeServerOverride(id: ServerId): this {
+    delete this.serverOverrides[id];
     return this;
   }
 
-  /** **Replaces** the host-context blob in full. */
-  setHostContext(context: Record<string, unknown>): this {
-    this.input.hostContext = structuredClone(context);
-    return this;
-  }
+  // ── MCP block. ────────────────────────────────────────────────────────────
 
   /**
-   * **Replaces** the MCP-Apps `hostCapabilities` blob in full. `{}` =
-   * advertise nothing (distinct from omitting the override, which means
-   * "use the host's default capabilities").
+   * Reset `mcp` to an empty object — equivalent to "use SDK defaults / no
+   * host-level MCP profile." Collapses to no `mcpProfile` in canonical.
    */
-  setHostCapabilitiesOverride(override: Record<string, unknown>): this {
-    this.input.hostCapabilitiesOverride = structuredClone(override);
+  clearMcp(): this {
+    this.mcp = {};
     return this;
   }
 
-  /** **Replaces** the chat-UI override blob (logo, fonts, ...) in full. */
-  setChatUiOverride(override: Record<string, unknown>): this {
-    this.input.chatUiOverride = structuredClone(override);
-    return this;
-  }
-
-  /** Set a per-server connection override (replaces any existing one). */
-  addServerOverride(id: ServerId, override: HostServerOverride): this {
-    (this.input.serverConnectionOverrides ??= {})[id] =
-      serverOverrideToInternal(structuredClone(override));
-    return this;
-  }
+  // ── Output. ───────────────────────────────────────────────────────────────
 
   /**
    * Throw a clear error if required fields (`style`, `model`) are still empty.
-   * Called from `toJSON()` so the failure lands at the moment of use, not deep
-   * inside the canonicalizer with a less obvious message.
+   * Called from `toJSON()` so the failure lands at the moment of use, not
+   * deep inside the canonicalizer with a less obvious message.
    */
   private requireConfigured(): void {
-    if (!this.input.hostStyle) {
+    if (!this.style) {
       throw new Error(
         "Host requires a `style` (e.g. \"mcpjam\", \"claude\", \"chatgpt\"). " +
-          "Pass it to the constructor (`new Host({ style: \"...\" })`) or call `.setStyle(...)`.",
+          'Pass it to the constructor (`new Host({ style: "..." })`) or assign `host.style = "..."`.',
       );
     }
-    if (!this.input.modelId) {
+    if (!this.model) {
       throw new Error(
         "Host requires a `model` (e.g. \"anthropic/claude-sonnet-4-6\"). " +
-          "Pass it to the constructor (`new Host({ model: \"...\" })`) or call `.setModel(...)`.",
+          'Pass it to the constructor (`new Host({ model: "..." })`) or assign `host.model = "..."`.',
       );
     }
   }
 
   /**
-   * Serialize to the normalized public `HostJson` shape (clean MCP vocabulary
-   * — `mcp`, `servers`, `style`; no `mcpProfile`/`schemaVersion`). Normalized
-   * and round-trippable: `new Host(host.toJSON())` reproduces an equivalent
-   * host. Throws if the configuration is invalid (e.g. `style`/`model` not
-   * set, a non-finite temperature, or a malformed MCP profile).
+   * Build the internal canonicalizer input from the current public-shape
+   * properties. Snapshotted (`structuredClone`) so the canonicalizer sees a
+   * stable copy even if the caller is mid-mutation.
+   */
+  private toInternalInput(): HostConfigInputV2 {
+    const snap = structuredClone({
+      style: this.style,
+      model: this.model,
+      systemPrompt: this.systemPrompt,
+      temperature: this.temperature,
+      requireToolApproval: this.requireToolApproval,
+      progressiveToolDiscovery: this.progressiveToolDiscovery,
+      respectToolVisibility: this.respectToolVisibility,
+      servers: this.servers,
+      optionalServers: this.optionalServers,
+      connectionDefaults: this.connectionDefaults,
+      clientCapabilities: this.clientCapabilities,
+      hostContext: this.hostContext,
+      hostCapabilitiesOverride: this.hostCapabilitiesOverride,
+      chatUiOverride: this.chatUiOverride,
+      mcp: this.mcp,
+      serverOverrides: this.serverOverrides,
+    });
+
+    const input: HostConfigInputV2 = {
+      hostStyle: snap.style,
+      modelId: snap.model,
+      systemPrompt: snap.systemPrompt,
+      temperature: snap.temperature,
+      requireToolApproval: snap.requireToolApproval,
+      serverIds: snap.servers,
+      optionalServerIds: snap.optionalServers,
+      connectionDefaults: snap.connectionDefaults,
+      clientCapabilities: snap.clientCapabilities,
+      hostContext: snap.hostContext,
+    };
+    if (snap.progressiveToolDiscovery !== undefined) {
+      input.progressiveToolDiscovery = snap.progressiveToolDiscovery;
+    }
+    if (snap.respectToolVisibility !== undefined) {
+      input.respectToolVisibility = snap.respectToolVisibility;
+    }
+    if (snap.hostCapabilitiesOverride !== undefined) {
+      input.hostCapabilitiesOverride = snap.hostCapabilitiesOverride;
+    }
+    if (snap.chatUiOverride !== undefined) {
+      input.chatUiOverride = snap.chatUiOverride;
+    }
+    // Collapse "empty mcp": an untouched `host.mcp = {}` (the default after
+    // construction) maps to no `mcpProfile`, so a freshly-constructed host
+    // hashes identically to one with `host.mcp = undefined`.
+    if (!isEmptyHostMcp(snap.mcp)) {
+      input.mcpProfile = hostMcpToProfile(snap.mcp);
+    }
+    const overrides = serverOverridesToInternal(snap.serverOverrides);
+    if (overrides !== undefined) input.serverConnectionOverrides = overrides;
+    return input;
+  }
+
+  /**
+   * Serialize to the normalized public `HostJson` shape (clean MCP
+   * vocabulary — `mcp`, `servers`, `style`; no `mcpProfile`/`schemaVersion`).
+   * Normalized and round-trippable: `new Host(host.toJSON())` reproduces an
+   * equivalent host. Throws if the configuration is invalid (e.g.
+   * `style`/`model` not set, a non-finite temperature, or a malformed MCP
+   * profile).
    */
   toJSON(): HostJson {
     this.requireConfigured();
-    return canonicalToPublic(canonicalizeHostConfigV2(this.input));
+    return canonicalToPublic(canonicalizeHostConfigV2(this.toInternalInput()));
   }
 }
 

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -15,24 +15,20 @@
  *   })
  *   .addServer("srv_abc");
  *
- * const json = host.toJSON();     // normalized public shape (clean vocab)
- * const fp   = await host.hash(); // sha256 fingerprint
+ * const json = host.toJSON(); // normalized public shape (clean vocab)
  * ```
  *
  * Setters mutate and return `this` for chaining. The public surface is pure
  * MCP vocabulary — `mcp`, `servers`, `protocolVersion`, `clientInfo`. The
- * storage-row vocabulary (`mcpProfile`, `schemaVersion`, the canonicalizer,
- * the hash function) never crosses this boundary: `toJSON()` projects to the
- * public shape, and `hash()` returns an opaque fingerprint.
+ * storage-row vocabulary (`mcpProfile`, `schemaVersion`, the canonicalizer)
+ * never crosses this boundary: `toJSON()` projects to the public shape.
  *
- * Backend compatibility: the fingerprint is computed over the internal
- * canonical form (which still uses `mcpProfile` on the wire), so it is
- * byte-identical to what the Convex backend derives from the same host
- * (golden-vector parity). That internal form is simply never surfaced.
+ * Content-addressed storage (canonical-form hashing for backend dedupe) is a
+ * first-party concern handled at the SDK↔backend boundary via
+ * `@mcpjam/sdk/host-config/internal`. Developers building hosts never call it.
  */
 
 import { canonicalizeHostConfigV2 } from "./canonicalize.js";
-import { computeHostConfigHashV2 } from "./hash.js";
 import type {
   CanonicalHostConfigV2,
   HostConfigInputV2,
@@ -314,8 +310,8 @@ export class Host {
 
   /**
    * Throw a clear error if required fields (`style`, `model`) are still empty.
-   * Called from `toJSON()` and `hash()` so the failure lands at the moment of
-   * use, not deep inside the canonicalizer with a less obvious message.
+   * Called from `toJSON()` so the failure lands at the moment of use, not deep
+   * inside the canonicalizer with a less obvious message.
    */
   private requireConfigured(): void {
     if (!this.input.hostStyle) {
@@ -336,24 +332,12 @@ export class Host {
    * Serialize to the normalized public `HostJson` shape (clean MCP vocabulary
    * — `mcp`, `servers`, `style`; no `mcpProfile`/`schemaVersion`). Normalized
    * and round-trippable: `new Host(host.toJSON())` reproduces an equivalent
-   * host with the same `hash()`. Throws if the configuration is invalid (e.g.
-   * `style`/`model` not set, a non-finite temperature, or a malformed MCP
-   * profile).
+   * host. Throws if the configuration is invalid (e.g. `style`/`model` not
+   * set, a non-finite temperature, or a malformed MCP profile).
    */
   toJSON(): HostJson {
     this.requireConfigured();
     return canonicalToPublic(canonicalizeHostConfigV2(this.input));
-  }
-
-  /**
-   * sha256 fingerprint — the host's content address. Computed over the
-   * internal canonical form (kept stable for backend compatibility), so it is
-   * identical to the value the Convex backend derives from the same host.
-   * Throws if `style` or `model` is missing.
-   */
-  async hash(): Promise<string> {
-    this.requireConfigured();
-    return computeHostConfigHashV2(this.input);
   }
 }
 

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -48,7 +48,11 @@ import type {
   ServerId,
 } from "./public-types.js";
 
-const DEFAULT_STYLE: HostStyleId = "mcpjam";
+// No default `style` or `model` — both are required to produce a valid host
+// and must be supplied by the caller (constructor `init` or `setStyle()` /
+// `setModel()`). The SDK deliberately refuses to pick a product-style default
+// here: an external agent author who forgets `style` should fail loudly, not
+// silently get MCPJam chrome on a Claude-style flow.
 const DEFAULT_TEMPERATURE = 0.7;
 const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
 
@@ -169,7 +173,11 @@ export class Host {
     // 20, Convex isolate).
     const cfg = structuredClone(init);
     this.input = {
-      hostStyle: cfg.style ?? DEFAULT_STYLE,
+      // `style` and `model` are required for a valid host but kept optional in
+      // `HostInit` so the setter pattern (`new Host().setStyle(...).setModel(...)`)
+      // works. Empty-string sentinels are caught by `requireConfigured()` at
+      // `toJSON()` / `hash()` time with a clear error message.
+      hostStyle: cfg.style ?? "",
       modelId: cfg.model ?? "",
       systemPrompt: cfg.systemPrompt ?? "",
       temperature: cfg.temperature ?? DEFAULT_TEMPERATURE,
@@ -305,13 +313,35 @@ export class Host {
   }
 
   /**
+   * Throw a clear error if required fields (`style`, `model`) are still empty.
+   * Called from `toJSON()` and `hash()` so the failure lands at the moment of
+   * use, not deep inside the canonicalizer with a less obvious message.
+   */
+  private requireConfigured(): void {
+    if (!this.input.hostStyle) {
+      throw new Error(
+        "Host requires a `style` (e.g. \"mcpjam\", \"claude\", \"chatgpt\"). " +
+          "Pass it to the constructor (`new Host({ style: \"...\" })`) or call `.setStyle(...)`.",
+      );
+    }
+    if (!this.input.modelId) {
+      throw new Error(
+        "Host requires a `model` (e.g. \"anthropic/claude-sonnet-4-6\"). " +
+          "Pass it to the constructor (`new Host({ model: \"...\" })`) or call `.setModel(...)`.",
+      );
+    }
+  }
+
+  /**
    * Serialize to the normalized public `HostJson` shape (clean MCP vocabulary
    * — `mcp`, `servers`, `style`; no `mcpProfile`/`schemaVersion`). Normalized
    * and round-trippable: `new Host(host.toJSON())` reproduces an equivalent
    * host with the same `hash()`. Throws if the configuration is invalid (e.g.
-   * a non-finite temperature or a malformed MCP profile).
+   * `style`/`model` not set, a non-finite temperature, or a malformed MCP
+   * profile).
    */
   toJSON(): HostJson {
+    this.requireConfigured();
     return canonicalToPublic(canonicalizeHostConfigV2(this.input));
   }
 
@@ -319,8 +349,10 @@ export class Host {
    * sha256 fingerprint — the host's content address. Computed over the
    * internal canonical form (kept stable for backend compatibility), so it is
    * identical to the value the Convex backend derives from the same host.
+   * Throws if `style` or `model` is missing.
    */
   async hash(): Promise<string> {
+    this.requireConfigured();
     return computeHostConfigHashV2(this.input);
   }
 }

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -161,42 +161,49 @@ export class Host {
   private input: HostConfigInputV2;
 
   constructor(init: HostInit = {}) {
+    // Defensive deep copy: a Host must be deterministic, so a caller mutating
+    // the objects they passed in (mcp / capabilities / headers / overrides)
+    // must not retroactively change this host's toJSON()/hash(). Arrays were
+    // already copied; this snapshots the object-valued inputs too.
+    // structuredClone is available across the SDK's targets (browser, Node >=
+    // 20, Convex isolate).
+    const cfg = structuredClone(init);
     this.input = {
-      hostStyle: init.style ?? DEFAULT_STYLE,
-      modelId: init.model ?? "",
-      systemPrompt: init.systemPrompt ?? "",
-      temperature: init.temperature ?? DEFAULT_TEMPERATURE,
-      requireToolApproval: init.requireToolApproval ?? false,
+      hostStyle: cfg.style ?? DEFAULT_STYLE,
+      modelId: cfg.model ?? "",
+      systemPrompt: cfg.systemPrompt ?? "",
+      temperature: cfg.temperature ?? DEFAULT_TEMPERATURE,
+      requireToolApproval: cfg.requireToolApproval ?? false,
       connectionDefaults: {
-        headers: init.connectionDefaults?.headers ?? {},
+        headers: cfg.connectionDefaults?.headers ?? {},
         requestTimeout:
-          init.connectionDefaults?.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_MS,
+          cfg.connectionDefaults?.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_MS,
       },
-      clientCapabilities: init.clientCapabilities ?? {},
-      hostContext: init.hostContext ?? {},
+      clientCapabilities: cfg.clientCapabilities ?? {},
+      hostContext: cfg.hostContext ?? {},
     };
-    if (init.progressiveToolDiscovery !== undefined) {
-      this.input.progressiveToolDiscovery = init.progressiveToolDiscovery;
+    if (cfg.progressiveToolDiscovery !== undefined) {
+      this.input.progressiveToolDiscovery = cfg.progressiveToolDiscovery;
     }
-    if (init.respectToolVisibility !== undefined) {
-      this.input.respectToolVisibility = init.respectToolVisibility;
+    if (cfg.respectToolVisibility !== undefined) {
+      this.input.respectToolVisibility = cfg.respectToolVisibility;
     }
-    if (init.servers !== undefined) this.input.serverIds = [...init.servers];
-    if (init.optionalServers !== undefined) {
-      this.input.optionalServerIds = [...init.optionalServers];
+    if (cfg.servers !== undefined) this.input.serverIds = [...cfg.servers];
+    if (cfg.optionalServers !== undefined) {
+      this.input.optionalServerIds = [...cfg.optionalServers];
     }
-    if (init.hostCapabilitiesOverride !== undefined) {
-      this.input.hostCapabilitiesOverride = init.hostCapabilitiesOverride;
+    if (cfg.hostCapabilitiesOverride !== undefined) {
+      this.input.hostCapabilitiesOverride = cfg.hostCapabilitiesOverride;
     }
-    if (init.chatUiOverride !== undefined) {
-      this.input.chatUiOverride = init.chatUiOverride;
+    if (cfg.chatUiOverride !== undefined) {
+      this.input.chatUiOverride = cfg.chatUiOverride;
     }
-    if (init.mcp !== undefined) {
-      this.input.mcpProfile = hostMcpToProfile(init.mcp);
+    if (cfg.mcp !== undefined) {
+      this.input.mcpProfile = hostMcpToProfile(cfg.mcp);
     }
-    if (init.serverOverrides !== undefined) {
+    if (cfg.serverOverrides !== undefined) {
       this.input.serverConnectionOverrides = serverOverridesToInternal(
-        init.serverOverrides,
+        cfg.serverOverrides,
       );
     }
   }
@@ -242,7 +249,7 @@ export class Host {
 
   /** The host's MCP settings (`protocolVersion`, `initialize`, `apps`). */
   setMcp(mcp: HostMcp): this {
-    this.input.mcpProfile = hostMcpToProfile(mcp);
+    this.input.mcpProfile = hostMcpToProfile(structuredClone(mcp));
     return this;
   }
 
@@ -261,7 +268,7 @@ export class Host {
   /** Merge connection defaults (headers and/or request timeout). */
   setConnectionDefaults(defaults: Partial<HostConnectionDefaults>): this {
     if (defaults.headers !== undefined) {
-      this.input.connectionDefaults.headers = defaults.headers;
+      this.input.connectionDefaults.headers = structuredClone(defaults.headers);
     }
     if (defaults.requestTimeout !== undefined) {
       this.input.connectionDefaults.requestTimeout = defaults.requestTimeout;
@@ -270,30 +277,30 @@ export class Host {
   }
 
   setClientCapabilities(capabilities: Record<string, unknown>): this {
-    this.input.clientCapabilities = capabilities;
+    this.input.clientCapabilities = structuredClone(capabilities);
     return this;
   }
 
   setHostContext(context: Record<string, unknown>): this {
-    this.input.hostContext = context;
+    this.input.hostContext = structuredClone(context);
     return this;
   }
 
   /** Override the MCP-Apps `hostCapabilities` blob. `{}` = advertise nothing. */
   setHostCapabilitiesOverride(override: Record<string, unknown>): this {
-    this.input.hostCapabilitiesOverride = override;
+    this.input.hostCapabilitiesOverride = structuredClone(override);
     return this;
   }
 
   setChatUiOverride(override: Record<string, unknown>): this {
-    this.input.chatUiOverride = override;
+    this.input.chatUiOverride = structuredClone(override);
     return this;
   }
 
   /** Set a per-server connection override (replaces any existing one). */
   addServerOverride(id: ServerId, override: HostServerOverride): this {
     (this.input.serverConnectionOverrides ??= {})[id] =
-      serverOverrideToInternal(override);
+      serverOverrideToInternal(structuredClone(override));
     return this;
   }
 

--- a/sdk/src/host-config/index.ts
+++ b/sdk/src/host-config/index.ts
@@ -1,34 +1,31 @@
 /**
- * `@mcpjam/sdk/host-config` — portable HostConfig v2 core.
+ * `@mcpjam/sdk/host-config` — public host configuration API.
  *
- * The canonical source of truth for the host-config shape, canonicalizer, and
- * content hash. Hand-mirrored (not imported) by the Convex backend; kept in
- * lockstep via a golden-vector parity test. See `./types.ts` for the full
- * parity-discipline note.
+ * Build and fingerprint a host with the `Host` class:
  *
- * This barrel is browser-safe — it carries no `MCPClientManager`/`ToolSet`
- * dependencies. Manager-aware helpers (tool-visibility filtering, host
- * execution policy) live in sibling modules added in later stages and are
- * exported only from the Node entry, not `@mcpjam/sdk/browser`.
+ * ```ts
+ * import { Host } from "@mcpjam/sdk/host-config"; // or from "@mcpjam/sdk"
+ * const host = new Host().setMcp({ protocolVersion: "2025-11-25" }).addServer("srv_abc");
+ * const fp = await host.hash();
+ * ```
+ *
+ * The internal canonicalizer/hash (and the storage-row vocabulary they use)
+ * are deliberately not exported — `Host.toJSON()` / `Host.hash()` are the
+ * public seam. The canonical output is hand-mirrored + golden-vector-parity
+ * tested against the Convex backend; see `./types.ts`.
  */
 
-export {
-  HOST_CONFIG_SCHEMA_VERSION_V2,
-  SEP_1865_PERMISSION_FEATURES,
-} from "./types.js";
+export { Host } from "./host.js";
 export type {
-  HostConfigInputV2,
-  CanonicalHostConfigV2,
-  HostConfigConnectionDefaults,
-  HostConfigMcpProfileV1,
-  HostConfigStyle,
+  HostInit,
+  HostJson,
+  HostMcp,
+  HostServerOverride,
+  HostConnectionDefaults,
   HostStyleId,
+  McpProtocolVersion,
   ServerId,
   CspDomainSet,
   OpenAiAppsCapabilities,
   McpAppsCapabilities,
-  McpProtocolVersion,
-} from "./types.js";
-
-export { canonicalizeHostConfigV2 } from "./canonicalize.js";
-export { sha256Hex, computeHostConfigHashV2 } from "./hash.js";
+} from "./public-types.js";

--- a/sdk/src/host-config/index.ts
+++ b/sdk/src/host-config/index.ts
@@ -1,0 +1,34 @@
+/**
+ * `@mcpjam/sdk/host-config` — portable HostConfig v2 core.
+ *
+ * The canonical source of truth for the host-config shape, canonicalizer, and
+ * content hash. Hand-mirrored (not imported) by the Convex backend; kept in
+ * lockstep via a golden-vector parity test. See `./types.ts` for the full
+ * parity-discipline note.
+ *
+ * This barrel is browser-safe — it carries no `MCPClientManager`/`ToolSet`
+ * dependencies. Manager-aware helpers (tool-visibility filtering, host
+ * execution policy) live in sibling modules added in later stages and are
+ * exported only from the Node entry, not `@mcpjam/sdk/browser`.
+ */
+
+export {
+  HOST_CONFIG_SCHEMA_VERSION_V2,
+  SEP_1865_PERMISSION_FEATURES,
+} from "./types.js";
+export type {
+  HostConfigInputV2,
+  CanonicalHostConfigV2,
+  HostConfigConnectionDefaults,
+  HostConfigMcpProfileV1,
+  HostConfigStyle,
+  HostStyleId,
+  ServerId,
+  CspDomainSet,
+  OpenAiAppsCapabilities,
+  McpAppsCapabilities,
+  McpProtocolVersion,
+} from "./types.js";
+
+export { canonicalizeHostConfigV2 } from "./canonicalize.js";
+export { sha256Hex, computeHostConfigHashV2 } from "./hash.js";

--- a/sdk/src/host-config/index.ts
+++ b/sdk/src/host-config/index.ts
@@ -6,8 +6,8 @@
  * ```ts
  * import { Host } from "@mcpjam/sdk/host-config"; // or from "@mcpjam/sdk"
  * const host = new Host({ style: "mcpjam", model: "anthropic/claude-sonnet-4-6" })
- *   .setMcp({ protocolVersion: "2025-11-25" })
  *   .addServer("srv_abc");
+ * host.mcp.protocolVersion = "2025-11-25";
  * const json = host.toJSON();
  * ```
  *

--- a/sdk/src/host-config/index.ts
+++ b/sdk/src/host-config/index.ts
@@ -1,18 +1,20 @@
 /**
  * `@mcpjam/sdk/host-config` — public host configuration API.
  *
- * Build and fingerprint a host with the `Host` class:
+ * Build a host with the `Host` class:
  *
  * ```ts
  * import { Host } from "@mcpjam/sdk/host-config"; // or from "@mcpjam/sdk"
- * const host = new Host().setMcp({ protocolVersion: "2025-11-25" }).addServer("srv_abc");
- * const fp = await host.hash();
+ * const host = new Host({ style: "mcpjam", model: "anthropic/claude-sonnet-4-6" })
+ *   .setMcp({ protocolVersion: "2025-11-25" })
+ *   .addServer("srv_abc");
+ * const json = host.toJSON();
  * ```
  *
  * The internal canonicalizer/hash (and the storage-row vocabulary they use)
- * are deliberately not exported — `Host.toJSON()` / `Host.hash()` are the
- * public seam. The canonical output is hand-mirrored + golden-vector-parity
- * tested against the Convex backend; see `./types.ts`.
+ * are deliberately not exported — `Host.toJSON()` is the public seam.
+ * Content-addressed storage is a first-party SDK↔backend concern handled via
+ * `@mcpjam/sdk/host-config/internal`; see `./types.ts`.
  */
 
 export { Host } from "./host.js";

--- a/sdk/src/host-config/internal.ts
+++ b/sdk/src/host-config/internal.ts
@@ -1,13 +1,20 @@
 /**
- * INTERNAL host-config entry — NOT part of the public API.
+ * `@mcpjam/sdk/host-config/internal` — LOW-LEVEL, FIRST-PARTY entry.
  *
- * Exposes the raw canonicalizer + hash + internal storage-row types for SDK
- * tooling (the parity-fixture generator) and SDK tests only. This module is
- * built to `dist/host-config/internal.js` but is intentionally absent from
- * `package.json#exports`, so it is not importable via the package name —
- * external consumers see only `Host` from `@mcpjam/sdk` / `./host-config`.
+ * Exposes the raw canonicalizer + hash + internal storage-row types
+ * (`canonicalizeHostConfigV2`, `computeHostConfigHashV2`, `HostConfigInputV2`,
+ * `CanonicalHostConfigV2`, …). This module is the single source of truth for
+ * the canonical form: it is fully self-contained (zero external/Node-only
+ * imports), so the MCPJam Convex backend imports it directly rather than
+ * hand-mirroring the canonicalizer. There is exactly one canonicalizer shared
+ * across the SDK and backend — no duplicated fixture, no parity ritual.
  *
- * Application code must use the `Host` class instead.
+ * NOT part of the stable public API and NOT semver-guaranteed. External SDK
+ * consumers should use the `Host` builder from `@mcpjam/sdk` /
+ * `@mcpjam/sdk/host-config` — that is the curated public surface (MCP
+ * vocabulary, no storage-row names). This subpath is for first-party
+ * consumers (the backend, the parity-fixture generator, SDK tests) that need
+ * the low-level canonicalizer.
  */
 
 export { canonicalizeHostConfigV2 } from "./canonicalize.js";

--- a/sdk/src/host-config/internal.ts
+++ b/sdk/src/host-config/internal.ts
@@ -1,0 +1,24 @@
+/**
+ * INTERNAL host-config entry — NOT part of the public API.
+ *
+ * Exposes the raw canonicalizer + hash + internal storage-row types for SDK
+ * tooling (the parity-fixture generator) and SDK tests only. This module is
+ * built to `dist/host-config/internal.js` but is intentionally absent from
+ * `package.json#exports`, so it is not importable via the package name —
+ * external consumers see only `Host` from `@mcpjam/sdk` / `./host-config`.
+ *
+ * Application code must use the `Host` class instead.
+ */
+
+export { canonicalizeHostConfigV2 } from "./canonicalize.js";
+export { sha256Hex, computeHostConfigHashV2 } from "./hash.js";
+export {
+  HOST_CONFIG_SCHEMA_VERSION_V2,
+  SEP_1865_PERMISSION_FEATURES,
+} from "./types.js";
+export type {
+  HostConfigInputV2,
+  CanonicalHostConfigV2,
+  HostConfigMcpProfileV1,
+  HostConfigConnectionDefaults,
+} from "./types.js";

--- a/sdk/src/host-config/public-types.ts
+++ b/sdk/src/host-config/public-types.ts
@@ -1,0 +1,105 @@
+/**
+ * `@mcpjam/sdk/host-config` — PUBLIC type surface.
+ *
+ * MCP-protocol vocabulary for the developer-facing `Host` API. These names are
+ * what an external agent author sees; the internal storage-row vocabulary
+ * (`HostConfigInputV2`, `mcpProfile`, schema versions) stays in `./types.ts`
+ * and `./canonicalize.ts` and is reached only through `Host`.
+ *
+ * Wire compatibility (option b): the *serialized* canonical shape
+ * (`HostJson`) keeps the on-disk field name `mcpProfile`; only the fluent API
+ * renames it to `mcp`. A small mapper in `./host.ts` bridges the two so the
+ * canonical JSON + hash never change (the golden-vector fixture still holds).
+ */
+
+import type {
+  CanonicalHostConfigV2,
+  CspDomainSet,
+  HostConfigConnectionDefaults,
+  HostConfigMcpProfileV1,
+  HostStyleId,
+  McpAppsCapabilities,
+  McpProtocolVersion,
+  OpenAiAppsCapabilities,
+  ServerId,
+} from "./types.js";
+
+export type {
+  McpProtocolVersion,
+  ServerId,
+  HostStyleId,
+  CspDomainSet,
+  OpenAiAppsCapabilities,
+  McpAppsCapabilities,
+};
+
+/** Per-host connection defaults (headers + request timeout in ms). */
+export type HostConnectionDefaults = HostConfigConnectionDefaults;
+
+/**
+ * A host's MCP settings — the host-facing rename of the internal `mcpProfile`.
+ * Spec-aligned vocabulary: `protocolVersion`, `initialize` (clientInfo,
+ * supported versions), and `apps` (sandbox, ui/initialize hostInfo, compat
+ * runtime, MCP-Apps overrides). The internal schema-version marker
+ * (`profileVersion`) is supplied by the SDK; authors never set it.
+ */
+export type HostMcp = Omit<
+  HostConfigMcpProfileV1,
+  "profileVersion" | "mcpProtocolVersion"
+> & {
+  /** Host-default pinned MCP protocol version (e.g. "2025-11-25"). */
+  protocolVersion?: McpProtocolVersion;
+};
+
+/**
+ * Normalized, content-addressable host JSON returned by `Host.toJSON()`.
+ *
+ * NOTE: this is the *serialized* shape that gets hashed and stored, so it
+ * keeps the on-disk field name `mcpProfile` (not `mcp`) for backend
+ * compatibility — see the option-(b) note above. Use the `Host` fluent API
+ * (`host.mcp` / `setMcp`) for authoring; use `toJSON()` only when you need the
+ * exact wire form.
+ */
+export type HostJson = CanonicalHostConfigV2;
+
+/** Per-server connection override (host-facing field names). */
+export interface HostServerOverride {
+  headers?: Record<string, string>;
+  requestTimeout?: number;
+  protocolVersion?: McpProtocolVersion;
+}
+
+/**
+ * Optional initial configuration for `new Host(init?)`. Every field is
+ * optional; omitted fields fall back to SDK defaults. Equivalent settings are
+ * also available as fluent setters (`setModel`, `setMcp`, `addServer`, …).
+ */
+export interface HostInit {
+  /** Host style id — a pointer into the host registry. Default: "mcpjam". */
+  style?: HostStyleId;
+  /** LLM model id (e.g. "anthropic/claude-sonnet-4-6"). */
+  model?: string;
+  systemPrompt?: string;
+  /** Sampling temperature. Default: 0.7. */
+  temperature?: number;
+  requireToolApproval?: boolean;
+  /** Opt into progressive MCP tool discovery (search/load meta-tools). */
+  progressiveToolDiscovery?: boolean;
+  /** SEP-1865 `_meta.ui.visibility` filtering. Undefined → spec default. */
+  respectToolVisibility?: boolean;
+  /** Required servers this host connects to. */
+  servers?: ServerId[];
+  /** Optional (auto-connect-if-available) servers. */
+  optionalServers?: ServerId[];
+  connectionDefaults?: Partial<HostConnectionDefaults>;
+  clientCapabilities?: Record<string, unknown>;
+  hostContext?: Record<string, unknown>;
+  /** Override the MCP-Apps `hostCapabilities` blob. {} = advertise nothing. */
+  hostCapabilitiesOverride?: Record<string, unknown>;
+  /** Override the chat-UI surface (logo, fonts, …). */
+  chatUiOverride?: Record<string, unknown>;
+  /** The host's MCP settings. */
+  mcp?: HostMcp;
+  /** Per-server connection overrides, keyed by server id. */
+  serverOverrides?: Record<string, HostServerOverride>;
+}

--- a/sdk/src/host-config/public-types.ts
+++ b/sdk/src/host-config/public-types.ts
@@ -88,16 +88,21 @@ export interface HostServerOverride {
 
 /**
  * Optional initial configuration for `new Host(init?)`. Every field is
- * type-optional so the setter pattern works
- * (`new Host().setStyle(...).setModel(...)`), but `style` and `model` are
- * **required at use** — `toJSON()` throws if either is missing. The SDK
- * deliberately ships no default `style` (so an external author isn't silently
- * opted into MCPJam product chrome) and no default `model`. Equivalent
- * settings are available as fluent setters (`setStyle`, `setModel`, `setMcp`,
- * `addServer`, …).
+ * type-optional so the imperative pattern works (`new Host(); host.style =
+ * "..."; host.model = "..."`), but `style` and `model` are **required at
+ * use** — `toJSON()` throws if either is missing. The SDK deliberately ships
+ * no default `style` (so an external author isn't silently opted into MCPJam
+ * product chrome) and no default `model`. After construction every field is
+ * also accessible as a mutable property on the `Host` instance (e.g.
+ * `host.mcp.protocolVersion = "..."`, `host.servers.push(...)`).
  */
 export interface HostInit {
-  /** Host style id (e.g. "mcpjam", "claude", "chatgpt"). Required at `toJSON()`; no SDK default. */
+  /**
+   * Host style id (e.g. "mcpjam", "claude", "chatgpt"). Required at
+   * `toJSON()`; no SDK default. **Product knob, not SEP-1865** — selects
+   * which host-style preset (chrome, capability defaults, compat-runtime
+   * shims) the inspector applies.
+   */
   style?: HostStyleId;
   /** LLM model id (e.g. "anthropic/claude-sonnet-4-6"). Required at `toJSON()`; no SDK default. */
   model?: string;
@@ -116,7 +121,14 @@ export interface HostInit {
   connectionDefaults?: Partial<HostConnectionDefaults>;
   clientCapabilities?: Record<string, unknown>;
   hostContext?: Record<string, unknown>;
-  /** Override the MCP-Apps `hostCapabilities` blob. {} = advertise nothing. */
+  /**
+   * Override the SEP-1865 MCP-Apps `hostCapabilities` blob advertised in
+   * `ui/initialize`. `undefined` = use the host-style preset; `{}` =
+   * advertise nothing (hashes distinctly from `undefined`). Used to *cap*
+   * what a host advertises (e.g. drop `serverTools` to block widget→server
+   * tool proxying), never to grant capabilities the preset doesn't already
+   * support.
+   */
   hostCapabilitiesOverride?: Record<string, unknown>;
   /** Override the chat-UI surface (logo, fonts, …). */
   chatUiOverride?: Record<string, unknown>;

--- a/sdk/src/host-config/public-types.ts
+++ b/sdk/src/host-config/public-types.ts
@@ -13,7 +13,6 @@
  */
 
 import type {
-  CanonicalHostConfigV2,
   CspDomainSet,
   HostConfigConnectionDefaults,
   HostConfigMcpProfileV1,
@@ -52,15 +51,34 @@ export type HostMcp = Omit<
 };
 
 /**
- * Normalized, content-addressable host JSON returned by `Host.toJSON()`.
+ * The normalized host configuration returned by `Host.toJSON()`.
  *
- * NOTE: this is the *serialized* shape that gets hashed and stored, so it
- * keeps the on-disk field name `mcpProfile` (not `mcp`) for backend
- * compatibility — see the option-(b) note above. Use the `Host` fluent API
- * (`host.mcp` / `setMcp`) for authoring; use `toJSON()` only when you need the
- * exact wire form.
+ * Pure public vocabulary — no implementation names leak here: `mcp` (not
+ * `mcpProfile`), `style`/`model`/`servers`, and no `schemaVersion`/
+ * `profileVersion` markers. It is normalized (sorted, deduped, derived) and
+ * round-trips: `new Host(host.toJSON())` reproduces an equivalent host with
+ * the same `hash()`. The internal content-addressed wire form (which the
+ * fingerprint is computed over and which the backend stores) is deliberately
+ * not exposed.
  */
-export type HostJson = CanonicalHostConfigV2;
+export interface HostJson {
+  style: HostStyleId;
+  model: string;
+  systemPrompt: string;
+  temperature: number;
+  requireToolApproval: boolean;
+  progressiveToolDiscovery?: boolean;
+  respectToolVisibility?: boolean;
+  servers: ServerId[];
+  optionalServers: ServerId[];
+  connectionDefaults: HostConnectionDefaults;
+  clientCapabilities: Record<string, unknown>;
+  hostContext: Record<string, unknown>;
+  hostCapabilitiesOverride?: Record<string, unknown>;
+  chatUiOverride?: Record<string, unknown>;
+  mcp?: HostMcp;
+  serverOverrides?: Record<string, HostServerOverride>;
+}
 
 /** Per-server connection override (host-facing field names). */
 export interface HostServerOverride {

--- a/sdk/src/host-config/public-types.ts
+++ b/sdk/src/host-config/public-types.ts
@@ -56,10 +56,9 @@ export type HostMcp = Omit<
  * Pure public vocabulary — no implementation names leak here: `mcp` (not
  * `mcpProfile`), `style`/`model`/`servers`, and no `schemaVersion`/
  * `profileVersion` markers. It is normalized (sorted, deduped, derived) and
- * round-trips: `new Host(host.toJSON())` reproduces an equivalent host with
- * the same `hash()`. The internal content-addressed wire form (which the
- * fingerprint is computed over and which the backend stores) is deliberately
- * not exposed.
+ * round-trips: `new Host(host.toJSON())` reproduces an equivalent host. The
+ * internal content-addressed wire form (which the backend stores) is
+ * deliberately not exposed.
  */
 export interface HostJson {
   style: HostStyleId;
@@ -91,16 +90,16 @@ export interface HostServerOverride {
  * Optional initial configuration for `new Host(init?)`. Every field is
  * type-optional so the setter pattern works
  * (`new Host().setStyle(...).setModel(...)`), but `style` and `model` are
- * **required at use** — `toJSON()` and `hash()` throw if either is missing.
- * The SDK deliberately ships no default `style` (so an external author isn't
- * silently opted into MCPJam product chrome) and no default `model`.
- * Equivalent settings are available as fluent setters
- * (`setStyle`, `setModel`, `setMcp`, `addServer`, …).
+ * **required at use** — `toJSON()` throws if either is missing. The SDK
+ * deliberately ships no default `style` (so an external author isn't silently
+ * opted into MCPJam product chrome) and no default `model`. Equivalent
+ * settings are available as fluent setters (`setStyle`, `setModel`, `setMcp`,
+ * `addServer`, …).
  */
 export interface HostInit {
-  /** Host style id (e.g. "mcpjam", "claude", "chatgpt"). Required at `toJSON()` / `hash()`; no SDK default. */
+  /** Host style id (e.g. "mcpjam", "claude", "chatgpt"). Required at `toJSON()`; no SDK default. */
   style?: HostStyleId;
-  /** LLM model id (e.g. "anthropic/claude-sonnet-4-6"). Required at `toJSON()` / `hash()`; no SDK default. */
+  /** LLM model id (e.g. "anthropic/claude-sonnet-4-6"). Required at `toJSON()`; no SDK default. */
   model?: string;
   systemPrompt?: string;
   /** Sampling temperature. Default: 0.7. */

--- a/sdk/src/host-config/public-types.ts
+++ b/sdk/src/host-config/public-types.ts
@@ -89,13 +89,18 @@ export interface HostServerOverride {
 
 /**
  * Optional initial configuration for `new Host(init?)`. Every field is
- * optional; omitted fields fall back to SDK defaults. Equivalent settings are
- * also available as fluent setters (`setModel`, `setMcp`, `addServer`, …).
+ * type-optional so the setter pattern works
+ * (`new Host().setStyle(...).setModel(...)`), but `style` and `model` are
+ * **required at use** — `toJSON()` and `hash()` throw if either is missing.
+ * The SDK deliberately ships no default `style` (so an external author isn't
+ * silently opted into MCPJam product chrome) and no default `model`.
+ * Equivalent settings are available as fluent setters
+ * (`setStyle`, `setModel`, `setMcp`, `addServer`, …).
  */
 export interface HostInit {
-  /** Host style id — a pointer into the host registry. Default: "mcpjam". */
+  /** Host style id (e.g. "mcpjam", "claude", "chatgpt"). Required at `toJSON()` / `hash()`; no SDK default. */
   style?: HostStyleId;
-  /** LLM model id (e.g. "anthropic/claude-sonnet-4-6"). */
+  /** LLM model id (e.g. "anthropic/claude-sonnet-4-6"). Required at `toJSON()` / `hash()`; no SDK default. */
   model?: string;
   systemPrompt?: string;
   /** Sampling temperature. Default: 0.7. */

--- a/sdk/src/host-config/public-types.ts
+++ b/sdk/src/host-config/public-types.ts
@@ -6,10 +6,10 @@
  * (`HostConfigInputV2`, `mcpProfile`, schema versions) stays in `./types.ts`
  * and `./canonicalize.ts` and is reached only through `Host`.
  *
- * Wire compatibility (option b): the *serialized* canonical shape
- * (`HostJson`) keeps the on-disk field name `mcpProfile`; only the fluent API
- * renames it to `mcp`. A small mapper in `./host.ts` bridges the two so the
- * canonical JSON + hash never change (the golden-vector fixture still holds).
+ * Wire compatibility (option b): the internal canonical shape keeps the
+ * on-disk field name `mcpProfile`, but `HostJson` deliberately exposes public
+ * vocabulary (`mcp`). A small mapper in `./host.ts` bridges the two so the
+ * storage-row canonical JSON + hash stay stable.
  */
 
 import type {

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -28,7 +28,13 @@ export type { McpProtocolVersion };
  */
 export type HostConfigStyle = string;
 
-/** Alias used by the inspector client; identical to {@link HostConfigStyle}. */
+/**
+ * Public alias of {@link HostConfigStyle}. **Intentionally `string`**, not a
+ * closed union — the host registry is extensible (users can register custom
+ * host styles via the client's `lib/host-styles` registry without an SDK or
+ * backend deploy). Don't "tighten" this to `'mcpjam' | 'claude' | 'chatgpt'`;
+ * it would break BYO hosts.
+ */
 export type HostStyleId = HostConfigStyle;
 
 /**

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -1,0 +1,281 @@
+/**
+ * HostConfig v2 — portable type surface.
+ *
+ * SOURCE OF TRUTH. This module is the canonical home of the host-config
+ * shape, canonicalizer, and hash. It is hand-mirrored (NOT imported) by the
+ * Convex backend in `convex/lib/hostConfigV2.ts`, because Convex's isolate
+ * bundling forbids importing `@mcpjam/sdk` (Node-only deps). Drift between
+ * the two implementations is caught by a golden-vector parity test that runs
+ * identical inputs through both canonicalizers and asserts byte-identical
+ * canonical JSON + sha256 (see `sdk/tests/host-config-parity.test.ts` and
+ * `mcpjam-backend/tests/convex/hostConfigV2Parity.test.ts`). When you change
+ * a type or canonicalization rule here, update the backend mirror in the
+ * same change set and regenerate both fixture copies.
+ *
+ * Pure + browser-safe: no `convex/values`, no `ctx.db`, no Node-only APIs.
+ */
+
+import type { McpProtocolVersion } from "../mcp-client-manager/mcp-protocol-version.js";
+
+export type { McpProtocolVersion };
+
+/**
+ * Identifier of a host-config host style. Storage is a free-form string —
+ * the canonical "what's a registered host" check lives in the inspector
+ * client's `lib/host-styles` registry, not here. Treated as an opaque
+ * pointer into that registry so users can register custom hosts (BYO)
+ * without a backend deploy.
+ */
+export type HostConfigStyle = string;
+
+/** Alias used by the inspector client; identical to {@link HostConfigStyle}. */
+export type HostStyleId = HostConfigStyle;
+
+/**
+ * Opaque MCP server identifier. The backend brands this as `Id<'servers'>`;
+ * the portable core treats it as a plain string because the canonicalizer
+ * only sorts/dedupes serverIds — it never dereferences them.
+ */
+export type ServerId = string;
+
+export const HOST_CONFIG_SCHEMA_VERSION_V2 = 2;
+
+/**
+ * Permissions Policy feature tokens corresponding to the four
+ * SEP-1865 spec permissions. These are the KEBAB-CASE browser tokens
+ * (as they appear in iframe `allow=` attributes), NOT the camelCase
+ * mcpProfile.permissions.allow keys. The canonicalizer uses this list to
+ * drop these features from `allowFeatures` (they belong in
+ * `permissions.allow`).
+ *
+ * Naming gap (intentional): `permissions.allow.clipboardWrite` (camel,
+ * spec field name) ↔ `allowFeatures["clipboard-write"]` (kebab,
+ * Permissions Policy token). Do NOT normalize casing on either side.
+ */
+export const SEP_1865_PERMISSION_FEATURES = [
+  "camera",
+  "microphone",
+  "geolocation",
+  "clipboard-write",
+] as const;
+
+export type HostConfigConnectionDefaults = {
+  headers: Record<string, string>;
+  requestTimeout: number;
+};
+
+// A CSP "domain set" — four parallel allowlists keyed by CSP directive
+// family (SEP-1865 is allowlist-only; there's no deny concept). Canonicalized
+// as a set (trimmed, deduped, sorted) so policies that differ only in array
+// order hash identically.
+export type CspDomainSet = {
+  connectDomains?: string[];
+  resourceDomains?: string[];
+  frameDomains?: string[];
+  baseUriDomains?: string[];
+};
+
+// Versioned envelope for host-level MCP state. Designed so the MCP spec
+// can evolve under `extensions` or a future `profileVersion: 2` without
+// adding new columns. The backend stores intent; the inspector SDK enforces
+// sandbox policy when it builds the proxy CSP. Domain syntax is intentionally
+// NOT validated here — that's a UI/SDK concern.
+export type HostConfigMcpProfileV1 = {
+  profileVersion: 1;
+  // Host-default pinned MCP protocol version. Absent → SDK chooses at
+  // request time. Per-server pins live on serverConnectionOverrides.
+  mcpProtocolVersion?: McpProtocolVersion;
+  initialize?: {
+    // Order is semantic. The first entry is sent in
+    // `initialize.params.protocolVersion`; all entries form the
+    // accept-list. A single-item array pins a reproducible version.
+    supportedProtocolVersions?: string[];
+    // Stored as the exact `initialize.clientInfo` object the SDK should
+    // send. Soft-validated (name & version required when set); everything
+    // else passes through verbatim so future spec additions land here
+    // without a schema migration.
+    clientInfo?: Record<string, unknown>;
+  };
+  apps?: {
+    sandbox?: {
+      csp?: {
+        mode?: "host-default" | "declared" | "relaxed";
+        // Intersection — never adds undeclared domains. Per SEP-1865:
+        // host MAY further restrict but MUST NOT loosen.
+        restrictTo?: CspDomainSet;
+        // Per-directive CSP source-expression overrides. Keys are CSP
+        // directive names (script-src, style-src, …); values are token
+        // arrays. Stored verbatim — no enum. Inspector-only emission knob.
+        cspDirectives?: Record<string, string[]>;
+        extensions?: Record<string, unknown>;
+      };
+      permissions?: {
+        mode?: "resource-declared" | "deny-all" | "custom";
+        allow?: Record<string, boolean>;
+        extensions?: Record<string, unknown>;
+      };
+      // Extra outer/inner iframe `sandbox=` tokens unioned with the
+      // mandatory `allow-scripts allow-same-origin`. Inspector-only.
+      sandboxAttrs?: string[];
+      // Extra Permissions Policy entries appended to outer/inner iframe
+      // `allow=`. Keys are RAW kebab Permissions Policy tokens
+      // (clipboard-write, not clipboardWrite). Spec-permission keys are
+      // dropped on canonicalize — those belong in `permissions.allow`.
+      allowFeatures?: Record<string, string>;
+    };
+    // Overrides for the MCP Apps `ui/initialize` response (SEP-1865).
+    // Sibling of `apps.sandbox`; distinct from `mcpProfile.initialize`
+    // (which targets the base-protocol `initialize`).
+    uiInitialize?: {
+      // Stored as the exact `hostInfo` object the inspector should emit in
+      // `ui/initialize`. Soft-validated (name & version required when set).
+      hostInfo?: Record<string, unknown>;
+    };
+    // Vendor compat-runtime shims the inspector injects into widget HTML.
+    // Claude/Cursor/Codex-style hosts leave these off; ChatGPT/Copilot and
+    // MCPJam's dev surface enable them. Absent → inspector falls back to the
+    // host style preset.
+    compatRuntime?: {
+      // Inject the OpenAI Apps SDK `window.openai` shim into widget HTML.
+      //   undefined → fall back to the host style preset.
+      //   true → inject the shim (preset baseline merged with overrides).
+      //   false → do NOT inject; `openaiAppsOverrides` ignored.
+      openaiApps?: boolean;
+      // Sparse per-method overrides applied on top of the host style preset
+      // when the shim IS injected. See canonicalizer for validation rules.
+      openaiAppsOverrides?: OpenAiAppsCapabilities;
+    };
+    // Sparse per-dimension override on the SEP-1865 MCP Apps `app.*`
+    // spec-bridge matrix. Independent from `compatRuntime`.
+    mcpAppsOverrides?: McpAppsCapabilities;
+  };
+  extensions?: Record<string, unknown>;
+};
+
+// Per-method `window.openai.*` surface controlled by
+// `mcpProfile.apps.compatRuntime.openaiAppsOverrides`. Sparse — every field
+// optional; user overrides only specify fields they're flipping.
+export type OpenAiAppsCapabilities = {
+  callTool?: boolean;
+  sendFollowUpMessage?: boolean;
+  setWidgetState?: boolean;
+  requestDisplayMode?: "all" | "fullscreen-only" | "none";
+  notifyIntrinsicHeight?: boolean;
+  openExternal?: boolean;
+  setOpenInAppUrl?: boolean;
+  requestModal?: boolean;
+  uploadFile?: boolean;
+  selectFiles?: boolean;
+  getFileDownloadUrl?: boolean;
+  requestCheckout?: boolean;
+  requestClose?: boolean;
+};
+
+// Per-dimension surface controlled by `mcpProfile.apps.mcpAppsOverrides`.
+// Sparse — every field optional. `availableDisplayModes` is the only
+// non-boolean: an array of spec-defined mode strings, replacement semantics.
+export type McpAppsCapabilities = {
+  availableDisplayModes?: ("inline" | "fullscreen" | "pip")[];
+  toolInputPartial?: boolean;
+  toolCancelled?: boolean;
+  hostContextChanged?: boolean;
+  resourceTeardown?: boolean;
+  toolInfo?: boolean;
+  openLinks?: boolean;
+  serverTools?: boolean;
+  serverResources?: boolean;
+  logging?: boolean;
+  updateModelContext?: boolean;
+  message?: boolean;
+  sandboxPermissions?: boolean;
+  cspFrameDomains?: boolean;
+  cspBaseUriDomains?: boolean;
+  resourcePrefersBorder?: boolean;
+  downloadFile?: boolean;
+  requestTeardown?: boolean;
+  // Host policy for `ui/request-display-mode` originating from the widget.
+  //   "accept": grant the requested mode
+  //   "user-initiated-only": grant only after the user moved off `inline`
+  //   "decline": always return the current mode
+  widgetDisplayModeRequests?: "accept" | "user-initiated-only" | "decline";
+};
+
+export type HostConfigInputV2 = {
+  hostStyle: HostConfigStyle;
+  modelId: string;
+  systemPrompt: string;
+  temperature: number;
+  requireToolApproval: boolean;
+  // Host-level opt-in for progressive MCP tool discovery. Optional + defaults
+  // to undefined ("off") so pre-feature rows hash byte-identically.
+  // JSON.stringify drops undefined, so `undefined` and `false` hash distinctly
+  // only when the value is explicitly written.
+  progressiveToolDiscovery?: boolean;
+  // Host-level switch for SEP-1865 `_meta.ui.visibility` filtering. `true` →
+  // hide tools whose visibility doesn't include "model" (spec default).
+  // `false` → show every tool (faithful to hosts that don't implement
+  // SEP-1865). `undefined` → "use the spec default" (filter).
+  respectToolVisibility?: boolean;
+  // Optional during the rollout of project-scoped server config: named hosts
+  // pass `undefined` (server set lives on `projects.serverIds`); chatbox/eval
+  // forks still pass real arrays. Normalized to `[]` BEFORE hashing so the
+  // canonical / hash output is byte-identical to the old "explicit empty
+  // array" case.
+  serverIds?: Array<ServerId>;
+  optionalServerIds?: Array<ServerId>;
+  connectionDefaults: HostConfigConnectionDefaults;
+  clientCapabilities: Record<string, unknown>;
+  hostContext: Record<string, unknown>;
+  // Optional user override of the MCP Apps `hostCapabilities` blob advertised
+  // in ui/initialize. undefined → use preset; `{}` → explicit empty (hashes
+  // distinctly).
+  hostCapabilitiesOverride?: Record<string, unknown>;
+  // User override of the chat-UI surface. Same undefined-vs-{} semantics.
+  chatUiOverride?: Record<string, unknown>;
+  // Versioned envelope for host-level MCP state. Optional; absent means "use
+  // SDK defaults / no host-level sandbox override."
+  mcpProfile?: HostConfigMcpProfileV1;
+  // Per-server connection overrides scoped to this host config. Keys are
+  // server IDs. Included in the canonical hash.
+  serverConnectionOverrides?: Record<
+    string,
+    {
+      headersOverride?: Record<string, string>;
+      requestTimeoutOverride?: number;
+      mcpProtocolVersionOverride?: McpProtocolVersion;
+    }
+  >;
+};
+
+export type CanonicalHostConfigV2 = {
+  schemaVersion: typeof HOST_CONFIG_SCHEMA_VERSION_V2;
+  hostStyle: HostConfigStyle;
+  modelId: string;
+  systemPrompt: string;
+  temperature: number;
+  requireToolApproval: boolean;
+  // Mirrors HostConfigInputV2.progressiveToolDiscovery. Optional so absent
+  // rows hash byte-identically to pre-feature rows.
+  progressiveToolDiscovery?: boolean;
+  // Mirrors HostConfigInputV2.respectToolVisibility. Same undefined-vs-set
+  // policy.
+  respectToolVisibility?: boolean;
+  serverIds: Array<ServerId>;
+  optionalServerIds: Array<ServerId>;
+  connectionDefaults: HostConfigConnectionDefaults;
+  clientCapabilities: Record<string, unknown>;
+  hostContext: Record<string, unknown>;
+  // Mirrors HostConfigInputV2.hostCapabilitiesOverride. Optional so
+  // `undefined` (use preset) and `{}` (explicit empty) hash distinctly.
+  hostCapabilitiesOverride?: Record<string, unknown>;
+  chatUiOverride?: Record<string, unknown>;
+  mcpProfile?: HostConfigMcpProfileV1;
+  serverConnectionOverrides?: Record<
+    string,
+    {
+      headersOverride?: Record<string, string>;
+      requestTimeoutOverride?: number;
+      mcpProtocolVersionOverride?: McpProtocolVersion;
+    }
+  >;
+};

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -537,23 +537,18 @@ export type {
   EvalToolCallMatchResult,
 } from "./matchers.js";
 
-// HostConfig v2 portable core (also exported from `@mcpjam/sdk/host-config`).
-// SOURCE OF TRUTH for the host-config shape + canonicalizer + hash; the Convex
-// backend hand-mirrors it under a golden-vector parity test. Browser-safe.
+// HostConfig — the public `Host` builder (also at `@mcpjam/sdk/host-config`).
+// SOURCE OF TRUTH for the host shape + canonicalizer + hash; the Convex
+// backend hand-mirrors it under a golden-vector parity test. The canonicalizer
+// itself is internal — `Host.toJSON()` / `Host.hash()` are the public seam.
 // `McpProtocolVersion` is intentionally omitted here — already exported above.
-export {
-  HOST_CONFIG_SCHEMA_VERSION_V2,
-  SEP_1865_PERMISSION_FEATURES,
-  canonicalizeHostConfigV2,
-  computeHostConfigHashV2,
-  sha256Hex,
-} from "./host-config/index.js";
+export { Host } from "./host-config/index.js";
 export type {
-  HostConfigInputV2,
-  CanonicalHostConfigV2,
-  HostConfigConnectionDefaults,
-  HostConfigMcpProfileV1,
-  HostConfigStyle,
+  HostInit,
+  HostJson,
+  HostMcp,
+  HostServerOverride,
+  HostConnectionDefaults,
   HostStyleId,
   ServerId,
   CspDomainSet,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -536,3 +536,27 @@ export type {
   EvalToolCall,
   EvalToolCallMatchResult,
 } from "./matchers.js";
+
+// HostConfig v2 portable core (also exported from `@mcpjam/sdk/host-config`).
+// SOURCE OF TRUTH for the host-config shape + canonicalizer + hash; the Convex
+// backend hand-mirrors it under a golden-vector parity test. Browser-safe.
+// `McpProtocolVersion` is intentionally omitted here — already exported above.
+export {
+  HOST_CONFIG_SCHEMA_VERSION_V2,
+  SEP_1865_PERMISSION_FEATURES,
+  canonicalizeHostConfigV2,
+  computeHostConfigHashV2,
+  sha256Hex,
+} from "./host-config/index.js";
+export type {
+  HostConfigInputV2,
+  CanonicalHostConfigV2,
+  HostConfigConnectionDefaults,
+  HostConfigMcpProfileV1,
+  HostConfigStyle,
+  HostStyleId,
+  ServerId,
+  CspDomainSet,
+  OpenAiAppsCapabilities,
+  McpAppsCapabilities,
+} from "./host-config/index.js";

--- a/sdk/tests/fixtures/host-config-parity-fixtures.json
+++ b/sdk/tests/fixtures/host-config-parity-fixtures.json
@@ -1,0 +1,425 @@
+{
+  "__inputHash": "8a680395dda47f356458db577201e723427be6e551217cba73c982e28a01b6c7",
+  "rows": [
+    {
+      "label": "base-minimal",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {}
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{}}",
+      "sha256": "f6df30e89bb13c7b9fe2a098bcdd1e2778a0612d831cd4497471ca8ef2a4d729"
+    },
+    {
+      "label": "explicit-false-flags",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "progressiveToolDiscovery": false,
+        "respectToolVisibility": false
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"progressiveToolDiscovery\":false,\"respectToolVisibility\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{}}",
+      "sha256": "a33c0cf10401316cdce2f679ad3be66938ed3644f1e48be4c8e5c71d5c0ec458"
+    },
+    {
+      "label": "headers-and-caps-key-order",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {
+            "X-Z": "1",
+            "A-Header": "2",
+            "m-mid": "3"
+          },
+          "requestTimeout": 30000
+        },
+        "clientCapabilities": {
+          "zeta": true,
+          "alpha": {
+            "nested": 1,
+            "deep": 2
+          }
+        },
+        "hostContext": {
+          "b": 2,
+          "a": 1
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{\"A-Header\":\"2\",\"X-Z\":\"1\",\"m-mid\":\"3\"},\"requestTimeout\":30000},\"clientCapabilities\":{\"alpha\":{\"nested\":1,\"deep\":2},\"zeta\":true},\"hostContext\":{\"a\":1,\"b\":2}}",
+      "sha256": "7b050c8dbee3bfd261854c4446a5351de06fdfd332f26caeb6b30154610d5c47"
+    },
+    {
+      "label": "server-ids-unsorted-plus-overrides",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "serverIds": [
+          "srv-c",
+          "srv-a",
+          "srv-b"
+        ],
+        "optionalServerIds": [
+          "opt-z",
+          "opt-a"
+        ],
+        "serverConnectionOverrides": {
+          "srv-b": {
+            "headersOverride": {
+              "Z": "1",
+              "A": "2"
+            },
+            "requestTimeoutOverride": 5000,
+            "mcpProtocolVersionOverride": "2025-06-18"
+          },
+          "srv-a": {}
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[\"srv-a\",\"srv-b\",\"srv-c\"],\"optionalServerIds\":[\"opt-a\",\"opt-z\"],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"serverConnectionOverrides\":{\"srv-b\":{\"headersOverride\":{\"A\":\"2\",\"Z\":\"1\"},\"mcpProtocolVersionOverride\":\"2025-06-18\",\"requestTimeoutOverride\":5000}}}",
+      "sha256": "16092163595b8b24018e0881195832543efbfd7a6f2f7bf27669497488d01a94"
+    },
+    {
+      "label": "mcp-profile-initialize-order-preserved",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "initialize": {
+            "supportedProtocolVersions": [
+              "2025-11-25",
+              "2025-06-18"
+            ],
+            "clientInfo": {
+              "version": "1.2.3",
+              "name": "mcpjam",
+              "title": "MCPJam"
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"initialize\":{\"clientInfo\":{\"name\":\"mcpjam\",\"title\":\"MCPJam\",\"version\":\"1.2.3\"},\"supportedProtocolVersions\":[\"2025-11-25\",\"2025-06-18\"]}}}",
+      "sha256": "dfd03c7cb66d7056adb4a298fa82fb3fa14de3fd366d60d4f17c71592494839f"
+    },
+    {
+      "label": "mcp-profile-stateful-pin-derives-supported",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "mcpProtocolVersion": "2025-06-18"
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"initialize\":{\"supportedProtocolVersions\":[\"2025-06-18\"]},\"mcpProtocolVersion\":\"2025-06-18\"}}",
+      "sha256": "f0f4fb70fcd748a67f8f5f9cc3402453aee6c6d44e03e5fbbb18225666ec9ef3"
+    },
+    {
+      "label": "mcp-profile-stateless-pin-no-derivation",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "mcpProtocolVersion": "2026-07-28"
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"mcpProtocolVersion\":\"2026-07-28\"}}",
+      "sha256": "76b9ef8f4c037389749b4a01ae3a855cc31e5238c7162d32c8ca84e6b67d13ce"
+    },
+    {
+      "label": "sandbox-csp-restrictto-sorted-plus-directives",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "apps": {
+            "sandbox": {
+              "csp": {
+                "mode": "declared",
+                "restrictTo": {
+                  "connectDomains": [
+                    "b.example.com",
+                    "a.example.com",
+                    "b.example.com"
+                  ],
+                  "frameDomains": [
+                    "x.example.com"
+                  ]
+                },
+                "cspDirectives": {
+                  "script-src": [
+                    "'wasm-unsafe-eval'",
+                    "'unsafe-eval'"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"apps\":{\"sandbox\":{\"csp\":{\"cspDirectives\":{\"script-src\":[\"'unsafe-eval'\",\"'wasm-unsafe-eval'\"]},\"mode\":\"declared\",\"restrictTo\":{\"connectDomains\":[\"a.example.com\",\"b.example.com\"],\"frameDomains\":[\"x.example.com\"]}}}}}}",
+      "sha256": "2b98518df04a16172cafa4bab520dfe0374d5675ca58955f7cce3ef1ad9b755b"
+    },
+    {
+      "label": "sandbox-permissions-allow-key-order",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "apps": {
+            "sandbox": {
+              "permissions": {
+                "mode": "custom",
+                "allow": {
+                  "microphone": true,
+                  "camera": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"apps\":{\"sandbox\":{\"permissions\":{\"allow\":{\"camera\":false,\"microphone\":true},\"mode\":\"custom\"}}}}}",
+      "sha256": "4a2b8da0632e7191d5ecf26bc127ce2bb7a6378e3c86490755fec6e822e53de6"
+    },
+    {
+      "label": "sandbox-allowfeatures-drops-spec-features",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "apps": {
+            "sandbox": {
+              "allowFeatures": {
+                "camera": "*",
+                "fullscreen": "'self'",
+                "clipboard-write": "*"
+              }
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"apps\":{\"sandbox\":{\"allowFeatures\":{\"fullscreen\":\"'self'\"}}}}}",
+      "sha256": "c226136ffb697956e33c48ad7b1314ddffa467c3fdd4ad40f9b3d716fd35684d"
+    },
+    {
+      "label": "compat-runtime-openai-overrides",
+      "input": {
+        "hostStyle": "chatgpt",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "apps": {
+            "compatRuntime": {
+              "openaiApps": true,
+              "openaiAppsOverrides": {
+                "requestDisplayMode": "fullscreen-only",
+                "uploadFile": false,
+                "callTool": true
+              }
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"chatgpt\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"apps\":{\"compatRuntime\":{\"openaiApps\":true,\"openaiAppsOverrides\":{\"callTool\":true,\"requestDisplayMode\":\"fullscreen-only\",\"uploadFile\":false}}}}}",
+      "sha256": "26b8da040cda618cacab9d6b11ff2a49b326b00de30b5a78b17545a1262b9ef4"
+    },
+    {
+      "label": "mcp-apps-overrides-display-modes-reordered",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "apps": {
+            "mcpAppsOverrides": {
+              "availableDisplayModes": [
+                "pip",
+                "inline"
+              ],
+              "widgetDisplayModeRequests": "user-initiated-only",
+              "logging": true
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"apps\":{\"mcpAppsOverrides\":{\"availableDisplayModes\":[\"inline\",\"pip\"],\"logging\":true,\"widgetDisplayModeRequests\":\"user-initiated-only\"}}}}",
+      "sha256": "a077644d119560766044be1bba3d1dd139e61cab9c914f9cec63930b48aed2df"
+    },
+    {
+      "label": "host-capabilities-override-explicit-empty",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "hostCapabilitiesOverride": {},
+        "chatUiOverride": {
+          "logo": "x"
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"hostCapabilitiesOverride\":{},\"chatUiOverride\":{\"logo\":\"x\"}}",
+      "sha256": "688fa1203c5197fe044ef781fbe5ca459cc963d3cb919310161fbc1179c05785"
+    },
+    {
+      "label": "adversarial-stray-deny-must-be-dropped",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "apps": {
+            "sandbox": {
+              "csp": {
+                "mode": "declared",
+                "restrictTo": {
+                  "connectDomains": [
+                    "api.example.com"
+                  ]
+                },
+                "deny": {
+                  "connectDomains": [
+                    "evil.example.com"
+                  ]
+                }
+              },
+              "permissions": {
+                "mode": "custom",
+                "allow": {
+                  "camera": true
+                },
+                "deny": [
+                  "microphone"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"apps\":{\"sandbox\":{\"csp\":{\"mode\":\"declared\",\"restrictTo\":{\"connectDomains\":[\"api.example.com\"]}},\"permissions\":{\"allow\":{\"camera\":true},\"mode\":\"custom\"}}}}}",
+      "sha256": "1f3ea06ff2905d5229c231cea0578a4ffd152ff7d791e13a52169c004082da28"
+    }
+  ]
+}

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -48,11 +48,15 @@ describe("canonicalizeHostConfigV2 — hash stability", () => {
     );
   });
 
-  it("sorts serverIds deterministically", () => {
+  it("sorts and dedupes serverIds deterministically", () => {
     const c = canonicalizeHostConfigV2(
-      base({ serverIds: ["c", "a", "b"] as string[] }),
+      base({
+        serverIds: ["c", "a", "b", "a"] as string[],
+        optionalServerIds: ["z", "x", "x"] as string[],
+      }),
     );
     expect(c.serverIds).toEqual(["a", "b", "c"]);
+    expect(c.optionalServerIds).toEqual(["x", "z"]);
   });
 });
 
@@ -103,6 +107,17 @@ describe("canonicalizeHostConfigV2 — validation", () => {
         }),
       ),
     ).toThrow(/not in serverIds or optionalServerIds/);
+  });
+
+  it("rejects a non-finite per-server request timeout override", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          serverIds: ["a"] as string[],
+          serverConnectionOverrides: { a: { requestTimeoutOverride: Infinity } },
+        }),
+      ),
+    ).toThrow(/requestTimeoutOverride must be finite/);
   });
 
   it("requires mcpProfile.profileVersion === 1", () => {

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -1,8 +1,8 @@
 import {
   canonicalizeHostConfigV2,
   computeHostConfigHashV2,
-} from "../src/host-config/index";
-import type { HostConfigInputV2 } from "../src/host-config/index";
+} from "../src/host-config/internal";
+import type { HostConfigInputV2 } from "../src/host-config/internal";
 
 function base(overrides: Partial<HostConfigInputV2> = {}): HostConfigInputV2 {
   return {

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -1,0 +1,191 @@
+import {
+  canonicalizeHostConfigV2,
+  computeHostConfigHashV2,
+} from "../src/host-config/index";
+import type { HostConfigInputV2 } from "../src/host-config/index";
+
+function base(overrides: Partial<HostConfigInputV2> = {}): HostConfigInputV2 {
+  return {
+    hostStyle: "claude",
+    modelId: "anthropic/claude-sonnet-4-6",
+    systemPrompt: "You are a helpful assistant.",
+    temperature: 0.7,
+    requireToolApproval: false,
+    connectionDefaults: { headers: {}, requestTimeout: 10000 },
+    clientCapabilities: {},
+    hostContext: {},
+    ...overrides,
+  };
+}
+
+const hash = (input: HostConfigInputV2) => computeHostConfigHashV2(input);
+
+describe("canonicalizeHostConfigV2 — hash stability", () => {
+  it("is independent of TOP-LEVEL header / capability key order (shallow sort)", async () => {
+    // connectionDefaults.headers, clientCapabilities and hostContext use a
+    // SHALLOW key sort — top-level order is normalized, nested order is NOT
+    // (matches the backend; only *Override + mcpProfile deep-sort).
+    const a = base({
+      connectionDefaults: { headers: { a: "1", b: "2" }, requestTimeout: 1 },
+      clientCapabilities: { x: 1, y: 3 },
+    });
+    const b = base({
+      connectionDefaults: { headers: { b: "2", a: "1" }, requestTimeout: 1 },
+      clientCapabilities: { y: 3, x: 1 },
+    });
+    expect(await hash(a)).toBe(await hash(b));
+  });
+
+  it("deep-sorts hostCapabilitiesOverride (nested order-independent)", async () => {
+    const a = base({ hostCapabilitiesOverride: { x: { p: 1, q: 2 }, y: 3 } });
+    const b = base({ hostCapabilitiesOverride: { y: 3, x: { q: 2, p: 1 } } });
+    expect(await hash(a)).toBe(await hash(b));
+  });
+
+  it("normalizes undefined serverIds to [] (same hash as explicit empty)", async () => {
+    expect(await hash(base())).toBe(
+      await hash(base({ serverIds: [], optionalServerIds: [] })),
+    );
+  });
+
+  it("sorts serverIds deterministically", () => {
+    const c = canonicalizeHostConfigV2(
+      base({ serverIds: ["c", "a", "b"] as string[] }),
+    );
+    expect(c.serverIds).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("canonicalizeHostConfigV2 — undefined vs explicit", () => {
+  it("distinguishes hostCapabilitiesOverride undefined from {}", async () => {
+    const omitted = canonicalizeHostConfigV2(base());
+    expect("hostCapabilitiesOverride" in JSON.parse(JSON.stringify(omitted))).toBe(
+      false,
+    );
+    expect(await hash(base())).not.toBe(
+      await hash(base({ hostCapabilitiesOverride: {} })),
+    );
+  });
+
+  it("distinguishes progressiveToolDiscovery undefined from false", async () => {
+    expect(await hash(base())).not.toBe(
+      await hash(base({ progressiveToolDiscovery: false })),
+    );
+  });
+});
+
+describe("canonicalizeHostConfigV2 — validation", () => {
+  it("throws on non-finite temperature", () => {
+    expect(() => canonicalizeHostConfigV2(base({ temperature: NaN }))).toThrow(
+      /temperature must be finite/,
+    );
+  });
+
+  it("rejects an unknown mcpAppsOverrides key (typo defense)", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            apps: { mcpAppsOverrides: { toolCanceled: true } as never },
+          },
+        }),
+      ),
+    ).toThrow(/unknown key "toolCanceled"/);
+  });
+
+  it("rejects a serverConnectionOverrides key not in serverIds", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          serverIds: ["a"] as string[],
+          serverConnectionOverrides: { b: { requestTimeoutOverride: 1 } },
+        }),
+      ),
+    ).toThrow(/not in serverIds or optionalServerIds/);
+  });
+
+  it("requires mcpProfile.profileVersion === 1", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({ mcpProfile: { profileVersion: 2 } as never }),
+      ),
+    ).toThrow(/profileVersion must be 1/);
+  });
+
+  it("rejects an empty availableDisplayModes array", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            apps: { mcpAppsOverrides: { availableDisplayModes: [] } },
+          },
+        }),
+      ),
+    ).toThrow(/must contain at least one mode/);
+  });
+
+  it("drops spec permission features from allowFeatures and blocks injection", () => {
+    const c = canonicalizeHostConfigV2(
+      base({
+        mcpProfile: {
+          profileVersion: 1,
+          apps: {
+            sandbox: { allowFeatures: { camera: "*", fullscreen: "'self'" } },
+          },
+        },
+      }),
+    );
+    const allowFeatures = c.mcpProfile?.apps?.sandbox?.allowFeatures ?? {};
+    expect("camera" in allowFeatures).toBe(false);
+    expect(allowFeatures.fullscreen).toBe("'self'");
+
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            apps: { sandbox: { allowFeatures: { fullscreen: "*; camera *" } } },
+          },
+        }),
+      ),
+    ).toThrow(/must not contain ';' or ','/);
+  });
+});
+
+describe("canonicalizeHostConfigV2 — mcpProfile derivation", () => {
+  it("derives supportedProtocolVersions for a stateful pin", () => {
+    const c = canonicalizeHostConfigV2(
+      base({
+        mcpProfile: { profileVersion: 1, mcpProtocolVersion: "2025-06-18" },
+      }),
+    );
+    expect(c.mcpProfile?.initialize?.supportedProtocolVersions).toEqual([
+      "2025-06-18",
+    ]);
+  });
+
+  it("does not derive for a stateless pin", () => {
+    const c = canonicalizeHostConfigV2(
+      base({
+        mcpProfile: { profileVersion: 1, mcpProtocolVersion: "2026-07-28" },
+      }),
+    );
+    expect(c.mcpProfile?.initialize).toBeUndefined();
+  });
+
+  it("throws ConflictingProtocolVersionPin when pin not advertised", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            mcpProtocolVersion: "2025-06-18",
+            initialize: { supportedProtocolVersions: ["2025-11-25"] },
+          },
+        }),
+      ),
+    ).toThrow(/ConflictingProtocolVersionPin/);
+  });
+});

--- a/sdk/tests/host-config-parity.test.ts
+++ b/sdk/tests/host-config-parity.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  canonicalizeHostConfigV2,
+  computeHostConfigHashV2,
+  sha256Hex,
+} from "../src/host-config/index";
+import type { HostConfigInputV2 } from "../src/host-config/index";
+
+/**
+ * Golden-vector parity fixture. The Convex backend keeps a BYTE-IDENTICAL copy
+ * and runs its own (hand-mirrored) canonicalizer against it. If either
+ * canonicalizer drifts, that repo's copy of this test fails because the
+ * canonical JSON / sha256 no longer matches the pinned golden values.
+ *
+ * `EXPECTED_INPUT_HASH` is the sha256 of the fixture's `rows` array, inlined
+ * here AND in `mcpjam-backend/tests/convex/hostConfigV2Parity.test.ts`. If you
+ * regenerate the fixture (scripts/gen-host-config-parity-fixture.mjs), copy the
+ * new fixture to the backend and update BOTH inlined constants in the same
+ * change set — a partial edit fails the stale side loudly.
+ */
+const EXPECTED_INPUT_HASH =
+  "8a680395dda47f356458db577201e723427be6e551217cba73c982e28a01b6c7";
+
+type FixtureRow = {
+  label: string;
+  input: HostConfigInputV2;
+  canonicalJson: string;
+  sha256: string;
+};
+type Fixture = { __inputHash: string; rows: FixtureRow[] };
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(
+  readFileSync(
+    join(here, "fixtures", "host-config-parity-fixtures.json"),
+    "utf8",
+  ),
+) as Fixture;
+
+describe("hostConfig v2 golden-vector parity", () => {
+  it("fixture self-hash matches the pinned constant (drift guard)", async () => {
+    expect(fixture.__inputHash).toBe(EXPECTED_INPUT_HASH);
+    const recomputed = await sha256Hex(JSON.stringify(fixture.rows));
+    expect(recomputed).toBe(EXPECTED_INPUT_HASH);
+  });
+
+  it("ships a non-trivial battery of vectors", () => {
+    expect(fixture.rows.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const row of fixture.rows) {
+    it(`canonicalizes "${row.label}" to the golden canonical JSON`, () => {
+      expect(JSON.stringify(canonicalizeHostConfigV2(row.input))).toBe(
+        row.canonicalJson,
+      );
+    });
+
+    it(`hashes "${row.label}" to the golden sha256`, async () => {
+      expect(await computeHostConfigHashV2(row.input)).toBe(row.sha256);
+    });
+  }
+
+  it("never persists a `deny` field (allowlist-only invariant)", () => {
+    // The adversarial vector feeds stray csp.deny + permissions.deny. The
+    // persisted host-config shape is allowlist-only, so they must be dropped.
+    // Guards against accidentally reusing the runtime resolver's
+    // deny-bearing policy types (sandbox-policy.ts) in the canonical shape.
+    const adversarial = fixture.rows.find((r) =>
+      r.label.includes("adversarial-stray-deny"),
+    );
+    expect(adversarial).toBeDefined();
+    expect(adversarial!.canonicalJson).not.toContain("deny");
+    expect(
+      JSON.stringify(canonicalizeHostConfigV2(adversarial!.input)),
+    ).not.toContain("deny");
+  });
+});

--- a/sdk/tests/host-config-parity.test.ts
+++ b/sdk/tests/host-config-parity.test.ts
@@ -5,8 +5,8 @@ import {
   canonicalizeHostConfigV2,
   computeHostConfigHashV2,
   sha256Hex,
-} from "../src/host-config/index";
-import type { HostConfigInputV2 } from "../src/host-config/index";
+} from "../src/host-config/internal";
+import type { HostConfigInputV2 } from "../src/host-config/internal";
 
 /**
  * Golden-vector parity fixture. The Convex backend keeps a BYTE-IDENTICAL copy

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -1,29 +1,9 @@
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { Host } from "../src/host-config/index";
 import type { HostMcp } from "../src/host-config/index";
 // Cross-entry check uses the browser entry (the Node `../src/index` barrel
 // transitively imports `.md` skill files that vitest's transform can't load;
 // the published `@mcpjam/sdk` main export is covered by `test:packaging`).
 import { Host as HostFromBrowser } from "../src/browser";
-
-type FixtureRow = { label: string; sha256: string };
-type Fixture = { rows: FixtureRow[] };
-
-const here = dirname(fileURLToPath(import.meta.url));
-const fixture = JSON.parse(
-  readFileSync(
-    join(here, "fixtures", "host-config-parity-fixtures.json"),
-    "utf8",
-  ),
-) as Fixture;
-
-const sha = (label: string): string => {
-  const row = fixture.rows.find((r) => r.label === label);
-  if (!row) throw new Error(`missing fixture row: ${label}`);
-  return row.sha256;
-};
 
 describe("Host — public surface", () => {
   it("is exported from both @mcpjam/sdk/host-config and @mcpjam/sdk/browser", () => {
@@ -84,46 +64,17 @@ describe("Host — public surface", () => {
     expect(() => host.toJSON()).toThrow(/must contain at least one mode/);
   });
 
-  it("throws if `style` is not set (no silent SDK default)", async () => {
+  it("throws if `style` is not set (no silent SDK default)", () => {
     const noStyle = new Host().setModel("test-model");
     expect(() => noStyle.toJSON()).toThrow(/requires a `style`/);
-    await expect(noStyle.hash()).rejects.toThrow(/requires a `style`/);
   });
 
-  it("throws if `model` is not set (no silent SDK default)", async () => {
+  it("throws if `model` is not set (no silent SDK default)", () => {
     const noModel = new Host().setStyle("mcpjam");
     expect(() => noModel.toJSON()).toThrow(/requires a `model`/);
-    await expect(noModel.hash()).rejects.toThrow(/requires a `model`/);
-  });
-});
-
-describe("Host — fingerprint matches the golden vectors", () => {
-  // hash() is computed over the internal canonical form, so it must equal the
-  // pinned golden sha256 (proving the facade preserves backend parity).
-  it("base-minimal", async () => {
-    const host = new Host({
-      style: "claude",
-      model: "anthropic/claude-sonnet-4-6",
-      systemPrompt: "You are a helpful assistant.",
-    });
-    expect(await host.hash()).toBe(sha("base-minimal"));
   });
 
-  it("mcp-profile-initialize-order-preserved", async () => {
-    const host = new Host({
-      style: "claude",
-      model: "anthropic/claude-sonnet-4-6",
-      systemPrompt: "You are a helpful assistant.",
-    }).setMcp({
-      initialize: {
-        supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
-        clientInfo: { version: "1.2.3", name: "mcpjam", title: "MCPJam" },
-      },
-    });
-    expect(await host.hash()).toBe(sha("mcp-profile-initialize-order-preserved"));
-  });
-
-  it("server-ids-unsorted-plus-overrides", async () => {
+  it("normalizes server ids: sorts, dedupes empty overrides, sorts header keys", () => {
     const host = new Host({
       style: "claude",
       model: "anthropic/claude-sonnet-4-6",
@@ -141,8 +92,6 @@ describe("Host — fingerprint matches the golden vectors", () => {
       })
       .addServerOverride("srv-a", {});
 
-    // Also assert the normalized public shape, not just the hash: servers are
-    // sorted and the empty "srv-a" override is dropped.
     const json = host.toJSON();
     expect(json.servers).toEqual(["srv-a", "srv-b", "srv-c"]);
     expect(json.optionalServers).toEqual(["opt-a", "opt-z"]);
@@ -152,13 +101,11 @@ describe("Host — fingerprint matches the golden vectors", () => {
       requestTimeout: 5000,
       protocolVersion: "2025-06-18",
     });
-
-    expect(await host.hash()).toBe(sha("server-ids-unsorted-plus-overrides"));
   });
 });
 
 describe("Host — toJSON() round-trips", () => {
-  it("new Host(host.toJSON()) reproduces the same JSON and hash", async () => {
+  it("new Host(host.toJSON()) reproduces the same JSON", () => {
     const host = new Host({ style: "chatgpt", model: "openai/gpt-5" })
       .setMcp({
         protocolVersion: "2025-06-18",
@@ -170,15 +117,12 @@ describe("Host — toJSON() round-trips", () => {
 
     const json1 = host.toJSON();
     const rebuilt = new Host(json1);
-    const json2 = rebuilt.toJSON();
-
-    expect(json2).toEqual(json1);
-    expect(await rebuilt.hash()).toBe(await host.hash());
+    expect(rebuilt.toJSON()).toEqual(json1);
   });
 });
 
 describe("Host — deterministic under post-construction input mutation", () => {
-  it("snapshots object inputs so later caller mutations don't leak in", async () => {
+  it("snapshots object inputs so later caller mutations don't leak in", () => {
     const mcp: HostMcp = {
       protocolVersion: "2025-06-18",
       apps: { compatRuntime: { openaiApps: true } },
@@ -190,25 +134,21 @@ describe("Host — deterministic under post-construction input mutation", () => 
       mcp,
       clientCapabilities,
     });
-    const hashBefore = await host.hash();
     const jsonBefore = JSON.stringify(host.toJSON());
 
     // Mutate the very objects the caller handed to the constructor.
     (mcp.apps!.compatRuntime as { openaiApps?: boolean }).openaiApps = false;
     (clientCapabilities.sampling as { tools: unknown }).tools = { added: true };
 
-    expect(await host.hash()).toBe(hashBefore);
     expect(JSON.stringify(host.toJSON())).toBe(jsonBefore);
   });
 
-  it("snapshots setter inputs too", async () => {
+  it("snapshots setter inputs too", () => {
     const caps = { a: { b: 1 } };
     const host = new Host({ style: "mcpjam", model: "test-model" })
       .setClientCapabilities(caps);
-    const hashBefore = await host.hash();
     const jsonBefore = JSON.stringify(host.toJSON());
     (caps.a as { b: number }).b = 2;
-    expect(await host.hash()).toBe(hashBefore);
     expect(JSON.stringify(host.toJSON())).toBe(jsonBefore);
   });
 });

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Host } from "../src/host-config/index";
+import type { HostMcp } from "../src/host-config/index";
 // Cross-entry check uses the browser entry (the Node `../src/index` barrel
 // transitively imports `.md` skill files that vitest's transform can't load;
 // the published `@mcpjam/sdk` main export is covered by `test:packaging`).
@@ -125,6 +126,19 @@ describe("Host — fingerprint matches the golden vectors", () => {
         protocolVersion: "2025-06-18",
       })
       .addServerOverride("srv-a", {});
+
+    // Also assert the normalized public shape, not just the hash: servers are
+    // sorted and the empty "srv-a" override is dropped.
+    const json = host.toJSON();
+    expect(json.servers).toEqual(["srv-a", "srv-b", "srv-c"]);
+    expect(json.optionalServers).toEqual(["opt-a", "opt-z"]);
+    expect(json.serverOverrides?.["srv-a"]).toBeUndefined();
+    expect(json.serverOverrides?.["srv-b"]).toEqual({
+      headers: { A: "2", Z: "1" },
+      requestTimeout: 5000,
+      protocolVersion: "2025-06-18",
+    });
+
     expect(await host.hash()).toBe(sha("server-ids-unsorted-plus-overrides"));
   });
 });
@@ -146,5 +160,38 @@ describe("Host — toJSON() round-trips", () => {
 
     expect(json2).toEqual(json1);
     expect(await rebuilt.hash()).toBe(await host.hash());
+  });
+});
+
+describe("Host — deterministic under post-construction input mutation", () => {
+  it("snapshots object inputs so later caller mutations don't leak in", async () => {
+    const mcp: HostMcp = {
+      protocolVersion: "2025-06-18",
+      apps: { compatRuntime: { openaiApps: true } },
+    };
+    const clientCapabilities = { sampling: { tools: {} } };
+    const host = new Host({
+      style: "chatgpt",
+      model: "openai/gpt-5",
+      mcp,
+      clientCapabilities,
+    });
+    const hashBefore = await host.hash();
+    const jsonBefore = JSON.stringify(host.toJSON());
+
+    // Mutate the very objects the caller handed to the constructor.
+    (mcp.apps!.compatRuntime as { openaiApps?: boolean }).openaiApps = false;
+    (clientCapabilities.sampling as { tools: unknown }).tools = { added: true };
+
+    expect(await host.hash()).toBe(hashBefore);
+    expect(JSON.stringify(host.toJSON())).toBe(jsonBefore);
+  });
+
+  it("snapshots setter inputs too", async () => {
+    const caps = { a: { b: 1 } };
+    const host = new Host().setClientCapabilities(caps);
+    const hashBefore = await host.hash();
+    (caps.a as { b: number }).b = 2;
+    expect(await host.hash()).toBe(hashBefore);
   });
 });

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -10,7 +10,7 @@ describe("Host — public surface", () => {
     expect(Host).toBe(HostFromBrowser);
   });
 
-  it("chains setters and accumulates servers (public `servers` field)", () => {
+  it("accumulates servers via addServer chaining", () => {
     const host = new Host({ style: "mcpjam", model: "test-model" })
       .addServer("a")
       .addServer("b");
@@ -18,17 +18,42 @@ describe("Host — public surface", () => {
     expect(host.toJSON().servers).toEqual(["a", "b"]);
   });
 
+  it("supports direct property mutation on every public field", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" });
+    host.systemPrompt = "You are helpful.";
+    host.temperature = 0.2;
+    host.requireToolApproval = true;
+    host.servers.push("srv_a");
+    host.mcp.protocolVersion = "2025-11-25";
+    host.mcp.apps = { sandbox: { csp: { mode: "declared" } } };
+    host.serverOverrides["srv_a"] = { requestTimeout: 1234 };
+
+    const json = host.toJSON();
+    expect(json.systemPrompt).toBe("You are helpful.");
+    expect(json.temperature).toBe(0.2);
+    expect(json.requireToolApproval).toBe(true);
+    expect(json.servers).toEqual(["srv_a"]);
+    expect(json.mcp?.protocolVersion).toBe("2025-11-25");
+    expect(json.mcp?.apps?.sandbox?.csp?.mode).toBe("declared");
+    expect(json.serverOverrides?.srv_a?.requestTimeout).toBe(1234);
+  });
+
+  it("untouched mcp is omitted from toJSON (empty default collapses)", () => {
+    const json = new Host({ style: "mcpjam", model: "test-model" }).toJSON();
+    expect(json.mcp).toBeUndefined();
+  });
+
   it("exposes only public MCP vocabulary in toJSON() — no impl names leak", () => {
     const host = new Host({
       style: "chatgpt",
       model: "openai/gpt-5",
-    })
-      .setMcp({ protocolVersion: "2025-06-18" })
-      .addServer("srv_a")
-      .addServerOverride("srv_a", {
-        headers: { A: "1" },
-        protocolVersion: "2025-11-25",
-      });
+    });
+    host.mcp.protocolVersion = "2025-06-18";
+    host.addServer("srv_a");
+    host.setServerOverride("srv_a", {
+      headers: { A: "1" },
+      protocolVersion: "2025-11-25",
+    });
     const json = host.toJSON();
 
     // Public vocabulary present.
@@ -58,19 +83,20 @@ describe("Host — public surface", () => {
   });
 
   it("validates lazily at toJSON() (invalid profile throws)", () => {
-    const host = new Host({ style: "mcpjam", model: "test-model" }).setMcp({
-      apps: { mcpAppsOverrides: { availableDisplayModes: [] } },
-    });
+    const host = new Host({ style: "mcpjam", model: "test-model" });
+    host.mcp.apps = { mcpAppsOverrides: { availableDisplayModes: [] } };
     expect(() => host.toJSON()).toThrow(/must contain at least one mode/);
   });
 
   it("throws if `style` is not set (no silent SDK default)", () => {
-    const noStyle = new Host().setModel("test-model");
+    const noStyle = new Host();
+    noStyle.model = "test-model";
     expect(() => noStyle.toJSON()).toThrow(/requires a `style`/);
   });
 
   it("throws if `model` is not set (no silent SDK default)", () => {
-    const noModel = new Host().setStyle("mcpjam");
+    const noModel = new Host();
+    noModel.style = "mcpjam";
     expect(() => noModel.toJSON()).toThrow(/requires a `model`/);
   });
 
@@ -85,12 +111,12 @@ describe("Host — public surface", () => {
       .addServer("srv-b")
       .addOptionalServer("opt-z")
       .addOptionalServer("opt-a")
-      .addServerOverride("srv-b", {
+      .setServerOverride("srv-b", {
         headers: { Z: "1", A: "2" },
         requestTimeout: 5000,
         protocolVersion: "2025-06-18",
       })
-      .addServerOverride("srv-a", {});
+      .setServerOverride("srv-a", {});
 
     const json = host.toJSON();
     expect(json.servers).toEqual(["srv-a", "srv-b", "srv-c"]);
@@ -104,16 +130,76 @@ describe("Host — public surface", () => {
   });
 });
 
+describe("Host — mutation helpers", () => {
+  it("addServer dedupes (idempotent)", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" })
+      .addServer("a")
+      .addServer("a")
+      .addServer("b")
+      .addServer("a");
+    expect(host.servers).toEqual(["a", "b"]);
+    expect(host.toJSON().servers).toEqual(["a", "b"]);
+  });
+
+  it("addOptionalServer dedupes (idempotent)", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" })
+      .addOptionalServer("z")
+      .addOptionalServer("z");
+    expect(host.optionalServers).toEqual(["z"]);
+  });
+
+  it("constructor dedupes servers and optionalServers from init", () => {
+    const host = new Host({
+      style: "mcpjam",
+      model: "test-model",
+      servers: ["a", "b", "a", "c"],
+      optionalServers: ["x", "x", "y"],
+    });
+    expect(host.servers).toEqual(["a", "b", "c"]);
+    expect(host.optionalServers).toEqual(["x", "y"]);
+  });
+
+  it("removeServer / removeOptionalServer are no-ops when absent", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" })
+      .addServer("a")
+      .addServer("b");
+    host.removeServer("missing");
+    host.removeServer("a");
+    expect(host.servers).toEqual(["b"]);
+
+    host.addOptionalServer("opt");
+    host.removeOptionalServer("nope");
+    host.removeOptionalServer("opt");
+    expect(host.optionalServers).toEqual([]);
+  });
+
+  it("removeServerOverride drops the entry from toJSON", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" })
+      .addServer("a")
+      .setServerOverride("a", { requestTimeout: 1000 });
+    expect(host.toJSON().serverOverrides?.a?.requestTimeout).toBe(1000);
+    host.removeServerOverride("a");
+    expect(host.toJSON().serverOverrides).toBeUndefined();
+  });
+
+  it("clearMcp resets mcp to {} and drops it from toJSON", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" });
+    host.mcp.protocolVersion = "2025-11-25";
+    expect(host.toJSON().mcp).toBeDefined();
+    host.clearMcp();
+    expect(host.mcp).toEqual({});
+    expect(host.toJSON().mcp).toBeUndefined();
+  });
+});
+
 describe("Host — toJSON() round-trips", () => {
   it("new Host(host.toJSON()) reproduces the same JSON", () => {
     const host = new Host({ style: "chatgpt", model: "openai/gpt-5" })
-      .setMcp({
-        protocolVersion: "2025-06-18",
-        apps: { compatRuntime: { openaiApps: true } },
-      })
       .addServer("srv-b")
       .addServer("srv-a")
-      .addServerOverride("srv-a", { requestTimeout: 1234 });
+      .setServerOverride("srv-a", { requestTimeout: 1234 });
+    host.mcp.protocolVersion = "2025-06-18";
+    host.mcp.apps = { compatRuntime: { openaiApps: true } };
 
     const json1 = host.toJSON();
     const rebuilt = new Host(json1);
@@ -143,12 +229,20 @@ describe("Host — deterministic under post-construction input mutation", () => 
     expect(JSON.stringify(host.toJSON())).toBe(jsonBefore);
   });
 
-  it("snapshots setter inputs too", () => {
-    const caps = { a: { b: 1 } };
-    const host = new Host({ style: "mcpjam", model: "test-model" })
-      .setClientCapabilities(caps);
-    const jsonBefore = JSON.stringify(host.toJSON());
-    (caps.a as { b: number }).b = 2;
-    expect(JSON.stringify(host.toJSON())).toBe(jsonBefore);
+  it("snapshots at toJSON() so a direct-property mutation between two calls is observable", () => {
+    // Sanity: direct mutation IS visible to later toJSON() calls (that's the
+    // whole point), but each toJSON() call sees a stable snapshot of the
+    // host's state at that moment.
+    const host = new Host({ style: "mcpjam", model: "test-model" });
+    host.mcp.protocolVersion = "2025-06-18";
+    const before = host.toJSON();
+    expect(before.mcp?.protocolVersion).toBe("2025-06-18");
+
+    host.mcp.protocolVersion = "2025-11-25";
+    const after = host.toJSON();
+    expect(after.mcp?.protocolVersion).toBe("2025-11-25");
+
+    // Earlier snapshot is unchanged.
+    expect(before.mcp?.protocolVersion).toBe("2025-06-18");
   });
 });

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -191,7 +191,9 @@ describe("Host — deterministic under post-construction input mutation", () => 
     const caps = { a: { b: 1 } };
     const host = new Host().setClientCapabilities(caps);
     const hashBefore = await host.hash();
+    const jsonBefore = JSON.stringify(host.toJSON());
     (caps.a as { b: number }).b = 2;
     expect(await host.hash()).toBe(hashBefore);
+    expect(JSON.stringify(host.toJSON())).toBe(jsonBefore);
   });
 });

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -38,6 +38,15 @@ describe("Host — public surface", () => {
     expect(json.serverOverrides?.srv_a?.requestTimeout).toBe(1234);
   });
 
+  it("dedupes server ids added through direct array mutation", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" });
+    host.servers.push("srv_b", "srv_a", "srv_b");
+    host.optionalServers.push("opt_b", "opt_a", "opt_a");
+
+    expect(host.toJSON().servers).toEqual(["srv_a", "srv_b"]);
+    expect(host.toJSON().optionalServers).toEqual(["opt_a", "opt_b"]);
+  });
+
   it("untouched mcp is omitted from toJSON (empty default collapses)", () => {
     const json = new Host({ style: "mcpjam", model: "test-model" }).toJSON();
     expect(json.mcp).toBeUndefined();
@@ -86,6 +95,14 @@ describe("Host — public surface", () => {
     const host = new Host({ style: "mcpjam", model: "test-model" });
     host.mcp.apps = { mcpAppsOverrides: { availableDisplayModes: [] } };
     expect(() => host.toJSON()).toThrow(/must contain at least one mode/);
+  });
+
+  it("validates per-server request timeout overrides at toJSON()", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" })
+      .addServer("srv_a")
+      .setServerOverride("srv_a", { requestTimeout: Infinity });
+
+    expect(() => host.toJSON()).toThrow(/requestTimeoutOverride must be finite/);
   });
 
   it("throws if `style` is not set (no silent SDK default)", () => {

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Host } from "../src/host-config/index";
+// Cross-entry check uses the browser entry (the Node `../src/index` barrel
+// transitively imports `.md` skill files that vitest's transform can't load;
+// the published `@mcpjam/sdk` main export is covered by `test:packaging`).
+import { Host as HostFromBrowser } from "../src/browser";
+
+type FixtureRow = { label: string; canonicalJson: string; sha256: string };
+type Fixture = { rows: FixtureRow[] };
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(
+  readFileSync(
+    join(here, "fixtures", "host-config-parity-fixtures.json"),
+    "utf8",
+  ),
+) as Fixture;
+
+const rowByLabel = (label: string): FixtureRow => {
+  const row = fixture.rows.find((r) => r.label === label);
+  if (!row) throw new Error(`missing fixture row: ${label}`);
+  return row;
+};
+
+describe("Host — public surface", () => {
+  it("is exported from both @mcpjam/sdk/host-config and @mcpjam/sdk/browser", () => {
+    expect(Host).toBe(HostFromBrowser);
+  });
+
+  it("chains setters and accumulates servers", () => {
+    const host = new Host().addServer("a").addServer("b");
+    expect(host).toBeInstanceOf(Host);
+    expect(host.toJSON().serverIds).toEqual(["a", "b"]);
+  });
+
+  it("maps `mcp` (spec vocab) onto the internal `mcpProfile` wire field", async () => {
+    const host = new Host().setMcp({ protocolVersion: "2025-06-18" });
+    const json = host.toJSON();
+    // Wire field stays `mcpProfile` (option b); profileVersion is supplied.
+    expect(json.mcpProfile?.profileVersion).toBe(1);
+    expect(json.mcpProfile?.mcpProtocolVersion).toBe("2025-06-18");
+    // Stateful pin derivation still runs through the facade.
+    expect(json.mcpProfile?.initialize?.supportedProtocolVersions).toEqual([
+      "2025-06-18",
+    ]);
+    expect(typeof (await host.hash())).toBe("string");
+  });
+
+  it("validates lazily at toJSON() (invalid profile throws)", () => {
+    const host = new Host().setMcp({
+      // availableDisplayModes must be non-empty.
+      apps: { mcpAppsOverrides: { availableDisplayModes: [] } },
+    });
+    expect(() => host.toJSON()).toThrow(/must contain at least one mode/);
+  });
+});
+
+describe("Host — golden-vector equivalence (facade == canonicalizer)", () => {
+  it("reproduces the `mcp-profile-initialize-order-preserved` vector", async () => {
+    const row = rowByLabel("mcp-profile-initialize-order-preserved");
+    const host = new Host({
+      style: "claude",
+      model: "anthropic/claude-sonnet-4-6",
+      systemPrompt: "You are a helpful assistant.",
+    }).setMcp({
+      initialize: {
+        supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+        clientInfo: { version: "1.2.3", name: "mcpjam", title: "MCPJam" },
+      },
+    });
+    expect(JSON.stringify(host.toJSON())).toBe(row.canonicalJson);
+    expect(await host.hash()).toBe(row.sha256);
+  });
+
+  it("reproduces the `server-ids-unsorted-plus-overrides` vector", async () => {
+    const row = rowByLabel("server-ids-unsorted-plus-overrides");
+    const host = new Host({
+      style: "claude",
+      model: "anthropic/claude-sonnet-4-6",
+      systemPrompt: "You are a helpful assistant.",
+    })
+      .addServer("srv-c")
+      .addServer("srv-a")
+      .addServer("srv-b")
+      .addOptionalServer("opt-z")
+      .addOptionalServer("opt-a")
+      .addServerOverride("srv-b", {
+        headers: { Z: "1", A: "2" },
+        requestTimeout: 5000,
+        protocolVersion: "2025-06-18",
+      })
+      .addServerOverride("srv-a", {});
+    expect(JSON.stringify(host.toJSON())).toBe(row.canonicalJson);
+    expect(await host.hash()).toBe(row.sha256);
+  });
+
+  it("reproduces the `base-minimal` vector from HostInit alone", async () => {
+    const row = rowByLabel("base-minimal");
+    const host = new Host({
+      style: "claude",
+      model: "anthropic/claude-sonnet-4-6",
+      systemPrompt: "You are a helpful assistant.",
+    });
+    expect(JSON.stringify(host.toJSON())).toBe(row.canonicalJson);
+    expect(await host.hash()).toBe(row.sha256);
+  });
+});

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -31,7 +31,9 @@ describe("Host — public surface", () => {
   });
 
   it("chains setters and accumulates servers (public `servers` field)", () => {
-    const host = new Host().addServer("a").addServer("b");
+    const host = new Host({ style: "mcpjam", model: "test-model" })
+      .addServer("a")
+      .addServer("b");
     expect(host).toBeInstanceOf(Host);
     expect(host.toJSON().servers).toEqual(["a", "b"]);
   });
@@ -76,10 +78,22 @@ describe("Host — public surface", () => {
   });
 
   it("validates lazily at toJSON() (invalid profile throws)", () => {
-    const host = new Host().setMcp({
+    const host = new Host({ style: "mcpjam", model: "test-model" }).setMcp({
       apps: { mcpAppsOverrides: { availableDisplayModes: [] } },
     });
     expect(() => host.toJSON()).toThrow(/must contain at least one mode/);
+  });
+
+  it("throws if `style` is not set (no silent SDK default)", async () => {
+    const noStyle = new Host().setModel("test-model");
+    expect(() => noStyle.toJSON()).toThrow(/requires a `style`/);
+    await expect(noStyle.hash()).rejects.toThrow(/requires a `style`/);
+  });
+
+  it("throws if `model` is not set (no silent SDK default)", async () => {
+    const noModel = new Host().setStyle("mcpjam");
+    expect(() => noModel.toJSON()).toThrow(/requires a `model`/);
+    await expect(noModel.hash()).rejects.toThrow(/requires a `model`/);
   });
 });
 
@@ -189,7 +203,8 @@ describe("Host — deterministic under post-construction input mutation", () => 
 
   it("snapshots setter inputs too", async () => {
     const caps = { a: { b: 1 } };
-    const host = new Host().setClientCapabilities(caps);
+    const host = new Host({ style: "mcpjam", model: "test-model" })
+      .setClientCapabilities(caps);
     const hashBefore = await host.hash();
     const jsonBefore = JSON.stringify(host.toJSON());
     (caps.a as { b: number }).b = 2;

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -7,7 +7,7 @@ import { Host } from "../src/host-config/index";
 // the published `@mcpjam/sdk` main export is covered by `test:packaging`).
 import { Host as HostFromBrowser } from "../src/browser";
 
-type FixtureRow = { label: string; canonicalJson: string; sha256: string };
+type FixtureRow = { label: string; sha256: string };
 type Fixture = { rows: FixtureRow[] };
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -18,10 +18,10 @@ const fixture = JSON.parse(
   ),
 ) as Fixture;
 
-const rowByLabel = (label: string): FixtureRow => {
+const sha = (label: string): string => {
   const row = fixture.rows.find((r) => r.label === label);
   if (!row) throw new Error(`missing fixture row: ${label}`);
-  return row;
+  return row.sha256;
 };
 
 describe("Host — public surface", () => {
@@ -29,37 +29,72 @@ describe("Host — public surface", () => {
     expect(Host).toBe(HostFromBrowser);
   });
 
-  it("chains setters and accumulates servers", () => {
+  it("chains setters and accumulates servers (public `servers` field)", () => {
     const host = new Host().addServer("a").addServer("b");
     expect(host).toBeInstanceOf(Host);
-    expect(host.toJSON().serverIds).toEqual(["a", "b"]);
+    expect(host.toJSON().servers).toEqual(["a", "b"]);
   });
 
-  it("maps `mcp` (spec vocab) onto the internal `mcpProfile` wire field", async () => {
-    const host = new Host().setMcp({ protocolVersion: "2025-06-18" });
+  it("exposes only public MCP vocabulary in toJSON() — no impl names leak", () => {
+    const host = new Host({
+      style: "chatgpt",
+      model: "openai/gpt-5",
+    })
+      .setMcp({ protocolVersion: "2025-06-18" })
+      .addServer("srv_a")
+      .addServerOverride("srv_a", {
+        headers: { A: "1" },
+        protocolVersion: "2025-11-25",
+      });
     const json = host.toJSON();
-    // Wire field stays `mcpProfile` (option b); profileVersion is supplied.
-    expect(json.mcpProfile?.profileVersion).toBe(1);
-    expect(json.mcpProfile?.mcpProtocolVersion).toBe("2025-06-18");
-    // Stateful pin derivation still runs through the facade.
-    expect(json.mcpProfile?.initialize?.supportedProtocolVersions).toEqual([
+
+    // Public vocabulary present.
+    expect(json.mcp?.protocolVersion).toBe("2025-06-18");
+    // Stateful pin derivation still runs (normalized output).
+    expect(json.mcp?.initialize?.supportedProtocolVersions).toEqual([
       "2025-06-18",
     ]);
-    expect(typeof (await host.hash())).toBe("string");
+    expect(json.serverOverrides?.srv_a?.headers).toEqual({ A: "1" });
+    expect(json.serverOverrides?.srv_a?.protocolVersion).toBe("2025-11-25");
+
+    // No storage-row / implementation names anywhere in the serialized output.
+    const str = JSON.stringify(json);
+    for (const impl of [
+      "mcpProfile",
+      "profileVersion",
+      "schemaVersion",
+      "mcpProtocolVersion",
+      "serverIds",
+      "hostStyle",
+      "modelId",
+      "headersOverride",
+      "serverConnectionOverrides",
+    ]) {
+      expect(str).not.toContain(impl);
+    }
   });
 
   it("validates lazily at toJSON() (invalid profile throws)", () => {
     const host = new Host().setMcp({
-      // availableDisplayModes must be non-empty.
       apps: { mcpAppsOverrides: { availableDisplayModes: [] } },
     });
     expect(() => host.toJSON()).toThrow(/must contain at least one mode/);
   });
 });
 
-describe("Host — golden-vector equivalence (facade == canonicalizer)", () => {
-  it("reproduces the `mcp-profile-initialize-order-preserved` vector", async () => {
-    const row = rowByLabel("mcp-profile-initialize-order-preserved");
+describe("Host — fingerprint matches the golden vectors", () => {
+  // hash() is computed over the internal canonical form, so it must equal the
+  // pinned golden sha256 (proving the facade preserves backend parity).
+  it("base-minimal", async () => {
+    const host = new Host({
+      style: "claude",
+      model: "anthropic/claude-sonnet-4-6",
+      systemPrompt: "You are a helpful assistant.",
+    });
+    expect(await host.hash()).toBe(sha("base-minimal"));
+  });
+
+  it("mcp-profile-initialize-order-preserved", async () => {
     const host = new Host({
       style: "claude",
       model: "anthropic/claude-sonnet-4-6",
@@ -70,12 +105,10 @@ describe("Host — golden-vector equivalence (facade == canonicalizer)", () => {
         clientInfo: { version: "1.2.3", name: "mcpjam", title: "MCPJam" },
       },
     });
-    expect(JSON.stringify(host.toJSON())).toBe(row.canonicalJson);
-    expect(await host.hash()).toBe(row.sha256);
+    expect(await host.hash()).toBe(sha("mcp-profile-initialize-order-preserved"));
   });
 
-  it("reproduces the `server-ids-unsorted-plus-overrides` vector", async () => {
-    const row = rowByLabel("server-ids-unsorted-plus-overrides");
+  it("server-ids-unsorted-plus-overrides", async () => {
     const host = new Host({
       style: "claude",
       model: "anthropic/claude-sonnet-4-6",
@@ -92,18 +125,26 @@ describe("Host — golden-vector equivalence (facade == canonicalizer)", () => {
         protocolVersion: "2025-06-18",
       })
       .addServerOverride("srv-a", {});
-    expect(JSON.stringify(host.toJSON())).toBe(row.canonicalJson);
-    expect(await host.hash()).toBe(row.sha256);
+    expect(await host.hash()).toBe(sha("server-ids-unsorted-plus-overrides"));
   });
+});
 
-  it("reproduces the `base-minimal` vector from HostInit alone", async () => {
-    const row = rowByLabel("base-minimal");
-    const host = new Host({
-      style: "claude",
-      model: "anthropic/claude-sonnet-4-6",
-      systemPrompt: "You are a helpful assistant.",
-    });
-    expect(JSON.stringify(host.toJSON())).toBe(row.canonicalJson);
-    expect(await host.hash()).toBe(row.sha256);
+describe("Host — toJSON() round-trips", () => {
+  it("new Host(host.toJSON()) reproduces the same JSON and hash", async () => {
+    const host = new Host({ style: "chatgpt", model: "openai/gpt-5" })
+      .setMcp({
+        protocolVersion: "2025-06-18",
+        apps: { compatRuntime: { openaiApps: true } },
+      })
+      .addServer("srv-b")
+      .addServer("srv-a")
+      .addServerOverride("srv-a", { requestTimeout: 1234 });
+
+    const json1 = host.toJSON();
+    const rebuilt = new Host(json1);
+    const json2 = rebuilt.toJSON();
+
+    expect(json2).toEqual(json1);
+    expect(await rebuilt.hash()).toBe(await host.hash());
   });
 });

--- a/sdk/tsup.config.ts
+++ b/sdk/tsup.config.ts
@@ -19,8 +19,7 @@ export default defineConfig({
     "src/matchers.ts",
     "src/predicates/index.ts",
     "src/host-config/index.ts",
-    // Internal entry: built for SDK tooling (the parity fixture generator) but
-    // NOT advertised in package.json#exports, so it is not publicly importable.
+    // Low-level first-party entry used by the backend and SDK tooling.
     "src/host-config/internal.ts",
   ],
   external: ["@sentry/node"],

--- a/sdk/tsup.config.ts
+++ b/sdk/tsup.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     "src/model-factory.ts",
     "src/matchers.ts",
     "src/predicates/index.ts",
+    "src/host-config/index.ts",
   ],
   external: ["@sentry/node"],
   format: ["esm"],

--- a/sdk/tsup.config.ts
+++ b/sdk/tsup.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
     "src/matchers.ts",
     "src/predicates/index.ts",
     "src/host-config/index.ts",
+    // Internal entry: built for SDK tooling (the parity fixture generator) but
+    // NOT advertised in package.json#exports, so it is not publicly importable.
+    "src/host-config/internal.ts",
   ],
   external: ["@sentry/node"],
   format: ["esm"],


### PR DESCRIPTION
## Summary

Introduces a complete host configuration system for the SDK with a portable, byte-stable canonicalizer, content hash, and developer-facing `Host` builder API. The canonicalizer is the source of truth and is hand-mirrored by the Convex backend to ensure parity across runtimes.

## Key Changes

- **HostConfig v2 canonicalizer** (`src/host-config/canonicalize.ts`): Pure, browser-safe implementation that normalizes host configurations with deterministic key ordering, validation, and injection guards. Handles:
  - Server ID sorting and deduplication
  - Deep key sorting for nested objects (headers, capabilities, CSP directives)
  - MCP protocol version pinning with stateful/stateless derivation rules
  - CSP domain allowlist normalization (trim, dedupe, sort)
  - Permissions Policy and CSP directive validation with separator injection guards
  - Forward-compatibility trip wires for schema/profile version mismatches

- **Content hash function** (`src/host-config/hash.ts`): Async SHA-256 hash using Web Crypto API for browser/Node/Convex compatibility. Computes over canonical JSON for byte-identical fingerprints across runtimes.

- **Type definitions** (`src/host-config/types.ts`): Internal storage-row vocabulary (`HostConfigInputV2`, `HostConfigMcpProfileV1`, `CspDomainSet`, etc.) with detailed comments on canonicalization rules and backend mirroring requirements.

- **Public Host builder API** (`src/host-config/host.ts`, `src/host-config/public-types.ts`): Developer-facing `Host` class with fluent setters (`setMcp()`, `addServer()`, `addServerOverride()`) using MCP-protocol vocabulary. Translates to/from internal storage-row format transparently.

- **Golden-vector parity fixture** (`tests/fixtures/host-config-parity-fixtures.json`): 10 test vectors covering minimal configs, key ordering, server overrides, MCP profile initialization, CSP policies, and permissions. Byte-identical copy maintained in Convex backend.

- **Parity test suite** (`tests/host-config-parity.test.ts`, `tests/host-config-canonicalize.test.ts`, `tests/host.test.ts`): Validates canonicalizer behavior, hash stability, undefined vs. explicit field distinction, and public API surface.

- **Fixture generator** (`scripts/gen-host-config-parity-fixture.mjs`): Builds golden vectors from the SDK canonicalizer; output must be copied to backend and both `EXPECTED_INPUT_HASH` constants updated in lockstep.

- **Package exports**: Added `@mcpjam/sdk/host-config` entry point (also available from main `@mcpjam/sdk`). Internal `internal.ts` entry built but not exported for SDK tooling only.

## Notable Implementation Details

- **Source of truth**: `src/host-config/types.ts` is the canonical home; Convex backend mirrors it in `convex/lib/hostConfigV2.ts` (NOT imported, to avoid bundling issues).
- **Vocabulary boundary**: Public API uses MCP terms (`mcp`, `protocolVersion`, `servers`); internal storage uses implementation names (`mcpProfile`, `mcpProtocolVersion`, `serverIds`). Mappers in `host.ts` bridge transparently.
- **Hash stability**: Deterministic key ordering at every nesting level (except `initialize.supportedProtocolVersions`, where order is semantic). Undefined fields omitted to preserve absent-vs-present distinction.
- **Validation**: Injection guards on CSP/Permissions Policy directives (reject `;` and `,` separators). Typo defense via allowlists of known capability keys.
- **Stateful protocol pin derivation**: When `mcpProtocolVersion` pins a pre-2026 stateful version, `initialize.supportedProtocolVersions` is auto-derived if absent; throws if both are set and misaligned.
- **Parity enforcement**: Fixture `__inputHash` pins the rows array SHA-256; partial ed

https://claude.ai/code/session_01HX9oY6K7X1ztbTFygyYHHj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new canonicalization surface affects persisted config hashes and backend parity; sandbox/CSP validation is security-sensitive but well-tested with golden vectors. Drift between SDK and mirrored backend canonicalizer would break dedupe until fixtures are regenerated.
> 
> **Overview**
> Adds **HostConfig v2** to the SDK: a byte-stable canonicalizer and async SHA-256 hash (Web Crypto) for content-addressed backend dedupe, plus a public **`Host`** builder that speaks MCP vocabulary (`mcp`, `servers`, `style`) while mapping to internal storage fields (`mcpProfile`, `serverIds`).
> 
> New package subpaths **`@mcpjam/sdk/host-config`** (public `Host` + types) and **`@mcpjam/sdk/host-config/internal`** (canonicalizer, hash, storage types for first-party/backend use). **`Host`** is also re-exported from the main entry and **`@mcpjam/sdk/browser`**. Build/packaging (`tsup`, `test:packaging`) includes both entries.
> 
> The canonicalizer normalizes server lists, key order, MCP profile (protocol pins, sandbox CSP/permissions, compat overrides), strips stray `deny` fields, and validates with typo allowlists and CSP/Permissions Policy injection guards. Golden-vector fixture + generator script and unit/parity tests lock SDK output to the hand-mirrored Convex canonicalizer.
> 
> **Follow-up behavior (on this branch):** `style` and `model` are required at **`toJSON()`** (no silent MCPJam defaults); public **`Host.hash()`** is removed—hashing stays on **`computeHostConfigHashV2`** via the internal subpath only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ded440a8417ccfaf0a0ac2a2709e4c9cf96918f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Update — follow-up commits on this branch

Two follow-up commits since the initial review:

- **`22c7df8`** — `style` and `model` are now required at `toJSON()`. The Host class previously hardcoded `style = "mcpjam"` and silently defaulted `model = ""`. Both are now type-optional on `HostInit` (setter pattern still works) but throw with a clear error if missing when `toJSON()` is called. Rationale: the SDK shouldn't silently opt external authors into MCPJam product chrome on a Claude/ChatGPT-style flow.

- **`acda5ab`** — `Host.hash()` removed from the public class. Canonicalize + content-addressing exist for backend dedupe (`hostConfigs` rows keyed by `configHash`) and aren't a developer-facing concern. `computeHostConfigHashV2` is still available via `@mcpjam/sdk/host-config/internal` (the first-party non-semver subpath the backend imports). `toJSON()` is now the sole egress on `Host`.

No change to the canonicalizer, the hash function, the golden-vector parity fixture, or the on-disk `hostConfigs` schema.
