### PR TITLE
eval→chatSessions: add 'eval' to inspector sourceType TS unions

### DIFF
--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -85,7 +85,7 @@ export interface RunAssistantTurnOptions {
    * the existing `MCPJamHandlerOptions.sourceType` union but kept
    * narrowed to the public values to avoid silent string churn.
    */
-  sourceType: "direct" | "chatbox";
+  sourceType: "direct" | "chatbox" | "eval";
   /**
    * Surface marker forwarded into chat-ingestion. Stage 1 only wires
    * the type-narrow union; existing callers still send the string

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -145,7 +145,7 @@ interface PersistChatSessionOptions {
   modelSource: "mcpjam" | "byok" | "local_byok";
   authHeader?: string;
   projectId?: string;
-  sourceType?: "chatbox" | "direct";
+  sourceType?: "chatbox" | "direct" | "eval";
   directVisibility?: "private" | "project";
   surface?: "preview" | "share_link";
   chatboxId?: string;

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -94,7 +94,7 @@ export type RequestEventMap = {
   "chat.session.persist.failed": {
     failureKind: "timeout" | "http_error" | "exception" | "version_conflict";
     statusCode?: number;
-    sourceType?: "chatbox" | "direct";
+    sourceType?: "chatbox" | "direct" | "eval";
   };
   "widget.resource.served": {
     widgetType: "mcp_apps" | "chatgpt_apps";


### PR DESCRIPTION
## Summary

Mirrors MCPJam/mcpjam-backend#423 — adds `'eval'` to the three inspector-side `sourceType` TS unions that flow into `persistChatSessionToConvex`, the request logger, and the assistant-turn runner. The backend's `chatConversationSourceTypeValidator` now accepts `'eval'` for eval-iteration transcripts (see the backend PR for the full unification design).

**No behavior change in this PR.** Inspector chat-v2 routes still produce only `'direct'` or `'chatbox'` via existing ternaries — those code paths never carry eval rows. The type widening prevents a future call site (or a tee'd log event) from tripping a narrow-union type error if eval traffic ever reaches these layers in a later PR.

## Files

- `server/utils/chat-ingestion.ts` — `PersistChatSessionOptions.sourceType` adds `"eval"`
- `server/utils/log-events.ts` — `chat.session.persist.failed` event's `sourceType` adds `"eval"`
- `server/utils/assistant-turn.ts` — `RunAssistantTurnOptions.sourceType` adds `"eval"`

## Test plan

- [ ] CI typecheck passes (no logic changes, pure union widening — only checks that no existing narrowed branch breaks).
- [ ] No runtime change to verify; smoke-test the existing Playground + chatbox flows to confirm they still emit `'direct'` / `'chatbox'` as before.

## Coordination

Land after the backend PR (MCPJam/mcpjam-backend#423) so the inspector's accepted values match what the backend validator persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure TypeScript union widening with no logic or routing changes; existing flows unchanged.
> 
> **Overview**
> Adds **`"eval"`** to three TypeScript `sourceType` unions so inspector types stay aligned with the backend’s expanded `chatConversationSourceTypeValidator` (eval-iteration transcripts).
> 
> **`RunAssistantTurnOptions`**, **`PersistChatSessionOptions`**, and the **`chat.session.persist.failed`** log event payload all accept `"eval"` in addition to `"direct"` and `"chatbox"`. Values still flow through to Convex ingest and request logging unchanged.
> 
> **No runtime behavior change** in this PR—chat-v2 routes still only emit `"direct"` or `"chatbox"`. The widening avoids type errors when a future eval call site or log path passes `"eval"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a61fbac1e2421a583aadf1bb3130cb8ec7c9a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->