### PR TITLE
fix(sdk): forward needsApproval from host policy in HostRuntime.run

### DIFF
--- a/sdk/src/host-config/host-runtime.ts
+++ b/sdk/src/host-config/host-runtime.ts
@@ -134,8 +134,15 @@ export class HostRuntime implements HostExecutor {
       hostSnapshot as unknown as Record<string, unknown>,
     );
     const serverIds = resolveKnownServerIds(hostSnapshot, this.manager);
+    // Forward BOTH visibility and approval-required from the resolved
+    // host policy. The server chat path already does this; without
+    // `needsApproval`, `HostRuntime`-backed evals/runs against a host
+    // with `requireToolApproval: true` resolve tools that lack the AI
+    // SDK approval marker and execute silently — bypassing the host's
+    // declared approval policy.
     const tools = await this.manager.getToolsForAiSdk(serverIds, {
       includeAppOnly: policy.respectToolVisibility === false,
+      needsApproval: policy.requireToolApproval,
     });
 
     // Dynamic import keeps `host-config` browser-safe: `HostRunner` pulls

--- a/sdk/tests/HostRuntime.test.ts
+++ b/sdk/tests/HostRuntime.test.ts
@@ -276,4 +276,38 @@ describe("HostRuntime end-to-end run", () => {
     const options = lastCall[1];
     expect(options?.includeAppOnly).toBe(true);
   });
+
+  it("forwards needsApproval to the manager when host.requireToolApproval is true", async () => {
+    // Regression: HostRuntime previously only forwarded includeAppOnly,
+    // so HostRuntime-backed evals/runs against a host with
+    // requireToolApproval: true resolved AI SDK tools without the
+    // approval marker and executed them silently — bypassing the host's
+    // declared approval policy. The server chat path already passes
+    // needsApproval; HostRuntime must too.
+    const host = new Host({
+      style: "mcpjam",
+      model: "openai/gpt-4o",
+      requireToolApproval: true,
+    });
+    const manager = fakeManager([]);
+    const runtime = host.withManager(manager, baseDefaults);
+
+    await runtime.run("x");
+
+    const lastCall = manager.getToolsForAiSdkSpy.mock.calls.at(-1)!;
+    const options = lastCall[1];
+    expect(options?.needsApproval).toBe(true);
+  });
+
+  it("forwards needsApproval: false (default) when host does not require approval", async () => {
+    const host = new Host({ style: "mcpjam", model: "openai/gpt-4o" });
+    const manager = fakeManager([]);
+    const runtime = host.withManager(manager, baseDefaults);
+
+    await runtime.run("x");
+
+    const lastCall = manager.getToolsForAiSdkSpy.mock.calls.at(-1)!;
+    const options = lastCall[1];
+    expect(options?.needsApproval).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2409 (Stage 4) addressing the post-merge `chatgpt-codex-connector` review.

`HostRuntime.run()` resolved tools by calling `this.manager.getToolsForAiSdk(serverIds, { includeAppOnly })` and dropped the `needsApproval` option that the manager uses to mark AI SDK tools as approval-required. The server chat path already derives `needsApproval` from `requireToolApproval`, so a `HostRuntime`-backed eval or run against a host configured with `requireToolApproval: true` silently executed tools without the host's declared approval marker — bypassing the policy.

## Fix

Forward `needsApproval: policy.requireToolApproval` alongside `includeAppOnly: policy.respectToolVisibility === false` in the same `getToolsForAiSdk` call. `policy.requireToolApproval` defaults to `false` (via `extractHostExecutionPolicy`) when the host doesn't set it, so non-approval hosts get `needsApproval: false` — matching today's behavior and the manager's existing default semantics.

## Test plan

- [x] `cd sdk && npm test` — 1248 SDK tests pass (+2 new regressions in `HostRuntime.test.ts`).
- [x] New regression covering `requireToolApproval: true` flow asserts the manager call carries `needsApproval: true`.
- [x] Sibling regression for `requireToolApproval` absent / false asserts the manager call carries `needsApproval: false` (explicit forwarding, not undefined).
- [ ] Reviewer to confirm there are no other callers of `HostRuntime`-style structural managers that would be surprised by a previously-absent `needsApproval` field appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted policy wiring with regression tests; behavior change only affects hosts that opt into requireToolApproval.
> 
> **Overview**
> **`HostRuntime.run()`** now passes **`needsApproval: policy.requireToolApproval`** into **`getToolsForAiSdk`**, alongside the existing **`includeAppOnly`** visibility flag. Hosts with **`requireToolApproval: true`** get AI SDK tools marked for approval on eval/run paths that use **`HostRuntime`**, aligning behavior with the server chat path instead of executing tools without the approval marker.
> 
> **Tests** in **`HostRuntime.test.ts`** assert **`needsApproval: true`** when approval is required and **`needsApproval: false`** when it is not (explicit forwarding, not omitted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5310d16790d1acd47b32afb8da47ec4210c249c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->