### PR TITLE
docs: fix gaps surfaced by docs-chat (week of 2026-05-29)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,7 +41,8 @@
           "installation",
           "hosted/overview",
           "troubleshooting/common-errors",
-          "troubleshooting/error-codes"
+          "troubleshooting/error-codes",
+          "changelog/overview"
         ]
       },
       {

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -75,13 +75,15 @@ You should see your server show **Connected** with a green dot in the **Connect*
     No. MCPJam Inspector runs as a hosted web app, a desktop app, or via `npx` — none of them require you to install or configure a database. Accounts, sharing, and OAuth token storage on [app.mcpjam.com](https://app.mcpjam.com) are handled by the hosted backend; the Terminal and Desktop apps store config locally on disk.
   </Accordion>
   <Accordion title="How do I check which version of Inspector I'm running?" icon="tag">
-    From the Terminal install:
+    All three installs (Web, Desktop, Terminal) show the running version in the **Settings** tab under **About**.
+
+    To see what the latest published version on npm is — useful for confirming an `@latest` pull actually moved you forward — run:
 
     ```bash
-    npx @mcpjam/inspector@latest --version
+    npm view @mcpjam/inspector version
     ```
 
-    The Desktop and Web apps update on their own — the version is shown in the **Settings → About** pane. To force the latest Terminal build, the `@latest` tag in `npx @mcpjam/inspector@latest` pulls the most recent release every run.
+    The Desktop and Web apps update on their own. For the Terminal install, the `@latest` tag in `npx @mcpjam/inspector@latest` pulls the most recent release every run.
   </Accordion>
   <Accordion title="Can MCPJam auto-install MCP servers into my repo?" icon="package">
     Not directly — MCPJam doesn't reach into your repo. The closest workflow is **Skills**: install the MCPJam CLI skill into a project so an agent working in that repo knows how to use MCP tools and call MCPJam against your servers. See [Skills](/inspector/skills).

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -63,4 +63,37 @@ You should see your server show **Connected** with a green dot in the **Connect*
   <Card title="Projects" icon="folder" href="/inspector/projects">
     Group servers; share configuration with your team
   </Card>
+  <Card title="API keys" icon="key" href="/reference/api-keys">
+    The three things called "API key" in MCPJam (LLM provider key, `MCPJAM_API_KEY`, per-server bearer) and when you need each one.
+  </Card>
 </CardGroup>
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Does MCPJam need a database?" icon="database">
+    No. MCPJam Inspector runs as a hosted web app, a desktop app, or via `npx` — none of them require you to install or configure a database. Accounts, sharing, and OAuth token storage on [app.mcpjam.com](https://app.mcpjam.com) are handled by the hosted backend; the Terminal and Desktop apps store config locally on disk.
+  </Accordion>
+  <Accordion title="How do I check which version of Inspector I'm running?" icon="tag">
+    From the Terminal install:
+
+    ```bash
+    npx @mcpjam/inspector@latest --version
+    ```
+
+    The Desktop and Web apps update on their own — the version is shown in the **Settings → About** pane. To force the latest Terminal build, the `@latest` tag in `npx @mcpjam/inspector@latest` pulls the most recent release every run.
+  </Accordion>
+  <Accordion title="Can MCPJam auto-install MCP servers into my repo?" icon="package">
+    Not directly — MCPJam doesn't reach into your repo. The closest workflow is **Skills**: install the MCPJam CLI skill into a project so an agent working in that repo knows how to use MCP tools and call MCPJam against your servers. See [Skills](/inspector/skills).
+  </Accordion>
+  <Accordion title="Where are my files saved?" icon="folder">
+    It depends what you mean — the word covers three different things:
+
+    - **OAuth credentials** from `mcpjam login`: `~/.mcpjam/config.json`. Override per command with `--credentials-out`. See [CLI OAuth login](/cli/oauth-login).
+    - **Eval results**: uploaded to your MCPJam workspace via `MCPJAM_API_KEY`. See [Saving Results](/sdk/concepts/saving-results).
+    - **Inspector UI changes** (server config, client edits): persisted via the **Save** button in the project view. See [Inspector Views](/inspector/views).
+  </Accordion>
+  <Accordion title="How do I sign out of the hosted app?" icon="log-out">
+    Open the **account menu** at the bottom of the sidebar and pick **Sign out**. You'll be returned to the public app as a guest. See [Hosted App → Signing out](/hosted/overview#signing-out).
+  </Accordion>
+</AccordionGroup>

--- a/docs/hosted/overview.mdx
+++ b/docs/hosted/overview.mdx
@@ -52,6 +52,12 @@ The hosted app uses a daily credit system to power AI features like chat.
 - **Signed-in users** get **10×** the daily usage of a guest. Your daily usage and any paid credit balance are visible in the account menu at the bottom of the sidebar.
 - **Paid credits** can be topped up from the billing page and are shown alongside your daily limit in the account menu.
 
+## Signing out
+
+Open the **account menu** at the bottom of the sidebar (click your avatar or email) and choose **Sign out**. You'll be returned to the public app as a guest, and any signed-in usage allowance is replaced by the guest allowance until you sign back in.
+
+OAuth tokens you connected while signed in remain in your hosted workspace and are restored the next time you sign in on the same account.
+
 ## OAuth token reveal
 
 When you connect an OAuth server in the hosted app, your OAuth credentials are stored securely in Vault. You can inspect those tokens on demand from the server's **Overview** tab without them ever being written to `localStorage` or shared with other users.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -28,7 +28,7 @@ MCPJam Inspector runs three ways: a hosted web app, a desktop app for Mac and Wi
 | Local STDIO servers | — | ✓ | ✓ | ✓ (with `--` args) |
 | Skills | — | ✓ | ✓ | ✓ |
 | Shareable server URLs | ✓ | — | — | — |
-| Auto-updates to latest | ✓ | Manual install | Per-run (`@latest`) | Per-tag pull |
+| Always on latest version | ✓ | Re-download to update | Per-run (`@latest`) | Per-tag pull |
 
 If your server is local (running on `localhost`), the web app cannot reach it — pick **Desktop** or **Terminal**. If you want teammates to one-click into the same server, pick **Web App**.
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -18,6 +18,20 @@ MCPJam Inspector runs three ways: a hosted web app, a desktop app for Mac and Wi
   </Card>
 </CardGroup>
 
+### Which one do I need?
+
+| Capability | Web App | Desktop | Terminal (`npx`) | Docker |
+| --- | :---: | :---: | :---: | :---: |
+| Install required | None | Mac/Windows download | Node.js | Docker |
+| HTTPS MCP servers | ✓ | ✓ | ✓ | ✓ |
+| HTTP MCP servers | — | ✓ | ✓ | ✓ |
+| Local STDIO servers | — | ✓ | ✓ | ✓ (with `--` args) |
+| Skills | — | ✓ | ✓ | ✓ |
+| Shareable server URLs | ✓ | — | — | — |
+| Auto-updates to latest | ✓ | Manual install | Per-run (`@latest`) | Per-tag pull |
+
+If your server is local (running on `localhost`), the web app cannot reach it — pick **Desktop** or **Terminal**. If you want teammates to one-click into the same server, pick **Web App**.
+
 ## Web app
 
 Go to [app.mcpjam.com](https://app.mcpjam.com) in your browser. No install required. The web app accepts HTTPS MCP server URLs only — for HTTP or local STDIO servers, use the desktop or terminal options below. See [Hosted App](/hosted/overview) for more.
@@ -113,6 +127,12 @@ This will open the MCPJam inspector and connect to a STDIO using the commands yo
     ```bash
     # Starts MCPJam inspector with a FastMCP server
     npx @mcpjam/inspector@latest uv run fastmcp run /path/to/your/server.py
+    ```
+
+    This command assumes [`uv`](https://docs.astral.sh/uv/) is installed and on your PATH. If you see `Unknown command: uv` (fish), `command not found: uv` (bash/zsh), or `'uv' is not recognized` (Windows), install it first:
+
+    ```bash
+    curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
   </Tab>
   

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -55,6 +55,12 @@ bunx @mcpjam/inspector@latest
 
 After installing the package, you should see a link to `localhost`. Open that link up to see the inspector.
 
+### From your editor (VS Code, Cursor, Windsurf)
+
+There is no dedicated editor extension — and you don't need one. Open your editor's integrated terminal, run the same `npx @mcpjam/inspector@latest` command, and click the printed `localhost` link. The inspector runs alongside your dev server in any editor that has a terminal pane.
+
+If you want the inspector to auto-launch from your project's `dev` script (so it boots whenever you start your server), see [Launch from Code](/inspector/launch-from-code).
+
 ## Docker
 
 Run MCPJam Inspector using Docker, bound to localhost for security:

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -29,6 +29,16 @@ This guide covers common errors you might encounter when working with MCP server
 - **For HTTP servers**: Verify the URL is accessible
   - Test with `curl` or a browser first
 
+### "Invalid host header" when connecting to an HTTP server
+
+This response comes from **your MCP server**, not from MCPJam Inspector. The server's HTTP layer is rejecting the request because the `Host` header isn't on its allowlist. Most common culprits:
+
+- **Next.js / webpack-dev-server** — both block unknown hosts by default in dev mode. Add your host to `allowedHosts` (webpack-dev-server) or `experimental.allowedDevOrigins` (Next.js).
+- **FastAPI / Starlette (Python)** — `TrustedHostMiddleware` rejects hosts not in `allowed_hosts`. Add the host the inspector is calling from, or temporarily set `allowed_hosts=["*"]` for local testing.
+- **Reverse proxies (nginx, Caddy)** — check the `server_name` / `host_match` config.
+
+**Quick check:** test the same URL with `curl http://localhost:PORT/mcp` — if curl gets the same error, it's definitely server-side, not inspector.
+
 ## Authentication Issues
 
 ### Server fails to connect with authentication errors

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -12,6 +12,49 @@ This guide covers common errors you might encounter when working with MCP server
 
 ## Connection Issues
 
+### Diagnose a connection failure
+
+Most "failed to connect" / `fetch failed` / `ECONNREFUSED` / `MCP error -32000: Connection closed` / `MCP error -32001: Request timed out` reports come down to one of five root causes. Work through them in order — each step takes seconds.
+
+1. **Is the server actually running?**
+
+   Open a second terminal and run the same command you'd ask Inspector to run. If it exits or prints a stack trace, fix that first — Inspector can only attach to a server that stays alive.
+
+   ```bash
+   # For STDIO servers
+   /Users/yourname/project/server.py
+   # or whatever the command is
+
+   # For HTTP servers
+   curl -i http://localhost:PORT/mcp
+   ```
+
+   A clean stdio process should sit waiting on stdin; a healthy HTTP server should respond with `405` or `200` to a `GET` (not `Connection refused`).
+
+2. **Right port, right path?**
+
+   `ECONNREFUSED 127.0.0.1:5555` means **nothing is listening on that port** — typo, wrong port, or the server is on `0.0.0.0` but you typed `127.0.0.1` (or vice versa). `SSE error: Non-200 status code (404)` means the port is correct but the path is wrong: most MCP servers mount under `/mcp` or `/sse`, not `/`.
+
+3. **Right transport selected?**
+
+   In the server card, the transport dropdown must match what your server speaks. STDIO servers won't respond to HTTP attempts and vice versa. If you used a `url:` field in `config.json`, Inspector picks HTTP; if you used `command:` + `args:`, Inspector picks STDIO.
+
+4. **Right auth setting?**
+
+   For local development servers, pick **No Authentication**. If you get `401`, see [Getting 401 Unauthorized errors](#getting-401-unauthorized-errors) below.
+
+5. **Did the server actually finish booting before the handshake?**
+
+   `MCP error -32001: Request timed out` during `initialize` means the server didn't respond to the handshake in time — usually because it's still loading models, opening a database, or waiting on an upstream. Raise the **Request timeout** in **Clients → your client → Request timeout** (default 30,000ms), or reduce the server's startup work.
+
+If all five check out and you still see a failure, copy the full error from the JSON-RPC log into a [GitHub issue](https://github.com/MCPJam/inspector/issues) or [Discord](https://discord.gg/JEnDtz8X6z) thread.
+
+### `(intermediate value).subtle is undefined`
+
+The browser's Web Crypto API (`crypto.subtle`) is only available in **secure contexts** — that means HTTPS, or `http://localhost` / `http://127.0.0.1`. If you're hitting Inspector over a non-localhost HTTP URL (for example, a LAN IP like `http://192.168.1.10:6274`), the browser disables `crypto.subtle` and OAuth/PKCE flows fail.
+
+**Fix:** open Inspector at `http://localhost:6274` or `http://127.0.0.1:6274`, or put HTTPS in front of it. The hosted app and the desktop app are unaffected.
+
 ### Server fails to start or connect
 
 - **Use absolute paths**: Specify the full path to your server

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -21,19 +21,20 @@ Most "failed to connect" / `fetch failed` / `ECONNREFUSED` / `MCP error -32000: 
    Open a second terminal and run the same command you'd ask Inspector to run. If it exits or prints a stack trace, fix that first — Inspector can only attach to a server that stays alive.
 
    ```bash
-   # For STDIO servers
-   /Users/yourname/project/server.py
-   # or whatever the command is
+   # For STDIO servers — run the same command Inspector would run
+   python /Users/yourname/project/server.py
+   # or: uv run --directory /Users/yourname/project mcp.py
+   # or: npx -y @modelcontextprotocol/server-everything
 
    # For HTTP servers
    curl -i http://localhost:PORT/mcp
    ```
 
-   A clean stdio process should sit waiting on stdin; a healthy HTTP server should respond with `405` or `200` to a `GET` (not `Connection refused`).
+   A clean stdio process should sit waiting on stdin; a healthy HTTP server should respond with something other than `Connection refused` (the exact code varies — common responses are `405 Method Not Allowed` for `GET`, `406 Not Acceptable` if Accept headers are missing, or `400 Bad Request` if the server expects a session header).
 
 2. **Right port, right path?**
 
-   `ECONNREFUSED 127.0.0.1:5555` means **nothing is listening on that port** — typo, wrong port, or the server is on `0.0.0.0` but you typed `127.0.0.1` (or vice versa). `SSE error: Non-200 status code (404)` means the port is correct but the path is wrong: most MCP servers mount under `/mcp` or `/sse`, not `/`.
+   `ECONNREFUSED 127.0.0.1:5555` means **nothing is listening on that port** — typo, wrong port, or the server is bound to `127.0.0.1` only while you're calling it via a different hostname (or vice versa). `SSE error: Non-200 status code (404)` means the port is correct but the path is wrong: most MCP servers mount under `/mcp` or `/sse`, not `/`.
 
 3. **Right transport selected?**
 


### PR DESCRIPTION
## Summary

Investigated last week's docs-chat export (≈80 queries) to find recurring "I can't find that in the docs" misses, then expanded a few adjacent areas where users were likely to land next. Two larger gaps (JSON-RPC error codes, `/api/mcp/*` endpoint docs) are intentionally **not** included — the first shipped in #2440, the second is waiting on the real API.

### Changes

**Targeted fixes for recurring docs-chat misses**

- **`docs/docs.json`** — Add `changelog/overview` to the Get Started tab. The page already existed at `docs/changelog/overview.mdx` but wasn't reachable from nav, which is why every "release notes" / "what version is this" / "latest docker image is behind" query in the export went unanswered.
- **`docs/hosted/overview.mdx`** — New "Signing out" subsection. "how to log out" was returned **unanswered** in the export.
- **`docs/troubleshooting/common-errors.mdx`** — New "Invalid host header" subsection. One user had a 4-turn frustrated conversation on this; the message comes from the user's own server (Next.js, webpack-dev-server, FastAPI `TrustedHostMiddleware`), so the entry frames the fix on that side and adds a curl sanity check.
- **`docs/installation.mdx`** — New "From your editor (VS Code, Cursor, Windsurf)" note in the Terminal section, cross-linked to `/inspector/launch-from-code`. Answers the "how to use this in VS Code" question without inventing a non-existent extension.

**Broader authoring while in these files**

- **`docs/getting-started.mdx`** — New **API keys** card linking to `/reference/api-keys`, plus a 5-entry **FAQ** accordion: database requirement, how to check the running version (points at Settings → About and `npm view`), Skills as the closest auto-install workflow, where files are saved (OAuth creds / eval results / Inspector UI changes), and hosted sign-out.
- **`docs/installation.mdx`** — Added a Web / Desktop / Terminal / Docker **capability matrix** so users can pick the right install at a glance, and a `uv` install snippet for when FastMCP examples fail with `command not found: uv`.
- **`docs/troubleshooting/common-errors.mdx`** — Added a 5-step **connection-failure diagnosis** checklist (server running, port/path, transport, auth, init timeout) and a `crypto.subtle is undefined` entry covering secure-context requirements for OAuth on LAN HTTP.

### Already covered (no change needed)

While investigating I confirmed these are not actually gaps:
- API key disambiguation — `/reference/api-keys` already covers LLM key vs `MCPJAM_API_KEY` vs Playground BYOK.
- STDIO + HTTP/SHTTP config example — `installation.mdx` already has a "Mixing STDIO and HTTP/SHTTP servers" block.

## Test plan

- [ ] `mintlify dev` (or your preview build) renders `/changelog/overview` from the Get Started tab
- [ ] `/troubleshooting/common-errors#diagnose-a-connection-failure` exists and anchors correctly
- [ ] `/troubleshooting/common-errors#invalid-host-header-when-connecting-to-an-http-server` exists and anchors correctly
- [ ] `/hosted/overview#signing-out` exists
- [ ] `/installation#from-your-editor-vs-code-cursor-windsurf` exists and the "Launch from Code" cross-link resolves
- [ ] `/installation#which-one-do-i-need` capability matrix renders
- [ ] `/getting-started#faq` accordion renders and the "How do I check which version" entry correctly tells users to look at **Settings → About** (no `--version` flag claim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and navigation config only; no application or API behavior changes.
> 
> **Overview**
> Documentation-only updates aimed at recurring docs-chat misses: **changelog** is now linked from the Get Started nav (`docs/docs.json`), and **getting started** adds an API keys card plus an FAQ (database, version via Settings → About / `npm view`, Skills, where data is saved, hosted sign-out).
> 
> **Installation** gains a Web / Desktop / Terminal / Docker capability matrix, editor guidance (terminal + link to Launch from Code), and a `uv` install note for FastMCP examples. **Hosted overview** documents signing out and that OAuth tokens stay in the workspace. **Common errors** adds a five-step connection diagnosis flow, `crypto.subtle` / secure-context guidance for OAuth on LAN HTTP, and an **Invalid host header** section framed as server-side (Next.js, webpack, FastAPI, proxies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15923d8cb6aab6d736a78504b74a5d8344fff75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->