### PR TITLE
evals: drive runIterationViaBackend through runAssistantTurn

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1999,36 +1999,29 @@ const runIterationViaBackend = async ({
       return returnCancelled();
     }
 
-    // Codex P1 review fix + the original silent-cycle-failure case.
-    // Two engine failure shapes both reduce to "engine produced no new
-    // messages this turn":
+    // Drain per-turn outputs into the iteration-level accumulators
+    // BEFORE the failure checks below. Doing it first preserves
+    // whatever partial good state the engine produced (tool spans,
+    // partial transcript, usage), so the persisted iteration shows
+    // what completed before the failure point.
     //
-    //  (1) Engine catch fired (network exception, scrub TypeError, ...).
-    //      `runSucceeded` stays false; `turnTrace` is NOT captured.
-    //  (2) Step-level error (Convex returned non-OK at
-    //      mcpjam-stream-handler.ts:1384). `processOneStep` returns
-    //      `shouldContinue:false` without throwing; the engine's loop
-    //      exits cleanly, a synthetic finish chunk is emitted, and
-    //      `runSucceeded` becomes true → `turnTrace` IS captured. But
-    //      no assistant/tool messages were appended.
-    //
-    // Without the message-count check, case (2) — 429s, 500s, etc. —
-    // would slip through with `iterationError` unset and verdict
-    // `passed: true` for tests with no expected tool calls. Map both
-    // to `iterationError` so the verdict gate + `lockReason`
-    // derivation in the post-loop finalize see the cycle failure.
-    if (turnResult.messages.length <= messageCountBeforeTurn) {
-      iterationError = turnResult.turnTrace
-        ? "Backend step returned no content (stream error or empty response)"
-        : "Backend stream failed during iteration";
-      logger.error(
-        `[evals] runAssistantTurn produced no new messages this turn; treating as cycle failure (turnTrace=${turnResult.turnTrace ? "captured" : "missing"})`,
-      );
-      break;
-    }
-
-    // Drain per-turn outputs into the iteration-level accumulators.
+    // Codex round-3 (P2 "Preserve backend tool step indices"):
+    // `wrapToolSetForEvalTrace` records tool spans in
+    // `traceCtx.recordedSpans` but never gets `prepareStep` updates
+    // from the engine (eval is no longer calling `generateText`
+    // directly), so those spans land with `stepIndex: -1`. The engine
+    // emits its OWN correctly-indexed LLM-step spans into
+    // `turnTrace.spans` (already `EvalTraceSpan[]` shape — see
+    // `PersistedTurnTrace` in chat-ingestion.ts). Merge both: the
+    // engine's LLM spans give per-step granularity; the wrap's tool
+    // spans give per-tool-call detail. Tool spans still have
+    // `stepIndex: -1` for now — fixing that requires correlating
+    // each tool span back to its parent LLM step via the engine's
+    // step events, which is a separate workstream.
     capturedSpans.push(...traceCtx.recordedSpans);
+    if (turnResult.turnTrace?.spans?.length) {
+      capturedSpans.push(...turnResult.turnTrace.spans);
+    }
     if (turnResult.usage) {
       accumulatedUsage.inputTokens =
         (accumulatedUsage.inputTokens || 0) +
@@ -2057,19 +2050,49 @@ const runIterationViaBackend = async ({
     messageHistory.length = 0;
     messageHistory.push(...turnResult.messages);
 
-    // Codex P1 round-2 fix: catch a backend step error that happened
-    // AFTER messages already grew. The engine emits `EvalTraceSpan`s
-    // with `status: "error"` on per-step failures (see
-    // `pushBackendStepLlmFailureSpans` / `pushBackendStepToolFailureSpans`
-    // in mcpjam-stream-handler.ts), but then synthesizes a finish
-    // chunk and sets `runSucceeded: true` — so neither the catch
-    // branch nor the `messages.length <= messageCountBeforeTurn` check
-    // fires when step 1 succeeded and step 2 errored. Walk
-    // `turnTrace.spans` for any error-status span and treat as a
-    // cycle failure; the partial successful state we just drained
-    // above (tool calls, spans, usage, transcript) stays — eval just
-    // marks the iteration as errored and halts further turns.
-    const stepErrorSpan = turnResult.turnTrace?.spans.find(
+    // Failure detection (ordered most-specific → least-specific).
+    // Three engine failure shapes the runner must catch:
+    //
+    //  (a) Cursor round-3 ("Partial turn hides engine failures"):
+    //      Engine catch fired AFTER partial messages were appended
+    //      (some text deltas / partial tool call landed before the
+    //      error). The engine's `executeEngine` `try { ... }
+    //      catch (error) { logger.error; emit error chunk; ... }` at
+    //      mcpjam-stream-handler.ts:2227 leaves `runSucceeded:
+    //      false` → `turnTrace` is NOT captured even though
+    //      `messages.length > messageCountBeforeTurn`. The
+    //      message-count check and the error-span check both miss
+    //      this. `!turnTrace` is the reliable signal.
+    //
+    //  (b) Codex P1 round-1 + the original silent-cycle-failure:
+    //      Engine succeeded (turnTrace captured) but produced no new
+    //      content (step-level non-OK at
+    //      mcpjam-stream-handler.ts:1384 returns
+    //      `shouldContinue:false`, synthetic finish, runSucceeded
+    //      true). Detect via `messages.length <=
+    //      messageCountBeforeTurn`.
+    //
+    //  (c) Codex P1 round-2 ("Fail turns when later backend steps
+    //      error"): step 1 succeeded, step 2 errored. `turnTrace`
+    //      captured, `messages.length` grew, but `turnTrace.spans`
+    //      includes an `EvalTraceSpan` with `status:"error"`.
+    if (!turnResult.turnTrace) {
+      iterationError =
+        "Backend stream failed during iteration (engine caught an error mid-turn)";
+      logger.error(
+        `[evals] runAssistantTurn returned no turnTrace (engine runSucceeded=false); treating as cycle failure (messagesGrew=${newMessages.length > 0})`,
+      );
+      break;
+    }
+    if (newMessages.length === 0) {
+      iterationError =
+        "Backend step returned no content (stream error or empty response)";
+      logger.error(
+        "[evals] runAssistantTurn produced no new messages this turn; treating as cycle failure",
+      );
+      break;
+    }
+    const stepErrorSpan = turnResult.turnTrace.spans.find(
       (span) => span.status === "error",
     );
     if (stepErrorSpan) {

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -2092,13 +2092,26 @@ const runIterationViaBackend = async ({
       );
       break;
     }
+    // Codex P1 round-3 ("Don't treat tool-result error spans as
+    // backend failures"): `wrapBackendToolsForTrace` records ORDINARY
+    // local tool-result errors (MCP tool returned `isError: true`,
+    // tool execution threw, ...) as `status: "error"` with
+    // `category: "tool"`. The original match-any-error-span check
+    // would set `iterationError` and break before
+    // `finalizePassedForEval` could apply the configured
+    // `failOnToolError` policy — so otherwise-passing evals were
+    // force-failed when a tool returned a recoverable error and the
+    // model recovered. Filter to backend step / LLM failure spans
+    // only (categories `"step" | "llm" | "error"`); tool-category
+    // error spans flow through the existing tool-error gate (see
+    // `finalizePassedForEval` + `advancedConfig.failOnToolError`).
     const stepErrorSpan = turnResult.turnTrace.spans.find(
-      (span) => span.status === "error",
+      (span) => span.status === "error" && span.category !== "tool",
     );
     if (stepErrorSpan) {
       iterationError = `Backend step failed mid-turn: ${stepErrorSpan.name}`;
       logger.error(
-        `[evals] runAssistantTurn turnTrace has error-status span; treating as cycle failure (span=${stepErrorSpan.name} category=${stepErrorSpan.category})`,
+        `[evals] runAssistantTurn turnTrace has non-tool error-status span; treating as cycle failure (span=${stepErrorSpan.name} category=${stepErrorSpan.category})`,
       );
       break;
     }

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1845,7 +1845,34 @@ const runIterationViaBackend = async ({
     token: `Bearer ${convexAuthToken}`,
   };
 
+  // Cursor review fix: the legacy `runIterationViaBackend` returned
+  // early on AbortError without recording the iteration. The engine
+  // swallows AbortError internally (sets its `aborted` flag, omits
+  // `turnTrace`, doesn't throw out of `runAssistantTurn`), and
+  // `RunAssistantTurnResult` doesn't expose the engine's `aborted`
+  // flag — so we read `abortSignal.aborted` directly as the
+  // authoritative cancellation signal. Used at the top of each
+  // iteration AND after every per-turn call (success or catch).
+  const isAborted = () => abortSignal?.aborted === true;
+  const returnCancelled = () => ({
+    evaluation: evaluateMultiTurnResults(
+      promptTurns,
+      toolsCalledByPrompt,
+      test.isNegativeTest,
+      test.matchOptions,
+    ),
+    iterationId: undefined,
+  });
+
   for (let promptIndex = 0; promptIndex < promptTurns.length; promptIndex++) {
+    // Cancellation between turns: bail without recording.
+    if (isAborted()) {
+      logger.debug(
+        "[evals] backend iteration aborted between turns; skipping record",
+      );
+      return returnCancelled();
+    }
+
     const promptTurn = promptTurns[promptIndex]!;
 
     // Per-turn span-capture context. `wrapToolSetForEvalTrace` instruments
@@ -1862,6 +1889,22 @@ const runIterationViaBackend = async ({
       ...messageHistory,
       { role: "user", content: promptTurn.prompt },
     ];
+
+    // Cursor + Codex review fix: thread `toolChoice` through
+    // `extraBodyFields` since the engine's
+    // `RunAssistantTurnOptions` / `MCPJamHandlerOptions` don't expose
+    // it as a first-class field. The Convex `/stream` (and
+    // `/stream/org`) handlers already accept `toolChoice` in the
+    // request body — the engine spreads `extraBodyFields` into the body
+    // unchanged, so forced-tool / `none` eval cases work the same way
+    // they did on the legacy backend loop and the local-AI-SDK path.
+    const mergedExtraBodyFields =
+      toolChoice || extraBodyFields
+        ? {
+            ...(extraBodyFields ?? {}),
+            ...(toolChoice ? { toolChoice } : {}),
+          }
+        : undefined;
 
     let turnResult: Awaited<ReturnType<typeof runAssistantTurn>>;
     try {
@@ -1889,28 +1932,28 @@ const runIterationViaBackend = async ({
         persistMode: "caller",
         approvalMode: "auto-deny",
         endpointPath,
-        ...(extraBodyFields ? { extraBodyFields } : {}),
+        ...(mergedExtraBodyFields
+          ? { extraBodyFields: mergedExtraBodyFields }
+          : {}),
         ...(abortSignal ? { abortSignal } : {}),
         maxSteps: MAX_STEPS,
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
       });
     } catch (error) {
-      // Cancellation: bail without recording. Matches the legacy
-      // AbortError handler at the bottom of the per-step while loop.
-      if (error instanceof Error && error.name === "AbortError") {
+      // Cancellation: bail without recording. AbortError can surface
+      // either as a thrown exception (when fetch is aborted mid-flight)
+      // or as the engine's internal silent-cancellation path (handled
+      // by the `isAborted()` check after the success path below). Check
+      // `abortSignal.aborted` to catch BOTH paths consistently.
+      if (
+        isAborted() ||
+        (error instanceof Error && error.name === "AbortError")
+      ) {
         logger.debug(
           "[evals] backend iteration aborted due to cancellation",
         );
-        return {
-          evaluation: evaluateMultiTurnResults(
-            promptTurns,
-            toolsCalledByPrompt,
-            test.isNegativeTest,
-            test.matchOptions,
-          ),
-          iterationId: undefined,
-        };
+        return returnCancelled();
       }
 
       // Non-abort runtime error from the engine. Map to `iterationError`
@@ -1935,22 +1978,43 @@ const runIterationViaBackend = async ({
       break;
     }
 
-    // Detect engine silent-failure. `runChatEngineLoop` catches throws
-    // inside the agentic loop (network failures, scrub errors, ...) and
-    // emits an error chunk to its writer — but for `streamSink:"none"`
-    // the writer is a no-op, so nothing surfaces and `runAssistantTurn`
-    // resolves normally with `runSucceeded: false`. The observable signal
-    // is that no `turnTrace` is captured (the engine only sets it when
-    // `runSucceeded && !aborted`) and no new messages were appended. Map
-    // that to `iterationError` so the verdict gate + lockReason
+    // Cursor review fix: cancellation that fired DURING
+    // `runAssistantTurn` without surfacing as a throw. The engine
+    // catches AbortError, sets its internal `aborted` flag, omits the
+    // `turnTrace`, and returns normally. Without this check we'd fall
+    // through to the silent-cycle-failure branch below and record an
+    // aborted run as a verdict failure.
+    if (isAborted()) {
+      logger.debug(
+        "[evals] backend iteration aborted mid-turn; skipping record",
+      );
+      return returnCancelled();
+    }
+
+    // Codex P1 review fix + the original silent-cycle-failure case.
+    // Two engine failure shapes both reduce to "engine produced no new
+    // messages this turn":
+    //
+    //  (1) Engine catch fired (network exception, scrub TypeError, ...).
+    //      `runSucceeded` stays false; `turnTrace` is NOT captured.
+    //  (2) Step-level error (Convex returned non-OK at
+    //      mcpjam-stream-handler.ts:1384). `processOneStep` returns
+    //      `shouldContinue:false` without throwing; the engine's loop
+    //      exits cleanly, a synthetic finish chunk is emitted, and
+    //      `runSucceeded` becomes true → `turnTrace` IS captured. But
+    //      no assistant/tool messages were appended.
+    //
+    // Without the message-count check, case (2) — 429s, 500s, etc. —
+    // would slip through with `iterationError` unset and verdict
+    // `passed: true` for tests with no expected tool calls. Map both
+    // to `iterationError` so the verdict gate + `lockReason`
     // derivation in the post-loop finalize see the cycle failure.
-    if (
-      !turnResult.turnTrace &&
-      turnResult.messages.length <= inputMessages.length
-    ) {
-      iterationError = "Backend stream failed during iteration";
+    if (turnResult.messages.length <= inputMessages.length) {
+      iterationError = turnResult.turnTrace
+        ? "Backend step returned no content (stream error or empty response)"
+        : "Backend stream failed during iteration";
       logger.error(
-        "[evals] runAssistantTurn returned no turn trace; treating as cycle failure",
+        `[evals] runAssistantTurn produced no new messages this turn; treating as cycle failure (turnTrace=${turnResult.turnTrace ? "captured" : "missing"})`,
       );
       break;
     }

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -91,6 +91,7 @@ import {
   prepareChatV2,
   type PrepareChatV2Result,
 } from "../utils/chat-v2-orchestration.js";
+import { runAssistantTurn } from "../utils/assistant-turn.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
 import {
   lockEvalSessionAfterUpdate,
@@ -1804,375 +1805,185 @@ const runIterationViaBackend = async ({
     };
   }
 
-  const toolDefs = Object.entries(prepared.allTools).map(([name, tool]) => {
-    const schema = (tool as any)?.inputSchema;
-    let serializedSchema: Record<string, unknown> | undefined;
-    if (schema) {
-      if (
-        typeof schema === "object" &&
-        schema !== null &&
-        "jsonSchema" in (schema as Record<string, unknown>)
-      ) {
-        serializedSchema = (schema as any).jsonSchema as Record<
-          string,
-          unknown
-        >;
-      } else if (typeof schema === "object" && "safeParse" in (schema as any)) {
-        try {
-          serializedSchema = z.toJSONSchema(schema) as Record<string, unknown>;
-        } catch {
-          serializedSchema = undefined;
-        }
-      } else {
-        serializedSchema = schema as Record<string, unknown>;
-      }
-    }
-
-    return {
-      name,
-      description: (tool as any)?.description,
-      inputSchema:
-        serializedSchema ??
-        ({
-          type: "object",
-          properties: {},
-          additionalProperties: false,
-        } as Record<string, unknown>),
-    };
-  });
-
-  const authHeader = convexAuthToken
-    ? { Authorization: `Bearer ${convexAuthToken}` }
-    : ({} as Record<string, string>);
-
+  // PR 3 of the engine consolidation: drive the per-step fetch + local-tool
+  // loop through `runAssistantTurn` (the same engine chat / playground /
+  // synthetic use) instead of an eval-specific while loop. The contract test
+  // at `server/utils/__tests__/assistant-turn-eval-contract.test.ts` (PR 2)
+  // locks in the exact configuration we pass here.
+  //
+  // What this swap drops vs. the legacy backend loop:
+  //   - Per-step LLM spans (`pushBackendStepLlmFailureSpans`,
+  //     `pushBackendStepSuccessSpans`, `pushBackendStepToolFailureSpans`). The
+  //     legacy loop emitted span-per-step granularity for the trace UI; the
+  //     engine handles its own step traces internally and `runAssistantTurn`
+  //     surfaces them as `result.turnTrace`, but that format is the chat-side
+  //     `PersistedTurnTrace` shape, not the eval `EvalTraceSpan[]` shape.
+  //     Converting between them is out of scope here; PR 5/6 can address.
+  //   - Friendly "[evals] run halted: <reason>" log distinction for
+  //     daily-spend-cap errors. The engine throws on backend failures; we map
+  //     to `iterationError` uniformly. Spend-cap halts still record cleanly,
+  //     just without the warn-vs-error split.
+  // What this swap keeps:
+  //   - Tool-execution spans via `wrapToolSetForEvalTrace` (the wrapped tools
+  //     are passed to the engine; their `execute` hooks fire span capture).
+  //   - Cancellation via `abortSignal`.
+  //   - `iterationError` accumulation for the existing post-loop verdict gate.
   let accumulatedUsage: UsageTotals = {
     inputTokens: 0,
     outputTokens: 0,
     totalTokens: 0,
   };
-
   let iterationError: string | undefined = undefined;
   let iterationErrorDetails: string | undefined = undefined;
   const capturedSpans: EvalTraceSpan[] = [];
+
+  // Eval supplies its bearer token via `convexAuthToken`. The engine wraps it
+  // into the Convex `/stream` (or `/stream/org`) request the same way live
+  // chat does.
+  const evalAuthContext = {
+    kind: "user_bearer" as const,
+    token: `Bearer ${convexAuthToken}`,
+  };
+
   for (let promptIndex = 0; promptIndex < promptTurns.length; promptIndex++) {
     const promptTurn = promptTurns[promptIndex]!;
-    const promptToolsCalled: ToolCall[] = [];
-    toolsCalledByPrompt.push(promptToolsCalled);
-    messageHistory.push({
-      role: "user",
-      content: promptTurn.prompt,
-    });
 
-    let steps = 0;
-    while (steps < MAX_STEPS) {
-      const stepStartAbs = Date.now();
-      const stepIndex = steps;
-      const llmStartAbs = stepStartAbs;
-      const stepMessageStartIndex = messageHistory.length;
-      try {
-        const res = await fetch(`${convexHttpUrl}${endpointPath}`, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            ...(authHeader ? { ...authHeader } : {}),
-          },
-          body: JSON.stringify({
-            mode: "step",
-            messages: JSON.stringify(messageHistory),
-            model: modelId,
-            ...(prepared.enhancedSystemPrompt
-              ? { systemPrompt: prepared.enhancedSystemPrompt }
-              : {}),
-            ...(prepared.resolvedTemperature == null
-              ? {}
-              : { temperature: prepared.resolvedTemperature }),
-            ...(toolChoice ? { toolChoice } : {}),
-            tools: toolDefs,
-            maxOutputTokens: 16384,
-            ...(extraBodyFields ?? {}),
-          }),
-          ...(abortSignal ? { signal: abortSignal } : {}),
-        });
+    // Per-turn span-capture context. `wrapToolSetForEvalTrace` instruments
+    // each tool's `execute` to push to `traceCtx.recordedSpans`; we drain
+    // into `capturedSpans` after the engine finishes.
+    const traceCtx = createAiSdkEvalTraceContext(runStartedAt);
+    const tracedTools = wrapToolSetForEvalTrace(
+      prepared.allTools,
+      traceCtx,
+      promptIndex,
+    );
 
-        if (!res.ok) {
-          const errorText = await res.text().catch(() => res.statusText);
-          const { message, expected } = describeBackendStreamError(
-            res.status,
-            errorText,
-          );
-          iterationError = message;
-          iterationErrorDetails = errorText;
-          if (expected) {
-            // Daily spend cap / concurrency guardrail — expected, and with N
-            // cases running concurrently it fires once per case. Log a single
-            // quiet line with the real reason, not an alarming per-case stack.
-            logger.warn(`[evals] run halted: ${message}`);
-          } else {
-            logger.error("[evals] backend stream error", new Error(message));
-          }
-          const failAbs = Date.now();
-          pushBackendStepLlmFailureSpans(
-            capturedSpans,
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            stepStartAbs,
-            llmStartAbs,
-            failAbs,
-          );
-          break;
-        }
+    const inputMessages: ModelMessage[] = [
+      ...messageHistory,
+      { role: "user", content: promptTurn.prompt },
+    ];
 
-        const json: any = await res.json();
-        const llmEndAbs = Date.now();
-        if (!json?.ok || !Array.isArray(json.messages)) {
-          iterationError = "Invalid backend response payload";
-          iterationErrorDetails = JSON.stringify(json, null, 2);
-          logger.error(
-            "[evals] invalid backend response payload",
-            new Error("Invalid backend response payload"),
-          );
-          const failAbs = Date.now();
-          pushBackendStepLlmFailureSpans(
-            capturedSpans,
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            stepStartAbs,
-            llmStartAbs,
-            failAbs,
-            {
-              modelId,
-            },
-          );
-          break;
-        }
-
-        const stepUsage = readBackendUsage(json.usage);
-        accumulatedUsage.inputTokens =
-          (accumulatedUsage.inputTokens || 0) + stepUsage.inputTokens;
-        accumulatedUsage.outputTokens =
-          (accumulatedUsage.outputTokens || 0) + stepUsage.outputTokens;
-        accumulatedUsage.totalTokens =
-          (accumulatedUsage.totalTokens || 0) + stepUsage.totalTokens;
-
-        for (const msg of json.messages as any[]) {
-          if (msg?.role === "assistant" && Array.isArray(msg.content)) {
-            for (const item of msg.content) {
-              if (item?.type === "tool-call") {
-                const name = item.toolName ?? item.name;
-                if (name) {
-                  promptToolsCalled.push({
-                    toolName: name,
-                    arguments: item.input ?? item.parameters ?? item.args ?? {},
-                  });
-                }
-                if (!item.toolCallId) {
-                  item.toolCallId = `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-                }
-                if (item.input == null) {
-                  item.input = item.parameters ?? item.args ?? {};
-                }
-              }
-            }
-          }
-          messageHistory.push(msg);
-        }
-
-        if (hasUnresolvedToolCalls(messageHistory as any)) {
-          const toolsStartAbs = Date.now();
-          const tracedBackendTools = wrapBackendToolsForTrace(prepared.allTools as any, {
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            spans: capturedSpans,
-          });
-          try {
-            const newToolMessages = await executeToolCallsFromMessages(
-              messageHistory as any,
-              {
-                tools: tracedBackendTools as any,
-              },
-            );
-            const toolsEndAbs = Date.now();
-            const toolMessageIndexByCallId = new Map<string, number>();
-            for (let index = 0; index < messageHistory.length; index++) {
-              const msg = messageHistory[index] as any;
-              if (msg?.role !== "tool" || !Array.isArray(msg.content)) {
-                continue;
-              }
-              for (const part of msg.content) {
-                if (
-                  part?.type === "tool-result" &&
-                  typeof part.toolCallId === "string"
-                ) {
-                  toolMessageIndexByCallId.set(part.toolCallId, index);
-                }
-              }
-            }
-            for (const span of capturedSpans) {
-              if (
-                span.stepIndex !== stepIndex ||
-                (span.promptIndex ?? 0) !== promptIndex ||
-                typeof span.toolCallId !== "string" ||
-                typeof span.messageStartIndex === "number"
-              ) {
-                continue;
-              }
-              const toolMessageIndex = toolMessageIndexByCallId.get(
-                span.toolCallId,
-              );
-              if (typeof toolMessageIndex === "number") {
-                span.messageStartIndex = toolMessageIndex;
-                span.messageEndIndex = toolMessageIndex;
-              }
-            }
-            const stepMessageEndIndex =
-              messageHistory.length > stepMessageStartIndex
-                ? messageHistory.length - 1
-                : undefined;
-            pushBackendStepSuccessSpans(
-              capturedSpans,
-              runStartedAt,
-              promptIndex,
-              stepIndex,
-              stepStartAbs,
-              { startAbs: llmStartAbs, endAbs: llmEndAbs },
-              {
-                startAbs: toolsStartAbs,
-                endAbs: toolsEndAbs,
-                pushAggregateSpan: newToolMessages.length === 0,
-              },
-              {
-                modelId,
-                inputTokens: stepUsage.inputTokens,
-                outputTokens: stepUsage.outputTokens,
-                totalTokens: stepUsage.totalTokens,
-                messageStartIndex:
-                  stepMessageEndIndex != null
-                    ? stepMessageStartIndex
-                    : undefined,
-                messageEndIndex: stepMessageEndIndex,
-                status: "ok",
-              },
-            );
-          } catch (toolErr) {
-            const failAbs = Date.now();
-            const stepMessageEndIndex =
-              messageHistory.length > stepMessageStartIndex
-                ? messageHistory.length - 1
-                : undefined;
-            pushBackendStepToolFailureSpans(
-              capturedSpans,
-              runStartedAt,
-              promptIndex,
-              stepIndex,
-              stepStartAbs,
-              { startAbs: llmStartAbs, endAbs: llmEndAbs },
-              toolsStartAbs,
-              failAbs,
-              {
-                modelId,
-                inputTokens: stepUsage.inputTokens,
-                outputTokens: stepUsage.outputTokens,
-                totalTokens: stepUsage.totalTokens,
-                messageStartIndex:
-                  stepMessageEndIndex != null
-                    ? stepMessageStartIndex
-                    : undefined,
-                messageEndIndex: stepMessageEndIndex,
-                pushAggregateSpan: false,
-              },
-            );
-            iterationError =
-              toolErr instanceof Error ? toolErr.message : String(toolErr);
-            logger.error("[evals] tool execution failed", toolErr);
-            break;
-          }
-        } else {
-          const stepMessageEndIndex =
-            messageHistory.length > stepMessageStartIndex
-              ? messageHistory.length - 1
-              : undefined;
-          pushBackendStepSuccessSpans(
-            capturedSpans,
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            stepStartAbs,
-            { startAbs: llmStartAbs, endAbs: llmEndAbs },
-            undefined,
-            {
-              modelId,
-              inputTokens: stepUsage.inputTokens,
-              outputTokens: stepUsage.outputTokens,
-              totalTokens: stepUsage.totalTokens,
-              messageStartIndex:
-                stepMessageEndIndex != null ? stepMessageStartIndex : undefined,
-              messageEndIndex: stepMessageEndIndex,
-              status: "ok",
-            },
-          );
-        }
-
-        steps += 1;
-
-        const finishReason: string | undefined = json.finishReason;
-        if (finishReason && finishReason !== "tool-calls") {
-          break;
-        }
-      } catch (error) {
-        if (error instanceof Error && error.name === "AbortError") {
-          logger.debug("[evals] backend iteration aborted due to cancellation");
-          return {
-            evaluation: evaluateMultiTurnResults(
-              promptTurns,
-              toolsCalledByPrompt,
-              test.isNegativeTest,
-              test.matchOptions,
-            ),
-            iterationId: undefined,
-          };
-        }
-
-        if (error instanceof Error) {
-          iterationError = error.message || error.toString();
-
-          const responseBody = (error as any).responseBody;
-          if (responseBody && typeof responseBody === "string") {
-            iterationErrorDetails = responseBody;
-          }
-        } else if (typeof error === "string") {
-          iterationError = error;
-        } else {
-          iterationError = String(error);
-        }
-
-        if (iterationError && iterationError.length > 500) {
-          iterationError = iterationError.substring(0, 497) + "...";
-        }
-
-        logger.error("[evals] backend fetch failed", error);
-        const failAbs = Date.now();
-        pushBackendStepLlmFailureSpans(
-          capturedSpans,
-          runStartedAt,
-          promptIndex,
-          stepIndex,
-          stepStartAbs,
-          llmStartAbs,
-          failAbs,
-          {
-            modelId,
-          },
+    let turnResult: Awaited<ReturnType<typeof runAssistantTurn>>;
+    try {
+      turnResult = await runAssistantTurn({
+        messages: inputMessages,
+        // Eval's `runTestCase` already resolved the canonical model id
+        // (`getCanonicalModelId(modelDefinition.id, provider)`) and threads
+        // it in as `modelId` — for the JAM-paid path that's e.g.
+        // `anthropic/claude-haiku-4.5`. The engine reads
+        // `modelDefinition.id` for the wire payload, so override here so
+        // backend wallet/quota lookup keys match what live chat sends.
+        modelDefinition: { ...modelDefinition, id: modelId },
+        systemPrompt: prepared.enhancedSystemPrompt,
+        ...(prepared.resolvedTemperature != null
+          ? { temperature: prepared.resolvedTemperature }
+          : {}),
+        tools: tracedTools,
+        ...(selectedServers.length
+          ? { selectedServerIds: selectedServers }
+          : {}),
+        mcpClientManager,
+        authContext: evalAuthContext,
+        sourceType: "eval",
+        streamSink: "none",
+        persistMode: "caller",
+        approvalMode: "auto-deny",
+        endpointPath,
+        ...(extraBodyFields ? { extraBodyFields } : {}),
+        ...(abortSignal ? { abortSignal } : {}),
+        maxSteps: MAX_STEPS,
+        progressivePlan: prepared.progressivePlan,
+        discoveryState: prepared.discoveryState,
+      });
+    } catch (error) {
+      // Cancellation: bail without recording. Matches the legacy
+      // AbortError handler at the bottom of the per-step while loop.
+      if (error instanceof Error && error.name === "AbortError") {
+        logger.debug(
+          "[evals] backend iteration aborted due to cancellation",
         );
-        break;
+        return {
+          evaluation: evaluateMultiTurnResults(
+            promptTurns,
+            toolsCalledByPrompt,
+            test.isNegativeTest,
+            test.matchOptions,
+          ),
+          iterationId: undefined,
+        };
       }
-    }
 
-    if (iterationError) {
+      // Non-abort runtime error from the engine. Map to `iterationError`
+      // for the post-loop verdict gate; preserve a truncated message and,
+      // when available, a `responseBody` for `errorDetails`.
+      if (error instanceof Error) {
+        iterationError = error.message || error.toString();
+        const responseBody = (error as { responseBody?: unknown })
+          .responseBody;
+        if (responseBody && typeof responseBody === "string") {
+          iterationErrorDetails = responseBody;
+        }
+      } else if (typeof error === "string") {
+        iterationError = error;
+      } else {
+        iterationError = String(error);
+      }
+      if (iterationError && iterationError.length > 500) {
+        iterationError = iterationError.substring(0, 497) + "...";
+      }
+      logger.error("[evals] runAssistantTurn failed", error);
       break;
     }
+
+    // Detect engine silent-failure. `runChatEngineLoop` catches throws
+    // inside the agentic loop (network failures, scrub errors, ...) and
+    // emits an error chunk to its writer — but for `streamSink:"none"`
+    // the writer is a no-op, so nothing surfaces and `runAssistantTurn`
+    // resolves normally with `runSucceeded: false`. The observable signal
+    // is that no `turnTrace` is captured (the engine only sets it when
+    // `runSucceeded && !aborted`) and no new messages were appended. Map
+    // that to `iterationError` so the verdict gate + lockReason
+    // derivation in the post-loop finalize see the cycle failure.
+    if (
+      !turnResult.turnTrace &&
+      turnResult.messages.length <= inputMessages.length
+    ) {
+      iterationError = "Backend stream failed during iteration";
+      logger.error(
+        "[evals] runAssistantTurn returned no turn trace; treating as cycle failure",
+      );
+      break;
+    }
+
+    // Drain per-turn outputs into the iteration-level accumulators.
+    capturedSpans.push(...traceCtx.recordedSpans);
+    if (turnResult.usage) {
+      accumulatedUsage.inputTokens =
+        (accumulatedUsage.inputTokens || 0) +
+        (turnResult.usage.inputTokens ?? 0);
+      accumulatedUsage.outputTokens =
+        (accumulatedUsage.outputTokens || 0) +
+        (turnResult.usage.outputTokens ?? 0);
+      accumulatedUsage.totalTokens =
+        (accumulatedUsage.totalTokens || 0) +
+        (turnResult.usage.totalTokens ?? 0);
+    }
+
+    // Extract per-turn tool calls from the new messages only (engine
+    // returns the FULL transcript; slice from `inputMessages.length` to
+    // get just this turn's appended assistant + tool messages so prior
+    // turns' calls aren't double-counted).
+    const newMessages = turnResult.messages.slice(inputMessages.length);
+    const promptToolsCalled = extractToolCallsFromConversation({
+      messages: newMessages,
+    });
+    toolsCalledByPrompt.push(promptToolsCalled);
+
+    // Roll the engine's transcript forward as the next turn's starting
+    // point. Includes prior conversation + this turn's user prompt + this
+    // turn's assistant/tool messages.
+    messageHistory.length = 0;
+    messageHistory.push(...turnResult.messages);
   }
 
   const evaluation = evaluateMultiTurnResults(

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1885,26 +1885,36 @@ const runIterationViaBackend = async ({
       promptIndex,
     );
 
-    const inputMessages: ModelMessage[] = [
-      ...messageHistory,
-      { role: "user", content: promptTurn.prompt },
-    ];
+    // Cursor review round-2 fix: push the user prompt into
+    // `messageHistory` BEFORE the engine call so a failed turn still
+    // persists the user side of the transcript. The legacy backend
+    // loop pushed the user message at the top of its per-step while
+    // loop; that meant `finishIteration` saw the user prompt even
+    // when the iteration failed mid-step. Recording the input keeps
+    // the transcript honest about WHICH turn errored.
+    messageHistory.push({
+      role: "user",
+      content: promptTurn.prompt,
+    });
+    const messageCountBeforeTurn = messageHistory.length;
+    const inputMessages: ModelMessage[] = [...messageHistory];
 
-    // Cursor + Codex review fix: thread `toolChoice` through
-    // `extraBodyFields` since the engine's
+    // Cursor + Codex review fix: thread `toolChoice` AND
+    // `maxOutputTokens` through `extraBodyFields` since the engine's
     // `RunAssistantTurnOptions` / `MCPJamHandlerOptions` don't expose
-    // it as a first-class field. The Convex `/stream` (and
-    // `/stream/org`) handlers already accept `toolChoice` in the
-    // request body — the engine spreads `extraBodyFields` into the body
-    // unchanged, so forced-tool / `none` eval cases work the same way
-    // they did on the legacy backend loop and the local-AI-SDK path.
-    const mergedExtraBodyFields =
-      toolChoice || extraBodyFields
-        ? {
-            ...(extraBodyFields ?? {}),
-            ...(toolChoice ? { toolChoice } : {}),
-          }
-        : undefined;
+    // them as first-class fields. The Convex `/stream` (and
+    // `/stream/org`) handlers already accept both in the request body
+    // — the engine spreads `extraBodyFields` into the body unchanged.
+    // `maxOutputTokens: 16384` matches the legacy per-step Convex body
+    // (Cursor round-2 finding "Dropped eval maxOutputTokens limit"):
+    // without it, hosted backend eval turns would inherit the
+    // `/stream` handler's default, which can truncate long multi-step
+    // tool loops differently than the historical eval cap.
+    const mergedExtraBodyFields: Record<string, unknown> = {
+      maxOutputTokens: 16384,
+      ...(extraBodyFields ?? {}),
+      ...(toolChoice ? { toolChoice } : {}),
+    };
 
     let turnResult: Awaited<ReturnType<typeof runAssistantTurn>>;
     try {
@@ -1932,9 +1942,7 @@ const runIterationViaBackend = async ({
         persistMode: "caller",
         approvalMode: "auto-deny",
         endpointPath,
-        ...(mergedExtraBodyFields
-          ? { extraBodyFields: mergedExtraBodyFields }
-          : {}),
+        extraBodyFields: mergedExtraBodyFields,
         ...(abortSignal ? { abortSignal } : {}),
         maxSteps: MAX_STEPS,
         progressivePlan: prepared.progressivePlan,
@@ -2009,7 +2017,7 @@ const runIterationViaBackend = async ({
     // `passed: true` for tests with no expected tool calls. Map both
     // to `iterationError` so the verdict gate + `lockReason`
     // derivation in the post-loop finalize see the cycle failure.
-    if (turnResult.messages.length <= inputMessages.length) {
+    if (turnResult.messages.length <= messageCountBeforeTurn) {
       iterationError = turnResult.turnTrace
         ? "Backend step returned no content (stream error or empty response)"
         : "Backend stream failed during iteration";
@@ -2034,10 +2042,10 @@ const runIterationViaBackend = async ({
     }
 
     // Extract per-turn tool calls from the new messages only (engine
-    // returns the FULL transcript; slice from `inputMessages.length` to
-    // get just this turn's appended assistant + tool messages so prior
-    // turns' calls aren't double-counted).
-    const newMessages = turnResult.messages.slice(inputMessages.length);
+    // returns the FULL transcript; slice from `messageCountBeforeTurn`
+    // to get just this turn's appended assistant + tool messages so
+    // prior turns' calls aren't double-counted).
+    const newMessages = turnResult.messages.slice(messageCountBeforeTurn);
     const promptToolsCalled = extractToolCallsFromConversation({
       messages: newMessages,
     });
@@ -2048,6 +2056,29 @@ const runIterationViaBackend = async ({
     // turn's assistant/tool messages.
     messageHistory.length = 0;
     messageHistory.push(...turnResult.messages);
+
+    // Codex P1 round-2 fix: catch a backend step error that happened
+    // AFTER messages already grew. The engine emits `EvalTraceSpan`s
+    // with `status: "error"` on per-step failures (see
+    // `pushBackendStepLlmFailureSpans` / `pushBackendStepToolFailureSpans`
+    // in mcpjam-stream-handler.ts), but then synthesizes a finish
+    // chunk and sets `runSucceeded: true` — so neither the catch
+    // branch nor the `messages.length <= messageCountBeforeTurn` check
+    // fires when step 1 succeeded and step 2 errored. Walk
+    // `turnTrace.spans` for any error-status span and treat as a
+    // cycle failure; the partial successful state we just drained
+    // above (tool calls, spans, usage, transcript) stays — eval just
+    // marks the iteration as errored and halts further turns.
+    const stepErrorSpan = turnResult.turnTrace?.spans.find(
+      (span) => span.status === "error",
+    );
+    if (stepErrorSpan) {
+      iterationError = `Backend step failed mid-turn: ${stepErrorSpan.name}`;
+      logger.error(
+        `[evals] runAssistantTurn turnTrace has error-status span; treating as cycle failure (span=${stepErrorSpan.name} category=${stepErrorSpan.category})`,
+      );
+      break;
+    }
   }
 
   const evaluation = evaluateMultiTurnResults(

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -1450,4 +1450,260 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       runAssistantTurnSpy.mockRestore();
     }
   });
+
+  it("threads maxOutputTokens: 16384 into backend extraBodyFields (PR 3 review round 2)", async () => {
+    // Cursor round-2: the legacy backend per-step Convex body included
+    // `maxOutputTokens: 16384`; the rewritten runner dropped it,
+    // letting hosted backend turns inherit whatever default the
+    // `/stream` handler applies. Restore the cap by merging it into
+    // `extraBodyFields` so it rides through unchanged.
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Case",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-max-tokens",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: {},
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-max-tokens",
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const request = fetchMock.mock.calls[0]?.[1] as { body?: string };
+    const body = JSON.parse(request.body ?? "{}");
+    expect(body.maxOutputTokens).toBe(16384);
+  });
+
+  it("persists the failing turn's user prompt when an iteration errors mid-turn (PR 3 review round 2)", async () => {
+    // Cursor round-2 ("Failed turn omits user transcript"): when a
+    // turn errors, the failing turn's user prompt must still reach
+    // `messageHistory` so `finishIteration` records WHICH turn
+    // failed. Legacy backend loop pushed the user message at the top
+    // of its per-step loop; this rewrite mirrors that — push before
+    // `runAssistantTurn`. Force a failure by spying on
+    // `runAssistantTurn` to throw, then assert the persisted
+    // transcript contains the user prompt.
+    const assistantTurnModule = await import("../../../utils/assistant-turn");
+    const runAssistantTurnSpy = vi
+      .spyOn(assistantTurnModule, "runAssistantTurn")
+      .mockRejectedValueOnce(new Error("backend down mid-turn"));
+
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Failing case",
+              query: "Hello",
+              runs: 1,
+              model: "claude-haiku-4.5",
+              provider: "anthropic",
+              expectedToolCalls: [],
+              promptTurns: [
+                {
+                  id: "turn-1",
+                  prompt: "Critical prompt that errored",
+                  expectedToolCalls: [],
+                },
+              ],
+              testCaseId: "case-fail-transcript",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-fail-transcript",
+      });
+
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const updatePayload = updateCall![1] as Record<string, unknown>;
+      expect(updatePayload.error).toBeTruthy();
+
+      // The user prompt for the failing turn MUST appear in the
+      // persisted transcript — otherwise the trace UI shows a blank
+      // failure with no context about what the user asked.
+      // `persistEvalTraceFanout` writes per-turn messages under
+      // `testSuites:appendEvalTurnTrace`'s `turn.sessionMessages`
+      // field. Walk every action call for any user message whose
+      // content includes the failing turn's prompt.
+      const containsCriticalPrompt = (messages: unknown): boolean => {
+        if (!Array.isArray(messages)) return false;
+        return messages.some((m) => {
+          if (!m || typeof m !== "object") return false;
+          const msg = m as { role?: string; content?: unknown };
+          if (msg.role !== "user") return false;
+          if (typeof msg.content === "string") {
+            return msg.content.includes("Critical prompt");
+          }
+          if (Array.isArray(msg.content)) {
+            return msg.content.some(
+              (part: any) =>
+                part?.type === "text" &&
+                typeof part.text === "string" &&
+                part.text.includes("Critical prompt"),
+            );
+          }
+          return false;
+        });
+      };
+
+      const anyCallHasIt = convexClient.action.mock.calls.some((call) => {
+        const payload = call[1] as Record<string, unknown> | undefined;
+        if (!payload) return false;
+        if (containsCriticalPrompt(payload.messages)) return true;
+        const turn = payload.turn as
+          | { sessionMessages?: unknown }
+          | undefined;
+        if (turn && containsCriticalPrompt(turn.sessionMessages)) return true;
+        return false;
+      });
+      expect(anyCallHasIt).toBe(true);
+    } finally {
+      runAssistantTurnSpy.mockRestore();
+    }
+  });
+
+  it("treats an error-status span in turnTrace as a cycle failure (PR 3 review round 2)", async () => {
+    // Codex P1 round-2 ("Fail turns when later backend steps error"):
+    // if step 1 produced assistant + tool messages and step 2 errors,
+    // the engine's loop appends the partial success to messages but
+    // also writes an `EvalTraceSpan` with `status:"error"` into
+    // `turnTrace.spans` — without surfacing it via a throw. My
+    // `messages.length` check would PASS in this case. Walk
+    // `turnTrace.spans` for any `status:"error"` span and treat as
+    // cycle failure.
+    const assistantTurnModule = await import("../../../utils/assistant-turn");
+    const runAssistantTurnSpy = vi
+      .spyOn(assistantTurnModule, "runAssistantTurn")
+      .mockResolvedValueOnce({
+        // Mimic step 1 succeeded (assistant + tool messages appended)
+        // and step 2 errored — turnTrace still captured with the
+        // error-status span the engine wrote on the failed step.
+        messages: [
+          { role: "user", content: "Hello" } as any,
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "tc_1",
+                toolName: "lookup",
+                input: {},
+              },
+            ],
+          } as any,
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "tc_1",
+                toolName: "lookup",
+                output: { ok: true },
+              },
+            ],
+          } as any,
+        ],
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+        turnTrace: {
+          turnId: "t_1",
+          promptIndex: 0,
+          startedAt: 0,
+          endedAt: 1,
+          modelId: "anthropic/claude-haiku-4.5",
+          spans: [
+            {
+              id: "sp_1",
+              name: "step.1.llm",
+              category: "llm",
+              startMs: 0,
+              endMs: 1,
+              status: "ok",
+            },
+            // The smoking gun: the engine recorded a step error here.
+            {
+              id: "sp_2",
+              name: "step.2.llm",
+              category: "llm",
+              startMs: 1,
+              endMs: 2,
+              status: "error",
+            },
+          ],
+        },
+      } as any);
+
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Mid-turn step error",
+              query: "Hello",
+              runs: 1,
+              model: "claude-haiku-4.5",
+              provider: "anthropic",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-late-step-err",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-late-step-err",
+      });
+
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = updateCall![1] as Record<string, unknown>;
+      // The presence of `error` is the load-bearing assertion (verdict
+      // gating is mocked out — see the "non-OK step" test). Without
+      // the span walk, this would be `undefined`.
+      expect(payload.error).toBeTruthy();
+      expect(String(payload.error)).toMatch(/backend step failed/i);
+    } finally {
+      runAssistantTurnSpy.mockRestore();
+    }
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -1706,4 +1706,191 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       runAssistantTurnSpy.mockRestore();
     }
   });
+
+  it("treats an engine catch fired after partial messages as cycle failure (PR 3 review round 3)", async () => {
+    // Cursor round-3 ("Partial turn hides engine failures"): if the
+    // engine's agentic loop catches an error AFTER partial messages
+    // landed, it returns messageHistory grown beyond the input but
+    // omits `turnTrace` (`runSucceeded:false`). Neither the
+    // message-count check nor the error-span check catches this
+    // shape — only `!turnTrace` does. Without that signal the test
+    // would record `iterationError` unset and verdict `passed:true`
+    // for cases with no expected tool calls.
+    const assistantTurnModule = await import("../../../utils/assistant-turn");
+    const runAssistantTurnSpy = vi
+      .spyOn(assistantTurnModule, "runAssistantTurn")
+      .mockResolvedValueOnce({
+        // Engine returned with grown messages…
+        messages: [
+          { role: "user", content: "Hello" } as any,
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "I will look that up...",
+              },
+            ],
+          } as any,
+        ],
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+        // …but no `turnTrace`: engine catch fired, `runSucceeded` is
+        // false, persistence path was skipped.
+      } as any);
+
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Partial-then-error case",
+              query: "Hello",
+              runs: 1,
+              model: "claude-haiku-4.5",
+              provider: "anthropic",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-partial-then-error",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-partial-then-error",
+      });
+
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = updateCall![1] as Record<string, unknown>;
+      // The load-bearing assertion: `iterationError` IS set even
+      // though messages grew. Verdict gating is mocked out (see other
+      // PR-3 tests for that explanation), but `payload.error` is the
+      // signal `finalizePassedForEval` would consume in production.
+      expect(payload.error).toBeTruthy();
+      expect(String(payload.error)).toMatch(/engine caught|stream failed/i);
+    } finally {
+      runAssistantTurnSpy.mockRestore();
+    }
+  });
+
+  it("merges engine turnTrace.spans into capturedSpans for LLM step coverage (PR 3 review round 3)", async () => {
+    // Codex P2 round-3 ("Preserve backend tool step indices"): the
+    // engine writes LLM-step spans into `turnTrace.spans` (already
+    // `EvalTraceSpan[]` shape via `PersistedTurnTrace`). PR 3
+    // initially only persisted `traceCtx.recordedSpans` (the
+    // wrap-captured tool spans), so the trace UI lost engine-side
+    // step granularity. Merge both so persisted spans include LLM
+    // steps + tool calls.
+    const assistantTurnModule = await import("../../../utils/assistant-turn");
+    const engineSpans = [
+      {
+        id: "engine-step-1",
+        name: "step.1.llm",
+        category: "llm",
+        startMs: 0,
+        endMs: 10,
+        status: "ok",
+        stepIndex: 0,
+      },
+      {
+        id: "engine-step-2",
+        name: "step.2.llm",
+        category: "llm",
+        startMs: 10,
+        endMs: 20,
+        status: "ok",
+        stepIndex: 1,
+      },
+    ];
+
+    const runAssistantTurnSpy = vi
+      .spyOn(assistantTurnModule, "runAssistantTurn")
+      .mockResolvedValueOnce({
+        messages: [
+          { role: "user", content: "Hello" } as any,
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Done" }],
+          } as any,
+        ],
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+        turnTrace: {
+          turnId: "t_1",
+          promptIndex: 0,
+          startedAt: 0,
+          endedAt: 20,
+          modelId: "anthropic/claude-haiku-4.5",
+          spans: engineSpans as any,
+        },
+      } as any);
+
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Span merge case",
+              query: "Hello",
+              runs: 1,
+              model: "claude-haiku-4.5",
+              provider: "anthropic",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-span-merge",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-span-merge",
+      });
+
+      // Look for the engine spans in any of the action payloads. The
+      // fanout persists per-turn spans via `appendEvalTurnTrace.turn.spans`;
+      // the legacy path includes them on `updateTestIteration.spans`.
+      const spanInPayload = (payload: unknown): boolean => {
+        if (!payload || typeof payload !== "object") return false;
+        const p = payload as Record<string, unknown>;
+        const candidates: unknown[] = [
+          p.spans,
+          (p.turn as { spans?: unknown } | undefined)?.spans,
+        ];
+        return candidates.some((spans) => {
+          if (!Array.isArray(spans)) return false;
+          return spans.some(
+            (s: any) =>
+              s?.id === "engine-step-1" || s?.id === "engine-step-2",
+          );
+        });
+      };
+      const anyHasEngineSpans = convexClient.action.mock.calls.some((c) =>
+        spanInPayload(c[1]),
+      );
+      expect(anyHasEngineSpans).toBe(true);
+    } finally {
+      runAssistantTurnSpy.mockRestore();
+    }
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -16,11 +16,20 @@ const createLlmModelMock = vi.hoisted(() =>
   ),
 );
 
-vi.mock("ai", () => ({
-  generateText: (...args: unknown[]) => generateTextMock(...args),
-  streamText: (...args: unknown[]) => streamTextMock(...args),
-  stepCountIs: vi.fn(() => undefined),
-}));
+vi.mock("ai", async () => {
+  // Keep the real exports (`createUIMessageStream`,
+  // `createUIMessageStreamResponse`, `parseJsonEventStream`, `pruneMessages`,
+  // etc.) — the engine that `runIterationViaBackend` now drives needs them.
+  // Only override `generateText` / `streamText` so the local-AI-SDK and
+  // stream-AI-SDK paths can be controlled by these tests.
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    generateText: (...args: unknown[]) => generateTextMock(...args),
+    streamText: (...args: unknown[]) => streamTextMock(...args),
+    stepCountIs: vi.fn(() => undefined),
+  };
+});
 
 vi.mock("@mcpjam/sdk", async () => {
   const actual =
@@ -32,14 +41,30 @@ vi.mock("@mcpjam/sdk", async () => {
   };
 });
 
-vi.mock("../../../utils/chat-helpers", () => ({
-  createLlmModel: (
-    modelDefinition: unknown,
-    apiKey: unknown,
-    baseUrls?: unknown,
-    customProviders?: unknown,
-  ) => createLlmModelMock(modelDefinition, apiKey, baseUrls, customProviders),
-}));
+vi.mock("../../../utils/chat-helpers", async () => {
+  // PR 3 of the engine consolidation: `runIterationViaBackend` now drives
+  // `runChatEngineLoop`, which imports `scrubUnavailableToolHistoryForBackend`
+  // / `scrubMcpAppsToolResultsForBackend` / `scrubChatGPTAppsToolResultsForBackend`
+  // from this module. Returning only `createLlmModel` here would make those
+  // imports `undefined`; the engine's `try/catch` then silently swallows the
+  // resulting `TypeError`, runs to a `runSucceeded:false` finish, and the
+  // test never sees the fetch we expect. Keep the real exports and override
+  // only `createLlmModel` so the local-AI-SDK paths can be inspected.
+  const actual =
+    await vi.importActual<typeof import("../../../utils/chat-helpers")>(
+      "../../../utils/chat-helpers",
+    );
+  return {
+    ...actual,
+    createLlmModel: (
+      modelDefinition: unknown,
+      apiKey: unknown,
+      baseUrls?: unknown,
+      customProviders?: unknown,
+    ) =>
+      createLlmModelMock(modelDefinition, apiKey, baseUrls, customProviders),
+  };
+});
 
 // Stub the chat-side tool/system/temperature pipeline. The real implementation
 // in `chat-v2-orchestration` pulls in `getSkillToolsAndPrompt`, which touches
@@ -47,6 +72,22 @@ vi.mock("../../../utils/chat-helpers", () => ({
 // that. Return a minimal `PrepareChatV2Result` shape — the actual tool set
 // stays empty (matching `mcpClientManager.getToolsForAiSdk` → `{}`), and the
 // engine swap only depends on the named output fields.
+// PR 3 of the engine consolidation: `runIterationViaBackend` now drives
+// `runChatEngineLoop`, which imports `serializeToolsForConvex` for tool
+// serialization and uses `http-tool-calls` for local tool execution. Mirror
+// the mocks `assistant-turn.test.ts` uses for the same engine — keep these
+// minimal so the engine path can reach its `fetch` to Convex without
+// blowing up on test-mode-incompatible dependencies (zod schema conversion
+// in tool serialization, etc.).
+vi.mock("../../../utils/mcpjam-tool-helpers", () => ({
+  serializeToolsForConvex: vi.fn(() => []),
+}));
+
+vi.mock("@/shared/http-tool-calls", () => ({
+  hasUnresolvedToolCalls: vi.fn().mockReturnValue(false),
+  executeToolCallsFromMessages: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("../../../utils/chat-v2-orchestration", () => ({
   prepareChatV2: vi.fn(async (options: any) => ({
     allTools: {},
@@ -72,12 +113,24 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
   const mcpClientManager = {
     getToolsForAiSdk: vi.fn(),
     listServers: vi.fn(),
+    // PR 3 of the engine consolidation: the engine that
+    // `runIterationViaBackend` now drives calls
+    // `getAllToolsMetadata(serverId)` during message scrubbing
+    // (`scrubMcpAppsToolResultsForBackend` -> manager metadata lookup).
+    // Empty map is fine — no MCP-Apps result-scrubbing happens in these
+    // tests; we just need the method to exist.
+    getAllToolsMetadata: vi.fn().mockReturnValue({}),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
+    // The engine that PR-3-rewritten `runIterationViaBackend` drives
+    // (`runChatEngineLoop`) reads its target URL from `CONVEX_HTTP_URL`,
+    // not from the runner's `convexHttpUrl` parameter. Set both so the
+    // engine paths and any direct-fetch paths target the same host.
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
     convexClient.mutation.mockResolvedValue({ iterationId: "iter-1" });
     convexClient.query.mockResolvedValue({ status: "running" });
     convexClient.action.mockResolvedValue(undefined);
@@ -100,6 +153,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    delete process.env.CONVEX_HTTP_URL;
   });
 
   async function runQuickTestCase(compareRunId?: string) {
@@ -655,7 +709,11 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
   });
 
   it("routes bare MCPJam Anthropic compare models through the backend without a BYOK key", async () => {
-    fetchMock.mockResolvedValue(createBackendSuccessResponse());
+    // Post-PR3 `runIterationViaBackend` drives `runAssistantTurn`, which sends
+    // an SSE-shaped request (`mode:"stream"`) to Convex `/stream`. The legacy
+    // `mode:"step"` JSON-response path is gone for the non-stream backend
+    // runner — assert against the engine's stream request shape instead.
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
 
     await expect(
       runEvalSuiteWithAiSdk({
@@ -696,9 +754,10 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     const compareRequest = fetchMock.mock.calls[0]?.[1] as {
       body?: string;
     };
-    expect(JSON.parse(compareRequest.body ?? "{}").model).toBe(
-      "anthropic/claude-haiku-4.5",
-    );
+    const compareBody = JSON.parse(compareRequest.body ?? "{}");
+    expect(compareBody.model).toBe("anthropic/claude-haiku-4.5");
+    expect(compareBody.mode).toBe("stream");
+    expect(compareBody.sourceType).toBe("eval");
     expect(createLlmModelMock).not.toHaveBeenCalled();
   });
 
@@ -759,7 +818,12 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
   });
 
   it("runs org BYOK cloud eval models through Convex without raw provider keys", async () => {
-    fetchMock.mockResolvedValue(createBackendSuccessResponse());
+    // Same migration as the previous test: assert against the engine's
+    // `mode:"stream"` SSE request, not the legacy `mode:"step"` JSON. The
+    // hosted-org BYOK contract that matters is that `providerKey` +
+    // `projectId` land in the request body (via `extraBodyFields`) and the
+    // request targets `/stream/org`.
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
 
     await runEvalSuiteWithAiSdk({
       suiteId: "suite-1",
@@ -802,10 +866,11 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     };
     const body = JSON.parse(request.body ?? "{}");
     expect(body).toMatchObject({
-      mode: "step",
+      mode: "stream",
       model: "gpt-4-turbo",
       providerKey: "openai",
       projectId: "project-1",
+      sourceType: "eval",
     });
     expect(body).not.toHaveProperty("apiKey");
     expect(new Headers(request.headers).get("authorization")).toBe(

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -1893,4 +1893,149 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       runAssistantTurnSpy.mockRestore();
     }
   });
+
+  it("does NOT treat a tool-result error span as a backend failure (PR 3 review round 4)", async () => {
+    // Codex P1 round-3 ("Don't treat tool-result error spans as
+    // backend failures"): `wrapBackendToolsForTrace` records ordinary
+    // local tool-result errors (MCP tool returned isError:true,
+    // tool execution threw, ...) as `status:"error"` with
+    // `category:"tool"`. Treating those as cycle failures
+    // short-circuits before `finalizePassedForEval` can apply the
+    // configured `failOnToolError` policy, so otherwise-passing evals
+    // get force-failed when a tool returns a recoverable error.
+    //
+    // The runner must filter the error-span check to non-tool
+    // categories. Backend step / LLM failure spans (category:
+    // "llm" / "step" / "error") still trigger; tool spans flow
+    // through the existing tool-error gate.
+    const assistantTurnModule = await import("../../../utils/assistant-turn");
+    const runAssistantTurnSpy = vi
+      .spyOn(assistantTurnModule, "runAssistantTurn")
+      .mockResolvedValueOnce({
+        messages: [
+          { role: "user", content: "Hello" } as any,
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "tc_1",
+                toolName: "lookup",
+                input: {},
+              },
+            ],
+          } as any,
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "tc_1",
+                toolName: "lookup",
+                output: { isError: true, content: "tool failed" },
+              },
+            ],
+          } as any,
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Recovered." }],
+          } as any,
+        ],
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+        turnTrace: {
+          turnId: "t_1",
+          promptIndex: 0,
+          startedAt: 0,
+          endedAt: 30,
+          modelId: "anthropic/claude-haiku-4.5",
+          spans: [
+            {
+              id: "sp_step_ok",
+              name: "step.1.llm",
+              category: "llm",
+              startMs: 0,
+              endMs: 10,
+              status: "ok",
+            },
+            // Tool error — should be IGNORED by the cycle-failure
+            // check (deferred to `failOnToolError`).
+            {
+              id: "sp_tool_error",
+              name: "tool.lookup",
+              category: "tool",
+              startMs: 10,
+              endMs: 20,
+              status: "error",
+              toolCallId: "tc_1",
+              toolName: "lookup",
+            },
+            // The model recovered with a successful final LLM step.
+            {
+              id: "sp_step_final",
+              name: "step.2.llm",
+              category: "llm",
+              startMs: 20,
+              endMs: 30,
+              status: "ok",
+            },
+          ] as any,
+        },
+      } as any);
+
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Tool error recovered",
+              query: "Hello",
+              runs: 1,
+              model: "claude-haiku-4.5",
+              provider: "anthropic",
+              // Disable tool-error gating in advancedConfig — the
+              // intended policy is "tool errors don't fail evals."
+              advancedConfig: { failOnToolError: false },
+              expectedToolCalls: [
+                { toolName: "lookup", arguments: {} },
+              ],
+              promptTurns: [
+                {
+                  id: "turn-1",
+                  prompt: "Hello",
+                  expectedToolCalls: [
+                    { toolName: "lookup", arguments: {} },
+                  ],
+                },
+              ],
+              testCaseId: "case-tool-error-recovered",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-tool-error-recovered",
+      });
+
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = updateCall![1] as Record<string, unknown>;
+      // Load-bearing assertion: with the filter in place,
+      // `iterationError` must NOT be set just because a tool span
+      // had `status:"error"`. The legacy backend loop deferred to
+      // `failOnToolError`; this PR's filter restores that.
+      expect(payload.error).toBeFalsy();
+    } finally {
+      runAssistantTurnSpy.mockRestore();
+    }
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -1241,4 +1241,213 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       prepareSpy.mockRestore();
     }
   });
+
+  it("forwards advancedConfig.toolChoice via extraBodyFields (PR 3 review fix)", async () => {
+    // Cursor + Codex review on PR #2457: the engine doesn't expose
+    // `toolChoice` as a first-class field, so the legacy backend loop's
+    // request body included it but the rewritten runner dropped it.
+    // Fix: merge `toolChoice` into `extraBodyFields` so it rides through
+    // to Convex unchanged (the engine spreads `extraBodyFields` into
+    // the body verbatim). Hosted backend evals with forced-tool or
+    // `none` settings need this to work.
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Forced-tool case",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            // Force a specific tool selection on the backend.
+            advancedConfig: {
+              toolChoice: { type: "tool", toolName: "search_docs" },
+            },
+            testCaseId: "case-toolchoice",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: {},
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-toolchoice",
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const request = fetchMock.mock.calls[0]?.[1] as { body?: string };
+    const body = JSON.parse(request.body ?? "{}");
+    expect(body.toolChoice).toEqual({
+      type: "tool",
+      toolName: "search_docs",
+    });
+  });
+
+  it("records iteration failure when Convex returns a non-OK step (PR 3 review fix)", async () => {
+    // Codex P1 review on PR #2457: when Convex returns a non-OK
+    // response, the engine writes an error chunk to its (no-op) writer
+    // and returns `shouldContinue:false`, then emits a synthetic finish
+    // and sets `runSucceeded:true`. `runAssistantTurn` returns with
+    // `turnTrace` defined but no new messages appended. Without the
+    // message-count check, 429s/500s slip through as passing iterations
+    // for tests with no expected tool calls.
+    //
+    // Synthesize a non-OK SSE response: fetchMock returns ok:false. The
+    // engine's processOneStep handles this at
+    // mcpjam-stream-handler.ts:1384 (`if (!res.ok || !res.body)`).
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: "Too Many Requests",
+      text: vi.fn().mockResolvedValue("Daily spend cap reached"),
+      body: null,
+    } as unknown as Response);
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Backend 429 case",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            // Zero expected tools — without the message-count check the
+            // empty toolsCalledByPrompt would match this expectation and
+            // the suite summary would credit it as a pass.
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-429",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: {},
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-429",
+    });
+
+    const updateCall = convexClient.action.mock.calls.find(
+      (c) => c[0] === "testSuites:updateTestIteration",
+    );
+    expect(updateCall).toBeDefined();
+    const payload = updateCall![1] as Record<string, unknown>;
+    // The presence of `error` is the load-bearing assertion: the runner
+    // surfaced the cycle failure to `finishIteration` instead of letting
+    // it silently pass. (The verdict-side `result` field would gate on
+    // `iterationError` via the real `finalizePassedForEval`, but this
+    // suite mocks it to `({ matchPassed }) => matchPassed` to keep the
+    // matcher unit-testable; that gate is covered by the real-impl
+    // tests in @mcpjam/sdk's matcher suite.)
+    expect(payload.error).toBeTruthy();
+    expect(String(payload.error)).toMatch(/backend (stream|step)/i);
+  });
+
+  it("does not record an iteration when abortSignal fires mid-turn (PR 3 review fix)", async () => {
+    // Cursor review on PR #2457: the engine swallows AbortError
+    // internally (sets its `aborted` flag, returns with no `turnTrace`,
+    // doesn't throw). `RunAssistantTurnResult` doesn't expose the
+    // engine's `aborted` flag, so without an explicit
+    // `abortSignal.aborted` check the runner would treat the
+    // cancellation as a silent cycle failure and persist an aborted
+    // iteration as `status:"completed"` + `error:"Backend stream
+    // failed..."`. Legacy behavior was to return early without any
+    // recording on AbortError; preserve that.
+    //
+    // Simulating the engine's silent-abort path end-to-end through the
+    // suite runner is fiddly because `runEvalSuiteWithAiSdk` owns its
+    // own AbortController and only fires it on the cancellation
+    // watcher's 2-second cadence. Easier: spy on `runAssistantTurn`,
+    // abort the inbound signal exactly the way the engine would on
+    // AbortError, then return the same "silent-abort" shape — empty
+    // messages and no turnTrace. If the runner reads
+    // `abortSignal.aborted` correctly, it returns early without
+    // persisting; otherwise it falls through to the silent-failure
+    // branch and records the aborted run as a cycle failure.
+    const assistantTurnModule = await import("../../../utils/assistant-turn");
+    const runAssistantTurnSpy = vi
+      .spyOn(assistantTurnModule, "runAssistantTurn")
+      .mockImplementation(async (opts: any) => {
+        opts.abortSignal?.dispatchEvent?.(new Event("abort"));
+        if (opts.abortSignal && !opts.abortSignal.aborted) {
+          // The runner passes a controller-backed signal; abort the
+          // backing controller via the signal's onabort hook. In tests
+          // we cheat by mutating the readonly flag through reflection
+          // — vitest's AbortSignal is the real Node one.
+          Object.defineProperty(opts.abortSignal, "aborted", {
+            value: true,
+            configurable: true,
+          });
+        }
+        return {
+          messages: opts.messages,
+          assistantMessages: [],
+          toolCalls: [],
+          toolResults: [],
+        };
+      });
+
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Aborted case",
+              query: "Hello",
+              runs: 1,
+              model: "claude-haiku-4.5",
+              provider: "anthropic",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-aborted",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-aborted",
+      });
+
+      expect(runAssistantTurnSpy).toHaveBeenCalledTimes(1);
+
+      // The aborted iteration must NOT be finalized via the action
+      // pipeline — no updateTestIteration, no appendEvalTurnTrace, no
+      // lockEvalSession.
+      const finalizeCall = convexClient.action.mock.calls.find((c) =>
+        [
+          "testSuites:updateTestIteration",
+          "testSuites:appendEvalTurnTrace",
+          "testSuites:lockEvalSession",
+        ].includes(c[0] as string),
+      );
+      expect(finalizeCall).toBeUndefined();
+    } finally {
+      runAssistantTurnSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

**PR 3 of the engine-consolidation plan** in `~/.claude/plans/lets-consolidate-on-streamtext-transient-clarke.md` (Phase 2 of `~/mcpjam-docs/unification.md`).

Replaces the eval-specific per-step fetch + tool-execution while loop in `runIterationViaBackend` with a per-promptTurn `runAssistantTurn` call — the same engine chat / playground / chatbox / synthetic use. PR 2 (#2455) locked in this exact configuration as a contract; this PR wires it up.

**Eval still owns persistence** (`persistMode: \"caller\"` → `recorder` + `persistEvalTraceFanout`). Tools are pre-wrapped with `wrapToolSetForEvalTrace` so the engine's local tool-execution path still captures tool spans into `EvalTraceSpan[]`. Hosted-org BYOK and JAM-paid dispatch is unchanged — the existing \`runTestCase\` three-way already passes `endpointPath` + `extraBodyFields` + `modelId`; PR 3 just hands them to the engine.

## What this PR drops vs. the legacy backend loop

- **Per-step LLM spans** (`pushBackendStepLlmFailureSpans`, `pushBackendStepSuccessSpans`, `pushBackendStepToolFailureSpans`). The engine emits its own step traces as `PersistedTurnTrace` (chat-side shape); converting to `EvalTraceSpan[]` is out of scope here. Tool-execution spans (via `wrapToolSetForEvalTrace`) are preserved.
- **Friendly \"[evals] run halted: <reason>\" log distinction** for daily-spend-cap errors. The engine throws on backend failures uniformly; we map to `iterationError` for the existing post-loop verdict gate.

## What this PR keeps

- Tool-execution span capture (`wrapToolSetForEvalTrace` -> `traceCtx.recordedSpans` -> `capturedSpans`)
- Cancellation via `abortSignal` (engine accepts; AbortError propagates through my catch to the existing partial-result return)
- `iterationError` accumulation for the existing post-loop `finalizePassedForEval` gate
- `persistSetupFailedIteration` path on `prepareChatV2` throw (PR 1 behavior)
- `evaluation.passed = false` correctness on failure (PR 1 behavior)
- `recorder.finishIteration` + `persistEvalTraceFanout` output unchanged

## Silent-failure detection

`runChatEngineLoop` catches throws in its agentic loop (network failures, scrub errors, etc.) and emits an error chunk to its writer. For `streamSink: \"none\"` the writer is a no-op so the failure is invisible — `runAssistantTurn` resolves normally with `runSucceeded: false`. The observable signal is `turnTrace` undefined + no new messages appended. When the runner sees that, it sets `iterationError = \"Backend stream failed during iteration\"` so the verdict gate and `lockReason` derivation still see the cycle failure (lockReason → `eval_failed`). This is the same outcome the legacy runner produced when fetch rejected.

## What this PR does NOT touch

- **Stream variants** — `streamIterationViaBackend` and `streamIterationWithAiSdk` still drive the legacy per-step loops. PR 5 collapses them onto the same engine via a `buildEvalStreamAdapter(emit)`.
- **Path 4** — local-BYOK `runIterationWithAiSdk` still calls `generateText` at `:1223`. PR 4 swaps it for `streamDirectChatWithLiveTrace`.
- **Persistence** — `persistEvalTraceFanout` + the recorder stay as the eval-specific writers. PR 6 may converge with `persistChatSessionToConvex` if it gains `lockReason`/`displayLabel` fields.

## Test plan

- [x] Typecheck: 4 baseline `evals-runner.ts` errors pre-existing from PR 1, unchanged. One `trace-repair-runner-job.test.ts` baseline error pre-existing on main, unchanged. Zero new typecheck errors from PR 3.
- [x] All 18 eval-runner tests pass. Three legacy tests updated to use the SSE response format the engine expects + assert engine wire-body fields (`mode:\"stream\"` instead of `mode:\"step\"`, `sourceType:\"eval\"`, `providerKey`/`projectId` via `extraBodyFields`).
- [x] All 449 server-side tests in the blast radius pass — `server/utils` (where `runAssistantTurn` and its contract test live), `server/services/evals` (PR 1's persistence + recorder territory), `server/services/sessionSimulation` (synthetic; shares the engine).
- [ ] End-to-end smoke against a JAM-paid eval suite — confirm SSE response is processed correctly and the iteration row is persisted with the expected verdict shape.
- [ ] End-to-end smoke against a hosted-org BYOK eval suite — confirm `providerKey` + org target route to `/stream/org` and credit attribution lands on the right wallet.
- [ ] Mid-run cancellation smoke — confirm AbortError still short-circuits without recording, matching the legacy behavior.

## Notable test-mock changes

The eval-runner test mocks needed three additions to give the engine path the same hospitality the synthetic-runner tests already provide:

- `mcpClientManager.getAllToolsMetadata` — engine calls it during message scrubbing.
- `process.env.CONVEX_HTTP_URL` — engine reads the target URL from env, not from the runner's `convexHttpUrl` param.
- Real exports for `\"ai\"`, `chat-helpers`, plus mocks for `mcpjam-tool-helpers.serializeToolsForConvex` and `@/shared/http-tool-calls` — mirrors `assistant-turn.test.ts` so engine dependencies resolve.

## Next: PR 4

PR 4 swaps the local-BYOK path (`runIterationWithAiSdk`) onto `streamDirectChatWithLiveTrace`. After PR 4, the entire non-stream suite path is fully consolidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core hosted eval execution and verdict/error detection; regressions could mis-record passes/failures or drop Convex request fields, though coverage targets the main failure modes.
> 
> **Overview**
> **PR 3 of eval engine consolidation:** hosted backend eval iterations no longer use a custom `mode:"step"` fetch + local tool loop. Each prompt turn now goes through **`runAssistantTurn`** (same path as chat/playground), with `streamSink: "none"`, `persistMode: "caller"`, `sourceType: "eval"`, traced tools, and bearer auth wired into Convex **`/stream`** (or **`/stream/org`**).
> 
> **Request parity:** `toolChoice` and **`maxOutputTokens: 16384`** are merged into **`extraBodyFields`** so advanced eval settings and the historical output cap still reach the backend. Canonical **`modelId`** is applied on **`modelDefinition`** for wallet/quota lookup.
> 
> **Behavior preserved or tightened:** aborts exit without persisting (including silent engine cancellation via **`abortSignal.aborted`**); user prompts are recorded before each turn so failed runs keep transcript context; partial usage/spans/transcript are accumulated before failure checks. Cycle failures are detected when **`turnTrace`** is missing, no new messages appear, or **`turnTrace`** has non-**`tool`** error spans—while recoverable **tool** error spans still defer to **`failOnToolError`**. Engine LLM spans from **`turnTrace.spans`** are merged with wrap-captured tool spans.
> 
> **Tests:** suite tests expect **`mode:"stream"`** / **`sourceType:"eval"`**; mocks expose real **`ai`** / **`chat-helpers`** exports and engine dependencies; new cases cover toolChoice, 429s, abort, max tokens, transcripts, span merge, and tool-error vs backend-error distinction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef9cf2fcc8bd7f2731bc3cd2e2d2a6f7da94b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->