### PR TITLE
evals: rewire streamIterationWithAiSdk onto runDirectChatTurn + adapter (engine consolidation PR 5a)

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -3378,6 +3378,28 @@ const streamIterationWithAiSdk = async ({
           return returnLocalCancelled();
         }
 
+      // Cursor PR 5a review round 2 fix (Medium "Streaming omits
+      // totalUsage before failures"): the per-step delta-update inside
+      // `onStepSnapshot` only captures usage for steps where the
+      // snapshot fired. If the stream resolves with zero completed
+      // steps — the same path the no-content failure branch handles —
+      // `accumulatedUsage` stays at the pre-turn baseline even when
+      // `handle.result.totalUsage` reports billed tokens. The
+      // non-stream runner (PR 4b) reads `headless.totalUsage` and
+      // merges before failure branches; PR 5a now does the same.
+      // Reconciles to the canonical post-stream total so failure
+      // branches + finishParams see the real billed value.
+      const finalTurnUsage = await handle.result.totalUsage;
+      accumulatedUsage.inputTokens =
+        accumulatedUsageBeforeTurn.inputTokens +
+        (finalTurnUsage?.inputTokens ?? 0);
+      accumulatedUsage.outputTokens =
+        accumulatedUsageBeforeTurn.outputTokens +
+        (finalTurnUsage?.outputTokens ?? 0);
+      accumulatedUsage.totalTokens =
+        accumulatedUsageBeforeTurn.totalTokens +
+        (finalTurnUsage?.totalTokens ?? 0);
+
       // After stream completes, resolve the helper's terminal promises.
       const steps = await handle.result.steps;
       const responseObj = await handle.result.response;

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1409,6 +1409,12 @@ const runIterationWithAiSdk = async ({
         llmModel,
         modelId: test.model,
         messageHistory: activePromptInputMessages,
+        // Cursor PR 5a review fix (also applies to PR 4b's non-stream
+        // runner): anchor trace span offsets to the iteration start so
+        // multi-turn timelines don't collapse to start-at-zero per
+        // turn. The helper defaults to `Date.now()` for the chat /
+        // single-turn case.
+        traceStartedAt: runStartedAt,
         systemPrompt: prepared.enhancedSystemPrompt ?? "",
         ...(prepared.resolvedTemperature == null
           ? {}
@@ -1520,7 +1526,20 @@ const runIterationWithAiSdk = async ({
         break;
       }
       const stepErrorSpan = activeTraceCtx.recordedSpans.find(
-        (span) => span.status === "error" && span.category !== "tool",
+        // Codex PR 5a review fix (also applies to PR 4b's non-stream
+        // runner): when a tool call fails, `wrapToolSetForEvalTrace`
+        // records BOTH a `category:"tool"` span AND a child
+        // `category:"error"` span carrying `toolCallId`/`toolName`
+        // (see eval-trace-capture.ts:258-275). The simple
+        // `category !== "tool"` filter catches the child error span
+        // and treats failed tool calls as cycle failures even when
+        // `advancedConfig.failOnToolError === false`. Excluding any
+        // span associated with a tool (carries `toolCallId`) restores
+        // the intended deferral to the `failOnToolError` gate.
+        (span) =>
+          span.status === "error" &&
+          span.category !== "tool" &&
+          !(span as { toolCallId?: string }).toolCallId,
       );
       if (stepErrorSpan) {
         iterationError = `Local-BYOK step failed mid-turn: ${stepErrorSpan.name}`;
@@ -3244,6 +3263,12 @@ const streamIterationWithAiSdk = async ({
         llmModel,
         modelId: test.model,
         messageHistory: activePromptInputMessages,
+        // Cursor PR 5a review fix (also applies to PR 4b's non-stream
+        // runner): anchor trace span offsets to the iteration start so
+        // multi-turn timelines don't collapse to start-at-zero per
+        // turn. The helper defaults to `Date.now()` for the chat /
+        // single-turn case.
+        traceStartedAt: runStartedAt,
         systemPrompt: prepared.enhancedSystemPrompt ?? "",
         ...(prepared.resolvedTemperature == null
           ? {}
@@ -3325,26 +3350,33 @@ const streamIterationWithAiSdk = async ({
       // used.
       activeTraceCtx = handle.traceContext;
 
-      // Drive the stream via the shared adapter — emits text_delta /
-      // tool_call / tool_result / step_finish SSE events. The runner
-      // owns the step counter via `getStepIndex` so the adapter stays
-      // stateless.
-      await consumeFullStreamAsEvalEvents(handle.result.fullStream, {
-        emit,
-        getStepIndex: () => activeCompletedStepCount,
-      });
+      // Cursor PR 5a review fix (Low "Stream throw skips handle
+      // cleanup"): wrap the stream drain + terminal-promise reads in a
+      // try/finally so `handle.cleanup()` always runs (idempotent), even
+      // when `consumeFullStreamAsEvalEvents` or any subsequent await
+      // throws into the outer catch. The abort listener inside the
+      // helper would otherwise leak when control jumps to a scope where
+      // `handle` is unreachable.
+      try {
+        // Drive the stream via the shared adapter — emits text_delta /
+        // tool_call / tool_result / step_finish SSE events. The runner
+        // owns the step counter via `getStepIndex` so the adapter stays
+        // stateless.
+        await consumeFullStreamAsEvalEvents(handle.result.fullStream, {
+          emit,
+          getStepIndex: () => activeCompletedStepCount,
+        });
 
-      // PR 5a abort check (mirror PR 4b): streamText can swallow
-      // AbortError silently when the underlying fetch is cancelled.
-      // Check the outer signal directly after the for-await loop
-      // resolves so cancelled runs drop without persisting.
-      if (handle.isAborted() || localIsAborted()) {
-        logger.debug(
-          "[evals] streaming local-BYOK iteration aborted mid-turn; skipping record",
-        );
-        handle.cleanup();
-        return returnLocalCancelled();
-      }
+        // PR 5a abort check (mirror PR 4b): streamText can swallow
+        // AbortError silently when the underlying fetch is cancelled.
+        // Check the outer signal directly after the for-await loop
+        // resolves so cancelled runs drop without persisting.
+        if (handle.isAborted() || localIsAborted()) {
+          logger.debug(
+            "[evals] streaming local-BYOK iteration aborted mid-turn; skipping record",
+          );
+          return returnLocalCancelled();
+        }
 
       // After stream completes, resolve the helper's terminal promises.
       const steps = await handle.result.steps;
@@ -3385,11 +3417,45 @@ const streamIterationWithAiSdk = async ({
         );
         recordedSpans.push(...activeTraceCtx.recordedSpans);
         toolsCalledByPrompt.push([]);
+        // Cursor PR 5a review fix (Medium "Soft failure skips streaming
+        // error events"): emit the failure trace_snapshot + error event
+        // before `break` so live SSE consumers see the failure signal
+        // immediately. Without these, a turn that already emitted
+        // `turn_start` ends silently from the consumer's POV.
+        emit(
+          buildTraceSnapshotEvent({
+            turnIndex: promptIndex,
+            ...(activeCompletedStepCount > 0
+              ? { stepIndex: activeCompletedStepCount - 1 }
+              : {}),
+            snapshotKind: "failure",
+            messages: withSystemPrefix(activePromptInputMessages),
+            spans: recordedSpans,
+            actualToolCalls: extractToolCallsFromConversation({
+              messages: activePromptInputMessages,
+            }),
+            usage: accumulatedUsage,
+          }),
+        );
+        emit({ type: "error", message: iterationError });
         handle.cleanup();
         break;
       }
       const stepErrorSpan = activeTraceCtx.recordedSpans.find(
-        (span) => span.status === "error" && span.category !== "tool",
+        // Codex PR 5a review fix (also applies to PR 4b's non-stream
+        // runner): when a tool call fails, `wrapToolSetForEvalTrace`
+        // records BOTH a `category:"tool"` span AND a child
+        // `category:"error"` span carrying `toolCallId`/`toolName`
+        // (see eval-trace-capture.ts:258-275). The simple
+        // `category !== "tool"` filter catches the child error span
+        // and treats failed tool calls as cycle failures even when
+        // `advancedConfig.failOnToolError === false`. Excluding any
+        // span associated with a tool (carries `toolCallId`) restores
+        // the intended deferral to the `failOnToolError` gate.
+        (span) =>
+          span.status === "error" &&
+          span.category !== "tool" &&
+          !(span as { toolCallId?: string }).toolCallId,
       );
       if (stepErrorSpan) {
         iterationError = `Local-BYOK step failed mid-turn: ${stepErrorSpan.name}`;
@@ -3411,6 +3477,25 @@ const streamIterationWithAiSdk = async ({
           ...activePromptInputMessages,
           ...promptResponseMessages,
         ];
+        // Cursor PR 5a review fix (Medium "Soft failure skips
+        // streaming error events"): emit the failure trace_snapshot +
+        // error event before `break` (mirror the no-msg branch above).
+        emit(
+          buildTraceSnapshotEvent({
+            turnIndex: promptIndex,
+            ...(activeCompletedStepCount > 0
+              ? { stepIndex: activeCompletedStepCount - 1 }
+              : {}),
+            snapshotKind: "failure",
+            messages: withSystemPrefix(conversationMessages),
+            spans: recordedSpans,
+            actualToolCalls: extractToolCallsFromConversation({
+              messages: conversationMessages,
+            }),
+            usage: accumulatedUsage,
+          }),
+        );
+        emit({ type: "error", message: iterationError });
         handle.cleanup();
         break;
       }
@@ -3429,27 +3514,34 @@ const streamIterationWithAiSdk = async ({
       // Note: `accumulatedUsage` was updated incrementally via
       // `onStepSnapshot`; no post-loop merge needed.
 
-      emit(
-        buildTraceSnapshotEvent({
-          turnIndex: promptIndex,
-          snapshotKind: "turn_finish",
-          messages: withSystemPrefix(conversationMessages),
-          spans: recordedSpans,
-          actualToolCalls: extractToolCallsFromConversation({
-            messages: conversationMessages,
+        emit(
+          buildTraceSnapshotEvent({
+            turnIndex: promptIndex,
+            snapshotKind: "turn_finish",
+            messages: withSystemPrefix(conversationMessages),
+            spans: recordedSpans,
+            actualToolCalls: extractToolCallsFromConversation({
+              messages: conversationMessages,
+            }),
+            usage: accumulatedUsage,
           }),
-          usage: accumulatedUsage,
-        }),
-      );
+        );
 
-      handle.cleanup();
+        activeTraceCtx = null;
+        activePromptInputMessages = [];
+        activePartialResponseMessages = [];
+        activeCompletedStepCount = 0;
 
-      activeTraceCtx = null;
-      activePromptInputMessages = [];
-      activePartialResponseMessages = [];
-      activeCompletedStepCount = 0;
-
-      emit({ type: "turn_finish", turnIndex: promptIndex });
+        emit({ type: "turn_finish", turnIndex: promptIndex });
+      } finally {
+        // Cursor PR 5a review fix (Low "Stream throw skips handle
+        // cleanup"): unconditional cleanup. Idempotent (the helper
+        // tracks `listenerAttached`), so the existing explicit
+        // `handle.cleanup()` calls inside the failure branches above
+        // are now safe redundancies — kept there for symmetry with
+        // PR 4b's pattern, but the real guarantee is here.
+        handle.cleanup();
+      }
     }
 
     const evaluation = evaluateMultiTurnResults(

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -32,6 +32,7 @@ import {
   consumeDirectChatTurnHeadless,
   runDirectChatTurn,
 } from "../utils/direct-chat-turn";
+import { consumeFullStreamAsEvalEvents } from "./evals/stream-adapter";
 import { resolveExecutionContext } from "../utils/host-execution-context";
 import { logger } from "../utils/logger";
 import { captureMcpAppWidgetSnapshots } from "../utils/mcp-app-widget-capture";
@@ -3107,6 +3108,16 @@ const streamIterationWithAiSdk = async ({
   let activeCompletedStepCount = 0;
   let activeTraceCtx: ReturnType<typeof createAiSdkEvalTraceContext> | null =
     null;
+  // PR 5a of the engine consolidation (`~/mcpjam-docs/unification.md`):
+  // streaming-runner equivalents of PR 4b's `iterationError` /
+  // `iterationErrorDetails` hoists. The streaming runner historically
+  // threw on driver failures and relied on the outer catch; PR 5a
+  // adopts the non-stream runner's three-signal failure detection
+  // (no-new-messages, non-tool error span) which records the failure
+  // via `status:"completed"` + `error` on `finishParams` so the run
+  // continues to complete cleanly while flagging the failure.
+  let iterationError: string | undefined = undefined;
+  let iterationErrorDetails: string | undefined = undefined;
   // PR 4d review fix (CodeRabbit): hoisted so persistence sites in the
   // success + catch paths can prepend the resolved system prompt to
   // the messages array. Mirrors `enhancedSystemPromptForPersist` in
@@ -3174,21 +3185,33 @@ const streamIterationWithAiSdk = async ({
       );
     }
 
+    // PR 5a abort helpers — mirror the non-stream runner's pattern so
+    // a cancellation between consume and check drops the iteration
+    // record without persisting cancelled state.
+    const localIsAborted = () => abortSignal?.aborted === true;
+    const returnLocalCancelled = () => ({
+      evaluation: evaluateMultiTurnResults(
+        promptTurns,
+        toolsCalledByPrompt,
+        test.isNegativeTest,
+        test.matchOptions,
+      ),
+      iterationId: undefined,
+    });
+
     for (let promptIndex = 0; promptIndex < promptTurns.length; promptIndex++) {
+      if (localIsAborted()) return returnLocalCancelled();
       const promptTurn = promptTurns[promptIndex]!;
       activePromptIndex = promptIndex;
-      activePromptInputMessages = [
-        ...conversationMessages,
-        { role: "user", content: promptTurn.prompt },
-      ];
+      // PR 5a invariant (mirror PR 4b round 2): push the user prompt to
+      // `conversationMessages` BEFORE the driver call so a failed turn
+      // still records the prompt in the persisted transcript. Without
+      // this, suite UI shows an empty failed iteration that's
+      // unactionable.
+      conversationMessages.push({ role: "user", content: promptTurn.prompt });
+      activePromptInputMessages = [...conversationMessages];
       activePartialResponseMessages = [];
       activeCompletedStepCount = 0;
-      activeTraceCtx = createAiSdkEvalTraceContext(runStartedAt);
-      const tracedTools = wrapToolSetForEvalTrace(
-        prepared.allTools,
-        activeTraceCtx,
-        promptIndex,
-      );
 
       emit({
         type: "turn_start",
@@ -3196,22 +3219,43 @@ const streamIterationWithAiSdk = async ({
         prompt: promptTurn.prompt,
       });
 
-      const result = streamText({
-        model: llmModel,
-        messages: activePromptInputMessages,
-        ...(prepared.enhancedSystemPrompt
-          ? { system: prepared.enhancedSystemPrompt }
-          : {}),
-        tools: tracedTools,
-        stopWhen: stepCountIs(20),
+      // PR 5a: drive `runDirectChatTurn`. The helper owns the streamText
+      // config, span recording, abort wiring, progressive-discovery
+      // gating, and prepareStep. Eval owns SSE event emission (via the
+      // adapter on `handle.result.fullStream`), failure detection,
+      // persistence, and grading.
+      //
+      // `traceEvents.onStepSnapshot` is the eval-side per-step hook:
+      // increment step counter, mirror partial state (so the outer
+      // catch + no-msg fallback can persist a partial transcript),
+      // update accumulatedUsage from `traceTurn.turnUsage` delta (so
+      // mid-run `trace_snapshot` events show running totals, and the
+      // PR 4b "totalUsage merged BEFORE failure branches" invariant
+      // holds — each completed step's usage lands before the next
+      // potential failure branch fires), and emit the `trace_snapshot`
+      // SSE event with `withSystemPrefix` applied.
+      const promptInputLength = activePromptInputMessages.length;
+      const accumulatedUsageBeforeTurn = {
+        inputTokens: accumulatedUsage.inputTokens,
+        outputTokens: accumulatedUsage.outputTokens,
+        totalTokens: accumulatedUsage.totalTokens,
+      };
+      const handle = runDirectChatTurn({
+        llmModel,
+        modelId: test.model,
+        messageHistory: activePromptInputMessages,
+        systemPrompt: prepared.enhancedSystemPrompt ?? "",
         ...(prepared.resolvedTemperature == null
           ? {}
           : { temperature: prepared.resolvedTemperature }),
+        tools: prepared.allTools,
+        progressivePlan: prepared.progressivePlan,
+        discoveryState: prepared.discoveryState,
+        ...(abortSignal ? { abortSignal } : {}),
         ...(toolChoice
           ? { toolChoice: toolChoice as ToolChoice<Record<string, AiTool>> }
           : {}),
-        ...(abortSignal ? { abortSignal } : {}),
-        experimental_telemetry: {
+        experimentalTelemetry: {
           isEnabled: true,
           functionId: "evals.streamText",
           recordInputs: false,
@@ -3228,116 +3272,83 @@ const streamIterationWithAiSdk = async ({
             promptIndex,
           },
         },
-        prepareStep: ({ stepNumber }) => {
-          registerAiSdkPrepareStep(activeTraceCtx!, stepNumber, {
-            modelId: test.model,
-            promptIndex,
-          });
-          return undefined;
-        },
-        onStepFinish: async (step) => {
-          activeCompletedStepCount += 1;
-          const stepFinishedAt = Date.now();
-          accumulatedUsage.inputTokens += step.usage?.inputTokens ?? 0;
-          accumulatedUsage.outputTokens += step.usage?.outputTokens ?? 0;
-          accumulatedUsage.totalTokens += step.usage?.totalTokens ?? 0;
-          const responseMessages = step.response?.messages ?? [];
-          const responseMessageCountBeforeAppend =
-            activePartialResponseMessages.length;
-          const messageStartIndex =
-            responseMessages.length > 0
-              ? activePromptInputMessages.length +
-                responseMessageCountBeforeAppend
-              : undefined;
-          appendDedupedModelMessages(
-            activePartialResponseMessages,
-            responseMessages as ModelMessage[],
-          );
-          const appendedMessageCount =
-            activePartialResponseMessages.length -
-            responseMessageCountBeforeAppend;
-          const messageEndIndex =
-            messageStartIndex != null && appendedMessageCount > 0
-              ? messageStartIndex + appendedMessageCount - 1
-              : undefined;
-          emitAiSdkOnStepFinish(activeTraceCtx!, stepFinishedAt, {
-            modelId: step.response?.modelId ?? test.model,
-            inputTokens: step.usage?.inputTokens,
-            outputTokens: step.usage?.outputTokens,
-            totalTokens: step.usage?.totalTokens,
-            messageStartIndex,
-            messageEndIndex,
-            status: "ok",
-          });
-          const snapshotMessages = [
-            ...activePromptInputMessages,
-            ...activePartialResponseMessages,
-          ];
-          emit(
-            buildTraceSnapshotEvent({
-              turnIndex: promptIndex,
-              stepIndex: activeCompletedStepCount - 1,
-              snapshotKind: "step_finish",
-              messages: withSystemPrefix(snapshotMessages),
-              spans: [...recordedSpans, ...activeTraceCtx!.recordedSpans],
-              actualToolCalls: extractToolCallsFromConversation({
-                messages: snapshotMessages,
+        traceEvents: {
+          onStepSnapshot: ({ traceHistory, traceTurn }) => {
+            activeCompletedStepCount += 1;
+            // Slice from `promptInputLength` to get just this turn's
+            // running response (PR 4d pattern).
+            activePartialResponseMessages = traceHistory.slice(
+              promptInputLength,
+            ) as ModelMessage[];
+            // Recompute accumulatedUsage from this turn's cumulative
+            // usage so far + the snapshot taken at turn start. This
+            // keeps the running total correct across multi-turn runs
+            // AND across the failure branches below (since the
+            // accumulated value is up-to-date by the time the
+            // for-await loop returns).
+            accumulatedUsage.inputTokens =
+              accumulatedUsageBeforeTurn.inputTokens +
+              (traceTurn.turnUsage?.inputTokens ?? 0);
+            accumulatedUsage.outputTokens =
+              accumulatedUsageBeforeTurn.outputTokens +
+              (traceTurn.turnUsage?.outputTokens ?? 0);
+            accumulatedUsage.totalTokens =
+              accumulatedUsageBeforeTurn.totalTokens +
+              (traceTurn.turnUsage?.totalTokens ?? 0);
+            const snapshotMessages = [
+              ...activePromptInputMessages,
+              ...activePartialResponseMessages,
+            ];
+            emit(
+              buildTraceSnapshotEvent({
+                turnIndex: promptIndex,
+                stepIndex: activeCompletedStepCount - 1,
+                snapshotKind: "step_finish",
+                messages: withSystemPrefix(snapshotMessages),
+                // Spans available on `traceTurn.turnSpans` so we don't
+                // need to reach into the closed-over handle, which the
+                // arrow function can't reference yet during option
+                // construction.
+                spans: [...recordedSpans, ...traceTurn.turnSpans],
+                actualToolCalls: extractToolCallsFromConversation({
+                  messages: snapshotMessages,
+                }),
+                usage: accumulatedUsage,
               }),
-              usage: accumulatedUsage,
-            }),
-          );
-        },
-        onFinish: async () => {
-          /* Final messages read from `result` after await; hook kept for symmetry with AI SDK lifecycle. */
+            );
+          },
         },
       });
+      // `runDirectChatTurn` exposes its internal traceContext so eval
+      // can fold its spans into `recordedSpans` after each turn,
+      // matching the per-turn cadence the old in-runner `activeTraceCtx`
+      // used.
+      activeTraceCtx = handle.traceContext;
 
-      // Consume the full stream and emit events
-      for await (const part of result.fullStream) {
-        switch (part.type) {
-          case "text-delta":
-            emit({ type: "text_delta", content: part.text });
-            break;
-          case "tool-call":
-            emit({
-              type: "tool_call",
-              toolName: part.toolName,
-              toolCallId: part.toolCallId,
-              args: (part.input ?? {}) as Record<string, unknown>,
-            });
-            break;
-          case "tool-result":
-            emit({
-              type: "tool_result",
-              toolCallId: part.toolCallId,
-              result: part.output,
-              isError: false,
-            });
-            break;
-          case "tool-error":
-            emit({
-              type: "tool_result",
-              toolCallId: part.toolCallId,
-              result: part.error,
-              isError: true,
-            });
-            break;
-          case "finish-step":
-            emit({
-              type: "step_finish",
-              stepNumber: activeCompletedStepCount,
-              usage: {
-                inputTokens: part.usage?.inputTokens ?? 0,
-                outputTokens: part.usage?.outputTokens ?? 0,
-              },
-            });
-            break;
-        }
+      // Drive the stream via the shared adapter — emits text_delta /
+      // tool_call / tool_result / step_finish SSE events. The runner
+      // owns the step counter via `getStepIndex` so the adapter stays
+      // stateless.
+      await consumeFullStreamAsEvalEvents(handle.result.fullStream, {
+        emit,
+        getStepIndex: () => activeCompletedStepCount,
+      });
+
+      // PR 5a abort check (mirror PR 4b): streamText can swallow
+      // AbortError silently when the underlying fetch is cancelled.
+      // Check the outer signal directly after the for-await loop
+      // resolves so cancelled runs drop without persisting.
+      if (handle.isAborted() || localIsAborted()) {
+        logger.debug(
+          "[evals] streaming local-BYOK iteration aborted mid-turn; skipping record",
+        );
+        handle.cleanup();
+        return returnLocalCancelled();
       }
 
-      // After stream completes, resolve the promises on the streamText result
-      const steps = await result.steps;
-      const responseObj = await result.response;
+      // After stream completes, resolve the helper's terminal promises.
+      const steps = await handle.result.steps;
+      const responseObj = await handle.result.response;
       const finalMessagesRaw = responseObj?.messages as
         | ModelMessage[]
         | undefined;
@@ -3355,6 +3366,55 @@ const streamIterationWithAiSdk = async ({
         );
       }
 
+      // PR 5a failure-detection (mirror PR 4b / 4d three-signal shape):
+      //   (a) No new messages → driver returned nothing (network
+      //       failure, model returned empty, …).
+      //   (b) Non-tool error span captured during the run (LLM step
+      //       failure, scrub failure, …). Tool error spans
+      //       (category "tool") flow through the existing
+      //       `failOnToolError` gate below — DON'T treat them as cycle
+      //       failures here.
+      // `accumulatedUsage` is already up-to-date from the last
+      // `onStepSnapshot`, so failure branches inherit correct token
+      // totals (PR 4b "totalUsage before failure" invariant).
+      if (promptResponseMessages.length === 0) {
+        iterationError =
+          "Stream returned no content (local-BYOK driver failed)";
+        logger.error(
+          "[evals] streamText returned no new messages this turn; treating as cycle failure",
+        );
+        recordedSpans.push(...activeTraceCtx.recordedSpans);
+        toolsCalledByPrompt.push([]);
+        handle.cleanup();
+        break;
+      }
+      const stepErrorSpan = activeTraceCtx.recordedSpans.find(
+        (span) => span.status === "error" && span.category !== "tool",
+      );
+      if (stepErrorSpan) {
+        iterationError = `Local-BYOK step failed mid-turn: ${stepErrorSpan.name}`;
+        logger.error(
+          `[evals] streamText recorded non-tool error span; treating as cycle failure (span=${stepErrorSpan.name} category=${stepErrorSpan.category})`,
+        );
+        recordedSpans.push(...activeTraceCtx.recordedSpans);
+        toolsCalledByPrompt.push(
+          extractToolCallsFromConversation({
+            steps,
+            messages: promptResponseMessages,
+          }),
+        );
+        // PR 4b review fix (Cursor "Step error drops assistant
+        // transcript"): merge the partial response into
+        // `conversationMessages` so persisted iterations include
+        // whatever the model produced before the failure.
+        conversationMessages = [
+          ...activePromptInputMessages,
+          ...promptResponseMessages,
+        ];
+        handle.cleanup();
+        break;
+      }
+
       const promptToolsCalled = extractToolCallsFromConversation({
         steps,
         messages: promptResponseMessages,
@@ -3366,6 +3426,8 @@ const streamIterationWithAiSdk = async ({
         ...activePromptInputMessages,
         ...promptResponseMessages,
       ];
+      // Note: `accumulatedUsage` was updated incrementally via
+      // `onStepSnapshot`; no post-loop merge needed.
 
       emit(
         buildTraceSnapshotEvent({
@@ -3379,6 +3441,8 @@ const streamIterationWithAiSdk = async ({
           usage: accumulatedUsage,
         }),
       );
+
+      handle.cleanup();
 
       activeTraceCtx = null;
       activePromptInputMessages = [];
@@ -3424,6 +3488,11 @@ const streamIterationWithAiSdk = async ({
     const passed = finalizePassedForEval({
       matchPassed: evaluation.passed,
       trace: traceForGate,
+      // PR 5a (mirror PR 4b): if the per-turn loop set `iterationError`
+      // via the failure-detection branch, feed it to the gate so a
+      // failed cycle doesn't sneak through as a verdict pass on
+      // negative tests / zero-expected-tool cases.
+      iterationError,
       failOnToolError,
       predicateResults,
     });
@@ -3467,6 +3536,12 @@ const streamIterationWithAiSdk = async ({
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
       status: "completed" as const,
       startedAt: runStartedAt,
+      // PR 5a (mirror PR 4b): if the per-turn loop set `iterationError`
+      // via the failure-detection branch, surface it on the persisted
+      // iteration via `status:"completed"` + `error` — the run
+      // completed cleanly but the cycle failed.
+      ...(iterationError ? { error: iterationError } : {}),
+      ...(iterationErrorDetails ? { errorDetails: iterationErrorDetails } : {}),
       resultSource: "reported" as const,
       metadata: {
         ...iterationMetadataBase,
@@ -3813,6 +3888,25 @@ const streamIterationViaBackend = async ({
   // throws — the setup-failure persistence path doesn't need a system
   // prefix.
   let backendEnhancedSystemPromptForPersist: string | undefined = undefined;
+  // PR 5a folds in the deferred 4d Cursor-Low fix: mid-run SSE
+  // snapshot events (`buildTraceSnapshotEvent`) in this streaming
+  // backend variant read from `messageHistory` directly. PR 4d
+  // round 2 added a `withSystemPrefix` closure to
+  // `streamIterationWithAiSdk` but deferred the equivalent here.
+  // The full runner-engine collapse stays for PR 5b; the
+  // snapshot-prefix shape is small and isolated, so it folds into
+  // PR 5a alongside the local stream rewrite. Closes the
+  // "live-on-main UI gap" risk entry in unification.md.
+  const withSystemPrefix = (msgs: ModelMessage[]): ModelMessage[] =>
+    backendEnhancedSystemPromptForPersist
+      ? [
+          {
+            role: "system",
+            content: backendEnhancedSystemPromptForPersist,
+          },
+          ...msgs,
+        ]
+      : msgs;
   let prepared: PrepareChatV2Result;
   try {
     prepared = await prepareChatV2({
@@ -3997,7 +4091,7 @@ const streamIterationViaBackend = async ({
               turnIndex: promptIndex,
               stepIndex,
               snapshotKind: "failure",
-              messages: messageHistory,
+              messages: withSystemPrefix(messageHistory),
               spans: capturedSpans,
               actualToolCalls: extractToolCallsFromConversation({
                 messages: messageHistory,
@@ -4031,7 +4125,7 @@ const streamIterationViaBackend = async ({
               turnIndex: promptIndex,
               stepIndex,
               snapshotKind: "failure",
-              messages: messageHistory,
+              messages: withSystemPrefix(messageHistory),
               spans: capturedSpans,
               actualToolCalls: extractToolCallsFromConversation({
                 messages: messageHistory,
@@ -4128,7 +4222,7 @@ const streamIterationViaBackend = async ({
               turnIndex: promptIndex,
               stepIndex,
               snapshotKind: "failure",
-              messages: messageHistory,
+              messages: withSystemPrefix(messageHistory),
               spans: capturedSpans,
               actualToolCalls: extractToolCallsFromConversation({
                 messages: messageHistory,
@@ -4317,7 +4411,7 @@ const streamIterationViaBackend = async ({
                 turnIndex: promptIndex,
                 stepIndex,
                 snapshotKind: "failure",
-                messages: messageHistory,
+                messages: withSystemPrefix(messageHistory),
                 spans: capturedSpans,
                 actualToolCalls: extractToolCallsFromConversation({
                   messages: messageHistory,
@@ -4373,7 +4467,7 @@ const streamIterationViaBackend = async ({
             turnIndex: promptIndex,
             stepIndex,
             snapshotKind: "step_finish",
-            messages: messageHistory,
+            messages: withSystemPrefix(messageHistory),
             spans: capturedSpans,
             actualToolCalls: extractToolCallsFromConversation({
               messages: messageHistory,
@@ -4437,7 +4531,7 @@ const streamIterationViaBackend = async ({
             turnIndex: promptIndex,
             stepIndex,
             snapshotKind: "failure",
-            messages: messageHistory,
+            messages: withSystemPrefix(messageHistory),
             spans: capturedSpans,
             actualToolCalls: extractToolCallsFromConversation({
               messages: messageHistory,
@@ -4462,7 +4556,7 @@ const streamIterationViaBackend = async ({
       buildTraceSnapshotEvent({
         turnIndex: promptIndex,
         snapshotKind: "turn_finish",
-        messages: messageHistory,
+        messages: withSystemPrefix(messageHistory),
         spans: capturedSpans,
         actualToolCalls: extractToolCallsFromConversation({
           messages: messageHistory,

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -3047,6 +3047,144 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       }
     });
 
+    it("emits failure trace_snapshot + error event before break on no-content cycle failure (PR 5a review — Cursor Medium)", async () => {
+      // PR 5a review fix: the no-content branch sets `iterationError`
+      // and persists via `status:"completed"` + `error`, but without
+      // emitting the SSE failure signal the live test-runner UI sees
+      // a turn_start without any matching terminal event. Lock the
+      // failure SSE shape: a `trace_snapshot` of `snapshotKind:"failure"`
+      // AND a `type:"error"` event fire before the loop breaks.
+      const emitted: Array<Record<string, unknown>> = [];
+      streamTextMock.mockReset();
+      streamTextMock.mockImplementationOnce(() => ({
+        fullStream: (async function* () {})(),
+        steps: Promise.resolve([]),
+        response: Promise.resolve({
+          modelId: "gpt-4-turbo",
+          messages: [],
+        }),
+        totalUsage: Promise.resolve({
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        }),
+        finishReason: Promise.resolve("stop"),
+        consumeStream: async () => {},
+      }));
+
+      await runStreamCase({ emitCollector: emitted });
+
+      const failureSnapshot = emitted.find(
+        (e) =>
+          e?.type === "trace_snapshot" &&
+          (e as { snapshotKind?: string }).snapshotKind === "failure",
+      );
+      const errorEvent = emitted.find((e) => e?.type === "error");
+      expect(failureSnapshot).toBeDefined();
+      expect(errorEvent).toBeDefined();
+      expect((errorEvent as { message: string }).message).toEqual(
+        expect.stringContaining("Stream returned no content"),
+      );
+    });
+
+    it("does NOT treat tool-error child spans (with toolCallId) as cycle failure (PR 5a review — Codex P2)", async () => {
+      // Codex P2 review fix: `wrapToolSetForEvalTrace` records a failed
+      // tool call as a `category:"tool"` span PLUS a child
+      // `category:"error"` span carrying `toolCallId`/`toolName`. The
+      // pre-fix filter `category !== "tool"` matched the child and set
+      // `iterationError` even when `advancedConfig.failOnToolError` was
+      // `false`. The fix also excludes spans with `toolCallId`. This
+      // test simulates the dual-span shape and asserts no
+      // `iterationError` is recorded.
+      streamTextMock.mockReset();
+      streamTextMock.mockImplementationOnce((options: any) => {
+        // Fire onStepFinish so the helper's onStepSnapshot fires and
+        // accumulatedUsage / partial state mirror.
+        void options.onStepFinish?.({
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          response: {
+            messages: [
+              { role: "assistant", content: "Recovered from tool failure." },
+            ],
+          },
+        });
+        return {
+          fullStream: (async function* () {})(),
+          steps: Promise.resolve([]),
+          response: Promise.resolve({
+            modelId: "gpt-4-turbo",
+            messages: [
+              { role: "assistant", content: "Recovered from tool failure." },
+            ],
+          }),
+          totalUsage: Promise.resolve({
+            inputTokens: 1,
+            outputTokens: 1,
+            totalTokens: 2,
+          }),
+          finishReason: Promise.resolve("stop"),
+          consumeStream: async () => {},
+        };
+      });
+
+      // Force the helper's traceContext to contain a tool-error child
+      // span shape via the direct-chat-turn module's exported helpers.
+      // Simpler approach: stub the trace capture so the runner sees the
+      // recordedSpans we want.
+      const traceCaptureModule = await import(
+        "../eval-trace-capture"
+      );
+      const realCreate = traceCaptureModule.createAiSdkEvalTraceContext;
+      const spy = vi
+        .spyOn(traceCaptureModule, "createAiSdkEvalTraceContext")
+        .mockImplementation((runStartedAt: number) => {
+          const ctx = realCreate(runStartedAt);
+          // Tool failure shape per eval-trace-capture.ts:241-275: the
+          // `category:"tool"` span has status:"error" AND a child
+          // `category:"error"` carries toolCallId/toolName.
+          ctx.recordedSpans.push({
+            id: "tool-tc_1",
+            name: "lookup",
+            category: "tool",
+            status: "error",
+            toolCallId: "tc_1",
+            toolName: "lookup",
+            startMs: 0,
+            endMs: 10,
+          } as any);
+          ctx.recordedSpans.push({
+            id: "tool-err-tc_1",
+            name: "lookup error",
+            category: "error",
+            status: "error",
+            toolCallId: "tc_1",
+            toolName: "lookup",
+            startMs: 0,
+            endMs: 10,
+          } as any);
+          return ctx;
+        });
+
+      try {
+        await runStreamCase({
+          caseAdvancedConfig: { failOnToolError: false },
+        });
+
+        const updateCall = convexClient.action.mock.calls.find(
+          (c) => c[0] === "testSuites:updateTestIteration",
+        );
+        expect(updateCall).toBeDefined();
+        const payload = updateCall![1] as Record<string, unknown>;
+        // Load-bearing assertion: `iterationError` must NOT be set
+        // just because the child error-span exists. The filter excludes
+        // any span carrying `toolCallId` so tool errors stay routed
+        // through `failOnToolError`.
+        expect(payload.error).toBeFalsy();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
     it("emits the existing fullStream → SSE event vocabulary via the shared adapter (PR 5a)", async () => {
       // Lock the byte-shape contract: the events emitted from the
       // streaming runner's terminal stream still match the existing

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -2762,4 +2762,370 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       expect(persistedCarriesIt).toBe(true);
     });
   });
+
+  describe("PR 5a — streamIterationWithAiSdk on runDirectChatTurn + adapter", () => {
+    // PR 5a of the engine consolidation
+    // (`~/mcpjam-docs/unification.md`): the local-AI-SDK streaming runner
+    // now drives `runDirectChatTurn` (PR 4a) + `consumeFullStreamAsEvalEvents`
+    // (PR 5-pre, #2466) instead of an inline `streamText({...})` call.
+    // These tests lock the 6 contract bullets carried from 4a–4d
+    // reviews onto the streaming runner.
+
+    async function runStreamCase(args: {
+      caseAdvancedConfig?: Record<string, unknown>;
+      suiteHostConfig?: Record<string, unknown> | null;
+      emitCollector?: Array<Record<string, unknown>>;
+    }) {
+      const emitted = args.emitCollector ?? [];
+      await streamTestCase({
+        test: {
+          title: "Case",
+          query: "Hello",
+          runs: 1,
+          model: "gpt-4-turbo",
+          provider: "openai",
+          expectedToolCalls: [],
+          promptTurns: [
+            { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+          ],
+          testCaseId: "case-stream-pr5a",
+          ...(args.caseAdvancedConfig
+            ? { advancedConfig: args.caseAdvancedConfig }
+            : {}),
+        },
+        tools: {},
+        selectedServers: [],
+        mcpClientManager: mcpClientManager as any,
+        recorder: null,
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        testCaseId: "case-stream-pr5a",
+        suiteId: "suite-1",
+        runId: null,
+        emit: (event) => emitted.push(event as Record<string, unknown>),
+        ...(args.suiteHostConfig !== undefined
+          ? { suiteHostConfig: args.suiteHostConfig }
+          : {}),
+      } as any);
+      return emitted;
+    }
+
+    it("records iteration with `error` set when streamed turn produces no new messages (PR 5a no-msg failure)", async () => {
+      // Mirror PR 4b's three-signal failure detection on the streaming
+      // path. Pre-PR-5a the streaming runner had no equivalent — a
+      // mid-run failure surfaced via throw or silent zero-token
+      // iteration. PR 5a now sets `iterationError` + records via
+      // `status:"completed"` + `error` on `finishParams`.
+      streamTextMock.mockReset();
+      streamTextMock.mockImplementationOnce((_options: any) => ({
+        fullStream: (async function* () {})(),
+        steps: Promise.resolve([]),
+        response: Promise.resolve({
+          modelId: "gpt-4-turbo",
+          messages: [],
+        }),
+        totalUsage: Promise.resolve({
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        }),
+        finishReason: Promise.resolve("stop"),
+        consumeStream: async () => {},
+      }));
+
+      await runStreamCase({});
+
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = updateCall![1] as Record<string, unknown>;
+      expect(payload.error).toEqual(
+        expect.stringContaining("Stream returned no content"),
+      );
+    });
+
+    it("persists the failing turn's user prompt for the streaming local-BYOK path (PR 5a user-prompt-before-call)", async () => {
+      // Mirror PR 4b's user-prompt-before-driver-call invariant. The
+      // streaming runner now pushes the user prompt to
+      // `conversationMessages` BEFORE the `runDirectChatTurn` call so
+      // a failed turn still records the prompt in the persisted
+      // transcript.
+      streamTextMock.mockReset();
+      streamTextMock.mockImplementationOnce((_options: any) => ({
+        fullStream: (async function* () {})(),
+        steps: Promise.resolve([]),
+        response: Promise.resolve({
+          modelId: "gpt-4-turbo",
+          messages: [],
+        }),
+        totalUsage: Promise.resolve({
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        }),
+        finishReason: Promise.resolve("stop"),
+        consumeStream: async () => {},
+      }));
+
+      await runStreamCase({});
+
+      const containsUserHello = (msgs: unknown): boolean => {
+        if (!Array.isArray(msgs)) return false;
+        return msgs.some((m: any) => {
+          if (m?.role !== "user") return false;
+          if (typeof m.content === "string") return m.content === "Hello";
+          if (Array.isArray(m.content)) {
+            return m.content.some(
+              (part: any) =>
+                part?.type === "text" && part.text === "Hello",
+            );
+          }
+          return false;
+        });
+      };
+      const anyCallHasIt = convexClient.action.mock.calls.some((call) => {
+        const payload = call[1] as Record<string, unknown> | undefined;
+        if (!payload) return false;
+        if (containsUserHello(payload.messages)) return true;
+        const turn = payload.turn as
+          | { sessionMessages?: unknown }
+          | undefined;
+        if (turn && containsUserHello(turn.sessionMessages)) return true;
+        return false;
+      });
+      expect(anyCallHasIt).toBe(true);
+    });
+
+    it("preserves PR 4d wire shape: `system:` field, no `role:system` in messages array (PR 5a)", async () => {
+      // The pre-PR-5a runner already aligned on chat's wire shape in
+      // PR 4d ("Use the dedicated system: field"). PR 5a's rewrite onto
+      // `runDirectChatTurn` flows the system through the helper, which
+      // adds it to the streamText `system:` field via the helper's
+      // internal wiring. Lock that the wire shape didn't regress.
+      streamTextMock.mockReset();
+      streamTextMock.mockImplementationOnce((_options: any) => ({
+        fullStream: (async function* () {})(),
+        steps: Promise.resolve([]),
+        response: Promise.resolve({
+          modelId: "gpt-4-turbo",
+          messages: [{ role: "assistant", content: "Done" }],
+        }),
+        totalUsage: Promise.resolve({
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+        }),
+        finishReason: Promise.resolve("stop"),
+        consumeStream: async () => {},
+      }));
+
+      await runStreamCase({
+        suiteHostConfig: {
+          systemPrompt: "Stream PR 5a system",
+        },
+      });
+
+      const streamCall = streamTextMock.mock.calls[0]?.[0];
+      expect(streamCall).toBeDefined();
+      expect(streamCall.system).toBe("Stream PR 5a system");
+      const wireMessages = streamCall.messages as Array<{ role: string }>;
+      expect(wireMessages.some((m) => m.role === "system")).toBe(false);
+    });
+
+    it("prepends resolved system to streamIterationViaBackend's mid-run SSE snapshots (PR 5a folds 4d Cursor-Low)", async () => {
+      // PR 4d round 2 deferred fix: the streaming backend runner
+      // (`streamIterationViaBackend`) emits `buildTraceSnapshotEvent`
+      // mid-run with `messages: messageHistory` (no system prefix).
+      // PR 4d closed the same gap on `streamIterationWithAiSdk` via a
+      // `withSystemPrefix` closure but deferred the backend equivalent
+      // to PR 5. PR 5a folds it in — the closure exists in
+      // `streamIterationViaBackend` too and is applied at every
+      // snapshot site.
+      const fetchMockBackend = vi.fn();
+      vi.stubGlobal("fetch", fetchMockBackend);
+      fetchMockBackend.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: vi.fn().mockResolvedValue({ ok: true }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        headers: new Headers({ "Content-Type": "text/event-stream" }),
+      });
+
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockResolvedValueOnce({
+          messages: [
+            { role: "user", content: "Hello" } as any,
+            { role: "assistant", content: "Done" } as any,
+          ],
+          assistantMessages: [],
+          toolCalls: [],
+          toolResults: [],
+          turnTrace: {
+            turnId: "t_1",
+            promptIndex: 0,
+            startedAt: 0,
+            endedAt: 10,
+            modelId: "anthropic/claude-haiku-4.5",
+            spans: [],
+          },
+        } as any);
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "Backend SSE prefix",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-backend-sse",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-backend-sse",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event) => emitted.push(event as Record<string, unknown>),
+          suiteHostConfig: {
+            systemPrompt: "Backend stream SSE prefix",
+          },
+        } as any);
+
+        // At least one trace_snapshot SSE event should have the system
+        // as the first message in its trace messages payload.
+        const hasSystemPrefix = (msgs: unknown): boolean => {
+          if (!Array.isArray(msgs) || msgs.length === 0) return false;
+          const first = msgs[0] as { role?: string; content?: unknown };
+          if (first?.role !== "system") return false;
+          if (typeof first.content === "string") {
+            return first.content === "Backend stream SSE prefix";
+          }
+          if (Array.isArray(first.content)) {
+            return first.content.some(
+              (part: any) =>
+                part?.type === "text" &&
+                part.text === "Backend stream SSE prefix",
+            );
+          }
+          return false;
+        };
+        const traceSnapshots = emitted.filter(
+          (e) => e?.type === "trace_snapshot",
+        );
+        const anySnapshotHasPrefix = traceSnapshots.some((snap) => {
+          const trace = snap.trace as { messages?: unknown } | undefined;
+          return hasSystemPrefix(trace?.messages);
+        });
+        expect(anySnapshotHasPrefix).toBe(true);
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it("emits the existing fullStream → SSE event vocabulary via the shared adapter (PR 5a)", async () => {
+      // Lock the byte-shape contract: the events emitted from the
+      // streaming runner's terminal stream still match the existing
+      // `streamTestCase` SSE event vocabulary. The adapter is unit-tested
+      // standalone in PR 5-pre; this asserts the runner routes through
+      // it correctly.
+      const emitted: Array<Record<string, unknown>> = [];
+      streamTextMock.mockReset();
+      streamTextMock.mockImplementationOnce((options: any) => {
+        // Fire onStepFinish so the helper's onStepSnapshot fires and the
+        // runner emits the per-step trace_snapshot SSE event.
+        void options.onStepFinish?.({
+          usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+          response: {
+            messages: [{ role: "assistant", content: "Done" }],
+          },
+        });
+        return {
+          fullStream: (async function* () {
+            yield { type: "text-delta", id: "t1", text: "Working" };
+            yield {
+              type: "tool-call",
+              toolCallId: "call-1",
+              toolName: "search",
+              input: { q: "status" },
+            };
+            yield {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "search",
+              output: { ok: true },
+            };
+            yield {
+              type: "finish-step",
+              usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+            };
+          })(),
+          steps: Promise.resolve([]),
+          response: Promise.resolve({
+            modelId: "gpt-4-turbo",
+            messages: [{ role: "assistant", content: "Done" }],
+          }),
+          totalUsage: Promise.resolve({
+            inputTokens: 2,
+            outputTokens: 3,
+            totalTokens: 5,
+          }),
+          finishReason: Promise.resolve("stop"),
+          consumeStream: async () => {},
+        };
+      });
+
+      await runStreamCase({ emitCollector: emitted });
+
+      // Spot-check: the canonical event vocabulary still flows.
+      expect(emitted).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "turn_start" }),
+          expect.objectContaining({
+            type: "text_delta",
+            content: "Working",
+          }),
+          expect.objectContaining({
+            type: "tool_call",
+            toolName: "search",
+            toolCallId: "call-1",
+          }),
+          expect.objectContaining({
+            type: "tool_result",
+            toolCallId: "call-1",
+            isError: false,
+          }),
+          expect.objectContaining({ type: "step_finish" }),
+          expect.objectContaining({
+            type: "trace_snapshot",
+          }),
+          expect.objectContaining({ type: "turn_finish" }),
+        ]),
+      );
+    });
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -3185,6 +3185,55 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       }
     });
 
+    it("records `tokensUsed` when streaming fails with zero completed steps (PR 5a review round 2 — Cursor Medium)", async () => {
+      // Cursor PR 5a review round 2: the delta-update in
+      // `onStepSnapshot` only captures usage for COMPLETED steps. If
+      // the stream resolves with zero completed steps (model returned
+      // empty / network error fell through), `accumulatedUsage` stays
+      // at the pre-turn baseline. The no-content failure branch then
+      // persists `tokensUsed: 0` even when `handle.result.totalUsage`
+      // reports billed tokens. PR 4b's non-stream runner reads
+      // `headless.totalUsage` before failure branches; PR 5a now
+      // mirrors that by awaiting `handle.result.totalUsage` post-stream
+      // and reconciling before the failure detection.
+      streamTextMock.mockReset();
+      streamTextMock.mockReturnValueOnce({
+        // Empty fullStream — onStepSnapshot never fires.
+        fullStream: (async function* () {})(),
+        steps: Promise.resolve([]),
+        response: Promise.resolve({
+          modelId: "gpt-4-turbo",
+          messages: [],
+        }),
+        // Model billed tokens despite zero completed steps.
+        totalUsage: Promise.resolve({
+          inputTokens: 9,
+          outputTokens: 4,
+          totalTokens: 13,
+        }),
+        finishReason: Promise.resolve("stop"),
+        consumeStream: async () => {},
+      });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      await runStreamCase({ emitCollector: emitted });
+
+      // Iteration was persisted as a soft failure (no-content branch
+      // fired) AND `tokensUsed` reflects the real billed totalUsage.
+      const updateCall = convexClient.action.mock.calls.find(
+        (c) => c[0] === "testSuites:updateTestIteration",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = updateCall![1] as {
+        tokensUsed?: number;
+        error?: string;
+      };
+      expect(payload.error).toEqual(
+        expect.stringContaining("Stream returned no content"),
+      );
+      expect(payload.tokensUsed).toBe(13);
+    });
+
     it("emits the existing fullStream → SSE event vocabulary via the shared adapter (PR 5a)", async () => {
       // Lock the byte-shape contract: the events emitted from the
       // streaming runner's terminal stream still match the existing

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -204,6 +204,18 @@ export interface RunDirectChatTurnOptions {
    */
   onPersistError?: (error: unknown) => void;
   /**
+   * Optional anchor timestamp for trace span offsets. The internal
+   * `createAiSdkEvalTraceContext` uses this as the `runStartedAt` ms
+   * epoch when computing `createOffsetInterval(ctx.runStartedAt, ...)`
+   * offsets. Default is `Date.now()` at helper construction time.
+   *
+   * Multi-turn eval callers MUST pass the ITERATION start time so all
+   * turn spans share the same epoch — otherwise each turn's spans
+   * collapse to start-at-zero and the trace UI timeline mis-renders
+   * multi-turn runs as overlapping. Cursor PR 5a review fix.
+   */
+  traceStartedAt?: number;
+  /**
    * Optional AI SDK `toolChoice`. Eval forwards `advancedConfig.toolChoice`
    * here; chat currently never sets it. Held outside `traceEvents` because
    * it's a model-call parameter, not a trace concern.
@@ -277,6 +289,7 @@ export function runDirectChatTurn(
     onPersistError,
     toolChoice,
     experimentalTelemetry,
+    traceStartedAt,
   } = options;
 
   // Separate array for tracing — we must NOT mutate `messageHistory` because
@@ -285,15 +298,20 @@ export function runDirectChatTurn(
   // Responses API rejects duplicates by id).
   const traceHistory = [...messageHistory];
   const initialMessageHistoryLength = messageHistory.length;
+  // Cursor PR 5a review fix: multi-turn trace anchor. Use the
+  // caller-supplied anchor when present so all turn spans share one
+  // epoch; default to `Date.now()` for the single-turn / chat case.
+  const turnStartedAt = Date.now();
+  const traceAnchor = traceStartedAt ?? turnStartedAt;
   const traceTurn: DirectChatTurnTraceTurn = {
     turnId: generateLiveTraceTurnId(),
     promptIndex: getPromptIndex(messageHistory),
     promptMessageStartIndex: getPromptMessageStartIndex(messageHistory),
-    turnStartedAt: Date.now(),
+    turnStartedAt,
     turnSpans: [],
     turnUsage: undefined,
   };
-  const traceContext = createAiSdkEvalTraceContext(traceTurn.turnStartedAt);
+  const traceContext = createAiSdkEvalTraceContext(traceAnchor);
   const providerSystemPrompt = normalizeSystemPromptForProvider(systemPrompt);
   let currentStepIndex = 0;
   let turnFinished = false;


### PR DESCRIPTION
## Summary

Rewires the local-AI-SDK streaming eval runner (`streamIterationWithAiSdk`) onto the shared driver substrate. Drops the inline `streamText({...})` call: the helper `runDirectChatTurn` (PR 4a, #2460) owns the streamText config, span recording, abort wiring, progressive-discovery gating, and `prepareStep`. The PR-5-pre adapter `consumeFullStreamAsEvalEvents` (#2466) drives `handle.result.fullStream` and emits the existing `StreamEmit` event vocabulary unchanged.

## Six PR 5a contract bullets honored (verbatim from 4a–4d review rounds)

1. **Wire shape**: `system: prepared.enhancedSystemPrompt` flows through the helper to `streamText`'s dedicated `system:` field; no `role:"system"` entry in the messages array.
2. **Persistence shape**: `streamEnhancedSystemPromptForPersist` hoist + `persistedStreamMessages` prefix at `finishParams` — already in place from PR 4d, preserved.
3. **SSE shape**: `withSystemPrefix(msgs)` applied at every `buildTraceSnapshotEvent` site (kept from PR 4d round 2).
4. **Eval correctness invariants:**
   - no-new-messages → cycle failure (new `iterationError` hoist + three-signal detection mirroring PR 4b)
   - user-prompt-before-driver-call (push to `conversationMessages` before `runDirectChatTurn`)
   - abort via `handle.isAborted()` || `signal.aborted` (drops record instead of persisting cancelled state)
   - non-tool error-span filter (tool errors defer to `failOnToolError`)
   - `totalUsage` merged BEFORE failure branches via `traceTurn.turnUsage` delta tracked in `onStepSnapshot`
   - partial-state mirrored into `activePartialResponseMessages` via `onStepSnapshot` so the catch path can persist partial transcripts
5. **Resolver wire-up**: already in place from PR 4d; preserved.
6. **UI event contract preserved**: PR-5-pre's contract tests lock the chunk-to-event translation; new runner-level test pins the full event vocabulary (`turn_start` / `text_delta` / `tool_call` / `tool_result` / `step_finish` / `trace_snapshot` / `turn_finish`) still flows.

## Folded in (small + isolated)

The deferred 4d backend SSE-snapshot prefix fix. `streamIterationViaBackend`'s 7 `buildTraceSnapshotEvent` sites now use `withSystemPrefix(messageHistory)` so live test-runner UI viewing a hosted-org streamed eval sees the system as the first message throughout the run, not just at finalize. Closes the "live-on-main UI gap" risk entry in `unification.md`.

## Explicitly NOT included (deferred to PR 5b)

- `streamIterationViaBackend` engine collapse onto `runAssistantTurn`. Requires extending the shared engine with `onToolCall` / `onToolResult` / `onStepFinish` callbacks (chat + synthetic + eval all share the engine; cross-caller review surface). Stays as its own PR.
- Tool-span `stepIndex:-1` regression — not surfaced by the `onStepSnapshot` wire-up; PR 5b territory once the backend runner also adopts shared step events.

## Test plan

- [x] 42 → 47 in `evals-runner.test.ts`. New PR 5a describe block with 5 regression tests:
  - No-new-messages → cycle failure with `iterationError` set
  - User prompt persists on failed turn for the streaming variant
  - Wire shape: `system:` field set, no `role:system` in messages
  - SSE event vocabulary preserved end-to-end
  - Backend SSE snapshot prefix (folds 4d Cursor-Low)
- [x] Broader sweep: 697/697 across `server/{utils,services/evals,services/sessionSimulation,routes/mcp}` + `chat-v2.hosted`.
- [x] Typecheck baseline-clean (same 4 pre-existing recorder shape errors; one per runner — unchanged count).
- [ ] Smoke (post-merge): open `streamTestCase` UI test runner, run a local-AI-SDK case with progressive discovery enabled. Confirm SSE events still flow (text_delta, tool_call, tool_result, trace_snapshot with system prefix, turn_finish) and the persisted iteration matches the displayed transcript.

## Plan context

`~/mcpjam-docs/unification.md` PR 5a row enumerates the 6 contract bullets. PR 5 was split into 5-pre (adapter, MERGED #2466) + 5a (this PR) + 5b (engine extension + backend stream collapse) after the investigation surfaced the `runAssistantTurn` event surface gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of the eval streaming execution path (failure detection, persistence, SSE, and token accounting) with broad regression tests, but behavior is intended to mirror an already-shipped non-stream runner rather than introduce new product surface.
> 
> **Overview**
> **Local-AI-SDK streaming evals** no longer call `streamText` inline. Each turn goes through **`runDirectChatTurn`**, with **`consumeFullStreamAsEvalEvents`** driving `fullStream` into the same SSE vocabulary (`text_delta`, tool events, `step_finish`).
> 
> The streaming path now **matches the non-stream runner (PR 4b)** on eval behavior: user prompt appended **before** the driver; **soft cycle failures** (empty response, non-tool error spans) set `iterationError` and persist as `completed` + `error` instead of throwing; **abort** drops the iteration without persisting; **`finalizePassedForEval`** sees iteration errors so passes don’t slip through. Failure paths emit **`trace_snapshot` (`failure`) + `error`** for live SSE consumers. **`totalUsage`** is merged after the stream (including zero-step failures) so token totals stay accurate. **`handle.cleanup()`** runs in a `finally` so abort listeners don’t leak on throws.
> 
> **Trace / grading fixes:** both stream and non-stream runners pass **`traceStartedAt: runStartedAt`** so multi-turn span timelines share one epoch. **Error-span detection** ignores tool-associated spans (`toolCallId`) so tool failures still honor **`failOnToolError`**.
> 
> **Backend streaming:** **`streamIterationViaBackend`** trace snapshots now use **`withSystemPrefix`** so mid-run SSE traces include the resolved system prompt (deferred 4d fix).
> 
> **`direct-chat-turn`** adds optional **`traceStartedAt`** for that anchor. New **PR 5a contract tests** cover no-content failure, persisted user prompt, wire shape, backend SSE prefix, failure SSE, tool-error span filtering, token usage on zero-step failure, and adapter event vocabulary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25cb76ffaf9aa5519c5d5b1e7a4d4df1baf4fbcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->