### PR TITLE
refactor(HomeTab): drop ensureOrgMetricFresh client effect

### DIFF
--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo } from "react";
-import { useMutation, useQuery } from "convex/react";
+import { useMemo } from "react";
+import { useQuery } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { Button } from "@mcpjam/design-system/button";
@@ -77,20 +77,6 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
       ? ({ organizationId, metric: "messages_sent_30d" } as any)
       : "skip"
   ) as OrgMetricResult;
-
-  const ensureMetricFresh = useMutation(
-    "orgMetrics:ensureOrgMetricFresh" as any
-  );
-  useEffect(() => {
-    if (!organizationId) return;
-    const args = { organizationId } as { organizationId: string };
-    Promise.all([
-      ensureMetricFresh({ ...args, metric: "tool_executions_30d" } as any),
-      ensureMetricFresh({ ...args, metric: "messages_sent_30d" } as any),
-    ]).catch(() => {
-      // Soft-fail: cache stays stale, UI shows last known value (or 0).
-    });
-  }, [organizationId, ensureMetricFresh]);
 
   const fullName =
     convexUser?.name ||


### PR DESCRIPTION
## Summary

The home tab tiles for **tool exec · 30d** and **messages · 30d** now read from a Convex write-time counter populated by chat ingestion instead of a PostHog-backed refresh action. Drop the client-side `useEffect` that called `orgMetrics.ensureOrgMetricFresh`; the two `useQuery(api.orgMetrics.getOrgMetric, …)` calls are unchanged and now return real values straight from Convex.

The paired backend PR removes the `ensureOrgMetricFresh` mutation export and reimplements `getOrgMetric` to range-scan the new `orgUsageDaily` table: https://github.com/MCPJam/mcpjam-backend/pull/413

This PR should land **after** the backend PR has deployed so the existing mutation call doesn't 404 during the window. The current `.catch(() => undefined)` soft-fail makes this graceful but cleaner to deploy in order.

## Test plan

- [x] `npm run typecheck:client` clean.
- [x] No other callers of `ensureOrgMetricFresh` in the repo.
- [ ] Manual on staging post-deploy: home tab tiles render real counts, no skeleton flash, no console error for the removed mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-only removal with unchanged query wiring; deploy after the backend change to avoid a brief missing-mutation call.
> 
> **Overview**
> Removes the **HomeTab** side effect that called `orgMetrics.ensureOrgMetricFresh` for **tool exec · 30d** and **messages · 30d** when an org is selected. Those tiles still use the same `orgMetrics.getOrgMetric` queries; counts are expected to come from the backend’s Convex-backed metrics without a client-triggered refresh.
> 
> Also drops unused `useEffect` / `useMutation` imports tied to that flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79f0a3c34cdb2a5c5639c324a9846bf1906d0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->