### PR TITLE
widget-snapshot: thread injectedOpenAiCompat* through shared converter + playground

### DIFF
--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -514,10 +514,18 @@ export function useSharedChatWidgetCapture({
         // reconstruct the same `window.openai` surface the widget was
         // captured against. Pulled from the widget-debug store (set by
         // the MCP-Apps renderer at fetch time).
+        //
+        // Capabilities are gated behind `injectedOpenAiCompat === true`:
+        // the matrix describes the injected surface, so persisting one
+        // alongside a false/undefined compat flag lets cached replay
+        // hash and treat the surface differently than the byte-frozen
+        // HTML. The runtime mirrors this — it only emits capabilities
+        // when the shim is injected.
         ...(typeof widget.injectedOpenAiCompat === "boolean"
           ? { injectedOpenAiCompat: widget.injectedOpenAiCompat }
           : {}),
-        ...(widget.injectedOpenAiCompatCapabilities
+        ...(widget.injectedOpenAiCompat === true &&
+        widget.injectedOpenAiCompatCapabilities
           ? {
               injectedOpenAiCompatCapabilities:
                 widget.injectedOpenAiCompatCapabilities,

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -510,6 +510,19 @@ export function useSharedChatWidgetCapture({
         widgetPermissive: widget.csp?.mode === "permissive",
         prefersBorder: widget.prefersBorder,
         displayContext: toDisplayContext(widget.globals),
+        // Persist the OpenAI Apps SDK shim provenance so replay can
+        // reconstruct the same `window.openai` surface the widget was
+        // captured against. Pulled from the widget-debug store (set by
+        // the MCP-Apps renderer at fetch time).
+        ...(typeof widget.injectedOpenAiCompat === "boolean"
+          ? { injectedOpenAiCompat: widget.injectedOpenAiCompat }
+          : {}),
+        ...(widget.injectedOpenAiCompatCapabilities
+          ? {
+              injectedOpenAiCompatCapabilities:
+                widget.injectedOpenAiCompatCapabilities,
+            }
+          : {}),
       };
       const snapshotPayload = {
         ...(chatboxId ? { chatboxId } : {}),

--- a/mcpjam-inspector/shared/__tests__/widget-snapshot.test.ts
+++ b/mcpjam-inspector/shared/__tests__/widget-snapshot.test.ts
@@ -157,7 +157,7 @@ describe("evalTraceSnapshotToPayload", () => {
     expect(minimal!.prefersBorder).toBeUndefined();
   });
 
-  test("forwards injectedOpenAiCompat + capabilities when set on the source", () => {
+  test("forwards injectedOpenAiCompat + capabilities when compat is true", () => {
     const out = evalTraceSnapshotToPayload(
       makeEvalSnap({
         injectedOpenAiCompat: true,
@@ -174,6 +174,35 @@ describe("evalTraceSnapshotToPayload", () => {
       sendFollowUpMessage: false,
       requestDisplayMode: "fullscreen-only",
     });
+  });
+
+  test("drops capabilities when injectedOpenAiCompat is false (no shim injected ⇒ no surface)", () => {
+    // A buggy producer could attach a capability matrix to a snapshot
+    // where the shim wasn't actually injected. Persisting that would let
+    // replay hash the matrix and treat the surface as different than
+    // the shim-less HTML actually represents.
+    const out = evalTraceSnapshotToPayload(
+      makeEvalSnap({
+        injectedOpenAiCompat: false,
+        injectedOpenAiCompatCapabilities: {
+          callTool: true,
+        },
+      }),
+    );
+    expect(out!.injectedOpenAiCompat).toBe(false);
+    expect(out!.injectedOpenAiCompatCapabilities).toBeUndefined();
+  });
+
+  test("drops capabilities when injectedOpenAiCompat is undefined", () => {
+    const out = evalTraceSnapshotToPayload(
+      makeEvalSnap({
+        injectedOpenAiCompatCapabilities: {
+          callTool: true,
+        },
+      }),
+    );
+    expect(out!.injectedOpenAiCompat).toBeUndefined();
+    expect(out!.injectedOpenAiCompatCapabilities).toBeUndefined();
   });
 
   test("omits OpenAI compat fields when absent (pre-feature snapshot)", () => {

--- a/mcpjam-inspector/shared/__tests__/widget-snapshot.test.ts
+++ b/mcpjam-inspector/shared/__tests__/widget-snapshot.test.ts
@@ -157,6 +157,44 @@ describe("evalTraceSnapshotToPayload", () => {
     expect(minimal!.prefersBorder).toBeUndefined();
   });
 
+  test("forwards injectedOpenAiCompat + capabilities when set on the source", () => {
+    const out = evalTraceSnapshotToPayload(
+      makeEvalSnap({
+        injectedOpenAiCompat: true,
+        injectedOpenAiCompatCapabilities: {
+          callTool: true,
+          sendFollowUpMessage: false,
+          requestDisplayMode: "fullscreen-only",
+        },
+      }),
+    );
+    expect(out!.injectedOpenAiCompat).toBe(true);
+    expect(out!.injectedOpenAiCompatCapabilities).toEqual({
+      callTool: true,
+      sendFollowUpMessage: false,
+      requestDisplayMode: "fullscreen-only",
+    });
+  });
+
+  test("omits OpenAI compat fields when absent (pre-feature snapshot)", () => {
+    const out = evalTraceSnapshotToPayload(makeEvalSnap());
+    expect(out!.injectedOpenAiCompat).toBeUndefined();
+    expect(out!.injectedOpenAiCompatCapabilities).toBeUndefined();
+  });
+
+  test("omits injectedOpenAiCompat when the source value is non-boolean", () => {
+    // EvalTraceWidgetSnapshot types it as `boolean | undefined`, but a
+    // round-tripped JSON snapshot could theoretically carry `null` from
+    // a misbehaved producer. We intentionally drop non-boolean values
+    // rather than forwarding them and tripping the Convex validator.
+    const out = evalTraceSnapshotToPayload(
+      makeEvalSnap({
+        injectedOpenAiCompat: null as unknown as boolean,
+      }),
+    );
+    expect(out!.injectedOpenAiCompat).toBeUndefined();
+  });
+
   test("drops toolMetadata and widgetHtmlUrl (backend stores them elsewhere or not at all)", () => {
     const out = evalTraceSnapshotToPayload(
       makeEvalSnap({

--- a/mcpjam-inspector/shared/widget-snapshot.ts
+++ b/mcpjam-inspector/shared/widget-snapshot.ts
@@ -15,12 +15,15 @@ import type { EvalTraceWidgetSnapshot } from "./eval-trace";
  * is the source of truth for the wire contract; this type is its
  * inspector-side mirror.
  *
- * Forward-looking note (`injectedOpenAiCompat*`):
- *   These exist on `EvalTraceWidgetSnapshot` and on the `mcpAppViews`
- *   table but NOT on `sharedChatWidgetSnapshots` yet. Once the backend
- *   schema PR lands those columns + accepting validators, add the
- *   fields here and thread them through `evalTraceSnapshotToPayload` —
- *   every writer picks them up for free.
+ * `injectedOpenAiCompat*`:
+ *   The OpenAI Apps SDK `window.openai` shim's provenance — was the
+ *   shim injected at capture time, and with which per-method
+ *   capability surface. Backend now accepts these on both
+ *   `chatSessions:createWidgetSnapshot` and `appendEvalTurnTrace`
+ *   (mcpjam-backend#435); persisted on the `sharedChatWidgetSnapshots`
+ *   row. Replay reads these to reconstruct the same `window.openai`
+ *   surface the widget was captured against, since the cached HTML
+ *   bytes embed shim assumptions made at capture time.
  */
 export type SharedChatWidgetSnapshotPayload = {
   toolCallId: string;
@@ -58,6 +61,49 @@ export type SharedChatWidgetSnapshotPayload = {
   widgetPermissive?: boolean;
   prefersBorder?: boolean;
   displayContext?: SharedChatWidgetDisplayContext;
+  /**
+   * Whether the OpenAI Apps SDK `window.openai` shim was injected into
+   * `widgetHtmlBlobId`'s contents at capture time. Persisted so replay
+   * can render the blob faithfully under a different host config —
+   * the cached HTML embeds shim assumptions, so a render without the
+   * matching shim would call methods that don't exist on `window`.
+   */
+  injectedOpenAiCompat?: boolean;
+  /**
+   * The per-method `window.openai.*` surface the runtime was configured
+   * with when the widget HTML was captured. The boolean above only
+   * answers "was a shim injected?"; this matrix tells replay *which*
+   * surface so debug/diff views can render the delta vs preset.
+   *
+   * Absent for snapshots captured before the matrix shipped — replay
+   * treats those as the full ChatGPT surface (pre-matrix default).
+   */
+  injectedOpenAiCompatCapabilities?: InjectedOpenAiCompatCapabilities;
+};
+
+/**
+ * Structurally identical to `OpenAiAppsCapabilities` in
+ * `client/src/lib/client-styles/types.ts` (and to the matching shape on
+ * `EvalTraceWidgetSnapshot`). All three are wire-level mirrors of the
+ * Convex `injectedOpenAiCompatCapabilitiesValidator` — kept separate
+ * because the client-styles file lives in `client/` and can't be
+ * imported from shared/. A future cleanup could move the canonical
+ * definition here and have the client-side alias re-export.
+ */
+export type InjectedOpenAiCompatCapabilities = {
+  callTool?: boolean;
+  sendFollowUpMessage?: boolean;
+  setWidgetState?: boolean;
+  requestDisplayMode?: "all" | "fullscreen-only" | "none";
+  notifyIntrinsicHeight?: boolean;
+  openExternal?: boolean;
+  setOpenInAppUrl?: boolean;
+  requestModal?: boolean;
+  uploadFile?: boolean;
+  selectFiles?: boolean;
+  getFileDownloadUrl?: boolean;
+  requestCheckout?: boolean;
+  requestClose?: boolean;
 };
 
 /**
@@ -163,8 +209,6 @@ export function sanitizeWidgetForBackend<
  *   `toolMetadata` (backend persists tool input/output separately, not
  *     as inline metadata)
  *   `widgetHtmlUrl` (backend stores only the blob id)
- *   `injectedOpenAiCompat`, `injectedOpenAiCompatCapabilities`
- *     (see file-header note — pending backend schema PR)
  *
  * Callers MUST run the result through `sanitizeWidgetForBackend`
  * before sending. (The two steps are kept separate so tests can exercise
@@ -192,6 +236,13 @@ export function evalTraceSnapshotToPayload(
   }
   if (typeof snap.prefersBorder === "boolean") {
     payload.prefersBorder = snap.prefersBorder;
+  }
+  if (typeof snap.injectedOpenAiCompat === "boolean") {
+    payload.injectedOpenAiCompat = snap.injectedOpenAiCompat;
+  }
+  if (snap.injectedOpenAiCompatCapabilities) {
+    payload.injectedOpenAiCompatCapabilities =
+      snap.injectedOpenAiCompatCapabilities;
   }
   return payload;
 }

--- a/mcpjam-inspector/shared/widget-snapshot.ts
+++ b/mcpjam-inspector/shared/widget-snapshot.ts
@@ -240,7 +240,17 @@ export function evalTraceSnapshotToPayload(
   if (typeof snap.injectedOpenAiCompat === "boolean") {
     payload.injectedOpenAiCompat = snap.injectedOpenAiCompat;
   }
-  if (snap.injectedOpenAiCompatCapabilities) {
+  // Capabilities are only meaningful when the shim was actually injected
+  // — they describe the surface the injected `window.openai` exposes.
+  // Persisting a matrix alongside `injectedOpenAiCompat: false` or
+  // `undefined` would let cached replay hash and treat the surface
+  // differently than the byte-frozen HTML (the HTML contains no shim, so
+  // the matrix is meaningless). Matches the MCP-Apps fetch response,
+  // which only echoes capabilities when the shim is injected.
+  if (
+    snap.injectedOpenAiCompat === true &&
+    snap.injectedOpenAiCompatCapabilities
+  ) {
     payload.injectedOpenAiCompatCapabilities =
       snap.injectedOpenAiCompatCapabilities;
   }


### PR DESCRIPTION
## Summary

Follow-up to **mcpjam-backend#435** (which adds the `injectedOpenAiCompat` + `injectedOpenAiCompatCapabilities` columns to `sharedChatWidgetSnapshots` and relaxes the four widget validators to accept them).

This PR threads those fields through the inspector. All three writers to `sharedChatWidgetSnapshots` pick up the OpenAI Apps SDK shim provenance in **one diff** — exactly the payoff the shared-converter refactor in #2443 was set up to enable.

## What changed

- **\`shared/widget-snapshot.ts\`**:
  - \`SharedChatWidgetSnapshotPayload\` gains \`injectedOpenAiCompat?\` + \`injectedOpenAiCompatCapabilities?\`.
  - New \`InjectedOpenAiCompatCapabilities\` type — structurally identical to \`OpenAiAppsCapabilities\` in \`client/src/lib/client-styles/types.ts\` (and to the shape on \`EvalTraceWidgetSnapshot\`). Comment cross-links the three. A future cleanup could promote the canonical definition here; out of scope today.
  - \`evalTraceSnapshotToPayload\` copies them through from the source snapshot. Eval per-turn fanout + synthetic-sessions runner inherit the behavior for free — both flow through the converter.

- **\`client/src/hooks/useSharedChatWidgetCapture.ts\`**:
  - Playground / visible-chatbox hook adds the same two fields to its inline \`WidgetDebugInfo\` → payload mapping. The widget-debug store already populates them at fetch time (set by the MCP-Apps renderer when it resolves the compat flag).

## Why this matters

The cached widget HTML embeds shim assumptions made at capture time. Without persisting which surface was injected, replay under a different host config calls methods that don't exist on \`window.openai\` — fields like \`requestDisplayMode\` and \`callTool\` silently differ between presets.

## Test plan

- [x] 3 new tests in \`shared/__tests__/widget-snapshot.test.ts\` (forwarded when set, omitted when absent, ignored when non-boolean)
- [x] Existing 18 eval-fanout tests + 11 playground-hook tests still pass
- [x] Full inspector vitest: **4991 passing** (was 4988)
- [x] Client typecheck (the CI gate that bit #2443) clean

## Merge ordering

Safe to merge in either order with mcpjam-backend#435:
- If this lands first, the new fields are sent on the wire but the backend's pre-#435 validators reject them at the argument boundary — write fails, falls back per the existing error handling, no corrupt data.
- If #435 lands first, this PR just starts populating fields the backend was happily accepting as undefined.

Recommend backend first to avoid a rejection window in staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive snapshot fields with strict gating; depends on backend #435 accepting them on the wire, but no auth or core chat-path logic changes.
> 
> **Overview**
> Widget snapshots now record **whether** the OpenAI Apps SDK `window.openai` shim was injected at capture time and **which** methods were on that surface, so replay can match the byte-frozen HTML instead of a different host preset.
> 
> **`shared/widget-snapshot.ts`** extends `SharedChatWidgetSnapshotPayload` with `injectedOpenAiCompat` and `injectedOpenAiCompatCapabilities` (new `InjectedOpenAiCompatCapabilities` type), updates docs for backend #435, and **`evalTraceSnapshotToPayload`** forwards the boolean when it is a real `boolean`, strips non-booleans, and only attaches the capability matrix when `injectedOpenAiCompat === true`—eval fanout and synthetic-session writers pick this up via the shared converter.
> 
> **`useSharedChatWidgetCapture`** applies the same gating when building playground payloads from the widget-debug store (MCP-Apps renderer at fetch time).
> 
> **Tests** cover forward-when-true, drop capabilities when compat is false/undefined, omit when absent, and drop invalid non-boolean compat values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4015e7715137ec86b53585e08beb62f817dab98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->