### PR TITLE
feat(home): render empty state in What's new card

### DIFF
--- a/mcpjam-inspector/client/src/components/home/ProductUpdatesFeed.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdatesFeed.tsx
@@ -60,13 +60,14 @@ export function ProductUpdatesFeed() {
   }, [isAuthenticated, initialize]);
 
   if (!isAuthenticated) return null;
+  // Hold render until the query has resolved at least once, so the card
+  // doesn't flash an empty state before the data arrives.
+  if (updates === undefined) return null;
 
-  const all = updates ?? [];
-  if (all.length === 0) return null;
-
-  const visible = all.filter((u) => !u.dismissed);
+  const visible = updates.filter((u) => !u.dismissed);
   const top = visible.slice(0, 5);
   const newCount = visible.filter((u) => u.isNew).length;
+  const hasAny = updates.length > 0;
 
   const handleDismiss = async (slug: string) => {
     try {
@@ -100,7 +101,9 @@ export function ProductUpdatesFeed() {
         <CardContent className="px-6 pb-4 pt-3">
           {top.length === 0 ? (
             <p className="py-2 text-[12.5px] text-muted-foreground">
-              You&apos;re all caught up.
+              {hasAny
+                ? "You’re all caught up."
+                : "No updates yet. Releases and platform changes will show up here."}
             </p>
           ) : (
             <ol className="relative">
@@ -192,16 +195,18 @@ export function ProductUpdatesFeed() {
             </ol>
           )}
 
-          <div className="mt-3 flex justify-end border-t border-border pt-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-[12px] text-muted-foreground hover:text-foreground"
-              onClick={() => setSheetOpen(true)}
-            >
-              See all &rarr;
-            </Button>
-          </div>
+          {hasAny ? (
+            <div className="mt-3 flex justify-end border-t border-border pt-3">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-[12px] text-muted-foreground hover:text-foreground"
+                onClick={() => setSheetOpen(true)}
+              >
+                See all &rarr;
+              </Button>
+            </div>
+          ) : null}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
Follow-up to #2401. The card returned `null` when the `productUpdates` table was empty, which made the feature look broken or missing instead of intentionally quiet — exactly what just happened on staging while we wait for backend Convex to deploy and rows to be seeded.

Now once the Convex query resolves:
- **empty table** → \"No updates yet. Releases and platform changes will show up here.\" Footer hidden (Sheet would be empty).
- **all dismissed** → existing \"you're all caught up\" copy, footer stays so the archive is reachable.
- **entries present** → unchanged timeline.

`updates === undefined` (still loading) still renders `null` so the empty state doesn't flash before data arrives.

## Test plan
- [ ] Sign in to staging once Convex is back: empty \`productUpdates\` table → card visible with empty-state copy, no \"See all\" button.
- [ ] Insert one row via dashboard → card flips to the timeline view, footer reappears.
- [ ] Dismiss it → card switches to \"you're all caught up\", footer stays, Sheet shows the dismissed entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Home UI copy and conditional footer only; no changes to auth, mutations, or data model.
> 
> **Overview**
> **What's new** no longer disappears when the `productUpdates` table is empty. After the Convex query resolves once, the card always renders for signed-in users.
> 
> **Empty table:** shows *No updates yet…* and hides **See all** (the sheet would be empty). **All dismissed:** keeps *You're all caught up* and the footer so the archive stays reachable. **Loading:** still returns `null` while `updates === undefined` to avoid flashing empty copy before data arrives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24a8d8da5e2b05ae54157a6ea83e63e3eb6c2d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->