### PR TITLE
refactor(host-config): inspector client consumes SDK leaf primitives

### DIFF
--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -1,14 +1,21 @@
 /**
  * Frontend types + utilities for HostConfig v2.
  *
- * Mirrors the shape declared in the backend's
- * `convex/lib/hostConfigV2.ts`. Kept in sync by hand: this file is the
- * single client-side source of truth so all four editors (Project Settings,
- * Chatbox Editor/Builder, Eval Suite Settings, Connection Settings) speak
- * one shape.
+ * Shareable leaf primitives (`CspDomainSet`, `HostConfigConnectionDefaults`,
+ * `HostConfigMcpProfileV1`, `McpProtocolVersion`,
+ * `SEP_1865_PERMISSION_FEATURES`, `DEFAULT_TEMPERATURE_V2`,
+ * `resolveEffectiveMcpProtocolVersion`) live in
+ * `@mcpjam/sdk/host-config/internal` — single source of truth shared with the
+ * backend canonicalizer. Re-exported below so the 60+ files importing from
+ * `@/lib/client-config-v2` don't churn.
  *
- * Phase 1 (additive). Subsequent phases will switch read/write paths in
- * place; the shape below is stable.
+ * Strict aggregate types (`HostConfigInputV2`, `HostConfigDtoV2`,
+ * `HostStyleId`) stay client-owned: the editor enforces invariants the
+ * storage layer leaves optional (required `serverIds`/`optionalServerIds`/
+ * `respectToolVisibility`, structured `ChatUiOverride`, closed
+ * `ChatboxHostStyle` union). Single client-side source of truth so all four
+ * editors (Project Settings, Chatbox Editor/Builder, Eval Suite Settings,
+ * Connection Settings) speak one shape.
  */
 
 import type { McpUiHostCapabilities } from "@modelcontextprotocol/ext-apps/app-bridge";
@@ -35,245 +42,35 @@ import type {
   ResolvedOpenAiAppsCapabilities,
 } from "@/lib/client-styles";
 import { getDefaultClientCapabilities } from "@mcpjam/sdk/browser";
+// Shareable host-config primitives + the portable protocol-version resolver
+// live in @mcpjam/sdk/host-config/internal — single source of truth for the
+// backend canonicalizer and the inspector client. Re-exported below so the
+// 60+ files importing from "@/lib/client-config-v2" don't churn.
+import {
+  DEFAULT_TEMPERATURE_V2,
+  resolveEffectiveMcpProtocolVersion,
+  SEP_1865_PERMISSION_FEATURES,
+} from "@mcpjam/sdk/host-config/internal";
+import type {
+  CspDomainSet,
+  HostConfigConnectionDefaults,
+  HostConfigMcpProfileV1,
+  McpProtocolVersion,
+} from "@mcpjam/sdk/host-config/internal";
+
+export {
+  DEFAULT_TEMPERATURE_V2,
+  resolveEffectiveMcpProtocolVersion,
+  SEP_1865_PERMISSION_FEATURES,
+};
+export type {
+  CspDomainSet,
+  HostConfigConnectionDefaults,
+  HostConfigMcpProfileV1,
+  McpProtocolVersion,
+};
 
 export type HostStyleId = ChatboxHostStyle;
-
-/**
- * Permissions Policy feature tokens corresponding to the four SEP-1865
- * spec permissions. KEBAB-CASE browser tokens (as they appear in iframe
- * `allow=` attributes), NOT the camelCase keys used in
- * `mcpProfile.permissions.allow`. The backend canonicalizer drops any
- * key in this list from `allowFeatures` — `permissions.allow` is the
- * single source of truth. Mirror of the same constant in
- * `convex/lib/hostConfigV2.ts`.
- *
- * Naming gap (intentional): `permissions.allow.clipboardWrite` (camel,
- * spec field name) ↔ `allowFeatures["clipboard-write"]` (kebab,
- * Permissions Policy token). Do NOT normalize casing on either side.
- */
-export const SEP_1865_PERMISSION_FEATURES = [
-  "camera",
-  "microphone",
-  "geolocation",
-  "clipboard-write",
-] as const;
-
-export type HostConfigConnectionDefaults = {
-  headers: Record<string, string>;
-  requestTimeout: number;
-};
-
-/**
- * Four parallel allowlists keyed by CSP directive family (SEP-1865 is
- * allowlist-only; there's no deny concept). Mirrors `CspDomainSet` in the
- * backend (`convex/lib/hostConfigV2.ts`). Canonicalized server-side as a set
- * (trimmed, deduped, sorted); the client may emit arrays in any order — the
- * backend hash dedupes regardless.
- */
-export type CspDomainSet = {
-  connectDomains?: string[];
-  resourceDomains?: string[];
-  frameDomains?: string[];
-  baseUriDomains?: string[];
-};
-
-/**
- * Versioned envelope for host-level MCP state. Mirror of
- * `HostConfigMcpProfileV1` in `convex/lib/hostConfigV2.ts` — kept in sync by
- * hand so the inspector and backend speak one shape.
- *
- * `profileVersion: 1` is a forward-compat trip wire: a future incompatible
- * shape will introduce `profileVersion: 2`. The backend rejects any other
- * value at write time.
- *
- * Every field is optional; `undefined` at any nest depth means "use SDK
- * defaults / no host-level override." `undefined` and `{ profileVersion: 1 }`
- * (empty envelope) hash distinctly on the backend, so the inspector MUST NOT
- * synthesize an empty envelope when the user hasn't opted in.
- */
-/**
- * Pinned MCP protocol version for a server connection. Values are wire
- * literals (mirror of `MCP_PROTOCOL_VERSIONS` in `@mcpjam/sdk`'s
- * `mcp-protocol-version.ts`, and `McpProtocolVersion` in
- * `convex/lib/hostConfigV2.ts`).
- *
- * `undefined` = "no opinion — SDK chooses at request time." Do NOT
- * materialize a default value at storage time; canonical hashes would
- * churn whenever the SDK default moves and future SDK default upgrades
- * would silently no-op against existing rows.
- */
-export type McpProtocolVersion =
-  | "2025-03-26"
-  | "2025-06-18"
-  | "2025-11-25"
-  | "2026-07-28";
-
-/**
- * Resolve the effective pinned protocol version for a server connection.
- * Mirror of the rule the backend stamps into `serverConnectionOverrides`
- * at fan-out time, applied at the bridge / wire-client factory site to
- * pick between `OfficialSdkClientAdapter` and
- * `StatelessMcpHttpPreviewClient` (the SDK routes via
- * `isStatelessProtocolVersion`).
- *
- *   server override wins; otherwise host default; otherwise undefined
- *
- * Returns `undefined` when neither layer has an opinion — preserves the
- * SDK-default semantics. Both inputs are optional so callers can read
- * straight off the hydrated host config row without normalizing first.
- */
-export function resolveEffectiveMcpProtocolVersion(
-  serverOverride: McpProtocolVersion | undefined,
-  hostDefault: McpProtocolVersion | undefined,
-): McpProtocolVersion | undefined {
-  return serverOverride ?? hostDefault;
-}
-
-export type HostConfigMcpProfileV1 = {
-  profileVersion: 1;
-  /**
-   * Host-level default pinned MCP protocol version. Absent → SDK chooses
-   * at request time (do NOT materialize a default at write time —
-   * preserves undefined-as-default semantics so canonical hashes don't
-   * churn when the SDK default moves). Sibling of `initialize` and
-   * `apps` because stateless versions explicitly skip the initialize
-   * handshake — keeping this out of `mcpProfile.initialize` keeps the
-   * source-of-truth obvious.
-   *
-   * Per-server overrides live on `serverConnectionOverrides[serverId]
-   * .mcpProtocolVersionOverride`. Resolution rule: server override wins;
-   * otherwise this default; otherwise `undefined` (SDK default).
-   */
-  mcpProtocolVersion?: McpProtocolVersion;
-  initialize?: {
-    /**
-     * Ordered accept-list. First entry is sent in
-     * `initialize.params.protocolVersion`; all entries form the accept-set.
-     * Order is semantic — do NOT sort on the client.
-     */
-    supportedProtocolVersions?: string[];
-    /**
-     * The exact `initialize.clientInfo` object the SDK should send. Backend
-     * soft-validates `name` and `version` (non-empty strings, required when
-     * `clientInfo` is set) and passes everything else through verbatim so
-     * future spec additions (e.g. `title`) land here without a schema
-     * migration.
-     */
-    clientInfo?: Record<string, unknown>;
-  };
-  apps?: {
-    sandbox?: {
-      csp?: {
-        /** Picks the starting baseline; restrictTo applies on top regardless of mode. */
-        mode?: "host-default" | "declared" | "relaxed";
-        /** Intersection — never adds undeclared domains (SEP-1865). */
-        restrictTo?: CspDomainSet;
-        /**
-         * Per-directive CSP source-expression overrides emitted in the inner
-         * doc's `<meta http-equiv="Content-Security-Policy">`. Keys are CSP
-         * directive names (`script-src`, `style-src`, …); values are
-         * source-expression token arrays (`["'unsafe-eval'", "'wasm-unsafe-eval'"]`).
-         * Stored verbatim — no enum — so future tokens (nonces, hashes,
-         * `'strict-dynamic'`) land here without schema churn.
-         * Inspector-only emission knob: NOT advertised in SEP-1865 metadata;
-         * models what real hosts emit at the browser layer.
-         */
-        cspDirectives?: Record<string, string[]>;
-        extensions?: Record<string, unknown>;
-      };
-      permissions?: {
-        mode?: "resource-declared" | "deny-all" | "custom";
-        allow?: Record<string, boolean>;
-        extensions?: Record<string, unknown>;
-      };
-      /**
-       * Extra outer/inner iframe `sandbox=` tokens unioned with the mandatory
-       * `allow-scripts allow-same-origin`. Inspector-only emission knob.
-       */
-      sandboxAttrs?: string[];
-      /**
-       * Extra Permissions Policy entries appended to the OUTER iframe's
-       * `allow=` attribute ONLY. The inner iframe gets only the 4 spec
-       * permissions (from `permissions.allow`), matching real claude.ai's
-       * pattern where the outer grants `fullscreen *; clipboard-write *`
-       * but the inner trims to `clipboard-write *`. Keys are RAW
-       * kebab-case Permissions Policy tokens (`clipboard-write`, not
-       * `clipboardWrite`); values are allowlist strings (`*`, `'self'`,
-       * an origin). The 4 spec features (camera / microphone /
-       * geolocation / clipboard-write) are silently dropped by the
-       * canonicalizer — `permissions.allow` is the single source of
-       * truth for them. Inspector-only.
-       */
-      allowFeatures?: Record<string, string>;
-    };
-    /**
-     * Overrides for the MCP Apps `ui/initialize` response advertised to
-     * the View iframe (SEP-1865). Sibling to `apps.sandbox` because the
-     * `ui/initialize` envelope is the MCP Apps extension's negotiation
-     * step — distinct from the base-protocol `initialize` whose overrides
-     * live under `mcpProfile.initialize`.
-     */
-    uiInitialize?: {
-      /**
-       * The exact `hostInfo` the inspector should report in the
-       * `ui/initialize` result. Backend soft-validates `name` and
-       * `version` (non-empty strings, required when `hostInfo` is set)
-       * and passes everything else through verbatim so future spec
-       * additions (e.g. `title`) land here without a schema migration.
-       * Mirror of `initialize.clientInfo`.
-       */
-      hostInfo?: Record<string, unknown>;
-    };
-    /**
-     * Vendor compat-runtime shims the inspector injects into widget
-     * HTML before handing it to the sandbox. Claude/Cursor/Codex-style
-     * hosts leave these surfaces off; ChatGPT/Copilot and MCPJam's dev
-     * surface enable them. Absent → resolver falls back to the host
-     * style preset (see `resolveEffectiveCompatRuntime`).
-     */
-    compatRuntime?: {
-      /**
-       * Inject the OpenAI Apps SDK `window.openai` shim
-       * (`@mcpjam/sdk`'s `injectOpenAICompat`). Only enable when
-       * emulating a host that historically exposed this surface, or
-       * when the widget under test depends on it.
-       *
-       * Semantics:
-       * - `undefined` (or field absent) → fall back to the host style preset.
-       * - `true` → inject the shim (per-method surface controlled by
-       *   `openaiAppsOverrides` merged over the preset's `openaiAppsCapabilities`).
-       * - `false` → do NOT inject the shim. Per-method overrides are
-       *   ignored when injection is off; `window.openai` is `undefined`
-       *   in the widget, which is what SEP-1865-only hosts advertise.
-       */
-      openaiApps?: boolean;
-      /**
-       * Sparse per-method overrides applied on top of the host style
-       * preset when the shim IS injected. Each present field replaces
-       * the corresponding preset value; absent fields fall back to the
-       * preset. Use this to model a specific host's published subset
-       * (e.g. Microsoft 365 Copilot's "no requestModal, no uploadFile,
-       * fullscreen-only display mode") without redefining the whole
-       * surface.
-       */
-      openaiAppsOverrides?: OpenAiAppsCapabilities;
-    };
-    /**
-     * Sparse user override on the SEP-1865 MCP Apps spec-bridge per-
-     * dimension matrix. Independent of {@link compatRuntime} — the spec
-     * bridge is the primary protocol, not a vendor shim, so the override
-     * is its own sibling. Each present field replaces the corresponding
-     * preset value; absent fields fall back to the host style preset's
-     * {@link ResolvedMcpAppsCapabilities}. Use this to model a host's
-     * published subset (e.g. Microsoft 365 Copilot's "no
-     * `tool-input-partial`, fullscreen-only display modes, no
-     * `_meta.ui.prefersBorder` honoring") without redefining the whole
-     * matrix.
-     */
-    mcpAppsOverrides?: McpAppsCapabilities;
-  };
-  extensions?: Record<string, unknown>;
-};
 
 /**
  * Mutable input shape. All fields are required at write time so the editor
@@ -407,7 +204,6 @@ export type HostConfigDtoV2 = {
 };
 
 export const DEFAULT_HOST_STYLE_V2: HostStyleId = "mcpjam";
-export const DEFAULT_TEMPERATURE_V2 = 0.7;
 
 export function emptyHostConfigInputV2(
   partial: Partial<HostConfigInputV2> = {},

--- a/mcpjam-inspector/client/vite.config.ts
+++ b/mcpjam-inspector/client/vite.config.ts
@@ -11,6 +11,16 @@ const rootDir = path.resolve(clientDir, "..");
 const workspaceNodeModulesDir = path.resolve(rootDir, "../node_modules");
 // The linked local SDK package can advertise ./browser before dist/browser.* exists.
 const sdkBrowserEntry = path.resolve(rootDir, "../sdk/src/browser.ts");
+// Same rationale: @mcpjam/sdk advertises ./host-config/internal via its package
+// exports, but a clean checkout has no dist/host-config/internal.* until
+// `npm run build -w @mcpjam/sdk` runs. The full `npm run build` chain builds
+// the SDK first, but `npm run dev:client` / `build:client` in isolation
+// (and Codex's `sdk/dist`-removed repro) fail Rollup resolution without
+// this alias.
+const sdkHostConfigInternalEntry = path.resolve(
+  rootDir,
+  "../sdk/src/host-config/internal.ts",
+);
 // Bypass stale Vite optimized deps for MCP SDK auth helpers by resolving
 // directly to the installed ESM entrypoints.
 const mcpSdkClientAuthEntry = path.resolve(
@@ -55,6 +65,7 @@ export default defineConfig(({ mode }) => {
         "@/shared": path.resolve(clientDir, "../shared"),
         "@": path.resolve(clientDir, "./src"),
         "@mcpjam/sdk/browser": sdkBrowserEntry,
+        "@mcpjam/sdk/host-config/internal": sdkHostConfigInternalEntry,
         "@modelcontextprotocol/sdk/client/auth.js": mcpSdkClientAuthEntry,
         "@modelcontextprotocol/sdk/shared/auth.js": mcpSdkSharedAuthEntry,
         // Resolve shared frontend deps from the workspace root now that installs

--- a/mcpjam-inspector/client/vitest.config.ts
+++ b/mcpjam-inspector/client/vitest.config.ts
@@ -10,6 +10,16 @@ const sdkSkillReferenceEntry = path.resolve(
   "../sdk/src/skill-reference.ts",
 );
 const sdkMatchersEntry = path.resolve(rootDir, "../sdk/src/matchers.ts");
+// Same rationale as sdkBrowserEntry: the workspace-linked @mcpjam/sdk advertises
+// ./host-config/internal via its package exports, but a clean checkout has no
+// dist/host-config/internal.* until `npm run build -w @mcpjam/sdk` runs. The
+// inspector's pretest doesn't build the SDK (root-level `npm test` does), so
+// without this alias, `npm test -w @mcpjam/inspector` fails to resolve the
+// import in client-config-v2.ts → Failed to resolve import "@mcpjam/sdk/host-config/internal".
+const sdkHostConfigInternalEntry = path.resolve(
+  rootDir,
+  "../sdk/src/host-config/internal.ts",
+);
 const mcpSdkClientAuthEntry = path.resolve(
   workspaceNodeModulesDir,
   "@modelcontextprotocol/sdk/dist/esm/client/auth.js",
@@ -66,6 +76,10 @@ export default defineConfig({
       },
       { find: "@mcpjam/sdk/browser", replacement: sdkBrowserEntry },
       { find: "@mcpjam/sdk/matchers", replacement: sdkMatchersEntry },
+      {
+        find: "@mcpjam/sdk/host-config/internal",
+        replacement: sdkHostConfigInternalEntry,
+      },
       {
         find: "@modelcontextprotocol/sdk/client/auth.js",
         replacement: mcpSdkClientAuthEntry,

--- a/sdk/src/host-config/defaults.ts
+++ b/sdk/src/host-config/defaults.ts
@@ -1,0 +1,47 @@
+/**
+ * HostConfig v2 — portable defaults + small pure resolvers.
+ *
+ * First-party, browser-safe, dependency-free. Exposed via
+ * `@mcpjam/sdk/host-config/internal`. The Convex backend imports these
+ * alongside the canonicalizer (one source of truth); the inspector client
+ * re-exports them from `@/lib/client-config-v2` so its 60+ importers stay
+ * untouched.
+ *
+ * Anything that mints a full `HostConfigInputV2` scaffold (an editor-facing
+ * default-filler) belongs in the application layer that knows its own style
+ * + model defaults — the SDK deliberately ships no default `style`/`model`
+ * (Stage 0b hardening). This module is just the small, opinionated knobs
+ * both backend and client can agree on.
+ */
+
+import type { McpProtocolVersion } from "./types.js";
+
+/**
+ * Default sampling temperature when an editor mints a fresh host config.
+ *
+ * Mirror of the backend's `DEFAULT_TEMPERATURE_V2` constant (used by
+ * `ensureProjectV2Default` to seed new project hosts) and the inspector
+ * client's `emptyHostConfigInputV2` default. Lives here so both readers
+ * agree on the same number — bumping it later is a one-place edit.
+ */
+export const DEFAULT_TEMPERATURE_V2 = 0.7;
+
+/**
+ * Resolve the effective pinned MCP protocol version for a server
+ * connection: per-server override beats host-level default; both
+ * undefined yields undefined ("no opinion — SDK chooses at request time").
+ *
+ * `undefined` is a load-bearing sentinel — do NOT materialize a concrete
+ * version when neither layer has an opinion, or canonical hashes churn
+ * whenever the SDK default moves and future SDK default upgrades silently
+ * no-op against existing rows.
+ *
+ * Both inputs are optional so callers can read straight off a hydrated
+ * host-config row without normalizing first.
+ */
+export function resolveEffectiveMcpProtocolVersion(
+  serverOverride: McpProtocolVersion | undefined,
+  hostDefault: McpProtocolVersion | undefined,
+): McpProtocolVersion | undefined {
+  return serverOverride ?? hostDefault;
+}

--- a/sdk/src/host-config/internal.ts
+++ b/sdk/src/host-config/internal.ts
@@ -23,9 +23,15 @@ export {
   HOST_CONFIG_SCHEMA_VERSION_V2,
   SEP_1865_PERMISSION_FEATURES,
 } from "./types.js";
+export {
+  DEFAULT_TEMPERATURE_V2,
+  resolveEffectiveMcpProtocolVersion,
+} from "./defaults.js";
 export type {
   HostConfigInputV2,
   CanonicalHostConfigV2,
   HostConfigMcpProfileV1,
   HostConfigConnectionDefaults,
+  CspDomainSet,
+  McpProtocolVersion,
 } from "./types.js";

--- a/sdk/tests/host-config-defaults.test.ts
+++ b/sdk/tests/host-config-defaults.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_TEMPERATURE_V2,
+  resolveEffectiveMcpProtocolVersion,
+} from "../src/host-config/internal";
+
+describe("DEFAULT_TEMPERATURE_V2", () => {
+  it("is 0.7 — agreed default shared with the backend's ensureProjectV2Default seed and the inspector's emptyHostConfigInputV2", () => {
+    expect(DEFAULT_TEMPERATURE_V2).toBe(0.7);
+  });
+});
+
+describe("resolveEffectiveMcpProtocolVersion", () => {
+  it("returns the per-server override when present (server wins over host default)", () => {
+    expect(
+      resolveEffectiveMcpProtocolVersion("2025-06-18", "2025-11-25"),
+    ).toBe("2025-06-18");
+  });
+
+  it("returns the host default when the server has no override", () => {
+    expect(
+      resolveEffectiveMcpProtocolVersion(undefined, "2025-11-25"),
+    ).toBe("2025-11-25");
+  });
+
+  it("returns undefined when neither layer has an opinion — load-bearing sentinel: SDK chooses at request time", () => {
+    expect(
+      resolveEffectiveMcpProtocolVersion(undefined, undefined),
+    ).toBeUndefined();
+  });
+
+  it("returns the per-server override even when host default is also set (no merge)", () => {
+    expect(
+      resolveEffectiveMcpProtocolVersion("2026-07-28", "2025-03-26"),
+    ).toBe("2026-07-28");
+  });
+
+  it("returns the per-server override when host default is undefined", () => {
+    expect(
+      resolveEffectiveMcpProtocolVersion("2025-03-26", undefined),
+    ).toBe("2025-03-26");
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2 of the hostConfig consolidation. Backend Stage 1 (mcpjam-backend PR #409) made the SDK the source of truth for the **canonicalizer + hash**. This PR makes the inspector client consume the same SDK for the **shareable leaf primitives** the canonicalizer operates on. The 65 importers of `@/lib/client-config-v2` keep their import paths unchanged.

**Moved to `@mcpjam/sdk/host-config/internal`** (re-exported by the client so no caller had to redirect):
- Types: `CspDomainSet`, `HostConfigConnectionDefaults`, `HostConfigMcpProfileV1`, `McpProtocolVersion`
- Constants: `SEP_1865_PERMISSION_FEATURES`, `DEFAULT_TEMPERATURE_V2`
- Function: `resolveEffectiveMcpProtocolVersion` (one-line `??`)

**Stays client-owned (stricter than SDK's storage-write shape — by design)**:
- `HostConfigInputV2` / `HostConfigDtoV2` — require `serverIds`/`optionalServerIds`/`respectToolVisibility`; use the structured `ChatUiOverride` instead of `Record<string, unknown>`. The editor enforces these invariants where the storage layer leaves them optional for the iterative-host rollout.
- `HostStyleId` — closed `ChatboxHostStyle` union (editor only knows registered styles; SDK is BYO-host friendly).
- `emptyHostConfigInputV2` / `hostConfigDtoToInput` — return the client's strict types; tightly bound to the editor's invariants.
- `resolveClientInfo` / `resolveSupportedProtocolVersions` / `resolveHostInfo` — logically portable but no external demand yet.
- All entangled resolvers (`resolveEffectiveHostCapabilities`, `resolveEffectiveCompatRuntime`, `resolveEffectiveMcpAppsCapabilities`, mergers, matrix mapper) — coupled to `@/lib/client-styles` + ext-apps; Stage 3+ effort.
- All dirty-detection equality + clone helpers — client-side change-tracking, not part of the canonical model.

SDK additions land at `/internal` (first-party only); the public `/host-config` barrel stays the `Host` facade per the Stage 0b vocabulary decision.

**Zero backend touch, zero hash math, zero production-data risk.** This is code-shape consolidation.

## Why the scope is smaller than the macro plan envisioned

The macro plan in `hostconfig-consolidation-plan.md` listed `HostConfigInputV2` and `HostConfigDtoV2` as candidates to move. After reading the client code, those types are deliberately **stricter** than the SDK's: client requires `serverIds`/`optionalServerIds`/`respectToolVisibility` (editor UX) while SDK leaves them optional (storage write contract during the project-scoped-server rollout). Moving them naively would cascade `undefined`-checks across ~30 importers and fight a real design intent. The robust call was to share only the leaf primitives where both sides genuinely agree, leaving the strict aggregate types as the client's responsibility. The plan was updated accordingly.

## Verification

- SDK: 1145/1145 tests including the new 6-test `host-config-defaults.test.ts`
- SDK build: dist regenerated with the new exports
- Inspector: `npm run typecheck:client` clean
- Client tests: 24/24 files touching `client-config-v2` → 418/418 tests passing
  - `client-config-v2.test.ts` 36/36
  - `client-config-v2-mcp-profile.test.ts` 27/27
- File size: `client-config-v2.ts` 1080 → 875 lines (−205)
- Importer count: 65 (unchanged)
- No-local-declarations grep: returns 0 for the moved items

## Test plan

- [x] SDK build + tests
- [x] Inspector client typecheck
- [x] Client test files touching `client-config-v2` (24 files, 418 tests)
- [ ] CI green
- [ ] Manual smoke: open inspector dev server, switch host styles in the client config editor, edit a chatbox's host config, verify dirty-detection still flags changes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: no backend or hash changes; behavior preserved via re-exports and tests. Main risk is build resolution if aliases are wrong in edge workflows.
> 
> **Overview**
> Stage 2 host-config consolidation: **shareable leaf primitives** that used to live in `client-config-v2.ts` now come from `@mcpjam/sdk/host-config/internal`, aligned with the backend canonicalizer. The inspector still **re-exports** them from `@/lib/client-config-v2`, so existing importers keep the same paths.
> 
> **Moved into the SDK** (new `defaults.ts`, wired through `internal.ts`): types `CspDomainSet`, `HostConfigConnectionDefaults`, `HostConfigMcpProfileV1`, `McpProtocolVersion`; constants `SEP_1865_PERMISSION_FEATURES` and `DEFAULT_TEMPERATURE_V2`; and `resolveEffectiveMcpProtocolVersion`. The large inline type/docs block was removed from the client file (~200 lines).
> 
> **Unchanged by design**: stricter client-only aggregates (`HostConfigInputV2` / `HostConfigDtoV2`, resolvers tied to client styles, dirty-detection helpers).
> 
> **Tooling**: Vite and Vitest resolve `@mcpjam/sdk/host-config/internal` to SDK source when `dist` is missing, matching the existing `@mcpjam/sdk/browser` pattern.
> 
> **Tests**: new `host-config-defaults.test.ts` covers the default temperature and protocol-version resolution rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf81115bfae50d5b7e7f978672f7bfb53d956fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->