### PR TITLE
eval→chatSessions widget repopulation (inspector): thread snapshots through fanout

### DIFF
--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ConvexHttpClient } from "convex/browser";
 import type { ModelMessage } from "ai";
-import type { EvalTraceSpan, PromptTraceSummary } from "@/shared/eval-trace";
+import type {
+  EvalTraceSpan,
+  EvalTraceWidgetSnapshot,
+  PromptTraceSummary,
+} from "@/shared/eval-trace";
 import {
   __resetEvalChatSessionsWriterFlagCacheForTests,
   isEvalChatSessionsWriterEnabled,
@@ -457,5 +461,149 @@ describe("lockEvalSessionAfterUpdate", () => {
         reason: "eval_completed",
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("persistEvalTraceFanout — widget serialization", () => {
+  const makeSnapshot = (
+    overrides: Partial<EvalTraceWidgetSnapshot> = {},
+  ): EvalTraceWidgetSnapshot => ({
+    toolCallId: "call-1",
+    toolName: "create_view",
+    protocol: "mcp-apps",
+    serverId: "excalidraw",
+    toolMetadata: {},
+    widgetHtmlBlobId: "storage-id-1",
+    ...overrides,
+  });
+
+  test("widgets are attached to the LAST turn call only", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    const prompts: PromptTraceSummary[] = [
+      {
+        promptIndex: 0,
+        prompt: "p0",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+      {
+        promptIndex: 1,
+        prompt: "p1",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+    ];
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: [
+        { role: "user", content: "q0" } as ModelMessage,
+        { role: "assistant", content: "a0" } as ModelMessage,
+        { role: "user", content: "q1" } as ModelMessage,
+        { role: "assistant", content: "a1" } as ModelMessage,
+      ],
+      spans: undefined,
+      prompts,
+      widgetSnapshots: [makeSnapshot()],
+    });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    expect(appendCalls).toHaveLength(2);
+    const firstTurn = appendCalls[0]!.args.turn as { widgets: unknown[] };
+    const lastTurn = appendCalls[1]!.args.turn as { widgets: unknown[] };
+    expect(firstTurn.widgets).toEqual([]);
+    expect(lastTurn.widgets).toHaveLength(1);
+  });
+
+  test("renames protocol → uiType and forwards friendly serverId verbatim", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: [{ role: "user", content: "q" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
+      widgetSnapshots: [
+        makeSnapshot({ protocol: "openai-apps", serverId: "my-server" }),
+      ],
+    });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    const widget = (appendCalls[0]!.args.turn as { widgets: any[] }).widgets[0];
+    expect(widget.uiType).toBe("openai-apps");
+    expect(widget.serverId).toBe("my-server");
+    // protocol is the inspector field name; backend never sees it.
+    expect(widget.protocol).toBeUndefined();
+  });
+
+  test("drops widgets without widgetHtmlBlobId; other widgets pass through", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: [{ role: "user", content: "q" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
+      widgetSnapshots: [
+        makeSnapshot({ toolCallId: "good", widgetHtmlBlobId: "blob-good" }),
+        makeSnapshot({ toolCallId: "missing-blob", widgetHtmlBlobId: undefined }),
+      ],
+    });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    const widgets = (appendCalls[0]!.args.turn as { widgets: any[] }).widgets;
+    expect(widgets).toHaveLength(1);
+    expect(widgets[0].toolCallId).toBe("good");
+  });
+
+  test("normalizes widgetCsp to backend shape, drops unknown keys", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: [{ role: "user", content: "q" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
+      widgetSnapshots: [
+        makeSnapshot({
+          widgetCsp: {
+            connectDomains: ["a.com", "b.com"],
+            // Non-string entries filtered out.
+            resourceDomains: ["good.com", 123 as unknown as string, null],
+            unrelatedField: "ignored",
+          },
+        }),
+      ],
+    });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    const csp = ((appendCalls[0]!.args.turn as { widgets: any[] }).widgets[0])
+      .widgetCsp;
+    expect(csp).toEqual({
+      connectDomains: ["a.com", "b.com"],
+      resourceDomains: ["good.com"],
+    });
+    expect(csp.unrelatedField).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -574,6 +574,47 @@ describe("persistEvalTraceFanout — widget serialization", () => {
     expect(widgets[0].toolCallId).toBe("good");
   });
 
+  test("sanitizes $-prefixed keys in widgetPermissions (Convex reserved-key protection)", async () => {
+    const { client, calls } = makeMockClient({ flagEnabled: true });
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: [{ role: "user", content: "q" } as ModelMessage],
+      spans: undefined,
+      prompts: undefined,
+      widgetSnapshots: [
+        makeSnapshot({
+          // JSON Schema-shaped permissions — `$ref` / `$schema` would
+          // otherwise be rejected by Convex's argument validator and
+          // collapse the entire `appendEvalTurnTrace` call.
+          widgetPermissions: {
+            $schema: "https://json-schema.org/draft/2020-12/schema",
+            properties: {
+              clipboard: {
+                $ref: "#/definitions/Capability",
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    const perms = ((appendCalls[0]!.args.turn as { widgets: any[] }).widgets[0])
+      .widgetPermissions;
+    expect(perms.$schema).toBeUndefined();
+    expect(perms.__convexReserved__schema).toBe(
+      "https://json-schema.org/draft/2020-12/schema",
+    );
+    expect(perms.properties.clipboard.$ref).toBeUndefined();
+    expect(perms.properties.clipboard.__convexReserved__ref).toBe(
+      "#/definitions/Capability",
+    );
+  });
+
   test("normalizes widgetCsp to backend shape, drops unknown keys", async () => {
     const { client, calls } = makeMockClient({ flagEnabled: true });
 

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -59,14 +59,14 @@ import { sanitizeForConvexTransport } from "./convex-sanitize.js";
  * Acceptable trade-off for a process-scoped feature flag; document
  * this in the deploy runbook before flipping the flag in prod.
  *
- * Widgets: PR-2 drops widgets from the forwarded payload for the same
- * reason PR-1's W1 path did — `EvalTraceWidgetSnapshot.serverId` is
- * `string` (could be a friendly server name from older runs), but
- * `appendEvalTurnTrace`'s validator requires `serverId: v.id('servers')`.
- * The legacy `testIteration.blob` fallback (when flag is off) still
- * carries widgets. A follow-up PR that resolves serverIds at the runner
- * layer (where the MCPClientManager is in scope) will repopulate
- * `sharedChatWidgetSnapshots` for eval rows.
+ * Widgets: forwarded on the LAST turn call so they persist once at
+ * finalize. Inspector capture (`captureMcpAppWidgetSnapshots`) supplies
+ * the friendly MCP server name as `serverId`; the backend resolves it
+ * to a Convex `Id<'servers'>` via `resolveEvalWidgetServerIds` before
+ * writing `sharedChatWidgetSnapshots`. Widgets whose serverId can't be
+ * resolved against the iteration's project/workspace, or whose HTML
+ * blob upload failed, are dropped — the persist call must not fail
+ * over a single bad widget.
  */
 
 let cachedFlagEnabled: boolean | null = null;
@@ -186,6 +186,94 @@ function sliceTraceIntoTurns(args: {
   });
 }
 
+/**
+ * Backend `appendEvalTurnTrace` widget shape (after renames). Kept inline
+ * rather than imported from `@convex` to avoid pulling generated types
+ * into the inspector server bundle. Mirror of
+ * `appendEvalTurnTraceWidgetValidator` in
+ * `mcpjam-backend/convex/testSuites.ts`.
+ */
+type BackendEvalWidget = {
+  toolCallId: string;
+  toolName: string;
+  /** Friendly MCP server name; backend resolves to Id<'servers'>. */
+  serverId: string;
+  widgetHtmlBlobId: string;
+  uiType: "mcp-apps" | "openai-apps";
+  resourceUri?: string;
+  widgetCsp?: {
+    connectDomains?: string[];
+    resourceDomains?: string[];
+    frameDomains?: string[];
+    baseUriDomains?: string[];
+  };
+  widgetPermissions?: unknown;
+  widgetPermissive?: boolean;
+  prefersBorder?: boolean;
+};
+
+function toStringArrayOrUndefined(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: string[] = [];
+  for (const item of v) {
+    if (typeof item === "string") out.push(item);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeWidgetCsp(
+  v: unknown,
+): BackendEvalWidget["widgetCsp"] | undefined {
+  if (!v || typeof v !== "object") return undefined;
+  const rec = v as Record<string, unknown>;
+  const out: BackendEvalWidget["widgetCsp"] = {};
+  const connect = toStringArrayOrUndefined(rec.connectDomains);
+  const resource = toStringArrayOrUndefined(rec.resourceDomains);
+  const frame = toStringArrayOrUndefined(rec.frameDomains);
+  const base = toStringArrayOrUndefined(rec.baseUriDomains);
+  if (connect) out.connectDomains = connect;
+  if (resource) out.resourceDomains = resource;
+  if (frame) out.frameDomains = frame;
+  if (base) out.baseUriDomains = base;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function serializeWidgetsForBackend(
+  snapshots: EvalTraceWidgetSnapshot[] | undefined,
+): BackendEvalWidget[] {
+  if (!snapshots || snapshots.length === 0) return [];
+  const out: BackendEvalWidget[] = [];
+  for (const snap of snapshots) {
+    if (!snap.widgetHtmlBlobId) {
+      // Required by `sharedChatWidgetSnapshots.widgetHtmlBlobId`. The
+      // capture path uploads when it can; widgets without an uploaded
+      // blob are unusable to the reader and dropped here.
+      continue;
+    }
+    const widget: BackendEvalWidget = {
+      toolCallId: snap.toolCallId,
+      toolName: snap.toolName,
+      serverId: snap.serverId,
+      widgetHtmlBlobId: snap.widgetHtmlBlobId,
+      uiType: snap.protocol,
+    };
+    if (snap.resourceUri) widget.resourceUri = snap.resourceUri;
+    const csp = normalizeWidgetCsp(snap.widgetCsp);
+    if (csp) widget.widgetCsp = csp;
+    if (snap.widgetPermissions !== undefined && snap.widgetPermissions !== null) {
+      widget.widgetPermissions = snap.widgetPermissions;
+    }
+    if (typeof snap.widgetPermissive === "boolean") {
+      widget.widgetPermissive = snap.widgetPermissive;
+    }
+    if (typeof snap.prefersBorder === "boolean") {
+      widget.prefersBorder = snap.prefersBorder;
+    }
+    out.push(widget);
+  }
+  return out;
+}
+
 type FanoutResult =
   | null
   | { persisted: true }
@@ -207,21 +295,32 @@ export async function persistEvalTraceFanout(args: {
   messages: ModelMessage[];
   spans: EvalTraceSpan[] | undefined;
   prompts: PromptTraceSummary[] | undefined;
-  /** Currently unused — see file header note about widgets. */
+  /**
+   * Eval widget snapshots captured via `captureMcpAppWidgetSnapshots`.
+   * Attached to the LAST turn call so they persist once, at finalize.
+   * The backend resolves the friendly `serverId` to a Convex doc id
+   * (`resolveEvalWidgetServerIds`); unresolved widgets are dropped
+   * server-side, not here.
+   */
   widgetSnapshots?: EvalTraceWidgetSnapshot[];
 }): Promise<FanoutResult> {
   const enabled = await isEvalChatSessionsWriterEnabled(args.convexClient);
   if (!enabled) return null;
-
-  // Avoid touching the widgetSnapshots param so linters don't flag it.
-  // Documented in the file header why widgets are PR-2-deferred.
-  void args.widgetSnapshots;
 
   const turns = sliceTraceIntoTurns({
     messages: args.messages,
     spans: args.spans ?? [],
     prompts: args.prompts ?? [],
   });
+
+  // Convert inspector-shape widgets to the backend `appendEvalTurnTrace`
+  // shape. Inspector snapshots optionally carry the HTML blob id;
+  // `sharedChatWidgetSnapshots.widgetHtmlBlobId` is required so widgets
+  // without an uploaded blob are dropped here. Field renames:
+  // `protocol` → `uiType`. Free-form `toolMetadata` is dropped — the
+  // backend persists tool input/output as separately-uploaded blobs,
+  // not the inline metadata object.
+  const lastTurnWidgets = serializeWidgetsForBackend(args.widgetSnapshots);
 
   const startedAt = args.iterationStartedAt ?? Date.now();
   const modelId = args.modelId ?? "eval/unknown";
@@ -237,7 +336,13 @@ export async function persistEvalTraceFanout(args: {
   try {
     for (let i = 0; i < turns.length; i++) {
       const turn = turns[i]!;
+      const isLastTurn = i === turns.length - 1;
       const now = Date.now();
+      // Widgets are session-scoped (`sharedChatWidgetSnapshots` keys on
+      // sessionId + toolCallId) and capture happens once per iteration at
+      // finalize, so we attach the full set to the last turn call. Earlier
+      // turns send `widgets: []` to keep per-turn payloads light.
+      const widgetsForThisTurn = isLastTurn ? lastTurnWidgets : [];
       const result = (await args.convexClient.action(
         "testSuites:appendEvalTurnTrace" as any,
         {
@@ -256,7 +361,7 @@ export async function persistEvalTraceFanout(args: {
             ...(turn.prompts.length > 0
               ? { prompts: sanitizeForConvexTransport(turn.prompts) }
               : {}),
-            widgets: [],
+            widgets: widgetsForThisTurn,
           },
         },
       )) as { skipped?: boolean } | undefined;

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -269,7 +269,15 @@ function serializeWidgetsForBackend(
     if (typeof snap.prefersBorder === "boolean") {
       widget.prefersBorder = snap.prefersBorder;
     }
-    out.push(widget);
+    // `widgetPermissions` is free-form `Record<string, unknown>` on the
+    // wire (typed `v.any()` server-side). JSON Schema fragments commonly
+    // appear there and use `$`-prefixed keys (`$ref`, `$schema`), which
+    // Convex rejects at the argument validator boundary, failing the
+    // whole `appendEvalTurnTrace` call and killing the fanout. Sanitize
+    // the widget so any `$`-prefixed key is escaped to
+    // `__convexReserved__*` for transport — same protection
+    // `sessionMessages` / `spans` / `prompts` already get.
+    out.push(sanitizeForConvexTransport(widget));
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Companion to **MCPJam/mcpjam-backend#434**. The inspector now sends widget snapshots through `persistEvalTraceFanout` → `appendEvalTurnTrace` instead of dropping them. Widgets attach to the LAST turn call so they persist once at finalize.

Without this PR, the eval iteration-details trace viewer still renders MCP App widgets (from inline tool-result content), but `sharedChatWidgetSnapshots` rows never materialize for eval sessions — breaking the unified Sessions viewer, "open eval as Playground session" affordances, and widget-usage analytics.

### Serialization at the boundary

- `protocol` → `uiType` (backend field name).
- Friendly `serverId` (e.g. `"excalidraw"`) forwarded verbatim — backend resolves to `Id<'servers'>` via the new `resolveEvalWidgetServerIds` helper.
- `toolMetadata` dropped (backend persists tool input/output as separate blob refs, not inline metadata).
- `widgetCsp` normalized to the strict backend shape: filter to string-array fields, drop unknown keys.
- Widgets without `widgetHtmlBlobId` are dropped at the inspector boundary (required by the backend table; without HTML the widget is unusable to the reader anyway).

### Why last-turn-only?

Widget capture in the eval runner happens once per iteration at finalize (`captureMcpAppWidgetSnapshots` after the agent loop completes), not per turn. `sharedChatWidgetSnapshots` is session-scoped — there's no per-turn ordering on the table. Attaching to the final turn keeps earlier turn payloads light and persists widgets exactly once.

## Test plan

- [x] 4 new unit tests in `persist-eval-trace.test.ts`:
  - widgets attached to last turn call only (earlier turns send `widgets: []`)
  - protocol → uiType rename + serverId passthrough
  - widgets without `widgetHtmlBlobId` are dropped
  - widgetCsp normalization (filters non-string entries, drops unknown keys)
- [x] All 13 existing tests still pass (17 total)
- [x] Local smoke after deploying both halves: re-ran Excalidraw quickstart with `USE_EVAL_CHAT_SESSIONS_WRITER=true`; verified `sharedChatWidgetSnapshots` materialized with resolved Convex serverIds for each `create_view` invocation (1 row per iteration; was 0 pre-fix)

## Rollout dependency

Merge **MCPJam/mcpjam-backend#434 first**. The inspector starts sending widgets with friendly serverIds the moment this PR ships; without the backend resolver, the backend's strict `serverId: v.id('servers')` validator would reject them. The backend PR is backward-compatible (relaxation of the validator), so it can ship and burn-in before this one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval→chatSessions write behavior when the writer flag is on and requires the companion backend deploy for friendly serverId resolution; failures are mitigated by dropping bad widgets rather than failing the fanout.
> 
> **Overview**
> **Eval chat-session persistence** now sends captured MCP App widget snapshots through `persistEvalTraceFanout` → `appendEvalTurnTrace` instead of always passing empty `widgets: []`.
> 
> Serialization maps inspector snapshots to the backend shape: **`protocol` → `uiType`**, friendly **`serverId`** forwarded as-is (backend resolves to Convex server ids), **`toolMetadata` omitted**, entries **without `widgetHtmlBlobId` dropped**, **`widgetCsp` narrowed** to allowed string-array fields, and **`widgetPermissions` run through `sanitizeForConvexTransport`** so `$`-prefixed JSON Schema keys do not fail the whole append call.
> 
> Because widgets are captured once at iteration finalize, the **full widget list is attached only on the last per-turn** `appendEvalTurnTrace` call; earlier turns still send `widgets: []`. Unit tests cover last-turn attachment, field renames, blob filtering, CSP normalization, and permission sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92cabd79a1c5e60b903ddee52c2fcdbe60fc68f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->