### PR TITLE
evals: lock in runAssistantTurn eval contract via dedicated test

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/assistant-turn-eval-contract.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/assistant-turn-eval-contract.test.ts
@@ -356,15 +356,20 @@ describe("runAssistantTurn — eval contract", () => {
     expect(fetchBody.providerKey).toBe("byok_anthropic_prod");
   });
 
-  it("accepts selectedServerIds (engine consumes inspector-side for tool filtering)", async () => {
+  it("accepts selectedServerIds (engine consumes inspector-side for history scrubbing)", async () => {
     setupSuccessfulStream();
 
     // Eval pre-builds the tool set via `prepareChatV2` and passes it as
-    // `tools`. `selectedServerIds` is consumed inspector-side by the
-    // engine to filter the tool set before sending tool definitions to
-    // Convex — it does NOT appear in the request body. PR 3 will still
-    // pass it for parity with chat; assert the call succeeds with the
-    // option present.
+    // `tools`. Tool definitions sent to Convex come straight from that
+    // map via `serializeToolsForConvex(tools)`. `selectedServerIds` is
+    // a separate signal threaded into the engine for MCP-Apps /
+    // ChatGPT-Apps tool-result history scrubbing
+    // (`scrubMcpAppsToolResultsForBackend` /
+    // `scrubChatGPTAppsToolResultsForBackend` consume it before the
+    // messages are forwarded). It does NOT filter the tool set and does
+    // NOT appear in the request body. PR 3 will still pass it for
+    // parity with chat; assert the call succeeds with the option
+    // present.
     const result = await runAssistantTurn({
       messages: [{ role: "user", content: "Hi." }] as any,
       modelDefinition: baseModelDefinition,

--- a/mcpjam-inspector/server/utils/__tests__/assistant-turn-eval-contract.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/assistant-turn-eval-contract.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Eval-contract tests for `runAssistantTurn` (PR 2 of the engine
+ * consolidation in `~/mcpjam-docs/unification.md`).
+ *
+ * Purpose: lock in the configuration eval will rely on when PR 3 rewrites
+ * `runIterationViaBackend` to drive `runAssistantTurn` directly. Eval's
+ * needs are a strict subset of synthetic's, but the existing
+ * `assistant-turn.test.ts` covers chatbox/direct surfaces — these tests
+ * exercise eval-only behavior (sourceType:"eval", hosted-org dispatch
+ * shape, JAM-paid attribution, the open-ended `extraBodyFields` channel
+ * for eval-run attribution) so PR 3's refactor has an explicit safety
+ * net.
+ *
+ * Audit conclusion: zero contract gaps in the engine surface. These
+ * tests document and assert that conclusion rather than introduce new
+ * surface.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  executeToolCallsFromMessages,
+  hasUnresolvedToolCalls,
+} from "@/shared/http-tool-calls";
+import { runAssistantTurn } from "../assistant-turn";
+import type { ModelDefinition } from "@/shared/types";
+
+let lastExecution: Promise<void> | null = null;
+let writtenChunks: any[] = [];
+
+const buildSsePayload = (events: any[]) =>
+  `${events
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .join("")}data: [DONE]\n\n`;
+
+const createSseResponse = (events: any[]) => {
+  const encoder = new TextEncoder();
+  const payload = buildSsePayload(events);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(payload));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    createUIMessageStream: vi.fn(({ execute, onFinish }) => {
+      const writer = {
+        write: vi.fn((chunk) => {
+          writtenChunks.push(chunk);
+        }),
+      };
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          lastExecution = Promise.resolve(execute({ writer })).then(
+            async () => {
+              await onFinish?.();
+            }
+          );
+          await lastExecution;
+          controller.close();
+        },
+      });
+      return stream;
+    }),
+    createUIMessageStreamResponse: vi.fn().mockImplementation(({ stream }) => {
+      return new Response(stream as ReadableStream<Uint8Array>, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }),
+  };
+});
+
+vi.mock("@/shared/http-tool-calls", () => ({
+  hasUnresolvedToolCalls: vi.fn().mockReturnValue(false),
+  executeToolCallsFromMessages: vi.fn(),
+}));
+
+vi.mock("../chat-helpers", async () => {
+  const actual = await vi.importActual<typeof import("../chat-helpers")>(
+    "../chat-helpers"
+  );
+  return {
+    ...actual,
+    scrubMcpAppsToolResultsForBackend: vi.fn((messages) => messages),
+    scrubChatGPTAppsToolResultsForBackend: vi.fn((messages) => messages),
+  };
+});
+
+vi.mock("../mcpjam-tool-helpers", () => ({
+  serializeToolsForConvex: vi.fn(() => []),
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const baseModelDefinition: ModelDefinition = {
+  id: "anthropic/claude-haiku-4.5",
+  provider: "anthropic",
+  name: "Claude Haiku 4.5",
+} as ModelDefinition;
+
+/**
+ * Minimal stand-in for the inspector's `MCPClientManager`. The engine
+ * touches `getAllToolsMetadata()` during tool prep; nothing else is
+ * exercised in `streamSink: "none"` mode.
+ */
+const mcpClientManagerStub = {
+  getAllToolsMetadata: vi.fn().mockReturnValue({}),
+} as any;
+
+describe("runAssistantTurn — eval contract", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastExecution = null;
+    writtenChunks = [];
+    process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
+    vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+    vi.mocked(executeToolCallsFromMessages).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.CONVEX_HTTP_URL;
+  });
+
+  function setupSuccessfulStream() {
+    global.fetch = vi.fn().mockResolvedValue(
+      createSseResponse([
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "Done." },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          totalUsage: { inputTokens: 5, outputTokens: 1, totalTokens: 6 },
+        },
+      ])
+    );
+  }
+
+  it("accepts sourceType:'eval' and threads it to the Convex /stream body", async () => {
+    setupSuccessfulStream();
+
+    await runAssistantTurn({
+      messages: [{ role: "user", content: "Hello." }] as any,
+      modelDefinition: baseModelDefinition,
+      systemPrompt: "You are an eval-mode assistant.",
+      tools: {},
+      mcpClientManager: mcpClientManagerStub,
+      authContext: {
+        kind: "user_bearer",
+        token: "Bearer convex-auth-token",
+      },
+      // Eval-specific configuration. These are the four switches PR 3 will
+      // pass for every iteration call.
+      sourceType: "eval",
+      streamSink: "none",
+      persistMode: "caller",
+      // `approvalMode: "auto-deny"` is honored inspector-side (the engine
+      // never prompts and auto-rejects pending tool calls); it is NOT
+      // forwarded to Convex. The assertion below covers `sourceType` only
+      // — the absence of an exception from the call confirms the engine
+      // accepted `approvalMode: "auto-deny"` for this `sourceType`.
+      approvalMode: "auto-deny",
+    });
+
+    await lastExecution;
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const fetchBody = JSON.parse(
+      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}"
+    );
+    expect(fetchBody.sourceType).toBe("eval");
+  });
+
+  it("returns the transcript synchronously for streamSink:'none' — no Response, no caller callback", async () => {
+    setupSuccessfulStream();
+
+    // Eval consumes the transcript via the return value, NOT via
+    // onConversationComplete. Asserting that:
+    //   (a) the result object carries `messages` + `turnTrace`;
+    //   (b) the caller-supplied `onConversationComplete` is NOT invoked
+    //       (eval owns its writer via persistEvalTraceFanout);
+    //   (c) no Hono Response is built (eval has no HTTP context).
+    const callerOnConversationComplete = vi.fn();
+
+    const result = await runAssistantTurn({
+      messages: [{ role: "user", content: "Hello." }] as any,
+      modelDefinition: baseModelDefinition,
+      systemPrompt: "",
+      tools: {},
+      mcpClientManager: mcpClientManagerStub,
+      authContext: {
+        kind: "user_bearer",
+        token: "Bearer convex-auth-token",
+      },
+      sourceType: "eval",
+      streamSink: "none",
+      persistMode: "caller",
+      approvalMode: "auto-deny",
+      onConversationComplete: callerOnConversationComplete,
+    });
+
+    await lastExecution;
+
+    // (a) Transcript + turnTrace populated by engine's internal capture tap.
+    expect(result.messages).toBeDefined();
+    expect(Array.isArray(result.messages)).toBe(true);
+    expect(result.turnTrace).toBeDefined();
+    expect(result.turnTrace?.modelId).toBe("anthropic/claude-haiku-4.5");
+    expect(result.usage).toMatchObject({
+      inputTokens: 5,
+      outputTokens: 1,
+      totalTokens: 6,
+    });
+    expect(result.finishReason).toBe("stop");
+
+    // (b) Caller's onConversationComplete suppressed in persistMode:"caller".
+    expect(callerOnConversationComplete).not.toHaveBeenCalled();
+
+    // (c) No Hono Response — eval is not an HTTP route.
+    expect(result.response).toBeUndefined();
+  });
+
+  it("threads hosted-org BYOK dispatch (endpointPath:'/stream/org' + providerKey)", async () => {
+    setupSuccessfulStream();
+
+    // Mirrors what PR 3's `dispatchEvalTurn` will pass when the test
+    // runs against a hosted-org BYOK provider — `endpointPath` flips to
+    // `/stream/org` and the providerKey + org-target ride on
+    // `extraBodyFields`, exactly like `handleHostedOrgChatModel` does
+    // for live chat today.
+    await runAssistantTurn({
+      messages: [{ role: "user", content: "Hi." }] as any,
+      modelDefinition: baseModelDefinition,
+      systemPrompt: "",
+      tools: {},
+      mcpClientManager: mcpClientManagerStub,
+      authContext: {
+        kind: "user_bearer",
+        token: "Bearer convex-auth-token",
+      },
+      sourceType: "eval",
+      streamSink: "none",
+      persistMode: "caller",
+      approvalMode: "auto-deny",
+      endpointPath: "/stream/org",
+      extraBodyFields: {
+        providerKey: "byok_anthropic_prod",
+        projectId: "proj_test",
+      },
+    });
+
+    await lastExecution;
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const fetchUrl = (global.fetch as any).mock.calls[0]?.[0];
+    expect(fetchUrl).toBe("https://test-convex.example.com/stream/org");
+
+    const fetchBody = JSON.parse(
+      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}"
+    );
+    expect(fetchBody.providerKey).toBe("byok_anthropic_prod");
+    expect(fetchBody.projectId).toBe("proj_test");
+  });
+
+  it("forwards JAM-paid billing target via extraBodyFields", async () => {
+    setupSuccessfulStream();
+
+    // JAM-paid eval path: `runIterationViaBackend` builds
+    // `extraBodyFields: { ...jamBillingTarget }` so Convex wallet rules
+    // can attribute the cost. The engine must thread it untouched.
+    await runAssistantTurn({
+      messages: [{ role: "user", content: "Hi." }] as any,
+      modelDefinition: baseModelDefinition,
+      systemPrompt: "",
+      tools: {},
+      mcpClientManager: mcpClientManagerStub,
+      authContext: {
+        kind: "user_bearer",
+        token: "Bearer convex-auth-token",
+      },
+      sourceType: "eval",
+      streamSink: "none",
+      persistMode: "caller",
+      approvalMode: "auto-deny",
+      // No endpointPath override → defaults to "/stream" (the JAM-paid endpoint).
+      extraBodyFields: {
+        projectId: "proj_jam_test",
+      },
+    });
+
+    await lastExecution;
+
+    const fetchUrl = (global.fetch as any).mock.calls[0]?.[0];
+    expect(fetchUrl).toBe("https://test-convex.example.com/stream");
+
+    const fetchBody = JSON.parse(
+      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}"
+    );
+    expect(fetchBody.projectId).toBe("proj_jam_test");
+  });
+
+  it("forwards eval-attribution fields verbatim via extraBodyFields (open-ended channel)", async () => {
+    setupSuccessfulStream();
+
+    // PR 3 may attach eval-run/iteration identifiers to extraBodyFields
+    // for backend-side usage attribution. The engine doesn't (and
+    // shouldn't) reject unknown fields — they ride alongside any known
+    // keys per `feedback_bridge_preserves_unknown_fields`.
+    await runAssistantTurn({
+      messages: [{ role: "user", content: "Hi." }] as any,
+      modelDefinition: baseModelDefinition,
+      systemPrompt: "",
+      tools: {},
+      mcpClientManager: mcpClientManagerStub,
+      authContext: {
+        kind: "user_bearer",
+        token: "Bearer convex-auth-token",
+      },
+      sourceType: "eval",
+      streamSink: "none",
+      persistMode: "caller",
+      approvalMode: "auto-deny",
+      extraBodyFields: {
+        providerKey: "byok_anthropic_prod",
+        evalRunId: "run_12345",
+        evalIterationId: "iter_abc",
+        evalSuiteId: "suite_98765",
+      },
+    });
+
+    await lastExecution;
+
+    const fetchBody = JSON.parse(
+      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}"
+    );
+    expect(fetchBody.evalRunId).toBe("run_12345");
+    expect(fetchBody.evalIterationId).toBe("iter_abc");
+    expect(fetchBody.evalSuiteId).toBe("suite_98765");
+    // Verify they don't displace known fields.
+    expect(fetchBody.providerKey).toBe("byok_anthropic_prod");
+  });
+
+  it("accepts selectedServerIds (engine consumes inspector-side for tool filtering)", async () => {
+    setupSuccessfulStream();
+
+    // Eval pre-builds the tool set via `prepareChatV2` and passes it as
+    // `tools`. `selectedServerIds` is consumed inspector-side by the
+    // engine to filter the tool set before sending tool definitions to
+    // Convex — it does NOT appear in the request body. PR 3 will still
+    // pass it for parity with chat; assert the call succeeds with the
+    // option present.
+    const result = await runAssistantTurn({
+      messages: [{ role: "user", content: "Hi." }] as any,
+      modelDefinition: baseModelDefinition,
+      systemPrompt: "",
+      tools: {},
+      mcpClientManager: mcpClientManagerStub,
+      authContext: {
+        kind: "user_bearer",
+        token: "Bearer convex-auth-token",
+      },
+      sourceType: "eval",
+      streamSink: "none",
+      persistMode: "caller",
+      approvalMode: "auto-deny",
+      selectedServerIds: ["srv-alpha", "srv-beta"],
+    });
+
+    await lastExecution;
+
+    // Documents the inspector-side consumption: option accepted, call
+    // completes, transcript captured. Wire-body assertion intentionally
+    // omitted — adding one would be testing an implementation detail
+    // outside the contract.
+    expect(result.turnTrace).toBeDefined();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mutate the caller's input messages array", async () => {
+    setupSuccessfulStream();
+
+    // Eval's per-turn loop reuses a `conversation` array as the
+    // accumulator: pre-call snapshot must remain untouched until the
+    // caller decides to overwrite it from `result.messages`. The engine
+    // already shallow-copies internally; this asserts no regression.
+    const inputMessages = [{ role: "user", content: "Hi." }] as any;
+    const originalLength = inputMessages.length;
+
+    const result = await runAssistantTurn({
+      messages: inputMessages,
+      modelDefinition: baseModelDefinition,
+      systemPrompt: "",
+      tools: {},
+      mcpClientManager: mcpClientManagerStub,
+      authContext: {
+        kind: "user_bearer",
+        token: "Bearer convex-auth-token",
+      },
+      sourceType: "eval",
+      streamSink: "none",
+      persistMode: "caller",
+      approvalMode: "auto-deny",
+    });
+
+    await lastExecution;
+
+    expect(inputMessages).toHaveLength(originalLength);
+    // The result's `messages` is a separate array the engine assembled.
+    expect(result.messages).not.toBe(inputMessages);
+  });
+});


### PR DESCRIPTION
## Summary

**PR 2 of the engine-consolidation plan** in `~/.claude/plans/lets-consolidate-on-streamtext-transient-clarke.md` (and Phase 2 of `~/mcpjam-docs/unification.md`).

PR 2's goal per the plan: *"verify/extend `runAssistantTurn` for the eval contract. If any contract gap exists, add it in this PR. No call-site changes yet — this PR confirms the engine is eval-ready without touching the runner."*

**Audit conclusion: zero contract gaps.** `runAssistantTurn` already covers every behavior PR 3 needs for eval paths 1+2 (JAM-paid + hosted-org BYOK). The interface already includes:

- `sourceType: "eval"` in the narrowed union
- `streamSink: "none"` with documented synchronous transcript capture via the engine's internal `onConversationComplete` tap
- `persistMode: "caller"` that suppresses the caller-provided `onConversationComplete` (eval will own its writer via `persistEvalTraceFanout`)
- `approvalMode: "auto-deny"` consumed inspector-side to auto-reject pending tool calls
- `endpointPath` switching for hosted-org (`"/stream/org"`)
- `extraBodyFields` (open-ended `Record<string, unknown>`) for `providerKey`, billing target, and any future eval-attribution fields
- `abortSignal`, `tools`, `mcpClientManager`, `maxSteps`, `progressivePlan`, `discoveryState`

So PR 2 adds **no runtime code**. What it adds is a dedicated **contract test** that locks in the configuration PR 3 will rely on, so PR 3's call-site refactor has an explicit safety net.

## What the new test asserts

`server/utils/__tests__/assistant-turn-eval-contract.test.ts` (7 tests, ~427 lines):

1. **`sourceType: "eval"` threads to the Convex `/stream` body** — the discriminator lands in the request as expected.
2. **`streamSink: "none"` + `persistMode: "caller"` returns the transcript synchronously**, with `turnTrace` populated, no Hono `Response`, and the caller-provided `onConversationComplete` NOT invoked. This is exactly how PR 3 will consume each iteration's output.
3. **Hosted-org dispatch** — `endpointPath: "/stream/org"` + `providerKey` + `projectId` on `extraBodyFields` land on the right URL with the right body, mirroring how `handleHostedOrgChatModel` invokes the engine for live chat today.
4. **JAM-paid billing target** — `extraBodyFields: { projectId }` rides through to the default `/stream` endpoint, same shape `runIterationViaBackend` uses today.
5. **Eval-attribution open-ended channel** — `evalRunId`, `evalIterationId`, `evalSuiteId` flow through unknown-fields without displacing known keys (per `feedback_bridge_preserves_unknown_fields`). PR 3 can attach these for Convex-side usage attribution without any engine code change.
6. **`selectedServerIds` accepted** — engine consumes inspector-side to filter the tool set; documents that the option flows through without error.
7. **Input messages array is not mutated** — eval's per-turn loop reuses a `conversation` accumulator; asserts the engine's internal shallow-copy still works.

## What I deliberately did NOT add

- **No new options on `RunAssistantTurnOptions`**. The existing surface is complete.
- **No docstring tweaks** to `assistant-turn.ts`. The Stage-1 docs already cover synthetic-runner mode, which is a strict superset of what eval needs.
- **No call-site changes** anywhere. PR 3 lands those.

## Why I dropped two initial wire-body assertions

My first cut of the test asserted `approvalMode` and `selectedServers` would appear in the Convex request body. Those are actually inspector-side controls (`approvalMode` decides whether to auto-deny pending tool calls; `selectedServers` filters the tool set before serialization). Asserting they appear on the wire would be testing an implementation detail outside the contract. The test now documents the inspector-side consumption with explanatory comments.

## Test plan

- [x] Typecheck: no new errors. The pre-existing `evals-runner.ts` baseline (4 errors, unrelated) and the missing-bundle errors in `routes/web/apps.ts` are unchanged.
- [x] `assistant-turn-eval-contract.test.ts`: 7 / 7 pass
- [x] Adjacent suites — `server/utils`, `server/services/evals`, `server/services/sessionSimulation`: 449 / 449 tests pass across 37 test files. No regression in the existing `assistant-turn.test.ts` (synthetic-runner contract) or in eval-runner tests from PR 1.

## Next: PR 3

PR 3 will rewrite `runIterationViaBackend` to call `runAssistantTurn` directly (paths 1+2 only), introduce a tiny `dispatchEvalTurn` provider router, and keep eval persistence on the existing `recorder` + `persistEvalTraceFanout`. The contract this PR locks in is the green light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition that documents existing engine behavior; no production paths or APIs are modified.
> 
> **Overview**
> Adds **`assistant-turn-eval-contract.test.ts`** only—no production or call-site changes. Seven Vitest cases lock how eval will drive **`runAssistantTurn`** when PR 3 rewires **`runIterationViaBackend`**.
> 
> The suite asserts eval wiring: **`sourceType: "eval"`** on the Convex stream body; **`streamSink: "none"`** + **`persistMode: "caller"`** returning **`messages`**, **`turnTrace`**, and usage without an HTTP **`response`** and without invoking the caller’s **`onConversationComplete`**; hosted-org **`/stream/org`** with **`providerKey`** / **`projectId`**; JAM-paid **`/stream`** billing via **`extraBodyFields`**; passthrough of eval attribution IDs; acceptance of **`selectedServerIds`**; and no in-place mutation of the input **`messages`** array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9ea6ad1aa6e78c1bbf4e052f4ce509c895fb212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->