### PR TITLE
update copies + error msgs team plan

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -150,6 +150,12 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.queryByRole("button", { name: /^top up$/i })
     ).not.toBeInTheDocument();
+    expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
+      "without waiting for your org's credits to reset"
+    );
+    expect(screen.getByTestId("limit-dialog-description")).not.toHaveTextContent(
+      /tomorrow/i
+    );
     expect(
       screen.getByRole("button", { name: /bring your own key/i })
     ).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -87,7 +87,7 @@ export function CreditTopupDialog({
           <DialogTitle>Buy credits to keep chatting</DialogTitle>
           <DialogDescription>
             Add credits to your organization so the team can keep using MCPJam
-            models without waiting for your free daily credits to reset.
+            models when your shared credits run low.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-4">

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -99,6 +99,22 @@ describe("formatErrorMessage", () => {
     expect(result).not.toHaveProperty("canTopUp");
   });
 
+  it("uses neutral billing copy when retry details are unavailable", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        code: "user_rate_limit",
+      }),
+    );
+
+    expect(result).toEqual({
+      code: "user_rate_limit",
+      message:
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or add credits from Billing.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+    });
+  });
+
   it("does not leak JSON delimiters from structured retry details", () => {
     const result = formatErrorMessage(
       JSON.stringify({

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -381,7 +381,7 @@ const formatMCPJamModelLimit = (
   code: extras?.code ?? MCPJAM_RATE_LIMIT_CODE,
   message: retryPhrase
     ? `Add your own API key in Settings > LLM Providers to keep chatting now, or ${retryPhrase}.`
-    : "Add your own API key in Settings > LLM Providers to keep chatting now, or wait until your free daily credits reset.",
+    : "Add your own API key in Settings > LLM Providers to keep chatting now, or add credits from Billing.",
   isRetryable: false,
   isMCPJamPlatformError: true,
   ...(extras?.canTopUp !== undefined ? { canTopUp: extras.canTopUp } : {}),

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -135,7 +135,7 @@ export function MCPJamLimitDialog() {
                   ? "Ask your org admin to top up credits."
                   : canBuyCredits
                   ? "Top up or bring your own key to allow your org to keep using MCPJam."
-                  : "Bring your own key to keep chatting on MCPJam's models without waiting for tomorrow's reset."}
+                  : "Bring your own key to keep chatting on MCPJam's models without waiting for your org's credits to reset."}
               </DialogDescription>
             </DialogHeader>
             {/* Non-managers get no CTAs — just the "ask your org admin" copy.


### PR DESCRIPTION
## Summary

- If a user is on a Team plan and the org runs out of both Team credits and top-up credits, we now show copy that does not mention daily credits.
- Updated backend 429 copy for that Team out-of-credits case.
- Updated frontend limit/top-up copy to avoid misleading daily-credit wording.
- Added tests to prevent Team out-of-credits copy from regressing.

## Not Included

- No changes to Stripe billing.
- No changes to how credits are spent.
- No changes to seat sync or proration.