### PR TITLE
fix(server): register elicitation callback at boot in hosted entrypoint

### DIFF
--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -17,6 +17,7 @@ import {
   warnOnConvexDevMisconfiguration,
 } from "./env";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy";
+import { initElicitationCallback } from "./routes/mcp/elicitation";
 
 // Security imports
 import {
@@ -245,6 +246,12 @@ const mcpClientManager = new MCPClientManager(
     },
   },
 );
+// Register the global elicitation callback before any server connects.
+// buildCapabilities only advertises (and wires) elicitation when a handler
+// is already registered, so without this the first connections — including
+// ones with an explicit `clientCapabilities.elicitation` — silently drop
+// the capability, and task-augmented requests fail with "Method not found".
+initElicitationCallback(mcpClientManager);
 // Middleware to inject client manager into context
 app.use("*", async (c, next) => {
   c.mcpClientManager = mcpClientManager;

--- a/mcpjam-inspector/server/routes/mcp/__tests__/elicitation-init.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/elicitation-init.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ElicitResult } from "@modelcontextprotocol/client";
+import type { MCPClientManager } from "@mcpjam/sdk";
+import { initElicitationCallback } from "../elicitation.js";
+
+type PendingElicitation = {
+  resolve: (value: ElicitResult) => void;
+  reject: (error: unknown) => void;
+};
+
+function createManagerStub() {
+  let callback:
+    | ((params: {
+        requestId: string;
+        message: string;
+        schema: unknown;
+        relatedTaskId?: string;
+      }) => Promise<ElicitResult>)
+    | undefined;
+  const pendingElicitations = new Map<string, PendingElicitation>();
+
+  const manager = {
+    setElicitationCallback: vi.fn((cb: typeof callback) => {
+      callback = cb;
+    }),
+    getPendingElicitations: vi.fn(() => pendingElicitations),
+  };
+
+  return {
+    manager: manager as unknown as MCPClientManager,
+    mocks: manager,
+    getCallback: () => callback,
+    pendingElicitations,
+  };
+}
+
+describe("initElicitationCallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers the global elicitation callback on the manager", () => {
+    const { manager, mocks } = createManagerStub();
+
+    initElicitationCallback(manager);
+
+    expect(mocks.setElicitationCallback).toHaveBeenCalledTimes(1);
+    expect(mocks.setElicitationCallback.mock.calls[0][0]).toBeTypeOf(
+      "function",
+    );
+  });
+
+  it("is idempotent per manager instance", () => {
+    const { manager, mocks } = createManagerStub();
+
+    initElicitationCallback(manager);
+    initElicitationCallback(manager);
+    initElicitationCallback(manager);
+
+    expect(mocks.setElicitationCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers separately for distinct manager instances", () => {
+    const first = createManagerStub();
+    const second = createManagerStub();
+
+    initElicitationCallback(first.manager);
+    initElicitationCallback(second.manager);
+
+    expect(first.mocks.setElicitationCallback).toHaveBeenCalledTimes(1);
+    expect(second.mocks.setElicitationCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores a pending resolver and resolves when answered", async () => {
+    const { manager, getCallback, pendingElicitations } = createManagerStub();
+
+    initElicitationCallback(manager);
+    const callback = getCallback();
+    expect(callback).toBeDefined();
+
+    const resultPromise = callback!({
+      requestId: "req-1",
+      message: "Pick a value",
+      schema: { type: "object" },
+    });
+
+    expect(pendingElicitations.has("req-1")).toBe(true);
+
+    const accepted: ElicitResult = {
+      action: "accept",
+      content: { value: "ok" },
+    };
+    pendingElicitations.get("req-1")!.resolve(accepted);
+
+    await expect(resultPromise).resolves.toEqual(accepted);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #2289.

The hosted/Docker entrypoint (`server/index.ts`) creates its `MCPClientManager` without calling `initElicitationCallback`, unlike `server/app.ts` which registers it right after construction. The global elicitation callback only gets registered lazily when something first hits the `/elicitation` routes.

Since #1902, `buildCapabilities` advertises `elicitation` only when a handler is already registered at connect time — and the post-connect wiring installs the elicitation request handler under the same condition. So on the hosted web app and Docker builds, any server connected before the elicitation routes are touched:

- silently drops `elicitation` from the `initialize` payload, **even when the user explicitly configures `clientCapabilities: { "elicitation": {} }`** (the repro in #2289 — note the on-wire `"capabilities": {}`), and
- never gets the `elicitation/create` handler installed, so task-augmented requests can fail with `Method not found` (the exact scenario the comment on `initElicitationCallback` warns about).

## Solution

Register the global elicitation callback in `server/index.ts` immediately after the manager is created, mirroring `server/app.ts`. `initElicitationCallback` is idempotent per manager instance (WeakSet-tracked), so the existing lazy registration in the elicitation routes stays harmless.

No SDK changes — the capability gating from #1902 is intentional and keeps working as designed; the bug was purely that the hosted entrypoint never installed the handler the gating checks for.

## Testing

- New `server/routes/mcp/__tests__/elicitation-init.test.ts`: callback registration, per-manager idempotency, distinct-instance registration, and pending-elicitation resolve flow (4 tests).
- `npx vitest run server/routes/mcp/__tests__/` — 12 files, 174 tests pass.
- `tsc --noEmit -p server/tsconfig.json` introduces no new errors (identical error count on `main` before/after the change).

Repro check: with this change, connecting a server right after boot advertises `elicitation` in `initialize` when configured via Client capabilities, matching the steps in #2289.