### PR TITLE
nux in playground + org race

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1235,6 +1235,7 @@ export default function App() {
   const locationContext = useContext(UNSAFE_LocationContext);
   const routeOrganizationId = currentOrgRoute?.orgId;
   const routeOrganizationSection = currentOrgRoute?.orgSection;
+  const { isEnsuringUser, isUserReady } = useDbUserBootstrapStatus();
   const { sortedOrganizations, isLoading: isLoadingOrganizations } =
     useOrganizationQueries({ isAuthenticated });
   useEffect(() => {
@@ -1441,7 +1442,6 @@ export default function App() {
 
   // Set up Electron OAuth callback handling
   useElectronOAuth();
-  const { isEnsuringUser, isUserReady } = useDbUserBootstrapStatus();
 
   const isDebugCallback = window.location.pathname.startsWith(
     "/oauth/callback/debug"

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizations.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizations.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DbUserReadyProvider } from "@/contexts/db-user-ready-context";
+import { useOrganizationQueries } from "../useOrganizations";
+
+const mockUseQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("convex/react", () => ({
+  useQuery: mockUseQuery,
+  useMutation: () => vi.fn(),
+  useAction: () => vi.fn(),
+}));
+
+function readyWrapper(isUserReady: boolean) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <DbUserReadyProvider isUserReady={isUserReady}>
+        {children}
+      </DbUserReadyProvider>
+    );
+  };
+}
+
+describe("useOrganizationQueries", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset();
+    mockUseQuery.mockReturnValue(undefined);
+  });
+
+  it("stays loading while an authenticated actor is waiting for user bootstrap", () => {
+    const { result } = renderHook(() =>
+      useOrganizationQueries({ isAuthenticated: true }), {
+        wrapper: readyWrapper(false),
+      }
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "organizations:getMyOrganizations",
+      "skip"
+    );
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.sortedOrganizations).toEqual([]);
+  });
+
+  it("queries and sorts once the user row is ready", () => {
+    mockUseQuery.mockReturnValue([
+      { _id: "a", updatedAt: 1 },
+      { _id: "b", updatedAt: 2 },
+    ]);
+
+    const { result } = renderHook(
+      () => useOrganizationQueries({ isAuthenticated: true }),
+      { wrapper: readyWrapper(true) }
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "organizations:getMyOrganizations",
+      {}
+    );
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.sortedOrganizations.map((o) => o._id)).toEqual([
+      "b",
+      "a",
+    ]);
+  });
+
+  it("does not report loading for unauthenticated actors", () => {
+    const { result } = renderHook(() =>
+      useOrganizationQueries({ isAuthenticated: false }), {
+        wrapper: readyWrapper(false),
+      }
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "organizations:getMyOrganizations",
+      "skip"
+    );
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useOrganizations.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizations.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useQuery, useMutation, useAction } from "convex/react";
+import { useDbUserReady } from "@/contexts/db-user-ready-context";
 
 export type OrganizationMembershipRole = "owner" | "admin" | "member" | "guest";
 
@@ -65,12 +66,15 @@ export function useOrganizationQueries({
 }: {
   isAuthenticated: boolean;
 }) {
+  const isUserReady = useDbUserReady();
+  const canQuery = isAuthenticated && isUserReady;
   const organizations = useQuery(
     "organizations:getMyOrganizations" as any,
-    isAuthenticated ? ({} as any) : "skip",
+    canQuery ? ({} as any) : "skip",
   ) as Organization[] | undefined;
 
-  const isLoading = isAuthenticated && organizations === undefined;
+  const isLoading =
+    isAuthenticated && (!isUserReady || organizations === undefined);
 
   const sortedOrganizations = useMemo(() => {
     if (!organizations) return [];

--- a/mcpjam-inspector/client/src/lib/__tests__/onboarding-state.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/onboarding-state.test.ts
@@ -91,6 +91,10 @@ describe("onboarding-state", () => {
       expect(isFirstRunEligible(false, "#hosts")).toBe(true);
     });
 
+    it("returns true when hash is #home (the default landing route)", () => {
+      expect(isFirstRunEligible(false, "#home")).toBe(true);
+    });
+
     it("returns false when hash points to a specific tab", () => {
       expect(isFirstRunEligible(false, "#tools")).toBe(false);
     });

--- a/mcpjam-inspector/client/src/lib/onboarding-state.ts
+++ b/mcpjam-inspector/client/src/lib/onboarding-state.ts
@@ -74,8 +74,8 @@ export function clearOnboardingState(): void {
 
 /**
  * Returns true when the user is eligible for first-run onboarding:
- * - No explicit hash route (empty, "#", "#/", or the default hub hash:
- *   `#servers`, `#connect`, or legacy `#hosts`)
+ * - No explicit hash route (empty, "#", "#/", the default hub hash
+ *   `#servers`/`#connect`/legacy `#hosts`, or the `#home` landing route)
  * - No saved servers that block first-run onboarding
  * - Onboarding has never been shown for the current identity. When a remote
  *   user row is available, that row is the source of truth; localStorage is
@@ -102,6 +102,7 @@ export function isFirstRunEligible(
     routeTab !== "connect" &&
     routeTab !== "clients" &&
     routeTab !== "hosts" &&
+    routeTab !== "home" &&
     routeTab
   )
     return false;


### PR DESCRIPTION
- Added home to the first-run allowlist so new guests landing on the Home page get sent into the NUX again
  - Fixed a guest startup crash: queries now wait for the user's DB row to exist instead of firing too early