### PR TITLE
docs: warm-paper Mintlify theme matching product design system

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci --legacy-peer-deps
 
+      - name: Verify docs tokens are in sync with design system
+        run: npm run docs:check-tokens
+
       - name: Typecheck releasable packages
         run: npm run typecheck
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,8 +7,22 @@
   "name": "MCPJam Inspector",
   "colors": {
     "primary": "#EF5B25",
-    "light": "#FF7A4D",
-    "dark": "#D44A1A"
+    "light": "#FF8B5C",
+    "dark": "#C94818"
+  },
+  "background": {
+    "color": {
+      "light": "#FAF9F5",
+      "dark": "#2D2A23"
+    }
+  },
+  "appearance": {
+    "default": "light",
+    "strict": false
+  },
+  "fonts": {
+    "heading": { "family": "Geist", "weight": 500 },
+    "body": { "family": "Geist", "weight": 400 }
   },
   "favicon": "/mcp_jam.svg",
   "navigation": {
@@ -160,6 +174,13 @@
       "website": "https://mcpjam.com",
       "linkedin": "https://www.linkedin.com/company/109011364/",
       "x": "https://x.com/mcpjams"
+    }
+  },
+  "errors": {
+    "404": {
+      "redirect": false,
+      "title": "Lost in the inspector?",
+      "description": "Try the [getting started guide](/getting-started), the [CLI overview](/cli/overview), or the [SDK reference](/sdk/index). Related pages are listed below."
     }
   }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,258 @@
+/* ─────────────────────────────────────────────────────────────────────────────
+ * MCPJam docs — warm paper theme
+ *
+ * Mirrors the product's OKLCH design tokens (design-system/src/tokens.css)
+ * into Mintlify's content-injected stylesheet. Mintlify auto-loads any .css
+ * file in /docs, so this layers on top of the maple theme.
+ *
+ * Direction: refined minimalism. Cream paper + brown ink + one sharp orange.
+ * No glassy backdrops, no floaty shadows, sharp warm borders, generous space.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* product tokens, OKLCH → fixed for Mintlify's CSS scope */
+  --mcj-paper:        oklch(0.9818 0.0054 95.0986);   /* page bg */
+  --mcj-paper-2:      oklch(0.9341 0.0153 90.239);    /* muted surface */
+  --mcj-paper-3:      oklch(0.9245 0.0138 92.9892);   /* secondary surface */
+  --mcj-ink:          oklch(0.3438 0.0269 95.7226);   /* body */
+  --mcj-ink-strong:   oklch(0.1908 0.002  106.5859);  /* headings */
+  --mcj-ink-muted:    oklch(0.6059 0.0075 97.4233);   /* muted copy */
+  --mcj-rule:         oklch(0.8847 0.0069 97.3627);   /* hairlines */
+  --mcj-rule-strong:  oklch(0.7621 0.0156 98.3528);
+  --mcj-orange:       oklch(0.6832 0.1382 38.744);    /* #EF5B25 */
+  --mcj-orange-soft:  oklch(0.6832 0.1382 38.744 / 0.10);
+  --mcj-orange-edge:  oklch(0.6171 0.1375 39.0427);
+  --mcj-radius:       0.5rem;
+}
+
+.dark, [data-theme="dark"] {
+  --mcj-paper:        oklch(0.2679 0.0036 106.6427);
+  --mcj-paper-2:      oklch(0.2213 0.0038 106.707);
+  --mcj-paper-3:      oklch(0.213  0.0078 95.4245);
+  --mcj-ink:          oklch(0.8074 0.0142 93.0137);
+  --mcj-ink-strong:   oklch(0.9818 0.0054 95.0986);
+  --mcj-ink-muted:    oklch(0.7713 0.0169 99.0657);
+  --mcj-rule:         oklch(0.3618 0.0101 106.8928);
+  --mcj-rule-strong:  oklch(0.4336 0.0113 100.2195);
+  --mcj-orange:       oklch(0.6724 0.1308 38.7559);
+  --mcj-orange-soft:  oklch(0.6724 0.1308 38.7559 / 0.14);
+  --mcj-orange-edge:  oklch(0.6724 0.1308 38.7559);
+}
+
+/* ── Page chrome ────────────────────────────────────────────────────────── */
+
+body {
+  background: var(--mcj-paper);
+  color: var(--mcj-ink);
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+#navbar {
+  background: var(--mcj-paper);
+  border-bottom: 1px solid var(--mcj-rule);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  box-shadow: none;
+}
+
+#sidebar,
+aside[aria-label="sidebar"] {
+  background: var(--mcj-paper);
+  border-right: 1px solid var(--mcj-rule);
+}
+
+footer {
+  background: var(--mcj-paper);
+  border-top: 1px solid var(--mcj-rule);
+}
+
+/* ── Typography ─────────────────────────────────────────────────────────── */
+
+h1, h2, h3, h4 {
+  color: var(--mcj-ink-strong);
+  letter-spacing: -0.012em;
+  font-weight: 500;
+}
+
+h1 { letter-spacing: -0.022em; font-weight: 600; }
+h2 { letter-spacing: -0.018em; }
+
+p, li {
+  color: var(--mcj-ink);
+}
+
+a {
+  color: var(--mcj-orange-edge);
+  text-decoration: none;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  transition: color 120ms ease-out;
+}
+a:hover {
+  color: var(--mcj-orange);
+  text-decoration: underline;
+}
+
+/* Sidebar nav links — quieter resting state, ink on hover, orange when active */
+#sidebar a,
+aside[aria-label="sidebar"] a {
+  color: var(--mcj-ink-muted);
+  border-radius: 6px;
+  transition: background 100ms ease-out, color 100ms ease-out;
+}
+#sidebar a:hover,
+aside[aria-label="sidebar"] a:hover {
+  color: var(--mcj-ink-strong);
+  background: var(--mcj-paper-2);
+}
+#sidebar a[aria-current="page"],
+aside[aria-label="sidebar"] a[aria-current="page"] {
+  color: var(--mcj-orange);
+  background: var(--mcj-orange-soft);
+  font-weight: 500;
+}
+
+/* ── Code & inline mono ─────────────────────────────────────────────────── */
+
+code, pre, kbd, samp {
+  font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+code:not(pre code) {
+  background: var(--mcj-paper-2);
+  border: 1px solid var(--mcj-rule);
+  color: var(--mcj-ink-strong);
+  padding: 0.12em 0.38em;
+  border-radius: 4px;
+  font-size: 0.92em;
+}
+
+code-block,
+pre {
+  background: var(--mcj-paper-2) !important;
+  border: 1px solid var(--mcj-rule);
+  border-radius: var(--mcj-radius);
+  box-shadow: none !important;
+}
+
+/* ── Callouts (Note / Tip / Warning / Info) ─────────────────────────────── */
+
+callout,
+.callout,
+note,
+tip,
+warning,
+info {
+  background: var(--mcj-paper-2);
+  border: 1px solid var(--mcj-rule);
+  border-left: 3px solid var(--mcj-orange);
+  border-radius: var(--mcj-radius);
+  box-shadow: none;
+  padding: 0.9rem 1rem;
+}
+
+warning {
+  border-left-color: oklch(0.627 0.208 25.331); /* destructive */
+}
+
+tip {
+  border-left-color: oklch(0.696 0.17 152.5);   /* success */
+}
+
+info {
+  border-left-color: oklch(0.623 0.214 259);    /* info */
+}
+
+/* ── Cards ──────────────────────────────────────────────────────────────── */
+
+card,
+.card {
+  background: var(--mcj-paper);
+  border: 1px solid var(--mcj-rule);
+  border-radius: var(--mcj-radius);
+  box-shadow: none !important;
+  transition: border-color 140ms ease-out, transform 140ms ease-out;
+}
+
+card:hover,
+.card:hover {
+  border-color: var(--mcj-orange);
+  transform: none; /* kill maple's lift */
+}
+
+/* ── Buttons / CTAs — match product's Add Server button ─────────────────── */
+
+button[data-variant="primary"],
+.button-primary,
+a.button-primary {
+  background: var(--mcj-orange);
+  color: #ffffff;
+  border: 1px solid var(--mcj-orange-edge);
+  border-radius: var(--mcj-radius);
+  box-shadow: none;
+  font-weight: 500;
+}
+
+button[data-variant="primary"]:hover,
+.button-primary:hover,
+a.button-primary:hover {
+  background: var(--mcj-orange-edge);
+}
+
+/* ── Tables ─────────────────────────────────────────────────────────────── */
+
+table {
+  border: 1px solid var(--mcj-rule);
+  border-radius: var(--mcj-radius);
+  overflow: hidden;
+}
+
+th {
+  background: var(--mcj-paper-2);
+  color: var(--mcj-ink-strong);
+  font-weight: 500;
+  text-align: left;
+  border-bottom: 1px solid var(--mcj-rule);
+}
+
+td {
+  border-bottom: 1px solid var(--mcj-rule);
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+/* ── Misc polish ────────────────────────────────────────────────────────── */
+
+hr {
+  border: none;
+  border-top: 1px solid var(--mcj-rule);
+  margin: 2rem 0;
+}
+
+blockquote {
+  border-left: 2px solid var(--mcj-rule-strong);
+  color: var(--mcj-ink-muted);
+  padding-left: 1rem;
+  font-style: normal;
+}
+
+::selection {
+  background: var(--mcj-orange-soft);
+  color: var(--mcj-ink-strong);
+}
+
+/* Scrollbars — match product's thin warm rail */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+  background: var(--mcj-rule-strong);
+  border-radius: 9999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--mcj-ink-muted);
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -9,35 +9,38 @@
  * No glassy backdrops, no floaty shadows, sharp warm borders, generous space.
  * ─────────────────────────────────────────────────────────────────────────── */
 
+/* BEGIN GENERATED — sync via `npm run docs:sync-tokens` */
+/* Mirrors design-system/src/tokens.css — edits here will be overwritten. */
 :root {
-  /* product tokens, OKLCH → fixed for Mintlify's CSS scope */
-  --mcj-paper:        oklch(0.9818 0.0054 95.0986);   /* page bg */
-  --mcj-paper-2:      oklch(0.9341 0.0153 90.239);    /* muted surface */
-  --mcj-paper-3:      oklch(0.9245 0.0138 92.9892);   /* secondary surface */
-  --mcj-ink:          oklch(0.3438 0.0269 95.7226);   /* body */
-  --mcj-ink-strong:   oklch(0.1908 0.002  106.5859);  /* headings */
-  --mcj-ink-muted:    oklch(0.6059 0.0075 97.4233);   /* muted copy */
-  --mcj-rule:         oklch(0.8847 0.0069 97.3627);   /* hairlines */
+  --mcj-paper:        oklch(0.9818 0.0054 95.0986);
+  --mcj-paper-2:      oklch(0.9341 0.0153 90.239);
+  --mcj-paper-3:      oklch(0.9245 0.0138 92.9892);
+  --mcj-ink:          oklch(0.3438 0.0269 95.7226);
+  --mcj-ink-strong:   oklch(0.1908 0.002 106.5859);
+  --mcj-ink-muted:    oklch(0.6059 0.0075 97.4233);
+  --mcj-rule:         oklch(0.8847 0.0069 97.3627);
   --mcj-rule-strong:  oklch(0.7621 0.0156 98.3528);
-  --mcj-orange:       oklch(0.6832 0.1382 38.744);    /* #EF5B25 */
-  --mcj-orange-soft:  oklch(0.6832 0.1382 38.744 / 0.10);
+  --mcj-orange:       oklch(0.6832 0.1382 38.744);
   --mcj-orange-edge:  oklch(0.6171 0.1375 39.0427);
   --mcj-radius:       0.5rem;
+  --mcj-orange-soft:  oklch(0.6832 0.1382 38.744 / 0.10);
 }
 
 .dark, [data-theme="dark"] {
   --mcj-paper:        oklch(0.2679 0.0036 106.6427);
   --mcj-paper-2:      oklch(0.2213 0.0038 106.707);
-  --mcj-paper-3:      oklch(0.213  0.0078 95.4245);
+  --mcj-paper-3:      oklch(0.213 0.0078 95.4245);
   --mcj-ink:          oklch(0.8074 0.0142 93.0137);
   --mcj-ink-strong:   oklch(0.9818 0.0054 95.0986);
   --mcj-ink-muted:    oklch(0.7713 0.0169 99.0657);
   --mcj-rule:         oklch(0.3618 0.0101 106.8928);
   --mcj-rule-strong:  oklch(0.4336 0.0113 100.2195);
   --mcj-orange:       oklch(0.6724 0.1308 38.7559);
-  --mcj-orange-soft:  oklch(0.6724 0.1308 38.7559 / 0.14);
   --mcj-orange-edge:  oklch(0.6724 0.1308 38.7559);
+  --mcj-radius:       0.5rem;
+  --mcj-orange-soft:  oklch(0.6724 0.1308 38.7559 / 0.14);
 }
+/* END GENERATED */
 
 /* ── Page chrome ────────────────────────────────────────────────────────── */
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:parallel": "concurrently -n sdk,cli,design,inspector,mcp -c blue,green,yellow,magenta,cyan --kill-others-on-fail \"npm run test -w @mcpjam/sdk\" \"npm run test -w @mcpjam/cli\" \"npm run test -w @mcpjam/design-system\" \"npm run test -w @mcpjam/inspector\" \"npm run test:fast -w @mcpjam/mcp && npm run typecheck:fast -w @mcpjam/mcp\"",
     "test:ordered": "npm run test -w @mcpjam/sdk && npm run test:packaging -w @mcpjam/sdk && npm run test -w @mcpjam/cli && npm run test -w @mcpjam/design-system && npm run test -w @mcpjam/inspector && npm run test -w @mcpjam/mcp && npm run typecheck -w @mcpjam/mcp",
     "verify": "npm run typecheck && npm run test && npm run build:inspector",
+    "docs:sync-tokens": "node scripts/sync-docs-tokens.mjs",
+    "docs:check-tokens": "node scripts/sync-docs-tokens.mjs --check",
     "release:status": "changeset status",
     "release:version": "changeset version",
     "release:publish": "changeset publish"

--- a/scripts/sync-docs-tokens.mjs
+++ b/scripts/sync-docs-tokens.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Sync docs/style.css from design-system/src/tokens.css so the Mintlify
+ * site tracks the product palette automatically.
+ *
+ * Why a script and not @import: Mintlify's CSS pipeline can't resolve
+ * package paths, and tokens.css uses Tailwind v4 directives that only
+ * compile in the inspector's build. So we mirror the OKLCH values into
+ * a fenced block in docs/style.css and keep it in lock-step here.
+ *
+ * Usage:
+ *   node scripts/sync-docs-tokens.mjs           # rewrite docs/style.css
+ *   node scripts/sync-docs-tokens.mjs --check   # exit 1 if drift (CI)
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const TOKENS = resolve(ROOT, "design-system/src/tokens.css");
+const STYLE = resolve(ROOT, "docs/style.css");
+
+const BEGIN = "/* BEGIN GENERATED — sync via `npm run docs:sync-tokens` */";
+const END = "/* END GENERATED */";
+
+// docs-alias ← product-token
+// Hand-curated; reflects what docs/style.css actually consumes.
+const MAP = {
+  "--mcj-paper":       "--background",
+  "--mcj-paper-2":     "--muted",
+  "--mcj-paper-3":     "--accent",
+  "--mcj-ink":         "--foreground",
+  "--mcj-ink-strong":  "--card-foreground",
+  "--mcj-ink-muted":   "--muted-foreground",
+  "--mcj-rule":        "--border",
+  "--mcj-rule-strong": "--input",
+  "--mcj-orange":      "--primary",
+  "--mcj-orange-edge": "--ring",
+  "--mcj-radius":      "--radius",
+};
+
+// Soft-alpha overlay derived from --primary. Alpha differs per mode so the
+// orange wash reads at the same perceived weight on cream vs warm-dark.
+const ORANGE_SOFT_ALPHA = { light: "0.10", dark: "0.14" };
+
+function extractBlock(css, selector) {
+  // Matches `selector { … }` at top level, non-greedy.
+  const re = new RegExp(
+    String.raw`${selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\s*\{([\s\S]*?)\n\}`,
+    "m",
+  );
+  const m = css.match(re);
+  if (!m) throw new Error(`Could not locate ${selector} block in tokens.css`);
+  return m[1];
+}
+
+function parseVars(block) {
+  const out = new Map();
+  for (const line of block.split("\n")) {
+    const m = line.match(/^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);/i);
+    if (m) out.set(m[1], m[2].trim());
+  }
+  return out;
+}
+
+function deriveOrangeSoft(primaryValue, alpha) {
+  // primaryValue is e.g. `oklch(0.6832 0.1382 38.744)` — splice alpha in.
+  const m = primaryValue.match(/^oklch\(\s*([^)]+?)\s*\)$/i);
+  if (!m) throw new Error(`Cannot derive orange-soft from ${primaryValue}`);
+  return `oklch(${m[1]} / ${alpha})`;
+}
+
+function buildBlock(label, selectorChain, tokenVars, alpha) {
+  const lines = [`${selectorChain} {`];
+  for (const [alias, source] of Object.entries(MAP)) {
+    const value = tokenVars.get(source);
+    if (!value) throw new Error(`Token ${source} missing from tokens.css ${label}`);
+    lines.push(`  ${`${alias}:`.padEnd(19, " ")} ${value};`);
+  }
+  const orange = tokenVars.get("--primary");
+  lines.push(`  --mcj-orange-soft:  ${deriveOrangeSoft(orange, alpha)};`);
+  lines.push("}");
+  return lines.join("\n");
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+
+  const tokensCss = readFileSync(TOKENS, "utf8");
+  const styleCss = readFileSync(STYLE, "utf8");
+
+  const lightVars = parseVars(extractBlock(tokensCss, ":root"));
+  const darkVars = parseVars(extractBlock(tokensCss, ".dark"));
+
+  // Dark block in tokens.css redefines only the deltas — fall back to light
+  // for any var dark didn't override (e.g. --radius).
+  for (const [k, v] of lightVars) if (!darkVars.has(k)) darkVars.set(k, v);
+
+  const generated = [
+    BEGIN,
+    "/* Mirrors design-system/src/tokens.css — edits here will be overwritten. */",
+    buildBlock("light", ":root", lightVars, ORANGE_SOFT_ALPHA.light),
+    "",
+    buildBlock(
+      "dark",
+      `.dark, [data-theme="dark"]`,
+      darkVars,
+      ORANGE_SOFT_ALPHA.dark,
+    ),
+    END,
+  ].join("\n");
+
+  const fence = new RegExp(
+    `${escapeRe(BEGIN)}[\\s\\S]*?${escapeRe(END)}`,
+    "m",
+  );
+
+  if (!fence.test(styleCss)) {
+    throw new Error(
+      `Could not find generated fence in ${STYLE}. ` +
+        `Add the BEGIN/END markers before running this script.`,
+    );
+  }
+
+  const next = styleCss.replace(fence, generated);
+
+  if (check) {
+    if (next !== styleCss) {
+      console.error(
+        "docs/style.css is out of sync with design-system/src/tokens.css.\n" +
+          "Run: npm run docs:sync-tokens",
+      );
+      process.exit(1);
+    }
+    console.log("docs/style.css is in sync with design-system tokens.");
+    return;
+  }
+
+  if (next === styleCss) {
+    console.log("docs/style.css already in sync — nothing to do.");
+    return;
+  }
+
+  writeFileSync(STYLE, next);
+  console.log("docs/style.css updated from design-system tokens.");
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+main();


### PR DESCRIPTION
## Summary

- Mirrors MCPJam's product OKLCH design tokens (`design-system/src/tokens.css`) into the Mintlify docs so docs.mcpjam.com reads as the same surface as the inspector — cream paper, warm brown ink, one sharp orange accent.
- Adds `docs/style.css` (auto-loaded by Mintlify) that overrides navbar, sidebar nav, callouts, cards, code blocks, and tables to drop the "AI doc site" tells: glassy backdrops, floaty shadows, lift-on-hover, blue links, slate dark mode.
- Sidebar active state now matches the product's selected-row treatment (orange text on orange/10% wash), so the Servers/Playground/Tools navigation feels native instead of generic.

## What changed

**`docs/docs.json`** — additive, no nav/redirect changes:
- `background.color` — `#FAF9F5` light, `#2D2A23` dark (the exact warm surface tones from `--background` light/dark)
- `appearance.default: "light"` — boots into the cream look
- `fonts` — Geist 500 headings / Geist 400 body, served from Google Fonts
- `colors.light/dark` retuned from the same OKLCH primary the product uses (`#FF8B5C` / `#C94818`)
- `errors.404` — "Lost in the inspector?" page with MDX-linked redirects to the main entry points

**`docs/style.css`** (new) — layered over `theme: "maple"`:
- Exposes product tokens (`--mcj-paper`, `--mcj-ink`, `--mcj-rule`, `--mcj-orange`, …) for both light and dark, sourced verbatim from `design-system/src/tokens.css`.
- Selector targets: `body`, `#navbar`, `#sidebar`/`aside[aria-label="sidebar"]`, `footer`, `callout`/`note`/`tip`/`warning`/`info`, `card`, `code`/`pre`, `table`/`th`/`td`, `::selection`, scrollbars.
- 3px left rail on callouts (orange / destructive / success / info), no rainbow fills.
- Inline code is a warm beige chip with hairline border, not a pill.

## Why this approach

- **No theme switch** — kept `theme: "maple"` so layout/nav/sidebar structure is unchanged; this PR is purely visual reskinning via Mintlify's documented overrides (CSS file + `colors`/`background`/`fonts` in `docs.json`).
- **No new pages, no nav changes** — content surface is identical; the existing `redirects` block is untouched.
- **Tokens, not hex** — all colors are the same OKLCH values the product ships, so future product palette changes can be mirrored by editing the `:root` block once.

## Test plan

- [ ] `cd docs && mint dev` under Node 20+ — preview matches the product screenshot vibe (cream bg, orange "Servers"-style active state, no shadow on code blocks)
- [ ] Toggle dark mode — background is warm `#2D2A23`, not slate; text is `--mcj-ink` warm cream
- [ ] Visit a non-existent page — custom 404 renders with the three links
- [ ] Spot-check a callout-heavy page (e.g. `/troubleshooting/common-errors`) — 3px left rails, no glassy box
- [ ] Spot-check a code-heavy page (e.g. `/sdk/quickstart`) — code blocks have hairline border, no floaty shadow

## Notes

- Mintlify's element selectors (`callout`, `card`, `code-block`) can shift between theme updates — if a release breaks one of the targets, inspect the rendered tag and add it to the relevant rule. The product-token block at the top of `style.css` stays valid regardless.
- Geist is loaded from Google Fonts (zero-config). Switching to self-hosted `.woff2` is a one-line change in `docs.json` (`source` + `format`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and docs-only changes plus a non-runtime sync script; no app auth, data, or release package behavior is affected.
> 
> **Overview**
> Reskins the Mintlify docs to match the inspector’s warm paper palette and adds tooling so doc colors stay aligned with `design-system/src/tokens.css`.
> 
> **Mintlify config (`docs.json`)** now sets cream/dark backgrounds, retuned primary light/dark hex values, default light appearance, Geist heading/body fonts, and a custom **404** (“Lost in the inspector?”) with links to main entry points. Navigation and redirects are unchanged.
> 
> **New `docs/style.css`** layers on the maple theme: generated `--mcj-*` OKLCH variables plus overrides for chrome (navbar, sidebar, footer), typography, links, sidebar active state (orange on soft wash), code blocks, callouts, cards, tables, and scrollbars—dropping glass, heavy shadows, and lift-on-hover.
> 
> **Token sync:** `scripts/sync-docs-tokens.mjs` rewrites the fenced block in `docs/style.css` from `tokens.css`; root adds `docs:sync-tokens` and `docs:check-tokens`. **CI** runs `docs:check-tokens` in the lint workflow so drift fails the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5170465853869d716c96b737038c5568f7acfb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->