### PR TITLE
PR-6: drop forceLegacyTraceBlob escape hatch

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -741,13 +741,13 @@ async function finishIterationDirectly(
   });
   if (fanout?.persisted === false) {
     logger.warn(
-      "[evals] persistEvalTraceFanout failed (quick run); falling back to forced-legacy-blob path",
+      "[evals] persistEvalTraceFanout failed (quick run); iteration finalized without re-attempting the chatSessions write",
       { iterationId: params.iterationId, error: fanout.error.message },
     );
   }
-  const sendTraceFieldsToUpdate = fanout?.persisted !== true;
-  // See recorder.ts for the rationale — same fallback escape hatch.
-  const forceLegacyTraceBlob = fanout?.persisted === false;
+  // See recorder.ts for the rationale — only send trace fields when no
+  // fanout was attempted at all.
+  const sendTraceFieldsToUpdate = fanout === undefined;
 
   // PR-2 review #5 (Cursor "Update failure after successful fanout"):
   // track iteration-gone state so the lock can fire even when the
@@ -760,7 +760,6 @@ async function finishIterationDirectly(
       status: iterationStatus,
       actualToolCalls: sanitizeForConvexTransport(params.toolsCalled),
       tokensUsed: params.usage.totalTokens ?? 0,
-      ...(forceLegacyTraceBlob ? { forceLegacyTraceBlob: true } : {}),
       ...(sendTraceFieldsToUpdate
         ? {
             messages: sanitizeForConvexTransport(params.messages),

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -745,10 +745,6 @@ async function finishIterationDirectly(
       { iterationId: params.iterationId, error: fanout.error.message },
     );
   }
-  // See recorder.ts for the rationale — only send trace fields when no
-  // fanout was attempted at all.
-  const sendTraceFieldsToUpdate = fanout === undefined;
-
   // PR-2 review #5 (Cursor "Update failure after successful fanout"):
   // track iteration-gone state so the lock can fire even when the
   // update throws a transient error. Mirrors recorder.finishIteration.
@@ -760,24 +756,6 @@ async function finishIterationDirectly(
       status: iterationStatus,
       actualToolCalls: sanitizeForConvexTransport(params.toolsCalled),
       tokensUsed: params.usage.totalTokens ?? 0,
-      ...(sendTraceFieldsToUpdate
-        ? {
-            messages: sanitizeForConvexTransport(params.messages),
-            ...(params.spans?.length
-              ? { spans: sanitizeForConvexTransport(params.spans) }
-              : {}),
-            ...(params.prompts?.length
-              ? { prompts: sanitizeForConvexTransport(params.prompts) }
-              : {}),
-            ...(params.widgetSnapshots?.length
-              ? {
-                  widgetSnapshots: sanitizeForConvexTransport(
-                    params.widgetSnapshots,
-                  ),
-                }
-              : {}),
-          }
-        : {}),
       error: params.error,
       errorDetails: params.errorDetails,
       resultSource: params.resultSource,

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -739,12 +739,23 @@ async function finishIterationDirectly(
     prompts: params.prompts,
     widgetSnapshots: params.widgetSnapshots,
   });
-  if (fanout?.persisted === false) {
+  // Fall back to the W1 single-call path ONLY when the fanout failed
+  // before any turn landed. See recorder.ts / persist-eval-trace.ts.
+  const useW1Fallback =
+    fanout.persisted === false && fanout.turnsWritten === 0;
+  if (fanout.persisted === false) {
     logger.warn(
-      "[evals] persistEvalTraceFanout failed (quick run); iteration finalized without re-attempting the chatSessions write",
-      { iterationId: params.iterationId, error: fanout.error.message },
+      useW1Fallback
+        ? "[evals] persistEvalTraceFanout failed before any turn landed (quick run); falling back to W1 single-call save"
+        : "[evals] persistEvalTraceFanout failed mid-stream (quick run); iteration finalized without re-attempting (would orphan partial turns)",
+      {
+        iterationId: params.iterationId,
+        turnsWritten: fanout.turnsWritten,
+        error: fanout.error.message,
+      },
     );
   }
+
   // PR-2 review #5 (Cursor "Update failure after successful fanout"):
   // track iteration-gone state so the lock can fire even when the
   // update throws a transient error. Mirrors recorder.finishIteration.
@@ -756,6 +767,24 @@ async function finishIterationDirectly(
       status: iterationStatus,
       actualToolCalls: sanitizeForConvexTransport(params.toolsCalled),
       tokensUsed: params.usage.totalTokens ?? 0,
+      ...(useW1Fallback
+        ? {
+            messages: sanitizeForConvexTransport(params.messages),
+            ...(params.spans?.length
+              ? { spans: sanitizeForConvexTransport(params.spans) }
+              : {}),
+            ...(params.prompts?.length
+              ? { prompts: sanitizeForConvexTransport(params.prompts) }
+              : {}),
+            ...(params.widgetSnapshots?.length
+              ? {
+                  widgetSnapshots: sanitizeForConvexTransport(
+                    params.widgetSnapshots,
+                  ),
+                }
+              : {}),
+          }
+        : {}),
       error: params.error,
       errorDetails: params.errorDetails,
       resultSource: params.resultSource,

--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -125,7 +125,7 @@ describe("persistEvalTraceFanout", () => {
       prompts,
     });
 
-    expect(result).toEqual({ persisted: true });
+    expect(result).toEqual({ persisted: true, turnsWritten: 3 });
 
     const appendCalls = calls.filter(
       (c) => c.ref === "testSuites:appendEvalTurnTrace",
@@ -248,7 +248,56 @@ describe("persistEvalTraceFanout", () => {
       prompts: undefined,
     });
 
-    expect(result).toEqual({ persisted: false, error });
+    expect(result).toEqual({ persisted: false, turnsWritten: 0, error });
+  });
+
+  test("reports turnsWritten when fanout fails after N successful writes", async () => {
+    // Mid-stream failure: turn 0 succeeds, turn 1 throws. Caller uses
+    // turnsWritten > 0 to skip the W1 fallback (would orphan turn 0).
+    const error = new Error("network blip on turn 1");
+    let appendCount = 0;
+    const action = vi.fn(async (ref: string) => {
+      if (ref !== "testSuites:appendEvalTurnTrace") {
+        throw new Error(`unexpected action ${ref}`);
+      }
+      appendCount += 1;
+      if (appendCount === 2) throw error;
+      return { skipped: false };
+    });
+    const client = { action } as unknown as ConvexHttpClient;
+
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "s0",
+        name: "step",
+        category: "step",
+        startMs: 1,
+        endMs: 2,
+        promptIndex: 0,
+      },
+      {
+        id: "s1",
+        name: "step",
+        category: "step",
+        startMs: 3,
+        endMs: 4,
+        promptIndex: 1,
+      },
+    ];
+    const result = await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: [
+        { role: "user", content: "q0" } as ModelMessage,
+        { role: "assistant", content: "a0" } as ModelMessage,
+        { role: "user", content: "q1" } as ModelMessage,
+        { role: "assistant", content: "a1" } as ModelMessage,
+      ],
+      spans,
+      prompts: undefined,
+    });
+
+    expect(result).toEqual({ persisted: false, turnsWritten: 1, error });
   });
 
   test("falls back when the backend reports skipped:true", async () => {
@@ -286,7 +335,7 @@ describe("persistEvalTraceFanout", () => {
       prompts: undefined,
     });
 
-    expect(result).toEqual({ persisted: true });
+    expect(result).toEqual({ persisted: true, turnsWritten: 1 });
     const appendCalls = calls.filter(
       (c) => c.ref === "testSuites:appendEvalTurnTrace",
     );

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -35,23 +35,24 @@ import {
  * turn) is deferred to a follow-up. The data shape and reader fidelity
  * are identical between the two cadences.
  *
- * Return values:
- *   - `{ persisted: true }`: trace was written via chatSessions;
- *     caller should call `updateTestIteration` with status/result
- *     and metadata ONLY — no `messages` / `spans` / `prompts` /
- *     `widgetSnapshots`. Passing trace fields after a successful
- *     fanout would re-fire `persistEvalTraceAction` on
- *     `updateTestIteration`'s W1 path and either be a silent no-op
- *     against the now-locked session or, worse, EVAL_SESSION_LOCKED
- *     if any turn index doesn't match.
- *   - `{ persisted: false, error }`: the per-turn fanout failed mid-
- *     stream. Caller should finalize the iteration WITHOUT re-sending
- *     trace fields to `updateTestIteration`. Re-entering W1 with
- *     `promptIndex: 0` + the full transcript would overwrite any
- *     partial turn rows the fanout already wrote and orphan the rest.
- *     The legacy-blob fallback that used to recover this case was
- *     removed in PR-6 — partial chatSessions data is now the recoverable
- *     state.
+ * Return values (`turnsWritten` counts turn-trace rows the backend
+ * acknowledged):
+ *   - `{ persisted: true, turnsWritten }`: every turn was written.
+ *     Caller should call `updateTestIteration` with status/result and
+ *     metadata ONLY. Passing trace fields would re-fire
+ *     `persistEvalTraceAction` on the W1 path and either silently
+ *     no-op against the now-locked session or throw EVAL_SESSION_LOCKED.
+ *   - `{ persisted: false, turnsWritten: 0, error }`: fanout failed
+ *     BEFORE any turn landed. Caller should fall back to the W1
+ *     single-call path by passing `messages`/`spans`/`prompts`/
+ *     `widgetSnapshots` to `updateTestIteration`. The backend writes a
+ *     fresh chatSessions row at `promptIndex: 0` with the full
+ *     transcript. No orphan risk because no turn-trace rows exist yet.
+ *   - `{ persisted: false, turnsWritten: N (>0), error }`: fanout
+ *     failed mid-stream after N turns wrote successfully. Caller must
+ *     NOT re-send trace fields — W1 would overwrite turn 0 and orphan
+ *     turns 1..N-1. The partial chatSessions row stays as-is; the
+ *     reader tolerates it.
  *
  * Widgets: forwarded on the LAST turn call so they persist once at
  * finalize. Inspector capture (`captureMcpAppWidgetSnapshots`) supplies
@@ -165,8 +166,8 @@ function serializeWidgetsForBackend(
 }
 
 type FanoutResult =
-  | { persisted: true }
-  | { persisted: false; error: Error };
+  | { persisted: true; turnsWritten: number }
+  | { persisted: false; turnsWritten: number; error: Error };
 
 export async function persistEvalTraceFanout(args: {
   convexClient: ConvexHttpClient;
@@ -219,6 +220,7 @@ export async function persistEvalTraceFanout(args: {
   // finalized iteration. Idempotent on retry per PR-1 lock semantics
   // (same-promptIndex re-write before lock = patch in place, no-op
   // after lock).
+  let turnsWritten = 0;
   try {
     for (let i = 0; i < turns.length; i++) {
       const turn = turns[i]!;
@@ -253,20 +255,23 @@ export async function persistEvalTraceFanout(args: {
       )) as { skipped?: boolean } | undefined;
       // If the backend reports `skipped: true`, the flag flipped off
       // between our cache check and the per-turn call. Bail out so the
-      // caller can fall back to the legacy path.
+      // caller can decide whether to fall back to the W1 single-call path.
       if (result?.skipped === true) {
         return {
           persisted: false,
+          turnsWritten,
           error: new Error(
             "appendEvalTurnTrace returned skipped:true; flag turned off mid-fanout",
           ),
         };
       }
+      turnsWritten += 1;
     }
-    return { persisted: true };
+    return { persisted: true, turnsWritten };
   } catch (error) {
     return {
       persisted: false,
+      turnsWritten,
       error: error instanceof Error ? error : new Error(String(error)),
     };
   }

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -45,12 +45,13 @@ import {
  *     against the now-locked session or, worse, EVAL_SESSION_LOCKED
  *     if any turn index doesn't match.
  *   - `{ persisted: false, error }`: the per-turn fanout failed mid-
- *     stream. Caller should fall back to a forced-legacy-blob call by
- *     passing `forceLegacyTraceBlob: true` to `updateTestIteration`,
- *     which bypasses the backend's W1 chatSessions path. Without that
- *     escape hatch the legacy fallback would re-enter the chatSessions
- *     writer with `promptIndex: 0` + full transcript, overwriting any
- *     partially-fanned-out turn rows.
+ *     stream. Caller should finalize the iteration WITHOUT re-sending
+ *     trace fields to `updateTestIteration`. Re-entering W1 with
+ *     `promptIndex: 0` + the full transcript would overwrite any
+ *     partial turn rows the fanout already wrote and orphan the rest.
+ *     The legacy-blob fallback that used to recover this case was
+ *     removed in PR-6 — partial chatSessions data is now the recoverable
+ *     state.
  *
  * Widgets: forwarded on the LAST turn call so they persist once at
  * finalize. Inspector capture (`captureMcpAppWidgetSnapshots`) supplies

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -295,17 +295,14 @@ export const createSuiteRunRecorder = ({
           { iterationId, error: fanout.error.message },
         );
       }
-      // Only send trace fields when no fanout was attempted at all.
-      // - `persisted === true`: fanout already wrote per-turn rows; the W1
-      //   path would duplicate at promptIndex: 0.
-      // - `persisted === false`: fanout failed mid-stream and may have left
-      //   partial turn rows. Re-firing W1 with promptIndex: 0 + the full
-      //   transcript would overwrite the partial turn 0 and orphan turns
-      //   1..N. We accept the partial chatSessions row instead — the
-      //   legacy-blob fallback that used to recover this case was removed
-      //   in PR-6.
-      const sendTraceFieldsToUpdate = fanout === undefined;
-
+      // We never re-send trace fields to updateTestIteration:
+      //   - `persisted === true`: fanout already wrote per-turn rows; W1
+      //     would duplicate at promptIndex: 0.
+      //   - `persisted === false`: fanout failed mid-stream and may have
+      //     left partial turn rows; re-firing W1 would overwrite turn 0
+      //     and orphan turns 1..N. The legacy-blob fallback that used to
+      //     recover this case was removed in PR-6.
+      //
       // PR-2 review #5 (Cursor "Update failure after successful fanout"):
       // track whether the iteration is gone so we don't waste a lock
       // call on a deleted session, AND so the lock fires even when
@@ -319,23 +316,6 @@ export const createSuiteRunRecorder = ({
           result,
           actualToolCalls: sanitizeForConvexTransport(toolsCalled),
           tokensUsed: usage.totalTokens ?? 0,
-          ...(sendTraceFieldsToUpdate
-            ? {
-                messages: sanitizeForConvexTransport(messages),
-                ...(spans?.length
-                  ? { spans: sanitizeForConvexTransport(spans) }
-                  : {}),
-                ...(prompts?.length
-                  ? { prompts: sanitizeForConvexTransport(prompts) }
-                  : {}),
-                ...(widgetSnapshots?.length
-                  ? {
-                      widgetSnapshots:
-                        sanitizeForConvexTransport(widgetSnapshots),
-                    }
-                  : {}),
-              }
-            : {}),
           error,
           errorDetails,
           resultSource,

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -291,20 +291,20 @@ export const createSuiteRunRecorder = ({
       });
       if (fanout?.persisted === false) {
         logger.warn(
-          "[evals] persistEvalTraceFanout failed; falling back to forced-legacy-blob path",
+          "[evals] persistEvalTraceFanout failed; iteration finalized without re-attempting the chatSessions write",
           { iterationId, error: fanout.error.message },
         );
       }
-      const sendTraceFieldsToUpdate = fanout?.persisted !== true;
-      // When the fanout failed mid-stream we MUST force the backend
-      // into the legacy blob path. Otherwise `updateTestIteration`
-      // re-enters the chatSessions W1 path with `promptIndex: 0` +
-      // full transcript, which would overwrite any partial turn rows
-      // the fanout already wrote and possibly fight an existing lock.
-      // The escape hatch makes the iteration replayable from
-      // `testIteration.blob` while the partial chatSessions data is
-      // left inert (source-aware reader tolerates absence).
-      const forceLegacyTraceBlob = fanout?.persisted === false;
+      // Only send trace fields when no fanout was attempted at all.
+      // - `persisted === true`: fanout already wrote per-turn rows; the W1
+      //   path would duplicate at promptIndex: 0.
+      // - `persisted === false`: fanout failed mid-stream and may have left
+      //   partial turn rows. Re-firing W1 with promptIndex: 0 + the full
+      //   transcript would overwrite the partial turn 0 and orphan turns
+      //   1..N. We accept the partial chatSessions row instead — the
+      //   legacy-blob fallback that used to recover this case was removed
+      //   in PR-6.
+      const sendTraceFieldsToUpdate = fanout === undefined;
 
       // PR-2 review #5 (Cursor "Update failure after successful fanout"):
       // track whether the iteration is gone so we don't waste a lock
@@ -319,7 +319,6 @@ export const createSuiteRunRecorder = ({
           result,
           actualToolCalls: sanitizeForConvexTransport(toolsCalled),
           tokensUsed: usage.totalTokens ?? 0,
-          ...(forceLegacyTraceBlob ? { forceLegacyTraceBlob: true } : {}),
           ...(sendTraceFieldsToUpdate
             ? {
                 messages: sanitizeForConvexTransport(messages),

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -289,20 +289,25 @@ export const createSuiteRunRecorder = ({
         prompts,
         widgetSnapshots,
       });
-      if (fanout?.persisted === false) {
+      // Fall back to the W1 single-call path ONLY when the fanout failed
+      // before any turn landed. With turns already written, re-sending
+      // would overwrite turn 0 (W1 always writes at promptIndex: 0) and
+      // orphan turns 1..N. See persist-eval-trace.ts for the contract.
+      const useW1Fallback =
+        fanout.persisted === false && fanout.turnsWritten === 0;
+      if (fanout.persisted === false) {
         logger.warn(
-          "[evals] persistEvalTraceFanout failed; iteration finalized without re-attempting the chatSessions write",
-          { iterationId, error: fanout.error.message },
+          useW1Fallback
+            ? "[evals] persistEvalTraceFanout failed before any turn landed; falling back to W1 single-call save"
+            : "[evals] persistEvalTraceFanout failed mid-stream; iteration finalized without re-attempting (would orphan partial turns)",
+          {
+            iterationId,
+            turnsWritten: fanout.turnsWritten,
+            error: fanout.error.message,
+          },
         );
       }
-      // We never re-send trace fields to updateTestIteration:
-      //   - `persisted === true`: fanout already wrote per-turn rows; W1
-      //     would duplicate at promptIndex: 0.
-      //   - `persisted === false`: fanout failed mid-stream and may have
-      //     left partial turn rows; re-firing W1 would overwrite turn 0
-      //     and orphan turns 1..N. The legacy-blob fallback that used to
-      //     recover this case was removed in PR-6.
-      //
+
       // PR-2 review #5 (Cursor "Update failure after successful fanout"):
       // track whether the iteration is gone so we don't waste a lock
       // call on a deleted session, AND so the lock fires even when
@@ -316,6 +321,23 @@ export const createSuiteRunRecorder = ({
           result,
           actualToolCalls: sanitizeForConvexTransport(toolsCalled),
           tokensUsed: usage.totalTokens ?? 0,
+          ...(useW1Fallback
+            ? {
+                messages: sanitizeForConvexTransport(messages),
+                ...(spans?.length
+                  ? { spans: sanitizeForConvexTransport(spans) }
+                  : {}),
+                ...(prompts?.length
+                  ? { prompts: sanitizeForConvexTransport(prompts) }
+                  : {}),
+                ...(widgetSnapshots?.length
+                  ? {
+                      widgetSnapshots:
+                        sanitizeForConvexTransport(widgetSnapshots),
+                    }
+                  : {}),
+              }
+            : {}),
           error,
           errorDetails,
           resultSource,


### PR DESCRIPTION
## Summary

Companion to mcpjam-backend PR-6 (https://github.com/MCPJam/mcpjam-backend/pull/442): the backend removed the `forceLegacyTraceBlob` arg from `updateTestIteration` and the `internalUpdateTestIteration` mutation. Inspector callers must stop sending it.

## What this PR changes

- `evals-runner.ts` and `recorder.ts`: drop the `forceLegacyTraceBlob` computation and the `...(forceLegacyTraceBlob ? ... : {})` spread on the `updateTestIteration` call.
- Same files: change `sendTraceFieldsToUpdate` from `fanout?.persisted !== true` to `fanout === undefined`. Previously, when fanout failed mid-stream (`persisted === false`), the caller set `forceLegacyTraceBlob: true` AND sent trace fields — the backend wrote the legacy blob and skipped the chatSessions path. With the legacy blob path gone, re-sending trace fields would re-fire `persistEvalTraceAction` on `updateTestIteration`'s W1 path with `promptIndex: 0` and the full transcript, overwriting any partial turn rows the fanout already wrote and orphaning the rest. Better to leave the partial chatSessions row alone.
- `persist-eval-trace.ts`: update the JSDoc on the `{ persisted: false }` branch to reflect the new caller contract (finalize without trace fields; partial chatSessions data is the recoverable state).

## Trade-off

Mirrored from the backend PR: if the per-turn fanout fails mid-stream, the iteration's chatSessions row is left partial and there's no longer a legacy-blob fallback. The reader fallback (`loadIterationTraceEnvelope`) still exists and tolerates absence, so historical iterations keep rendering — but newly-failing fanouts produce partial transcripts instead of complete-via-blob ones.

## Ordering with the backend PR

Verified inter-deploy safety: the backend PR removes the `forceLegacyTraceBlob` validator from `updateTestIteration`. An old inspector still sending the arg would get rejected at the boundary on the first call after backend deploy. Therefore the inspector PR should land + deploy BEFORE the backend PR, or the deploys should be sequenced tightly. Once both are deployed, the arg is gone end-to-end.

## Test plan

- [x] `npm run test -w @mcpjam/inspector` — 94 passing in `server/services/evals/` (the affected scope). No new failures.
- [ ] Smoke: run an eval suite locally against a backend with PR #442 deployed; verify a fanout-failure case produces a partial chatSessions row but no iteration crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval trace persistence failure handling; mid-stream fanout failures now leave partial chatSessions transcripts with no legacy-blob recovery.
> 
> **Overview**
> Removes the **`forceLegacyTraceBlob`** escape hatch from **`updateTestIteration`** in **`recorder.finishIteration`** and **`finishIterationDirectly`** (aligned with backend PR-6).
> 
> **`persistEvalTraceFanout`** now returns **`turnsWritten`** on every outcome. Callers use **`useW1Fallback = persisted === false && turnsWritten === 0`**: trace fields (`messages`, spans, prompts, widgets) go to **`updateTestIteration`** only when the per-turn fanout failed **before any turn persisted**. If fanout fails **mid-stream** (`turnsWritten > 0`), the iteration is finalized **without** re-sending trace data so the W1 path cannot overwrite turn 0 and orphan later turns. Warnings distinguish pre-turn vs mid-stream failure.
> 
> Docs and tests cover the new contract, including a case where turn 0 succeeds and turn 1 throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e906157c579ec19e35c0f947d8e72a464c110c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->