### PR TITLE
docs: sync Mintlify backlog into current docs structure

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -119,6 +119,25 @@ Structured debug artifacts only record the explicit env keys you pass through
   not accept stdio targets.
 </Note>
 
+## Update notifications
+
+After a successful command, the CLI checks whether a newer version of `@mcpjam/cli` is available and prints a notice to stderr when one is found:
+
+```
+Update available: @mcpjam/cli 1.2.0 -> 1.3.0
+Run npm install -g @mcpjam/cli to update
+```
+
+The check is non-blocking: version data is fetched in a detached background process and cached locally for 24 hours, so it never slows down your commands. The notice only appears on interactive terminals (when stderr is a TTY) and is suppressed automatically in CI.
+
+To opt out, set one of these environment variables before running any command:
+
+| Variable | Effect |
+|----------|--------|
+| `MCPJAM_NO_UPDATE_CHECK=1` | Disable update checks for `@mcpjam/cli` |
+| `NO_UPDATE_NOTIFIER=1` | Disable update checks (conventional npm opt-out) |
+| `CI=true` | Automatically suppressed in CI environments |
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/cli/server-inspection.mdx
+++ b/docs/cli/server-inspection.mdx
@@ -32,6 +32,8 @@ Use this when you want to check reachability and OAuth metadata without triggeri
 - OAuth metadata (resource metadata URL, authorization server metadata, registration strategies, scopes)
 - `WWW-Authenticate` header parsing
 
+Sensitive fields such as `Authorization` headers are automatically redacted to `[REDACTED]` in the printed result.
+
 ### `server doctor`
 
 Combined triage — runs probe, then attempts a full client connection, then sweeps tools, resources, resource templates, and prompts. Returns a single JSON artifact.
@@ -56,6 +58,8 @@ mcpjam server doctor --command node --args server.js --cwd /path/to/project
 The `--out <path>` flag writes the full JSON artifact to a file — useful for handoff to another engineer or agent.
 For stdio targets, those artifacts only record the explicit env keys you passed
 via `-e/--env`; inherited shell variables are not enumerated.
+
+Sensitive fields such as `Authorization` headers are automatically redacted to `[REDACTED]` in all printed output and written artifacts, including RPC logs attached via `--rpc`.
 
 ### `server info`
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,10 +28,12 @@
         "group": "Inspector Features",
         "icon": "star",
         "pages": [
+          "inspector/home",
           "inspector/playground",
           "inspector/clients",
           "inspector/protocol-versions",
           "inspector/guided-oauth",
+          "inspector/xaa-debugger",
           "inspector/tools-prompts-resources",
           "inspector/evals",
           "inspector/projects",

--- a/docs/guides/first-chatgpt-app-react.mdx
+++ b/docs/guides/first-chatgpt-app-react.mdx
@@ -47,9 +47,6 @@ server.registerResource(
       text: WIDGET_HTML,
       _meta: {
         "openai/widgetPrefersBorder": true,  // Adds a border around your widget in the chat
-        "openai/widgetCSP": {
-          redirect_domains: ["https://www.mcpjam.com"]  // Domains users can be redirected to
-        }
       }
     }]
   })
@@ -166,17 +163,20 @@ This capability is optional — hosts can turn it off, in which case `window.ope
 
 ### Content Security Policy (CSP)
 
-Widgets run in a sandboxed iframe, so you need to declare which external domains your widget can interact with. Set `openai/widgetCSP` in your resource's `_meta` to configure these permissions:
+Widgets run in a sandboxed iframe, so you need to declare which external domains your widget can interact with. Configure these permissions in your resource's `_meta` using one of two formats:
 
-- **`connect_domains`** - Domains your widget can fetch from (API calls)
-- **`resource_domains`** - Domains for static assets (images, fonts, scripts)
-- **`redirect_domains`** - Domains for `window.openai.openExternal()` redirects
+- **`_meta.ui.csp`** (preferred) — uses camelCase field names and is the standard MCP Apps format
+- **`_meta["openai/widgetCSP"]`** (legacy) — the original ChatGPT Apps format, still supported
 
-Our Coffee Shop uses `redirect_domains` to allow the "Learn more" button to redirect users to mcpjam.com:
+When both are present, `ui.csp` values take precedence field-by-field; any field absent from `ui.csp` falls back to `openai/widgetCSP`.
 
-```javascript src/CoffeeShopWidget.tsx
-window.openai.openExternal({ href: "https://www.mcpjam.com" });
-```
+Both formats support the same domain categories:
+
+| `ui.csp` field | `openai/widgetCSP` field | Purpose |
+|---|---|---|
+| `connectDomains` | `connect_domains` | Domains your widget can fetch from (API calls) |
+| `resourceDomains` | `resource_domains` | Domains for static assets (images, fonts, scripts) |
+| `frameDomains` | `frame_domains` | Domains allowed in nested iframes |
 
 <Note>
 Without declaring a domain in your CSP, the sandbox will block the request. Only declare the domains you actually need.
@@ -209,8 +209,9 @@ The easiest way to test your app:
 
 To connect your app to ChatGPT:
 
-1. In MCPJam Inspector, click **Create ngrok tunnel** with your server connected
-2. Use the tunnel URL as your connector endpoint in ChatGPT
+1. Sign in to MCPJam Inspector (ngrok tunnels require an account)
+2. Click **Create ngrok tunnel** with your server connected
+3. Use the tunnel URL as your connector endpoint in ChatGPT
 
 For more information, see our [ngrok tunneling feature blog](https://www.mcpjam.com/blog/ngrok).
 

--- a/docs/hosted/overview.mdx
+++ b/docs/hosted/overview.mdx
@@ -44,6 +44,33 @@ Try it yourself with the [Excalidraw MCP server](https://app.mcpjam.com/shared/e
 3. Choose your authentication method (None, Bearer Token, or OAuth 2.0)
 4. Start inspecting tools, resources, and prompts
 
+## Usage limits
+
+The hosted app uses a daily credit system to power AI features like chat.
+
+- **Guests** get a free daily usage allowance. The sidebar shows a progress bar with how much of your daily limit you've used and when it resets. When you reach the limit, you'll be prompted to sign in.
+- **Signed-in users** get **10×** the daily usage of a guest. Your daily usage and any paid credit balance are visible in the account menu at the bottom of the sidebar.
+- **Paid credits** can be topped up from the billing page and are shown alongside your daily limit in the account menu.
+
+## OAuth token reveal
+
+When you connect an OAuth server in the hosted app, your OAuth credentials are stored securely in Vault. You can inspect those tokens on demand from the server's **Overview** tab without them ever being written to `localStorage` or shared with other users.
+
+To reveal tokens:
+
+1. Open the **Servers** tab and click the server name to open its detail modal.
+2. Go to the **Overview** tab.
+3. Under **OAuth Tokens**, click **Reveal tokens**.
+4. Each token (access token, refresh token, ID token) is masked by default. Click the eye icon next to a token to reveal its value, or click the copy icon to copy it directly without revealing it.
+
+Expired tokens are automatically refreshed before being returned. Revealed values are kept component-local and are cleared when you close the modal.
+
+<Note>
+  The **Reveal tokens** button only appears after the server has been synced to
+  your hosted workspace. If the button is not visible, disconnect and reconnect
+  the server to trigger a sync.
+</Note>
+
 ## What's different
 
 The following features are not available in the hosted app. They are available when running MCPJam locally via [npx, Docker, or the desktop app](/installation).
@@ -67,3 +94,20 @@ Skills live on your filesystem and can only be discovered and run from the local
 ### No tasks
 
 Tasks are not yet available in the hosted app.
+
+## Billing
+
+### Payment history
+
+The **Payment history** card on the org billing page lists your recent credit top-ups. Each row shows:
+
+| Column | Details |
+|--------|---------|
+| Date | When the top-up was processed |
+| Amount | Amount charged in USD |
+| Status | `Succeeded`, `Pending`, or `Failed` |
+| Receipt | Link to the Stripe-hosted receipt (opens in a new tab) |
+
+If a receipt isn't available yet the cell shows **Processing** (for pending charges) or **Not available** (for succeeded charges without a receipt link).
+
+To add credits, click **Top up** — either from the empty state when you have no history, or from the credit balance card above.

--- a/docs/inspector/clients.mdx
+++ b/docs/inspector/clients.mdx
@@ -32,19 +32,48 @@ These map directly to fields the inspector sends during the standard MCP `initia
 
 ### Per-server connection overrides
 
-You can override the request timeout and headers **per server attached to the Client**. This lets a single Client talk to one server with a long timeout and an auth header while keeping defaults for the others.
+You can override the request timeout and headers **per server** from the project-wide server list. This lets a single project connect to one server with a long timeout and an auth header while keeping defaults for the others.
+
+### Agent behavior
+
+These settings control how the model interacts with tools during a chat session. They appear in the **Agent** tab of the Client focus panel.
+
+- **Require tool approval** — When on, the model pauses before each tool call so you can approve or deny it manually.
+- **Respect tool visibility** — Controls whether the inspector honors the SEP-1865 `_meta.ui.visibility` field. When on (the default for all templates except Cursor), tools whose visibility is `["app"]` are hidden from the model's tool list. When off, every tool flows to the model regardless of visibility, matching hosts that don't yet implement visibility filtering (for example, real Cursor as of version 3.4.20).
+- **Progressive tools** — Three-state toggle (`On` / `Off` / `Auto`). When on, the inspector injects `search_mcp_tools` and `load_mcp_tools` meta-tools instead of sending the full tool catalog upfront, reducing context usage for large tool sets. `Auto` lets the backend decide based on catalog size.
 
 ### MCP App settings (SEP-1865)
 
 When your server exposes [MCP Apps](https://modelcontextprotocol.io/docs/extensions/apps) — interactive UIs delivered via `ui://` resources — the Client controls how the inspector renders and sandboxes them. These map to the fields a real host advertises in `HostCapabilities` and `HostContext`.
 
-- **Host capabilities** — Toggle which app-facing features the inspector advertises: `openLinks`, `serverTools`, `serverResources`, `logging`. Use this to simulate hosts that don't support all of them and confirm your app degrades gracefully.
+- **Host capabilities** — The set of `HostCapabilities` keys the inspector advertises in the `ui/initialize` handshake. Each host preset reflects that host's published capability subset: for example, the **Copilot** preset advertises only `openLinks`, `serverTools`, `updateModelContext`, and `message` — matching Microsoft 365 Copilot's published Component-bridge table — and omits `serverResources` and `logging`. Use this to verify your app degrades gracefully when a capability it relies on is absent.
 - **Sandbox CSP mode** — `host-default`, `declared`, or `relaxed`. Controls the baseline Content Security Policy the inspector applies to your app's iframe.
 - **CSP restrictTo** — Per-directive intersections (`connectDomains`, `resourceDomains`, `frameDomains`, `baseUriDomains`) that further narrow what the app is allowed to fetch, embed, or set as a base URI. Restrict-only — the inspector never adds an undeclared domain.
 - **Custom CSP directives** — Verbatim source-expression overrides (e.g. `script-src: 'unsafe-eval' 'wasm-unsafe-eval'`) for cases where you need to model exactly what a particular host emits at the browser layer.
 - **Permission Policy** — Per-feature toggles for `camera`, `microphone`, `geolocation`, and `clipboard-write`. Choose `resource-declared` (grant what the app's resource metadata asks for), `deny-all`, or `custom` (your own allow map).
 - **Display modes** — Which of `inline`, `fullscreen`, and `pip` the inspector advertises in `HostContext.availableDisplayModes`. Test how your app responds when a requested mode isn't available.
 - **Theme and styles** — The CSS variables and font block the inspector injects into `HostContext.styles` so you can verify your app picks up host theming.
+- **`window.openai` injection** — Toggle whether the inspector injects the OpenAI Apps SDK `window.openai` shim into widget HTML before sandboxing. ChatGPT, Copilot, and MCPJam host presets enable this by default; Claude, Cursor, and Codex presets leave it off. You can override the preset per host using the toggle in the **Apps Extension** tab. The chip in the host capability matrix shows the current state and whether it comes from the preset or a manual override.
+
+#### Apps Extension tab
+
+The Apps Extension tab contains two independent capability matrices that never cross-gate — toggling a row in one has no effect on the other.
+
+**`window.openai` matrix (ChatGPT compat shim)** — Controls the `window.openai.*` surface advertised to apps using the ChatGPT compatibility shim. A master **Inject window.openai** toggle enables or disables injection entirely; a collapsed per-method disclosure lets you activate individual methods to build an exact subset from scratch. Switching on any single method turns injection on with only that method enabled; turning the last method off disables injection again.
+
+**`app.*` matrix (SEP-1865 spec bridge)** — Controls the `app.*` surface advertised to apps using the primary MCP Apps protocol. A master **MCP App support** switch advertises the MCP UI client extension (`io.modelcontextprotocol/ui`). The matrix rows include:
+- **`availableDisplayModes`** — multi-checkbox cluster (`inline`, `fullscreen`, `pip`); unchecking the last mode force-enables `inline`.
+- **`widgetDisplayModeRequests`** — tri-state host policy (`accept`, `user-initiated-only`, `decline`) for widget-initiated display-mode requests.
+- **Boolean dimensions** — a flat list of all `app.*` capability flags (e.g. `toolInputPartial`, `toolCancelled`, `serverResources`, `logging`, `toolInfo`, `openLinks`, `serverTools`, `updateModelContext`, `message`). Rows that diverge from the selected host preset are stored as sparse overrides.
+
+<Note>
+  Widget iframes are only rendered when the effective `clientCapabilities` advertise
+  `io.modelcontextprotocol/ui` with a `mimeTypes` array that includes
+  `text/html;profile=mcp-app`. Custom capability configs with a bare
+  `{ extensions: { "io.modelcontextprotocol/ui": {} } }` entry (no `mimeTypes`
+  array) will not render widgets. SDK-default host shapes (Claude, ChatGPT,
+  Copilot, MCPJam) include the correct `mimeTypes` and are unaffected.
+</Note>
 
 <Note>
   All MCP App settings only take effect when the connected server actually
@@ -57,9 +86,15 @@ When your server exposes [MCP Apps](https://modelcontextprotocol.io/docs/extensi
 1. Open the **Clients** tab in the inspector.
 2. Click **New Client**.
 3. Give it a name (e.g. `Claude Desktop`, `ChatGPT`, `Strict CSP`).
-4. Pick the servers it should attach to.
-5. Open the focus panel to drill into protocol or MCP App settings.
-6. Click **Save**.
+4. Open the focus panel to drill into protocol or MCP App settings.
+5. Click **Save**.
+
+<Note>
+  Server selection is project-wide, not per-client. Use the **Auto-connect**
+  toggle in the Servers tab header to enroll all project servers for
+  auto-connection. Per-server overrides (headers, timeout) are also configured
+  there.
+</Note>
 
 The canvas on the left shows a live diagram of the Client — the model, attached servers, and any per-server overrides. Cards flash briefly when you switch between Clients so you can see what changed.
 
@@ -72,6 +107,31 @@ Once saved, a Client shows up in the picker at the top of every consumer:
 - **Evals** — Every test run inside an Eval uses the selected Client, so results are reproducible across teammates.
 
 Switching the active Client in any of these views swaps the entire configuration in place. There's no separate "apply" step.
+
+## Server attachments
+
+A **server attachment** is a named, reusable set of servers drawn from the project pool. Server attachments let you decouple *which servers are active* from the Client configuration itself, so you can swap the server set without touching the model or prompt settings.
+
+### Eval suites
+
+When you create an eval suite, you can pick a server attachment in the **Servers** section of the create dialog. All hosts attached to the suite run against that same server set. You can also change the attachment later from the suite header.
+
+- If no attachment is selected, the suite header shows an amber indicator. Runs will be rejected at start until an attachment is picked.
+- Click the attachment pill in the suite header to open the picker and switch to a different attachment or create a new one inline.
+
+**Creating an attachment inline:**
+
+1. Open the server attachment picker (suite create dialog or suite header).
+2. Click **Create new attachment…** in the dropdown.
+3. Enter a name (e.g. `Production servers`) and check the servers to include.
+4. Click **Create**. The new attachment is selected immediately.
+
+### Chatboxes
+
+The **Servers** section on the chatbox Publish tab shows which project servers the chatbox connects to. Click **Edit servers** to open the attachment editor and update the selection.
+
+- If no servers are picked, the chatbox displays an amber warning. Chat sessions started from that chatbox will have no tools until at least one server is selected.
+- The server pick is sticky — editing the client's model or system prompt does not change it.
 
 ## Managing Clients
 
@@ -90,9 +150,32 @@ From the Clients index page:
 
 Clients are scoped to the project, like servers and views. Every member of a shared project sees the same Client list and any saves sync automatically. This means a teammate can reproduce your exact test conditions by selecting the same Client from the picker — no copy-pasting settings.
 
+## Comparing hosts
+
+The **Compare** view lets you see how multiple host configurations stack up side by side — useful for spotting differences in capabilities, sandbox policies, or protocol settings before you ship to a specific host.
+
+### Opening Compare
+
+Compare is the third tab in the Connect section of the sidebar (`Servers | Client | Compare`). Click **Compare** from any Connect view to open it. The `/host-compare` route is preserved, so any existing bookmarks or links continue to work.
+
+### Deep-linking to a specific selection
+
+Append `?hosts=<id1>,<id2>` to the `/host-compare` URL to pre-select a specific set of hosts on load:
+
+```
+/host-compare?hosts=host-abc,host-def
+```
+
+The URL updates automatically as you toggle hosts on or off. When all live hosts are selected (the default), the `?hosts` parameter is omitted so shared links stay clean.
+
+### Compare from the Eval Playground
+
+In the Eval Playground, the **Hosts** row next to **+ Attach host** includes a **Compare** button. When two or more hosts are attached to the suite, clicking **Compare** opens the Compare view with exactly those hosts pre-selected. The button is disabled (with a tooltip) when fewer than two hosts are attached.
+
 ## Best practices
 
 - **Mirror your target hosts.** Create one Client per real host you care about (`Claude Desktop`, `ChatGPT`, your own product) and keep its `clientInfo`, capabilities, and sandbox settings aligned with what that host actually advertises.
 - **Test the negative paths.** Build a "minimal" Client with most capabilities disabled and a strict CSP — running your server against it surfaces assumptions that won't hold on more restrictive hosts.
 - **Pin Evals to a Client.** Always select a Client before running an eval suite so the results are reproducible. Evals run against ambient settings drift the moment someone toggles something elsewhere.
 - **Duplicate before debugging.** When you're chasing a bug, duplicate the Client first and tweak the copy. Your baseline stays intact for comparison.
+- **Share Compare links.** Toggle down to the hosts you care about and copy the URL — the `?hosts=` parameter preserves your selection for teammates.

--- a/docs/inspector/evals.mdx
+++ b/docs/inspector/evals.mdx
@@ -6,6 +6,10 @@ icon: "flask-conical"
 
 A benchmark score doesn't tell you whether your server holds up in production. Evaluate lets you pin down the behaviors you care about — which tools fire, with what arguments, what the final answer looks like — and run them across the models your users actually use.
 
+## Requirements
+
+Evals require a signed-in MCPJam account. As a guest you'll see a sign-in prompt instead of the testing interface.
+
 ## How it's organized
 
 <Steps>
@@ -64,6 +68,18 @@ Tool-call argument comparison runs in one of three modes, configured at the suit
 
 Type placeholders (`"string"`, `"number"`, `"boolean"`) match any value of that type, which lets you assert shape without locking in a literal.
 
+### Validator settings
+
+Each suite has default validator settings controlling how tool calls are matched. Override them at three levels:
+
+| Level | Where | Persists? |
+|-------|-------|-----------|
+| Suite default | Suite settings → Default validators | Yes |
+| Case override | Test case editor → Validators | Yes |
+| Run override | Suite header → validators (sliders) icon | No — one run |
+
+A run override shows an **override** badge; click **Reset** in the popover to clear it.
+
 ## LLM as judge
 
 For cases where "did the right tools fire" isn't enough — anything graded on the quality of the final answer — the judge grades the run against your **expected output** if you set one, and against the user prompt otherwise. It's advisory: it produces a score and a rationale, but doesn't gate the run unless you ask it to.
@@ -71,6 +87,8 @@ For cases where "did the right tools fire" isn't enough — anything graded on t
 - **On by default** at the suite level. The cost is gated by an explicit **Run judge** click on the run-detail page — it won't run for every iteration unless you turn auto-run on.
 - **Calibrate per suite.** Judge scores aren't comparable across domains; a 0.7 on one suite isn't a 0.7 on another.
 - When grading against the prompt rather than an expected output, scores are capped at 0.85 — you can't get a "perfect" without saying what perfect means.
+
+Open a completed run and find the **Goal completion** panel. Pick a judge model (default: `openai/gpt-5.4-mini`) and a threshold (default 0.7), then click **Run judge**. Each case gets a score, an advisory verdict, a one-line reason, and rubric hits. The judge never runs automatically unless you enable **Auto-run** in suite settings.
 
 ## Running
 
@@ -84,6 +102,21 @@ A run needs three things, all picked from the suite header:
   If **Run all** is disabled, a connected server is missing or no models are selected. The header pickers will tell you which.
 </Tip>
 
+### Frozen execution snapshots
+
+The first run of a suite saves the set of MCP servers used as a frozen snapshot; reruns reuse it, so connecting new servers can't silently change what a suite runs against. Click **Update snapshot** in the suite header to re-save the current servers and start a new run.
+
+## Suite execution config
+
+Each eval suite has a **Default Execution Config** section that controls the model, system prompt, temperature, tool approval, connection settings, capabilities, and host context used when running the suite.
+
+- **Model and prompt** — Set the default model ID, system prompt, and temperature for all runs in the suite.
+- **Tool approval** — Toggle `requireToolApproval` to pause before each tool call during a run.
+- **Server selection** — Servers are not configured here. They come from the suite's environment. The server picker is intentionally hidden in this editor.
+- **Save / Reset** — Click **Save config** to persist changes. Click **Reset** to revert to the last saved state. Unsaved edits are preserved if the page refreshes the config from the server, but are discarded when you switch to a different suite.
+
+Changes to the suite execution config apply to future runs only. Existing run snapshots are not affected.
+
 ## Reading results
 
 ### Suite view
@@ -92,13 +125,32 @@ A run needs three things, all picked from the suite header:
 - **Run insights** — an AI-written diff against your previous completed run: which cases moved, which tools changed behavior, which models diverged. Skim this first; it usually points at the right rabbit hole.
 - **Runs tab** — every run with its summary metrics. Click in for the iteration-level breakdown.
 - **Cases tab** — every case with its latest verdict and a quick replay button.
+- **Executions tab** — a flat, filterable list of every individual test execution across all cases, sorted most-recent-first. Each row shows the case name, result (passed/failed/pending/cancelled), and timestamp. Click any row to open it in the compare view.
+
+When you run a suite against multiple host configurations at once, the Runs list groups them into a single collapsible **run group** row showing mean accuracy and longest duration across all hosts. Expand it to inspect each host's individual run.
+
+The **Runs / Cases** segmented control switches between the run history list and the test-cases overview. **Performance by Model** in the run summary appears only when more than one model was used. To compare two runs, check their boxes in the Runs list and click **Compare**.
+
+#### Cross-host matrix
+
+When two or more host configurations are attached to a suite, a **By case / By host** toggle appears. **By host** shows a matrix — one column per host, one row per case. Each cell shows pass/fail dots, pass rate, median latency, and token usage. A host detached after runs were recorded stays visible, labelled **historical**.
 
 ### Run view
 
 - **Per-iteration row** with case, model, pass/fail, tokens, duration, and the tool calls that actually happened.
-- **Expected vs actual** tool calls side-by-side when an iteration fails.
+- **Expected vs actual** tool calls side-by-side when an iteration fails. For failed iterations, a **Categorized diff** above the raw Expected/Actual grids groups discrepancies into four categories:
+  - **Missing** — expected tool calls that were never made
+  - **Extra** — actual calls that weren't expected (reported but non-fatal by default)
+  - **Out of order** — calls that happened in the wrong sequence (when order checking is enabled)
+  - **Arg mismatch** — right tool name, wrong arguments (shown side-by-side)
 - **Full trace** — every turn, every tool call, every token. This is the thing you couldn't see before; spend time here.
 - **Per-model breakdown** to compare how the same case behaves across models.
+- **AI Triage** — after a run completes, an AI Triage panel ranks tool-quality and workflow issues by impact. Each issue has a **Copy** button that copies a ready-to-use fix prompt (tool description + input schema) for a coding agent; **Copy top 3** copies the top three combined.
+- **Predicate Gate** — when `successPredicates` are configured on a case, an expandable Predicate Gate section in the iteration detail lists each predicate with a PASS/FAIL verdict, a one-line summary, and the evaluator's reason. Hidden when no predicates are configured.
+
+#### Comparing two runs
+
+Select any two completed runs and click **Compare**. The diff view shows per-case status changes: **Passed**, **Still failing**, **Regressed** (pass→fail), **Fixed** (fail→pass), **New**, **Removed**, and **Changed** (config differed). Summary metrics show deltas for tokens, cost, and duration.
 
 ### Case view
 
@@ -109,6 +161,8 @@ A run needs three things, all picked from the suite header:
 ## Generating cases from your tools
 
 The **Generate** button reads your attached servers' tool catalog and drafts realistic cases — a mix of positive ("call `search` with a query") and negative ("don't call `delete_user` on a meta-question"). Treat it as a draft: skim, edit the prompts to match how your users actually talk, tighten the checks, then save.
+
+When the suite has a saved server attachment spanning two or more servers, the generator produces coverage for each server individually plus at least one cross-server case. Suites without a saved attachment treat all available servers as a single pool.
 
 ## What to author first
 

--- a/docs/inspector/guided-oauth.mdx
+++ b/docs/inspector/guided-oauth.mdx
@@ -27,6 +27,22 @@ The OAuth Debugger provides comprehensive tooling for testing OAuth implementati
 - **Sequence Diagram** - Visual representation of the OAuth flow synchronized with your progress
 - **Export Capabilities** - Copy logs in guide or raw format for debugging and documentation
 
+## Inline OAuth tracing
+
+When you connect a server using OAuth 2.0, Inspector automatically records a trace of every step in the flow and surfaces it in the connection UI — no separate tool required.
+
+**On the connection card**, if OAuth fails, a banner identifies the exact step where the failure occurred (for example, "OAuth failed during Token Request").
+
+**In the server detail panel**, the **Last OAuth Trace** section shows:
+
+- Each OAuth step (discovery, client registration, PKCE, authorization redirect, token exchange) with a status indicator and message
+- The error text for any failed step
+- An **HTTP History** log of every request and response, with tokens and secrets automatically redacted
+
+The trace persists across page reloads so you can inspect it after the browser returns from the authorization redirect. It is cleared when you disconnect or reset OAuth data for the server.
+
+Use the inline trace for a quick diagnosis of real connection attempts, and switch to the OAuth Debugger when you need a guided, step-by-step walkthrough against a specific protocol version.
+
 ## Getting Started
 
 To begin debugging OAuth flows:
@@ -38,3 +54,53 @@ To begin debugging OAuth flows:
 5. **Start Testing** - Click **Continue** to begin the OAuth flow
 
 The debugger will guide you through each step of the OAuth handshake, providing real-time feedback and educational context.
+
+## OAuth trace in server overview
+
+When you connect a server using OAuth, Inspector records a structured trace of the entire flow. You can view this trace at any time — even after a failed connection — by opening the server's detail panel and scrolling to the **Last OAuth Trace** section.
+
+The trace shows:
+
+- **Source** - Which part of the flow produced the trace (`interactive_connect`, `callback`, `refresh`, or `hosted_callback`)
+- **Current step** - The step the flow reached before completing or failing
+- **Step-by-step breakdown** - Each OAuth step with its status (`success`, `pending`, or `error`), a summary message, and optional HTTP request/response details
+- **HTTP history** - A bounded list of all HTTP calls made during the flow, with headers and bodies sanitized to redact sensitive values such as tokens and secrets
+- **Failure highlight** - If a step failed, the error panel on the server card and the overview both identify the specific step that caused the failure
+
+The trace persists across page reloads so you can inspect a failed OAuth flow after returning to the inspector.
+
+### Reading OAuth log entries
+
+OAuth trace steps also appear as filterable entries in the traffic log. Select **OAuth** from the **Source** filter in the log panel to isolate them. See [OAuth log entries](/inspector/tools-prompts-resources#oauth-log-entries) for details on the status indicators.
+
+## Pre-registered client secrets
+
+When you configure a pre-registered OAuth client with a client secret, the secret is stored securely and never exposed in the UI after saving. The client secret field shows the following controls:
+
+- **Reveal** (hosted mode only) — Fetches and temporarily displays the stored secret so you can copy it. The value is hidden again when you close the panel or navigate away.
+- **Clear** — Marks the secret for removal. The secret is deleted from storage when you save. Click **Undo** to cancel before saving.
+- **Replace** — Type a new value into the client secret field to replace the stored secret on the next save. Entering a new value automatically cancels any pending clear.
+
+<Note>
+In hosted mode, client secrets are stored in a secure vault and are never written to your browser's local storage. In local mode, the secret is stored in your browser's local storage alongside the rest of your server configuration.
+</Note>
+
+### Authorization header conflict warning
+
+If you enable OAuth and also add a custom `Authorization` header under **Advanced settings**, a warning appears. OAuth automatically sets the `Authorization` header when exchanging tokens, which may override or conflict with your custom value. Remove the custom header or switch to a different authentication method to avoid unexpected behavior.
+
+## Navigating to the OAuth Debugger from the logger
+
+When an OAuth error appears in the request log, a **Continue in OAuth Debugger** button is shown on hover for that log row. Clicking it switches the selected server to the one that produced the error and deep-links directly to the OAuth Debugger (`#oauth-flow`), so you can investigate the failure without manually locating the right server.
+
+## Reconnecting OAuth servers
+
+The enable/connect toggle on a server card or detail modal reuses existing credentials only — it will not launch a new OAuth consent screen. If the existing tokens are expired or missing and a fresh consent flow is required, the toggle reports a re-authentication error instead of redirecting you to the authorization server.
+
+To start a full OAuth flow, use the explicit **Reconnect** button on the server card or detail modal. This is the only path that will open the OAuth consent screen when new credentials are needed.
+
+## Desktop app behavior
+
+When using the OAuth Debugger in the MCPJam Desktop app, the authorization step opens in your system browser instead of inside the app. After you approve access in the browser, you will see a **"Continue in MCPJam Desktop"** page that automatically hands control back to the desktop app. If the handoff does not happen automatically, click the link on that page to return.
+
+Once the browser callback is received, the desktop app resumes the OAuth flow and displays the result in the OAuth Flow tab.

--- a/docs/inspector/home.mdx
+++ b/docs/inspector/home.mdx
@@ -1,0 +1,70 @@
+---
+title: "Home"
+description: "Org-scoped dashboard with activity stats, recommended servers, and quick-start clients"
+icon: "house"
+---
+
+The Home dashboard is the default landing page for authenticated users with an active organization. It gives you a snapshot of your org's activity and lets you connect recommended MCP servers or spin up sandbox clients without leaving the page.
+
+<Note>
+The Home dashboard is available in the hosted app at [app.mcpjam.com](https://app.mcpjam.com) and requires you to be signed in with an active organization.
+</Note>
+
+## Overview
+
+When you open MCPJam, the Home tab loads at `/home` (also the root `/`). If you don't have an active organization yet, the page shows a **Get started** prompt that takes you to the Organizations page.
+
+With an organization selected, the dashboard shows:
+
+- **Greeting** — a time-aware greeting and today's date.
+- **Org stats strip** — live counts for teammates, projects, servers, eval suites, tool executions (last 30 days), and messages sent (last 30 days).
+- **Recommended servers** — a curated list of MCP servers you can connect to your active project with one click.
+- **Recommended clients** — sandbox client templates (Claude, ChatGPT, Cursor) you can create directly from the dashboard.
+- **What's new** — a feed of recent platform releases and changes.
+
+## Org stats strip
+
+The stats strip shows six metrics for your organization:
+
+| Stat | Description |
+|------|-------------|
+| Teammates | Number of members in your organization |
+| Projects | Total projects in your organization |
+| Servers | Total MCP servers across all projects |
+| Eval suites | Number of evaluation suites |
+| Tool executions · 30d | Tool calls made in the last 30 days |
+| Messages · 30d | Messages sent in the last 30 days |
+
+Click **projects** or **servers** to jump to the Servers tab. Click **eval suites** to jump to the Evals tab. The 30-day metrics refresh automatically in the background.
+
+## Recommended servers
+
+The **Recommended servers** card shows a hand-picked list of MCP servers. To connect one:
+
+1. Make sure you have an active project selected.
+2. Click **Connect** next to the server you want.
+3. MCPJam creates the server on your active project and navigates to the Servers tab.
+
+If the server is already connected to your project, you'll see an info toast and be taken to the Servers tab instead.
+
+Click **Browse all** to go directly to the Servers tab and see all your servers.
+
+## Recommended clients
+
+The **Recommended clients** card lets you create a pre-configured sandbox client from a template. Available templates include Claude, ChatGPT, and Cursor.
+
+To create a client:
+
+1. Make sure you have an active project selected.
+2. Click the template you want.
+3. MCPJam creates the client on your active project and opens it in the Clients tab.
+
+## What's new
+
+The **What's new** card shows a timeline of recent platform updates — new features, changes, and releases — so you can stay current without leaving the app.
+
+## What's next
+
+- [Projects](/inspector/projects) — create and manage projects for your servers
+- [Clients](/inspector/clients) — configure and test MCP clients
+- [Servers](/getting-started#3-connect-your-own-server) — connect your own MCP servers

--- a/docs/inspector/launch-from-code.mdx
+++ b/docs/inspector/launch-from-code.mdx
@@ -81,7 +81,7 @@ await inspector.stop();
 | `server.url`      | `string`                 | -       | HTTP URL of the MCP server                                                                |
 | `server.headers`  | `Record<string, string>` | -       | Custom headers to send with requests                                                      |
 | `server.useOAuth` | `boolean`                | `false` | Trigger OAuth flow on connect                                                             |
-| `defaultTab`      | `string`                 | -       | Initial tab: `"servers"`, `"tools"`, `"resources"`, `"prompts"`, `"chat"`, `"playground"` |
+| `defaultTab`      | `string`                 | -       | Initial tab: `"servers"`, `"tools"`, `"resources"`, `"prompts"`, `"playground"` |
 
 ### InspectorInstance
 

--- a/docs/inspector/playground.mdx
+++ b/docs/inspector/playground.mdx
@@ -65,7 +65,7 @@ Switch between three perspectives on the same conversation from the segmented co
 
 - **Chat** — The normal thread with inline messages, tool calls, and rendered widgets.
 - **Trace** — A timestamped timeline of every step (user turns, agent turns, tool calls) with per-step and total latency and token counts. Expand any step to inspect its raw input and output.
-- **Raw** — The full JSON payload sent to the model (system prompt, tool definitions, conversation history). Updates as the conversation changes. Useful for debugging tool schemas and verifying what the model actually sees.
+- **Raw** — The full JSON payload sent to the model (system prompt, tool definitions, conversation history). Available for both live sessions and previously-saved sessions you reopen.
 
 <Frame>
   <img
@@ -88,9 +88,25 @@ Open the **Tools** tab in the left rail to invoke any tool by hand:
 
 When multiple servers are selected at the same time, the Tools rail aggregates every server's tools into one list and routes each execution to the right server automatically.
 
+## Model Picker
+
+The model picker in the chat input lets you choose which LLM to use. Models are organized into two tabs:
+
+- **Free models** — Frontier models (Claude, GPT, Gemini, DeepSeek, and more) available at no cost with no API key required.
+- **Your providers** — Models from providers you've configured in Settings with your own API key.
+
+The picker opens on the tab that matches your currently selected model. When you search, results from both tabs appear together.
+
 ## Multi-Model Compare
 
 Send one prompt to up to 3 models simultaneously. Open the model picker, toggle **Multiple models** on, and select the models you want to compare. Each model's response — including tool calls and rendered widgets — appears in its own column.
+
+<Note>
+  The **Multiple models** toggle is hidden when the active session is shared
+  with the project (project-visible). Enabling it on a shared session would
+  mutate experiment state for every collaborator. Switch the session back to
+  private to use multi-model compare.
+</Note>
 
 <Frame>
   <img
@@ -108,6 +124,13 @@ Toggle **Multiple hosts** on in the host picker (top-left of the center header) 
 One column is designated the **lead host**; chip tooltips in the toolbar say "Editing lead host: \<name\>" so it's clear which column the host controls (theme, device, locale, etc.) currently bind to. Click another column's chip to promote it to lead.
 
 This is the fastest way to verify that a widget renders correctly across the host environments you intend to ship to.
+
+<Note>
+  The **Multiple hosts** toggle and the host picker are hidden when the active
+  session is shared with the project (project-visible), for the same reason as
+  multi-model compare. Switch the session back to private to use multi-host
+  compare.
+</Note>
 
 ## Sessions
 
@@ -139,6 +162,30 @@ Toggle light and dark mode to test both appearances.
 
 Switch between Claude and ChatGPT host styles. For MCP Apps that use the MCP Apps style variables, the ChatGPT toggle translates the widget's styles to ChatGPT's design tokens.
 
+Each host style ships with a distinct `hostCapabilities` preset. Switching from one preset to another changes the capabilities advertised in the `ui/initialize` handshake, so widgets that gate on optional fields (such as `serverResources` or `logging`) will behave differently under each style.
+
+| Preset | `HostContext.toolInfo` | `availableDisplayModes` |
+|---|---|---|
+| Claude | Included | `["inline", "fullscreen", "pip"]` |
+| Copilot | Omitted (`undefined`) | `["inline", "fullscreen"]` |
+| ChatGPT | Included | `["inline", "fullscreen", "pip"]` |
+
+**Copilot** follows Microsoft 365 Copilot's published bridge: `toolInfo` is not delivered and `pip` is not advertised, so a widget that calls `app.getHostContext()?.toolInfo` on the Copilot preset correctly sees `undefined`.
+
+### Host Capabilities
+
+The **Host Capabilities** button in the toolbar (next to Host Context) lets you override the `hostCapabilities` blob advertised to MCP App widgets in the `ui/initialize` response.
+
+By default, the active host style's preset is used. Click **Host Capabilities** to open the editor and customize which capabilities the mock host claims to support. This is useful for testing how your widget behaves when specific capabilities are absent or present — for example, verifying that your widget degrades gracefully when `serverResources` is not advertised.
+
+- **No override** — the active host style's preset is used (shown as the placeholder in the editor)
+- **Custom override** — your JSON object is advertised verbatim; an "Override" badge appears on the button
+- **Clear override** — resets back to the host style preset
+
+<Note>
+  Host Capabilities configures what the mock host *advertises*. Enforcement — rejecting widget requests for capabilities not in the blob — is a planned follow-up. Until then, the inspector will still service all widget requests regardless of what the handshake advertises.
+</Note>
+
 ### Locale
 
 Pick a BCP 47 locale (e.g. `en-US`, `es-ES`, `ja-JP`, `fr-FR`) to verify internationalization.
@@ -153,8 +200,8 @@ Choose from 19 IANA timezones plus `UTC` to test time-aware widgets.
 
 ### CSP Mode
 
-- **Permissive** (default) — Allows all HTTPS resources. Recommended for development.
-- **Strict** — Only allows domains declared in your widget's CSP metadata (`openai/widgetCSP` for ChatGPT Apps, `ui.csp` for MCP Apps).
+- **Permissive** (default) — Allows all HTTP and HTTPS resources. Recommended for development.
+- **Strict** — Only allows domains declared in your widget's CSP metadata (`openai/widgetCSP` or `_meta.ui.csp` for ChatGPT Apps, `ui.csp` for MCP Apps).
 
 ### Device Capabilities
 
@@ -177,14 +224,11 @@ All three display modes are supported for both ChatGPT Apps and MCP Apps:
 
 Widgets can request mode changes from their own code; users can exit PiP or Fullscreen via the close button.
 
-### Protocol Selector
+### Widget rendering
 
-When a tool declares both `openai/outputTemplate` and `ui.resourceUri`, a protocol toggle appears in the tool row so you can flip between the two host bridges:
+All widgets — whether they declare `openai/outputTemplate` (ChatGPT Apps), `_meta.ui.resourceUri` (MCP Apps), or both — render through a single unified renderer. The `window.openai` compatibility shim is always injected, so both `window.openai.*` calls and `ui/*` JSON-RPC messages work regardless of which metadata the tool declares.
 
-- **ChatGPT Apps** — Renders using the `window.openai` host bridge.
-- **MCP Apps** — Renders using the `ui/*` JSON-RPC host bridge.
-
-Tools that use a single protocol render under that protocol automatically.
+Widget rendering is gated on the active Client's `clientCapabilities`. Hosts that advertise the MCP UI extension (Claude, ChatGPT, MCPJam, Copilot, Cursor) render widgets as normal. Hosts that strip the extension — such as Codex, an elicitation-only CLI — show the plain tool result row instead. Per-server capability overrides are honored.
 
 ## Per-Widget Debugging
 
@@ -209,6 +253,10 @@ In Strict mode, a badge shows the number of blocked requests. The panel includes
 - **Suggested fix** — Copyable JSON snippet to add to your `openai/widgetCSP` or `ui.csp` field.
 - **Blocked requests** — Each violation with the directive and source that was blocked.
 - **Declared domains** — The connect, resource, frame, and base URI domains your widget currently declares.
+
+#### Mounts
+
+The debug panel includes a **Mounts** section that appears only when a widget iframe has been torn down and rebuilt more than once during a session. Each entry shows the mount index, the reason it fired, and a timestamp. A healthy widget has exactly one mount; multiple entries indicate an unexpected re-mount that may have wiped widget state.
 
 ### Save View
 

--- a/docs/inspector/projects.mdx
+++ b/docs/inspector/projects.mdx
@@ -16,10 +16,13 @@ Each project saves its own set of MCP servers. Switch between projects with one 
 
 ## Getting Started
 
-1. **Click the project name** in the header bar
-2. **Create a project** - Click "Add Project" and give it a name
+The combined org and project switcher sits at the top of the sidebar. It shows your active project name and, below it, the organization it belongs to.
+
+1. **Click the switcher** at the top of the sidebar to open the context menu
+2. **Create a project** - Click the **+** icon next to the **Projects** heading and give it a name
 3. **Add your servers** - Configure your MCP servers in the Servers tab
-4. **Share with your team** - Click the share button and invite collaborators
+4. **Enable auto-connect** - Use the **Auto-connect** toggle in the Servers tab header to automatically connect all project servers whenever a host opens
+5. **Share with your team** - Click the share button and invite collaborators
 
 <Info>
 When you switch projects, all servers disconnect automatically to give you a clean slate.
@@ -33,17 +36,47 @@ When you switch projects, all servers disconnect automatically to give you a cle
   allowFullScreen
 ></iframe>
 
+## Switching Organizations
+
+The **Organization** section at the top of the context menu shows your active organization. Click the organization chip to open a popover listing all your organizations and select a different one. Switching organizations reloads the sidebar with that organization's projects — no page reload required.
+
+- On desktop, hovering over the chip also opens the organization list.
+- The gear icon next to an organization name (visible to admins and owners) navigates to that organization's settings.
+- Per-project settings gears and member avatars are shown on each project row in the list.
+
+<Info>
+After completing an OAuth flow, you are returned to the organization you were in when the flow started, so you never land on the wrong organization after authenticating.
+</Info>
+
 ## Sharing Projects
 
 Project sharing lets your entire team work with the same servers. Set up your project once, invite your team by email, and everyone gets access to the same servers with the same configurations instantly.
 
 ### What Gets Shared
 
-Members get access to every server in the project with the same configuration.
+Members get access to every server in the project with the same configuration. Project admins can also configure which servers auto-connect and set per-server overrides (headers, timeout) from the Servers tab — these settings apply across every host in the project.
 
 <Note>
 For security, authorization headers and OAuth tokens are never shared. Each team member authenticates with their own credentials when connecting to servers that require authentication.
 </Note>
+
+## Secret storage for env vars and headers
+
+When you save a server that has **environment variables** (stdio) or **custom HTTP headers**, those values are stored as encrypted secrets. The next time you open the server's edit form, those fields show **"Hidden — Reveal to view"** instead of the raw values.
+
+### Revealing saved secrets
+
+Click **Reveal** next to the hidden section to fetch and display the stored values. You can then view or edit them as normal.
+
+<Warning>
+If you want to change the **authentication type** (for example, switching from Bearer Token to a different method) on an HTTP server that has hidden headers, you must click **Reveal** first. Saving an auth change without revealing will show a validation error to prevent accidentally overwriting hidden headers.
+</Warning>
+
+### How updates work
+
+- **Env vars**: Any edit to the env vars section (add, remove, or change a value) replaces the stored secret with the new set of values on save.
+- **Custom headers**: Any edit to headers or the authentication type replaces the stored headers secret on save.
+- If you save without revealing or editing a secret section, the existing stored secret is left unchanged.
 
 ### Real-Time Sync
 
@@ -63,6 +96,18 @@ Once they sign in with that email address, the shared project will appear in the
 If you created the project, you can remove any member by clicking the X next to their name.
 
 If you're not the creator, you can leave the project at any time. The creator can also remove you from the project.
+
+## Project Settings
+
+Open **Project Settings** (gear icon in the header) to manage project-level configuration.
+
+### Default host config
+
+The **Default Host Config** section sets the seed configuration applied to new chatboxes, eval suites, and direct chat tabs when they are created. It controls the default model, system prompt, temperature, tool approval, connection settings, capabilities, and host context for anything new in the project.
+
+Editing the default host config does **not** change existing chatboxes or eval suites — each owns its own config once created.
+
+The editor is only visible when you are signed in and have a saved project. Members without manage permissions see the editor in read-only mode.
 
 ## What's Next
 

--- a/docs/inspector/protocol-versions.mdx
+++ b/docs/inspector/protocol-versions.mdx
@@ -8,6 +8,10 @@ The inspector can speak more than one version of the MCP protocol. By default it
 
 This page covers how to pick a version. Automatic per-server version detection is on the roadmap; for now you tell the inspector which version to use.
 
+<Warning>
+  **Migration required if you used the old Draft version.** The previous `DRAFT-2026-v1` placeholder has been retired and replaced with the upstream RC literal `2026-07-28`. If you had any servers pinned to `DRAFT-2026-v1`, you must re-select the protocol version in the inspector UI. Stored `DRAFT-2026-v1` pins are rejected by spec-conforming servers with a `-32004 UnsupportedProtocolVersionError`.
+</Warning>
+
 ## Where the setting lives
 
 There are two places to set a version, and they layer:

--- a/docs/inspector/tools-prompts-resources.mdx
+++ b/docs/inspector/tools-prompts-resources.mdx
@@ -6,6 +6,13 @@ icon: "hammer"
 
 The MCP Inspector provides a complete testing environment for your MCP server. Manually invoke tools, read resources, fetch prompts, and view all JSON-RPC messages between MCPJam and your server.
 
+<Note>
+  The Tools, Resources, and Prompts tabs only load data when the selected server
+  is connected. If the server is disconnected, the tabs clear any previously
+  loaded primitives and display a prompt to reconnect. Refresh, run, and read
+  actions are disabled until the server is connected again.
+</Note>
+
 <Frame>
   <img
     className="block"
@@ -54,3 +61,18 @@ All communication between MCPJam and your MCP server is logged in real-time:
 - **Timestamps** - Track message timing and performance
 
 The JSON-RPC logger helps you debug your MCP server implementation and understand the complete protocol flow.
+
+### OAuth log entries
+
+When a server uses OAuth, each step of the OAuth flow appears as a log entry in the traffic log alongside regular JSON-RPC messages. Use the **Source** filter dropdown and select **OAuth** to show only OAuth entries.
+
+Each OAuth log entry displays a status indicator:
+
+| Indicator | Meaning |
+|-----------|---------|
+| `oauth ✓` | Step completed successfully |
+| `oauth ✗` | Step failed |
+| `oauth …` | Step is in progress |
+| `oauth ↺` | Step failed but was recovered (for example, after re-registering the client) |
+
+Click any entry to expand it and inspect the full step payload, including HTTP request and response details.

--- a/docs/inspector/views.mdx
+++ b/docs/inspector/views.mdx
@@ -64,6 +64,8 @@ Click the **pencil icon** on any view in the sidebar to enter edit mode. The lef
 
 The editor shows a JSON object with the view's input, output, and other metadata. Edit any field and the widget preview updates in real time.
 
+The editor is powered by CodeMirror and includes syntax highlighting, line numbers, bracket matching, and proper cursor placement for long lines.
+
 Click the view name at the top of the editor to rename it inline.
 
 ### Running with Modified Input

--- a/docs/inspector/xaa-debugger.mdx
+++ b/docs/inspector/xaa-debugger.mdx
@@ -1,0 +1,85 @@
+---
+title: "XAA Debugger"
+description: "Debug Cross-App Access flows with authorization server compatibility checks and actionable error guidance"
+icon: "shield-check"
+---
+
+The XAA (Cross-App Access) Debugger helps you test and debug MCP server implementations that use the jwt-bearer grant type (RFC 7523) for federated authorization. The debugger validates authorization server compatibility, surfaces configuration issues before they cause failures, and provides actionable guidance when errors occur.
+
+## Key Features
+
+The XAA Debugger provides comprehensive tooling for testing Cross-App Access implementations:
+
+- **Authorization Server Preflight** - Automatic compatibility checks after discovery that verify jwt-bearer grant support and detect known authorization server vendors (Okta, Auth0, Keycloak, WorkOS, Stytch)
+- **Actionable Error Guidance** - Plain-English explanations and action buttons for common failure modes instead of raw error messages
+- **Visual Sequence Diagram** - Four-actor swimlanes showing Agent, IdP, MCP Server, and Authorization Server interactions
+- **Network Inspection** - View all HTTP requests and responses including the `/proxy/token` wrapper for authorization server calls
+- **Vendor-Specific Hints** - Configuration guidance tailored to your authorization server (native support, requires config, or unsupported with workarounds)
+
+## Getting Started
+
+To begin debugging XAA flows:
+
+1. **Navigate to the XAA Debugger** - Click the XAA Flow tab in MCPJam Inspector
+2. **Configure Target** - Provide your MCP server URL and authorization server details
+3. **Run Mock Authentication** - Complete the synthetic identity provider flow to obtain an ID token
+4. **Review Compatibility** - After authorization server discovery, check the green/amber/red banner for capability warnings
+5. **Exchange Tokens** - The debugger will attempt the ID-JAG (Identity JSON Assertion Grant) exchange and surface any configuration issues
+
+The debugger guides you through each step of the XAA flow with real-time feedback and vendor-specific recommendations.
+
+## Authorization Server Compatibility
+
+After step 4 (authorization server discovery), the debugger displays a compatibility banner:
+
+- **Green (Pass)** - Authorization server advertises `urn:ietf:params:oauth:grant-type:jwt-bearer` and has a token endpoint. The flow should succeed if issuer trust is configured.
+- **Amber (Warn)** - The authorization server didn't advertise `grant_types_supported` in its metadata. Support can't be verified without attempting the token exchange.
+- **Red (Fail)** - The authorization server doesn't advertise jwt-bearer grant support, or is a known-unsupported vendor. The flow will fail at step 11.
+
+### Vendor Detection
+
+The debugger recognizes common authorization server vendors and provides tailored guidance:
+
+- **Okta** - Native jwt-bearer support. Register MCPJam as a trusted identity issuer using the JWKS URL from the Register Issuer dialog.
+- **Auth0** - Supports jwt-bearer with configuration. Set up a trusted issuer pointing at MCPJam's JWKS and map subjects to Auth0 users.
+- **Keycloak** - Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's JWKS.
+- **WorkOS / Stytch** - Currently unsupported. Workaround: run a bridge service that verifies the ID-JAG against MCPJam's JWKS and mints access tokens via the vendor's admin API.
+
+## Error Guidance
+
+When the flow encounters an error, the debugger surfaces a guidance callout with:
+
+- **Title** - A user-friendly summary of what went wrong
+- **Explanation** - Plain-English description of the root cause
+- **Actions** - Buttons to fix the issue (Configure Target, Register Issuer, Reset Flow)
+
+### Common Error Scenarios
+
+**Client ID Required**
+- The ID-JAG needs a `client_id` claim. Configure it in the target settings and register the client at your authorization server.
+
+**Authorization Server Doesn't Support jwt-bearer Grant**
+- The AS returned `unsupported_grant_type`. Most authorization servers don't support RFC 7523 yet. Check vendor-specific guidance or run a bridge service.
+
+**Authorization Server Rejected the ID-JAG**
+- The AS returned `invalid_grant`. Common causes: MCPJam isn't registered as a trusted issuer, the `aud` claim doesn't match the AS issuer, or the `resource` claim isn't recognized.
+
+**MCP Server Rejected the Access Token**
+- The AS issued a token but the MCP server returned 401. The `resource` or `aud` claim on the access token likely doesn't match the MCP server's canonical resource URL.
+
+## Sequence Diagram
+
+The XAA flow sequence diagram shows four actors:
+
+- **Agent** - The MCP client initiating the flow
+- **IdP** - MCPJam's synthetic identity provider (for testing)
+- **MCP Server** - Your MCP server that requires XAA authorization
+- **Authorization Server** - The OAuth 2.0 authorization server that issues access tokens
+
+Each step in the flow is synchronized with the diagram, making it easy to understand where failures occur in the multi-party handshake.
+
+## Next Steps
+
+- Review the [MCP OAuth specification](https://modelcontextprotocol.io/specification/draft/basic/authorization) for XAA requirements
+- Check your authorization server's documentation for jwt-bearer grant configuration
+- Use the Register Issuer dialog to get the JWKS URL for configuring issuer trust

--- a/docs/inspector/xaa-debugger.mdx
+++ b/docs/inspector/xaa-debugger.mdx
@@ -34,7 +34,7 @@ After step 4 (authorization server discovery), the debugger displays a compatibi
 
 - **Green (Pass)** - Authorization server advertises `urn:ietf:params:oauth:grant-type:jwt-bearer` and has a token endpoint. The flow should succeed if issuer trust is configured.
 - **Amber (Warn)** - The authorization server didn't advertise `grant_types_supported` in its metadata. Support can't be verified without attempting the token exchange.
-- **Red (Fail)** - The authorization server doesn't advertise jwt-bearer grant support, or is a known-unsupported vendor. The flow will fail at step 11.
+- **Red (Fail)** - The authorization server doesn't advertise jwt-bearer grant support, or is a known-unsupported vendor. The flow will fail at the token exchange step.
 
 ### Vendor Detection
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -121,6 +121,8 @@ This will start the MCPJam inspector with a custom port number. The default port
 npx @mcpjam/inspector@latest --port 4000
 ```
 
+The port must be a valid integer between 1 and 65535. Passing an invalid value (e.g. a string or out-of-range number) exits immediately with an error.
+
 ## Start with Ollama
 
 This will open the MCPJam inspector and start an Ollama model with the `ollama serve <model>` command. Make sure you have Ollama installed.

--- a/docs/sdk/concepts/connecting-servers.mdx
+++ b/docs/sdk/concepts/connecting-servers.mdx
@@ -67,11 +67,12 @@ const manager = new MCPClientManager({
 
 ### HTTP Authentication Options
 
-For HTTP servers, `MCPClientManager` supports three auth patterns:
+For HTTP servers, `MCPClientManager` supports four auth patterns:
 
 - `accessToken` for a static bearer token
 - `refreshToken` + `clientId` for non-interactive OAuth token exchange with automatic refresh
 - `authProvider` when you need to provide a custom MCP SDK OAuth provider
+- `onUnauthorized` for custom 401 recovery when you manage tokens externally
 
 If you already have a refresh token, you can let the SDK handle access token exchange and refresh for you:
 
@@ -94,6 +95,35 @@ With this configuration, the SDK:
 
 <Note>
 `refreshToken` is only supported for HTTP servers. When you use it, do not also set `accessToken`, `authProvider`, or an `Authorization` header in `requestInit.headers`.
+</Note>
+
+#### Custom 401 recovery with onUnauthorized
+
+Use `onUnauthorized` when you supply an `accessToken` but manage token rotation yourself — for example, when tokens come from a secrets vault or a backend service rather than a standard OAuth flow:
+
+```typescript
+const manager = new MCPClientManager({
+  myServer: {
+    url: "https://mcp.example.com/mcp",
+    accessToken: currentToken,
+    onUnauthorized: async ({ serverId }) => {
+      // Call your own token endpoint to get a fresh token
+      const { accessToken } = await myTokenService.refresh(serverId);
+      return { accessToken };
+    },
+  },
+});
+```
+
+When the server returns HTTP 401, the SDK:
+
+1. Calls `onUnauthorized` once to obtain a fresh access token.
+2. Strips any stale `Authorization` header from `requestInit`.
+3. Rebuilds the transport with the new token and retries the operation.
+4. If the retry also returns 401, the error is surfaced to the caller.
+
+<Note>
+`onUnauthorized` only fires on strict HTTP 401 responses — not 403. It is also skipped when `refreshToken` or `authProvider` is configured, since those patterns handle token refresh internally. Parallel 401s for the same server share a single refresh call.
 </Note>
 
 ## Connecting and Disconnecting

--- a/docs/sdk/concepts/running-evals.mdx
+++ b/docs/sdk/concepts/running-evals.mdx
@@ -168,6 +168,27 @@ await test.run(agent, {
 
 See [Eval reporting — Tool execution and `passed`](/sdk/reference/eval-reporting#tool-execution-and-passed) for full detail and [`createEvalRunReporter`](/sdk/reference/eval-reporting#createevalrunreporter) overrides.
 
+### Predicate gate
+
+`successPredicates` lets you express richer pass/fail criteria beyond tool-call matching — without an LLM judge. Predicates are pure functions of the iteration transcript, so they produce the same verdict every time and are safe to use as a CI release gate.
+
+A case passes iff **all** predicates pass. An absent or empty list means no predicate gate.
+
+The eight built-in predicate types:
+
+| Type | What it checks |
+|------|----------------|
+| `toolCalledWith` | A specific tool was called with matching args (partial/exact/ignore mode) |
+| `toolCalledAtLeastOnce` | A tool was called at least once |
+| `toolNeverCalled` | A forbidden tool was never called |
+| `responseContains` | The final assistant message contains a substring |
+| `responseMatches` | The final assistant message matches a regex |
+| `noToolErrors` | No tool produced an error (MCP `isError` or transport failure) |
+| `finalAssistantMessageNonEmpty` | The final assistant message is non-empty |
+| `tokenBudgetUnder` | Total token usage is strictly under a budget |
+
+Predicates are authored in the corpus JSON (V1) and threaded through the runner automatically. See [Predicate gate reference](/sdk/reference/eval-reporting#predicate-gate) for the full type definitions and a code example.
+
 ### Suite Results
 
 ```typescript
@@ -254,7 +275,7 @@ if (suite.accuracy() < 0.90) {
 
 ## Generate evals from the Inspector
 
-You can also generate eval code from the MCPJam Inspector. Click **⋮ → Copy markdown for server evals** on any server card, then paste it into an LLM. See the [Quickstart](/sdk/quickstart#generate-evals-from-the-inspector) for details.
+You can also generate eval code from the MCPJam Inspector. Click **⋮ → Copy markdown for evals** on any server card, then paste it into an LLM. See the [Quickstart](/sdk/quickstart#generate-evals-from-the-inspector) for details.
 
 If you have a `MCPJAM_API_KEY`, the generated code will automatically save results to the **Evals** tab in the Inspector. Go to **Settings > Project API Key** to get your key.
 

--- a/docs/sdk/quickstart.mdx
+++ b/docs/sdk/quickstart.mdx
@@ -186,7 +186,7 @@ You can also generate eval code directly from the MCPJam Inspector:
 
 1. Connect your MCP server in the Inspector
 2. Click the **⋮** menu on the server card
-3. Select **Copy markdown for server evals**
+3. Select **Copy markdown for evals**
 4. Paste the copied markdown into an LLM (Claude, ChatGPT, etc.)
 5. The LLM will generate eval test code using `@mcpjam/sdk`
 

--- a/docs/sdk/quickstart.mdx
+++ b/docs/sdk/quickstart.mdx
@@ -194,7 +194,7 @@ You can also generate eval code directly from the MCPJam Inspector:
   <img
     className="block"
     src="/images/copy-markdown-menu.png"
-    alt="Copy markdown for server evals menu option"
+    alt="Copy markdown for evals menu option"
     width="300"
   />
 </Frame>

--- a/docs/sdk/reference/eval-reporting.mdx
+++ b/docs/sdk/reference/eval-reporting.mdx
@@ -32,7 +32,7 @@ Uploaded iterations have a single boolean `passed` that drives pass rate on the 
 
 **Manual `reportEvalResults`:** If you build `results[]` yourself and set `passed` explicitly, MCPJam stores your values as-is. The execution gate applies to code paths that **compute** `passed` from prompts, traces, and iterations.
 
-**Programmatic reuse:** `@mcpjam/sdk` also exports `finalizePassedForEval`, `traceIndicatesToolExecutionFailure`, `isCallToolResultError`, and `traceMessagePartIndicatesToolFailure` for custom ingestion pipelines.
+**Programmatic reuse:** `@mcpjam/sdk` also exports `finalizePassedForEval`, `traceIndicatesToolExecutionFailure`, `isCallToolResultError`, `traceMessagePartIndicatesToolFailure`, `classifyToolFailurePart`, and `extractToolErrors` for custom ingestion pipelines. The `@mcpjam/sdk/predicates` sub-package exports the full predicate evaluator (`evaluatePredicate`, `evaluatePredicates`, `allPredicatesPassed`, `buildIterationTranscript`) and all predicate types.
 
 ---
 
@@ -402,10 +402,91 @@ Advanced replay override. Most users should not construct this manually.
 | `trace` | `EvalTraceInput` | No | Conversation trace |
 | `externalIterationId` | `string` | No | Custom iteration ID |
 | `externalCaseId` | `string` | No | Custom case ID |
-| `metadata` | `Record<string, string \| number \| boolean>` | No | Custom metadata |
+| `metadata` | `Record<string, unknown>` | No | Custom metadata. When `successPredicates` are evaluated, the runner persists `{ predicate, passed, reason }[]` under `metadata.predicates` automatically. |
+| `successPredicates` | `Predicate[]` | No | State-based predicate gate evaluated over the iteration transcript. See [Predicate gate](#predicate-gate). |
 | `isNegativeTest` | `boolean` | No | Whether this is a negative test |
 | `matchOptions` | `EvalMatchOptions` | No | Per-result match options. When present, the inspector snapshots these onto the iteration so historical pass/fail computation honors them. See [`EvalMatchOptions`](/sdk/reference/validators#evalmatchoptions) |
 | `widgetSnapshots` | `EvalWidgetSnapshotInput[]` | No | MCP App HTML replay payloads (typically from [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) on [`PromptResult`](/sdk/reference/prompt-result)). Omitted when not using MCP Apps or when `TestAgent` had no `mcpClientManager` |
+
+### Predicate gate
+
+`successPredicates` adds a deterministic, state-based assertion layer on top of tool-call matching. Each predicate is a pure function of the iteration transcript — same transcript, same verdict — which makes it suitable as a CI release gate.
+
+A case passes the predicate gate iff **all** predicates pass. An absent or empty list means no predicate gate (the case is judged solely by tool-call matching and `failOnToolError`).
+
+#### Predicate types
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `toolCalledWith` | `toolName`, `args` ([`ArgMatcher`](#argmatcher)), `minCount?` | A call to `toolName` whose args satisfy `args` occurred at least `minCount` (default 1) times. |
+| `toolCalledAtLeastOnce` | `toolName` | `toolName` was called at least once (args irrelevant). |
+| `toolNeverCalled` | `toolName` | `toolName` was never called (forbidden-tool check). |
+| `responseContains` | `needle`, `caseSensitive?` | The final assistant message contains `needle`. Case-insensitive by default. |
+| `responseMatches` | `pattern` | The final assistant message matches the regular expression `pattern` (regex source string, no flags). |
+| `noToolErrors` | — | No tool produced an error (neither MCP `isError: true` nor a JSON-RPC/transport failure). |
+| `finalAssistantMessageNonEmpty` | — | The final assistant message is a non-empty, non-whitespace string. |
+| `tokenBudgetUnder` | `tokens` | Total token usage for the iteration is strictly under `tokens`. Fails closed when usage is unavailable. |
+
+#### ArgMatcher
+
+Used by `toolCalledWith` to specify expected arguments and matching mode.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `args` | `Record<string, unknown>` | Expected argument shape. |
+| `argumentMatching` | `"partial" \| "exact" \| "ignore"` | Matching mode. `"partial"` (default) checks only the keys present in `args`; `"exact"` requires deep equality; `"ignore"` skips argument comparison. |
+
+#### Fail-closed behavior
+
+Malformed predicates (unknown type, missing required fields, invalid `minCount`, empty `needle`/`pattern`) always fail the case rather than silently passing. `responseMatches` also fails closed on patterns with nested quantifiers (ReDoS guard) and on messages exceeding 100,000 characters.
+
+#### Example
+
+```typescript
+import type { Predicate } from "@mcpjam/sdk/predicates";
+
+const predicates: Predicate[] = [
+  // Tool was called with the right airline argument
+  {
+    type: "toolCalledWith",
+    toolName: "book_flight",
+    args: { args: { airline: "DL" } },
+  },
+  // Response mentions the booking confirmation
+  { type: "responseContains", needle: "confirmed" },
+  // No tool errors occurred
+  { type: "noToolErrors" },
+  // Token budget respected
+  { type: "tokenBudgetUnder", tokens: 2000 },
+];
+
+// Pass predicates via the per-run override in the Inspector corpus,
+// or use evaluatePredicates() directly in custom pipelines:
+import { evaluatePredicates, buildIterationTranscript } from "@mcpjam/sdk/predicates";
+
+const transcript = buildIterationTranscript({
+  trace: myTrace,
+  toolCalls: myToolCalls,
+  usage: { totalTokens: 1200 },
+});
+
+const results = evaluatePredicates(transcript, predicates);
+const allPassed = results.every((r) => r.passed);
+```
+
+#### Predicate results in metadata
+
+When the Inspector runner evaluates predicates, it persists one row per predicate to `testIteration.metadata.predicates`:
+
+```typescript
+type PredicateResult = {
+  predicate: Predicate;   // The authored predicate (sensitive arg keys are redacted)
+  passed: boolean;
+  reason: string;         // Structured explanation, e.g. "tool "book_flight" called with matching args"
+};
+```
+
+---
 
 ### ReportEvalResultsOutput
 

--- a/docs/sdk/reference/mcp-client-manager.mdx
+++ b/docs/sdk/reference/mcp-client-manager.mdx
@@ -70,6 +70,7 @@ For remote MCP servers via SSE or Streamable HTTP.
 | `preferSSE` | `boolean` | No | Forces SSE instead of Streamable HTTP |
 | `clientInfo` | `{ name?: string; version?: string } & Record<string, unknown>` | No | Override the MCP `initialize.params.clientInfo` sent to this server. Useful for testing how servers respond to different client identities. |
 | `supportedProtocolVersions` | `string[]` | No | Ordered list of MCP protocol versions to advertise. The first entry is proposed in `initialize.params.protocolVersion`; the full list is the accept-set. |
+| `onUnauthorized` | `UnauthorizedRefreshHandler` | No | 401 recovery hook. Called once when an operation fails with HTTP 401; return a new `accessToken` and the SDK rebuilds the transport and retries. Not invoked for 403, or when `refreshToken`/`authProvider` is set. |
 
 ```typescript
 {
@@ -119,6 +120,39 @@ Use `clientInfo` to pin the identity sent in MCP `initialize`. This is useful wh
 ```
 
 The first entry in `supportedProtocolVersions` is proposed to the server; the full list is the accept-set. A server that negotiates any listed version is accepted.
+
+##### onUnauthorized Example
+
+Use `onUnauthorized` when you manage access tokens externally (e.g., from a secrets vault) and want the SDK to automatically recover from a 401 without a full reconnect flow:
+
+```typescript
+import { MCPClientManager, UnauthorizedRefreshHandler } from "@mcpjam/sdk";
+
+const refreshToken: UnauthorizedRefreshHandler = async ({ serverId }) => {
+  // Fetch a fresh token from your own token store or backend
+  const response = await fetch("https://auth.example.com/token/refresh", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${process.env.SERVICE_TOKEN}` },
+    body: JSON.stringify({ serverId }),
+  });
+  const { accessToken } = await response.json();
+  return { accessToken };
+};
+
+const manager = new MCPClientManager({
+  myServer: {
+    url: "https://mcp.example.com/mcp",
+    accessToken: await getInitialToken(),
+    onUnauthorized: refreshToken,
+  },
+});
+```
+
+When the server returns HTTP 401, the SDK calls `onUnauthorized` once, updates the access token, rebuilds the transport, and retries the operation. A second 401 after the retry surfaces the error to the caller.
+
+<Note>
+`onUnauthorized` is only active for `accessToken`-based HTTP configs. It is ignored when `refreshToken` or `authProvider` is set, and it is never triggered by 403 responses.
+</Note>
 
 ### Example
 

--- a/docs/sdk/reference/test-agent.mdx
+++ b/docs/sdk/reference/test-agent.mdx
@@ -36,6 +36,7 @@ new TestAgent(options: TestAgentOptions)
 | `maxSteps`        | `number`                         | No       | `10`        | Maximum agentic loop iterations                               |
 | `customProviders` | `Record<string, CustomProvider>` | No       | `undefined` | Custom LLM provider definitions                               |
 | `mcpClientManager`| `MCPClientManager`               | No       | `undefined` | Same connected manager used for `connectToServer` / `getToolsForAiSdk`. **Required** to populate [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) on each [`PromptResult`](/sdk/reference/prompt-result) (see note below). |
+| `injectOpenAiCompat` | `boolean`                     | No       | `false`     | When `true`, injects the OpenAI Apps SDK `window.openai` shim into captured widget HTML snapshots. Enable this when testing widgets written against the OpenAI Apps SDK (ChatGPT / Copilot hosts). Leave it off for SEP-1865-native widgets (Claude, Cursor, Codex) — those hosts don't expose `window.openai` and snapshots should match what the live host produces. |
 
 ### Example
 
@@ -281,6 +282,38 @@ maxSteps: 5; // Stop after 5 tool calls
   Setting `maxSteps` too low may prevent complex tasks from completing. Setting
   it too high may allow runaway loops.
 </Warning>
+
+### injectOpenAiCompat
+
+Controls whether the OpenAI Apps SDK `window.openai` shim is injected into captured widget HTML snapshots. Defaults to `false`.
+
+Set this to `true` when your widget is written against the OpenAI Apps SDK (i.e. it targets ChatGPT or Copilot). Leave it `false` for SEP-1865-native widgets targeting Claude, Cursor, Codex, or other hosts that don't expose `window.openai` — snapshots should match what the live host would have produced.
+
+```typescript
+// Testing an OpenAI Apps SDK widget (ChatGPT / Copilot host)
+const agent = new TestAgent({
+  tools,
+  model: "openai/gpt-4o",
+  apiKey: process.env.OPENAI_API_KEY,
+  mcpClientManager: manager,
+  injectOpenAiCompat: true,
+});
+
+// Testing a SEP-1865 widget (Claude / Cursor / Codex host) — default
+const agent = new TestAgent({
+  tools,
+  model: "anthropic/claude-sonnet-4-20250514",
+  apiKey: process.env.ANTHROPIC_API_KEY,
+  mcpClientManager: manager,
+  // injectOpenAiCompat defaults to false
+});
+```
+
+<Note>
+  This flag is stamped onto each widget snapshot (`injectedOpenAiCompat`) so the
+  MCPJam trace viewer can replay the widget faithfully under a different host
+  config without rewriting the cached bytes.
+</Note>
 
 ---
 

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -50,12 +50,50 @@ If you're seeing **401 Unauthorized** errors when trying to connect to your serv
   process and identify where things might be going wrong.
 </Info>
 
+### OAuth connection failures
+
+When an OAuth flow fails, Inspector surfaces the failure directly in the connection UI so you can diagnose the problem without leaving the Servers tab.
+
+**Connection card** — a banner above the error message identifies the exact OAuth step that failed (for example, "OAuth failed during Token Request").
+
+**Server detail panel** — open the server's detail view to see the full **Last OAuth Trace**, which includes:
+
+- Each OAuth step with its status (pending / success / error) and a short message
+- The specific error for any failed step
+- An **HTTP History** log of every request and response made during the flow, with sensitive values automatically redacted
+
+Use the trace to pinpoint whether the failure occurred during discovery, client registration, PKCE generation, the authorization redirect, or the token exchange, then cross-reference with the OAuth Debugger for a guided walkthrough of the same steps.
+
+### Toggle shows a re-authentication error for an OAuth server
+
+The enable/connect toggle on a server card or detail modal reuses existing credentials only. If your tokens are expired or missing, the toggle will report a re-authentication error rather than opening the OAuth consent screen.
+
+**Solution:** Use the **Reconnect** button on the server card or detail modal to start a full OAuth flow and obtain new credentials. The toggle is intentionally non-interactive for OAuth to avoid unexpected browser redirects.
+
 ### Common Configuration Mistakes
 
 - Missing required environment variables
 - Incorrect transport type selection
 - Typos in server URLs or commands
 - Missing file permissions or executable flags
+
+## Chat Model Limit
+
+### "MCPJam model limit reached" warning
+
+MCPJam provides free frontier models for chat. When you hit the daily usage limit, the chat surface shows a warning:
+
+> **MCPJam model limit reached.** Add your own API key under LLM Providers in Settings to continue now, or try again in _N_ minutes.
+
+This is an expected quota state, not an error with your MCP server.
+
+**To continue immediately:**
+
+1. Go to **Settings → LLM Providers**
+2. Add an API key for any supported provider (OpenAI, Anthropic, Gemini, etc.)
+3. Select that provider's model in the chat model picker
+
+**To wait for the limit to reset:** The warning includes the retry window. Free quota resets daily.
 
 ## Getting Help
 


### PR DESCRIPTION
Consolidates the backlog of open Mintlify docs-bot PRs into the **current** docs site. Most were authored before the docs restructure, so pages they targeted (`inspector/test-cases`, `inspector/chat`, `inspector/app-builder`) no longer exist — that content is re-homed into `inspector/evals` and `inspector/playground`.

Every incorporated PR's content was **verified against the current code** before landing. Backend-internal material was excluded, and several inaccuracies were corrected along the way:
- daily-credit multiplier **15× → 10×** (`hosted/overview`)
- traffic-log indicator **`oauth !` → `oauth ✗`** (`tools-prompts-resources`)
- Copilot `availableDisplayModes` → `["inline","fullscreen"]` (`playground`)
- removed the **non-existent per-tool protocol selector** section (`playground`)
- dropped `"app-builder"`/`"chat"` from `defaultTab` options (`launch-from-code`)

**New pages:** `inspector/home`, `inspector/xaa-debugger`.

**Incorporates:** #1816, #1874, #1886, #1904, #1907, #1914, #1940, #1942, #1950, #1972, #2000, #2008, #2013, #2050, #2053, #2085, #2089, #2091, #2095, #2148, #2152, #2155, #2160, #2170, #2177, #2185, #2188, #2198, #2200, #2209, #2215, #2229, #2237, #2241, #2253, #2256, #2260, #2263, #2264, #2282, #2283, #2297, #2304, #2309, #2312, #2317, #2320, #2344, #2346, #2347, #2348, #2350, #2354, #2356, #2366, #2367, #2369, #2377, #2394

**Closed separately** as stale / backend-internal / inaccurate (not incorporated): #1827, #1860, #1866, #1898, #1960, #1998, #1999, #2162, #2192, #2234, #2245, #2277, #2300, #2349, #2358

---
_Generated by [Claude Code](https://claude.ai/code/session_01LExdyi7zaPZZRz9dvjU9Yp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or deployment impact; risk is limited to possible doc inaccuracies for reviewers to spot.
> 
> **Overview**
> This PR **restructures and expands Mintlify documentation** so it matches the current product layout (Playground/Evals instead of removed Chat, App Builder, and test-cases pages), and folds in a large backlog of verified doc updates.
> 
> **Navigation and new pages:** `docs.json` adds **Home** and **XAA Debugger** under Inspector Features and keeps redirects from legacy routes to **Playground** and **Evals**.
> 
> **Inspector / hosted:** New or heavily expanded coverage includes the org **Home** dashboard, **Playground** (model picker, unified widget rendering, host capability presets, shared-session limits on multi-model/multi-host compare), **Clients** (project-wide servers, server attachments, Apps Extension matrices, host **Compare** deep links), **Evals** (sign-in requirement, frozen server snapshots, execution config, cross-host matrix, AI Triage, predicate gate), **Projects** (org switcher, encrypted env/header secrets, default host config), inline **OAuth** tracing and reconnect behavior, **protocol version** migration off `DRAFT-2026-v1`, and hosted **usage limits**, **OAuth token reveal**, and **billing** payment history.
> 
> **CLI / SDK / guides / troubleshooting:** CLI docs add **update notifications**, **Authorization redaction** in probe/doctor output, and SDK docs document **`onUnauthorized`**, **`successPredicates` / `@mcpjam/sdk/predicates`**, and **`injectOpenAiCompat`** on `TestAgent`. The ChatGPT app guide documents **`_meta.ui.csp`** vs legacy `widgetCSP` and ngrok sign-in steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f534635c283c5e4e407b515ad917ac2ba739e27d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->