### PR TITLE
feat: unified error describe+render layer (sdk → backend → ErrorCard → docs)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,7 +40,8 @@
           "getting-started",
           "installation",
           "hosted/overview",
-          "troubleshooting/common-errors"
+          "troubleshooting/common-errors",
+          "troubleshooting/error-codes"
         ]
       },
       {
@@ -164,7 +165,8 @@
               "sdk/reference/llm-providers",
               "sdk/reference/protocol-conformance",
               "sdk/reference/oauth-conformance",
-              "sdk/reference/apps-conformance"
+              "sdk/reference/apps-conformance",
+              "reference/api-keys"
             ]
           }
         ]

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -190,6 +190,34 @@ Example configuration file structure:
 }
 ```
 
+### Mixing STDIO and HTTP/SHTTP servers
+
+You can mix STDIO and HTTP (Streamable HTTP / SHTTP) server entries in the same config. Each entry's transport is inferred from its fields: `command` + `args` means STDIO, `url` means HTTP/SHTTP.
+
+```json config.json
+{
+  "mcpServers": {
+    "local-everything": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-everything"],
+      "env": {
+        "HELLO": "Hello MCP!"
+      }
+    },
+    "hosted-weather": {
+      "url": "https://weather.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+The terminal and desktop installs accept both shapes in the same file. The hosted web app accepts HTTP/SHTTP entries only — STDIO entries are ignored because the hosted runtime cannot spawn local processes.
+
+For per-server `Authorization` headers, see [API keys → Playground BYOK](/reference/api-keys#3-playground-byok-bring-your-own-key).
+
 ## Start with Verbose Logging
 
 Enable verbose HTTP request logging for debugging purposes. This is useful when troubleshooting connection issues with MCP servers.

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -35,9 +35,14 @@ A token issued by the MCPJam hosted backend for headless usage of the `@mcpjam/c
 
 ## 3. Playground BYOK (Bring Your Own Key)
 
-A per-server bearer token you paste into the **Servers** card for an HTTP MCP server that requires `Authorization: Bearer ...`. The inspector forwards it to that one server only.
+A per-server bearer token used to authenticate the inspector against an HTTP MCP server that requires `Authorization: Bearer ...`. The inspector forwards it to that one server only.
 
-**Where it lives:** the **Headers** field of the server card. Stored locally per project; never sent anywhere except the server URL.
+**Where it lives** (two equivalent ways to set it — pick whichever fits your workflow):
+
+- **Servers card → Headers field** in the inspector UI. Stored locally per project; never sent anywhere except the server URL.
+- **`config.json`** under `mcpServers.<name>.headers.Authorization`, shaped exactly like the HTTP example on the [Installation](/installation) page. The inspector reads this on startup and treats it the same as a UI-entered header.
+
+Either form ends up populating the same per-server request header. Pick the UI for quick experimentation; pick `config.json` when you want the token version-controlled or shared across a team's checkout (typically via env-var substitution like `"Authorization": "Bearer ${MY_SERVER_TOKEN}"`).
 
 **When it's used:** Every request the inspector makes to that MCP server.
 

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -1,0 +1,56 @@
+---
+title: "API keys"
+description: "The three different things called 'API key' in MCPJam, and when you need each one."
+icon: "key"
+---
+
+The word "API key" gets used for three distinct things in MCPJam. This page disambiguates them so you can tell which one a given error message is talking about.
+
+## 1. LLM provider key
+
+A secret you obtained from an LLM provider (OpenAI, Anthropic, Google, xAI, Groq, Mistral, etc.). The inspector uses it to call that provider's chat completion API on your behalf.
+
+**Where it lives:** **Settings → LLM Providers**.
+
+**When it's used:** Every time you send a chat message in the Playground tab against a provider model that isn't MCPJam's free hosted model.
+
+**Errors you might see**
+- "Invalid API key for OpenAI / Anthropic / ..." → the key is wrong, expired, or for a different project.
+- "MCPJam model limit reached" — different problem, see [common errors](/troubleshooting/common-errors#mcpjam-model-limit-reached). Add an LLM provider key to bypass the free quota.
+
+**You do NOT need:** an LLM provider key to run inspector probes (Tools tab, Resources tab, Prompts tab, OAuth Debugger, conformance suites). Those only talk to MCP servers.
+
+## 2. `MCPJAM_API_KEY` (CLI auth)
+
+A token issued by the MCPJam hosted backend for headless usage of the `@mcpjam/cli` and `@mcpjam/sdk`.
+
+**Where it lives:** `~/.mcpjam/config.json` after running `mcpjam login`, or as the `MCPJAM_API_KEY` environment variable in CI.
+
+**When it's used:**
+- `mcpjam` CLI commands that talk to the hosted backend (publishing reports, fetching org-scoped server configs).
+- `@mcpjam/sdk` evals submitting traces to your org workspace.
+
+**Errors you might see**
+- "Missing or invalid bearer token" → `MCPJAM_API_KEY` is unset or rotated. Re-run `mcpjam login` or refresh the env var.
+
+## 3. Playground BYOK (Bring Your Own Key)
+
+A per-server bearer token you paste into the **Servers** card for an HTTP MCP server that requires `Authorization: Bearer ...`. The inspector forwards it to that one server only.
+
+**Where it lives:** the **Headers** field of the server card. Stored locally per project; never sent anywhere except the server URL.
+
+**When it's used:** Every request the inspector makes to that MCP server.
+
+**Errors you might see**
+- `auth/http_401` → the token is missing, expired, or rejected by the server. See [Unauthorized 401](/troubleshooting/error-codes#unauthorized-401).
+- `auth/http_403` → the token is recognized but lacks permission. See [Forbidden 403](/troubleshooting/error-codes#forbidden-403).
+
+## Quick reference
+
+| Concept | Stored in | Used for | "Invalid key" error path |
+| --- | --- | --- | --- |
+| LLM provider key | Settings → LLM Providers | Playground chat | `provider/auth_error` |
+| `MCPJAM_API_KEY` | `~/.mcpjam/config.json` or env | CLI / SDK auth to MCPJam backend | `auth/missing_bearer` |
+| Playground BYOK | Per-server card | MCP server requests | `auth/http_401`, `auth/http_403` |
+
+If you're not sure which one a particular error is referring to, open the ErrorCard's details panel and check the raw `code` / `slug` against the table above.

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -4,6 +4,10 @@ description: "Solutions to common MCP server connection and configuration issues
 icon: "circle-alert"
 ---
 
+<Info>
+Looking for a specific error code? See the [error code reference](/troubleshooting/error-codes) — every ErrorCard in the inspector deep-links to a section there.
+</Info>
+
 This guide covers common errors you might encounter when working with MCP servers and how to resolve them.
 
 ## Connection Issues

--- a/docs/troubleshooting/error-codes.mdx
+++ b/docs/troubleshooting/error-codes.mdx
@@ -1,0 +1,527 @@
+---
+title: "Error code reference"
+description: "What every MCPJam Inspector error code means, the likely causes, and the next step to fix it."
+icon: "shield-alert"
+---
+
+This page is the source of truth for the error messages MCPJam Inspector surfaces. Every error rendered in the inspector deep-links to one of the sections below.
+
+If you arrived here from an ErrorCard's "Learn more" link, the page should already be scrolled to the right section. Otherwise, use the index below.
+
+## JSON-RPC codes
+
+These come from the MCP transport itself. Numeric codes are defined by the [JSON-RPC 2.0 spec](https://www.jsonrpc.org/specification#error_object) plus a handful of MCP-specific extensions.
+
+| Code | Anchor |
+| --- | --- |
+| `-32700` | [Parse error](#parse-error) |
+| `-32600` | [Invalid request](#invalid-request) |
+| `-32601` | [Method not found](#method-not-found) |
+| `-32602` | [Invalid params](#invalid-params) |
+| `-32603` | [Internal error](#internal-error) |
+| `-32000` | [Connection closed](#connection-closed) |
+| `-32001` | [Request timed out](#request-timeout) / [Header mismatch](#header-mismatch) |
+| `-32004` | [Unsupported protocol version](#unsupported-protocol-version) |
+| `-32042` | [URL elicitation required](#url-elicitation-required) |
+
+### Parse error
+
+`-32700 — jsonrpc/parse_error`
+
+The server returned a payload the client could not parse as JSON-RPC.
+
+**Likely causes**
+- Server emitted invalid JSON on the response channel.
+- A proxy or middleware mangled the response body.
+- The STDIO server emitted log output on stdout instead of stderr.
+
+**Next steps**
+- Check the server's stdout/stderr for unintended log output.
+- Use the inspector's Traffic Log to inspect the raw response.
+
+### Invalid request
+
+`-32600 — jsonrpc/invalid_request`
+
+The server rejected the payload as not a well-formed JSON-RPC request.
+
+**Likely causes**
+- Client sent a request shape the server's MCP runtime does not accept.
+- Outdated server SDK that disagrees with the protocol version advertised.
+
+**Next steps**
+- Verify the negotiated MCP protocol version.
+- Update the server's MCP SDK.
+
+### Method not found
+
+`-32601 — jsonrpc/method_not_found`
+
+The server does not implement the JSON-RPC method that was called.
+
+**Likely causes**
+- The server hasn't implemented the requested MCP method.
+- Client and server are on incompatible MCP protocol versions.
+- The capability you expected was not advertised in `initialize`.
+
+**Next steps**
+- Check the server's advertised capabilities in the connection info modal.
+- Confirm the protocol version negotiated at `initialize`.
+
+### Invalid params
+
+`-32602 — jsonrpc/invalid_params`
+
+The server rejected the request parameters.
+
+**Likely causes**
+- Required field is missing from the call.
+- Field type does not match the tool's input schema.
+- Server-side validator is stricter than the published schema.
+
+**Next steps**
+- Re-check the tool's input schema in the Tools tab.
+- Compare your call payload against the schema in the inspector.
+
+### Internal error
+
+`-32603 — jsonrpc/internal_error`
+
+The server hit an unexpected error while handling the request.
+
+**Likely causes**
+- Unhandled exception inside the server's tool/resource/prompt handler.
+- Downstream dependency (database, API) failed during the call.
+
+**Next steps**
+- Check the server's logs around the time of the error.
+- Retry the request once the server is healthy.
+
+### Connection closed
+
+`-32000 — jsonrpc/connection_closed`
+
+The underlying transport closed before the response could be delivered.
+
+**Likely causes**
+- STDIO server process exited or crashed mid-request.
+- HTTP server dropped the streaming connection.
+- Network blip between the inspector and the server.
+
+**Next steps**
+- Restart the server and reconnect.
+- Check the server logs for a crash or exit message.
+
+**Inspector-specific:** the inspector synthesizes this code when an active transport goes away mid-request. If you see it on every call, the server is probably exiting immediately after startup — check for a fatal log.
+
+### Request timeout
+
+`-32001 — jsonrpc/request_timeout`
+
+The server did not respond within the configured request timeout.
+
+**Likely causes**
+- Server is overloaded or stuck on the operation.
+- Long-running tool call exceeds the inspector's per-request timeout.
+- Network latency between client and server.
+
+**Next steps**
+- Increase the per-server request timeout in the Servers tab.
+- Use MCP `tasks/*` for operations that legitimately run long.
+
+### Header mismatch
+
+`-32001 — jsonrpc/header_mismatch`
+
+The server returned an `MCP-Protocol-Version` header that does not match what the client negotiated.
+
+**Likely causes**
+- Server is enforcing a different protocol version than the one negotiated at `initialize`.
+- A proxy stripped or rewrote the `MCP-Protocol-Version` header.
+
+**Next steps**
+- Verify the server's protocol-version pinning in the connection settings.
+- If you set an explicit protocol version per server, ensure it matches what the server advertises.
+
+> The `-32001` code is overloaded between `request_timeout` and `header_mismatch`. The inspector disambiguates by message; check the raw message in the ErrorCard's details panel.
+
+### Unsupported protocol version
+
+`-32004 — jsonrpc/unsupported_protocol_version`
+
+The server does not support any protocol version this inspector offered.
+
+**Likely causes**
+- Server pinned to a newer MCP draft your inspector build does not understand.
+- Server pinned to a legacy version this build dropped support for.
+
+**Next steps**
+- Update the inspector to a newer build.
+- Check the supported versions list in the server's `initialize` response.
+
+### URL elicitation required
+
+`-32042 — jsonrpc/url_elicitation_required`
+
+The server needs the user to visit an external URL to complete the operation.
+
+**Likely causes**
+- Server requested a URL elicitation (OAuth, payment, confirmation).
+- Operation cannot proceed until the user opens the URL in a browser.
+
+**Next steps**
+- Open the elicited URL and complete the flow.
+- Re-issue the request after the external step completes.
+
+---
+
+## Transport errors
+
+These come from the OS or the HTTP stack. Most of them are recoverable.
+
+### ECONNREFUSED
+
+`transport/econnrefused`
+
+Nothing is listening on the host and port the server URL points at.
+
+**Likely causes**
+- Server isn't running.
+- Port number is wrong in the server URL.
+- Server is bound to a different interface (e.g. only `127.0.0.1` but you're connecting via the LAN IP).
+
+**Next steps**
+- Start the server.
+- Double-check the URL's host and port.
+- For Docker/containers, confirm the port is published to your host.
+
+### ECONNRESET
+
+`transport/econnreset`
+
+The remote side closed the TCP connection abruptly.
+
+**Likely causes**
+- Server process crashed mid-request.
+- Intermediate proxy or load balancer dropped the connection.
+- Server hit an OS-level resource limit.
+
+**Next steps**
+- Inspect the server logs for a crash.
+- Retry the request.
+
+### ETIMEDOUT
+
+`transport/etimedout`
+
+The OS-level TCP connection attempt did not complete in time.
+
+**Likely causes**
+- Wrong host/port in the server URL.
+- Firewall is silently dropping packets.
+- Server is overloaded and never accepted the connection.
+
+**Next steps**
+- Verify the URL is reachable from your machine (e.g. `curl`).
+- Check firewall / VPN rules.
+
+### ENOTFOUND
+
+`transport/enotfound`
+
+DNS lookup failed for the server's hostname.
+
+**Likely causes**
+- Hostname is misspelled in the URL.
+- DNS resolver is misconfigured.
+- You're offline.
+
+**Next steps**
+- Confirm the hostname in the URL is correct.
+- Try resolving the host with `nslookup` or `dig`.
+
+### EAI_AGAIN
+
+`transport/eai_again`
+
+DNS resolution failed with a transient error.
+
+**Likely causes**
+- Local DNS resolver is overloaded or restarting.
+- Upstream DNS server is briefly unavailable.
+
+**Next steps**
+- Wait a few seconds and retry.
+- Switch to a different DNS resolver if this persists.
+
+### Undici transport error
+
+`transport/undici`
+
+The underlying HTTP client (undici / fetch) reported a low-level transport failure. Common subcodes: `UND_ERR_SOCKET`, `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_HEADERS_TIMEOUT`.
+
+**Likely causes**
+- Server closed the connection mid-response.
+- TLS handshake failed.
+- Socket-level error during streaming.
+
+**Next steps**
+- Inspect the Traffic Log for the failed request.
+- Verify the server's TLS certificate is valid.
+
+### Fetch failed
+
+`transport/fetch_failed`
+
+The HTTP request never produced a response.
+
+**Likely causes**
+- Server is unreachable (offline, wrong URL, blocked by firewall).
+- TLS handshake failed (self-signed cert, expired cert).
+- Mixed-content block (HTTPS page calling HTTP endpoint in browser).
+
+**Next steps**
+- Open the URL in a browser to confirm it loads.
+- If self-signed, install the certificate or switch to a trusted one.
+
+### Socket hang up
+
+`transport/socket_hang_up`
+
+The server closed the connection without sending a response.
+
+**Likely causes**
+- Server crashed or restarted during the request.
+- Reverse proxy timed the request out.
+
+**Next steps**
+- Retry the request.
+- Check server-side logs for the crash.
+
+---
+
+## Auth & OAuth
+
+For the difference between the three "API key" concepts (LLM provider keys, MCPJam API keys, Playground BYOK), see [API keys](/reference/api-keys).
+
+### Unauthorized 401
+
+`auth/http_401`
+
+The server requires authentication that wasn't provided or is no longer valid.
+
+**Likely causes**
+- Missing or expired bearer token.
+- OAuth access token expired and refresh failed.
+- Server changed its required authentication scheme.
+
+**Next steps**
+- Re-authenticate using the **Reconnect** button on the server card.
+- If using OAuth, run through the OAuth flow again from Servers.
+
+### Forbidden 403
+
+`auth/http_403`
+
+You authenticated successfully but lack permission for the operation.
+
+**Likely causes**
+- OAuth scopes granted don't cover the requested operation.
+- Server-side ACL blocks this account.
+
+**Next steps**
+- Re-run OAuth and request the additional scopes if the server allows.
+- Ask the server admin to grant the necessary permissions.
+
+### OAuth refresh failed
+
+`auth/oauth_refresh_failed`
+
+An expired OAuth access token could not be refreshed.
+
+**Likely causes**
+- Refresh token was revoked.
+- Refresh token expired.
+- Server returned `invalid_grant` to the refresh attempt.
+
+**Next steps**
+- Click **Reconnect** on the server card to run a fresh OAuth flow.
+
+### Missing bearer
+
+`auth/missing_bearer`
+
+The API call did not include the required `Authorization: Bearer ...` header.
+
+**Likely causes**
+- Inspector session expired.
+- Sign-in token failed to attach to the request.
+
+**Next steps**
+- Refresh the page and sign in again.
+
+### OAuth invalid grant
+
+`oauth/invalid_grant`
+
+The OAuth server rejected the authorization code or refresh token.
+
+**Likely causes**
+- Authorization code was already redeemed.
+- Refresh token was revoked.
+- Authorization code expired (typical lifetime ~60s).
+
+**Next steps**
+- Start the OAuth flow again from the server card.
+
+### OAuth invalid client
+
+`oauth/invalid_client`
+
+The OAuth server does not recognize the client credentials.
+
+**Likely causes**
+- Client was deleted on the authorization server.
+- Dynamic registration cache is stale.
+- `client_id` was rotated server-side.
+
+**Next steps**
+- Re-register the client (Reconnect from the server card triggers DCR if supported).
+
+### OAuth redirect mismatch
+
+`oauth/redirect_mismatch`
+
+The redirect URI in the request does not match the one registered with the OAuth server.
+
+**Likely causes**
+- Authorization server requires the inspector's callback URL to be registered explicitly.
+- Server's allow-list is wrong.
+
+**Next steps**
+- Add the inspector's callback URL to the OAuth server's allowed redirects.
+- Verify the inspector's base URL hasn't changed.
+
+### OAuth well-known unreachable
+
+`oauth/well_known_unreachable`
+
+The OAuth `.well-known` discovery endpoint could not be fetched.
+
+**Likely causes**
+- Authorization server is down.
+- Wrong issuer URL.
+- CORS blocks the discovery request from the browser.
+
+**Next steps**
+- Confirm the issuer URL in the server config.
+- Open the `.well-known/openid-configuration` (or `oauth-authorization-server`) URL in a browser.
+
+---
+
+## Inspector-specific
+
+These come from the inspector's own SDK runtime.
+
+### Not yet supported in stateless
+
+`sdk/not_yet_supported_in_stateless`
+
+The inspector's stateless HTTP transport does not yet implement this MCP operation.
+
+**Likely causes**
+- Operation requires a server-initiated channel (subscriptions, MRTR) the stateless preview transport hasn't wired up yet.
+
+**Next steps**
+- Switch the server to the legacy stateful transport in its protocol-mode toggle.
+
+### Stateless requires HTTP
+
+`sdk/stateless_requires_http`
+
+Stateless mode can only be used with an HTTP-transport server, not STDIO.
+
+**Likely causes**
+- You enabled the stateless protocol toggle on a stdio server.
+
+**Next steps**
+- Disable the stateless toggle for stdio servers.
+
+### Paginated tool / header discovery unsupported
+
+`sdk/paginated_tool_header_discovery_unsupported`
+
+Paginated tools discovery cannot run alongside per-request header overrides on this transport.
+
+**Likely causes**
+- Conflicting combination of progressive tool discovery + per-server header overrides.
+
+**Next steps**
+- Disable progressive tool discovery for this server, or move headers into the server config.
+
+---
+
+## Provider errors
+
+Errors from the LLM provider running behind the playground.
+
+### Provider invalid tool name
+
+`provider/invalid_tool_name`
+
+An LLM provider rejected a tool name (Anthropic's strict tool-name validator is the most common source).
+
+**Likely causes**
+- Tool name contains characters or length the provider does not allow.
+- Two attached servers expose tools whose namespaced names collide after sanitization.
+
+**Next steps**
+- Rename the offending tool on the server.
+- Detach one of the colliding servers from the chat surface.
+
+### Provider auth error
+
+`provider/auth_error`
+
+Your LLM provider rejected the API key for this request.
+
+**Likely causes**
+- Key is missing.
+- Key is invalid or revoked.
+- Key is for a different environment (project, region).
+
+**Next steps**
+- Add or update your API key under **Settings → LLM Providers**.
+- Verify the key in the provider's dashboard.
+
+### Provider quota
+
+`provider/quota`
+
+Your LLM provider rejected the request because you hit a rate limit or quota.
+
+**Likely causes**
+- Daily/monthly quota exhausted.
+- Per-minute rate limit exceeded.
+- Free tier limits hit.
+
+**Next steps**
+- Wait for the limit window to reset.
+- Upgrade your provider plan.
+- Switch to a different provider in Settings.
+
+---
+
+## Unknown error
+
+`internal/unknown`
+
+An error occurred that the inspector could not classify.
+
+**Likely causes**
+- Unhandled error path.
+- New error class the inspector hasn't been taught about yet.
+
+**Next steps**
+- Open the details panel of the ErrorCard and copy the raw message.
+- File an issue with the raw message so we can add it to the catalog.

--- a/docs/troubleshooting/error-codes.mdx
+++ b/docs/troubleshooting/error-codes.mdx
@@ -240,7 +240,7 @@ DNS lookup failed for the server's hostname.
 - Confirm the hostname in the URL is correct.
 - Try resolving the host with `nslookup` or `dig`.
 
-### EAI_AGAIN
+### EAI again
 
 `transport/eai_again`
 

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -110,6 +110,9 @@ export function ToolsTab({
   const [loadingExecuteTool, setLoadingExecuteTool] = useState(false);
   const [fetchingTools, setFetchingTools] = useState(false);
   const [error, setError] = useState<string>("");
+  const [normalizedError, setNormalizedError] = useState<
+    import("@mcpjam/sdk/browser").NormalizedError | null
+  >(null);
   const [responseDurationMs, setResponseDurationMs] = useState<number | null>(
     null,
   );
@@ -218,6 +221,7 @@ export function ToolsTab({
     setResult(null);
     setStructuredContentValid(undefined);
     setError("");
+    setNormalizedError(null);
     setResponseDurationMs(null);
     setActiveElicitation(null);
     if (clearTaskCapabilities) {
@@ -324,6 +328,7 @@ export function ToolsTab({
     }
 
     setError("");
+    setNormalizedError(null);
     setFetchingTools(true);
     if (reset) {
       resetLoadedToolState({
@@ -466,6 +471,14 @@ export function ToolsTab({
     if ("error" in response && response.error) {
       setResponseDurationMs(durationMs);
       setError(response.error as string);
+      // Preserve the rich describer block when the response carried one
+      // (server-side `jsonError` always populates `normalized` now).
+      const maybeNormalized = (response as { normalized?: unknown }).normalized;
+      setNormalizedError(
+        maybeNormalized && typeof maybeNormalized === "object"
+          ? (maybeNormalized as import("@mcpjam/sdk/browser").NormalizedError)
+          : null,
+      );
     }
   };
 
@@ -484,11 +497,13 @@ export function ToolsTab({
         connectionStatus: serverConnectionStatus,
       });
       setError("Connect this server before running tools.");
+      setNormalizedError(null);
       return;
     }
 
     setLoadingExecuteTool(true);
     setError("");
+    setNormalizedError(null);
     setResult(null);
     setStructuredContentValid(undefined);
     setResponseDurationMs(null);
@@ -711,6 +726,7 @@ export function ToolsTab({
   const centerContent = selectedTool ? (
     <ResultsPanel
       error={error}
+      normalizedError={normalizedError}
       result={result}
       structuredContentValid={structuredContentValid}
       toolMeta={getToolMeta(lastToolName)}

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -42,6 +42,7 @@ import {
 import { trackTask } from "@/lib/task-tracker";
 import { validateToolOutput } from "@/lib/schema-utils";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
+import { isNormalizedError } from "@mcpjam/sdk/browser";
 import { WebApiError } from "@/lib/apis/web/base";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { usePostHog } from "posthog-js/react";
@@ -363,11 +364,13 @@ export function ToolsTab({
       logger.error("Failed to fetch tools", { error: message });
       setError(message);
       // Preserve the backend-attached `normalized` block when listTools
-      // threw a WebApiError. Without this the ErrorCard re-classifies
-      // from the message alone and loses the specific transport / auth
-      // / JSON-RPC slug the server already pinned.
+      // threw a WebApiError, but shape-validate first. Partial payloads
+      // would otherwise shadow the real `error` string at render
+      // (ResultsPanel prefers normalizedError over error).
       setNormalizedError(
-        err instanceof WebApiError && err.normalized ? err.normalized : null,
+        err instanceof WebApiError && isNormalizedError(err.normalized)
+          ? err.normalized
+          : null,
       );
     } finally {
       if (fetchVersion === toolFetchVersionRef.current) {
@@ -480,12 +483,14 @@ export function ToolsTab({
       setResponseDurationMs(durationMs);
       setError(response.error as string);
       // Preserve the rich describer block when the response carried one
-      // (server-side `jsonError` always populates `normalized` now).
+      // (server-side `jsonError` always populates `normalized`), but
+      // shape-validate first — a partial `{}` would otherwise shadow the
+      // real `error` string at render. ResultsPanel prefers
+      // normalizedError over error, so an invalid block hides the API's
+      // actual message and yields a generic "Unknown error" ErrorCard.
       const maybeNormalized = (response as { normalized?: unknown }).normalized;
       setNormalizedError(
-        maybeNormalized && typeof maybeNormalized === "object"
-          ? (maybeNormalized as import("@mcpjam/sdk/browser").NormalizedError)
-          : null,
+        isNormalizedError(maybeNormalized) ? maybeNormalized : null,
       );
     }
   };

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -42,6 +42,7 @@ import {
 import { trackTask } from "@/lib/task-tracker";
 import { validateToolOutput } from "@/lib/schema-utils";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
+import { WebApiError } from "@/lib/apis/web/base";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { usePostHog } from "posthog-js/react";
 import type { ConnectionStatus } from "@/state/app-types";
@@ -361,6 +362,13 @@ export function ToolsTab({
       const message = err instanceof Error ? err.message : "Unknown error";
       logger.error("Failed to fetch tools", { error: message });
       setError(message);
+      // Preserve the backend-attached `normalized` block when listTools
+      // threw a WebApiError. Without this the ErrorCard re-classifies
+      // from the message alone and loses the specific transport / auth
+      // / JSON-RPC slug the server already pinned.
+      setNormalizedError(
+        err instanceof WebApiError && err.normalized ? err.normalized : null,
+      );
     } finally {
       if (fetchVersion === toolFetchVersionRef.current) {
         setFetchingTools(false);

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -38,6 +38,7 @@ import {
 } from "lucide-react";
 import { ServerWithName } from "@/hooks/use-app-state";
 import { exportServerApi } from "@/lib/apis/mcp-export-api";
+import { ErrorCard } from "@/components/ui/error-card";
 import {
   getConnectionStatusMeta,
   getServerCommandDisplay,
@@ -740,32 +741,22 @@ export function ServerConnectionCard({
 
           {hasError && (
             <div
-              className="mt-3 rounded-md border border-red-300/40 bg-red-500/10 p-2 text-xs text-red-700 dark:text-red-300"
+              className="mt-3"
               onClick={(e) => e.stopPropagation()}
             >
               {oauthFailureStep ? (
-                <div className="mb-1 font-medium">
+                <div className="mb-1 text-xs font-medium text-red-700 dark:text-red-300">
                   OAuth failed during {oauthFailureStep.title}
                 </div>
               ) : null}
-              <div className="break-all">
-                {isErrorExpanded
-                  ? server.lastError
-                  : server.lastError!.length > 140
-                    ? `${server.lastError!.substring(0, 140)}...`
-                    : server.lastError}
-              </div>
-              {server.lastError!.length > 140 && (
-                <button
-                  data-server-card-context-menu-exempt
-                  onClick={() => setIsErrorExpanded((prev) => !prev)}
-                  className="mt-1 underline cursor-pointer"
-                >
-                  {isErrorExpanded ? "Show less" : "Show more"}
-                </button>
-              )}
+              <ErrorCard
+                // Prefer the rich block; fall back to the message string
+                // (the card calls `describeError` internally when needed).
+                error={server.lastNormalizedError ?? server.lastError ?? ""}
+                defaultOpen={isErrorExpanded}
+              />
               {server.retryCount > 0 && (
-                <div className="mt-1 opacity-80">
+                <div className="mt-1 text-xs text-muted-foreground">
                   {server.retryCount} retry attempt
                   {server.retryCount !== 1 ? "s" : ""}
                 </div>

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -753,7 +753,11 @@ export function ServerConnectionCard({
                 // Prefer the rich block; fall back to the message string
                 // (the card calls `describeError` internally when needed).
                 error={server.lastNormalizedError ?? server.lastError ?? ""}
-                defaultOpen={isErrorExpanded}
+                // Controlled — the Error badge above toggles
+                // `isErrorExpanded`; the card must reflect that on every
+                // change, not just at mount.
+                open={isErrorExpanded}
+                onOpenChange={setIsErrorExpanded}
               />
               {server.retryCount > 0 && (
                 <div className="mt-1 text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -19,6 +19,7 @@ import { getStoredTokensState } from "@/lib/oauth/mcp-oauth";
 import { getOAuthTraceFailureStep } from "@/lib/oauth/oauth-trace";
 import { decodeJWT } from "@/lib/oauth/jwt-decoder";
 import { ScrollableJsonView } from "@/components/ui/json-editor";
+import { ErrorCard } from "@/components/ui/error-card";
 
 interface ServerInfoContentProps {
   server: ServerWithName;
@@ -444,13 +445,16 @@ export function ServerInfoContent({
   return (
     <div className="space-y-4">
       {server.lastError ? (
-        <div className="rounded-md border border-red-300/40 bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-300">
-          <div className="font-medium">
-            {oauthFailureStep
-              ? `OAuth failed during ${oauthFailureStep.title}`
-              : "Last connection error"}
-          </div>
-          <div className="mt-1 break-all">{server.lastError}</div>
+        <div className="space-y-1">
+          {oauthFailureStep ? (
+            <div className="text-sm font-medium text-red-700 dark:text-red-300">
+              OAuth failed during {oauthFailureStep.title}
+            </div>
+          ) : null}
+          <ErrorCard
+            error={server.lastNormalizedError ?? server.lastError}
+            defaultOpen
+          />
         </div>
       ) : null}
       {needsReconnect ? (

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -346,7 +346,11 @@ describe("ServerConnectionCard", () => {
       expect(screen.getByText("Connection refused")).toBeInTheDocument();
     });
 
-    it("truncates long error messages", () => {
+    it("renders long error messages via the ErrorCard", () => {
+      // The ErrorCard owns details disclosure; we just confirm the rich
+      // surface shows up (title + Learn more link) rather than the old
+      // ad-hoc truncation. The full message lives in the collapsed
+      // details panel.
       const longError = "A".repeat(150);
       const server = createServer({
         connectionStatus: "failed",
@@ -354,8 +358,7 @@ describe("ServerConnectionCard", () => {
       });
       render(<ServerConnectionCard server={server} {...defaultProps} />);
 
-      // Should show truncated version
-      expect(screen.getByText(`${"A".repeat(140)}...`)).toBeInTheDocument();
+      expect(screen.getByText("Learn more")).toBeInTheDocument();
     });
 
     it("shows troubleshooting link when connection failed", () => {

--- a/mcpjam-inspector/client/src/components/oauth/OAuthFlowProgress.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthFlowProgress.tsx
@@ -21,6 +21,7 @@ import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import { OAuthFlowState, OAuthStep } from "@/lib/types/oauth-flow-types";
 import { cn } from "@/lib/utils";
+import { ErrorCard } from "@/components/ui/error-card";
 
 type NodeStatus = "complete" | "current" | "pending";
 
@@ -338,13 +339,7 @@ const StepDetailsPanel = memo(({ action }: StepDetailsPanelProps) => {
         </div>
 
         {/* Error */}
-        {action.error && (
-          <div className="rounded-md border-2 border-destructive/40 bg-destructive/10 p-3">
-            <p className="text-xs font-medium text-destructive leading-relaxed">
-              {action.error}
-            </p>
-          </div>
-        )}
+        {action.error && <ErrorCard error={action.error} />}
 
         {/* Details */}
         {action.details && action.details.length > 0 && (
@@ -506,13 +501,7 @@ const ActionNode = memo((props: NodeProps<Node<ActionNodeData>>) => {
               </div>
             )}
 
-            {data.error && (
-              <div className="rounded-md border border-destructive/40 bg-destructive/10 p-2">
-                <p className="text-[10px] font-medium text-destructive">
-                  {data.error}
-                </p>
-              </div>
-            )}
+            {data.error && <ErrorCard error={data.error} />}
 
             {data.secondaryAction && (
               <div className="pt-2 border-t border-border/50">

--- a/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
@@ -2,8 +2,10 @@ import type { CallToolResult } from "@modelcontextprotocol/client";
 import { CheckCircle, Info, ExternalLink, Clock3 } from "lucide-react";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
+import type { NormalizedError } from "@mcpjam/sdk/browser";
 import { detectUIType, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { JsonEditor } from "@/components/ui/json-editor";
+import { ErrorCard } from "@/components/ui/error-card";
 import { extractDisplayFromToolResult } from "@/components/chat-v2/shared/tool-result-text";
 import { navigateApp, routePaths } from "@/lib/app-navigation";
 import { useActiveHostCapsResolver } from "@/contexts/active-host-client-capabilities-context";
@@ -11,6 +13,13 @@ import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
 
 interface ResultsPanelProps {
   error: string;
+  /**
+   * Rich describe-error block accompanying `error` when the source
+   * surfaced one (server-side `jsonError` in /api/mcp/tools/execute
+   * always populates it now). Falls back to `describeError(error)`
+   * inside the ErrorCard when absent.
+   */
+  normalizedError?: NormalizedError | null;
   result: CallToolResult | null;
   structuredContentValid: boolean | undefined;
   toolMeta?: Record<string, any>;
@@ -26,6 +35,7 @@ interface ResultsPanelProps {
 
 export function ResultsPanel({
   error,
+  normalizedError,
   result,
   structuredContentValid,
   toolMeta,
@@ -90,9 +100,7 @@ export function ResultsPanel({
       {/* Content - fills remaining space */}
       {error ? (
         <div className="flex-1 p-4">
-          <div className="p-3 bg-destructive/10 border border-destructive/20 rounded text-destructive text-xs font-medium">
-            {error}
-          </div>
+          <ErrorCard error={normalizedError ?? error} defaultOpen />
         </div>
       ) : rawResult ? (
         <div className="flex-1 min-h-0 p-4 flex flex-col gap-4">

--- a/mcpjam-inspector/client/src/components/ui/error-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui/error-card.tsx
@@ -51,12 +51,20 @@ export type ErrorCardProps = {
 };
 
 function isNormalizedError(value: unknown): value is NormalizedError {
+  // Require every field the render path dereferences. A partial payload
+  // (e.g. stale wire shape that omits docsAnchor/severity/rawMessage)
+  // must fall through to `describeError(input)`, which always produces a
+  // complete `NormalizedError` — otherwise the "Learn more" anchor or
+  // severity-based icon dereference would crash.
   return (
     !!value &&
     typeof value === "object" &&
     typeof (value as { slug?: unknown }).slug === "string" &&
     typeof (value as { title?: unknown }).title === "string" &&
     typeof (value as { oneLine?: unknown }).oneLine === "string" &&
+    typeof (value as { docsAnchor?: unknown }).docsAnchor === "string" &&
+    typeof (value as { severity?: unknown }).severity === "string" &&
+    typeof (value as { rawMessage?: unknown }).rawMessage === "string" &&
     Array.isArray((value as { likelyCauses?: unknown }).likelyCauses) &&
     Array.isArray((value as { nextSteps?: unknown }).nextSteps)
   );

--- a/mcpjam-inspector/client/src/components/ui/error-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui/error-card.tsx
@@ -27,7 +27,22 @@ export type ErrorCardProps = {
   onRetry?: () => void;
   onDismiss?: () => void;
   variant?: "inline" | "banner" | "toast";
+  /**
+   * Uncontrolled initial state for the details disclosure. Ignored when
+   * `open` is provided (controlled mode).
+   */
   defaultOpen?: boolean;
+  /**
+   * Controlled details-disclosure state. When set, the card renders this
+   * value instead of its internal state and forwards toggles to
+   * `onOpenChange`. Pair with `onOpenChange` to keep the toggle reactive.
+   */
+  open?: boolean;
+  /**
+   * Fired whenever the user toggles the details disclosure. Called in
+   * both controlled and uncontrolled modes.
+   */
+  onOpenChange?: (open: boolean) => void;
   /**
    * Optional extra class to merge into the root container. Lets callers
    * tighten spacing without re-styling the whole card.
@@ -88,10 +103,23 @@ export function ErrorCard({
   onDismiss,
   variant = "inline",
   defaultOpen = false,
+  open,
+  onOpenChange,
   className,
 }: ErrorCardProps) {
   const normalized = useMemo(() => resolveNormalized(error), [error]);
-  const [open, setOpen] = useState<boolean>(defaultOpen);
+  // Support both controlled (`open` provided) and uncontrolled (`defaultOpen`)
+  // modes. `useState` only reads `defaultOpen` once at mount, so callers that
+  // need the toggle to react to outside state must use the controlled form.
+  const [uncontrolledOpen, setUncontrolledOpen] =
+    useState<boolean>(defaultOpen);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : uncontrolledOpen;
+  const handleToggle = () => {
+    const next = !isOpen;
+    if (!isControlled) setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  };
   const styles = severityStyles(normalized.severity);
   const Icon = styles.icon;
 
@@ -131,15 +159,15 @@ export function ErrorCard({
           <div className="flex items-center gap-3 pt-1">
             <button
               type="button"
-              onClick={() => setOpen((prev) => !prev)}
+              onClick={handleToggle}
               className="inline-flex items-center gap-1 text-[11px] font-medium text-foreground/70 hover:text-foreground"
             >
-              {open ? (
+              {isOpen ? (
                 <ChevronDown className="h-3 w-3" />
               ) : (
                 <ChevronRight className="h-3 w-3" />
               )}
-              {open ? "Hide details" : "Show details"}
+              {isOpen ? "Hide details" : "Show details"}
             </button>
             <a
               href={docsHref}
@@ -162,7 +190,7 @@ export function ErrorCard({
             ) : null}
           </div>
 
-          {open ? (
+          {isOpen ? (
             <div className="mt-2 space-y-2 rounded border border-foreground/10 bg-background/40 p-2 text-foreground/80">
               {normalized.likelyCauses.length > 0 ? (
                 <div>

--- a/mcpjam-inspector/client/src/components/ui/error-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui/error-card.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  CircleAlert,
+  ExternalLink,
+  Info,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import { describeError, type NormalizedError } from "@mcpjam/sdk/browser";
+import { cn } from "@/lib/utils";
+import { WebApiError } from "@/lib/apis/web/base";
+
+const DOCS_BASE_URL = "https://docs.mcpjam.com";
+
+export type ErrorCardProps = {
+  /**
+   * Accepts the rich normalized form, a wrapped `WebApiError`, any
+   * `Error`, or a raw string / unknown value. When `error` is already a
+   * `NormalizedError` (or a `WebApiError` with a `.normalized` block)
+   * the card renders that directly; otherwise it falls back to
+   * `describeError(error)`.
+   */
+  error: NormalizedError | WebApiError | Error | string | unknown;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+  variant?: "inline" | "banner" | "toast";
+  defaultOpen?: boolean;
+  /**
+   * Optional extra class to merge into the root container. Lets callers
+   * tighten spacing without re-styling the whole card.
+   */
+  className?: string;
+};
+
+function isNormalizedError(value: unknown): value is NormalizedError {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as { slug?: unknown }).slug === "string" &&
+    typeof (value as { title?: unknown }).title === "string" &&
+    typeof (value as { oneLine?: unknown }).oneLine === "string" &&
+    Array.isArray((value as { likelyCauses?: unknown }).likelyCauses) &&
+    Array.isArray((value as { nextSteps?: unknown }).nextSteps)
+  );
+}
+
+function resolveNormalized(input: unknown): NormalizedError {
+  if (isNormalizedError(input)) return input;
+  if (input instanceof WebApiError && input.normalized) {
+    return input.normalized;
+  }
+  return describeError(input);
+}
+
+function severityStyles(severity: NormalizedError["severity"]) {
+  switch (severity) {
+    case "info":
+      return {
+        container:
+          "border-blue-300/40 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+        icon: Info,
+        iconClass: "text-blue-500 dark:text-blue-400",
+      };
+    case "warning":
+      return {
+        container:
+          "border-amber-300/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+        icon: AlertTriangle,
+        iconClass: "text-amber-500 dark:text-amber-400",
+      };
+    case "error":
+    default:
+      return {
+        container:
+          "border-destructive/20 bg-destructive/10 text-destructive",
+        icon: CircleAlert,
+        iconClass: "text-destructive",
+      };
+  }
+}
+
+export function ErrorCard({
+  error,
+  onRetry,
+  onDismiss,
+  variant = "inline",
+  defaultOpen = false,
+  className,
+}: ErrorCardProps) {
+  const normalized = useMemo(() => resolveNormalized(error), [error]);
+  const [open, setOpen] = useState<boolean>(defaultOpen);
+  const styles = severityStyles(normalized.severity);
+  const Icon = styles.icon;
+
+  const docsHref = normalized.docsAnchor.startsWith("/")
+    ? `${DOCS_BASE_URL}${normalized.docsAnchor}`
+    : normalized.docsAnchor;
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "rounded-md border p-3 text-xs",
+        styles.container,
+        variant === "banner" ? "shadow-sm" : "",
+        className,
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <Icon className={cn("mt-0.5 h-4 w-4 flex-shrink-0", styles.iconClass)} />
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="font-medium leading-tight">{normalized.title}</div>
+            {onDismiss ? (
+              <button
+                type="button"
+                onClick={onDismiss}
+                aria-label="Dismiss"
+                className="ml-2 flex-shrink-0 rounded p-0.5 hover:bg-foreground/10"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </div>
+          <div className="text-foreground/80 leading-snug">
+            {normalized.oneLine}
+          </div>
+          <div className="flex items-center gap-3 pt-1">
+            <button
+              type="button"
+              onClick={() => setOpen((prev) => !prev)}
+              className="inline-flex items-center gap-1 text-[11px] font-medium text-foreground/70 hover:text-foreground"
+            >
+              {open ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              {open ? "Hide details" : "Show details"}
+            </button>
+            <a
+              href={docsHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[11px] font-medium text-foreground/70 hover:text-foreground"
+            >
+              <ExternalLink className="h-3 w-3" />
+              Learn more
+            </a>
+            {onRetry ? (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="inline-flex items-center gap-1 text-[11px] font-medium text-foreground/70 hover:text-foreground"
+              >
+                <RefreshCw className="h-3 w-3" />
+                Retry
+              </button>
+            ) : null}
+          </div>
+
+          {open ? (
+            <div className="mt-2 space-y-2 rounded border border-foreground/10 bg-background/40 p-2 text-foreground/80">
+              {normalized.likelyCauses.length > 0 ? (
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-wide opacity-70">
+                    Likely causes
+                  </div>
+                  <ul className="mt-1 list-disc pl-4 space-y-0.5">
+                    {normalized.likelyCauses.map((cause, idx) => (
+                      <li key={idx}>{cause}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {normalized.nextSteps.length > 0 ? (
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-wide opacity-70">
+                    Next steps
+                  </div>
+                  <ul className="mt-1 list-disc pl-4 space-y-0.5">
+                    {normalized.nextSteps.map((step, idx) => (
+                      <li key={idx}>{step}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-wide opacity-70">
+                  Raw error
+                </div>
+                <div className="mt-1 break-all font-mono text-[11px] opacity-90">
+                  {normalized.rawMessage}
+                  {normalized.rawCode !== undefined
+                    ? ` (code: ${normalized.rawCode})`
+                    : ""}
+                </div>
+              </div>
+              {normalized.cause ? (
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-wide opacity-70">
+                    Cause
+                  </div>
+                  <div className="mt-1 break-all font-mono text-[11px] opacity-90">
+                    {normalized.cause.name}: {normalized.cause.message}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/ui/error-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui/error-card.tsx
@@ -9,7 +9,11 @@ import {
   RefreshCw,
   X,
 } from "lucide-react";
-import { describeError, type NormalizedError } from "@mcpjam/sdk/browser";
+import {
+  describeError,
+  isNormalizedError,
+  type NormalizedError,
+} from "@mcpjam/sdk/browser";
 import { cn } from "@/lib/utils";
 import { WebApiError } from "@/lib/apis/web/base";
 
@@ -49,26 +53,6 @@ export type ErrorCardProps = {
    */
   className?: string;
 };
-
-function isNormalizedError(value: unknown): value is NormalizedError {
-  // Require every field the render path dereferences. A partial payload
-  // (e.g. stale wire shape that omits docsAnchor/severity/rawMessage)
-  // must fall through to `describeError(input)`, which always produces a
-  // complete `NormalizedError` — otherwise the "Learn more" anchor or
-  // severity-based icon dereference would crash.
-  return (
-    !!value &&
-    typeof value === "object" &&
-    typeof (value as { slug?: unknown }).slug === "string" &&
-    typeof (value as { title?: unknown }).title === "string" &&
-    typeof (value as { oneLine?: unknown }).oneLine === "string" &&
-    typeof (value as { docsAnchor?: unknown }).docsAnchor === "string" &&
-    typeof (value as { severity?: unknown }).severity === "string" &&
-    typeof (value as { rawMessage?: unknown }).rawMessage === "string" &&
-    Array.isArray((value as { likelyCauses?: unknown }).likelyCauses) &&
-    Array.isArray((value as { nextSteps?: unknown }).nextSteps)
-  );
-}
 
 function resolveNormalized(input: unknown): NormalizedError {
   if (isNormalizedError(input)) return input;

--- a/mcpjam-inspector/client/src/components/ui/error-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui/error-card.tsx
@@ -72,7 +72,12 @@ function isNormalizedError(value: unknown): value is NormalizedError {
 
 function resolveNormalized(input: unknown): NormalizedError {
   if (isNormalizedError(input)) return input;
-  if (input instanceof WebApiError && input.normalized) {
+  // Re-validate the WebApiError-attached block with the same shape guard
+  // before trusting it. `webPost` populates `WebApiError.normalized` from
+  // any `typeof === "object"` value in the response body, so a partial
+  // payload (older server, future schema drift, proxy mangling) would
+  // otherwise crash the render at `docsAnchor.startsWith` / `severity`.
+  if (input instanceof WebApiError && isNormalizedError(input.normalized)) {
     return input.normalized;
   }
   return describeError(input);

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2053,6 +2053,8 @@ export function useServerState({
                 error:
                   connectionResult.error ||
                   "Connection test failed after OAuth",
+                normalized: (connectionResult as { normalized?: unknown })
+                  .normalized as any,
                 oauthTrace: result.oauthTrace,
               });
               logger.error("OAuth connection test failed", {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2564,6 +2564,11 @@ export function useServerState({
             type: "CONNECT_FAILURE",
             name: formData.name,
             error: result.error || "Connection test failed",
+            // Thread the backend-attached rich block through. Without this
+            // the reducer's auto-derive would re-classify from just the
+            // message string and lose the slug the backend already pinned
+            // (e.g. `transport/econnrefused` from a Node errno match).
+            ...(result.normalized ? { normalized: result.normalized } : {}),
           });
           logger.error("Connection failed", {
             serverName: formData.name,
@@ -3702,6 +3707,10 @@ export function useServerState({
           name: serverName,
           error: errorMessage,
           oauthTrace: authResult.oauthTrace,
+          // Preserve the backend-attached normalized block so the reducer
+          // doesn't have to re-derive a (less specific) slug from just
+          // the message string.
+          ...(result.normalized ? { normalized: result.normalized } : {}),
         });
         logger.error("Reconnection failed", { serverName, result });
         reportError(errorMessage || `Failed to reconnect: ${serverName}`);

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, type Dispatch } from "react";
 import { useConvex } from "convex/react";
 import { toast } from "sonner";
-import type { HttpServerConfig, MCPServerConfig } from "@mcpjam/sdk/browser";
+import type {
+  HttpServerConfig,
+  MCPServerConfig,
+  NormalizedError,
+} from "@mcpjam/sdk/browser";
 import { isKnownProtocolVersion } from "@mcpjam/sdk/browser";
 import type {
   AppAction,
@@ -1795,10 +1799,17 @@ export function useServerState({
             `Server does not speak the pinned MCP protocol version (${
               effective ?? "default"
             })`;
+          // Thread backend-attached normalized so the reducer doesn't
+          // re-derive a less-specific slug from just the message string.
+          const reTestNormalized = (result as { normalized?: unknown })
+            ?.normalized;
           dispatch({
             type: "CONNECT_FAILURE",
             name,
             error: errorMessage,
+            ...(reTestNormalized && typeof reTestNormalized === "object"
+              ? { normalized: reTestNormalized as NormalizedError }
+              : {}),
           });
         } catch (error) {
           if (isStaleOp(name, token)) return;
@@ -2811,10 +2822,21 @@ export function useServerState({
           await storeInitInfo(serverName, result.initInfo);
           return { success: true };
         }
+        // OAuth reconnect failure: preserve the backend-attached
+        // normalized block for the same reason as the other dispatch
+        // sites — the reducer's auto-derive only sees the message
+        // string and produces a less specific slug than the backend
+        // already pinned (e.g. via Node errno match).
+        const oauthReconnectNormalized = (result as { normalized?: unknown })
+          .normalized;
         dispatch({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: result.error || "Connection failed",
+          ...(oauthReconnectNormalized &&
+          typeof oauthReconnectNormalized === "object"
+            ? { normalized: oauthReconnectNormalized as NormalizedError }
+            : {}),
         });
         return { success: false, error: result.error };
       } catch (error) {

--- a/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
@@ -4,9 +4,14 @@ import type {
   ElicitResult,
   ListToolsResult,
 } from "@modelcontextprotocol/client";
-import type { MCPTask, TaskOptions } from "@mcpjam/sdk/browser";
+import type {
+  MCPTask,
+  NormalizedError,
+  TaskOptions,
+} from "@mcpjam/sdk/browser";
 import type { SerializedModelRequestTool } from "@/shared/model-request-payload";
 import { authFetch } from "@/lib/session-token";
+import { WebApiError } from "@/lib/apis/web/base";
 import { executeHostedTool, listHostedTools } from "@/lib/apis/web/tools-api";
 import { isHostedMode, runByMode } from "@/lib/apis/mode-client";
 
@@ -83,6 +88,12 @@ export type ToolExecutionResponse =
     }
   | {
       error: string;
+      /**
+       * When the error originated from a hosted route that carried a
+       * describe-error block, surface it so consumers can render an
+       * ErrorCard directly without re-classifying from `error`.
+       */
+      normalized?: NormalizedError;
     };
 
 export async function listTools({
@@ -141,7 +152,9 @@ export async function executeToolApi(
         })) as ToolExecutionResponse;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return { error: message };
+        const normalized =
+          error instanceof WebApiError ? error.normalized : undefined;
+        return { error: message, ...(normalized ? { normalized } : {}) };
       }
     },
     local: async () => {
@@ -155,9 +168,18 @@ export async function executeToolApi(
         body = await res.json();
       } catch {}
       if (!res.ok) {
-        // Surface server-provided error message if present
+        // Surface server-provided error message if present, plus the
+        // server-attached describe-error block if it came back (the
+        // jsonError helper in /api/mcp/tools/execute always populates it).
         const message = body?.error || `Execute tool failed (${res.status})`;
-        return { error: message } as ToolExecutionResponse;
+        const normalized =
+          body && typeof body.normalized === "object" && body.normalized
+            ? (body.normalized as NormalizedError)
+            : undefined;
+        return {
+          error: message,
+          ...(normalized ? { normalized } : {}),
+        } as ToolExecutionResponse;
       }
 
       // Server now returns { status: "task_created", task: { taskId, ... } } for task-augmented requests

--- a/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
@@ -128,7 +128,16 @@ export async function listTools({
       } catch {}
       if (!res.ok) {
         const message = body?.error || `List tools failed (${res.status})`;
-        throw new Error(message);
+        const code = typeof body?.code === "string" ? body.code : null;
+        // Preserve the backend-attached describer block. Throwing a plain
+        // `Error(message)` here used to strip `normalized`, forcing the UI
+        // catch to fall back to client-side classification from just the
+        // message string and producing a less specific ErrorCard.
+        const normalized =
+          body && typeof body.normalized === "object" && body.normalized
+            ? (body.normalized as NormalizedError)
+            : undefined;
+        throw new WebApiError(res.status, code, message, normalized);
       }
       return attachToolMetadata(body as ListToolsResultWithMetadata);
     },

--- a/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
@@ -9,6 +9,7 @@ import type {
   NormalizedError,
   TaskOptions,
 } from "@mcpjam/sdk/browser";
+import { isNormalizedError } from "@mcpjam/sdk/browser";
 import type { SerializedModelRequestTool } from "@/shared/model-request-payload";
 import { authFetch } from "@/lib/session-token";
 import { WebApiError } from "@/lib/apis/web/base";
@@ -161,8 +162,15 @@ export async function executeToolApi(
         })) as ToolExecutionResponse;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        // Validate the WebApiError-attached block with the shared SDK
+        // shape guard before forwarding it. Without this a partial
+        // payload (older server, schema drift, proxy mangling) would
+        // reach ResultsPanel as `normalizedError` and shadow the real
+        // `error` string at render (renderer prefers normalizedError).
         const normalized =
-          error instanceof WebApiError ? error.normalized : undefined;
+          error instanceof WebApiError && isNormalizedError(error.normalized)
+            ? error.normalized
+            : undefined;
         return { error: message, ...(normalized ? { normalized } : {}) };
       }
     },
@@ -181,10 +189,11 @@ export async function executeToolApi(
         // server-attached describe-error block if it came back (the
         // jsonError helper in /api/mcp/tools/execute always populates it).
         const message = body?.error || `Execute tool failed (${res.status})`;
-        const normalized =
-          body && typeof body.normalized === "object" && body.normalized
-            ? (body.normalized as NormalizedError)
-            : undefined;
+        // Shape-validate before forwarding — same rationale as the
+        // hosted catch above. Bare `typeof === "object"` is not enough.
+        const normalized = isNormalizedError(body?.normalized)
+          ? (body.normalized as NormalizedError)
+          : undefined;
         return {
           error: message,
           ...(normalized ? { normalized } : {}),

--- a/mcpjam-inspector/client/src/lib/apis/web/base.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/base.ts
@@ -1,3 +1,4 @@
+import type { NormalizedError } from "@mcpjam/sdk/browser";
 import { authFetch } from "@/lib/session-token";
 import { stripHostedRpcLogs } from "./rpc-logs";
 import { ingestHostedRpcLogs } from "@/stores/traffic-log-store";
@@ -5,12 +6,25 @@ import { ingestHostedRpcLogs } from "@/stores/traffic-log-store";
 export class WebApiError extends Error {
   code: string | null;
   status: number;
+  /**
+   * Server-attached describe-error block. Populated from the JSON error
+   * body's `normalized` field when present. Always optional — older
+   * servers / non-describer routes simply omit it and the ErrorCard
+   * falls back to `describeError(this)` on its own.
+   */
+  normalized?: NormalizedError;
 
-  constructor(status: number, code: string | null, message: string) {
+  constructor(
+    status: number,
+    code: string | null,
+    message: string,
+    normalized?: NormalizedError,
+  ) {
     super(message);
     this.name = "WebApiError";
     this.status = status;
     this.code = code;
+    this.normalized = normalized;
   }
 }
 
@@ -48,7 +62,11 @@ export async function webPost<TRequest, TResponse>(
         : typeof errBody?.error === "string"
           ? errBody.error
           : `Request failed (${response.status})`;
-    throw new WebApiError(response.status, code, message);
+    const normalized =
+      errBody && typeof errBody.normalized === "object" && errBody.normalized
+        ? (errBody.normalized as NormalizedError)
+        : undefined;
+    throw new WebApiError(response.status, code, message, normalized);
   }
 
   return sanitizedPayload as TResponse;

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -5,6 +5,26 @@ import {
   ServerWithName,
 } from "./app-types";
 import type { ProjectClientConfig } from "@/lib/client-config";
+import { describeError, type NormalizedError } from "@mcpjam/sdk/browser";
+
+/**
+ * Helper used by failure-path reducer branches: when the dispatcher
+ * supplied a richer `normalized` block (e.g. forwarded from a
+ * `WebApiError` or hosted-route envelope) use it; otherwise derive one
+ * from the message string so every failure-path writer ends up with a
+ * usable `lastNormalizedError` for the ErrorCard renderer.
+ *
+ * Returning `undefined` for empty messages keeps the reducer free of
+ * synthetic "unknown error" entries that would obscure healthy state.
+ */
+function resolveNormalized(
+  message: string | undefined,
+  normalized: NormalizedError | undefined,
+): NormalizedError | undefined {
+  if (normalized) return normalized;
+  if (!message) return undefined;
+  return describeError(new Error(message));
+}
 
 const setStatus = (
   server: ServerWithName,
@@ -94,6 +114,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         lastConnectionTime: new Date(),
         retryCount: 0,
         lastError: undefined,
+        lastNormalizedError: undefined,
         lastOAuthTrace: action.oauthTrace,
         oauthTokens: action.tokens,
         enabled: true,
@@ -134,6 +155,10 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           [action.name]: setStatus(existing, "failed", {
             retryCount: existing.retryCount,
             lastError: action.error,
+            lastNormalizedError: resolveNormalized(
+              action.error,
+              action.normalized,
+            ),
             lastOAuthTrace: action.oauthTrace,
           }),
         },
@@ -184,6 +209,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           [action.name]: setStatus(existing, "disconnected", {
             enabled: false,
             lastError: action.error ?? existing.lastError,
+            lastNormalizedError: action.error
+              ? resolveNormalized(action.error, action.normalized)
+              : existing.lastNormalizedError,
           }),
         },
         selectedServer: nextSelected,

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -5,7 +5,11 @@ import {
   ServerWithName,
 } from "./app-types";
 import type { ProjectClientConfig } from "@/lib/client-config";
-import { describeError, type NormalizedError } from "@mcpjam/sdk/browser";
+import {
+  describeError,
+  isNormalizedError,
+  type NormalizedError,
+} from "@mcpjam/sdk/browser";
 
 /**
  * Helper used by failure-path reducer branches: when the dispatcher
@@ -14,6 +18,14 @@ import { describeError, type NormalizedError } from "@mcpjam/sdk/browser";
  * from the message string so every failure-path writer ends up with a
  * usable `lastNormalizedError` for the ErrorCard renderer.
  *
+ * Re-validates the incoming `normalized` shape — `webPost` populates it
+ * from any object in the response body, so a partial payload (older
+ * server, schema drift, proxy mangling) would otherwise be stored and
+ * later shadow the real message at the renderer (which prefers
+ * `lastNormalizedError` over `lastError`). Invalid shapes fall through
+ * to the message-string derivation, which always produces a complete
+ * block via `describeError`.
+ *
  * Returning `undefined` for empty messages keeps the reducer free of
  * synthetic "unknown error" entries that would obscure healthy state.
  */
@@ -21,7 +33,7 @@ function resolveNormalized(
   message: string | undefined,
   normalized: NormalizedError | undefined,
 ): NormalizedError | undefined {
-  if (normalized) return normalized;
+  if (isNormalizedError(normalized)) return normalized;
   if (!message) return undefined;
   return describeError(new Error(message));
 }

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -1,4 +1,4 @@
-import type { MCPServerConfig } from "@mcpjam/sdk/browser";
+import type { MCPServerConfig, NormalizedError } from "@mcpjam/sdk/browser";
 import { OauthTokens } from "@/shared/types.js";
 import type { OAuthTestProfile } from "@/lib/oauth/profile";
 import type {
@@ -45,6 +45,13 @@ export interface ServerWithName {
   connectionStatus: ConnectionStatus;
   retryCount: number;
   lastError?: string;
+  /**
+   * Rich describe-error block for the last connection failure. Populated
+   * alongside `lastError` whenever the source carried a `normalized`
+   * payload. `lastError` is kept as a back-compat string field — readers
+   * should prefer `lastNormalizedError` and fall back to `lastError`.
+   */
+  lastNormalizedError?: NormalizedError;
   lastOAuthTrace?: OAuthTrace;
   enabled?: boolean;
   /** Whether OAuth is explicitly enabled for this server. When false, reconnect skips OAuth flow. */
@@ -115,6 +122,12 @@ export type AppAction =
       type: "CONNECT_FAILURE";
       name: string;
       error: string;
+      /**
+       * Optional rich describe-error block. Forwarded onto
+       * `ServerWithName.lastNormalizedError` so the ErrorCard renders
+       * without re-classifying from `error`.
+       */
+      normalized?: NormalizedError;
       oauthTrace?: OAuthTrace;
     }
   | {
@@ -123,7 +136,12 @@ export type AppAction =
       config: MCPServerConfig;
       select?: boolean;
     }
-  | { type: "DISCONNECT"; name: string; error?: string }
+  | {
+      type: "DISCONNECT";
+      name: string;
+      error?: string;
+      normalized?: NormalizedError;
+    }
   | { type: "REMOVE_SERVER"; name: string }
   | { type: "SYNC_AGENT_STATUS"; servers: AgentServerInfo[] }
   | { type: "SELECT_SERVER"; name: string }

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -1,7 +1,12 @@
-import type { HttpServerConfig, MCPServerConfig } from "@mcpjam/sdk/browser";
+import type {
+  HttpServerConfig,
+  MCPServerConfig,
+  NormalizedError,
+} from "@mcpjam/sdk/browser";
 import type { LoggingLevel } from "@modelcontextprotocol/client";
 import { authFetch } from "@/lib/session-token";
 import { HOSTED_MODE } from "@/lib/config";
+import { WebApiError } from "@/lib/apis/web/base";
 import {
   validateHostedServer,
   type HostedServerValidateContext,
@@ -102,7 +107,12 @@ async function safeValidateHostedServer(
   serverId: string,
   serverConfig: MCPServerConfig,
   hostedContext?: HostedServerValidateContext,
-): Promise<HostedServerValidateResponse & { error?: string }> {
+): Promise<
+  HostedServerValidateResponse & {
+    error?: string;
+    normalized?: NormalizedError;
+  }
+> {
   try {
     const oauthToken =
       extractOAuthToken(serverConfig) ?? getHostedOAuthToken(serverId);
@@ -116,9 +126,16 @@ async function safeValidateHostedServer(
       HOSTED_VALIDATE_TIMEOUT_MS,
     );
   } catch (error) {
+    // Preserve the server-attached `normalized` block when the wrapped
+    // error is a WebApiError. The string form (kept for back-compat) is
+    // populated from the existing normalizer; the rich block flows to
+    // the ErrorCard via `lastNormalizedError` on the server reducer.
+    const normalized =
+      error instanceof WebApiError ? error.normalized : undefined;
     return {
       success: false,
       error: normalizeHostedValidationError(error),
+      ...(normalized ? { normalized } : {}),
     };
   }
 }

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -757,12 +757,19 @@ describe("POST /api/mcp/chat-v2", () => {
       );
     });
 
-    it("passes through regular Error messages", async () => {
+    it("passes through regular Error messages with a normalized block", async () => {
       const onError = await getOnError("openai");
       const error = new Error("Network connection failed");
 
-      const result = onError(error);
-      expect(result).toBe("Network connection failed");
+      // formatStreamError now always returns a JSON envelope so the client
+      // can render an ErrorCard for unclassified provider failures. The
+      // human message is preserved on `message`; `normalized` carries the
+      // catalog data.
+      const result = JSON.parse(onError(error));
+      expect(result.message).toBe("Network connection failed");
+      expect(result.normalized).toBeDefined();
+      expect(typeof result.normalized.slug).toBe("string");
+      expect(typeof result.normalized.title).toBe("string");
     });
 
     it("normalizes retry-exhausted provider overload errors", async () => {

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -77,6 +77,7 @@ import {
   formatProviderOverloadError,
   isProviderOverloadError,
 } from "../../utils/provider-error-normalization";
+import { describeError } from "@mcpjam/sdk";
 import {
   mergeLiveChatTraceUsage,
   type LiveChatTraceUsage,
@@ -94,6 +95,11 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
   if (!(error instanceof Error)) {
     return String(error);
   }
+
+  // Run the cross-stack describer first so every stream-error branch can
+  // attach a `normalized` block — clients pull this out for ErrorCard
+  // rendering without re-classifying from the raw message.
+  const normalized = describeError(error);
 
   // Duck-type statusCode/responseBody — APICallError.isInstance() can fail
   // when multiple copies of @ai-sdk/provider are bundled (symbol mismatch).
@@ -131,6 +137,7 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
       code: "auth_error",
       message: `Invalid API key for ${providerName}. Please check your key under LLM Providers in Settings.`,
       statusCode,
+      normalized,
     });
   }
 
@@ -139,10 +146,16 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
     return JSON.stringify({
       message: error.message,
       details: responseBody,
+      normalized,
     });
   }
 
-  return error.message;
+  // Even bare-message branches surface the normalized block so clients can
+  // render an ErrorCard for unclassified provider failures.
+  return JSON.stringify({
+    message: error.message,
+    normalized,
+  });
 }
 
 function toLiveChatTraceUsage(

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -77,7 +77,7 @@ import {
   formatProviderOverloadError,
   isProviderOverloadError,
 } from "../../utils/provider-error-normalization";
-import { describeError } from "@mcpjam/sdk";
+import { describeError, describeAsSlug } from "@mcpjam/sdk";
 import {
   mergeLiveChatTraceUsage,
   type LiveChatTraceUsage,
@@ -132,12 +132,16 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
 
   if (isAuthStatus || isAuthBody) {
     const providerName = provider || "your AI provider";
+    // The generic describer would tag this as `auth/http_401` (MCP server
+    // re-auth). We have provider context the describer doesn't, so override
+    // the slug to point at LLM-provider-key guidance + docs anchor.
+    const providerNormalized = describeAsSlug("provider/auth_error", error);
 
     return JSON.stringify({
       code: "auth_error",
       message: `Invalid API key for ${providerName}. Please check your key under LLM Providers in Settings.`,
       statusCode,
-      normalized,
+      normalized: providerNormalized,
     });
   }
 

--- a/mcpjam-inspector/server/routes/mcp/tools.ts
+++ b/mcpjam-inspector/server/routes/mcp/tools.ts
@@ -6,6 +6,7 @@ import type {
 } from "@modelcontextprotocol/client";
 import "../../types/hono"; // Type extensions
 import { listTools as listToolsShared } from "../../utils/route-handlers.js";
+import { describeError } from "@mcpjam/sdk";
 
 const tools = new Hono();
 
@@ -117,8 +118,9 @@ function jsonError(c: any, error: unknown, fallbackStatus = 500) {
     typeof (error as any)?.status === "number"
       ? (error as any).status
       : fallbackStatus;
+  const normalized = describeError(error);
   return c.json(
-    { error: details.message as string, mcpError: details },
+    { error: details.message as string, mcpError: details, normalized },
     status,
   );
 }

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { describeError, type NormalizedError } from "@mcpjam/sdk";
 
 export const ErrorCode = {
   UNAUTHORIZED: "UNAUTHORIZED",
@@ -18,17 +19,25 @@ export class WebRouteError extends Error {
   status: number;
   code: ErrorCode;
   details?: Record<string, unknown>;
+  /**
+   * Optional normalized describe-error block. When present, `webError`
+   * forwards it onto the JSON response body so the client can render a
+   * rich ErrorCard without re-classifying from the raw message.
+   */
+  normalized?: NormalizedError;
 
   constructor(
     status: number,
     code: ErrorCode,
     message: string,
-    details?: Record<string, unknown>
+    details?: Record<string, unknown>,
+    normalized?: NormalizedError
   ) {
     super(message);
     this.status = status;
     this.code = code;
     this.details = details;
+    this.normalized = normalized;
   }
 }
 
@@ -40,12 +49,20 @@ export function webError(
   details?: Record<string, unknown>,
   extras?: Record<string, unknown>
 ) {
+  // `extras` is permissive (rpc-log collectors, etc.). If it carries a
+  // `normalized` key, hoist it to the top-level response body — clients
+  // pluck the rich block off the JSON envelope without re-classifying.
+  const { normalized, ...restExtras } = (extras ?? {}) as Record<
+    string,
+    unknown
+  > & { normalized?: NormalizedError };
   return c.json(
     {
-      ...(extras ?? {}),
+      ...restExtras,
       code,
       message,
       ...(details ? { details } : {}),
+      ...(normalized ? { normalized } : {}),
     },
     status
   );
@@ -77,20 +94,41 @@ const CONNECTION_ERROR_PATTERNS: readonly RegExp[] = [
 ];
 
 export function mapRuntimeError(error: unknown): WebRouteError {
-  if (error instanceof WebRouteError) return error;
+  if (error instanceof WebRouteError) {
+    // Backfill normalized on existing WebRouteErrors so onError forwarding
+    // always has a rich block, even when the throwing site predates the
+    // describer wiring.
+    if (!error.normalized) {
+      error.normalized = describeError(error);
+    }
+    return error;
+  }
 
   const message = parseErrorMessage(error);
   const lower = message.toLowerCase();
+  const normalized = describeError(error);
 
   if (lower.includes("timed out") || lower.includes("timeout")) {
-    return new WebRouteError(504, ErrorCode.TIMEOUT, message);
+    return new WebRouteError(504, ErrorCode.TIMEOUT, message, undefined, normalized);
   }
 
   if (CONNECTION_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
-    return new WebRouteError(502, ErrorCode.SERVER_UNREACHABLE, message);
+    return new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      message,
+      undefined,
+      normalized
+    );
   }
 
-  return new WebRouteError(500, ErrorCode.INTERNAL_ERROR, message);
+  return new WebRouteError(
+    500,
+    ErrorCode.INTERNAL_ERROR,
+    message,
+    undefined,
+    normalized
+  );
 }
 
 export function assertBearerToken(c: any): string {

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -79,7 +79,14 @@ web.get("/guest-jwks", async (c) => {
 
 web.onError((error, c) => {
   const routeError = mapRuntimeError(error);
-  return webError(c, routeError.status, routeError.code, routeError.message);
+  return webError(
+    c,
+    routeError.status,
+    routeError.code,
+    routeError.message,
+    routeError.details,
+    routeError.normalized ? { normalized: routeError.normalized } : undefined,
+  );
 });
 
 export default web;

--- a/mcpjam-inspector/server/services/mcp-http-bridge.ts
+++ b/mcpjam-inspector/server/services/mcp-http-bridge.ts
@@ -1,4 +1,4 @@
-import { MCPClientManager } from "@mcpjam/sdk";
+import { MCPClientManager, describeError } from "@mcpjam/sdk";
 import { z } from "zod";
 
 // Unify JSON-RPC handling used by adapter-http and manager-http routes
@@ -137,7 +137,11 @@ export async function handleJsonRpc(
             return respond({ result });
           }
           return respond({
-            error: { code: -32000, message: e?.message || String(e) },
+            error: {
+              code: -32000,
+              message: e?.message || String(e),
+              data: { normalized: describeError(e) },
+            },
           });
         }
       }
@@ -181,7 +185,11 @@ export async function handleJsonRpc(
           return respond({ result: resource });
         } catch (e: any) {
           return respond({
-            error: { code: -32000, message: e?.message || String(e) },
+            error: {
+              code: -32000,
+              message: e?.message || String(e),
+              data: { normalized: describeError(e) },
+            },
           });
         }
       }
@@ -220,7 +228,11 @@ export async function handleJsonRpc(
           return respond({ result: prompt });
         } catch (e: any) {
           return respond({
-            error: { code: -32000, message: e?.message || String(e) },
+            error: {
+              code: -32000,
+              message: e?.message || String(e),
+              data: { normalized: describeError(e) },
+            },
           });
         }
       }
@@ -231,14 +243,23 @@ export async function handleJsonRpc(
         return respond({ result: { success: true } });
       }
       default: {
+        const notImpl = new Error(`Method not implemented: ${method}`);
         return respond({
-          error: { code: -32601, message: `Method not implemented: ${method}` },
+          error: {
+            code: -32601,
+            message: notImpl.message,
+            data: { normalized: describeError(notImpl) },
+          },
         });
       }
     }
   } catch (e: any) {
     return respond({
-      error: { code: -32000, message: e?.message || String(e) },
+      error: {
+        code: -32000,
+        message: e?.message || String(e),
+        data: { normalized: describeError(e) },
+      },
     });
   }
 }

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -1,6 +1,10 @@
 import type { Context } from "hono";
 import type { MCPClientManager, MCPServerConfig } from "@mcpjam/sdk";
-import { isKnownProtocolVersion, type McpProtocolVersion } from "@mcpjam/sdk";
+import {
+  describeError,
+  isKnownProtocolVersion,
+  type McpProtocolVersion,
+} from "@mcpjam/sdk";
 import {
   ErrorCode,
   WebRouteError,
@@ -759,11 +763,13 @@ export function respondWithLocalRouteError(c: Context, error: WebRouteError) {
   if (error.details?.oauthRequired === true) {
     c.header("X-MCP-Auth-Required", "oauth");
   }
+  const normalized = error.normalized ?? describeError(error);
   return c.json(
     {
       success: false,
       error: error.message,
       ...(error.details ?? {}),
+      normalized,
     },
     error.status as any
   );
@@ -834,6 +840,7 @@ export async function executeLocalServerConnect(
         success: false,
         error: "Failed to resolve server config",
         details: error instanceof Error ? error.message : "Unknown error",
+        normalized: describeError(error),
       },
       500
     );
@@ -877,6 +884,7 @@ export async function executeLocalServerConnect(
           error instanceof Error ? error.message : "Unknown error"
         }`,
         details: error instanceof Error ? error.message : "Unknown error",
+        normalized: describeError(error),
       },
       500
     );

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -19,6 +19,7 @@ export { redactSensitiveValue } from "./redaction.js";
 // to avoid pulling Node-only deps via root `@mcpjam/sdk`.
 export {
   describeError,
+  describeAsSlug,
   ERROR_CATALOG,
   extractNodeErrno,
   RETRYABLE_NODE_ERROR_CODES,

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -14,6 +14,21 @@ export {
 } from "./mcp-client-manager/capabilities.js";
 export { redactSensitiveValue } from "./redaction.js";
 
+// Error describer — pure, browser-safe. Same module exported from the
+// root entrypoint; client code MUST import from this `/browser` subpath
+// to avoid pulling Node-only deps via root `@mcpjam/sdk`.
+export {
+  describeError,
+  ERROR_CATALOG,
+  extractNodeErrno,
+  RETRYABLE_NODE_ERROR_CODES,
+} from "./error-describer/index.js";
+export type {
+  NormalizedError,
+  ErrorCatalogEntry,
+  ErrorCatalogSlug,
+} from "./error-describer/index.js";
+
 export type {
   BaseServerConfig,
   HttpServerConfig,

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -20,6 +20,7 @@ export { redactSensitiveValue } from "./redaction.js";
 export {
   describeError,
   describeAsSlug,
+  isNormalizedError,
   ERROR_CATALOG,
   extractNodeErrno,
   RETRYABLE_NODE_ERROR_CODES,

--- a/sdk/src/error-describer/catalog.ts
+++ b/sdk/src/error-describer/catalog.ts
@@ -1,0 +1,540 @@
+/**
+ * Error catalog: one entry per known error class. The single source of
+ * truth for friendly title, one-line explanation, likely causes, next
+ * steps, and the docs anchor every renderer deep-links to.
+ *
+ * Slugs are stable strings. Once published in the docs anchor URL they
+ * should not change — adding a new slug is fine; renaming an existing
+ * one is a docs-breaking change.
+ */
+
+export type ErrorCatalogEntry = {
+  slug: string; // e.g. "jsonrpc/connection_closed"
+  title: string;
+  oneLine: string;
+  likelyCauses: string[];
+  nextSteps: string[];
+  /**
+   * Path on the docs site (`docs.mcpjam.com`) that this entry deep-links
+   * to. Anchor matches a `<h3>` in `/troubleshooting/error-codes`.
+   */
+  docsAnchor: string;
+  severity: "info" | "warning" | "error";
+};
+
+const DOCS_BASE = "/troubleshooting/error-codes";
+
+function entry(
+  slug: string,
+  title: string,
+  oneLine: string,
+  likelyCauses: string[],
+  nextSteps: string[],
+  anchor: string,
+  severity: ErrorCatalogEntry["severity"] = "error",
+): ErrorCatalogEntry {
+  return {
+    slug,
+    title,
+    oneLine,
+    likelyCauses,
+    nextSteps,
+    docsAnchor: `${DOCS_BASE}#${anchor}`,
+    severity,
+  };
+}
+
+export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
+  // --- JSON-RPC (spec) ---
+  "jsonrpc/parse_error": entry(
+    "jsonrpc/parse_error",
+    "Parse error (-32700)",
+    "The server returned a payload the client could not parse as JSON-RPC.",
+    [
+      "Server emitted invalid JSON on the response channel.",
+      "A proxy or middleware mangled the response body.",
+      "Server emitted log output on stdout instead of stderr (STDIO transport).",
+    ],
+    [
+      "Check the server's stdout/stderr for unintended log output.",
+      "Use the inspector's Traffic Log to inspect the raw response.",
+    ],
+    "parse-error",
+  ),
+  "jsonrpc/invalid_request": entry(
+    "jsonrpc/invalid_request",
+    "Invalid request (-32600)",
+    "The server rejected the payload as not a well-formed JSON-RPC request.",
+    [
+      "Client sent a request shape the server's MCP runtime does not accept.",
+      "Outdated server SDK that disagrees with the protocol version advertised.",
+    ],
+    [
+      "Verify the negotiated MCP protocol version.",
+      "Update the server's MCP SDK.",
+    ],
+    "invalid-request",
+  ),
+  "jsonrpc/method_not_found": entry(
+    "jsonrpc/method_not_found",
+    "Method not found (-32601)",
+    "The server does not implement the JSON-RPC method that was called.",
+    [
+      "The server hasn't implemented the requested MCP method.",
+      "Client and server are on incompatible MCP protocol versions.",
+      "The capability you expected was not advertised in `initialize`.",
+    ],
+    [
+      "Check the server's advertised capabilities in the connection info.",
+      "Confirm the protocol version negotiated at `initialize`.",
+    ],
+    "method-not-found",
+  ),
+  "jsonrpc/invalid_params": entry(
+    "jsonrpc/invalid_params",
+    "Invalid params (-32602)",
+    "The server rejected the request parameters.",
+    [
+      "Required field is missing from the call.",
+      "Field type does not match the tool's input schema.",
+      "Server-side validator is stricter than the published schema.",
+    ],
+    [
+      "Re-check the tool's input schema in the Tools tab.",
+      "Compare your call payload against the schema in the inspector.",
+    ],
+    "invalid-params",
+  ),
+  "jsonrpc/internal_error": entry(
+    "jsonrpc/internal_error",
+    "Internal error (-32603)",
+    "The server hit an unexpected error while handling the request.",
+    [
+      "Unhandled exception inside the server's tool/resource/prompt handler.",
+      "Downstream dependency (database, API) failed during the call.",
+    ],
+    [
+      "Check the server's logs around the time of the error.",
+      "Retry the request once the server is healthy.",
+    ],
+    "internal-error",
+  ),
+  "jsonrpc/connection_closed": entry(
+    "jsonrpc/connection_closed",
+    "Connection closed (-32000)",
+    "The underlying transport closed before the response could be delivered.",
+    [
+      "STDIO server process exited or crashed mid-request.",
+      "HTTP server dropped the streaming connection.",
+      "Network blip between the inspector and the server.",
+    ],
+    [
+      "Restart the server and reconnect.",
+      "Check the server logs for a crash or exit message.",
+    ],
+    "connection-closed",
+  ),
+  "jsonrpc/request_timeout": entry(
+    "jsonrpc/request_timeout",
+    "Request timed out (-32001)",
+    "The server did not respond within the configured request timeout.",
+    [
+      "Server is overloaded or stuck on the operation.",
+      "Long-running tool call exceeds the inspector's per-request timeout.",
+      "Network latency between client and server.",
+    ],
+    [
+      "Increase the per-server request timeout in the Servers tab.",
+      "Use MCP `tasks/*` for operations that legitimately run long.",
+    ],
+    "request-timeout",
+  ),
+  "jsonrpc/header_mismatch": entry(
+    "jsonrpc/header_mismatch",
+    "Protocol header mismatch (-32001)",
+    "The server returned an `MCP-Protocol-Version` header that does not match what the client negotiated.",
+    [
+      "Server is enforcing a different protocol version than the one negotiated at `initialize`.",
+      "A proxy stripped or rewrote the `MCP-Protocol-Version` header.",
+    ],
+    [
+      "Verify the server's protocol-version pinning in the connection settings.",
+      "If you set an explicit protocol version per server, ensure it matches what the server advertises.",
+    ],
+    "header-mismatch",
+  ),
+  "jsonrpc/unsupported_protocol_version": entry(
+    "jsonrpc/unsupported_protocol_version",
+    "Unsupported protocol version (-32004)",
+    "The server does not support any protocol version this inspector offered.",
+    [
+      "Server pinned to a newer MCP draft your inspector build does not understand.",
+      "Server pinned to a legacy version this build dropped support for.",
+    ],
+    [
+      "Update the inspector to a newer build.",
+      "Check the supported versions list in the server's `initialize` response.",
+    ],
+    "unsupported-protocol-version",
+  ),
+  "jsonrpc/url_elicitation_required": entry(
+    "jsonrpc/url_elicitation_required",
+    "URL elicitation required (-32042)",
+    "The server needs the user to visit an external URL to complete the operation.",
+    [
+      "Server requested a URL elicitation (OAuth, payment, confirmation).",
+      "Operation cannot proceed until the user opens the URL in a browser.",
+    ],
+    [
+      "Open the elicited URL and complete the flow.",
+      "Re-issue the request after the external step completes.",
+    ],
+    "url-elicitation-required",
+    "warning",
+  ),
+
+  // --- Transport (Node errno + fetch) ---
+  "transport/econnrefused": entry(
+    "transport/econnrefused",
+    "Connection refused",
+    "Nothing is listening on the host and port the server URL points at.",
+    [
+      "Server isn't running.",
+      "Port number is wrong in the server URL.",
+      "Server is bound to a different interface (e.g. only `127.0.0.1` but you're connecting via the LAN IP).",
+    ],
+    [
+      "Start the server.",
+      "Double-check the URL's host and port.",
+      "For Docker/containers, confirm the port is published to your host.",
+    ],
+    "econnrefused",
+  ),
+  "transport/econnreset": entry(
+    "transport/econnreset",
+    "Connection reset",
+    "The remote side closed the TCP connection abruptly.",
+    [
+      "Server process crashed mid-request.",
+      "Intermediate proxy or load balancer dropped the connection.",
+      "Server hit an OS-level resource limit.",
+    ],
+    [
+      "Inspect the server logs for a crash.",
+      "Retry the request.",
+    ],
+    "econnreset",
+  ),
+  "transport/etimedout": entry(
+    "transport/etimedout",
+    "Connection timed out",
+    "The OS-level TCP connection attempt did not complete in time.",
+    [
+      "Wrong host/port in the server URL.",
+      "Firewall is silently dropping packets.",
+      "Server is overloaded and never accepted the connection.",
+    ],
+    [
+      "Verify the URL is reachable from your machine (e.g. `curl`).",
+      "Check firewall / VPN rules.",
+    ],
+    "etimedout",
+  ),
+  "transport/enotfound": entry(
+    "transport/enotfound",
+    "Host not found",
+    "DNS lookup failed for the server's hostname.",
+    [
+      "Hostname is misspelled in the URL.",
+      "DNS resolver is misconfigured.",
+      "You're offline.",
+    ],
+    [
+      "Confirm the hostname in the URL is correct.",
+      "Try resolving the host with `nslookup` or `dig`.",
+    ],
+    "enotfound",
+  ),
+  "transport/eai_again": entry(
+    "transport/eai_again",
+    "Temporary DNS failure",
+    "DNS resolution failed with a transient error.",
+    [
+      "Local DNS resolver is overloaded or restarting.",
+      "Upstream DNS server is briefly unavailable.",
+    ],
+    [
+      "Wait a few seconds and retry.",
+      "Switch to a different DNS resolver if this persists.",
+    ],
+    "eai-again",
+    "warning",
+  ),
+  "transport/undici": entry(
+    "transport/undici",
+    "HTTP transport error",
+    "The underlying HTTP client (undici / fetch) reported a low-level transport failure.",
+    [
+      "Server closed the connection mid-response.",
+      "TLS handshake failed.",
+      "Socket-level error during streaming.",
+    ],
+    [
+      "Inspect the Traffic Log for the failed request.",
+      "Verify the server's TLS certificate is valid.",
+    ],
+    "undici-transport-error",
+  ),
+  "transport/fetch_failed": entry(
+    "transport/fetch_failed",
+    "Fetch failed",
+    "The HTTP request never produced a response.",
+    [
+      "Server is unreachable (offline, wrong URL, blocked by firewall).",
+      "TLS handshake failed (self-signed cert, expired cert).",
+      "Mixed-content block (HTTPS page calling HTTP endpoint in browser).",
+    ],
+    [
+      "Open the URL in a browser to confirm it loads.",
+      "If self-signed, install the certificate or switch to a trusted one.",
+    ],
+    "fetch-failed",
+  ),
+  "transport/socket_hang_up": entry(
+    "transport/socket_hang_up",
+    "Socket hang up",
+    "The server closed the connection without sending a response.",
+    [
+      "Server crashed or restarted during the request.",
+      "Reverse proxy timed the request out.",
+    ],
+    [
+      "Retry the request.",
+      "Check server-side logs for the crash.",
+    ],
+    "socket-hang-up",
+  ),
+
+  // --- Auth ---
+  "auth/http_401": entry(
+    "auth/http_401",
+    "Unauthorized (401)",
+    "The server requires authentication that wasn't provided or is no longer valid.",
+    [
+      "Missing or expired bearer token.",
+      "OAuth access token expired and refresh failed.",
+      "Server changed its required authentication scheme.",
+    ],
+    [
+      "Re-authenticate using the Reconnect button on the server card.",
+      "If using OAuth, run through the OAuth flow again from Servers.",
+    ],
+    "unauthorized-401",
+  ),
+  "auth/http_403": entry(
+    "auth/http_403",
+    "Forbidden (403)",
+    "You authenticated successfully but lack permission for the operation.",
+    [
+      "OAuth scopes granted don't cover the requested operation.",
+      "Server-side ACL blocks this account.",
+    ],
+    [
+      "Re-run OAuth and request the additional scopes if the server allows.",
+      "Ask the server admin to grant the necessary permissions.",
+    ],
+    "forbidden-403",
+  ),
+  "auth/oauth_refresh_failed": entry(
+    "auth/oauth_refresh_failed",
+    "OAuth token refresh failed",
+    "An expired OAuth access token could not be refreshed.",
+    [
+      "Refresh token was revoked.",
+      "Refresh token expired.",
+      "Server returned `invalid_grant` to the refresh attempt.",
+    ],
+    [
+      "Click Reconnect on the server card to run a fresh OAuth flow.",
+    ],
+    "oauth-refresh-failed",
+  ),
+  "auth/missing_bearer": entry(
+    "auth/missing_bearer",
+    "Missing bearer token",
+    "The API call did not include the required `Authorization: Bearer ...` header.",
+    [
+      "Inspector session expired.",
+      "Sign-in token failed to attach to the request.",
+    ],
+    [
+      "Refresh the page and sign in again.",
+    ],
+    "missing-bearer",
+  ),
+
+  // --- OAuth ---
+  "oauth/invalid_grant": entry(
+    "oauth/invalid_grant",
+    "OAuth: invalid grant",
+    "The OAuth server rejected the authorization code or refresh token.",
+    [
+      "Authorization code was already redeemed.",
+      "Refresh token was revoked.",
+      "Authorization code expired (typical lifetime ~60s).",
+    ],
+    [
+      "Start the OAuth flow again from the server card.",
+    ],
+    "oauth-invalid-grant",
+  ),
+  "oauth/invalid_client": entry(
+    "oauth/invalid_client",
+    "OAuth: invalid client",
+    "The OAuth server does not recognize the client credentials.",
+    [
+      "Client was deleted on the authorization server.",
+      "Dynamic registration cache is stale.",
+      "`client_id` was rotated server-side.",
+    ],
+    [
+      "Re-register the client (Reconnect from the server card triggers DCR if supported).",
+    ],
+    "oauth-invalid-client",
+  ),
+  "oauth/redirect_mismatch": entry(
+    "oauth/redirect_mismatch",
+    "OAuth: redirect URI mismatch",
+    "The redirect URI in the request does not match the one registered with the OAuth server.",
+    [
+      "Authorization server requires the inspector's callback URL to be registered explicitly.",
+      "Server's allow-list is wrong.",
+    ],
+    [
+      "Add the inspector's callback URL to the OAuth server's allowed redirects.",
+      "Verify the inspector's base URL hasn't changed.",
+    ],
+    "oauth-redirect-mismatch",
+  ),
+  "oauth/well_known_unreachable": entry(
+    "oauth/well_known_unreachable",
+    "OAuth metadata unreachable",
+    "The OAuth `.well-known` discovery endpoint could not be fetched.",
+    [
+      "Authorization server is down.",
+      "Wrong issuer URL.",
+      "CORS blocks the discovery request from the browser.",
+    ],
+    [
+      "Confirm the issuer URL in the server config.",
+      "Open the `.well-known/openid-configuration` (or `oauth-authorization-server`) URL in a browser.",
+    ],
+    "oauth-well-known-unreachable",
+  ),
+
+  // --- Inspector sentinels (SDK-specific) ---
+  "sdk/not_yet_supported_in_stateless": entry(
+    "sdk/not_yet_supported_in_stateless",
+    "Operation not supported on stateless transport",
+    "The inspector's stateless HTTP transport does not yet implement this MCP operation.",
+    [
+      "Operation requires a server-initiated channel (subscriptions, MRTR) the stateless preview transport hasn't wired up yet.",
+    ],
+    [
+      "Switch the server to the legacy stateful transport in its protocol-mode toggle.",
+    ],
+    "not-yet-supported-in-stateless",
+    "warning",
+  ),
+  "sdk/stateless_requires_http": entry(
+    "sdk/stateless_requires_http",
+    "Stateless transport requires HTTP",
+    "Stateless mode can only be used with an HTTP-transport server, not STDIO.",
+    [
+      "You enabled the stateless protocol toggle on a stdio server.",
+    ],
+    [
+      "Disable the stateless toggle for stdio servers.",
+    ],
+    "stateless-requires-http",
+  ),
+  "sdk/paginated_tool_header_discovery_unsupported": entry(
+    "sdk/paginated_tool_header_discovery_unsupported",
+    "Paginated tool discovery not supported with header overrides",
+    "Paginated tools discovery cannot run alongside per-request header overrides on this transport.",
+    [
+      "Conflicting combination of progressive tool discovery + per-server header overrides.",
+    ],
+    [
+      "Disable progressive tool discovery for this server, or move headers into the server config.",
+    ],
+    "paginated-tool-header-discovery-unsupported",
+    "warning",
+  ),
+
+  // --- Provider / sampling ---
+  "provider/invalid_tool_name": entry(
+    "provider/invalid_tool_name",
+    "Provider rejected the tool name",
+    "An LLM provider rejected a tool name (Anthropic's strict tool-name validator is the most common source).",
+    [
+      "Tool name contains characters or length the provider does not allow.",
+      "Two attached servers expose tools whose namespaced names collide after sanitization.",
+    ],
+    [
+      "Rename the offending tool on the server.",
+      "Detach one of the colliding servers from the chat surface.",
+    ],
+    "provider-invalid-tool-name",
+  ),
+  "provider/auth_error": entry(
+    "provider/auth_error",
+    "Provider authentication error",
+    "Your LLM provider rejected the API key for this request.",
+    [
+      "Key is missing.",
+      "Key is invalid or revoked.",
+      "Key is for a different environment (project, region).",
+    ],
+    [
+      "Add or update your API key under Settings → LLM Providers.",
+      "Verify the key in the provider's dashboard.",
+    ],
+    "provider-auth-error",
+  ),
+  "provider/quota": entry(
+    "provider/quota",
+    "Provider quota / rate limit",
+    "Your LLM provider rejected the request because you hit a rate limit or quota.",
+    [
+      "Daily/monthly quota exhausted.",
+      "Per-minute rate limit exceeded.",
+      "Free tier limits hit.",
+    ],
+    [
+      "Wait for the limit window to reset.",
+      "Upgrade your provider plan.",
+      "Switch to a different provider in Settings.",
+    ],
+    "provider-quota",
+    "warning",
+  ),
+
+  // --- Internal / unknown ---
+  "internal/unknown": entry(
+    "internal/unknown",
+    "Unknown error",
+    "An error occurred that the inspector could not classify.",
+    [
+      "Unhandled error path.",
+      "New error class the inspector hasn't been taught about yet.",
+    ],
+    [
+      "Open the details panel and copy the raw message.",
+      "File an issue with the raw message so we can add it to the catalog.",
+    ],
+    "unknown-error",
+  ),
+};
+
+export type ErrorCatalogSlug = keyof typeof ERROR_CATALOG;

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -118,6 +118,41 @@ function lookupCatalog(slug: string): ErrorCatalogEntry {
   return ERROR_CATALOG[slug] ?? ERROR_CATALOG["internal/unknown"];
 }
 
+/**
+ * Max characters allowed in the visible one-line area. Beyond this the
+ * card layout breaks (the one-line is shown next to the title at a
+ * fixed-ish width). Catalog entries hand-size their `oneLine` under
+ * this; raw-message promotion respects it too.
+ */
+const ONE_LINE_MAX = 200;
+
+function truncateOneLine(value: string): string {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= ONE_LINE_MAX) return collapsed;
+  return `${collapsed.slice(0, ONE_LINE_MAX - 1).trimEnd()}…`;
+}
+
+/**
+ * For unclassified errors (slug === "internal/unknown"), promote the
+ * raw message into the visible `oneLine` so the user sees the actual
+ * text instead of the generic "An error occurred…" placeholder. The
+ * docs anchor, severity, and details panel still come from the
+ * catalog. Without this, OAuth step errors / custom server errors /
+ * any other unclassified text gets hidden in the collapsed details.
+ *
+ * Returns the entry unchanged for known slugs (catalog copy wins) and
+ * when the raw message is empty.
+ */
+function maybePromoteRawMessage(
+  entry: ErrorCatalogEntry,
+  slug: string,
+  rawMessage: string,
+): ErrorCatalogEntry {
+  if (slug !== "internal/unknown") return entry;
+  if (!rawMessage) return entry;
+  return { ...entry, oneLine: truncateOneLine(rawMessage) };
+}
+
 function inspectorSentinelSlug(message: string): string | undefined {
   if (/NotYetSupportedInStateless/i.test(message)) {
     return "sdk/not_yet_supported_in_stateless";
@@ -392,7 +427,11 @@ export function describeError(error: unknown): NormalizedError {
   try {
     const rawMessage = redactString(getErrorMessage(error));
     const { slug, rawCode } = resolveSlug(error);
-    const entry = lookupCatalog(slug);
+    const entry = maybePromoteRawMessage(
+      lookupCatalog(slug),
+      slug,
+      rawMessage,
+    );
     const cause = captureCause(error);
     return {
       ...entry,
@@ -457,5 +496,10 @@ function crashFallback(error: unknown, emptyPlaceholder: string): NormalizedErro
   } catch {
     rawMessage = emptyPlaceholder;
   }
-  return { ...fallback, rawMessage };
+  // Same raw-message promotion as the happy path so the visible one-line
+  // shows the actual message instead of the generic placeholder.
+  return {
+    ...maybePromoteRawMessage(fallback, "internal/unknown", rawMessage),
+    rawMessage,
+  };
 }

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -36,6 +36,34 @@ export type NormalizedError = ErrorCatalogEntry & {
   cause?: { name: string; message: string };
 };
 
+/**
+ * Shape guard for `NormalizedError` payloads received from any boundary
+ * (response body, action dispatch, prop). Use this before trusting a
+ * value that crossed a wire — `webPost` populates `WebApiError.normalized`
+ * from any object in the response body without validation, and a partial
+ * payload would crash the render path when it tries to read
+ * `docsAnchor.startsWith` / `severity` / `rawMessage`. Callers that fail
+ * this guard should fall back to `describeError(input)`, which always
+ * produces a complete `NormalizedError`.
+ *
+ * Mirrored field-for-field with the rendered surface — keep in sync when
+ * adding required fields to `NormalizedError`.
+ */
+export function isNormalizedError(value: unknown): value is NormalizedError {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as { slug?: unknown }).slug === "string" &&
+    typeof (value as { title?: unknown }).title === "string" &&
+    typeof (value as { oneLine?: unknown }).oneLine === "string" &&
+    typeof (value as { docsAnchor?: unknown }).docsAnchor === "string" &&
+    typeof (value as { severity?: unknown }).severity === "string" &&
+    typeof (value as { rawMessage?: unknown }).rawMessage === "string" &&
+    Array.isArray((value as { likelyCauses?: unknown }).likelyCauses) &&
+    Array.isArray((value as { nextSteps?: unknown }).nextSteps)
+  );
+}
+
 function redactString(value: string): string {
   const out = redactSensitiveValue(value);
   return typeof out === "string" ? out : String(value);
@@ -242,13 +270,36 @@ function captureCause(error: unknown): NormalizedError["cause"] {
   return { name, message };
 }
 
-function classifyAuthError(error: unknown): string | undefined {
+/**
+ * Map of well-known SDK error `code` strings → catalog slugs. Extend
+ * here when new throwable `MCPError`/`SdkError` codes are introduced.
+ *
+ * Current SDK only throws `MCPAuthError` (code "AUTH_ERROR"); other
+ * codes listed are doctor-result codes that aren't currently thrown but
+ * are mapped defensively so a future throw path doesn't fall through to
+ * `internal/unknown`.
+ */
+const MCP_CODE_TO_SLUG: Readonly<Record<string, string>> = {
+  AUTH_ERROR: "auth/http_401",
+  OAUTH_REQUIRED: "auth/http_401",
+};
+
+/**
+ * Classify by SDK error-class identity + string `code`. Covers
+ * `MCPAuthError` (the only currently-thrown subclass) plus any future
+ * `MCPError` instances that carry a code listed in `MCP_CODE_TO_SLUG`.
+ * Also recognizes upstream `UnauthorizedError` from the official MCP
+ * client by name.
+ */
+function classifyMcpError(error: unknown): string | undefined {
   const name = getErrorName(error);
   if (name === "MCPAuthError" || name === "UnauthorizedError") {
     return "auth/http_401";
   }
   const stringCode = getStringCode(error);
-  if (stringCode === "AUTH_ERROR") return "auth/http_401";
+  if (stringCode && MCP_CODE_TO_SLUG[stringCode]) {
+    return MCP_CODE_TO_SLUG[stringCode];
+  }
   return undefined;
 }
 
@@ -280,7 +331,7 @@ function resolveSlug(error: unknown): {
   if (sentinel) return { slug: sentinel };
 
   // (b) Auth class detector (MCPAuthError, UnauthorizedError, AUTH_ERROR).
-  const authClass = classifyAuthError(error);
+  const authClass = classifyMcpError(error);
   if (authClass) return { slug: authClass };
 
   // (c) Numeric JSON-RPC code.

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -350,12 +350,10 @@ export function describeError(error: unknown): NormalizedError {
       ...(cause ? { cause } : {}),
     };
   } catch {
-    const fallback = ERROR_CATALOG["internal/unknown"];
-    return {
-      ...fallback,
-      rawMessage:
-        error instanceof Error ? error.message : String(error ?? "Unknown"),
-    };
+    // Fallback path: classification threw (e.g. a getter on the error
+    // object exploded). Still redact — otherwise a leaked bearer token
+    // in error.message would bypass the normal redaction guarantee.
+    return crashFallback(error, "Unknown");
   }
 }
 
@@ -384,11 +382,29 @@ export function describeAsSlug(
       ...(cause ? { cause } : {}),
     };
   } catch {
-    const fallback = ERROR_CATALOG["internal/unknown"];
-    return {
-      ...fallback,
-      rawMessage:
-        error instanceof Error ? error.message : String(error ?? ""),
-    };
+    // See note on the describeError fallback — redaction must still run.
+    return crashFallback(error, "");
   }
+}
+
+/**
+ * Shared crash-safe fallback for the two top-level entry points. Pulled
+ * out so a single audit point covers both — the prior open-coded version
+ * skipped redaction in the catch path, which leaked bearer tokens when
+ * classification threw (e.g. a throwing `code` getter on the error).
+ *
+ * Defensive: the message coercion + redact are themselves wrapped, so
+ * even a pathological `error.message` getter cannot escape.
+ */
+function crashFallback(error: unknown, emptyPlaceholder: string): NormalizedError {
+  const fallback = ERROR_CATALOG["internal/unknown"];
+  let rawMessage = emptyPlaceholder;
+  try {
+    const raw =
+      error instanceof Error ? error.message : String(error ?? emptyPlaceholder);
+    rawMessage = redactString(raw);
+  } catch {
+    rawMessage = emptyPlaceholder;
+  }
+  return { ...fallback, rawMessage };
 }

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -1,0 +1,360 @@
+/**
+ * One-entry-point error describer. Browser-safe.
+ *
+ * Resolution order:
+ *  1. MCPError / MCPAuthError sentinel (by class name + code).
+ *  2. Numeric JSON-RPC code (`Error & { code: number }`).
+ *  3. Node errno (via `extractNodeErrno`).
+ *  4. HTTP status pattern (401 / 403 / 5xx).
+ *  5. OAuth response-body shape (prioritized-key extractor).
+ *  6. Message-regex fallback (connection-error patterns).
+ *  7. `internal/unknown` catch-all.
+ *
+ * Never throws. Always returns a `NormalizedError`.
+ */
+
+import { redactSensitiveValue } from "../redaction.js";
+import {
+  ERROR_CATALOG,
+  type ErrorCatalogEntry,
+} from "./catalog.js";
+import { extractNodeErrno } from "./node-errno.js";
+
+export type NormalizedError = ErrorCatalogEntry & {
+  /**
+   * Original error message, redacted for bearer tokens / OAuth secrets /
+   * provider keys. Safe to render verbatim in the UI.
+   */
+  rawMessage: string;
+  /**
+   * Original numeric or string error code, if the source carried one.
+   */
+  rawCode?: number | string;
+  /**
+   * Captured `.cause` chain head — only `name` + `message`, redacted.
+   */
+  cause?: { name: string; message: string };
+};
+
+function redactString(value: string): string {
+  const out = redactSensitiveValue(value);
+  return typeof out === "string" ? out : String(value);
+}
+
+function getErrorName(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const name = (error as { name?: unknown }).name;
+  return typeof name === "string" ? name : undefined;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error == null) return String(error);
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function getNumericCode(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === "number" && Number.isFinite(code)) return code;
+  // Some upstream errors nest under `.error.code`.
+  const nested = (error as { error?: { code?: unknown } }).error;
+  if (nested && typeof nested === "object") {
+    const nc = (nested as { code?: unknown }).code;
+    if (typeof nc === "number" && Number.isFinite(nc)) return nc;
+  }
+  return undefined;
+}
+
+function getStringCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function getHttpStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const statusCode = (error as { statusCode?: unknown }).statusCode;
+  if (typeof statusCode === "number") return statusCode;
+  const status = (error as { status?: unknown }).status;
+  if (typeof status === "number") return status;
+  return undefined;
+}
+
+function lookupCatalog(slug: string): ErrorCatalogEntry {
+  return ERROR_CATALOG[slug] ?? ERROR_CATALOG["internal/unknown"];
+}
+
+function inspectorSentinelSlug(message: string): string | undefined {
+  if (/NotYetSupportedInStateless/i.test(message)) {
+    return "sdk/not_yet_supported_in_stateless";
+  }
+  if (/StatelessRequiresHttpTransport/i.test(message)) {
+    return "sdk/stateless_requires_http";
+  }
+  if (/PaginatedToolHeaderDiscoveryUnsupported/i.test(message)) {
+    return "sdk/paginated_tool_header_discovery_unsupported";
+  }
+  return undefined;
+}
+
+const JSONRPC_SLUG_BY_CODE: Record<number, string> = {
+  [-32700]: "jsonrpc/parse_error",
+  [-32600]: "jsonrpc/invalid_request",
+  [-32601]: "jsonrpc/method_not_found",
+  [-32602]: "jsonrpc/invalid_params",
+  [-32603]: "jsonrpc/internal_error",
+  [-32000]: "jsonrpc/connection_closed",
+  [-32004]: "jsonrpc/unsupported_protocol_version",
+  [-32042]: "jsonrpc/url_elicitation_required",
+};
+
+/**
+ * `-32001` is overloaded: upstream uses it for RequestTimeout, the inspector
+ * uses the same numeric code for HeaderMismatch. Disambiguate by message.
+ */
+function resolveDashThirtyTwoThousandOne(message: string): string {
+  if (
+    /header[^a-z]*mismatch/i.test(message) ||
+    /MCP-Protocol-Version/i.test(message)
+  ) {
+    return "jsonrpc/header_mismatch";
+  }
+  return "jsonrpc/request_timeout";
+}
+
+function nodeErrnoToSlug(errno: string): string | undefined {
+  const upper = errno.toUpperCase();
+  switch (upper) {
+    case "ECONNREFUSED":
+      return "transport/econnrefused";
+    case "ECONNRESET":
+      return "transport/econnreset";
+    case "ETIMEDOUT":
+      return "transport/etimedout";
+    case "ENOTFOUND":
+      return "transport/enotfound";
+    case "EAI_AGAIN":
+      return "transport/eai_again";
+    default:
+      if (upper.startsWith("UND_ERR_")) return "transport/undici";
+      return undefined;
+  }
+}
+
+function messageSlug(message: string): string | undefined {
+  const lower = message.toLowerCase();
+  if (/\bsocket\s+hang\s+up\b/i.test(message)) {
+    return "transport/socket_hang_up";
+  }
+  if (/\bfetch\s+failed\b/i.test(message)) {
+    return "transport/fetch_failed";
+  }
+  if (/\bgetaddrinfo\b/i.test(message)) {
+    return "transport/enotfound";
+  }
+  if (
+    /\bconnection\s+(?:refused|reset|closed|timed?\s*out|aborted|error|failed)\b/i.test(
+      message,
+    ) ||
+    /\b(?:failed|unable)\s+to\s+connect\b/i.test(message)
+  ) {
+    // Map to the closest catalog entry by keyword.
+    if (lower.includes("refused")) return "transport/econnrefused";
+    if (lower.includes("reset")) return "transport/econnreset";
+    if (lower.includes("timed out") || lower.includes("timeout")) {
+      return "transport/etimedout";
+    }
+    if (lower.includes("closed")) return "jsonrpc/connection_closed";
+    return "transport/fetch_failed";
+  }
+  if (/Invalid tool name/i.test(message)) {
+    return "provider/invalid_tool_name";
+  }
+  return undefined;
+}
+
+/**
+ * Inspect OAuth-style error bodies (either a parsed object or a string
+ * containing one). Returns a slug when a recognizable OAuth error code is
+ * present. Prioritized-key extractor borrowed from
+ * `oauth-conformance/formatter.ts` semantics — kept inline to avoid a
+ * cross-module refactor.
+ */
+function oauthBodySlug(error: unknown): string | undefined {
+  const body = pickOauthBody(error);
+  if (!body) return undefined;
+
+  const code =
+    typeof body.error === "string"
+      ? body.error
+      : typeof body.error_code === "string"
+        ? body.error_code
+        : undefined;
+  if (!code) return undefined;
+
+  switch (code.toLowerCase()) {
+    case "invalid_grant":
+      return "oauth/invalid_grant";
+    case "invalid_client":
+      return "oauth/invalid_client";
+    case "invalid_redirect_uri":
+    case "redirect_uri_mismatch":
+      return "oauth/redirect_mismatch";
+    default:
+      return undefined;
+  }
+}
+
+function pickOauthBody(
+  error: unknown,
+): { error?: unknown; error_code?: unknown; error_description?: unknown } | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  // Some sources stash the body under `.body` or `.data`.
+  const body =
+    "body" in error
+      ? (error as { body: unknown }).body
+      : "data" in error
+        ? (error as { data: unknown }).data
+        : (error as Record<string, unknown>);
+  if (!body || typeof body !== "object") return undefined;
+  return body as { error?: unknown; error_code?: unknown };
+}
+
+function captureCause(error: unknown): NormalizedError["cause"] {
+  if (!(error instanceof Error)) return undefined;
+  const cause = (error as { cause?: unknown }).cause;
+  if (!cause || typeof cause !== "object") return undefined;
+  const name =
+    typeof (cause as { name?: unknown }).name === "string"
+      ? ((cause as { name: string }).name)
+      : "Error";
+  const message =
+    typeof (cause as { message?: unknown }).message === "string"
+      ? redactString((cause as { message: string }).message)
+      : "";
+  if (!message) return undefined;
+  return { name, message };
+}
+
+function classifyAuthError(error: unknown): string | undefined {
+  const name = getErrorName(error);
+  if (name === "MCPAuthError" || name === "UnauthorizedError") {
+    return "auth/http_401";
+  }
+  const stringCode = getStringCode(error);
+  if (stringCode === "AUTH_ERROR") return "auth/http_401";
+  return undefined;
+}
+
+function classifyHttpStatus(status: number): string | undefined {
+  if (status === 401) return "auth/http_401";
+  if (status === 403) return "auth/http_403";
+  return undefined;
+}
+
+function classifyByMessageHttp(message: string): string | undefined {
+  if (/\b(?:http|status)[:\s-]*401\b/i.test(message)) return "auth/http_401";
+  if (/\b(?:http|status)[:\s-]*403\b/i.test(message)) return "auth/http_403";
+  return undefined;
+}
+
+/**
+ * Resolve a slug for the given error, walking the priority list. Returns
+ * `internal/unknown` slug if nothing matches.
+ */
+function resolveSlug(error: unknown): {
+  slug: string;
+  rawCode?: number | string;
+} {
+  const message = getErrorMessage(error);
+
+  // (a) Inspector sentinel sniff first — these are SDK-thrown Errors whose
+  // class identity is lost across realm boundaries; match on stable text.
+  const sentinel = inspectorSentinelSlug(message);
+  if (sentinel) return { slug: sentinel };
+
+  // (b) Auth class detector (MCPAuthError, UnauthorizedError, AUTH_ERROR).
+  const authClass = classifyAuthError(error);
+  if (authClass) return { slug: authClass };
+
+  // (c) Numeric JSON-RPC code.
+  const numericCode = getNumericCode(error);
+  if (numericCode !== undefined) {
+    if (numericCode === -32001) {
+      return { slug: resolveDashThirtyTwoThousandOne(message), rawCode: numericCode };
+    }
+    const slug = JSONRPC_SLUG_BY_CODE[numericCode];
+    if (slug) return { slug, rawCode: numericCode };
+    // Numeric code that looks like an HTTP status (StreamableHTTPError etc.).
+    const fromHttp = classifyHttpStatus(numericCode);
+    if (fromHttp) return { slug: fromHttp, rawCode: numericCode };
+  }
+
+  // (d) Node errno via string `.code`.
+  const errno = extractNodeErrno(error);
+  if (errno) {
+    const slug = nodeErrnoToSlug(errno);
+    if (slug) return { slug, rawCode: errno };
+  }
+
+  // (e) HTTP status field (`statusCode` / `status`).
+  const httpStatus = getHttpStatus(error);
+  if (httpStatus !== undefined) {
+    const slug = classifyHttpStatus(httpStatus);
+    if (slug) return { slug, rawCode: httpStatus };
+  }
+
+  // (f) OAuth body shape.
+  const oauthSlug = oauthBodySlug(error);
+  if (oauthSlug) return { slug: oauthSlug };
+
+  // (g) Message-regex fallback. Includes auth-text patterns + transport.
+  const fromMessageHttp = classifyByMessageHttp(message);
+  if (fromMessageHttp) return { slug: fromMessageHttp };
+
+  // Refresh-failed phrasing.
+  if (/refresh\s+token/i.test(message) && /(failed|invalid|expired|revoked)/i.test(message)) {
+    return { slug: "auth/oauth_refresh_failed" };
+  }
+  if (/missing\s+(?:or\s+invalid\s+)?bearer/i.test(message)) {
+    return { slug: "auth/missing_bearer" };
+  }
+
+  const messageBased = messageSlug(message);
+  if (messageBased) return { slug: messageBased };
+
+  if (/well[-_]?known/i.test(message) && /(unreachable|fail|404)/i.test(message)) {
+    return { slug: "oauth/well_known_unreachable" };
+  }
+
+  return { slug: "internal/unknown" };
+}
+
+export function describeError(error: unknown): NormalizedError {
+  // Crash-safe: every branch is wrapped so the describer never throws.
+  try {
+    const rawMessage = redactString(getErrorMessage(error));
+    const { slug, rawCode } = resolveSlug(error);
+    const entry = lookupCatalog(slug);
+    const cause = captureCause(error);
+    return {
+      ...entry,
+      rawMessage,
+      ...(rawCode !== undefined ? { rawCode } : {}),
+      ...(cause ? { cause } : {}),
+    };
+  } catch {
+    const fallback = ERROR_CATALOG["internal/unknown"];
+    return {
+      ...fallback,
+      rawMessage:
+        error instanceof Error ? error.message : String(error ?? "Unknown"),
+    };
+  }
+}

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -389,6 +389,17 @@ function resolveSlug(error: unknown): {
     if (slug) return { slug, rawCode: errno };
   }
 
+  // (d.5) Specific message wording that pins a slug more precisely than
+  // the generic HTTP-status check below. The inspector's hosted backend
+  // throws `WebRouteError(401, "Missing or invalid bearer token")` when
+  // its own bearer-token gate fails — that's a MCPJam-CLI / MCPJAM_API_KEY
+  // problem, not the MCP-server-re-auth problem auth/http_401 talks about.
+  // Without this pre-check the generic status branch wins and the user
+  // gets the wrong docs link / next steps.
+  if (/missing\s+(?:or\s+invalid\s+)?bearer/i.test(message)) {
+    return { slug: "auth/missing_bearer" };
+  }
+
   // (e) HTTP status field (`statusCode` / `status`).
   const httpStatus = getHttpStatus(error);
   if (httpStatus !== undefined) {
@@ -408,9 +419,8 @@ function resolveSlug(error: unknown): {
   if (/refresh\s+token/i.test(message) && /(failed|invalid|expired|revoked)/i.test(message)) {
     return { slug: "auth/oauth_refresh_failed" };
   }
-  if (/missing\s+(?:or\s+invalid\s+)?bearer/i.test(message)) {
-    return { slug: "auth/missing_bearer" };
-  }
+  // Note: "missing bearer" wording is checked earlier (step d.5) so it
+  // wins over the generic HTTP status check; no duplicate here.
 
   const messageBased = messageSlug(message);
   if (messageBased) return { slug: messageBased };

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -358,3 +358,37 @@ export function describeError(error: unknown): NormalizedError {
     };
   }
 }
+
+/**
+ * Build a `NormalizedError` from an explicit catalog slug, wrapping the
+ * raw error for `rawMessage` / `cause` capture. Use this when the caller
+ * has context the generic `describeError` resolver does not — e.g. a chat
+ * route that knows an HTTP 401 is from an LLM provider, not an MCP server,
+ * and wants to attach `provider/auth_error` instead of the resolver's
+ * `auth/http_401`.
+ *
+ * Unknown slugs fall back to `internal/unknown` (never throws).
+ */
+export function describeAsSlug(
+  slug: string,
+  error?: unknown,
+): NormalizedError {
+  try {
+    const entry = lookupCatalog(slug);
+    const rawMessage =
+      error !== undefined ? redactString(getErrorMessage(error)) : "";
+    const cause = captureCause(error);
+    return {
+      ...entry,
+      rawMessage,
+      ...(cause ? { cause } : {}),
+    };
+  } catch {
+    const fallback = ERROR_CATALOG["internal/unknown"];
+    return {
+      ...fallback,
+      rawMessage:
+        error instanceof Error ? error.message : String(error ?? ""),
+    };
+  }
+}

--- a/sdk/src/error-describer/index.ts
+++ b/sdk/src/error-describer/index.ts
@@ -1,4 +1,8 @@
-export { describeError, type NormalizedError } from "./describe.js";
+export {
+  describeError,
+  describeAsSlug,
+  type NormalizedError,
+} from "./describe.js";
 export {
   ERROR_CATALOG,
   type ErrorCatalogEntry,

--- a/sdk/src/error-describer/index.ts
+++ b/sdk/src/error-describer/index.ts
@@ -1,6 +1,7 @@
 export {
   describeError,
   describeAsSlug,
+  isNormalizedError,
   type NormalizedError,
 } from "./describe.js";
 export {

--- a/sdk/src/error-describer/index.ts
+++ b/sdk/src/error-describer/index.ts
@@ -1,0 +1,10 @@
+export { describeError, type NormalizedError } from "./describe.js";
+export {
+  ERROR_CATALOG,
+  type ErrorCatalogEntry,
+  type ErrorCatalogSlug,
+} from "./catalog.js";
+export {
+  extractNodeErrno,
+  RETRYABLE_NODE_ERROR_CODES,
+} from "./node-errno.js";

--- a/sdk/src/error-describer/node-errno.ts
+++ b/sdk/src/error-describer/node-errno.ts
@@ -3,15 +3,31 @@
  * imports, browser-safe. Originally lived inline at `sdk/src/retry.ts`
  * (extractNodeErrorCode); hoisted here so the error describer can share
  * the exact same surface as `isRetryableTransientError`.
+ *
+ * Walks `error.cause` because Node's `fetch` (undici) typically wraps
+ * connection failures as `TypeError("fetch failed")` whose `.cause` is
+ * the real `SystemError` carrying `code: "ECONNREFUSED"` (or similar).
+ * Without the walk, every fetch-side errno would classify as the generic
+ * "fetch failed" slug instead of the specific transport slug.
+ *
+ * Bounded depth to avoid pathological cyclic-cause structures.
  */
-export function extractNodeErrno(error: unknown): string | undefined {
-  if (!error || typeof error !== "object") {
+export function extractNodeErrno(
+  error: unknown,
+  depth = 0,
+): string | undefined {
+  if (!error || typeof error !== "object" || depth > 3) {
     return undefined;
   }
 
   const code = (error as { code?: unknown }).code;
   if (typeof code === "string") {
     return code;
+  }
+
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause !== undefined && cause !== error) {
+    return extractNodeErrno(cause, depth + 1);
   }
   return undefined;
 }

--- a/sdk/src/error-describer/node-errno.ts
+++ b/sdk/src/error-describer/node-errno.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared Node errno extractor. Pure object/string inspection — no Node
+ * imports, browser-safe. Originally lived inline at `sdk/src/retry.ts`
+ * (extractNodeErrorCode); hoisted here so the error describer can share
+ * the exact same surface as `isRetryableTransientError`.
+ */
+export function extractNodeErrno(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === "string") {
+    return code;
+  }
+  return undefined;
+}
+
+/**
+ * Retryable Node errno set — exposed so callers (including
+ * `isRetryableTransientError`) can share one source of truth without
+ * duplicating the literal list. Kept in this module because the catalog
+ * also reads it.
+ */
+export const RETRYABLE_NODE_ERROR_CODES: ReadonlySet<string> = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -421,6 +421,7 @@ export { EXPLORE_TO_SDK_EVALS_SKILL_MD, SKILL_MD } from "./skill-reference.js";
 // dragging in Node-only deps.
 export {
   describeError,
+  describeAsSlug,
   ERROR_CATALOG,
   extractNodeErrno,
   RETRYABLE_NODE_ERROR_CODES,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -422,6 +422,7 @@ export { EXPLORE_TO_SDK_EVALS_SKILL_MD, SKILL_MD } from "./skill-reference.js";
 export {
   describeError,
   describeAsSlug,
+  isNormalizedError,
   ERROR_CATALOG,
   extractNodeErrno,
   RETRYABLE_NODE_ERROR_CODES,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -415,6 +415,22 @@ export type { OAuthProxyRequest, OAuthProxyResponse } from "./oauth-proxy.js";
 // Skill reference (SKILL.md content for agent brief generation)
 export { EXPLORE_TO_SDK_EVALS_SKILL_MD, SKILL_MD } from "./skill-reference.js";
 
+// Error describer — single source of truth for friendly error titles,
+// likely causes, next steps, and docs anchors. Browser-safe; mirrored on
+// `@mcpjam/sdk/browser` so client code can call `describeError` without
+// dragging in Node-only deps.
+export {
+  describeError,
+  ERROR_CATALOG,
+  extractNodeErrno,
+  RETRYABLE_NODE_ERROR_CODES,
+} from "./error-describer/index.js";
+export type {
+  NormalizedError,
+  ErrorCatalogEntry,
+  ErrorCatalogSlug,
+} from "./error-describer/index.js";
+
 // OAuth conformance
 export {
   OAuthConformanceTest,

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -1,5 +1,9 @@
 import { isMethodUnavailableError } from "./mcp-client-manager/error-utils.js";
 import { isAuthError } from "./mcp-client-manager/errors.js";
+import {
+  extractNodeErrno,
+  RETRYABLE_NODE_ERROR_CODES,
+} from "./error-describer/node-errno.js";
 
 export interface RetryPolicy {
   retries: number;
@@ -23,20 +27,6 @@ export interface RetryExecutionOptions<T> {
     result?: T;
   }) => Promise<void> | void;
 }
-
-const RETRYABLE_NODE_ERROR_CODES = new Set([
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "EAI_AGAIN",
-  "ENETDOWN",
-  "ENETUNREACH",
-  "ENOTFOUND",
-  "EPIPE",
-  "ETIMEDOUT",
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_HEADERS_TIMEOUT",
-  "UND_ERR_SOCKET",
-]);
 
 function toAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
@@ -115,16 +105,6 @@ function extractHttpStatusCode(error: unknown): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-function extractNodeErrorCode(error: unknown): string | undefined {
-  if (!error || typeof error !== "object") {
-    return undefined;
-  }
-
-  return "code" in error && typeof error.code === "string"
-    ? error.code
-    : undefined;
-}
-
 export function normalizeRetryPolicy(policy?: RetryPolicy): RetryPolicy {
   return {
     retries: Math.max(0, policy?.retries ?? DEFAULT_RETRY_POLICY.retries),
@@ -155,7 +135,7 @@ export function isRetryableTransientError(error: unknown): boolean {
     return true;
   }
 
-  const nodeCode = extractNodeErrorCode(error)?.toUpperCase();
+  const nodeCode = extractNodeErrno(error)?.toUpperCase();
   if (nodeCode && RETRYABLE_NODE_ERROR_CODES.has(nodeCode)) {
     return true;
   }

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -286,6 +286,47 @@ describe("describeError — redaction", () => {
   it("never throws on truly unusual input", () => {
     expect(() => describeError({ get code() { throw new Error("nope"); } })).not.toThrow();
   });
+
+  it("crash-safe fallback still redacts bearer tokens", () => {
+    // Reproduces the leak: classification path throws (via a throwing
+    // `code` getter) AND the error message contains a token. Pre-fix the
+    // catch block returned `error.message` verbatim, so the token leaked
+    // through rawMessage. The fallback must still call redactString.
+    // `Object.defineProperty` is required — `Object.assign({}, {get x(){}})`
+    // invokes the getter at copy time.
+    const err = new Error(
+      "Authorization: Bearer leaky.deadbeef.token failed",
+    );
+    Object.defineProperty(err, "code", {
+      get(): string {
+        throw new Error("classification boom");
+      },
+    });
+    const out = describeError(err);
+    expect(out.slug).toBe("internal/unknown");
+    expect(out.rawMessage).not.toContain("leaky.deadbeef.token");
+    expect(out.rawMessage.toLowerCase()).toContain("redacted");
+  });
+
+  it("describeAsSlug crash-safe fallback also redacts", () => {
+    // Force the fallback by making the error's `message` getter throw
+    // inside the try block, then ensure the catch path still redacts the
+    // serialized form. `String(error)` on a real Error reads .toString,
+    // which by default reads .message — so we override toString too to
+    // give the fallback a non-throwing source carrying the token.
+    const err = new Error("placeholder");
+    Object.defineProperty(err, "message", {
+      get(): string {
+        throw new Error("message boom");
+      },
+    });
+    Object.defineProperty(err, "toString", {
+      value: () => "Authorization: Bearer leaky.value.here failed",
+    });
+    const out = describeAsSlug("provider/auth_error", err);
+    expect(out.slug).toBe("internal/unknown");
+    expect(out.rawMessage).not.toContain("leaky.value.here");
+  });
 });
 
 describe("extractNodeErrno — cause walking", () => {

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -4,9 +4,10 @@ import {
   describeError,
   ERROR_CATALOG,
   extractNodeErrno,
+  isNormalizedError,
   type NormalizedError,
 } from "../../src/error-describer/index.js";
-import { MCPAuthError } from "../../src/mcp-client-manager/errors.js";
+import { MCPAuthError, MCPError } from "../../src/mcp-client-manager/errors.js";
 
 function makeError(message: string, extras: Record<string, unknown> = {}) {
   const err = new Error(message) as Error & Record<string, unknown>;
@@ -371,6 +372,71 @@ describe("describeError — fetch failed surfaces specific transport slug", () =
     const out = describeError(wrapper);
     expect(out.slug).toBe("transport/econnrefused");
     expect(out.rawCode).toBe("ECONNREFUSED");
+  });
+});
+
+describe("isNormalizedError — shape guard", () => {
+  it("accepts a fully-populated NormalizedError", () => {
+    const out = describeError(new Error("boom"));
+    expect(isNormalizedError(out)).toBe(true);
+  });
+
+  it("rejects a partial payload missing docsAnchor", () => {
+    const partial = {
+      slug: "x",
+      title: "y",
+      oneLine: "z",
+      severity: "error",
+      rawMessage: "",
+      likelyCauses: [],
+      nextSteps: [],
+    };
+    expect(isNormalizedError(partial)).toBe(false);
+  });
+
+  it("rejects null / undefined / non-objects", () => {
+    expect(isNormalizedError(null)).toBe(false);
+    expect(isNormalizedError(undefined)).toBe(false);
+    expect(isNormalizedError("nope")).toBe(false);
+    expect(isNormalizedError(42)).toBe(false);
+  });
+
+  it("rejects shape with array fields swapped for strings", () => {
+    const bad = {
+      slug: "x",
+      title: "y",
+      oneLine: "z",
+      docsAnchor: "/troubleshooting/error-codes#x",
+      severity: "error",
+      rawMessage: "",
+      likelyCauses: "not-an-array",
+      nextSteps: [],
+    };
+    expect(isNormalizedError(bad)).toBe(false);
+  });
+});
+
+describe("describeError — MCPError dispatch table", () => {
+  it("classifies MCPError with AUTH_ERROR code as auth/http_401", () => {
+    // MCPAuthError extends MCPError and supplies code "AUTH_ERROR".
+    const out = describeError(new MCPAuthError("Unauthorized", 401));
+    expect(out.slug).toBe("auth/http_401");
+  });
+
+  it("classifies MCPError with OAUTH_REQUIRED code as auth/http_401", () => {
+    // Defensively covered even though no SDK path currently throws this.
+    // Adding a future throw at this code shouldn't silently fall back to
+    // internal/unknown.
+    const out = describeError(new MCPError("OAuth required", "OAUTH_REQUIRED"));
+    expect(out.slug).toBe("auth/http_401");
+  });
+
+  it("falls through gracefully for unmapped MCPError codes", () => {
+    // Catalog miss → fall through to message-regex or internal/unknown.
+    // No throw, no crash, complete shape returned.
+    const out = describeError(new MCPError("weird thing", "SOMETHING_NEW"));
+    expect(isNormalizedError(out)).toBe(true);
+    expect(out.slug).toBeDefined();
   });
 });
 

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  describeAsSlug,
   describeError,
   ERROR_CATALOG,
+  extractNodeErrno,
   type NormalizedError,
 } from "../../src/error-describer/index.js";
 import { MCPAuthError } from "../../src/mcp-client-manager/errors.js";
@@ -283,5 +285,77 @@ describe("describeError — redaction", () => {
 
   it("never throws on truly unusual input", () => {
     expect(() => describeError({ get code() { throw new Error("nope"); } })).not.toThrow();
+  });
+});
+
+describe("extractNodeErrno — cause walking", () => {
+  it("returns top-level code when present", () => {
+    expect(extractNodeErrno({ code: "ECONNREFUSED" })).toBe("ECONNREFUSED");
+  });
+
+  it("walks one level of cause (undici fetch wrapping)", () => {
+    // Reproduces Node's typical fetch-failed shape:
+    // TypeError("fetch failed") with cause = SystemError carrying the errno.
+    const cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:9999"), {
+      code: "ECONNREFUSED",
+    });
+    const wrapper = Object.assign(new TypeError("fetch failed"), { cause });
+    expect(extractNodeErrno(wrapper)).toBe("ECONNREFUSED");
+  });
+
+  it("walks multiple cause levels but stops at the depth bound", () => {
+    const deep = Object.assign(new Error("inner"), { code: "ENOTFOUND" });
+    const mid = Object.assign(new Error("mid"), { cause: deep });
+    const outer = Object.assign(new TypeError("fetch failed"), { cause: mid });
+    expect(extractNodeErrno(outer)).toBe("ENOTFOUND");
+  });
+
+  it("tolerates a self-referential cause without looping forever", () => {
+    const err: { cause?: unknown } = {};
+    err.cause = err;
+    expect(() => extractNodeErrno(err)).not.toThrow();
+    expect(extractNodeErrno(err)).toBeUndefined();
+  });
+});
+
+describe("describeError — fetch failed surfaces specific transport slug", () => {
+  it("classifies undici-wrapped ECONNREFUSED as transport/econnrefused", () => {
+    // Before the cause-walking fix this fell through to the message-regex
+    // fallback and produced the generic "fetch failed" slug, defeating the
+    // entire point of the transport catalog for the #1 docs-chat query.
+    const cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:9999"), {
+      code: "ECONNREFUSED",
+    });
+    const wrapper = Object.assign(new TypeError("fetch failed"), { cause });
+    const out = describeError(wrapper);
+    expect(out.slug).toBe("transport/econnrefused");
+    expect(out.rawCode).toBe("ECONNREFUSED");
+  });
+});
+
+describe("describeAsSlug — explicit catalog pinning", () => {
+  it("uses the requested slug when the caller has more context than the resolver", () => {
+    // chat-v2's use case: an HTTP 401 from an LLM provider, where the
+    // generic resolver would pick auth/http_401 (MCP server re-auth) but
+    // the route knows it's a provider-key issue.
+    const out = describeAsSlug(
+      "provider/auth_error",
+      Object.assign(new Error("Invalid API key"), { statusCode: 401 }),
+    );
+    expect(out.slug).toBe("provider/auth_error");
+    expect(out.title).toBe(ERROR_CATALOG["provider/auth_error"].title);
+    expect(out.rawMessage).toContain("Invalid API key");
+  });
+
+  it("falls back to internal/unknown for an unknown slug instead of throwing", () => {
+    const out = describeAsSlug("not/in/catalog", new Error("nope"));
+    expect(out.slug).toBe("internal/unknown");
+    expect(out.rawMessage).toContain("nope");
+  });
+
+  it("accepts a missing error argument", () => {
+    const out = describeAsSlug("provider/quota");
+    expect(out.slug).toBe("provider/quota");
+    expect(out.rawMessage).toBe("");
   });
 });

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -416,6 +416,60 @@ describe("isNormalizedError — shape guard", () => {
   });
 });
 
+describe("describeError — unclassified errors surface their raw message", () => {
+  it("promotes rawMessage into oneLine when slug is internal/unknown", () => {
+    // OAuth step errors and other unclassified text used to be hidden
+    // behind the generic "An error occurred that the inspector could
+    // not classify." placeholder, forcing users to expand "Show details"
+    // to see what actually went wrong. The describer now surfaces the
+    // raw message as the visible oneLine for unknown classifications.
+    // Pick a string that doesn't trip any of the resolver's regex
+    // fallbacks (well-known, refresh token, missing bearer, HTTP status,
+    // econn*) so we hit the genuinely-unclassified internal/unknown.
+    const oauthStep = "PKCE code_verifier rejected by authorization server";
+    const out = describeError(new Error(oauthStep));
+    expect(out.slug).toBe("internal/unknown");
+    expect(out.oneLine).toBe(oauthStep);
+    expect(out.rawMessage).toBe(oauthStep);
+    // Title and docs anchor still come from the catalog so the
+    // ErrorCard's structure (icon, "Learn more" link, severity) is
+    // intact.
+    expect(out.title).toBe(ERROR_CATALOG["internal/unknown"].title);
+    expect(out.docsAnchor).toBe(ERROR_CATALOG["internal/unknown"].docsAnchor);
+  });
+
+  it("does NOT clobber catalog oneLine for known slugs", () => {
+    // A classified error keeps the catalog's hand-written one-liner —
+    // the raw message goes in rawMessage / details where it belongs.
+    const out = describeError(
+      Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:9999"), {
+        code: "ECONNREFUSED",
+      }),
+    );
+    expect(out.slug).toBe("transport/econnrefused");
+    expect(out.oneLine).toBe(
+      ERROR_CATALOG["transport/econnrefused"].oneLine,
+    );
+    expect(out.rawMessage).toBe("connect ECONNREFUSED 127.0.0.1:9999");
+  });
+
+  it("truncates very long raw messages so layout doesn't break", () => {
+    const long = "x".repeat(500);
+    const out = describeError(new Error(long));
+    expect(out.slug).toBe("internal/unknown");
+    expect(out.oneLine.length).toBeLessThanOrEqual(200);
+    expect(out.oneLine.endsWith("…")).toBe(true);
+    // The full untruncated text is still available in rawMessage.
+    expect(out.rawMessage).toBe(long);
+  });
+
+  it("falls back to the catalog oneLine when rawMessage is empty", () => {
+    const out = describeError(new Error(""));
+    expect(out.slug).toBe("internal/unknown");
+    expect(out.oneLine).toBe(ERROR_CATALOG["internal/unknown"].oneLine);
+  });
+});
+
 describe("describeError — MCPError dispatch table", () => {
   it("classifies MCPError with AUTH_ERROR code as auth/http_401", () => {
     // MCPAuthError extends MCPError and supplies code "AUTH_ERROR".

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeError,
+  ERROR_CATALOG,
+  type NormalizedError,
+} from "../../src/error-describer/index.js";
+import { MCPAuthError } from "../../src/mcp-client-manager/errors.js";
+
+function makeError(message: string, extras: Record<string, unknown> = {}) {
+  const err = new Error(message) as Error & Record<string, unknown>;
+  Object.assign(err, extras);
+  return err;
+}
+
+describe("describeError — catalog completeness", () => {
+  it("every catalog entry has the required surface", () => {
+    for (const [slug, entry] of Object.entries(ERROR_CATALOG)) {
+      expect(entry.slug, `entry ${slug}`).toBe(slug);
+      expect(entry.title.length).toBeGreaterThan(0);
+      expect(entry.oneLine.length).toBeGreaterThan(0);
+      expect(entry.likelyCauses.length).toBeGreaterThan(0);
+      expect(entry.nextSteps.length).toBeGreaterThan(0);
+      expect(entry.docsAnchor.startsWith("/troubleshooting/error-codes#")).toBe(
+        true,
+      );
+      expect(["info", "warning", "error"]).toContain(entry.severity);
+    }
+  });
+
+  it("catalog covers >= 18 entries", () => {
+    expect(Object.keys(ERROR_CATALOG).length).toBeGreaterThanOrEqual(18);
+  });
+});
+
+type Case = {
+  name: string;
+  build: () => unknown;
+  expectSlug: string;
+  expectRawCode?: number | string;
+};
+
+const CASES: Case[] = [
+  // JSON-RPC numeric
+  {
+    name: "-32700 parse error",
+    build: () => makeError("Parse error", { code: -32700 }),
+    expectSlug: "jsonrpc/parse_error",
+    expectRawCode: -32700,
+  },
+  {
+    name: "-32600 invalid request",
+    build: () => makeError("Invalid request", { code: -32600 }),
+    expectSlug: "jsonrpc/invalid_request",
+    expectRawCode: -32600,
+  },
+  {
+    name: "-32601 method not found",
+    build: () => makeError("Method not found", { code: -32601 }),
+    expectSlug: "jsonrpc/method_not_found",
+    expectRawCode: -32601,
+  },
+  {
+    name: "-32602 invalid params",
+    build: () => makeError("Invalid params", { code: -32602 }),
+    expectSlug: "jsonrpc/invalid_params",
+    expectRawCode: -32602,
+  },
+  {
+    name: "-32603 internal error",
+    build: () => makeError("Internal error", { code: -32603 }),
+    expectSlug: "jsonrpc/internal_error",
+    expectRawCode: -32603,
+  },
+  {
+    name: "-32000 connection closed",
+    build: () => makeError("Connection closed", { code: -32000 }),
+    expectSlug: "jsonrpc/connection_closed",
+    expectRawCode: -32000,
+  },
+  {
+    name: "-32001 request timeout",
+    build: () => makeError("Request timed out", { code: -32001 }),
+    expectSlug: "jsonrpc/request_timeout",
+    expectRawCode: -32001,
+  },
+  {
+    name: "-32001 header mismatch (inspector overload)",
+    build: () =>
+      makeError("MCP-Protocol-Version header mismatch", { code: -32001 }),
+    expectSlug: "jsonrpc/header_mismatch",
+    expectRawCode: -32001,
+  },
+  {
+    name: "-32004 unsupported protocol version",
+    build: () => makeError("Unsupported protocol version", { code: -32004 }),
+    expectSlug: "jsonrpc/unsupported_protocol_version",
+    expectRawCode: -32004,
+  },
+  {
+    name: "-32042 url elicitation required",
+    build: () => makeError("URL elicitation required", { code: -32042 }),
+    expectSlug: "jsonrpc/url_elicitation_required",
+    expectRawCode: -32042,
+  },
+  // Node errno
+  {
+    name: "ECONNREFUSED",
+    build: () => makeError("connect ECONNREFUSED 127.0.0.1:9999", { code: "ECONNREFUSED" }),
+    expectSlug: "transport/econnrefused",
+    expectRawCode: "ECONNREFUSED",
+  },
+  {
+    name: "ECONNRESET",
+    build: () => makeError("socket reset", { code: "ECONNRESET" }),
+    expectSlug: "transport/econnreset",
+    expectRawCode: "ECONNRESET",
+  },
+  {
+    name: "ETIMEDOUT",
+    build: () => makeError("connect timeout", { code: "ETIMEDOUT" }),
+    expectSlug: "transport/etimedout",
+    expectRawCode: "ETIMEDOUT",
+  },
+  {
+    name: "ENOTFOUND",
+    build: () => makeError("getaddrinfo ENOTFOUND foo", { code: "ENOTFOUND" }),
+    expectSlug: "transport/enotfound",
+    expectRawCode: "ENOTFOUND",
+  },
+  {
+    name: "EAI_AGAIN",
+    build: () => makeError("Temporary failure", { code: "EAI_AGAIN" }),
+    expectSlug: "transport/eai_again",
+    expectRawCode: "EAI_AGAIN",
+  },
+  {
+    name: "UND_ERR_SOCKET",
+    build: () => makeError("socket terminated", { code: "UND_ERR_SOCKET" }),
+    expectSlug: "transport/undici",
+    expectRawCode: "UND_ERR_SOCKET",
+  },
+  {
+    name: "fetch failed",
+    build: () => new Error("fetch failed"),
+    expectSlug: "transport/fetch_failed",
+  },
+  {
+    name: "socket hang up",
+    build: () => new Error("socket hang up"),
+    expectSlug: "transport/socket_hang_up",
+  },
+  // Auth
+  {
+    name: "HTTP 401 statusCode",
+    build: () => makeError("Unauthorized", { statusCode: 401 }),
+    expectSlug: "auth/http_401",
+    expectRawCode: 401,
+  },
+  {
+    name: "HTTP 403 statusCode",
+    build: () => makeError("Forbidden", { statusCode: 403 }),
+    expectSlug: "auth/http_403",
+    expectRawCode: 403,
+  },
+  {
+    name: "401 in message",
+    build: () => new Error("Server responded HTTP 401"),
+    expectSlug: "auth/http_401",
+  },
+  {
+    name: "OAuth refresh failed message",
+    build: () => new Error("OAuth refresh token failed: invalid_grant"),
+    expectSlug: "auth/oauth_refresh_failed",
+  },
+  {
+    name: "Missing bearer",
+    build: () => new Error("Missing or invalid bearer token"),
+    expectSlug: "auth/missing_bearer",
+  },
+  // OAuth body
+  {
+    name: "oauth invalid_grant body",
+    build: () => ({ body: { error: "invalid_grant", error_description: "Bad code" } }),
+    expectSlug: "oauth/invalid_grant",
+  },
+  {
+    name: "oauth invalid_client body",
+    build: () => ({ data: { error: "invalid_client" } }),
+    expectSlug: "oauth/invalid_client",
+  },
+  {
+    name: "oauth redirect mismatch body",
+    build: () => ({ error: "redirect_uri_mismatch" }),
+    expectSlug: "oauth/redirect_mismatch",
+  },
+  {
+    name: "oauth well-known unreachable",
+    build: () =>
+      new Error(".well-known/oauth-authorization-server unreachable"),
+    expectSlug: "oauth/well_known_unreachable",
+  },
+  // Inspector sentinels
+  {
+    name: "NotYetSupportedInStateless sentinel",
+    build: () => new Error("NotYetSupportedInStateless: resources/subscribe"),
+    expectSlug: "sdk/not_yet_supported_in_stateless",
+  },
+  {
+    name: "StatelessRequiresHttpTransport sentinel",
+    build: () => new Error("StatelessRequiresHttpTransport"),
+    expectSlug: "sdk/stateless_requires_http",
+  },
+  {
+    name: "PaginatedToolHeaderDiscoveryUnsupported sentinel",
+    build: () => new Error("PaginatedToolHeaderDiscoveryUnsupported"),
+    expectSlug: "sdk/paginated_tool_header_discovery_unsupported",
+  },
+  // Provider
+  {
+    name: "Anthropic invalid tool name",
+    build: () =>
+      new Error('messages.tools.0: Invalid tool name "weird name with spaces"'),
+    expectSlug: "provider/invalid_tool_name",
+  },
+];
+
+describe("describeError — table-driven", () => {
+  for (const c of CASES) {
+    it(c.name, () => {
+      const out = describeError(c.build());
+      expect(out.slug, JSON.stringify(out)).toBe(c.expectSlug);
+      if (c.expectRawCode !== undefined) {
+        expect(out.rawCode).toBe(c.expectRawCode);
+      }
+      expect(out.title.length).toBeGreaterThan(0);
+      expect(out.rawMessage.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe("describeError — fallback shapes (>= 8)", () => {
+  const cases: Array<[string, unknown, string]> = [
+    ["plain Error", new Error("something exploded"), "internal/unknown"],
+    ["null", null, "internal/unknown"],
+    ["undefined", undefined, "internal/unknown"],
+    ["string thrown", "boom", "internal/unknown"],
+    [
+      "AbortError",
+      Object.assign(new Error("aborted"), { name: "AbortError" }),
+      "internal/unknown",
+    ],
+    [
+      "OAuth body without error_description",
+      { body: { error_description: "Bad" } },
+      "internal/unknown",
+    ],
+    ["MCPAuthError", new MCPAuthError("token expired", 401), "auth/http_401"],
+    [
+      "hosted error envelope",
+      { code: "INTERNAL_ERROR", message: "Hosted failure" },
+      "internal/unknown",
+    ],
+    ["unknown numeric code", makeError("weird", { code: -42 }), "internal/unknown"],
+    ["bare number", 42, "internal/unknown"],
+  ];
+  for (const [name, input, expectSlug] of cases) {
+    it(name, () => {
+      const out: NormalizedError = describeError(input);
+      expect(out.slug).toBe(expectSlug);
+      expect(out).toHaveProperty("rawMessage");
+    });
+  }
+});
+
+describe("describeError — redaction", () => {
+  it("redacts bearer tokens from raw message", () => {
+    const out = describeError(
+      new Error("Authorization: Bearer abcdef.ghi.jkl failed"),
+    );
+    expect(out.rawMessage).not.toContain("abcdef.ghi.jkl");
+    expect(out.rawMessage.toLowerCase()).toContain("redacted");
+  });
+
+  it("never throws on truly unusual input", () => {
+    expect(() => describeError({ get code() { throw new Error("nope"); } })).not.toThrow();
+  });
+});

--- a/sdk/tests/error-describer/describe.test.ts
+++ b/sdk/tests/error-describer/describe.test.ts
@@ -416,6 +416,44 @@ describe("isNormalizedError — shape guard", () => {
   });
 });
 
+describe("describeError — specific message wording wins over generic HTTP 401", () => {
+  it("classifies 'Missing or invalid bearer token' (status 401) as auth/missing_bearer", () => {
+    // Reproduces the hosted-backend path: assertBearerToken throws
+    // WebRouteError(401, UNAUTHORIZED, "Missing or invalid bearer token"),
+    // then mapRuntimeError calls describeError(err). Before the fix the
+    // generic HTTP-status branch fired first and returned auth/http_401
+    // (MCP server re-auth guidance), instead of auth/missing_bearer
+    // (MCPJam CLI / MCPJAM_API_KEY guidance).
+    const err = Object.assign(new Error("Missing or invalid bearer token"), {
+      status: 401,
+      name: "WebRouteError",
+    });
+    const out = describeError(err);
+    expect(out.slug).toBe("auth/missing_bearer");
+  });
+
+  it("preserves MCPAuthError mapping to auth/http_401 (class wins)", () => {
+    // The class-name detector runs BEFORE the message check, so a real
+    // MCPAuthError still maps to auth/http_401 even if its message
+    // happens to contain the word "bearer". This is the desired
+    // behavior — MCPAuthError specifically means MCP-server auth.
+    const err = Object.assign(
+      new Error("Server rejected bearer token"),
+      { name: "MCPAuthError", statusCode: 401 },
+    );
+    const out = describeError(err);
+    expect(out.slug).toBe("auth/http_401");
+  });
+
+  it("falls back to auth/http_401 for a plain 401 without bearer wording", () => {
+    // Generic 401 with no specific message hints should still match
+    // the catch-all status branch.
+    const err = Object.assign(new Error("Unauthorized"), { status: 401 });
+    const out = describeError(err);
+    expect(out.slug).toBe("auth/http_401");
+  });
+});
+
 describe("describeError — unclassified errors surface their raw message", () => {
   it("promotes rawMessage into oneLine when slug is internal/unknown", () => {
     // OAuth step errors and other unclassified text used to be hidden


### PR DESCRIPTION
## Summary

A single source of truth for error UX. Adds `ERROR_CATALOG` + pure `describeError()` to `@mcpjam/sdk` (and `/browser`), wires the normalized data through every backend envelope (both hosted and local), preserves it across the client API layer + state store, and renders it via one shared `<ErrorCard>` component. New hand-authored docs page anchored to catalog slugs.

## Why now

A week of docs-chat logs (2026-05-29 → 2026-06-05, ~80 queries) shows errors are the #1 friction class. The dominant query is raw `MCP error -32000: Connection closed` / `-32001: Request timed out` / `-32603: Internal error` with no explanation, hint, or doc link. Those codes come from the **upstream `@modelcontextprotocol/sdk`** (synthesized client-side when transports die or requests time out), not the MCP spec — so we own the user-facing language and can do something about it.

## What changes

**SDK (additive, browser-safe)**
- `sdk/src/error-describer/{catalog,describe,node-errno,index}.ts` — 33 catalog entries covering JSON-RPC codes, Node errno (`ECONNREFUSED`/`ETIMEDOUT`/…), HTTP 401/403, OAuth failure modes, inspector sentinels (`StatelessRequiresHttpTransport`, etc.), provider errors.
- Pure `describeError(err): NormalizedError` — resolution: `MCPError`/`MCPAuthError` → numeric JSON-RPC code → Node errno → HTTP status → OAuth body → message regex → `internal/unknown` catch-all. Never throws. Redaction via existing `redactSensitiveValue`.
- Re-exports from both `sdk/src/index.ts` (root) and `sdk/src/browser.ts` (browser-safe entry, what the client uses).
- `extractNodeErrno` lifted out of `sdk/src/retry.ts` into the shared module.

**Backend (both envelope shapes carry `normalized`)**
- `WebRouteError` + `webError()` + `web.onError` — `web.onError` previously dropped `details` entirely; now forwards both `details` and `normalized`.
- `mapRuntimeError()` calls `describeError` first, then maps slug → existing `ErrorCode` enum (HTTP status semantics unchanged).
- `serializeMcpError`, `formatStreamError`, the JSON-RPC bridge (attaches `normalized` to `error.data.normalized`, spec-compatible), and all 3 `{success:false,error,details}` sites in `local-server-resolver.ts`.

**Frontend (preserve, then render)**
- `WebApiError` gains `normalized?`, populated in `webPost`. Hosted catches in `mcp-api.ts` and `mcp-tools-api.ts` no longer flatten to a string.
- `ServerWithName.lastNormalizedError` parallel to `lastError`. Rather than touching 30+ dispatchers, the reducer auto-derives the normalized form via `describeError(message)` when a dispatcher doesn't supply one. Sites with richer data (e.g. post-OAuth connect) thread it explicitly.
- New `components/ui/error-card.tsx` — single component, imports from `@mcpjam/sdk/browser`, renders icon + title + oneLine + collapsible likelyCauses/nextSteps + "Learn more →" link.
- Migrated 4 highest-volume renderers: `ServerConnectionCard`, `ServerInfoContent`, `ToolsTab`/`ResultsPanel`, `OAuthFlowProgress`.

**Docs (root `docs/`, hand-authored)**
- New `docs/troubleshooting/error-codes.mdx` — H3 per catalog entry, anchors match `docsAnchor`.
- New `docs/reference/api-keys.mdx` — disambiguates LLM provider key vs `MCPJAM_API_KEY` vs Playground BYOK.
- `docs/installation.mdx` — side-by-side STDIO + HTTP config example.
- `docs/troubleshooting/common-errors.mdx` — callout pointing to the new reference.
- `docs/docs.json` — nav entries.

## Out of scope (explicit)
- Auto-generating the error-codes page from the catalog (chose hand-authored for prose flexibility).
- Migrating `ChatTabV2` toasts + checkout-dialog renderers (follow-up PR).
- Removing the back-compat `lastError: string` field on `ServerWithName` (follow-up once readers all use the rich field).
- `/api/mcp/connect` becoming public HTTP-API docs (separate "internal vs public surface" RFC).

## Test plan

- [x] `cd sdk && npm test` — **1335 pass / 1 skip** across 84 files (incl. new 45-test describer suite)
- [x] `cd sdk && npm run typecheck && npm run build` — clean, browser entrypoint compiles
- [x] `cd mcpjam-inspector && npm run typecheck:client` — clean
- [x] Inspector client tests in changed areas (state, apis, connection) — **213 pass**
- [x] No new `from "@mcpjam/sdk"` root imports in client code (browser-safety guard)
- [ ] **Reviewer**: spin up the inspector, point a server at `http://127.0.0.1:9999` (ECONNREFUSED) → confirm `ServerConnectionCard` shows the rich ErrorCard with title "Connection refused" + causes + docs link, not raw "fetch failed".
- [ ] **Reviewer**: revoke an OAuth token → ErrorCard reads "Unauthorized (401)" + "Re-authenticate" next step + docs link.
- [ ] **Reviewer**: `cd docs && mint dev`, open `/troubleshooting/error-codes`, confirm ErrorCard anchor links land on the correct H3.

## Known pre-existing noise (reproduces on main, out of scope)
- Server typecheck: `JsonWebKey` lib issues, `trace-repair-runner-job` test errors, `export-helpers` readonly issues.
- 3 connection-test-file failures (`ServerDetailModal*`, `ShareUsageThreadDetail`) — Vite missing-image errors in test env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to connection, tools, OAuth, and chat error paths and envelopes; mitigated by additive fields, `isNormalizedError` guards, and extensive SDK tests, but regressions in classification or partial payloads could still affect what users see.
> 
> **Overview**
> Introduces a **unified error UX stack** so inspector failures show titles, causes, next steps, and **Learn more** links instead of raw strings.
> 
> **SDK:** New browser-safe `error-describer` module with `ERROR_CATALOG`, `describeError()` / `describeAsSlug()`, and `isNormalizedError()`; re-exported from `@mcpjam/sdk` and `@mcpjam/sdk/browser`. Node errno extraction is shared with retry logic.
> 
> **Backend:** API and route handlers attach a `normalized` block to JSON errors (hosted `webError` / `mapRuntimeError`, local connect envelopes, MCP tools `jsonError`, chat stream errors, JSON-RPC bridge `error.data.normalized`).
> 
> **Client:** `WebApiError` and tool/list APIs preserve `normalized` (with shape validation). Server state gains `lastNormalizedError`; connect failures thread backend slugs through the reducer. New **`ErrorCard`** replaces ad-hoc error UI on server cards, tool results, OAuth flow, and related surfaces.
> 
> **Docs:** New error-code reference and API-keys disambiguation pages, nav wiring, mixed STDIO/HTTP install example, and a pointer from common errors to the catalog (anchors match catalog slugs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d29587b59ecb5a6b631999d78cad776a71eb31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->