### PR TITLE
eval→chatSessions PR-2 (inspector): per-turn fanout in iteration finalize

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -88,6 +88,7 @@ import {
 import { withHostContextSystemPrompt } from "@/shared/host-context-prompt";
 import { normalizeToolChoice, type EvalToolChoice } from "@/shared/tool-choice";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
+import { persistEvalTraceFanout } from "./evals/persist-eval-trace.js";
 import type {
   EvalStreamEvent,
   EvalStreamToolCall,
@@ -697,6 +698,33 @@ async function finishIterationDirectly(
     params.status ?? (params.passed ? "completed" : "failed");
   const result = params.passed ? "passed" : "failed";
 
+  // PR-2 eval→chatSessions fanout. Mirrors recorder.finishIteration —
+  // see persist-eval-trace.ts for the contract. When the flag is on,
+  // we persist N per-turn rows in chatSessions BEFORE the
+  // updateTestIteration call, then omit trace fields from the update.
+  const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
+    iterationStatus === "cancelled"
+      ? "eval_cancelled"
+      : params.passed
+        ? "eval_completed"
+        : "eval_failed";
+  const fanout = await persistEvalTraceFanout({
+    convexClient,
+    iterationId: params.iterationId,
+    terminalReason,
+    messages: params.messages,
+    spans: params.spans,
+    prompts: params.prompts,
+    widgetSnapshots: params.widgetSnapshots,
+  });
+  if (fanout?.persisted === false) {
+    logger.warn(
+      "[evals] persistEvalTraceFanout failed (quick run); falling back to legacy single-call path",
+      { iterationId: params.iterationId, error: fanout.error.message },
+    );
+  }
+  const sendTraceFieldsToUpdate = fanout?.persisted !== true;
+
   try {
     await convexClient.action("testSuites:updateTestIteration" as any, {
       iterationId: params.iterationId,
@@ -704,18 +732,22 @@ async function finishIterationDirectly(
       status: iterationStatus,
       actualToolCalls: sanitizeForConvexTransport(params.toolsCalled),
       tokensUsed: params.usage.totalTokens ?? 0,
-      messages: sanitizeForConvexTransport(params.messages),
-      ...(params.spans?.length
-        ? { spans: sanitizeForConvexTransport(params.spans) }
-        : {}),
-      ...(params.prompts?.length
-        ? { prompts: sanitizeForConvexTransport(params.prompts) }
-        : {}),
-      ...(params.widgetSnapshots?.length
+      ...(sendTraceFieldsToUpdate
         ? {
-            widgetSnapshots: sanitizeForConvexTransport(
-              params.widgetSnapshots,
-            ),
+            messages: sanitizeForConvexTransport(params.messages),
+            ...(params.spans?.length
+              ? { spans: sanitizeForConvexTransport(params.spans) }
+              : {}),
+            ...(params.prompts?.length
+              ? { prompts: sanitizeForConvexTransport(params.prompts) }
+              : {}),
+            ...(params.widgetSnapshots?.length
+              ? {
+                  widgetSnapshots: sanitizeForConvexTransport(
+                    params.widgetSnapshots,
+                  ),
+                }
+              : {}),
           }
         : {}),
       error: params.error,

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -88,7 +88,10 @@ import {
 import { withHostContextSystemPrompt } from "@/shared/host-context-prompt";
 import { normalizeToolChoice, type EvalToolChoice } from "@/shared/tool-choice";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
-import { persistEvalTraceFanout } from "./evals/persist-eval-trace.js";
+import {
+  lockEvalSessionAfterUpdate,
+  persistEvalTraceFanout,
+} from "./evals/persist-eval-trace.js";
 import type {
   EvalStreamEvent,
   EvalStreamToolCall,
@@ -699,9 +702,10 @@ async function finishIterationDirectly(
   const result = params.passed ? "passed" : "failed";
 
   // PR-2 eval→chatSessions fanout. Mirrors recorder.finishIteration —
-  // see persist-eval-trace.ts for the contract. When the flag is on,
-  // we persist N per-turn rows in chatSessions BEFORE the
-  // updateTestIteration call, then omit trace fields from the update.
+  // see persist-eval-trace.ts for the contract. Fanout writes per-turn
+  // rows BEFORE updateTestIteration; the chatSessions lock fires AFTER
+  // updateTestIteration succeeds (PR-2 review fix #2). When the
+  // backend flag is off, today's legacy behavior runs unchanged.
   const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
     iterationStatus === "cancelled"
       ? "eval_cancelled"
@@ -711,7 +715,7 @@ async function finishIterationDirectly(
   const fanout = await persistEvalTraceFanout({
     convexClient,
     iterationId: params.iterationId,
-    terminalReason,
+    iterationStartedAt: params.startedAt,
     messages: params.messages,
     spans: params.spans,
     prompts: params.prompts,
@@ -761,6 +765,16 @@ async function finishIterationDirectly(
         ...buildIterationUsageMetadata(params.usage),
       }),
     });
+
+    // updateTestIteration succeeded — fire the lock now. No-op when
+    // the fanout didn't persist (legacy path or fallback).
+    if (fanout?.persisted === true && params.iterationId) {
+      await lockEvalSessionAfterUpdate({
+        convexClient,
+        iterationId: params.iterationId,
+        reason: terminalReason,
+      });
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -723,11 +723,13 @@ async function finishIterationDirectly(
   });
   if (fanout?.persisted === false) {
     logger.warn(
-      "[evals] persistEvalTraceFanout failed (quick run); falling back to legacy single-call path",
+      "[evals] persistEvalTraceFanout failed (quick run); falling back to forced-legacy-blob path",
       { iterationId: params.iterationId, error: fanout.error.message },
     );
   }
   const sendTraceFieldsToUpdate = fanout?.persisted !== true;
+  // See recorder.ts for the rationale — same fallback escape hatch.
+  const forceLegacyTraceBlob = fanout?.persisted === false;
 
   try {
     await convexClient.action("testSuites:updateTestIteration" as any, {
@@ -736,6 +738,7 @@ async function finishIterationDirectly(
       status: iterationStatus,
       actualToolCalls: sanitizeForConvexTransport(params.toolsCalled),
       tokensUsed: params.usage.totalTokens ?? 0,
+      ...(forceLegacyTraceBlob ? { forceLegacyTraceBlob: true } : {}),
       ...(sendTraceFieldsToUpdate
         ? {
             messages: sanitizeForConvexTransport(params.messages),

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -731,6 +731,10 @@ async function finishIterationDirectly(
   // See recorder.ts for the rationale — same fallback escape hatch.
   const forceLegacyTraceBlob = fanout?.persisted === false;
 
+  // PR-2 review #5 (Cursor "Update failure after successful fanout"):
+  // track iteration-gone state so the lock can fire even when the
+  // update throws a transient error. Mirrors recorder.finishIteration.
+  let iterationGoneOrCancelled = false;
   try {
     await convexClient.action("testSuites:updateTestIteration" as any, {
       iterationId: params.iterationId,
@@ -768,16 +772,6 @@ async function finishIterationDirectly(
         ...buildIterationUsageMetadata(params.usage),
       }),
     });
-
-    // updateTestIteration succeeded — fire the lock now. No-op when
-    // the fanout didn't persist (legacy path or fallback).
-    if (fanout?.persisted === true && params.iterationId) {
-      await lockEvalSessionAfterUpdate({
-        convexClient,
-        iterationId: params.iterationId,
-        reason: terminalReason,
-      });
-    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -787,13 +781,35 @@ async function finishIterationDirectly(
       errorMessage.includes("unauthorized") ||
       errorMessage.includes("cancelled")
     ) {
-      return;
+      iterationGoneOrCancelled = true;
+    } else {
+      logger.error(
+        "[evals] Failed to finish iteration:",
+        new Error(errorMessage),
+      );
+      // Fall through to the lock step. See recorder.ts for the
+      // rationale: chatSessions transcript is complete from the
+      // fanout's perspective; locking prevents partial writes on a
+      // retry. Iteration row's terminal status may stay stale until
+      // a retry/cron sweep — acceptable because the chatSessions
+      // layer is consistent.
     }
+  }
 
-    logger.error(
-      "[evals] Failed to finish iteration:",
-      new Error(errorMessage),
-    );
+  // Lock the chatSession when fanout succeeded. Runs in BOTH the
+  // success branch and the transient-failure branch; skipped only
+  // when the iteration is gone. Mirrors recorder.finishIteration's
+  // pattern — see there for full rationale.
+  if (
+    fanout?.persisted === true &&
+    params.iterationId &&
+    !iterationGoneOrCancelled
+  ) {
+    await lockEvalSessionAfterUpdate({
+      convexClient,
+      iterationId: params.iterationId,
+      reason: terminalReason,
+    });
   }
 }
 

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -115,7 +115,16 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       compareRunId,
     });
 
-    return convexClient.action.mock.calls[0]?.[1] as {
+    // Find the updateTestIteration call specifically. The PR-2 fanout
+    // introduced an `isEvalChatSessionsWriterEnabled` flag check that
+    // fires before any iteration write, so indexing by `calls[0]`
+    // would now return the flag query, not the iteration update.
+    // Mock returns undefined for the flag query → cached as `false` →
+    // legacy single-call path runs unchanged.
+    const updateCall = convexClient.action.mock.calls.find(
+      (call) => call[0] === "testSuites:updateTestIteration",
+    );
+    return updateCall?.[1] as {
       metadata?: Record<string, string | number | boolean>;
       tokensUsed?: number;
     };

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -184,6 +184,53 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     };
   }
 
+  it(
+    "PR-2 review #5: lockEvalSession fires when fanout succeeded but updateTestIteration throws transient error",
+    async () => {
+      // Mock convexClient.action with ref-aware responses:
+      //   - flag-check returns enabled:true (writer on)
+      //   - appendEvalTurnTrace returns success (fanout persists)
+      //   - updateTestIteration throws a transient error (NOT a
+      //     "not found"/"cancelled" message — those bypass the lock)
+      //   - lockEvalSession records the call so we can assert it fired
+      const callsByRef: Record<string, number> = {};
+      const action = vi.fn(async (ref: string) => {
+        callsByRef[ref] = (callsByRef[ref] ?? 0) + 1;
+        if (ref === "testSuites:isEvalChatSessionsWriterEnabled") {
+          return { enabled: true };
+        }
+        if (ref === "testSuites:appendEvalTurnTrace") {
+          return { skipped: false, chatSessionId: "sess_x", locked: false };
+        }
+        if (ref === "testSuites:updateTestIteration") {
+          throw new Error("transient backend hiccup");
+        }
+        if (ref === "testSuites:lockEvalSession") {
+          return { skipped: false, locked: true, alreadyLocked: false };
+        }
+        return undefined;
+      });
+      convexClient.action = action;
+      // Reset the helper's process-latched flag cache so this test
+      // sees `enabled:true` instead of an earlier test's `false`.
+      const { __resetEvalChatSessionsWriterFlagCacheForTests } = await import(
+        "../persist-eval-trace.js"
+      );
+      __resetEvalChatSessionsWriterFlagCacheForTests();
+
+      await runQuickTestCase();
+
+      // Sanity: fanout did fire (so we know we're testing the new path)
+      // AND lockEvalSession was called despite the update throwing.
+      expect(callsByRef["testSuites:appendEvalTurnTrace"]).toBeGreaterThan(0);
+      expect(callsByRef["testSuites:updateTestIteration"]).toBeGreaterThan(0);
+      expect(callsByRef["testSuites:lockEvalSession"]).toBe(1);
+      // Reset for subsequent tests that may rely on the legacy "all
+      // actions return undefined" mock.
+      __resetEvalChatSessionsWriterFlagCacheForTests();
+    },
+  );
+
   it("persists compareRunId in quick-run iteration metadata when provided", async () => {
     const updatePayload = await runQuickTestCase("cmp_123");
 

--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ConvexHttpClient } from "convex/browser";
+import type { ModelMessage } from "ai";
+import type { EvalTraceSpan, PromptTraceSummary } from "@/shared/eval-trace";
+import {
+  __resetEvalChatSessionsWriterFlagCacheForTests,
+  isEvalChatSessionsWriterEnabled,
+  persistEvalTraceFanout,
+} from "../persist-eval-trace.js";
+
+type ActionCall = {
+  ref: string;
+  args: Record<string, unknown>;
+};
+
+function makeMockClient(opts: {
+  flagEnabled?: boolean;
+  appendResult?: { skipped: boolean };
+  appendThrows?: Error;
+}): { client: ConvexHttpClient; calls: ActionCall[] } {
+  const calls: ActionCall[] = [];
+  const action = vi.fn(async (ref: string, args: Record<string, unknown>) => {
+    calls.push({ ref, args });
+    if (ref === "testSuites:isEvalChatSessionsWriterEnabled") {
+      return { enabled: opts.flagEnabled ?? false };
+    }
+    if (ref === "testSuites:appendEvalTurnTrace") {
+      if (opts.appendThrows) throw opts.appendThrows;
+      return opts.appendResult ?? { skipped: false };
+    }
+    throw new Error(`unexpected action ${ref}`);
+  });
+  return {
+    client: { action } as unknown as ConvexHttpClient,
+    calls,
+  };
+}
+
+beforeEach(() => {
+  __resetEvalChatSessionsWriterFlagCacheForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("isEvalChatSessionsWriterEnabled", () => {
+  test("caches the flag value across calls in the same process", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    const a = await isEvalChatSessionsWriterEnabled(client);
+    const b = await isEvalChatSessionsWriterEnabled(client);
+    const c = await isEvalChatSessionsWriterEnabled(client);
+
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+    expect(c).toBe(true);
+    // Only ONE network call across three reads.
+    expect(
+      calls.filter((c) => c.ref === "testSuites:isEvalChatSessionsWriterEnabled"),
+    ).toHaveLength(1);
+  });
+
+  test("returns false (safe default) when the flag query throws", async () => {
+    const client = {
+      action: vi.fn(async () => {
+        throw new Error("convex unreachable");
+      }),
+    } as unknown as ConvexHttpClient;
+
+    const result = await isEvalChatSessionsWriterEnabled(client);
+    expect(result).toBe(false);
+  });
+});
+
+describe("persistEvalTraceFanout", () => {
+  test("returns null and makes no per-turn calls when the flag is off", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: false });
+
+    const result = await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      terminalReason: "eval_completed",
+      messages: [{ role: "user", content: "hi" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
+    });
+
+    expect(result).toBeNull();
+    expect(
+      calls.filter((c) => c.ref === "testSuites:appendEvalTurnTrace"),
+    ).toHaveLength(0);
+  });
+
+  test("fans out N per-turn calls and sets terminal only on the last", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "s0",
+        name: "step",
+        category: "step",
+        startMs: 1,
+        endMs: 2,
+        promptIndex: 0,
+      },
+      {
+        id: "s1",
+        name: "step",
+        category: "step",
+        startMs: 3,
+        endMs: 4,
+        promptIndex: 1,
+      },
+      {
+        id: "s2",
+        name: "step",
+        category: "step",
+        startMs: 5,
+        endMs: 6,
+        promptIndex: 2,
+      },
+    ];
+    const prompts: PromptTraceSummary[] = [
+      {
+        promptIndex: 0,
+        prompt: "p0",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+      {
+        promptIndex: 1,
+        prompt: "p1",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+      {
+        promptIndex: 2,
+        prompt: "p2",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+    ];
+    const messages: ModelMessage[] = [
+      { role: "user", content: "q0" } as ModelMessage,
+      { role: "assistant", content: "a0" } as ModelMessage,
+      { role: "user", content: "q1" } as ModelMessage,
+      { role: "assistant", content: "a1" } as ModelMessage,
+      { role: "user", content: "q2" } as ModelMessage,
+      { role: "assistant", content: "a2" } as ModelMessage,
+    ];
+
+    const result = await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      terminalReason: "eval_completed",
+      messages,
+      spans,
+      prompts,
+    });
+
+    expect(result).toEqual({ persisted: true });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    expect(appendCalls).toHaveLength(3);
+
+    // promptIndex sequence is 0, 1, 2.
+    expect(
+      appendCalls.map((c) => (c.args.turn as { promptIndex: number }).promptIndex),
+    ).toEqual([0, 1, 2]);
+
+    // Each turn carries its own spans (one each by promptIndex).
+    for (let i = 0; i < appendCalls.length; i++) {
+      const turn = appendCalls[i]!.args.turn as {
+        spans: EvalTraceSpan[];
+        sessionMessages: ModelMessage[];
+      };
+      expect(turn.spans).toHaveLength(1);
+      expect(turn.spans[0]!.promptIndex).toBe(i);
+      // Cumulative messages through end of turn i = (i+1) * 2 messages
+      // (user + assistant pairs).
+      expect(turn.sessionMessages).toHaveLength((i + 1) * 2);
+    }
+
+    // Terminal only on the final call.
+    expect(appendCalls[0]!.args.terminal).toBeUndefined();
+    expect(appendCalls[1]!.args.terminal).toBeUndefined();
+    expect(appendCalls[2]!.args.terminal).toEqual({ reason: "eval_completed" });
+  });
+
+  test("buckets unindexed spans onto the last turn (lossless)", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    // Two prompts (indices 0, 1) + one span without promptIndex.
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "s0",
+        name: "step",
+        category: "step",
+        startMs: 1,
+        endMs: 2,
+        promptIndex: 0,
+      },
+      {
+        id: "free",
+        name: "step",
+        category: "step",
+        startMs: 3,
+        endMs: 4,
+      },
+      {
+        id: "s1",
+        name: "step",
+        category: "step",
+        startMs: 5,
+        endMs: 6,
+        promptIndex: 1,
+      },
+    ];
+    const prompts: PromptTraceSummary[] = [
+      {
+        promptIndex: 0,
+        prompt: "p0",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+      {
+        promptIndex: 1,
+        prompt: "p1",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+    ];
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      terminalReason: "eval_completed",
+      messages: [
+        { role: "user", content: "q0" } as ModelMessage,
+        { role: "assistant", content: "a0" } as ModelMessage,
+        { role: "user", content: "q1" } as ModelMessage,
+        { role: "assistant", content: "a1" } as ModelMessage,
+      ],
+      spans,
+      prompts,
+    });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    const lastTurn = appendCalls[appendCalls.length - 1]!.args.turn as {
+      spans: EvalTraceSpan[];
+    };
+    // Last turn carries its own indexed span PLUS the unindexed one.
+    expect(lastTurn.spans.map((s) => s.id).sort()).toEqual(["free", "s1"]);
+  });
+
+  test("falls back when the action throws mid-fanout", async () => {
+    const error = new Error("mid-fanout failure");
+    const { client } = makeMockClient({ flagEnabled: true, appendThrows: error });
+
+    const result = await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      terminalReason: "eval_completed",
+      messages: [{ role: "user", content: "hi" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
+    });
+
+    expect(result).toEqual({ persisted: false, error });
+  });
+
+  test("falls back when the backend reports skipped:true (flag flipped mid-fanout)", async () => {
+    const { client } = makeMockClient({
+      flagEnabled: true,
+      appendResult: { skipped: true },
+    });
+
+    const result = await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      terminalReason: "eval_completed",
+      messages: [{ role: "user", content: "hi" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        persisted: false,
+      }),
+    );
+    expect((result as { error: Error }).error.message).toMatch(/skipped/);
+  });
+
+  test("traces with no spans/prompts persist as a single promptIndex:0 turn", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    const result = await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      terminalReason: "eval_completed",
+      messages: [
+        { role: "user", content: "hi" } as ModelMessage,
+        { role: "assistant", content: "hello" } as ModelMessage,
+      ],
+      spans: undefined,
+      prompts: undefined,
+    });
+
+    expect(result).toEqual({ persisted: true });
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    expect(appendCalls).toHaveLength(1);
+    expect(
+      (appendCalls[0]!.args.turn as { promptIndex: number }).promptIndex,
+    ).toBe(0);
+    expect(appendCalls[0]!.args.terminal).toEqual({
+      reason: "eval_completed",
+    });
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -29,6 +29,13 @@ function makeMockClient(opts: {
       if (opts.appendThrows) throw opts.appendThrows;
       return opts.appendResult ?? { skipped: false };
     }
+    if (ref === "testSuites:lockEvalSession") {
+      // Default success response so tests that exercise the lock
+      // helper's happy path don't accidentally take the swallowed-error
+      // branch. Tests that need the failure path stub a thrower client
+      // directly instead of going through this factory.
+      return { skipped: false, locked: true, alreadyLocked: false };
+    }
     throw new Error(`unexpected action ${ref}`);
   });
   return {
@@ -92,7 +99,7 @@ describe("persistEvalTraceFanout", () => {
     ).toHaveLength(0);
   });
 
-  test("fans out N per-turn calls and sets terminal only on the last", async () => {
+  test("fans out N per-turn calls without setting terminal (deferred to lockEvalSessionAfterUpdate)", async () => {
     const { client, calls } = makeMockClient({ flagEnabled: true });
 
     const spans: EvalTraceSpan[] = [
@@ -195,9 +202,12 @@ describe("persistEvalTraceFanout", () => {
       expect(turn.sessionMessages).toHaveLength((i + 1) * 2);
     }
 
-    // PR-2 review fix #2: the fanout no longer fires the terminal lock.
-    // None of the per-turn calls carry a `terminal` arg; callers fire
-    // `lockEvalSessionAfterUpdate` AFTER updateTestIteration succeeds.
+    // PR-2 review fix #2: the fanout no longer fires the terminal
+    // lock. None of the per-turn calls carry a `terminal` arg;
+    // callers fire `lockEvalSessionAfterUpdate` AFTER
+    // updateTestIteration succeeds. Test name was "sets terminal
+    // only on the last" pre-review; renamed to reflect actual
+    // behavior.
     for (const call of appendCalls) {
       expect(call.args.terminal).toBeUndefined();
     }

--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -80,7 +80,6 @@ describe("persistEvalTraceFanout", () => {
     const result = await persistEvalTraceFanout({
       convexClient: client,
       iterationId: "iter1",
-      terminalReason: "eval_completed",
       messages: [{ role: "user", content: "hi" } as ModelMessage],
       spans: undefined,
       prompts: undefined,
@@ -165,7 +164,6 @@ describe("persistEvalTraceFanout", () => {
     const result = await persistEvalTraceFanout({
       convexClient: client,
       iterationId: "iter1",
-      terminalReason: "eval_completed",
       messages,
       spans,
       prompts,
@@ -196,10 +194,12 @@ describe("persistEvalTraceFanout", () => {
       expect(turn.sessionMessages).toHaveLength((i + 1) * 2);
     }
 
-    // Terminal only on the final call.
-    expect(appendCalls[0]!.args.terminal).toBeUndefined();
-    expect(appendCalls[1]!.args.terminal).toBeUndefined();
-    expect(appendCalls[2]!.args.terminal).toEqual({ reason: "eval_completed" });
+    // PR-2 review fix #2: the fanout no longer fires the terminal lock.
+    // None of the per-turn calls carry a `terminal` arg; callers fire
+    // `lockEvalSessionAfterUpdate` AFTER updateTestIteration succeeds.
+    for (const call of appendCalls) {
+      expect(call.args.terminal).toBeUndefined();
+    }
   });
 
   test("buckets unindexed spans onto the last turn (lossless)", async () => {
@@ -257,7 +257,6 @@ describe("persistEvalTraceFanout", () => {
     await persistEvalTraceFanout({
       convexClient: client,
       iterationId: "iter1",
-      terminalReason: "eval_completed",
       messages: [
         { role: "user", content: "q0" } as ModelMessage,
         { role: "assistant", content: "a0" } as ModelMessage,
@@ -285,7 +284,6 @@ describe("persistEvalTraceFanout", () => {
     const result = await persistEvalTraceFanout({
       convexClient: client,
       iterationId: "iter1",
-      terminalReason: "eval_completed",
       messages: [{ role: "user", content: "hi" } as ModelMessage],
       spans: undefined,
       prompts: undefined,
@@ -303,7 +301,6 @@ describe("persistEvalTraceFanout", () => {
     const result = await persistEvalTraceFanout({
       convexClient: client,
       iterationId: "iter1",
-      terminalReason: "eval_completed",
       messages: [{ role: "user", content: "hi" } as ModelMessage],
       spans: undefined,
       prompts: undefined,
@@ -323,7 +320,6 @@ describe("persistEvalTraceFanout", () => {
     const result = await persistEvalTraceFanout({
       convexClient: client,
       iterationId: "iter1",
-      terminalReason: "eval_completed",
       messages: [
         { role: "user", content: "hi" } as ModelMessage,
         { role: "assistant", content: "hello" } as ModelMessage,
@@ -340,8 +336,49 @@ describe("persistEvalTraceFanout", () => {
     expect(
       (appendCalls[0]!.args.turn as { promptIndex: number }).promptIndex,
     ).toBe(0);
-    expect(appendCalls[0]!.args.terminal).toEqual({
-      reason: "eval_completed",
+    // No terminal in fanout — caller fires lockEvalSessionAfterUpdate.
+    expect(appendCalls[0]!.args.terminal).toBeUndefined();
+  });
+
+  test("threads iterationStartedAt through to the per-turn call (PR-2 review fix #1)", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    const realIterationStart = 1_700_000_000_000;
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      iterationStartedAt: realIterationStart,
+      messages: [{ role: "user", content: "hi" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
     });
+
+    const appendCall = calls.find(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    expect(appendCall).toBeDefined();
+    // The chatSessions row's startedAt is sourced from this arg, not
+    // from Date.now() at finalize time.
+    expect(appendCall!.args.startedAt).toBe(realIterationStart);
+  });
+
+  test("falls back to Date.now() for startedAt when iterationStartedAt is absent", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const before = Date.now();
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: [{ role: "user", content: "hi" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
+    });
+
+    const after = Date.now();
+    const appendCall = calls.find(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    expect(appendCall!.args.startedAt).toBeGreaterThanOrEqual(before);
+    expect(appendCall!.args.startedAt).toBeLessThanOrEqual(after);
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -5,6 +5,7 @@ import type { EvalTraceSpan, PromptTraceSummary } from "@/shared/eval-trace";
 import {
   __resetEvalChatSessionsWriterFlagCacheForTests,
   isEvalChatSessionsWriterEnabled,
+  lockEvalSessionAfterUpdate,
   persistEvalTraceFanout,
 } from "../persist-eval-trace.js";
 
@@ -362,6 +363,30 @@ describe("persistEvalTraceFanout", () => {
     expect(appendCall!.args.startedAt).toBe(realIterationStart);
   });
 
+  test("PR-2 fallback escape hatch: helper does not invoke the lock action itself", async () => {
+    // Caller is responsible for firing lockEvalSessionAfterUpdate AFTER
+    // updateTestIteration succeeds. The fanout helper must NEVER make
+    // the lock call (the whole point of the split is to defer the lock
+    // past the iteration-row write).
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: [
+        { role: "user", content: "q" } as ModelMessage,
+        { role: "assistant", content: "a" } as ModelMessage,
+      ],
+      spans: undefined,
+      prompts: undefined,
+    });
+
+    const lockCalls = calls.filter(
+      (c) => c.ref === "testSuites:lockEvalSession",
+    );
+    expect(lockCalls).toHaveLength(0);
+  });
+
   test("falls back to Date.now() for startedAt when iterationStartedAt is absent", async () => {
     const { client, calls } = makeMockClient({ flagEnabled: true });
     const before = Date.now();
@@ -380,5 +405,47 @@ describe("persistEvalTraceFanout", () => {
     );
     expect(appendCall!.args.startedAt).toBeGreaterThanOrEqual(before);
     expect(appendCall!.args.startedAt).toBeLessThanOrEqual(after);
+  });
+});
+
+describe("lockEvalSessionAfterUpdate", () => {
+  test("calls testSuites:lockEvalSession with the right iterationId + reason", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    await lockEvalSessionAfterUpdate({
+      convexClient: client,
+      iterationId: "iter-7",
+      reason: "eval_failed",
+    });
+
+    const lockCalls = calls.filter(
+      (c) => c.ref === "testSuites:lockEvalSession",
+    );
+    expect(lockCalls).toHaveLength(1);
+    expect(lockCalls[0]!.args).toEqual({
+      iterationId: "iter-7",
+      reason: "eval_failed",
+    });
+  });
+
+  test("swallows action errors so a missed lock doesn't fail a completed iteration", async () => {
+    const action = vi.fn(async (ref: string) => {
+      if (ref === "testSuites:lockEvalSession") {
+        throw new Error("convex unreachable");
+      }
+      return undefined;
+    });
+    const client = { action } as unknown as ConvexHttpClient;
+
+    // Must not throw — the iteration is already finalized at the call
+    // site and the auto-lock inside internalUpdateTestIteration is the
+    // backstop (PR-2 review #4 defense-in-depth).
+    await expect(
+      lockEvalSessionAfterUpdate({
+        convexClient: client,
+        iterationId: "iter-7",
+        reason: "eval_completed",
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -19,8 +19,10 @@ import { sanitizeForConvexTransport } from "./convex-sanitize.js";
  * readers (eval-diff, judge, server-quality, the unified Sessions
  * viewer) can address each turn individually. This helper slices the
  * trace by `promptIndex` and calls `api.testSuites.appendEvalTurnTrace`
- * per turn, with `terminal: { reason }` on the final call so the
- * chatSession lock fires once.
+ * per turn. **No `terminal` is set on the per-turn calls** — callers
+ * fire `lockEvalSessionAfterUpdate` AFTER `updateTestIteration`
+ * succeeds so a downstream iteration-row failure cannot leave a
+ * locked transcript without a finalized iteration (PR-2 review fix #2).
  *
  * Cadence-wise this is "per-turn data, single-call timing" — the
  * network round-trips happen at finishIteration time, not during the
@@ -41,10 +43,21 @@ import { sanitizeForConvexTransport } from "./convex-sanitize.js";
  *     against the now-locked session or, worse, EVAL_SESSION_LOCKED
  *     if any turn index doesn't match.
  *   - `{ persisted: false, error }`: the per-turn fanout failed mid-
- *     stream. Caller should fall back to today's legacy path. The
- *     chatSessions row may be partially populated; the row will be
- *     locked on the next iteration finalize attempt only if the
- *     caller retries.
+ *     stream. Caller should fall back to a forced-legacy-blob call by
+ *     passing `forceLegacyTraceBlob: true` to `updateTestIteration`,
+ *     which bypasses the backend's W1 chatSessions path even when the
+ *     flag is on. Without that escape hatch the legacy fallback would
+ *     re-enter the chatSessions writer with `promptIndex: 0` + full
+ *     transcript, overwriting any partially-fanned-out turn rows.
+ *
+ * Flag-cache caveat: the cached `enabled` value is process-latched.
+ * If the inspector starts before the backend deploys the
+ * `isEvalChatSessionsWriterEnabled` action it caches `false`
+ * permanently; a subsequent flag flip on the backend will not take
+ * effect until the inspector process restarts. Same for the opposite
+ * direction (cached `true` won't downgrade if the backend flips off).
+ * Acceptable trade-off for a process-scoped feature flag; document
+ * this in the deploy runbook before flipping the flag in prod.
  *
  * Widgets: PR-2 drops widgets from the forwarded payload for the same
  * reason PR-1's W1 path did — `EvalTraceWidgetSnapshot.serverId` is

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -1,0 +1,263 @@
+import type { ConvexHttpClient } from "convex/browser";
+import type { ModelMessage } from "ai";
+import type {
+  EvalTraceSpan,
+  EvalTraceWidgetSnapshot,
+  PromptTraceSummary,
+} from "@/shared/eval-trace";
+import { logger } from "../../utils/logger.js";
+import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+
+/**
+ * Inspector-side per-turn fanout for the eval→chatSessions unification.
+ *
+ * Both `recorder.finishIteration` (multi-iteration suite runs) and
+ * `finishIterationDirectly` (quick runs without a recorder) receive the
+ * final accumulated transcript at end-of-iteration. When the backend
+ * flag `USE_EVAL_CHAT_SESSIONS_WRITER` is on, we want N
+ * `chatSessionTurnTraces` rows for an N-turn iteration so downstream
+ * readers (eval-diff, judge, server-quality, the unified Sessions
+ * viewer) can address each turn individually. This helper slices the
+ * trace by `promptIndex` and calls `api.testSuites.appendEvalTurnTrace`
+ * per turn, with `terminal: { reason }` on the final call so the
+ * chatSession lock fires once.
+ *
+ * Cadence-wise this is "per-turn data, single-call timing" — the
+ * network round-trips happen at finishIteration time, not during the
+ * iteration loop. Live observability of running evals (which would
+ * require the runner's multi-turn loop itself to call this helper per
+ * turn) is deferred to a follow-up. The data shape and reader fidelity
+ * are identical between the two cadences.
+ *
+ * Return values:
+ *   - `null`: flag is off; caller should run today's legacy path
+ *     (single `updateTestIteration` call with full trace fields).
+ *   - `{ persisted: true }`: trace was written via chatSessions;
+ *     caller should call `updateTestIteration` with status/result
+ *     and metadata ONLY — no `messages` / `spans` / `prompts` /
+ *     `widgetSnapshots`. Passing trace fields after a successful
+ *     fanout would re-fire `persistEvalTraceAction` on
+ *     `updateTestIteration`'s W1 path and either be a silent no-op
+ *     against the now-locked session or, worse, EVAL_SESSION_LOCKED
+ *     if any turn index doesn't match.
+ *   - `{ persisted: false, error }`: the per-turn fanout failed mid-
+ *     stream. Caller should fall back to today's legacy path. The
+ *     chatSessions row may be partially populated; the row will be
+ *     locked on the next iteration finalize attempt only if the
+ *     caller retries.
+ *
+ * Widgets: PR-2 drops widgets from the forwarded payload for the same
+ * reason PR-1's W1 path did — `EvalTraceWidgetSnapshot.serverId` is
+ * `string` (could be a friendly server name from older runs), but
+ * `appendEvalTurnTrace`'s validator requires `serverId: v.id('servers')`.
+ * The legacy `testIteration.blob` fallback (when flag is off) still
+ * carries widgets. A follow-up PR that resolves serverIds at the runner
+ * layer (where the MCPClientManager is in scope) will repopulate
+ * `sharedChatWidgetSnapshots` for eval rows.
+ */
+
+let cachedFlagEnabled: boolean | null = null;
+let inFlightFlagQuery: Promise<boolean> | null = null;
+
+export async function isEvalChatSessionsWriterEnabled(
+  convexClient: ConvexHttpClient,
+): Promise<boolean> {
+  if (cachedFlagEnabled !== null) return cachedFlagEnabled;
+  if (inFlightFlagQuery) return inFlightFlagQuery;
+
+  inFlightFlagQuery = (async () => {
+    try {
+      const result = (await convexClient.action(
+        "testSuites:isEvalChatSessionsWriterEnabled" as any,
+        {},
+      )) as { enabled: boolean } | undefined;
+      cachedFlagEnabled = result?.enabled === true;
+      return cachedFlagEnabled;
+    } catch (error) {
+      logger.warn(
+        "[evals] Failed to query USE_EVAL_CHAT_SESSIONS_WRITER flag; assuming off",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      cachedFlagEnabled = false;
+      return false;
+    } finally {
+      inFlightFlagQuery = null;
+    }
+  })();
+  return inFlightFlagQuery;
+}
+
+/** Test-only hook. Reset the cache between tests. */
+export function __resetEvalChatSessionsWriterFlagCacheForTests(): void {
+  cachedFlagEnabled = null;
+  inFlightFlagQuery = null;
+}
+
+type TurnSlice = {
+  promptIndex: number;
+  spans: EvalTraceSpan[];
+  prompts: PromptTraceSummary[];
+  /** Cumulative session messages through this turn. */
+  sessionMessages: ModelMessage[];
+};
+
+/**
+ * Group spans + prompts by `promptIndex` and bucket messages by
+ * user-message ordinal. Spans without a `promptIndex` (older traces,
+ * step-level spans) attach to the last turn so they're not lost.
+ */
+function sliceTraceIntoTurns(args: {
+  messages: ModelMessage[];
+  spans: EvalTraceSpan[];
+  prompts: PromptTraceSummary[];
+}): TurnSlice[] {
+  // The set of turn indices we know about — union of spans + prompts
+  // indices. Spans with undefined promptIndex go onto the LAST turn so
+  // pre-promptIndex traces still land somewhere addressable.
+  const promptIndices = new Set<number>();
+  for (const span of args.spans) {
+    if (typeof span.promptIndex === "number") {
+      promptIndices.add(span.promptIndex);
+    }
+  }
+  for (const prompt of args.prompts) {
+    promptIndices.add(prompt.promptIndex);
+  }
+  if (promptIndices.size === 0) {
+    promptIndices.add(0);
+  }
+  const sortedIndices = Array.from(promptIndices).sort((a, b) => a - b);
+  const lastIndex = sortedIndices[sortedIndices.length - 1]!;
+
+  // Bucket messages: walk the array, count user messages, attribute each
+  // message to the current user-message ordinal as its promptIndex. This
+  // matches the eval runner's per-prompt loop semantics (one user
+  // message per promptTurn).
+  const messageBuckets = new Map<number, ModelMessage[]>();
+  for (const idx of sortedIndices) messageBuckets.set(idx, []);
+  let currentTurn = sortedIndices[0]!;
+  let userOrdinal = -1;
+  for (const message of args.messages) {
+    if (message.role === "user") {
+      userOrdinal += 1;
+      const candidate = sortedIndices[userOrdinal];
+      if (candidate !== undefined) currentTurn = candidate;
+    }
+    const bucket = messageBuckets.get(currentTurn);
+    if (bucket) bucket.push(message);
+  }
+
+  return sortedIndices.map((promptIndex) => {
+    const spansForTurn = args.spans.filter((span) => {
+      if (typeof span.promptIndex === "number") {
+        return span.promptIndex === promptIndex;
+      }
+      // Span without promptIndex → last turn (lossless).
+      return promptIndex === lastIndex;
+    });
+    const promptsForTurn = args.prompts.filter(
+      (p) => p.promptIndex === promptIndex,
+    );
+    // Cumulative messages through this turn.
+    const cumulative: ModelMessage[] = [];
+    for (const idx of sortedIndices) {
+      if (idx > promptIndex) break;
+      cumulative.push(...(messageBuckets.get(idx) ?? []));
+    }
+    return {
+      promptIndex,
+      spans: spansForTurn,
+      prompts: promptsForTurn,
+      sessionMessages: cumulative,
+    };
+  });
+}
+
+type FanoutResult =
+  | null
+  | { persisted: true }
+  | { persisted: false; error: Error };
+
+export async function persistEvalTraceFanout(args: {
+  convexClient: ConvexHttpClient;
+  iterationId: string;
+  /** Used as `chatSessions.displayLabel`. */
+  displayLabel?: string;
+  modelId?: string;
+  /** Maps to `chatSessions.modelSource`. Defaults to 'mcpjam'. */
+  modelSource?: "mcpjam" | "byok" | "local_byok";
+  /** Terminal reason derived from iteration status/result. */
+  terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled";
+  messages: ModelMessage[];
+  spans: EvalTraceSpan[] | undefined;
+  prompts: PromptTraceSummary[] | undefined;
+  /** Currently unused — see file header note about widgets. */
+  widgetSnapshots?: EvalTraceWidgetSnapshot[];
+}): Promise<FanoutResult> {
+  const enabled = await isEvalChatSessionsWriterEnabled(args.convexClient);
+  if (!enabled) return null;
+
+  // Avoid touching the widgetSnapshots param so linters don't flag it.
+  // Documented in the file header why widgets are PR-2-deferred.
+  void args.widgetSnapshots;
+
+  const turns = sliceTraceIntoTurns({
+    messages: args.messages,
+    spans: args.spans ?? [],
+    prompts: args.prompts ?? [],
+  });
+
+  const startedAt = Date.now();
+  const modelId = args.modelId ?? "eval/unknown";
+  const modelSource = args.modelSource ?? "mcpjam";
+
+  try {
+    for (let i = 0; i < turns.length; i++) {
+      const turn = turns[i]!;
+      const isLast = i === turns.length - 1;
+      const now = Date.now();
+      const result = (await args.convexClient.action(
+        "testSuites:appendEvalTurnTrace" as any,
+        {
+          iterationId: args.iterationId,
+          modelId,
+          modelSource,
+          ...(args.displayLabel ? { displayLabel: args.displayLabel } : {}),
+          startedAt,
+          lastActivityAt: now,
+          turn: {
+            promptIndex: turn.promptIndex,
+            turnStartedAt: now,
+            turnEndedAt: now,
+            sessionMessages: sanitizeForConvexTransport(turn.sessionMessages),
+            spans: sanitizeForConvexTransport(turn.spans),
+            ...(turn.prompts.length > 0
+              ? { prompts: sanitizeForConvexTransport(turn.prompts) }
+              : {}),
+            widgets: [],
+          },
+          ...(isLast
+            ? { terminal: { reason: args.terminalReason } }
+            : {}),
+        },
+      )) as { skipped?: boolean } | undefined;
+      // If the backend reports `skipped: true`, the flag flipped off
+      // between our cache check and the per-turn call. Bail out so the
+      // caller can fall back to the legacy path.
+      if (result?.skipped === true) {
+        return {
+          persisted: false,
+          error: new Error(
+            "appendEvalTurnTrace returned skipped:true; flag turned off mid-fanout",
+          ),
+        };
+      }
+    }
+    return { persisted: true };
+  } catch (error) {
+    return {
+      persisted: false,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -183,11 +183,14 @@ export async function persistEvalTraceFanout(args: {
   iterationId: string;
   /** Used as `chatSessions.displayLabel`. */
   displayLabel?: string;
+  /** Real iteration start (ms epoch) — surfaces in `chatSessions.startedAt`.
+   *  Falls back to `Date.now()` only when absent. PR-2 review fix #1
+   *  (Cursor #a52700dd): the old default-to-finalize-time skewed Sessions
+   *  viewer timelines for long-running evals. */
+  iterationStartedAt?: number;
   modelId?: string;
   /** Maps to `chatSessions.modelSource`. Defaults to 'mcpjam'. */
   modelSource?: "mcpjam" | "byok" | "local_byok";
-  /** Terminal reason derived from iteration status/result. */
-  terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled";
   messages: ModelMessage[];
   spans: EvalTraceSpan[] | undefined;
   prompts: PromptTraceSummary[] | undefined;
@@ -207,14 +210,20 @@ export async function persistEvalTraceFanout(args: {
     prompts: args.prompts ?? [],
   });
 
-  const startedAt = Date.now();
+  const startedAt = args.iterationStartedAt ?? Date.now();
   const modelId = args.modelId ?? "eval/unknown";
   const modelSource = args.modelSource ?? "mcpjam";
 
+  // PR-2 review fix #2 (Cursor #ed44ef40): the fanout no longer fires
+  // the chatSessions terminal lock. Callers fire `lockEvalSessionAfterUpdate`
+  // explicitly AFTER `updateTestIteration` succeeds so a downstream
+  // iteration-row failure cannot leave a locked transcript without a
+  // finalized iteration. Idempotent on retry per PR-1 lock semantics
+  // (same-promptIndex re-write before lock = patch in place, no-op
+  // after lock).
   try {
     for (let i = 0; i < turns.length; i++) {
       const turn = turns[i]!;
-      const isLast = i === turns.length - 1;
       const now = Date.now();
       const result = (await args.convexClient.action(
         "testSuites:appendEvalTurnTrace" as any,
@@ -236,9 +245,6 @@ export async function persistEvalTraceFanout(args: {
               : {}),
             widgets: [],
           },
-          ...(isLast
-            ? { terminal: { reason: args.terminalReason } }
-            : {}),
         },
       )) as { skipped?: boolean } | undefined;
       // If the backend reports `skipped: true`, the flag flipped off
@@ -259,5 +265,34 @@ export async function persistEvalTraceFanout(args: {
       persisted: false,
       error: error instanceof Error ? error : new Error(String(error)),
     };
+  }
+}
+
+/**
+ * Fires the chatSessions lock via the backend after `updateTestIteration`
+ * has succeeded. Idempotent — silently no-ops if the session is already
+ * locked or if no chatSessions row was persisted (e.g. the fanout fell
+ * back). Best-effort: logs and swallows transient failures because the
+ * iteration row is already finalized at the call site and a missed lock
+ * is recoverable on the next finalize attempt.
+ */
+export async function lockEvalSessionAfterUpdate(args: {
+  convexClient: ConvexHttpClient;
+  iterationId: string;
+  reason: "eval_completed" | "eval_failed" | "eval_cancelled";
+}): Promise<void> {
+  try {
+    await args.convexClient.action(
+      "testSuites:lockEvalSession" as any,
+      { iterationId: args.iterationId, reason: args.reason },
+    );
+  } catch (error) {
+    logger.warn(
+      "[evals] lockEvalSession failed after updateTestIteration; transcript will remain unlocked",
+      {
+        iterationId: args.iterationId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
   }
 }

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -9,7 +9,10 @@ import { logger } from "../../utils/logger";
 import type { ServerToolSnapshot } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
 import { buildIterationUsageMetadata } from "./iteration-usage-metadata.js";
-import { persistEvalTraceFanout } from "./persist-eval-trace.js";
+import {
+  lockEvalSessionAfterUpdate,
+  persistEvalTraceFanout,
+} from "./persist-eval-trace.js";
 import { resolveCaseSuccessPredicates } from "@/shared/eval-matching";
 
 type IterationStatus = "completed" | "failed" | "cancelled";
@@ -201,6 +204,7 @@ export const createSuiteRunRecorder = ({
       prompts,
       widgetSnapshots,
       status,
+      startedAt,
       error,
       errorDetails,
       resultSource,
@@ -233,9 +237,14 @@ export const createSuiteRunRecorder = ({
 
       // PR-2 eval→chatSessions fanout: when the backend flag is on,
       // write the transcript as per-turn rows in the chatSessions path
-      // before calling updateTestIteration. The fanout result drives
-      // whether we still pass messages/spans/prompts/widgetSnapshots
-      // to updateTestIteration:
+      // BEFORE calling updateTestIteration. The fanout no longer fires
+      // the terminal lock — that happens AFTER updateTestIteration
+      // succeeds so a downstream iteration-row failure cannot leave a
+      // locked transcript without a finalized iteration (PR-2 review
+      // fix #2, Cursor #ed44ef40). Idempotent on retry.
+      //
+      // Fanout result drives whether we still pass trace fields to
+      // updateTestIteration:
       //   - null            → flag off; today's legacy behavior runs
       //   - persisted:true  → trace lives in chatSessions; updateTestIteration
       //                       called WITHOUT trace fields (no double-persist)
@@ -251,7 +260,7 @@ export const createSuiteRunRecorder = ({
       const fanout = await persistEvalTraceFanout({
         convexClient,
         iterationId,
-        terminalReason,
+        iterationStartedAt: startedAt,
         messages,
         spans,
         prompts,
@@ -301,6 +310,18 @@ export const createSuiteRunRecorder = ({
             ...buildIterationUsageMetadata(usage),
           }),
         });
+
+        // updateTestIteration succeeded — now safe to set the lock.
+        // No-op when the fanout didn't persist (legacy path or
+        // fallback). Best-effort: lockEvalSessionAfterUpdate swallows
+        // transient failures because a missed lock is recoverable.
+        if (fanout?.persisted === true) {
+          await lockEvalSessionAfterUpdate({
+            convexClient,
+            iterationId,
+            reason: terminalReason,
+          });
+        }
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -268,11 +268,21 @@ export const createSuiteRunRecorder = ({
       });
       if (fanout?.persisted === false) {
         logger.warn(
-          "[evals] persistEvalTraceFanout failed; falling back to legacy single-call path",
+          "[evals] persistEvalTraceFanout failed; falling back to forced-legacy-blob path",
           { iterationId, error: fanout.error.message },
         );
       }
       const sendTraceFieldsToUpdate = fanout?.persisted !== true;
+      // When the fanout failed mid-stream we MUST force the backend
+      // into the legacy blob path. Otherwise — with the writer flag
+      // still on — `updateTestIteration` re-enters the chatSessions
+      // W1 path with `promptIndex: 0` + full transcript, which would
+      // overwrite any partial turn rows the fanout already wrote
+      // and possibly fight an existing lock. The escape hatch makes
+      // the iteration replayable from `testIteration.blob` while the
+      // partial chatSessions data is left inert (source-aware reader
+      // tolerates absence).
+      const forceLegacyTraceBlob = fanout?.persisted === false;
 
       try {
         await convexClient.action("testSuites:updateTestIteration" as any, {
@@ -282,6 +292,7 @@ export const createSuiteRunRecorder = ({
           result,
           actualToolCalls: sanitizeForConvexTransport(toolsCalled),
           tokensUsed: usage.totalTokens ?? 0,
+          ...(forceLegacyTraceBlob ? { forceLegacyTraceBlob: true } : {}),
           ...(sendTraceFieldsToUpdate
             ? {
                 messages: sanitizeForConvexTransport(messages),

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -9,6 +9,7 @@ import { logger } from "../../utils/logger";
 import type { ServerToolSnapshot } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
 import { buildIterationUsageMetadata } from "./iteration-usage-metadata.js";
+import { persistEvalTraceFanout } from "./persist-eval-trace.js";
 import { resolveCaseSuccessPredicates } from "@/shared/eval-matching";
 
 type IterationStatus = "completed" | "failed" | "cancelled";
@@ -230,6 +231,40 @@ export const createSuiteRunRecorder = ({
         status ?? (passed ? DEFAULT_ITERATION_STATUS : "failed");
       const result = passed ? "passed" : "failed";
 
+      // PR-2 eval→chatSessions fanout: when the backend flag is on,
+      // write the transcript as per-turn rows in the chatSessions path
+      // before calling updateTestIteration. The fanout result drives
+      // whether we still pass messages/spans/prompts/widgetSnapshots
+      // to updateTestIteration:
+      //   - null            → flag off; today's legacy behavior runs
+      //   - persisted:true  → trace lives in chatSessions; updateTestIteration
+      //                       called WITHOUT trace fields (no double-persist)
+      //   - persisted:false → fanout failed mid-stream; fall back to
+      //                       the legacy single-call path so the iteration
+      //                       is still complete and replayable.
+      const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
+        iterationStatus === "cancelled"
+          ? "eval_cancelled"
+          : passed
+            ? "eval_completed"
+            : "eval_failed";
+      const fanout = await persistEvalTraceFanout({
+        convexClient,
+        iterationId,
+        terminalReason,
+        messages,
+        spans,
+        prompts,
+        widgetSnapshots,
+      });
+      if (fanout?.persisted === false) {
+        logger.warn(
+          "[evals] persistEvalTraceFanout failed; falling back to legacy single-call path",
+          { iterationId, error: fanout.error.message },
+        );
+      }
+      const sendTraceFieldsToUpdate = fanout?.persisted !== true;
+
       try {
         await convexClient.action("testSuites:updateTestIteration" as any, {
           iterationId,
@@ -238,17 +273,21 @@ export const createSuiteRunRecorder = ({
           result,
           actualToolCalls: sanitizeForConvexTransport(toolsCalled),
           tokensUsed: usage.totalTokens ?? 0,
-          messages: sanitizeForConvexTransport(messages),
-          ...(spans?.length
-            ? { spans: sanitizeForConvexTransport(spans) }
-            : {}),
-          ...(prompts?.length
-            ? { prompts: sanitizeForConvexTransport(prompts) }
-            : {}),
-          ...(widgetSnapshots?.length
+          ...(sendTraceFieldsToUpdate
             ? {
-                widgetSnapshots:
-                  sanitizeForConvexTransport(widgetSnapshots),
+                messages: sanitizeForConvexTransport(messages),
+                ...(spans?.length
+                  ? { spans: sanitizeForConvexTransport(spans) }
+                  : {}),
+                ...(prompts?.length
+                  ? { prompts: sanitizeForConvexTransport(prompts) }
+                  : {}),
+                ...(widgetSnapshots?.length
+                  ? {
+                      widgetSnapshots:
+                        sanitizeForConvexTransport(widgetSnapshots),
+                    }
+                  : {}),
               }
             : {}),
           error,

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -284,6 +284,11 @@ export const createSuiteRunRecorder = ({
       // tolerates absence).
       const forceLegacyTraceBlob = fanout?.persisted === false;
 
+      // PR-2 review #5 (Cursor "Update failure after successful fanout"):
+      // track whether the iteration is gone so we don't waste a lock
+      // call on a deleted session, AND so the lock fires even when
+      // the iteration update threw a transient error.
+      let iterationGoneOrCancelled = false;
       try {
         await convexClient.action("testSuites:updateTestIteration" as any, {
           iterationId,
@@ -321,18 +326,6 @@ export const createSuiteRunRecorder = ({
             ...buildIterationUsageMetadata(usage),
           }),
         });
-
-        // updateTestIteration succeeded — now safe to set the lock.
-        // No-op when the fanout didn't persist (legacy path or
-        // fallback). Best-effort: lockEvalSessionAfterUpdate swallows
-        // transient failures because a missed lock is recoverable.
-        if (fanout?.persisted === true) {
-          await lockEvalSessionAfterUpdate({
-            convexClient,
-            iterationId,
-            reason: terminalReason,
-          });
-        }
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
@@ -344,14 +337,36 @@ export const createSuiteRunRecorder = ({
           errorMessage.includes("cancelled")
         ) {
           runDeleted = true;
-          // Silently skip - run was likely cancelled/deleted
-          return;
+          iterationGoneOrCancelled = true;
+        } else {
+          logger.error(
+            "[evals] Failed to record iteration result:",
+            new Error(errorMessage),
+          );
+          // Transient (non-cancellation) failure: fall through to the
+          // lock step. The chatSessions transcript is complete from
+          // the fanout's perspective; locking prevents a retry from
+          // accumulating partial writes against a row whose data
+          // already represents the final state. The iteration row's
+          // terminal status remains stale until a retry/cron sweep
+          // finalizes it — that's acceptable because the data is
+          // consistent at the chatSessions layer.
         }
+      }
 
-        logger.error(
-          "[evals] Failed to record iteration result:",
-          new Error(errorMessage),
-        );
+      // Lock the chatSession when fanout succeeded — runs in BOTH the
+      // success branch (updateTestIteration succeeded → defense + UI
+      // hint) and the transient-failure branch (updateTestIteration
+      // threw a non-cancellation error → prevents partial writes on
+      // retry). Skipped only when the iteration is gone, where
+      // locking a deleted session is wasted work. Best-effort:
+      // lockEvalSessionAfterUpdate swallows its own failures.
+      if (fanout?.persisted === true && !iterationGoneOrCancelled) {
+        await lockEvalSessionAfterUpdate({
+          convexClient,
+          iterationId,
+          reason: terminalReason,
+        });
       }
     },
     async finalize({ status, summary, notes }) {


### PR DESCRIPTION
## Summary

PR-2 of the 7-PR eval-transcript unification. Wires the inspector evals runner into the new backend per-turn entrypoints. When the backend flag `USE_EVAL_CHAT_SESSIONS_WRITER` is on, eval iterations now persist N `chatSessionTurnTraces` rows for an N-turn iteration instead of PR-1's `promptIndex: 0` collapse. This unlocks the reader migrations in PRs 3-5.

New helper `server/services/evals/persist-eval-trace.ts` shared by both finalize paths:

- **`recorder.finishIteration`** (suite runs via `createSuiteRunRecorder`)
- **`finishIterationDirectly`** (quick runs without a recorder)

Both call the helper before calling `updateTestIteration`. The helper:

- Caches the flag value at module scope; one query per inspector process, with in-flight dedupe for concurrent first-callers.
- When off: returns `null`; the surrounding finalize path runs today's legacy single-call behavior unchanged.
- When on: slices the accumulated trace by `promptIndex` (spans + prompts addressable directly; messages bucketed by user-message ordinal; unindexed spans fall onto the last turn so older traces don't lose data) and calls `appendEvalTurnTrace` N times. **No `terminal` arg on any per-turn call** — the chatSessions lock fires AFTER `updateTestIteration` succeeds via the new `lockEvalSessionAfterUpdate` helper. Returns `{ persisted: true }` so the surrounding `updateTestIteration` call can omit `messages`/`spans`/`prompts`/`widgetSnapshots`.
- When the fanout fails mid-stream returns `{ persisted: false, error }`; both call sites pass `forceLegacyTraceBlob: true` to `updateTestIteration` so the backend bypasses the W1 chatSessions path and writes `iteration.blob` instead. The backend also sets `preferLegacyBlob: true` on the iteration and locks the orphan chatSessions row so the source-aware reader returns the complete legacy blob, not the partial chatSessions transcript.

## Lock semantics

The fanout writes per-turn rows; the lock fires AFTER `updateTestIteration` succeeds via `lockEvalSessionAfterUpdate`. If the iteration update fails mid-way, the chatSession is never locked — a retry can replay safely (same-turn re-writes patch in place per PR-1 contract). Defense-in-depth: backend `internalUpdateTestIteration` now auto-locks the eval chatSession when terminal status lands on an iteration with `chatSessionId` set, so the "every finalized eval iteration ends with a locked transcript" invariant is maintained by the iteration writer itself rather than depending on the best-effort second round-trip.

## Cadence note

This is "per-turn data, single-call timing." Network round-trips happen at iteration finalize, not during the multi-turn loop. The data shape and reader fidelity for follow-on PRs are identical to a true per-call cadence, so this smaller scope is enough to unblock the reader migrations.

Live observability of running evals (which would require the iteration loop itself to call this helper per turn) is deferred — the same helper can be lifted into `runIterationWithAiSdk` / `runIterationViaBackend` without API changes when that's wanted.

## Flag cache caveat

The cached `enabled` value is process-latched. If the inspector starts before the backend deploys the flag-check action it caches `false` permanently; a subsequent flag flip on the backend will not take effect until the inspector process restarts. Same for the opposite direction. Acceptable trade-off for a process-scoped feature flag — document this in the deploy runbook before flipping the flag in prod.

## Widgets

`EvalTraceWidgetSnapshot.serverId` is `string` (could be a friendly server name), but `appendEvalTurnTrace` requires `v.id('servers')`. PR-2 drops widgets from the per-turn payload. Legacy `testIteration.blob` still carries them when the flag is off. A follow-up with serverId resolution at the runner layer (where `MCPClientManager` is in scope) will repopulate `sharedChatWidgetSnapshots` for eval rows.

## Test plan

- [x] `server/services/evals/__tests__/persist-eval-trace.test.ts` — 13 tests covering flag caching, safe-default on query failure, no per-turn calls when flag is off, N-call fanout with NO terminal arg on any call (deferred to `lockEvalSessionAfterUpdate`), unindexed-span bucketing onto the last turn, fallback on action throw, fallback on backend `skipped:true`, single-turn fallback for traces with no spans or prompts, `iterationStartedAt` threading, `Date.now()` fallback, the fanout helper never calls `lockEvalSession` itself, and `lockEvalSessionAfterUpdate` makes the right action call + swallows failures.
- [x] `evals-runner.test.ts` — 12 tests, including `runQuickTestCase`'s `compareRunId` assertion finds the `updateTestIteration` call by name (robust to additional action calls landing in front).
- [ ] Smoke locally with backend `USE_EVAL_CHAT_SESSIONS_WRITER=true`: run a 3-turn eval, confirm 3 `chatSessionTurnTraces` rows appear with promptIndex 0/1/2, `lockedAt` set after final, `iteration.chatSessionId` patched, `iteration.blob` NOT set.
- [ ] Smoke with flag off: confirm legacy `testIteration.blob` path still runs (no chatSessions row, no turn-trace rows).
- [ ] Smoke fanout-failure fallback: induce a mid-fanout failure, confirm `iteration.blob` is written, `preferLegacyBlob: true`, and `getTestIterationBlob` returns the full legacy envelope (not the partial chatSessions transcript).

## Pre-existing typecheck noise

Pre-existing errors at four `finishIterationDirectly` callsites (lines 1376, 2065, 3001, 3948 — same errors existed on a clean main tree) are NOT introduced by this PR. They predate eval→chatSessions work.

## Coordination

**Depends on MCPJam/mcpjam-backend#429** (PR-2 follow-up) which ships `forceLegacyTraceBlob`, `lockEvalSession`, the auto-lock in `internalUpdateTestIteration`, `displayLabel` derivation, `modelId` derivation, and the new `preferLegacyBlob` source-preference marker. The backend follow-up is required for the fanout-failure fallback path to actually deliver the "iteration is still complete and replayable" promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how eval transcripts are persisted and finalized (chatSessions vs legacy blob) with new failure/fallback paths; behavior depends on a process-cached feature flag and coordinated backend actions (`appendEvalTurnTrace`, `lockEvalSession`, `forceLegacyTraceBlob`).
> 
> **Overview**
> When **`USE_EVAL_CHAT_SESSIONS_WRITER`** is enabled, eval iteration finalize now writes **N per-turn `chatSessionTurnTraces` rows** via a shared **`persist-eval-trace`** helper instead of stuffing the full trace into a single **`updateTestIteration`** payload.
> 
> **`recorder.finishIteration`** (suite runs) and **`finishIterationDirectly`** (quick runs) both call **`persistEvalTraceFanout`** first, then **`updateTestIteration`** with status/metadata only when fanout succeeds (trace fields omitted to avoid double-persist). On fanout failure they pass **`forceLegacyTraceBlob: true`** and still send the legacy blob fields. **`lockEvalSessionAfterUpdate`** runs after a successful fanout when the iteration still exists—including if **`updateTestIteration`** throws a transient error, so the transcript is locked without leaving partial retry writes.
> 
> The helper caches the writer flag per process, slices traces by **`promptIndex`** (cumulative messages per turn; unindexed spans on the last turn), and defers session lock to callers (no **`terminal`** on append calls). Widget snapshots are omitted from the fanout payload for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245506807a3fa606b05e6f8b0aea6e52d76c3008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->