### PR TITLE
docs: split nav into Get Started / Inspector / CLI / SDK tabs (+ SDK v1.x signal)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -31,58 +31,87 @@
   },
   "favicon": "/mcp_jam.svg",
   "navigation": {
-    "groups": [
+    "tabs": [
       {
-        "group": "Overview",
-        "icon": "book-open",
+        "tab": "Get Started",
+        "icon": "rocket",
         "pages": [
           "index",
           "getting-started",
           "installation",
-          "inspector/launch-from-code",
-          "hosted/overview"
+          "hosted/overview",
+          "troubleshooting/common-errors"
         ]
       },
       {
-        "group": "Inspector Features",
-        "icon": "star",
-        "pages": [
-          "inspector/home",
-          "inspector/playground",
-          "inspector/clients",
-          "inspector/protocol-versions",
-          "inspector/guided-oauth",
-          "inspector/xaa-debugger",
-          "inspector/tools-prompts-resources",
-          "inspector/evals",
-          "inspector/projects",
-          "inspector/views",
-          "inspector/skills"
+        "tab": "Inspector",
+        "icon": "binoculars",
+        "groups": [
+          {
+            "group": "Features",
+            "icon": "star",
+            "pages": [
+              "inspector/home",
+              "inspector/playground",
+              "inspector/clients",
+              "inspector/protocol-versions",
+              "inspector/guided-oauth",
+              "inspector/xaa-debugger",
+              "inspector/tools-prompts-resources",
+              "inspector/evals",
+              "inspector/projects",
+              "inspector/views",
+              "inspector/skills"
+            ]
+          },
+          {
+            "group": "Embedding",
+            "icon": "code",
+            "pages": ["inspector/launch-from-code"]
+          },
+          {
+            "group": "Recipes",
+            "icon": "map",
+            "pages": ["guides/first-mcp-app", "guides/first-chatgpt-app-react"]
+          }
         ]
       },
       {
-        "group": "CLI",
+        "tab": "CLI",
         "icon": "terminal",
-        "pages": [
-          "cli/overview",
-          "cli/server-inspection",
-          "cli/oauth-conformance",
-          "cli/oauth-login",
-          "cli/apps-conformance",
-          "cli/tools-resources-prompts",
-          "cli/ci",
-          "cli/telemetry",
-          "cli/reference"
-        ]
-      },
-      {
-        "group": "SDK",
-        "icon": "code",
-        "pages": [
-          "sdk/index",
-          "sdk/quickstart",
+        "groups": [
           {
             "group": "Guides",
+            "icon": "map",
+            "pages": [
+              "cli/overview",
+              "cli/server-inspection",
+              "cli/oauth-conformance",
+              "cli/oauth-login",
+              "cli/apps-conformance",
+              "cli/tools-resources-prompts",
+              "cli/ci",
+              "cli/telemetry"
+            ]
+          },
+          {
+            "group": "Reference",
+            "icon": "book",
+            "pages": ["cli/reference"]
+          }
+        ]
+      },
+      {
+        "tab": "SDK",
+        "icon": "code",
+        "groups": [
+          {
+            "group": "Get Started",
+            "icon": "rocket",
+            "pages": ["sdk/index", "sdk/quickstart"]
+          },
+          {
+            "group": "Concepts",
             "icon": "map",
             "pages": [
               "sdk/concepts/connecting-servers",
@@ -110,16 +139,6 @@
             ]
           }
         ]
-      },
-      {
-        "group": "Guides",
-        "icon": "map",
-        "pages": ["guides/first-mcp-app", "guides/first-chatgpt-app-react"]
-      },
-      {
-        "group": "Troubleshooting",
-        "icon": "wrench",
-        "pages": ["troubleshooting/common-errors"]
       }
     ],
     "global": {

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -4,6 +4,8 @@ description: "MCP server unit testing, end-to-end (e2e) testing, and server eval
 icon: "box"
 ---
 
+<span className="sdk-version-pill">v1.x · Latest</span>
+
 The [**@mcpjam/sdk**](https://www.npmjs.com/package/@mcpjam/sdk) is a TypeScript SDK for testing, evaluating, and building applications with MCP (Model Context Protocol) servers. It provides everything you need to ensure your MCP server works reliably across different LLMs and environments.
 
 ## Who is this for?

--- a/docs/style.css
+++ b/docs/style.css
@@ -390,6 +390,44 @@ tbody tr:hover td {
   text-decoration-color: var(--mcj-orange) !important;
 }
 
+/* ── Top-nav tabs (Get Started / Inspector / CLI / SDK) ─────────────────── */
+
+/* Brand-orange underline + ink-strong text on the active tab. Selector net
+   covers Mintlify Maple's likely tab shapes — tablist role, aria-selected,
+   data-state="active", or a direct anchor in a tablist container. */
+:is([role="tablist"], nav[aria-label*="tab" i], [data-slot="tabs"]) :is(a, button)[aria-selected="true"],
+:is([role="tablist"], nav[aria-label*="tab" i], [data-slot="tabs"]) :is(a, button)[data-state="active"] {
+  color: var(--mcj-ink-strong) !important;
+  font-weight: 500 !important;
+  border-bottom: 2px solid var(--mcj-orange) !important;
+  margin-bottom: -1px;
+}
+
+:is([role="tablist"], nav[aria-label*="tab" i], [data-slot="tabs"]) :is(a, button):not([aria-selected="true"]):not([data-state="active"]) {
+  color: var(--mcj-ink-muted);
+  transition: color 120ms ease-out;
+}
+:is([role="tablist"], nav[aria-label*="tab" i], [data-slot="tabs"]) :is(a, button):not([aria-selected="true"]):not([data-state="active"]):hover {
+  color: var(--mcj-ink-strong);
+}
+
+/* SDK version pill — visible interim signal that the docs describe v1.x of
+   @mcpjam/sdk. Lives at the top of sdk/index.mdx. Native Mintlify tab tags
+   aren't a thing (`tag` is only on `navigation.versions[]`), so we mark
+   the version in MDX and brand-tint it here. */
+.sdk-version-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.55rem;
+  border-radius: 9999px;
+  background: var(--mcj-orange-soft);
+  color: var(--mcj-orange-edge);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.75rem;
+}
+
 /* ── Misc polish ────────────────────────────────────────────────────────── */
 
 hr {


### PR DESCRIPTION
## Summary

Splits the docs sidebar from one 32-page scroll into four scoped tabs — **Get Started · Inspector · CLI · SDK** — matching the multi-surface treatment Cline, Kiro, and OpenAI Codex use to separate their products. Visitors landing on the CLI surface no longer have to wade past Inspector Features and Hosted to find what they came for.

Also lands the interim **v1.x · Latest** version signal on the SDK landing page that we agreed was the right call vs. forking the doc tree behind `navigation.versions[]`.

**No URL changes. No content changes. No new redirects.** Page paths stay exactly where they are; the existing `/inspector/workspaces`, `/inspector/chat` etc. redirects still target valid pages within the Inspector tab.

## Tab structure

| Tab | Shape | Pages |
|---|---|---|
| **Get Started** | flat | `index`, `getting-started`, `installation`, `hosted/overview`, `troubleshooting/common-errors` |
| **Inspector** | 3 groups | Features (11), Embedding (`inspector/launch-from-code`), Recipes (the two `guides/*` pages — they're inspector workflows) |
| **CLI** | 2 groups | Guides (8), Reference (`cli/reference`) |
| **SDK** | 3 groups | Get Started (index, quickstart), Concepts (5), Reference (11) |

Mintlify's schema enforces `pages` XOR `groups` per tab — so flat-or-grouped is per-tab, not mixed. Get Started uses `pages` (one flat list); the other three use `groups`.

## SDK version signal

Mintlify's `tag` field only exists on `navigation.versions[]`, which is the heavyweight versioned-docs mechanism. We discussed using that and decided it's overkill until v2 actually ships breaking changes.

Interim instead: a small `<span className="sdk-version-pill">v1.x · Latest</span>` at the top of `sdk/index.mdx`, brand-tinted via a new `.sdk-version-pill` rule in `style.css`. Visible signal that the docs describe a specific major; zero maintenance until we want real versioning.

## CSS additions

- **Active-tab underline.** Selector net covers `[role="tablist"]`, `nav[aria-label*="tab"]`, and `[data-slot="tabs"]` — one will match Maple's actual DOM. Active tab gets ink-strong text + 2px brand-orange underline. Inactive tabs are ink-muted with ink-strong on hover.
- **`.sdk-version-pill`.** Orange-edge text on `--mcj-orange-soft` background, 9999px radius, 0.72rem. Sits inline at the top of the SDK landing prose.

If the active-tab underline doesn't catch (Maple may render tabs as something my selectors miss), I can tighten the selector once we see the actual DOM — but the selector list is broad enough to handle the common shapes.

## Test plan

- [ ] `cd docs && mint dev` under Node 20+
- [ ] Top nav shows four tabs: Get Started, Inspector, CLI, SDK
- [ ] Active tab has the brand-orange underline; clicking between tabs swaps the sidebar
- [ ] Every existing URL still works:
  - `/getting-started`, `/installation`, `/hosted/overview`, `/troubleshooting/common-errors`
  - `/inspector/playground`, `/inspector/launch-from-code`
  - `/cli/overview`, `/cli/reference`
  - `/sdk/index`, `/sdk/concepts/connecting-servers`, `/sdk/reference/test-agent`
  - `/guides/first-mcp-app` (now under Inspector → Recipes)
- [ ] SDK landing page shows the **v1.x · Latest** pill above the intro paragraph
- [ ] `npm run docs:check-tokens` passes

## Not in this PR (deferred)

- **Native `navigation.versions[]` SDK fork.** Defer until v2 ships with breaking changes. Forking the doc tree now creates two trees where one of them serves no one.
- **Content rewrite of "Where to go next" card grids.** Separate, content-heavy PR per page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only navigation and CSS; no runtime, API, or URL path changes.
> 
> **Overview**
> Reorganizes Mintlify navigation from a single long **groups** sidebar into four top-level **tabs** — **Get Started**, **Inspector**, **CLI**, and **SDK** — so each product surface has its own scoped sidebar. Page slugs are unchanged; items are regrouped (e.g. troubleshooting and hosted under Get Started, guide recipes under Inspector → Recipes, CLI split into Guides vs Reference).
> 
> Adds a **v1.x · Latest** pill on the SDK landing page and styles for it plus active-tab treatment (brand-orange underline, stronger active/inactive tab colors) in `style.css`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d246ecff97665ea14bbd5a94fcedb7f01c788f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->