### PR TITLE
evals: extract fullStream → EvalStreamEvent adapter (engine consolidation PR 5-pre)

### DIFF
--- a/mcpjam-inspector/server/services/evals/__tests__/stream-adapter.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/stream-adapter.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Contract tests for `consumeFullStreamAsEvalEvents` (PR 5a of the
+ * engine consolidation in `~/mcpjam-docs/unification.md`).
+ *
+ * Pre-PR-5a these chunk-to-event translations lived inline in
+ * `streamIterationWithAiSdk`. The adapter is byte-shape-equivalent;
+ * these tests lock that contract so future stream consumers
+ * (PR 5b's backend stream runner; chat reuse) can trust the helper.
+ */
+import { describe, expect, it } from "vitest";
+import { consumeFullStreamAsEvalEvents } from "../stream-adapter";
+
+function asyncStream<T>(items: T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) yield item;
+    },
+  };
+}
+
+describe("consumeFullStreamAsEvalEvents", () => {
+  it("emits `text_delta` for text-delta chunks", async () => {
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        { type: "text-delta", id: "t1", text: "Hello " },
+        { type: "text-delta", id: "t2", text: "world" },
+      ]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    expect(events).toEqual([
+      { type: "text_delta", content: "Hello " },
+      { type: "text_delta", content: "world" },
+    ]);
+  });
+
+  it("emits `tool_call` for tool-call chunks with normalized args", async () => {
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        {
+          type: "tool_call",
+          toolCallId: "tc_1",
+          toolName: "lookup",
+          input: { q: "hello" },
+          dynamic: true,
+        },
+      ] as any) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    // Adapter listens for `tool-call` not `tool_call` — verify the
+    // exact chunk type the AI SDK emits.
+    expect(events).toEqual([]);
+  });
+
+  it("emits `tool_call` for tool-call chunks (hyphenated chunk type)", async () => {
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        {
+          type: "tool-call",
+          toolCallId: "tc_1",
+          toolName: "lookup",
+          input: { q: "hello" },
+        } as any,
+      ]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    expect(events).toEqual([
+      {
+        type: "tool_call",
+        toolName: "lookup",
+        toolCallId: "tc_1",
+        args: { q: "hello" },
+      },
+    ]);
+  });
+
+  it("defaults tool-call args to `{}` when input is undefined", async () => {
+    // Pre-PR-5a the inline switch used `(part.input ?? {})` for the
+    // `args:` field — lock that fallback in case the AI SDK ever
+    // surfaces a no-arg tool call as undefined.
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        {
+          type: "tool-call",
+          toolCallId: "tc_noargs",
+          toolName: "ping",
+        } as any,
+      ]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    expect(events[0]).toMatchObject({
+      type: "tool_call",
+      toolName: "ping",
+      toolCallId: "tc_noargs",
+      args: {},
+    });
+  });
+
+  it("emits `tool_result` (isError:false) for tool-result chunks", async () => {
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        {
+          type: "tool-result",
+          toolCallId: "tc_1",
+          toolName: "lookup",
+          output: { ok: true },
+        } as any,
+      ]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    expect(events).toEqual([
+      {
+        type: "tool_result",
+        toolCallId: "tc_1",
+        result: { ok: true },
+        isError: false,
+      },
+    ]);
+  });
+
+  it("emits `tool_result` (isError:true) for tool-error chunks", async () => {
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        {
+          type: "tool-error",
+          toolCallId: "tc_2",
+          toolName: "lookup",
+          error: { message: "boom" },
+        } as any,
+      ]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    expect(events).toEqual([
+      {
+        type: "tool_result",
+        toolCallId: "tc_2",
+        result: { message: "boom" },
+        isError: true,
+      },
+    ]);
+  });
+
+  it("emits `step_finish` with the runner-managed step index + usage", async () => {
+    // The runner owns the step counter (also used to gate trace span
+    // emission and SSE snapshot stepIndex); the adapter reads via
+    // `getStepIndex()` so the runner's view stays authoritative.
+    let stepIndex = 3;
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        {
+          type: "finish-step",
+          usage: { inputTokens: 11, outputTokens: 7, totalTokens: 18 },
+          finishReason: "stop",
+        } as any,
+      ]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => stepIndex },
+    );
+    expect(events).toEqual([
+      {
+        type: "step_finish",
+        stepNumber: 3,
+        usage: { inputTokens: 11, outputTokens: 7 },
+      },
+    ]);
+  });
+
+  it("defaults step_finish usage to zeros when not reported", async () => {
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([{ type: "finish-step" } as any]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    expect(events[0]).toMatchObject({
+      type: "step_finish",
+      stepNumber: 0,
+      usage: { inputTokens: 0, outputTokens: 0 },
+    });
+  });
+
+  it("ignores chunk types outside the eval vocabulary", async () => {
+    // AI SDK emits chunk types the runner doesn't translate
+    // (text-start, text-end, finish, raw, file, source). The runner
+    // consumes terminal state via `result.response` / `.totalUsage`
+    // after the stream completes; the adapter MUST stay silent on
+    // these so the SSE event stream shape is preserved.
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        { type: "text-start", id: "t1" } as any,
+        { type: "text-end", id: "t1" } as any,
+        { type: "raw", chunk: "anything" } as any,
+        { type: "finish" } as any,
+      ]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    expect(events).toEqual([]);
+  });
+
+  it("preserves chunk order in the emitted event stream", async () => {
+    // Snapshot test of a representative multi-event sequence — locks
+    // the exact ordering future runners will produce.
+    const events: any[] = [];
+    await consumeFullStreamAsEvalEvents(
+      asyncStream([
+        { type: "text-delta", id: "t", text: "Looking up... " },
+        {
+          type: "tool-call",
+          toolCallId: "tc",
+          toolName: "lookup",
+          input: { q: "x" },
+        } as any,
+        {
+          type: "tool-result",
+          toolCallId: "tc",
+          toolName: "lookup",
+          output: { found: true },
+        } as any,
+        {
+          type: "finish-step",
+          usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+        } as any,
+        { type: "text-delta", id: "t2", text: "Found it." },
+      ]) as any,
+      { emit: (e) => events.push(e), getStepIndex: () => 0 },
+    );
+    expect(events).toEqual([
+      { type: "text_delta", content: "Looking up... " },
+      {
+        type: "tool_call",
+        toolName: "lookup",
+        toolCallId: "tc",
+        args: { q: "x" },
+      },
+      {
+        type: "tool_result",
+        toolCallId: "tc",
+        result: { found: true },
+        isError: false,
+      },
+      {
+        type: "step_finish",
+        stepNumber: 0,
+        usage: { inputTokens: 5, outputTokens: 3 },
+      },
+      { type: "text_delta", content: "Found it." },
+    ]);
+  });
+});

--- a/mcpjam-inspector/server/services/evals/stream-adapter.ts
+++ b/mcpjam-inspector/server/services/evals/stream-adapter.ts
@@ -1,0 +1,111 @@
+/**
+ * Translate AI SDK `streamText.fullStream` chunks → `EvalStreamEvent`
+ * shapes for the eval streaming runners.
+ *
+ * Engine consolidation PR 5a (`~/mcpjam-docs/unification.md`). The
+ * local-AI-SDK streaming runner (`streamIterationWithAiSdk`) used to
+ * inline a `for await (const part of result.fullStream)` switch on
+ * chunk types to emit `text_delta` / `tool_call` / `tool_result` /
+ * `step_finish` events. PR 5a rewires the runner onto
+ * `runDirectChatTurn` (PR 4a) and lifts that switch into a named
+ * adapter so the same translation can be applied to other future
+ * stream consumers (PR 5b will use a similar pattern when
+ * `streamIterationViaBackend` adopts the to-be-extended
+ * `runAssistantTurn` event surface).
+ *
+ * Pure refactor — the emitted event shapes are byte-identical to the
+ * pre-PR-5a inline switch. Snapshot tests in
+ * `stream-adapter.test.ts` lock the contract.
+ *
+ * Trace-snapshot events (`trace_snapshot`) are NOT emitted from here.
+ * They fire from the runner's per-step / per-turn / failure paths via
+ * `buildTraceSnapshotEvent` because they carry runner-specific state
+ * (recordedSpans, activePromptInputMessages, conversationMessages) the
+ * adapter doesn't see.
+ */
+
+import type { streamText } from "ai";
+import type { EvalStreamEvent } from "@/shared/eval-stream-events";
+
+/** Single emit shape that this module produces. Subset of `EvalStreamEvent`. */
+export type FullStreamAdapterEvent = Extract<
+  EvalStreamEvent,
+  | { type: "text_delta" }
+  | { type: "tool_call" }
+  | { type: "tool_result" }
+  | { type: "step_finish" }
+>;
+
+export interface FullStreamAdapterContext {
+  /** Emit callback — typically the eval runner's `StreamEmit`. */
+  emit: (event: FullStreamAdapterEvent) => void;
+  /**
+   * Read the current step number. Used as the `step_finish.stepNumber`
+   * field. The runner owns the counter (it's also used to gate trace
+   * span emission and SSE snapshot stepIndex) so the adapter reads
+   * rather than tracks it.
+   */
+  getStepIndex: () => number;
+}
+
+type FullStream = ReturnType<typeof streamText>["fullStream"];
+
+/**
+ * Drives `fullStream` to completion, emitting `EvalStreamEvent` shapes
+ * for each chunk. Returns when the stream closes; throws only if the
+ * stream itself throws. The helper does NOT call `consumeStream()` —
+ * iterating `fullStream` consumes it directly.
+ *
+ * Caller is responsible for awaiting `result.response` / `result.steps`
+ * / `result.totalUsage` AFTER this returns for the final assembly.
+ */
+export async function consumeFullStreamAsEvalEvents(
+  fullStream: FullStream,
+  ctx: FullStreamAdapterContext,
+): Promise<void> {
+  for await (const part of fullStream) {
+    switch (part.type) {
+      case "text-delta":
+        ctx.emit({ type: "text_delta", content: part.text });
+        break;
+      case "tool-call":
+        ctx.emit({
+          type: "tool_call",
+          toolName: part.toolName,
+          toolCallId: part.toolCallId,
+          args: (part.input ?? {}) as Record<string, unknown>,
+        });
+        break;
+      case "tool-result":
+        ctx.emit({
+          type: "tool_result",
+          toolCallId: part.toolCallId,
+          result: part.output,
+          isError: false,
+        });
+        break;
+      case "tool-error":
+        ctx.emit({
+          type: "tool_result",
+          toolCallId: part.toolCallId,
+          result: part.error,
+          isError: true,
+        });
+        break;
+      case "finish-step":
+        ctx.emit({
+          type: "step_finish",
+          stepNumber: ctx.getStepIndex(),
+          usage: {
+            inputTokens: part.usage?.inputTokens ?? 0,
+            outputTokens: part.usage?.outputTokens ?? 0,
+          },
+        });
+        break;
+      // Other chunk types (text-start, text-end, finish, error, raw,
+      // file, source, …) are not part of the eval event vocabulary —
+      // the runner consumes terminal state via `result.response` /
+      // `result.totalUsage` / `result.finishReason` after this returns.
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Pure refactor preparation — lifts the chunk-to-event switch out of `streamIterationWithAiSdk`'s inline `for await (const part of result.fullStream)` loop into a named helper `consumeFullStreamAsEvalEvents(fullStream, ctx)` at `server/services/evals/stream-adapter.ts`.

The runner is unchanged in this PR. PR 5a will rewire `streamIterationWithAiSdk` onto `runDirectChatTurn` + this adapter as its terminal. Shipping the adapter independently locks the byte-shape contract (the `streamTestCase` SSE event stream is a closed client dependency the UI test runner depends on) so PR 5a's diff focuses on the runner rewire, not on re-litigating event translation.

## Why a pre-PR

- The `streamTestCase` SSE event vocabulary is a closed client contract. The client UI test runner depends on the exact event shapes; a translation refactor on its own is the right unit to review.
- A named adapter is reusable: PR 5b will need an analogous translation when `streamIterationViaBackend` adopts the to-be-extended `runAssistantTurn` event surface. Currently the shared engine exposes `onLiveTextDelta` + `onConversationComplete` only; per-tool / per-step callbacks need to be added — that's its own PR with cross-engine review surface.
- Splitting the adapter from the runner rewrite mirrors the `4a (helper)` → `4b (caller uses helper)` pattern that worked well.

## Scope

- New `server/services/evals/stream-adapter.ts` (~110 LOC) — `consumeFullStreamAsEvalEvents(fullStream, {emit, getStepIndex})`. The runner owns the step counter (used to gate trace span emission + SSE snapshot `stepIndex`) so the adapter reads via `getStepIndex()` rather than tracking its own state.
- New `stream-adapter.test.ts` — 10 contract tests:
  - text-delta → `text_delta`
  - tool-call → `tool_call` with hyphenated chunk type
  - tool-call args default to `{}` when input undefined
  - tool-result → `tool_result` (`isError: false`)
  - tool-error → `tool_result` (`isError: true`)
  - finish-step → `step_finish` with runner-owned step index + usage
  - finish-step usage defaults to zeros when not reported
  - Silent on out-of-vocab chunks (text-start, text-end, raw, finish)
  - Order preservation across mixed-event sequences
- Trace-snapshot events (`trace_snapshot`) stay out of the adapter — they carry runner-specific state the adapter doesn't see (recordedSpans, `activePromptInputMessages`, `conversationMessages`).

## What this PR explicitly does NOT touch

- `evals-runner.ts` unchanged. `streamIterationWithAiSdk` still uses its inline `for await` loop until PR 5a swaps in the adapter.
- `streamIterationViaBackend` unchanged. Its `runAssistantTurn` adoption + deferred 4d SSE-snapshot prefix is PR 5b territory.
- Tool-span `stepIndex:-1` regression unchanged. Folds into PR 5a/5b only if it falls out cleanly.

## Test plan

- [x] 10/10 new adapter tests pass
- [x] Broader sweep: 692/692 across `server/{utils,services/evals,services/sessionSimulation,routes/mcp}` + `chat-v2.hosted`
- [x] Typecheck baseline-clean (zero errors in the new files)
- [ ] Smoke (post-merge): no behavior change to test in this PR — the adapter is unused until PR 5a wires it in

## Plan context

`~/mcpjam-docs/unification.md` Phase 2 PR 5 row enumerates 6 contract bullets PR 5a must honor (wire shape, persistence shape, SSE shape, eval correctness invariants, resolver wire-up, UI event contract). PR 5 was split into 5a (`streamIterationWithAiSdk` only; this adapter unblocks it) and 5b (extend `runAssistantTurn` + collapse `streamIterationViaBackend`) after the investigation surfaced the engine surface gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated module plus tests only; production paths are untouched until PR 5a wires the adapter in.
> 
> **Overview**
> Introduces **`consumeFullStreamAsEvalEvents`** in `stream-adapter.ts`, lifting the AI SDK `fullStream` chunk switch (text, tool-call/result/error, finish-step) out of the inline logic that **`streamIterationWithAiSdk`** still uses until PR 5a. The helper maps chunks to eval SSE shapes (`text_delta`, `tool_call`, `tool_result`, `step_finish`) via an **`emit`** callback and reads **`stepNumber`** from the runner through **`getStepIndex()`**; it does not emit **`trace_snapshot`**.
> 
> Adds **10 contract tests** in `stream-adapter.test.ts` to lock byte-equivalent behavior (defaults, ignored chunk types, ordering). **No runtime wiring in this PR** — eval runners and SSE behavior stay unchanged until the follow-up rewire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d20d8e738217ddbad9f02d2d40ef7ce65cb56e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->