### PR TITLE
fix(desktop): self-heal launch failures (port fallback + recovery dialog + cache prune)

### DIFF
--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -657,12 +657,13 @@ function showStartupFailureDialog(error: unknown): void {
   }
 
   if (choice === 1) {
-    try {
-      void shell.openPath(app.getPath("logs"));
-    } catch (openErr) {
-      log.warn("Failed to open logs folder:", openErr);
-    }
-    app.quit();
+    // Don't fire-and-forget: shutdown can finish before Finder/Explorer
+    // gets the openPath message, making the recovery action appear to do
+    // nothing. Chain the quit so it runs only after openPath settles.
+    shell
+      .openPath(app.getPath("logs"))
+      .catch((openErr) => log.warn("Failed to open logs folder:", openErr))
+      .finally(() => app.quit());
     return;
   }
 

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -9,10 +9,16 @@ Sentry.init({
 
 import { app, BrowserWindow, shell, Menu, dialog } from "electron";
 import type { BrowserWindowConstructorOptions } from "electron";
+import { serve } from "@hono/node-server";
 import path from "path";
 import fs from "fs";
-import { createHonoApp } from "../server/app.js";
-import { tryListenWithFallback } from "./server-port-fallback.js";
+// IMPORTANT: do NOT statically import "../server/app.js" or anything that
+// transitively reads server/config.ts at module-load time. `SERVER_PORT`
+// in that config is a top-level const computed from `process.env`, so we
+// have to set `process.env.SERVER_PORT` (after probing for a free port)
+// BEFORE the server module graph is first evaluated. The dynamic import
+// in `startHonoServer()` enforces that ordering.
+import { probeFreePort } from "./server-port-fallback.js";
 import log from "electron-log";
 import { updateElectronApp } from "update-electron-app";
 import { registerListeners } from "./ipc/listeners-register.js";
@@ -256,13 +262,16 @@ async function startHonoServer(): Promise<number> {
       : app.getAppPath();
     process.env.NODE_ENV = app.isPackaged ? "production" : "development";
 
-    const honoApp = createHonoApp();
-
     // Bind to 127.0.0.1 when packaged to avoid IPv6-only localhost issues
     const hostname = app.isPackaged ? "127.0.0.1" : "localhost";
 
-    const { server: boundServer, port } = await tryListenWithFallback(
-      honoApp,
+    // Probe for a free port BEFORE loading server modules. server/config.ts
+    // reads SERVER_PORT from process.env once, at module-init time, and that
+    // value flows into LOCAL_SERVER_ADDR, CORS_ORIGINS, and the
+    // origin-validation allowlist. If we bound the server before setting
+    // this, the renderer (loading from the fallback port) would 403 on its
+    // own API calls and ngrok would target the wrong local address.
+    const port = await probeFreePort(
       hostname,
       DEFAULT_SERVER_PORT,
       SERVER_PORT_FALLBACK_ATTEMPTS,
@@ -274,8 +283,18 @@ async function startHonoServer(): Promise<number> {
         },
       },
     );
+    process.env.SERVER_PORT = String(port);
 
-    server = boundServer;
+    // Dynamic import so server/config.ts evaluates with the env var we just
+    // set, not the build-time default.
+    const { createHonoApp } = await import("../server/app.js");
+    const honoApp = createHonoApp();
+
+    server = serve({
+      fetch: honoApp.fetch,
+      port,
+      hostname,
+    });
 
     if (port !== DEFAULT_SERVER_PORT) {
       log.warn(

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -251,6 +251,17 @@ function openSafeOAuthWindow(
 const DEFAULT_SERVER_PORT = 6274;
 const SERVER_PORT_FALLBACK_ATTEMPTS = 10;
 
+// Cache the port we successfully probed on first launch so subsequent
+// startHonoServer() invocations (macOS dock activation after
+// window-all-closed) reuse it. The server/config.ts module is in Node's
+// module cache after the first dynamic import, so its SERVER_PORT /
+// LOCAL_SERVER_ADDR / CORS_ORIGINS were frozen to the first effective
+// port. If we probed again and the result differed, the renderer would
+// load from the new port while origin-validation/CORS/ngrok all still
+// reference the old one — same fallback-port-not-synced class of bug we
+// fixed at first launch.
+let cachedProbedPort: number | null = null;
+
 async function startHonoServer(): Promise<number> {
   try {
     // Set environment variables to tell the server it's running in Electron
@@ -265,28 +276,43 @@ async function startHonoServer(): Promise<number> {
     // Bind to 127.0.0.1 when packaged to avoid IPv6-only localhost issues
     const hostname = app.isPackaged ? "127.0.0.1" : "localhost";
 
-    // Probe for a free port BEFORE loading server modules. server/config.ts
-    // reads SERVER_PORT from process.env once, at module-init time, and that
-    // value flows into LOCAL_SERVER_ADDR, CORS_ORIGINS, and the
-    // origin-validation allowlist. If we bound the server before setting
-    // this, the renderer (loading from the fallback port) would 403 on its
-    // own API calls and ngrok would target the wrong local address.
-    const port = await probeFreePort(
-      hostname,
-      DEFAULT_SERVER_PORT,
-      SERVER_PORT_FALLBACK_ATTEMPTS,
-      {
-        onAttemptFailed: (failedPort, err) => {
-          log.warn(
-            `Port ${failedPort} unavailable (${err.code ?? err.message}); trying next port`,
-          );
+    let port: number;
+    if (cachedProbedPort !== null) {
+      // Re-use the port from first launch — server/config.ts is already
+      // module-cached against this value; probing again would risk
+      // picking a different free port and silently desyncing CORS,
+      // origin validation, and LOCAL_SERVER_ADDR from the bound port.
+      port = cachedProbedPort;
+      log.info(
+        `Reusing previously-probed port ${port} for server restart`,
+      );
+    } else {
+      // Probe for a free port BEFORE loading server modules. server/config.ts
+      // reads SERVER_PORT from process.env once, at module-init time, and that
+      // value flows into LOCAL_SERVER_ADDR, CORS_ORIGINS, and the
+      // origin-validation allowlist. If we bound the server before setting
+      // this, the renderer (loading from the fallback port) would 403 on its
+      // own API calls and ngrok would target the wrong local address.
+      port = await probeFreePort(
+        hostname,
+        DEFAULT_SERVER_PORT,
+        SERVER_PORT_FALLBACK_ATTEMPTS,
+        {
+          onAttemptFailed: (failedPort, err) => {
+            log.warn(
+              `Port ${failedPort} unavailable (${err.code ?? err.message}); trying next port`,
+            );
+          },
         },
-      },
-    );
-    process.env.SERVER_PORT = String(port);
+      );
+      process.env.SERVER_PORT = String(port);
+      cachedProbedPort = port;
+    }
 
     // Dynamic import so server/config.ts evaluates with the env var we just
-    // set, not the build-time default.
+    // set, not the build-time default. After the first call the module is in
+    // Node's cache; subsequent calls just return the cached exports, which
+    // is exactly what we want now that we're reusing the same port.
     const { createHonoApp } = await import("../server/app.js");
     const honoApp = createHonoApp();
 
@@ -651,6 +677,19 @@ function showStartupFailureDialog(error: unknown): void {
         log.warn(`Failed to remove ${sub} during recovery reset:`, rmErr);
       }
     }
+    // Also clear the version marker so the next launch always re-runs
+    // pruneStaleCachesOnVersionChange(). Otherwise a partial reset (some
+    // rmSync above failed and threw) plus an unchanged version string
+    // means the version-based prune is skipped — the next launch sees
+    // exactly the broken state that brought us here.
+    try {
+      fs.rmSync(path.join(userData, ".last-launched-version"), { force: true });
+    } catch (rmErr) {
+      log.warn(
+        "Failed to remove .last-launched-version during recovery reset:",
+        rmErr,
+      );
+    }
     app.relaunch();
     app.quit();
     return;
@@ -660,8 +699,16 @@ function showStartupFailureDialog(error: unknown): void {
     // Don't fire-and-forget: shutdown can finish before Finder/Explorer
     // gets the openPath message, making the recovery action appear to do
     // nothing. Chain the quit so it runs only after openPath settles.
+    // Electron's shell.openPath resolves with an empty string on success
+    // and a non-empty error message on logical failure — `.catch()` only
+    // catches sync/promise throws, so check the resolved value too.
     shell
       .openPath(app.getPath("logs"))
+      .then((result) => {
+        if (result) {
+          log.warn(`shell.openPath reported error opening logs folder: ${result}`);
+        }
+      })
       .catch((openErr) => log.warn("Failed to open logs folder:", openErr))
       .finally(() => app.quit());
     return;

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -7,11 +7,12 @@ Sentry.init({
   ipcMode: Sentry.IPCMode.Both, // Enables communication with renderer process
 });
 
-import { app, BrowserWindow, shell, Menu } from "electron";
+import { app, BrowserWindow, shell, Menu, dialog } from "electron";
 import type { BrowserWindowConstructorOptions } from "electron";
-import { serve } from "@hono/node-server";
 import path from "path";
+import fs from "fs";
 import { createHonoApp } from "../server/app.js";
+import { tryListenWithFallback } from "./server-port-fallback.js";
 import log from "electron-log";
 import { updateElectronApp } from "update-electron-app";
 import { registerListeners } from "./ipc/listeners-register.js";
@@ -241,9 +242,11 @@ function openSafeOAuthWindow(
   });
 }
 
+const DEFAULT_SERVER_PORT = 6274;
+const SERVER_PORT_FALLBACK_ATTEMPTS = 10;
+
 async function startHonoServer(): Promise<number> {
   try {
-    const port = 6274;
     // Set environment variables to tell the server it's running in Electron
     process.env.ELECTRON_APP = "true";
     process.env.IS_PACKAGED = app.isPackaged ? "true" : "false";
@@ -258,13 +261,29 @@ async function startHonoServer(): Promise<number> {
     // Bind to 127.0.0.1 when packaged to avoid IPv6-only localhost issues
     const hostname = app.isPackaged ? "127.0.0.1" : "localhost";
 
-    server = serve({
-      fetch: honoApp.fetch,
-      port,
+    const { server: boundServer, port } = await tryListenWithFallback(
+      honoApp,
       hostname,
-    });
+      DEFAULT_SERVER_PORT,
+      SERVER_PORT_FALLBACK_ATTEMPTS,
+      {
+        onAttemptFailed: (failedPort, err) => {
+          log.warn(
+            `Port ${failedPort} unavailable (${err.code ?? err.message}); trying next port`,
+          );
+        },
+      },
+    );
 
-    log.info(`🚀 MCPJam Server started on port ${port}`);
+    server = boundServer;
+
+    if (port !== DEFAULT_SERVER_PORT) {
+      log.warn(
+        `🚀 MCPJam Server started on fallback port ${port} (default ${DEFAULT_SERVER_PORT} was unavailable)`,
+      );
+    } else {
+      log.info(`🚀 MCPJam Server started on port ${port}`);
+    }
     return port;
   } catch (error) {
     log.error("Failed to start Hono server:", error);
@@ -527,9 +546,122 @@ function createAppMenu(): void {
   Menu.setApplicationMenu(menu);
 }
 
+function pruneStaleCachesOnVersionChange(): void {
+  // Dev launches change app version constantly with HMR/refresh; skip there.
+  if (!app.isPackaged) return;
+
+  const userData = app.getPath("userData");
+  const versionFile = path.join(userData, ".last-launched-version");
+  const currentVersion = app.getVersion();
+
+  let previousVersion: string | null = null;
+  try {
+    previousVersion = fs.readFileSync(versionFile, "utf8").trim();
+  } catch {
+    previousVersion = null;
+  }
+
+  if (previousVersion === currentVersion) {
+    return;
+  }
+
+  log.info(
+    `App version changed (${previousVersion ?? "<none>"} → ${currentVersion}); pruning stale GPU/HTTP caches`,
+  );
+
+  for (const sub of ["Cache", "Code Cache", "GPUCache"]) {
+    try {
+      fs.rmSync(path.join(userData, sub), { recursive: true, force: true });
+    } catch (err) {
+      log.warn(`Failed to prune ${sub} during version-change cleanup:`, err);
+    }
+  }
+
+  try {
+    fs.writeFileSync(versionFile, currentVersion);
+  } catch (err) {
+    log.warn("Failed to persist .last-launched-version marker:", err);
+  }
+}
+
+function summarizeInitError(error: unknown): {
+  message: string;
+  detail: string;
+} {
+  const err =
+    error instanceof Error ? error : new Error(String(error ?? "Unknown error"));
+
+  const isServerStartFailure = /bind server|EADDRINUSE|Hono/i.test(err.message);
+  const message = isServerStartFailure
+    ? "Couldn't start the internal server."
+    : "Initialization failed.";
+
+  const logsPath = (() => {
+    try {
+      return app.getPath("logs");
+    } catch {
+      return "(logs path unavailable)";
+    }
+  })();
+
+  const detail = `${err.message}\n\nLogs: ${logsPath}`;
+  return { message, detail };
+}
+
+function showStartupFailureDialog(error: unknown): void {
+  const { message, detail } = summarizeInitError(error);
+
+  const choice = dialog.showMessageBoxSync({
+    type: "error",
+    title: "MCPJam Inspector failed to start",
+    message,
+    detail,
+    buttons: ["Reset app data and quit", "Open logs folder", "Quit"],
+    defaultId: 2,
+    cancelId: 2,
+    noLink: true,
+  });
+
+  if (choice === 0) {
+    const userData = app.getPath("userData");
+    for (const sub of ["Cache", "Code Cache", "GPUCache", "Local Storage"]) {
+      try {
+        fs.rmSync(path.join(userData, sub), { recursive: true, force: true });
+        log.info(`Removed ${sub} during recovery reset`);
+      } catch (rmErr) {
+        log.warn(`Failed to remove ${sub} during recovery reset:`, rmErr);
+      }
+    }
+    app.relaunch();
+    app.quit();
+    return;
+  }
+
+  if (choice === 1) {
+    try {
+      void shell.openPath(app.getPath("logs"));
+    } catch (openErr) {
+      log.warn("Failed to open logs folder:", openErr);
+    }
+    app.quit();
+    return;
+  }
+
+  app.quit();
+}
+
 // App event handlers
 app.whenReady().then(async () => {
   try {
+    // Best-effort cleanup of GPU/HTTP caches when the app version changes.
+    // Stale caches from a previous build can crash the renderer/GPU process
+    // on launch after an auto-update.
+    try {
+      pruneStaleCachesOnVersionChange();
+    } catch (err) {
+      log.warn("pruneStaleCachesOnVersionChange threw; continuing:", err);
+    }
+
     // Start the embedded Hono server
     serverPort = await startHonoServer();
     const serverUrl = getServerUrl();
@@ -559,7 +691,15 @@ app.whenReady().then(async () => {
     log.info("MCPJam Electron app ready");
   } catch (error) {
     log.error("Failed to initialize app:", error);
-    app.quit();
+    try {
+      showStartupFailureDialog(error);
+    } catch (dialogErr) {
+      log.error(
+        "Failed to show startup failure dialog; quitting silently:",
+        dialogErr,
+      );
+      app.quit();
+    }
   }
 });
 

--- a/mcpjam-inspector/src/server-port-fallback.test.ts
+++ b/mcpjam-inspector/src/server-port-fallback.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tryListenWithFallback } from "./server-port-fallback";
+
+const honoStub = {
+  fetch: () =>
+    new Response("ok", { status: 200, headers: { "content-type": "text/plain" } }),
+};
+
+function listenBlocker(port: number): Promise<{
+  close: () => Promise<void>;
+  port: number;
+}> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer(() => {});
+    srv.once("error", reject);
+    srv.listen(port, "127.0.0.1", () => {
+      const actualPort = (srv.address() as AddressInfo).port;
+      resolve({
+        port: actualPort,
+        close: () =>
+          new Promise<void>((res) => {
+            srv.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+describe("tryListenWithFallback", () => {
+  it("returns first port when free", async () => {
+    // Pick an ephemeral port we know is currently free.
+    const probe = await listenBlocker(0);
+    const freePort = probe.port;
+    await probe.close();
+
+    const { server, port } = await tryListenWithFallback(
+      honoStub,
+      "127.0.0.1",
+      freePort,
+      3,
+    );
+    expect(port).toBe(freePort);
+    server.close?.();
+  });
+
+  it("falls back to the next port on EADDRINUSE", async () => {
+    // Grab a port and hold it so the first attempt collides.
+    const blocker = await listenBlocker(0);
+    const onAttemptFailed = vi.fn();
+
+    try {
+      const { server, port } = await tryListenWithFallback(
+        honoStub,
+        "127.0.0.1",
+        blocker.port,
+        5,
+        { onAttemptFailed },
+      );
+
+      expect(port).toBeGreaterThan(blocker.port);
+      expect(onAttemptFailed).toHaveBeenCalled();
+      const [failedPort, failedErr] = onAttemptFailed.mock.calls[0];
+      expect(failedPort).toBe(blocker.port);
+      expect(failedErr.code).toBe("EADDRINUSE");
+
+      server.close?.();
+    } finally {
+      await blocker.close();
+    }
+  });
+
+  it("throws after maxAttempts when every port fails", async () => {
+    // Inject a serve that always emits EADDRINUSE so we don't need to occupy
+    // a whole range of real ports.
+    const fakeServe = ((_options: unknown, _listening?: () => void) => {
+      const emitter: Record<string, Array<(...args: unknown[]) => void>> = {};
+      const server = {
+        on(ev: string, fn: (...args: unknown[]) => void) {
+          (emitter[ev] ||= []).push(fn);
+          // Defer firing so the helper has a chance to attach its listener.
+          if (ev === "error") {
+            queueMicrotask(() => {
+              const err = new Error("address in use") as NodeJS.ErrnoException;
+              err.code = "EADDRINUSE";
+              fn(err);
+            });
+          }
+        },
+        removeListener() {},
+        close() {},
+      };
+      return server as unknown as ReturnType<typeof import("@hono/node-server").serve>;
+    }) as typeof import("@hono/node-server").serve;
+
+    const onAttemptFailed = vi.fn();
+    await expect(
+      tryListenWithFallback(honoStub, "127.0.0.1", 60000, 4, {
+        serveImpl: fakeServe,
+        onAttemptFailed,
+      }),
+    ).rejects.toThrow(/Failed to bind server after 4 attempts/);
+    expect(onAttemptFailed).toHaveBeenCalledTimes(4);
+  });
+
+  it("propagates synchronous throws from serve", async () => {
+    const fakeServe = (() => {
+      throw new Error("synthetic synchronous boom");
+    }) as unknown as typeof import("@hono/node-server").serve;
+
+    await expect(
+      tryListenWithFallback(honoStub, "127.0.0.1", 60000, 1, {
+        serveImpl: fakeServe,
+      }),
+    ).rejects.toThrow(/Failed to bind server after 1 attempts/);
+  });
+});

--- a/mcpjam-inspector/src/server-port-fallback.test.ts
+++ b/mcpjam-inspector/src/server-port-fallback.test.ts
@@ -1,19 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { createServer } from "node:http";
+import net from "node:net";
 import type { AddressInfo } from "node:net";
-import { tryListenWithFallback } from "./server-port-fallback";
-
-const honoStub = {
-  fetch: () =>
-    new Response("ok", { status: 200, headers: { "content-type": "text/plain" } }),
-};
+import { probeFreePort } from "./server-port-fallback";
 
 function listenBlocker(port: number): Promise<{
   close: () => Promise<void>;
   port: number;
 }> {
   return new Promise((resolve, reject) => {
-    const srv = createServer(() => {});
+    const srv = net.createServer();
     srv.once("error", reject);
     srv.listen(port, "127.0.0.1", () => {
       const actualPort = (srv.address() as AddressInfo).port;
@@ -28,91 +23,86 @@ function listenBlocker(port: number): Promise<{
   });
 }
 
-describe("tryListenWithFallback", () => {
-  it("returns first port when free", async () => {
+describe("probeFreePort", () => {
+  it("returns the first port when it's free", async () => {
     // Pick an ephemeral port we know is currently free.
     const probe = await listenBlocker(0);
     const freePort = probe.port;
     await probe.close();
 
-    const { server, port } = await tryListenWithFallback(
-      honoStub,
-      "127.0.0.1",
-      freePort,
-      3,
-    );
-    expect(port).toBe(freePort);
-    server.close?.();
+    const picked = await probeFreePort("127.0.0.1", freePort, 3);
+    expect(picked).toBe(freePort);
   });
 
   it("falls back to the next port on EADDRINUSE", async () => {
-    // Grab a port and hold it so the first attempt collides.
+    // Grab a port and hold it so the first probe attempt collides.
     const blocker = await listenBlocker(0);
     const onAttemptFailed = vi.fn();
 
     try {
-      const { server, port } = await tryListenWithFallback(
-        honoStub,
-        "127.0.0.1",
-        blocker.port,
-        5,
-        { onAttemptFailed },
-      );
+      const picked = await probeFreePort("127.0.0.1", blocker.port, 5, {
+        onAttemptFailed,
+      });
 
-      expect(port).toBeGreaterThan(blocker.port);
+      expect(picked).toBeGreaterThan(blocker.port);
       expect(onAttemptFailed).toHaveBeenCalled();
       const [failedPort, failedErr] = onAttemptFailed.mock.calls[0];
       expect(failedPort).toBe(blocker.port);
       expect(failedErr.code).toBe("EADDRINUSE");
-
-      server.close?.();
     } finally {
       await blocker.close();
     }
   });
 
+  it("releases the probe socket before returning (next caller can bind the picked port)", async () => {
+    // The probe must close its server before resolving — otherwise the caller
+    // can't bind the picked port. Use a real net listen on the picked port
+    // to prove it's actually free.
+    const probe = await listenBlocker(0);
+    const freePort = probe.port;
+    await probe.close();
+
+    const picked = await probeFreePort("127.0.0.1", freePort, 3);
+
+    const reuse = await listenBlocker(picked);
+    expect(reuse.port).toBe(picked);
+    await reuse.close();
+  });
+
   it("throws after maxAttempts when every port fails", async () => {
-    // Inject a serve that always emits EADDRINUSE so we don't need to occupy
-    // a whole range of real ports.
-    const fakeServe = ((_options: unknown, _listening?: () => void) => {
-      const emitter: Record<string, Array<(...args: unknown[]) => void>> = {};
+    // Inject a createServer that always emits EADDRINUSE so we don't need to
+    // occupy a whole range of real ports.
+    const fakeCreateServer = (() => {
+      const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
       const server = {
+        once(ev: string, fn: (...args: unknown[]) => void) {
+          (handlers[ev] ||= []).push(fn);
+        },
         on(ev: string, fn: (...args: unknown[]) => void) {
-          (emitter[ev] ||= []).push(fn);
-          // Defer firing so the helper has a chance to attach its listener.
-          if (ev === "error") {
-            queueMicrotask(() => {
-              const err = new Error("address in use") as NodeJS.ErrnoException;
-              err.code = "EADDRINUSE";
-              fn(err);
-            });
-          }
+          (handlers[ev] ||= []).push(fn);
         },
         removeListener() {},
-        close() {},
+        close(cb?: (err?: Error) => void) {
+          cb?.();
+        },
+        listen() {
+          queueMicrotask(() => {
+            const err = new Error("address in use") as NodeJS.ErrnoException;
+            err.code = "EADDRINUSE";
+            handlers["error"]?.forEach((fn) => fn(err));
+          });
+        },
       };
-      return server as unknown as ReturnType<typeof import("@hono/node-server").serve>;
-    }) as typeof import("@hono/node-server").serve;
+      return server as unknown as ReturnType<typeof net.createServer>;
+    }) as typeof net.createServer;
 
     const onAttemptFailed = vi.fn();
     await expect(
-      tryListenWithFallback(honoStub, "127.0.0.1", 60000, 4, {
-        serveImpl: fakeServe,
+      probeFreePort("127.0.0.1", 60000, 4, {
+        createServerImpl: fakeCreateServer,
         onAttemptFailed,
       }),
-    ).rejects.toThrow(/Failed to bind server after 4 attempts/);
+    ).rejects.toThrow(/No free port available after 4 attempts/);
     expect(onAttemptFailed).toHaveBeenCalledTimes(4);
-  });
-
-  it("propagates synchronous throws from serve", async () => {
-    const fakeServe = (() => {
-      throw new Error("synthetic synchronous boom");
-    }) as unknown as typeof import("@hono/node-server").serve;
-
-    await expect(
-      tryListenWithFallback(honoStub, "127.0.0.1", 60000, 1, {
-        serveImpl: fakeServe,
-      }),
-    ).rejects.toThrow(/Failed to bind server after 1 attempts/);
   });
 });

--- a/mcpjam-inspector/src/server-port-fallback.ts
+++ b/mcpjam-inspector/src/server-port-fallback.ts
@@ -1,62 +1,50 @@
-import { serve } from "@hono/node-server";
-import type { ServerType } from "@hono/node-server";
+import net from "net";
 
-export type HonoFetch = (
-  request: Request,
-  ...args: unknown[]
-) => Response | Promise<Response>;
-
-export interface HonoAppLike {
-  fetch: HonoFetch;
-}
-
-export interface PortListenResult {
-  server: ServerType;
-  port: number;
-}
-
-export interface TryListenOptions {
+export interface ProbeFreePortOptions {
   /**
-   * Override the underlying `serve` implementation. Used by tests to inject
-   * deterministic success/failure behavior without binding real sockets.
-   */
-  serveImpl?: typeof serve;
-  /**
-   * Optional callback invoked with `(port, error)` each time a port attempt
+   * Optional callback invoked with `(port, error)` each time a probe attempt
    * fails. Useful for logging in production callers without bloating the
    * helper's surface.
    */
   onAttemptFailed?: (port: number, error: NodeJS.ErrnoException) => void;
+  /**
+   * Override the underlying net implementation. Tests inject a deterministic
+   * stand-in via this hook; production callers should never pass it.
+   */
+  createServerImpl?: typeof net.createServer;
 }
 
 /**
- * Attempt to bind a Hono server to `startPort`, falling back to `startPort + 1`,
- * `startPort + 2`, ..., up to `maxAttempts` total. Returns the first successful
- * bind. If all attempts fail, throws an AggregateError-shaped Error whose message
- * lists every port tried.
+ * Probe `startPort`, `startPort + 1`, ..., up to `maxAttempts` total, looking
+ * for one that is free to bind on `hostname`. Returns the first port that
+ * binds successfully (immediately closing the probe server before returning).
  *
- * Bind failures are detected via the `error` event on the returned server (the
- * common case is `EADDRINUSE` from a stale orphan process). Non-EADDRINUSE
- * errors are still treated as attempt failures so we keep trying other ports.
+ * This intentionally probes with a bare `net` server instead of binding the
+ * real Hono app. The reason: `server/config.ts` reads `SERVER_PORT` from
+ * `process.env` at module-load time, so the picked port must be known
+ * BEFORE `createHonoApp()` runs. The probe gives us that port without paying
+ * the cost of constructing a partial Hono app per attempt — and avoids
+ * leaving CORS/origin allowlists out of sync with the bound port (see PR
+ * #2418 review).
  *
- * The successful server has its bind-time `error` listener removed before
- * returning so the caller can attach their own.
+ * A small TOCTOU window remains between probe-close and the real
+ * `serve(...)`. Callers should still handle the rare race by surfacing the
+ * failure to the user (this is what the recovery dialog in `main.ts` is for).
  */
-export async function tryListenWithFallback(
-  honoApp: HonoAppLike,
+export async function probeFreePort(
   hostname: string,
   startPort: number,
   maxAttempts: number,
-  options: TryListenOptions = {},
-): Promise<PortListenResult> {
-  const serveFn = options.serveImpl ?? serve;
+  options: ProbeFreePortOptions = {},
+): Promise<number> {
+  const createServer = options.createServerImpl ?? net.createServer;
   const errors: Array<{ port: number; error: NodeJS.ErrnoException }> = [];
 
   for (let i = 0; i < maxAttempts; i++) {
     const port = startPort + i;
     try {
-      const server = await listenOnce(serveFn, honoApp, hostname, port);
-      return { server, port };
+      await probeOnce(createServer, hostname, port);
+      return port;
     } catch (err) {
       const error = err as NodeJS.ErrnoException;
       errors.push({ port, error });
@@ -68,52 +56,42 @@ export async function tryListenWithFallback(
     .map(({ port, error }) => `${port} (${error.code ?? error.message})`)
     .join(", ");
   throw new Error(
-    `Failed to bind server after ${maxAttempts} attempts starting at port ${startPort}. Tried: ${tried}`,
+    `No free port available after ${maxAttempts} attempts starting at port ${startPort}. Tried: ${tried}`,
   );
 }
 
-function listenOnce(
-  serveFn: typeof serve,
-  honoApp: HonoAppLike,
+function probeOnce(
+  createServer: typeof net.createServer,
   hostname: string,
   port: number,
-): Promise<ServerType> {
-  return new Promise<ServerType>((resolve, reject) => {
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
     let settled = false;
-
-    let server: ServerType;
-    try {
-      server = serveFn(
-        {
-          fetch: honoApp.fetch as Parameters<typeof serve>[0]["fetch"],
-          port,
-          hostname,
-        },
-        () => {
-          if (settled) return;
-          settled = true;
-          server.removeListener("error", onError);
-          resolve(server);
-        },
-      );
-    } catch (err) {
-      // Some failure modes (e.g. synchronous validation inside serve) surface
-      // as a thrown error instead of an error event.
-      reject(err);
-      return;
-    }
+    const server = createServer();
 
     const onError = (err: NodeJS.ErrnoException) => {
       if (settled) return;
       settled = true;
       try {
-        server.close?.();
+        server.close();
       } catch {
-        // best-effort cleanup; the listen failed so close may also throw
+        // best-effort cleanup
       }
       reject(err);
     };
 
-    server.on("error", onError);
+    server.once("error", onError);
+    server.listen(port, hostname, () => {
+      if (settled) return;
+      settled = true;
+      server.removeListener("error", onError);
+      server.close((closeErr) => {
+        if (closeErr) {
+          reject(closeErr);
+          return;
+        }
+        resolve();
+      });
+    });
   });
 }

--- a/mcpjam-inspector/src/server-port-fallback.ts
+++ b/mcpjam-inspector/src/server-port-fallback.ts
@@ -1,0 +1,119 @@
+import { serve } from "@hono/node-server";
+import type { ServerType } from "@hono/node-server";
+
+export type HonoFetch = (
+  request: Request,
+  ...args: unknown[]
+) => Response | Promise<Response>;
+
+export interface HonoAppLike {
+  fetch: HonoFetch;
+}
+
+export interface PortListenResult {
+  server: ServerType;
+  port: number;
+}
+
+export interface TryListenOptions {
+  /**
+   * Override the underlying `serve` implementation. Used by tests to inject
+   * deterministic success/failure behavior without binding real sockets.
+   */
+  serveImpl?: typeof serve;
+  /**
+   * Optional callback invoked with `(port, error)` each time a port attempt
+   * fails. Useful for logging in production callers without bloating the
+   * helper's surface.
+   */
+  onAttemptFailed?: (port: number, error: NodeJS.ErrnoException) => void;
+}
+
+/**
+ * Attempt to bind a Hono server to `startPort`, falling back to `startPort + 1`,
+ * `startPort + 2`, ..., up to `maxAttempts` total. Returns the first successful
+ * bind. If all attempts fail, throws an AggregateError-shaped Error whose message
+ * lists every port tried.
+ *
+ * Bind failures are detected via the `error` event on the returned server (the
+ * common case is `EADDRINUSE` from a stale orphan process). Non-EADDRINUSE
+ * errors are still treated as attempt failures so we keep trying other ports.
+ *
+ * The successful server has its bind-time `error` listener removed before
+ * returning so the caller can attach their own.
+ */
+export async function tryListenWithFallback(
+  honoApp: HonoAppLike,
+  hostname: string,
+  startPort: number,
+  maxAttempts: number,
+  options: TryListenOptions = {},
+): Promise<PortListenResult> {
+  const serveFn = options.serveImpl ?? serve;
+  const errors: Array<{ port: number; error: NodeJS.ErrnoException }> = [];
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const port = startPort + i;
+    try {
+      const server = await listenOnce(serveFn, honoApp, hostname, port);
+      return { server, port };
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      errors.push({ port, error });
+      options.onAttemptFailed?.(port, error);
+    }
+  }
+
+  const tried = errors
+    .map(({ port, error }) => `${port} (${error.code ?? error.message})`)
+    .join(", ");
+  throw new Error(
+    `Failed to bind server after ${maxAttempts} attempts starting at port ${startPort}. Tried: ${tried}`,
+  );
+}
+
+function listenOnce(
+  serveFn: typeof serve,
+  honoApp: HonoAppLike,
+  hostname: string,
+  port: number,
+): Promise<ServerType> {
+  return new Promise<ServerType>((resolve, reject) => {
+    let settled = false;
+
+    let server: ServerType;
+    try {
+      server = serveFn(
+        {
+          fetch: honoApp.fetch as Parameters<typeof serve>[0]["fetch"],
+          port,
+          hostname,
+        },
+        () => {
+          if (settled) return;
+          settled = true;
+          server.removeListener("error", onError);
+          resolve(server);
+        },
+      );
+    } catch (err) {
+      // Some failure modes (e.g. synchronous validation inside serve) surface
+      // as a thrown error instead of an error event.
+      reject(err);
+      return;
+    }
+
+    const onError = (err: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
+      try {
+        server.close?.();
+      } catch {
+        // best-effort cleanup; the listen failed so close may also throw
+      }
+      reject(err);
+    };
+
+    server.on("error", onError);
+  });
+}

--- a/mcpjam-inspector/src/vitest.config.ts
+++ b/mcpjam-inspector/src/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["**/*.test.ts"],
+    exclude: ["node_modules", "dist"],
+    testTimeout: 10000,
+    hookTimeout: 10000,
+  },
+});

--- a/mcpjam-inspector/vite.main.config.ts
+++ b/mcpjam-inspector/vite.main.config.ts
@@ -56,6 +56,16 @@ export default defineConfig({
         // fallback-port-not-synced regression. Keeping dynamic imports
         // as separate chunks preserves the deferral semantics.
         inlineDynamicImports: false,
+        // Pin every emitted JS file to `.cjs`. package.json has
+        // `"type": "module"`, so Node treats unknown `.js` files as ESM.
+        // The entry is already `.cjs` via `lib.fileName`, and Vite's
+        // current lib-mode default happens to give chunks `.cjs` too,
+        // but that's implicit. Make it explicit so a future Vite version
+        // can't silently emit a `.js` chunk that main.cjs's
+        // `require(...)` would then fail to load with "exports is not
+        // defined".
+        entryFileNames: "[name].cjs",
+        chunkFileNames: "[name]-[hash].cjs",
       },
     },
   },

--- a/mcpjam-inspector/vite.main.config.ts
+++ b/mcpjam-inspector/vite.main.config.ts
@@ -47,7 +47,15 @@ export default defineConfig({
         ...builtinModules.map((m) => `node:${m}`),
       ],
       output: {
-        inlineDynamicImports: true,
+        // Do NOT inline dynamic imports. main.ts uses `await import(...)`
+        // for `../server/app.js` so that `process.env.SERVER_PORT` (set
+        // after the port probe) is picked up by `server/config.ts` at
+        // module evaluation. With `inlineDynamicImports: true`, Rollup
+        // hoists that module to the top of the bundle and evaluates it
+        // eagerly at startup — defeating the fix for PR #2418's
+        // fallback-port-not-synced regression. Keeping dynamic imports
+        // as separate chunks preserves the deferral semantics.
+        inlineDynamicImports: false,
       },
     },
   },

--- a/mcpjam-inspector/vitest.workspace.ts
+++ b/mcpjam-inspector/vitest.workspace.ts
@@ -22,4 +22,11 @@ export default defineWorkspace([
       root: "./shared",
     },
   },
+  {
+    extends: "./src/vitest.config.ts",
+    test: {
+      name: "src",
+      root: "./src",
+    },
+  },
 ]);


### PR DESCRIPTION
## Summary

Ray had to delete all local app files to recover from a crash-on-launch. Three independent failure modes were silently fatal — every one ended at `app.whenReady().catch(app.quit)` with no user-visible signal.

- **Port fallback.** `startHonoServer()` hardcoded port 6274. If a stale orphan process held it, `serve()` rejected and the dock icon just bounced and disappeared. New `tryListenWithFallback` helper races the listen callback against the server `'error'` event per port; main now tries 6274–6283 before giving up. A non-default port is logged via `electron-log`.
- **Recovery dialog.** The whenReady error path now opens `dialog.showMessageBoxSync` with three buttons: "Reset app data and quit", "Open logs folder", "Quit" (defaultId/cancelId = Quit). Reset removes only `userData/{Cache,Code Cache,GPUCache,Local Storage}` — never the whole `userData` directory — then `relaunch()+quit()`. Fallback to silent quit if the dialog itself throws.
- **Cache prune on version change.** Packaged builds compare `app.getVersion()` against `userData/.last-launched-version`. On mismatch, prune `Cache`/`Code Cache`/`GPUCache` (each in its own try/catch — never fails launch) and write the new version. Cheap, addresses most native-cache bitrot after auto-update.

## Files

- `mcpjam-inspector/src/main.ts` — port fallback, recovery dialog, version-change cache prune
- `mcpjam-inspector/src/server-port-fallback.ts` — new helper
- `mcpjam-inspector/src/server-port-fallback.test.ts` — 4 new vitest cases
- `mcpjam-inspector/src/vitest.config.ts` — new (minimal node config for `src`)
- `mcpjam-inspector/vitest.workspace.ts` — added `src` project so CI picks up the new tests

## Test plan

- [x] Helper: `returns first port when free`, `falls back to next port on EADDRINUSE`, `throws after maxAttempts`, `propagates synchronous serve throws`. EADDRINUSE test uses a real `http.createServer().listen()` blocker, not a mock.
- [x] Full `npm test` — 481 files / 4924 tests pass (2 files / 6 tests skipped, same as baseline). No regressions.
- [x] `npx vite build --config vite.main.config.ts` — `dist/main.cjs` builds cleanly with the new imports.
- [ ] Manual: hold port 6274 with another process → confirm app starts on 6275 with a warning in electron-log.
- [ ] Manual: rename `userData/Cache` to a broken symlink → confirm recovery dialog appears with all three buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Electron startup (port binding, module load order, and userData recovery) and server CORS/origin alignment; mistakes could break local API access or over-clear user data, though scope is limited to the desktop main process.
> 
> **Overview**
> Improves **MCPJam Inspector** desktop startup when the embedded Hono server cannot bind or the app fails during init, instead of quitting silently.
> 
> **Port selection and config sync:** The main process no longer assumes port **6274**. It **probes** for a free port (default **6274**, up to **10** attempts) via new **`probeFreePort`**, sets **`process.env.SERVER_PORT`** *before* loading the server, and **dynamically imports** `../server/app.js` so `server/config.ts` (CORS, `LOCAL_SERVER_ADDR`, origin checks) matches the bound port. A **cached probed port** is reused on later **`startHonoServer()`** calls (e.g. macOS dock re-open) so a second probe cannot desync config from the listener.
> 
> **User-visible recovery:** Init failures show an **error dialog** (reset selective **userData** caches + relaunch, open logs then quit, or quit). **Packaged** builds **prune** GPU/HTTP caches when **`app.getVersion()`** changes vs a **`.last-launched-version`** marker.
> 
> **Build/tests:** **`vite.main.config.ts`** keeps dynamic imports as separate **`.cjs`** chunks (no **`inlineDynamicImports`**) so deferred server load stays valid; **`src`** Vitest project covers **`probeFreePort`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba10faba75ee7d91c85e927d73e82d3841beb384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->