### PR TITLE
docs: revamp landing + Inspector IA (pillars, accordion, banner, NEW tags)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -31,7 +31,7 @@
   },
   "favicon": "/mcp_jam.svg",
   "banner": {
-    "content": "New: [@mcpjam/sdk v1.12](/sdk) — programmatic evals + conformance suites for Jest and Vitest.",
+    "content": "New: [@mcpjam/sdk v1.12](/sdk) — programmatic evals and conformance checks, runnable from Jest or Vitest.",
     "dismissible": true
   },
   "navigation": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,6 +30,10 @@
     }
   },
   "favicon": "/mcp_jam.svg",
+  "banner": {
+    "content": "New: [@mcpjam/sdk v1.12](/sdk) — programmatic evals + conformance suites for Jest and Vitest.",
+    "dismissible": true
+  },
   "navigation": {
     "tabs": [
       {
@@ -48,20 +52,44 @@
         "icon": "binoculars",
         "groups": [
           {
-            "group": "Features",
-            "icon": "star",
+            "group": "Connect",
+            "icon": "plug",
             "pages": [
               "inspector/home",
-              "inspector/playground",
               "inspector/clients",
-              "inspector/protocol-versions",
-              "inspector/guided-oauth",
-              "inspector/xaa-debugger",
-              "inspector/tools-prompts-resources",
-              "inspector/evals",
               "inspector/projects",
+              {
+                "page": "inspector/protocol-versions",
+                "tag": "Preview"
+              }
+            ]
+          },
+          {
+            "group": "MCP Apps",
+            "icon": "layout-dashboard",
+            "pages": [
+              {
+                "page": "inspector/playground",
+                "tag": "NEW"
+              },
               "inspector/views",
-              "inspector/skills"
+              "inspector/evals"
+            ]
+          },
+          {
+            "group": "Auth & Conformance",
+            "icon": "shield-check",
+            "pages": ["inspector/guided-oauth", "inspector/xaa-debugger"]
+          },
+          {
+            "group": "Primitives",
+            "icon": "puzzle",
+            "pages": [
+              "inspector/tools-prompts-resources",
+              {
+                "page": "inspector/skills",
+                "tag": "NEW"
+              }
             ]
           },
           {
@@ -104,6 +132,7 @@
       {
         "tab": "SDK",
         "icon": "code",
+        "tag": "v1",
         "groups": [
           {
             "group": "Get Started",

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -31,7 +31,7 @@ Draw me an MCP architecture diagram
 Press **Send**. The diagram renders in the app. No API key, ngrok, or ChatGPT/Claude subscription needed. Sequence: tool call → widget → inspect.
 
 <Check>
-You should see a tool call to `excalidraw.create_drawing` followed by a rendered diagram inline in the chat. If you don't, check that the Excalidraw server shows **Connected** in the **Connect** tab.
+You should see a tool call to `create_view` followed by a rendered diagram inline in the chat. If you don't, check that the Excalidraw server shows **Connected** in the **Connect** tab.
 </Check>
 
 <Tip>

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -30,18 +30,26 @@ Draw me an MCP architecture diagram
 
 Press **Send**. The diagram renders in the app. No API key, ngrok, or ChatGPT/Claude subscription needed. Sequence: tool call → widget → inspect.
 
+<Check>
+You should see a tool call to `excalidraw.create_drawing` followed by a rendered diagram inline in the chat. If you don't, check that the Excalidraw server shows **Connected** in the **Connect** tab.
+</Check>
+
 <Tip>
   Use the widget debug icons to open tool input/output, CSP activity, widget state, and JSON-RPC for that result.
 </Tip>
 
 ## 3. Connect your own server
 
-Open **Servers** in the left sidebar. Click **Add server**.
+Open the **Connect** tab in the left sidebar (labelled **Servers** in some builds). Click **Add server**.
 
 - **HTTP**: Paste a URL ending in `/mcp`. The web app accepts **HTTPS** URLs only. Desktop and Terminal accept **HTTP** or **HTTPS**. Add a bearer token or use the [OAuth Debugger](/inspector/guided-oauth) if the server requires auth.
 - **STDIO** (Desktop and Terminal only): Paste a command such as `npx -y @modelcontextprotocol/server-everything`. Not available in the web app. See [Hosted App](/hosted/overview).
 
-Each **Connected** server is available in the Playground, Tools, Prompts, and Resources. Connect more from **Servers** anytime.
+Each **Connected** server is available in the Playground, Tools, Prompts, and Resources. Connect more from the **Connect** tab anytime.
+
+<Check>
+You should see your server show **Connected** with a green dot in the **Connect** tab, and its tools should appear in the Playground's left rail.
+</Check>
 
 ## 4. Where to go next
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -76,8 +76,8 @@ MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps
 
     [Evaluate in Inspector →](/inspector/evals) · [Run evals from the SDK →](/sdk/concepts/running-evals) · [CI integration →](/cli/ci)
   </Accordion>
-  <Accordion title="Embed Inspector in your product" icon="code">
-    Launch the Inspector with prefilled servers, tools, and tabs from your own code or a Docker container.
+  <Accordion title="Auto-launch Inspector from your dev workflow" icon="code">
+    Launch the Inspector with a prefilled server URL, bearer token, and starting tab via CLI flags — wire it into your dev script or a framework integration.
 
     [Launch from code →](/inspector/launch-from-code)
   </Accordion>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,10 +1,11 @@
 ---
-title: "Introduction"
-description: "MCPJam is the fastest way to test, debug, and evaluate MCP servers, MCP apps, and ChatGPT apps."
+title: "MCPJam"
+description: "Test, debug, and evaluate MCP servers, MCP apps, and ChatGPT apps."
 icon: "book-open"
+mode: "wide"
 ---
 
-MCPJam is the development platform for MCP servers, MCP apps, and ChatGPT apps. Debug every JSON-RPC message and OAuth exchange, run evaluations across multiple LLMs, and track accuracy over time. Catch regressions early, improve your server with every iteration, and ship with confidence.
+MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps**. Debug every JSON-RPC message and OAuth exchange, run evaluations across multiple LLMs, and track accuracy over time — so you catch regressions early and ship with confidence.
 
 <Frame>
   <img
@@ -15,22 +16,83 @@ MCPJam is the development platform for MCP servers, MCP apps, and ChatGPT apps. 
   />
 </Frame>
 
-## Quick Start
+## Start in one command
 
-<Card
-  title="Get Started"
-  icon="rocket"
-  href="/getting-started"
-  horizontal
->
-  Start testing your MCP server in seconds
-</Card>
+<CardGroup cols={3}>
+  <Card title="Web" icon="globe" href="https://app.mcpjam.com">
+    Open [app.mcpjam.com](https://app.mcpjam.com). HTTPS servers, no install, shareable links.
+  </Card>
+  <Card title="Terminal" icon="terminal">
+    ```bash
+    npx @mcpjam/inspector@latest
+    ```
+    HTTP/S and local STDIO.
+  </Card>
+  <Card title="CLI" icon="square-terminal" href="/cli/overview">
+    ```bash
+    npm i -g @mcpjam/cli
+    ```
+    Probe, doctor, OAuth, evals — in CI or your shell.
+  </Card>
+</CardGroup>
 
-## Key features
+## Four surfaces, one product
+
+<CardGroup cols={2}>
+  <Card title="Inspector" icon="binoculars" href="/inspector/playground">
+    IDE-style workspace for MCP development. Chat with frontier models, invoke tools by hand, render widgets, compare hosts and models side by side.
+  </Card>
+  <Card title="CLI" icon="terminal" href="/cli/overview">
+    Stateless tool for connectivity, OAuth, conformance, and tool execution. JUnit/JSON reporters built for CI.
+  </Card>
+  <Card title="SDK" icon="code" href="/sdk">
+    `@mcpjam/sdk` — TypeScript toolkit for unit tests, e2e tests, and evals. Works inside Jest or Vitest.
+  </Card>
+  <Card title="Hosted" icon="cloud" href="/hosted/overview">
+    Run MCPJam in the browser at [app.mcpjam.com](https://app.mcpjam.com). Share servers and sessions with your team.
+  </Card>
+</CardGroup>
+
+## What you can build
+
+<AccordionGroup>
+  <Accordion title="Debug an MCP server end-to-end" icon="bug">
+    Connect any HTTP, HTTPS, or STDIO server, watch every JSON-RPC message live in the Playground, and inspect tool input/output, widget state, and CSP activity per call.
+
+    [Open the Playground →](/inspector/playground) · [JSON-RPC logger →](/inspector/playground#json-rpc-logger)
+  </Accordion>
+  <Accordion title="Build an MCP App or ChatGPT App widget" icon="layout-dashboard">
+    The unified widget renderer handles both `_meta.ui.resourceUri` (MCP Apps) and `openai/outputTemplate` (ChatGPT Apps). The `window.openai` shim is always injected, so you can iterate without a real host.
+
+    [First MCP App →](/guides/first-mcp-app) · [First ChatGPT App in React →](/guides/first-chatgpt-app-react)
+  </Accordion>
+  <Accordion title="Validate OAuth conformance across protocol versions" icon="shield-check">
+    Step through every stage of the MCP authorization flow against protocol versions 03-26, 06-18, and 11-25, with DCR, pre-registration, and CIMD coverage.
+
+    [Guided OAuth →](/inspector/guided-oauth) · [CLI OAuth conformance →](/cli/oauth-conformance)
+  </Accordion>
+  <Accordion title="Run evals across LLMs and gate CI on regressions" icon="flask-conical">
+    Author cases with expected tool calls, optional expected outputs, and deterministic checks. Run across Claude, GPT, Gemini, and your own providers — or move the same suite into Jest/Vitest with `@mcpjam/sdk`.
+
+    [Evaluate in Inspector →](/inspector/evals) · [Run evals from the SDK →](/sdk/concepts/running-evals) · [CI integration →](/cli/ci)
+  </Accordion>
+  <Accordion title="Embed Inspector in your product" icon="code">
+    Launch the Inspector with prefilled servers, tools, and tabs from your own code or a Docker container.
+
+    [Launch from code →](/inspector/launch-from-code)
+  </Accordion>
+  <Accordion title="Share a server with your team" icon="users">
+    In the hosted app, share a server URL the same way you'd share a Google Doc. Teammates connect with one click and pick up where you left off.
+
+    [Hosted overview →](/hosted/overview)
+  </Accordion>
+</AccordionGroup>
+
+## Capabilities at a glance
 
 | Capability | Description |
 | --- | --- |
-| Playground | IDE-style workspace combining chat, manual tool calls, widget rendering, Chat/Trace/Raw views, and multi-model compare. OpenAI Apps SDK and MCP app UIs, text tools, Chrome DevTools-style widget emulator. [Read more](/inspector/playground) |
+| Playground | IDE-style workspace combining chat, manual tool calls, widget rendering, Chat/Trace/Raw views, and multi-model and multi-host compare. OpenAI Apps SDK and MCP App UIs, text tools, Chrome DevTools-style widget emulator. [Read more](/inspector/playground) |
 | OAuth Debugger | Guided MCP OAuth conformance checks: protocol versions 03-26, 06-18, 11-25; DCR, client pre-registration, CIMD. [Read more](/inspector/guided-oauth) |
 | MCP Server Debugging | Manually run tools, resources, templates, and elicitation; full JSON-RPC logs. |
 | Skills | Skills in the Playground; local filesystem only. [Read more](/inspector/skills) |
@@ -39,3 +101,17 @@ MCPJam is the development platform for MCP servers, MCP apps, and ChatGPT apps. 
 | CLI | Run MCPJam checks, probes, and evals from the terminal. Perfect for local dev loops and CI. [Read more](/cli/overview) |
 | SDK | Programmatic access to MCPJam for custom tooling, scripting, and integrations. [Read more](/sdk) |
 | CI/CD | Run MCPJam checks and evals in GitHub Actions and other CI systems to gate PRs on regressions. [Read more](/cli/ci) |
+
+## Get help
+
+<CardGroup cols={3}>
+  <Card title="Discord" icon="discord" href="https://discord.gg/JEnDtz8X6z">
+    Ask the team and the community.
+  </Card>
+  <Card title="GitHub" icon="github" href="https://github.com/MCPJam/inspector">
+    File an issue or open a PR.
+  </Card>
+  <Card title="Changelog" icon="newspaper" href="/changelog/overview">
+    What shipped, and when.
+  </Card>
+</CardGroup>

--- a/docs/inspector/clients.mdx
+++ b/docs/inspector/clients.mdx
@@ -4,7 +4,11 @@ description: "Reusable MCP client configurations for testing servers and apps un
 icon: "user-cog"
 ---
 
-A **Client** is a named, reusable configuration that defines how MCPJam connects to and talks to your MCP servers when you test them in Chat, Chatboxes, and Evals. It bundles everything that would normally be scattered across one-off settings — model, system prompt, attached servers, protocol-level knobs, and MCP App sandbox controls — behind a single picker.
+<Note>
+Open the **Connect** tab in the left sidebar to manage Clients (labelled **Servers** in some builds). The page name "Clients" refers to the configuration object, not the sidebar label.
+</Note>
+
+A **Client** is a named, reusable configuration that defines how MCPJam connects to and talks to your MCP servers when you test them in the Playground, Chatboxes, and Evals. It bundles everything that would normally be scattered across one-off settings — model, system prompt, attached servers, protocol-level knobs, and MCP App sandbox controls — behind a single picker.
 
 Real MCP hosts (Claude Desktop, ChatGPT, Cursor, your own product) each advertise slightly different capabilities and apply different sandbox policies to MCP Apps. Clients let you reproduce those environments in MCPJam so you can verify your server behaves correctly *before* shipping to a specific host.
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -35,9 +35,23 @@ The desktop app supports HTTP/S and local STDIO servers, and does not require No
 
 Run the command in your terminal:
 
-```bash
+<CodeGroup>
+```bash npm
 npx @mcpjam/inspector@latest
 ```
+
+```bash pnpm
+pnpm dlx @mcpjam/inspector@latest
+```
+
+```bash yarn
+yarn dlx @mcpjam/inspector@latest
+```
+
+```bash bun
+bunx @mcpjam/inspector@latest
+```
+</CodeGroup>
 
 After installing the package, you should see a link to `localhost`. Open that link up to see the inspector.
 

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -4,8 +4,6 @@ description: "MCP server unit testing, end-to-end (e2e) testing, and server eval
 icon: "box"
 ---
 
-<span className="sdk-version-pill">v1.x · Latest</span>
-
 The [**@mcpjam/sdk**](https://www.npmjs.com/package/@mcpjam/sdk) is a TypeScript SDK for testing, evaluating, and building applications with MCP (Model Context Protocol) servers. It provides everything you need to ensure your MCP server works reliably across different LLMs and environments.
 
 ## Who is this for?


### PR DESCRIPTION
## Summary

Brings the docs site up to the bar set by [ai-sdk.dev](https://ai-sdk.dev/docs/introduction), [mastra.ai/docs](https://mastra.ai/docs), and [developers.openai.com](https://developers.openai.com/) — pillar-card landing, use-case-driven accordion, announcement banner, sidebar NEW/Preview tags.

- **Landing page rewrite** (`docs/index.mdx`): 3-card "Start in one command" → 4-card product pillars (Inspector / CLI / SDK / Hosted) → 6-item "What you can build" `AccordionGroup` → existing capabilities table moved below the fold → "Get help" row. First use of the accordion pattern in the docset.
- **Inspector tab IA** (`docs/docs.json`): regrouped the flat "Features" list into **Connect / MCP Apps / Auth & Conformance / Primitives**, mirroring the in-product sidebar sections (`client/src/components/mcp-sidebar.tsx`). No page paths moved — pure `groups` reshape.
- **Sidebar tags**: `NEW` on Playground & Skills, `Preview` on Protocol Versions, `v1` on the SDK tab. Drops the bespoke inline `<span class="sdk-version-pill">` on `sdk/index.mdx` since the tab badge covers it.
- **Announcement banner**: surfaces the @mcpjam/sdk v1.12 release; dismissible.
- **Getting Started polish**: `<Check>` verification callouts after the Excalidraw and connect-server steps; updated the sidebar label reference from "Servers" to "Connect" to match current product naming (Hosts → Clients rename per `53aa94cad`).
- **Installation polish**: install command wrapped in `<CodeGroup>` (npm / pnpm / yarn / bun).
- **Terminology fix**: one-line `<Note>` on `inspector/clients.mdx` clarifying that Clients are managed from the **Connect** tab (also labelled **Servers** in some builds). Closes a search-vs-label gap surfaced by a terminology audit.

No new pages, no page renames, no redirect churn.

## Out of scope (intentional)

- **Ask AI widget**: Mintlify Ask AI is dashboard-gated on most plans; no `docs.json` change is required to enable. Flip on the Mintlify dashboard.
- **`llms.txt` / `llms-full.txt`**: Mintlify auto-serves these at `/llms.txt` and `/llms-full.txt`; verify by hitting the paths after deploy.
- Underweight content pages (`inspector/debugging.mdx`, `inspector/home.mdx`, `inspector/xaa-debugger.mdx`, `changelog/overview.mdx` missing icon) — content debt, not IA debt; flagged for follow-up.

## Test plan

- [ ] `docs.json` is valid JSON (verified locally: `python3 -c "import json; json.load(open('docs.json'))"`)
- [ ] Mintlify preview build renders without errors (Node 25 blocked local `mintlify dev`; needs CI / LTS-Node workstation)
- [ ] Landing page shows the announcement banner above the hero and the banner is dismissible per-session
- [ ] Inspector sidebar shows the four new groups (Connect / MCP Apps / Auth & Conformance / Primitives) in order with the expected `NEW` / `Preview` chips
- [ ] SDK tab shows the `v1` badge
- [ ] Existing redirects still resolve: `/inspector/workspaces`, `/inspector/chat`, `/inspector/app-builder`, `/inspector/test-cases`
- [ ] All inline links on the new `index.mdx` resolve (especially `/changelog/overview` — page exists but is not yet in nav)
- [ ] Visual regression spot check under light + dark mode on Playground, Evals, Clients pages (custom `.callout` rail, code-chip orange tint, `.sdk-version-pill` removal all unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation metadata only; no application code, auth, or data paths affected.
> 
> **Overview**
> **Docs-only refresh** of the Mintlify site: landing narrative, Inspector sidebar structure, and small onboarding/terminology fixes. No page moves or new routes.
> 
> **`docs.json`** adds a dismissible **@mcpjam/sdk v1.12** banner, splits the flat Inspector **Features** list into **Connect / MCP Apps / Auth & Conformance / Primitives** (same page URLs), and adds nav badges (**NEW** on Playground & Skills, **Preview** on Protocol Versions, **v1** on the SDK tab).
> 
> **`index.mdx`** is rewritten for wide layout: **Start in one command** cards, four product pillars, a **What you can build** accordion, capabilities table kept below the fold, and a **Get help** row.
> 
> **Getting started**, **installation**, and **clients** get verification callouts, **Connect** vs **Servers** labeling, a multi-package **CodeGroup** for the inspector CLI, and removal of the inline SDK version pill on **`sdk/index.mdx`** (replaced by the tab badge).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 484bb4500e35035bd8e40094ce3f62916d15e5c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->