### PR TITLE
Revert "chore: release rollup — @mcpjam/sdk 1.12.0" (#2427)

### DIFF
--- a/.changeset/sdk-host-config-canonicalize-tightening.md
+++ b/.changeset/sdk-host-config-canonicalize-tightening.md
@@ -1,0 +1,16 @@
+---
+"@mcpjam/sdk": minor
+---
+
+SDK: tighten the HostConfig v2 canonicalizer (four follow-up items deferred from #2392). All four ship together as the second-half of the Stage 1 backend consolidation — the backend imports the canonicalizer directly from `@mcpjam/sdk/host-config/internal`, so this PR is the single source of behavior change for both sides.
+
+Behavior changes (all on `canonicalizeHostConfigV2` / `computeHostConfigHashV2`):
+
+- **Deep-sort `clientCapabilities` and `hostContext`.** Previously a shallow `sortStringKeys` left nested key order leaking into the canonical hash, so `{ extensions: { ui: { a, b } } }` and `{ extensions: { ui: { b, a } } }` minted distinct rows for identical capability sets. Now both fields go through the same recursive sort already used for `*Override` and `mcpProfile`.
+- **Collapse empty `allowFeatures` to absent.** A user `allowFeatures: {}` (or `{ camera: "*" }` whose only keys are spec-permission features that the canonicalizer drops) now omits the field entirely, matching the sibling `openaiAppsOverrides` collapse and preventing semantic dupes.
+- **Drop `openaiAppsOverrides` when `compatRuntime.openaiApps === false`.** The resolver ignores per-method overrides when the shim isn't injected; letting them affect the hash minted rows that resolved to identical runtime behavior.
+- **Fail-fast on missing `clientCapabilities` / `hostContext`.** The previous `?? {}` coalescing silently merged a writer-bug `undefined` into the empty-cap dedupe pool. Both fields are required on the input type; the canonicalizer now enforces it at the boundary.
+
+Audit confirmed all four items are **hash-neutral for current production data** (15,389 prod hostConfigs rows scanned across the four predicates; 0 hits). The bundled parity fixture was regenerated; `EXPECTED_INPUT_HASH` bumped accordingly. External SDK consumers using the public `Host` builder are unaffected — the canonicalizer is internal-only.
+
+Out of scope: the eight `@mcpjam/sdk` items still tracked elsewhere (Stage 3+ in the macro plan).

--- a/.changeset/stage5-step1-sdk-evals-normalizer.md
+++ b/.changeset/stage5-step1-sdk-evals-normalizer.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/sdk": minor
+---
+
+host-config: add `normalizeSdkEvalHostConfigForWire` (Stage 5 helper, `/internal` only).
+
+Strips runtime-manager identifiers (`serverIds`, `optionalServerIds`, `serverConnectionOverrides`) so SDK eval reporters and backend ingestion hash byte-identical wire shapes. Accepts either `HostConfigInputV2` or `HostJson` (Host.toJSON()). Reporter wire-send is gated behind backend capability (Step 3, later PR).

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpjam/sdk",
-  "version": "1.12.0",
+  "version": "1.11.0",
   "description": "MCP server unit testing, end to end (e2e) testing, and server evals",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Reverts #2427 because the release rollup PR was the wrong shape for this repo's workflow.

The `release.yml` workflow itself runs `changeset version` + `changeset publish` on `workflow_dispatch`. PR #2427 pre-ran `changeset version` locally, deleting the changeset files and bumping `sdk/package.json` to 1.12.0 in the PR. When the release workflow then ran on the merged commit, the "Select release scope" step found zero unpublished changesets and aborted:

```
Error: Scope "packages-only" does not include any unpublished changesets.
```

So **no SDK publish happened**, but main now has a half-released state (version bumped, changesets gone). This PR restores the pre-rollup state:
- Restores both pending changesets in `.changeset/`
- Reverts `sdk/package.json` 1.12.0 → 1.11.0

## Correct sequence (next steps after this merges)
1. Merge this revert.
2. Trigger the **Release** workflow via `workflow_dispatch` with `scope=packages-only` (no backend/inspector deploy). The workflow consumes the restored changesets, bumps SDK to 1.12.0, and publishes to npm.
3. Bump `@mcpjam/sdk` to `^1.12.0` in mcpjam-backend PR #427.

## Test plan
- [x] `sdk/package.json` is back at `1.11.0`
- [x] Both changeset files restored
- [x] No other files touched (`git diff --stat origin/main..HEAD` is exactly the inverse of #2427)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/process-only revert with no application code changes; main risk is briefly inconsistent version tags on main until the proper release workflow runs.
> 
> **Overview**
> **Undoes the premature `changeset version` rollup from #2427** so the repo’s Release workflow can consume unpublished changesets again and actually publish `@mcpjam/sdk`.
> 
> Restores the two pending `.changeset/` entries (HostConfig v2 canonicalizer tightening and Stage 5 `normalizeSdkEvalHostConfigForWire`) that the rollup had deleted, and rolls **`sdk/package.json` back from `1.12.0` to `1.11.0`**. No SDK source or runtime behavior changes in this diff—only release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93d18970d7feb841cc672273de13d330e49178e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->