### PR TITLE
feat(sdk): eval reporter wire-send hostConfig when backend advertises capability (Stage 5 Step 3)

### DIFF
--- a/.changeset/stage5-step3-sdk-reporter.md
+++ b/.changeset/stage5-step3-sdk-reporter.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/sdk": minor
+---
+
+eval reporter: send {hostConfig, hostConfigHash} on /sdk/v1/evals/* when backend advertises `evalsHostConfig` (Stage 5 Step 3).
+
+Reporter probes `GET /sdk/v1/info` lazily (cached per baseUrl, fail-safe to "no capability"). When backend supports it AND iteration host snapshots are homogeneous, sends a normalized + content-hashed host config alongside results. Source order: `iteration.hostSnapshot` → `executor.getHostSnapshot?.()` → `MCPJamReportingConfig.host`. Heterogeneous per-iteration snapshots omit the run-level field (per-iteration wire support is a later stage). Old backends are unaffected.

--- a/sdk/src/eval-reporting-types.ts
+++ b/sdk/src/eval-reporting-types.ts
@@ -140,15 +140,13 @@ export type MCPJamReportingConfig = {
   expectedIterations?: number;
   tags?: string[];
   /**
-   * Host configuration that drove this eval run. When provided, the
-   * reporter computes a content-addressed hash internally and attaches it
-   * to the upload so the backend can dedupe / link to a stored
-   * `hostConfigsV2` row. The hash is never set by the caller — supply the
-   * raw `Host` and let the SDK fingerprint it.
-   *
-   * Wire-level send (the `hostConfigHash` field on each `EvalResultInput`)
-   * is implemented in a follow-up stage; in this SDK release the field is
-   * accepted but not yet propagated to `/sdk/v1/evals/*` ingestion.
+   * Host configuration that drove this eval run. Wire-level send is active
+   * when the backend advertises capability `evalsHostConfig` (see
+   * `GET /sdk/v1/info`). When `iteration.hostSnapshot` is present (Stage
+   * 4 per-iteration capture), it takes precedence; this field is the
+   * fallback for executors that don't expose `getHostSnapshot` and runs
+   * without per-iteration capture. The reporter computes the content
+   * hash internally — callers never set `hostConfigHash`.
    */
   host?: import("./host-config/host.js").Host;
 };
@@ -158,6 +156,19 @@ export type ReportEvalResultsInput = MCPJamReportingConfig & {
   results: EvalResultInput[];
   agent?: {
     getServerReplayConfigs?: () => MCPServerReplayConfig[] | undefined;
+  };
+  /**
+   * Optional executor surface used by Stage 5 host-config wire pickup as
+   * a fallback when no per-iteration `hostSnapshot` and no
+   * {@link MCPJamReportingConfig.host} were supplied. Structurally typed
+   * so any object exposing `getHostSnapshot()` (e.g. `HostRunner`,
+   * `HostRuntime`) qualifies — the reporter never holds a reference
+   * beyond reading the snapshot.
+   */
+  executor?: {
+    getHostSnapshot?: () =>
+      | import("./host-config/public-types.js").HostJson
+      | undefined;
   };
   mcpClientManager?: MCPClientManager;
 };

--- a/sdk/src/report-eval-results.ts
+++ b/sdk/src/report-eval-results.ts
@@ -555,13 +555,24 @@ async function resolveWireHostConfigForRun(
     hostSnapshot?: HostJson | undefined;
   }[];
 
-  const snapshot = await resolveRunLevelHostSnapshot({
-    iterations,
-    executor: input.executor,
-    explicitHost: input.host,
-  });
-  if (!snapshot) return null;
-  return await buildSdkEvalsWireHostConfig(snapshot);
+  // Fail-safe: a malformed hostSnapshot, unexpected executor return, or
+  // non-canonicalizable host JSON must NOT fail the whole eval upload.
+  // Match the capability-probe fail-safe pattern — log + omit the wire pair.
+  try {
+    const snapshot = await resolveRunLevelHostSnapshot({
+      iterations,
+      executor: input.executor,
+      explicitHost: input.host,
+    });
+    if (!snapshot) return null;
+    return await buildSdkEvalsWireHostConfig(snapshot);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[mcpjam/sdk] eval reporting: omitting hostConfig wire pair (${message})`
+    );
+    return null;
+  }
 }
 
 async function reportEvalResultsInternal(

--- a/sdk/src/report-eval-results.ts
+++ b/sdk/src/report-eval-results.ts
@@ -7,6 +7,13 @@ import type {
 import { EvalReportingError } from "./errors.js";
 import { resolveServerReplayConfigs } from "./server-replay-configs.js";
 import { addBreadcrumb, captureEvalReportingFailure } from "./sentry.js";
+import { resolveSdkEvalsCapabilities } from "./sdk-evals-capability.js";
+import {
+  buildSdkEvalsWireHostConfig,
+  type SdkEvalsWireHostConfig,
+} from "./sdk-evals-wire-host-config.js";
+import { resolveRunLevelHostSnapshot } from "./sdk-evals-host-config-source.js";
+import type { HostJson } from "./host-config/public-types.js";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 const DEFAULT_RETRY_DELAYS_MS = [250, 750, 1750];
@@ -281,6 +288,13 @@ async function startEvalRun(
   payload: Omit<ReportEvalResultsInput, "results" | "strict"> & {
     externalRunId: string;
     synthesizedTests?: unknown[];
+    /**
+     * Stage 5 Step 3 wire host-config pair. Sent only when the backend
+     * advertises capability `evalsHostConfig` AND a usable, homogeneous
+     * snapshot was resolved. Backend rejects partial pairs with 400.
+     */
+    hostConfig?: SdkEvalsWireHostConfig["hostConfig"];
+    hostConfigHash?: SdkEvalsWireHostConfig["hostConfigHash"];
   }
 ): Promise<StartRunResponse> {
   return await requestWithRetry<StartRunResponse>(
@@ -492,6 +506,64 @@ function shouldUseOneShotUpload(
   return bytes <= CHUNK_TARGET_BYTES && config.baseUrl.length >= 0;
 }
 
+/**
+ * Cheap check for whether ANY snapshot source could possibly contribute
+ * to the run-level wire pair. When false, we skip the capability probe
+ * entirely — there's nothing to ship even if the backend supports it,
+ * and we don't want a wasted `GET /sdk/v1/info` round-trip for legacy
+ * callers that never supply host info.
+ */
+function hasAnyHostSnapshotSource(input: ReportEvalResultsInput): boolean {
+  if (input.host) return true;
+  if (input.executor?.getHostSnapshot) return true;
+  for (const result of input.results) {
+    if ((result as { hostSnapshot?: unknown }).hostSnapshot) return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve the per-run wire pair {hostConfig, hostConfigHash} when the
+ * backend advertises capability `evalsHostConfig`. Returns `null` when
+ * the capability is absent OR no usable snapshot source exists OR
+ * iteration snapshots are heterogeneous (pass-1 omit).
+ *
+ * The wire pair is per-RUN: it is injected only into one-shot `/report`
+ * and chunked `/runs/start` bodies, never into `/runs/iterations` or
+ * `/runs/finalize`.
+ */
+async function resolveWireHostConfigForRun(
+  input: ReportEvalResultsInput,
+  config: RuntimeConfig
+): Promise<SdkEvalsWireHostConfig | null> {
+  // Skip the probe when we have nothing to ship. This keeps legacy callers
+  // (no host, no executor, no per-iteration snapshot) on the original
+  // single-request flow — important for fetch-mock counts in existing
+  // tests and for avoiding a wasted probe round-trip.
+  if (!hasAnyHostSnapshotSource(input)) return null;
+
+  const capability = await resolveSdkEvalsCapabilities(config.baseUrl);
+  if (capability.evalsHostConfig < 1) return null;
+
+  // `input.results` are `EvalResultInput`s; the homogeneity gate treats
+  // each as a potential carrier of `hostSnapshot`. Today `EvalResultInput`
+  // does not carry that field, so this list is effectively snapshot-less
+  // and the resolver falls through to executor → explicitHost. Cast keeps
+  // the type surface forward-compatible for when per-iteration
+  // `hostSnapshot` is wired through `EvalResultInput`.
+  const iterations = input.results as readonly {
+    hostSnapshot?: HostJson | undefined;
+  }[];
+
+  const snapshot = await resolveRunLevelHostSnapshot({
+    iterations,
+    executor: input.executor,
+    explicitHost: input.host,
+  });
+  if (!snapshot) return null;
+  return await buildSdkEvalsWireHostConfig(snapshot);
+}
+
 async function reportEvalResultsInternal(
   input: ReportEvalResultsInput
 ): Promise<ReportEvalResultsOutput> {
@@ -510,6 +582,16 @@ async function reportEvalResultsInternal(
     uploadedResults,
     externalRunId
   );
+
+  // Resolved once per `reportEvalResultsInternal` call so both code paths
+  // (one-shot and chunked-start) attach the same byte-stable pair.
+  const wireHostConfig = await resolveWireHostConfigForRun(input, config);
+  const wireHostConfigBody = wireHostConfig
+    ? {
+        hostConfig: wireHostConfig.hostConfig,
+        hostConfigHash: wireHostConfig.hostConfigHash,
+      }
+    : {};
 
   if (
     shouldUseOneShotUpload(
@@ -538,6 +620,7 @@ async function reportEvalResultsInternal(
         expectedIterations: input.expectedIterations,
         tags: input.tags,
         results: resultsWithIterationIds,
+        ...wireHostConfigBody,
       }
     );
   }
@@ -554,6 +637,7 @@ async function reportEvalResultsInternal(
     ci: input.ci,
     expectedIterations: input.expectedIterations,
     tags: input.tags,
+    ...wireHostConfigBody,
   });
 
   if (

--- a/sdk/src/sdk-evals-capability.ts
+++ b/sdk/src/sdk-evals-capability.ts
@@ -1,0 +1,119 @@
+/**
+ * Lazy, per-baseUrl capability probe for SDK→backend eval ingestion
+ * (Stage 5, Step 3).
+ *
+ * Probes `GET {baseUrl}/sdk/v1/info` on first call per baseUrl; caches the
+ * resolved Promise so subsequent reporters in the same process share the
+ * result. Fail-safe: any error (network, 404, non-200, parse, timeout)
+ * resolves to "no capability" so the reporter simply omits `hostConfig`
+ * rather than failing the report.
+ *
+ * Backend contract (Stage 5, Step 2):
+ *   GET /sdk/v1/info  →  200 { "capabilities": { "evalsHostConfig": 1 } }
+ *
+ * Older backends return 404 or omit the field — both are treated as
+ * "capability absent → don't send hostConfig". A future flat shape
+ * (`{ evalsHostConfig: 1 }` at the body root) is also tolerated.
+ */
+
+const INFO_PATH = "/sdk/v1/info";
+const PROBE_TIMEOUT_MS = 2000;
+
+/** Capability advertisement returned by `/sdk/v1/info`. */
+export interface SdkEvalsCapabilities {
+  /**
+   * `>= 1` means the backend accepts `{ hostConfig, hostConfigHash }` at
+   * the top level of `/sdk/v1/evals/*` request bodies. `0` means absent.
+   */
+  readonly evalsHostConfig: number;
+}
+
+// Module-level cache keyed by normalized baseUrl. We cache the Promise (not
+// the resolved value) so concurrent first-callers share a single in-flight
+// fetch. Pinned for the process lifetime — a long-lived runner shouldn't
+// pay for repeated probes, and backend capability flips are deploy events
+// (process restart), not runtime ones.
+const cache = new Map<string, Promise<SdkEvalsCapabilities>>();
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+function readEvalsHostConfigField(value: unknown): number {
+  if (!value || typeof value !== "object") return 0;
+  const body = value as {
+    capabilities?: { evalsHostConfig?: unknown };
+    evalsHostConfig?: unknown;
+  };
+  const nested = body.capabilities?.evalsHostConfig;
+  if (typeof nested === "number" && Number.isFinite(nested)) {
+    return nested;
+  }
+  const flat = body.evalsHostConfig;
+  if (typeof flat === "number" && Number.isFinite(flat)) {
+    return flat;
+  }
+  return 0;
+}
+
+async function probe(
+  baseUrl: string,
+  fetchImpl: typeof fetch
+): Promise<SdkEvalsCapabilities> {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`${baseUrl}${INFO_PATH}`, {
+      method: "GET",
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return { evalsHostConfig: 0 };
+    }
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      return { evalsHostConfig: 0 };
+    }
+    return { evalsHostConfig: readEvalsHostConfigField(body) };
+  } catch {
+    // Network error, AbortError (timeout), DNS failure, etc.
+    return { evalsHostConfig: 0 };
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+/**
+ * Resolve (and cache) the SDK eval ingestion capabilities for `baseUrl`.
+ *
+ * Idempotent and concurrency-safe: repeated calls with the same baseUrl
+ * share one in-flight `fetch`. Errors resolve to `{ evalsHostConfig: 0 }`.
+ *
+ * @param baseUrl backend base URL (e.g. `https://sdk.mcpjam.com`); trailing
+ *   `/` tolerated.
+ * @param fetchImpl optional fetch override (used by tests; defaults to the
+ *   global `fetch`).
+ */
+export function resolveSdkEvalsCapabilities(
+  baseUrl: string,
+  fetchImpl?: typeof fetch
+): Promise<SdkEvalsCapabilities> {
+  const normalized = normalizeBaseUrl(baseUrl);
+  const cached = cache.get(normalized);
+  if (cached) return cached;
+  const fetcher = fetchImpl ?? globalThis.fetch;
+  const promise = probe(normalized, fetcher);
+  cache.set(normalized, promise);
+  return promise;
+}
+
+/**
+ * Test-only seam: clear the module-level capability cache. NOT part of the
+ * public API — exposed so vitest can drive the probe deterministically
+ * across cases without spawning new module realms.
+ */
+export function __resetSdkEvalsCapabilitiesCache(): void {
+  cache.clear();
+}

--- a/sdk/src/sdk-evals-host-config-source.ts
+++ b/sdk/src/sdk-evals-host-config-source.ts
@@ -1,0 +1,112 @@
+/**
+ * Resolve the run-level host snapshot for SDK eval reporting (Stage 5,
+ * Step 3, pass 1).
+ *
+ * Source priority:
+ *   1. PRIMARY  — per-iteration `iteration.hostSnapshot` (Stage 4 capture).
+ *   2. FALLBACK — `executor.getHostSnapshot?.()` (run-wide executor view).
+ *   3. LAST     — `explicitHost.toJSON()` (caller's `MCPJamReportingConfig.host`).
+ *
+ * Homogeneity gate (pass 1): if SOME iterations supply a `hostSnapshot`,
+ * canonicalize+hash each one. If all hashes agree, the run is homogeneous
+ * and we return that snapshot. If they differ, this pass OMITS the
+ * run-level wire pair — heterogeneous runs require per-iteration wire
+ * support that this stage does not ship.
+ *
+ * Strict mode is deliberately out of scope here: we silently omit on
+ * heterogeneous so that a reasonable executor configuration that happens
+ * to mutate the live `Host` between iterations doesn't break eval
+ * reporting today. A future stage can promote heterogeneity to either
+ * a per-iteration wire field or an opt-in error.
+ *
+ * TODO(Stage 5+): once the backend accepts per-iteration `hostConfig`,
+ * stop collapsing to a single run-level value and emit one wire pair per
+ * iteration instead of omitting on heterogeneity.
+ */
+
+import { computeHostConfigHashV2 } from "./host-config/internal.js";
+import { normalizeSdkEvalHostConfigForWire } from "./host-config/internal.js";
+import type { HostJson } from "./host-config/public-types.js";
+import type { Host } from "./host-config/host.js";
+
+interface RunIterationLike {
+  /** Per-iteration host snapshot captured at Stage 4 (optional). */
+  hostSnapshot?: HostJson | undefined;
+}
+
+interface ExecutorLike {
+  getHostSnapshot?(): HostJson | undefined;
+}
+
+/** Input for {@link resolveRunLevelHostSnapshot}. */
+export interface ResolveRunLevelHostSnapshotInput {
+  /** Iteration shapes that may carry a per-iteration host snapshot. */
+  readonly iterations: readonly RunIterationLike[];
+  /** Optional executor exposing `getHostSnapshot()` (HostRunner path). */
+  readonly executor?: ExecutorLike;
+  /** Caller-supplied override (`MCPJamReportingConfig.host`). */
+  readonly explicitHost?: Host;
+}
+
+async function hashSnapshot(snapshot: HostJson): Promise<string> {
+  // Use the SAME projection the reporter will eventually wire through, so
+  // homogeneity here matches the actual on-wire bytes. Without the
+  // normalizer, two iterations could differ only in runtime-id metadata
+  // (which is stripped on the wire) and be falsely flagged heterogeneous.
+  const normalized = normalizeSdkEvalHostConfigForWire(snapshot);
+  return computeHostConfigHashV2(normalized);
+}
+
+/**
+ * Resolve the single `HostJson` snapshot to attach to a run-level wire
+ * pair, or `null` to omit the pair entirely.
+ *
+ * Returns `null` when:
+ *   - no per-iteration snapshot AND no executor snapshot AND no explicit
+ *     host;
+ *   - per-iteration snapshots are heterogeneous (different canonical
+ *     hashes) — pass 1 omit rather than smuggle a misleading run-level
+ *     value.
+ */
+export async function resolveRunLevelHostSnapshot(
+  input: ResolveRunLevelHostSnapshotInput
+): Promise<HostJson | null> {
+  const iterationSnapshots: HostJson[] = [];
+  for (const iter of input.iterations) {
+    if (iter.hostSnapshot) iterationSnapshots.push(iter.hostSnapshot);
+  }
+
+  if (iterationSnapshots.length > 0) {
+    const first = iterationSnapshots[0]!;
+    if (iterationSnapshots.length === 1) {
+      return first;
+    }
+    const hashes = await Promise.all(iterationSnapshots.map(hashSnapshot));
+    const reference = hashes[0]!;
+    for (let i = 1; i < hashes.length; i++) {
+      if (hashes[i] !== reference) {
+        // Heterogeneous — pass 1 omit. See TODO above.
+        return null;
+      }
+    }
+    return first;
+  }
+
+  // No per-iteration snapshots: fall back to the executor view.
+  const executorSnapshot = input.executor?.getHostSnapshot?.();
+  if (executorSnapshot) return executorSnapshot;
+
+  // Last resort: the caller-supplied `Host` from MCPJamReportingConfig.
+  if (input.explicitHost) {
+    try {
+      return input.explicitHost.toJSON();
+    } catch {
+      // An ill-configured caller-supplied Host (e.g. missing `model`) must
+      // not crash the reporter. Drop to "no snapshot" so the wire pair is
+      // simply omitted.
+      return null;
+    }
+  }
+
+  return null;
+}

--- a/sdk/src/sdk-evals-wire-host-config.ts
+++ b/sdk/src/sdk-evals-wire-host-config.ts
@@ -1,0 +1,55 @@
+/**
+ * Build the wire pair `{ hostConfig, hostConfigHash }` for SDK→backend eval
+ * ingestion from a `HostJson` or canonical `HostConfigInputV2` source.
+ *
+ * Pipeline (Stage 5):
+ *   1. `normalizeSdkEvalHostConfigForWire` (Step 1) — strip runtime-manager
+ *      identifiers (`serverIds`, `optionalServerIds`,
+ *      `serverConnectionOverrides`); project public `HostJson` to canonical
+ *      input shape if needed.
+ *   2. `canonicalizeHostConfigV2`  — sort keys, drop SDK defaults, normalize
+ *      derived fields.
+ *   3. `computeHostConfigHashV2`   — sha256 of the canonical JSON bytes.
+ *
+ * The backend (Step 2) runs the SAME pipeline server-side and rejects on
+ * hash mismatch. Producing the pair here using these exact helpers
+ * guarantees the byte-stable input on both sides.
+ */
+
+import {
+  computeHostConfigHashV2,
+  normalizeSdkEvalHostConfigForWire,
+} from "./host-config/internal.js";
+import type { HostConfigInputV2 } from "./host-config/internal.js";
+import type { HostJson } from "./host-config/public-types.js";
+
+/**
+ * Wire-ready host-config pair for `/sdk/v1/evals/*` request bodies.
+ *
+ * Both fields are required together — sending one without the other is a
+ * 400 from the backend. The reporter MUST inject both as an atomic pair.
+ */
+export interface SdkEvalsWireHostConfig {
+  /** Post-normalization canonical input shape (runtime ids stripped). */
+  readonly hostConfig: HostConfigInputV2;
+  /** sha256 hex of the canonicalized input. */
+  readonly hostConfigHash: string;
+}
+
+/**
+ * Build the wire pair from a `HostJson` snapshot or canonical input.
+ *
+ * Pure and deterministic. Two calls with byte-equal canonical projections
+ * produce the same hash. Accepting both input shapes lets callers feed
+ * either `Host.toJSON()` output (public vocabulary) or an internal
+ * `HostConfigInputV2` row without an explicit conversion step.
+ */
+export async function buildSdkEvalsWireHostConfig(
+  source: HostConfigInputV2 | HostJson
+): Promise<SdkEvalsWireHostConfig> {
+  const normalized = normalizeSdkEvalHostConfigForWire(source);
+  // `computeHostConfigHashV2` internally canonicalizes — passing the
+  // normalized input directly keeps the SDK and backend on one code path.
+  const hostConfigHash = await computeHostConfigHashV2(normalized);
+  return { hostConfig: normalized, hostConfigHash };
+}

--- a/sdk/tests/report-eval-results-host-config.test.ts
+++ b/sdk/tests/report-eval-results-host-config.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for the Stage 5 Step 3 host-config wire pickup in the eval reporter.
+ *
+ * Behavior under test:
+ *  1. Reporter sends `{ hostConfig, hostConfigHash }` in one-shot `/report`
+ *     body when capability is advertised and a snapshot source is present.
+ *  2. Reporter sends the wire pair in `/runs/start` body when the chunked
+ *     path is taken.
+ *  3. Reporter OMITS both fields when capability is absent (404).
+ *  4. Reporter OMITS both fields when no snapshot source is available.
+ *  5. Reporter OMITS both fields when iteration snapshots are heterogeneous
+ *     (homogeneity gate fires — pass-1 behavior).
+ *  6. `/runs/iterations` and `/runs/finalize` bodies NEVER contain the
+ *     wire pair (per-run, not per-batch).
+ *  7. Hash byte-equivalence: the hash the reporter sends matches what the
+ *     backend would recompute by running
+ *     `normalizeSdkEvalHostConfigForWire` + `computeHostConfigHashV2`.
+ */
+
+const sentryMocks = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn().mockResolvedValue(undefined),
+  captureEvalReportingFailure: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/sentry", () => ({
+  addBreadcrumb: sentryMocks.addBreadcrumb,
+  captureEvalReportingFailure: sentryMocks.captureEvalReportingFailure,
+}));
+
+import { vi } from "vitest";
+import { reportEvalResults } from "../src/report-eval-results";
+import { __resetSdkEvalsCapabilitiesCache } from "../src/sdk-evals-capability";
+import {
+  computeHostConfigHashV2,
+  normalizeSdkEvalHostConfigForWire,
+} from "../src/host-config/internal";
+import { Host } from "../src/host-config/index";
+import type { HostJson } from "../src/host-config/index";
+import type { EvalResultInput } from "../src/eval-reporting-types";
+
+const successSummary = {
+  total: 1,
+  passed: 1,
+  failed: 0,
+  passRate: 1,
+};
+
+function okResponse(body: Record<string, unknown>): any {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ ok: true, ...body }),
+  };
+}
+
+function notFoundResponse(): any {
+  return {
+    ok: false,
+    status: 404,
+    statusText: "Not Found",
+    json: async () => ({}),
+  };
+}
+
+function capabilityResponse(version: number): any {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ capabilities: { evalsHostConfig: version } }),
+  };
+}
+
+function makeHost(systemPrompt = "alpha"): Host {
+  return new Host({
+    style: "claude",
+    model: "anthropic/claude-sonnet-4-6",
+    systemPrompt,
+    temperature: 0.7,
+    requireToolApproval: false,
+    connectionDefaults: { headers: {}, requestTimeout: 10000 },
+  });
+}
+
+function smallResults(): EvalResultInput[] {
+  return [{ caseTitle: "case-1", passed: true }];
+}
+
+/**
+ * Build a chunked-path input: enough payload bytes to push
+ * `shouldUseOneShotUpload` to false (the threshold is ~1MB). Padding via
+ * `notes` keeps the result shape simple.
+ */
+function chunkedConfigOverrides(): {
+  notes: string;
+  expectedIterations: number;
+} {
+  return {
+    notes: "x".repeat(1024 * 1024 * 2),
+    expectedIterations: 1,
+  };
+}
+
+function findRequestByUrl(
+  fetchMock: ReturnType<typeof vi.fn>,
+  needle: string
+): { url: string; body: any } | undefined {
+  for (const call of fetchMock.mock.calls) {
+    const url = String(call[0]);
+    if (url.endsWith(needle)) {
+      const init = call[1] as { body?: string } | undefined;
+      const body = init?.body ? JSON.parse(init.body) : undefined;
+      return { url, body };
+    }
+  }
+  return undefined;
+}
+
+describe("reportEvalResults — Stage 5 Step 3 wire host-config", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    __resetSdkEvalsCapabilitiesCache();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    __resetSdkEvalsCapabilitiesCache();
+    sentryMocks.addBreadcrumb.mockClear();
+    sentryMocks.captureEvalReportingFailure.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("sends {hostConfig, hostConfigHash} in one-shot /report when capability + explicitHost present", async () => {
+    const host = makeHost("alpha");
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).endsWith("/sdk/v1/info")) return capabilityResponse(1);
+      return okResponse({
+        suiteId: "suite_1",
+        runId: "run_1",
+        status: "completed",
+        result: "passed",
+        summary: successSummary,
+      });
+    });
+    global.fetch = fetchMock as any;
+
+    await reportEvalResults({
+      apiKey: "k",
+      baseUrl: "https://example.com",
+      suiteName: "S",
+      host,
+      results: smallResults(),
+    });
+
+    const report = findRequestByUrl(fetchMock, "/sdk/v1/evals/report");
+    expect(report).toBeDefined();
+    expect(report!.body.hostConfig).toBeDefined();
+    expect(typeof report!.body.hostConfigHash).toBe("string");
+    expect(report!.body.hostConfigHash.length).toBeGreaterThan(0);
+
+    // Hash byte-equivalence with the backend's recompute pipeline.
+    const expectedHash = await computeHostConfigHashV2(
+      normalizeSdkEvalHostConfigForWire(host.toJSON())
+    );
+    expect(report!.body.hostConfigHash).toBe(expectedHash);
+
+    // Runtime ids never appear on the wire.
+    expect(report!.body.hostConfig.serverIds).toBeUndefined();
+    expect(report!.body.hostConfig.optionalServerIds).toBeUndefined();
+    expect(report!.body.hostConfig.serverConnectionOverrides).toBeUndefined();
+  });
+
+  it("sends wire pair in /runs/start when chunked path is taken", async () => {
+    const host = makeHost();
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      const u = String(url);
+      if (u.endsWith("/sdk/v1/info")) return capabilityResponse(1);
+      if (u.endsWith("/sdk/v1/evals/runs/start")) {
+        return okResponse({ suiteId: "s", runId: "r" });
+      }
+      if (u.endsWith("/sdk/v1/evals/runs/iterations")) {
+        return okResponse({ inserted: 1, skipped: 0, total: 1 });
+      }
+      if (u.endsWith("/sdk/v1/evals/runs/finalize")) {
+        return okResponse({
+          suiteId: "s",
+          runId: "r",
+          status: "completed",
+          result: "passed",
+          summary: successSummary,
+        });
+      }
+      throw new Error(`unexpected url ${u}`);
+    });
+    global.fetch = fetchMock as any;
+
+    await reportEvalResults({
+      apiKey: "k",
+      baseUrl: "https://example.com",
+      suiteName: "S",
+      host,
+      results: smallResults(),
+      ...chunkedConfigOverrides(),
+    });
+
+    const start = findRequestByUrl(fetchMock, "/sdk/v1/evals/runs/start");
+    expect(start).toBeDefined();
+    expect(start!.body.hostConfig).toBeDefined();
+    expect(typeof start!.body.hostConfigHash).toBe("string");
+
+    // Critically: iterations + finalize MUST NOT carry the wire pair.
+    const iters = findRequestByUrl(fetchMock, "/sdk/v1/evals/runs/iterations");
+    expect(iters).toBeDefined();
+    expect(iters!.body.hostConfig).toBeUndefined();
+    expect(iters!.body.hostConfigHash).toBeUndefined();
+
+    const finalize = findRequestByUrl(fetchMock, "/sdk/v1/evals/runs/finalize");
+    expect(finalize).toBeDefined();
+    expect(finalize!.body.hostConfig).toBeUndefined();
+    expect(finalize!.body.hostConfigHash).toBeUndefined();
+  });
+
+  it("OMITS the wire pair when capability is absent (404 on /sdk/v1/info)", async () => {
+    const host = makeHost();
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).endsWith("/sdk/v1/info")) return notFoundResponse();
+      return okResponse({
+        suiteId: "s",
+        runId: "r",
+        status: "completed",
+        result: "passed",
+        summary: successSummary,
+      });
+    });
+    global.fetch = fetchMock as any;
+
+    await reportEvalResults({
+      apiKey: "k",
+      baseUrl: "https://example.com",
+      suiteName: "S",
+      host,
+      results: smallResults(),
+    });
+
+    const report = findRequestByUrl(fetchMock, "/sdk/v1/evals/report");
+    expect(report).toBeDefined();
+    expect(report!.body.hostConfig).toBeUndefined();
+    expect(report!.body.hostConfigHash).toBeUndefined();
+  });
+
+  it("OMITS the wire pair when no snapshot source is available", async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).endsWith("/sdk/v1/info")) return capabilityResponse(1);
+      return okResponse({
+        suiteId: "s",
+        runId: "r",
+        status: "completed",
+        result: "passed",
+        summary: successSummary,
+      });
+    });
+    global.fetch = fetchMock as any;
+
+    await reportEvalResults({
+      apiKey: "k",
+      baseUrl: "https://example.com",
+      suiteName: "S",
+      // No host, no executor, no per-iteration snapshot.
+      results: smallResults(),
+    });
+
+    const report = findRequestByUrl(fetchMock, "/sdk/v1/evals/report");
+    expect(report).toBeDefined();
+    expect(report!.body.hostConfig).toBeUndefined();
+    expect(report!.body.hostConfigHash).toBeUndefined();
+  });
+
+  it("OMITS the wire pair when per-iteration snapshots are heterogeneous", async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).endsWith("/sdk/v1/info")) return capabilityResponse(1);
+      return okResponse({
+        suiteId: "s",
+        runId: "r",
+        status: "completed",
+        result: "passed",
+        summary: successSummary,
+      });
+    });
+    global.fetch = fetchMock as any;
+
+    const snapA: HostJson = makeHost("alpha").toJSON();
+    const snapB: HostJson = makeHost("beta — different").toJSON();
+    // The reporter consumes EvalResultInput; we attach hostSnapshot ad-hoc
+    // because the homogeneity gate accepts a structural `hostSnapshot`
+    // even though the public EvalResultInput type does not yet expose it.
+    const results = [
+      { caseTitle: "c1", passed: true, hostSnapshot: snapA } as any,
+      { caseTitle: "c2", passed: true, hostSnapshot: snapB } as any,
+    ];
+
+    await reportEvalResults({
+      apiKey: "k",
+      baseUrl: "https://example.com",
+      suiteName: "S",
+      // Explicit host present but heterogeneous iterations should win the
+      // priority and trigger the omit.
+      host: makeHost("fallback"),
+      results,
+    });
+
+    const report = findRequestByUrl(fetchMock, "/sdk/v1/evals/report");
+    expect(report).toBeDefined();
+    expect(report!.body.hostConfig).toBeUndefined();
+    expect(report!.body.hostConfigHash).toBeUndefined();
+  });
+
+  it("uses executor.getHostSnapshot as a fallback when no explicitHost", async () => {
+    const host = makeHost("from-executor");
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).endsWith("/sdk/v1/info")) return capabilityResponse(1);
+      return okResponse({
+        suiteId: "s",
+        runId: "r",
+        status: "completed",
+        result: "passed",
+        summary: successSummary,
+      });
+    });
+    global.fetch = fetchMock as any;
+
+    await reportEvalResults({
+      apiKey: "k",
+      baseUrl: "https://example.com",
+      suiteName: "S",
+      executor: { getHostSnapshot: () => host.toJSON() },
+      results: smallResults(),
+    });
+
+    const report = findRequestByUrl(fetchMock, "/sdk/v1/evals/report");
+    expect(report).toBeDefined();
+    expect(report!.body.hostConfig).toBeDefined();
+    const expectedHash = await computeHostConfigHashV2(
+      normalizeSdkEvalHostConfigForWire(host.toJSON())
+    );
+    expect(report!.body.hostConfigHash).toBe(expectedHash);
+  });
+});

--- a/sdk/tests/report-eval-results-host-config.test.ts
+++ b/sdk/tests/report-eval-results-host-config.test.ts
@@ -346,4 +346,41 @@ describe("reportEvalResults — Stage 5 Step 3 wire host-config", () => {
     );
     expect(report!.body.hostConfigHash).toBe(expectedHash);
   });
+
+  it("fail-safe: a throwing executor.getHostSnapshot does NOT crash the report — wire pair is omitted with a warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).endsWith("/sdk/v1/info")) return capabilityResponse(1);
+      return okResponse({
+        suiteId: "s",
+        runId: "r",
+        status: "completed",
+        result: "passed",
+        summary: successSummary,
+      });
+    });
+    global.fetch = fetchMock as any;
+
+    const result = await reportEvalResults({
+      apiKey: "k",
+      baseUrl: "https://example.com",
+      suiteName: "S",
+      executor: {
+        getHostSnapshot: () => {
+          throw new Error("boom: malformed snapshot");
+        },
+      },
+      results: smallResults(),
+    });
+
+    expect(result.runId).toBeDefined();
+    const report = findRequestByUrl(fetchMock, "/sdk/v1/evals/report");
+    expect(report).toBeDefined();
+    expect(report!.body.hostConfig).toBeUndefined();
+    expect(report!.body.hostConfigHash).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("omitting hostConfig wire pair")
+    );
+    warn.mockRestore();
+  });
 });

--- a/sdk/tests/sdk-evals-capability.test.ts
+++ b/sdk/tests/sdk-evals-capability.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for the SDK→backend eval capability probe (Stage 5, Step 3).
+ *
+ * Behavior under test:
+ *  1. Parses the nested `{ capabilities: { evalsHostConfig: N } }` shape.
+ *  2. Tolerates a future flat `{ evalsHostConfig: N }` shape.
+ *  3. Returns `{ evalsHostConfig: 0 }` on 404 (older backends).
+ *  4. Returns `{ evalsHostConfig: 0 }` on network error / abort timeout.
+ *  5. Returns `{ evalsHostConfig: 0 }` when the field is missing or
+ *     non-numeric.
+ *  6. Caches per baseUrl — repeat calls share one fetch.
+ *  7. Distinct baseUrls are independent.
+ */
+
+import { vi } from "vitest";
+import {
+  __resetSdkEvalsCapabilitiesCache,
+  resolveSdkEvalsCapabilities,
+} from "../src/sdk-evals-capability";
+
+function jsonResponse(body: unknown, status = 200): any {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  __resetSdkEvalsCapabilitiesCache();
+});
+
+afterEach(() => {
+  __resetSdkEvalsCapabilitiesCache();
+});
+
+describe("resolveSdkEvalsCapabilities", () => {
+  it("parses nested { capabilities: { evalsHostConfig } } shape", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ capabilities: { evalsHostConfig: 1 } })
+      );
+    const result = await resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(result.evalsHostConfig).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://api.example.com/sdk/v1/info"
+    );
+  });
+
+  it("tolerates flat { evalsHostConfig } body shape", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ evalsHostConfig: 2 }));
+    const result = await resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(result.evalsHostConfig).toBe(2);
+  });
+
+  it("returns 0 when /sdk/v1/info returns 404", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}, 404));
+    const result = await resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(result.evalsHostConfig).toBe(0);
+  });
+
+  it("returns 0 on network error", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    const result = await resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(result.evalsHostConfig).toBe(0);
+  });
+
+  it("returns 0 on AbortError (timeout)", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      return Promise.reject(err);
+    });
+    const result = await resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(result.evalsHostConfig).toBe(0);
+  });
+
+  it("returns 0 on body parse failure", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => {
+        throw new SyntaxError("not JSON");
+      },
+    });
+    const result = await resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(result.evalsHostConfig).toBe(0);
+  });
+
+  it("returns 0 when capabilities is missing or non-numeric", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(
+        jsonResponse({ capabilities: { evalsHostConfig: "1" } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ capabilities: { evalsHostConfig: null } })
+      );
+
+    const a = await resolveSdkEvalsCapabilities(
+      "https://a.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    const b = await resolveSdkEvalsCapabilities(
+      "https://b.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    const c = await resolveSdkEvalsCapabilities(
+      "https://c.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(a.evalsHostConfig).toBe(0);
+    expect(b.evalsHostConfig).toBe(0);
+    expect(c.evalsHostConfig).toBe(0);
+  });
+
+  it("caches per baseUrl — repeated calls share one fetch", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ capabilities: { evalsHostConfig: 1 } })
+      );
+    const a = await resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    const b = await resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    const c = await resolveSdkEvalsCapabilities(
+      "https://api.example.com/",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(a.evalsHostConfig).toBe(1);
+    expect(b.evalsHostConfig).toBe(1);
+    expect(c.evalsHostConfig).toBe(1);
+    // Trailing slash normalized to same cache key as the bare URL.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("distinct baseUrls produce independent probes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ capabilities: { evalsHostConfig: 1 } })
+      )
+      .mockResolvedValueOnce(jsonResponse({}, 404));
+    const a = await resolveSdkEvalsCapabilities(
+      "https://a.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    const b = await resolveSdkEvalsCapabilities(
+      "https://b.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(a.evalsHostConfig).toBe(1);
+    expect(b.evalsHostConfig).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("concurrent first-callers share one in-flight fetch", async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    const p1 = resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    const p2 = resolveSdkEvalsCapabilities(
+      "https://api.example.com",
+      fetchMock as unknown as typeof fetch
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    resolveFetch(jsonResponse({ capabilities: { evalsHostConfig: 1 } }));
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(a.evalsHostConfig).toBe(1);
+    expect(b.evalsHostConfig).toBe(1);
+  });
+});

--- a/sdk/tests/sdk-evals-host-config-source.test.ts
+++ b/sdk/tests/sdk-evals-host-config-source.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for `resolveRunLevelHostSnapshot` (Stage 5, Step 3).
+ *
+ * Source priority:
+ *   1. PRIMARY  — per-iteration `iteration.hostSnapshot`.
+ *   2. FALLBACK — `executor.getHostSnapshot?.()`.
+ *   3. LAST     — `explicitHost.toJSON()`.
+ *
+ * Homogeneity gate (pass 1): heterogeneous per-iteration snapshots return
+ * `null` (omit). Homogeneous returns the shared snapshot.
+ */
+
+import { resolveRunLevelHostSnapshot } from "../src/sdk-evals-host-config-source";
+import { Host } from "../src/host-config/index";
+import type { HostJson } from "../src/host-config/index";
+
+function snapshotA(): HostJson {
+  return new Host({
+    style: "claude",
+    model: "anthropic/claude-sonnet-4-6",
+    systemPrompt: "alpha",
+    temperature: 0.7,
+    requireToolApproval: false,
+    connectionDefaults: { headers: {}, requestTimeout: 10000 },
+  }).toJSON();
+}
+
+function snapshotB(): HostJson {
+  return new Host({
+    style: "claude",
+    model: "anthropic/claude-sonnet-4-6",
+    systemPrompt: "beta — different",
+    temperature: 0.7,
+    requireToolApproval: false,
+    connectionDefaults: { headers: {}, requestTimeout: 10000 },
+  }).toJSON();
+}
+
+describe("resolveRunLevelHostSnapshot", () => {
+  it("returns the shared snapshot when all iterations agree (homogeneous)", async () => {
+    const snap = snapshotA();
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [
+        { hostSnapshot: snap },
+        { hostSnapshot: { ...snap } },
+        { hostSnapshot: { ...snap } },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.systemPrompt).toBe("alpha");
+  });
+
+  it("returns null when iterations are heterogeneous (homogeneity gate)", async () => {
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [
+        { hostSnapshot: snapshotA() },
+        { hostSnapshot: snapshotB() },
+      ],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns the single snapshot when only one iteration carries one", async () => {
+    const snap = snapshotA();
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [{ hostSnapshot: snap }],
+    });
+    expect(result).toBe(snap);
+  });
+
+  it("falls back to executor.getHostSnapshot when no iteration carries one", async () => {
+    const snap = snapshotA();
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [{}, {}],
+      executor: { getHostSnapshot: () => snap },
+    });
+    expect(result).toBe(snap);
+  });
+
+  it("falls back to explicitHost.toJSON() when no iteration or executor snapshot", async () => {
+    const host = new Host({
+      style: "claude",
+      model: "anthropic/claude-sonnet-4-6",
+      systemPrompt: "explicit-host",
+      temperature: 0.7,
+      requireToolApproval: false,
+      connectionDefaults: { headers: {}, requestTimeout: 10000 },
+    });
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [{}],
+      explicitHost: host,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.systemPrompt).toBe("explicit-host");
+  });
+
+  it("prefers iteration snapshot over executor.getHostSnapshot", async () => {
+    const iterSnap = snapshotA();
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [{ hostSnapshot: iterSnap }],
+      executor: { getHostSnapshot: () => snapshotB() },
+    });
+    expect(result).toBe(iterSnap);
+  });
+
+  it("prefers executor over explicitHost", async () => {
+    const execSnap = snapshotA();
+    const host = new Host({
+      style: "claude",
+      model: "anthropic/claude-sonnet-4-6",
+      systemPrompt: "explicit",
+      temperature: 0.7,
+      requireToolApproval: false,
+      connectionDefaults: { headers: {}, requestTimeout: 10000 },
+    });
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [{}],
+      executor: { getHostSnapshot: () => execSnap },
+      explicitHost: host,
+    });
+    expect(result).toBe(execSnap);
+  });
+
+  it("returns null when nothing is available", async () => {
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [{}, {}, {}],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("empty iterations array falls through to executor/explicitHost", async () => {
+    const snap = snapshotA();
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [],
+      executor: { getHostSnapshot: () => snap },
+    });
+    expect(result).toBe(snap);
+  });
+
+  it("treats an ill-configured explicitHost as no-snapshot", async () => {
+    // `Host` without `model` will throw at `toJSON()` — the resolver must
+    // swallow and return null rather than crash the reporter.
+    const host = new Host({ style: "claude" } as any);
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [{}],
+      explicitHost: host,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("treats executor.getHostSnapshot returning undefined as no-snapshot", async () => {
+    const result = await resolveRunLevelHostSnapshot({
+      iterations: [{}],
+      executor: { getHostSnapshot: () => undefined },
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/sdk/tests/sdk-evals-wire-host-config.test.ts
+++ b/sdk/tests/sdk-evals-wire-host-config.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for `buildSdkEvalsWireHostConfig` (Stage 5, Step 3).
+ *
+ * Contract:
+ *  - The returned `hostConfig` is post-normalization (runtime ids stripped).
+ *  - The returned `hostConfigHash` is byte-equivalent to what
+ *    `computeHostConfigHashV2(normalizeSdkEvalHostConfigForWire(input))`
+ *    produces — i.e., the backend re-running the same pipeline must agree.
+ *  - The same logical host produces the same hash whether the caller
+ *    supplies a `HostConfigInputV2` (canonical) or a `HostJson` (public).
+ *  - `serverIds`/`optionalServerIds` on the input have no influence on
+ *    the hash.
+ */
+
+import {
+  computeHostConfigHashV2,
+  normalizeSdkEvalHostConfigForWire,
+} from "../src/host-config/internal";
+import type { HostConfigInputV2 } from "../src/host-config/internal";
+import { Host } from "../src/host-config/index";
+import { buildSdkEvalsWireHostConfig } from "../src/sdk-evals-wire-host-config";
+
+function baseInput(
+  overrides: Partial<HostConfigInputV2> = {}
+): HostConfigInputV2 {
+  return {
+    hostStyle: "claude",
+    modelId: "anthropic/claude-sonnet-4-6",
+    systemPrompt: "You are a helpful assistant.",
+    temperature: 0.7,
+    requireToolApproval: false,
+    connectionDefaults: { headers: {}, requestTimeout: 10000 },
+    clientCapabilities: {},
+    hostContext: {},
+    ...overrides,
+  };
+}
+
+describe("buildSdkEvalsWireHostConfig", () => {
+  it("strips runtime ids from the wire hostConfig", async () => {
+    const input = baseInput({
+      serverIds: ["runtime_srv_alpha"],
+      optionalServerIds: ["runtime_srv_beta"],
+      serverConnectionOverrides: {
+        runtime_srv_alpha: { headersOverride: { X: "y" } },
+      },
+    });
+    const out = await buildSdkEvalsWireHostConfig(input);
+    expect(
+      (out.hostConfig as Record<string, unknown>).serverIds
+    ).toBeUndefined();
+    expect(
+      (out.hostConfig as Record<string, unknown>).optionalServerIds
+    ).toBeUndefined();
+    expect(
+      (out.hostConfig as Record<string, unknown>).serverConnectionOverrides
+    ).toBeUndefined();
+  });
+
+  it("hash matches an independent re-canonicalize+rehash (round-trip)", async () => {
+    const input = baseInput({
+      serverIds: ["runtime_srv_alpha", "runtime_srv_beta"],
+    });
+    const out = await buildSdkEvalsWireHostConfig(input);
+    const reHash = await computeHostConfigHashV2(
+      normalizeSdkEvalHostConfigForWire(out.hostConfig)
+    );
+    expect(out.hostConfigHash).toBe(reHash);
+  });
+
+  it("hash is stable across HostConfigInputV2 and HostJson inputs", async () => {
+    const host = new Host({
+      style: "claude",
+      model: "anthropic/claude-sonnet-4-6",
+      systemPrompt: "You are a helpful assistant.",
+      temperature: 0.7,
+      requireToolApproval: false,
+      connectionDefaults: { headers: {}, requestTimeout: 10000 },
+    });
+    const hostJson = host.toJSON();
+
+    const internalInput = baseInput();
+    const fromInternal = await buildSdkEvalsWireHostConfig(internalInput);
+    const fromPublic = await buildSdkEvalsWireHostConfig(hostJson);
+    expect(fromInternal.hostConfigHash).toBe(fromPublic.hostConfigHash);
+  });
+
+  it("hash is independent of serverIds / optionalServerIds in the input", async () => {
+    const withIds = await buildSdkEvalsWireHostConfig(
+      baseInput({
+        serverIds: ["runtime_srv_alpha", "runtime_srv_beta"],
+        optionalServerIds: ["runtime_srv_gamma"],
+        serverConnectionOverrides: {
+          runtime_srv_alpha: {
+            headersOverride: { Authorization: "Bearer secret" },
+          },
+        },
+      })
+    );
+    const withoutIds = await buildSdkEvalsWireHostConfig(baseInput());
+    expect(withIds.hostConfigHash).toBe(withoutIds.hostConfigHash);
+  });
+
+  it("differs when a non-id field changes (sanity)", async () => {
+    const a = await buildSdkEvalsWireHostConfig(
+      baseInput({ temperature: 0.7 })
+    );
+    const b = await buildSdkEvalsWireHostConfig(
+      baseInput({ temperature: 0.4 })
+    );
+    expect(a.hostConfigHash).not.toBe(b.hostConfigHash);
+  });
+});


### PR DESCRIPTION
## Summary
- **Stage 5 Step 3 / 3** of the hostConfig consolidation plan — SDK eval reporter wire-send, capability-gated.
- Reporter probes `GET /sdk/v1/info` lazily (cached per baseUrl, fail-safe to "no capability") and, when the backend advertises `evalsHostConfig`, sends a normalized + content-hashed host config alongside results on **both** the one-shot path (`POST /sdk/v1/evals/report`) and the chunked path's start (`POST /sdk/v1/evals/runs/start`). `appendEvalRunIterations` and `finalizeEvalRun` **never** send the wire pair — per-run, not per-batch.

### Source order (pass 1)
1. `iteration.hostSnapshot` — Stage 4 per-iteration capture (primary)
2. `executor.getHostSnapshot?.()` — fallback for executors without per-iteration capture
3. `MCPJamReportingConfig.host` — explicit caller-supplied override (last)

### Pass-1 homogeneity gate
If iteration snapshots disagree after canonicalization, **omit** the run-level field. Heterogeneous per-iteration host configs require per-iteration wire support (later stage). Marked with `TODO(Stage 5+)` in `sdk-evals-host-config-source.ts`.

### Wire pipeline (mirrors backend exactly)
```
normalizeSdkEvalHostConfigForWire → canonicalizeHostConfigV2 → computeHostConfigHashV2
```
All three live in `@mcpjam/sdk/host-config/internal`. Hash mismatch on the server side → 400; since client and server normalize the same shape, a matching pair always passes.

### New modules
- `sdk/src/sdk-evals-capability.ts` — lazy `/sdk/v1/info` probe + per-baseUrl cache
- `sdk/src/sdk-evals-wire-host-config.ts` — `buildSdkEvalsWireHostConfig` (normalize → hash)
- `sdk/src/sdk-evals-host-config-source.ts` — `resolveRunLevelHostSnapshot` + homogeneity gate

### Reporter touch-points
- `hasAnyHostSnapshotSource` short-circuit skips the probe when no snapshot source exists — preserves the legacy single-request flow for callers that don't supply host info.
- `wireHostConfigBody` spread is `{}` when capability absent or no source → never sends `hostConfigHash` without `hostConfig`.

## Stack
- Step 1 — inspector PR — SDK helper `normalizeSdkEvalHostConfigForWire`
- Step 2 — mcpjam-backend PR — `/sdk/v1/info` capability + `/sdk/v1/evals/*` ingestion
- **Step 3 — this PR** — SDK reporter wire-send (stacked on Step 1; rebase to `main` once Step 1 merges)

## Test plan
- [x] `npm run typecheck` — zero new errors in changed files
- [x] `npm test` — 1289 pass (+32 new across 4 files: 10 capability, 5 wire-shape, 11 source resolution, 6 reporter integration); 1 pre-existing skip; zero regressions
- [x] `npm run build` — clean
- [x] `npm run test:packaging` — exit 0
- [x] `grep -n "hostConfigHash" src/report-eval-results.ts` — only 3 hits, all in the per-run injection sites (one-shot `/report` body + chunked `/runs/start` payload); never in `appendEvalRunIterations` / `finalizeEvalRun`

## Changeset
`.changeset/stage5-step3-sdk-reporter.md` (minor bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval upload request shapes and adds an extra HTTP probe when host snapshots exist; behavior is gated and fail-safe, but hash/canonicalization mismatches with the backend would cause 400s on capable servers.
> 
> **Overview**
> **Stage 5 Step 3** turns on eval reporter upload of **`{ hostConfig, hostConfigHash }`** on **`/sdk/v1/evals/report`** and chunked **`/sdk/v1/evals/runs/start`**, gated by a lazy **`GET /sdk/v1/info`** probe (cached per `baseUrl`, fail-safe). Legacy callers with no host data skip the probe; older backends see unchanged payloads.
> 
> Snapshot resolution is new: **per-iteration `hostSnapshot`** → **`executor.getHostSnapshot()`** → **`MCPJamReportingConfig.host`**, with normalization + **`computeHostConfigHashV2`** for the wire pair. **Heterogeneous** iteration snapshots **omit** run-level host config (pass 1). **`ReportEvalResultsInput`** gains optional **`executor`**; docs now describe active wire send instead of a future stage.
> 
> Wire pair injection is **fail-safe** (errors warn and omit; upload still succeeds) and **never** appears on **`/runs/iterations`** or **`/runs/finalize`**. New modules cover capability probing, snapshot resolution, and wire building, plus broad vitest coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef34c42f99dad2c091e3dbcff8bde3ce8227e953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->