### PR TITLE
docs: remove SDK v1.12 announcement banner

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,10 +30,6 @@
     }
   },
   "favicon": "/mcp_jam.svg",
-  "banner": {
-    "content": "New: [@mcpjam/sdk v1.12](/sdk) — programmatic evals and conformance checks, runnable from Jest or Vitest.",
-    "dismissible": true
-  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
## Summary
- Drops the orange "New: @mcpjam/sdk v1.12" banner from the top of docs.mcpjam.com

## Test plan
- [ ] Mintlify preview: confirm banner is gone on docs home + section pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only config change with no runtime, auth, or data impact.
> 
> **Overview**
> Removes the Mintlify **site-wide announcement banner** from `docs/docs.json` that promoted **@mcpjam/sdk v1.12** (evals/conformance from Jest/Vitest) with a link to `/sdk`.
> 
> The banner was dismissible; deleting the `banner` block stops it from appearing on the docs home and all section pages. No navigation or page content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c25606d1abf006f58bf92d0d7baf42d5af78938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->