### PR TITLE
feat(home): Convex-backed What's new feed with video embeds

### DIFF
--- a/mcpjam-inspector/client/src/components/home/ProductUpdatesFeed.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdatesFeed.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import {
   Card,
   CardHeader,
@@ -6,82 +8,202 @@ import {
   CardContent,
 } from "@mcpjam/design-system/card";
 import { Badge } from "@mcpjam/design-system/badge";
-import { Newspaper } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Newspaper, Play, X } from "lucide-react";
+import { parseVideoEmbed } from "./productUpdateVideo";
+import { ProductUpdatesSheet } from "./ProductUpdatesSheet";
 
-interface ProductUpdate {
-  date: string;
+export interface ProductUpdateEntry {
+  _id: string;
+  slug: string;
+  publishAt: number;
   title: string;
   body: string;
   tag?: string;
+  href?: string;
+  videoUrl?: string;
+  videoPosterUrl?: string;
+  dismissed: boolean;
+  isNew: boolean;
 }
 
-const UPDATES: ProductUpdate[] = [
-  {
-    date: "May 2026",
-    title: "Stateless MCP (2026 RC, 2026-07-28)",
-    body: "Try the MCP 2026-07-28 stateless RC against your own servers — per-server protocol mode with three layers of control from org default to per-server override.",
-    tag: "New",
-  },
-  {
-    date: "May 2026",
-    title: "Playground",
-    body: "App Builder and Chat are now one tab. Build, preview, and test MCP-powered apps without switching views.",
-  },
-  {
-    date: "Apr 2026",
-    title: "MCP Apps SDK",
-    body: "Build interactive UIs that live inside any MCP client. Register resources, handle messages, render rich views.",
-  },
-];
+function formatPublishDate(ts: number): string {
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    year: "numeric",
+  });
+}
 
 export function ProductUpdatesFeed() {
-  return (
-    <Card className="gap-0 overflow-hidden py-0">
-      <CardHeader className="px-6 pb-3 pt-5">
-        <CardTitle className="flex items-center gap-2 text-[15px] tracking-[-0.005em]">
-          <Newspaper className="size-4 text-muted-foreground" strokeWidth={1.75} />
-          What&apos;s new
-        </CardTitle>
-        <CardDescription className="text-[12.5px]">
-          Recent releases and platform changes.
-        </CardDescription>
-      </CardHeader>
+  const { isAuthenticated } = useConvexAuth();
+  const updates = useQuery(
+    "productUpdates:listVisibleUpdates" as any,
+    isAuthenticated ? ({} as any) : "skip"
+  ) as ProductUpdateEntry[] | undefined;
 
-      <CardContent className="px-6 pb-6 pt-3">
-        <ol className="relative">
-          {/* timeline rail */}
-          <span
-            aria-hidden
-            className="absolute left-[5px] top-1.5 bottom-2 w-px bg-border"
-          />
-          {UPDATES.map((update, i) => (
-            <li key={update.title} className="relative pb-5 pl-7 last:pb-0">
-              <span
-                aria-hidden
-                className={`absolute left-0 top-[5px] size-[11px] rounded-full ring-4 ring-card ${
-                  i === 0 ? "bg-primary" : "bg-border"
-                }`}
-              />
-              <div className="flex items-center gap-2">
-                <span className="text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
-                  {update.date}
-                </span>
-                {update.tag ? (
-                  <Badge className="h-4 px-1.5 text-[9.5px] tracking-wider">
-                    {update.tag}
-                  </Badge>
-                ) : null}
-              </div>
-              <p className="mt-1 text-[14px] font-semibold tracking-[-0.005em] text-foreground">
-                {update.title}
-              </p>
-              <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">
-                {update.body}
-              </p>
-            </li>
-          ))}
-        </ol>
-      </CardContent>
-    </Card>
+  const dismissUpdate = useMutation("productUpdates:dismissUpdate" as any);
+  const initialize = useMutation(
+    "productUpdates:initializeIfNeeded" as any
+  );
+
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const initRef = useRef(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || initRef.current) return;
+    initRef.current = true;
+    initialize({}).catch((err) => {
+      // Reset the guard so a transient failure can be retried on next mount.
+      initRef.current = false;
+      console.error("Failed to initialize product updates:", err);
+    });
+  }, [isAuthenticated, initialize]);
+
+  if (!isAuthenticated) return null;
+
+  const visible = (updates ?? []).filter((u) => !u.dismissed);
+  if (visible.length === 0) return null;
+
+  const top = visible.slice(0, 5);
+  const newCount = visible.filter((u) => u.isNew).length;
+
+  const handleDismiss = async (slug: string) => {
+    try {
+      await dismissUpdate({ slug });
+    } catch (err) {
+      console.error("Failed to dismiss product update:", err);
+    }
+  };
+
+  return (
+    <>
+      <Card className="gap-0 overflow-hidden py-0">
+        <CardHeader className="px-6 pb-3 pt-5">
+          <CardTitle className="flex items-center gap-2 text-[15px] tracking-[-0.005em]">
+            <Newspaper
+              className="size-4 text-muted-foreground"
+              strokeWidth={1.75}
+            />
+            What&apos;s new
+            {newCount > 0 ? (
+              <Badge className="h-4 px-1.5 text-[9.5px] tracking-wider">
+                {newCount} NEW
+              </Badge>
+            ) : null}
+          </CardTitle>
+          <CardDescription className="text-[12.5px]">
+            Recent releases and platform changes.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="px-6 pb-4 pt-3">
+          <ol className="relative">
+            {/* timeline rail */}
+            <span
+              aria-hidden
+              className="absolute left-[5px] top-1.5 bottom-2 w-px bg-border"
+            />
+            {top.map((update) => {
+              const embed = update.videoUrl
+                ? parseVideoEmbed(update.videoUrl)
+                : null;
+              return (
+                <li
+                  key={update.slug}
+                  className="group relative pb-5 pl-7 last:pb-0"
+                >
+                  <span
+                    aria-hidden
+                    className={`absolute left-0 top-[5px] size-[11px] rounded-full ring-4 ring-card ${
+                      update.isNew ? "bg-primary" : "bg-border"
+                    }`}
+                  />
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                      {formatPublishDate(update.publishAt)}
+                    </span>
+                    {update.tag ? (
+                      <Badge className="h-4 px-1.5 text-[9.5px] tracking-wider">
+                        {update.tag}
+                      </Badge>
+                    ) : update.isNew ? (
+                      <Badge className="h-4 px-1.5 text-[9.5px] tracking-wider">
+                        NEW
+                      </Badge>
+                    ) : null}
+                    <button
+                      type="button"
+                      aria-label={`Dismiss "${update.title}"`}
+                      onClick={() => handleDismiss(update.slug)}
+                      className="ml-auto inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+                    >
+                      <X className="size-3" strokeWidth={2} />
+                    </button>
+                  </div>
+                  {update.href ? (
+                    <a
+                      href={update.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-1 block text-[14px] font-semibold tracking-[-0.005em] text-foreground hover:underline"
+                    >
+                      {update.title}
+                    </a>
+                  ) : (
+                    <p className="mt-1 text-[14px] font-semibold tracking-[-0.005em] text-foreground">
+                      {update.title}
+                    </p>
+                  )}
+                  <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">
+                    {update.body}
+                  </p>
+                  {embed ? (
+                    <div className="mt-2">
+                      <Button
+                        asChild
+                        variant="outline"
+                        size="sm"
+                        className="h-6 gap-1 px-2 text-[11px]"
+                      >
+                        <a
+                          href={
+                            embed.provider === "raw"
+                              ? embed.embedSrc
+                              : (update.videoUrl as string)
+                          }
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <Play className="size-3" strokeWidth={2} />
+                          Watch
+                        </a>
+                      </Button>
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ol>
+
+          <div className="mt-3 flex justify-end border-t border-border pt-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-[12px] text-muted-foreground hover:text-foreground"
+              onClick={() => setSheetOpen(true)}
+            >
+              See all &rarr;
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <ProductUpdatesSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        updates={updates ?? []}
+        onDismiss={handleDismiss}
+      />
+    </>
   );
 }

--- a/mcpjam-inspector/client/src/components/home/ProductUpdatesFeed.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdatesFeed.tsx
@@ -61,9 +61,10 @@ export function ProductUpdatesFeed() {
 
   if (!isAuthenticated) return null;
 
-  const visible = (updates ?? []).filter((u) => !u.dismissed);
-  if (visible.length === 0) return null;
+  const all = updates ?? [];
+  if (all.length === 0) return null;
 
+  const visible = all.filter((u) => !u.dismissed);
   const top = visible.slice(0, 5);
   const newCount = visible.filter((u) => u.isNew).length;
 
@@ -97,13 +98,18 @@ export function ProductUpdatesFeed() {
         </CardHeader>
 
         <CardContent className="px-6 pb-4 pt-3">
-          <ol className="relative">
-            {/* timeline rail */}
-            <span
-              aria-hidden
-              className="absolute left-[5px] top-1.5 bottom-2 w-px bg-border"
-            />
-            {top.map((update) => {
+          {top.length === 0 ? (
+            <p className="py-2 text-[12.5px] text-muted-foreground">
+              You&apos;re all caught up.
+            </p>
+          ) : (
+            <ol className="relative">
+              {/* timeline rail */}
+              <span
+                aria-hidden
+                className="absolute left-[5px] top-1.5 bottom-2 w-px bg-border"
+              />
+              {top.map((update) => {
               const embed = update.videoUrl
                 ? parseVideoEmbed(update.videoUrl)
                 : null;
@@ -135,7 +141,7 @@ export function ProductUpdatesFeed() {
                       type="button"
                       aria-label={`Dismiss "${update.title}"`}
                       onClick={() => handleDismiss(update.slug)}
-                      className="ml-auto inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+                      className="ml-auto inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground md:opacity-0 md:group-hover:opacity-100 md:focus:opacity-100"
                     >
                       <X className="size-3" strokeWidth={2} />
                     </button>
@@ -182,8 +188,9 @@ export function ProductUpdatesFeed() {
                   ) : null}
                 </li>
               );
-            })}
-          </ol>
+              })}
+            </ol>
+          )}
 
           <div className="mt-3 flex justify-end border-t border-border pt-3">
             <Button

--- a/mcpjam-inspector/client/src/components/home/ProductUpdatesSheet.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdatesSheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Sheet,
   SheetContent,
@@ -35,6 +35,12 @@ export function ProductUpdatesSheet({
   onDismiss,
 }: ProductUpdatesSheetProps) {
   const [playing, setPlaying] = useState<Set<string>>(new Set());
+
+  // Stop any inline iframes (and their autoplay state) when the drawer closes,
+  // so reopening doesn't immediately restart playback.
+  useEffect(() => {
+    if (!open) setPlaying(new Set());
+  }, [open]);
 
   const togglePlaying = (slug: string) => {
     setPlaying((prev) => {
@@ -113,7 +119,7 @@ export function ProductUpdatesSheet({
                         type="button"
                         aria-label={`Dismiss "${update.title}"`}
                         onClick={() => onDismiss(update.slug)}
-                        className="ml-auto inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+                        className="ml-auto inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground md:opacity-0 md:group-hover:opacity-100 md:focus:opacity-100"
                       >
                         <X className="size-3" strokeWidth={2} />
                       </button>

--- a/mcpjam-inspector/client/src/components/home/ProductUpdatesSheet.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdatesSheet.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@mcpjam/design-system/sheet";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { ScrollArea } from "@mcpjam/design-system/scroll-area";
+import { Play, X } from "lucide-react";
+import { parseVideoEmbed } from "./productUpdateVideo";
+import type { ProductUpdateEntry } from "./ProductUpdatesFeed";
+
+function formatPublishDate(ts: number): string {
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+interface ProductUpdatesSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  updates: ProductUpdateEntry[];
+  onDismiss: (slug: string) => void | Promise<void>;
+}
+
+export function ProductUpdatesSheet({
+  open,
+  onOpenChange,
+  updates,
+  onDismiss,
+}: ProductUpdatesSheetProps) {
+  const [playing, setPlaying] = useState<Set<string>>(new Set());
+
+  const togglePlaying = (slug: string) => {
+    setPlaying((prev) => {
+      const next = new Set(prev);
+      next.add(slug);
+      return next;
+    });
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 sm:max-w-md"
+      >
+        <SheetHeader className="border-b border-border px-6 py-4">
+          <SheetTitle className="text-[15px] tracking-[-0.005em]">
+            What&apos;s new
+          </SheetTitle>
+          <SheetDescription className="text-[12.5px]">
+            All releases and platform changes.
+          </SheetDescription>
+        </SheetHeader>
+
+        <ScrollArea className="flex-1">
+          <ol className="relative px-6 py-5">
+            <span
+              aria-hidden
+              className="absolute left-[29px] top-7 bottom-6 w-px bg-border"
+            />
+            {updates.length === 0 ? (
+              <p className="text-[12.5px] text-muted-foreground">
+                No updates yet.
+              </p>
+            ) : null}
+            {updates.map((update) => {
+              const embed = update.videoUrl
+                ? parseVideoEmbed(update.videoUrl)
+                : null;
+              const isInlineEmbeddable =
+                embed && embed.provider !== "raw";
+              const isPlaying = playing.has(update.slug);
+              const poster =
+                update.videoPosterUrl || embed?.posterSrc || undefined;
+
+              return (
+                <li
+                  key={update.slug}
+                  className={`group relative pb-6 pl-7 last:pb-0 ${
+                    update.dismissed ? "opacity-60" : ""
+                  }`}
+                >
+                  <span
+                    aria-hidden
+                    className={`absolute left-0 top-[5px] size-[11px] rounded-full ring-4 ring-background ${
+                      update.isNew && !update.dismissed
+                        ? "bg-primary"
+                        : "bg-border"
+                    }`}
+                  />
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                      {formatPublishDate(update.publishAt)}
+                    </span>
+                    {update.tag ? (
+                      <Badge className="h-4 px-1.5 text-[9.5px] tracking-wider">
+                        {update.tag}
+                      </Badge>
+                    ) : update.isNew && !update.dismissed ? (
+                      <Badge className="h-4 px-1.5 text-[9.5px] tracking-wider">
+                        NEW
+                      </Badge>
+                    ) : null}
+                    {!update.dismissed ? (
+                      <button
+                        type="button"
+                        aria-label={`Dismiss "${update.title}"`}
+                        onClick={() => onDismiss(update.slug)}
+                        className="ml-auto inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+                      >
+                        <X className="size-3" strokeWidth={2} />
+                      </button>
+                    ) : (
+                      <span className="ml-auto text-[10px] uppercase tracking-wider text-muted-foreground">
+                        Dismissed
+                      </span>
+                    )}
+                  </div>
+                  {update.href ? (
+                    <a
+                      href={update.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-1 block text-[14px] font-semibold tracking-[-0.005em] text-foreground hover:underline"
+                    >
+                      {update.title}
+                    </a>
+                  ) : (
+                    <p className="mt-1 text-[14px] font-semibold tracking-[-0.005em] text-foreground">
+                      {update.title}
+                    </p>
+                  )}
+                  <p className="mt-1 text-[12.5px] leading-relaxed text-muted-foreground">
+                    {update.body}
+                  </p>
+
+                  {isInlineEmbeddable ? (
+                    <div className="mt-2">
+                      {isPlaying ? (
+                        <iframe
+                          src={`${embed!.embedSrc}${
+                            embed!.embedSrc.includes("?") ? "&" : "?"
+                          }autoplay=1`}
+                          title={update.title}
+                          loading="lazy"
+                          allow="autoplay; encrypted-media"
+                          allowFullScreen
+                          className="aspect-video w-full rounded-md border border-border"
+                        />
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => togglePlaying(update.slug)}
+                          aria-label={`Play video for ${update.title}`}
+                          className="group/play relative block aspect-video w-full overflow-hidden rounded-md border border-border bg-muted"
+                        >
+                          {poster ? (
+                            <img
+                              src={poster}
+                              alt=""
+                              loading="lazy"
+                              className="absolute inset-0 size-full object-cover"
+                            />
+                          ) : null}
+                          <span className="absolute inset-0 flex items-center justify-center bg-black/20 transition-colors group-hover/play:bg-black/30">
+                            <span className="flex size-12 items-center justify-center rounded-full bg-white/90 text-foreground shadow-md transition-transform group-hover/play:scale-105">
+                              <Play
+                                className="size-5 translate-x-[1px]"
+                                strokeWidth={2}
+                                fill="currentColor"
+                              />
+                            </span>
+                          </span>
+                        </button>
+                      )}
+                    </div>
+                  ) : embed && embed.provider === "raw" ? (
+                    <div className="mt-2">
+                      <Button
+                        asChild
+                        variant="outline"
+                        size="sm"
+                        className="h-6 gap-1 px-2 text-[11px]"
+                      >
+                        <a
+                          href={embed.embedSrc}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <Play className="size-3" strokeWidth={2} />
+                          Watch
+                        </a>
+                      </Button>
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ol>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/mcpjam-inspector/client/src/components/home/productUpdateVideo.ts
+++ b/mcpjam-inspector/client/src/components/home/productUpdateVideo.ts
@@ -6,29 +6,27 @@ export interface VideoEmbed {
   posterSrc?: string;
 }
 
-function extractYouTubeId(url: string): string | null {
-  // youtube.com/watch?v=<id>
-  const watchMatch = url.match(/[?&]v=([A-Za-z0-9_-]{6,})/);
-  if (watchMatch) return watchMatch[1];
+function extractYouTubeId(u: URL): string | null {
   // youtu.be/<id>
-  const shortMatch = url.match(/youtu\.be\/([A-Za-z0-9_-]{6,})/);
-  if (shortMatch) return shortMatch[1];
-  // youtube.com/shorts/<id>
-  const shortsMatch = url.match(/youtube\.com\/shorts\/([A-Za-z0-9_-]{6,})/);
-  if (shortsMatch) return shortsMatch[1];
-  // youtube.com/embed/<id>
-  const embedMatch = url.match(/youtube\.com\/embed\/([A-Za-z0-9_-]{6,})/);
-  if (embedMatch) return embedMatch[1];
-  return null;
-}
-
-function extractLoomId(url: string): string | null {
-  const m = url.match(/loom\.com\/(?:share|embed)\/([A-Za-z0-9]+)/);
+  if (u.hostname === "youtu.be") {
+    const m = u.pathname.match(/^\/([A-Za-z0-9_-]{6,})/);
+    return m ? m[1] : null;
+  }
+  // youtube.com/watch?v=<id>
+  const v = u.searchParams.get("v");
+  if (v && /^[A-Za-z0-9_-]{6,}$/.test(v)) return v;
+  // youtube.com/shorts/<id> or youtube.com/embed/<id>
+  const m = u.pathname.match(/^\/(?:shorts|embed)\/([A-Za-z0-9_-]{6,})/);
   return m ? m[1] : null;
 }
 
-function extractVimeoId(url: string): string | null {
-  const m = url.match(/vimeo\.com\/(?:video\/)?(\d+)/);
+function extractLoomId(u: URL): string | null {
+  const m = u.pathname.match(/^\/(?:share|embed)\/([A-Za-z0-9]+)/);
+  return m ? m[1] : null;
+}
+
+function extractVimeoId(u: URL): string | null {
+  const m = u.pathname.match(/^\/(?:video\/)?(\d+)/);
   return m ? m[1] : null;
 }
 
@@ -37,8 +35,24 @@ export function parseVideoEmbed(url: string): VideoEmbed | null {
   const trimmed = url.trim();
   if (!trimmed) return null;
 
-  if (/youtube\.com|youtu\.be/.test(trimmed)) {
-    const id = extractYouTubeId(trimmed);
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+
+  // Hostname checks accept the canonical host and any subdomain (e.g.
+  // www.youtube.com, m.youtube.com), but reject lookalikes like
+  // evil.com/youtube.com that the previous string-regex matched.
+  const host = parsed.hostname.toLowerCase();
+  const isHost = (h: string) => host === h || host.endsWith(`.${h}`);
+
+  if (isHost("youtube.com") || host === "youtu.be") {
+    const id = extractYouTubeId(parsed);
     if (id) {
       return {
         provider: "youtube",
@@ -48,8 +62,8 @@ export function parseVideoEmbed(url: string): VideoEmbed | null {
     }
   }
 
-  if (/loom\.com/.test(trimmed)) {
-    const id = extractLoomId(trimmed);
+  if (isHost("loom.com")) {
+    const id = extractLoomId(parsed);
     if (id) {
       return {
         provider: "loom",
@@ -58,8 +72,8 @@ export function parseVideoEmbed(url: string): VideoEmbed | null {
     }
   }
 
-  if (/vimeo\.com/.test(trimmed)) {
-    const id = extractVimeoId(trimmed);
+  if (isHost("vimeo.com")) {
+    const id = extractVimeoId(parsed);
     if (id) {
       return {
         provider: "vimeo",
@@ -68,8 +82,5 @@ export function parseVideoEmbed(url: string): VideoEmbed | null {
     }
   }
 
-  // Basic sanity check before treating as raw
-  if (!/^https?:\/\//i.test(trimmed)) return null;
-
-  return { provider: "raw", embedSrc: trimmed };
+  return { provider: "raw", embedSrc: parsed.href };
 }

--- a/mcpjam-inspector/client/src/components/home/productUpdateVideo.ts
+++ b/mcpjam-inspector/client/src/components/home/productUpdateVideo.ts
@@ -1,0 +1,75 @@
+export type VideoProvider = "youtube" | "loom" | "vimeo" | "raw";
+
+export interface VideoEmbed {
+  provider: VideoProvider;
+  embedSrc: string;
+  posterSrc?: string;
+}
+
+function extractYouTubeId(url: string): string | null {
+  // youtube.com/watch?v=<id>
+  const watchMatch = url.match(/[?&]v=([A-Za-z0-9_-]{6,})/);
+  if (watchMatch) return watchMatch[1];
+  // youtu.be/<id>
+  const shortMatch = url.match(/youtu\.be\/([A-Za-z0-9_-]{6,})/);
+  if (shortMatch) return shortMatch[1];
+  // youtube.com/shorts/<id>
+  const shortsMatch = url.match(/youtube\.com\/shorts\/([A-Za-z0-9_-]{6,})/);
+  if (shortsMatch) return shortsMatch[1];
+  // youtube.com/embed/<id>
+  const embedMatch = url.match(/youtube\.com\/embed\/([A-Za-z0-9_-]{6,})/);
+  if (embedMatch) return embedMatch[1];
+  return null;
+}
+
+function extractLoomId(url: string): string | null {
+  const m = url.match(/loom\.com\/(?:share|embed)\/([A-Za-z0-9]+)/);
+  return m ? m[1] : null;
+}
+
+function extractVimeoId(url: string): string | null {
+  const m = url.match(/vimeo\.com\/(?:video\/)?(\d+)/);
+  return m ? m[1] : null;
+}
+
+export function parseVideoEmbed(url: string): VideoEmbed | null {
+  if (!url || typeof url !== "string") return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  if (/youtube\.com|youtu\.be/.test(trimmed)) {
+    const id = extractYouTubeId(trimmed);
+    if (id) {
+      return {
+        provider: "youtube",
+        embedSrc: `https://www.youtube.com/embed/${id}`,
+        posterSrc: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
+      };
+    }
+  }
+
+  if (/loom\.com/.test(trimmed)) {
+    const id = extractLoomId(trimmed);
+    if (id) {
+      return {
+        provider: "loom",
+        embedSrc: `https://www.loom.com/embed/${id}`,
+      };
+    }
+  }
+
+  if (/vimeo\.com/.test(trimmed)) {
+    const id = extractVimeoId(trimmed);
+    if (id) {
+      return {
+        provider: "vimeo",
+        embedSrc: `https://player.vimeo.com/video/${id}`,
+      };
+    }
+  }
+
+  // Basic sanity check before treating as raw
+  if (!/^https?:\/\//i.test(trimmed)) return null;
+
+  return { provider: "raw", embedSrc: trimmed };
+}


### PR DESCRIPTION
## Summary
- Replaces the static `UPDATES` array in `ProductUpdatesFeed.tsx` with a live Convex query (`productUpdates:listVisibleUpdates`).
- Adds per-user dismiss, an `isNew` badge driven server-side, and a "See all →" right-side `Sheet` drawer with lazy YouTube / Loom / Vimeo embeds (`productUpdateVideo.ts` parser).
- Card hidden for unauthed sessions; unrecognized video URLs fall back to a "▶ Watch" button that opens in a new tab.

Paired with the backend PR that adds the `productUpdates` schema + queries — that one needs to ship first (or together).

## Test plan
- [ ] With the backend PR deployed and 3 entries seeded via dashboard: home card shows the entries with the newest one badged "NEW"; header shows a count badge.
- [ ] Click an entry's `href` → opens in new tab.
- [ ] Dismiss an entry via the hover X → entry disappears from the card and "NEW" count decrements; refresh confirms it stays dismissed.
- [ ] Click "See all →" → Sheet opens showing all entries including dismissed ones (de-emphasized).
- [ ] Seed an entry with a YouTube `videoUrl`: home card shows "▶ Watch" button (opens new tab); Sheet shows a thumbnail-with-play-overlay that swaps to an inline iframe on click.
- [ ] Repeat with a Loom share URL and a Vimeo URL — same behavior.
- [ ] Repeat with an arbitrary `.mp4` URL — Sheet shows the "▶ Watch" button (raw fallback), no inline embed.
- [ ] Sign out / open in incognito with no auth → card silently absent, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Depends on paired Convex backend APIs and loads third-party iframe/video URLs from server-provided fields; mis-seeded URLs could affect UX but hostname checks limit embed abuse.
> 
> **Overview**
> Replaces the hardcoded home **What's new** list with **Convex**-loaded entries for signed-in users only, including one-time **`initializeIfNeeded`** on mount and **per-slug dismiss** via mutation.
> 
> The card now shows up to five non-dismissed items with server-driven **NEW** badges and counts, optional **links**, and a **Watch** shortcut when a `videoUrl` is present; dismissed items collapse to an “all caught up” state while **See all →** opens a full-history drawer.
> 
> Adds **`ProductUpdatesSheet`** for the complete timeline (including dismissed entries) with inline **YouTube / Loom / Vimeo** playback on click, plus **`parseVideoEmbed`** for safe host checks and a **raw URL** fallback that only opens in a new tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62a99bb3d4a993156af4c7e0dede18886d2bb70e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->