### PR TITLE
eval→chatSessions (inspector): render trace for chatSessionId-only iterations

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -274,26 +274,32 @@ export function IterationDetails({
     layoutMode === "full" ? iteration.result !== "passed" : true,
   );
 
+  // Source-aware trace identity. New iterations carry `chatSessionId`
+  // (unified path); legacy iterations carry `blob`. The hook gates on
+  // either being present and re-runs when either changes.
+  const traceSourceKey = iteration.blob ?? iteration.chatSessionId;
+
   useEffect(() => {
     let cancelled = false;
     async function run() {
-      if (!iteration.blob) {
+      if (!traceSourceKey) {
         prevBlobIdRef.current = undefined;
         setBlob(null);
         setLoading(false);
         setError(null);
         return;
       }
-      if (prevBlobIdRef.current !== iteration.blob) {
-        prevBlobIdRef.current = iteration.blob;
+      if (prevBlobIdRef.current !== traceSourceKey) {
+        prevBlobIdRef.current = traceSourceKey;
         setIsBlobErrorDetailsOpen(false);
       }
       setLoading(true);
       setError(null);
       try {
-        // Backend authorizes via the iteration's testSuite and derives the
-        // blob id server-side. We still gate on `iteration.blob` above to
-        // skip the roundtrip for blobless iterations.
+        // Backend `getTestIterationBlob` is source-aware: it returns the
+        // chatSessions transcript when `iteration.chatSessionId` is set,
+        // otherwise reads from `iteration.blob`. Both paths return the
+        // same envelope shape to `TraceViewer`.
         const data = await getBlob({ iterationId: iteration._id });
         if (!cancelled) setBlob(data);
       } catch (e: any) {
@@ -309,7 +315,7 @@ export function IterationDetails({
     return () => {
       cancelled = true;
     };
-  }, [iteration.blob, getBlob, blobRetryTick]);
+  }, [traceSourceKey, getBlob, blobRetryTick]);
 
   useEffect(() => {
     if (layoutMode !== "full") return;
@@ -595,7 +601,8 @@ export function IterationDetails({
 
   const hasToolCalls =
     expectedToolCalls.length > 0 || actualToolCalls.length > 0;
-  const traceFirst = layoutMode === "full" && Boolean(iteration.blob);
+  const hasTrace = Boolean(iteration.blob || iteration.chatSessionId);
+  const traceFirst = layoutMode === "full" && hasTrace;
   const toolCallsSummary = formatToolCallsSummary(
     expectedToolCalls,
     actualToolCalls,
@@ -727,7 +734,7 @@ export function IterationDetails({
   );
 
   const toolCallsSection =
-    hasToolCalls && !iteration.blob ? (
+    hasToolCalls && !hasTrace ? (
       layoutMode === "full" ? (
         <Collapsible
           open={toolCallsSectionOpen}
@@ -804,7 +811,7 @@ export function IterationDetails({
     </div>
   ) : null;
 
-  const traceSection = iteration.blob ? (
+  const traceSection = hasTrace ? (
     <div
       className={cn(
         "flex flex-col",
@@ -820,7 +827,7 @@ export function IterationDetails({
         className={cn(
           layoutMode === "compact" && "rounded-md bg-muted/20 p-3",
           layoutMode === "full" &&
-            iteration.blob &&
+            hasTrace &&
             !error &&
             "flex min-h-0 flex-1 flex-col",
           layoutMode === "full" &&
@@ -862,7 +869,7 @@ export function IterationDetails({
   ) : null;
 
   const caseInsightFallback =
-    caseInsightSlot && !iteration.blob ? (
+    caseInsightSlot && !hasTrace ? (
       <div className="min-w-0" data-testid="iteration-case-insight-fallback">
         {caseInsightSlot}
       </div>


### PR DESCRIPTION
## Summary

Follow-up regression fix for the eval→chatSessions unification (PR-1..PR-5). After the writer flag is on, new iterations carry `chatSessionId` and have no `blob`. The iteration-details panel still gated the load effect, the trace section, the tool-calls fallback, and the layout switch on `iteration.blob` alone — so the trace didn't render and the UI fell through to the standalone Tool Calls panel.

- Introduce `hasTrace = blob || chatSessionId` and use it for every gate.
- Re-key the load effect on `traceSourceKey = blob ?? chatSessionId` so it re-runs when either identity changes.
- No backend change: `getTestIterationBlob` has been source-aware since PR-4.

Verified live in local sandbox: failed and passed iterations both render the unified trace + inline MCP App widgets (Excalidraw `create_view`) instead of the Tool Calls fallback.

## Test plan

- [x] `vitest run client/src/components/evals/__tests__/iteration-details*` — 10 passed
- [x] Local sandbox smoke: re-ran the Excalidraw quickstart suite with `USE_EVAL_CHAT_SESSIONS_WRITER=true`; iteration-details now shows the Turn Breakdown + Trace + widget render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component UI gating change with no API or backend edits; behavior for legacy blob iterations is unchanged when `blob` is set.
> 
> **Overview**
> Fixes a regression where **iteration-details** treated `iteration.blob` as the only signal that a trace exists. Unified eval iterations can have **`chatSessionId` only** (no blob), so the panel skipped loading, hid the trace, and showed the standalone Tool Calls fallback instead.
> 
> Adds **`hasTrace`** (`blob || chatSessionId`) for layout and section visibility (trace vs tool calls vs case insight). Adds **`traceSourceKey`** (`blob ?? chatSessionId`) so the blob-load effect and cache reset run when either identity changes, still calling **`getTestIterationBlob`** by `iterationId` (backend already resolves chat session vs blob).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd0946d5de08b406d89b65256e8a12734100ef42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->