### PR TITLE
docs: clarify SDK eval host config wire hash

### DIFF
--- a/sdk/src/host-config/sdk-evals-normalizer.ts
+++ b/sdk/src/host-config/sdk-evals-normalizer.ts
@@ -5,8 +5,9 @@
  * the SDK eval reporter (Step 3) and the backend ingestion handler (Step 2)
  * feed into `canonicalizeHostConfigV2` + `computeHostConfigHashV2`. By
  * normalizing on the wire — not on either side independently — we guarantee
- * client and backend mint the same content-addressed `hostConfigsV2` id from
- * the same logical configuration.
+ * client and backend agree on the transport-integrity hash. The eventual
+ * stored v2 `hostConfigs` row may have a different hash because backend
+ * materialization layers suite-resolved Convex `serverIds` back in.
  *
  * The normalizer's only behavior is to STRIP fields that are runtime-manager
  * identifiers, never `Id<'servers'>`:


### PR DESCRIPTION
## Summary
- clarify that normalizeSdkEvalHostConfigForWire establishes the transport-integrity hash
- note that the final stored v2 hostConfigs row may hash differently once backend materialization layers suite-resolved Convex serverIds back in

## Testing
- Not run; comment-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation change with no code or test modifications.
> 
> **Overview**
> Updates the module-level comment on **`normalizeSdkEvalHostConfigForWire`** so it no longer implies SDK and backend always produce the same content-addressed **`hostConfigsV2`** id.
> 
> The comment now states that shared wire normalization yields a matching **transport-integrity hash**, and that the persisted v2 **`hostConfigs`** row can hash differently once backend materialization re-adds suite-resolved Convex **`serverIds`**. No runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac94b20882b77ad6fb73e0df3f55bfbf7ae1051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->