### PR TITLE
design-system: add --code-* syntax palette, drive docs Mintlify Shiki from it

### DIFF
--- a/design-system/src/tokens.css
+++ b/design-system/src/tokens.css
@@ -71,6 +71,26 @@
   --json-boolean-false: oklch(0.55 0.18 25); /* Red/coral (for false) */
   --json-null: oklch(0.55 0.02 270); /* Gray */
   --json-punctuation: oklch(0.55 0.01 270); /* Muted gray */
+  /* General code-syntax palette (light) — consumed by surfaces that
+     render multi-language code: docs Mintlify code blocks, future
+     terminal/log viewers, in-app code editors. JSON-only viewer keeps
+     using the --json-* tokens above. Tuned for warm-paper backgrounds:
+     coral keyword + indigo class/key + muted forest string. */
+  --code-bg: oklch(0.9341 0.0153 90.239);              /* warm beige inset */
+  --code-text: oklch(0.1908 0.002 106.5859);           /* ink-strong */
+  --code-keyword: oklch(0.55 0.16 35);                 /* deep coral */
+  --code-function: oklch(0.1908 0.002 106.5859);       /* = text */
+  --code-class-name: oklch(0.48 0.13 250);             /* indigo */
+  --code-property: oklch(0.45 0.14 250);               /* indigo (JSON-key flavor) */
+  --code-variable: oklch(0.1908 0.002 106.5859);       /* = text */
+  --code-parameter: oklch(0.3438 0.0269 95.7226);      /* full ink */
+  --code-string: oklch(0.45 0.09 145);                 /* muted forest */
+  --code-number: oklch(0.52 0.08 60);                  /* warm sand */
+  --code-boolean: oklch(0.52 0.08 60);                 /* warm sand */
+  --code-comment: oklch(0.62 0.01 95);                 /* italic muted */
+  --code-punctuation: oklch(0.58 0.005 95);            /* dim ink */
+  --code-operator: oklch(0.55 0.16 35);                /* coral */
+  --code-link: oklch(0.6171 0.1375 39.0427);           /* brand orange */
   --radius: 0.5rem;
   --shadow-x: 0;
   --shadow-y: 1px;
@@ -105,6 +125,24 @@
   --json-boolean-false: oklch(0.68 0.16 25); /* Red/coral (for false) */
   --json-null: oklch(0.6 0.02 270); /* Gray */
   --json-punctuation: oklch(0.5 0.01 270); /* Muted gray */
+  /* General code-syntax palette (dark) — paired with the light values
+     above. Same hue family lifted in lightness/chroma for warm-dark
+     backgrounds. */
+  --code-bg: oklch(0.2213 0.0038 106.707);             /* warm-dark inset */
+  --code-text: oklch(0.92 0.01 95);                    /* near-white */
+  --code-keyword: oklch(0.75 0.13 35);                 /* lifted coral */
+  --code-function: oklch(0.92 0.01 95);                /* = text */
+  --code-class-name: oklch(0.70 0.13 250);             /* lifted indigo */
+  --code-property: oklch(0.72 0.14 250);               /* lifted indigo */
+  --code-variable: oklch(0.92 0.01 95);                /* = text */
+  --code-parameter: oklch(0.86 0.01 95);
+  --code-string: oklch(0.78 0.10 145);                 /* lifted forest */
+  --code-number: oklch(0.78 0.09 65);                  /* lifted sand */
+  --code-boolean: oklch(0.78 0.09 65);                 /* lifted sand */
+  --code-comment: oklch(0.55 0.01 95);
+  --code-punctuation: oklch(0.60 0.005 95);
+  --code-operator: oklch(0.75 0.13 35);                /* lifted coral */
+  --code-link: oklch(0.7400 0.1308 38.7559);           /* brand orange */
   --card: oklch(0.2679 0.0036 106.6427);
   --card-foreground: oklch(0.9818 0.0054 95.0986);
   --popover: oklch(0.3085 0.0035 106.6039);

--- a/design-system/src/tokens.ts
+++ b/design-system/src/tokens.ts
@@ -71,6 +71,26 @@ export const tokensCss: string = `@theme {
   --json-boolean-false: oklch(0.55 0.18 25); /* Red/coral (for false) */
   --json-null: oklch(0.55 0.02 270); /* Gray */
   --json-punctuation: oklch(0.55 0.01 270); /* Muted gray */
+  /* General code-syntax palette (light) — consumed by surfaces that
+     render multi-language code: docs Mintlify code blocks, future
+     terminal/log viewers, in-app code editors. JSON-only viewer keeps
+     using the --json-* tokens above. Tuned for warm-paper backgrounds:
+     coral keyword + indigo class/key + muted forest string. */
+  --code-bg: oklch(0.9341 0.0153 90.239);              /* warm beige inset */
+  --code-text: oklch(0.1908 0.002 106.5859);           /* ink-strong */
+  --code-keyword: oklch(0.55 0.16 35);                 /* deep coral */
+  --code-function: oklch(0.1908 0.002 106.5859);       /* = text */
+  --code-class-name: oklch(0.48 0.13 250);             /* indigo */
+  --code-property: oklch(0.45 0.14 250);               /* indigo (JSON-key flavor) */
+  --code-variable: oklch(0.1908 0.002 106.5859);       /* = text */
+  --code-parameter: oklch(0.3438 0.0269 95.7226);      /* full ink */
+  --code-string: oklch(0.45 0.09 145);                 /* muted forest */
+  --code-number: oklch(0.52 0.08 60);                  /* warm sand */
+  --code-boolean: oklch(0.52 0.08 60);                 /* warm sand */
+  --code-comment: oklch(0.62 0.01 95);                 /* italic muted */
+  --code-punctuation: oklch(0.58 0.005 95);            /* dim ink */
+  --code-operator: oklch(0.55 0.16 35);                /* coral */
+  --code-link: oklch(0.6171 0.1375 39.0427);           /* brand orange */
   --radius: 0.5rem;
   --shadow-x: 0;
   --shadow-y: 1px;
@@ -105,6 +125,24 @@ export const tokensCss: string = `@theme {
   --json-boolean-false: oklch(0.68 0.16 25); /* Red/coral (for false) */
   --json-null: oklch(0.6 0.02 270); /* Gray */
   --json-punctuation: oklch(0.5 0.01 270); /* Muted gray */
+  /* General code-syntax palette (dark) — paired with the light values
+     above. Same hue family lifted in lightness/chroma for warm-dark
+     backgrounds. */
+  --code-bg: oklch(0.2213 0.0038 106.707);             /* warm-dark inset */
+  --code-text: oklch(0.92 0.01 95);                    /* near-white */
+  --code-keyword: oklch(0.75 0.13 35);                 /* lifted coral */
+  --code-function: oklch(0.92 0.01 95);                /* = text */
+  --code-class-name: oklch(0.70 0.13 250);             /* lifted indigo */
+  --code-property: oklch(0.72 0.14 250);               /* lifted indigo */
+  --code-variable: oklch(0.92 0.01 95);                /* = text */
+  --code-parameter: oklch(0.86 0.01 95);
+  --code-string: oklch(0.78 0.10 145);                 /* lifted forest */
+  --code-number: oklch(0.78 0.09 65);                  /* lifted sand */
+  --code-boolean: oklch(0.78 0.09 65);                 /* lifted sand */
+  --code-comment: oklch(0.55 0.01 95);
+  --code-punctuation: oklch(0.60 0.005 95);
+  --code-operator: oklch(0.75 0.13 35);                /* lifted coral */
+  --code-link: oklch(0.7400 0.1308 38.7559);           /* brand orange */
   --card: oklch(0.2679 0.0036 106.6427);
   --card-foreground: oklch(0.9818 0.0054 95.0986);
   --popover: oklch(0.3085 0.0035 106.6039);

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,10 +26,7 @@
   },
   "styling": {
     "codeblocks": {
-      "theme": {
-        "light": "github-light",
-        "dark": "vesper"
-      }
+      "theme": "css-variables"
     }
   },
   "favicon": "/mcp_jam.svg",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -24,6 +24,14 @@
     "heading": { "family": "Geist", "weight": 500 },
     "body": { "family": "Geist", "weight": 400 }
   },
+  "styling": {
+    "codeblocks": {
+      "theme": {
+        "light": "github-light",
+        "dark": "vesper"
+      }
+    }
+  },
   "favicon": "/mcp_jam.svg",
   "navigation": {
     "groups": [

--- a/docs/style.css
+++ b/docs/style.css
@@ -16,33 +16,59 @@
 /* BEGIN GENERATED — sync via `npm run docs:sync-tokens` */
 /* Mirrors design-system/src/tokens.css — edits here will be overwritten. */
 :root {
-  --mcj-paper:        oklch(0.9818 0.0054 95.0986);
-  --mcj-paper-2:      oklch(0.9341 0.0153 90.239);
-  --mcj-paper-3:      oklch(0.9245 0.0138 92.9892);
-  --mcj-ink:          oklch(0.3438 0.0269 95.7226);
-  --mcj-ink-strong:   oklch(0.1908 0.002 106.5859);
-  --mcj-ink-muted:    oklch(0.6059 0.0075 97.4233);
-  --mcj-rule:         oklch(0.8847 0.0069 97.3627);
-  --mcj-rule-strong:  oklch(0.7621 0.0156 98.3528);
-  --mcj-orange:       oklch(0.6832 0.1382 38.744);
-  --mcj-orange-edge:  oklch(0.6171 0.1375 39.0427);
-  --mcj-radius:       0.5rem;
-  --mcj-orange-soft:  oklch(0.6832 0.1382 38.744 / 0.10);
+  --mcj-paper:               oklch(0.9818 0.0054 95.0986);
+  --mcj-paper-2:             oklch(0.9341 0.0153 90.239);
+  --mcj-paper-3:             oklch(0.9245 0.0138 92.9892);
+  --mcj-ink:                 oklch(0.3438 0.0269 95.7226);
+  --mcj-ink-strong:          oklch(0.1908 0.002 106.5859);
+  --mcj-ink-muted:           oklch(0.6059 0.0075 97.4233);
+  --mcj-rule:                oklch(0.8847 0.0069 97.3627);
+  --mcj-rule-strong:         oklch(0.7621 0.0156 98.3528);
+  --mcj-orange:              oklch(0.6832 0.1382 38.744);
+  --mcj-orange-edge:         oklch(0.6171 0.1375 39.0427);
+  --mcj-radius:              0.5rem;
+  --mcj-orange-soft:         oklch(0.6832 0.1382 38.744 / 0.10);
+
+  /* code syntax (Mintlify Shiki) */
+  --mint-color-text:                 oklch(0.1908 0.002 106.5859);
+  --mint-color-background:           oklch(0.9341 0.0153 90.239);
+  --mint-token-keyword:              oklch(0.55 0.16 35);
+  --mint-token-function:             oklch(0.1908 0.002 106.5859);
+  --mint-token-string:               oklch(0.45 0.09 145);
+  --mint-token-string-expression:    oklch(0.45 0.09 145);
+  --mint-token-constant:             oklch(0.52 0.08 60);
+  --mint-token-parameter:            oklch(0.3438 0.0269 95.7226);
+  --mint-token-punctuation:          oklch(0.58 0.005 95);
+  --mint-token-comment:              oklch(0.62 0.01 95);
+  --mint-token-link:                 oklch(0.6171 0.1375 39.0427);
 }
 
 .dark, [data-theme="dark"] {
-  --mcj-paper:        oklch(0.2679 0.0036 106.6427);
-  --mcj-paper-2:      oklch(0.2213 0.0038 106.707);
-  --mcj-paper-3:      oklch(0.213 0.0078 95.4245);
-  --mcj-ink:          oklch(0.8074 0.0142 93.0137);
-  --mcj-ink-strong:   oklch(0.9818 0.0054 95.0986);
-  --mcj-ink-muted:    oklch(0.7713 0.0169 99.0657);
-  --mcj-rule:         oklch(0.3618 0.0101 106.8928);
-  --mcj-rule-strong:  oklch(0.4336 0.0113 100.2195);
-  --mcj-orange:       oklch(0.6724 0.1308 38.7559);
-  --mcj-orange-edge:  oklch(0.6724 0.1308 38.7559);
-  --mcj-radius:       0.5rem;
-  --mcj-orange-soft:  oklch(0.6724 0.1308 38.7559 / 0.14);
+  --mcj-paper:               oklch(0.2679 0.0036 106.6427);
+  --mcj-paper-2:             oklch(0.2213 0.0038 106.707);
+  --mcj-paper-3:             oklch(0.213 0.0078 95.4245);
+  --mcj-ink:                 oklch(0.8074 0.0142 93.0137);
+  --mcj-ink-strong:          oklch(0.9818 0.0054 95.0986);
+  --mcj-ink-muted:           oklch(0.7713 0.0169 99.0657);
+  --mcj-rule:                oklch(0.3618 0.0101 106.8928);
+  --mcj-rule-strong:         oklch(0.4336 0.0113 100.2195);
+  --mcj-orange:              oklch(0.6724 0.1308 38.7559);
+  --mcj-orange-edge:         oklch(0.6724 0.1308 38.7559);
+  --mcj-radius:              0.5rem;
+  --mcj-orange-soft:         oklch(0.6724 0.1308 38.7559 / 0.14);
+
+  /* code syntax (Mintlify Shiki) */
+  --mint-color-text:                 oklch(0.92 0.01 95);
+  --mint-color-background:           oklch(0.2213 0.0038 106.707);
+  --mint-token-keyword:              oklch(0.75 0.13 35);
+  --mint-token-function:             oklch(0.92 0.01 95);
+  --mint-token-string:               oklch(0.78 0.10 145);
+  --mint-token-string-expression:    oklch(0.78 0.10 145);
+  --mint-token-constant:             oklch(0.78 0.09 65);
+  --mint-token-parameter:            oklch(0.86 0.01 95);
+  --mint-token-punctuation:          oklch(0.60 0.005 95);
+  --mint-token-comment:              oklch(0.55 0.01 95);
+  --mint-token-link:                 oklch(0.7400 0.1308 38.7559);
 }
 /* END GENERATED */
 
@@ -143,15 +169,28 @@ code, pre, kbd, samp {
   line-height: 1.45 !important;
 }
 
-/* Code block container — let the Shiki theme's own background and the
-   rounded corner do all the chrome. No border, no shadow. docs.json
-   sets theme to github-light (light) + vesper (dark): two curated
-   palettes that read against our warm-paper page without competing. */
+/* Code block container — Mintlify's css-variables theme (set in
+   docs.json) drives Shiki from --mint-* vars that the sync script
+   feeds from the design-system --code-* palette. */
 code-block,
 pre {
   border: none !important;
   border-radius: var(--mcj-radius);
   box-shadow: none !important;
+}
+
+/* Shiki's css-variables theme only exposes a subset of token types
+   (keyword/string/comment/function/parameter/punctuation/constant/link).
+   Tokens it doesn't categorize (property keys, class names, imported
+   identifiers, generic variables) inherit the element's base color.
+   Anchor pre/code's base color to ink-strong so these fall back to a
+   visible color in light mode instead of Shiki's near-white default.
+   --mcj-ink-strong already flips per mode via the sync. */
+pre,
+pre code,
+.shiki,
+.shiki code {
+  color: var(--mcj-ink-strong) !important;
 }
 
 /* Thin warm scrollbar clipped inside the rounded corner. */
@@ -166,6 +205,26 @@ pre::-webkit-scrollbar-thumb {
   border-radius: 9999px;
 }
 pre::-webkit-scrollbar-thumb:hover { background: var(--mcj-ink-muted); }
+
+/* Copy button — Mintlify Maple hides it until hover; pin it to always
+   visible at ink-muted contrast like the Claude API docs. Selector net
+   covers the variants Mintlify renders (button + a11y-labeled span). */
+:is(pre, code-block, figure[data-rehype-pretty-code-figure]) :is(button, [role="button"], [aria-label*="opy" i], [aria-label*="lipboard" i]) {
+  opacity: 1 !important;
+  color: var(--mcj-ink-muted) !important;
+  background: transparent !important;
+  border: none !important;
+  transition: color 120ms ease-out, background 120ms ease-out;
+}
+:is(pre, code-block, figure[data-rehype-pretty-code-figure]) :is(button, [role="button"], [aria-label*="opy" i], [aria-label*="lipboard" i]):hover {
+  color: var(--mcj-ink-strong) !important;
+  background: var(--mcj-paper-3) !important;
+}
+/* Force the icon glyph itself to inherit (some themes inline-style SVGs) */
+:is(pre, code-block) :is(button, [role="button"]) svg {
+  color: inherit !important;
+  opacity: 1 !important;
+}
 
 /* ── Callouts (Note / Tip / Warning / Info) ─────────────────────────────── */
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -9,6 +9,10 @@
  * No glassy backdrops, no floaty shadows, sharp warm borders, generous space.
  * ─────────────────────────────────────────────────────────────────────────── */
 
+/* Geist Mono — docs.json fonts only accepts heading+body, so the code face
+   is loaded here. */
+@import url("https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&display=swap");
+
 /* BEGIN GENERATED — sync via `npm run docs:sync-tokens` */
 /* Mirrors design-system/src/tokens.css — edits here will be overwritten. */
 :root {
@@ -124,22 +128,44 @@ code, pre, kbd, samp {
     Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
-code:not(pre code) {
-  background: var(--mcj-paper-2);
-  border: 1px solid var(--mcj-rule);
-  color: var(--mcj-ink-strong);
-  padding: 0.12em 0.38em;
-  border-radius: 4px;
-  font-size: 0.92em;
+/* Inline code — defeat .prose code AND any deeper Mintlify selectors
+   like `.prose p code`. Tighter chip, no browser bold, sits on the
+   baseline of the surrounding sentence. */
+:is(article, .prose, main, body) :is(p, li, td, h1, h2, h3, h4, h5, h6, span) code:not(pre code),
+:is(article, .prose, main, body) > code:not(pre code) {
+  background: var(--mcj-paper-2) !important;
+  border: 1px solid var(--mcj-rule) !important;
+  color: var(--mcj-ink-strong) !important;
+  padding: 0.08em 0.36em !important;
+  border-radius: 4px !important;
+  font-size: 0.86em !important;
+  font-weight: 400 !important;
+  line-height: 1.45 !important;
 }
 
+/* Code block container — let the Shiki theme's own background and the
+   rounded corner do all the chrome. No border, no shadow. docs.json
+   sets theme to github-light (light) + vesper (dark): two curated
+   palettes that read against our warm-paper page without competing. */
 code-block,
 pre {
-  background: var(--mcj-paper-2) !important;
-  border: 1px solid var(--mcj-rule);
+  border: none !important;
   border-radius: var(--mcj-radius);
   box-shadow: none !important;
 }
+
+/* Thin warm scrollbar clipped inside the rounded corner. */
+pre {
+  scrollbar-width: thin;
+  scrollbar-color: var(--mcj-rule-strong) transparent;
+}
+pre::-webkit-scrollbar { height: 5px; width: 5px; }
+pre::-webkit-scrollbar-track { background: transparent; }
+pre::-webkit-scrollbar-thumb {
+  background: var(--mcj-rule-strong);
+  border-radius: 9999px;
+}
+pre::-webkit-scrollbar-thumb:hover { background: var(--mcj-ink-muted); }
 
 /* ── Callouts (Note / Tip / Warning / Info) ─────────────────────────────── */
 
@@ -205,28 +231,64 @@ a.button-primary:hover {
   background: var(--mcj-orange-edge);
 }
 
-/* ── Tables ─────────────────────────────────────────────────────────────── */
+/* ── Tables — bottom-hairline rows only, no header tint, generous padding.
+       Matches the Claude API docs treatment: flat, content-forward, no chrome.
+       Inline code chips inside table cells stay normal-sized; row links are
+       quieted to body color so they read as text first, link second. */
 
 table {
-  border: 1px solid var(--mcj-rule);
-  border-radius: var(--mcj-radius);
-  overflow: hidden;
+  border: none !important;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+thead tr,
+thead th {
+  background: transparent !important;
 }
 
 th {
-  background: var(--mcj-paper-2);
-  color: var(--mcj-ink-strong);
-  font-weight: 500;
+  color: var(--mcj-ink-strong) !important;
+  font-weight: 500 !important;
   text-align: left;
-  border-bottom: 1px solid var(--mcj-rule);
+  border-bottom: 1px solid var(--mcj-rule) !important;
+  padding: 0.55rem 0.9rem !important;
+  font-size: 0.92em;
 }
 
 td {
-  border-bottom: 1px solid var(--mcj-rule);
+  color: var(--mcj-ink) !important;
+  border-top: none !important;
+  border-bottom: 1px solid var(--mcj-rule) !important;
+  border-left: none !important;
+  border-right: none !important;
+  padding: 0.7rem 0.9rem !important;
+  vertical-align: top;
 }
 
-tr:last-child td {
-  border-bottom: none;
+tbody tr:last-child td {
+  border-bottom: none !important;
+}
+
+/* Row hover — minimal lift, matches Anthropic's subtle row treatment */
+tbody tr:hover td {
+  background: var(--mcj-paper-2);
+}
+
+/* In-table links — read as part of the sentence, accent on hover only.
+   This is the "Read more" treatment from image #5: was too loud. */
+:is(td, th) a:not(.button-primary) {
+  color: var(--mcj-ink-strong) !important;
+  text-decoration: underline !important;
+  text-decoration-color: var(--mcj-rule-strong) !important;
+  text-decoration-thickness: 1px !important;
+  text-underline-offset: 3px !important;
+  transition: text-decoration-color 120ms ease-out, color 120ms ease-out;
+}
+
+:is(td, th) a:not(.button-primary):hover {
+  color: var(--mcj-orange) !important;
+  text-decoration-color: var(--mcj-orange) !important;
 }
 
 /* ── Misc polish ────────────────────────────────────────────────────────── */

--- a/scripts/sync-docs-tokens.mjs
+++ b/scripts/sync-docs-tokens.mjs
@@ -41,6 +41,26 @@ const MAP = {
   "--mcj-radius":      "--radius",
 };
 
+// Mintlify Shiki vars ← design-system code-syntax tokens. Activated by
+// docs.json `styling.codeblocks.theme = "css-variables"`. Mintlify maps
+// object-property names to `keyword`, so the property-key color is
+// effectively shared with keywords; we set `keyword` to --code-keyword
+// and accept that compromise (one accent for both is the Anthropic-ish
+// look anyway).
+const CODE_MAP = {
+  "--mint-color-text":              "--code-text",
+  "--mint-color-background":        "--code-bg",
+  "--mint-token-keyword":           "--code-keyword",
+  "--mint-token-function":          "--code-function",
+  "--mint-token-string":            "--code-string",
+  "--mint-token-string-expression": "--code-string",
+  "--mint-token-constant":          "--code-number",
+  "--mint-token-parameter":         "--code-parameter",
+  "--mint-token-punctuation":       "--code-punctuation",
+  "--mint-token-comment":           "--code-comment",
+  "--mint-token-link":              "--code-link",
+};
+
 // Soft-alpha overlay derived from --primary. Alpha differs per mode so the
 // orange wash reads at the same perceived weight on cream vs warm-dark.
 const ORANGE_SOFT_ALPHA = { light: "0.10", dark: "0.14" };
@@ -74,13 +94,28 @@ function deriveOrangeSoft(primaryValue, alpha) {
 
 function buildBlock(label, selectorChain, tokenVars, alpha) {
   const lines = [`${selectorChain} {`];
+
+  // Surface palette (page chrome, borders, etc.)
   for (const [alias, source] of Object.entries(MAP)) {
     const value = tokenVars.get(source);
     if (!value) throw new Error(`Token ${source} missing from tokens.css ${label}`);
-    lines.push(`  ${`${alias}:`.padEnd(19, " ")} ${value};`);
+    lines.push(`  ${`${alias}:`.padEnd(26, " ")} ${value};`);
   }
   const orange = tokenVars.get("--primary");
-  lines.push(`  --mcj-orange-soft:  ${deriveOrangeSoft(orange, alpha)};`);
+  lines.push(`  ${"--mcj-orange-soft:".padEnd(26, " ")} ${deriveOrangeSoft(orange, alpha)};`);
+
+  // Code-syntax palette — derived from --code-* tokens, exposed to
+  // Mintlify Shiki via --mint-* vars.
+  lines.push("");
+  lines.push("  /* code syntax (Mintlify Shiki) */");
+  for (const [mintVar, codeVar] of Object.entries(CODE_MAP)) {
+    const value = tokenVars.get(codeVar);
+    if (!value) {
+      throw new Error(`Token ${codeVar} missing from tokens.css ${label}`);
+    }
+    lines.push(`  ${`${mintVar}:`.padEnd(34, " ")} ${value};`);
+  }
+
   lines.push("}");
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary

- Adds a general code-syntax palette (`--code-*`) to `design-system/src/tokens.css` alongside the existing `--json-*` and surface palettes, so multi-language code surfaces (docs Mintlify blocks today; future in-app terminal/log viewers/editors) can share one source of truth.
- Switches the docs Mintlify config to `styling.codeblocks.theme: "css-variables"` and grows the existing sync script to emit `--mint-token-*` ← `--code-*` mappings alongside the surface `--mcj-*` mappings.
- Also fixes the docs copy button (was hover-revealed and near-invisible against warm-paper).

Follow-up to #2413. Architectural change rather than a visual one — the rendered docs aim to look the same; the difference is what's driving the colors.

## Why now

#2413 ended on a curated Shiki theme pair (`github-light` / `vesper`) because the design system had no general syntax palette. That looked great but it's third-party config in `docs.json` — not coupled to the product. This PR fills the gap: the design system now ships its own syntax palette, the docs consume it.

The inspector's JSON viewer (`mcpjam-inspector/client/src/components/ui/json-editor/codemirror-json-editor.tsx`) already runs this loop perfectly via `--json-*` tokens — it was the model. The PR generalizes the pattern for non-JSON code rendering.

## What changed

### `design-system/src/tokens.css`
15 new tokens × 2 modes, in the same section as `--json-*`:

| Token | Role | Light | Dark |
|---|---|---|---|
| `--code-bg` | code block background | warm beige inset | warm-dark inset |
| `--code-text` | default identifiers | ink-strong | near-white |
| `--code-keyword` | `import`, `const`, `from`, `new`, `await`, `return` | deep coral | lifted coral |
| `--code-function` | function names | = text | = text |
| `--code-class-name` | class / type names | indigo | lifted indigo |
| `--code-property` | object keys | indigo | lifted indigo |
| `--code-variable` | identifiers | = text | = text |
| `--code-parameter` | params, flags | full ink | parameter near-white |
| `--code-string` | string literals | muted forest | lifted forest |
| `--code-number` | numeric literals | warm sand | lifted sand |
| `--code-boolean` | booleans | warm sand | lifted sand |
| `--code-comment` | comments (italic) | muted | dim muted |
| `--code-punctuation` | brackets, dots, semicolons | dim ink | dim |
| `--code-operator` | =, +, => | coral | lifted coral |
| `--code-link` | URLs in code | brand orange | brand orange |

Aesthetic: one true accent (coral keyword), indigo for structural roles (keys, types), muted hues for strings/comments/punctuation. Tuned to read against the warm-paper page.

### `docs/docs.json`
`styling.codeblocks.theme` flips from the named-theme object back to `"css-variables"` so Mintlify reads token colors from `--mint-token-*` instead of baking Vesper / github-light into the docs config.

### `scripts/sync-docs-tokens.mjs`
New `CODE_MAP` constant maps Mintlify's documented Shiki vars to our `--code-*` tokens. `buildBlock` now emits a `/* code syntax (Mintlify Shiki) */` section in the GENERATED fence alongside the existing surface tokens. One `npm run docs:sync-tokens` covers everything. `--check` mode (used by CI in `lint.yml`) continues to gate drift on the whole block.

### `docs/style.css`
- `pre`/`pre code`/`.shiki` base color anchored to `var(--mcj-ink-strong)` — necessary because Shiki's `css-variables` theme only covers ~9 token types, and tokens it doesn't categorize (property keys, class names, imported identifiers) inherit the element color. Without this anchor those tokens fall back to a near-white default and disappear in light mode.
- Copy button always-visible at ink-muted, with a warm-paper-3 tile fill on hover. Selector net covers `button`, `[role="button"]`, and `aria-label*="opy" | "lipboard"` to catch Mintlify Maple's variants. SVG `color: inherit !important` so the icon glyph follows.

## Test plan

- [ ] `cd docs && mint dev` under Node 20+
- [ ] Light mode: code blocks read at ink-strong contrast — `MCPClientManager`, `TestAgent`, `EvalTest`, object keys (`mySerever:`, `command:`, `args:`) all visible
- [ ] Dark mode: unchanged feel from #2413 (coral keywords, indigo keys, cream identifiers)
- [ ] Copy button visible top-right of every code block; click copies the code
- [ ] `npm run docs:check-tokens` passes
- [ ] Edit a `--code-*` value in `design-system/src/tokens.css`, run `npm run docs:sync-tokens`, confirm the change shows up in the docs

## Not in this PR

- The inspector's JSON viewer keeps its dedicated `--json-*` palette — different problem (JSON-only with semantic keys/values), different tuning.
- New in-app surfaces that could consume `--code-*` (terminal pane, log viewer) aren't built. The tokens are available for whoever picks that up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and design-token changes only; no runtime app logic. CI `--check` on token sync should catch drift.
> 
> **Overview**
> Introduces a shared **`--code-*` syntax palette** in the design system (light and dark), parallel to existing `--json-*`, so multi-language code surfaces can use one source of truth. The JSON viewer keeps `--json-*`; docs and future editors can consume `--code-*`.
> 
> **Docs wiring:** Mintlify `docs.json` switches code blocks to **`styling.codeblocks.theme: "css-variables"`** instead of named Shiki themes. `sync-docs-tokens.mjs` gains **`CODE_MAP`** to emit `--mint-token-*` from `--code-*` in the generated block in `docs/style.css`.
> 
> **Docs CSS:** Adds Geist Mono import; syncs Mint Shiki vars; anchors Shiki fallback text to **`--mcj-ink-strong`** so uncategorized tokens stay visible in light mode; makes the **copy button always visible**; refreshes **inline code**, **tables**, and **pre** scrollbar styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17256d18c451076cc70563fc7ba9965be55053cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->