### PR TITLE
evals: derive lockReason from iteration status, not verdict

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -710,10 +710,19 @@ async function finishIterationDirectly(
   // see recorder.ts for the full rationale. A failed-verdict iteration
   // that ran cleanly still gets eval_completed; eval_failed is reserved
   // for cycle failures (provider errors, transport crashes, etc.).
+  //
+  // The `params.error` check covers a runner quirk (Codex review on
+  // #2446): some backend eval paths set `iterationError` but still
+  // pass `status: "completed"` to finishIteration (see
+  // evals-runner.ts:2079-2082 / :3962-3965). Treating those as
+  // eval_completed would lock an error transcript with the wrong reason.
+  const isCycleFailure =
+    iterationStatus === "failed" ||
+    (params.error !== undefined && params.error !== "");
   const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
     iterationStatus === "cancelled"
       ? "eval_cancelled"
-      : iterationStatus === "failed"
+      : isCycleFailure
         ? "eval_failed"
         : "eval_completed";
   const fanout = await persistEvalTraceFanout({

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -706,12 +706,16 @@ async function finishIterationDirectly(
   // rows BEFORE updateTestIteration; the chatSessions lock fires AFTER
   // updateTestIteration succeeds (PR-2 review fix #2). When the
   // backend flag is off, today's legacy behavior runs unchanged.
+  // lockReason describes the transcript LIFECYCLE, not the verdict —
+  // see recorder.ts for the full rationale. A failed-verdict iteration
+  // that ran cleanly still gets eval_completed; eval_failed is reserved
+  // for cycle failures (provider errors, transport crashes, etc.).
   const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
     iterationStatus === "cancelled"
       ? "eval_cancelled"
-      : params.passed
-        ? "eval_completed"
-        : "eval_failed";
+      : iterationStatus === "failed"
+        ? "eval_failed"
+        : "eval_completed";
   const fanout = await persistEvalTraceFanout({
     convexClient,
     iterationId: params.iterationId,

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -231,6 +231,105 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     },
   );
 
+  it(
+    "derives lockReason from iteration STATUS, not verdict: failed-verdict + clean cycle → eval_completed",
+    async () => {
+      // Regression test for the transcript-lifecycle vs verdict split.
+      // The lock-reason describes whether the eval CYCLE ran to completion
+      // (so the chatSessions transcript is consistent), NOT whether the
+      // verdict passed. A failed-verdict iteration that ran cleanly
+      // (status: "completed", result: "failed", passed: false) must still
+      // get lockReason: "eval_completed". eval_failed is reserved for
+      // cycle failures (provider errors, transport crashes, status:"failed").
+      //
+      // Force passed=false by configuring an expectedToolCall the mock
+      // assistant won't make. The runner's success path then calls
+      // finishIterationDirectly with status:"completed" + passed:false.
+      // Before the fix this site derived terminalReason from `passed` and
+      // would have called lockEvalSession with reason:"eval_failed".
+      const lockCalls: Array<{ iterationId: string; reason: string }> = [];
+      const action = vi.fn(async (ref: string, payload: any) => {
+        if (ref === "testSuites:isEvalChatSessionsWriterEnabled") {
+          return { enabled: true };
+        }
+        if (ref === "testSuites:appendEvalTurnTrace") {
+          return { skipped: false, chatSessionId: "sess_x", locked: false };
+        }
+        if (ref === "testSuites:updateTestIteration") {
+          return undefined;
+        }
+        if (ref === "testSuites:lockEvalSession") {
+          lockCalls.push({
+            iterationId: payload?.iterationId,
+            reason: payload?.reason,
+          });
+          return { skipped: false, locked: true, alreadyLocked: false };
+        }
+        return undefined;
+      });
+      convexClient.action = action;
+      const { __resetEvalChatSessionsWriterFlagCacheForTests } = await import(
+        "../persist-eval-trace.js"
+      );
+      __resetEvalChatSessionsWriterFlagCacheForTests();
+
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              // Expecting a tool the mock assistant never calls → matchPassed=false
+              // → finalizePassedForEval mock returns false → passed=false.
+              expectedToolCalls: [
+                { toolName: "never-called-tool", arguments: {} },
+              ],
+              promptTurns: [
+                {
+                  id: "turn-1",
+                  prompt: "Hello",
+                  expectedToolCalls: [
+                    { toolName: "never-called-tool", arguments: {} },
+                  ],
+                },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      });
+
+      // Confirm we exercised the success path: updateTestIteration was
+      // called with result:"failed" + status:"completed", and the lock
+      // fired with reason:"eval_completed" (lifecycle-clean), not
+      // "eval_failed" (which is for cycle failures).
+      const updateCall = action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      expect(updateCall?.[1]).toMatchObject({
+        result: "failed",
+        status: "completed",
+      });
+      expect(lockCalls).toHaveLength(1);
+      expect(lockCalls[0].reason).toBe("eval_completed");
+
+      __resetEvalChatSessionsWriterFlagCacheForTests();
+    },
+  );
+
   it("persists compareRunId in quick-run iteration metadata when provided", async () => {
     const updatePayload = await runQuickTestCase("cmp_123");
 

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -330,6 +330,97 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     },
   );
 
+  it(
+    "derives lockReason from iteration STATUS + error: backend cycle error (status:completed + error set) → eval_failed",
+    async () => {
+      // Codex review on #2446: the BACKEND-routed eval path's success
+      // tail passes `status: "completed"` to finishIteration[Directly]
+      // even when `iterationError` was captured during the run (see
+      // evals-runner.ts:2079-2082 and :3962-3965 / line 2088, 3971 —
+      // both hardcoded `status: "completed" as const`). A pure
+      // status-based derivation would lock those as eval_completed,
+      // even though the transcript represents a cycle failure.
+      // Presence of `error` is the cycle-failure signal.
+      //
+      // The local-generateText error path uses `status: "failed"` and
+      // is already correctly mapped — it's the backend path that has
+      // the status/error mismatch. Force the backend path by using a
+      // hosted MCPJam-routed model (no BYOK key needed) + making fetch
+      // reject mid-iteration.
+      fetchMock.mockRejectedValueOnce(new Error("backend down"));
+
+      const lockCalls: Array<{ iterationId: string; reason: string }> = [];
+      const action = vi.fn(async (ref: string, payload: any) => {
+        if (ref === "testSuites:isEvalChatSessionsWriterEnabled") {
+          return { enabled: true };
+        }
+        if (ref === "testSuites:appendEvalTurnTrace") {
+          return { skipped: false, chatSessionId: "sess_x", locked: false };
+        }
+        if (ref === "testSuites:updateTestIteration") {
+          return undefined;
+        }
+        if (ref === "testSuites:lockEvalSession") {
+          lockCalls.push({
+            iterationId: payload?.iterationId,
+            reason: payload?.reason,
+          });
+          return { skipped: false, locked: true, alreadyLocked: false };
+        }
+        return undefined;
+      });
+      convexClient.action = action;
+      const { __resetEvalChatSessionsWriterFlagCacheForTests } = await import(
+        "../persist-eval-trace.js"
+      );
+      __resetEvalChatSessionsWriterFlagCacheForTests();
+
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "claude-haiku-4.5",
+              provider: "anthropic",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      });
+
+      // Confirm we exercised the cycle-failure path: the iteration was
+      // finalized with error:set, status:"completed", and the lock
+      // fired with reason:"eval_failed" — the codex finding.
+      const updateCall = action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      expect(updateCall?.[1]).toMatchObject({
+        status: "completed",
+      });
+      expect(updateCall?.[1]?.error).toBeTruthy();
+      expect(lockCalls).toHaveLength(1);
+      expect(lockCalls[0].reason).toBe("eval_failed");
+
+      __resetEvalChatSessionsWriterFlagCacheForTests();
+    },
+  );
+
   it("persists compareRunId in quick-run iteration metadata when provided", async () => {
     const updatePayload = await runQuickTestCase("cmp_123");
 

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -251,12 +251,25 @@ export const createSuiteRunRecorder = ({
       //   - persisted:false → fanout failed mid-stream; fall back to
       //                       the legacy single-call path so the iteration
       //                       is still complete and replayable.
+      // lockReason describes the transcript LIFECYCLE (did the eval cycle
+      // run to completion?), NOT the verdict. A failed-verdict iteration
+      // that ran cleanly (status: "completed", result: "failed") still
+      // gets eval_completed; eval_failed is reserved for cycle failures
+      // like provider errors, MCP transport crashes, etc. The verdict
+      // lives on testIteration.result (passed | failed | pending).
+      //
+      // Today this is defense-in-depth: the backend's
+      // internalUpdateTestIteration auto-lock (W1) fires first with the
+      // same status-based derivation, and internalLockEvalSession is
+      // "first lock wins" — so this recorder-side lock call no-ops. But
+      // if W1 ever doesn't run (iteration finalized without status
+      // patches) the wrong `passed`-based reason would land.
       const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
         iterationStatus === "cancelled"
           ? "eval_cancelled"
-          : passed
-            ? "eval_completed"
-            : "eval_failed";
+          : iterationStatus === "failed"
+            ? "eval_failed"
+            : "eval_completed";
       const fanout = await persistEvalTraceFanout({
         convexClient,
         iterationId,

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -258,16 +258,26 @@ export const createSuiteRunRecorder = ({
       // like provider errors, MCP transport crashes, etc. The verdict
       // lives on testIteration.result (passed | failed | pending).
       //
+      // The `error != null` check covers a runner quirk (Codex review on
+      // #2446): the backend eval paths sometimes set
+      // `iterationError` while still calling finishIteration with
+      // `status: "completed"` (see evals-runner.ts:2079-2082 and
+      // :3962-3965). Treating those as eval_completed would lock an
+      // error transcript with the wrong reason. Presence of `error`
+      // is the cycle-failure signal we already have in scope.
+      //
       // Today this is defense-in-depth: the backend's
       // internalUpdateTestIteration auto-lock (W1) fires first with the
       // same status-based derivation, and internalLockEvalSession is
       // "first lock wins" — so this recorder-side lock call no-ops. But
       // if W1 ever doesn't run (iteration finalized without status
       // patches) the wrong `passed`-based reason would land.
+      const isCycleFailure =
+        iterationStatus === "failed" || (error !== undefined && error !== "");
       const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
         iterationStatus === "cancelled"
           ? "eval_cancelled"
-          : iterationStatus === "failed"
+          : isCycleFailure
             ? "eval_failed"
             : "eval_completed";
       const fanout = await persistEvalTraceFanout({


### PR DESCRIPTION
## Summary

- `chatSessions.lockReason` describes the transcript **lifecycle** (did the eval cycle run to completion?), not the **verdict** (which lives on `testIteration.result`). Two inspector-side sites that fire the post-update lock — `recorder.finishIteration` and `evals-runner.finishIterationDirectly` — were deriving `terminalReason` from `passed`, so a failed-verdict iteration that ran cleanly (`status:"completed"`, `result:"failed"`) would map to `lockReason:"eval_failed"` instead of `"eval_completed"`. Switch both sites to the same status-based derivation the backend already uses (`internalUpdateTestIteration` auto-lock at `mcpjam-backend/convex/testSuites.ts:7480`):

  ```ts
  status === "cancelled" → eval_cancelled
  status === "failed"    → eval_failed   // cycle failure: provider, transport, …
  otherwise              → eval_completed // clean cycle; verdict may still be failed
  ```

- This is **inert today** because the backend's W1 auto-lock fires first with the correct status-based derivation, and `internalLockEvalSession` is first-lock-wins — so the recorder's later `lockEvalSessionAfterUpdate` call no-ops. The change is defense-in-depth: if W1 ever doesn't run (iteration finalized without status patches), the recorder's wrong `passed`-based reason would land. `passed` stays in scope for its other uses (result string, metadata, evaluation reporting); only its use in the `terminalReason` expression changes.

- Adds a regression test that drives the runner through a failed-verdict + clean-cycle iteration and asserts `lockEvalSession` is called with `reason:"eval_completed"`. Verified to fail against the old `passed`-based derivation.

## Test plan

- [x] `npx vitest run server/services/evals/__tests__/evals-runner.test.ts` (14/14 pass; was 13/13)
- [x] `npx vitest run server/services/evals/__tests__/persist-eval-trace.test.ts server/services/evals/__tests__/recorder.test.ts` (no regressions)
- [x] Full `npx vitest run --reporter=dot` — 4945 passing on this branch vs 4944 on `main` (+1 for the new regression test); pre-existing 9 file-collection failures unrelated to evals
- [x] Sanity: reverted the runner-side fix locally and confirmed the new test fails with `expected 'eval_failed' to be 'eval_completed'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logic-only alignment with backend lock semantics and defense-in-depth; verdict persistence is unchanged and coverage is added via unit tests.
> 
> **Overview**
> **Eval chatSession locks** now use **transcript lifecycle** (did the eval cycle finish cleanly?) instead of **pass/fail verdict** when choosing `lockReason` after trace fanout.
> 
> In `recorder.finishIteration` and `finishIterationDirectly`, `terminalReason` no longer maps `passed: false` to `eval_failed`. It follows iteration **status** and cycle-failure signals: `cancelled` → `eval_cancelled`; `status: "failed"` or a non-empty **`error`** → `eval_failed`; otherwise → **`eval_completed`** (including failed verdicts with `status: "completed"`). The **`error`** branch covers backend paths that finalize with `status: "completed"` while still recording an iteration error.
> 
> Two **regression tests** lock in a clean failed-verdict run → `eval_completed`, and backend error + completed status → `eval_failed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65d85ef30f44c6f36d99c9e0c2cbf4acf4eeab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->