### PR TITLE
chat-v2: share hostConfig resolution via resolveExecutionContext (engine consolidation PR 4c)

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -68,6 +68,7 @@ import {
   runDirectChatTurn,
   type RunDirectChatTurnHandle,
 } from "../../utils/direct-chat-turn";
+import { resolveExecutionContext } from "../../utils/host-execution-context";
 
 function formatStreamError(error: unknown, provider?: ModelProvider): string {
   if (!(error instanceof Error)) {
@@ -390,17 +391,19 @@ chatV2.post("/", async (c) => {
     // temperature / requireToolApproval). Mirrors the web/chat-v2 path.
     // Soft-fall-through on Convex blip — chat keeps running with body
     // values, matching pre-rollout behavior.
-    let resolvedSystemPrompt = bodySystemPrompt;
-    let resolvedTemperatureOverride = bodyTemperature;
-    let resolvedRequireToolApproval = bodyRequireToolApproval;
-    let resolvedRespectToolVisibility = bodyRespectToolVisibility;
+    //
+    // PR 4c of the engine consolidation (`~/mcpjam-docs/unification.md`):
+    // the field-by-field merge between body and `fetchChatboxRuntimeConfig`
+    // was duplicated across `mcp/chat-v2.ts` and `web/chat-v2.ts` and
+    // drifted from eval's separate hostConfig resolver. Routed through the
+    // shared `resolveExecutionContext` so a single helper owns the merge,
+    // the precedence (`host-wins` for chatbox security model — body
+    // values are warned-and-overwritten), and the drift surfacing. Pure
+    // refactor: resolved values for the existing fields are byte-identical
+    // to the inline code below by construction (snapshot tests in
+    // `host-execution-context.test.ts` lock the contract).
     let resolvedModelOverride: typeof model | null = null;
-    // See web/chat-v2 for rationale: body is authoritative for direct
-    // chat (sourced from the project default), host overrides for
-    // chatbox-bound sessions to keep guest / share-link clients from
-    // flipping the host-level setting.
-    let resolvedProgressiveToolDiscovery: boolean | undefined =
-      body.progressiveToolDiscovery;
+    let hostRuntimeConfig: Record<string, unknown> | null = null;
     if (isChatboxSession && bodyChatboxId) {
       const bearer = c.req.header("authorization") ?? "";
       if (bearer) {
@@ -409,88 +412,13 @@ chatV2.post("/", async (c) => {
           bearer,
         });
         if (runtime.ok) {
-          const cfg = runtime.config;
-          if (
-            bodyRequireToolApproval !== undefined &&
-            cfg.requireToolApproval !== bodyRequireToolApproval
-          ) {
-            logger.warn(
-              "[mcp/chat-v2] client requireToolApproval differs from host; using host value",
-              {
-                chatboxId: bodyChatboxId,
-                body: bodyRequireToolApproval,
-                host: cfg.requireToolApproval,
-              }
-            );
-          }
-          resolvedSystemPrompt = cfg.systemPrompt;
-          resolvedTemperatureOverride = cfg.temperature;
-          resolvedRequireToolApproval = cfg.requireToolApproval;
-          // Host wins on chatbox-bound turns — but only when the
-          // runtime config actually carries the field. Older backends
-          // omit it; without this gate the override would replace the
-          // body's value (sourced from the chatbox doc client-side)
-          // with `undefined` and the orchestrator's auto policy would
-          // re-enable progressive mode on large catalogs.
-          if (cfg.progressiveToolDiscovery !== undefined) {
-            if (
-              body.progressiveToolDiscovery !== undefined &&
-              cfg.progressiveToolDiscovery !== body.progressiveToolDiscovery
-            ) {
-              logger.warn(
-                "[mcp/chat-v2] client progressiveToolDiscovery differs from host; using host value",
-                {
-                  chatboxId: bodyChatboxId,
-                  body: body.progressiveToolDiscovery,
-                  host: cfg.progressiveToolDiscovery,
-                }
-              );
-            }
-            resolvedProgressiveToolDiscovery = cfg.progressiveToolDiscovery;
-          }
-          if (cfg.respectToolVisibility !== undefined) {
-            if (
-              bodyRespectToolVisibility !== undefined &&
-              cfg.respectToolVisibility !== bodyRespectToolVisibility
-            ) {
-              logger.warn(
-                "[mcp/chat-v2] client respectToolVisibility differs from host; using host value",
-                {
-                  chatboxId: bodyChatboxId,
-                  body: bodyRespectToolVisibility,
-                  host: cfg.respectToolVisibility,
-                }
-              );
-            }
-            resolvedRespectToolVisibility = cfg.respectToolVisibility;
-          }
-          // See web/chat-v2 for rationale: host's modelId wins on
-          // chatbox-bound turns. Built-in catalog hit → full
-          // ModelDefinition; miss → swap id only, keep body provider.
-          if (model && cfg.modelId && cfg.modelId !== model.id) {
-            const hostModel = getModelById(cfg.modelId);
-            if (hostModel) {
-              logger.warn(
-                "[mcp/chat-v2] client model differs from host; using host model",
-                {
-                  chatboxId: bodyChatboxId,
-                  body: model.id,
-                  host: cfg.modelId,
-                }
-              );
-              resolvedModelOverride = hostModel;
-            } else {
-              logger.warn(
-                "[mcp/chat-v2] host model not in catalog; swapping id only",
-                {
-                  chatboxId: bodyChatboxId,
-                  body: model.id,
-                  host: cfg.modelId,
-                }
-              );
-              resolvedModelOverride = { ...model, id: cfg.modelId };
-            }
-          }
+          // Cast the typed `ChatboxRuntimeConfig` to a plain record so
+          // `resolveExecutionContext` can read it — the type narrowing
+          // re-enters via the resolver's per-field typeof checks.
+          hostRuntimeConfig = runtime.config as unknown as Record<
+            string,
+            unknown
+          >;
         } else {
           logger.warn(
             "[mcp/chat-v2] runtime-config fetch failed; using body values",
@@ -503,10 +431,91 @@ chatV2.post("/", async (c) => {
         }
       }
     }
-    const systemPrompt = resolvedSystemPrompt;
-    const temperature = resolvedTemperatureOverride;
-    const requireToolApproval = resolvedRequireToolApproval;
-    const respectToolVisibility = resolvedRespectToolVisibility;
+    const resolvedExecution = resolveExecutionContext({
+      hostConfig: hostRuntimeConfig,
+      overrides: {
+        systemPrompt: bodySystemPrompt,
+        temperature: bodyTemperature,
+        requireToolApproval: bodyRequireToolApproval,
+        respectToolVisibility: bodyRespectToolVisibility,
+        progressiveToolDiscovery: body.progressiveToolDiscovery,
+      },
+      precedence: "host-wins",
+    });
+    // Preserve the per-field warnings the inline code emitted — the
+    // resolver returns drift as data so the call site can keep its
+    // existing log shape unchanged.
+    for (const entry of resolvedExecution.drift) {
+      if (entry.field === "requireToolApproval") {
+        logger.warn(
+          "[mcp/chat-v2] client requireToolApproval differs from host; using host value",
+          {
+            chatboxId: bodyChatboxId,
+            body: entry.overrideValue,
+            host: entry.hostValue,
+          },
+        );
+      } else if (entry.field === "progressiveToolDiscovery") {
+        logger.warn(
+          "[mcp/chat-v2] client progressiveToolDiscovery differs from host; using host value",
+          {
+            chatboxId: bodyChatboxId,
+            body: entry.overrideValue,
+            host: entry.hostValue,
+          },
+        );
+      } else if (entry.field === "respectToolVisibility") {
+        logger.warn(
+          "[mcp/chat-v2] client respectToolVisibility differs from host; using host value",
+          {
+            chatboxId: bodyChatboxId,
+            body: entry.overrideValue,
+            host: entry.hostValue,
+          },
+        );
+      }
+    }
+    // `modelId` stays special-cased: chat resolves it to a `ModelDefinition`
+    // via the catalog (built-in hit → full def; miss → swap id only,
+    // keep body provider). The resolver yields the resolved `modelId`
+    // string; the call site does the catalog lookup and warn.
+    if (
+      isChatboxSession &&
+      hostRuntimeConfig &&
+      model &&
+      resolvedExecution.modelId &&
+      resolvedExecution.modelId !== model.id
+    ) {
+      const hostModelId = resolvedExecution.modelId;
+      const hostModel = getModelById(hostModelId);
+      if (hostModel) {
+        logger.warn(
+          "[mcp/chat-v2] client model differs from host; using host model",
+          {
+            chatboxId: bodyChatboxId,
+            body: model.id,
+            host: hostModelId,
+          }
+        );
+        resolvedModelOverride = hostModel;
+      } else {
+        logger.warn(
+          "[mcp/chat-v2] host model not in catalog; swapping id only",
+          {
+            chatboxId: bodyChatboxId,
+            body: model.id,
+            host: hostModelId,
+          }
+        );
+        resolvedModelOverride = { ...model, id: hostModelId };
+      }
+    }
+    const systemPrompt = resolvedExecution.systemPrompt;
+    const temperature = resolvedExecution.temperature;
+    const requireToolApproval = resolvedExecution.requireToolApproval;
+    const respectToolVisibility = resolvedExecution.respectToolVisibility;
+    const resolvedProgressiveToolDiscovery =
+      resolvedExecution.progressiveToolDiscovery;
 
     // Local-mode `selectedServers` is server *names*, not Convex Ids. The
     // backend's `hostConfigPayloadValidator` requires `v.array(v.id('servers'))`,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -26,6 +26,7 @@ import {
 import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
+import { resolveExecutionContext } from "../../utils/host-execution-context.js";
 import { logger } from "../../utils/logger.js";
 
 const chatV2 = new Hono();
@@ -99,107 +100,24 @@ chatV2.post("/", async (c) => {
     // Convex so a stale client snapshot or tampered body can't route the
     // session through a different model or skip tool approval. The
     // helper is a no-op (returns body values) for non-chatbox surfaces.
-    let resolvedSystemPrompt = bodySystemPrompt;
-    let resolvedTemperatureOverride = bodyTemperature;
-    let resolvedRequireToolApproval = bodyRequireToolApproval;
-    let resolvedRespectToolVisibility = bodyRespectToolVisibility;
-    // Host-level toggle. For non-chatbox direct chat the body is the
-    // source (the inspector reads the project's default HostConfigV2 and
-    // threads the value through); for chatbox sessions we re-resolve from
-    // the chatbox's pinned host below so guest / share-link clients can't
-    // omit or flip the field to silently degrade the host's tool
-    // exposure.
-    let resolvedProgressiveToolDiscovery: boolean | undefined =
-      body.progressiveToolDiscovery;
+    //
+    // PR 4c of the engine consolidation: this merge is now owned by the
+    // shared `resolveExecutionContext` helper alongside `mcp/chat-v2.ts`
+    // (chat surface) and PR 4d's eval rewire. Single contract for
+    // body × hostConfig × precedence; per-field warnings preserved via
+    // `result.drift`. Pure refactor — `host-execution-context.test.ts`
+    // locks the shape.
+    let hostRuntimeConfig: Record<string, unknown> | null = null;
     if (isChatboxSession && chatboxId) {
       const runtime = await fetchChatboxRuntimeConfig({
         chatboxId,
         bearer: bearerToken,
       });
       if (runtime.ok) {
-        const cfg = runtime.config;
-        if (
-          bodyRequireToolApproval !== undefined &&
-          cfg.requireToolApproval !== bodyRequireToolApproval
-        ) {
-          logger.warn(
-            "[chat-v2] client requireToolApproval differs from host; using host value",
-            {
-              chatboxId,
-              body: bodyRequireToolApproval,
-              host: cfg.requireToolApproval,
-            }
-          );
-        }
-        // Model is part of the host-owned contract: a tampered body
-        // mustn't be able to route a chatbox session through a different
-        // model than the host's hostConfigs row specifies. When the
-        // host's modelId is in our built-in catalog we substitute the
-        // full ModelDefinition (correct provider routing); otherwise
-        // (custom provider unknown to backend) we swap just the id and
-        // keep the body's provider fields, then warn.
-        if (cfg.modelId && cfg.modelId !== modelDefinition.id) {
-          const hostModel = getModelById(cfg.modelId);
-          if (hostModel) {
-            logger.warn(
-              "[chat-v2] client model differs from host; using host model",
-              { chatboxId, body: modelDefinition.id, host: cfg.modelId }
-            );
-            modelDefinition = hostModel;
-          } else {
-            logger.warn(
-              "[chat-v2] host model not in catalog; swapping id only",
-              { chatboxId, body: modelDefinition.id, host: cfg.modelId }
-            );
-            modelDefinition = { ...modelDefinition, id: cfg.modelId };
-          }
-        }
-        resolvedSystemPrompt = cfg.systemPrompt;
-        resolvedTemperatureOverride = cfg.temperature;
-        resolvedRequireToolApproval = cfg.requireToolApproval;
-        // Same trust model as requireToolApproval: warn when the body
-        // differs from the host, then always prefer the host value.
-        // Backends older than mcpjam-backend PR #334 omit this field
-        // entirely (undefined), in which case we just fall back to the
-        // body and the orchestrator's auto policy.
-        // Only override when the runtime config actually carries the
-        // field. Older backends omit it; without this gate we'd clobber
-        // the body's value (sourced from the chatbox doc client-side)
-        // with `undefined` and the orchestrator's auto policy would
-        // re-enable progressive mode on large catalogs even when the
-        // host explicitly turned it off.
-        if (cfg.progressiveToolDiscovery !== undefined) {
-          if (
-            body.progressiveToolDiscovery !== undefined &&
-            cfg.progressiveToolDiscovery !== body.progressiveToolDiscovery
-          ) {
-            logger.warn(
-              "[chat-v2] client progressiveToolDiscovery differs from host; using host value",
-              {
-                chatboxId,
-                body: body.progressiveToolDiscovery,
-                host: cfg.progressiveToolDiscovery,
-              }
-            );
-          }
-          resolvedProgressiveToolDiscovery = cfg.progressiveToolDiscovery;
-        }
-        if (cfg.respectToolVisibility !== undefined) {
-          if (
-            bodyRespectToolVisibility !== undefined &&
-            cfg.respectToolVisibility !== bodyRespectToolVisibility
-          ) {
-            logger.warn(
-              "[chat-v2] client respectToolVisibility differs from host; using host value",
-              {
-                chatboxId,
-                body: bodyRespectToolVisibility,
-                host: cfg.respectToolVisibility,
-              }
-            );
-          }
-          resolvedRespectToolVisibility = cfg.respectToolVisibility;
-        }
+        hostRuntimeConfig = runtime.config as unknown as Record<
+          string,
+          unknown
+        >;
       } else {
         // Don't fail the chat send on a transient Convex blip — fall
         // through to client-supplied values and warn. The chat will run
@@ -216,10 +134,79 @@ chatV2.post("/", async (c) => {
         );
       }
     }
-    const systemPrompt = resolvedSystemPrompt;
-    const temperature = resolvedTemperatureOverride;
-    const requireToolApproval = resolvedRequireToolApproval;
-    const respectToolVisibility = resolvedRespectToolVisibility;
+    const resolvedExecution = resolveExecutionContext({
+      hostConfig: hostRuntimeConfig,
+      overrides: {
+        systemPrompt: bodySystemPrompt,
+        temperature: bodyTemperature,
+        requireToolApproval: bodyRequireToolApproval,
+        respectToolVisibility: bodyRespectToolVisibility,
+        progressiveToolDiscovery: body.progressiveToolDiscovery,
+      },
+      precedence: "host-wins",
+    });
+    for (const entry of resolvedExecution.drift) {
+      if (entry.field === "requireToolApproval") {
+        logger.warn(
+          "[chat-v2] client requireToolApproval differs from host; using host value",
+          {
+            chatboxId,
+            body: entry.overrideValue,
+            host: entry.hostValue,
+          },
+        );
+      } else if (entry.field === "progressiveToolDiscovery") {
+        logger.warn(
+          "[chat-v2] client progressiveToolDiscovery differs from host; using host value",
+          {
+            chatboxId,
+            body: entry.overrideValue,
+            host: entry.hostValue,
+          },
+        );
+      } else if (entry.field === "respectToolVisibility") {
+        logger.warn(
+          "[chat-v2] client respectToolVisibility differs from host; using host value",
+          {
+            chatboxId,
+            body: entry.overrideValue,
+            host: entry.hostValue,
+          },
+        );
+      }
+    }
+    // `modelId` stays a special case — the resolver yields the resolved
+    // string, but chat needs to lift it to a `ModelDefinition` via
+    // catalog lookup (built-in hit → full def; miss → swap id only,
+    // keep body provider fields).
+    if (
+      isChatboxSession &&
+      hostRuntimeConfig &&
+      resolvedExecution.modelId &&
+      resolvedExecution.modelId !== modelDefinition.id
+    ) {
+      const hostModelId = resolvedExecution.modelId;
+      const hostModel = getModelById(hostModelId);
+      if (hostModel) {
+        logger.warn(
+          "[chat-v2] client model differs from host; using host model",
+          { chatboxId, body: modelDefinition.id, host: hostModelId }
+        );
+        modelDefinition = hostModel;
+      } else {
+        logger.warn(
+          "[chat-v2] host model not in catalog; swapping id only",
+          { chatboxId, body: modelDefinition.id, host: hostModelId }
+        );
+        modelDefinition = { ...modelDefinition, id: hostModelId };
+      }
+    }
+    const systemPrompt = resolvedExecution.systemPrompt;
+    const temperature = resolvedExecution.temperature;
+    const requireToolApproval = resolvedExecution.requireToolApproval;
+    const respectToolVisibility = resolvedExecution.respectToolVisibility;
+    const resolvedProgressiveToolDiscovery =
+      resolvedExecution.progressiveToolDiscovery;
 
     // Membership chat (no share/chatbox token) is the default — the backend
     // authorizes via project ownership for both guest and authed users.

--- a/mcpjam-inspector/server/utils/__tests__/host-execution-context.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/host-execution-context.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Contract tests for `resolveExecutionContext` (PR 4c of the engine
+ * consolidation in `~/mcpjam-docs/unification.md`).
+ *
+ * Purpose: lock the resolver shape that chat-v2 (mcp + web) will swap
+ * its inline hostConfig reads onto in this PR, and that eval will swap
+ * its `advancedConfig.system`-only resolution onto in PR 4d (closing
+ * the suite-systemPrompt gap).
+ *
+ * Tests cover every precedence + hostConfig + overrides permutation
+ * the live callers actually hit:
+ *
+ *   - `host-wins` with full hostConfig (chat chatbox path).
+ *   - `host-wins` with null hostConfig (chat direct path — degenerate).
+ *   - `override-wins` with hostConfig + overrides (eval per-case).
+ *   - Optional-only host fields (older backends omitting
+ *     `progressiveToolDiscovery` / `respectToolVisibility`).
+ *   - Drift surfacing — both sides defined and disagree.
+ *   - Drift NOT surfacing — same value on both sides.
+ *   - Default semantics for `requireToolApproval` (must be a boolean,
+ *     never undefined).
+ *   - Progressive discovery dual shape (plain boolean vs
+ *     `{enabled, ...}` wire shape).
+ *   - hostPolicy threading through unchanged from
+ *     `extractHostExecutionPolicy`.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveExecutionContext } from "../host-execution-context";
+
+describe("resolveExecutionContext — `host-wins` precedence (chat chatbox)", () => {
+  it("returns hostConfig values verbatim when host carries every field", () => {
+    const result = resolveExecutionContext({
+      hostConfig: {
+        systemPrompt: "host system prompt",
+        temperature: 0.42,
+        requireToolApproval: true,
+        respectToolVisibility: false,
+        progressiveToolDiscovery: true,
+        modelId: "claude-haiku-4.5",
+        selectedServerIds: ["srv-1", "srv-2"],
+      },
+      overrides: {
+        systemPrompt: "body system prompt",
+        temperature: 0.99,
+        requireToolApproval: false,
+        respectToolVisibility: true,
+        progressiveToolDiscovery: false,
+        modelId: "gpt-4-turbo",
+        selectedServerIds: ["other-srv"],
+      },
+      precedence: "host-wins",
+    });
+
+    expect(result.systemPrompt).toBe("host system prompt");
+    expect(result.temperature).toBe(0.42);
+    expect(result.requireToolApproval).toBe(true);
+    expect(result.respectToolVisibility).toBe(false);
+    expect(result.progressiveToolDiscovery).toBe(true);
+    expect(result.modelId).toBe("claude-haiku-4.5");
+    expect(result.selectedServerIds).toEqual(["srv-1", "srv-2"]);
+  });
+
+  it("falls back to overrides when host omits a field", () => {
+    // Older backends (pre-mcpjam-backend PR #334) omit
+    // `progressiveToolDiscovery`. `host-wins` precedence must NOT
+    // clobber the override with undefined just because host is silent;
+    // it should fall back to the override.
+    const result = resolveExecutionContext({
+      hostConfig: {
+        systemPrompt: "host system prompt",
+        temperature: 0.5,
+        requireToolApproval: true,
+        // progressiveToolDiscovery + respectToolVisibility omitted.
+      },
+      overrides: {
+        progressiveToolDiscovery: true,
+        respectToolVisibility: false,
+      },
+      precedence: "host-wins",
+    });
+
+    expect(result.progressiveToolDiscovery).toBe(true);
+    expect(result.respectToolVisibility).toBe(false);
+    expect(result.systemPrompt).toBe("host system prompt");
+  });
+
+  it("falls back to overrides when hostConfig is null (direct chat path)", () => {
+    // mcp/chat-v2 direct chat (non-chatbox) skips
+    // `fetchChatboxRuntimeConfig`; callers pass `hostConfig: null` and
+    // the resolver returns the body fields unmodified.
+    const result = resolveExecutionContext({
+      hostConfig: null,
+      overrides: {
+        systemPrompt: "body system prompt",
+        temperature: 0.3,
+        requireToolApproval: false,
+        selectedServerIds: ["srv-A"],
+      },
+      precedence: "host-wins",
+    });
+
+    expect(result.systemPrompt).toBe("body system prompt");
+    expect(result.temperature).toBe(0.3);
+    expect(result.requireToolApproval).toBe(false);
+    expect(result.selectedServerIds).toEqual(["srv-A"]);
+  });
+
+  it("emits a drift entry when override and host disagree", () => {
+    // Chat-v2 logs a per-field `logger.warn` when the body's
+    // `requireToolApproval` differs from the host's value. The
+    // resolver surfaces this as data so callers can decide whether to
+    // log. Drift is reported even though `host-wins` precedence makes
+    // the host value the winner — the SIGNAL is that the body tried.
+    const result = resolveExecutionContext({
+      hostConfig: { requireToolApproval: true },
+      overrides: { requireToolApproval: false },
+      precedence: "host-wins",
+    });
+
+    expect(result.requireToolApproval).toBe(true);
+    expect(result.drift).toEqual([
+      {
+        field: "requireToolApproval",
+        overrideValue: false,
+        hostValue: true,
+      },
+    ]);
+  });
+
+  it("does NOT emit drift when override and host agree", () => {
+    const result = resolveExecutionContext({
+      hostConfig: {
+        systemPrompt: "same",
+        temperature: 0.5,
+      },
+      overrides: {
+        systemPrompt: "same",
+        temperature: 0.5,
+      },
+      precedence: "host-wins",
+    });
+
+    expect(result.drift).toEqual([]);
+  });
+
+  it("does NOT emit drift when only one side has a value", () => {
+    // Pure fallback isn't drift — only meaningful when BOTH sides set
+    // and disagreed.
+    const result = resolveExecutionContext({
+      hostConfig: { systemPrompt: "host only" },
+      overrides: { temperature: 0.7 },
+      precedence: "host-wins",
+    });
+
+    expect(result.systemPrompt).toBe("host only");
+    expect(result.temperature).toBe(0.7);
+    expect(result.drift).toEqual([]);
+  });
+});
+
+describe("resolveExecutionContext — `override-wins` precedence (eval per-case)", () => {
+  it("returns override values when both host and override define a field", () => {
+    // Eval per-case `advancedConfig.system` beats suite hostConfig
+    // default — the per-case override is the authoritative value, the
+    // suite default is a fallback.
+    const result = resolveExecutionContext({
+      hostConfig: {
+        systemPrompt: "suite default system prompt",
+        temperature: 0.5,
+      },
+      overrides: {
+        systemPrompt: "per-case system prompt",
+        temperature: 0.9,
+      },
+      precedence: "override-wins",
+    });
+
+    expect(result.systemPrompt).toBe("per-case system prompt");
+    expect(result.temperature).toBe(0.9);
+    // Drift is still reported — the eval runner may stash it on
+    // iteration metadata for observability.
+    expect(result.drift).toEqual(
+      expect.arrayContaining([
+        {
+          field: "systemPrompt",
+          overrideValue: "per-case system prompt",
+          hostValue: "suite default system prompt",
+        },
+        {
+          field: "temperature",
+          overrideValue: 0.9,
+          hostValue: 0.5,
+        },
+      ]),
+    );
+  });
+
+  it("falls back to host value when override is undefined", () => {
+    // The eval design comment at
+    // client/src/components/evals/use-eval-handlers.ts:302 says: per-case
+    // advancedConfig deliberately does NOT bake the suite default in
+    // (to avoid stale copies). The runtime applies the suite default at
+    // resolution time — this test locks that behavior.
+    const result = resolveExecutionContext({
+      hostConfig: {
+        systemPrompt: "suite default",
+        temperature: 0.5,
+      },
+      overrides: {
+        // systemPrompt + temperature intentionally undefined.
+        modelId: "gpt-4-turbo",
+      },
+      precedence: "override-wins",
+    });
+
+    expect(result.systemPrompt).toBe("suite default");
+    expect(result.temperature).toBe(0.5);
+    expect(result.modelId).toBe("gpt-4-turbo");
+  });
+});
+
+describe("resolveExecutionContext — `requireToolApproval` default semantic", () => {
+  it("defaults to false when neither host nor override sets it", () => {
+    // `requireToolApproval` is a boolean-required slot — undefined is
+    // not a valid output. Mirrors `extractHostExecutionPolicy`'s
+    // default. Without this default downstream code (chat-v2's
+    // orchestrator) would treat `undefined` as falsy and inconsistency
+    // could creep in.
+    const result = resolveExecutionContext({
+      hostConfig: null,
+      precedence: "host-wins",
+    });
+
+    expect(result.requireToolApproval).toBe(false);
+  });
+
+  it("respects an explicit false from overrides when host is null", () => {
+    const result = resolveExecutionContext({
+      hostConfig: null,
+      overrides: { requireToolApproval: false },
+      precedence: "host-wins",
+    });
+
+    expect(result.requireToolApproval).toBe(false);
+  });
+
+  it("respects an explicit true from overrides when host is null", () => {
+    const result = resolveExecutionContext({
+      hostConfig: null,
+      overrides: { requireToolApproval: true },
+      precedence: "host-wins",
+    });
+
+    expect(result.requireToolApproval).toBe(true);
+  });
+});
+
+describe("resolveExecutionContext — `progressiveToolDiscovery` dual shape", () => {
+  it("reads a plain boolean from hostConfigV2 records", () => {
+    // HostConfigV2 storage shape.
+    const result = resolveExecutionContext({
+      hostConfig: { progressiveToolDiscovery: true },
+      precedence: "host-wins",
+    });
+
+    expect(result.progressiveToolDiscovery).toBe(true);
+    expect(result.hostPolicy.progressiveDiscoveryEnabled).toBe(true);
+  });
+
+  it("reads `{enabled: true}` from chat-v2 wire payloads", () => {
+    // Chat-v2 wraps the field as `{ enabled, threshold }`. Mirror
+    // `extractHostExecutionPolicy`'s dual read.
+    const result = resolveExecutionContext({
+      hostConfig: {
+        progressiveToolDiscovery: { enabled: true, threshold: 0.03 },
+      },
+      precedence: "host-wins",
+    });
+
+    expect(result.progressiveToolDiscovery).toBe(true);
+    expect(result.hostPolicy.progressiveDiscoveryEnabled).toBe(true);
+  });
+
+  it("returns false when wire payload sets `{enabled: false}`", () => {
+    const result = resolveExecutionContext({
+      hostConfig: {
+        progressiveToolDiscovery: { enabled: false },
+      },
+      precedence: "host-wins",
+    });
+
+    expect(result.progressiveToolDiscovery).toBe(false);
+  });
+
+  it("treats invalid wire shapes as undefined", () => {
+    const result = resolveExecutionContext({
+      hostConfig: {
+        // Bad shape — not a boolean, not a `{enabled}` record.
+        progressiveToolDiscovery: "yes",
+      },
+      precedence: "host-wins",
+    });
+
+    expect(result.progressiveToolDiscovery).toBeUndefined();
+  });
+});
+
+describe("resolveExecutionContext — type coercion guards", () => {
+  it("ignores non-string systemPrompt on hostConfig", () => {
+    const result = resolveExecutionContext({
+      hostConfig: { systemPrompt: 42 },
+      overrides: { systemPrompt: "fallback" },
+      precedence: "host-wins",
+    });
+
+    expect(result.systemPrompt).toBe("fallback");
+  });
+
+  it("ignores non-number temperature on hostConfig", () => {
+    const result = resolveExecutionContext({
+      hostConfig: { temperature: "0.5" },
+      overrides: { temperature: 0.7 },
+      precedence: "host-wins",
+    });
+
+    expect(result.temperature).toBe(0.7);
+  });
+
+  it("ignores non-string-array selectedServerIds on hostConfig", () => {
+    const result = resolveExecutionContext({
+      hostConfig: { selectedServerIds: ["srv-1", 42, "srv-3"] },
+      overrides: { selectedServerIds: ["fallback"] },
+      precedence: "host-wins",
+    });
+
+    expect(result.selectedServerIds).toEqual(["fallback"]);
+  });
+});
+
+describe("resolveExecutionContext — hostPolicy passthrough", () => {
+  it("forwards `extractHostExecutionPolicy`'s shape unchanged", () => {
+    // The resolver computes `hostPolicy` via the existing SDK helper so
+    // chat/eval can keep using `buildHostIterationMetadata` etc.
+    // without changes. This test asserts the policy shape matches the
+    // SDK helper's output for the same input.
+    const result = resolveExecutionContext({
+      hostConfig: {
+        requireToolApproval: true,
+        respectToolVisibility: false,
+        progressiveToolDiscovery: true,
+        hostStyle: "claude",
+      },
+      precedence: "host-wins",
+      namedHostId: "host-abc",
+    });
+
+    expect(result.hostPolicy).toEqual({
+      requireToolApproval: true,
+      respectToolVisibility: false,
+      progressiveDiscoveryEnabled: true,
+      hostStyle: "claude",
+      namedHostId: "host-abc",
+    });
+  });
+
+  it("emits a null-hostConfig hostPolicy when hostConfig is null", () => {
+    const result = resolveExecutionContext({
+      hostConfig: null,
+      precedence: "host-wins",
+      namedHostId: "host-xyz",
+    });
+
+    expect(result.hostPolicy).toEqual({
+      requireToolApproval: false,
+      respectToolVisibility: undefined,
+      progressiveDiscoveryEnabled: false,
+      hostStyle: undefined,
+      namedHostId: "host-xyz",
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/host-execution-context.ts
+++ b/mcpjam-inspector/server/utils/host-execution-context.ts
@@ -1,0 +1,307 @@
+/**
+ * Shared resolver: hostConfig record + per-call overrides → resolved execution fields.
+ *
+ * Engine consolidation PR 4c (`~/mcpjam-docs/unification.md`). Until this
+ * lands, every caller that drove the chat/eval engines did its own
+ * hostConfig-to-fields read inline. The reads drifted: chat-v2 (mcp +
+ * web) routes resolved `systemPrompt` / `temperature` / `requireToolApproval`
+ * / `respectToolVisibility` / `progressiveToolDiscovery` / `modelId` from
+ * `fetchChatboxRuntimeConfig` for chatbox sessions; the eval runner only
+ * extracted policy fields (`extractHostExecutionPolicy`) from
+ * `suiteHostConfig` and never read `systemPrompt` / `temperature` /
+ * `selectedServerIds` — even though the suite hostConfig record carries
+ * them. The eval client deliberately does NOT bake the suite default
+ * into per-case `advancedConfig` (see
+ * `client/src/components/evals/use-eval-handlers.ts:302`) on the
+ * understanding that the runtime applies it; the runtime never did.
+ *
+ * This resolver subsumes both shapes. Callers pass a hostConfig (or
+ * null), per-call overrides, and a precedence mode; the resolver runs
+ * the field-by-field merge plus the existing
+ * `extractHostExecutionPolicy` derivation and emits a single
+ * `ResolvedExecutionContext`. Drift between override and host is
+ * captured as data — the caller decides whether to log per-field
+ * warnings (chat does today; eval probably won't).
+ *
+ * PR 4c is a pure refactor on the chat side — `resolveExecutionContext`
+ * is wired into `mcp/chat-v2.ts` + `web/chat-v2.ts` with shape-preserving
+ * snapshot tests. PR 4d wires eval onto it and closes the
+ * suite-systemPrompt gap (behavior change; called out separately).
+ *
+ * Lives inspector-side so it can iterate without a SDK publish cycle.
+ * If the contract stabilizes it can be promoted to
+ * `@mcpjam/sdk/host-config/internal` alongside `extractHostExecutionPolicy`.
+ */
+
+import {
+  extractHostExecutionPolicy,
+  type HostExecutionPolicy,
+} from "@mcpjam/sdk/host-config/internal";
+
+/**
+ * How the resolver picks a winner when both the hostConfig and the
+ * caller-supplied overrides provide a value for the same field.
+ *
+ * - `host-wins`: hostConfig value beats override (chat chatbox security
+ *   model — guest / share-link clients can't bypass the host's pinned
+ *   config). Override only used when the host omits the field.
+ * - `override-wins`: caller's override beats hostConfig value (eval
+ *   per-case `advancedConfig` shape — explicit case-level overrides
+ *   beat the suite default). Host fills in when the override is
+ *   undefined.
+ *
+ * When `hostConfig` is `null` the precedence doesn't matter — the
+ * resolver returns the overrides as-is.
+ */
+export type ResolverPrecedence = "host-wins" | "override-wins";
+
+/**
+ * Per-call overrides layered on top of (or under, per `precedence`) the
+ * hostConfig record. All fields optional — `undefined` means "no
+ * override; use hostConfig value (or fall back to default)."
+ */
+export interface ExecutionOverrides {
+  systemPrompt?: string;
+  temperature?: number;
+  requireToolApproval?: boolean;
+  respectToolVisibility?: boolean;
+  progressiveToolDiscovery?: boolean;
+  modelId?: string;
+  selectedServerIds?: string[];
+}
+
+/**
+ * Record of a field where the override and the hostConfig disagreed.
+ * The resolver emits one entry per drifted field; callers choose
+ * whether to surface them as warnings (chat-v2 does so per-field with a
+ * `logger.warn` shape, eval may stash them on metadata or ignore).
+ *
+ * Drift is only reported when BOTH sources have a defined value and
+ * the values differ — pure missing-side fallback is not drift.
+ */
+export interface ExecutionDriftEntry {
+  field: keyof ExecutionOverrides;
+  overrideValue: unknown;
+  hostValue: unknown;
+}
+
+/**
+ * Resolved execution fields plus the policy block. Subsumes everything
+ * downstream code (`prepareChatV2`, `runDirectChatTurn`, `runAssistantTurn`,
+ * eval runners) needs from the host execution context.
+ *
+ * `hostPolicy` is the existing `HostExecutionPolicy` extracted via
+ * `extractHostExecutionPolicy` — kept on the result so callers don't
+ * have to call both helpers. Note that `hostPolicy.requireToolApproval`
+ * / `hostPolicy.respectToolVisibility` reflect the HOST record alone,
+ * whereas the top-level fields reflect the RESOLVED value (host vs
+ * override per precedence). Both are useful; eval uses the policy
+ * block for `buildHostIterationMetadata`, chat uses the resolved
+ * fields for the model call.
+ */
+export interface ResolvedExecutionContext {
+  systemPrompt: string | undefined;
+  temperature: number | undefined;
+  requireToolApproval: boolean;
+  respectToolVisibility: boolean | undefined;
+  progressiveToolDiscovery: boolean | undefined;
+  modelId: string | undefined;
+  selectedServerIds: string[] | undefined;
+  hostPolicy: HostExecutionPolicy;
+  drift: ExecutionDriftEntry[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(
+  hostConfig: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = hostConfig[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(
+  hostConfig: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = hostConfig[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function readBoolean(
+  hostConfig: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const value = hostConfig[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function readStringArray(
+  hostConfig: Record<string, unknown>,
+  key: string,
+): string[] | undefined {
+  const value = hostConfig[key];
+  if (!Array.isArray(value)) return undefined;
+  if (!value.every((entry) => typeof entry === "string")) return undefined;
+  return value as string[];
+}
+
+/**
+ * Progressive discovery is stored as a plain boolean on `hostConfigV2`
+ * records (`progressiveToolDiscovery: true`) BUT as `{ enabled, threshold }`
+ * on chat-v2 wire payloads. Mirror `extractHostExecutionPolicy`'s dual
+ * read so the resolver accepts both shapes.
+ */
+function readProgressiveToolDiscovery(
+  hostConfig: Record<string, unknown>,
+): boolean | undefined {
+  const raw = hostConfig.progressiveToolDiscovery;
+  if (typeof raw === "boolean") return raw;
+  if (isRecord(raw) && raw.enabled === true) return true;
+  if (isRecord(raw) && raw.enabled === false) return false;
+  return undefined;
+}
+
+/**
+ * Pick the winning value for a field given the resolver precedence.
+ * Returns the winner AND, if both sides disagreed, a drift entry the
+ * caller can log.
+ */
+function pickField<T>(
+  field: keyof ExecutionOverrides,
+  override: T | undefined,
+  host: T | undefined,
+  precedence: ResolverPrecedence,
+): { value: T | undefined; drift?: ExecutionDriftEntry } {
+  const overrideDefined = override !== undefined;
+  const hostDefined = host !== undefined;
+  if (!overrideDefined && !hostDefined) {
+    return { value: undefined };
+  }
+  if (!overrideDefined) {
+    return { value: host };
+  }
+  if (!hostDefined) {
+    return { value: override };
+  }
+  // Both defined — apply precedence + record drift when they differ.
+  const drift =
+    override !== host
+      ? {
+          field,
+          overrideValue: override as unknown,
+          hostValue: host as unknown,
+        }
+      : undefined;
+  const winner = precedence === "host-wins" ? host : override;
+  return drift ? { value: winner, drift } : { value: winner };
+}
+
+export function resolveExecutionContext(args: {
+  hostConfig: Record<string, unknown> | null;
+  overrides?: ExecutionOverrides;
+  precedence: ResolverPrecedence;
+  namedHostId?: string;
+}): ResolvedExecutionContext {
+  const { hostConfig, overrides = {}, precedence, namedHostId } = args;
+  const hostPolicy = extractHostExecutionPolicy(hostConfig, namedHostId);
+  const drift: ExecutionDriftEntry[] = [];
+
+  // hostConfig === null short-circuit: no host values, return overrides
+  // as-is. `requireToolApproval` still has its boolean-default semantic.
+  if (!hostConfig) {
+    return {
+      systemPrompt: overrides.systemPrompt,
+      temperature: overrides.temperature,
+      requireToolApproval: overrides.requireToolApproval ?? false,
+      respectToolVisibility: overrides.respectToolVisibility,
+      progressiveToolDiscovery: overrides.progressiveToolDiscovery,
+      modelId: overrides.modelId,
+      selectedServerIds: overrides.selectedServerIds,
+      hostPolicy,
+      drift,
+    };
+  }
+
+  const hostFields = {
+    systemPrompt: readString(hostConfig, "systemPrompt"),
+    temperature: readNumber(hostConfig, "temperature"),
+    requireToolApproval: readBoolean(hostConfig, "requireToolApproval"),
+    respectToolVisibility: readBoolean(hostConfig, "respectToolVisibility"),
+    progressiveToolDiscovery: readProgressiveToolDiscovery(hostConfig),
+    modelId: readString(hostConfig, "modelId"),
+    selectedServerIds: readStringArray(hostConfig, "selectedServerIds"),
+  };
+
+  const systemPrompt = pickField(
+    "systemPrompt",
+    overrides.systemPrompt,
+    hostFields.systemPrompt,
+    precedence,
+  );
+  if (systemPrompt.drift) drift.push(systemPrompt.drift);
+
+  const temperature = pickField(
+    "temperature",
+    overrides.temperature,
+    hostFields.temperature,
+    precedence,
+  );
+  if (temperature.drift) drift.push(temperature.drift);
+
+  const requireToolApprovalPick = pickField(
+    "requireToolApproval",
+    overrides.requireToolApproval,
+    hostFields.requireToolApproval,
+    precedence,
+  );
+  if (requireToolApprovalPick.drift) drift.push(requireToolApprovalPick.drift);
+
+  const respectToolVisibility = pickField(
+    "respectToolVisibility",
+    overrides.respectToolVisibility,
+    hostFields.respectToolVisibility,
+    precedence,
+  );
+  if (respectToolVisibility.drift) drift.push(respectToolVisibility.drift);
+
+  const progressiveToolDiscovery = pickField(
+    "progressiveToolDiscovery",
+    overrides.progressiveToolDiscovery,
+    hostFields.progressiveToolDiscovery,
+    precedence,
+  );
+  if (progressiveToolDiscovery.drift) drift.push(progressiveToolDiscovery.drift);
+
+  const modelId = pickField(
+    "modelId",
+    overrides.modelId,
+    hostFields.modelId,
+    precedence,
+  );
+  if (modelId.drift) drift.push(modelId.drift);
+
+  const selectedServerIds = pickField(
+    "selectedServerIds",
+    overrides.selectedServerIds,
+    hostFields.selectedServerIds,
+    precedence,
+  );
+  if (selectedServerIds.drift) drift.push(selectedServerIds.drift);
+
+  return {
+    systemPrompt: systemPrompt.value,
+    temperature: temperature.value,
+    // `requireToolApproval` defaults to `false` (boolean-required slot).
+    requireToolApproval: requireToolApprovalPick.value ?? false,
+    respectToolVisibility: respectToolVisibility.value,
+    progressiveToolDiscovery: progressiveToolDiscovery.value,
+    modelId: modelId.value,
+    selectedServerIds: selectedServerIds.value,
+    hostPolicy,
+    drift,
+  };
+}


### PR DESCRIPTION
## Summary

Pure refactor — pulls the inline hostConfig × body merge out of `mcp/chat-v2.ts` and `web/chat-v2.ts` into a shared `resolveExecutionContext` helper. Chat behavior unchanged. Sets up PR 4d (eval rewire) so the suite-systemPrompt / temperature gap can close without inventing a parallel resolver.

The two chat files duplicated ~90 lines apiece of body-vs-host field-by-field merge logic (systemPrompt / temperature / requireToolApproval / respectToolVisibility / progressiveToolDiscovery + per-field `logger.warn` drift surfacing). The eval runner had its own incomplete version that only read policy fields — never `systemPrompt` / `temperature` / `selectedServerIds` off the suite hostConfig (gap surfaces in PR 4d).

## What this PR closes

- Single helper owns the body × hostConfig merge across chatbox / direct chat / (PR 4d) eval.
- Precedence is an explicit parameter — `host-wins` for chat (security model: tampered body can't bypass host); `override-wins` for eval (per-case `advancedConfig` beats suite default).
- Drift surfaced as data (`result.drift`), call site decides whether to log per-field warnings. Chat keeps its existing `logger.warn` shapes via a small loop over the drift entries.
- Optional-field gating (older backends omitting `progressiveToolDiscovery` / `respectToolVisibility`) is centralized — single read, single fallback path.

## What this PR explicitly does NOT close

- Eval still doesn't read `suiteHostConfig.systemPrompt` / `.temperature`. PR 4d wires `evals-runner.ts` onto the helper with `precedence: "override-wins"`. That's a behavior change (per-case tests without explicit `advancedConfig.system` will pick up the suite default — desired per the design comment at `client/src/components/evals/use-eval-handlers.ts:302` but observable).
- `selectedServerIds` resolution stays unchanged for chat (still body-read). Eval picks it up in PR 4d.
- `modelId` stays special-cased at the chat call sites — resolver yields a string but chat needs to lift it to a `ModelDefinition` via catalog lookup.

## Where it lives

`server/utils/host-execution-context.ts` (inspector-side). Pure function; sits above `extractHostExecutionPolicy` (`@mcpjam/sdk/host-config/internal`) and reuses it verbatim for the policy block. Promote to SDK later if the contract stabilizes — same reasoning as `loadSuiteHostConfig` staying inspector-side.

## Test plan

- [x] New `host-execution-context.test.ts` (20 tests) covers every permutation: `host-wins` + full hostConfig; `host-wins` + partial hostConfig (older-backend omissions); `host-wins` + null hostConfig (direct chat path); `override-wins` + both defined; `override-wins` + override-undefined fallback; drift surfacing when both defined and disagree; drift NOT surfacing on agreement or one-sided values; `requireToolApproval` boolean default; progressive discovery dual shape (plain boolean vs `{enabled, threshold}`); type-coercion guards on malformed fields; hostPolicy passthrough.
- [x] Existing chat-v2 tests (mcp + web hosted) pass unchanged: 452/452 in `server/utils` + `server/routes/{mcp,web/chat-v2.hosted}`.
- [x] Full sweep used in prior PRs: 672/672 across `server/{utils,services/evals,services/sessionSimulation,routes/mcp}` + `chat-v2.hosted.test.ts`.
- [x] Typecheck baseline-clean (zero new errors in the three touched files).
- [ ] Smoke (post-merge): a chatbox session with body values differing from host — confirm the `logger.warn` lines still fire with the same field names, body and host values match the pre-refactor shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how chatbox execution config is resolved on both MCP and web chat-v2 paths (security-sensitive host-wins model), though the PR targets byte-identical outputs and adds contract tests.
> 
> **Overview**
> **Engine consolidation PR 4c:** duplicated body × `fetchChatboxRuntimeConfig` merge logic in `mcp/chat-v2.ts` and `web/chat-v2.ts` is replaced by a shared **`resolveExecutionContext`** helper in `server/utils/host-execution-context.ts`.
> 
> Chatbox turns still use **`host-wins`** precedence (host pins model, prompt, temperature, tool approval, visibility, progressive discovery). Body/host mismatches are returned as **`result.drift`**; both routes keep the same per-field **`logger.warn`** loops. **`modelId`** is still lifted to **`ModelDefinition`** at the route (catalog hit vs id-only swap). Eval is not wired yet (PR 4d).
> 
> Adds **`host-execution-context.test.ts`** to lock precedence, optional-field fallback, drift, defaults, and progressive-discovery wire shapes. Intended as a **behavior-neutral** chat refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e1922470c5524164c18a252c3a8b7cae670c702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->