### PR TITLE
fix(evals): call getTestIterationBlob with iterationId, not blobId

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/iteration-details-ui.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/iteration-details-ui.test.tsx
@@ -250,7 +250,7 @@ describe("IterationDetails trace blob load error", () => {
     fireEvent.click(screen.getByRole("button", { name: /try again/i }));
 
     await waitFor(() => expect(mockGetBlob).toHaveBeenCalledTimes(2));
-    expect(mockGetBlob).toHaveBeenLastCalledWith({ blobId: "blob-conn" });
+    expect(mockGetBlob).toHaveBeenLastCalledWith({ iterationId: "iter-1" });
     await screen.findByTestId("mock-trace-viewer");
   });
 

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -251,7 +251,7 @@ export function IterationDetails({
 }) {
   const getBlob = useAction(
     "testSuites:getTestIterationBlob" as any,
-  ) as unknown as (args: { blobId: string }) => Promise<any>;
+  ) as unknown as (args: { iterationId: string }) => Promise<any>;
 
   const [blob, setBlob] = useState<any>(null);
   const [loading, setLoading] = useState(false);
@@ -291,7 +291,10 @@ export function IterationDetails({
       setLoading(true);
       setError(null);
       try {
-        const data = await getBlob({ blobId: iteration.blob });
+        // Backend authorizes via the iteration's testSuite and derives the
+        // blob id server-side. We still gate on `iteration.blob` above to
+        // skip the roundtrip for blobless iterations.
+        const data = await getBlob({ iterationId: iteration._id });
         if (!cancelled) setBlob(data);
       } catch (e: any) {
         if (!cancelled) {

--- a/mcpjam-inspector/client/src/components/evals/use-eval-trace-blob.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-trace-blob.ts
@@ -13,7 +13,7 @@ export function useEvalTraceBlob({
 }) {
   const getBlob = useAction(
     "testSuites:getTestIterationBlob" as any,
-  ) as unknown as (args: { blobId: string }) => Promise<any>;
+  ) as unknown as (args: { iterationId: string }) => Promise<any>;
   const [blob, setBlob] = useState<any>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -46,7 +46,10 @@ export function useEvalTraceBlob({
       setError(null);
 
       try {
-        const data = await getBlob({ blobId: iteration.blob });
+        // Backend authorizes via the iteration's testSuite and derives the
+        // blob id server-side. We still gate on `iteration.blob` above to
+        // skip the roundtrip for blobless iterations.
+        const data = await getBlob({ iterationId: iteration._id });
         if (!cancelled) {
           setBlob(data);
           onTraceLoadedRef.current?.();


### PR DESCRIPTION
## Summary

Companion to backend [MCPJam/mcpjam-backend#417](https://github.com/MCPJam/mcpjam-backend/pull/417). That PR fixed a real security issue in `testSuites.getTestIterationBlob` — it used to accept an arbitrary `blobId: v.id('_storage')` with no authorization check, so any signed-in client could enumerate storage IDs to read other users' trace blobs. The new shape takes `iterationId: v.id('testIteration')` and derives the blob id server-side after running the same iteration→testSuite auth path the rest of that file already uses. There is no backwards-compat shim, so until this PR ships, the trace viewer in production returns errors for every iteration.

## Changes

Three callsites updated (all under `client/src/components/evals/`):

- **`use-eval-trace-blob.ts`** — `useAction` type annotation flips from `{ blobId: string }` to `{ iterationId: string }`; the call passes `iteration._id` instead of `iteration.blob`. Kept the local `if (!iteration?.blob)` early-exit gate so blobless iterations don't round-trip — the server returns null in that case either way, but the iteration object already tells us.
- **`iteration-details.tsx`** — same two changes; this component has an inline duplicate of the hook's load logic that wasn't using the hook itself. Worth a separate refactor PR but kept untouched here.
- **`__tests__/iteration-details-ui.test.tsx`** — the connection-lost retry assertion now expects `{ iterationId: 'iter-1' }` instead of `{ blobId: 'blob-conn' }`. The iteration test fixture already carries `_id: 'iter-1'`.

## Test plan

- [x] `npx vitest run client/src/components/evals/__tests__/iteration-details-ui.test.tsx` — 6/6 pass.
- [ ] Manual smoke: load any iteration's trace viewer on staging once both PRs are merged.

## Notes

Whole-repo `tsc -p client/tsconfig.json` surfaces pre-existing errors in `App.hosted-oauth.test.tsx` that aren't related to this change. None of the files touched here had typecheck errors.

The inline-duplicate of the hook inside `iteration-details.tsx` is worth flagging — the existence of two copies of the same load-state machine is the reason this PR had to update two callsites instead of one. Consolidating to the hook is a small follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow client contract change for trace loading; no auth or data-model logic on the client beyond the new argument shape.
> 
> **Overview**
> Aligns the eval trace viewer with the hardened **`testSuites:getTestIterationBlob`** API: callers now pass **`iterationId`** (`iteration._id`) instead of a raw storage **`blobId`**, so blob access is authorized on the server via the iteration’s test suite.
> 
> **`use-eval-trace-blob.ts`** and the inline loader in **`iteration-details.tsx`** both update the action typing and invoke `getBlob({ iterationId: iteration._id })`. The existing **`iteration.blob`** guard stays so blobless iterations skip the network call. The retry UI test expects **`{ iterationId: 'iter-1' }`** on the second fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee036825275477778d01c144c1c576c3fd5d464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->