### PR TITLE
docs: fix Inspector tab navigation (page-object schema)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -55,26 +55,17 @@
               "inspector/home",
               "inspector/clients",
               "inspector/projects",
-              {
-                "page": "inspector/protocol-versions",
-                "tag": "Preview"
-              }
+              "inspector/protocol-versions"
             ]
           },
           {
             "group": "MCP Apps",
             "icon": "layout-dashboard",
             "pages": [
-              {
-                "page": "inspector/playground",
-                "tag": "NEW"
-              },
+              "inspector/playground",
               "inspector/views",
               "inspector/evals",
-              {
-                "page": "inspector/host-templates",
-                "tag": "NEW"
-              }
+              "inspector/host-templates"
             ]
           },
           {
@@ -87,10 +78,7 @@
             "icon": "puzzle",
             "pages": [
               "inspector/tools-prompts-resources",
-              {
-                "page": "inspector/skills",
-                "tag": "NEW"
-              }
+              "inspector/skills"
             ]
           },
           {

--- a/docs/inspector/host-templates.mdx
+++ b/docs/inspector/host-templates.mdx
@@ -2,6 +2,7 @@
 title: "Contribute a Host"
 description: "Add a new host preset to MCPJam so widgets can render under that host's identity, capabilities, and sandbox policy."
 icon: "plus-square"
+tag: "NEW"
 ---
 
 MCPJam ships built-in host presets for Claude, ChatGPT, Cursor, Copilot, Codex, and MCPJam itself. Each preset captures what a real host publishes during MCP `initialize` and `ui/initialize` — `clientInfo`, `hostInfo`, capability advertise, `hostContext` (theme, viewport, device, locale), and sandbox policy (CSP directives, permissions, allow-features). With a preset selected, a widget rendered in the [Playground](/inspector/playground) or [Views](/inspector/views) behaves the way it would in production under that host.

--- a/docs/inspector/playground.mdx
+++ b/docs/inspector/playground.mdx
@@ -2,6 +2,7 @@
 title: "Playground"
 description: "Chat with your MCP servers, invoke tools by hand, render widgets, and inspect every step — all in one IDE-style workspace"
 icon: "joystick"
+tag: "NEW"
 ---
 
 The Playground is the main workspace for developing against your MCP servers. It combines chat, manual tool invocation, widget rendering, traces, and a live JSON-RPC logger into a single IDE-style surface so you can build, test, and debug an MCP server (or compare several side by side) without switching tabs.

--- a/docs/inspector/protocol-versions.mdx
+++ b/docs/inspector/protocol-versions.mdx
@@ -2,6 +2,7 @@
 title: "MCP protocol versions"
 description: "Pin the inspector to a specific MCP protocol version — including the 2026-07-28 stateless RC — to test how your server behaves across versions."
 icon: "git-branch"
+tag: "Preview"
 ---
 
 The inspector can speak more than one version of the MCP protocol. By default it negotiates whatever the SDK considers current, but you can pin a different version when you want to test how your server behaves against a specific draft — including the new **2026-07-28 stateless RC**.

--- a/docs/inspector/skills.mdx
+++ b/docs/inspector/skills.mdx
@@ -2,6 +2,7 @@
 title: "Skills"
 description: "Load and use skills to give your agents the context they need to use MCP tools effectively"
 icon: "square-slash"
+tag: "NEW"
 ---
 
 [Skills](https://agentskills.io/what-are-skills) are an open format that provide instructions on how to use MCP tools and complete workflows. MCPJam lets you discover skills from your filesystem, upload new ones, and use them in the Playground — either automatically based on the user's prompt or deterministically with the `/` command.


### PR DESCRIPTION
## Summary

- Clicking **Inspector** in the docs tabs did nothing — the link's `href` resolved to `/`, so it stayed on Get Started.
- Root cause: Mintlify's `docs.json` schema rejects `{ "page": "...", "tag": "..." }` objects inside `groups[].pages`. When it hit the four entries added in #2433 (Preview / NEW badges), it dropped the whole `groups` field for the Inspector tab — so the tab had no first page to link to.
- Fix: replace the four page-object entries with plain string slugs, and move each `tag` into the page's MDX frontmatter, which Mintlify reads as the sidebar badge.

After the fix the Inspector tab links to `/inspector/home`, and the NEW / Preview badges still render in the sidebar.

## Test plan

- [ ] `cd docs && npx mint dev` (node 22), open `/`, click **Inspector** — lands on `/inspector/home`.
- [ ] Sidebar shows `Preview` badge on **MCP protocol versions** and `NEW` badges on **Playground**, **Contribute a Host**, and **Skills**.
- [ ] Other tabs (Get Started, CLI, SDK) still navigate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only navigation and badge placement changes with no runtime or security impact.
> 
> **Overview**
> Fixes a broken **Inspector** docs tab by aligning `docs.json` navigation with Mintlify’s expected `groups[].pages` shape.
> 
> **`docs.json`** replaces four `{ "page", "tag" }` entries with plain page slugs for protocol versions, playground, host templates, and skills so Mintlify keeps the Inspector `groups` config and the tab can resolve its first page (e.g. `/inspector/home`) instead of falling back to `/`.
> 
> **MDX frontmatter** moves each sidebar badge into the matching page: `tag: "Preview"` on `protocol-versions.mdx` and `tag: "NEW"` on `playground.mdx`, `host-templates.mdx`, and `skills.mdx`, preserving NEW/Preview labels without inline nav objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea0bcb9e5de6c36a4f825d5b3492128dee7b3e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->