### PR TITLE
shared/widget-snapshot: unify the three writers to sharedChatWidgetSnapshots

### DIFF
--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -11,6 +11,10 @@ import {
   useWidgetDebugStore,
   type WidgetDebugInfo,
 } from "@/stores/widget-debug-store";
+import {
+  sanitizeWidgetForBackend,
+  type SharedChatWidgetSnapshotPayload,
+} from "@/shared/widget-snapshot";
 
 interface UseSharedChatWidgetCaptureOptions {
   enabled: boolean;
@@ -484,12 +488,15 @@ export function useSharedChatWidgetCapture({
 
       if (!scopeStillValid()) return;
 
-      const snapshotPayload = {
-        ...(chatboxId ? { chatboxId } : {}),
-        ...(chatboxId && Number.isFinite(accessVersion)
-          ? { accessVersion }
-          : {}),
-        chatSessionId: sessionIdRef.current,
+      // Build the shared payload (the part every writer to
+      // `sharedChatWidgetSnapshots` produces), sanitize for Convex
+      // transport, then layer the playground/chatbox session context
+      // (chatboxId / accessVersion / chatSessionId) on top. The shared
+      // pipeline owns the $-key escaping inside `widgetPermissions`
+      // (JSON Schema fragments routinely use `$ref` / `$schema` which
+      // Convex's argument validator rejects raw) and any future
+      // normalization the table wants from every caller.
+      const widgetPayload: SharedChatWidgetSnapshotPayload = {
         ...(toolSource.serverId ? { serverId: toolSource.serverId } : {}),
         toolCallId,
         toolName: toolSource.toolName,
@@ -503,6 +510,14 @@ export function useSharedChatWidgetCapture({
         widgetPermissive: widget.csp?.mode === "permissive",
         prefersBorder: widget.prefersBorder,
         displayContext: toDisplayContext(widget.globals),
+      };
+      const snapshotPayload = {
+        ...(chatboxId ? { chatboxId } : {}),
+        ...(chatboxId && Number.isFinite(accessVersion)
+          ? { accessVersion }
+          : {}),
+        chatSessionId: sessionIdRef.current,
+        ...sanitizeWidgetForBackend(widgetPayload),
       };
       const snapshotResult = await createWidgetSnapshot(snapshotPayload);
 

--- a/mcpjam-inspector/client/src/hooks/useViews.ts
+++ b/mcpjam-inspector/client/src/hooks/useViews.ts
@@ -6,28 +6,13 @@ import { shouldQueryProjectId, type RemoteServer } from "./useProjects";
 // Type definitions matching backend
 export type ViewProtocol = "mcp-apps" | "openai-apps";
 
-export type DisplayContext = {
-  theme?: "light" | "dark";
-  displayMode?: "inline" | "pip" | "fullscreen";
-  deviceType?: "mobile" | "tablet" | "desktop";
-  viewport?: { width: number; height: number };
-  locale?: string;
-  timeZone?: string;
-  capabilities?: { hover: boolean; touch: boolean };
-  safeAreaInsets?: {
-    top: number;
-    right: number;
-    bottom: number;
-    left: number;
-  };
-};
-
-export type WidgetCsp = {
-  connectDomains?: string[];
-  resourceDomains?: string[];
-  frameDomains?: string[];
-  baseUriDomains?: string[];
-};
+// Re-exported from the shared module so the playground hook, eval
+// fanout, and synthetic runner all reference the same definitions.
+// See `shared/widget-snapshot.ts` for the source of truth.
+export type {
+  SharedChatWidgetDisplayContext as DisplayContext,
+  SharedChatWidgetCsp as WidgetCsp,
+} from "@/shared/widget-snapshot";
 
 export type ServerInfo = {
   name: string;

--- a/mcpjam-inspector/client/src/hooks/useViews.ts
+++ b/mcpjam-inspector/client/src/hooks/useViews.ts
@@ -8,11 +8,17 @@ export type ViewProtocol = "mcp-apps" | "openai-apps";
 
 // Re-exported from the shared module so the playground hook, eval
 // fanout, and synthetic runner all reference the same definitions.
-// See `shared/widget-snapshot.ts` for the source of truth.
-export type {
+// See `shared/widget-snapshot.ts` for the source of truth. The
+// `import type` brings the names into local scope so type references
+// below (`defaultContext: DisplayContext`, `widgetCsp?: WidgetCsp`)
+// resolve — `export type { ... }` alone is a pure re-export and does
+// not create a local binding.
+import type {
   SharedChatWidgetDisplayContext as DisplayContext,
   SharedChatWidgetCsp as WidgetCsp,
 } from "@/shared/widget-snapshot";
+
+export type { DisplayContext, WidgetCsp };
 
 export type ServerInfo = {
   name: string;

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -7,6 +7,11 @@ import type {
 } from "@/shared/eval-trace";
 import { logger } from "../../utils/logger.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+import {
+  evalTraceSnapshotToPayload,
+  sanitizeWidgetForBackend,
+  type SharedChatWidgetSnapshotPayload,
+} from "@/shared/widget-snapshot";
 
 /**
  * Inspector-side per-turn fanout for the eval→chatSessions unification.
@@ -187,97 +192,22 @@ function sliceTraceIntoTurns(args: {
 }
 
 /**
- * Backend `appendEvalTurnTrace` widget shape (after renames). Kept inline
- * rather than imported from `@convex` to avoid pulling generated types
- * into the inspector server bundle. Mirror of
- * `appendEvalTurnTraceWidgetValidator` in
- * `mcpjam-backend/convex/testSuites.ts`.
+ * Translate the eval runner's captured snapshots to the shared
+ * `sharedChatWidgetSnapshots` payload shape and run them through the
+ * Convex transport sanitizer. The mapping + CSP normalization + $-key
+ * sanitization all live in `shared/widget-snapshot.ts` so every writer
+ * to that table (playground hook, synthetic runner, eval) goes through
+ * the same pipeline.
  */
-type BackendEvalWidget = {
-  toolCallId: string;
-  toolName: string;
-  /** Friendly MCP server name; backend resolves to Id<'servers'>. */
-  serverId: string;
-  widgetHtmlBlobId: string;
-  uiType: "mcp-apps" | "openai-apps";
-  resourceUri?: string;
-  widgetCsp?: {
-    connectDomains?: string[];
-    resourceDomains?: string[];
-    frameDomains?: string[];
-    baseUriDomains?: string[];
-  };
-  widgetPermissions?: unknown;
-  widgetPermissive?: boolean;
-  prefersBorder?: boolean;
-};
-
-function toStringArrayOrUndefined(v: unknown): string[] | undefined {
-  if (!Array.isArray(v)) return undefined;
-  const out: string[] = [];
-  for (const item of v) {
-    if (typeof item === "string") out.push(item);
-  }
-  return out.length > 0 ? out : undefined;
-}
-
-function normalizeWidgetCsp(
-  v: unknown,
-): BackendEvalWidget["widgetCsp"] | undefined {
-  if (!v || typeof v !== "object") return undefined;
-  const rec = v as Record<string, unknown>;
-  const out: BackendEvalWidget["widgetCsp"] = {};
-  const connect = toStringArrayOrUndefined(rec.connectDomains);
-  const resource = toStringArrayOrUndefined(rec.resourceDomains);
-  const frame = toStringArrayOrUndefined(rec.frameDomains);
-  const base = toStringArrayOrUndefined(rec.baseUriDomains);
-  if (connect) out.connectDomains = connect;
-  if (resource) out.resourceDomains = resource;
-  if (frame) out.frameDomains = frame;
-  if (base) out.baseUriDomains = base;
-  return Object.keys(out).length > 0 ? out : undefined;
-}
-
 function serializeWidgetsForBackend(
   snapshots: EvalTraceWidgetSnapshot[] | undefined,
-): BackendEvalWidget[] {
+): SharedChatWidgetSnapshotPayload[] {
   if (!snapshots || snapshots.length === 0) return [];
-  const out: BackendEvalWidget[] = [];
+  const out: SharedChatWidgetSnapshotPayload[] = [];
   for (const snap of snapshots) {
-    if (!snap.widgetHtmlBlobId) {
-      // Required by `sharedChatWidgetSnapshots.widgetHtmlBlobId`. The
-      // capture path uploads when it can; widgets without an uploaded
-      // blob are unusable to the reader and dropped here.
-      continue;
-    }
-    const widget: BackendEvalWidget = {
-      toolCallId: snap.toolCallId,
-      toolName: snap.toolName,
-      serverId: snap.serverId,
-      widgetHtmlBlobId: snap.widgetHtmlBlobId,
-      uiType: snap.protocol,
-    };
-    if (snap.resourceUri) widget.resourceUri = snap.resourceUri;
-    const csp = normalizeWidgetCsp(snap.widgetCsp);
-    if (csp) widget.widgetCsp = csp;
-    if (snap.widgetPermissions !== undefined && snap.widgetPermissions !== null) {
-      widget.widgetPermissions = snap.widgetPermissions;
-    }
-    if (typeof snap.widgetPermissive === "boolean") {
-      widget.widgetPermissive = snap.widgetPermissive;
-    }
-    if (typeof snap.prefersBorder === "boolean") {
-      widget.prefersBorder = snap.prefersBorder;
-    }
-    // `widgetPermissions` is free-form `Record<string, unknown>` on the
-    // wire (typed `v.any()` server-side). JSON Schema fragments commonly
-    // appear there and use `$`-prefixed keys (`$ref`, `$schema`), which
-    // Convex rejects at the argument validator boundary, failing the
-    // whole `appendEvalTurnTrace` call and killing the fanout. Sanitize
-    // the widget so any `$`-prefixed key is escaped to
-    // `__convexReserved__*` for transport — same protection
-    // `sessionMessages` / `spans` / `prompts` already get.
-    out.push(sanitizeForConvexTransport(widget));
+    const payload = evalTraceSnapshotToPayload(snap);
+    if (!payload) continue;
+    out.push(sanitizeWidgetForBackend(payload));
   }
   return out;
 }

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -17,6 +17,10 @@ import { exportConnectedServerToolSnapshotForEvalAuthoring } from "../../utils/e
 import { captureMcpAppWidgetSnapshots } from "../../utils/mcp-app-widget-capture.js";
 import type { EvalTraceWidgetSnapshot } from "@/shared/eval-trace";
 import {
+  evalTraceSnapshotToPayload,
+  sanitizeWidgetForBackend,
+} from "@/shared/widget-snapshot";
+import {
   createRun,
   getRun,
   personaNextTurn,
@@ -725,9 +729,14 @@ async function captureAndPersistWidgetSnapshotsForSession(args: {
     snapshots.map(async (snap) => {
       // The capture helper short-circuits when readResource fails or the
       // resource is missing HTML, but it still emits a snapshot stub.
-      // The Convex mutation requires a `widgetHtmlBlobId`, so drop the
-      // stub instead of sending an invalid call.
-      if (!snap.widgetHtmlBlobId) return;
+      // `evalTraceSnapshotToPayload` returns null in that case so we
+      // drop the stub instead of sending an invalid call.
+      const widgetPayload = evalTraceSnapshotToPayload(snap);
+      if (!widgetPayload) return;
+      // Sanitize for Convex transport — `widgetPermissions` is free-form
+      // and JSON Schema fragments use $-prefixed keys (`$ref`, `$schema`)
+      // which Convex rejects at the argument-validator boundary.
+      const sanitized = sanitizeWidgetForBackend(widgetPayload);
       try {
         await convexClient.mutation(
           "chatSessions:createWidgetSnapshot" as any,
@@ -735,22 +744,7 @@ async function captureAndPersistWidgetSnapshotsForSession(args: {
             chatboxId,
             ...(accessVersion !== undefined ? { accessVersion } : {}),
             chatSessionId,
-            serverId: snap.serverId,
-            toolCallId: snap.toolCallId,
-            toolName: snap.toolName,
-            widgetHtmlBlobId: snap.widgetHtmlBlobId,
-            uiType: snap.protocol,
-            ...(snap.resourceUri ? { resourceUri: snap.resourceUri } : {}),
-            ...(snap.widgetCsp ? { widgetCsp: snap.widgetCsp } : {}),
-            ...(snap.widgetPermissions
-              ? { widgetPermissions: snap.widgetPermissions }
-              : {}),
-            ...(snap.widgetPermissive !== undefined
-              ? { widgetPermissive: snap.widgetPermissive }
-              : {}),
-            ...(snap.prefersBorder !== undefined
-              ? { prefersBorder: snap.prefersBorder }
-              : {}),
+            ...sanitized,
           },
         );
       } catch (err) {

--- a/mcpjam-inspector/shared/__tests__/widget-snapshot.test.ts
+++ b/mcpjam-inspector/shared/__tests__/widget-snapshot.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "vitest";
+import type { EvalTraceWidgetSnapshot } from "../eval-trace";
+import {
+  evalTraceSnapshotToPayload,
+  normalizeWidgetCsp,
+  sanitizeWidgetForBackend,
+  type SharedChatWidgetSnapshotPayload,
+} from "../widget-snapshot";
+
+function makeEvalSnap(
+  overrides: Partial<EvalTraceWidgetSnapshot> = {},
+): EvalTraceWidgetSnapshot {
+  return {
+    toolCallId: "call-1",
+    toolName: "create_view",
+    protocol: "mcp-apps",
+    serverId: "excalidraw",
+    toolMetadata: {},
+    widgetHtmlBlobId: "html-blob-1",
+    ...overrides,
+  };
+}
+
+describe("normalizeWidgetCsp", () => {
+  test("picks string-array fields and drops non-string entries", () => {
+    expect(
+      normalizeWidgetCsp({
+        connectDomains: ["a.com", "b.com"],
+        resourceDomains: ["good.com", 123 as unknown as string, null],
+        unknownField: "ignored",
+      }),
+    ).toEqual({
+      connectDomains: ["a.com", "b.com"],
+      resourceDomains: ["good.com"],
+    });
+  });
+
+  test("returns undefined for non-object input", () => {
+    expect(normalizeWidgetCsp(null)).toBeUndefined();
+    expect(normalizeWidgetCsp(undefined)).toBeUndefined();
+    expect(normalizeWidgetCsp("string")).toBeUndefined();
+    expect(normalizeWidgetCsp(42)).toBeUndefined();
+  });
+
+  test("returns undefined when no recognized fields survive normalization", () => {
+    // Empty record, record with only non-string-array fields, or record
+    // with empty arrays — all collapse to absent CSP. Callers depend on
+    // absent vs `{}` being distinguishable (backend mutations treat them
+    // differently in the widgetCsp validator path).
+    expect(normalizeWidgetCsp({})).toBeUndefined();
+    expect(normalizeWidgetCsp({ unrelated: "x" })).toBeUndefined();
+    expect(normalizeWidgetCsp({ connectDomains: [] })).toBeUndefined();
+  });
+});
+
+describe("sanitizeWidgetForBackend", () => {
+  test("escapes $-prefixed keys inside widgetPermissions", () => {
+    const payload: SharedChatWidgetSnapshotPayload = {
+      toolCallId: "c",
+      toolName: "t",
+      serverId: "s",
+      widgetHtmlBlobId: "b",
+      uiType: "mcp-apps",
+      widgetPermissions: {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        properties: {
+          clipboard: {
+            $ref: "#/definitions/Capability",
+          },
+        },
+      },
+    };
+    const out = sanitizeWidgetForBackend(payload);
+    const perms = out.widgetPermissions as Record<string, any>;
+    expect(perms.$schema).toBeUndefined();
+    expect(perms.__convexReserved__schema).toBe(
+      "https://json-schema.org/draft/2020-12/schema",
+    );
+    expect(perms.properties.clipboard.$ref).toBeUndefined();
+    expect(perms.properties.clipboard.__convexReserved__ref).toBe(
+      "#/definitions/Capability",
+    );
+  });
+
+  test("is a no-op for payloads with no reserved keys", () => {
+    const payload: SharedChatWidgetSnapshotPayload = {
+      toolCallId: "c",
+      toolName: "t",
+      serverId: "s",
+      widgetHtmlBlobId: "b",
+      uiType: "openai-apps",
+      widgetCsp: { connectDomains: ["a.com"] },
+      widgetPermissive: true,
+      prefersBorder: false,
+    };
+    expect(sanitizeWidgetForBackend(payload)).toEqual(payload);
+  });
+});
+
+describe("evalTraceSnapshotToPayload", () => {
+  test("maps protocol → uiType and forwards friendly serverId verbatim", () => {
+    const out = evalTraceSnapshotToPayload(
+      makeEvalSnap({ protocol: "openai-apps", serverId: "my-server" }),
+    );
+    expect(out).not.toBeNull();
+    expect(out!.uiType).toBe("openai-apps");
+    expect(out!.serverId).toBe("my-server");
+    // `protocol` is the source-side field name; the payload doesn't
+    // carry it through under either name.
+    expect((out as unknown as Record<string, unknown>).protocol).toBeUndefined();
+  });
+
+  test("returns null when widgetHtmlBlobId is missing", () => {
+    expect(
+      evalTraceSnapshotToPayload(
+        makeEvalSnap({ widgetHtmlBlobId: undefined }),
+      ),
+    ).toBeNull();
+  });
+
+  test("normalizes widgetCsp via normalizeWidgetCsp", () => {
+    const out = evalTraceSnapshotToPayload(
+      makeEvalSnap({
+        widgetCsp: {
+          connectDomains: ["a.com"],
+          resourceDomains: ["good.com", 99 as unknown as string],
+          extra: "x",
+        },
+      }),
+    );
+    expect(out!.widgetCsp).toEqual({
+      connectDomains: ["a.com"],
+      resourceDomains: ["good.com"],
+    });
+  });
+
+  test("forwards optional fields when set, omits when absent", () => {
+    const withAll = evalTraceSnapshotToPayload(
+      makeEvalSnap({
+        resourceUri: "ui://x",
+        widgetPermissions: { camera: true },
+        widgetPermissive: true,
+        prefersBorder: false,
+      }),
+    );
+    expect(withAll).toMatchObject({
+      resourceUri: "ui://x",
+      widgetPermissions: { camera: true },
+      widgetPermissive: true,
+      prefersBorder: false,
+    });
+
+    const minimal = evalTraceSnapshotToPayload(makeEvalSnap());
+    expect(minimal!.resourceUri).toBeUndefined();
+    expect(minimal!.widgetPermissions).toBeUndefined();
+    expect(minimal!.widgetPermissive).toBeUndefined();
+    expect(minimal!.prefersBorder).toBeUndefined();
+  });
+
+  test("drops toolMetadata and widgetHtmlUrl (backend stores them elsewhere or not at all)", () => {
+    const out = evalTraceSnapshotToPayload(
+      makeEvalSnap({
+        toolMetadata: { someKey: "value" },
+        widgetHtmlUrl: "http://example.test/widget",
+      }),
+    );
+    expect((out as unknown as Record<string, unknown>).toolMetadata)
+      .toBeUndefined();
+    expect((out as unknown as Record<string, unknown>).widgetHtmlUrl)
+      .toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/shared/widget-snapshot.ts
+++ b/mcpjam-inspector/shared/widget-snapshot.ts
@@ -1,0 +1,197 @@
+import { sanitizeForConvexTransport } from "./convex-sanitize";
+import type { EvalTraceWidgetSnapshot } from "./eval-trace";
+
+/**
+ * Wire shape of a `sharedChatWidgetSnapshots` row, less the
+ * session/scope context that varies by writer (the playground threads
+ * `chatboxId`/`accessVersion`/`chatSessionId`; the eval per-turn fanout
+ * embeds widgets in `appendEvalTurnTrace.turn.widgets`; the synthetic
+ * runner adds its own ambient scope at the mutation site).
+ *
+ * Every writer to `sharedChatWidgetSnapshots` (client playground hook,
+ * server synthetic-sessions runner, server eval persist) builds this
+ * shape and then layers site-specific context on top. The backend table
+ * schema in `mcpjam-backend/convex/schema.ts::sharedChatWidgetSnapshots`
+ * is the source of truth for the wire contract; this type is its
+ * inspector-side mirror.
+ *
+ * Forward-looking note (`injectedOpenAiCompat*`):
+ *   These exist on `EvalTraceWidgetSnapshot` and on the `mcpAppViews`
+ *   table but NOT on `sharedChatWidgetSnapshots` yet. Once the backend
+ *   schema PR lands those columns + accepting validators, add the
+ *   fields here and thread them through `evalTraceSnapshotToPayload` —
+ *   every writer picks them up for free.
+ */
+export type SharedChatWidgetSnapshotPayload = {
+  toolCallId: string;
+  toolName: string;
+  /**
+   * The MCP server identifier. Optional because the playground's
+   * `createWidgetSnapshot` mutation can derive it from the session row
+   * server-side when absent (visitor sessions know their server).
+   * Required by the eval `appendEvalTurnTrace` path — that caller MUST
+   * supply it. Wire shape:
+   *   - eval: friendly name (e.g. `"excalidraw"`); backend resolves via
+   *     `resolveEvalWidgetServerIds`.
+   *   - playground/synthetic: already-resolved `Id<'servers'>` string.
+   */
+  serverId?: string;
+  widgetHtmlBlobId: string;
+  uiType: "mcp-apps" | "openai-apps";
+  resourceUri?: string;
+  toolInputBlobId?: string;
+  toolOutputBlobId?: string;
+  widgetCsp?: {
+    connectDomains?: string[];
+    resourceDomains?: string[];
+    frameDomains?: string[];
+    baseUriDomains?: string[];
+  };
+  /**
+   * Free-form on the wire — backend validator is `v.any()`. JSON Schema
+   * fragments routinely appear here and use $-prefixed keys (`$ref`,
+   * `$schema`). Callers MUST pass the result through
+   * `sanitizeWidgetForBackend` before sending; Convex's argument
+   * validator rejects raw $-prefixed keys.
+   */
+  widgetPermissions?: unknown;
+  widgetPermissive?: boolean;
+  prefersBorder?: boolean;
+  displayContext?: SharedChatWidgetDisplayContext;
+};
+
+/**
+ * Per-render display environment threaded with a widget snapshot. Same
+ * shape the `displayContextValidator` enforces server-side. Re-exported
+ * from `client/src/hooks/useViews.ts` as `DisplayContext` for callers
+ * that imported it from there before this module existed.
+ */
+export type SharedChatWidgetDisplayContext = {
+  theme?: "light" | "dark";
+  displayMode?: "inline" | "pip" | "fullscreen";
+  deviceType?: "mobile" | "tablet" | "desktop";
+  viewport?: { width: number; height: number };
+  locale?: string;
+  timeZone?: string;
+  capabilities?: { hover: boolean; touch: boolean };
+  safeAreaInsets?: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  };
+};
+
+/**
+ * CSP fields persisted with a widget snapshot. Re-exported from
+ * `useViews.ts` as `WidgetCsp` for compatibility.
+ */
+export type SharedChatWidgetCsp = NonNullable<
+  SharedChatWidgetSnapshotPayload["widgetCsp"]
+>;
+
+function toStringArrayOrUndefined(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: string[] = [];
+  for (const item of v) {
+    if (typeof item === "string") out.push(item);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Defensive normalization for `widgetCsp` when the caller has it as a
+ * loose record. Used by writers whose source captures CSP via JSON
+ * (eval/synthetic, which round-trip through `_storage`); the playground
+ * has it from the live runtime widget shape, which is already typed,
+ * but running it through this is a no-op on a well-shaped input so
+ * callers can use the same pipeline.
+ *
+ * Returns `undefined` rather than `{}` when no recognized fields are
+ * present — both `chatSessions:createWidgetSnapshot` and
+ * `appendEvalTurnTrace` treat absent CSP differently from an empty
+ * one, so the distinction matters.
+ */
+export function normalizeWidgetCsp(
+  input: unknown,
+): SharedChatWidgetSnapshotPayload["widgetCsp"] | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const rec = input as Record<string, unknown>;
+  const csp: NonNullable<SharedChatWidgetSnapshotPayload["widgetCsp"]> = {};
+  const connect = toStringArrayOrUndefined(rec.connectDomains);
+  const resource = toStringArrayOrUndefined(rec.resourceDomains);
+  const frame = toStringArrayOrUndefined(rec.frameDomains);
+  const base = toStringArrayOrUndefined(rec.baseUriDomains);
+  if (connect) csp.connectDomains = connect;
+  if (resource) csp.resourceDomains = resource;
+  if (frame) csp.frameDomains = frame;
+  if (base) csp.baseUriDomains = base;
+  return Object.keys(csp).length > 0 ? csp : undefined;
+}
+
+/**
+ * Sanitize a widget payload for Convex transport. Escapes $-prefixed
+ * keys (typically inside `widgetPermissions`) to `__convexReserved__*`
+ * so Convex's argument validator accepts them. Idempotent on payloads
+ * with no reserved keys.
+ *
+ * Why every writer needs this: backend `widgetPermissions` validator is
+ * `v.any()` for shape flexibility, but Convex still enforces the
+ * reserved-key prefix at the transport layer, so the validator never
+ * gets the chance to see the data — the whole mutation call fails. The
+ * sibling `sessionMessages` / `spans` / `prompts` arrays in the eval
+ * fanout already use the same sanitizer for the same reason.
+ */
+export function sanitizeWidgetForBackend<
+  T extends SharedChatWidgetSnapshotPayload,
+>(payload: T): T {
+  return sanitizeForConvexTransport(payload);
+}
+
+/**
+ * Convert an `EvalTraceWidgetSnapshot` (the serialized capture shape
+ * used by `captureMcpAppWidgetSnapshots` and shared between the eval
+ * and synthetic-sessions runners) to the shared payload.
+ *
+ * Returns `null` when the widget is unsendable. Today that means
+ * `widgetHtmlBlobId` is missing — the backend table requires it, and
+ * without HTML the widget is unusable to the Sessions viewer anyway.
+ *
+ * Field renames:
+ *   `protocol` → `uiType`
+ * Dropped:
+ *   `toolMetadata` (backend persists tool input/output separately, not
+ *     as inline metadata)
+ *   `widgetHtmlUrl` (backend stores only the blob id)
+ *   `injectedOpenAiCompat`, `injectedOpenAiCompatCapabilities`
+ *     (see file-header note — pending backend schema PR)
+ *
+ * Callers MUST run the result through `sanitizeWidgetForBackend`
+ * before sending. (The two steps are kept separate so tests can exercise
+ * the mapping without the sanitizer's key-mangling and vice versa.)
+ */
+export function evalTraceSnapshotToPayload(
+  snap: EvalTraceWidgetSnapshot,
+): SharedChatWidgetSnapshotPayload | null {
+  if (!snap.widgetHtmlBlobId) return null;
+  const payload: SharedChatWidgetSnapshotPayload = {
+    toolCallId: snap.toolCallId,
+    toolName: snap.toolName,
+    serverId: snap.serverId,
+    widgetHtmlBlobId: snap.widgetHtmlBlobId,
+    uiType: snap.protocol,
+  };
+  if (snap.resourceUri) payload.resourceUri = snap.resourceUri;
+  const csp = normalizeWidgetCsp(snap.widgetCsp);
+  if (csp) payload.widgetCsp = csp;
+  if (snap.widgetPermissions !== undefined && snap.widgetPermissions !== null) {
+    payload.widgetPermissions = snap.widgetPermissions;
+  }
+  if (typeof snap.widgetPermissive === "boolean") {
+    payload.widgetPermissive = snap.widgetPermissive;
+  }
+  if (typeof snap.prefersBorder === "boolean") {
+    payload.prefersBorder = snap.prefersBorder;
+  }
+  return payload;
+}


### PR DESCRIPTION
## Summary

Before this PR, three call sites built the `sharedChatWidgetSnapshots` payload inline with their own translation:

- `client/src/hooks/useSharedChatWidgetCapture.ts` — playground / visible chatbox
- `server/services/sessionSimulation/runner.ts` — synthetic sessions
- `server/services/evals/persist-eval-trace.ts` — eval per-turn fanout

They differed in:
- **\$-key sanitization** — only the eval site had it (added in #2441 review). Synthetic and playground would silently fail the whole mutation call if `widgetPermissions` contained a JSON Schema fragment (`\$ref`, `\$schema`), which Convex rejects at the argument-validator boundary.
- **CSP normalization** — only the eval site had defensive normalization for loose-record sources.
- **\`protocol\` → \`uiType\` rename** repeated at each site.

A third writer (synthetic) was already in the codebase by the time we shipped eval, so the drift was already real.

## What's shared

New `shared/widget-snapshot.ts`:
- **\`SharedChatWidgetSnapshotPayload\`** — wire shape mirror of the backend table, sans session/scope context (which varies by writer).
- **\`normalizeWidgetCsp(unknown)\`** — picks string-array fields, drops non-string entries and unknown keys; returns undefined when nothing recognized survives.
- **\`sanitizeWidgetForBackend(payload)\`** — wraps \`sanitizeForConvexTransport\` for callers that don't need to know about Convex transport details.
- **\`evalTraceSnapshotToPayload(snap)\`** — converter for the \`EvalTraceWidgetSnapshot\` source (used by eval + synthetic). Returns null when \`widgetHtmlBlobId\` is missing (unsendable).

Each writer keeps its own field mapping where the source type forces it (playground reads from \`WidgetDebugInfo\` which is client-only), but routes the result through the shared sanitize step — closing the previously-latent \$-key bug at all three sites.

\`useViews.ts\` re-exports \`DisplayContext\` and \`WidgetCsp\` from the shared module so the duplicate type definitions are gone.

## Forward path for F1 (\`injectedOpenAiCompat*\`)

CodeRabbit flagged the \`injectedOpenAiCompat\` / \`injectedOpenAiCompatCapabilities\` drop on #2441. Backend \`sharedChatWidgetSnapshots\` schema doesn't have those columns yet — only \`mcpAppViews\` does. Once a backend PR adds them + relaxes the validators on \`createWidgetSnapshot\` and \`appendEvalTurnTrace\`, threading them through is a **single diff in this PR's file** (add to \`SharedChatWidgetSnapshotPayload\` + \`evalTraceSnapshotToPayload\`) and all three writers pick them up.

## Test plan

- [x] 10 new tests in \`shared/__tests__/widget-snapshot.test.ts\` cover CSP normalization, \$-key sanitization, and the eval-snapshot converter.
- [x] All 18 existing eval-fanout tests still pass.
- [x] All 11 existing playground-hook tests still pass.
- [x] Full inspector vitest: **4988 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all three persistence paths for widget snapshots; behavior change is mainly consistent sanitization and CSP normalization, but a regression could break snapshot writes or eval turn fanout.
> 
> **Overview**
> Introduces **`shared/widget-snapshot.ts`** as the single pipeline for rows written to **`sharedChatWidgetSnapshots`**: **`SharedChatWidgetSnapshotPayload`**, **`normalizeWidgetCsp`**, **`sanitizeWidgetForBackend`** (escapes `$ref` / `$schema` in **`widgetPermissions`** for Convex), and **`evalTraceSnapshotToPayload`** (`protocol` → **`uiType`**, drops stubs without **`widgetHtmlBlobId`**).
> 
> **Playground** (`useSharedChatWidgetCapture`) now builds that payload and runs **`sanitizeWidgetForBackend`** before **`createWidgetSnapshot`**—fixing a latent failure when JSON Schema fragments appear in permissions. **Eval fanout** (`persist-eval-trace`) and **synthetic sessions** (`sessionSimulation/runner`) drop duplicated inline mappers and use the same converter + sanitizer.
> 
> **`useViews.ts`** removes duplicate **`DisplayContext`** / **`WidgetCsp`** definitions and re-exports them from the shared module. **10 vitest cases** cover CSP normalization, sanitization, and eval snapshot mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a452d7f63ad6f00c46110663efa73c0e1f986e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->