### PR TITLE
fix(mcpjam-agent): clear hydrating after StrictMode-cancelled fetch

### DIFF
--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -110,17 +110,13 @@ export function useMcpjamAgentSession(
   // land on an empty thread despite the session being on disk.
   const [initialMessages, setInitialMessages] = useState<UIMessage[]>([]);
   const [hydrating, setHydrating] = useState<boolean>(Boolean(providedSessionId));
-  const hydrationKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!providedSessionId) {
       setInitialMessages([]);
       setHydrating(false);
-      hydrationKeyRef.current = null;
       return;
     }
-    if (hydrationKeyRef.current === providedSessionId) return;
-    hydrationKeyRef.current = providedSessionId;
     let cancelled = false;
     setHydrating(true);
     (async () => {


### PR DESCRIPTION
## Summary
- `useMcpjamAgentSession`'s hydration effect early-returned on re-runs when `hydrationKeyRef.current === providedSessionId`, which in React StrictMode dev double-mount left `hydrating` permanently `true` after the first run's fetch got cancelled — every hero→thread transition on localhost showed a stuck "Loading conversation..." spinner.
- Dropped the ref-based dedup. The deps array (`providedSessionId`, `projectId`) already controls re-runs, and the existing `cancelled` flag ensures only the latest run's results land in state.

## Why this didn't bite production
StrictMode is a no-op in production, so the second mount that triggers the bug never happens on staging. The race is dev-only; the fix is harmless in prod (one extra fetch only if a dep legitimately changes mid-hydration).

## Test plan
- [x] Localhost: hero → submit → thread loads streaming reply (no stuck spinner)
- [ ] Existing-session URL still hydrates from the persisted transcript
- [ ] No regression on `?session=<id>` cold reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small hook change to mount/hydration timing; production behavior is unchanged aside from possibly one extra fetch if deps change mid-hydration.
> 
> **Overview**
> Fixes a **dev-only stuck "Loading conversation…"** state when opening the MCPJam agent thread with a known session id (e.g. hero → submit on localhost).
> 
> **`useMcpjamAgentSession`** no longer uses **`hydrationKeyRef`** to skip re-running transcript hydration when `providedSessionId` is unchanged. That early return could leave **`hydrating` true forever** after React StrictMode’s second mount cancelled the first fetch without a follow-up run that clears loading.
> 
> Hydration now relies on the effect deps (`providedSessionId`, `projectId`) and the existing **`cancelled`** cleanup so only the latest fetch updates state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8161893c64ce6b1d55b04bd87e0550726a9513d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->