### PR TITLE
refactor(host-config): extract host-policy + compat + filterAppOnlyTools into SDK (Stage 3)

### DIFF
--- a/mcpjam-inspector/server/services/evals/compat-runtime.ts
+++ b/mcpjam-inspector/server/services/evals/compat-runtime.ts
@@ -1,56 +1,20 @@
+/**
+ * OpenAI Apps compat resolution + Convex-bound suite hostConfig loader.
+ *
+ * As of Stage 3 of the hostConfig consolidation, `resolveOpenAiCompatForHostConfig`
+ * lives in `@mcpjam/sdk/host-config/internal` (alongside the canonical
+ * hostConfig model) and is re-exported here so call sites don't churn.
+ *
+ * `loadSuiteHostConfig` stays inspector-side — it takes a `ConvexHttpClient`
+ * and does Convex queries, so it can't move into the pure SDK module.
+ */
+
 import type { ConvexHttpClient } from "convex/browser";
+
+export { resolveOpenAiCompatForHostConfig } from "@mcpjam/sdk/host-config/internal";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function readOpenAiCompatOverride(value: unknown): boolean | undefined {
-  if (!isRecord(value)) return undefined;
-  const profile = isRecord(value.mcpProfile) ? value.mcpProfile : undefined;
-  const apps = isRecord(profile?.apps) ? profile.apps : undefined;
-  const compatRuntime = isRecord(apps?.compatRuntime)
-    ? apps.compatRuntime
-    : undefined;
-  return typeof compatRuntime?.openaiApps === "boolean"
-    ? compatRuntime.openaiApps
-    : undefined;
-}
-
-function compatPresetForHostStyle(hostStyle: unknown): boolean | undefined {
-  switch (hostStyle) {
-    case "chatgpt":
-    case "copilot":
-    case "mcpjam":
-      return true;
-    case "claude":
-    case "cursor":
-    case "codex":
-      return false;
-    default:
-      return undefined;
-  }
-}
-
-export function resolveOpenAiCompatForHostConfig(
-  hostConfig: unknown,
-  hostConfigOverride?: Record<string, unknown>,
-): boolean {
-  const explicitOverride = readOpenAiCompatOverride(hostConfigOverride);
-  if (explicitOverride !== undefined) return explicitOverride;
-
-  const overridePreset = compatPresetForHostStyle(
-    hostConfigOverride?.hostStyle,
-  );
-  if (overridePreset !== undefined) return overridePreset;
-
-  const explicitBase = readOpenAiCompatOverride(hostConfig);
-  if (explicitBase !== undefined) return explicitBase;
-
-  return (
-    compatPresetForHostStyle(
-      isRecord(hostConfig) ? hostConfig.hostStyle : undefined,
-    ) ?? false
-  );
 }
 
 export async function loadSuiteHostConfig(

--- a/mcpjam-inspector/server/services/evals/host-execution-policy.ts
+++ b/mcpjam-inspector/server/services/evals/host-execution-policy.ts
@@ -1,141 +1,20 @@
 /**
- * Extracts host execution policy from a hostConfig snapshot and provides
- * helpers to compute tool exposure signals and stamp scalar iteration metadata.
+ * Host execution policy + visibility filter + iteration metadata stamping.
  *
- * Uses the same policy switches as chat-v2 (`requireToolApproval`,
- * `respectToolVisibility`, `progressiveToolDiscovery`) without duplicating
- * their semantics. The visibility filter itself is imported from
- * `chat-v2-orchestration` so the filtering logic stays authoritative.
+ * As of Stage 3 of the hostConfig consolidation, this module is a thin
+ * re-export over `@mcpjam/sdk/host-config/internal`. The eval runtime
+ * continues to import from this path so call sites don't churn, but the
+ * authoritative implementation lives in the SDK alongside the canonical
+ * hostConfig model. This also removes the eval path's reach into
+ * `server/utils/chat-v2-orchestration` for `filterAppOnlyTools`.
  */
 
-import type { MCPClientManager } from "@mcpjam/sdk";
-import { filterAppOnlyTools } from "../../utils/chat-v2-orchestration.js";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-export type HostExecutionPolicy = {
-  requireToolApproval: boolean;
-  /** undefined = spec default (filter app-only tools from model). false = opt out. */
-  respectToolVisibility: boolean | undefined;
-  progressiveDiscoveryEnabled: boolean;
-  hostStyle: string | undefined;
-  namedHostId: string | undefined;
-};
-
-export type ToolExposureSignals = {
-  toolsTotalBefore: number;
-  toolsExposed: number;
-  toolsDroppedVisibility: number;
-};
-
-export function extractHostExecutionPolicy(
-  hostConfig: Record<string, unknown> | null,
-  namedHostId?: string,
-): HostExecutionPolicy {
-  if (!hostConfig) {
-    return {
-      requireToolApproval: false,
-      respectToolVisibility: undefined,
-      progressiveDiscoveryEnabled: false,
-      hostStyle: undefined,
-      namedHostId,
-    };
-  }
-
-  const requireToolApproval =
-    typeof hostConfig.requireToolApproval === "boolean"
-      ? hostConfig.requireToolApproval
-      : false;
-
-  const respectToolVisibility =
-    typeof hostConfig.respectToolVisibility === "boolean"
-      ? hostConfig.respectToolVisibility
-      : undefined;
-
-  // HostConfigV2 stores this as a plain boolean; chat-v2 wire payloads wrap
-  // it as `{ enabled, threshold }`. Accept both shapes so iteration metadata
-  // is stamped regardless of which form the snapshot was built from.
-  const discoveryRaw = hostConfig.progressiveToolDiscovery;
-  const progressiveDiscoveryEnabled =
-    typeof discoveryRaw === "boolean"
-      ? discoveryRaw
-      : isRecord(discoveryRaw) && discoveryRaw.enabled === true;
-
-  const hostStyle =
-    typeof hostConfig.hostStyle === "string" ? hostConfig.hostStyle : undefined;
-
-  return {
-    requireToolApproval,
-    respectToolVisibility,
-    progressiveDiscoveryEnabled,
-    hostStyle,
-    namedHostId,
-  };
-}
-
-/**
- * Applies the host visibility policy to `tools` (mutates in place, same as
- * `prepareChatV2`) and returns tool exposure counts for metadata stamping.
- *
- * Call this AFTER loading the full tool set so `toolsTotalBefore` is accurate.
- */
-export function applyVisibilityPolicyAndCountSignals(
-  tools: Record<string, unknown>,
-  manager: InstanceType<typeof MCPClientManager>,
-  policy: HostExecutionPolicy,
-): ToolExposureSignals {
-  const toolsTotalBefore = Object.keys(tools).length;
-  if (policy.respectToolVisibility !== false) {
-    filterAppOnlyTools(tools as Parameters<typeof filterAppOnlyTools>[0], manager);
-  }
-  const toolsExposed = Object.keys(tools).length;
-  return {
-    toolsTotalBefore,
-    toolsExposed,
-    toolsDroppedVisibility: toolsTotalBefore - toolsExposed,
-  };
-}
-
-/**
- * Builds the scalar host-policy metadata fields to merge into
- * `EvalIteration.metadata`. Only includes keys with meaningful values to
- * avoid inflating rows with zero-valued noise.
- *
- * The `approvalsWouldRequire` count is the number of tool calls that
- * actually occurred in this iteration and would have required approval
- * under the host's `requireToolApproval` policy. Evals do not block on
- * approval prompts — this is a "would prompt N times" signal only.
- */
-export function buildHostIterationMetadata(
-  policy: HostExecutionPolicy,
-  signals: ToolExposureSignals,
-  approvalsWouldRequire: number,
-  injectOpenAiCompat: boolean,
-): Record<string, string | number | boolean> {
-  const meta: Record<string, string | number | boolean> = {
-    tools_total_before: signals.toolsTotalBefore,
-    tools_exposed: signals.toolsExposed,
-  };
-
-  if (signals.toolsDroppedVisibility > 0) {
-    meta.tools_dropped_visibility = signals.toolsDroppedVisibility;
-  }
-  if (policy.requireToolApproval && approvalsWouldRequire > 0) {
-    meta.approvals_would_require = approvalsWouldRequire;
-  }
-  if (policy.progressiveDiscoveryEnabled) {
-    meta.progressive_discovery_enabled = true;
-  }
-  if (injectOpenAiCompat) {
-    meta.openai_compat_injected = true;
-  }
-  if (policy.namedHostId) {
-    meta.host_id = policy.namedHostId;
-  }
-  if (policy.hostStyle) {
-    meta.host_style = policy.hostStyle;
-  }
-  return meta;
-}
+export {
+  extractHostExecutionPolicy,
+  buildHostIterationMetadata,
+  applyVisibilityPolicyAndCountSignals,
+} from "@mcpjam/sdk/host-config/internal";
+export type {
+  HostExecutionPolicy,
+  ToolExposureSignals,
+} from "@mcpjam/sdk/host-config/internal";

--- a/mcpjam-inspector/server/tsup.config.ts
+++ b/mcpjam-inspector/server/tsup.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
     "@mcpjam/sdk/model-factory",
     "@mcpjam/sdk/matchers",
     "@mcpjam/sdk/predicates",
+    "@mcpjam/sdk/host-config/internal",
   ],
   esbuildOptions(options) {
     options.platform = "node";
@@ -58,6 +59,10 @@ export default defineConfig({
       "@mcpjam/sdk/model-factory": join(rootDir, "../sdk/dist/model-factory.js"),
       "@mcpjam/sdk/matchers": join(rootDir, "../sdk/dist/matchers.js"),
       "@mcpjam/sdk/predicates": join(rootDir, "../sdk/dist/predicates/index.js"),
+      "@mcpjam/sdk/host-config/internal": join(
+        rootDir,
+        "../sdk/dist/host-config/internal.js",
+      ),
     };
   },
 });

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -18,7 +18,7 @@
 import type { ModelMessage } from "@ai-sdk/provider-utils";
 import { jsonSchema, tool, type ToolSet } from "ai";
 import { MCPClientManager } from "@mcpjam/sdk";
-import { isToolVisibilityAppOnly } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { filterAppOnlyTools } from "@mcpjam/sdk/host-config/internal";
 import {
   isAnthropicCompatibleModel,
   getInvalidAnthropicToolNames,
@@ -45,43 +45,11 @@ import { createProgressiveMetaTools } from "./progressive-tool-meta-tools.js";
 
 const DEFAULT_TEMPERATURE = 0.7;
 
-/**
- * Mutates `tools` in place, removing entries whose source MCP tool
- * declares SEP-1865 `_meta.ui.visibility` as exactly `["app"]`.
- *
- * The visibility array defaults to `["model", "app"]` per SEP-1865, so a
- * tool with no visibility metadata is treated as visible to both.
- *
- * Exported so eval runner can apply the same filter and compute visibility
- * drop counts for cross-host dashboard metadata.
- */
-export function filterAppOnlyTools(
-  tools: ToolSet,
-  manager: InstanceType<typeof MCPClientManager>
-): void {
-  // Cache per-server metadata maps so we don't repeatedly clone them.
-  const metaByServer = new Map<string, Record<string, Record<string, any>>>();
-  const getMeta = (serverId: string) => {
-    let cached = metaByServer.get(serverId);
-    if (!cached) {
-      cached = manager.getAllToolsMetadata(serverId);
-      metaByServer.set(serverId, cached);
-    }
-    return cached;
-  };
-
-  for (const [name, tool] of Object.entries(tools)) {
-    const serverId = (tool as { _serverId?: unknown })._serverId;
-    if (typeof serverId !== "string") continue;
-    const meta = getMeta(serverId)[name];
-    // SDK helper takes a tool-shaped object with `_meta`; wrap the per-tool
-    // metadata to match its expected shape. Returns true iff `_meta.ui.visibility`
-    // is exactly `["app"]`.
-    if (isToolVisibilityAppOnly({ _meta: meta })) {
-      delete tools[name];
-    }
-  }
-}
+// `filterAppOnlyTools` now lives in `@mcpjam/sdk/host-config/internal` so the
+// eval runtime can apply it without reaching into this file. Re-exported here
+// so existing importers (web/mcp routes, tests) continue to work without
+// churning their import paths.
+export { filterAppOnlyTools };
 
 /**
  * SEP-1865 App-Provided Tool descriptor as accepted by `prepareChatV2`,

--- a/mcpjam-inspector/server/vitest.config.ts
+++ b/mcpjam-inspector/server/vitest.config.ts
@@ -18,6 +18,10 @@ const sdkPredicatesEntry = path.resolve(
   rootDir,
   "../sdk/src/predicates/index.ts",
 );
+const sdkHostConfigInternalEntry = path.resolve(
+  rootDir,
+  "../sdk/src/host-config/internal.ts",
+);
 
 export default defineConfig({
   define: {
@@ -55,6 +59,7 @@ export default defineConfig({
           "@mcpjam/sdk/model-factory",
           "@mcpjam/sdk/matchers",
           "@mcpjam/sdk/predicates",
+          "@mcpjam/sdk/host-config/internal",
         ],
       },
     },
@@ -80,6 +85,10 @@ export default defineConfig({
       { find: "@mcpjam/sdk/model-factory", replacement: sdkModelFactoryEntry },
       { find: "@mcpjam/sdk/matchers", replacement: sdkMatchersEntry },
       { find: "@mcpjam/sdk/predicates", replacement: sdkPredicatesEntry },
+      {
+        find: "@mcpjam/sdk/host-config/internal",
+        replacement: sdkHostConfigInternalEntry,
+      },
       { find: "@mcpjam/sdk", replacement: sdkIndexEntry },
     ],
   },

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -71,7 +71,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:packaging": "npm run build && node --input-type=module -e \"await import('@mcpjam/sdk'); await import('@mcpjam/sdk/browser'); await import('@mcpjam/sdk/worker'); await import('@mcpjam/sdk/operations'); await import('@mcpjam/sdk/skill-reference'); await import('@mcpjam/sdk/model-factory'); await import('@mcpjam/sdk/matchers'); await import('@mcpjam/sdk/predicates'); await import('@mcpjam/sdk/host-config'); await import('@mcpjam/sdk/host-config/internal');\"",
+    "test:packaging": "npm run build && node --input-type=module -e \"await import('@mcpjam/sdk'); await import('@mcpjam/sdk/browser'); await import('@mcpjam/sdk/worker'); await import('@mcpjam/sdk/operations'); await import('@mcpjam/sdk/skill-reference'); await import('@mcpjam/sdk/model-factory'); await import('@mcpjam/sdk/matchers'); await import('@mcpjam/sdk/predicates'); await import('@mcpjam/sdk/host-config'); const m = await import('@mcpjam/sdk/host-config/internal'); for (const n of ['canonicalizeHostConfigV2','computeHostConfigHashV2','isAppOnlyTool','filterAppOnlyTools','applyVisibilityPolicyAndCountSignals','extractHostExecutionPolicy','buildHostIterationMetadata','resolveOpenAiCompatForHostConfig','readOpenAiCompatOverride','compatPresetForHostStyle']) { if (typeof m[n] !== 'function') { throw new Error('missing export: ' + n); } }\"",
     "lint": "eslint src tests",
     "lint:fix": "eslint src tests --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",

--- a/sdk/src/host-config/app-only-tool.ts
+++ b/sdk/src/host-config/app-only-tool.ts
@@ -1,0 +1,31 @@
+/**
+ * SEP-1865 app-only-tool predicate.
+ *
+ * Pure leaf — no runtime imports. Lives in `host-config/` so the
+ * `@mcpjam/sdk/host-config/internal` barrel can re-export it without
+ * pulling Node-only deps (e.g. `ai`, `@modelcontextprotocol/client`)
+ * that `mcp-client-manager/tool-converters.ts` brings in.
+ *
+ * `tool-converters.ts` re-exports `isAppOnlyTool` from this file so
+ * existing external import paths continue to work.
+ */
+
+/**
+ * Checks whether a tool is app-only per SEP-1865 (`_meta.ui.visibility = ["app"]`).
+ *
+ * Per SEP-1865, tools whose visibility does not include `"model"` MUST NOT be
+ * included in the agent's tool list. They remain callable from the iframe/app
+ * via `tools/call`, but the model never sees them.
+ *
+ * @param toolMeta - The tool's `_meta` field from listTools result
+ * @returns true if the tool is app-only (must be hidden from the model)
+ */
+export function isAppOnlyTool(
+  toolMeta: Record<string, unknown> | undefined,
+): boolean {
+  if (!toolMeta) return false;
+  const visibility = (toolMeta as { ui?: { visibility?: unknown } }).ui
+    ?.visibility;
+  if (!Array.isArray(visibility)) return false;
+  return visibility.length === 1 && visibility[0] === "app";
+}

--- a/sdk/src/host-config/compat-runtime.ts
+++ b/sdk/src/host-config/compat-runtime.ts
@@ -1,0 +1,73 @@
+/**
+ * OpenAI Apps compat resolution from a hostConfig (+ optional override).
+ *
+ * Pure — no Convex / Node / ai-sdk imports. The eval runner uses this to
+ * decide whether to inject the OpenAI Apps compat shim into widget HTML
+ * snapshots for hosts that emulate ChatGPT-style apps.
+ *
+ * Resolution order (first match wins):
+ *   1. Explicit override on `hostConfigOverride.mcpProfile.apps.compatRuntime.openaiApps`
+ *   2. Host-style preset from `hostConfigOverride.hostStyle`
+ *   3. Explicit base on `hostConfig.mcpProfile.apps.compatRuntime.openaiApps`
+ *   4. Host-style preset from `hostConfig.hostStyle` (defaults to `false`)
+ *
+ * Style presets:
+ *   - "chatgpt" | "copilot" | "mcpjam" → true
+ *   - "claude"  | "cursor"  | "codex"  → false
+ *   - anything else → undefined (falls through; ultimate default is false)
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function readOpenAiCompatOverride(value: unknown): boolean | undefined {
+  if (!isRecord(value)) return undefined;
+  const profile = isRecord(value.mcpProfile) ? value.mcpProfile : undefined;
+  const apps = isRecord(profile?.apps) ? profile.apps : undefined;
+  const compatRuntime = isRecord(apps?.compatRuntime)
+    ? apps.compatRuntime
+    : undefined;
+  return typeof compatRuntime?.openaiApps === "boolean"
+    ? compatRuntime.openaiApps
+    : undefined;
+}
+
+export function compatPresetForHostStyle(
+  hostStyle: unknown,
+): boolean | undefined {
+  switch (hostStyle) {
+    case "chatgpt":
+    case "copilot":
+    case "mcpjam":
+      return true;
+    case "claude":
+    case "cursor":
+    case "codex":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+export function resolveOpenAiCompatForHostConfig(
+  hostConfig: unknown,
+  hostConfigOverride?: Record<string, unknown>,
+): boolean {
+  const explicitOverride = readOpenAiCompatOverride(hostConfigOverride);
+  if (explicitOverride !== undefined) return explicitOverride;
+
+  const overridePreset = compatPresetForHostStyle(
+    hostConfigOverride?.hostStyle,
+  );
+  if (overridePreset !== undefined) return overridePreset;
+
+  const explicitBase = readOpenAiCompatOverride(hostConfig);
+  if (explicitBase !== undefined) return explicitBase;
+
+  return (
+    compatPresetForHostStyle(
+      isRecord(hostConfig) ? hostConfig.hostStyle : undefined,
+    ) ?? false
+  );
+}

--- a/sdk/src/host-config/host-policy.ts
+++ b/sdk/src/host-config/host-policy.ts
@@ -1,0 +1,112 @@
+/**
+ * Host execution policy extraction + iteration-metadata stamping.
+ *
+ * Pure — derived from a hostConfig snapshot. Used by both the live chat
+ * runtime (via `prepareChatV2`'s `respectToolVisibility` gate) and the eval
+ * runtime (via `applyVisibilityPolicyAndCountSignals` + `buildHostIterationMetadata`).
+ *
+ * `extractHostExecutionPolicy` accepts the dual progressiveToolDiscovery
+ * shape because HostConfigV2 stores it as a plain boolean while chat-v2
+ * wire payloads wrap it as `{ enabled, threshold }`. Both flow through here.
+ */
+
+import type { ToolExposureSignals } from "./tool-visibility.js";
+
+export type { ToolExposureSignals } from "./tool-visibility.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export type HostExecutionPolicy = {
+  requireToolApproval: boolean;
+  /** undefined = spec default (filter app-only tools from model). false = opt out. */
+  respectToolVisibility: boolean | undefined;
+  progressiveDiscoveryEnabled: boolean;
+  hostStyle: string | undefined;
+  namedHostId: string | undefined;
+};
+
+export function extractHostExecutionPolicy(
+  hostConfig: Record<string, unknown> | null,
+  namedHostId?: string,
+): HostExecutionPolicy {
+  if (!hostConfig) {
+    return {
+      requireToolApproval: false,
+      respectToolVisibility: undefined,
+      progressiveDiscoveryEnabled: false,
+      hostStyle: undefined,
+      namedHostId,
+    };
+  }
+
+  const requireToolApproval =
+    typeof hostConfig.requireToolApproval === "boolean"
+      ? hostConfig.requireToolApproval
+      : false;
+
+  const respectToolVisibility =
+    typeof hostConfig.respectToolVisibility === "boolean"
+      ? hostConfig.respectToolVisibility
+      : undefined;
+
+  const discoveryRaw = hostConfig.progressiveToolDiscovery;
+  const progressiveDiscoveryEnabled =
+    typeof discoveryRaw === "boolean"
+      ? discoveryRaw
+      : isRecord(discoveryRaw) && discoveryRaw.enabled === true;
+
+  const hostStyle =
+    typeof hostConfig.hostStyle === "string" ? hostConfig.hostStyle : undefined;
+
+  return {
+    requireToolApproval,
+    respectToolVisibility,
+    progressiveDiscoveryEnabled,
+    hostStyle,
+    namedHostId,
+  };
+}
+
+/**
+ * Builds the scalar host-policy metadata fields to merge into
+ * `EvalIteration.metadata`. Only includes keys with meaningful values to
+ * avoid inflating rows with zero-valued noise.
+ *
+ * The `approvalsWouldRequire` count is the number of tool calls that
+ * actually occurred in this iteration and would have required approval
+ * under the host's `requireToolApproval` policy. Evals do not block on
+ * approval prompts — this is a "would prompt N times" signal only.
+ */
+export function buildHostIterationMetadata(
+  policy: HostExecutionPolicy,
+  signals: ToolExposureSignals,
+  approvalsWouldRequire: number,
+  injectOpenAiCompat: boolean,
+): Record<string, string | number | boolean> {
+  const meta: Record<string, string | number | boolean> = {
+    tools_total_before: signals.toolsTotalBefore,
+    tools_exposed: signals.toolsExposed,
+  };
+
+  if (signals.toolsDroppedVisibility > 0) {
+    meta.tools_dropped_visibility = signals.toolsDroppedVisibility;
+  }
+  if (policy.requireToolApproval && approvalsWouldRequire > 0) {
+    meta.approvals_would_require = approvalsWouldRequire;
+  }
+  if (policy.progressiveDiscoveryEnabled) {
+    meta.progressive_discovery_enabled = true;
+  }
+  if (injectOpenAiCompat) {
+    meta.openai_compat_injected = true;
+  }
+  if (policy.namedHostId) {
+    meta.host_id = policy.namedHostId;
+  }
+  if (policy.hostStyle) {
+    meta.host_style = policy.hostStyle;
+  }
+  return meta;
+}

--- a/sdk/src/host-config/internal.ts
+++ b/sdk/src/host-config/internal.ts
@@ -35,3 +35,28 @@ export type {
   CspDomainSet,
   McpProtocolVersion,
 } from "./types.js";
+
+// Stage 3: host-execution policy + visibility filter + OpenAI compat.
+// Stays browser-safe — `tool-visibility.ts` is structurally typed
+// (no `MCPClientManager` runtime import) and `app-only-tool.ts` is a pure
+// leaf, so re-exporting them from this barrel does not drag runtime SDK
+// or Vercel AI SDK code into the inspector client bundle.
+export { isAppOnlyTool } from "./app-only-tool.js";
+export {
+  filterAppOnlyTools,
+  applyVisibilityPolicyAndCountSignals,
+} from "./tool-visibility.js";
+export type { ToolMetadataSource } from "./tool-visibility.js";
+export {
+  extractHostExecutionPolicy,
+  buildHostIterationMetadata,
+} from "./host-policy.js";
+export type {
+  HostExecutionPolicy,
+  ToolExposureSignals,
+} from "./host-policy.js";
+export {
+  readOpenAiCompatOverride,
+  compatPresetForHostStyle,
+  resolveOpenAiCompatForHostConfig,
+} from "./compat-runtime.js";

--- a/sdk/src/host-config/tool-visibility.ts
+++ b/sdk/src/host-config/tool-visibility.ts
@@ -1,0 +1,96 @@
+/**
+ * SEP-1865 host visibility filter and exposure-signal counting.
+ *
+ * Structurally pure — depends only on `isAppOnlyTool` (a pure leaf) and the
+ * `HostExecutionPolicy` type. Does NOT import `MCPClientManager` or any AI
+ * SDK code, so this module can ship from `@mcpjam/sdk/host-config/internal`
+ * (which the inspector client imports as source via Vite alias) without
+ * dragging Node-heavy deps into the browser bundle.
+ *
+ * The `ToolMetadataSource` duck-type below is satisfied by
+ * `MCPClientManager` (its `getAllToolsMetadata` signature matches), so
+ * inspector callers pass their existing manager unchanged.
+ */
+
+import { isAppOnlyTool } from "./app-only-tool.js";
+import type { HostExecutionPolicy } from "./host-policy.js";
+
+/**
+ * Structural type for anything that can supply per-server tool metadata.
+ * `MCPClientManager.getAllToolsMetadata(serverId)` satisfies this.
+ */
+export interface ToolMetadataSource {
+  getAllToolsMetadata(
+    serverId: string,
+  ): Record<string, Record<string, unknown>>;
+}
+
+export type ToolExposureSignals = {
+  toolsTotalBefore: number;
+  toolsExposed: number;
+  toolsDroppedVisibility: number;
+};
+
+/**
+ * Mutates `tools` in place, removing entries whose source MCP tool declares
+ * SEP-1865 `_meta.ui.visibility` as exactly `["app"]`.
+ *
+ * Per SEP-1865, the visibility array defaults to `["model", "app"]` so a tool
+ * with no visibility metadata is treated as visible to both.
+ *
+ * `tools` is expected to be the tool-set shape produced by
+ * `MCPClientManager.getToolsForAiSdk(...)` — each entry carries a `_serverId`
+ * string used to look up its source metadata. Tools without `_serverId` are
+ * left untouched (they did not originate from an MCP server).
+ */
+export function filterAppOnlyTools(
+  tools: Record<string, unknown>,
+  source: ToolMetadataSource,
+): void {
+  // Cache per-server metadata maps so we don't repeatedly clone them.
+  const metaByServer = new Map<
+    string,
+    Record<string, Record<string, unknown>>
+  >();
+  const getMeta = (serverId: string) => {
+    let cached = metaByServer.get(serverId);
+    if (!cached) {
+      cached = source.getAllToolsMetadata(serverId);
+      metaByServer.set(serverId, cached);
+    }
+    return cached;
+  };
+
+  for (const [name, tool] of Object.entries(tools)) {
+    const serverId = (tool as { _serverId?: unknown })._serverId;
+    if (typeof serverId !== "string") continue;
+    const meta = getMeta(serverId)[name];
+    if (isAppOnlyTool(meta)) {
+      delete tools[name];
+    }
+  }
+}
+
+/**
+ * Applies the host visibility policy to `tools` (mutates in place, same as
+ * `prepareChatV2`) and returns tool exposure counts for iteration metadata
+ * stamping.
+ *
+ * Call this AFTER loading the full tool set so `toolsTotalBefore` is accurate.
+ */
+export function applyVisibilityPolicyAndCountSignals(
+  tools: Record<string, unknown>,
+  source: ToolMetadataSource,
+  policy: HostExecutionPolicy,
+): ToolExposureSignals {
+  const toolsTotalBefore = Object.keys(tools).length;
+  if (policy.respectToolVisibility !== false) {
+    filterAppOnlyTools(tools, source);
+  }
+  const toolsExposed = Object.keys(tools).length;
+  return {
+    toolsTotalBefore,
+    toolsExposed,
+    toolsDroppedVisibility: toolsTotalBefore - toolsExposed,
+  };
+}

--- a/sdk/src/mcp-client-manager/tool-converters.ts
+++ b/sdk/src/mcp-client-manager/tool-converters.ts
@@ -142,25 +142,8 @@ export function isChatGPTAppTool(
   return typeof toolMeta["openai/outputTemplate"] === "string";
 }
 
-/**
- * Checks whether a tool is app-only per SEP-1865 (`_meta.ui.visibility = ["app"]`).
- *
- * Per SEP-1865, tools whose visibility does not include `"model"` MUST NOT be
- * included in the agent's tool list. They remain callable from the iframe/app
- * via `tools/call`, but the model never sees them.
- *
- * @param toolMeta - The tool's `_meta` field from listTools result
- * @returns true if the tool is app-only (must be hidden from the model)
- */
-export function isAppOnlyTool(
-  toolMeta: Record<string, unknown> | undefined
-): boolean {
-  if (!toolMeta) return false;
-  const visibility = (toolMeta as { ui?: { visibility?: unknown } }).ui
-    ?.visibility;
-  if (!Array.isArray(visibility)) return false;
-  return visibility.length === 1 && visibility[0] === "app";
-}
+import { isAppOnlyTool } from "../host-config/app-only-tool.js";
+export { isAppOnlyTool };
 
 /**
  * Removes only the _meta field from a tool result (shallow copy).

--- a/sdk/tests/host-config-compat-runtime.test.ts
+++ b/sdk/tests/host-config-compat-runtime.test.ts
@@ -1,0 +1,120 @@
+import {
+  readOpenAiCompatOverride,
+  compatPresetForHostStyle,
+  resolveOpenAiCompatForHostConfig,
+} from "../src/host-config/internal";
+
+describe("readOpenAiCompatOverride", () => {
+  it("returns undefined for non-record input", () => {
+    expect(readOpenAiCompatOverride(null)).toBeUndefined();
+    expect(readOpenAiCompatOverride("string")).toBeUndefined();
+    expect(readOpenAiCompatOverride(42)).toBeUndefined();
+    expect(readOpenAiCompatOverride([])).toBeUndefined();
+  });
+
+  it("returns undefined when mcpProfile.apps.compatRuntime path is absent", () => {
+    expect(readOpenAiCompatOverride({})).toBeUndefined();
+    expect(readOpenAiCompatOverride({ mcpProfile: {} })).toBeUndefined();
+    expect(
+      readOpenAiCompatOverride({ mcpProfile: { apps: {} } }),
+    ).toBeUndefined();
+  });
+
+  it("returns the boolean when the openaiApps flag is set", () => {
+    const cfg = {
+      mcpProfile: { apps: { compatRuntime: { openaiApps: true } } },
+    };
+    expect(readOpenAiCompatOverride(cfg)).toBe(true);
+
+    const cfgFalse = {
+      mcpProfile: { apps: { compatRuntime: { openaiApps: false } } },
+    };
+    expect(readOpenAiCompatOverride(cfgFalse)).toBe(false);
+  });
+
+  it("returns undefined when openaiApps is not a boolean", () => {
+    const cfg = {
+      mcpProfile: { apps: { compatRuntime: { openaiApps: "yes" } } },
+    };
+    expect(readOpenAiCompatOverride(cfg)).toBeUndefined();
+  });
+});
+
+describe("compatPresetForHostStyle", () => {
+  it("returns true for chatgpt-family styles", () => {
+    expect(compatPresetForHostStyle("chatgpt")).toBe(true);
+    expect(compatPresetForHostStyle("copilot")).toBe(true);
+    expect(compatPresetForHostStyle("mcpjam")).toBe(true);
+  });
+
+  it("returns false for claude-family styles", () => {
+    expect(compatPresetForHostStyle("claude")).toBe(false);
+    expect(compatPresetForHostStyle("cursor")).toBe(false);
+    expect(compatPresetForHostStyle("codex")).toBe(false);
+  });
+
+  it("returns undefined for unknown styles or non-string input", () => {
+    expect(compatPresetForHostStyle("custom")).toBeUndefined();
+    expect(compatPresetForHostStyle(undefined)).toBeUndefined();
+    expect(compatPresetForHostStyle(42)).toBeUndefined();
+    expect(compatPresetForHostStyle(null)).toBeUndefined();
+  });
+});
+
+describe("resolveOpenAiCompatForHostConfig — resolution order", () => {
+  // Order: override explicit > override style > base explicit > base style > false
+
+  it("1. explicit override profile wins over everything", () => {
+    const result = resolveOpenAiCompatForHostConfig(
+      {
+        hostStyle: "chatgpt",
+        mcpProfile: { apps: { compatRuntime: { openaiApps: true } } },
+      },
+      {
+        hostStyle: "chatgpt",
+        mcpProfile: { apps: { compatRuntime: { openaiApps: false } } },
+      },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("2. override hostStyle wins over base explicit + base style", () => {
+    const result = resolveOpenAiCompatForHostConfig(
+      {
+        hostStyle: "chatgpt",
+        mcpProfile: { apps: { compatRuntime: { openaiApps: true } } },
+      },
+      { hostStyle: "claude" },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("3. base explicit wins over base style when no override", () => {
+    const result = resolveOpenAiCompatForHostConfig({
+      hostStyle: "claude",
+      mcpProfile: { apps: { compatRuntime: { openaiApps: true } } },
+    });
+    expect(result).toBe(true);
+  });
+
+  it("4. base hostStyle preset applies when nothing else set", () => {
+    expect(
+      resolveOpenAiCompatForHostConfig({ hostStyle: "chatgpt" }),
+    ).toBe(true);
+    expect(
+      resolveOpenAiCompatForHostConfig({ hostStyle: "claude" }),
+    ).toBe(false);
+  });
+
+  it("5. defaults to false when nothing matches", () => {
+    expect(resolveOpenAiCompatForHostConfig(null)).toBe(false);
+    expect(resolveOpenAiCompatForHostConfig({})).toBe(false);
+    expect(resolveOpenAiCompatForHostConfig({ hostStyle: "custom" })).toBe(false);
+  });
+
+  it("treats override absent the same as no override", () => {
+    expect(
+      resolveOpenAiCompatForHostConfig({ hostStyle: "mcpjam" }, undefined),
+    ).toBe(true);
+  });
+});

--- a/sdk/tests/host-config-policy.test.ts
+++ b/sdk/tests/host-config-policy.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect } from "vitest";
 import {
   extractHostExecutionPolicy,
   buildHostIterationMetadata,
   type HostExecutionPolicy,
   type ToolExposureSignals,
-} from "../host-execution-policy";
+} from "../src/host-config/internal";
 
 describe("extractHostExecutionPolicy", () => {
   it("returns safe defaults when hostConfig is null", () => {
@@ -60,7 +59,10 @@ describe("extractHostExecutionPolicy", () => {
   });
 
   it("extracts hostStyle and namedHostId", () => {
-    const policy = extractHostExecutionPolicy({ hostStyle: "cursor" }, "h_abc");
+    const policy = extractHostExecutionPolicy(
+      { hostStyle: "cursor" },
+      "h_abc",
+    );
     expect(policy.hostStyle).toBe("cursor");
     expect(policy.namedHostId).toBe("h_abc");
   });
@@ -103,7 +105,10 @@ describe("buildHostIterationMetadata", () => {
   });
 
   it("stamps approvals_would_require when requireToolApproval and count > 0", () => {
-    const policy: HostExecutionPolicy = { ...basePolicy, requireToolApproval: true };
+    const policy: HostExecutionPolicy = {
+      ...basePolicy,
+      requireToolApproval: true,
+    };
     const meta = buildHostIterationMetadata(policy, baseSignals, 3, false);
     expect(meta.approvals_would_require).toBe(3);
   });

--- a/sdk/tests/host-config-tool-visibility.test.ts
+++ b/sdk/tests/host-config-tool-visibility.test.ts
@@ -1,0 +1,194 @@
+import {
+  filterAppOnlyTools,
+  applyVisibilityPolicyAndCountSignals,
+  isAppOnlyTool,
+  type HostExecutionPolicy,
+  type ToolMetadataSource,
+} from "../src/host-config/internal";
+
+function mockSource(
+  metaByServer: Record<string, Record<string, Record<string, unknown>>>,
+): ToolMetadataSource {
+  return {
+    getAllToolsMetadata(serverId: string) {
+      return metaByServer[serverId] ?? {};
+    },
+  };
+}
+
+describe("isAppOnlyTool", () => {
+  it("returns false for undefined meta", () => {
+    expect(isAppOnlyTool(undefined)).toBe(false);
+  });
+
+  it("returns false when visibility is missing", () => {
+    expect(isAppOnlyTool({})).toBe(false);
+    expect(isAppOnlyTool({ ui: {} })).toBe(false);
+  });
+
+  it("returns false when visibility is not an array", () => {
+    expect(isAppOnlyTool({ ui: { visibility: "app" } })).toBe(false);
+  });
+
+  it("returns true only when visibility is exactly ['app']", () => {
+    expect(isAppOnlyTool({ ui: { visibility: ["app"] } })).toBe(true);
+    expect(isAppOnlyTool({ ui: { visibility: ["model"] } })).toBe(false);
+    expect(isAppOnlyTool({ ui: { visibility: ["model", "app"] } })).toBe(false);
+    expect(isAppOnlyTool({ ui: { visibility: ["app", "model"] } })).toBe(false);
+    expect(isAppOnlyTool({ ui: { visibility: [] } })).toBe(false);
+  });
+});
+
+describe("filterAppOnlyTools", () => {
+  it("drops tools whose source metadata is visibility=['app']", () => {
+    const tools: Record<string, unknown> = {
+      model_tool: { _serverId: "srv" },
+      app_tool: { _serverId: "srv" },
+      both_tool: { _serverId: "srv" },
+    };
+    const source = mockSource({
+      srv: {
+        model_tool: { ui: { visibility: ["model"] } },
+        app_tool: { ui: { visibility: ["app"] } },
+        both_tool: { ui: { visibility: ["model", "app"] } },
+      },
+    });
+
+    filterAppOnlyTools(tools, source);
+
+    expect(Object.keys(tools).sort()).toEqual(["both_tool", "model_tool"]);
+  });
+
+  it("preserves tools without _serverId (non-MCP origin)", () => {
+    const tools: Record<string, unknown> = {
+      skill_tool: { description: "skill tool, no _serverId" },
+      app_tool: { _serverId: "srv" },
+    };
+    const source = mockSource({
+      srv: { app_tool: { ui: { visibility: ["app"] } } },
+    });
+
+    filterAppOnlyTools(tools, source);
+
+    expect(Object.keys(tools).sort()).toEqual(["skill_tool"]);
+  });
+
+  it("caches metadata per server (only one lookup per server)", () => {
+    let lookups = 0;
+    const source: ToolMetadataSource = {
+      getAllToolsMetadata(serverId: string) {
+        lookups += 1;
+        return serverId === "srv"
+          ? {
+              a: { ui: { visibility: ["app"] } },
+              b: { ui: { visibility: ["app"] } },
+              c: { ui: { visibility: ["app"] } },
+            }
+          : {};
+      },
+    };
+    const tools: Record<string, unknown> = {
+      a: { _serverId: "srv" },
+      b: { _serverId: "srv" },
+      c: { _serverId: "srv" },
+    };
+
+    filterAppOnlyTools(tools, source);
+
+    expect(lookups).toBe(1);
+    expect(Object.keys(tools)).toEqual([]);
+  });
+
+  it("leaves tools alone whose metadata is missing", () => {
+    const tools: Record<string, unknown> = {
+      mystery: { _serverId: "srv" },
+    };
+    const source = mockSource({ srv: {} });
+
+    filterAppOnlyTools(tools, source);
+
+    expect(Object.keys(tools)).toEqual(["mystery"]);
+  });
+});
+
+describe("applyVisibilityPolicyAndCountSignals", () => {
+  const basePolicy: HostExecutionPolicy = {
+    requireToolApproval: false,
+    respectToolVisibility: undefined,
+    progressiveDiscoveryEnabled: false,
+    hostStyle: undefined,
+    namedHostId: undefined,
+  };
+
+  function makeTools() {
+    return {
+      model_tool: { _serverId: "srv" },
+      app_tool: { _serverId: "srv" },
+      both_tool: { _serverId: "srv" },
+    } as Record<string, unknown>;
+  }
+
+  function makeSource() {
+    return mockSource({
+      srv: {
+        model_tool: { ui: { visibility: ["model"] } },
+        app_tool: { ui: { visibility: ["app"] } },
+        both_tool: { ui: { visibility: ["model", "app"] } },
+      },
+    });
+  }
+
+  it("applies the filter when respectToolVisibility is undefined (spec default)", () => {
+    const tools = makeTools();
+    const signals = applyVisibilityPolicyAndCountSignals(
+      tools,
+      makeSource(),
+      basePolicy,
+    );
+    expect(Object.keys(tools).sort()).toEqual(["both_tool", "model_tool"]);
+    expect(signals.toolsTotalBefore).toBe(3);
+    expect(signals.toolsExposed).toBe(2);
+    expect(signals.toolsDroppedVisibility).toBe(1);
+  });
+
+  it("applies the filter when respectToolVisibility is true", () => {
+    const tools = makeTools();
+    const signals = applyVisibilityPolicyAndCountSignals(tools, makeSource(), {
+      ...basePolicy,
+      respectToolVisibility: true,
+    });
+    expect(Object.keys(tools).sort()).toEqual(["both_tool", "model_tool"]);
+    expect(signals.toolsDroppedVisibility).toBe(1);
+  });
+
+  it("skips the filter when respectToolVisibility is false (opt-out)", () => {
+    const tools = makeTools();
+    const signals = applyVisibilityPolicyAndCountSignals(tools, makeSource(), {
+      ...basePolicy,
+      respectToolVisibility: false,
+    });
+    expect(Object.keys(tools).sort()).toEqual([
+      "app_tool",
+      "both_tool",
+      "model_tool",
+    ]);
+    expect(signals.toolsTotalBefore).toBe(3);
+    expect(signals.toolsExposed).toBe(3);
+    expect(signals.toolsDroppedVisibility).toBe(0);
+  });
+
+  // Stage 4: the private raw-`Tool[]` conversion in `sdk/src/TestAgent.ts:90`
+  // drops app-only tools unconditionally — before this function runs. We
+  // can't recover a tool that path already dropped, so a passing test here
+  // would be misleading. Stage 4 single-gates the filter (rename
+  // `TestAgent` → `HostRunner`, route both `Tool[]` and `AiSdkTool` paths
+  // through `applyVisibilityPolicyAndCountSignals`) and converts this skip
+  // into a real assertion.
+  // eslint-disable-next-line vitest/no-disabled-tests
+  it.skip(
+    "preserves raw Tool[] app-only when respectToolVisibility=false — fix at TestAgent.ts:90 (Stage 4)",
+    () => {
+      // TODO(Stage 4): mock raw Tool[] input + assert post-filter preservation.
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Moves the host-execution-policy, OpenAI compat resolver, and SEP-1865 visibility filter into `@mcpjam/sdk/host-config/internal` so both inspector runtimes (live chat + eval) read from one source of truth.
- Deletes the eval path's reach into the live path — `server/services/evals/host-execution-policy.ts` no longer imports `filterAppOnlyTools` from `server/utils/chat-v2-orchestration.ts`. The two runtimes now share a single SDK implementation.
- Stage 3 of the hostConfig consolidation plan (Stages 0–2 + B already merged via #2392, #2396, #2400; mcpjam-backend #409).

## What moved

| Symbol | From | To |
|---|---|---|
| `isAppOnlyTool` | `sdk/src/mcp-client-manager/tool-converters.ts` (re-exported) | `sdk/src/host-config/app-only-tool.ts` (pure leaf) |
| `filterAppOnlyTools` | `mcpjam-inspector/server/utils/chat-v2-orchestration.ts` | `sdk/src/host-config/tool-visibility.ts` |
| `applyVisibilityPolicyAndCountSignals` | `mcpjam-inspector/server/services/evals/host-execution-policy.ts` | `sdk/src/host-config/tool-visibility.ts` |
| `extractHostExecutionPolicy`, `buildHostIterationMetadata` | `mcpjam-inspector/server/services/evals/host-execution-policy.ts` | `sdk/src/host-config/host-policy.ts` |
| `resolveOpenAiCompatForHostConfig`, `readOpenAiCompatOverride`, `compatPresetForHostStyle` | `mcpjam-inspector/server/services/evals/compat-runtime.ts` | `sdk/src/host-config/compat-runtime.ts` |

`loadSuiteHostConfig` stays inspector-side (Convex-bound).

## Browser-safety

The new SDK files ship from the existing `@mcpjam/sdk/host-config/internal` subpath. That subpath is documented as zero-Node-dep and is imported by the inspector client via Vite source alias (`client-config-v2.ts`). To preserve that contract:

- `tool-visibility.ts` uses a structural `ToolMetadataSource` duck-type instead of `MCPClientManager` (no runtime SDK import).
- `isAppOnlyTool` was moved out of `tool-converters.ts` (which imports `ai` + `@modelcontextprotocol/client`) into a 30-line pure leaf in `host-config/`. `tool-converters.ts` now re-exports it for back-compat.

esbuild metafile dry-run confirms the `/internal` browser bundle resolves to host-config files only — no `ai`, no `MCPClientManager`, no `node:*`.

## Stage 4 deferred

`sdk/src/TestAgent.ts:90` still drops app-only tools unconditionally on the raw-`Tool[]` path. `applyVisibilityPolicyAndCountSignals` runs over the already-converted set, so it cannot recover that drop. Stage 4 (the `TestAgent` → `HostRunner` rename) single-gates the filter and converts the existing `it.skip` in `host-config-tool-visibility.test.ts` into a real assertion.

## Test plan

- [x] SDK: `npm test` — 1195 passed + 1 skipped (Stage 4 placeholder)
- [x] SDK: `npm run typecheck` — clean
- [x] SDK: `npm run test:packaging` — exits 0; asserts all 10 expected exports are functions
- [x] SDK: esbuild `--platform=browser` metafile on `host-config/internal.ts` — only host-config files + the pre-existing `mcp-protocol-version.ts` leaf
- [x] Inspector: `npm test` — 4910 passed + 6 skipped
- [x] Inspector: `npx tsc --noEmit -p server/tsconfig.json` — no new errors vs origin/main baseline
- [x] Inspector: `npm run typecheck:client` — clean
- [x] Inspector: `npm run build:client` — clean
- [x] `grep -rn "utils/chat-v2-orchestration" mcpjam-inspector/server/services/evals/` — only a doc-comment match (no import)
- [x] `grep "isToolVisibilityAppOnly" mcpjam-inspector/server/utils/chat-v2-orchestration.ts` — no matches
- [x] `@modelcontextprotocol/ext-apps` dep entry preserved in `mcpjam-inspector/package.json` (still used by 3 other server files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior is intended to be a move/refactor, but it touches shared tool-exposure and eval metadata paths used by both chat and eval runtimes; Stage 4 still leaves a known gap where `TestAgent` drops app-only tools before the shared filter runs.
> 
> **Overview**
> **Stage 3 hostConfig consolidation** moves shared host-runtime logic into `@mcpjam/sdk/host-config/internal` so live chat and evals use one implementation instead of duplicated inspector code.
> 
> **SDK additions:** New pure modules for `isAppOnlyTool`, SEP-1865 `filterAppOnlyTools` / `applyVisibilityPolicyAndCountSignals` (via a structural `ToolMetadataSource` instead of `MCPClientManager`), `extractHostExecutionPolicy` / `buildHostIterationMetadata`, and OpenAI Apps compat resolution (`resolveOpenAiCompatForHostConfig` and helpers). These are exported from the `host-config/internal` barrel; `isAppOnlyTool` is re-exported from `tool-converters.ts` for backward compatibility.
> 
> **Inspector changes:** Eval `compat-runtime` and `host-execution-policy` shrink to re-exports (Convex-only `loadSuiteHostConfig` stays local). `chat-v2-orchestration` imports and re-exports `filterAppOnlyTools` from the SDK, removing the local implementation and the eval path’s dependency on chat orchestration for visibility filtering.
> 
> **Tooling:** Server `tsup` and Vitest aliases inline `@mcpjam/sdk/host-config/internal`; SDK `test:packaging` asserts the new exports. Tests for compat, policy, and tool visibility live under `sdk/tests/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e3f28a1e7000db1a7fcc40969e78b08af24544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->