### PR TITLE
docs: refresh SDK + contributing docs for hostConfig consolidation

### DIFF
--- a/docs/contributing/evals-architecture.mdx
+++ b/docs/contributing/evals-architecture.mdx
@@ -8,6 +8,74 @@ icon: "flask-conical"
 
 The Evals system in MCPJam Inspector is a comprehensive testing framework designed to evaluate MCP (Model Context Protocol) server implementations. This guide provides a deep dive into the architecture, data flows, and key components to help you contribute effectively.
 
+<Note>
+**Heads up.** Some of the diagrams and file paths below predate the chat-v2 / hostConfig consolidation. The current architecture is summarized in the [HostConfig consolidation](#hostconfig-consolidation) section directly below; treat that as the canonical reference when it conflicts with the older sections.
+</Note>
+
+## HostConfig consolidation
+
+The Playground (live chat) and Evals share a single, portable `hostConfig` core that lives in `@mcpjam/sdk/host-config/`. Everything that drives an LLM-plus-MCP loop — host style, model, sandbox/permission policy, OpenAI-Apps compat, tool-visibility, MCP server selection — flows through one canonical shape and one hash.
+
+```
+@mcpjam/sdk/host-config/
+  types.ts          # HostConfigInputV2, HostJson, CspDomainSet, …
+  canonicalize.ts   # canonicalizeHostConfigV2 — byte-stable JSON
+  hash.ts           # computeHostConfigHashV2 — sha256(canonical)
+  defaults.ts       # emptyHostConfigInputV2, resolveEffectiveMcpProtocolVersion, …
+  host-policy.ts    # extractHostExecutionPolicy, buildHostIterationMetadata
+  compat-runtime.ts # resolveOpenAiCompatForHostConfig
+  tool-visibility.ts# filterAppOnlyTools, applyVisibilityPolicyAndCountSignals
+  sdk-evals-normalizer.ts # normalizeSdkEvalHostConfigForWire (Stage 5)
+```
+
+This module is the **one source of truth**. The MCPJam backend imports the canonicalizer + hasher directly from `@mcpjam/sdk/host-config/internal`; see `mcpjam-backend/convex/lib/hostConfigV2.ts` — the file is a thin Convex-bound wrapper (server-scope validation, `Id<'servers'>` boundary cast) over the SDK functions, not a parallel implementation.
+
+**Two boundaries inside the inspector consume this module:**
+
+- **Outbound (backend → target MCP server).** The eval runner builds an `MCPClientManager`, connects to the suite's servers, and drives an `HostRunner` over the resolved host. Imports:
+  - `extractHostExecutionPolicy` / `buildHostIterationMetadata` from `@mcpjam/sdk/host-config/internal` (Stage 3) — was previously `server/services/evals/host-execution-policy.ts`; the local file is now deleted.
+  - `resolveOpenAiCompatForHostConfig` from `@mcpjam/sdk/host-config/internal` (Stage 3) — was previously the local `compat-runtime.ts`; only the Convex-bound `loadSuiteHostConfig` remains in the inspector.
+  - `filterAppOnlyTools` from `@mcpjam/sdk/host-config/internal` (Stage 3) — same predicate the chat-v2 path uses, no fork.
+- **Inbound (frontend → backend).** The eval results API persists per-iteration `hostConfigId` rows that reference the same `hostConfigs` table the chatbox/playground writes.
+
+The Playground's chat-v2 path consumes the same module — playground and evals are two surfaces over the same configuration vocabulary; see [playground-architecture.mdx](./playground-architecture#hostconfig-consolidation) for the live-path side of the same picture.
+
+### `HostRunner`, `HostRuntime`, `HostExecutor` (Stage 4 rename)
+
+Inside `@mcpjam/sdk`, the executor surface was renamed in 1.11 to align with MCP spec vocabulary:
+
+- `TestAgent` → `HostRunner` — synchronous executor over a host snapshot with tools pre-resolved.
+- `EvalAgent` → `HostExecutor` — interface implemented by both `HostRunner` and `HostRuntime`.
+- `.prompt()` → `.run()` on the interface and both impls.
+- `Host.addServer()` → `Host.requireServer()`.
+- `HostRuntime` (new) — live binding of a `Host` to an `MCPClientManager` (`host.withManager(manager, { apiKey })`). Snapshots the live host on every `.run()`; stateless across turns.
+- `EvalTest.run` / `EvalSuite.run` parameter renamed `agent` → `executor`.
+
+`EvalTest` and `EvalSuite` accept any `HostExecutor`, so an external user can run the same eval against their own runtime as long as it implements `getHostSnapshot?.()`.
+
+### Per-iteration host metadata + Stage 5 wire-send
+
+`HostRunner` snapshots the host once at construction; `HostRuntime` re-snapshots on every `.run()`, so mid-eval mutation to the bound `Host` is captured per-iteration. Each `IterationResult` carries `hostSnapshot?: HostJson` and a derived metadata stamp (`buildHostSnapshotMetadata`) that is additively merged into `EvalResultInput.metadata` (existing keys are never overwritten — conflicting host keys are namespaced under `host.<key>`).
+
+When the MCPJam backend advertises the `evalsHostConfig` capability at `GET /sdk/v1/info`, the SDK eval reporter additionally sends `{ hostConfig, hostConfigHash }` at the run boundary:
+
+- `POST /sdk/v1/evals/runs/start` (chunked path) — body includes the pair when the capability probe succeeds and iteration snapshots are homogeneous.
+- `POST /sdk/v1/evals/report` (one-shot path) — same.
+- `POST /sdk/v1/evals/runs/:id/iterations` (chunked append) and `POST /sdk/v1/evals/runs/:id/finalize` — **never** carry the pair (per-run, not per-batch).
+
+Source order, run-level only: `iteration.hostSnapshot` → `executor.getHostSnapshot?.()` → `MCPJamReportingConfig.host`. Pass-1 homogeneity gate: send only when all available iteration snapshots canonicalize to the same hash; heterogeneous runs omit (per-iteration wire support is a later stage). Capability probe is **fail-safe to "no capability"** on any error.
+
+`hostConfigHash` is a transport-integrity check — the backend re-runs `normalizeSdkEvalHostConfigForWire → canonicalizeHostConfigV2 → computeHostConfigHashV2` and rejects on mismatch. It is **not** the persisted storage id; suite-resolved Convex `Id<'servers'>` are layered on top at storage time, so the persisted `hostConfigsV2` row's hash differs from the wire hash by design.
+
+### Two distinct sandbox layers
+
+- The persisted host-config sandbox shape (`mcpProfile.apps.sandbox.csp` + `.permissions`) is **allowlist-only** — there is no `deny` field. This is the shape the backend stores and the canonicalizer hashes.
+- The SDK runtime CSP **resolver** (`sandbox-policy.ts`) carries `deny` plus a hosted clamp for render-time enforcement. It is NOT the same type; the two share only leaf subtypes (`SandboxCspMode`, `SandboxPermissionsMode`, four-directive domain-set).
+
+A canonicalize-time guard in the SDK rejects sandbox shapes that leak a `deny` key. Don't reuse `SandboxCspPolicy` / `SandboxPermissionsPolicy` for persisted host configs.
+
+---
+
 ## Overview
 
 The Evals system allows developers to:

--- a/docs/contributing/playground-architecture.mdx
+++ b/docs/contributing/playground-architecture.mdx
@@ -4,6 +4,24 @@ description: "Technical deep-dive into the MCPJam Inspector Playground: LLM chat
 icon: "message-circle"
 ---
 
+<Note>
+**Heads up.** Some of the diagrams and file paths below predate the chat-v2 / hostConfig consolidation. The current architecture is summarized in the [HostConfig consolidation](#hostconfig-consolidation) section directly below; treat that as the canonical reference when it conflicts with the older sections.
+</Note>
+
+## HostConfig consolidation
+
+Playground (live chat) and Evals share a single, portable `hostConfig` core that lives in `@mcpjam/sdk/host-config/`. Both surfaces are wired onto the **same** canonicalizer, host-execution policy resolver, OpenAI-Apps compat resolver, and `filterAppOnlyTools` predicate — there is no playground fork.
+
+Key consumption points in the inspector server:
+
+- `server/utils/chat-v2-orchestration.ts:prepareChatV2` — the live playground entry point. Imports `filterAppOnlyTools` from `@mcpjam/sdk/host-config/internal` (Stage 3); the local copy is deleted. The `@modelcontextprotocol/ext-apps` dep stays only because three other server files still use it.
+- `server/services/evals/host-execution-policy.ts` — **deleted** after Stage 4. The eval path imports `extractHostExecutionPolicy` and `buildHostIterationMetadata` directly from `@mcpjam/sdk/host-config/internal`.
+- `server/services/evals/compat-runtime.ts` — slimmed to only `loadSuiteHostConfig` (Convex-bound). `resolveOpenAiCompatForHostConfig` and friends moved to the SDK.
+
+The MCPJam backend (`mcpjam-backend/convex/lib/hostConfigV2.ts`) imports the canonicalizer + hasher from the same `@mcpjam/sdk/host-config/internal` subpath — one source of truth, no hand-mirror. See [evals-architecture.mdx → HostConfig consolidation](./evals-architecture#hostconfig-consolidation) for the cross-surface picture.
+
+**Two distinct sandbox layers.** The persisted host-config sandbox shape (`mcpProfile.apps.sandbox.csp` + `.permissions`) is allowlist-only — no `deny`. The runtime CSP **resolver** in `sandbox-policy.ts` carries `deny` plus a hosted clamp. They share only leaf subtypes; do not reuse the resolver's policy types for persisted configs.
+
 ## Overview
 
 The **Playground** (Chat Tab) is MCPJam Inspector's interactive testing environment for MCP servers with LLM integration. It enables real-time conversation with AI models while automatically invoking MCP tools, handling elicitations, and streaming responses.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -155,7 +155,7 @@
             "icon": "book",
             "pages": [
               "sdk/reference/mcp-client-manager",
-              "sdk/reference/test-agent",
+              "sdk/reference/host-runner",
               "sdk/reference/prompt-result",
               "sdk/reference/eval-test",
               "sdk/reference/eval-suite",
@@ -198,7 +198,8 @@
     { "source": "/inspector/workspaces", "destination": "/inspector/projects" },
     { "source": "/inspector/chat", "destination": "/inspector/playground" },
     { "source": "/inspector/app-builder", "destination": "/inspector/playground" },
-    { "source": "/inspector/test-cases", "destination": "/inspector/evals" }
+    { "source": "/inspector/test-cases", "destination": "/inspector/evals" },
+    { "source": "/sdk/reference/test-agent", "destination": "/sdk/reference/host-runner" }
   ],
   "navbar": {
     "links": [

--- a/docs/sdk/concepts/connecting-servers.mdx
+++ b/docs/sdk/concepts/connecting-servers.mdx
@@ -195,9 +195,9 @@ console.log(result); // 8
 expect(result).toBe(8);
 ```
 
-## Integration with TestAgent
+## Integration with HostRunner
 
-The most common pattern is connecting servers, then creating a `TestAgent` with their tools:
+The most common pattern is connecting servers, then creating a `HostRunner` with their tools:
 
 ```typescript
 const manager = new MCPClientManager({
@@ -206,18 +206,18 @@ const manager = new MCPClientManager({
 
 await manager.connectToServer("myServer");
 
-// Get tools for TestAgent
+// Get tools for HostRunner
 const tools = await manager.getTools();
 
 // Create agent with those tools
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
 // Now prompt the agent
-const result = await agent.prompt("Add 2 and 3");
+const result = await agent.run("Add 2 and 3");
 ```
 
 ## Error Handling

--- a/docs/sdk/concepts/multi-provider.mdx
+++ b/docs/sdk/concepts/multi-provider.mdx
@@ -41,7 +41,7 @@ The SDK supports 9 providers out of the box:
 Create agents for each provider and run the same tests:
 
 ```typescript
-import { MCPClientManager, TestAgent, EvalTest } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner, EvalTest } from "@mcpjam/sdk";
 
 const manager = new MCPClientManager({
   myServer: { command: "node", args: ["./server.js"] },
@@ -54,7 +54,7 @@ const tools = await manager.getTools();
 const additionTest = new EvalTest({
   name: "addition",
   test: async (agent) => {
-    const r = await agent.prompt("Add 2 and 3");
+    const r = await agent.run("Add 2 and 3");
     return r.hasToolCall("add");
   },
 });
@@ -71,7 +71,7 @@ for (const { model, key } of providers) {
   const apiKey = process.env[key];
   if (!apiKey) continue;
 
-  const agent = new TestAgent({ tools, model, apiKey });
+  const agent = new HostRunner({ tools, model, apiKey });
   await additionTest.run(agent, { iterations: 20 });
 
   console.log(`${model}: ${(additionTest.accuracy() * 100).toFixed(1)}%`);
@@ -83,7 +83,7 @@ for (const { model, key } of providers) {
 A complete script for benchmarking:
 
 ```typescript
-import { MCPClientManager, TestAgent, EvalSuite, EvalTest } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner, EvalSuite, EvalTest } from "@mcpjam/sdk";
 
 async function compareProviders() {
   // Setup
@@ -101,12 +101,12 @@ async function compareProviders() {
 
   suite.add(new EvalTest({
     name: "add",
-    test: async (a) => (await a.prompt("Add 2+3")).hasToolCall("add"),
+    test: async (a) => (await a.run("Add 2+3")).hasToolCall("add"),
   }));
 
   suite.add(new EvalTest({
     name: "echo",
-    test: async (a) => (await a.prompt("Echo 'hello'")).hasToolCall("echo"),
+    test: async (a) => (await a.run("Echo 'hello'")).hasToolCall("echo"),
   }));
 
   // Providers
@@ -125,7 +125,7 @@ async function compareProviders() {
       continue;
     }
 
-    const agent = new TestAgent({ tools, model, apiKey, temperature: 0.1 });
+    const agent = new HostRunner({ tools, model, apiKey, temperature: 0.1 });
 
     console.log(`🧪 Testing ${name}...`);
     await suite.run(agent, { iterations: 20, concurrency: 3 });
@@ -153,7 +153,7 @@ compareProviders();
 Add your own OpenAI or Anthropic-compatible endpoints:
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "my-provider/gpt-4",
   apiKey: process.env.MY_API_KEY,
@@ -173,7 +173,7 @@ const agent = new TestAgent({
 Test many models through a single proxy:
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "litellm/gpt-4",
   apiKey: process.env.LITELLM_API_KEY,

--- a/docs/sdk/concepts/running-evals.mdx
+++ b/docs/sdk/concepts/running-evals.mdx
@@ -28,7 +28,7 @@ import { EvalTest } from "@mcpjam/sdk";
 const test = new EvalTest({
   name: "addition-accuracy",
   test: async (agent) => {
-    const result = await agent.prompt("Add 2 and 3");
+    const result = await agent.run("Add 2 and 3");
     return result.hasToolCall("add"); // Return true/false
   },
 });
@@ -42,26 +42,26 @@ console.log(`${result.successes}/${result.iterations} passed`);
 
 ### Writing Test Functions
 
-Test functions receive an `EvalAgent` (implemented by `TestAgent` and mock agents) and return `boolean`:
+Test functions receive an `HostExecutor` (implemented by `HostRunner` and mock agents) and return `boolean`:
 
 ```typescript
 // Simple: did the right tool get called?
 test: async (agent) => {
-  const result = await agent.prompt("Add 5 and 3");
+  const result = await agent.run("Add 5 and 3");
   return result.hasToolCall("add");
 }
 
 // Detailed: check arguments too
 test: async (agent) => {
-  const result = await agent.prompt("Add 10 and 20");
+  const result = await agent.run("Add 10 and 20");
   const args = result.getToolArguments("add");
   return args?.a === 10 && args?.b === 20;
 }
 
 // Complex: multi-step workflow
 test: async (agent) => {
-  const r1 = await agent.prompt("Create a project called 'Test'");
-  const r2 = await agent.prompt("Add a task to it", { context: r1 });
+  const r1 = await agent.run("Create a project called 'Test'");
+  const r2 = await agent.run("Add a task to it", { context: r1 });
   return r1.hasToolCall("createProject") && r2.hasToolCall("createTask");
 }
 ```
@@ -108,7 +108,7 @@ const suite = new EvalSuite({ name: "Math Operations" });
 suite.add(new EvalTest({
   name: "addition",
   test: async (agent) => {
-    const r = await agent.prompt("Add 5 and 3");
+    const r = await agent.run("Add 5 and 3");
     return r.hasToolCall("add");
   },
 }));
@@ -116,7 +116,7 @@ suite.add(new EvalTest({
 suite.add(new EvalTest({
   name: "multiplication",
   test: async (agent) => {
-    const r = await agent.prompt("Multiply 4 by 6");
+    const r = await agent.run("Multiply 4 by 6");
     return r.hasToolCall("multiply");
   },
 }));
@@ -124,7 +124,7 @@ suite.add(new EvalTest({
 suite.add(new EvalTest({
   name: "division",
   test: async (agent) => {
-    const r = await agent.prompt("Divide 20 by 4");
+    const r = await agent.run("Divide 20 by 4");
     return r.hasToolCall("divide");
   },
 }));
@@ -221,7 +221,7 @@ console.log(`Addition accuracy: ${addTest.accuracy()}`);
 More deterministic results for testing:
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   // ...
   temperature: 0.1,
 });
@@ -246,7 +246,7 @@ Don't just test the happy path:
 suite.add(new EvalTest({
   name: "handles-empty-input",
   test: async (agent) => {
-    const r = await agent.prompt("Add numbers"); // No numbers given
+    const r = await agent.run("Add numbers"); // No numbers given
     return !r.hasError(); // Should handle gracefully
   },
 }));
@@ -254,7 +254,7 @@ suite.add(new EvalTest({
 suite.add(new EvalTest({
   name: "handles-large-numbers",
   test: async (agent) => {
-    const r = await agent.prompt("Add 999999999 and 1");
+    const r = await agent.run("Add 999999999 and 1");
     return r.hasToolCall("add");
   },
 }));
@@ -272,6 +272,48 @@ if (suite.accuracy() < 0.90) {
   process.exit(1);
 }
 ```
+
+## Bring your own host
+
+`HostRunner` is the right starting point when you just need an LLM + tools + a model string. For richer setups — pinning a host style/profile, applying sandbox/permission policy, or running the same configuration in CI that the MCPJam Inspector uses for its Playground — start from a `Host` spec instead:
+
+```typescript
+import { MCPClientManager, Host, EvalTest } from "@mcpjam/sdk";
+
+const manager = new MCPClientManager();
+await manager.connectToServer("everything", {
+  command: "npx",
+  args: ["-y", "@modelcontextprotocol/server-everything"],
+});
+
+const host = new Host({
+  style: "mcpjam",
+  model: "openai/gpt-4o",
+  systemPrompt: "You are a helpful assistant.",
+}).requireServer("everything");
+
+// Bind the spec to the live manager. apiKey lives on the runtime, not per-call.
+const runtime = host.withManager(manager, {
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+
+const test = new EvalTest({
+  name: "add",
+  test: async (runner) => (await runner.run("Add 2+3")).hasToolCall("add"),
+});
+await test.run(runtime, { iterations: 10 });
+```
+
+`HostRuntime` (returned by `host.withManager(...)`) snapshots the live `Host` on every `.run()`, so mutating the bound host between iterations takes effect on the next iteration. `HostRunner` snapshots once at construction — pick `HostRunner` for a static spec, `HostRuntime` when you want the spec editable across calls.
+
+**Statelessness.** `HostRuntime.run()` does NOT auto-replay history across turns. Use `PromptOptions.context` to thread context explicitly:
+
+```typescript
+const r1 = await runtime.run("Who am I?");
+const r2 = await runtime.run("List my projects", { context: [r1] });
+```
+
+**Eval reporting (Stage 5).** When you upload results to MCPJam, the reporter additionally sends the canonical host config alongside each run (`{ hostConfig, hostConfigHash }`) so the persisted row in the Evals UI shows the exact host you ran with. Pass 1 sends a run-level snapshot only when all iteration snapshots match; heterogeneous runs (mutating the bound `Host` between iterations) omit the run-level field for now. Old backends without the capability are unaffected. Source order is `iteration.hostSnapshot` → `executor.getHostSnapshot?.()` → `MCPJamReportingConfig.host`.
 
 ## Generate evals from the Inspector
 

--- a/docs/sdk/concepts/saving-results.mdx
+++ b/docs/sdk/concepts/saving-results.mdx
@@ -22,7 +22,7 @@ That's it — both `EvalTest` and `EvalSuite` will auto-save results when this k
 
 `MCPJAM_API_KEY` enables result uploads.
 
-**Attach the connected `MCPClientManager` to [`TestAgent`](/sdk/reference/test-agent)** (or pass `agent` / `mcpClientManager` to manual reporting APIs) when you need either of the following:
+**Attach the connected `MCPClientManager` to [`HostRunner`](/sdk/reference/host-runner)** (or pass `agent` / `mcpClientManager` to manual reporting APIs) when you need either of the following:
 
 1. **MCP App / widget replay in Evals traces** — After each MCP App tool call, the agent uses the manager’s [`readResource`](/sdk/reference/mcp-client-manager#readresource) to fetch HTML from the tool’s `ui.resourceUri` and fills [`widgetSnapshots`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) on [`PromptResult`](/sdk/reference/prompt-result). Without the manager, traces still upload (messages + spans) but **widgets will not replay** in the dashboard. The tool’s JSON result alone is not enough for offline iframe replay.
 2. **Replay credentials (authenticated HTTP MCP)** — The SDK can persist server connection details for debugging and reruns. You do not need to build a second secret object yourself; replay config is derived automatically when the agent or manager is attached.
@@ -46,7 +46,7 @@ await test.run(agent, {
 For authenticated HTTP servers:
 
 ```typescript
-import { MCPClientManager, TestAgent } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner } from "@mcpjam/sdk";
 
 const manager = new MCPClientManager({
   asana: {
@@ -59,7 +59,7 @@ const manager = new MCPClientManager({
 
 await manager.connectToServer("asana");
 
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools: await manager.getTools(),
   model: "openai/gpt-4o-mini",
   apiKey: process.env.OPENAI_API_KEY!,
@@ -154,7 +154,7 @@ Most users should pass `agent` or `mcpClientManager` and let the SDK derive repl
 
 When replay configs are inferred from `agent` or `mcpClientManager`, the SDK limits them to the `serverNames` you attach to the run when `serverNames` is provided.
 
-**Manual reporters (Vitest/Jest hooks):** Pass `agent` or `mcpClientManager` into [`createEvalRunReporter`](/sdk/reference/eval-reporting#createevalrunreporter) — not only on `TestAgent` — and call **`await reporter.finalize()` before `await manager.disconnectAllServers()`** so replay config is still available at upload time. See [Replay metadata for the MCPJam UI](/sdk/reference/eval-reporting#replay-metadata-for-the-mcpjam-ui).
+**Manual reporters (Vitest/Jest hooks):** Pass `agent` or `mcpClientManager` into [`createEvalRunReporter`](/sdk/reference/eval-reporting#createevalrunreporter) — not only on `HostRunner` — and call **`await reporter.finalize()` before `await manager.disconnectAllServers()`** so replay config is still available at upload time. See [Replay metadata for the MCPJam UI](/sdk/reference/eval-reporting#replay-metadata-for-the-mcpjam-ui).
 
 ## CI Metadata
 

--- a/docs/sdk/concepts/testing-with-llms.mdx
+++ b/docs/sdk/concepts/testing-with-llms.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Testing with LLMs"
-description: "Use TestAgent to run prompts and inspect tool calls"
+description: "Use HostRunner to run prompts and inspect tool calls"
 icon: "bot"
 ---
 
-The `TestAgent` connects an LLM to your MCP tools, letting you test how models interact with your server. It handles the agentic loop (prompt → tool call → result → response) and gives you rich inspection capabilities.
+The `HostRunner` connects an LLM to your MCP tools, letting you test how models interact with your server. It handles the agentic loop (prompt → tool call → result → response) and gives you rich inspection capabilities.
 
 ## Why Test with LLMs?
 
@@ -15,10 +15,10 @@ Unit tests verify your tools work correctly in isolation. But in production, an 
 - Tools that the model consistently misuses
 - Edge cases in natural language interpretation
 
-## Creating a TestAgent
+## Creating a HostRunner
 
 ```typescript
-import { MCPClientManager, TestAgent } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner } from "@mcpjam/sdk";
 
 // Connect to your MCP server
 const manager = new MCPClientManager({
@@ -30,7 +30,7 @@ const manager = new MCPClientManager({
 await manager.connectToServer("myServer");
 
 // Create an agent with your tools
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools: await manager.getTools(),
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -38,14 +38,14 @@ const agent = new TestAgent({
 });
 ```
 
-Pass the same **`mcpClientManager`** instance when you use **MCP App** tools and upload evals to MCPJam: that enables [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) (HTML from `readResource` on `ui.resourceUri`) so traces can replay widgets offline. See the [TestAgent reference](/sdk/reference/test-agent).
+Pass the same **`mcpClientManager`** instance when you use **MCP App** tools and upload evals to MCPJam: that enables [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) (HTML from `readResource` on `ui.resourceUri`) so traces can replay widgets offline. See the [HostRunner reference](/sdk/reference/host-runner).
 
 ## Running Prompts
 
 Send natural language prompts and inspect what happens:
 
 ```typescript
-const result = await agent.prompt("What is 15 plus 27?");
+const result = await agent.run("What is 15 plus 27?");
 
 // What did the model say?
 console.log(result.getText());
@@ -65,7 +65,7 @@ console.log(result.getToolArguments("add"));
 Every prompt returns a `PromptResult` with rich inspection methods:
 
 ```typescript
-const result = await agent.prompt("...");
+const result = await agent.run("...");
 
 // Tool inspection
 result.toolsCalled();           // string[] - names of tools called
@@ -88,7 +88,7 @@ result.getWidgetSnapshots();    // HTML snapshots for MCPJam trace replay
 ```
 
 <Info>
-`TestAgent` never throws exceptions. Errors are captured in the result, making it safe to run many tests without try/catch blocks.
+`HostRunner` never throws exceptions. Errors are captured in the result, making it safe to run many tests without try/catch blocks.
 </Info>
 
 ## Multi-Turn Conversations
@@ -97,15 +97,15 @@ Pass previous results as context to maintain conversation history:
 
 ```typescript
 // First turn
-const r1 = await agent.prompt("Create a task called 'Buy groceries'");
+const r1 = await agent.run("Create a task called 'Buy groceries'");
 
 // Second turn (model sees the first exchange)
-const r2 = await agent.prompt("Mark it as high priority", {
+const r2 = await agent.run("Mark it as high priority", {
   context: r1,
 });
 
 // Third turn (model sees both previous exchanges)
-const r3 = await agent.prompt("Now show me all my tasks", {
+const r3 = await agent.run("Now show me all my tasks", {
   context: [r1, r2],
 });
 ```
@@ -119,7 +119,7 @@ This is essential for testing workflows that span multiple interactions.
 Guide the model's behavior:
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -132,7 +132,7 @@ const agent = new TestAgent({
 Control randomness (lower = more deterministic):
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   // ...
   temperature: 0.1, // More consistent for testing
 });
@@ -143,7 +143,7 @@ const agent = new TestAgent({
 Limit the agentic loop iterations:
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   // ...
   maxSteps: 5, // Stop after 5 tool calls
 });
@@ -157,7 +157,7 @@ Use `stopWhen` when you want to stop the multi-step loop after a particular step
 import { hasToolCall } from "@mcpjam/sdk";
 
 // Stop after the step where the tool is called
-const result = await agent.prompt("Search for open tasks", {
+const result = await agent.run("Search for open tasks", {
   stopWhen: hasToolCall("search_tasks"),
 });
 
@@ -165,15 +165,15 @@ expect(result.hasToolCall("search_tasks")).toBe(true);
 ```
 
 <Tip>
-`stopWhen` does not skip tool execution. It controls whether the prompt loop continues after the current step completes, and `TestAgent` also applies `stepCountIs(maxSteps)` as a safety guard.
+`stopWhen` does not skip tool execution. It controls whether the prompt loop continues after the current step completes, and `HostRunner` also applies `stepCountIs(maxSteps)` as a safety guard.
 </Tip>
 
 ## Bound Prompt Runtime with timeout
 
-Use `timeout` when you want to bound how long `TestAgent.prompt()` can run:
+Use `timeout` when you want to bound how long `HostRunner.run()` can run:
 
 ```typescript
-const result = await agent.prompt("Run a long workflow", {
+const result = await agent.run("Run a long workflow", {
   timeout: { totalMs: 10_000, stepMs: 2_500 },
 });
 
@@ -193,7 +193,7 @@ Use validators to assert tool call behavior:
 ```typescript
 import { matchToolCalls, matchToolCallWithArgs } from "@mcpjam/sdk";
 
-const result = await agent.prompt("Add 10 and 5");
+const result = await agent.run("Add 10 and 5");
 
 // Check the right tool was called
 expect(matchToolCalls(["add"], result.toolsCalled())).toBe(true);
@@ -209,7 +209,7 @@ expect(
 Understand where time is spent:
 
 ```typescript
-const result = await agent.prompt("Run a complex operation");
+const result = await agent.run("Run a complex operation");
 
 const latency = result.getLatency();
 console.log(`Total: ${latency.e2eMs}ms`);
@@ -226,7 +226,7 @@ console.log(`Tokens: ${result.totalTokens()}`);
   <Card title="Running Evals" icon="chart-bar" href="/sdk/concepts/running-evals">
     Run statistical evaluations
   </Card>
-  <Card title="TestAgent Reference" icon="book" href="/sdk/reference/test-agent">
+  <Card title="HostRunner Reference" icon="book" href="/sdk/reference/host-runner">
     Full API documentation
   </Card>
   <Card title="PromptResult Reference" icon="book" href="/sdk/reference/prompt-result">

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -41,7 +41,7 @@ npm install @mcpjam/sdk
 ## Quick Example
 
 ```typescript
-import { MCPClientManager, TestAgent, EvalTest } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner, EvalTest } from "@mcpjam/sdk";
 
 // Connect to your MCP server
 const manager = new MCPClientManager({
@@ -51,26 +51,62 @@ const manager = new MCPClientManager({
   },
 });
 
-// Create an agent with LLM + MCP tools
-const agent = new TestAgent({
-  tools: await manager.getTools(),
+// Create a runner with LLM + MCP tools
+const runner = new HostRunner({
+  tools: await manager.getToolsForAiSdk(),
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
 // Run a prompt and inspect results
-const result = await agent.prompt("Add 2 and 3");
+const result = await runner.run("Add 2 and 3");
 console.log(result.toolsCalled());     // ["add"]
 console.log(result.e2eLatencyMs());    // 1234
 
 // Run statistical evaluation
 const test = new EvalTest({
   name: "addition",
-  test: async (agent) => {
-    const r = await agent.prompt("Add 2+3");
+  test: async (runner) => {
+    const r = await runner.run("Add 2+3");
     return r.hasToolCall("add");
   },
 });
-await test.run(agent, { iterations: 30 });
+await test.run(runner, { iterations: 30 });
 console.log(`Accuracy: ${(test.accuracy() * 100).toFixed(1)}%`);
 ```
+
+<Note>
+**Renames in 1.11.** `TestAgent` → `HostRunner`, `EvalAgent` → `HostExecutor`, `.prompt()` → `.run()`, `Host.addServer()` → `Host.requireServer()`. No deprecation aliases. The same code with the old names will not type-check against `@mcpjam/sdk@>=1.11`.
+</Note>
+
+## Spec-first: `Host` + `HostRuntime`
+
+For richer setups — pinning a host style/profile, applying sandbox/permission policy, or running the same configuration in CI that the MCPJam Inspector uses — start from a `Host` spec instead of constructing a runner directly:
+
+```typescript
+import { MCPClientManager, Host, EvalTest } from "@mcpjam/sdk";
+
+const manager = new MCPClientManager();
+await manager.connectToServer("everything", {
+  command: "npx",
+  args: ["-y", "@modelcontextprotocol/server-everything"],
+});
+
+const host = new Host({
+  style: "mcpjam",
+  model: "openai/gpt-4o",
+}).requireServer("everything");
+
+// Bind the spec to the live manager. apiKey lives on the runtime, not per-call.
+const runtime = host.withManager(manager, {
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+
+const test = new EvalTest({
+  name: "add",
+  test: async (runner) => (await runner.run("Add 2+3")).hasToolCall("add"),
+});
+await test.run(runtime, { iterations: 10 });
+```
+
+See [Run evals from your own runtime](/sdk/concepts/running-evals#bring-your-own-host) for the full Host / HostRunner / HostRuntime story.

--- a/docs/sdk/quickstart.mdx
+++ b/docs/sdk/quickstart.mdx
@@ -69,14 +69,14 @@ const result = await manager.executeTool("everything", "add", {
 console.log("5 + 3 =", result); // 8
 ```
 
-## Step 3: Create a TestAgent
+## Step 3: Create a HostRunner
 
 Connect an LLM to your MCP tools:
 
 ```typescript
-import { MCPClientManager, TestAgent } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner } from "@mcpjam/sdk";
 
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools: await manager.getTools(),
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -89,7 +89,7 @@ If `MCPJAM_API_KEY` is set, attaching the connected `MCPClientManager` also lets
 ## Step 4: Run Prompts
 
 ```typescript
-const result = await agent.prompt("What is 15 plus 27?");
+const result = await agent.run("What is 15 plus 27?");
 
 console.log("Response:", result.getText());
 console.log("Tools called:", result.toolsCalled());
@@ -105,7 +105,7 @@ import { describe, it, expect } from "vitest";
 
 describe("Math MCP Server", () => {
   it("should call add for addition", async () => {
-    const result = await agent.prompt("Add 10 and 5");
+    const result = await agent.run("Add 10 and 5");
     expect(matchToolCalls(["add"], result.toolsCalled())).toBe(true);
   });
 });
@@ -119,7 +119,7 @@ import { EvalTest } from "@mcpjam/sdk";
 const test = new EvalTest({
   name: "addition-accuracy",
   test: async (agent) => {
-    const result = await agent.prompt("Add 2 and 3");
+    const result = await agent.run("Add 2 and 3");
     return result.hasToolCall("add");
   },
 });
@@ -132,7 +132,7 @@ console.log(`Accuracy: ${(test.accuracy() * 100).toFixed(1)}%`);
 ## Complete Example
 
 ```typescript
-import { MCPClientManager, TestAgent, EvalSuite, EvalTest } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner, EvalSuite, EvalTest } from "@mcpjam/sdk";
 
 async function main() {
   // Setup
@@ -144,7 +144,7 @@ async function main() {
   });
   await manager.connectToServer("everything");
 
-  const agent = new TestAgent({
+  const agent = new HostRunner({
     tools: await manager.getTools(),
     model: "anthropic/claude-sonnet-4-20250514",
     apiKey: process.env.ANTHROPIC_API_KEY,
@@ -152,7 +152,7 @@ async function main() {
   });
 
   // Quick test
-  const result = await agent.prompt("Echo 'Hello!'");
+  const result = await agent.run("Echo 'Hello!'");
   console.log("Response:", result.getText());
   console.log("Tools:", result.toolsCalled());
 
@@ -161,12 +161,12 @@ async function main() {
 
   suite.add(new EvalTest({
     name: "echo",
-    test: async (a) => (await a.prompt("Echo 'test'")).hasToolCall("echo"),
+    test: async (a) => (await a.run("Echo 'test'")).hasToolCall("echo"),
   }));
 
   suite.add(new EvalTest({
     name: "add",
-    test: async (a) => (await a.prompt("Add 1 and 2")).hasToolCall("add"),
+    test: async (a) => (await a.run("Add 1 and 2")).hasToolCall("add"),
   }));
 
   await suite.run(agent, { iterations: 10 });

--- a/docs/sdk/reference/eval-reporting.mdx
+++ b/docs/sdk/reference/eval-reporting.mdx
@@ -15,7 +15,7 @@ The SDK provides APIs to save eval results to MCPJam for visualization in the CI
 
 Use `MCPJAM_BASE_URL` only when you need to override the default ingest host, such as internal development against a non-production backend.
 
-`MCPJAM_API_KEY` controls whether results are uploaded. **Replay credential** capture only happens when you provide `serverReplayConfigs`, `agent`, or `mcpClientManager`. **MCP App widget snapshots** in each result’s trace (for iframe replay in MCPJam) come from [`PromptResult.getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots), which is only populated when [`TestAgent`](/sdk/reference/test-agent) was constructed with [`mcpClientManager`](/sdk/reference/test-agent#parameters).
+`MCPJAM_API_KEY` controls whether results are uploaded. **Replay credential** capture only happens when you provide `serverReplayConfigs`, `agent`, or `mcpClientManager`. **MCP App widget snapshots** in each result’s trace (for iframe replay in MCPJam) come from [`PromptResult.getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots), which is only populated when [`HostRunner`](/sdk/reference/host-runner) was constructed with [`mcpClientManager`](/sdk/reference/host-runner#parameters).
 
 ---
 
@@ -227,7 +227,7 @@ If you also provide `serverNames`, inferred replay configs are filtered to those
 Uploaded runs can show **Replay this run** / server-side MCP replay when the ingest payload includes derived **`serverReplayConfigs`** (stored as **`hasServerReplayConfig`** on the run). In practice:
 
 - **HTTP MCP (`url`)** — Replay configs are built for typical streamable HTTP connections. **Stdio** transports **do not** produce entries from [`MCPClientManager.getServerReplayConfigs()`](/sdk/reference/mcp-client-manager); use HTTP when you need dashboard replay.
-- **`TestAgent` vs reporter** — Putting `mcpClientManager` on [`TestAgent`](/sdk/reference/test-agent) fills **MCP App widget snapshots** on [`PromptResult`](/sdk/reference/prompt-result). The **reporter** (and one-shot `report*`) resolves **server replay** from its **own** `agent` / `mcpClientManager` fields. Pass `agent` or `mcpClientManager` into [`createEvalRunReporter`](#createevalrunreporter) as well; **agent-only** wiring can still upload traces and widgets but **omit** `hasServerReplayConfig`.
+- **`HostRunner` vs reporter** — Putting `mcpClientManager` on [`HostRunner`](/sdk/reference/host-runner) fills **MCP App widget snapshots** on [`PromptResult`](/sdk/reference/prompt-result). The **reporter** (and one-shot `report*`) resolves **server replay** from its **own** `agent` / `mcpClientManager` fields. Pass `agent` or `mcpClientManager` into [`createEvalRunReporter`](#createevalrunreporter) as well; **agent-only** wiring can still upload traces and widgets but **omit** `hasServerReplayConfig`.
 - **Teardown order** — `finalize()` / one-shot reporting calls `getServerReplayConfigs()` against **connected** registrations. In `afterAll`, run **`await reporter.finalize()`** (or `reportEvalResults`) **before** **`await manager.disconnectAllServers()`**. Disconnecting first clears manager state and uploads **without** replay metadata.
 
 **LLM API keys** are **not** stored on the run. Replaying in the MCPJam UI still requires provider keys (e.g. OpenRouter) in **Settings** for your suite’s models.
@@ -238,7 +238,7 @@ Uploaded runs can show **Replay this run** / server-side MCP replay when the ing
 // Pass `agent` or `mcpClientManager` when you need server replay metadata in MCPJam
 const reporter = createEvalRunReporter({ suiteName: "Prompt Tests", agent });
 
-const result = await agent.prompt("Add 2 and 3");
+const result = await agent.run("Add 2 and 3");
 reporter.addFromPrompt(result, {
   caseTitle: "addition",
   passed: result.hasToolCall("add"),
@@ -254,7 +254,7 @@ const reporter = createEvalRunReporter({ suiteName: "Full Suite" });
 
 const test = new EvalTest({
   name: "addition",
-  test: async (agent) => (await agent.prompt("Add 2+3")).hasToolCall("add"),
+  test: async (agent) => (await agent.run("Add 2+3")).hasToolCall("add"),
 });
 
 const run = await test.run(agent, { iterations: 10 });
@@ -356,8 +356,35 @@ type ReportEvalResultsInput = MCPJamReportingConfig & {
 | `ci` | `EvalCiMetadata` | No | CI/CD pipeline context |
 | `expectedIterations` | `number` | No | Expected total iterations for progress tracking |
 | `tags` | `string[]` | No | Free-form tags attached to the run for filtering in the MCPJam dashboard |
-| `agent` | `{ getServerReplayConfigs?: () => MCPServerReplayConfig[] \| undefined }` | No | Preferred replay source for manual reporting; use an agent created with `mcpClientManager` so results can include [`widgetSnapshots`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) from [`PromptResult.toEvalResult()`](/sdk/reference/prompt-result) |
+| `agent` | `{ getServerReplayConfigs?: () => MCPServerReplayConfig[] \| undefined }` | No | Preferred replay source for manual reporting; use an executor (HostRunner / HostRuntime) created with `mcpClientManager` so results can include [`widgetSnapshots`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) from [`PromptResult.toEvalResult()`](/sdk/reference/prompt-result). Field name predates the Stage 4 rename; any `HostExecutor` is accepted. |
 | `mcpClientManager` | `MCPClientManager` | No | Replay source when no `agent` is provided; does not populate `widgetSnapshots` unless your `results[].widgetSnapshots` or trace payloads already include them |
+| `host` | `Host` | No | Explicit host snapshot override. The reporter prefers `iteration.hostSnapshot` (per-iteration capture from `HostRuntime`) and falls back to `executor.getHostSnapshot?.()`; supply `host` only when neither source is available. See [Run-level host snapshot](#run-level-host-snapshot) below. |
+
+### Run-level host snapshot
+
+When the inspector backend advertises the `evalsHostConfig` capability at `GET /sdk/v1/info`, the reporter additionally includes a normalized + content-hashed host config alongside the run body:
+
+```jsonc
+POST /sdk/v1/evals/runs/start
+{
+  "suiteName": "...",
+  "results": [...],
+  "hostConfig":     {/* canonical HostConfigInputV2 with serverIds stripped */},
+  "hostConfigHash": "sha256(canonical)"
+}
+```
+
+**Source order (highest priority first):**
+
+1. `iteration.hostSnapshot` — per-iteration capture from `HostRuntime` (Stage 4). Reflects the bound `Host` state at the iteration's end.
+2. `executor.getHostSnapshot?.()` — fallback for executors that don't expose per-iteration snapshots.
+3. `MCPJamReportingConfig.host` — explicit override, compatibility path.
+
+**Pass-1 homogeneity gate.** The reporter only sends a run-level `{ hostConfig, hostConfigHash }` when all available iteration snapshots canonicalize to the same hash. Heterogeneous runs (e.g. mutating the bound `Host` between iterations) omit the run-level field — per-iteration wire support is a later stage.
+
+**Fail-safe to "no capability".** The lazy capability probe (`GET /sdk/v1/info`, cached per `baseUrl`) treats any error — network failure, 404, timeout, malformed JSON — as "no capability". The reporter then omits `hostConfig` rather than failing the eval upload. Old backends without the capability are unaffected; the body shape stays the same.
+
+**Server-id normalization.** Runtime-manager identifiers (`serverIds`, `optionalServerIds`, `serverConnectionOverrides`) are stripped by `normalizeSdkEvalHostConfigForWire` on both ends so SDK runtime ids like `"everything"` never reach the backend's `validateServerScope` as `Id<'servers'>`. The persisted `hostConfigsV2` row's hash will differ from the wire `hostConfigHash` because suite-resolved Convex server ids are layered on top at storage time — the wire hash is a transport-integrity check, not the storage id.
 
 ### MCPServerReplayConfig
 
@@ -406,7 +433,7 @@ Advanced replay override. Most users should not construct this manually.
 | `successPredicates` | `Predicate[]` | No | State-based predicate gate evaluated over the iteration transcript. See [Predicate gate](#predicate-gate). |
 | `isNegativeTest` | `boolean` | No | Whether this is a negative test |
 | `matchOptions` | `EvalMatchOptions` | No | Per-result match options. When present, the inspector snapshots these onto the iteration so historical pass/fail computation honors them. See [`EvalMatchOptions`](/sdk/reference/validators#evalmatchoptions) |
-| `widgetSnapshots` | `EvalWidgetSnapshotInput[]` | No | MCP App HTML replay payloads (typically from [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) on [`PromptResult`](/sdk/reference/prompt-result)). Omitted when not using MCP Apps or when `TestAgent` had no `mcpClientManager` |
+| `widgetSnapshots` | `EvalWidgetSnapshotInput[]` | No | MCP App HTML replay payloads (typically from [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapshots) on [`PromptResult`](/sdk/reference/prompt-result)). Omitted when not using MCP Apps or when `HostRunner` had no `mcpClientManager` |
 
 ### Predicate gate
 

--- a/docs/sdk/reference/eval-suite.mdx
+++ b/docs/sdk/reference/eval-suite.mdx
@@ -77,7 +77,7 @@ add(test: EvalTest): void
 suite.add(new EvalTest({
   name: "addition",
   test: async (agent) => {
-    const r = await agent.prompt("Add 2 and 3");
+    const r = await agent.run("Add 2 and 3");
     return r.hasToolCall("add");
   },
 }));
@@ -85,7 +85,7 @@ suite.add(new EvalTest({
 suite.add(new EvalTest({
   name: "multiplication",
   test: async (agent) => {
-    const r = await agent.prompt("Multiply 4 by 5");
+    const r = await agent.run("Multiply 4 by 5");
     return r.hasToolCall("multiply");
   },
 }));
@@ -98,15 +98,15 @@ suite.add(new EvalTest({
 Runs all tests in the suite and returns aggregate results.
 
 ```typescript
-run(agent: EvalAgent, options: EvalTestRunOptions): Promise<EvalSuiteResult>
+run(executor: HostExecutor, options: EvalTestRunOptions): Promise<EvalSuiteResult>
 ```
 
 #### Parameters
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `agent` | `EvalAgent` | The agent to test with (`TestAgent` or mock) |
-| `options` | `EvalTestRunOptions` | Run configuration (same as EvalTest) |
+| Parameter  | Type                 | Description                                                  |
+| ---------- | -------------------- | ------------------------------------------------------------ |
+| `executor` | `HostExecutor`       | The executor to test with (`HostRunner`, `HostRuntime`, or mock) |
+| `options`  | `EvalTestRunOptions` | Run configuration (same as EvalTest)                         |
 
 #### EvalTestRunOptions
 
@@ -315,7 +315,7 @@ suite.getName() // "Math Operations"
 ## Complete Example
 
 ```typescript
-import { MCPClientManager, TestAgent, EvalSuite, EvalTest } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner, EvalSuite, EvalTest } from "@mcpjam/sdk";
 
 async function main() {
   // Setup
@@ -327,7 +327,7 @@ async function main() {
   });
   await manager.connectToServer("everything");
 
-  const agent = new TestAgent({
+  const agent = new HostRunner({
     tools: await manager.getTools(),
     model: "anthropic/claude-sonnet-4-20250514",
     apiKey: process.env.ANTHROPIC_API_KEY,
@@ -345,17 +345,17 @@ async function main() {
 
   suite.add(new EvalTest({
     name: "add",
-    test: async (a) => (await a.prompt("Add 2+3")).hasToolCall("add"),
+    test: async (a) => (await a.run("Add 2+3")).hasToolCall("add"),
   }));
 
   suite.add(new EvalTest({
     name: "echo",
-    test: async (a) => (await a.prompt("Echo 'test'")).hasToolCall("echo"),
+    test: async (a) => (await a.run("Echo 'test'")).hasToolCall("echo"),
   }));
 
   suite.add(new EvalTest({
     name: "longRunningOperation",
-    test: async (a) => (await a.prompt("Run a long operation")).hasToolCall("longRunningOperation"),
+    test: async (a) => (await a.run("Run a long operation")).hasToolCall("longRunningOperation"),
   }));
 
   // Run
@@ -438,7 +438,7 @@ const providers = [
 ];
 
 for (const { model, key } of providers) {
-  const agent = new TestAgent({
+  const agent = new HostRunner({
     tools,
     model,
     apiKey: process.env[key],

--- a/docs/sdk/reference/eval-test.mdx
+++ b/docs/sdk/reference/eval-test.mdx
@@ -34,15 +34,15 @@ new EvalTest(options: EvalTestConfig)
 ### TestFunction Type
 
 ```typescript
-type TestFunction = (agent: EvalAgent) => boolean | Promise<boolean>;
+type TestFunction = (executor: HostExecutor) => boolean | Promise<boolean>;
 ```
 
-The test function receives an [`EvalAgent`](/sdk/reference/test-agent) and must return a `boolean`:
+The test function receives a [`HostExecutor`](/sdk/reference/host-runner) (the interface implemented by both `HostRunner` and `HostRuntime`) and must return a `boolean`:
 
 - `true` = test passed
 - `false` = test failed
 
-Both `TestAgent` and mock agents implement the `EvalAgent` interface, so you can use either for testing.
+Both `HostRunner`, `HostRuntime`, and mock executors implement the `HostExecutor` interface, so you can use any of them for testing.
 
 ### Example
 
@@ -50,7 +50,7 @@ Both `TestAgent` and mock agents implement the `EvalAgent` interface, so you can
 const test = new EvalTest({
   name: "addition-accuracy",
   test: async (agent) => {
-    const result = await agent.prompt("Add 2 and 3");
+    const result = await agent.run("Add 2 and 3");
     return result.hasToolCall("add");
   },
 });
@@ -65,15 +65,15 @@ const test = new EvalTest({
 Executes the test multiple times and returns detailed results.
 
 ```typescript
-run(agent: EvalAgent, options: EvalTestRunOptions): Promise<EvalRunResult>
+run(executor: HostExecutor, options: EvalTestRunOptions): Promise<EvalRunResult>
 ```
 
 #### Parameters
 
-| Parameter | Type                 | Description                                  |
-| --------- | -------------------- | -------------------------------------------- |
-| `agent`   | `EvalAgent`          | The agent to test with (`TestAgent` or mock) |
-| `options` | `EvalTestRunOptions` | Run configuration                            |
+| Parameter  | Type                 | Description                                                  |
+| ---------- | -------------------- | ------------------------------------------------------------ |
+| `executor` | `HostExecutor`       | The executor to test with (`HostRunner`, `HostRuntime`, or mock) |
+| `options`  | `EvalTestRunOptions` | Run configuration                                            |
 
 #### EvalTestRunOptions
 
@@ -351,7 +351,7 @@ test.getName(); // "addition-accuracy"
 
 ```typescript
 test: async (agent) => {
-  const result = await agent.prompt("Add 5 and 3");
+  const result = await agent.run("Add 5 and 3");
   return result.hasToolCall("add");
 };
 ```
@@ -360,7 +360,7 @@ test: async (agent) => {
 
 ```typescript
 test: async (agent) => {
-  const result = await agent.prompt("Add 10 and 20");
+  const result = await agent.run("Add 10 and 20");
   const args = result.getToolArguments("add");
   return args?.a === 10 && args?.b === 20;
 };
@@ -370,7 +370,7 @@ test: async (agent) => {
 
 ```typescript
 test: async (agent) => {
-  const result = await agent.prompt("What is 5 + 5?");
+  const result = await agent.run("What is 5 + 5?");
   return result.getText().includes("10");
 };
 ```
@@ -379,7 +379,7 @@ test: async (agent) => {
 
 ```typescript
 test: async (agent) => {
-  const result = await agent.prompt("Calculate 5 * 3");
+  const result = await agent.run("Calculate 5 * 3");
   return (
     result.hasToolCall("multiply") &&
     !result.hasError() &&
@@ -392,8 +392,8 @@ test: async (agent) => {
 
 ```typescript
 test: async (agent) => {
-  const r1 = await agent.prompt("Create a project");
-  const r2 = await agent.prompt("Add a task to it", { context: r1 });
+  const r1 = await agent.run("Create a project");
+  const r2 = await agent.run("Add a task to it", { context: r1 });
   return r1.hasToolCall("createProject") && r2.hasToolCall("createTask");
 };
 ```
@@ -404,7 +404,7 @@ test: async (agent) => {
 import { matchToolCallWithArgs } from "@mcpjam/sdk";
 
 test: async (agent) => {
-  const result = await agent.prompt("Add 2 and 3");
+  const result = await agent.run("Add 2 and 3");
   return matchToolCallWithArgs("add", { a: 2, b: 3 }, result.getToolCalls());
 };
 ```
@@ -414,7 +414,7 @@ test: async (agent) => {
 ## Complete Example
 
 ```typescript
-import { MCPClientManager, TestAgent, EvalTest } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner, EvalTest } from "@mcpjam/sdk";
 
 async function main() {
   const manager = new MCPClientManager({
@@ -425,7 +425,7 @@ async function main() {
   });
   await manager.connectToServer("everything");
 
-  const agent = new TestAgent({
+  const agent = new HostRunner({
     tools: await manager.getTools(),
     model: "anthropic/claude-sonnet-4-20250514",
     apiKey: process.env.ANTHROPIC_API_KEY,
@@ -435,7 +435,7 @@ async function main() {
   const test = new EvalTest({
     name: "addition",
     test: async (agent) => {
-      const r = await agent.prompt("Add 2 and 3");
+      const r = await agent.run("Add 2 and 3");
       return r.hasToolCall("add");
     },
   });

--- a/docs/sdk/reference/host-runner.mdx
+++ b/docs/sdk/reference/host-runner.mdx
@@ -1,30 +1,30 @@
 ---
-title: "TestAgent"
-description: "API reference for TestAgent"
+title: "HostRunner"
+description: "API reference for HostRunner"
 icon: "book"
 ---
 
-The `TestAgent` class runs prompts with MCP tools enabled. It handles the multi-step prompt loop and returns rich result objects.
+The `HostRunner` class runs prompts with MCP tools enabled. It handles the multi-step prompt loop and returns rich result objects.
 
 ## Import
 
 ```typescript
-import { TestAgent } from "@mcpjam/sdk";
+import { HostRunner } from "@mcpjam/sdk";
 ```
 
 ## Constructor
 
 ```typescript
-new TestAgent(options: TestAgentOptions)
+new HostRunner(options: HostRunnerOptions)
 ```
 
 ### Parameters
 
-<ParamField path="options" type="TestAgentOptions" required>
+<ParamField path="options" type="HostRunnerOptions" required>
   Configuration for the test agent.
 </ParamField>
 
-### TestAgentOptions
+### HostRunnerOptions
 
 | Property          | Type                             | Required | Default     | Description                                                   |
 | ----------------- | -------------------------------- | -------- | ----------- | ------------------------------------------------------------- |
@@ -41,7 +41,7 @@ new TestAgent(options: TestAgentOptions)
 ### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools: await manager.getTools(),
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -52,19 +52,19 @@ const agent = new TestAgent({
 ```
 
 <Info>
-  **MCP Apps, traces, and `mcpClientManager`:** MCP App widgets are backed by HTML served from an MCP **resource** (`ui.resourceUri`), not by the tool’s JSON result alone. After each tool call, `TestAgent` uses the manager’s [`readResource`](/sdk/reference/mcp-client-manager#readresource) to fetch that HTML and attach **`widgetSnapshots`** to the [`PromptResult`](/sdk/reference/prompt-result). When you upload results to MCPJam, those snapshots are stored so the Evals trace viewer can **replay the widget offline**. If you omit `mcpClientManager`, prompts still run and tools still execute — but **`widgetSnapshots` stay empty** and uploaded traces will only contain messages and spans (no embedded app replay). Passing `manager` is also what enables **replay credential** capture for authenticated HTTP servers when reporting to MCPJam.
+  **MCP Apps, traces, and `mcpClientManager`:** MCP App widgets are backed by HTML served from an MCP **resource** (`ui.resourceUri`), not by the tool’s JSON result alone. After each tool call, `HostRunner` uses the manager’s [`readResource`](/sdk/reference/mcp-client-manager#readresource) to fetch that HTML and attach **`widgetSnapshots`** to the [`PromptResult`](/sdk/reference/prompt-result). When you upload results to MCPJam, those snapshots are stored so the Evals trace viewer can **replay the widget offline**. If you omit `mcpClientManager`, prompts still run and tools still execute — but **`widgetSnapshots` stay empty** and uploaded traces will only contain messages and spans (no embedded app replay). Passing `manager` is also what enables **replay credential** capture for authenticated HTTP servers when reporting to MCPJam.
 </Info>
 
 ---
 
 ## Methods
 
-### prompt()
+### run()
 
 Sends a prompt to the LLM and returns the result.
 
 ```typescript
-prompt(
+run(
   message: string,
   options?: PromptOptions
 ): Promise<PromptResult>
@@ -85,7 +85,7 @@ Use [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapsho
 | ------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `context`           | `PromptResult \| PromptResult[]`                                    | Previous result(s) for multi-turn conversations                                                                                                                                       |
 | `abortSignal`       | `AbortSignal`                                                       | Cancels the prompt runtime when aborted                                                                                                                                               |
-| `stopWhen`          | `StopCondition<ToolSet> \| Array<StopCondition<ToolSet>>`           | Additional conditions for the multi-step prompt loop. Tools still execute normally. `TestAgent` always applies `stepCountIs(maxSteps)` as a safety guard.                             |
+| `stopWhen`          | `StopCondition<ToolSet> \| Array<StopCondition<ToolSet>>`           | Additional conditions for the multi-step prompt loop. Tools still execute normally. `HostRunner` always applies `stepCountIs(maxSteps)` as a safety guard.                             |
 | `timeout`           | `number \| { totalMs?: number; stepMs?: number; chunkMs?: number }` | Bounds prompt runtime. `number` and `totalMs` cap the full prompt, `stepMs` caps each generation step, and `chunkMs` is accepted for parity but is mainly relevant to streaming APIs. |
 | `timeoutMs`         | `number`                                                            | Shortcut for a total prompt timeout in milliseconds                                                                                                                                   |
 | `stopAfterToolCall` | `string \| string[]`                                                | Short-circuits the named tool(s) with a stub result and stops after the step where they were called. Tool names and args are still captured in the `PromptResult`.                    |
@@ -100,23 +100,23 @@ Use [`getWidgetSnapshots()`](/sdk/reference/prompt-result#mcp-app-widget-snapsho
 import { hasToolCall } from "@mcpjam/sdk";
 
 // Simple prompt
-const result = await agent.prompt("Add 2 and 3");
+const result = await agent.run("Add 2 and 3");
 
 // Multi-turn conversation
-const r1 = await agent.prompt("Create a task called 'Test'");
-const r2 = await agent.prompt("Mark it complete", { context: r1 });
+const r1 = await agent.run("Create a task called 'Test'");
+const r2 = await agent.run("Mark it complete", { context: r1 });
 
 // Multiple context items
-const r3 = await agent.prompt("Show summary", { context: [r1, r2] });
+const r3 = await agent.run("Show summary", { context: [r1, r2] });
 
 // Stop the loop after the step where a tool is called
-const r4 = await agent.prompt("Search for tasks", {
+const r4 = await agent.run("Search for tasks", {
   stopWhen: hasToolCall("search_tasks"),
 });
 console.log(r4.hasToolCall("search_tasks"));
 
 // Bound prompt runtime
-const r5 = await agent.prompt("Run a long workflow", {
+const r5 = await agent.run("Run a long workflow", {
   timeout: { totalMs: 10_000, stepMs: 2_500 },
 });
 
@@ -125,7 +125,7 @@ if (r5.hasError()) {
 }
 
 // Exit early after selecting a tool, without waiting for the real MCP call
-const r6 = await agent.prompt("Search for tasks", {
+const r6 = await agent.run("Search for tasks", {
   stopAfterToolCall: "search_tasks",
   timeoutMs: 5_000,
 });
@@ -133,7 +133,7 @@ console.log(r6.getToolArguments("search_tasks"));
 ```
 
 <Note>
-  `prompt()` never throws exceptions. Errors are captured in the `PromptResult`.
+  `run()` never throws exceptions. Errors are captured in the `PromptResult`.
   Check `result.hasError()` to detect failures.
 </Note>
 
@@ -208,7 +208,7 @@ Add custom OpenAI or Anthropic-compatible endpoints.
 ### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "my-litellm/gpt-4",
   apiKey: process.env.LITELLM_API_KEY,
@@ -234,7 +234,7 @@ The MCP tools available to the agent. Obtained from `MCPClientManager.getTools()
 
 ```typescript
 const tools = await manager.getTools();
-const agent = new TestAgent({ tools, ... });
+const agent = new HostRunner({ tools, ... });
 ```
 
 ### model
@@ -291,7 +291,7 @@ Set this to `true` when your widget is written against the OpenAI Apps SDK (i.e.
 
 ```typescript
 // Testing an OpenAI Apps SDK widget (ChatGPT / Copilot host)
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "openai/gpt-4o",
   apiKey: process.env.OPENAI_API_KEY,
@@ -300,7 +300,7 @@ const agent = new TestAgent({
 });
 
 // Testing a SEP-1865 widget (Claude / Cursor / Codex host) — default
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -325,21 +325,21 @@ Use `stopWhen` to control whether the agent starts another step after the curren
 import { hasToolCall } from "@mcpjam/sdk";
 
 // Stop after the step where "search_tasks" is called
-const result = await agent.prompt("Find my open tasks", {
+const result = await agent.run("Find my open tasks", {
   stopWhen: hasToolCall("search_tasks"),
 });
 
 expect(result.hasToolCall("search_tasks")).toBe(true);
 
 // Stop after any of multiple conditions
-const result2 = await agent.prompt("Do something", {
+const result2 = await agent.run("Do something", {
   stopWhen: [hasToolCall("tool_a"), hasToolCall("tool_b")],
 });
 ```
 
 <Info>
   `stopWhen` does not skip tool execution. It controls whether the prompt loop
-  continues after the current step completes, and `TestAgent` also applies
+  continues after the current step completes, and `HostRunner` also applies
   `stepCountIs(maxSteps)` as a safety guard.
 </Info>
 
@@ -347,21 +347,21 @@ const result2 = await agent.prompt("Do something", {
 
 ## Bound Prompt Runtime with timeout
 
-Use `timeout` when you want to bound how long `TestAgent.prompt()` can run:
+Use `timeout` when you want to bound how long `HostRunner.run()` can run:
 
 ```typescript
-const result = await agent.prompt("Run a long workflow", {
+const result = await agent.run("Run a long workflow", {
   timeout: 10_000,
 });
 
-const result2 = await agent.prompt("Run a long workflow", {
+const result2 = await agent.run("Run a long workflow", {
   timeout: { totalMs: 10_000, stepMs: 2_500, chunkMs: 1_000 },
 });
 ```
 
 <Info>
   `chunkMs` is accepted for parity, but it is mainly useful for streaming APIs.
-  For `TestAgent.prompt()`, `number`, `totalMs`, and `stepMs` are the main
+  For `HostRunner.run()`, `number`, `totalMs`, and `stepMs` are the main
   settings to focus on.
 </Info>
 
@@ -370,7 +370,7 @@ const result2 = await agent.prompt("Run a long workflow", {
 ## Complete Example
 
 ```typescript
-import { MCPClientManager, TestAgent } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner } from "@mcpjam/sdk";
 
 async function main() {
   // Setup
@@ -383,7 +383,7 @@ async function main() {
   await manager.connectToServer("everything");
 
   // Create agent (pass manager when you need widget snapshots or MCPJam replay configs)
-  const agent = new TestAgent({
+  const agent = new HostRunner({
     tools: await manager.getTools(),
     model: "anthropic/claude-sonnet-4-20250514",
     apiKey: process.env.ANTHROPIC_API_KEY,
@@ -394,12 +394,12 @@ async function main() {
   });
 
   // Single prompt
-  const r1 = await agent.prompt("What is 15 + 27?");
+  const r1 = await agent.run("What is 15 + 27?");
   console.log(r1.getText());
   console.log("Tools:", r1.toolsCalled());
 
   // Multi-turn
-  const r2 = await agent.prompt("Now multiply that by 2", { context: r1 });
+  const r2 = await agent.run("Now multiply that by 2", { context: r1 });
   console.log(r2.getText());
 
   // Error handling

--- a/docs/sdk/reference/llm-providers.mdx
+++ b/docs/sdk/reference/llm-providers.mdx
@@ -39,7 +39,7 @@ All models use the format `provider/model-id`:
 #### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -68,7 +68,7 @@ const agent = new TestAgent({
 #### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "openai/gpt-4o",
   apiKey: process.env.OPENAI_API_KEY,
@@ -99,7 +99,7 @@ const agent = new TestAgent({
 // AZURE_OPENAI_API_KEY=...
 // AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "azure/gpt-4o",
   apiKey: process.env.AZURE_OPENAI_API_KEY,
@@ -126,7 +126,7 @@ const agent = new TestAgent({
 #### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "google/gemini-1.5-pro",
   apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
@@ -155,7 +155,7 @@ const agent = new TestAgent({
 #### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "mistral/mistral-large-latest",
   apiKey: process.env.MISTRAL_API_KEY,
@@ -181,7 +181,7 @@ const agent = new TestAgent({
 #### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "deepseek/deepseek-chat",
   apiKey: process.env.DEEPSEEK_API_KEY,
@@ -213,7 +213,7 @@ Ensure Ollama is running locally before use. The API key parameter is required b
 #### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "ollama/llama3",
   apiKey: "ollama", // Required but not used
@@ -241,7 +241,7 @@ Access many models through one API:
 #### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "openrouter/anthropic/claude-3-opus",
   apiKey: process.env.OPENROUTER_API_KEY,
@@ -266,7 +266,7 @@ const agent = new TestAgent({
 #### Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "xai/grok-beta",
   apiKey: process.env.XAI_API_KEY,
@@ -306,7 +306,7 @@ interface CustomProvider {
 ### OpenAI-Compatible Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "my-openai/gpt-4",
   apiKey: process.env.MY_API_KEY,
@@ -324,7 +324,7 @@ const agent = new TestAgent({
 ### Anthropic-Compatible Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "my-anthropic/claude-3-sonnet",
   apiKey: process.env.MY_API_KEY,
@@ -342,7 +342,7 @@ const agent = new TestAgent({
 ### LiteLLM Example
 
 ```typescript
-const agent = new TestAgent({
+const agent = new HostRunner({
   tools,
   model: "litellm/gpt-4",
   apiKey: process.env.LITELLM_API_KEY,
@@ -448,4 +448,4 @@ const provider = createCustomProvider({
 ## Related
 
 - [Testing Across Providers](/sdk/concepts/multi-provider) - Conceptual guide
-- [TestAgent Reference](/sdk/reference/test-agent) - Agent configuration
+- [HostRunner Reference](/sdk/reference/host-runner) - Agent configuration

--- a/docs/sdk/reference/mcp-client-manager.mdx
+++ b/docs/sdk/reference/mcp-client-manager.mdx
@@ -537,14 +537,14 @@ for (const tool of allTools) {
   console.log(`${tool.name}: ${tool.description}`);
 }
 
-// Use with TestAgent
-const agent = new TestAgent({
+// Use with HostRunner
+const agent = new HostRunner({
   tools: await manager.getTools(),
   model: "anthropic/claude-sonnet-4-20250514",
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
-const result = await agent.prompt("Add 2 and 3");
+const result = await agent.run("Add 2 and 3");
 console.log(result.getText());
 ```
 
@@ -609,7 +609,7 @@ const response = await generateText({
 ## Complete Example
 
 ```typescript
-import { MCPClientManager, TestAgent } from "@mcpjam/sdk";
+import { MCPClientManager, HostRunner } from "@mcpjam/sdk";
 
 async function main() {
   const manager = new MCPClientManager({
@@ -641,13 +641,13 @@ async function main() {
     console.log("Asana tools:", asanaTools.tools.length);
 
     // Create agent with all tools
-    const agent = new TestAgent({
+    const agent = new HostRunner({
       tools: await manager.getTools(),
       model: "anthropic/claude-sonnet-4-20250514",
       apiKey: process.env.ANTHROPIC_API_KEY,
     });
 
-    const result = await agent.prompt("Add 2 and 3");
+    const result = await agent.run("Add 2 and 3");
     console.log(result.getText());
   } finally {
     await manager.disconnectServer("math");
@@ -659,4 +659,4 @@ async function main() {
 ## Related
 
 - [Connecting to Servers](/sdk/concepts/connecting-servers) - Conceptual guide
-- [TestAgent Reference](/sdk/reference/test-agent) - Use tools with LLMs
+- [HostRunner Reference](/sdk/reference/host-runner) - Use tools with LLMs

--- a/docs/sdk/reference/prompt-result.mdx
+++ b/docs/sdk/reference/prompt-result.mdx
@@ -4,15 +4,15 @@ description: "API reference for PromptResult"
 icon: "book"
 ---
 
-The `PromptResult` class wraps every response from `TestAgent.prompt()`. It provides methods to inspect tool calls, performance metrics, errors, and conversation history.
+The `PromptResult` class wraps every response from `HostRunner.run()`. It provides methods to inspect tool calls, performance metrics, errors, and conversation history.
 
 ## Import
 
 ```typescript
-// PromptResult is returned by TestAgent.prompt()
+// PromptResult is returned by HostRunner.run()
 // You don't import it directly
 
-const result = await agent.prompt("...");
+const result = await agent.run("...");
 // result is a PromptResult
 ```
 
@@ -35,7 +35,7 @@ readonly text: string
 #### Example
 
 ```typescript
-const result = await agent.prompt("What is 2 + 2?");
+const result = await agent.run("What is 2 + 2?");
 console.log(result.text); // "2 + 2 equals 4."
 ```
 
@@ -58,7 +58,7 @@ toolsCalled(): string[]
 #### Example
 
 ```typescript
-const result = await agent.prompt("Add 2 and 3, then multiply by 4");
+const result = await agent.run("Add 2 and 3, then multiply by 4");
 console.log(result.toolsCalled()); // ["add", "multiply"]
 ```
 
@@ -394,18 +394,18 @@ getWidgetSnapshots(): EvalWidgetSnapshotInput[]
 
 #### Returns
 
-`EvalWidgetSnapshotInput[]` — metadata plus inline HTML (before upload) or storage ids after reporting. Empty if no MCP App tools ran or if [`TestAgent`](/sdk/reference/test-agent) was created **without** [`mcpClientManager`](/sdk/reference/test-agent#parameters).
+`EvalWidgetSnapshotInput[]` — metadata plus inline HTML (before upload) or storage ids after reporting. Empty if no MCP App tools ran or if [`HostRunner`](/sdk/reference/host-runner) was created **without** [`mcpClientManager`](/sdk/reference/host-runner#parameters).
 
 #### Why the manager matters
 
-MCP App UIs reference HTML via **`ui.resourceUri`**. That HTML is fetched with MCP **`resources/read`**, which only the connected [`MCPClientManager`](/sdk/reference/mcp-client-manager) can perform. The model’s tool **result** is not a substitute for that document, so **`getWidgetSnapshots()` stays empty unless you pass the same `manager` into `new TestAgent({ …, mcpClientManager: manager })`**.
+MCP App UIs reference HTML via **`ui.resourceUri`**. That HTML is fetched with MCP **`resources/read`**, which only the connected [`MCPClientManager`](/sdk/reference/mcp-client-manager) can perform. The model’s tool **result** is not a substitute for that document, so **`getWidgetSnapshots()` stays empty unless you pass the same `manager` into `new HostRunner({ …, mcpClientManager: manager })`**.
 
 When you report results to MCPJam (for example via [`createEvalRunReporter`](/sdk/reference/eval-reporting#createevalrunreporter) or [`PromptResult.toEvalResult()`](/sdk/reference/prompt-result)), snapshots are uploaded and linked from the trace so the dashboard can **replay widgets offline**.
 
 #### Example
 
 ```typescript
-const result = await agent.prompt("Open the chart widget");
+const result = await agent.run("Open the chart widget");
 
 const snapshots = result.getWidgetSnapshots();
 console.log("Snapshots:", snapshots.length);
@@ -437,13 +437,13 @@ See [Tool execution and `passed`](/sdk/reference/eval-reporting#tool-execution-a
 Pass `PromptResult` as context for multi-turn conversations.
 
 ```typescript
-const r1 = await agent.prompt("Create a project");
+const r1 = await agent.run("Create a project");
 
 // Single result as context
-const r2 = await agent.prompt("Add a task", { context: r1 });
+const r2 = await agent.run("Add a task", { context: r1 });
 
 // Multiple results as context
-const r3 = await agent.prompt("Show summary", { context: [r1, r2] });
+const r3 = await agent.run("Show summary", { context: [r1, r2] });
 ```
 
 ---
@@ -451,7 +451,7 @@ const r3 = await agent.prompt("Show summary", { context: [r1, r2] });
 ## Complete Example
 
 ```typescript
-const result = await agent.prompt("Add 100 and 200");
+const result = await agent.run("Add 100 and 200");
 
 // Response
 console.log("Text:", result.text);
@@ -490,4 +490,4 @@ console.log("Messages:", result.getMessages().length);
 
 - [Testing with LLMs](/sdk/concepts/testing-with-llms) - Conceptual guide
 - [Validators Reference](/sdk/reference/validators) - Assert tool calls
-- [TestAgent Reference](/sdk/reference/test-agent) - Agent configuration
+- [HostRunner Reference](/sdk/reference/host-runner) - Agent configuration

--- a/docs/sdk/reference/validators.mdx
+++ b/docs/sdk/reference/validators.mdx
@@ -56,7 +56,7 @@ matchToolCalls(expected: string[], actual: string[]): boolean
 #### Example
 
 ```typescript
-const result = await agent.prompt("Add 2+3, then multiply by 4");
+const result = await agent.run("Add 2+3, then multiply by 4");
 // toolsCalled() = ["add", "multiply"]
 
 matchToolCalls(["add", "multiply"], result.toolsCalled()); // true
@@ -183,7 +183,7 @@ matchNoToolCalls(actual: string[]): boolean
 #### Example
 
 ```typescript
-const result = await agent.prompt("What is the capital of France?");
+const result = await agent.run("What is the capital of France?");
 matchNoToolCalls(result.toolsCalled()); // true (if no tools called)
 ```
 
@@ -218,7 +218,7 @@ matchToolCallWithArgs(
 #### Example
 
 ```typescript
-const result = await agent.prompt("Add 2 and 3");
+const result = await agent.run("Add 2 and 3");
 
 matchToolCallWithArgs("add", { a: 2, b: 3 }, result.getToolCalls()); // true
 matchToolCallWithArgs("add", { a: 2 }, result.getToolCalls());       // false (missing b)
@@ -372,12 +372,12 @@ import { matchToolCalls, matchToolCallWithArgs } from "@mcpjam/sdk";
 
 describe("Calculator", () => {
   it("calls add for addition", async () => {
-    const result = await agent.prompt("Add 5 and 3");
+    const result = await agent.run("Add 5 and 3");
     expect(matchToolCalls(["add"], result.toolsCalled())).toBe(true);
   });
 
   it("passes correct arguments", async () => {
-    const result = await agent.prompt("Add 10 and 20");
+    const result = await agent.run("Add 10 and 20");
     expect(
       matchToolCallWithArgs("add", { a: 10, b: 20 }, result.getToolCalls())
     ).toBe(true);
@@ -393,7 +393,7 @@ import { EvalTest, matchToolCallsSubset } from "@mcpjam/sdk";
 const test = new EvalTest({
   name: "multi-step",
   test: async (agent) => {
-    const result = await agent.prompt("Add 2+3, then multiply by 4");
+    const result = await agent.run("Add 2+3, then multiply by 4");
     return matchToolCallsSubset(["add", "multiply"], result.toolsCalled());
   },
 });
@@ -444,7 +444,7 @@ evaluateToolCalls(
 ```typescript
 import { evaluateToolCalls } from "@mcpjam/sdk";
 
-const result = await agent.prompt("Create a task called 'Deploy' with high priority");
+const result = await agent.run("Create a task called 'Deploy' with high priority");
 
 const match = evaluateToolCalls(
   [{ toolName: "createTask", arguments: { priority: "high" } }],

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,8 +1,29 @@
 # `@mcpjam/sdk` changelog
 
-## Unreleased — Stage 4 (HostRunner rename + HostRuntime binding)
+## Unreleased — Stage 5 Step 3 (eval reporter wire-sends hostConfig)
 
-**Breaking changes** — ship as the next major.
+- Eval reporter now sends `{ hostConfig, hostConfigHash }` on `POST /sdk/v1/evals/runs/start` and `POST /sdk/v1/evals/report` when the backend advertises `evalsHostConfig` at `GET /sdk/v1/info`. Lazy capability probe is cached per `baseUrl` and **fail-safe to "no capability"** — any error (network / 404 / timeout / parse) makes the reporter omit `hostConfig` rather than fail the report.
+- Source order for the run-level host snapshot: `iteration.hostSnapshot` → `executor.getHostSnapshot?.()` → `MCPJamReportingConfig.host`. Pass-1 homogeneity gate: send run-level only when all available iteration snapshots canonicalize to the same hash; heterogeneous runs omit the field (per-iteration wire support is a later stage).
+- Old backends without the capability are unaffected — body shape stays the same.
+
+## 1.12.0
+
+### Stage 5 Step 1 — SDK helper for backend ingestion
+
+- New helper `normalizeSdkEvalHostConfigForWire` exported from `@mcpjam/sdk/host-config/internal` (not the public barrel). Strips runtime-manager identifiers (`serverIds`, `optionalServerIds`, `serverConnectionOverrides`) so the SDK reporter and the `/sdk/v1/evals/*` ingestion route hash byte-identical wire shapes. Accepts both canonical `HostConfigInputV2` and public `HostJson` from `Host.toJSON()`. Pure, browser-safe, idempotent.
+
+### Stage B — Canonicalizer tightening
+
+- Deep-sort nested `clientCapabilities` / `hostContext` records (matches `*Override` + `mcpProfile`).
+- Drop empty `allowFeatures` from canonical (matches sibling `openaiAppsOverrides`).
+- `requireRecord` helper fails fast on missing required `clientCapabilities` / `hostContext` (replaces `?? {}` coalescing — surfaces caller bugs at canonicalize time).
+- Drop `openaiAppsOverrides` when `compatRuntime.openaiApps === false` (the resolver ignores them anyway).
+- Tightened the shared `isPlainObject` predicate with a prototype guard (`Object.prototype` or `null`) so `Date` / `Map` / `Set` / class instances no longer canonicalize to `{}`.
+- Hash-neutral against all 15,389 prod `hostConfigs` rows at the time of release. Backend consumers should bump to `^1.12.0` to pick up the tightened behavior.
+
+## 1.11.0 — Stage 4 (HostRunner rename + HostRuntime binding)
+
+**Breaking changes** — major-style rename shipped under 1.11.0 because there were no public adopters at the time.
 
 ### Renamed surface
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -53,6 +53,8 @@ describe("Everything MCP example", () => {
 
 Test that an LLM correctly understands how to use your MCP server. Evals are non-deterministic and multiple runs are needed.
 
+> **Heads up: renames in 1.11.** `TestAgent` → `HostRunner`, `EvalAgent` → `HostExecutor`, `.prompt()` → `.run()`, `Host.addServer()` → `Host.requireServer()`. No deprecation aliases. See the [changelog](./CHANGELOG.md) for the codemod.
+
 ```ts
 import { MCPClientManager, HostRunner, EvalTest } from "@mcpjam/sdk";
 
@@ -146,6 +148,82 @@ describe("Asana MCP Evals", () => {
   });
 });
 ```
+
+### Host + HostRuntime: bring your own runtime
+
+`Host` is the portable host-configuration spec — the same object the MCPJam Inspector uses to drive its Playground and eval suites. You can build one in your own code and run evals against it, so the inspector and your CI exercise the same host behavior (style, model, MCP profile, sandbox/permission policy, OpenAI-Apps compat, tool-visibility policy, etc.).
+
+```ts
+import { MCPClientManager, Host, EvalTest } from "@mcpjam/sdk";
+
+const manager = new MCPClientManager();
+await manager.connectToServer("everything", {
+  command: "npx",
+  args: ["-y", "@modelcontextprotocol/server-everything"],
+});
+
+// Build the spec — Host is just an editable wrapper around the canonical JSON.
+const host = new Host({
+  style: "mcpjam",
+  model: "openai/gpt-4o",
+  systemPrompt: "You are a helpful assistant.",
+}).requireServer("everything");
+
+// Bind the spec to a live MCP manager. `apiKey` lives on the runtime, not per-call.
+const runtime = host.withManager(manager, { apiKey: process.env.OPENAI_API_KEY! });
+
+const evalTest = new EvalTest({
+  name: "add",
+  test: async (runner) => (await runner.run("Add 2 and 3")).hasToolCall("add"),
+});
+await evalTest.run(runtime, { iterations: 10 });
+```
+
+**`HostRuntime.run()` is stateless across turns.** Prior `PromptResult`s accumulate in `runtime.getPromptHistory()` for inspection but are NOT auto-replayed. Multi-turn continuity stays explicit via `PromptOptions.context`:
+
+```ts
+const r1 = await runtime.run("Who am I?");
+const r2 = await runtime.run("List my projects", { context: [r1] });
+```
+
+**Static specs use `HostRunner` directly.** When you've already resolved the tool set and don't need live-binding to a manager, skip the runtime and pass `host` straight into `HostRunner`:
+
+```ts
+import { HostRunner } from "@mcpjam/sdk";
+
+const runner = new HostRunner({
+  host: host.toJSON(),
+  tools: await manager.getToolsForAiSdk(["everything"]),
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+```
+
+`HostRunner` snapshots the host once at construction; post-construction mutations to the original `Host` do NOT affect the runner. `HostRuntime` snapshots on every `.run()` so live mutations to the bound `Host` take effect on the next iteration.
+
+**One-shot sugar:**
+
+```ts
+await host.run("write me a haiku", {
+  apiKey: process.env.OPENAI_API_KEY!,
+  mcpClientManager: manager,
+});
+```
+
+#### Eval reporting (Stage 5)
+
+When the inspector backend advertises the `evalsHostConfig` capability at `GET /sdk/v1/info`, the eval reporter additionally sends `{ hostConfig, hostConfigHash }` so the persisted run row in the MCPJam UI shows the exact host you ran with. Source order:
+
+1. `iteration.hostSnapshot` (per-iteration capture from `HostRuntime`)
+2. `executor.getHostSnapshot?.()` (fallback for executors that don't expose per-iteration snapshots)
+3. `MCPJamReportingConfig.host` (explicit override, compatibility path)
+
+Pass-1 only sends a run-level host config when all iteration snapshots canonicalize to the same hash. If you mutate the bound `Host` between iterations, the reporter omits the run-level field (per-iteration wire support is a later stage). Old backends without the capability are unaffected.
+
+#### `@mcpjam/sdk/host-config/internal`
+
+The `internal` subpath exposes the canonicalizer, hasher, normalizer, and policy resolvers (`canonicalizeHostConfigV2`, `computeHostConfigHashV2`, `normalizeSdkEvalHostConfigForWire`, `extractHostExecutionPolicy`, `resolveOpenAiCompatForHostConfig`, …) that the MCPJam backend and the inspector server both import. It is **first-party-only, not semver-stable** — external consumers should use the `Host` facade. The MCPJam backend `convex/lib/hostConfigV2.ts` imports the canonicalizer directly from this subpath so there is exactly one source of truth shared between the SDK and the persisted `hostConfigs` rows.
+
+---
 
 ### OAuth Conformance
 


### PR DESCRIPTION
## Summary

Stage 6 of the SDK hostConfig consolidation: public-facing docs catch up to the `Host` / `HostRunner` / `HostRuntime` surface that shipped in 1.11, the wire-level `hostConfig` propagation in Stage 5, and the canonicalizer single-source-of-truth split between `@mcpjam/sdk/host-config/internal` and the MCPJam backend.

- **SDK README + CHANGELOG.** New "Host + HostRuntime: bring your own runtime" section, statelessness/one-shot/`/internal` callouts; CHANGELOG restructured into Unreleased (Stage 5 Step 3 reporter wire-send) / 1.12.0 (Stage 5 Step 1 normalizer + Stage B canonicalizer tightening) / 1.11.0 (Stage 4 rename).
- **`docs/sdk/`.** Bulk renamed `TestAgent` → `HostRunner`, `EvalAgent` → `HostExecutor`, `.prompt()` → `.run()`, `Host.addServer()` → `Host.requireServer()`, `TestAgentOptions` → `HostRunnerOptions` across 18 SDK mdx files. `test-agent.mdx` renamed to `host-runner.mdx` with a `/sdk/reference/test-agent` → `/sdk/reference/host-runner` redirect added to `docs.json`. New "Spec-first / Bring your own host" sections in `index.mdx` and `running-evals.mdx`.
- **`docs/sdk/reference/eval-reporting.mdx`.** Documented Stage 5 wire-send semantics — capability probe at `GET /sdk/v1/info`, fail-safe-to-omit on any error, source order (`iteration.hostSnapshot` → `executor.getHostSnapshot?.()` → `MCPJamReportingConfig.host`), pass-1 homogeneity gate, server-id normalization (wire hash ≠ storage hash by design).
- **`docs/sdk/reference/eval-test.mdx` + `eval-suite.mdx`.** `run(executor: HostExecutor, …)` parameter rename + clarifying both `HostRunner` and `HostRuntime` implement the interface.
- **`docs/contributing/playground-architecture.mdx` + `evals-architecture.mdx`.** Added "HostConfig consolidation" sections at the top describing the single-source-of-truth module layout (`sdk/host-config/`), Stage 3 import paths in the inspector server, Stage 4 rename surface, per-iteration host snapshot capture, Stage 5 wire-send, and the two-sandbox-layer distinction (allowlist-only persisted shape vs deny-capable runtime resolver). Older sections below kept as-is with a stale-doc warning at the top.

## Verification

- `cd sdk && npm run typecheck` — clean.
- `cd sdk && npm run test:packaging` — all 11 expected exports load (`canonicalizeHostConfigV2`, `computeHostConfigHashV2`, `isAppOnlyTool`, `filterAppOnlyTools`, `applyVisibilityPolicyAndCountSignals`, `extractHostExecutionPolicy`, `buildHostIterationMetadata`, `resolveOpenAiCompatForHostConfig`, `readOpenAiCompatOverride`, `compatPresetForHostStyle`, `normalizeSdkEvalHostConfigForWire`).
- `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8'))"` — valid.
- Plan one-canonicalizer check: backend `convex/lib/hostConfigV2.ts:canonicalizeHostConfigV2` and `:computeHostConfigHashV2` are delegating wrappers over `@mcpjam/sdk/host-config/internal` ✓.
- No client-local `HostConfigInputV2` / `HostConfigDtoV2` declarations remain ✓.
- `server/services/evals/` does not import `chat-v2-orchestration` ✓.

## Companion PR

A one-line file-header comment in `mcpjam-backend/convex/lib/hostConfigV2.ts` ships separately in the backend repo, calling out the canonicalizer as imported from `@mcpjam/sdk/host-config/internal` so a future reader doesn't accidentally hand-patch a parallel implementation.

## Test plan

- [ ] Mintlify preview renders cleanly for `docs/sdk/index`, `docs/sdk/quickstart`, `docs/sdk/reference/host-runner`, `docs/sdk/reference/eval-reporting`, `docs/sdk/concepts/running-evals`.
- [ ] `/sdk/reference/test-agent` redirects to `/sdk/reference/host-runner`.
- [ ] Spot-check at least one cross-link out of each changed file resolves.
- [ ] `docs/contributing/playground-architecture` and `evals-architecture` render the new top-of-file `<Note>` and the HostConfig consolidation section without breaking the rest of the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with redirects and cross-links; no runtime or API behavior in this diff.
> 
> **Overview**
> Documentation-only PR that aligns Mintlify SDK and contributing guides with **1.11** renames (`TestAgent` → `HostRunner`, `.prompt()` → `.run()`, `EvalAgent` → `HostExecutor`, `run(agent)` → `run(executor)`) and with **hostConfig** consolidation across Playground and Evals.
> 
> **SDK surface:** Examples and reference pages are updated across concepts, quickstart, and reference; nav points at `host-runner` instead of `test-agent`, with a redirect from the old URL. New material covers **spec-first** `Host` + `HostRuntime`, 1.11 breaking renames, and Stage 5 eval reporting (`hostConfig` / `hostConfigHash` on upload when the backend advertises `evalsHostConfig`).
> 
> **Contributing architecture:** `playground-architecture.mdx` and `evals-architecture.mdx` gain canonical **HostConfig consolidation** sections (shared `@mcpjam/sdk/host-config/`, inspector import paths, Stage 4 executor names, Stage 5 wire-send, persisted vs runtime sandbox shapes), plus a note that older diagrams may be stale.
> 
> **SDK README / CHANGELOG:** README adds Host/HostRuntime usage and reporting notes; CHANGELOG is reorganized around Unreleased Stage 5 reporter behavior, 1.12.0 canonicalizer work, and 1.11.0 renames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ebe877a6bd1e22022b9c2590b96ab8aee5e2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->