### PR TITLE
refactor(host-config): tighten canonicalizer with the 4 deferred #2392 follow-ups

### DIFF
--- a/.changeset/sdk-host-config-canonicalize-tightening.md
+++ b/.changeset/sdk-host-config-canonicalize-tightening.md
@@ -1,0 +1,16 @@
+---
+"@mcpjam/sdk": minor
+---
+
+SDK: tighten the HostConfig v2 canonicalizer (four follow-up items deferred from #2392). All four ship together as the second-half of the Stage 1 backend consolidation — the backend imports the canonicalizer directly from `@mcpjam/sdk/host-config/internal`, so this PR is the single source of behavior change for both sides.
+
+Behavior changes (all on `canonicalizeHostConfigV2` / `computeHostConfigHashV2`):
+
+- **Deep-sort `clientCapabilities` and `hostContext`.** Previously a shallow `sortStringKeys` left nested key order leaking into the canonical hash, so `{ extensions: { ui: { a, b } } }` and `{ extensions: { ui: { b, a } } }` minted distinct rows for identical capability sets. Now both fields go through the same recursive sort already used for `*Override` and `mcpProfile`.
+- **Collapse empty `allowFeatures` to absent.** A user `allowFeatures: {}` (or `{ camera: "*" }` whose only keys are spec-permission features that the canonicalizer drops) now omits the field entirely, matching the sibling `openaiAppsOverrides` collapse and preventing semantic dupes.
+- **Drop `openaiAppsOverrides` when `compatRuntime.openaiApps === false`.** The resolver ignores per-method overrides when the shim isn't injected; letting them affect the hash minted rows that resolved to identical runtime behavior.
+- **Fail-fast on missing `clientCapabilities` / `hostContext`.** The previous `?? {}` coalescing silently merged a writer-bug `undefined` into the empty-cap dedupe pool. Both fields are required on the input type; the canonicalizer now enforces it at the boundary.
+
+Audit confirmed all four items are **hash-neutral for current production data** (15,389 prod hostConfigs rows scanned across the four predicates; 0 hits). The bundled parity fixture was regenerated; `EXPECTED_INPUT_HASH` bumped accordingly. External SDK consumers using the public `Host` builder are unaffected — the canonicalizer is internal-only.
+
+Out of scope: the eight `@mcpjam/sdk` items still tracked elsewhere (Stage 3+ in the macro plan).

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -101,6 +101,23 @@ function sortStringKeys<T extends Record<string, unknown>>(input: T): T {
   return out as T;
 }
 
+// Fail-fast guard for fields the HostConfigInputV2 type marks required
+// but the canonicalizer historically coalesced via `?? {}`. The empty-object
+// fallback hides a real write-path bug: a caller passing undefined silently
+// dedupes into whichever existing row also happens to have empty caps.
+// Plain-object check defends against arrays/primitives slipping past
+// upstream `v.any()` validators. Returns a deep-sorted copy so nested key
+// order doesn't leak into the hash.
+function requireRecord(value: unknown, fieldName: string): Record<string, unknown> {
+  if (value === undefined || value === null) {
+    throw new Error(`hostConfigV2: ${fieldName} is required`);
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`hostConfigV2: ${fieldName} must be a plain object`);
+  }
+  return deepSortStringKeys(value as Record<string, unknown>);
+}
+
 // Deep variant: recursively sorts keys at every object level so nested
 // records hash the same regardless of original key order.
 function deepSortStringKeys<T>(input: T): T {
@@ -234,6 +251,10 @@ function canonicalizeAllowFeatures(
     }
     out[k] = v;
   }
+  // Collapse to absent when every key was dropped (input was `{}` or only
+  // contained spec-feature keys). Matches the sibling `openaiAppsOverrides`
+  // behavior so an empty allowlist doesn't hash distinctly from "no entries".
+  if (Object.keys(out).length === 0) return undefined;
   return out;
 }
 
@@ -678,7 +699,14 @@ function canonicalizeMcpProfile(
           }
         }
         // Empty `{}` collapses to absent (same runtime behavior as absent).
-        if (Object.keys(overridesOut).length > 0) {
+        // Also drop when injection is explicitly disabled: the resolver
+        // ignores per-method overrides when `openaiApps: false`, so letting
+        // them affect the hash would mint distinct rows that resolve to
+        // identical runtime behavior.
+        if (
+          Object.keys(overridesOut).length > 0 &&
+          compatRuntimeOut.openaiApps !== false
+        ) {
           const sortedOverrides = {} as OpenAiAppsCapabilities;
           for (const k of Object.keys(overridesOut).sort()) {
             (sortedOverrides as Record<string, unknown>)[k] = (
@@ -935,8 +963,14 @@ export function canonicalizeHostConfigV2(
       headers: sortStringKeys(input.connectionDefaults.headers),
       requestTimeout: input.connectionDefaults.requestTimeout,
     },
-    clientCapabilities: sortStringKeys(input.clientCapabilities ?? {}),
-    hostContext: sortStringKeys(input.hostContext ?? {}),
+    // Deep-sort: nested key order shouldn't leak into the hash. Shallow
+    // sort would let `{ extensions: { ui: { a, b } } }` and the same with
+    // `{ b, a }` produce distinct hashes for identical capabilities.
+    // Fail-fast on missing: HostConfigInputV2 requires both fields; a
+    // `?? {}` fallback hides write-path bugs that would silently dedupe
+    // distinct callers' configs into a stray empty-capability row.
+    clientCapabilities: requireRecord(input.clientCapabilities, "clientCapabilities"),
+    hostContext: requireRecord(input.hostContext, "hostContext"),
     // Preserve undefined (omitted → dedupes with preset) vs {} (explicit empty
     // → hashes distinctly).
     hostCapabilitiesOverride:

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -109,13 +109,18 @@ function sortStringKeys<T extends Record<string, unknown>>(input: T): T {
 // upstream `v.any()` validators. Returns a deep-sorted copy so nested key
 // order doesn't leak into the hash.
 function requireRecord(value: unknown, fieldName: string): Record<string, unknown> {
-  if (value === undefined || value === null) {
+  if (value === undefined) {
     throw new Error(`hostConfigV2: ${fieldName} is required`);
   }
-  if (typeof value !== "object" || Array.isArray(value)) {
+  // Reuses the shared isPlainObject predicate (now prototype-guarded), so
+  // Date / class instance / Map / Set inputs hit a hard error here instead
+  // of silently canonicalizing to `{}` and merging with the empty-record
+  // dedupe pool. Only `{}` literals and Object.create(null) records are
+  // accepted — both are valid JSON-serializable plain objects.
+  if (!isPlainObject(value)) {
     throw new Error(`hostConfigV2: ${fieldName} must be a plain object`);
   }
-  return deepSortStringKeys(value as Record<string, unknown>);
+  return deepSortStringKeys(value);
 }
 
 // Deep variant: recursively sorts keys at every object level so nested
@@ -143,7 +148,16 @@ function sortUniqueServerIds(ids: Array<ServerId> | undefined): Array<ServerId> 
 // Arrays/null satisfy `typeof === 'object'`; the canonicalizer is the
 // chokepoint.
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  // Reject Date, Map, Set, class instances, etc. — `Object.keys` returns
+  // `[]` on most of these, so without this guard they'd canonicalize to
+  // `{}` and silently merge with the empty-record dedupe pool. Plain
+  // objects have a prototype of either `Object.prototype` (literal `{}`)
+  // or `null` (Object.create(null)).
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 // Canonicalize a CSP domain list as a SET: trim, drop empty, dedupe, sort.

--- a/sdk/tests/fixtures/host-config-parity-fixtures.json
+++ b/sdk/tests/fixtures/host-config-parity-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "__inputHash": "8a680395dda47f356458db577201e723427be6e551217cba73c982e28a01b6c7",
+  "__inputHash": "32a8406b9ff8d090c2ba3e0c2f4093c3af06e9a54fb6f5913c24e72458ca29c4",
   "rows": [
     {
       "label": "base-minimal",
@@ -67,8 +67,8 @@
           "a": 1
         }
       },
-      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{\"A-Header\":\"2\",\"X-Z\":\"1\",\"m-mid\":\"3\"},\"requestTimeout\":30000},\"clientCapabilities\":{\"alpha\":{\"nested\":1,\"deep\":2},\"zeta\":true},\"hostContext\":{\"a\":1,\"b\":2}}",
-      "sha256": "7b050c8dbee3bfd261854c4446a5351de06fdfd332f26caeb6b30154610d5c47"
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{\"A-Header\":\"2\",\"X-Z\":\"1\",\"m-mid\":\"3\"},\"requestTimeout\":30000},\"clientCapabilities\":{\"alpha\":{\"deep\":2,\"nested\":1},\"zeta\":true},\"hostContext\":{\"a\":1,\"b\":2}}",
+      "sha256": "f95d474377553529dc64a66b48513aec7af86c48eed135d799fa6d30f2dda1eb"
     },
     {
       "label": "server-ids-unsorted-plus-overrides",

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -237,6 +237,41 @@ describe("canonicalizeHostConfigV2 — tightening (Stage B)", () => {
     ).toThrow(/clientCapabilities must be a plain object/);
   });
 
+  // Regression: Date / Map / Set / class instances all return `[]` from
+  // `Object.keys`, so without the prototype guard in isPlainObject they
+  // would silently canonicalize to `{}` and merge with the empty-record
+  // dedupe pool — the exact dedupe collapse the fail-fast is meant to
+  // prevent. CodeRabbit flagged this on the original PR.
+  it("rejects Date / Map / Set / class instances on plain-object fields (prototype-guarded)", () => {
+    const samples: Array<[string, unknown]> = [
+      ["Date", new Date(0)],
+      ["Map", new Map()],
+      ["Set", new Set()],
+      ["class instance", new (class { x = 1 })()],
+    ];
+    for (const [label, value] of samples) {
+      expect(
+        () =>
+          canonicalizeHostConfigV2(
+            base({ clientCapabilities: value as Record<string, unknown> }),
+          ),
+        `clientCapabilities = ${label}`,
+      ).toThrow(/clientCapabilities must be a plain object/);
+    }
+  });
+
+  it("accepts Object.create(null) records on plain-object fields (no prototype, still serializable)", async () => {
+    const nullProto = Object.create(null) as Record<string, unknown>;
+    nullProto.foo = 1;
+    nullProto.bar = { baz: 2 };
+    expect(() => canonicalizeHostConfigV2(base({ clientCapabilities: nullProto }))).not.toThrow();
+    // And hashes identically to the `{}`-literal form — proto difference
+    // doesn't leak into canonical JSON.
+    const a = base({ clientCapabilities: nullProto });
+    const b = base({ clientCapabilities: { foo: 1, bar: { baz: 2 } } });
+    expect(await hash(a)).toBe(await hash(b));
+  });
+
   // Item 3: empty allowFeatures collapses to absent. Sibling
   // openaiAppsOverrides already does this; allowFeatures was the odd one
   // out and minted distinct hashes for semantically identical configs.

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -21,17 +21,19 @@ function base(overrides: Partial<HostConfigInputV2> = {}): HostConfigInputV2 {
 const hash = (input: HostConfigInputV2) => computeHostConfigHashV2(input);
 
 describe("canonicalizeHostConfigV2 — hash stability", () => {
-  it("is independent of TOP-LEVEL header / capability key order (shallow sort)", async () => {
-    // connectionDefaults.headers, clientCapabilities and hostContext use a
-    // SHALLOW key sort — top-level order is normalized, nested order is NOT
-    // (matches the backend; only *Override + mcpProfile deep-sort).
+  it("is independent of header / capability key order at every depth (deep sort)", async () => {
+    // connectionDefaults.headers stays shallow (flat by design).
+    // clientCapabilities and hostContext now deep-sort: nested key order
+    // must not leak into the canonical hash.
     const a = base({
       connectionDefaults: { headers: { a: "1", b: "2" }, requestTimeout: 1 },
-      clientCapabilities: { x: 1, y: 3 },
+      clientCapabilities: { x: { p: 1, q: 2 }, y: 3 },
+      hostContext: { foo: { a: 1, b: 2 } },
     });
     const b = base({
       connectionDefaults: { headers: { b: "2", a: "1" }, requestTimeout: 1 },
-      clientCapabilities: { y: 3, x: 1 },
+      clientCapabilities: { y: 3, x: { q: 2, p: 1 } },
+      hostContext: { foo: { b: 2, a: 1 } },
     });
     expect(await hash(a)).toBe(await hash(b));
   });
@@ -202,5 +204,109 @@ describe("canonicalizeHostConfigV2 — mcpProfile derivation", () => {
         }),
       ),
     ).toThrow(/ConflictingProtocolVersionPin/);
+  });
+});
+
+describe("canonicalizeHostConfigV2 — tightening (Stage B)", () => {
+  // Item 5: fail-fast on missing required record fields. The previous
+  // `?? {}` coalescing silently merged undefined-cap rows with explicit-{}
+  // rows; both now reach an explicit error at the canonicalize boundary.
+  it("throws when clientCapabilities is missing (fail-fast, no `?? {}` fallback)", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        // The Input type marks it required; cast simulates an upstream bug
+        // (writer who let v.any() through with undefined).
+        base({ clientCapabilities: undefined as unknown as Record<string, unknown> }),
+      ),
+    ).toThrow(/clientCapabilities is required/);
+  });
+
+  it("throws when hostContext is missing (fail-fast)", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({ hostContext: undefined as unknown as Record<string, unknown> }),
+      ),
+    ).toThrow(/hostContext is required/);
+  });
+
+  it("throws when clientCapabilities is not a plain object", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({ clientCapabilities: [] as unknown as Record<string, unknown> }),
+      ),
+    ).toThrow(/clientCapabilities must be a plain object/);
+  });
+
+  // Item 3: empty allowFeatures collapses to absent. Sibling
+  // openaiAppsOverrides already does this; allowFeatures was the odd one
+  // out and minted distinct hashes for semantically identical configs.
+  it("collapses empty allowFeatures to absent (hash-identical to omitting it)", async () => {
+    const omitted = base({
+      mcpProfile: { profileVersion: 1, apps: { sandbox: {} } },
+    });
+    const explicitEmpty = base({
+      mcpProfile: { profileVersion: 1, apps: { sandbox: { allowFeatures: {} } } },
+    });
+    expect(await hash(omitted)).toBe(await hash(explicitEmpty));
+  });
+
+  it("collapses an allowFeatures with only spec-feature keys (all dropped) to absent", async () => {
+    const omitted = base({
+      mcpProfile: { profileVersion: 1, apps: { sandbox: {} } },
+    });
+    const onlySpecKeys = base({
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          sandbox: { allowFeatures: { camera: "*", microphone: "self" } },
+        },
+      },
+    });
+    expect(await hash(omitted)).toBe(await hash(onlySpecKeys));
+  });
+
+  // Item 6: drop openaiAppsOverrides when openaiApps:false. The resolver
+  // ignores them when the shim isn't injected; letting them affect the
+  // hash mints rows that resolve to identical runtime behavior.
+  it("drops openaiAppsOverrides when compatRuntime.openaiApps is false (resolver ignores them)", async () => {
+    const withOverrides = base({
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          compatRuntime: {
+            openaiApps: false,
+            openaiAppsOverrides: { requestModal: true, uploadFile: false },
+          },
+        },
+      },
+    });
+    const withoutOverrides = base({
+      mcpProfile: {
+        profileVersion: 1,
+        apps: { compatRuntime: { openaiApps: false } },
+      },
+    });
+    expect(await hash(withOverrides)).toBe(await hash(withoutOverrides));
+  });
+
+  it("keeps openaiAppsOverrides when compatRuntime.openaiApps is true (overrides are live)", async () => {
+    const withOverrides = base({
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          compatRuntime: {
+            openaiApps: true,
+            openaiAppsOverrides: { requestModal: true },
+          },
+        },
+      },
+    });
+    const withoutOverrides = base({
+      mcpProfile: {
+        profileVersion: 1,
+        apps: { compatRuntime: { openaiApps: true } },
+      },
+    });
+    expect(await hash(withOverrides)).not.toBe(await hash(withoutOverrides));
   });
 });

--- a/sdk/tests/host-config-parity.test.ts
+++ b/sdk/tests/host-config-parity.test.ts
@@ -14,14 +14,17 @@ import type { HostConfigInputV2 } from "../src/host-config/internal";
  * canonicalizer drifts, that repo's copy of this test fails because the
  * canonical JSON / sha256 no longer matches the pinned golden values.
  *
- * `EXPECTED_INPUT_HASH` is the sha256 of the fixture's `rows` array, inlined
- * here AND in `mcpjam-backend/tests/convex/hostConfigV2Parity.test.ts`. If you
- * regenerate the fixture (scripts/gen-host-config-parity-fixture.mjs), copy the
- * new fixture to the backend and update BOTH inlined constants in the same
- * change set — a partial edit fails the stale side loudly.
+ * `EXPECTED_INPUT_HASH` is the sha256 of the fixture's `rows` array. Bump it
+ * whenever you regenerate the fixture (scripts/gen-host-config-parity-fixture.mjs)
+ * so the drift guard fails loudly on a stale copy.
+ *
+ * The backend used to mirror this fixture + constant for cross-repo parity,
+ * but Stage 1 (mcpjam-backend PR #409) collapsed that into a one-import
+ * delegation — the backend's canonicalize tests now exercise the SDK
+ * directly, so the SDK-side constant is the single source of truth.
  */
 const EXPECTED_INPUT_HASH =
-  "8a680395dda47f356458db577201e723427be6e551217cba73c982e28a01b6c7";
+  "32a8406b9ff8d090c2ba3e0c2f4093c3af06e9a54fb6f5913c24e72458ca29c4";
 
 type FixtureRow = {
   label: string;


### PR DESCRIPTION
## Summary

Stage B in the macro hostConfig consolidation: ship the four canonicalizer tightening items that were deferred from #2392 and the macro plan. All four behavior changes live on `canonicalizeHostConfigV2` / `computeHostConfigHashV2` in `@mcpjam/sdk/host-config/internal`. Because Stage 1 (mcpjam-backend PR #409) already made the backend import these functions directly from the SDK, this single PR is the source of truth for both sides — there is no separate backend change set to coordinate.

### Behavior changes

- **Deep-sort `clientCapabilities` + `hostContext` (item 1).** Shallow `sortStringKeys` let nested key order leak into the canonical hash, so semantically identical capability trees minted distinct rows. Both fields now go through the same recursive sort already used for `*Override` + `mcpProfile`.
- **Collapse empty `allowFeatures` to absent (item 3).** A user `{}` (or an `allowFeatures` whose only keys are spec-permission features that the canonicalizer drops because `permissions.allow` is the SoT) now omits the field entirely. Matches the sibling `openaiAppsOverrides` collapse.
- **Drop `openaiAppsOverrides` when `compatRuntime.openaiApps === false` (item 6).** The resolver ignores per-method overrides when the shim isn't injected; letting them affect the hash minted rows that resolved to identical runtime behavior.
- **Fail-fast on missing `clientCapabilities` / `hostContext` (item 5).** The previous `?? {}` coalescing silently merged a writer-bug `undefined` into the empty-cap dedupe pool. New `requireRecord()` helper enforces required + plain-object + non-null at the canonicalize boundary.

### Pre-merge prod audit (15,389 hostConfigs rows, hash-neutral confirmed)

| Item | Affected rows |
|---|---|
| 1 — deep-sort `clientCapabilities` | 0 |
| 1 — deep-sort `hostContext` | 0 |
| 3 — empty `allowFeatures` collapse | 0 |
| 6 — drop overrides on `openaiApps:false` | 0 |
| 5 — null/undefined cC/hC | 0 in V2 rows (1 V1 row, never canonicalized via this path) |

So the tightening is hash-neutral for current production data — no mint+repoint migration needed. Same shape as Stage 1.

`mcpProfile` adoption context (for sanity): 391/15,389 rows have any mcpProfile; 359 use sandbox; 160 use compatRuntime — real production use, none in the affected edge cases.

## Verification

- SDK: **1152/1152** tests (was 1145 baseline; +7 new tightening tests in `host-config-canonicalize.test.ts`, +1 updated assertion replacing the old "shallow sort" guard)
- Regenerated `tests/fixtures/host-config-parity-fixtures.json` via `scripts/gen-host-config-parity-fixture.mjs` (one fixture vector intentionally tested the old shallow-sort behavior and rolled with the new behavior)
- `EXPECTED_INPUT_HASH` in `tests/host-config-parity.test.ts` bumped to match the regenerated fixture; comment block updated to reflect Stage 1's one-import collapse (the backend no longer mirrors the constant)
- Inspector client suites that touch host-config (workspace-linked SDK): **63/63** in `client-config-v2.test.ts` + `client-config-v2-mcp-profile.test.ts`

## SDK API stability

External SDK consumers using the public `Host` builder are unaffected — the canonicalizer is on the `/internal` subpath, which is first-party-only and explicitly not semver-stable. Bumped to a `minor` (1.12.0) via changeset since the behavior changes are real and a few internal callers see a different hash for the edge cases above.

## Out of scope

- Stage 3 (host-policy + compat + filterAppOnlyTools runtime extraction) and later stages remain queued.
- Backend bump to `@mcpjam/sdk@^1.12.0` will happen as part of normal renovate/dependabot once this lands and 1.12.0 is published. The backend's existing 105-case `hostConfigV2Canonicalize.test.ts` will exercise the tightened behavior automatically since it imports through the SDK.

## Test plan

- [x] SDK 1152/1152
- [x] Inspector client host-config suites 63/63
- [x] Prod audit 0/15,389 across all four items
- [x] Parity fixture regenerated; drift guard re-pinned
- [ ] CI green
- [ ] Post-publish: bump backend `@mcpjam/sdk` to `^1.12.0` and re-run `npm run test:once -- hostConfigV2Canonicalize` against the published version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Canonical hash behavior changes can mint different hostConfig rows for edge-case inputs; prod audit reported hash-neutral for existing data, but buggy callers passing undefined/non-plain caps will now throw instead of silently deduping.
> 
> **Overview**
> Tightens the internal **HostConfig v2** canonicalizer (`canonicalizeHostConfigV2` / `computeHostConfigHashV2`) so dedupe hashes match runtime semantics. **`clientCapabilities`** and **`hostContext`** are now **deep-sorted** and validated via **`requireRecord`** (required plain objects; no `?? {}`), with a stricter **`isPlainObject`** that rejects Date/Map/class instances. **`allowFeatures`** collapses to absent when empty or only spec-permission keys remain; **`openaiAppsOverrides`** is omitted when **`compatRuntime.openaiApps === false`**.
> 
> Golden parity fixture and **`EXPECTED_INPUT_HASH`** are regenerated; new Stage B unit tests cover these rules. Changeset bumps **`@mcpjam/sdk`** minor — internal `/host-config/internal` only; public Host builder unchanged per PR notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe85d98ef637ab3e4a3f154a5b73355b7ea84e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->