### PR TITLE
remove USE_EVAL_CHAT_SESSIONS_WRITER flag (inspector): new path is the only path

### DIFF
--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -116,11 +116,9 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     });
 
     // Find the updateTestIteration call specifically. The PR-2 fanout
-    // introduced an `isEvalChatSessionsWriterEnabled` flag check that
-    // fires before any iteration write, so indexing by `calls[0]`
-    // would now return the flag query, not the iteration update.
-    // Mock returns undefined for the flag query → cached as `false` →
-    // legacy single-call path runs unchanged.
+    // calls multiple actions per iteration (appendEvalTurnTrace,
+    // lockEvalSession, updateTestIteration), so we search by ref
+    // rather than indexing by position.
     const updateCall = convexClient.action.mock.calls.find(
       (call) => call[0] === "testSuites:updateTestIteration",
     );
@@ -188,7 +186,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     "PR-2 review #5: lockEvalSession fires when fanout succeeded but updateTestIteration throws transient error",
     async () => {
       // Mock convexClient.action with ref-aware responses:
-      //   - flag-check returns enabled:true (writer on)
       //   - appendEvalTurnTrace returns success (fanout persists)
       //   - updateTestIteration throws a transient error (NOT a
       //     "not found"/"cancelled" message — those bypass the lock)
@@ -196,9 +193,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       const callsByRef: Record<string, number> = {};
       const action = vi.fn(async (ref: string) => {
         callsByRef[ref] = (callsByRef[ref] ?? 0) + 1;
-        if (ref === "testSuites:isEvalChatSessionsWriterEnabled") {
-          return { enabled: true };
-        }
         if (ref === "testSuites:appendEvalTurnTrace") {
           return { skipped: false, chatSessionId: "sess_x", locked: false };
         }
@@ -211,12 +205,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
         return undefined;
       });
       convexClient.action = action;
-      // Reset the helper's process-latched flag cache so this test
-      // sees `enabled:true` instead of an earlier test's `false`.
-      const { __resetEvalChatSessionsWriterFlagCacheForTests } = await import(
-        "../persist-eval-trace.js"
-      );
-      __resetEvalChatSessionsWriterFlagCacheForTests();
 
       await runQuickTestCase();
 
@@ -225,9 +213,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       expect(callsByRef["testSuites:appendEvalTurnTrace"]).toBeGreaterThan(0);
       expect(callsByRef["testSuites:updateTestIteration"]).toBeGreaterThan(0);
       expect(callsByRef["testSuites:lockEvalSession"]).toBe(1);
-      // Reset for subsequent tests that may rely on the legacy "all
-      // actions return undefined" mock.
-      __resetEvalChatSessionsWriterFlagCacheForTests();
     },
   );
 
@@ -249,9 +234,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       // would have called lockEvalSession with reason:"eval_failed".
       const lockCalls: Array<{ iterationId: string; reason: string }> = [];
       const action = vi.fn(async (ref: string, payload: any) => {
-        if (ref === "testSuites:isEvalChatSessionsWriterEnabled") {
-          return { enabled: true };
-        }
         if (ref === "testSuites:appendEvalTurnTrace") {
           return { skipped: false, chatSessionId: "sess_x", locked: false };
         }
@@ -268,10 +250,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
         return undefined;
       });
       convexClient.action = action;
-      const { __resetEvalChatSessionsWriterFlagCacheForTests } = await import(
-        "../persist-eval-trace.js"
-      );
-      __resetEvalChatSessionsWriterFlagCacheForTests();
 
       await runEvalSuiteWithAiSdk({
         suiteId: "suite-1",
@@ -325,8 +303,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       });
       expect(lockCalls).toHaveLength(1);
       expect(lockCalls[0].reason).toBe("eval_completed");
-
-      __resetEvalChatSessionsWriterFlagCacheForTests();
     },
   );
 
@@ -351,9 +327,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
 
       const lockCalls: Array<{ iterationId: string; reason: string }> = [];
       const action = vi.fn(async (ref: string, payload: any) => {
-        if (ref === "testSuites:isEvalChatSessionsWriterEnabled") {
-          return { enabled: true };
-        }
         if (ref === "testSuites:appendEvalTurnTrace") {
           return { skipped: false, chatSessionId: "sess_x", locked: false };
         }
@@ -370,10 +343,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
         return undefined;
       });
       convexClient.action = action;
-      const { __resetEvalChatSessionsWriterFlagCacheForTests } = await import(
-        "../persist-eval-trace.js"
-      );
-      __resetEvalChatSessionsWriterFlagCacheForTests();
 
       await runEvalSuiteWithAiSdk({
         suiteId: "suite-1",
@@ -416,8 +385,6 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       expect(updateCall?.[1]?.error).toBeTruthy();
       expect(lockCalls).toHaveLength(1);
       expect(lockCalls[0].reason).toBe("eval_failed");
-
-      __resetEvalChatSessionsWriterFlagCacheForTests();
     },
   );
 

--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import type { ConvexHttpClient } from "convex/browser";
 import type { ModelMessage } from "ai";
 import type {
@@ -7,8 +7,6 @@ import type {
   PromptTraceSummary,
 } from "@/shared/eval-trace";
 import {
-  __resetEvalChatSessionsWriterFlagCacheForTests,
-  isEvalChatSessionsWriterEnabled,
   lockEvalSessionAfterUpdate,
   persistEvalTraceFanout,
 } from "../persist-eval-trace.js";
@@ -19,16 +17,12 @@ type ActionCall = {
 };
 
 function makeMockClient(opts: {
-  flagEnabled?: boolean;
   appendResult?: { skipped: boolean };
   appendThrows?: Error;
-}): { client: ConvexHttpClient; calls: ActionCall[] } {
+} = {}): { client: ConvexHttpClient; calls: ActionCall[] } {
   const calls: ActionCall[] = [];
   const action = vi.fn(async (ref: string, args: Record<string, unknown>) => {
     calls.push({ ref, args });
-    if (ref === "testSuites:isEvalChatSessionsWriterEnabled") {
-      return { enabled: opts.flagEnabled ?? false };
-    }
     if (ref === "testSuites:appendEvalTurnTrace") {
       if (opts.appendThrows) throw opts.appendThrows;
       return opts.appendResult ?? { skipped: false };
@@ -48,63 +42,13 @@ function makeMockClient(opts: {
   };
 }
 
-beforeEach(() => {
-  __resetEvalChatSessionsWriterFlagCacheForTests();
-});
-
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("isEvalChatSessionsWriterEnabled", () => {
-  test("caches the flag value across calls in the same process", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
-
-    const a = await isEvalChatSessionsWriterEnabled(client);
-    const b = await isEvalChatSessionsWriterEnabled(client);
-    const c = await isEvalChatSessionsWriterEnabled(client);
-
-    expect(a).toBe(true);
-    expect(b).toBe(true);
-    expect(c).toBe(true);
-    // Only ONE network call across three reads.
-    expect(
-      calls.filter((c) => c.ref === "testSuites:isEvalChatSessionsWriterEnabled"),
-    ).toHaveLength(1);
-  });
-
-  test("returns false (safe default) when the flag query throws", async () => {
-    const client = {
-      action: vi.fn(async () => {
-        throw new Error("convex unreachable");
-      }),
-    } as unknown as ConvexHttpClient;
-
-    const result = await isEvalChatSessionsWriterEnabled(client);
-    expect(result).toBe(false);
-  });
-});
-
 describe("persistEvalTraceFanout", () => {
-  test("returns null and makes no per-turn calls when the flag is off", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: false });
-
-    const result = await persistEvalTraceFanout({
-      convexClient: client,
-      iterationId: "iter1",
-      messages: [{ role: "user", content: "hi" } as ModelMessage],
-      spans: undefined,
-      prompts: undefined,
-    });
-
-    expect(result).toBeNull();
-    expect(
-      calls.filter((c) => c.ref === "testSuites:appendEvalTurnTrace"),
-    ).toHaveLength(0);
-  });
-
   test("fans out N per-turn calls without setting terminal (deferred to lockEvalSessionAfterUpdate)", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     const spans: EvalTraceSpan[] = [
       {
@@ -218,7 +162,7 @@ describe("persistEvalTraceFanout", () => {
   });
 
   test("buckets unindexed spans onto the last turn (lossless)", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     // Two prompts (indices 0, 1) + one span without promptIndex.
     const spans: EvalTraceSpan[] = [
@@ -294,7 +238,7 @@ describe("persistEvalTraceFanout", () => {
 
   test("falls back when the action throws mid-fanout", async () => {
     const error = new Error("mid-fanout failure");
-    const { client } = makeMockClient({ flagEnabled: true, appendThrows: error });
+    const { client } = makeMockClient({ appendThrows: error });
 
     const result = await persistEvalTraceFanout({
       convexClient: client,
@@ -307,9 +251,8 @@ describe("persistEvalTraceFanout", () => {
     expect(result).toEqual({ persisted: false, error });
   });
 
-  test("falls back when the backend reports skipped:true (flag flipped mid-fanout)", async () => {
+  test("falls back when the backend reports skipped:true", async () => {
     const { client } = makeMockClient({
-      flagEnabled: true,
       appendResult: { skipped: true },
     });
 
@@ -330,7 +273,7 @@ describe("persistEvalTraceFanout", () => {
   });
 
   test("traces with no spans/prompts persist as a single promptIndex:0 turn", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     const result = await persistEvalTraceFanout({
       convexClient: client,
@@ -356,7 +299,7 @@ describe("persistEvalTraceFanout", () => {
   });
 
   test("threads iterationStartedAt through to the per-turn call (PR-2 review fix #1)", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     const realIterationStart = 1_700_000_000_000;
     await persistEvalTraceFanout({
@@ -382,7 +325,7 @@ describe("persistEvalTraceFanout", () => {
     // updateTestIteration succeeds. The fanout helper must NEVER make
     // the lock call (the whole point of the split is to defer the lock
     // past the iteration-row write).
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     await persistEvalTraceFanout({
       convexClient: client,
@@ -402,7 +345,7 @@ describe("persistEvalTraceFanout", () => {
   });
 
   test("falls back to Date.now() for startedAt when iterationStartedAt is absent", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
     const before = Date.now();
 
     await persistEvalTraceFanout({
@@ -424,7 +367,7 @@ describe("persistEvalTraceFanout", () => {
 
 describe("lockEvalSessionAfterUpdate", () => {
   test("calls testSuites:lockEvalSession with the right iterationId + reason", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     await lockEvalSessionAfterUpdate({
       convexClient: client,
@@ -478,7 +421,7 @@ describe("persistEvalTraceFanout — widget serialization", () => {
   });
 
   test("widgets are attached to the LAST turn call only", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     const prompts: PromptTraceSummary[] = [
       {
@@ -528,7 +471,7 @@ describe("persistEvalTraceFanout — widget serialization", () => {
   });
 
   test("renames protocol → uiType and forwards friendly serverId verbatim", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     await persistEvalTraceFanout({
       convexClient: client,
@@ -552,7 +495,7 @@ describe("persistEvalTraceFanout — widget serialization", () => {
   });
 
   test("drops widgets without widgetHtmlBlobId; other widgets pass through", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     await persistEvalTraceFanout({
       convexClient: client,
@@ -575,7 +518,7 @@ describe("persistEvalTraceFanout — widget serialization", () => {
   });
 
   test("sanitizes $-prefixed keys in widgetPermissions (Convex reserved-key protection)", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     await persistEvalTraceFanout({
       convexClient: client,
@@ -616,7 +559,7 @@ describe("persistEvalTraceFanout — widget serialization", () => {
   });
 
   test("normalizes widgetCsp to backend shape, drops unknown keys", async () => {
-    const { client, calls } = makeMockClient({ flagEnabled: true });
+    const { client, calls } = makeMockClient();
 
     await persistEvalTraceFanout({
       convexClient: client,

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -18,8 +18,7 @@ import {
  *
  * Both `recorder.finishIteration` (multi-iteration suite runs) and
  * `finishIterationDirectly` (quick runs without a recorder) receive the
- * final accumulated transcript at end-of-iteration. When the backend
- * flag `USE_EVAL_CHAT_SESSIONS_WRITER` is on, we want N
+ * final accumulated transcript at end-of-iteration. We want N
  * `chatSessionTurnTraces` rows for an N-turn iteration so downstream
  * readers (eval-diff, judge, server-quality, the unified Sessions
  * viewer) can address each turn individually. This helper slices the
@@ -37,8 +36,6 @@ import {
  * are identical between the two cadences.
  *
  * Return values:
- *   - `null`: flag is off; caller should run today's legacy path
- *     (single `updateTestIteration` call with full trace fields).
  *   - `{ persisted: true }`: trace was written via chatSessions;
  *     caller should call `updateTestIteration` with status/result
  *     and metadata ONLY — no `messages` / `spans` / `prompts` /
@@ -50,19 +47,10 @@ import {
  *   - `{ persisted: false, error }`: the per-turn fanout failed mid-
  *     stream. Caller should fall back to a forced-legacy-blob call by
  *     passing `forceLegacyTraceBlob: true` to `updateTestIteration`,
- *     which bypasses the backend's W1 chatSessions path even when the
- *     flag is on. Without that escape hatch the legacy fallback would
- *     re-enter the chatSessions writer with `promptIndex: 0` + full
- *     transcript, overwriting any partially-fanned-out turn rows.
- *
- * Flag-cache caveat: the cached `enabled` value is process-latched.
- * If the inspector starts before the backend deploys the
- * `isEvalChatSessionsWriterEnabled` action it caches `false`
- * permanently; a subsequent flag flip on the backend will not take
- * effect until the inspector process restarts. Same for the opposite
- * direction (cached `true` won't downgrade if the backend flips off).
- * Acceptable trade-off for a process-scoped feature flag; document
- * this in the deploy runbook before flipping the flag in prod.
+ *     which bypasses the backend's W1 chatSessions path. Without that
+ *     escape hatch the legacy fallback would re-enter the chatSessions
+ *     writer with `promptIndex: 0` + full transcript, overwriting any
+ *     partially-fanned-out turn rows.
  *
  * Widgets: forwarded on the LAST turn call so they persist once at
  * finalize. Inspector capture (`captureMcpAppWidgetSnapshots`) supplies
@@ -73,43 +61,6 @@ import {
  * blob upload failed, are dropped — the persist call must not fail
  * over a single bad widget.
  */
-
-let cachedFlagEnabled: boolean | null = null;
-let inFlightFlagQuery: Promise<boolean> | null = null;
-
-export async function isEvalChatSessionsWriterEnabled(
-  convexClient: ConvexHttpClient,
-): Promise<boolean> {
-  if (cachedFlagEnabled !== null) return cachedFlagEnabled;
-  if (inFlightFlagQuery) return inFlightFlagQuery;
-
-  inFlightFlagQuery = (async () => {
-    try {
-      const result = (await convexClient.action(
-        "testSuites:isEvalChatSessionsWriterEnabled" as any,
-        {},
-      )) as { enabled: boolean } | undefined;
-      cachedFlagEnabled = result?.enabled === true;
-      return cachedFlagEnabled;
-    } catch (error) {
-      logger.warn(
-        "[evals] Failed to query USE_EVAL_CHAT_SESSIONS_WRITER flag; assuming off",
-        { error: error instanceof Error ? error.message : String(error) },
-      );
-      cachedFlagEnabled = false;
-      return false;
-    } finally {
-      inFlightFlagQuery = null;
-    }
-  })();
-  return inFlightFlagQuery;
-}
-
-/** Test-only hook. Reset the cache between tests. */
-export function __resetEvalChatSessionsWriterFlagCacheForTests(): void {
-  cachedFlagEnabled = null;
-  inFlightFlagQuery = null;
-}
 
 type TurnSlice = {
   promptIndex: number;
@@ -213,7 +164,6 @@ function serializeWidgetsForBackend(
 }
 
 type FanoutResult =
-  | null
   | { persisted: true }
   | { persisted: false; error: Error };
 
@@ -242,9 +192,6 @@ export async function persistEvalTraceFanout(args: {
    */
   widgetSnapshots?: EvalTraceWidgetSnapshot[];
 }): Promise<FanoutResult> {
-  const enabled = await isEvalChatSessionsWriterEnabled(args.convexClient);
-  if (!enabled) return null;
-
   const turns = sliceTraceIntoTurns({
     messages: args.messages,
     spans: args.spans ?? [],

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -297,14 +297,13 @@ export const createSuiteRunRecorder = ({
       }
       const sendTraceFieldsToUpdate = fanout?.persisted !== true;
       // When the fanout failed mid-stream we MUST force the backend
-      // into the legacy blob path. Otherwise — with the writer flag
-      // still on — `updateTestIteration` re-enters the chatSessions
-      // W1 path with `promptIndex: 0` + full transcript, which would
-      // overwrite any partial turn rows the fanout already wrote
-      // and possibly fight an existing lock. The escape hatch makes
-      // the iteration replayable from `testIteration.blob` while the
-      // partial chatSessions data is left inert (source-aware reader
-      // tolerates absence).
+      // into the legacy blob path. Otherwise `updateTestIteration`
+      // re-enters the chatSessions W1 path with `promptIndex: 0` +
+      // full transcript, which would overwrite any partial turn rows
+      // the fanout already wrote and possibly fight an existing lock.
+      // The escape hatch makes the iteration replayable from
+      // `testIteration.blob` while the partial chatSessions data is
+      // left inert (source-aware reader tolerates absence).
       const forceLegacyTraceBlob = fanout?.persisted === false;
 
       // PR-2 review #5 (Cursor "Update failure after successful fanout"):


### PR DESCRIPTION
## Summary

Removes the inspector-side rollout gate for the eval→chatSessions unification. The flag (`USE_EVAL_CHAT_SESSIONS_WRITER` on the backend, queried per-process via `isEvalChatSessionsWriterEnabled`) was a temporary hedge for PR-2; all PRs in the sequence have merged and the new path is the only path we want.

What goes away:
- `isEvalChatSessionsWriterEnabled` helper + its `cachedFlagEnabled` / `inFlightFlagQuery` process-latched cache
- `__resetEvalChatSessionsWriterFlagCacheForTests` test hook
- The `if (!enabled) return null` gate at the top of `persistEvalTraceFanout`
- Tests that exclusively covered the flag-off state
- `flagEnabled: true` argument noise from `makeMockClient` and from the runner test's ref-aware action mocks

What stays:
- Per-turn fanout, lock-reason derivation, widget serialization + sanitization, the `forceLegacyTraceBlob` escape hatch for mid-fanout failures, source-aware reader paths
- The `skipped:true` fallback branch (defensive — cheap and the backend may keep that signal)

`persistEvalTraceFanout` now returns `{ persisted: true }` or `{ persisted: false, error }`; the `null` branch is gone. Existing callers (`recorder.finishIteration`, `finishIterationDirectly`) already handled `!== true` as "send trace fields to update" and `=== false` as "force legacy blob", so no caller behavior change.

## Deploy ordering

Deploy the matching backend cleanup PR (in mcpjam-backend, removing the `testSuites:isEvalChatSessionsWriterEnabled` action) **before** this inspector PR.

**Inter-deploy safety finding:** Verified by reading `persist-eval-trace.ts` directly. If the backend deploys the action removal first while the OLD inspector is still live, the old `isEvalChatSessionsWriterEnabled` call will throw `function not found`. The old code catches that in `isEvalChatSessionsWriterEnabled`'s `try/catch`, calls `logger.warn`, and returns `false` — which causes `persistEvalTraceFanout` to return `null` and the caller to run the legacy single-call `updateTestIteration` path unchanged. No iteration crashes, no transcript corruption. Safe for a normal staged deploy.

The reverse (inspector deploys this PR first while backend still has the flag action) is also safe — the new inspector simply stops querying that action, and `appendEvalTurnTrace` already worked when the flag was on. No behavior change there either.

So the deploy order is a preference (backend-first keeps the dead action call out of logs sooner), not a hard requirement.

## Test plan

- [x] `npx vitest run` from `mcpjam-inspector/` — 4992 passed, 6 skipped, 0 failed
- [x] `npm run typecheck:client -w @mcpjam/inspector` — clean
- [x] Server typecheck (`tsc --noEmit -p server/tsconfig.json`) — no new errors introduced by this diff (pre-existing errors on main are unrelated: predicates type, `JsonWebKey`, `describeError`, trace-repair generics, export-helpers readonly args)
- [ ] After merge: confirm one prod eval runs end-to-end through the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every eval iteration persists traces (always chatSessions fanout first), which is behaviorally significant for eval persistence though callers and fallbacks are already in place; coordinate backend removal of the flag action as noted in the PR.
> 
> **Overview**
> Removes the temporary **eval→chatSessions** rollout gate on the inspector so **per-turn trace fanout is always used** at end-of-iteration.
> 
> **`persist-eval-trace.ts`** drops `isEvalChatSessionsWriterEnabled`, its process-latched cache, and the test reset hook. **`persistEvalTraceFanout`** no longer returns `null` when the flag is off—it always fans out to `appendEvalTurnTrace` or returns `{ persisted: false, error }`. Docs/comments are updated to describe the single-path behavior; **`forceLegacyTraceBlob`** on mid-fanout failure is unchanged.
> 
> **Tests** remove flag-off coverage and mock noise (`flagEnabled`, `isEvalChatSessionsWriterEnabled` stubs, cache resets). Runner tests still assert fanout, **`updateTestIteration`**, and **`lockEvalSession`** by action ref. **`recorder.ts`** only trims comments about the removed flag; **`fanout?.persisted !== true`** / legacy blob escape hatch logic is the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0b3935e2a6d8bb056f0d8cb942763ea2c476c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->