### PR TITLE
docs: editorial pass — branded inline code, left-rail callouts, sidebar dividers

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -147,6 +147,29 @@ aside[aria-label="sidebar"] a[aria-current="page"] {
   font-weight: 500;
 }
 
+/* Sidebar group headers — Anaconda-style all-caps section labels with a
+   hairline rule above. Mintlify Maple renders group titles inside
+   `<button>` or `<div role="button">` with the group label as text; we
+   target both common shapes. */
+:is(#sidebar, aside[aria-label="sidebar"]) :is(h2, h3, h4, h5, [role="heading"], button[aria-expanded], [data-sidebar-group-label]) {
+  font-size: 0.68rem !important;
+  font-weight: 600 !important;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase !important;
+  color: var(--mcj-ink-muted) !important;
+  margin-top: 1.5rem !important;
+  padding-top: 1rem !important;
+  border-top: 1px solid var(--mcj-rule);
+}
+
+/* First group in the sidebar shouldn't get a divider above it. */
+:is(#sidebar, aside[aria-label="sidebar"]) > :first-child :is(h2, h3, h4, button[aria-expanded]):first-of-type,
+:is(#sidebar, aside[aria-label="sidebar"]) :is(h2, h3, h4, button[aria-expanded]):first-of-type {
+  border-top: none;
+  margin-top: 0.5rem !important;
+  padding-top: 0 !important;
+}
+
 /* ── Code & inline mono ─────────────────────────────────────────────────── */
 
 code, pre, kbd, samp {
@@ -155,17 +178,18 @@ code, pre, kbd, samp {
 }
 
 /* Inline code — defeat .prose code AND any deeper Mintlify selectors
-   like `.prose p code`. Tighter chip, no browser bold, sits on the
-   baseline of the surrounding sentence. */
+   like `.prose p code`. Tighter chip on a warm orange-tint background so
+   the brand flows through running prose (cf. Laravel's red inline code
+   treatment) instead of reading as a neutral beige pill. */
 :is(article, .prose, main, body) :is(p, li, td, h1, h2, h3, h4, h5, h6, span) code:not(pre code),
 :is(article, .prose, main, body) > code:not(pre code) {
-  background: var(--mcj-paper-2) !important;
-  border: 1px solid var(--mcj-rule) !important;
-  color: var(--mcj-ink-strong) !important;
-  padding: 0.08em 0.36em !important;
+  background: var(--mcj-orange-soft) !important;
+  border: none !important;
+  color: var(--mcj-orange-edge) !important;
+  padding: 0.08em 0.38em !important;
   border-radius: 4px !important;
   font-size: 0.86em !important;
-  font-weight: 400 !important;
+  font-weight: 500 !important;
   line-height: 1.45 !important;
 }
 
@@ -226,33 +250,49 @@ pre::-webkit-scrollbar-thumb:hover { background: var(--mcj-ink-muted); }
   opacity: 1 !important;
 }
 
-/* ── Callouts (Note / Tip / Warning / Info) ─────────────────────────────── */
+/* ── Callouts — editorial left-rail-only, no soft-fill box ──────────────── */
 
+/* Strip the rounded tinted box that ships by default. Replace with a clean
+   left rail in the tone color and slightly larger body text — reads as a
+   newspaper aside / pull-quote, not a generic alert. Tones derive from the
+   design-system semantic status colors. */
 callout,
 .callout,
 note,
 tip,
 warning,
 info {
-  background: var(--mcj-paper-2);
-  border: 1px solid var(--mcj-rule);
-  border-left: 3px solid var(--mcj-orange);
-  border-radius: var(--mcj-radius);
-  box-shadow: none;
-  padding: 0.9rem 1rem;
+  background: transparent !important;
+  border: none !important;
+  border-left: 2px solid var(--mcj-orange) !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  padding: 0.35rem 0 0.35rem 1rem !important;
+  margin: 1.25rem 0;
 }
 
-warning {
-  border-left-color: oklch(0.627 0.208 25.331); /* destructive */
+/* Body text inside a callout reads at ink, not ink-muted — the rail is
+   the only chrome, so the prose needs to carry the weight. */
+:is(callout, .callout, note, tip, warning, info) :is(p, li, span) {
+  color: var(--mcj-ink) !important;
 }
 
-tip {
-  border-left-color: oklch(0.696 0.17 152.5);   /* success */
+/* Icon inherits the rail color, slightly inset so it lines up with the
+   first line of body copy. */
+:is(callout, .callout, note, tip, warning, info) :is(svg, [class*="icon"]) {
+  color: inherit !important;
+  opacity: 1 !important;
 }
 
-info {
-  border-left-color: oklch(0.623 0.214 259);    /* info */
-}
+note   { border-left-color: var(--mcj-orange) !important;        color: var(--mcj-orange-edge) !important; }
+tip    { border-left-color: oklch(0.55 0.13 152.5) !important;   color: oklch(0.40 0.10 152.5) !important; }
+info   { border-left-color: oklch(0.55 0.16 259) !important;     color: oklch(0.40 0.14 259) !important; }
+warning{ border-left-color: oklch(0.627 0.208 25.331) !important;color: oklch(0.50 0.18 25.331) !important; }
+
+.dark note,    [data-theme="dark"] note    { color: oklch(0.78 0.13 38.7) !important; }
+.dark tip,     [data-theme="dark"] tip     { color: oklch(0.78 0.12 152.5) !important; }
+.dark info,    [data-theme="dark"] info    { color: oklch(0.78 0.14 259) !important; }
+.dark warning, [data-theme="dark"] warning { color: oklch(0.78 0.16 25.331) !important; }
 
 /* ── Cards ──────────────────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary

Three CSS-only moves to push the docs from a clean-but-generic Mintlify Maple look toward something closer to Laravel / Anaconda's editorial vibe. **No content changes** — diff is `docs/style.css` only.

This is the first half of the "stop looking boilerplate" effort I scoped after #2413/#2420 shipped. Follow-up will be content work (kill card-grid filler on "Where to go next" pages, rewrite a few high-traffic landings as prose).

## What changed

### Inline code — brand-tinted instead of neutral chip
**Before:** beige paper-2 chip with hairline border, neutral ink-strong text.
**After:** orange-edge text on `--mcj-orange-soft` background, no border, weight 500.

Same trick Laravel uses with red — when ``npx @mcpjam/cli``, ``--port``, ``mcpjam`` etc. appear inside running prose, the brand color flows through every paragraph instead of disappearing the moment the user leaves a CTA.

### Callouts — newspaper-aside, not generic alert box
**Before:** soft-fill tinted rounded box with full border and a 3px left rail. Reads like every Mintlify "Note" everywhere.
**After:** no fill, no border, just a 2px left rail in the tone color + colored icon. Body text at full ink contrast carries the weight.

Per-tone palette:
- `note` → brand orange
- `tip` → forest green (`oklch(0.55 0.13 152.5)`)
- `info` → indigo (`oklch(0.55 0.16 259)`)
- `warning` → destructive coral

Each gets a lifted dark-mode variant so the rail stays readable on the warm-dark bg.

### Sidebar — Anaconda-style group dividers
**Before:** group headers ("Inspector Features", "CLI", "SDK", "Guides") render as plain medium-weight labels indistinguishable from page links. Visual rhythm is flat.
**After:** group headers become small all-caps tracked labels (`0.68rem`, `letter-spacing: 0.08em`, weight 600) in ink-muted, with a hairline rule above each section. First group keeps its top untouched.

Selector net covers the shapes Mintlify Maple might use for group labels (`h2`/`h3`/`h4`/`button[aria-expanded]`/`[role="heading"]`/`[data-sidebar-group-label]`). One of those should hit; if Maple changes its DOM shape in a future release, the selector list is the obvious thing to update.

## Why CSS-only

The bigger boilerplate problem is content shape — uniform 3-card grids at the bottom of every page that just rehash the sidebar. Killing those is a content rewrite per page (`index.mdx`, `installation.mdx`, `inspector/playground.mdx`, etc.) and worth its own PR so the visual review and the copy review don't blur together.

This PR is the highest-leverage *visual* change that requires zero MDX edits — brand presence in inline content + editorial callouts + sidebar rhythm.

## Test plan

- [ ] `cd docs && mint dev` under Node 20+
- [ ] Visit any prose page (e.g. `/getting-started`, `/cli/overview`) — inline code reads as orange text on a soft-orange wash, no border
- [ ] Visit a callout-heavy page (e.g. `/troubleshooting/common-errors`, `/installation`) — callouts render as left-rail-only, no fill
- [ ] Sidebar group headers are small all-caps with hairline rules between sections
- [ ] Dark mode: rails stay readable, inline-code orange isn't blown out
- [ ] `npm run docs:check-tokens` passes (no token-sync changes here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in docs; no runtime, auth, or data paths affected. Mintlify DOM changes could require selector updates later.
> 
> **Overview**
> **CSS-only** refresh in `docs/style.css` to make Mintlify docs feel more editorial (Laravel/Anaconda-style). No MDX or content changes.
> 
> **Inline code** switches from neutral beige chips with borders to **orange-edge text** on `--mcj-orange-soft`, slightly heavier weight—brand color in running prose.
> 
> **Callouts** (`note`, `tip`, `info`, `warning`) drop the filled rounded box for a **transparent left-rail** (2px tone-colored border), full **ink** body text, per-type rail/icon colors, plus **dark-mode** text lifts.
> 
> **Sidebar** group labels get **small all-caps tracked headers** with a **hairline rule** above each section; the first group skips the top divider. Selectors cover several Mintlify Maple DOM shapes for group titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92fbfad283c87b9412e27bc8f2517eaaa409d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->