### PR TITLE
Backlog quick wins: elicitation close, OAuth secret length, Playground popover, predev bundle

### DIFF
--- a/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/ElicitationDialog.tsx
@@ -225,7 +225,17 @@ export function ElicitationDialog({
   };
 
   return (
-    <Dialog open={!!elicitationRequest} onOpenChange={() => {}}>
+    <Dialog
+      open={!!elicitationRequest}
+      onOpenChange={(open) => {
+        // Treat closing via the X button, Esc, or an outside click the same as
+        // pressing Cancel, so the dialog can never get stuck open. Ignore close
+        // attempts while a response is already in flight.
+        if (!open && !loading) {
+          void handleResponse("cancel");
+        }
+      }}
+    >
       <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-sm font-medium">

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -434,8 +434,11 @@ export function useServerForm(
   };
 
   const validateClientSecret = (value: string): string | null => {
-    if (value && value.length < 8) {
-      return "Client Secret must be at least 8 characters if provided";
+    // The OAuth spec only *recommends* an 8-character minimum; it does not
+    // mandate it, and some identity providers issue shorter secrets that users
+    // cannot control. Accept any provided (non-empty) value.
+    if (value && value.length < 1) {
+      return "Client Secret cannot be empty if provided";
     }
     return null;
   };

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -211,12 +211,6 @@ const navigationSections: NavSection[] = [
         title: "Playground",
         url: "/playground",
         icon: MessageCircle,
-        announcement: {
-          id: "playground-tab-rename-2026-05",
-          badge: "NEW",
-          title: "Playground just got more powerful",
-          body: "Playground now includes everything from App Builder — generate, preview, and test MCP-powered apps without switching tabs.",
-        },
       },
     ],
   },

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -44,7 +44,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "predev": "npm run sdk:build",
+    "predev": "npm run sdk:build && npm run bundle:sandbox-proxies",
     "dev": "run-script-os",
     "dev:default": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:win32": "concurrently --raw \"npm run dev:server\" \"npm run dev:client\"",


### PR DESCRIPTION
## Summary

Bundles four small, independent backlog fixes. Each was verified still-needed against current `main` and re-implemented fresh on top of `main` so they apply cleanly and can land together.

| Change | File | Supersedes |
|---|---|---|
| Elicitation dialog now closes on **X / Esc / outside-click** — `onOpenChange` was a no-op (`() => {}`), so the dialog could get stuck open | `client/src/components/ElicitationDialog.tsx` | #1919 |
| Drop the **8-char minimum on OAuth client secret** — the spec only *recommends* it, and some IdPs issue shorter secrets users can't control | `client/src/components/connection/hooks/use-server-form.ts` | #1920 |
| Remove the one-time **"Playground just got more powerful" announcement popover** | `client/src/components/mcp-sidebar.tsx` | #2293 |
| Run **`bundle:sandbox-proxies` in `predev`** so a fresh clone boots without `ERR_MODULE_NOT_FOUND` | `mcpjam-inspector/package.json` | #1973 |

## Notes
- **Elicitation:** close attempts are ignored while a response is in flight (`!loading`), matching the already-disabled Cancel button.
- **Credit** to the original authors — @nuthalapativarun (#1919, #1920) and @abedawi (#1973). Those originals can be closed once this merges.

## Testing
- Changes are mechanical and isolated; relying on CI for typecheck + unit tests (no full local install in this environment).

## Deliberately left out of this bundle (need a decision, see triage doc)
- **`outputSchema` → LLM** (#1964 vs #1986) — the two PRs disagree on *how* (pass to AI SDK `dynamicTool.outputSchema` vs. embed in the tool description + preserve raw). Needs a maintainer call on approach.
- **Read Resource button position** (#1917) — moving `ml-auto` would shift the Refresh/Hide buttons on the Resources tab too; needs a quick design confirmation.

https://claude.ai/code/session_01SMtSZ3m7ccsX1bv17YZs9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMtSZ3m7ccsX1bv17YZs9Z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated UI and dev-script tweaks with no auth or data-model changes beyond accepting shorter OAuth secrets users already have from IdPs.
> 
> **Overview**
> Four small, independent fixes land together.
> 
> **Elicitation dialog** — `onOpenChange` no longer ignores dismissals. Closing via X, Esc, or outside click now triggers the same **cancel** path as the Cancel button (skipped while `loading` is true), so the modal cannot stay open with no way out.
> 
> **OAuth server form** — Custom **client secret** validation drops the enforced 8-character minimum; any non-empty secret is accepted, matching providers that issue shorter secrets.
> 
> **Sidebar** — The one-time **Playground** “NEW” announcement block is removed from nav config.
> 
> **Dev bootstrap** — `predev` runs **`bundle:sandbox-proxies`** after `sdk:build`, aligning fresh clones with full `build`/`pretest` so dev server startup does not hit missing sandbox proxy modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ffbb181ab104599efa2a545b6ad61dcebf16cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->