### PR TITLE
docs: document window.openai.setOpenInAppUrl in the ChatGPT app guide

### DIFF
--- a/docs/guides/first-chatgpt-app-react.mdx
+++ b/docs/guides/first-chatgpt-app-react.mdx
@@ -154,6 +154,14 @@ window.openai.requestDisplayMode({ mode: "fullscreen" });
 
 Users can exit PiP or fullscreen by clicking the close button, returning to inline. Our Coffee Shop uses the default inline mode, but you can test all three in MCPJam Inspector's Playground.
 
+When your widget is in fullscreen, you can add an **"Open in \<server name\>"** button to the header chrome by calling `setOpenInAppUrl`. This lets users open the widget's underlying web app in a new tab:
+
+```javascript
+window.openai.setOpenInAppUrl({ href: "https://app.example.com/item/42" });
+```
+
+Only `http` and `https` URLs are accepted. The link opens in a new tab with `noopener,noreferrer`.
+
 ### Content Security Policy (CSP)
 
 Widgets run in a sandboxed iframe, so you need to declare which external domains your widget can interact with. Set `openai/widgetCSP` in your resource's `_meta` to configure these permissions:

--- a/docs/guides/first-chatgpt-app-react.mdx
+++ b/docs/guides/first-chatgpt-app-react.mdx
@@ -162,6 +162,8 @@ window.openai.setOpenInAppUrl({ href: "https://app.example.com/item/42" });
 
 Only `http` and `https` URLs are accepted. The link opens in a new tab with `noopener,noreferrer`.
 
+This capability is optional — hosts can turn it off, in which case `window.openai.setOpenInAppUrl` won't be defined. Guard for it before calling, for example `window.openai.setOpenInAppUrl?.({ href: "https://app.example.com/item/42" })`.
+
 ### Content Security Policy (CSP)
 
 Widgets run in a sandboxed iframe, so you need to declare which external domains your widget can interact with. Set `openai/widgetCSP` in your resource's `_meta` to configure these permissions:


### PR DESCRIPTION
Documents the `window.openai.setOpenInAppUrl` widget API (shipped in #2281) in the ChatGPT app guide, right next to the existing `requestDisplayMode` docs. It's currently undocumented anywhere in `docs/`.

### Why a new PR instead of merging the Mintlify PR
This is the still-relevant, user-facing portion of the stale Mintlify docs PR #2284, re-applied on current `main`:
- The original bot branch was based on a pre-rename tree, so merging it would have reverted "Playground" back to "App Builder".
- It also added an internal "Implementation files" source-path list to the contributing docs, which is intentionally omitted here (user-facing docs only, no internals).

Supersedes the user-facing part of #2284.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LExdyi7zaPZZRz9dvjU9Yp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds user-facing documentation for **`window.openai.setOpenInAppUrl`** in `docs/guides/first-chatgpt-app-react.mdx`, placed in the **Display Modes** section after the existing **`requestDisplayMode`** examples.
> 
> The new content explains that fullscreen widgets can show an **"Open in \<server name\>"** header button, documents the **`href`** call pattern, notes **http/https-only** URLs and **noopener,noreferrer** tab behavior, and recommends optional chaining because hosts may omit the API when the capability is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49997e7f0d37874cbe084e5fe159d1c660510572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->