### PR TITLE
chat-v2: extract runDirectChatTurn from streamDirectChatWithLiveTrace (engine consolidation PR 4a)

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -3,8 +3,6 @@ import {
   createUIMessageStream,
   createUIMessageStreamResponse,
   convertToModelMessages,
-  streamText,
-  stepCountIs,
   type ToolSet,
 } from "ai";
 import type { ChatV2Request } from "@/shared/chat-v2";
@@ -49,47 +47,27 @@ import {
   validateWidgetModelContextEntries,
   WidgetModelContextValidationError,
 } from "../../utils/chat-v2-orchestration";
-import { appendDedupedModelMessages } from "@/shared/eval-trace";
-import {
-  createAiSdkEvalTraceContext,
-  emitAiSdkOnStepFinish,
-  finalizeAiSdkTraceOnFailure,
-  patchAiSdkRecordedSpansMessageRangesFromSteps,
-  registerAiSdkPrepareStep,
-  wrapToolSetForEvalTrace,
-} from "../../services/evals/eval-trace-capture";
 import {
   emitRequestPayload,
   emitTraceSnapshot,
-  generateLiveTraceTurnId,
-  getPromptIndex,
-  getPromptMessageStartIndex,
-  readToolServerId,
-  setToolSpanMessageRangesFromResults,
-  toTraceRecord,
   writeTraceEvent,
 } from "../../utils/live-chat-trace-stream";
-import {
-  buildResolvedModelRequestPayload,
-  normalizeSystemPromptForProvider,
-} from "../../utils/model-request-payload";
+import { buildResolvedModelRequestPayload } from "../../utils/model-request-payload";
 import {
   formatProviderOverloadError,
   isProviderOverloadError,
 } from "../../utils/provider-error-normalization";
 import { describeError, describeAsSlug } from "@mcpjam/sdk";
-import {
-  mergeLiveChatTraceUsage,
-  type LiveChatTraceUsage,
-} from "@/shared/live-chat-trace";
+import { type LiveChatTraceUsage } from "@/shared/live-chat-trace";
 import { isAbortError } from "@/shared/abort-errors";
 import {
-  commitNewlyLoaded,
-  gateToolsToActiveSubset,
-  resolveActiveToolNames,
   type ProgressiveToolPlan,
   type ToolDiscoveryState,
 } from "@/shared/progressive-tool-discovery";
+import {
+  runDirectChatTurn,
+  type RunDirectChatTurnHandle,
+} from "../../utils/direct-chat-turn";
 
 function formatStreamError(error: unknown, provider?: ModelProvider): string {
   if (!(error instanceof Error)) {
@@ -162,34 +140,6 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
   });
 }
 
-function toLiveChatTraceUsage(
-  usage:
-    | {
-        inputTokens?: number;
-        outputTokens?: number;
-        totalTokens?: number;
-      }
-    | null
-    | undefined
-): LiveChatTraceUsage | undefined {
-  if (!usage) {
-    return undefined;
-  }
-
-  const next: LiveChatTraceUsage = {};
-  if (typeof usage.inputTokens === "number") {
-    next.inputTokens = usage.inputTokens;
-  }
-  if (typeof usage.outputTokens === "number") {
-    next.outputTokens = usage.outputTokens;
-  }
-  if (typeof usage.totalTokens === "number") {
-    next.totalTokens = usage.totalTokens;
-  }
-
-  return Object.keys(next).length > 0 ? next : undefined;
-}
-
 function toPersistedUsage(
   usage: LiveChatTraceUsage | undefined
 ): { inputTokens: number; outputTokens: number } | undefined {
@@ -206,26 +156,17 @@ function toPersistedUsage(
   };
 }
 
-function collectStepToolCallIds(
-  toolCalls: Array<{ toolCallId?: string } | undefined> | null | undefined
-): Set<string> {
-  const toolCallIds = new Set<string>();
-  if (!Array.isArray(toolCalls)) {
-    return toolCallIds;
-  }
-
-  for (const toolCall of toolCalls) {
-    if (
-      typeof toolCall?.toolCallId === "string" &&
-      toolCall.toolCallId.length > 0
-    ) {
-      toolCallIds.add(toolCall.toolCallId);
-    }
-  }
-
-  return toolCallIds;
-}
-
+/**
+ * Chat user-API-key path. The `streamText` driver, trace span management,
+ * abort wiring, and progressive-discovery gating live in
+ * `runDirectChatTurn` (`server/utils/direct-chat-turn.ts`). This function
+ * is the SSE terminal — it wraps the helper's trace-event callbacks in
+ * `createUIMessageStream` writer events and drives the result through
+ * `result.toUIMessageStream(...)` into the writer.
+ *
+ * Eval's local-BYOK suite path (PR 4b) uses the same helper with the
+ * headless terminal (`consumeDirectChatTurnHeadless`).
+ */
 function streamDirectChatWithLiveTrace(options: {
   llmModel: ReturnType<typeof createLlmModel>;
   modelId: string;
@@ -247,306 +188,125 @@ function streamDirectChatWithLiveTrace(options: {
     turnTrace: PersistedTurnTrace;
   }) => Promise<void> | void;
 }): Response {
-  const {
-    llmModel,
-    modelId,
-    provider,
-    messageHistory,
-    systemPrompt,
-    temperature,
-    tools,
-    abortSignal,
-    onPersist,
-  } = options;
-
-  // Separate array for tracing — we must NOT mutate `messageHistory` because
-  // `streamText` holds a reference and internally accumulates step responses.
-  // Mutating it would cause duplicate items on the next API call (OpenAI
-  // Responses API rejects duplicates by id).
-  const traceHistory = [...messageHistory];
-  const initialMessageHistoryLength = messageHistory.length;
-  const traceTurn = {
-    turnId: generateLiveTraceTurnId(),
-    promptIndex: getPromptIndex(messageHistory),
-    promptMessageStartIndex: getPromptMessageStartIndex(messageHistory),
-    turnStartedAt: Date.now(),
-    turnSpans: [] as Awaited<
-      ReturnType<typeof createAiSdkEvalTraceContext>
-    >["recordedSpans"],
-    turnUsage: undefined as LiveChatTraceUsage | undefined,
-  };
-  const traceContext = createAiSdkEvalTraceContext(traceTurn.turnStartedAt);
-  const providerSystemPrompt = normalizeSystemPromptForProvider(systemPrompt);
-  let currentStepIndex = 0;
-  let turnFinished = false;
-  let aborted = abortSignal?.aborted === true;
-  const markAborted = () => {
-    aborted = true;
-  };
-  abortSignal?.addEventListener("abort", markAborted, { once: true });
+  const { provider, abortSignal, onPersist, ...turnOptions } = options;
+  // Declared before `createUIMessageStream` so the top-level `onError`
+  // (which can fire before `execute` runs) can read it; assigned inside
+  // `execute` once the helper is configured.
+  let handle: RunDirectChatTurnHandle | undefined;
 
   const stream = createUIMessageStream({
     onError: (error) => {
-      if (aborted || isAbortError(error)) {
+      if (handle?.isAborted() || isAbortError(error)) {
         return "";
       }
       logger.error("[mcp/chat-v2] stream error", error);
       return formatStreamError(error, provider);
     },
     execute: async ({ writer }) => {
-      writeTraceEvent(writer, {
-        type: "turn_start",
-        turnId: traceTurn.turnId,
-        promptIndex: traceTurn.promptIndex,
-        startedAtMs: traceTurn.turnStartedAt,
-      });
-
-      emitRequestPayload(writer, {
-        turnId: traceTurn.turnId,
-        promptIndex: traceTurn.promptIndex,
-        stepIndex: 0,
-        payload: buildResolvedModelRequestPayload({
-          systemPrompt,
-          tools,
-          messages: messageHistory,
-        }),
-      });
-
-      const tracedTools = wrapToolSetForEvalTrace(
-        tools as Record<string, unknown>,
-        traceContext,
-        traceTurn.promptIndex
-      ) as ToolSet;
-
-      const { progressivePlan, discoveryState } = options;
-      // Progressive mode: gate execution to the active subset.
-      // `activeTools` (set in `prepareStep` below) narrows what the model
-      // sees, but a hallucinated/remembered call to a non-active tool
-      // would still execute against the full map. Gating wraps each
-      // tool's `execute` to throw a structured "not loaded" error,
-      // which the AI SDK surfaces as an error tool-result the model can
-      // recover from via `load_mcp_tools`.
-      const executableTools = gateToolsToActiveSubset(
-        tracedTools as Record<string, unknown>,
-        progressivePlan,
-        () => discoveryState,
-      ) as ToolSet;
-      const streamTextOptions: Parameters<typeof streamText>[0] = {
-        model: llmModel,
-        messages: messageHistory,
-        ...(temperature !== undefined ? { temperature } : {}),
-        system: providerSystemPrompt,
-        tools: executableTools,
-        stopWhen: stepCountIs(20),
-        ...(abortSignal ? { abortSignal } : {}),
-        prepareStep: ({ stepNumber }) => {
-          currentStepIndex = stepNumber;
-          registerAiSdkPrepareStep(traceContext, stepNumber, {
-            modelId,
-            promptIndex: traceTurn.promptIndex,
+      handle = runDirectChatTurn({
+        ...turnOptions,
+        abortSignal,
+        onPersist,
+        onPersistError: (error) => {
+          logger.warn("[mcp/chat-v2] onFinish ingestion error", {
+            error: error instanceof Error ? error.message : String(error),
           });
-          if (progressivePlan?.enabled && discoveryState) {
-            commitNewlyLoaded(discoveryState);
-            const active = resolveActiveToolNames(
-              progressivePlan,
-              discoveryState,
-            );
-            return { activeTools: active };
-          }
-          return {};
         },
-        onChunk: async ({ chunk }) => {
-          if (chunk.type === "text-delta") {
+        traceEvents: {
+          onTurnStart: (event) => {
+            writeTraceEvent(writer, {
+              type: "turn_start",
+              turnId: event.turnId,
+              promptIndex: event.promptIndex,
+              startedAtMs: event.startedAtMs,
+            });
+          },
+          onRequestPayload: (event) => {
+            emitRequestPayload(writer, {
+              turnId: event.turnId,
+              promptIndex: event.promptIndex,
+              stepIndex: event.stepIndex,
+              payload: buildResolvedModelRequestPayload({
+                systemPrompt: event.systemPrompt,
+                tools: event.tools,
+                messages: event.messages,
+              }),
+            });
+          },
+          onTextDelta: (event) => {
             writeTraceEvent(writer, {
               type: "text_delta",
-              turnId: traceTurn.turnId,
-              promptIndex: traceTurn.promptIndex,
-              stepIndex: currentStepIndex,
-              delta: chunk.text,
+              turnId: event.turnId,
+              promptIndex: event.promptIndex,
+              stepIndex: event.stepIndex,
+              delta: event.delta,
             });
-            return;
-          }
-
-          if (chunk.type === "tool-call") {
+          },
+          onToolCallChunk: (event) => {
             writeTraceEvent(writer, {
               type: "tool_call",
-              turnId: traceTurn.turnId,
-              promptIndex: traceTurn.promptIndex,
-              stepIndex: currentStepIndex,
-              toolCallId: chunk.toolCallId,
-              toolName: chunk.toolName,
-              input: toTraceRecord(chunk.input),
-              serverId: readToolServerId(tracedTools, chunk.toolName),
+              turnId: event.turnId,
+              promptIndex: event.promptIndex,
+              stepIndex: event.stepIndex,
+              toolCallId: event.toolCallId,
+              toolName: event.toolName,
+              input: event.input,
+              serverId: event.serverId,
             });
-            return;
-          }
-
-          if (chunk.type === "tool-result") {
+          },
+          onToolResultChunk: (event) => {
             writeTraceEvent(writer, {
               type: "tool_result",
-              turnId: traceTurn.turnId,
-              promptIndex: traceTurn.promptIndex,
-              stepIndex: currentStepIndex,
-              toolCallId: chunk.toolCallId,
-              toolName: chunk.toolName,
-              output: chunk.output,
-              serverId: readToolServerId(tracedTools, chunk.toolName),
+              turnId: event.turnId,
+              promptIndex: event.promptIndex,
+              stepIndex: event.stepIndex,
+              toolCallId: event.toolCallId,
+              toolName: event.toolName,
+              output: event.output,
+              serverId: event.serverId,
             });
-          }
-        },
-        onStepFinish: async (step) => {
-          const responseMessages = Array.isArray(step?.response?.messages)
-            ? (step.response.messages as ModelMessage[])
-            : [];
-          const beforeLength = traceHistory.length;
-          appendDedupedModelMessages(traceHistory, responseMessages);
-          const afterLength = traceHistory.length;
-          const messageStartIndex =
-            afterLength > beforeLength ? beforeLength : undefined;
-          const messageEndIndex =
-            afterLength > beforeLength ? afterLength - 1 : undefined;
-          const stepUsage = toLiveChatTraceUsage(step.usage);
-
-          traceTurn.turnUsage = mergeLiveChatTraceUsage(
-            traceTurn.turnUsage,
-            stepUsage
-          );
-
-          emitAiSdkOnStepFinish(traceContext, Date.now(), {
-            modelId,
-            inputTokens: stepUsage?.inputTokens,
-            outputTokens: stepUsage?.outputTokens,
-            totalTokens: stepUsage?.totalTokens,
-            messageStartIndex,
-            messageEndIndex,
-          });
-
-          setToolSpanMessageRangesFromResults(
-            traceContext.recordedSpans,
+          },
+          onStepSnapshot: ({ traceHistory, tracedTools, traceTurn }) => {
+            emitTraceSnapshot(writer, traceHistory, tracedTools, traceTurn);
+          },
+          onTurnError: ({
+            turnId,
+            promptIndex,
+            stepIndex,
+            errorText,
+            traceTurn,
+            tracedTools,
             traceHistory,
-            traceTurn.promptIndex,
-            currentStepIndex,
-            collectStepToolCallIds(step.toolCalls)
-          );
-
-          traceTurn.turnSpans = [...traceContext.recordedSpans];
-          emitTraceSnapshot(writer, traceHistory, tracedTools, traceTurn);
-        },
-        onError: async ({ error }) => {
-          if (turnFinished) {
-            return;
-          }
-          if (aborted || isAbortError(error)) {
-            aborted = true;
-            turnFinished = true;
-            return;
-          }
-
-          const failAt = Date.now();
-          finalizeAiSdkTraceOnFailure(traceContext, failAt, {
-            completedStepCount: currentStepIndex,
-            lastStepEndedAt: traceContext.lastStepClosedEndAt,
-            modelId,
-            promptIndex: traceTurn.promptIndex,
-          });
-          traceTurn.turnSpans = [...traceContext.recordedSpans];
-          emitTraceSnapshot(writer, traceHistory, tracedTools, traceTurn);
-          writeTraceEvent(writer, {
-            type: "error",
-            turnId: traceTurn.turnId,
-            promptIndex: traceTurn.promptIndex,
-            stepIndex: currentStepIndex,
-            errorText: error instanceof Error ? error.message : String(error),
-          });
-          writeTraceEvent(writer, {
-            type: "turn_finish",
-            turnId: traceTurn.turnId,
-            promptIndex: traceTurn.promptIndex,
-            usage: traceTurn.turnUsage,
-          });
-          turnFinished = true;
-        },
-        onFinish: async (event) => {
-          if (aborted || abortSignal?.aborted) {
-            aborted = true;
-            turnFinished = true;
-            return;
-          }
-
-          patchAiSdkRecordedSpansMessageRangesFromSteps(
-            traceContext.recordedSpans,
-            initialMessageHistoryLength,
-            event.steps,
-            traceTurn.promptIndex
-          );
-          traceTurn.turnSpans = [...traceContext.recordedSpans];
-          traceTurn.turnUsage =
-            toLiveChatTraceUsage(event.totalUsage) ?? traceTurn.turnUsage;
-
-          if (!turnFinished) {
+          }) => {
+            emitTraceSnapshot(writer, traceHistory, tracedTools, traceTurn);
+            writeTraceEvent(writer, {
+              type: "error",
+              turnId,
+              promptIndex,
+              stepIndex,
+              errorText,
+            });
             writeTraceEvent(writer, {
               type: "turn_finish",
-              turnId: traceTurn.turnId,
-              promptIndex: traceTurn.promptIndex,
-              finishReason: event.finishReason,
+              turnId,
+              promptIndex,
               usage: traceTurn.turnUsage,
             });
-            turnFinished = true;
-          }
-
-          const responseMessages: ModelMessage[] = [];
-          for (const step of event.steps) {
-            appendDedupedModelMessages(
-              responseMessages,
-              Array.isArray(step?.response?.messages)
-                ? (step.response.messages as ModelMessage[])
-                : []
-            );
-          }
-
-          try {
-            await onPersist?.({
-              responseMessages,
-              assistantText: event.text,
-              toolCalls: event.steps.flatMap((step) => step.toolCalls ?? []),
-              toolResults: event.steps.flatMap(
-                (step) => step.toolResults ?? []
-              ),
-              usage: traceTurn.turnUsage,
-              finishReason: event.finishReason,
-              turnTrace: {
-                turnId: traceTurn.turnId,
-                promptIndex: traceTurn.promptIndex,
-                startedAt: traceTurn.turnStartedAt,
-                endedAt: Date.now(),
-                spans: [...traceTurn.turnSpans],
-                usage: traceTurn.turnUsage,
-                finishReason: event.finishReason,
-                modelId,
-              },
+          },
+          onTurnFinish: ({ turnId, promptIndex, finishReason, usage }) => {
+            writeTraceEvent(writer, {
+              type: "turn_finish",
+              turnId,
+              promptIndex,
+              finishReason,
+              usage,
             });
-          } catch (error) {
-            logger.warn("[mcp/chat-v2] onFinish ingestion error", {
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
+          },
         },
-      };
-
-      let result: ReturnType<typeof streamText>;
-      try {
-        result = streamText(streamTextOptions);
-      } catch (error) {
-        abortSignal?.removeEventListener("abort", markAborted);
-        if (aborted || isAbortError(error)) {
-          aborted = true;
-          return;
-        }
-        throw error;
-      }
+      });
 
       try {
-        for await (const chunk of result.toUIMessageStream({
+        for await (const chunk of handle.result.toUIMessageStream({
           messageMetadata: ({ part }) => {
             if (part.type === "finish-step") {
               return {
@@ -557,20 +317,19 @@ function streamDirectChatWithLiveTrace(options: {
             }
           },
           onError: (error) => {
-            if (aborted || isAbortError(error)) return "";
+            if (handle!.isAborted() || isAbortError(error)) return "";
             return formatStreamError(error, provider);
           },
         })) {
           writer.write(chunk);
         }
       } catch (error) {
-        if (aborted || isAbortError(error)) {
-          aborted = true;
+        if (handle.isAborted() || isAbortError(error)) {
           return;
         }
         throw error;
       } finally {
-        abortSignal?.removeEventListener("abort", markAborted);
+        handle.cleanup();
       }
     },
   });

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -196,7 +196,19 @@ function streamDirectChatWithLiveTrace(options: {
 
   const stream = createUIMessageStream({
     onError: (error) => {
-      if (handle?.isAborted() || isAbortError(error)) {
+      // Cursor PR 4a review #1: the top-level `onError` can fire BEFORE
+      // `execute` runs (e.g., stream creation failure), or for an
+      // error that isn't `AbortError`. The pre-refactor code captured
+      // `aborted` from an abort-listener attached at function entry so
+      // either condition still suppressed formatting. Mirror that by
+      // reading `abortSignal?.aborted` directly here — `handle` may be
+      // undefined and `isAbortError` only matches the throw shape, not
+      // a generic provider error that arrived after the signal flipped.
+      if (
+        abortSignal?.aborted ||
+        handle?.isAborted() ||
+        isAbortError(error)
+      ) {
         return "";
       }
       logger.error("[mcp/chat-v2] stream error", error);

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1003,32 +1003,6 @@ function hasExplicitModelApiKeys(
   return Boolean(modelApiKeys && Object.keys(modelApiKeys).length > 0);
 }
 
-function readBackendUsage(usage: unknown): {
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-} {
-  const record =
-    usage && typeof usage === "object"
-      ? (usage as Record<string, unknown>)
-      : {};
-  const inputTokens =
-    typeof record.inputTokens === "number"
-      ? record.inputTokens
-      : typeof record.promptTokens === "number"
-        ? record.promptTokens
-        : 0;
-  const outputTokens =
-    typeof record.outputTokens === "number"
-      ? record.outputTokens
-      : typeof record.completionTokens === "number"
-        ? record.completionTokens
-        : 0;
-  const totalTokens =
-    typeof record.totalTokens === "number" ? record.totalTokens : 0;
-  return { inputTokens, outputTokens, totalTokens };
-}
-
 function resolveOrgTargetForEval(
   test: EvalTestCase,
   explicitTarget?: ResolveOrgModelConfigTarget,
@@ -1632,7 +1606,13 @@ const runIterationViaBackend = async ({
   mcpClientManager,
   recorder,
   testCaseId,
-  convexHttpUrl,
+  // `convexHttpUrl` is in the RunIterationBackendParams type because the
+  // streaming variant (`streamIterationViaBackend`) still uses it for
+  // its legacy per-step fetch loop (PR 5 collapses that). The non-stream
+  // path now drives `runAssistantTurn`, which reads
+  // `process.env.CONVEX_HTTP_URL` directly — so the runner-level param
+  // is dead here. Kept in the type signature (no API churn) but no
+  // longer destructured.
   convexAuthToken,
   modelId,
   modelDefinition,

--- a/mcpjam-inspector/server/utils/__tests__/direct-chat-turn.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/direct-chat-turn.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Contract tests for `runDirectChatTurn` (PR 4a of the engine
+ * consolidation in `~/mcpjam-docs/unification.md`).
+ *
+ * Purpose: lock the headless terminal shape that PR 4b will consume from
+ * eval's local-BYOK suite path. The closed PR #2458 attempted to inline
+ * `streamText` in eval and was rejected for creating a second hand-rolled
+ * driver; the rescope extracts `runDirectChatTurn` so chat + eval + the
+ * stream UI variants (PR 5) all converge on one configured pipeline.
+ *
+ * Scope:
+ *
+ *   - Headless mode resolves to `{messages, steps, totalUsage,
+ *     finishReason, spans, aborted}` without requiring a UI writer.
+ *   - `traceEvents` is fully optional — the SSE-writer concerns are
+ *     caller-side; eval omits them entirely.
+ *   - Progressive discovery still wires `prepareStep -> activeTools`
+ *     (the chat-side correctness invariant carries over).
+ *   - Abort flips `isAborted()` true so callers can drop the result
+ *     instead of persisting cancelled state.
+ *
+ * These tests are wire shape tests, not behavior tests — they assert
+ * that the helper's contract matches what PR 4b's eval call site needs.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const streamTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    streamText: (...args: unknown[]) => streamTextMock(...args),
+    stepCountIs: vi.fn(() => undefined),
+  };
+});
+
+import {
+  consumeDirectChatTurnHeadless,
+  runDirectChatTurn,
+} from "../direct-chat-turn";
+
+describe("runDirectChatTurn — eval headless contract (PR 4a)", () => {
+  beforeEach(() => {
+    streamTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function defaultStreamTextReturn(
+    overrides: Partial<{
+      messages: Array<{ role: string; content: unknown }>;
+      steps: unknown[];
+      totalUsage: {
+        inputTokens?: number;
+        outputTokens?: number;
+        totalTokens?: number;
+      };
+      finishReason: string;
+    }> = {},
+  ) {
+    return {
+      consumeStream: async () => {},
+      response: Promise.resolve({
+        modelId: "gpt-4-turbo",
+        messages: overrides.messages ?? [
+          { role: "assistant", content: "Hi" },
+        ],
+      }),
+      steps: Promise.resolve(overrides.steps ?? []),
+      totalUsage: Promise.resolve(
+        overrides.totalUsage ?? {
+          inputTokens: 1,
+          outputTokens: 2,
+          totalTokens: 3,
+        },
+      ),
+      finishReason: Promise.resolve(overrides.finishReason ?? "stop"),
+      toUIMessageStream: () => ({
+        [Symbol.asyncIterator]() {
+          return { next: async () => ({ value: undefined, done: true }) };
+        },
+      }),
+    };
+  }
+
+  it("returns a fully assembled result in headless mode (no UI writer)", async () => {
+    streamTextMock.mockReturnValueOnce(
+      defaultStreamTextReturn({
+        messages: [
+          { role: "assistant", content: "Done" },
+        ],
+        totalUsage: {
+          inputTokens: 5,
+          outputTokens: 7,
+          totalTokens: 12,
+        },
+      }),
+    );
+
+    const handle = runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "gpt-4-turbo",
+      messageHistory: [{ role: "user", content: "Hello" } as any],
+      systemPrompt: "system",
+      tools: {} as any,
+    });
+
+    const result = await consumeDirectChatTurnHeadless(handle);
+
+    expect(result.messages).toEqual([{ role: "assistant", content: "Done" }]);
+    expect(result.totalUsage.totalTokens).toBe(12);
+    expect(result.finishReason).toBe("stop");
+    expect(result.aborted).toBe(false);
+    expect(Array.isArray(result.spans)).toBe(true);
+  });
+
+  it("treats `traceEvents` as fully optional — no UI writer dependency", async () => {
+    // PR 4a invariant: eval (PR 4b) calls runDirectChatTurn without ANY
+    // `traceEvents`. If the helper internally required a writer or threw
+    // when callbacks were absent, eval couldn't drive it headless.
+    streamTextMock.mockReturnValueOnce(defaultStreamTextReturn());
+
+    const handle = runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "gpt-4-turbo",
+      messageHistory: [{ role: "user", content: "Hi" } as any],
+      systemPrompt: "s",
+      tools: {} as any,
+      // traceEvents intentionally omitted.
+    });
+
+    await expect(consumeDirectChatTurnHeadless(handle)).resolves.toBeDefined();
+  });
+
+  it("threads progressive-discovery `activeTools` through `prepareStep`", async () => {
+    // PR 4a invariant: the chat-side active-tool gating from PR 1
+    // carries over to the shared helper so eval (PR 4b) gets it for
+    // free. `prepareStep` must return `{activeTools: [...]}` when the
+    // plan is enabled and the discovery state is populated.
+    let prepareStepReturn: any;
+    streamTextMock.mockImplementationOnce((options: any) => {
+      prepareStepReturn = options.prepareStep({ stepNumber: 0 });
+      return defaultStreamTextReturn();
+    });
+
+    const handle = runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "gpt-4-turbo",
+      messageHistory: [{ role: "user", content: "Hi" } as any],
+      systemPrompt: "s",
+      tools: { search_tools: { description: "" } } as any,
+      progressivePlan: {
+        enabled: true,
+        reasons: [],
+        policy: {
+          thresholdPct: 0.03,
+          maxToolTokens: 10_000,
+          maxToolCount: 30,
+          searchLimit: 8,
+        },
+        catalog: [
+          {
+            toolId: "search_tools",
+            serverId: "meta",
+            displayName: "search_tools",
+            description: "",
+            tokenEstimate: 100,
+          },
+        ],
+        totalTokenEstimate: 100,
+      } as any,
+      discoveryState: {
+        loadedToolIds: new Set(["search_tools"]),
+        newlyLoadedToolIds: new Set<string>(),
+        pendingApprovalToolIds: new Set<string>(),
+        catalogVersion: 1,
+      } as any,
+    });
+
+    await consumeDirectChatTurnHeadless(handle);
+
+    // Proves the wire: when `progressivePlan.enabled` + `discoveryState`
+    // are present, `prepareStep` returns `{activeTools: [...]}` — not
+    // `{}`. The exact set depends on the discovery state (meta tools
+    // `search_mcp_tools` / `load_mcp_tools` are always loaded), which
+    // PR 1 already locks down on the eval side via prepareChatV2 tests.
+    expect(prepareStepReturn).toHaveProperty("activeTools");
+    expect(Array.isArray(prepareStepReturn.activeTools)).toBe(true);
+  });
+
+  it("flips `isAborted` true when the abort signal fires", async () => {
+    // PR 4a invariant (mirrors PR 3 "Abort no longer skips persistence"):
+    // `streamText` can swallow AbortError silently. The helper exposes
+    // `isAborted()` so callers (eval PR 4b, chat) can drop the result
+    // cleanly instead of persisting a partial/cancelled turn.
+    const controller = new AbortController();
+    streamTextMock.mockImplementationOnce(() => {
+      controller.abort();
+      return defaultStreamTextReturn();
+    });
+
+    const handle = runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "gpt-4-turbo",
+      messageHistory: [{ role: "user", content: "Hi" } as any],
+      systemPrompt: "s",
+      tools: {} as any,
+      abortSignal: controller.signal,
+    });
+
+    const result = await consumeDirectChatTurnHeadless(handle);
+
+    expect(result.aborted).toBe(true);
+  });
+
+  it("forwards temperature when set; omits when undefined", async () => {
+    // PR 4a invariant (carry-over from chat): `temperature` is only
+    // included in the streamText options when defined. Eval depends on
+    // this — its `prepareChatV2` returns `resolvedTemperature: undefined`
+    // when the test case doesn't override, and the SDK default must apply.
+    streamTextMock.mockReturnValueOnce(defaultStreamTextReturn());
+    runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "gpt-4-turbo",
+      messageHistory: [{ role: "user", content: "Hi" } as any],
+      systemPrompt: "s",
+      tools: {} as any,
+      // temperature undefined
+    });
+    expect(streamTextMock.mock.calls[0]?.[0]).not.toHaveProperty(
+      "temperature",
+    );
+
+    streamTextMock.mockReturnValueOnce(defaultStreamTextReturn());
+    runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "gpt-4-turbo",
+      messageHistory: [{ role: "user", content: "Hi" } as any],
+      systemPrompt: "s",
+      tools: {} as any,
+      temperature: 0.42,
+    });
+    expect(streamTextMock.mock.calls[1]?.[0]).toMatchObject({
+      temperature: 0.42,
+    });
+  });
+
+  it("does not mutate the caller's messageHistory array", async () => {
+    // PR 4a invariant (carry-over): `streamText` holds a reference to
+    // `messages` and accumulates step responses internally. If the
+    // helper mutated the caller's array, the next API call would re-send
+    // duplicated items (OpenAI Responses API rejects duplicate ids).
+    // The helper uses an internal `traceHistory` copy for trace work.
+    streamTextMock.mockReturnValueOnce(
+      defaultStreamTextReturn({
+        messages: [{ role: "assistant", content: "Reply" }],
+      }),
+    );
+    const messageHistory = [
+      { role: "user", content: "Hello" } as any,
+    ];
+    const snapshotLen = messageHistory.length;
+
+    const handle = runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "gpt-4-turbo",
+      messageHistory,
+      systemPrompt: "s",
+      tools: {} as any,
+    });
+    await consumeDirectChatTurnHeadless(handle);
+
+    expect(messageHistory.length).toBe(snapshotLen);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/direct-chat-turn.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/direct-chat-turn.test.ts
@@ -248,6 +248,38 @@ describe("runDirectChatTurn — eval headless contract (PR 4a)", () => {
     });
   });
 
+  it("removes the abort listener on synchronous streamText throw (PR 4a review)", async () => {
+    // Cursor PR 4a review #2 / CodeRabbit "outside-diff": the pre-refactor
+    // inline code at chat-v2's call site try/caught the synchronous
+    // `streamText` call and removed the abort listener. The helper owns
+    // the listener now, so it must own that cleanup — otherwise a sync
+    // throw leaks the listener and the SSE caller has no handle to
+    // call `cleanup()` against.
+    streamTextMock.mockImplementationOnce(() => {
+      throw new Error("synthetic sync provider error");
+    });
+
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+    expect(() =>
+      runDirectChatTurn({
+        llmModel: { id: "mock" } as any,
+        modelId: "gpt-4-turbo",
+        messageHistory: [{ role: "user", content: "Hi" } as any],
+        systemPrompt: "s",
+        tools: {} as any,
+        abortSignal: controller.signal,
+      }),
+    ).toThrow(/synthetic sync provider error/);
+
+    // The listener that was attached during construction must be removed
+    // on throw — same number of adds and removes.
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("does not mutate the caller's messageHistory array", async () => {
     // PR 4a invariant (carry-over): `streamText` holds a reference to
     // `messages` and accumulates step responses internally. If the

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -326,7 +326,16 @@ export function runDirectChatTurn(
     () => discoveryState,
   ) as ToolSet;
 
-  const result = streamText({
+  // Cursor PR 4a review #2 / CodeRabbit "outside-diff": the original
+  // inline code at the chat-v2.ts call site caught synchronous
+  // `streamText` failures and removed the abort listener. The helper
+  // owns the listener now, so it must own that cleanup too — otherwise
+  // a sync throw (provider config error, ToolSet shape validation, …)
+  // leaks the listener and the SSE caller has no handle to call
+  // `cleanup()` against.
+  let result: ReturnType<typeof streamText>;
+  try {
+    result = streamText({
     model: llmModel,
     messages: messageHistory,
     ...(temperature !== undefined ? { temperature } : {}),
@@ -516,6 +525,10 @@ export function runDirectChatTurn(
       }
     },
   });
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
 
   return {
     result,

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -1,0 +1,569 @@
+import { streamText, stepCountIs, type ToolSet } from "ai";
+import type { ModelMessage } from "@ai-sdk/provider-utils";
+import type { createLlmModel } from "./chat-helpers";
+import { appendDedupedModelMessages } from "@/shared/eval-trace";
+import {
+  createAiSdkEvalTraceContext,
+  emitAiSdkOnStepFinish,
+  finalizeAiSdkTraceOnFailure,
+  patchAiSdkRecordedSpansMessageRangesFromSteps,
+  registerAiSdkPrepareStep,
+  wrapToolSetForEvalTrace,
+} from "../services/evals/eval-trace-capture";
+import {
+  generateLiveTraceTurnId,
+  getPromptIndex,
+  getPromptMessageStartIndex,
+  readToolServerId,
+  setToolSpanMessageRangesFromResults,
+  toTraceRecord,
+} from "./live-chat-trace-stream";
+import { normalizeSystemPromptForProvider } from "./model-request-payload";
+import {
+  mergeLiveChatTraceUsage,
+  type LiveChatTraceUsage,
+} from "@/shared/live-chat-trace";
+import { isAbortError } from "@/shared/abort-errors";
+import {
+  commitNewlyLoaded,
+  gateToolsToActiveSubset,
+  resolveActiveToolNames,
+  type ProgressiveToolPlan,
+  type ToolDiscoveryState,
+} from "@/shared/progressive-tool-discovery";
+import type { PersistedTurnTrace } from "./chat-ingestion";
+
+/**
+ * The chat-v2 user-API-key path (`streamDirectChatWithLiveTrace`) used to
+ * own the `streamText` driver inline. PR 4a (engine consolidation,
+ * `~/mcpjam-docs/unification.md`) extracts the driver into this helper so
+ * eval's local-BYOK suite path (PR 4b) and the stream UI variants (PR 5)
+ * can share ONE configured pipeline instead of three drifting copies.
+ *
+ * Two terminals are first-class from day 1:
+ *
+ *   1. SSE (chat) — caller passes `traceEvents` callbacks that write to
+ *      a `createUIMessageStream` writer, then drives the assembled
+ *      `result.toUIMessageStream(...)` into the writer.
+ *   2. Headless (eval, PR 4b) — caller omits `traceEvents` and calls
+ *      `consumeDirectChatTurnHeadless(handle)` to drive
+ *      `result.consumeStream()` + read the terminal promises.
+ *
+ * Trace span recording, abort signal management, progressive-discovery
+ * gating, and `prepareStep`/`onStepFinish`/`onError`/`onFinish` shape
+ * stay identical to chat's existing wire — this is a refactor, not a
+ * behavior change.
+ */
+
+export interface DirectChatTurnTraceTurn {
+  turnId: string;
+  promptIndex: number;
+  promptMessageStartIndex: number;
+  turnStartedAt: number;
+  turnSpans: Awaited<
+    ReturnType<typeof createAiSdkEvalTraceContext>
+  >["recordedSpans"];
+  turnUsage: LiveChatTraceUsage | undefined;
+}
+
+export interface DirectChatTurnRequestPayloadInfo {
+  turnId: string;
+  promptIndex: number;
+  stepIndex: number;
+  systemPrompt: string;
+  messages: ModelMessage[];
+  tools: ToolSet;
+}
+
+export interface DirectChatTurnTextDelta {
+  turnId: string;
+  promptIndex: number;
+  stepIndex: number;
+  delta: string;
+}
+
+export interface DirectChatTurnToolCallChunk {
+  turnId: string;
+  promptIndex: number;
+  stepIndex: number;
+  toolCallId: string;
+  toolName: string;
+  /** Already-normalized via `toTraceRecord` — safe to forward to wire events. */
+  input: Record<string, unknown>;
+  serverId: string | undefined;
+}
+
+export interface DirectChatTurnToolResultChunk {
+  turnId: string;
+  promptIndex: number;
+  stepIndex: number;
+  toolCallId: string;
+  toolName: string;
+  output: unknown;
+  serverId: string | undefined;
+}
+
+export interface DirectChatTurnStepSnapshot {
+  turnId: string;
+  traceHistory: ModelMessage[];
+  tracedTools: ToolSet;
+  traceTurn: DirectChatTurnTraceTurn;
+}
+
+export interface DirectChatTurnError {
+  turnId: string;
+  promptIndex: number;
+  stepIndex: number;
+  errorText: string;
+  traceTurn: DirectChatTurnTraceTurn;
+  tracedTools: ToolSet;
+  traceHistory: ModelMessage[];
+}
+
+export interface DirectChatTurnFinish {
+  turnId: string;
+  promptIndex: number;
+  stepIndex: number;
+  finishReason?: string;
+  usage?: LiveChatTraceUsage;
+  traceTurn: DirectChatTurnTraceTurn;
+}
+
+export interface DirectChatTurnStart {
+  turnId: string;
+  promptIndex: number;
+  startedAtMs: number;
+}
+
+export interface DirectChatTurnPersistEvent {
+  responseMessages: ModelMessage[];
+  assistantText: string;
+  toolCalls: unknown[];
+  toolResults: unknown[];
+  usage?: LiveChatTraceUsage;
+  finishReason?: string;
+  turnTrace: PersistedTurnTrace;
+}
+
+export interface DirectChatTurnTraceEvents {
+  /** Fired once at the start of the turn. Chat writes a `turn_start` SSE event. */
+  onTurnStart?: (event: DirectChatTurnStart) => void;
+  /** Fired once with the resolved request payload (system prompt, messages, tools). */
+  onRequestPayload?: (event: DirectChatTurnRequestPayloadInfo) => void;
+  /** Fired for every text-delta chunk. */
+  onTextDelta?: (event: DirectChatTurnTextDelta) => void;
+  /** Fired for every tool-call chunk. */
+  onToolCallChunk?: (event: DirectChatTurnToolCallChunk) => void;
+  /** Fired for every tool-result chunk. */
+  onToolResultChunk?: (event: DirectChatTurnToolResultChunk) => void;
+  /**
+   * Fired after each step finishes — after spans have been emitted into
+   * `traceContext` and `traceHistory` has been updated. Chat uses this to
+   * emit a `trace_snapshot` over SSE.
+   */
+  onStepSnapshot?: (event: DirectChatTurnStepSnapshot) => void;
+  /**
+   * Fired when the engine emits an error mid-turn (excludes abort). Chat
+   * uses this to emit `error` + `turn_finish` SSE events.
+   */
+  onTurnError?: (event: DirectChatTurnError) => void;
+  /**
+   * Fired when the turn completes successfully. Chat uses this to emit a
+   * final `turn_finish` SSE event.
+   */
+  onTurnFinish?: (event: DirectChatTurnFinish) => void;
+}
+
+export interface RunDirectChatTurnOptions {
+  llmModel: ReturnType<typeof createLlmModel>;
+  modelId: string;
+  messageHistory: ModelMessage[];
+  systemPrompt: string;
+  temperature?: number;
+  tools: ToolSet;
+  progressivePlan?: ProgressiveToolPlan;
+  discoveryState?: ToolDiscoveryState;
+  abortSignal?: AbortSignal;
+  /** Optional bag of trace-event callbacks. Chat passes these; eval/headless omits. */
+  traceEvents?: DirectChatTurnTraceEvents;
+  /**
+   * Optional post-turn persistence callback. Fires from `onFinish` after the
+   * response messages are assembled. Chat passes this to write a
+   * `chatSessions` row; eval has its own writer and omits.
+   */
+  onPersist?: (event: DirectChatTurnPersistEvent) => Promise<void> | void;
+  /**
+   * Optional warning sink, called from the catch-block inside `onPersist`
+   * dispatch. Defaults to no-op. Chat passes a logger.warn.
+   */
+  onPersistError?: (error: unknown) => void;
+}
+
+export interface RunDirectChatTurnHandle {
+  result: ReturnType<typeof streamText>;
+  traceContext: ReturnType<typeof createAiSdkEvalTraceContext>;
+  traceTurn: DirectChatTurnTraceTurn;
+  /** Removes the abort listener (idempotent). Call from a finally block. */
+  cleanup: () => void;
+  /** True once the abort signal has fired (mirrors chat's local flag). */
+  isAborted: () => boolean;
+}
+
+function toLiveChatTraceUsage(
+  usage:
+    | {
+        inputTokens?: number;
+        outputTokens?: number;
+        totalTokens?: number;
+      }
+    | null
+    | undefined,
+): LiveChatTraceUsage | undefined {
+  if (!usage) return undefined;
+  const next: LiveChatTraceUsage = {};
+  if (typeof usage.inputTokens === "number") next.inputTokens = usage.inputTokens;
+  if (typeof usage.outputTokens === "number")
+    next.outputTokens = usage.outputTokens;
+  if (typeof usage.totalTokens === "number") next.totalTokens = usage.totalTokens;
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+function collectStepToolCallIds(
+  toolCalls: Array<{ toolCallId?: string } | undefined> | null | undefined,
+): Set<string> {
+  const ids = new Set<string>();
+  if (!Array.isArray(toolCalls)) return ids;
+  for (const call of toolCalls) {
+    if (typeof call?.toolCallId === "string" && call.toolCallId.length > 0) {
+      ids.add(call.toolCallId);
+    }
+  }
+  return ids;
+}
+
+export function runDirectChatTurn(
+  options: RunDirectChatTurnOptions,
+): RunDirectChatTurnHandle {
+  const {
+    llmModel,
+    modelId,
+    messageHistory,
+    systemPrompt,
+    temperature,
+    tools,
+    progressivePlan,
+    discoveryState,
+    abortSignal,
+    traceEvents,
+    onPersist,
+    onPersistError,
+  } = options;
+
+  // Separate array for tracing — we must NOT mutate `messageHistory` because
+  // `streamText` holds a reference and internally accumulates step responses.
+  // Mutating it would cause duplicate items on the next API call (OpenAI
+  // Responses API rejects duplicates by id).
+  const traceHistory = [...messageHistory];
+  const initialMessageHistoryLength = messageHistory.length;
+  const traceTurn: DirectChatTurnTraceTurn = {
+    turnId: generateLiveTraceTurnId(),
+    promptIndex: getPromptIndex(messageHistory),
+    promptMessageStartIndex: getPromptMessageStartIndex(messageHistory),
+    turnStartedAt: Date.now(),
+    turnSpans: [],
+    turnUsage: undefined,
+  };
+  const traceContext = createAiSdkEvalTraceContext(traceTurn.turnStartedAt);
+  const providerSystemPrompt = normalizeSystemPromptForProvider(systemPrompt);
+  let currentStepIndex = 0;
+  let turnFinished = false;
+  let aborted = abortSignal?.aborted === true;
+  let listenerAttached = false;
+  const markAborted = () => {
+    aborted = true;
+  };
+  if (abortSignal) {
+    abortSignal.addEventListener("abort", markAborted, { once: true });
+    listenerAttached = true;
+  }
+  const cleanup = () => {
+    if (listenerAttached && abortSignal) {
+      abortSignal.removeEventListener("abort", markAborted);
+      listenerAttached = false;
+    }
+  };
+
+  traceEvents?.onTurnStart?.({
+    turnId: traceTurn.turnId,
+    promptIndex: traceTurn.promptIndex,
+    startedAtMs: traceTurn.turnStartedAt,
+  });
+
+  const tracedTools = wrapToolSetForEvalTrace(
+    tools as Record<string, unknown>,
+    traceContext,
+    traceTurn.promptIndex,
+  ) as ToolSet;
+
+  traceEvents?.onRequestPayload?.({
+    turnId: traceTurn.turnId,
+    promptIndex: traceTurn.promptIndex,
+    stepIndex: 0,
+    systemPrompt,
+    messages: messageHistory,
+    tools,
+  });
+
+  // Progressive mode: gate execution to the active subset. `activeTools`
+  // (set in `prepareStep` below) narrows what the model sees, but a
+  // hallucinated/remembered call to a non-active tool would still execute
+  // against the full map. Gating wraps each tool's `execute` to throw a
+  // structured "not loaded" error, which the AI SDK surfaces as an error
+  // tool-result the model can recover from via `load_mcp_tools`.
+  const executableTools = gateToolsToActiveSubset(
+    tracedTools as Record<string, unknown>,
+    progressivePlan,
+    () => discoveryState,
+  ) as ToolSet;
+
+  const result = streamText({
+    model: llmModel,
+    messages: messageHistory,
+    ...(temperature !== undefined ? { temperature } : {}),
+    system: providerSystemPrompt,
+    tools: executableTools,
+    stopWhen: stepCountIs(20),
+    ...(abortSignal ? { abortSignal } : {}),
+    prepareStep: ({ stepNumber }) => {
+      currentStepIndex = stepNumber;
+      registerAiSdkPrepareStep(traceContext, stepNumber, {
+        modelId,
+        promptIndex: traceTurn.promptIndex,
+      });
+      if (progressivePlan?.enabled && discoveryState) {
+        commitNewlyLoaded(discoveryState);
+        const active = resolveActiveToolNames(progressivePlan, discoveryState);
+        return { activeTools: active };
+      }
+      return {};
+    },
+    onChunk: async ({ chunk }) => {
+      if (chunk.type === "text-delta") {
+        traceEvents?.onTextDelta?.({
+          turnId: traceTurn.turnId,
+          promptIndex: traceTurn.promptIndex,
+          stepIndex: currentStepIndex,
+          delta: chunk.text,
+        });
+        return;
+      }
+      if (chunk.type === "tool-call") {
+        traceEvents?.onToolCallChunk?.({
+          turnId: traceTurn.turnId,
+          promptIndex: traceTurn.promptIndex,
+          stepIndex: currentStepIndex,
+          toolCallId: chunk.toolCallId,
+          toolName: chunk.toolName,
+          input: toTraceRecord(chunk.input),
+          serverId: readToolServerId(tracedTools, chunk.toolName),
+        });
+        return;
+      }
+      if (chunk.type === "tool-result") {
+        traceEvents?.onToolResultChunk?.({
+          turnId: traceTurn.turnId,
+          promptIndex: traceTurn.promptIndex,
+          stepIndex: currentStepIndex,
+          toolCallId: chunk.toolCallId,
+          toolName: chunk.toolName,
+          output: chunk.output,
+          serverId: readToolServerId(tracedTools, chunk.toolName),
+        });
+      }
+    },
+    onStepFinish: async (step) => {
+      const responseMessages = Array.isArray(step?.response?.messages)
+        ? (step.response.messages as ModelMessage[])
+        : [];
+      const beforeLength = traceHistory.length;
+      appendDedupedModelMessages(traceHistory, responseMessages);
+      const afterLength = traceHistory.length;
+      const messageStartIndex =
+        afterLength > beforeLength ? beforeLength : undefined;
+      const messageEndIndex =
+        afterLength > beforeLength ? afterLength - 1 : undefined;
+      const stepUsage = toLiveChatTraceUsage(step.usage);
+
+      traceTurn.turnUsage = mergeLiveChatTraceUsage(
+        traceTurn.turnUsage,
+        stepUsage,
+      );
+
+      emitAiSdkOnStepFinish(traceContext, Date.now(), {
+        modelId,
+        inputTokens: stepUsage?.inputTokens,
+        outputTokens: stepUsage?.outputTokens,
+        totalTokens: stepUsage?.totalTokens,
+        messageStartIndex,
+        messageEndIndex,
+      });
+
+      setToolSpanMessageRangesFromResults(
+        traceContext.recordedSpans,
+        traceHistory,
+        traceTurn.promptIndex,
+        currentStepIndex,
+        collectStepToolCallIds(step.toolCalls),
+      );
+
+      traceTurn.turnSpans = [...traceContext.recordedSpans];
+      traceEvents?.onStepSnapshot?.({
+        turnId: traceTurn.turnId,
+        traceHistory,
+        tracedTools,
+        traceTurn,
+      });
+    },
+    onError: async ({ error }) => {
+      if (turnFinished) return;
+      if (aborted || isAbortError(error)) {
+        aborted = true;
+        turnFinished = true;
+        return;
+      }
+
+      const failAt = Date.now();
+      finalizeAiSdkTraceOnFailure(traceContext, failAt, {
+        completedStepCount: currentStepIndex,
+        lastStepEndedAt: traceContext.lastStepClosedEndAt,
+        modelId,
+        promptIndex: traceTurn.promptIndex,
+      });
+      traceTurn.turnSpans = [...traceContext.recordedSpans];
+      const errorText = error instanceof Error ? error.message : String(error);
+
+      traceEvents?.onTurnError?.({
+        turnId: traceTurn.turnId,
+        promptIndex: traceTurn.promptIndex,
+        stepIndex: currentStepIndex,
+        errorText,
+        traceTurn,
+        tracedTools,
+        traceHistory,
+      });
+      turnFinished = true;
+    },
+    onFinish: async (event) => {
+      if (aborted || abortSignal?.aborted) {
+        aborted = true;
+        turnFinished = true;
+        return;
+      }
+
+      patchAiSdkRecordedSpansMessageRangesFromSteps(
+        traceContext.recordedSpans,
+        initialMessageHistoryLength,
+        event.steps,
+        traceTurn.promptIndex,
+      );
+      traceTurn.turnSpans = [...traceContext.recordedSpans];
+      traceTurn.turnUsage =
+        toLiveChatTraceUsage(event.totalUsage) ?? traceTurn.turnUsage;
+
+      if (!turnFinished) {
+        traceEvents?.onTurnFinish?.({
+          turnId: traceTurn.turnId,
+          promptIndex: traceTurn.promptIndex,
+          stepIndex: currentStepIndex,
+          finishReason: event.finishReason,
+          usage: traceTurn.turnUsage,
+          traceTurn,
+        });
+        turnFinished = true;
+      }
+
+      if (!onPersist) return;
+      const responseMessages: ModelMessage[] = [];
+      for (const step of event.steps) {
+        appendDedupedModelMessages(
+          responseMessages,
+          Array.isArray(step?.response?.messages)
+            ? (step.response.messages as ModelMessage[])
+            : [],
+        );
+      }
+      try {
+        await onPersist({
+          responseMessages,
+          assistantText: event.text,
+          toolCalls: event.steps.flatMap((step) => step.toolCalls ?? []),
+          toolResults: event.steps.flatMap((step) => step.toolResults ?? []),
+          usage: traceTurn.turnUsage,
+          finishReason: event.finishReason,
+          turnTrace: {
+            turnId: traceTurn.turnId,
+            promptIndex: traceTurn.promptIndex,
+            startedAt: traceTurn.turnStartedAt,
+            endedAt: Date.now(),
+            spans: [...traceTurn.turnSpans],
+            usage: traceTurn.turnUsage,
+            finishReason: event.finishReason,
+            modelId,
+          },
+        });
+      } catch (error) {
+        onPersistError?.(error);
+      }
+    },
+  });
+
+  return {
+    result,
+    traceContext,
+    traceTurn,
+    cleanup,
+    isAborted: () => aborted || abortSignal?.aborted === true,
+  };
+}
+
+export interface DirectChatTurnHeadlessResult {
+  messages: ModelMessage[];
+  steps: Awaited<ReturnType<typeof streamText>["steps"]>;
+  totalUsage: Awaited<ReturnType<typeof streamText>["totalUsage"]>;
+  finishReason: Awaited<ReturnType<typeof streamText>["finishReason"]>;
+  spans: Awaited<
+    ReturnType<typeof createAiSdkEvalTraceContext>
+  >["recordedSpans"];
+  /** True if the abort signal fired mid-turn. The caller should drop the result on true. */
+  aborted: boolean;
+}
+
+/**
+ * Drives a `runDirectChatTurn` handle to completion in headless mode (no SSE).
+ * Used by eval's local-BYOK path (PR 4b) and the contract test. Cleans up the
+ * abort listener even on error.
+ */
+export async function consumeDirectChatTurnHeadless(
+  handle: RunDirectChatTurnHandle,
+): Promise<DirectChatTurnHeadlessResult> {
+  try {
+    await handle.result.consumeStream();
+    const response = await handle.result.response;
+    const steps = await handle.result.steps;
+    const totalUsage = await handle.result.totalUsage;
+    const finishReason = await handle.result.finishReason;
+    const messages = Array.isArray(response?.messages)
+      ? (response.messages as ModelMessage[])
+      : [];
+    return {
+      messages,
+      steps,
+      totalUsage,
+      finishReason,
+      spans: handle.traceContext.recordedSpans,
+      aborted: handle.isAborted(),
+    };
+  } finally {
+    handle.cleanup();
+  }
+}


### PR DESCRIPTION
## Summary

Pure refactor — pulls the `streamText` driver block out of `streamDirectChatWithLiveTrace` in `routes/mcp/chat-v2.ts` into a shared `runDirectChatTurn` helper. Chat's behavior is unchanged; the helper is the foundation for PR 4b (eval local-BYOK wires onto it) and PR 5 (UI stream variants).

**Rescope context.** The first attempt at PR 4 (#2458) swapped eval onto `streamText` inline, creating a second hand-rolled driver. Team review flagged that as defeating the one-shared-engine goal in `~/mcpjam-docs/unification.md`. PR 4 is now split: 4a extracts; 4b wires eval; PR 5 wires stream variants. All converge on one configured pipeline instead of three drifting copies.

## What this PR closes

- Single source of truth for the `streamText` config used by chat path 4 (user API key), eval local-BYOK (after 4b), and UI stream variants (after PR 5).
- All four PR 3 correctness invariants are now structural to the helper, not duplicated per call site:
  - `temperature` / system prompt assembly / progressive-discovery `prepareStep -> activeTools`.
  - Abort signal listener with idempotent cleanup; `isAborted()` accessor for callers that need to drop cancelled state without persisting.
  - `onStepFinish` trace span emission via `createAiSdkEvalTraceContext` + `wrapToolSetForEvalTrace`.
  - `onError` / `onFinish` shape with optional `onPersist` callback for post-turn ingestion.
- Two terminals first-class from day 1:
  - **SSE** (chat): `traceEvents` callbacks fire writer events; caller drives `result.toUIMessageStream(...)` into the `createUIMessageStream` writer.
  - **Headless** (eval, PR 4b): caller omits `traceEvents` and calls `consumeDirectChatTurnHeadless(handle)` for `{messages, steps, totalUsage, finishReason, spans, aborted}`.
- Folded in PR 3's cleanup nit: dead `readBackendUsage` removed; unused `convexHttpUrl` destructure removed from `runIterationViaBackend` (kept in the type for the streaming variant).

## What this PR explicitly does NOT close

- Eval still calls `generateText` in `runIterationWithAiSdk`. That's PR 4b — a thin wire-up onto `runDirectChatTurn` now that the helper exists.
- Stream variants (`streamIterationWithAiSdk` / `streamIterationViaBackend`) still drive their own loops. PR 5.
- `persistEvalTraceFanout` ownership unchanged. PR 7.

## Test plan

- [x] New `server/utils/__tests__/direct-chat-turn.test.ts` (6 tests) locks the headless terminal contract: assembled result shape, optional `traceEvents`, progressive-discovery `prepareStep` wire, abort surfacing, temperature passthrough, messageHistory non-mutation.
- [x] Broader sweep (`server/utils`, `server/services/evals`, `server/services/sessionSimulation`, `server/routes/mcp`): 634/634 pass.
- [x] Typecheck baseline-clean (same 4 pre-existing recorder shape errors as PR 3; no new errors in `chat-v2.ts`, `direct-chat-turn.ts`, or `evals-runner.ts`).
- [ ] Smoke (post-merge): chat path 4 user-API-key session with a tool call — confirm SSE events unchanged (text_delta, tool_call, tool_result, trace_snapshot, turn_finish), `chatSessions` row persists with `sourceType: "direct"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the user-API-key chat streaming core; behavior is intended to be identical but regressions would affect SSE traces, abort handling, tool gating, and session persistence.
> 
> **Overview**
> Extracts the inline **`streamText`** driver from **`streamDirectChatWithLiveTrace`** in **`chat-v2.ts`** into a new shared helper **`runDirectChatTurn`** (`server/utils/direct-chat-turn.ts`), so chat SSE, future eval local-BYOK (PR 4b), and stream UI variants (PR 5) can share one configured pipeline.
> 
> **`chat-v2.ts`** now only wires SSE: it calls **`runDirectChatTurn`**, maps optional **`traceEvents`** to live trace writer events, streams via **`handle.result.toUIMessageStream`**, and uses **`handle.cleanup()`** / **`handle.isAborted()`** (including top-level stream **`onError`** reading **`abortSignal?.aborted`** when the handle is not yet set). Trace, progressive tool gating, eval span capture, and **`onPersist`** behavior move into the helper unchanged in intent.
> 
> Adds **`consumeDirectChatTurnHeadless`** for non-SSE callers and **`direct-chat-turn.test.ts`** contract tests (headless shape, optional trace callbacks, progressive **`prepareStep`**, abort, temperature, no **`messageHistory`** mutation, sync **`streamText`** throw cleanup).
> 
> **`evals-runner.ts`**: removes unused **`readBackendUsage`**; stops destructuring dead **`convexHttpUrl`** on the non-stream backend path (comment only; type unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50caf9360189cef9da56f25c68507f1f5e88d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->