### PR TITLE
evals: drive systemPrompt/temperature via resolveExecutionContext (engine consolidation PR 4d)

### DIFF
--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -964,6 +964,11 @@ export async function runEvalsWithManager(
     recorder,
     suiteInjectOpenAiCompat,
     hostExecutionPolicy: suiteHostPolicy,
+    // PR 4d: thread the raw suite hostConfig record into the runner so
+    // it can resolve CONFIG fields (`systemPrompt` / `temperature` /
+    // `selectedServerIds`) via `resolveExecutionContext`. `hostPolicy`
+    // is the POLICY subset extracted upstream; this is the rest.
+    suiteHostConfig,
   });
 
   return {
@@ -1137,6 +1142,8 @@ export async function runEvalTestCaseWithManager(
     compareRunId,
     suiteInjectOpenAiCompat,
     hostExecutionPolicy: suiteHostPolicy,
+    // PR 4d: see comment on the suite-run wire-up site above.
+    suiteHostConfig,
   });
 
   const expectedIterationId =
@@ -1513,6 +1520,12 @@ export async function streamEvalTestCaseWithManager(
           compareRunId,
           injectOpenAiCompat: suiteInjectOpenAiCompat,
           hostPolicy: suiteHostPolicy,
+          // PR 4d: thread the raw hostConfig for the streamTestCase path
+          // so its runners (`streamIterationWithAiSdk` /
+          // `streamIterationViaBackend`) can resolve CONFIG fields via
+          // `resolveExecutionContext`. PR 5 will reduce these runners
+          // further; the threading still applies in the meantime.
+          suiteHostConfig,
           toolSignals: streamToolSignals,
           emit: (event: EvalStreamEvent) => {
             try {

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1968,6 +1968,12 @@ const runIterationViaBackend = async ({
   const backendCustomProviders = orgModelConfig
     ? buildLlmRuntimeConfigFromOrgConfig(orgModelConfig).customProviders
     : undefined;
+  // PR 4d review fix (Codex P2 / Cursor Medium): hoisted up-front (above
+  // the `prepareChatV2` try) so the catch path and the assignment
+  // inside the try are both in scope. Stays `undefined` if prepareChatV2
+  // throws — the setup-failure persistence path doesn't need a system
+  // prefix.
+  let backendEnhancedSystemPromptForPersist: string | undefined = undefined;
   let prepared: PrepareChatV2Result;
   try {
     prepared = await prepareChatV2({
@@ -1982,6 +1988,13 @@ const runIterationViaBackend = async ({
         : {}),
       priorMessages: [],
     });
+    // PR 4d review fix (Codex P2 / Cursor Medium): stash the resolved
+    // system prompt for the persistence prefix below. The engine
+    // (`runAssistantTurn`) sends it to the model via its `systemPrompt:`
+    // arg, but the returned message history doesn't carry a system entry
+    // and `appendEvalTurnTrace` has no `systemPrompt` slot. Prepend at
+    // persistence time — same shape as the local runners' Codex-P2 fix.
+    backendEnhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : String(error);
@@ -2042,6 +2055,8 @@ const runIterationViaBackend = async ({
   let iterationError: string | undefined = undefined;
   let iterationErrorDetails: string | undefined = undefined;
   const capturedSpans: EvalTraceSpan[] = [];
+  // PR 4d review fix (Codex P2 / Cursor Medium): see hoist above the
+  // `prepareChatV2` try.
 
   // Eval supplies its bearer token via `convexAuthToken`. The engine wraps it
   // into the Convex `/stream` (or `/stream/org`) request the same way live
@@ -2372,13 +2387,26 @@ const runIterationViaBackend = async ({
     mcpClientManager,
     convexClient,
   });
+  // PR 4d review fix (Codex P2 / Cursor Medium): prepend the resolved
+  // system at persistence so the backend's transcript carries it.
+  // Engine sent it via `runAssistantTurn`'s `systemPrompt:` arg.
+  const persistedBackendMessages: ModelMessage[] =
+    backendEnhancedSystemPromptForPersist
+      ? [
+          {
+            role: "system",
+            content: backendEnhancedSystemPromptForPersist,
+          },
+          ...messageHistory,
+        ]
+      : messageHistory;
 
   const finishParams = {
     iterationId,
     passed,
     toolsCalled: evaluation.toolsCalled,
     usage: accumulatedUsage,
-    messages: messageHistory,
+    messages: persistedBackendMessages,
     ...(capturedSpans.length ? { spans: capturedSpans } : {}),
     ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
     ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -3079,6 +3107,24 @@ const streamIterationWithAiSdk = async ({
   // `runIterationWithAiSdk`. Empty when `prepareChatV2` throws before
   // returning.
   let streamEnhancedSystemPromptForPersist: string | undefined = undefined;
+  // PR 4d review fix (Cursor Low "Stream snapshots drop system prompt"):
+  // PR 4d dropped the `conversationMessages.push({role:"system"})` in
+  // this runner, but `buildTraceSnapshotEvent` reads from those arrays
+  // mid-run — live SSE traces during a streamed quick run no longer
+  // include the resolved system until the final persistence prepend.
+  // Wrap message slices with the system prefix everywhere the SSE
+  // snapshot consumes them so trace UI viewers see the system as the
+  // first message throughout the run.
+  const withSystemPrefix = (msgs: ModelMessage[]): ModelMessage[] =>
+    streamEnhancedSystemPromptForPersist
+      ? [
+          {
+            role: "system",
+            content: streamEnhancedSystemPromptForPersist,
+          },
+          ...msgs,
+        ]
+      : msgs;
 
   try {
     // See `runIterationWithAiSdk`: adopt the chat-side pipeline inside the try
@@ -3226,7 +3272,7 @@ const streamIterationWithAiSdk = async ({
               turnIndex: promptIndex,
               stepIndex: activeCompletedStepCount - 1,
               snapshotKind: "step_finish",
-              messages: snapshotMessages,
+              messages: withSystemPrefix(snapshotMessages),
               spans: [...recordedSpans, ...activeTraceCtx!.recordedSpans],
               actualToolCalls: extractToolCallsFromConversation({
                 messages: snapshotMessages,
@@ -3319,7 +3365,7 @@ const streamIterationWithAiSdk = async ({
         buildTraceSnapshotEvent({
           turnIndex: promptIndex,
           snapshotKind: "turn_finish",
-          messages: conversationMessages,
+          messages: withSystemPrefix(conversationMessages),
           spans: recordedSpans,
           actualToolCalls: extractToolCallsFromConversation({
             messages: conversationMessages,
@@ -3522,7 +3568,7 @@ const streamIterationWithAiSdk = async ({
           ? { stepIndex: activeCompletedStepCount - 1 }
           : {}),
         snapshotKind: "failure",
-        messages: failMessages,
+        messages: withSystemPrefix(failMessages),
         spans: recordedSpans,
         actualToolCalls: extractToolCallsFromConversation({
           messages: failMessages,
@@ -3755,6 +3801,12 @@ const streamIterationViaBackend = async ({
   const backendCustomProviders = orgModelConfig
     ? buildLlmRuntimeConfigFromOrgConfig(orgModelConfig).customProviders
     : undefined;
+  // PR 4d review fix (Codex P2 / Cursor Medium): hoisted up-front (above
+  // the `prepareChatV2` try) so the catch path and the assignment
+  // inside the try are both in scope. Stays `undefined` if prepareChatV2
+  // throws — the setup-failure persistence path doesn't need a system
+  // prefix.
+  let backendEnhancedSystemPromptForPersist: string | undefined = undefined;
   let prepared: PrepareChatV2Result;
   try {
     prepared = await prepareChatV2({
@@ -3769,6 +3821,9 @@ const streamIterationViaBackend = async ({
         : {}),
       priorMessages: [],
     });
+    // PR 4d review fix (Codex P2 / Cursor Medium): same persistence
+    // prefix shape as the non-stream backend runner.
+    backendEnhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : String(error);
@@ -3857,6 +3912,8 @@ const streamIterationViaBackend = async ({
   let iterationError: string | undefined = undefined;
   let iterationErrorDetails: string | undefined = undefined;
   const capturedSpans: EvalTraceSpan[] = [];
+  // PR 4d review fix (Codex P2 / Cursor Medium): see hoist above the
+  // `prepareChatV2` try.
   for (let promptIndex = 0; promptIndex < promptTurns.length; promptIndex++) {
     const promptTurn = promptTurns[promptIndex]!;
     const promptToolsCalled: ToolCall[] = [];
@@ -4459,13 +4516,26 @@ const streamIterationViaBackend = async ({
     mcpClientManager,
     convexClient,
   });
+  // PR 4d review fix (Codex P2 / Cursor Medium): prepend the resolved
+  // system at persistence so the backend's transcript carries it.
+  // Engine sent it via `runAssistantTurn`'s `systemPrompt:` arg.
+  const persistedBackendMessages: ModelMessage[] =
+    backendEnhancedSystemPromptForPersist
+      ? [
+          {
+            role: "system",
+            content: backendEnhancedSystemPromptForPersist,
+          },
+          ...messageHistory,
+        ]
+      : messageHistory;
 
   const finishParams = {
     iterationId,
     passed,
     toolsCalled: evaluation.toolsCalled,
     usage: accumulatedUsage,
-    messages: messageHistory,
+    messages: persistedBackendMessages,
     ...(capturedSpans.length ? { spans: capturedSpans } : {}),
     ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
     ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1277,6 +1277,21 @@ const runIterationWithAiSdk = async ({
   // tool cases.
   let iterationError: string | undefined = undefined;
   let iterationErrorDetails: string | undefined = undefined;
+  // PR 4d review fix (Codex P2 "Persist the resolved system prompt with
+  // eval traces"): chat ships the system via the helper's `system:`
+  // field, but eval's persistence path (`finishIteration` →
+  // `persistEvalTraceFanout`'s `appendEvalTurnTrace` payload) has no
+  // dedicated `systemPrompt` slot. Pre-4d, the system rode along as
+  // the first entry in `conversationMessages` and was naturally
+  // persisted. PR 4d dropped that push to align with chat's wire shape,
+  // and accidentally removed the only path the persistence layer had
+  // for capturing it. Hoist the resolved system prompt to outer scope
+  // so we can prepend it to the messages array AT PERSISTENCE TIME
+  // (not in `conversationMessages` — that stays system-free so the
+  // streamText `system:` field isn't double-sent). The persisted
+  // shape now matches pre-4d (system is the first message in
+  // `messages`) while the wire shape stays chat-aligned.
+  let enhancedSystemPromptForPersist: string | undefined = undefined;
 
   try {
     // Adopt the chat-side tool/system/temperature pipeline. Eval used to skip
@@ -1305,10 +1320,11 @@ const runIterationWithAiSdk = async ({
     // emit `""` would have double-sent the system. Match chat's shape —
     // `enhancedSystemPrompt` flows to `runDirectChatTurn` via the
     // `systemPrompt:` argument below; `conversationMessages` no longer
-    // carries a system message entry. The persisted transcript still
-    // shows the system because the helper assembles it via the
-    // `system:` field and the chatbox/eval persistence pipeline
-    // stamps `systemPrompt` as its own column.
+    // carries a system message entry. PR 4d review fix (Codex P2):
+    // hoist the resolved value so it can be prepended to the messages
+    // array at persistence time, since eval's wire shape to Convex
+    // (`appendEvalTurnTrace`) has no dedicated `systemPrompt` slot.
+    enhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
 
     const llmModel = createLlmModel(
       modelDefinition,
@@ -1606,12 +1622,25 @@ const runIterationWithAiSdk = async ({
       convexClient,
     });
 
+    // PR 4d review fix (Codex P2): prepend the resolved system prompt
+    // so persisted eval transcripts carry it. The streamText `system:`
+    // field already covered the wire shape to the model; this restores
+    // the pre-4d persistence shape (first message is `role: "system"`)
+    // for downstream consumers of `appendEvalTurnTrace.sessionMessages`
+    // and the legacy `testIteration.blob` fallback.
+    const persistedMessages: ModelMessage[] = enhancedSystemPromptForPersist
+      ? [
+          { role: "system", content: enhancedSystemPromptForPersist },
+          ...conversationMessages,
+        ]
+      : conversationMessages;
+
     const finishParams = {
       iterationId,
       passed,
       toolsCalled: evaluation.toolsCalled,
       usage,
-      messages: conversationMessages,
+      messages: persistedMessages,
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -1720,6 +1749,20 @@ const runIterationWithAiSdk = async ({
       mcpClientManager,
       convexClient,
     });
+    // PR 4d review fix (Codex P2): same prefix as the success path — if
+    // `prepared` ran far enough to populate
+    // `enhancedSystemPromptForPersist`, surface the resolved system in
+    // the persisted failure transcript. Catches that fire BEFORE
+    // `prepareChatV2` returned leave the prefix empty (no system to
+    // persist anyway). Applied only in `runIterationWithAiSdk`; the
+    // streaming variant still pushes the system into
+    // `conversationMessages` itself (PR 5 territory).
+    const persistedFailMessages: ModelMessage[] = enhancedSystemPromptForPersist
+      ? [
+          { role: "system", content: enhancedSystemPromptForPersist },
+          ...failMessages,
+        ]
+      : failMessages;
 
     const failParams = {
       iterationId,
@@ -1730,7 +1773,7 @@ const runIterationWithAiSdk = async ({
         outputTokens: accumulatedUsage.outputTokens,
         totalTokens: accumulatedUsage.totalTokens,
       },
-      messages: failMessages,
+      messages: persistedFailMessages,
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -3030,6 +3073,12 @@ const streamIterationWithAiSdk = async ({
   let activeCompletedStepCount = 0;
   let activeTraceCtx: ReturnType<typeof createAiSdkEvalTraceContext> | null =
     null;
+  // PR 4d review fix (CodeRabbit): hoisted so persistence sites in the
+  // success + catch paths can prepend the resolved system prompt to
+  // the messages array. Mirrors `enhancedSystemPromptForPersist` in
+  // `runIterationWithAiSdk`. Empty when `prepareChatV2` throws before
+  // returning.
+  let streamEnhancedSystemPromptForPersist: string | undefined = undefined;
 
   try {
     // See `runIterationWithAiSdk`: adopt the chat-side pipeline inside the try
@@ -3044,12 +3093,17 @@ const streamIterationWithAiSdk = async ({
       customProviders: modelRuntime.customProviders,
       priorMessages: [],
     });
-    if (prepared.enhancedSystemPrompt) {
-      conversationMessages.push({
-        role: "system",
-        content: prepared.enhancedSystemPrompt,
-      });
-    }
+    // PR 4d review fix (CodeRabbit "Use the dedicated system: field in
+    // streamIterationWithAiSdk"): align the streaming local-BYOK runner
+    // with the non-stream variant's chat-aligned shape. Pre-fix this
+    // runner pushed the system into `conversationMessages` AND omitted
+    // `system:` on the `streamText({...})` call below, so a streamed
+    // eval and a non-stream eval of the same case produced different
+    // transcript shapes. Now the system flows via the dedicated
+    // `system:` field, the runner-side `conversationMessages` stays
+    // system-free, and persistence prepends the resolved value at write
+    // time (mirroring the non-stream runner's PR 4d Codex P2 fix).
+    streamEnhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
 
     const llmModel = createLlmModel(
       modelDefinition,
@@ -3093,6 +3147,9 @@ const streamIterationWithAiSdk = async ({
       const result = streamText({
         model: llmModel,
         messages: activePromptInputMessages,
+        ...(prepared.enhancedSystemPrompt
+          ? { system: prepared.enhancedSystemPrompt }
+          : {}),
         tools: tracedTools,
         stopWhen: stepCountIs(20),
         ...(prepared.resolvedTemperature == null
@@ -3333,13 +3390,26 @@ const streamIterationWithAiSdk = async ({
       mcpClientManager,
       convexClient,
     });
+    // PR 4d review fix (CodeRabbit): prepend the resolved system at
+    // persistence time so the streamed eval's transcript matches the
+    // non-stream runner's shape (`role: "system"` first entry).
+    const persistedStreamMessages: ModelMessage[] =
+      streamEnhancedSystemPromptForPersist
+        ? [
+            {
+              role: "system",
+              content: streamEnhancedSystemPromptForPersist,
+            },
+            ...conversationMessages,
+          ]
+        : conversationMessages;
 
     const finishParams = {
       iterationId,
       passed,
       toolsCalled: evaluation.toolsCalled,
       usage: usageFinal,
-      messages: conversationMessages,
+      messages: persistedStreamMessages,
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -3471,6 +3541,20 @@ const streamIterationWithAiSdk = async ({
       details: errorDetails,
     });
 
+    // PR 4d review fix (CodeRabbit): mirror the non-stream runner — if
+    // `prepared` populated the resolved system prompt before the throw,
+    // prepend it to the persisted failure transcript.
+    const persistedStreamFailMessages: ModelMessage[] =
+      streamEnhancedSystemPromptForPersist
+        ? [
+            {
+              role: "system",
+              content: streamEnhancedSystemPromptForPersist,
+            },
+            ...failMessages,
+          ]
+        : failMessages;
+
     const failParams = {
       iterationId,
       passed: false,
@@ -3480,7 +3564,7 @@ const streamIterationWithAiSdk = async ({
         outputTokens: accumulatedUsage.outputTokens,
         totalTokens: accumulatedUsage.totalTokens,
       },
-      messages: failMessages,
+      messages: persistedStreamFailMessages,
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -32,6 +32,7 @@ import {
   consumeDirectChatTurnHeadless,
   runDirectChatTurn,
 } from "../utils/direct-chat-turn";
+import { resolveExecutionContext } from "../utils/host-execution-context";
 import { logger } from "../utils/logger";
 import { captureMcpAppWidgetSnapshots } from "../utils/mcp-app-widget-capture";
 import {
@@ -227,6 +228,13 @@ export type RunEvalSuiteOptions = {
    * cross-host dashboard.
    */
   hostExecutionPolicy?: HostExecutionPolicy;
+  /**
+   * Raw suite hostConfig record. PR 4d threads this through so per-iteration
+   * runners can resolve CONFIG fields (`systemPrompt` / `temperature` /
+   * `selectedServerIds`) via `resolveExecutionContext` — the runner used
+   * to read `advancedConfig.system` only and ignore the suite default.
+   */
+  suiteHostConfig?: Record<string, unknown> | null;
 };
 
 /** One executed iteration inside a suite/quick run (evaluation + optional persisted iteration id). */
@@ -910,6 +918,23 @@ type RunIterationBaseParams = {
   hostPolicy?: HostExecutionPolicy;
   /** Pre-computed tool exposure signals for this run (set by runEvalSuiteWithAiSdk). */
   toolSignals?: ToolExposureSignals;
+  /**
+   * Raw suite hostConfig record — the same one the route layer feeds
+   * to `extractHostExecutionPolicy` for the `hostPolicy` field above.
+   * PR 4d of the engine consolidation (`~/mcpjam-docs/unification.md`)
+   * threads this through so per-iteration runners can resolve CONFIG
+   * fields (`systemPrompt` / `temperature` / `selectedServerIds`) off
+   * it via `resolveExecutionContext` — the runner used to read
+   * `advancedConfig.system` only, leaving the suite-default systemPrompt
+   * unused at runtime even though the eval client deliberately omits
+   * it from per-case `advancedConfig` (see comment at
+   * `client/src/components/evals/use-eval-handlers.ts:302`).
+   *
+   * Optional so quick-run paths that don't load a suite hostConfig keep
+   * working — the resolver treats `null`/`undefined` as "no host opinion;
+   * use overrides as-is."
+   */
+  suiteHostConfig?: Record<string, unknown> | null;
 };
 
 type RunIterationAiSdkParams = RunIterationBaseParams & {
@@ -1092,6 +1117,7 @@ const runIterationWithAiSdk = async ({
   injectOpenAiCompat,
   hostPolicy,
   toolSignals,
+  suiteHostConfig,
 }: RunIterationAiSdkParams) => {
   const resolvedTest = resolveEvalTestCase(test);
 
@@ -1141,18 +1167,44 @@ const runIterationWithAiSdk = async ({
     expectedOutput,
     promptTurns,
   } = resolvedTest;
+  // PR 4d of the engine consolidation (`~/mcpjam-docs/unification.md`):
+  // resolve `systemPrompt` and `temperature` via the shared
+  // `resolveExecutionContext` so the suite-level hostConfig's
+  // `systemPrompt` / `temperature` act as defaults under the per-case
+  // `advancedConfig` overrides. Pre-4d the runner ignored
+  // `suiteHostConfig.systemPrompt` / `.temperature` entirely — even
+  // though the eval client deliberately omits suite defaults from per-case
+  // advancedConfig (see comment at
+  // `client/src/components/evals/use-eval-handlers.ts:302`) on the
+  // understanding that the runtime applies them. `override-wins`
+  // precedence keeps per-case overrides authoritative; the hostConfig
+  // fills the gap when the per-case value is absent.
+  //
+  // `withHostContextSystemPrompt` runs AFTER the resolver because
+  // `{{var}}` substitution context is per-RUN
+  // (`test.hostConfigOverride.hostContext`), not part of the suite
+  // hostConfig.
+  const resolvedExecution = resolveExecutionContext({
+    hostConfig: suiteHostConfig ?? null,
+    overrides: {
+      systemPrompt:
+        typeof advancedConfig?.system === "string"
+          ? advancedConfig.system
+          : undefined,
+      temperature:
+        typeof advancedConfig?.temperature === "number"
+          ? advancedConfig.temperature
+          : undefined,
+    },
+    precedence: "override-wins",
+  });
   const system = withHostContextSystemPrompt(
-    typeof advancedConfig?.system === "string"
-      ? advancedConfig.system
-      : undefined,
+    resolvedExecution.systemPrompt,
     test.hostConfigOverride?.hostContext as
       | Record<string, unknown>
       | undefined,
   );
-  const temperature =
-    typeof advancedConfig?.temperature === "number"
-      ? advancedConfig.temperature
-      : undefined;
+  const temperature = resolvedExecution.temperature;
   const toolChoice = normalizeToolChoice(advancedConfig?.toolChoice);
 
   const modelRuntime = resolveEvalModelRuntime({
@@ -1242,12 +1294,21 @@ const runIterationWithAiSdk = async ({
       customProviders: modelRuntime.customProviders,
       priorMessages: [],
     });
-    if (prepared.enhancedSystemPrompt) {
-      conversationMessages.push({
-        role: "system",
-        content: prepared.enhancedSystemPrompt,
-      });
-    }
+    // PR 4d of the engine consolidation: drop the PR 4b
+    // `systemPrompt: ""` quirk. Pre-4d, eval pushed
+    // `prepared.enhancedSystemPrompt` as a `role: "system"` message into
+    // `conversationMessages` and passed `systemPrompt: ""` to the
+    // helper — `normalizeSystemPromptForProvider("")` resolved to
+    // `undefined` so streamText received the system via messages, not
+    // the dedicated `system:` field. That worked but was a latent
+    // footgun: any refactor of `normalizeSystemPromptForProvider` to
+    // emit `""` would have double-sent the system. Match chat's shape —
+    // `enhancedSystemPrompt` flows to `runDirectChatTurn` via the
+    // `systemPrompt:` argument below; `conversationMessages` no longer
+    // carries a system message entry. The persisted transcript still
+    // shows the system because the helper assembles it via the
+    // `system:` field and the chatbox/eval persistence pipeline
+    // stamps `systemPrompt` as its own column.
 
     const llmModel = createLlmModel(
       modelDefinition,
@@ -1301,11 +1362,12 @@ const runIterationWithAiSdk = async ({
       // Eval owns failure detection + persistence + grading, layered
       // on top of `consumeDirectChatTurnHeadless`'s assembled return.
       //
-      // `systemPrompt: ""` is intentional: eval keeps the system message
-      // inside `conversationMessages` (so the persisted transcript still
-      // includes it for the UI), so we don't pass it separately to
-      // streamText. `normalizeSystemPromptForProvider("")` returns
-      // `undefined`, so the helper skips the `system:` field.
+      // PR 4d: `systemPrompt: prepared.enhancedSystemPrompt` matches
+      // chat's shape — the helper passes it to streamText via the
+      // dedicated `system:` field. `conversationMessages` no longer
+      // contains a system message; the persisted transcript carries
+      // the system via its own column (chatSession.systemPrompt /
+      // testIteration column), same as chat's path.
       // PR 4b review fix (Cursor "Partial messages never mirrored" +
       // Codex P2): the legacy `generateText` loop updated
       // `activePartialResponseMessages` and `activeCompletedStepCount`
@@ -1324,7 +1386,7 @@ const runIterationWithAiSdk = async ({
         llmModel,
         modelId: test.model,
         messageHistory: activePromptInputMessages,
-        systemPrompt: "",
+        systemPrompt: prepared.enhancedSystemPrompt ?? "",
         ...(prepared.resolvedTemperature == null
           ? {}
           : { temperature: prepared.resolvedTemperature }),
@@ -1734,6 +1796,7 @@ const runIterationViaBackend = async ({
   injectOpenAiCompat,
   hostPolicy,
   toolSignals,
+  suiteHostConfig,
 }: RunIterationBackendParams) => {
   const resolvedTest = resolveEvalTestCase(test);
 
@@ -1783,18 +1846,31 @@ const runIterationViaBackend = async ({
     promptTurns,
     advancedConfig,
   } = resolvedTest;
+  // PR 4d of the engine consolidation: same resolver shape as
+  // `runIterationWithAiSdk` above — suite hostConfig provides defaults,
+  // per-case `advancedConfig` overrides win. `withHostContextSystemPrompt`
+  // applies {{var}} substitution on the resolved value.
+  const resolvedExecution = resolveExecutionContext({
+    hostConfig: suiteHostConfig ?? null,
+    overrides: {
+      systemPrompt:
+        typeof advancedConfig?.system === "string"
+          ? advancedConfig.system
+          : undefined,
+      temperature:
+        typeof advancedConfig?.temperature === "number"
+          ? advancedConfig.temperature
+          : undefined,
+    },
+    precedence: "override-wins",
+  });
   const systemPrompt = withHostContextSystemPrompt(
-    typeof advancedConfig?.system === "string"
-      ? advancedConfig.system
-      : undefined,
+    resolvedExecution.systemPrompt,
     test.hostConfigOverride?.hostContext as
       | Record<string, unknown>
       | undefined,
   );
-  const temperature =
-    typeof advancedConfig?.temperature === "number"
-      ? advancedConfig.temperature
-      : undefined;
+  const temperature = resolvedExecution.temperature;
   const toolChoice = normalizeToolChoice(advancedConfig?.toolChoice);
 
   const messageHistory: ModelMessage[] = [];
@@ -2318,6 +2394,8 @@ const runTestCase = async (params: {
   hostPolicy?: HostExecutionPolicy;
   /** Pre-computed tool exposure signals for metadata stamping. */
   toolSignals?: ToolExposureSignals;
+  /** Raw suite hostConfig record. PR 4d — see RunIterationBaseParams. */
+  suiteHostConfig?: Record<string, unknown> | null;
 }) => {
   const {
     test,
@@ -2339,6 +2417,7 @@ const runTestCase = async (params: {
     injectOpenAiCompat,
     hostPolicy,
     toolSignals,
+    suiteHostConfig,
   } = params;
   const testCaseId = test.testCaseId || parentTestCaseId;
   const modelDefinition = buildModelDefinition(test);
@@ -2445,6 +2524,7 @@ const runTestCase = async (params: {
         injectOpenAiCompat,
         hostPolicy,
         toolSignals,
+        suiteHostConfig,
       });
       outcomes.push(iterationOutcome);
       continue;
@@ -2480,6 +2560,7 @@ const runTestCase = async (params: {
         injectOpenAiCompat,
         hostPolicy,
         toolSignals,
+        suiteHostConfig,
       });
       outcomes.push(iterationOutcome);
       continue;
@@ -2509,6 +2590,7 @@ const runTestCase = async (params: {
       injectOpenAiCompat,
       hostPolicy,
       toolSignals,
+      suiteHostConfig,
     });
     outcomes.push(iterationOutcome);
   }
@@ -2532,6 +2614,7 @@ export const runEvalSuiteWithAiSdk = async ({
   compareRunId,
   suiteInjectOpenAiCompat,
   hostExecutionPolicy,
+  suiteHostConfig,
 }: RunEvalSuiteOptions): Promise<RunEvalSuiteWithAiSdkResult | undefined> => {
   const injectOpenAiCompat = suiteInjectOpenAiCompat === true;
   const tests = config.tests ?? [];
@@ -2633,6 +2716,7 @@ export const runEvalSuiteWithAiSdk = async ({
         injectOpenAiCompat,
         hostPolicy: hostExecutionPolicy,
         toolSignals: resolvedToolSignals,
+        suiteHostConfig,
       }),
     );
 
@@ -2797,6 +2881,7 @@ const streamIterationWithAiSdk = async ({
   injectOpenAiCompat,
   hostPolicy,
   toolSignals,
+  suiteHostConfig,
 }: RunIterationAiSdkParams & {
   emit: StreamEmit;
 }): Promise<EvalIterationOutcome> => {
@@ -2847,18 +2932,44 @@ const streamIterationWithAiSdk = async ({
     expectedOutput,
     promptTurns,
   } = resolvedTest;
+  // PR 4d of the engine consolidation (`~/mcpjam-docs/unification.md`):
+  // resolve `systemPrompt` and `temperature` via the shared
+  // `resolveExecutionContext` so the suite-level hostConfig's
+  // `systemPrompt` / `temperature` act as defaults under the per-case
+  // `advancedConfig` overrides. Pre-4d the runner ignored
+  // `suiteHostConfig.systemPrompt` / `.temperature` entirely — even
+  // though the eval client deliberately omits suite defaults from per-case
+  // advancedConfig (see comment at
+  // `client/src/components/evals/use-eval-handlers.ts:302`) on the
+  // understanding that the runtime applies them. `override-wins`
+  // precedence keeps per-case overrides authoritative; the hostConfig
+  // fills the gap when the per-case value is absent.
+  //
+  // `withHostContextSystemPrompt` runs AFTER the resolver because
+  // `{{var}}` substitution context is per-RUN
+  // (`test.hostConfigOverride.hostContext`), not part of the suite
+  // hostConfig.
+  const resolvedExecution = resolveExecutionContext({
+    hostConfig: suiteHostConfig ?? null,
+    overrides: {
+      systemPrompt:
+        typeof advancedConfig?.system === "string"
+          ? advancedConfig.system
+          : undefined,
+      temperature:
+        typeof advancedConfig?.temperature === "number"
+          ? advancedConfig.temperature
+          : undefined,
+    },
+    precedence: "override-wins",
+  });
   const system = withHostContextSystemPrompt(
-    typeof advancedConfig?.system === "string"
-      ? advancedConfig.system
-      : undefined,
+    resolvedExecution.systemPrompt,
     test.hostConfigOverride?.hostContext as
       | Record<string, unknown>
       | undefined,
   );
-  const temperature =
-    typeof advancedConfig?.temperature === "number"
-      ? advancedConfig.temperature
-      : undefined;
+  const temperature = resolvedExecution.temperature;
   const toolChoice = normalizeToolChoice(advancedConfig?.toolChoice);
 
   const modelRuntime = resolveEvalModelRuntime({
@@ -3430,6 +3541,7 @@ const streamIterationViaBackend = async ({
   injectOpenAiCompat,
   hostPolicy,
   toolSignals,
+  suiteHostConfig,
 }: RunIterationBackendParams & {
   emit: StreamEmit;
 }): Promise<EvalIterationOutcome> => {
@@ -3480,18 +3592,31 @@ const streamIterationViaBackend = async ({
     promptTurns,
     advancedConfig,
   } = resolvedTest;
+  // PR 4d of the engine consolidation: same resolver shape as
+  // `runIterationWithAiSdk` above — suite hostConfig provides defaults,
+  // per-case `advancedConfig` overrides win. `withHostContextSystemPrompt`
+  // applies {{var}} substitution on the resolved value.
+  const resolvedExecution = resolveExecutionContext({
+    hostConfig: suiteHostConfig ?? null,
+    overrides: {
+      systemPrompt:
+        typeof advancedConfig?.system === "string"
+          ? advancedConfig.system
+          : undefined,
+      temperature:
+        typeof advancedConfig?.temperature === "number"
+          ? advancedConfig.temperature
+          : undefined,
+    },
+    precedence: "override-wins",
+  });
   const systemPrompt = withHostContextSystemPrompt(
-    typeof advancedConfig?.system === "string"
-      ? advancedConfig.system
-      : undefined,
+    resolvedExecution.systemPrompt,
     test.hostConfigOverride?.hostContext as
       | Record<string, unknown>
       | undefined,
   );
-  const temperature =
-    typeof advancedConfig?.temperature === "number"
-      ? advancedConfig.temperature
-      : undefined;
+  const temperature = resolvedExecution.temperature;
   const toolChoice = normalizeToolChoice(advancedConfig?.toolChoice);
 
   const messageHistory: ModelMessage[] = [];
@@ -4321,6 +4446,8 @@ export const streamTestCase = async (params: {
   hostPolicy?: HostExecutionPolicy;
   /** Pre-computed tool exposure signals for the stream run. */
   toolSignals?: ToolExposureSignals;
+  /** Raw suite hostConfig record. PR 4d — see RunIterationBaseParams. */
+  suiteHostConfig?: Record<string, unknown> | null;
 }) => {
   const {
     test,
@@ -4343,6 +4470,7 @@ export const streamTestCase = async (params: {
     injectOpenAiCompat,
     hostPolicy,
     toolSignals,
+    suiteHostConfig,
   } = params;
   const testCaseId = test.testCaseId || parentTestCaseId;
   const modelDefinition = buildModelDefinition(test);
@@ -4453,6 +4581,7 @@ export const streamTestCase = async (params: {
         injectOpenAiCompat,
         hostPolicy,
         toolSignals,
+        suiteHostConfig,
       });
       outcomes.push(iterationOutcome);
       continue;
@@ -4489,6 +4618,7 @@ export const streamTestCase = async (params: {
         injectOpenAiCompat,
         hostPolicy,
         toolSignals,
+        suiteHostConfig,
       });
       outcomes.push(iterationOutcome);
       continue;
@@ -4519,6 +4649,7 @@ export const streamTestCase = async (params: {
       injectOpenAiCompat,
       hostPolicy,
       toolSignals,
+      suiteHostConfig,
     });
     outcomes.push(iterationOutcome);
   }

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -2395,4 +2395,147 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     // through buildIterationUsageMetadata).
     expect(updatePayload.tokensUsed).toBe(18);
   });
+
+  describe("PR 4d — suite hostConfig systemPrompt resolution", () => {
+    // PR 4d of the engine consolidation
+    // (`~/mcpjam-docs/unification.md`): eval was reading
+    // `advancedConfig.system` only and ignoring
+    // `suiteHostConfig.systemPrompt` / `.temperature`. The eval client
+    // deliberately omits suite defaults from per-case `advancedConfig`
+    // (comment at `client/src/components/evals/use-eval-handlers.ts:302`)
+    // on the understanding that the runtime applies them. PR 4d closes
+    // that gap by routing the resolution through the shared
+    // `resolveExecutionContext` helper with `override-wins` precedence
+    // — per-case stays authoritative; suite default fills the gap.
+
+    async function runWithSuiteHostConfig(
+      suiteHostConfig: Record<string, unknown> | null,
+      caseAdvancedConfig?: Record<string, unknown>,
+    ) {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+              ...(caseAdvancedConfig
+                ? { advancedConfig: caseAdvancedConfig }
+                : {}),
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+        suiteHostConfig,
+      });
+    }
+
+    it("uses suiteHostConfig.systemPrompt when advancedConfig.system is absent (gap closure)", async () => {
+      // **Behavior change** locked here: pre-PR-4d this test would have
+      // seen `system: ""` (or undefined) on the streamText call because
+      // the runner ignored `suiteHostConfig.systemPrompt`. Post-4d the
+      // suite default flows through.
+      await runWithSuiteHostConfig({
+        systemPrompt: "Suite-default system prompt",
+      });
+
+      const streamTextCall = streamTextMock.mock.calls[0]?.[0];
+      expect(streamTextCall).toBeDefined();
+      // `prepareChatV2` is stubbed to passthrough — `prepared.enhancedSystemPrompt`
+      // equals the input `systemPrompt`. Helper sends it via the `system:`
+      // field per PR 4d (drops the `""` quirk).
+      expect(streamTextCall.system).toBe("Suite-default system prompt");
+    });
+
+    it("per-case advancedConfig.system overrides suiteHostConfig.systemPrompt", async () => {
+      await runWithSuiteHostConfig(
+        { systemPrompt: "Suite default" },
+        { system: "Per-case override" },
+      );
+
+      const streamTextCall = streamTextMock.mock.calls[0]?.[0];
+      expect(streamTextCall).toBeDefined();
+      expect(streamTextCall.system).toBe("Per-case override");
+    });
+
+    it("falls back gracefully when suiteHostConfig is null and advancedConfig.system is absent", async () => {
+      // Quick-run paths that don't load a suite hostConfig pass `null` /
+      // `undefined`; the resolver returns the override (undefined here)
+      // and downstream code emits no `system:` field.
+      await runWithSuiteHostConfig(null);
+
+      const streamTextCall = streamTextMock.mock.calls[0]?.[0];
+      expect(streamTextCall).toBeDefined();
+      // With no source for systemPrompt, the helper's
+      // `normalizeSystemPromptForProvider(undefined)` returns undefined
+      // and streamText doesn't receive a `system:` field.
+      expect(streamTextCall.system).toBeUndefined();
+    });
+
+    it("uses suiteHostConfig.temperature when advancedConfig.temperature is absent", async () => {
+      await runWithSuiteHostConfig({
+        temperature: 0.42,
+      });
+
+      const streamTextCall = streamTextMock.mock.calls[0]?.[0];
+      expect(streamTextCall).toBeDefined();
+      expect(streamTextCall.temperature).toBe(0.42);
+    });
+
+    it("per-case advancedConfig.temperature overrides suiteHostConfig.temperature", async () => {
+      await runWithSuiteHostConfig(
+        { temperature: 0.42 },
+        { temperature: 0.99 },
+      );
+
+      const streamTextCall = streamTextMock.mock.calls[0]?.[0];
+      expect(streamTextCall).toBeDefined();
+      expect(streamTextCall.temperature).toBe(0.99);
+    });
+
+    it("does NOT push the system message into conversationMessages anymore (drops PR 4b quirk)", async () => {
+      // PR 4b pushed the resolved system prompt as a `role: "system"`
+      // message into `conversationMessages` and passed `systemPrompt: ""`
+      // to runDirectChatTurn. PR 4d aligns with chat-v2 — system goes
+      // via the helper's `systemPrompt:` field, never as a message.
+      // Persisted transcript must NOT contain a `role: "system"` entry.
+      await runWithSuiteHostConfig({
+        systemPrompt: "Test system prompt",
+      });
+
+      const noSystemRoleInPersistedMessages = (msgs: unknown): boolean => {
+        if (!Array.isArray(msgs)) return true;
+        return !msgs.some((m: any) => m?.role === "system");
+      };
+      const allCallsLackSystemRole = convexClient.action.mock.calls.every(
+        (call) => {
+          const payload = call[1] as Record<string, unknown> | undefined;
+          if (!payload) return true;
+          if (!noSystemRoleInPersistedMessages(payload.messages)) return false;
+          const turn = payload.turn as
+            | { sessionMessages?: unknown }
+            | undefined;
+          if (turn && !noSystemRoleInPersistedMessages(turn.sessionMessages))
+            return false;
+          return true;
+        },
+      );
+      expect(allCallsLackSystemRole).toBe(true);
+    });
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -2576,6 +2576,104 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       expect(anyCallCarriesIt).toBe(true);
     });
 
+    it("prepends the resolved system to the backend runner's persisted transcript (PR 4d review — Codex P2 / Cursor Medium)", async () => {
+      // Codex P2 / Cursor Medium: `runIterationViaBackend` sends the
+      // resolved system to the model via `runAssistantTurn`'s
+      // `systemPrompt:` arg, but the engine's returned message history
+      // doesn't carry a system entry. `appendEvalTurnTrace` has no
+      // dedicated `systemPrompt` slot, so the persisted transcript
+      // omits a prompt that affected the model. Fix: prepend at
+      // persistence time, mirroring the local runner's fix.
+      const assistantTurnModule = await import("../../../utils/assistant-turn");
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockResolvedValueOnce({
+          messages: [
+            { role: "user", content: "Hello" } as any,
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Backend response" }],
+            } as any,
+          ],
+          assistantMessages: [],
+          toolCalls: [],
+          toolResults: [],
+          turnTrace: {
+            turnId: "t_1",
+            promptIndex: 0,
+            startedAt: 0,
+            endedAt: 10,
+            modelId: "anthropic/claude-haiku-4.5",
+            spans: [],
+          },
+        } as any);
+
+      try {
+        await runEvalSuiteWithAiSdk({
+          suiteId: "suite-1",
+          runId: null,
+          config: {
+            tests: [
+              {
+                title: "Backend system prefix",
+                query: "Hello",
+                runs: 1,
+                model: "claude-haiku-4.5",
+                provider: "anthropic",
+                expectedToolCalls: [],
+                promptTurns: [
+                  { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+                ],
+                testCaseId: "case-backend-sys",
+              },
+            ],
+            environment: { servers: ["srv-1"] },
+          },
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          mcpClientManager: mcpClientManager as any,
+          testCaseId: "case-backend-sys",
+          suiteHostConfig: {
+            systemPrompt: "Backend suite default",
+          },
+        });
+
+        const hasSystemPrefix = (msgs: unknown): boolean => {
+          if (!Array.isArray(msgs) || msgs.length === 0) return false;
+          const first = msgs[0] as { role?: string; content?: unknown };
+          if (first?.role !== "system") return false;
+          if (typeof first.content === "string") {
+            return first.content === "Backend suite default";
+          }
+          if (Array.isArray(first.content)) {
+            return first.content.some(
+              (part: any) =>
+                part?.type === "text" &&
+                part.text === "Backend suite default",
+            );
+          }
+          return false;
+        };
+        const anyCallCarriesIt = convexClient.action.mock.calls.some(
+          (call) => {
+            const payload = call[1] as Record<string, unknown> | undefined;
+            if (!payload) return false;
+            if (hasSystemPrefix(payload.messages)) return true;
+            const turn = payload.turn as
+              | { sessionMessages?: unknown }
+              | undefined;
+            if (turn && hasSystemPrefix(turn.sessionMessages)) return true;
+            return false;
+          },
+        );
+        expect(anyCallCarriesIt).toBe(true);
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
     it("aligns streamIterationWithAiSdk with the chat wire shape (PR 4d review — CodeRabbit)", async () => {
       // CodeRabbit Major review fix: pre-fix, the streaming runner
       // pushed the system into `conversationMessages` AND omitted

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -2508,34 +2508,160 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       expect(streamTextCall.temperature).toBe(0.99);
     });
 
-    it("does NOT push the system message into conversationMessages anymore (drops PR 4b quirk)", async () => {
+    it("sends the system to streamText via system: field, not as a message in messageHistory", async () => {
       // PR 4b pushed the resolved system prompt as a `role: "system"`
-      // message into `conversationMessages` and passed `systemPrompt: ""`
-      // to runDirectChatTurn. PR 4d aligns with chat-v2 — system goes
-      // via the helper's `systemPrompt:` field, never as a message.
-      // Persisted transcript must NOT contain a `role: "system"` entry.
+      // message into the messageHistory passed to streamText. PR 4d
+      // aligns with chat-v2 — the system goes via streamText's
+      // dedicated `system:` field, NOT in the messages array.
+      // (The persisted transcript DOES carry the system as a
+      // first-message prefix; see the next test for that — applied at
+      // persistence time, not in the runner's `conversationMessages`.)
       await runWithSuiteHostConfig({
         systemPrompt: "Test system prompt",
       });
 
-      const noSystemRoleInPersistedMessages = (msgs: unknown): boolean => {
-        if (!Array.isArray(msgs)) return true;
-        return !msgs.some((m: any) => m?.role === "system");
+      const streamTextCall = streamTextMock.mock.calls[0]?.[0];
+      expect(streamTextCall).toBeDefined();
+      expect(streamTextCall.system).toBe("Test system prompt");
+      // No `role: "system"` entry in the messages array — that's chat's
+      // shape, and PR 4d adopts it for the wire layer.
+      const messageHistory = streamTextCall.messages as Array<{ role: string }>;
+      const hasSystemEntry = messageHistory.some((m) => m.role === "system");
+      expect(hasSystemEntry).toBe(false);
+    });
+
+    it("prepends the resolved system prompt to persisted messages (PR 4d review — Codex P2)", async () => {
+      // Codex P2 review fix: pre-4d the system rode along as the first
+      // entry in `conversationMessages` and was naturally persisted via
+      // the messages-array path. PR 4d dropped that push to align the
+      // streamText wire shape with chat-v2; persistence had no
+      // dedicated `systemPrompt` slot on `appendEvalTurnTrace`, so the
+      // resolved system prompt was lost from the persisted transcript.
+      //
+      // Fix: prepend the resolved value as a `role: "system"` message
+      // at PERSISTENCE TIME (not in `conversationMessages` — the wire
+      // shape stays chat-aligned, no double-send). This restores the
+      // pre-4d persistence shape exactly: first message is
+      // `role: "system"` with the resolved content.
+      await runWithSuiteHostConfig({
+        systemPrompt: "Resolved system prompt for persistence",
+      });
+
+      const hasSystemPrefix = (msgs: unknown): boolean => {
+        if (!Array.isArray(msgs) || msgs.length === 0) return false;
+        const first = msgs[0] as { role?: string; content?: unknown };
+        if (first?.role !== "system") return false;
+        if (typeof first.content === "string") {
+          return first.content === "Resolved system prompt for persistence";
+        }
+        if (Array.isArray(first.content)) {
+          return first.content.some(
+            (part: any) =>
+              part?.type === "text" &&
+              part.text === "Resolved system prompt for persistence",
+          );
+        }
+        return false;
       };
-      const allCallsLackSystemRole = convexClient.action.mock.calls.every(
+      const anyCallCarriesIt = convexClient.action.mock.calls.some((call) => {
+        const payload = call[1] as Record<string, unknown> | undefined;
+        if (!payload) return false;
+        if (hasSystemPrefix(payload.messages)) return true;
+        const turn = payload.turn as
+          | { sessionMessages?: unknown }
+          | undefined;
+        if (turn && hasSystemPrefix(turn.sessionMessages)) return true;
+        return false;
+      });
+      expect(anyCallCarriesIt).toBe(true);
+    });
+
+    it("aligns streamIterationWithAiSdk with the chat wire shape (PR 4d review — CodeRabbit)", async () => {
+      // CodeRabbit Major review fix: pre-fix, the streaming runner
+      // pushed the system into `conversationMessages` AND omitted
+      // `system:` on streamText. A streamed eval of the same case
+      // produced a different transcript shape from the non-stream
+      // runner. Align: system flows via the dedicated `system:` field;
+      // wire-shape messages do NOT carry a `role: "system"` entry;
+      // persistence prepends the resolved system at write time.
+      streamTextMock.mockReset();
+      streamTextMock.mockImplementationOnce((_options: any) => ({
+        fullStream: (async function* () {})(),
+        steps: Promise.resolve([]),
+        response: Promise.resolve({
+          messages: [{ role: "assistant", content: "Done" }],
+        }),
+      }));
+
+      await streamTestCase({
+        test: {
+          title: "Case",
+          query: "Hello",
+          runs: 1,
+          model: "gpt-4-turbo",
+          provider: "openai",
+          expectedToolCalls: [],
+          promptTurns: [
+            { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+          ],
+          testCaseId: "case-stream-sys",
+        },
+        tools: {},
+        selectedServers: [],
+        mcpClientManager: mcpClientManager as any,
+        recorder: null,
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        testCaseId: "case-stream-sys",
+        suiteId: "suite-1",
+        runId: null,
+        emit: () => {},
+        suiteHostConfig: {
+          systemPrompt: "Stream-runner suite default",
+        },
+      } as any);
+
+      const streamCall = streamTextMock.mock.calls[0]?.[0];
+      expect(streamCall).toBeDefined();
+      // Wire shape: `system:` carries the resolved value; messages
+      // array does NOT include a `role: "system"` entry.
+      expect(streamCall.system).toBe("Stream-runner suite default");
+      const wireMessages = streamCall.messages as Array<{ role: string }>;
+      expect(wireMessages.some((m) => m.role === "system")).toBe(false);
+
+      // Persistence shape: first message is the resolved system,
+      // matching the non-stream runner's prefix.
+      const hasSystemPrefix = (msgs: unknown): boolean => {
+        if (!Array.isArray(msgs) || msgs.length === 0) return false;
+        const first = msgs[0] as { role?: string; content?: unknown };
+        if (first?.role !== "system") return false;
+        if (typeof first.content === "string") {
+          return first.content === "Stream-runner suite default";
+        }
+        if (Array.isArray(first.content)) {
+          return first.content.some(
+            (part: any) =>
+              part?.type === "text" &&
+              part.text === "Stream-runner suite default",
+          );
+        }
+        return false;
+      };
+      const persistedCarriesIt = convexClient.action.mock.calls.some(
         (call) => {
           const payload = call[1] as Record<string, unknown> | undefined;
-          if (!payload) return true;
-          if (!noSystemRoleInPersistedMessages(payload.messages)) return false;
+          if (!payload) return false;
+          if (hasSystemPrefix(payload.messages)) return true;
           const turn = payload.turn as
             | { sessionMessages?: unknown }
             | undefined;
-          if (turn && !noSystemRoleInPersistedMessages(turn.sessionMessages))
-            return false;
-          return true;
+          if (turn && hasSystemPrefix(turn.sessionMessages)) return true;
+          return false;
         },
       );
-      expect(allCallsLackSystemRole).toBe(true);
+      expect(persistedCarriesIt).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Wires the eval runner onto the shared `resolveExecutionContext` helper (landed in PR 4c) so the suite-level hostConfig's `systemPrompt` and `temperature` apply to per-case test runs as defaults. Closes the gap flagged in PR 4b review.

Same pass drops the PR 4b `systemPrompt: ""` quirk in `runIterationWithAiSdk` — the resolved value now flows via `runDirectChatTurn`'s `systemPrompt:` argument; the persisted transcript carries the system via its own column on chatSessions / testIteration (matching chat's shape).

## ⚠️ BEHAVIOR CHANGE — observable on real eval suites

Pre-4d: eval read `advancedConfig.system` only and ignored `suiteHostConfig.systemPrompt`. A test case with no explicit `advancedConfig.system` ran with no system prompt at all.

Post-4d:

- A test case with no explicit `advancedConfig.system` picks up `suiteHostConfig.systemPrompt` as the default. **This is the intended design** per the comment at `client/src/components/evals/use-eval-handlers.ts:302` — the client deliberately doesn't bake suite defaults into per-case `advancedConfig` (to avoid stale copies on later suite edits); the runtime was supposed to apply them.
- Same applies to `temperature`: `suiteHostConfig.temperature` becomes the default.
- Per-case overrides REMAIN authoritative when set (`override-wins` precedence). No change for tests that already specified `advancedConfig.system` / `.temperature`.

## What this PR closes

- `evals-runner.ts` now reads `suiteHostConfig.systemPrompt` / `.temperature` via `resolveExecutionContext({precedence: "override-wins"})`.
- `withHostContextSystemPrompt` ({{var}} substitution) runs AFTER the resolver so per-RUN hostContext still applies to the resolved system text.
- All four runners (`runIterationWithAiSdk`, `runIterationViaBackend`, `streamIterationWithAiSdk`, `streamIterationViaBackend`) share the same resolution shape.
- PR 4b's `systemPrompt: ""` quirk in `runIterationWithAiSdk` removed; helper receives `prepared.enhancedSystemPrompt` directly.

## What this PR explicitly does NOT close

- Stream variants (`streamIterationWithAiSdk` / `streamIterationViaBackend`) still drive their own loops + still push the system message into `conversationMessages`. PR 5 collapses both onto the shared driver.
- `selectedServerIds` resolution at the suite-hostConfig level. The resolver covers this field; the runner's `selectedServers` arg today is threaded from the route layer's separate path. PR 5 / PR 6 align it.

## Threading

- `RunEvalSuiteOptions` gained `suiteHostConfig?: Record<string, unknown> | null`.
- `RunIterationBaseParams` gained the same field; threaded through `runTestCase` → all 4 iteration runners.
- Three load sites in `server/routes/shared/evals.ts` (suite run + quick run + streamTestCase) now pass `suiteHostConfig` alongside `hostExecutionPolicy`. Same Convex record feeds both — the resolver reads CONFIG fields, `extractHostExecutionPolicy` reads POLICY fields.

## Test plan

- [x] 33 → 39 in `evals-runner.test.ts`; new PR 4d describe block with 6 regression tests:
  - Suite default systemPrompt applies when `advancedConfig.system` absent
  - Per-case `advancedConfig.system` overrides suite default
  - Null `suiteHostConfig` + absent `advancedConfig.system` → no `system:` field
  - Suite default temperature applies when `advancedConfig.temperature` absent
  - Per-case `advancedConfig.temperature` overrides suite default
  - System message NOT pushed into `conversationMessages` (drops PR 4b quirk)
- [x] Broader sweep: 678/678 pass.
- [x] Typecheck baseline-clean (same 4 pre-existing recorder shape errors; no new errors).
- [ ] Smoke (post-merge): pick a real suite with `hostConfig.systemPrompt` set and a test case with no `advancedConfig.system`; confirm the persisted iteration transcript shows the suite default system prompt in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval execution semantics (suite defaults now affect model calls and grades) across all runner paths; mitigated by override-wins precedence and broad regression tests, but real suites without per-case system prompts will behave differently post-merge.
> 
> **Overview**
> **Behavior change:** Eval iterations no longer ignore `suiteHostConfig.systemPrompt` / `.temperature` when a case omits `advancedConfig.system` / `.temperature`. All four runners (`runIterationWithAiSdk`, backend, and streaming variants) resolve those fields through **`resolveExecutionContext`** with **`override-wins`**, then apply **`withHostContextSystemPrompt`** for per-run `{{var}}` substitution.
> 
> **Threading:** `suiteHostConfig` is passed from **`server/routes/shared/evals.ts`** (suite run, quick run, streamed test case) into **`runEvalSuiteWithAiSdk`** / **`streamTestCase`** and down every iteration path alongside **`hostExecutionPolicy`**.
> 
> **Wire vs persistence:** The resolved system prompt is sent to the model via the dedicated **`system:`** field (replacing the PR 4b **`systemPrompt: ""`** quirk and removing system entries from in-flight **`conversationMessages`**). Because eval persistence has no separate system column, the runner **prepends a `role: "system"` message at write time** (success/failure paths, including backend and streaming SSE trace snapshots via **`withSystemPrefix`**).
> 
> **Tests:** New **`evals-runner.test.ts`** describe block locks suite defaults, overrides, null hostConfig, wire shape, persistence prefix, backend path, and streaming alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2303f7b307caf6bad691f26493eef3d3cc7602f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->