### PR TITLE
feat(mcpjam-agent): home takeover surface + docs-link fixes

### DIFF
--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import { useQuery } from "convex/react";
 import { useSearchParams } from "react-router";
 import { useAuth } from "@workos-inc/authkit-react";
+import { Plus } from "lucide-react";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { Button } from "@mcpjam/design-system/button";
 import { OrgStatsStrip } from "./home/OrgStatsStrip";
@@ -89,6 +90,17 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
     },
     [setSearchParams]
   );
+
+  const handleNewChat = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("session");
+        return next;
+      },
+      { replace: false }
+    );
+  }, [setSearchParams]);
   const { user } = useAuth();
   const convexUser = useQuery("users:getCurrentUser" as any) as
     | { name?: string }
@@ -166,6 +178,36 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
 
   const isLoading = data === undefined;
 
+  // PostHog/Attio-style chat takeover: when a session is active, the entire
+  // home screen *becomes* the conversation — the greeting, stats, and
+  // recommended cards drop out until the user starts a new chat.
+  if (sessionParam) {
+    return (
+      <div className="flex h-full flex-col bg-background">
+        <div className="flex items-center justify-end px-4 pt-3">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleNewChat}
+            className="h-8 gap-1.5 rounded-full px-3 text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden />
+            <span>New chat</span>
+          </Button>
+        </div>
+        <McpjamAgentThread
+          sessionId={sessionParam}
+          projectId={projectId}
+          organizationId={organizationId}
+          surface="home"
+          variant="full"
+          className="flex-1 min-h-0"
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="h-full overflow-y-auto bg-background">
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 pb-20 pt-14">
@@ -182,29 +224,17 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
           </h1>
         </header>
 
-        {/* MCPJam Agent surface — hero composer, or inline thread when a
-            ?session=<id> URL param is present. The future bubble reuses
-            these same components without renaming. */}
-        {sessionParam ? (
-          <McpjamAgentThread
-            sessionId={sessionParam}
-            projectId={projectId}
-            organizationId={organizationId}
-            surface="home"
-          />
-        ) : (
-          <McpjamAgentHero
-            surface="home"
-            onSessionStart={handleSessionStart}
-            onResumeSession={handleResumeSession}
-            // The backend route requires `projectId`; without it, submit
-            // would 400. The hero's own model gate runs inside
-            // `useMcpjamAgentSession` on the thread side — the hero itself
-            // doesn't see the model, but `projectId` is the gate that
-            // matters at mint time.
-            ready={Boolean(projectId)}
-          />
-        )}
+        <McpjamAgentHero
+          surface="home"
+          onSessionStart={handleSessionStart}
+          onResumeSession={handleResumeSession}
+          // The backend route requires `projectId`; without it, submit
+          // would 400. The hero's own model gate runs inside
+          // `useMcpjamAgentSession` on the thread side — the hero itself
+          // doesn't see the model, but `projectId` is the gate that
+          // matters at mint time.
+          ready={Boolean(projectId)}
+        />
 
         {/* Slim stats — pills with dot separators */}
         <OrgStatsStrip

--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -76,6 +76,21 @@ function McpjamAgentTakeoverFrame({
   );
 }
 
+// Mirrors the key handleSessionStart writes and McpjamAgentThread's autosubmit
+// effect removes; lives here so the takeover Back / New chat handlers can
+// clean up unconsumed payloads when the thread unmounts before its effect
+// runs.
+function clearPendingForSession(sessionId: string | null | undefined) {
+  if (!sessionId || typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(`mcpjam:agent-pending:${sessionId}`);
+  } catch {
+    // Quota/disabled storage — stale entry will be a no-op unless the user
+    // returns to this session, and even then the duplicate-send is the only
+    // visible regression. Not worth surfacing.
+  }
+}
+
 export function HomeTab({ organizationId, projectId }: HomeTabProps) {
   const navigate = useAppNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -135,6 +150,10 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
   const handleBackToHome = useCallback(() => {
     setSearchParams(
       (prev) => {
+        // Drop any unconsumed pending payload for the session we're leaving;
+        // otherwise a later resume of the same id replays the prompt and
+        // re-renders the optimistic bubble over the hydrated transcript.
+        clearPendingForSession(prev.get("session"));
         const next = new URLSearchParams(prev);
         next.delete("session");
         next.delete("compose");
@@ -151,6 +170,9 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
   const handleNewChat = useCallback(() => {
     setSearchParams(
       (prev) => {
+        // Same rationale as handleBackToHome — drop the leaving session's
+        // unconsumed pending payload so a later resume doesn't double-send.
+        clearPendingForSession(prev.get("session"));
         const next = new URLSearchParams(prev);
         next.delete("session");
         next.set("compose", "1");

--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -184,7 +184,11 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
   if (sessionParam) {
     return (
       <div className="flex h-full flex-col bg-background">
-        <div className="flex items-center justify-end px-4 pt-3">
+        <div className="flex items-center justify-between border-b border-border/40 px-4 py-2">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <img src="/mcp_jam.svg" alt="" aria-hidden className="h-5 w-5" />
+            <span>MCPJam Agent</span>
+          </div>
           <Button
             type="button"
             variant="ghost"

--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import { useQuery } from "convex/react";
 import { useSearchParams } from "react-router";
 import { useAuth } from "@workos-inc/authkit-react";
-import { Plus } from "lucide-react";
+import { ArrowLeft, Plus } from "lucide-react";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { Button } from "@mcpjam/design-system/button";
 import { OrgStatsStrip } from "./home/OrgStatsStrip";
@@ -38,10 +38,49 @@ function deriveFirstName(opts: {
   return "there";
 }
 
+function McpjamAgentTakeoverFrame({
+  onBack,
+  onNewChat,
+  children,
+}: {
+  onBack: () => void;
+  onNewChat: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex h-full flex-col bg-background">
+      <div className="flex items-center justify-between border-b border-border/40 px-4 py-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onBack}
+          aria-label="Back to home"
+          className="h-8 w-8 rounded-full p-0 text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onNewChat}
+          className="h-8 gap-1.5 rounded-full px-3 text-muted-foreground hover:text-foreground"
+        >
+          <Plus className="h-3.5 w-3.5" aria-hidden />
+          <span>New chat</span>
+        </Button>
+      </div>
+      {children}
+    </div>
+  );
+}
+
 export function HomeTab({ organizationId, projectId }: HomeTabProps) {
   const navigate = useAppNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const sessionParam = searchParams.get("session");
+  const composeParam = searchParams.get("compose") === "1";
 
   const handleSessionStart = useCallback(
     (id: string, firstMessage: string) => {
@@ -69,6 +108,7 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
         (prev) => {
           const next = new URLSearchParams(prev);
           next.set("session", id);
+          next.delete("compose");
           return next;
         },
         { replace: false }
@@ -83,6 +123,7 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
         (prev) => {
           const next = new URLSearchParams(prev);
           next.set("session", id);
+          next.delete("compose");
           return next;
         },
         { replace: false }
@@ -91,11 +132,28 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
     [setSearchParams]
   );
 
+  const handleBackToHome = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("session");
+        next.delete("compose");
+        return next;
+      },
+      { replace: false }
+    );
+  }, [setSearchParams]);
+
+  // "New chat" inside the takeover keeps the user on the agent surface and
+  // swaps the thread for an empty composer (Hero). A session id is minted
+  // only when they actually submit, mirroring the chatbox "Clear chat"
+  // affordance — fresh slate without bouncing back to the greeting.
   const handleNewChat = useCallback(() => {
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
         next.delete("session");
+        next.set("compose", "1");
         return next;
       },
       { replace: false }
@@ -178,37 +236,38 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
 
   const isLoading = data === undefined;
 
-  // PostHog/Attio-style chat takeover: when a session is active, the entire
-  // home screen *becomes* the conversation — the greeting, stats, and
-  // recommended cards drop out until the user starts a new chat.
-  if (sessionParam) {
+  // PostHog/Attio-style chat takeover: when a session is active OR the user
+  // chose "New chat" from inside the takeover, the entire home screen *becomes*
+  // the conversation surface. The greeting, stats, and recommended cards drop
+  // out until the user clicks Back.
+  if (sessionParam || composeParam) {
     return (
-      <div className="flex h-full flex-col bg-background">
-        <div className="flex items-center justify-between border-b border-border/40 px-4 py-2">
-          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-            <img src="/mcp_jam.svg" alt="" aria-hidden className="h-5 w-5" />
-            <span>MCPJam Agent</span>
+      <McpjamAgentTakeoverFrame
+        onBack={handleBackToHome}
+        onNewChat={handleNewChat}
+      >
+        {sessionParam ? (
+          <McpjamAgentThread
+            sessionId={sessionParam}
+            projectId={projectId}
+            organizationId={organizationId}
+            surface="home"
+            variant="full"
+            className="flex-1 min-h-0"
+          />
+        ) : (
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 pb-20 pt-16">
+              <McpjamAgentHero
+                surface="home"
+                onSessionStart={handleSessionStart}
+                onResumeSession={handleResumeSession}
+                ready={Boolean(projectId)}
+              />
+            </div>
           </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleNewChat}
-            className="h-8 gap-1.5 rounded-full px-3 text-muted-foreground hover:text-foreground"
-          >
-            <Plus className="h-3.5 w-3.5" aria-hidden />
-            <span>New chat</span>
-          </Button>
-        </div>
-        <McpjamAgentThread
-          sessionId={sessionParam}
-          projectId={projectId}
-          organizationId={organizationId}
-          surface="home"
-          variant="full"
-          className="flex-1 min-h-0"
-        />
-      </div>
+        )}
+      </McpjamAgentTakeoverFrame>
     );
   }
 

--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -248,6 +248,7 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
       >
         {sessionParam ? (
           <McpjamAgentThread
+            key={sessionParam}
             sessionId={sessionParam}
             projectId={projectId}
             organizationId={organizationId}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
@@ -1,6 +1,44 @@
 import { marked } from "marked";
-import { memo, useMemo } from "react";
+import {
+  createContext,
+  memo,
+  useContext,
+  useMemo,
+  type ReactNode,
+} from "react";
 import { Streamdown } from "streamdown";
+
+// Resolves root-relative markdown links (`/foo/bar`) against a remote origin
+// for assistant surfaces that inline markdown authored elsewhere — e.g. the
+// MCPJam Agent home, which streams snippets from docs.mcpjam.com whose links
+// are written relative to that site. Defaults to null so every other chat
+// surface keeps rendering links exactly as the model emitted them.
+const MarkdownLinkBaseContext = createContext<string | null>(null);
+
+export function MarkdownLinkBaseProvider({
+  base,
+  children,
+}: {
+  base: string | null;
+  children: ReactNode;
+}) {
+  return (
+    <MarkdownLinkBaseContext.Provider value={base}>
+      {children}
+    </MarkdownLinkBaseContext.Provider>
+  );
+}
+
+function buildUrlTransform(base: string | null) {
+  if (!base) return undefined;
+  const trimmed = base.replace(/\/$/, "");
+  return (url: string) => {
+    if (url.startsWith("/") && !url.startsWith("//")) {
+      return trimmed + url;
+    }
+    return url;
+  };
+}
 
 function parseMarkdownIntoBlocks(markdown: string): string[] {
   const tokens = marked.lexer(markdown);
@@ -12,8 +50,12 @@ function parseMarkdownIntoBlocks(markdown: string): string[] {
 
 const MemoizedMarkdownBlock = memo(
   ({ content }: { content: string }) => {
+    const base = useContext(MarkdownLinkBaseContext);
+    const urlTransform = useMemo(() => buildUrlTransform(base), [base]);
     return (
-      <Streamdown linkSafety={{ enabled: false }}>{content}</Streamdown>
+      <Streamdown linkSafety={{ enabled: false }} urlTransform={urlTransform}>
+        {content}
+      </Streamdown>
     );
   },
   (prevProps, nextProps) => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
@@ -6,7 +6,7 @@ import {
   useMemo,
   type ReactNode,
 } from "react";
-import { Streamdown } from "streamdown";
+import { Streamdown, defaultUrlTransform, type UrlTransform } from "streamdown";
 
 // Per-surface markdown rendering knobs for surfaces that inline content
 // authored elsewhere — e.g. the MCPJam Agent home, which streams docs from
@@ -52,14 +52,19 @@ export function MarkdownLinkBaseProvider({
   );
 }
 
-function buildUrlTransform(base: string | null) {
+function buildUrlTransform(base: string | null): UrlTransform | undefined {
   if (!base) return undefined;
   const trimmed = base.replace(/\/$/, "");
-  return (url: string) => {
+  // Only the root-relative rewrite is custom; every other href falls through
+  // to Streamdown's defaultUrlTransform so dangerous protocols
+  // (`javascript:`, `vbscript:`, non-image `data:`, …) are still stripped.
+  // Without this delegation a model-emitted `[x](javascript:alert(1))` on a
+  // `trustLinks` surface would render as a clickable anchor.
+  return (url, key, node) => {
     if (url.startsWith("/") && !url.startsWith("//")) {
       return trimmed + url;
     }
-    return url;
+    return defaultUrlTransform(url, key, node);
   };
 }
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
@@ -8,24 +8,47 @@ import {
 } from "react";
 import { Streamdown } from "streamdown";
 
-// Resolves root-relative markdown links (`/foo/bar`) against a remote origin
-// for assistant surfaces that inline markdown authored elsewhere — e.g. the
-// MCPJam Agent home, which streams snippets from docs.mcpjam.com whose links
-// are written relative to that site. Defaults to null so every other chat
-// surface keeps rendering links exactly as the model emitted them.
-const MarkdownLinkBaseContext = createContext<string | null>(null);
+// Per-surface markdown rendering knobs for surfaces that inline content
+// authored elsewhere — e.g. the MCPJam Agent home, which streams docs from
+// docs.mcpjam.com. The defaults (`linkBase: null`, `trustLinks: false`) keep
+// every other chat surface rendering links exactly as the model emitted them
+// and preserve Streamdown's built-in link-safety confirmation.
+type MarkdownSurfaceConfig = {
+  // When set, root-relative hrefs (`/foo`) are rewritten to `${linkBase}/foo`
+  // via Streamdown's `urlTransform`.
+  linkBase: string | null;
+  // When true, Streamdown's `linkSafety` confirmation modal is disabled for
+  // this surface — use only when the surface inlines content from a trusted
+  // origin and Streamdown's modal styling would otherwise render unusably
+  // (the project does not import `streamdown/styles.css`).
+  trustLinks: boolean;
+};
+
+const DEFAULT_SURFACE_CONFIG: MarkdownSurfaceConfig = {
+  linkBase: null,
+  trustLinks: false,
+};
+
+const MarkdownSurfaceContext =
+  createContext<MarkdownSurfaceConfig>(DEFAULT_SURFACE_CONFIG);
 
 export function MarkdownLinkBaseProvider({
   base,
+  trustLinks = false,
   children,
 }: {
   base: string | null;
+  trustLinks?: boolean;
   children: ReactNode;
 }) {
+  const value = useMemo<MarkdownSurfaceConfig>(
+    () => ({ linkBase: base, trustLinks }),
+    [base, trustLinks],
+  );
   return (
-    <MarkdownLinkBaseContext.Provider value={base}>
+    <MarkdownSurfaceContext.Provider value={value}>
       {children}
-    </MarkdownLinkBaseContext.Provider>
+    </MarkdownSurfaceContext.Provider>
   );
 }
 
@@ -50,10 +73,17 @@ function parseMarkdownIntoBlocks(markdown: string): string[] {
 
 const MemoizedMarkdownBlock = memo(
   ({ content }: { content: string }) => {
-    const base = useContext(MarkdownLinkBaseContext);
-    const urlTransform = useMemo(() => buildUrlTransform(base), [base]);
+    const { linkBase, trustLinks } = useContext(MarkdownSurfaceContext);
+    const urlTransform = useMemo(
+      () => buildUrlTransform(linkBase),
+      [linkBase],
+    );
+    const linkSafety = useMemo(
+      () => (trustLinks ? { enabled: false } : undefined),
+      [trustLinks],
+    );
     return (
-      <Streamdown linkSafety={{ enabled: false }} urlTransform={urlTransform}>
+      <Streamdown linkSafety={linkSafety} urlTransform={urlTransform}>
         {content}
       </Streamdown>
     );

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
@@ -12,7 +12,9 @@ function parseMarkdownIntoBlocks(markdown: string): string[] {
 
 const MemoizedMarkdownBlock = memo(
   ({ content }: { content: string }) => {
-    return <Streamdown>{content}</Streamdown>;
+    return (
+      <Streamdown linkSafety={{ enabled: false }}>{content}</Streamdown>
+    );
   },
   (prevProps, nextProps) => {
     if (prevProps.content !== nextProps.content) return false;

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -11,16 +11,29 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type FormEvent,
   type KeyboardEvent,
 } from "react";
-import { ArrowUp, Loader2, Square } from "lucide-react";
+import { ArrowUp, Square } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { cn } from "@/lib/utils";
 import { TranscriptThread } from "@/components/chat-v2/thread/transcript-thread";
+import {
+  getLastRenderableConversationMessage,
+  hasRenderableConversationContent,
+} from "@/components/chat-v2/thread/thread-helpers";
+import { ThinkingIndicator } from "@/components/chat-v2/shared/thinking-indicator";
+import { LoadingIndicatorContent } from "@/components/chat-v2/shared/loading-indicator-content";
+import {
+  ChatboxHostStyleProvider,
+  ChatboxHostThemeProvider,
+} from "@/contexts/chatbox-client-style-context";
+import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { useMcpjamAgentSession } from "@/hooks/use-mcpjam-agent-session";
 import {
   appendRecentMcpjamAgentSession,
@@ -177,98 +190,134 @@ export function McpjamAgentThread({
   }, [handleSubmit, isReady, session.hydrating, sessionId]);
 
   const isFull = variant === "full";
+  const themeMode = usePreferencesStore((state) => state.themeMode);
+  const shellStyle = getChatboxShellStyle("mcpjam", themeMode);
 
+  // Mirror `Thread`'s standalone-thinking-indicator gating: the MCPJam-family
+  // transcript paints the brand mark in the FOOTER of the last assistant
+  // message, but only after that message exists. Between "user sent" and
+  // "first assistant token", we need a standalone indicator — otherwise
+  // streaming feels dead (which is what the user reported).
+  const lastRenderableMessage = useMemo(
+    () => getLastRenderableConversationMessage(session.messages),
+    [session.messages]
+  );
+  const hasVisibleAssistantResponse =
+    lastRenderableMessage?.role === "assistant" &&
+    hasRenderableConversationContent(lastRenderableMessage);
+  const shouldShowStandaloneThinking =
+    isStreaming && !hasVisibleAssistantResponse && session.model != null;
+
+  // The chat-v2 transcript and `LoadingIndicatorContent` resolve their
+  // chrome (avatar, bubbles, thinking dot, fonts) from the chatbox host
+  // context. Declaring the MCPJam host style here makes the agent thread
+  // visually distinct from the regular `ChatTabV2` surface even when the
+  // resolved model is `anthropic` (which would otherwise dress this up
+  // as Claude).
   return (
-    <div
-      className={cn(
-        "flex flex-col gap-4",
-        isFull
-          ? "h-full"
-          : "min-h-[36rem] rounded-2xl border border-border/70 bg-card/30 p-4 shadow-sm",
-        className
-      )}
-    >
-      <div
-        className={cn(
-          "flex-1 overflow-y-auto",
-          isFull && "mx-auto w-full max-w-3xl px-6 pt-6"
-        )}
-      >
-        {session.hydrating ? (
-          <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-            Loading conversation…
+    <ChatboxHostStyleProvider value="mcpjam">
+      <ChatboxHostThemeProvider value={themeMode}>
+        <div
+          className={cn(
+            "chatbox-host-shell flex flex-col gap-4",
+            isFull
+              ? "h-full"
+              : "min-h-[36rem] rounded-2xl border border-border/70 bg-card/30 p-4 shadow-sm",
+            className
+          )}
+          data-host-style="mcpjam"
+          style={shellStyle}
+        >
+          <div
+            className={cn(
+              "flex-1 overflow-y-auto",
+              isFull && "mx-auto w-full max-w-3xl px-6 pt-6"
+            )}
+          >
+            {session.hydrating ? (
+              <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+                <LoadingIndicatorContent />
+                <span>Loading conversation…</span>
+              </div>
+            ) : session.messages.length === 0 ? (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Ask anything to start the conversation.
+              </div>
+            ) : session.model ? (
+              <>
+                <TranscriptThread
+                  chatSessionId={sessionId}
+                  messages={session.messages}
+                  model={session.model}
+                  toolsMetadata={{}}
+                  toolServerMap={{}}
+                  sendFollowUpMessage={handleSubmit}
+                  isLoading={isStreaming}
+                />
+                {shouldShowStandaloneThinking && (
+                  <div className="mt-2 px-2">
+                    <ThinkingIndicator model={session.model} />
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Resolving model…
+              </div>
+            )}
           </div>
-        ) : session.messages.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Ask anything to start the conversation.
-          </div>
-        ) : session.model ? (
-          <TranscriptThread
-            chatSessionId={sessionId}
-            messages={session.messages}
-            model={session.model}
-            toolsMetadata={{}}
-            toolServerMap={{}}
-            sendFollowUpMessage={handleSubmit}
-            isLoading={isStreaming}
-          />
-        ) : (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Resolving model…
-          </div>
-        )}
-      </div>
 
-      <form
-        onSubmit={onFormSubmit}
-        className={cn(
-          "relative rounded-2xl border border-border/70 bg-card/60 p-2 shadow-sm transition focus-within:border-border focus-within:bg-card focus-within:shadow",
-          isFull && "mx-auto w-full max-w-3xl mb-6 px-2"
-        )}
-      >
-        <TextareaAutosize
-          ref={textareaRef}
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder={isReady ? "Continue the conversation…" : "Loading…"}
-          minRows={2}
-          maxRows={8}
-          className="min-h-[3rem] resize-none border-0 bg-transparent px-3 py-2 text-[15px] shadow-none outline-none focus-visible:border-0 focus-visible:ring-0"
-        />
-        <div className="flex items-center justify-end gap-2 px-1 pt-1">
-          {isStreaming ? (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={() => session.stop()}
-              className="h-8 gap-1.5 rounded-full px-3"
-            >
-              <Square className="h-3.5 w-3.5" aria-hidden />
-              <span>Stop</span>
-            </Button>
-          ) : (
-            <Button
-              type="submit"
-              size="sm"
-              disabled={draft.trim().length === 0 || !isReady}
-              title={isReady ? undefined : "Loading project and model…"}
-              className="h-8 gap-1.5 rounded-full px-3"
-            >
-              <ArrowUp className="h-3.5 w-3.5" aria-hidden />
-              <span>Send</span>
-            </Button>
+          <form
+            onSubmit={onFormSubmit}
+            className={cn(
+              "relative rounded-2xl border border-border/70 bg-card/60 p-2 shadow-sm transition focus-within:border-border focus-within:bg-card focus-within:shadow",
+              isFull && "mx-auto w-full max-w-3xl mb-6 px-2"
+            )}
+          >
+            <TextareaAutosize
+              ref={textareaRef}
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={onKeyDown}
+              placeholder={isReady ? "Continue the conversation…" : "Loading…"}
+              minRows={2}
+              maxRows={8}
+              className="min-h-[3rem] resize-none border-0 bg-transparent px-3 py-2 text-[15px] shadow-none outline-none focus-visible:border-0 focus-visible:ring-0"
+            />
+            <div className="flex items-center justify-end gap-2 px-1 pt-1">
+              {isStreaming ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => session.stop()}
+                  className="h-8 gap-1.5 rounded-full px-3"
+                >
+                  <Square className="h-3.5 w-3.5" aria-hidden />
+                  <span>Stop</span>
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={draft.trim().length === 0 || !isReady}
+                  title={isReady ? undefined : "Loading project and model…"}
+                  className="h-8 gap-1.5 rounded-full px-3"
+                >
+                  <ArrowUp className="h-3.5 w-3.5" aria-hidden />
+                  <span>Send</span>
+                </Button>
+              )}
+            </div>
+          </form>
+
+          {session.error && (
+            <p className="text-xs text-destructive">
+              {session.error.message ?? "Something went wrong."}
+            </p>
           )}
         </div>
-      </form>
-
-      {session.error && (
-        <p className="text-xs text-destructive">
-          {session.error.message ?? "Something went wrong."}
-        </p>
-      )}
-    </div>
+      </ChatboxHostThemeProvider>
+    </ChatboxHostStyleProvider>
   );
 }

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -34,6 +34,12 @@ export interface McpjamAgentThreadProps {
   organizationId: string | null;
   /** Telemetry surface. */
   surface: string;
+  /**
+   * Visual mode. `"card"` (default) is the embedded rounded card used inside
+   * a wider page. `"full"` is the PostHog/Attio-style takeover: no border,
+   * fills the parent, composer pinned to the bottom.
+   */
+  variant?: "card" | "full";
   className?: string;
 }
 
@@ -42,6 +48,7 @@ export function McpjamAgentThread({
   projectId,
   organizationId,
   surface: _surface,
+  variant = "card",
   className,
 }: McpjamAgentThreadProps) {
   const session = useMcpjamAgentSession({
@@ -169,14 +176,24 @@ export function McpjamAgentThread({
     }
   }, [handleSubmit, isReady, session.hydrating, sessionId]);
 
+  const isFull = variant === "full";
+
   return (
     <div
       className={cn(
-        "flex min-h-[36rem] flex-col gap-4 rounded-2xl border border-border/70 bg-card/30 p-4 shadow-sm",
+        "flex flex-col gap-4",
+        isFull
+          ? "h-full"
+          : "min-h-[36rem] rounded-2xl border border-border/70 bg-card/30 p-4 shadow-sm",
         className
       )}
     >
-      <div className="flex-1 overflow-y-auto">
+      <div
+        className={cn(
+          "flex-1 overflow-y-auto",
+          isFull && "mx-auto w-full max-w-3xl px-6 pt-6"
+        )}
+      >
         {session.hydrating ? (
           <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
@@ -205,7 +222,10 @@ export function McpjamAgentThread({
 
       <form
         onSubmit={onFormSubmit}
-        className="relative rounded-2xl border border-border/70 bg-card/60 p-2 shadow-sm transition focus-within:border-border focus-within:bg-card focus-within:shadow"
+        className={cn(
+          "relative rounded-2xl border border-border/70 bg-card/60 p-2 shadow-sm transition focus-within:border-border focus-within:bg-card focus-within:shadow",
+          isFull && "mx-auto w-full max-w-3xl mb-6 px-2"
+        )}
       >
         <TextareaAutosize
           ref={textareaRef}

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -348,7 +348,7 @@ export function McpjamAgentThread({
   }
 
   return (
-    <MarkdownLinkBaseProvider base="https://docs.mcpjam.com">
+    <MarkdownLinkBaseProvider base="https://docs.mcpjam.com" trustLinks>
       <ChatboxHostStyleProvider value="mcpjam">
         <ChatboxHostThemeProvider value={themeMode}>
         <div

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -27,6 +27,7 @@ import { cn } from "@/lib/utils";
 import { Thread } from "@/components/chat-v2/thread";
 import { ScrollToBottomButton } from "@/components/chat-v2/shared/scroll-to-bottom-button";
 import { LoadingIndicatorContent } from "@/components/chat-v2/shared/loading-indicator-content";
+import { UserMessageBubble } from "@/components/chat-v2/thread/user-message-bubble";
 import {
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
@@ -71,6 +72,35 @@ export function McpjamAgentThread({
 
   const [draft, setDraft] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Peek at the hero-stashed pending prompt at mount so we can render an
+  // optimistic user bubble during the hydrate → autosubmit window. Without
+  // this, the user sees the brand mark centered on an empty surface and
+  // wonders if their submit landed. We only PEEK here (read, don't remove)
+  // — the autosubmit effect below is still the authoritative consumer that
+  // also writes the `mcpjam:agent-pending` key, so removing it twice would
+  // race the autosubmit.
+  const [optimisticPending] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = window.sessionStorage.getItem(
+        `mcpjam:agent-pending:${sessionId}`
+      );
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        (parsed as { fresh?: unknown }).fresh === true &&
+        typeof (parsed as { text?: unknown }).text === "string"
+      ) {
+        return (parsed as { text: string }).text;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  });
 
   const isStreaming =
     session.status === "submitted" || session.status === "streaming";
@@ -191,7 +221,9 @@ export function McpjamAgentThread({
       onSubmit={onFormSubmit}
       className={cn(
         "relative rounded-2xl border border-border/70 bg-card/60 p-2 shadow-sm transition focus-within:border-border focus-within:bg-card focus-within:shadow",
-        isFull && "mx-auto w-full max-w-3xl mb-6 px-2"
+        // Match Thread's content column (max-w-4xl + px-4) so the composer
+        // sits exactly under the message column.
+        isFull && "mx-auto w-full max-w-4xl mb-6 px-4"
       )}
     >
       <TextareaAutosize
@@ -235,12 +267,36 @@ export function McpjamAgentThread({
   // Hydration / model-resolution placeholders — keep these in the host-style
   // shell so the brand chrome is consistent with the loaded state. We render
   // the composer below them so the user can start typing while we wait.
+  // Show the optimistic bubble only when there's nothing real yet — once
+  // `session.messages` has the user message the real Thread takes over and
+  // the optimistic UI unmounts.
+  const showOptimisticPending =
+    optimisticPending != null && session.messages.length === 0;
+
   let body: React.ReactNode;
-  if (session.hydrating) {
+  if (showOptimisticPending) {
+    // Hero → submit landing: render the user's pending text in the same
+    // column the real chat uses, plus the brand thinking indicator below.
+    // No "Loading conversation…" text — the user just wants to see their
+    // message land.
     body = (
-      <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+      <div className="flex flex-1 flex-col min-h-0 overflow-y-auto">
+        <div className="min-w-0 w-full max-w-4xl mx-auto px-4 pt-6 pb-8 space-y-6">
+          <UserMessageBubble>
+            <p className="whitespace-pre-wrap">{optimisticPending}</p>
+          </UserMessageBubble>
+          <div className="text-sm text-muted-foreground">
+            <LoadingIndicatorContent />
+          </div>
+        </div>
+      </div>
+    );
+  } else if (session.hydrating) {
+    // Resumed session (no optimistic pending): the user came from the
+    // Recent Chat pill or a direct URL, so brand-marker-only is fine.
+    body = (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
         <LoadingIndicatorContent />
-        <span>Loading conversation…</span>
       </div>
     );
   } else if (session.messages.length === 0) {
@@ -277,10 +333,11 @@ export function McpjamAgentThread({
               sendFollowUpMessage={handleSubmit}
               isLoading={isStreaming}
               minimalMode
-              contentClassName={cn(
-                "min-w-0 w-full mx-auto px-4 pt-6 pb-8 space-y-6",
-                isFull ? "max-w-3xl" : "max-w-3xl"
-              )}
+              // Match `Thread`'s standalone-thinking-indicator wrapper
+              // (`thread.tsx:368` uses `max-w-4xl mx-auto px-4`) so the dots
+              // sit in the same column as the would-be assistant message
+              // instead of floating ~64px to the left of it.
+              contentClassName="min-w-0 w-full max-w-4xl mx-auto px-4 pt-6 pb-8 space-y-6"
             />
           </StickToBottom.Content>
           <ScrollToBottomButton />
@@ -309,7 +366,7 @@ export function McpjamAgentThread({
             <p
               className={cn(
                 "text-xs text-destructive",
-                isFull && "mx-auto w-full max-w-3xl px-2"
+                isFull && "mx-auto w-full max-w-4xl px-4"
               )}
             >
               {session.error.message ?? "Something went wrong."}

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -1,32 +1,31 @@
 /**
  * McpjamAgentThread — full conversation surface for the MCPJam Agent.
  *
- * Wraps `useMcpjamAgentSession` and reuses the chat-v2 thread presenters
- * (`TranscriptThread`). Renders a continue-conversation input row at the
- * bottom that calls back into the hook's `submit()`.
+ * Wraps `useMcpjamAgentSession` and mounts the chat-v2 `Thread` (the same
+ * wrapper `ChatTabV2` uses) inside a `<StickToBottom>` viewport, so the
+ * agent inherits autoscroll-while-streaming, the scroll-to-bottom button,
+ * the standalone thinking indicator, MCP Apps widget surfaces, and the
+ * fullscreen chat overlay infrastructure without reimplementing any of it.
  *
- * Verified that `TranscriptThread` accepts `UIMessage[]` directly (`messages`
- * prop) — no shared-code refactor needed.
+ * `minimalMode` strips the inspector/debugging affordances (save-as-test-case,
+ * save-view, prompts popover, attachments toolbar, etc.) — appropriate for
+ * this conversational helper surface.
  */
 import {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type FormEvent,
   type KeyboardEvent,
 } from "react";
 import { ArrowUp, Square } from "lucide-react";
+import { StickToBottom } from "use-stick-to-bottom";
 import { Button } from "@mcpjam/design-system/button";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { cn } from "@/lib/utils";
-import { TranscriptThread } from "@/components/chat-v2/thread/transcript-thread";
-import {
-  getLastRenderableConversationMessage,
-  hasRenderableConversationContent,
-} from "@/components/chat-v2/thread/thread-helpers";
-import { ThinkingIndicator } from "@/components/chat-v2/shared/thinking-indicator";
+import { Thread } from "@/components/chat-v2/thread";
+import { ScrollToBottomButton } from "@/components/chat-v2/shared/scroll-to-bottom-button";
 import { LoadingIndicatorContent } from "@/components/chat-v2/shared/loading-indicator-content";
 import {
   ChatboxHostStyleProvider,
@@ -88,8 +87,6 @@ export function McpjamAgentThread({
       if (!isReady) return;
       session.submit(trimmed);
       setDraft("");
-      // Refresh the local registry so the title reflects the most recent
-      // exchange (best-effort — purely for the home-page pill).
       const existing = loadRecentMcpjamAgentSessions().find(
         (s) => s.id === sessionId
       );
@@ -126,8 +123,6 @@ export function McpjamAgentThread({
     [draft, handleSubmit]
   );
 
-  // Once hydration completes and the thread has messages, scroll the input
-  // into view so the user can keep typing.
   useEffect(() => {
     if (session.hydrating) return;
     requestAnimationFrame(() => {
@@ -179,8 +174,6 @@ export function McpjamAgentThread({
         isFresh = (parsed as { fresh?: unknown }).fresh === true;
       }
     } catch {
-      // Legacy plain-string payload — refuse to autosubmit (see comment
-      // above).
       pendingText = "";
       isFresh = false;
     }
@@ -193,33 +186,115 @@ export function McpjamAgentThread({
   const themeMode = usePreferencesStore((state) => state.themeMode);
   const shellStyle = getChatboxShellStyle("mcpjam", themeMode);
 
-  // Mirror `Thread`'s standalone-thinking-indicator gating: the MCPJam-family
-  // transcript paints the brand mark in the FOOTER of the last assistant
-  // message, but only after that message exists. Between "user sent" and
-  // "first assistant token", we need a standalone indicator — otherwise
-  // streaming feels dead (which is what the user reported).
-  const lastRenderableMessage = useMemo(
-    () => getLastRenderableConversationMessage(session.messages),
-    [session.messages]
+  const composer = (
+    <form
+      onSubmit={onFormSubmit}
+      className={cn(
+        "relative rounded-2xl border border-border/70 bg-card/60 p-2 shadow-sm transition focus-within:border-border focus-within:bg-card focus-within:shadow",
+        isFull && "mx-auto w-full max-w-3xl mb-6 px-2"
+      )}
+    >
+      <TextareaAutosize
+        ref={textareaRef}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={isReady ? "Continue the conversation…" : "Loading…"}
+        minRows={2}
+        maxRows={8}
+        className="min-h-[3rem] resize-none border-0 bg-transparent px-3 py-2 text-[15px] shadow-none outline-none focus-visible:border-0 focus-visible:ring-0"
+      />
+      <div className="flex items-center justify-end gap-2 px-1 pt-1">
+        {isStreaming ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => session.stop()}
+            className="h-8 gap-1.5 rounded-full px-3"
+          >
+            <Square className="h-3.5 w-3.5" aria-hidden />
+            <span>Stop</span>
+          </Button>
+        ) : (
+          <Button
+            type="submit"
+            size="sm"
+            disabled={draft.trim().length === 0 || !isReady}
+            title={isReady ? undefined : "Loading project and model…"}
+            className="h-8 gap-1.5 rounded-full px-3"
+          >
+            <ArrowUp className="h-3.5 w-3.5" aria-hidden />
+            <span>Send</span>
+          </Button>
+        )}
+      </div>
+    </form>
   );
-  const hasVisibleAssistantResponse =
-    lastRenderableMessage?.role === "assistant" &&
-    hasRenderableConversationContent(lastRenderableMessage);
-  const shouldShowStandaloneThinking =
-    isStreaming && !hasVisibleAssistantResponse && session.model != null;
 
-  // The chat-v2 transcript and `LoadingIndicatorContent` resolve their
-  // chrome (avatar, bubbles, thinking dot, fonts) from the chatbox host
-  // context. Declaring the MCPJam host style here makes the agent thread
-  // visually distinct from the regular `ChatTabV2` surface even when the
-  // resolved model is `anthropic` (which would otherwise dress this up
-  // as Claude).
+  // Hydration / model-resolution placeholders — keep these in the host-style
+  // shell so the brand chrome is consistent with the loaded state. We render
+  // the composer below them so the user can start typing while we wait.
+  let body: React.ReactNode;
+  if (session.hydrating) {
+    body = (
+      <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+        <LoadingIndicatorContent />
+        <span>Loading conversation…</span>
+      </div>
+    );
+  } else if (session.messages.length === 0) {
+    body = (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        Ask anything to start the conversation.
+      </div>
+    );
+  } else if (!session.model) {
+    body = (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        Resolving model…
+      </div>
+    );
+  } else {
+    // The real chat surface: chat-v2 `Thread` (with widget hosts, fullscreen
+    // overlay, standalone thinking indicator) inside a `<StickToBottom>` so
+    // streaming output auto-scrolls and the scroll-to-bottom button appears
+    // when the user scrolls up — matching `ChatTabV2.tsx:2483`.
+    body = (
+      <StickToBottom
+        className="relative flex flex-1 flex-col min-h-0"
+        resize="smooth"
+        initial="smooth"
+      >
+        <div className="relative flex-1 min-h-0">
+          <StickToBottom.Content className="flex flex-col min-h-0">
+            <Thread
+              chatSessionId={sessionId}
+              messages={session.messages}
+              model={session.model}
+              toolsMetadata={{}}
+              toolServerMap={{}}
+              sendFollowUpMessage={handleSubmit}
+              isLoading={isStreaming}
+              minimalMode
+              contentClassName={cn(
+                "min-w-0 w-full mx-auto px-4 pt-6 pb-8 space-y-6",
+                isFull ? "max-w-3xl" : "max-w-3xl"
+              )}
+            />
+          </StickToBottom.Content>
+          <ScrollToBottomButton />
+        </div>
+      </StickToBottom>
+    );
+  }
+
   return (
     <ChatboxHostStyleProvider value="mcpjam">
       <ChatboxHostThemeProvider value={themeMode}>
         <div
           className={cn(
-            "chatbox-host-shell flex flex-col gap-4",
+            "chatbox-host-shell flex flex-col gap-4 min-h-0",
             isFull
               ? "h-full"
               : "min-h-[36rem] rounded-2xl border border-border/70 bg-card/30 p-4 shadow-sm",
@@ -228,91 +303,15 @@ export function McpjamAgentThread({
           data-host-style="mcpjam"
           style={shellStyle}
         >
-          <div
-            className={cn(
-              "flex-1 overflow-y-auto",
-              isFull && "mx-auto w-full max-w-3xl px-6 pt-6"
-            )}
-          >
-            {session.hydrating ? (
-              <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-                <LoadingIndicatorContent />
-                <span>Loading conversation…</span>
-              </div>
-            ) : session.messages.length === 0 ? (
-              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Ask anything to start the conversation.
-              </div>
-            ) : session.model ? (
-              <>
-                <TranscriptThread
-                  chatSessionId={sessionId}
-                  messages={session.messages}
-                  model={session.model}
-                  toolsMetadata={{}}
-                  toolServerMap={{}}
-                  sendFollowUpMessage={handleSubmit}
-                  isLoading={isStreaming}
-                />
-                {shouldShowStandaloneThinking && (
-                  <div className="mt-2 px-2">
-                    <ThinkingIndicator model={session.model} />
-                  </div>
-                )}
-              </>
-            ) : (
-              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Resolving model…
-              </div>
-            )}
-          </div>
-
-          <form
-            onSubmit={onFormSubmit}
-            className={cn(
-              "relative rounded-2xl border border-border/70 bg-card/60 p-2 shadow-sm transition focus-within:border-border focus-within:bg-card focus-within:shadow",
-              isFull && "mx-auto w-full max-w-3xl mb-6 px-2"
-            )}
-          >
-            <TextareaAutosize
-              ref={textareaRef}
-              value={draft}
-              onChange={(event) => setDraft(event.target.value)}
-              onKeyDown={onKeyDown}
-              placeholder={isReady ? "Continue the conversation…" : "Loading…"}
-              minRows={2}
-              maxRows={8}
-              className="min-h-[3rem] resize-none border-0 bg-transparent px-3 py-2 text-[15px] shadow-none outline-none focus-visible:border-0 focus-visible:ring-0"
-            />
-            <div className="flex items-center justify-end gap-2 px-1 pt-1">
-              {isStreaming ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => session.stop()}
-                  className="h-8 gap-1.5 rounded-full px-3"
-                >
-                  <Square className="h-3.5 w-3.5" aria-hidden />
-                  <span>Stop</span>
-                </Button>
-              ) : (
-                <Button
-                  type="submit"
-                  size="sm"
-                  disabled={draft.trim().length === 0 || !isReady}
-                  title={isReady ? undefined : "Loading project and model…"}
-                  className="h-8 gap-1.5 rounded-full px-3"
-                >
-                  <ArrowUp className="h-3.5 w-3.5" aria-hidden />
-                  <span>Send</span>
-                </Button>
-              )}
-            </div>
-          </form>
-
+          {body}
+          {composer}
           {session.error && (
-            <p className="text-xs text-destructive">
+            <p
+              className={cn(
+                "text-xs text-destructive",
+                isFull && "mx-auto w-full max-w-3xl px-2"
+              )}
+            >
               {session.error.message ?? "Something went wrong."}
             </p>
           )}

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -25,6 +25,7 @@ import { Button } from "@mcpjam/design-system/button";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { cn } from "@/lib/utils";
 import { Thread } from "@/components/chat-v2/thread";
+import { MarkdownLinkBaseProvider } from "@/components/chat-v2/thread/memomized-markdown";
 import { ScrollToBottomButton } from "@/components/chat-v2/shared/scroll-to-bottom-button";
 import { LoadingIndicatorContent } from "@/components/chat-v2/shared/loading-indicator-content";
 import { UserMessageBubble } from "@/components/chat-v2/thread/user-message-bubble";
@@ -347,8 +348,9 @@ export function McpjamAgentThread({
   }
 
   return (
-    <ChatboxHostStyleProvider value="mcpjam">
-      <ChatboxHostThemeProvider value={themeMode}>
+    <MarkdownLinkBaseProvider base="https://docs.mcpjam.com">
+      <ChatboxHostStyleProvider value="mcpjam">
+        <ChatboxHostThemeProvider value={themeMode}>
         <div
           className={cn(
             "chatbox-host-shell flex flex-col gap-4 min-h-0",
@@ -373,7 +375,8 @@ export function McpjamAgentThread({
             </p>
           )}
         </div>
-      </ChatboxHostThemeProvider>
-    </ChatboxHostStyleProvider>
+        </ChatboxHostThemeProvider>
+      </ChatboxHostStyleProvider>
+    </MarkdownLinkBaseProvider>
   );
 }


### PR DESCRIPTION
## Summary
- MCPJam Agent home takeover: full-bleed chat surface on the Home tab, with MCPJam host chrome and a chat-v2 `Thread` (StickToBottom + ScrollToBottomButton) wired to `useMcpjamAgentSession`.
- Split Back + New chat affordances in the takeover bar; optimistic pending bubble + column alignment fixes for the takeover thread.
- Docs-link fixes for assistant-rendered markdown sourced from `docs.mcpjam.com/mcp`:
  - Disable Streamdown's `linkSafety` confirmation modal (rendered invisibly because `streamdown/styles.css` isn't imported, so link clicks looked like dead taps).
  - New `MarkdownLinkBaseProvider` context read by `MemoizedMarkdown` to prefix root-relative hrefs via Streamdown's `urlTransform`. Only the agent surface opts in (`base="https://docs.mcpjam.com"`); chat-v2 + chatboxes still render links exactly as the model emitted them, so developer-owned apps are unaffected.

## Test plan
- [ ] Home tab: agent takeover renders, scrolls correctly during streaming, scroll-to-bottom button appears when scrolled up.
- [ ] Back returns to the greeting; New chat clears the thread but stays on the agent surface.
- [ ] Send a question that triggers a docs link (e.g. "how do I run evals?") and confirm the "Running Evals guide" link opens `https://docs.mcpjam.com/sdk/concepts/running-evals` in a new tab (not `localhost:5173/...`).
- [ ] Open a chat-v2 chat with a model-emitted root-relative link and confirm it still renders as-is (no rewrite).
- [ ] `npm run typecheck:client` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI/navigation and shared markdown rendering change; agent-only `trustLinks` still strips dangerous protocols via `defaultUrlTransform`, but disabling link confirmation is a deliberate tradeoff for trusted docs content.
> 
> **Overview**
> **Home tab** now uses a full-screen MCPJam Agent takeover when `?session=` or `?compose=1` is set: greeting and dashboard cards hide behind a top bar with **Back** and **New chat**, which clears unconsumed `sessionStorage` pending prompts to avoid double-send on resume.
> 
> **McpjamAgentThread** swaps the lightweight `TranscriptThread` for chat-v2 **`Thread`** with `StickToBottom`, scroll-to-bottom, MCPJam host chrome, a **`full`** layout variant, and an **optimistic user bubble** while hero-stashed prompts autosubmit.
> 
> **Markdown** gains **`MarkdownLinkBaseProvider`**: only the agent opts in to rewrite root-relative links to `https://docs.mcpjam.com`, disable Streamdown link-safety (broken without `streamdown/styles.css`), while still delegating dangerous URLs to `defaultUrlTransform`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c67737a1d339a397b1056ba9471a583d64651a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->