### PR TITLE
evals: route iteration runners through prepareChatV2

### DIFF
--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -1498,6 +1498,7 @@ export async function streamEvalTestCaseWithManager(
         const outcomes = await streamTestCase({
           test,
           tools,
+          selectedServers: resolvedServerIds,
           mcpClientManager: clientManager,
           recorder: null,
           modelApiKeys: resolvedStreamModelApiKeys ?? undefined,

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -3543,6 +3543,15 @@ const streamIterationViaBackend = async ({
       recorder,
       convexClient,
     });
+    // Mirror the in-stream failure signal `streamIterationWithAiSdk` already
+    // sends from its outer catch. Without this, the live test-runner UI
+    // watching `streamTestCase` SSE finishes silently on hosted-model /
+    // hosted-org-BYOK setup errors while the local-AI-SDK stream variant
+    // emits an `error` event for the same failure mode.
+    emit({
+      type: "error",
+      message: errorMessage,
+    });
     // Suite summary aggregates `evaluation.passed`; a fresh
     // `evaluateMultiTurnResults([], ...)` returns `passed: true` for negative
     // tests and for positive tests with no expected tools, so setup failures

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1563,6 +1563,13 @@ const runIterationWithAiSdk = async ({
       test.isNegativeTest,
       test.matchOptions,
     );
+    // Suite summary aggregates `evaluation.passed` (see runEvalSuiteWithAiSdk).
+    // The persisted iteration is hard-coded `passed: false` below, but the
+    // returned evaluation could still report `passed: true` on negative tests
+    // or tests with no expected tools when the catch fires before any tools
+    // are called — that would inflate suite-pass counts. Force false here so
+    // the persisted and returned verdicts agree.
+    evaluation.passed = false;
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
     const widgetSnapshots = await captureMcpAppWidgetSnapshots({ injectOpenAiCompat,
       messages: failMessages,
@@ -1628,6 +1635,7 @@ const runIterationViaBackend = async ({
   convexAuthToken,
   modelId,
   modelDefinition,
+  orgModelConfig,
   endpointPath = "/stream",
   extraBodyFields,
   convexClient,
@@ -1745,6 +1753,14 @@ const runIterationViaBackend = async ({
   // executes them locally on tool-call events. Run AFTER iteration creation
   // and inside a try/catch so prep failures persist as a failed iteration row
   // rather than rejecting the test case with no iteration record.
+  //
+  // `customProviders` is derived from `orgModelConfig` so Anthropic name
+  // validation fires for hosted-org BYOK runs that use Anthropic-compatible
+  // custom providers (matches the local-AI-SDK runner, which threads the same
+  // shape via `resolveEvalModelRuntime`).
+  const backendCustomProviders = orgModelConfig
+    ? buildLlmRuntimeConfigFromOrgConfig(orgModelConfig).customProviders
+    : undefined;
   let prepared: PrepareChatV2Result;
   try {
     prepared = await prepareChatV2({
@@ -1754,6 +1770,9 @@ const runIterationViaBackend = async ({
       systemPrompt,
       temperature,
       respectToolVisibility: hostPolicy?.respectToolVisibility,
+      ...(backendCustomProviders?.length
+        ? { customProviders: backendCustomProviders }
+        : {}),
       priorMessages: [],
     });
   } catch (error) {
@@ -1768,13 +1787,19 @@ const runIterationViaBackend = async ({
       recorder,
       convexClient,
     });
+    // Suite summary aggregates `evaluation.passed`; a fresh
+    // `evaluateMultiTurnResults([], ...)` returns `passed: true` for negative
+    // tests and for positive tests with no expected tools, so setup failures
+    // would silently count as suite passes if we returned that as-is.
+    const failedEvaluation = evaluateMultiTurnResults(
+      promptTurns,
+      [],
+      test.isNegativeTest,
+      test.matchOptions,
+    );
+    failedEvaluation.passed = false;
     return {
-      evaluation: evaluateMultiTurnResults(
-        promptTurns,
-        [],
-        test.isNegativeTest,
-        test.matchOptions,
-      ),
+      evaluation: failedEvaluation,
       iterationId,
     };
   }
@@ -3266,6 +3291,13 @@ const streamIterationWithAiSdk = async ({
       test.isNegativeTest,
       test.matchOptions,
     );
+    // Suite summary aggregates `evaluation.passed` (see runEvalSuiteWithAiSdk).
+    // The persisted iteration is hard-coded `passed: false` below, but the
+    // returned evaluation could still report `passed: true` on negative tests
+    // or tests with no expected tools when the catch fires before any tools
+    // are called — that would inflate suite-pass counts. Force false here so
+    // the persisted and returned verdicts agree.
+    evaluation.passed = false;
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
     const widgetSnapshots = await captureMcpAppWidgetSnapshots({ injectOpenAiCompat,
       messages: failMessages,
@@ -3357,6 +3389,7 @@ const streamIterationViaBackend = async ({
   convexAuthToken,
   modelId,
   modelDefinition,
+  orgModelConfig,
   endpointPath = "/stream",
   extraBodyFields,
   convexClient,
@@ -3476,6 +3509,14 @@ const streamIterationViaBackend = async ({
   // executes them locally on tool-call events. Run AFTER iteration creation
   // and inside a try/catch so prep failures persist as a failed iteration row
   // rather than rejecting the test case with no iteration record.
+  //
+  // `customProviders` is derived from `orgModelConfig` so Anthropic name
+  // validation fires for hosted-org BYOK runs that use Anthropic-compatible
+  // custom providers (matches the local-AI-SDK runner, which threads the same
+  // shape via `resolveEvalModelRuntime`).
+  const backendCustomProviders = orgModelConfig
+    ? buildLlmRuntimeConfigFromOrgConfig(orgModelConfig).customProviders
+    : undefined;
   let prepared: PrepareChatV2Result;
   try {
     prepared = await prepareChatV2({
@@ -3485,6 +3526,9 @@ const streamIterationViaBackend = async ({
       systemPrompt,
       temperature,
       respectToolVisibility: hostPolicy?.respectToolVisibility,
+      ...(backendCustomProviders?.length
+        ? { customProviders: backendCustomProviders }
+        : {}),
       priorMessages: [],
     });
   } catch (error) {
@@ -3499,13 +3543,19 @@ const streamIterationViaBackend = async ({
       recorder,
       convexClient,
     });
+    // Suite summary aggregates `evaluation.passed`; a fresh
+    // `evaluateMultiTurnResults([], ...)` returns `passed: true` for negative
+    // tests and for positive tests with no expected tools, so setup failures
+    // would silently count as suite passes if we returned that as-is.
+    const failedEvaluation = evaluateMultiTurnResults(
+      promptTurns,
+      [],
+      test.isNegativeTest,
+      test.matchOptions,
+    );
+    failedEvaluation.passed = false;
     return {
-      evaluation: evaluateMultiTurnResults(
-        promptTurns,
-        [],
-        test.isNegativeTest,
-        test.matchOptions,
-      ),
+      evaluation: failedEvaluation,
       iterationId,
     };
   }

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -87,6 +87,7 @@ import {
 } from "@/shared/prompt-turns";
 import { withHostContextSystemPrompt } from "@/shared/host-context-prompt";
 import { normalizeToolChoice, type EvalToolChoice } from "@/shared/tool-choice";
+import { prepareChatV2 } from "../utils/chat-v2-orchestration.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
 import {
   lockEvalSessionAfterUpdate,
@@ -829,7 +830,16 @@ async function finishIterationDirectly(
 type RunIterationBaseParams = {
   test: EvalTestCase;
   runIndex: number;
+  /**
+   * Suite-level raw tool set, kept for `toolSignals` telemetry only.
+   * Iteration runners route the actual tool prep through `prepareChatV2`
+   * (per PR 1 of the engine consolidation) so eval gets skill tools,
+   * progressive-discovery meta-tools, Anthropic name validation, and the
+   * system-prompt assembly chat already applies. Removed in a later PR.
+   */
   tools: ToolSet;
+  /** Server ids the iteration runner hands to `prepareChatV2`. */
+  selectedServers: string[];
   mcpClientManager: MCPClientManager;
   recorder: SuiteRunRecorder | null;
   testCaseId?: string;
@@ -870,6 +880,8 @@ type RunIterationBackendParams = RunIterationBaseParams & {
   convexHttpUrl: string;
   convexAuthToken: string;
   modelId: string;
+  /** Resolved model definition — fed to `prepareChatV2` for Anthropic name validation. */
+  modelDefinition: ModelDefinition;
   endpointPath?: "/stream" | "/stream/org";
   extraBodyFields?: Record<string, unknown>;
 };
@@ -1047,7 +1059,10 @@ async function resolveOrgByokEvalRuntime(args: {
 const runIterationWithAiSdk = async ({
   test,
   runIndex,
-  tools,
+  // `tools` is the suite-level raw set kept for `toolSignals` telemetry;
+  // this runner now goes through prepareChatV2 below for its actual tool prep.
+  tools: _suiteTools,
+  selectedServers,
   mcpClientManager,
   recorder,
   testCaseId,
@@ -1133,6 +1148,22 @@ const runIterationWithAiSdk = async ({
     orgModelConfig,
   });
 
+  // Adopt the chat-side tool/system/temperature pipeline. Eval used to skip
+  // this and call `getToolsForAiSdk` + an inline system/temperature wiring,
+  // missing progressive discovery, skill tools, Anthropic name validation,
+  // and skills-prompt assembly. Per-turn hydration of `discoveryState` is a
+  // later PR; this PR threads the initial state through.
+  const prepared = await prepareChatV2({
+    mcpClientManager,
+    selectedServers,
+    modelDefinition,
+    systemPrompt: system,
+    temperature,
+    respectToolVisibility: hostPolicy?.respectToolVisibility,
+    customProviders: modelRuntime.customProviders,
+    priorMessages: [],
+  });
+
   const runStartedAt = Date.now();
   const iterationMetadataBase: Record<string, string | number | boolean> = {};
   if (promptTurns.length > 1) {
@@ -1168,8 +1199,8 @@ const runIterationWithAiSdk = async ({
       : await createIterationDirectly(convexClient, iterationParams);
 
   const baseMessages: ModelMessage[] = [];
-  if (system) {
-    baseMessages.push({ role: "system", content: system });
+  if (prepared.enhancedSystemPrompt) {
+    baseMessages.push({ role: "system", content: prepared.enhancedSystemPrompt });
   }
   let conversationMessages: ModelMessage[] = [...baseMessages];
   const recordedSpans: EvalTraceSpan[] = [];
@@ -1197,7 +1228,7 @@ const runIterationWithAiSdk = async ({
     if (
       toolChoice &&
       typeof toolChoice === "object" &&
-      !Object.hasOwn(tools, toolChoice.toolName)
+      !Object.hasOwn(prepared.allTools, toolChoice.toolName)
     ) {
       throw new Error(
         `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`,
@@ -1215,7 +1246,7 @@ const runIterationWithAiSdk = async ({
       activeCompletedStepCount = 0;
       activeTraceCtx = createAiSdkEvalTraceContext(runStartedAt);
       const tracedTools = wrapToolSetForEvalTrace(
-        tools,
+        prepared.allTools,
         activeTraceCtx,
         promptIndex,
       );
@@ -1225,7 +1256,9 @@ const runIterationWithAiSdk = async ({
         messages: activePromptInputMessages,
         tools: tracedTools,
         stopWhen: stepCountIs(20),
-        ...(temperature == null ? {} : { temperature }),
+        ...(prepared.resolvedTemperature == null
+          ? {}
+          : { temperature: prepared.resolvedTemperature }),
         ...(toolChoice
           ? { toolChoice: toolChoice as ToolChoice<Record<string, AiTool>> }
           : {}),
@@ -1542,13 +1575,17 @@ const runIterationWithAiSdk = async ({
 const runIterationViaBackend = async ({
   test,
   runIndex,
-  tools,
+  // Suite-level raw set retained for `toolSignals`; per-iteration tool prep
+  // is delegated to prepareChatV2 below.
+  tools: _suiteTools,
+  selectedServers,
   mcpClientManager,
   recorder,
   testCaseId,
   convexHttpUrl,
   convexAuthToken,
   modelId,
+  modelDefinition,
   endpointPath = "/stream",
   extraBodyFields,
   convexClient,
@@ -1622,6 +1659,21 @@ const runIterationViaBackend = async ({
       : undefined;
   const toolChoice = normalizeToolChoice(advancedConfig?.toolChoice);
 
+  // Adopt the chat-side tool/system/temperature pipeline. Same change as the
+  // local-AI-SDK runner: pulls in skill tools, progressive-discovery meta-
+  // tools, Anthropic name validation, and the assembled system prompt. The
+  // backend path serializes `prepared.allTools` to `toolDefs` below and
+  // executes them locally on tool-call events.
+  const prepared = await prepareChatV2({
+    mcpClientManager,
+    selectedServers,
+    modelDefinition,
+    systemPrompt,
+    temperature,
+    respectToolVisibility: hostPolicy?.respectToolVisibility,
+    priorMessages: [],
+  });
+
   const messageHistory: ModelMessage[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
   const runStartedAt = Date.now();
@@ -1659,7 +1711,7 @@ const runIterationViaBackend = async ({
       ? await recorder.startIteration(iterationParams)
       : await createIterationDirectly(convexClient, iterationParams);
 
-  const toolDefs = Object.entries(tools).map(([name, tool]) => {
+  const toolDefs = Object.entries(prepared.allTools).map(([name, tool]) => {
     const schema = (tool as any)?.inputSchema;
     let serializedSchema: Record<string, unknown> | undefined;
     if (schema) {
@@ -1735,8 +1787,12 @@ const runIterationViaBackend = async ({
             mode: "step",
             messages: JSON.stringify(messageHistory),
             model: modelId,
-            ...(systemPrompt ? { systemPrompt } : {}),
-            ...(temperature == null ? {} : { temperature }),
+            ...(prepared.enhancedSystemPrompt
+              ? { systemPrompt: prepared.enhancedSystemPrompt }
+              : {}),
+            ...(prepared.resolvedTemperature == null
+              ? {}
+              : { temperature: prepared.resolvedTemperature }),
             ...(toolChoice ? { toolChoice } : {}),
             tools: toolDefs,
             maxOutputTokens: 16384,
@@ -1832,7 +1888,7 @@ const runIterationViaBackend = async ({
 
         if (hasUnresolvedToolCalls(messageHistory as any)) {
           const toolsStartAbs = Date.now();
-          const tracedBackendTools = wrapBackendToolsForTrace(tools as any, {
+          const tracedBackendTools = wrapBackendToolsForTrace(prepared.allTools as any, {
             runStartedAt,
             promptIndex,
             stepIndex,
@@ -2120,6 +2176,7 @@ const runIterationViaBackend = async ({
 const runTestCase = async (params: {
   test: EvalTestCase;
   tools: ToolSet;
+  selectedServers: string[];
   mcpClientManager: MCPClientManager;
   recorder: SuiteRunRecorder | null;
   modelApiKeys?: Record<string, string>;
@@ -2143,6 +2200,7 @@ const runTestCase = async (params: {
   const {
     test,
     tools,
+    selectedServers,
     mcpClientManager,
     recorder,
     modelApiKeys,
@@ -2245,6 +2303,7 @@ const runTestCase = async (params: {
         test,
         runIndex,
         tools,
+        selectedServers,
         mcpClientManager,
         recorder,
         testCaseId,
@@ -2252,6 +2311,7 @@ const runTestCase = async (params: {
         convexHttpUrl,
         convexAuthToken,
         modelId: resolvedModelId,
+        modelDefinition,
         extraBodyFields: jamBillingTarget ? { ...jamBillingTarget } : undefined,
         convexClient,
         modelApiKeys,
@@ -2273,6 +2333,7 @@ const runTestCase = async (params: {
         test,
         runIndex,
         tools,
+        selectedServers,
         mcpClientManager,
         recorder,
         testCaseId,
@@ -2280,6 +2341,7 @@ const runTestCase = async (params: {
         convexHttpUrl,
         convexAuthToken,
         modelId: String(modelDefinition.id),
+        modelDefinition,
         endpointPath: "/stream/org",
         extraBodyFields: {
           providerKey: orgByokRuntime.providerKey,
@@ -2305,6 +2367,7 @@ const runTestCase = async (params: {
       test,
       runIndex,
       tools,
+      selectedServers,
       mcpClientManager,
       recorder,
       testCaseId,
@@ -2431,6 +2494,7 @@ export const runEvalSuiteWithAiSdk = async ({
       runTestCase({
         test,
         tools,
+        selectedServers: serverIds,
         mcpClientManager,
         recorder,
         modelApiKeys,
@@ -2591,7 +2655,10 @@ export type StreamEmit = (event: EvalStreamEvent) => void;
 const streamIterationWithAiSdk = async ({
   test,
   runIndex,
-  tools,
+  // Suite-level raw set retained for `toolSignals`; per-iteration tool prep
+  // is delegated to prepareChatV2 below.
+  tools: _suiteTools,
+  selectedServers,
   mcpClientManager,
   recorder,
   testCaseId,
@@ -2679,6 +2746,20 @@ const streamIterationWithAiSdk = async ({
     orgModelConfig,
   });
 
+  // See `runIterationWithAiSdk`: adopt prepareChatV2 so this stream variant
+  // also gets skill tools, progressive-discovery meta-tools, Anthropic name
+  // validation, and the assembled system prompt.
+  const prepared = await prepareChatV2({
+    mcpClientManager,
+    selectedServers,
+    modelDefinition,
+    systemPrompt: system,
+    temperature,
+    respectToolVisibility: hostPolicy?.respectToolVisibility,
+    customProviders: modelRuntime.customProviders,
+    priorMessages: [],
+  });
+
   const runStartedAt = Date.now();
   const iterationMetadataBase: Record<string, string | number | boolean> = {};
   if (promptTurns.length > 1) {
@@ -2714,8 +2795,8 @@ const streamIterationWithAiSdk = async ({
       : await createIterationDirectly(convexClient, iterationParams);
 
   const baseMessages: ModelMessage[] = [];
-  if (system) {
-    baseMessages.push({ role: "system", content: system });
+  if (prepared.enhancedSystemPrompt) {
+    baseMessages.push({ role: "system", content: prepared.enhancedSystemPrompt });
   }
   let conversationMessages: ModelMessage[] = [...baseMessages];
   const recordedSpans: EvalTraceSpan[] = [];
@@ -2743,7 +2824,7 @@ const streamIterationWithAiSdk = async ({
     if (
       toolChoice &&
       typeof toolChoice === "object" &&
-      !Object.hasOwn(tools, toolChoice.toolName)
+      !Object.hasOwn(prepared.allTools, toolChoice.toolName)
     ) {
       throw new Error(
         `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`,
@@ -2761,7 +2842,7 @@ const streamIterationWithAiSdk = async ({
       activeCompletedStepCount = 0;
       activeTraceCtx = createAiSdkEvalTraceContext(runStartedAt);
       const tracedTools = wrapToolSetForEvalTrace(
-        tools,
+        prepared.allTools,
         activeTraceCtx,
         promptIndex,
       );
@@ -2777,7 +2858,9 @@ const streamIterationWithAiSdk = async ({
         messages: activePromptInputMessages,
         tools: tracedTools,
         stopWhen: stepCountIs(20),
-        ...(temperature == null ? {} : { temperature }),
+        ...(prepared.resolvedTemperature == null
+          ? {}
+          : { temperature: prepared.resolvedTemperature }),
         ...(toolChoice
           ? { toolChoice: toolChoice as ToolChoice<Record<string, AiTool>> }
           : {}),
@@ -3191,13 +3274,17 @@ const streamIterationWithAiSdk = async ({
 const streamIterationViaBackend = async ({
   test,
   runIndex,
-  tools,
+  // Suite-level raw set retained for `toolSignals`; per-iteration tool prep
+  // is delegated to prepareChatV2 below.
+  tools: _suiteTools,
+  selectedServers,
   mcpClientManager,
   recorder,
   testCaseId,
   convexHttpUrl,
   convexAuthToken,
   modelId,
+  modelDefinition,
   endpointPath = "/stream",
   extraBodyFields,
   convexClient,
@@ -3273,6 +3360,21 @@ const streamIterationViaBackend = async ({
       : undefined;
   const toolChoice = normalizeToolChoice(advancedConfig?.toolChoice);
 
+  // Adopt the chat-side tool/system/temperature pipeline. Same change as the
+  // local-AI-SDK runner: pulls in skill tools, progressive-discovery meta-
+  // tools, Anthropic name validation, and the assembled system prompt. The
+  // backend path serializes `prepared.allTools` to `toolDefs` below and
+  // executes them locally on tool-call events.
+  const prepared = await prepareChatV2({
+    mcpClientManager,
+    selectedServers,
+    modelDefinition,
+    systemPrompt,
+    temperature,
+    respectToolVisibility: hostPolicy?.respectToolVisibility,
+    priorMessages: [],
+  });
+
   const messageHistory: ModelMessage[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
   const runStartedAt = Date.now();
@@ -3310,7 +3412,7 @@ const streamIterationViaBackend = async ({
       ? await recorder.startIteration(iterationParams)
       : await createIterationDirectly(convexClient, iterationParams);
 
-  const toolDefs = Object.entries(tools).map(([name, tool]) => {
+  const toolDefs = Object.entries(prepared.allTools).map(([name, tool]) => {
     const schema = (tool as any)?.inputSchema;
     let serializedSchema: Record<string, unknown> | undefined;
     if (schema) {
@@ -3392,8 +3494,12 @@ const streamIterationViaBackend = async ({
             skipChatIngestion: true,
             messages: JSON.stringify(messageHistory),
             model: modelId,
-            ...(systemPrompt ? { systemPrompt } : {}),
-            ...(temperature == null ? {} : { temperature }),
+            ...(prepared.enhancedSystemPrompt
+              ? { systemPrompt: prepared.enhancedSystemPrompt }
+              : {}),
+            ...(prepared.resolvedTemperature == null
+              ? {}
+              : { temperature: prepared.resolvedTemperature }),
             ...(toolChoice ? { toolChoice } : {}),
             tools: toolDefs,
             maxOutputTokens: 16384,
@@ -3619,7 +3725,7 @@ const streamIterationViaBackend = async ({
 
         if (hasUnresolvedToolCalls(messageHistory as any)) {
           const toolsStartAbs = Date.now();
-          const tracedBackendTools = wrapBackendToolsForTrace(tools as any, {
+          const tracedBackendTools = wrapBackendToolsForTrace(prepared.allTools as any, {
             runStartedAt,
             promptIndex,
             stepIndex,
@@ -4003,6 +4109,7 @@ const streamIterationViaBackend = async ({
 export const streamTestCase = async (params: {
   test: EvalTestCase;
   tools: ToolSet;
+  selectedServers: string[];
   mcpClientManager: MCPClientManager;
   recorder: SuiteRunRecorder | null;
   modelApiKeys?: Record<string, string>;
@@ -4032,6 +4139,7 @@ export const streamTestCase = async (params: {
   const {
     test,
     tools,
+    selectedServers,
     mcpClientManager,
     recorder,
     modelApiKeys,
@@ -4138,6 +4246,7 @@ export const streamTestCase = async (params: {
         test,
         runIndex,
         tools,
+        selectedServers,
         mcpClientManager,
         recorder,
         testCaseId,
@@ -4145,6 +4254,7 @@ export const streamTestCase = async (params: {
         convexHttpUrl,
         convexAuthToken,
         modelId: resolvedModelId,
+        modelDefinition,
         extraBodyFields: jamBillingTarget ? { ...jamBillingTarget } : undefined,
         convexClient,
         modelApiKeys,
@@ -4167,6 +4277,7 @@ export const streamTestCase = async (params: {
         test,
         runIndex,
         tools,
+        selectedServers,
         mcpClientManager,
         recorder,
         testCaseId,
@@ -4174,6 +4285,7 @@ export const streamTestCase = async (params: {
         convexHttpUrl,
         convexAuthToken,
         modelId: String(modelDefinition.id),
+        modelDefinition,
         endpointPath: "/stream/org",
         extraBodyFields: {
           providerKey: orgByokRuntime.providerKey,
@@ -4200,6 +4312,7 @@ export const streamTestCase = async (params: {
       test,
       runIndex,
       tools,
+      selectedServers,
       mcpClientManager,
       recorder,
       testCaseId,

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -87,7 +87,10 @@ import {
 } from "@/shared/prompt-turns";
 import { withHostContextSystemPrompt } from "@/shared/host-context-prompt";
 import { normalizeToolChoice, type EvalToolChoice } from "@/shared/tool-choice";
-import { prepareChatV2 } from "../utils/chat-v2-orchestration.js";
+import {
+  prepareChatV2,
+  type PrepareChatV2Result,
+} from "../utils/chat-v2-orchestration.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
 import {
   lockEvalSessionAfterUpdate,
@@ -827,6 +830,39 @@ async function finishIterationDirectly(
   }
 }
 
+/**
+ * Persist a failed iteration row when iteration setup throws BEFORE the
+ * per-prompt loop can start (e.g. `prepareChatV2` rejects on Anthropic
+ * tool-name validation or meta-tool collisions). Used by the backend
+ * runners, which lack the outer try/catch the AI-SDK runners have.
+ */
+async function persistSetupFailedIteration(args: {
+  iterationId: string | undefined;
+  runStartedAt: number;
+  errorMessage: string;
+  iterationMetadataBase: Record<string, string | number | boolean>;
+  recorder: SuiteRunRecorder | null;
+  convexClient: ConvexHttpClient;
+}): Promise<void> {
+  const failParams = {
+    ...(args.iterationId ? { iterationId: args.iterationId } : {}),
+    passed: false,
+    toolsCalled: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    messages: [] as ModelMessage[],
+    status: "failed" as const,
+    startedAt: args.runStartedAt,
+    error: args.errorMessage,
+    resultSource: "reported" as const,
+    metadata: { ...args.iterationMetadataBase },
+  };
+  if (args.recorder) {
+    await args.recorder.finishIteration(failParams);
+  } else {
+    await finishIterationDirectly(args.convexClient, failParams);
+  }
+}
+
 type RunIterationBaseParams = {
   test: EvalTestCase;
   runIndex: number;
@@ -1148,22 +1184,6 @@ const runIterationWithAiSdk = async ({
     orgModelConfig,
   });
 
-  // Adopt the chat-side tool/system/temperature pipeline. Eval used to skip
-  // this and call `getToolsForAiSdk` + an inline system/temperature wiring,
-  // missing progressive discovery, skill tools, Anthropic name validation,
-  // and skills-prompt assembly. Per-turn hydration of `discoveryState` is a
-  // later PR; this PR threads the initial state through.
-  const prepared = await prepareChatV2({
-    mcpClientManager,
-    selectedServers,
-    modelDefinition,
-    systemPrompt: system,
-    temperature,
-    respectToolVisibility: hostPolicy?.respectToolVisibility,
-    customProviders: modelRuntime.customProviders,
-    priorMessages: [],
-  });
-
   const runStartedAt = Date.now();
   const iterationMetadataBase: Record<string, string | number | boolean> = {};
   if (promptTurns.length > 1) {
@@ -1198,11 +1218,11 @@ const runIterationWithAiSdk = async ({
       ? await recorder.startIteration(iterationParams)
       : await createIterationDirectly(convexClient, iterationParams);
 
-  const baseMessages: ModelMessage[] = [];
-  if (prepared.enhancedSystemPrompt) {
-    baseMessages.push({ role: "system", content: prepared.enhancedSystemPrompt });
-  }
-  let conversationMessages: ModelMessage[] = [...baseMessages];
+  // `conversationMessages` starts empty; the system message is pushed below
+  // inside the try block, AFTER `prepareChatV2` (which can throw on Anthropic
+  // name validation / meta-tool collisions / skill-tool prep). Building it
+  // inside the try lets the catch path persist a failed iteration row.
+  let conversationMessages: ModelMessage[] = [];
   const recordedSpans: EvalTraceSpan[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
   let accumulatedUsage = {
@@ -1218,6 +1238,28 @@ const runIterationWithAiSdk = async ({
     null;
 
   try {
+    // Adopt the chat-side tool/system/temperature pipeline. Eval used to skip
+    // this and call `getToolsForAiSdk` + an inline system/temperature wiring,
+    // missing skill tools, Anthropic name validation, and skills-prompt
+    // assembly. Called inside the try so prep failures become a recorded
+    // failed iteration rather than an uncaught setup error.
+    const prepared = await prepareChatV2({
+      mcpClientManager,
+      selectedServers,
+      modelDefinition,
+      systemPrompt: system,
+      temperature,
+      respectToolVisibility: hostPolicy?.respectToolVisibility,
+      customProviders: modelRuntime.customProviders,
+      priorMessages: [],
+    });
+    if (prepared.enhancedSystemPrompt) {
+      conversationMessages.push({
+        role: "system",
+        content: prepared.enhancedSystemPrompt,
+      });
+    }
+
     const llmModel = createLlmModel(
       modelDefinition,
       modelRuntime.apiKey,
@@ -1659,21 +1701,6 @@ const runIterationViaBackend = async ({
       : undefined;
   const toolChoice = normalizeToolChoice(advancedConfig?.toolChoice);
 
-  // Adopt the chat-side tool/system/temperature pipeline. Same change as the
-  // local-AI-SDK runner: pulls in skill tools, progressive-discovery meta-
-  // tools, Anthropic name validation, and the assembled system prompt. The
-  // backend path serializes `prepared.allTools` to `toolDefs` below and
-  // executes them locally on tool-call events.
-  const prepared = await prepareChatV2({
-    mcpClientManager,
-    selectedServers,
-    modelDefinition,
-    systemPrompt,
-    temperature,
-    respectToolVisibility: hostPolicy?.respectToolVisibility,
-    priorMessages: [],
-  });
-
   const messageHistory: ModelMessage[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
   const runStartedAt = Date.now();
@@ -1710,6 +1737,47 @@ const runIterationViaBackend = async ({
     : recorder
       ? await recorder.startIteration(iterationParams)
       : await createIterationDirectly(convexClient, iterationParams);
+
+  // Adopt the chat-side tool/system/temperature pipeline. Same change as the
+  // local-AI-SDK runner: pulls in skill tools, progressive-discovery meta-
+  // tools, Anthropic name validation, and the assembled system prompt. The
+  // backend path serializes `prepared.allTools` to `toolDefs` below and
+  // executes them locally on tool-call events. Run AFTER iteration creation
+  // and inside a try/catch so prep failures persist as a failed iteration row
+  // rather than rejecting the test case with no iteration record.
+  let prepared: PrepareChatV2Result;
+  try {
+    prepared = await prepareChatV2({
+      mcpClientManager,
+      selectedServers,
+      modelDefinition,
+      systemPrompt,
+      temperature,
+      respectToolVisibility: hostPolicy?.respectToolVisibility,
+      priorMessages: [],
+    });
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : String(error);
+    logger.error("[evals] iteration setup failed (prepareChatV2)", error);
+    await persistSetupFailedIteration({
+      iterationId,
+      runStartedAt,
+      errorMessage,
+      iterationMetadataBase,
+      recorder,
+      convexClient,
+    });
+    return {
+      evaluation: evaluateMultiTurnResults(
+        promptTurns,
+        [],
+        test.isNegativeTest,
+        test.matchOptions,
+      ),
+      iterationId,
+    };
+  }
 
   const toolDefs = Object.entries(prepared.allTools).map(([name, tool]) => {
     const schema = (tool as any)?.inputSchema;
@@ -2746,20 +2814,6 @@ const streamIterationWithAiSdk = async ({
     orgModelConfig,
   });
 
-  // See `runIterationWithAiSdk`: adopt prepareChatV2 so this stream variant
-  // also gets skill tools, progressive-discovery meta-tools, Anthropic name
-  // validation, and the assembled system prompt.
-  const prepared = await prepareChatV2({
-    mcpClientManager,
-    selectedServers,
-    modelDefinition,
-    systemPrompt: system,
-    temperature,
-    respectToolVisibility: hostPolicy?.respectToolVisibility,
-    customProviders: modelRuntime.customProviders,
-    priorMessages: [],
-  });
-
   const runStartedAt = Date.now();
   const iterationMetadataBase: Record<string, string | number | boolean> = {};
   if (promptTurns.length > 1) {
@@ -2794,11 +2848,10 @@ const streamIterationWithAiSdk = async ({
       ? await recorder.startIteration(iterationParams)
       : await createIterationDirectly(convexClient, iterationParams);
 
-  const baseMessages: ModelMessage[] = [];
-  if (prepared.enhancedSystemPrompt) {
-    baseMessages.push({ role: "system", content: prepared.enhancedSystemPrompt });
-  }
-  let conversationMessages: ModelMessage[] = [...baseMessages];
+  // `conversationMessages` starts empty; the system message is pushed below
+  // inside the try block, AFTER `prepareChatV2`. See the suite-style runner
+  // for the rationale (prep failures persist as failed iteration rows).
+  let conversationMessages: ModelMessage[] = [];
   const recordedSpans: EvalTraceSpan[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
   const accumulatedUsage = {
@@ -2814,6 +2867,25 @@ const streamIterationWithAiSdk = async ({
     null;
 
   try {
+    // See `runIterationWithAiSdk`: adopt the chat-side pipeline inside the try
+    // so prep failures become a recorded failed iteration.
+    const prepared = await prepareChatV2({
+      mcpClientManager,
+      selectedServers,
+      modelDefinition,
+      systemPrompt: system,
+      temperature,
+      respectToolVisibility: hostPolicy?.respectToolVisibility,
+      customProviders: modelRuntime.customProviders,
+      priorMessages: [],
+    });
+    if (prepared.enhancedSystemPrompt) {
+      conversationMessages.push({
+        role: "system",
+        content: prepared.enhancedSystemPrompt,
+      });
+    }
+
     const llmModel = createLlmModel(
       modelDefinition,
       modelRuntime.apiKey,
@@ -3360,21 +3432,6 @@ const streamIterationViaBackend = async ({
       : undefined;
   const toolChoice = normalizeToolChoice(advancedConfig?.toolChoice);
 
-  // Adopt the chat-side tool/system/temperature pipeline. Same change as the
-  // local-AI-SDK runner: pulls in skill tools, progressive-discovery meta-
-  // tools, Anthropic name validation, and the assembled system prompt. The
-  // backend path serializes `prepared.allTools` to `toolDefs` below and
-  // executes them locally on tool-call events.
-  const prepared = await prepareChatV2({
-    mcpClientManager,
-    selectedServers,
-    modelDefinition,
-    systemPrompt,
-    temperature,
-    respectToolVisibility: hostPolicy?.respectToolVisibility,
-    priorMessages: [],
-  });
-
   const messageHistory: ModelMessage[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
   const runStartedAt = Date.now();
@@ -3411,6 +3468,47 @@ const streamIterationViaBackend = async ({
     : recorder
       ? await recorder.startIteration(iterationParams)
       : await createIterationDirectly(convexClient, iterationParams);
+
+  // Adopt the chat-side tool/system/temperature pipeline. Same change as the
+  // local-AI-SDK runner: pulls in skill tools, progressive-discovery meta-
+  // tools, Anthropic name validation, and the assembled system prompt. The
+  // backend path serializes `prepared.allTools` to `toolDefs` below and
+  // executes them locally on tool-call events. Run AFTER iteration creation
+  // and inside a try/catch so prep failures persist as a failed iteration row
+  // rather than rejecting the test case with no iteration record.
+  let prepared: PrepareChatV2Result;
+  try {
+    prepared = await prepareChatV2({
+      mcpClientManager,
+      selectedServers,
+      modelDefinition,
+      systemPrompt,
+      temperature,
+      respectToolVisibility: hostPolicy?.respectToolVisibility,
+      priorMessages: [],
+    });
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : String(error);
+    logger.error("[evals] iteration setup failed (prepareChatV2)", error);
+    await persistSetupFailedIteration({
+      iterationId,
+      runStartedAt,
+      errorMessage,
+      iterationMetadataBase,
+      recorder,
+      convexClient,
+    });
+    return {
+      evaluation: evaluateMultiTurnResults(
+        promptTurns,
+        [],
+        test.isNegativeTest,
+        test.matchOptions,
+      ),
+      iterationId,
+    };
+  }
 
   const toolDefs = Object.entries(prepared.allTools).map(([name, tool]) => {
     const schema = (tool as any)?.inputSchema;

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -1038,4 +1038,62 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
 
     prepareSpy.mockRestore();
   });
+
+  it("does not count a negative-test setup failure as a suite pass", async () => {
+    // Regression guard for the Cursor review #2: with `isNegativeTest: true`
+    // and an empty `expectedToolCalls`, `evaluateMultiTurnResults([], ...)`
+    // returns `passed: true`. If the runner returned that evaluation as-is on
+    // setup failure, the suite summary would credit it as a pass even though
+    // the persisted iteration row is `failed`. The setup-failure path must
+    // force `evaluation.passed = false` before returning.
+    const orchestration = await import(
+      "../../../utils/chat-v2-orchestration"
+    );
+    const prepareSpy = vi
+      .spyOn(orchestration, "prepareChatV2")
+      .mockRejectedValueOnce(new Error("simulated prep failure"));
+
+    convexClient.mutation.mockResolvedValueOnce({
+      iterationId: "iter-negative-setup-fail",
+    });
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Negative case",
+            query: "Hello",
+            runs: 1,
+            model: "gpt-4-turbo",
+            provider: "openai",
+            isNegativeTest: true,
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-neg",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: { openai: "sk-test" },
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-neg",
+    });
+
+    const updateCall = convexClient.action.mock.calls.find(
+      (c) => c[0] === "testSuites:updateTestIteration",
+    );
+    expect(updateCall).toBeDefined();
+    const payload = updateCall![1] as Record<string, unknown>;
+    expect(payload.result).toBe("failed");
+    expect(payload.status).toBe("failed");
+
+    prepareSpy.mockRestore();
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -990,53 +990,57 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       iterationId: "iter-failed-setup",
     });
 
-    await expect(
-      runEvalSuiteWithAiSdk({
-        suiteId: "suite-1",
-        runId: null,
-        config: {
-          tests: [
-            {
-              title: "Case",
-              query: "Hello",
-              runs: 1,
-              model: "gpt-4-turbo",
-              provider: "openai",
-              expectedToolCalls: [],
-              promptTurns: [
-                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
-              ],
-              testCaseId: "case-1",
-            },
-          ],
-          environment: { servers: ["srv-1"] },
-        },
-        modelApiKeys: { openai: "sk-test" },
-        convexClient: convexClient as any,
-        convexHttpUrl: "https://example.convex.site",
-        convexAuthToken: "token",
-        mcpClientManager: mcpClientManager as any,
-        testCaseId: "case-1",
-      }),
-    ).resolves.toBeDefined();
+    try {
+      await expect(
+        runEvalSuiteWithAiSdk({
+          suiteId: "suite-1",
+          runId: null,
+          config: {
+            tests: [
+              {
+                title: "Case",
+                query: "Hello",
+                runs: 1,
+                model: "gpt-4-turbo",
+                provider: "openai",
+                expectedToolCalls: [],
+                promptTurns: [
+                  { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+                ],
+                testCaseId: "case-1",
+              },
+            ],
+            environment: { servers: ["srv-1"] },
+          },
+          modelApiKeys: { openai: "sk-test" },
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          mcpClientManager: mcpClientManager as any,
+          testCaseId: "case-1",
+        }),
+      ).resolves.toBeDefined();
 
-    expect(prepareSpy).toHaveBeenCalled();
+      expect(prepareSpy).toHaveBeenCalled();
 
-    const updateCall = convexClient.action.mock.calls.find(
-      (c) => c[0] === "testSuites:updateTestIteration",
-    );
-    expect(updateCall).toBeDefined();
-    const payload = updateCall![1] as Record<string, unknown>;
-    expect(payload.status).toBe("failed");
-    expect(payload.result).toBe("failed");
-    expect(payload.error).toEqual(expect.stringContaining("Invalid tool name"));
-    expect(payload.iterationId).toBe("iter-failed-setup");
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = updateCall![1] as Record<string, unknown>;
+      expect(payload.status).toBe("failed");
+      expect(payload.result).toBe("failed");
+      expect(payload.error).toEqual(
+        expect.stringContaining("Invalid tool name"),
+      );
+      expect(payload.iterationId).toBe("iter-failed-setup");
 
-    // The runner must NOT have called generateText — the failure happens
-    // before any model invocation.
-    expect(generateTextMock).not.toHaveBeenCalled();
-
-    prepareSpy.mockRestore();
+      // The runner must NOT have called generateText — the failure happens
+      // before any model invocation.
+      expect(generateTextMock).not.toHaveBeenCalled();
+    } finally {
+      prepareSpy.mockRestore();
+    }
   });
 
   it("does not count a negative-test setup failure as a suite pass", async () => {
@@ -1057,43 +1061,45 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       iterationId: "iter-negative-setup-fail",
     });
 
-    await runEvalSuiteWithAiSdk({
-      suiteId: "suite-1",
-      runId: null,
-      config: {
-        tests: [
-          {
-            title: "Negative case",
-            query: "Hello",
-            runs: 1,
-            model: "gpt-4-turbo",
-            provider: "openai",
-            isNegativeTest: true,
-            expectedToolCalls: [],
-            promptTurns: [
-              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
-            ],
-            testCaseId: "case-neg",
-          },
-        ],
-        environment: { servers: ["srv-1"] },
-      },
-      modelApiKeys: { openai: "sk-test" },
-      convexClient: convexClient as any,
-      convexHttpUrl: "https://example.convex.site",
-      convexAuthToken: "token",
-      mcpClientManager: mcpClientManager as any,
-      testCaseId: "case-neg",
-    });
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Negative case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              isNegativeTest: true,
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-neg",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-neg",
+      });
 
-    const updateCall = convexClient.action.mock.calls.find(
-      (c) => c[0] === "testSuites:updateTestIteration",
-    );
-    expect(updateCall).toBeDefined();
-    const payload = updateCall![1] as Record<string, unknown>;
-    expect(payload.result).toBe("failed");
-    expect(payload.status).toBe("failed");
-
-    prepareSpy.mockRestore();
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = updateCall![1] as Record<string, unknown>;
+      expect(payload.result).toBe("failed");
+      expect(payload.status).toBe("failed");
+    } finally {
+      prepareSpy.mockRestore();
+    }
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -41,6 +41,26 @@ vi.mock("../../../utils/chat-helpers", () => ({
   ) => createLlmModelMock(modelDefinition, apiKey, baseUrls, customProviders),
 }));
 
+// Stub the chat-side tool/system/temperature pipeline. The real implementation
+// in `chat-v2-orchestration` pulls in `getSkillToolsAndPrompt`, which touches
+// the filesystem outside HOSTED_MODE; the eval test environment doesn't need
+// that. Return a minimal `PrepareChatV2Result` shape — the actual tool set
+// stays empty (matching `mcpClientManager.getToolsForAiSdk` → `{}`), and the
+// engine swap only depends on the named output fields.
+vi.mock("../../../utils/chat-v2-orchestration", () => ({
+  prepareChatV2: vi.fn(async (options: any) => ({
+    allTools: {},
+    enhancedSystemPrompt: options?.systemPrompt ?? "",
+    resolvedTemperature: options?.temperature,
+    scrubMessages: (msgs: unknown[]) => msgs,
+    progressivePlan: { enabled: false },
+    discoveryState: {
+      loadedToolIds: new Set<string>(),
+      catalogVersion: 0,
+    },
+  })),
+}));
+
 import { runEvalSuiteWithAiSdk, streamTestCase } from "../../evals-runner";
 
 describe("runEvalSuiteWithAiSdk compare session metadata", () => {
@@ -589,6 +609,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
         testCaseId: "case-1",
       },
       tools: {},
+      selectedServers: [],
       mcpClientManager: mcpClientManager as any,
       recorder: null,
       modelApiKeys: { openai: "sk-test" },
@@ -700,6 +721,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
           testCaseId: "case-1",
         },
         tools: {},
+        selectedServers: [],
         mcpClientManager: mcpClientManager as any,
         recorder: null,
         modelApiKeys: {},

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -965,4 +965,77 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       undefined,
     );
   });
+
+  it("records prepareChatV2 setup failures as a failed iteration", async () => {
+    // Force prepareChatV2 to throw — simulates Anthropic name validation,
+    // meta-tool name collision, or skill-tool prep failure. The runner must
+    // catch this and persist a failed iteration row, NOT propagate the throw.
+    const orchestration = await import(
+      "../../../utils/chat-v2-orchestration"
+    );
+    const prepareSpy = vi
+      .spyOn(orchestration, "prepareChatV2")
+      .mockRejectedValueOnce(
+        new Error(
+          "Invalid tool name(s) for Anthropic: 'bad.name'. Tool names must only contain letters, numbers, underscores, and hyphens (max 64 characters).",
+        ),
+      );
+
+    // The iteration row is created via `mutation` (default mock returns
+    // { iterationId: "iter-1" }); the finalize call goes through `action`
+    // (testSuites:updateTestIteration). Convex serializes `passed` into
+    // separate `result` ("failed") and `status` ("failed") fields — see
+    // `finishIterationDirectly`.
+    convexClient.mutation.mockResolvedValueOnce({
+      iterationId: "iter-failed-setup",
+    });
+
+    await expect(
+      runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      }),
+    ).resolves.toBeDefined();
+
+    expect(prepareSpy).toHaveBeenCalled();
+
+    const updateCall = convexClient.action.mock.calls.find(
+      (c) => c[0] === "testSuites:updateTestIteration",
+    );
+    expect(updateCall).toBeDefined();
+    const payload = updateCall![1] as Record<string, unknown>;
+    expect(payload.status).toBe("failed");
+    expect(payload.result).toBe("failed");
+    expect(payload.error).toEqual(expect.stringContaining("Invalid tool name"));
+    expect(payload.iterationId).toBe("iter-failed-setup");
+
+    // The runner must NOT have called generateText — the failure happens
+    // before any model invocation.
+    expect(generateTextMock).not.toHaveBeenCalled();
+
+    prepareSpy.mockRestore();
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -1102,4 +1102,78 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       prepareSpy.mockRestore();
     }
   });
+
+  it("emits an error event when streamTestCase backend setup fails", async () => {
+    // Regression guard for Cursor review on commit 3924d0c: the
+    // `streamIterationViaBackend` setup-failure catch persists the failed
+    // iteration row but used to return silently. The live test-runner UI
+    // watching `streamTestCase` SSE then finished with no failure signal,
+    // unlike the local-AI-SDK stream variant whose outer catch already
+    // emits an `error` event. Setup failures must now emit one too.
+    const orchestration = await import(
+      "../../../utils/chat-v2-orchestration"
+    );
+    const prepareSpy = vi
+      .spyOn(orchestration, "prepareChatV2")
+      .mockRejectedValueOnce(new Error("backend stream prep boom"));
+
+    convexClient.mutation.mockResolvedValueOnce({
+      iterationId: "iter-stream-setup-fail",
+    });
+
+    const emitted: Array<Record<string, unknown>> = [];
+    try {
+      await streamTestCase({
+        test: {
+          title: "Stream backend setup-fail case",
+          query: "Hello",
+          runs: 1,
+          model: "claude-haiku-4.5",
+          provider: "anthropic",
+          expectedToolCalls: [],
+          promptTurns: [
+            { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+          ],
+          testCaseId: "case-stream-setup",
+        },
+        tools: {},
+        selectedServers: [],
+        mcpClientManager: mcpClientManager as any,
+        recorder: null,
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        testCaseId: "case-stream-setup",
+        suiteId: "suite-stream",
+        runId: null,
+        emit: (event) => emitted.push(event as Record<string, unknown>),
+      });
+
+      // The SSE consumer must see an in-stream error event.
+      expect(emitted).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "error",
+            message: expect.stringContaining("backend stream prep boom"),
+          }),
+        ]),
+      );
+
+      // And the failure must still be persisted (status:"failed").
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = updateCall![1] as Record<string, unknown>;
+      expect(payload.status).toBe("failed");
+      expect(payload.result).toBe("failed");
+
+      // The runner must NOT have hit the backend — failure happens before
+      // the per-step fetch loop.
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      prepareSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Eval ran its own tool-prep + system-prompt + temperature wiring, skipping `prepareChatV2`. That silently dropped skill tools, Anthropic name validation, skills-prompt assembly, and any progressive-discovery meta-tools from every eval run — users were evaluating a different surface than the one chat / playground / chatbox exposes.

This PR adopts `prepareChatV2` inside all four iteration runners — `runIterationWithAiSdk`, `runIterationViaBackend`, `streamIterationWithAiSdk`, `streamIterationViaBackend` — and threads `selectedServers` + `modelDefinition` through `RunIterationBaseParams` and the `runTestCase` / `streamTestCase` outer args. The engine (`generateText` / `streamText` / backend stream) and persistence (`persistEvalTraceFanout`, recorder, etc.) are unchanged.

This is **PR 1** of the engine-consolidation plan that lands eval on the same engine stack chat/playground/chatbox use. The plan lives at `~/.claude/plans/lets-consolidate-on-streamtext-transient-clarke.md`; subsequent PRs swap eval onto `runAssistantTurn` and collapse the four runners.

### Honest scoping on progressive discovery

`prepareChatV2` returns `{ allTools, progressivePlan, discoveryState }`. After this PR eval **advertises** the progressive-discovery meta-tools (`search_mcp_tools` / `load_mcp_tools`) when the plan is enabled — i.e. the meta-tools are now in the tool set the model sees. What this PR does **not** change:

- Eval's `prepareStep` still returns `undefined`. Chat's local path returns `activeTools` from `prepareStep` after a `gateToolsToActiveSubset` pass; eval skips that, so it advertises both the meta-tools and the full tool set every step instead of narrowing to the discovered subset.
- The backend runner serializes every entry from `prepared.allTools` into `toolDefs`, so the same lack-of-gating applies for hosted-model + hosted-org-BYOK paths.

Net effect: this PR closes the "skill tools / Anthropic validation / system prompt assembly / meta-tool presence" gap; it does **not** yet replicate chat's full progressive-exposure model. Active-tool gating lands when eval moves onto `runAssistantTurn` in a subsequent PR.

### Setup-failure behavior

`prepareChatV2` can throw on Anthropic name validation, meta-tool collisions, and skill-tool prep failures. Two adjustments to keep those visible:

- **AI-SDK runners** (`runIterationWithAiSdk` + `streamIterationWithAiSdk`): the `prepareChatV2` call is inside the existing outer try/catch, after iteration row creation. Setup throws land in the existing failed-iteration write path.
- **Backend runners** (`runIterationViaBackend` + `streamIterationViaBackend`): no outer try/catch existed. Added a small `persistSetupFailedIteration` helper; `prepareChatV2` is wrapped in a try/catch that records the failure (`status: "failed"`, `result: "failed"`, `error: <message>`) and returns early before the per-step fetch loop.

### What stays unchanged

- AI SDK call surface: `generateText` / `streamText` / Convex `/stream` + `/stream/org` backend loop
- Verdict + lock writer (`persistEvalTraceFanout`, `recorder.finalizeIteration`)
- `testIteration` row writes, configSnapshot, predicate verdicts
- Cancellation (AbortController + watcher unchanged)
- `wrapToolSetForEvalTrace` span capture
- `applyVisibilityPolicyAndCountSignals` at `runEvalSuiteWithAiSdk` level retained for `toolSignals` telemetry (`prepareChatV2` performs equivalent visibility filtering internally, but doesn't expose the dropped-count signals)

### Why `prepareChatV2` is one-shot per iteration (not per turn)

Chat-v2 calls `prepareChatV2` once per HTTP request — which is once per assistant turn, since each chat turn is its own request. Eval calls it once per iteration with `priorMessages: []`, meaning the progressive-discovery `discoveryState` only sees the initial empty state. A later PR (when eval moves to `runAssistantTurn`) naturally gets per-turn cadence because each turn becomes one driver call.

## Test plan

- [x] Typecheck: no new errors vs `main` baseline (4 pre-existing recorder shape issues, unrelated)
- [x] Eval-runner unit tests: 16 / 16 pass (15 originals + 1 new failure-path test asserting `prepareChatV2` throws are recorded as `status: "failed"` iteration rows)
- [x] All `server/services/evals` tests: 83 / 83 pass
- [x] Adjacent server suites (`utils/`, `services/`, `routes/web/`, `routes/mcp/`, `sessionSimulation/`): 759 / 759 pass — no chat/synthetic/route regressions
- [ ] End-to-end smoke on a local eval suite with a skill-enabled server — confirm skill tools appear in the transcript (today they don't)
- [ ] End-to-end smoke on a local eval suite with Anthropic + an MCP server exposing a tool with an invalid name — confirm the iteration is recorded as `status: "failed"` with the validation error, not as a suite-level crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core eval execution paths and can alter which tools/prompts models see versus prior runs; failure handling fixes reduce silent pass inflation but behavior shifts are user-visible.
> 
> **Overview**
> Eval iteration runs now use the same **`prepareChatV2`** pipeline as chat for tools, system prompt, and temperature, instead of ad-hoc `getToolsForAiSdk` wiring. **`selectedServers`** and **`modelDefinition`** are threaded through **`runTestCase`**, **`streamTestCase`**, and all four runners (local AI SDK, backend, and their stream variants). Model calls use **`prepared.allTools`**, **`enhancedSystemPrompt`**, and **`resolvedTemperature`**.
> 
> **Setup failures** from `prepareChatV2` (e.g. Anthropic tool-name validation) are handled explicitly: backend paths get **`persistSetupFailedIteration`** and early return; streaming backend paths also emit an SSE **`error`** event. Returned **`evaluation.passed`** is forced to **`false`** on setup and outer-catch failures so suite pass counts are not inflated (including negative tests with no tool calls).
> 
> Suite-level **`tools`** remains only for **`toolSignals`** telemetry. Tests mock **`prepareChatV2`** and add coverage for failed setup persistence, negative-test pass counting, and stream error emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4928abde6a857d724ce910a21fd7d814563fde16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->