### PR TITLE
eval→chatSessions PR-4 (inspector): trace-repair predicate accepts chatSessionId iterations

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -225,6 +225,21 @@ export type EvalIteration = {
   iterationNumber: number;
   updatedAt: number;
   blob?: string;
+  /**
+   * PR-4 R6: present on iterations whose transcript was written via the
+   * unified chatSessions path (eval→chatSessions writer flag on).
+   * Trace-repair candidate selection considers iterations with either
+   * `blob` or `chatSessionId` as trace-bearing — both source paths feed
+   * the source-aware `getTestIterationBlob` action.
+   */
+  chatSessionId?: string;
+  /**
+   * PR-4 R6: set when the inspector's fanout-failure fallback flipped
+   * the iteration to legacy-only reads. Doesn't change trace-repair
+   * eligibility — readers still get a usable transcript via
+   * `getTestIterationBlob` regardless of which source feeds it.
+   */
+  preferLegacyBlob?: boolean;
   status: "pending" | "running" | "completed" | "failed" | "cancelled";
   result: "pending" | "passed" | "failed" | "cancelled";
   actualToolCalls: Array<{

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/pick-trace-repair-case-iteration.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/pick-trace-repair-case-iteration.test.ts
@@ -37,6 +37,54 @@ describe("pickTraceRepairCaseSourceIteration", () => {
     ).toBeNull();
   });
 
+  it("PR-4 R6: accepts iterations with only chatSessionId (no legacy blob)", () => {
+    // Post-flag-flip iterations may have only `chatSessionId` set when
+    // the per-turn fanout succeeded and the legacy blob path was
+    // skipped. The trace-repair source picker must consider these
+    // valid candidates — `getTestIterationBlob` is source-aware and
+    // synthesizes the envelope from chatSessions data.
+    const iters: EvalIteration[] = [
+      {
+        _id: "chatsessions-only",
+        testCaseId: "tc",
+        createdBy: "u",
+        createdAt: 2,
+        iterationNumber: 1,
+        updatedAt: 5,
+        status: "completed",
+        result: "failed",
+        suiteRunId: "run1",
+        chatSessionId: "sess-x",
+        actualToolCalls: [],
+        tokensUsed: 0,
+      },
+    ];
+    const picked = pickTraceRepairCaseSourceIteration("tc", iters, [baseRun]);
+    expect(picked?._id).toBe("chatsessions-only");
+  });
+
+  it("PR-4 R6: rejects iterations with neither blob nor chatSessionId", () => {
+    const iters: EvalIteration[] = [
+      {
+        _id: "no-trace",
+        testCaseId: "tc",
+        createdBy: "u",
+        createdAt: 2,
+        iterationNumber: 1,
+        updatedAt: 5,
+        status: "completed",
+        result: "failed",
+        suiteRunId: "run1",
+        // No blob, no chatSessionId — not a valid trace-repair source.
+        actualToolCalls: [],
+        tokensUsed: 0,
+      },
+    ];
+    expect(
+      pickTraceRepairCaseSourceIteration("tc", iters, [baseRun]),
+    ).toBeNull();
+  });
+
   it("picks latest failed traced iteration with replay config", () => {
     const iters: EvalIteration[] = [
       {

--- a/mcpjam-inspector/client/src/lib/evals/pick-trace-repair-case-iteration.ts
+++ b/mcpjam-inspector/client/src/lib/evals/pick-trace-repair-case-iteration.ts
@@ -1,8 +1,11 @@
 import type { EvalIteration, EvalSuiteRun } from "@/components/evals/types";
 
 /**
- * Latest failed iteration suitable as trace-repair source: failed playground run,
- * trace blob present, suite run has stored replay config.
+ * Latest failed iteration suitable as trace-repair source: failed playground
+ * run, trace present (via either the legacy `blob` field or the unified
+ * `chatSessionId` pointer added in PR-4 of the eval→chatSessions
+ * unification — `getTestIterationBlob` reads from whichever source is
+ * present), suite run has stored replay config.
  */
 export function pickTraceRepairCaseSourceIteration(
   testCaseId: string,
@@ -14,9 +17,13 @@ export function pickTraceRepairCaseSourceIteration(
     if (it.testCaseId !== testCaseId || it.result !== "failed") {
       return false;
     }
-    if (!it.suiteRunId || !it.blob) {
-      return false;
-    }
+    if (!it.suiteRunId) return false;
+    // PR-4 R6: accept either a legacy blob OR a chatSessions pointer.
+    // Pre-PR-1 iterations only have `blob`; post-flag-flip iterations
+    // may have only `chatSessionId` (when the fanout succeeds and the
+    // legacy blob path is skipped). Mid-rollout iterations can have
+    // both — either is a valid trace source for repair.
+    if (!it.blob && !it.chatSessionId) return false;
     const run = runById.get(it.suiteRunId);
     return run?.hasServerReplayConfig === true;
   });


### PR DESCRIPTION
## Summary

Inspector R6 from the eval→chatSessions plan. The
`pickTraceRepairCaseSourceIteration` predicate filtered candidates on `!it.blob`, so post-flag-flip iterations that succeeded the per-turn fanout (and thus skipped the legacy blob path) would be silently dropped from trace-repair selection even though `getTestIterationBlob` is source-aware and fully capable of serving their transcript.

- Extend `EvalIteration` with optional `chatSessionId` + `preferLegacyBlob` mirrors of the testIteration row fields.
- Update the predicate: `if (!it.blob && !it.chatSessionId) return false`. Either source is a valid trace-repair candidate.
- `preferLegacyBlob` is added for type-shape symmetry with the backend record but doesn't gate trace-repair eligibility — when either source is present, `getTestIterationBlob` returns a usable transcript.

## Test plan

- [x] Existing 2 tests still pass (blob-only iterations remain valid; "newest blob-bearing" tiebreak unchanged).
- [x] **New regression** — iterations with only `chatSessionId` (no blob) are accepted as repair candidates.
- [x] **New regression** — iterations with neither field are rejected.
- [ ] Smoke locally with backend PR-4 (#431) deployed and `USE_EVAL_CHAT_SESSIONS_WRITER=true`: trigger trace-repair on an iteration that has only `chatSessionId`. The "open trace repair" affordance should appear and the repair flow should successfully load the transcript.

## Coordination

Depends on MCPJam/mcpjam-backend#431 (R2/R3/R5 source-aware reader migrations) for the end-to-end story, but safe to merge in either order — this is purely an eligibility filter. A mismatch (one PR merged, other not) just means slightly different candidate sets temporarily, no broken state.

After both PR-4s ship, the staging → prod flag flip becomes safe. Remaining plan items (PR-5 backfill, PR-6 dead-code cleanup) are post-flip work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small eligibility-filter change in the inspector with regression tests; no auth or persistence logic touched.
> 
> **Overview**
> Aligns **trace-repair source selection** with eval→chatSessions PR-4: failed iterations are no longer dropped when they have **`chatSessionId`** but no legacy **`blob`**, matching what the source-aware **`getTestIterationBlob`** action can already load.
> 
> **`EvalIteration`** gains optional **`chatSessionId`** and **`preferLegacyBlob`** (type parity with backend; **`preferLegacyBlob`** does not affect repair eligibility). **`pickTraceRepairCaseSourceIteration`** now requires **`blob` or `chatSessionId`** instead of **`blob` alone**; latest-failed tie-breaking is unchanged.
> 
> Unit tests cover chatSessionId-only acceptance and rejection when neither trace pointer exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de52e5e0b0e6c9c245d3f76849488cd374ce1c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->