### PR TITLE
feat(mcpjam-agent): surface agent as persistent right-side panel

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -59,6 +59,7 @@ import {
   computeHostsHubFlagEnabled,
 } from "./components/mcp-sidebar";
 import { SidebarInset, SidebarProvider } from "./components/ui/sidebar";
+import { AgentSidePanelMount } from "./components/mcpjam-agent/AgentSidePanelMount";
 import {
   Alert,
   AlertDescription,
@@ -3056,6 +3057,11 @@ export default function App() {
           </AppRouteReactContext.Provider>
         </div>
       </SidebarInset>
+      <AgentSidePanelMount
+        projectId={activeProjectId ?? null}
+        organizationId={activeOrganizationId ?? null}
+        activeTab={activeTab}
+      />
       <Dialog
         open={showTrialDecisionModal}
         onOpenChange={(open) => {

--- a/mcpjam-inspector/client/src/components/auth/auth-upper-area.tsx
+++ b/mcpjam-inspector/client/src/components/auth/auth-upper-area.tsx
@@ -9,6 +9,7 @@ import {
   ActiveServerSelectorProps,
 } from "@/components/ActiveServerSelector";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
+import { AgentSidePanelTrigger } from "@/components/mcpjam-agent/AgentSidePanelTrigger";
 import { GlobalClientBar } from "@/components/clients/GlobalClientBar";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import type { GlobalHostBarProps } from "@/components/Header";
@@ -85,6 +86,7 @@ export function AuthUpperArea({
           </a>
         </Button>
         {communityLinks}
+        <AgentSidePanelTrigger />
         <NotificationBell />
         {!user && !isLoading && (
           <>

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanel.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanel.tsx
@@ -55,11 +55,23 @@ export function AgentSidePanel({
   const isMobile = useIsMobile();
   const isOpen = useAgentPanelStore((s) => s.isOpen);
   const width = useAgentPanelStore((s) => s.width);
-  const activeSessionId = useAgentPanelStore((s) => s.activeSessionId);
+  const storedSessionId = useAgentPanelStore((s) => s.activeSessionId);
+  const storedSessionProjectId = useAgentPanelStore(
+    (s) => s.activeSessionProjectId
+  );
   const setOpen = useAgentPanelStore((s) => s.setOpen);
   const setWidth = useAgentPanelStore((s) => s.setWidth);
-  const setActiveSessionId = useAgentPanelStore((s) => s.setActiveSessionId);
+  const setActiveSession = useAgentPanelStore((s) => s.setActiveSession);
   const posthog = usePostHog();
+
+  // Only honor the persisted session pointer when it was stored under the
+  // currently active project. Cross-tab sync or a fresh reload landing on a
+  // different project would otherwise hydrate a transcript from project A
+  // into a panel currently scoped to project B.
+  const activeSessionId =
+    storedSessionId && storedSessionProjectId === projectId
+      ? storedSessionId
+      : null;
 
   // Track previous open state to fire close telemetry exactly when the user
   // closes the panel — not on every render where `isOpen` happens to be false.
@@ -72,8 +84,8 @@ export function AgentSidePanel({
   }, [activeTab, isOpen, posthog]);
 
   const handleNewChat = useCallback(() => {
-    setActiveSessionId(null);
-  }, [setActiveSessionId]);
+    setActiveSession(null, null);
+  }, [setActiveSession]);
 
   const handleSessionStart = useCallback(
     (sessionId: string, firstMessage: string) => {
@@ -91,16 +103,16 @@ export function AgentSidePanel({
       } catch {
         // Quota/disabled storage — user will retype if it doesn't autosubmit.
       }
-      setActiveSessionId(sessionId);
+      setActiveSession(sessionId, projectId);
     },
-    [setActiveSessionId]
+    [projectId, setActiveSession]
   );
 
   const handleResumeSession = useCallback(
     (sessionId: string) => {
-      setActiveSessionId(sessionId);
+      setActiveSession(sessionId, projectId);
     },
-    [setActiveSessionId]
+    [projectId, setActiveSession]
   );
 
   const handleClose = useCallback(() => {

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanel.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanel.tsx
@@ -1,0 +1,293 @@
+/**
+ * MCPJam Agent right-side panel.
+ *
+ * Mounted as a sibling of `<SidebarInset>` inside `<SidebarProvider>` so the
+ * panel sits outside the router `<Outlet>` and survives navigation — a chat
+ * started on Playground stays open and streaming when the user jumps to
+ * Evaluate. The panel is kept mounted regardless of `isOpen` (just visually
+ * hidden when closed) so closing the panel never tears down an in-flight
+ * stream.
+ *
+ * On viewports < 768px the panel renders as a full-width `Sheet` drawer
+ * instead of an inline resizable panel.
+ */
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { ArrowLeft, Plus, X } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@mcpjam/design-system/sheet";
+import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { McpjamAgentHero } from "@/components/mcpjam-agent/McpjamAgentHero";
+import { McpjamAgentThread } from "@/components/mcpjam-agent/McpjamAgentThread";
+import {
+  AGENT_PANEL_MIN_WIDTH,
+  useAgentPanelStore,
+} from "@/stores/agent-panel/agent-panel-store";
+
+interface AgentSidePanelProps {
+  projectId: string | null;
+  organizationId: string | null;
+  /** Current top-level route tab name, used for telemetry payloads. */
+  activeTab: string;
+}
+
+const SURFACE = "side-panel";
+
+export function AgentSidePanel({
+  projectId,
+  organizationId,
+  activeTab,
+}: AgentSidePanelProps) {
+  const isMobile = useIsMobile();
+  const isOpen = useAgentPanelStore((s) => s.isOpen);
+  const width = useAgentPanelStore((s) => s.width);
+  const activeSessionId = useAgentPanelStore((s) => s.activeSessionId);
+  const setOpen = useAgentPanelStore((s) => s.setOpen);
+  const setWidth = useAgentPanelStore((s) => s.setWidth);
+  const setActiveSessionId = useAgentPanelStore((s) => s.setActiveSessionId);
+  const posthog = usePostHog();
+
+  // Track previous open state to fire close telemetry exactly when the user
+  // closes the panel — not on every render where `isOpen` happens to be false.
+  const previousOpenRef = useRef(isOpen);
+  useEffect(() => {
+    if (previousOpenRef.current && !isOpen) {
+      posthog?.capture("mcpjam_agent_panel_closed", { tab: activeTab });
+    }
+    previousOpenRef.current = isOpen;
+  }, [activeTab, isOpen, posthog]);
+
+  const handleNewChat = useCallback(() => {
+    setActiveSessionId(null);
+  }, [setActiveSessionId]);
+
+  const handleSessionStart = useCallback(
+    (sessionId: string, firstMessage: string) => {
+      // Stash the prompt for `McpjamAgentThread` to autosubmit on mount,
+      // mirroring the home-tab hero → thread handoff. `fresh: true` flags it
+      // as a freshly-minted session so the thread doesn't replay it against
+      // a hydrated transcript (see `McpjamAgentThread`'s consumePending).
+      try {
+        if (typeof window !== "undefined") {
+          window.sessionStorage.setItem(
+            `mcpjam:agent-pending:${sessionId}`,
+            JSON.stringify({ text: firstMessage, fresh: true })
+          );
+        }
+      } catch {
+        // Quota/disabled storage — user will retype if it doesn't autosubmit.
+      }
+      setActiveSessionId(sessionId);
+    },
+    [setActiveSessionId]
+  );
+
+  const handleResumeSession = useCallback(
+    (sessionId: string) => {
+      setActiveSessionId(sessionId);
+    },
+    [setActiveSessionId]
+  );
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+
+  const body = useMemo<ReactNode>(() => {
+    if (activeSessionId) {
+      return (
+        <McpjamAgentThread
+          key={activeSessionId}
+          sessionId={activeSessionId}
+          projectId={projectId}
+          organizationId={organizationId}
+          surface={SURFACE}
+          variant="sidebar"
+          className="flex-1 min-h-0"
+        />
+      );
+    }
+    return (
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="flex w-full flex-col gap-6 px-4 pb-8 pt-6">
+          <McpjamAgentHero
+            surface={SURFACE}
+            onSessionStart={handleSessionStart}
+            onResumeSession={handleResumeSession}
+            ready={Boolean(projectId)}
+          />
+        </div>
+      </div>
+    );
+  }, [
+    activeSessionId,
+    handleResumeSession,
+    handleSessionStart,
+    organizationId,
+    projectId,
+  ]);
+
+  const header = (
+    <div className="flex items-center justify-between border-b border-border/40 px-3 py-2">
+      <div className="flex items-center gap-1">
+        {activeSessionId && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleNewChat}
+            aria-label="Back to compose"
+            className="h-8 w-8 rounded-full p-0 text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleNewChat}
+          className="h-8 gap-1.5 rounded-full px-3 text-muted-foreground hover:text-foreground"
+        >
+          <Plus className="h-3.5 w-3.5" aria-hidden />
+          <span className="text-xs">New chat</span>
+        </Button>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={handleClose}
+        aria-label="Close MCPJam Agent"
+        className="h-8 w-8 rounded-full p-0 text-muted-foreground hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden />
+      </Button>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Sheet open={isOpen} onOpenChange={setOpen}>
+        <SheetContent
+          side="right"
+          className="flex w-full flex-col gap-0 bg-background p-0 sm:max-w-md [&>button]:hidden"
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>MCPJam Agent</SheetTitle>
+            <SheetDescription>
+              Ask the MCPJam Agent for help with docs, evals, and tools.
+            </SheetDescription>
+          </SheetHeader>
+          {header}
+          {body}
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <InlineSidePanelShell
+      isOpen={isOpen}
+      width={width}
+      onWidthChange={setWidth}
+      onWidthCommit={(committed) => {
+        if (committed < AGENT_PANEL_MIN_WIDTH * 0.9) {
+          setOpen(false);
+        } else {
+          posthog?.capture("mcpjam_agent_panel_resized", { width: committed });
+        }
+      }}
+    >
+      {header}
+      {body}
+    </InlineSidePanelShell>
+  );
+}
+
+interface InlineSidePanelShellProps {
+  isOpen: boolean;
+  width: number;
+  onWidthChange: (next: number) => void;
+  onWidthCommit: (committed: number) => void;
+  children: ReactNode;
+}
+
+function InlineSidePanelShell({
+  isOpen,
+  width,
+  onWidthChange,
+  onWidthCommit,
+  children,
+}: InlineSidePanelShellProps) {
+  const draggingRef = useRef(false);
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const handle = event.currentTarget;
+      handle.setPointerCapture(event.pointerId);
+      draggingRef.current = true;
+
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        if (!draggingRef.current) return;
+        // Panel sits on the right edge; pulling left increases width.
+        const next = window.innerWidth - moveEvent.clientX;
+        onWidthChange(next);
+      };
+      const onPointerUp = (upEvent: PointerEvent) => {
+        if (!draggingRef.current) return;
+        draggingRef.current = false;
+        handle.releasePointerCapture(upEvent.pointerId);
+        window.removeEventListener("pointermove", onPointerMove);
+        window.removeEventListener("pointerup", onPointerUp);
+        const committed = window.innerWidth - upEvent.clientX;
+        onWidthCommit(committed);
+      };
+      window.addEventListener("pointermove", onPointerMove);
+      window.addEventListener("pointerup", onPointerUp);
+    },
+    [onWidthChange, onWidthCommit]
+  );
+
+  const style: CSSProperties = {
+    width: `${width}px`,
+    // Keep the panel mounted even when closed so an in-flight stream isn't
+    // canceled by toggling the trigger. `display: none` is enough to drop it
+    // out of the flex layout without unmounting `useChat`.
+    display: isOpen ? undefined : "none",
+  };
+
+  return (
+    <aside
+      data-slot="agent-side-panel"
+      className={cn(
+        "relative hidden shrink-0 flex-col border-l border-border/60 bg-background md:flex"
+      )}
+      style={style}
+    >
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize MCPJam Agent panel"
+        onPointerDown={onPointerDown}
+        className="absolute inset-y-0 left-0 z-10 w-1.5 -translate-x-1/2 cursor-col-resize bg-transparent transition hover:bg-border/70 active:bg-border"
+      />
+      {children}
+    </aside>
+  );
+}

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
@@ -9,7 +9,7 @@
  * navigation between tabs without unmounting the in-flight `useChat`
  * instance.
  */
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
 import { AgentSidePanel } from "@/components/mcpjam-agent/AgentSidePanel";
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
@@ -61,12 +61,25 @@ export function AgentSidePanelMount({
 
   // Even when the flag is off, an already-persisted `isOpen=true` should not
   // be honored — the entry point is hidden, so a stale stored value must not
-  // leave the panel showing.
+  // leave the panel showing. Gate on the explicit `false` so the brief window
+  // where `useFeatureFlagEnabled` returns `undefined` during PostHog hydration
+  // doesn't silently close a panel the user reopened across reloads.
   useEffect(() => {
-    if (!homeEnabled && isOpen) {
+    if (homeEnabled === false && isOpen) {
       useAgentPanelStore.getState().setOpen(false);
     }
   }, [homeEnabled, isOpen]);
+
+  // Switching projects must drop the active session pointer — sessions are
+  // project-scoped on the backend, so reusing an id from a different project
+  // would post under the wrong project or 404 on hydration. Skip the very
+  // first render so the persisted sessionId survives reload.
+  const lastProjectIdRef = useRef<string | null>(projectId);
+  useEffect(() => {
+    if (lastProjectIdRef.current === projectId) return;
+    lastProjectIdRef.current = projectId;
+    useAgentPanelStore.getState().setActiveSessionId(null);
+  }, [projectId]);
 
   if (!homeEnabled) return null;
 

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
@@ -12,6 +12,7 @@
 import { useEffect, useRef } from "react";
 import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
 import { AgentSidePanel } from "@/components/mcpjam-agent/AgentSidePanel";
+import { useAppReady } from "@/hooks/use-app-ready";
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
 
 interface AgentSidePanelMountProps {
@@ -72,14 +73,28 @@ export function AgentSidePanelMount({
 
   // Switching projects must drop the active session pointer — sessions are
   // project-scoped on the backend, so reusing an id from a different project
-  // would post under the wrong project or 404 on hydration. Skip the very
-  // first render so the persisted sessionId survives reload.
-  const lastProjectIdRef = useRef<string | null>(projectId);
+  // would post under the wrong project or 404 on hydration. Two things this
+  // guard has to avoid:
+  //   1. The initial render (would clear the persisted sessionId on reload).
+  //   2. The bootstrap window where `activeProjectId` flips from a synthetic
+  //      local-fallback id to the real Convex-scoped id — that's normal
+  //      hydration, not a user-initiated switch.
+  // Gating on `useAppReady().status === "ready"` covers (2), and a seeded
+  // ref covers (1) post-ready.
+  const appReady = useAppReady();
+  const lastProjectIdRef = useRef<string | null>(null);
+  const projectIdSeededRef = useRef(false);
   useEffect(() => {
+    if (appReady.status !== "ready") return;
+    if (!projectIdSeededRef.current) {
+      projectIdSeededRef.current = true;
+      lastProjectIdRef.current = projectId;
+      return;
+    }
     if (lastProjectIdRef.current === projectId) return;
     lastProjectIdRef.current = projectId;
     useAgentPanelStore.getState().setActiveSessionId(null);
-  }, [projectId]);
+  }, [appReady.status, projectId]);
 
   if (!homeEnabled) return null;
 

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
@@ -9,7 +9,7 @@
  * navigation between tabs without unmounting the in-flight `useChat`
  * instance.
  */
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
 import { AgentSidePanel } from "@/components/mcpjam-agent/AgentSidePanel";
 import { useAppReady } from "@/hooks/use-app-ready";
@@ -71,32 +71,31 @@ export function AgentSidePanelMount({
     }
   }, [homeEnabled, isOpen]);
 
-  // Switching projects must drop the active session pointer — sessions are
-  // project-scoped on the backend, so reusing an id from a different project
-  // would post under the wrong project or 404 on hydration. Two things this
-  // guard has to avoid:
-  //   1. The initial render (would clear the persisted sessionId on reload).
-  //   2. The bootstrap window where `activeProjectId` flips from a synthetic
-  //      local-fallback id to the real Convex-scoped id — that's normal
-  //      hydration, not a user-initiated switch.
-  // Gating on `useAppReady().status === "ready"` covers (2), and a seeded
-  // ref covers (1) post-ready.
+  // Drop the persisted session pointer whenever the panel state and the
+  // current active project disagree about which project the session belongs
+  // to. The render path (`AgentSidePanel`) already gates the thread on a
+  // project match, so a stale pointer is inert; this effect just GCs it so
+  // it doesn't linger in localStorage. Wait for `useAppReady` so the normal
+  // bootstrap step where `activeProjectId` flips from a synthetic
+  // local-fallback id to the real Convex-scoped id isn't treated as a
+  // project switch.
   const appReady = useAppReady();
-  const lastProjectIdRef = useRef<string | null>(null);
-  const projectIdSeededRef = useRef(false);
+  const activeSessionId = useAgentPanelStore((s) => s.activeSessionId);
+  const activeSessionProjectId = useAgentPanelStore(
+    (s) => s.activeSessionProjectId
+  );
   useEffect(() => {
     if (appReady.status !== "ready") return;
-    if (!projectIdSeededRef.current) {
-      projectIdSeededRef.current = true;
-      lastProjectIdRef.current = projectId;
-      return;
-    }
-    if (lastProjectIdRef.current === projectId) return;
-    lastProjectIdRef.current = projectId;
-    useAgentPanelStore.getState().setActiveSessionId(null);
-  }, [appReady.status, projectId]);
+    if (activeSessionId === null) return;
+    if (activeSessionProjectId === projectId) return;
+    useAgentPanelStore.getState().setActiveSession(null, null);
+  }, [activeSessionId, activeSessionProjectId, appReady.status, projectId]);
 
-  if (!homeEnabled) return null;
+  // Render the panel during the brief PostHog flag-hydration window so an
+  // in-flight `useChat` stream isn't unmounted by `useFeatureFlagEnabled`
+  // returning `undefined` before resolving. Only an explicit `false`
+  // disconnects the trigger and tears down the panel.
+  if (homeEnabled === false) return null;
 
   return (
     <AgentSidePanel

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
@@ -1,0 +1,80 @@
+/**
+ * Glue between the side-panel store and the rest of the app:
+ * - gates the panel + shortcut behind the `home-page-enabled` PostHog flag;
+ * - wires the global ⌘\ / Ctrl+\ shortcut to toggle the panel (skipping
+ *   inputs/textareas/contentEditable to stay friendly to the composer);
+ * - renders the panel itself.
+ *
+ * Lives at the SidebarProvider scope (above `<Outlet>`) so the panel survives
+ * navigation between tabs without unmounting the in-flight `useChat`
+ * instance.
+ */
+import { useEffect } from "react";
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+import { AgentSidePanel } from "@/components/mcpjam-agent/AgentSidePanel";
+import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
+
+interface AgentSidePanelMountProps {
+  projectId: string | null;
+  organizationId: string | null;
+  activeTab: string;
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+export function AgentSidePanelMount({
+  projectId,
+  organizationId,
+  activeTab,
+}: AgentSidePanelMountProps) {
+  const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
+  const isOpen = useAgentPanelStore((s) => s.isOpen);
+  const toggle = useAgentPanelStore((s) => s.toggle);
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    if (!homeEnabled) return undefined;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== "\\") return;
+      if (!(event.metaKey || event.ctrlKey)) return;
+      if (event.shiftKey || event.altKey) return;
+      if (isEditableTarget(event.target)) return;
+      event.preventDefault();
+      const willOpen = !useAgentPanelStore.getState().isOpen;
+      if (willOpen) {
+        posthog?.capture("mcpjam_agent_panel_opened", {
+          via: "shortcut",
+          tab: activeTab,
+        });
+      }
+      toggle();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [activeTab, homeEnabled, posthog, toggle]);
+
+  // Even when the flag is off, an already-persisted `isOpen=true` should not
+  // be honored — the entry point is hidden, so a stale stored value must not
+  // leave the panel showing.
+  useEffect(() => {
+    if (!homeEnabled && isOpen) {
+      useAgentPanelStore.getState().setOpen(false);
+    }
+  }, [homeEnabled, isOpen]);
+
+  if (!homeEnabled) return null;
+
+  return (
+    <AgentSidePanel
+      projectId={projectId}
+      organizationId={organizationId}
+      activeTab={activeTab}
+    />
+  );
+}

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelTrigger.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelTrigger.tsx
@@ -1,0 +1,65 @@
+/**
+ * Header sparkle button that toggles the MCPJam Agent side panel.
+ *
+ * Gated behind the same `home-page-enabled` PostHog flag as the home-tab
+ * takeover so the agent's entry points stay in sync. Renders nothing when
+ * the flag is off (or still loading).
+ */
+import { useCallback } from "react";
+import { Sparkles } from "lucide-react";
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import { useActiveTab } from "@/lib/app-navigation";
+import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
+
+const SHORTCUT_LABEL =
+  typeof navigator !== "undefined" && /Mac|iP(hone|od|ad)/.test(navigator.platform)
+    ? "⌘\\"
+    : "Ctrl+\\";
+
+export function AgentSidePanelTrigger() {
+  const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
+  const isOpen = useAgentPanelStore((s) => s.isOpen);
+  const toggle = useAgentPanelStore((s) => s.toggle);
+  const posthog = usePostHog();
+  const activeTab = useActiveTab();
+
+  const onClick = useCallback(() => {
+    const next = !isOpen;
+    if (next) {
+      posthog?.capture("mcpjam_agent_panel_opened", {
+        via: "click",
+        tab: activeTab,
+      });
+    }
+    toggle();
+  }, [activeTab, isOpen, posthog, toggle]);
+
+  if (!homeEnabled) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Ask MCPJam"
+          aria-pressed={isOpen}
+          onClick={onClick}
+          className="h-9 w-9"
+        >
+          <Sparkles className="h-4 w-4" aria-hidden />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        Ask MCPJam ({SHORTCUT_LABEL})
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -51,9 +51,11 @@ export interface McpjamAgentThreadProps {
   /**
    * Visual mode. `"card"` (default) is the embedded rounded card used inside
    * a wider page. `"full"` is the PostHog/Attio-style takeover: no border,
-   * fills the parent, composer pinned to the bottom.
+   * fills the parent, composer pinned to the bottom. `"sidebar"` is the
+   * right-side panel surface: fills the parent like `"full"` but without
+   * the centered max-width column — the panel itself is already narrow.
    */
-  variant?: "card" | "full";
+  variant?: "card" | "full" | "sidebar";
   className?: string;
 }
 
@@ -214,6 +216,16 @@ export function McpjamAgentThread({
   }, [handleSubmit, isReady, session.hydrating, sessionId]);
 
   const isFull = variant === "full";
+  const isSidebar = variant === "sidebar";
+  const fillsParent = isFull || isSidebar;
+  // The takeover surface centers content in a max-w-4xl column; the sidebar
+  // surface is already narrow, so it fills the available width instead.
+  const contentColumnClassName = isSidebar
+    ? "min-w-0 w-full px-4 pt-6 pb-8 space-y-6"
+    : "min-w-0 w-full max-w-4xl mx-auto px-4 pt-6 pb-8 space-y-6";
+  const composerColumnClassName = isSidebar
+    ? "w-full mb-4 px-3"
+    : "mx-auto w-full max-w-4xl mb-6 px-4";
   const themeMode = usePreferencesStore((state) => state.themeMode);
   const shellStyle = getChatboxShellStyle("mcpjam", themeMode);
 
@@ -223,8 +235,8 @@ export function McpjamAgentThread({
       className={cn(
         "relative rounded-2xl border border-border/70 bg-card/60 p-2 shadow-sm transition focus-within:border-border focus-within:bg-card focus-within:shadow",
         // Match Thread's content column (max-w-4xl + px-4) so the composer
-        // sits exactly under the message column.
-        isFull && "mx-auto w-full max-w-4xl mb-6 px-4"
+        // sits exactly under the message column. Sidebar fills its parent.
+        fillsParent && composerColumnClassName
       )}
     >
       <TextareaAutosize
@@ -282,7 +294,7 @@ export function McpjamAgentThread({
     // message land.
     body = (
       <div className="flex flex-1 flex-col min-h-0 overflow-y-auto">
-        <div className="min-w-0 w-full max-w-4xl mx-auto px-4 pt-6 pb-8 space-y-6">
+        <div className={contentColumnClassName}>
           <UserMessageBubble>
             <p className="whitespace-pre-wrap">{optimisticPending}</p>
           </UserMessageBubble>
@@ -338,7 +350,7 @@ export function McpjamAgentThread({
               // (`thread.tsx:368` uses `max-w-4xl mx-auto px-4`) so the dots
               // sit in the same column as the would-be assistant message
               // instead of floating ~64px to the left of it.
-              contentClassName="min-w-0 w-full max-w-4xl mx-auto px-4 pt-6 pb-8 space-y-6"
+              contentClassName={contentColumnClassName}
             />
           </StickToBottom.Content>
           <ScrollToBottomButton />
@@ -354,7 +366,7 @@ export function McpjamAgentThread({
         <div
           className={cn(
             "chatbox-host-shell flex flex-col gap-4 min-h-0",
-            isFull
+            fillsParent
               ? "h-full"
               : "min-h-[36rem] rounded-2xl border border-border/70 bg-card/30 p-4 shadow-sm",
             className
@@ -368,7 +380,8 @@ export function McpjamAgentThread({
             <p
               className={cn(
                 "text-xs text-destructive",
-                isFull && "mx-auto w-full max-w-4xl px-4"
+                isFull && "mx-auto w-full max-w-4xl px-4",
+                isSidebar && "w-full px-3"
               )}
             >
               {session.error.message ?? "Something went wrong."}

--- a/mcpjam-inspector/client/src/stores/agent-panel/agent-panel-store.ts
+++ b/mcpjam-inspector/client/src/stores/agent-panel/agent-panel-store.ts
@@ -156,4 +156,13 @@ if (isWindowAvailable()) {
       activeSessionId: next.activeSessionId,
     });
   });
+
+  // Re-clamp width when the viewport shrinks. Without this, a width persisted
+  // at a larger viewport size would exceed the 50vw cap and overflow the main
+  // layout. `setWidth` is a no-op when the clamped value equals the current
+  // one, so this is cheap when the viewport grows or stays the same.
+  window.addEventListener("resize", () => {
+    const { width, setWidth } = useAgentPanelStore.getState();
+    setWidth(width);
+  });
 }

--- a/mcpjam-inspector/client/src/stores/agent-panel/agent-panel-store.ts
+++ b/mcpjam-inspector/client/src/stores/agent-panel/agent-panel-store.ts
@@ -1,0 +1,159 @@
+/**
+ * MCPJam Agent side-panel state.
+ *
+ * Persists `isOpen`, `width`, and `activeSessionId` to localStorage so the
+ * panel survives page reloads and stays open across navigation. A `storage`
+ * listener mirrors changes from other tabs so opening the agent in one tab
+ * is reflected in others (matches `recent-sessions.ts`).
+ *
+ * The active session id is a uuid minted client-side and also persisted
+ * server-side via the existing chat-history flow — this store only owns the
+ * "which session is selected in the panel" pointer, not the transcript.
+ */
+import { create } from "zustand";
+
+export const AGENT_PANEL_STORAGE_KEY = "mcpjam:agent-panel:v1";
+export const AGENT_PANEL_MIN_WIDTH = 360;
+export const AGENT_PANEL_DEFAULT_WIDTH = 420;
+
+export interface AgentPanelState {
+  isOpen: boolean;
+  width: number;
+  activeSessionId: string | null;
+  setOpen: (next: boolean) => void;
+  toggle: () => void;
+  setWidth: (next: number) => void;
+  setActiveSessionId: (id: string | null) => void;
+}
+
+interface PersistedShape {
+  isOpen?: unknown;
+  width?: unknown;
+  activeSessionId?: unknown;
+}
+
+function isWindowAvailable(): boolean {
+  return (
+    typeof window !== "undefined" && typeof window.localStorage !== "undefined"
+  );
+}
+
+function clampWidth(raw: number): number {
+  if (!Number.isFinite(raw)) return AGENT_PANEL_DEFAULT_WIDTH;
+  const max =
+    typeof window !== "undefined" && window.innerWidth > 0
+      ? Math.floor(window.innerWidth * 0.5)
+      : Number.POSITIVE_INFINITY;
+  const lowerBounded = Math.max(AGENT_PANEL_MIN_WIDTH, raw);
+  return Math.min(lowerBounded, max);
+}
+
+function loadPersisted(): {
+  isOpen: boolean;
+  width: number;
+  activeSessionId: string | null;
+} {
+  const fallback = {
+    isOpen: false,
+    width: AGENT_PANEL_DEFAULT_WIDTH,
+    activeSessionId: null as string | null,
+  };
+  if (!isWindowAvailable()) return fallback;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(AGENT_PANEL_STORAGE_KEY);
+  } catch {
+    return fallback;
+  }
+  if (!raw) return fallback;
+  try {
+    const parsed = JSON.parse(raw) as PersistedShape;
+    if (!parsed || typeof parsed !== "object") return fallback;
+    return {
+      isOpen: parsed.isOpen === true,
+      width:
+        typeof parsed.width === "number"
+          ? clampWidth(parsed.width)
+          : AGENT_PANEL_DEFAULT_WIDTH,
+      activeSessionId:
+        typeof parsed.activeSessionId === "string"
+          ? parsed.activeSessionId
+          : null,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function persist(state: {
+  isOpen: boolean;
+  width: number;
+  activeSessionId: string | null;
+}): void {
+  if (!isWindowAvailable()) return;
+  try {
+    window.localStorage.setItem(
+      AGENT_PANEL_STORAGE_KEY,
+      JSON.stringify({
+        isOpen: state.isOpen,
+        width: state.width,
+        activeSessionId: state.activeSessionId,
+      })
+    );
+  } catch {
+    // Quota/disabled — silently skip; panel will revert to defaults next load.
+  }
+}
+
+const initial = loadPersisted();
+
+export const useAgentPanelStore = create<AgentPanelState>((set, get) => ({
+  isOpen: initial.isOpen,
+  width: initial.width,
+  activeSessionId: initial.activeSessionId,
+  setOpen: (next) => {
+    if (get().isOpen === next) return;
+    const state = { ...get(), isOpen: next };
+    persist(state);
+    set({ isOpen: next });
+  },
+  toggle: () => {
+    const next = !get().isOpen;
+    const state = { ...get(), isOpen: next };
+    persist(state);
+    set({ isOpen: next });
+  },
+  setWidth: (next) => {
+    const clamped = clampWidth(next);
+    if (get().width === clamped) return;
+    const state = { ...get(), width: clamped };
+    persist(state);
+    set({ width: clamped });
+  },
+  setActiveSessionId: (id) => {
+    if (get().activeSessionId === id) return;
+    const state = { ...get(), activeSessionId: id };
+    persist(state);
+    set({ activeSessionId: id });
+  },
+}));
+
+if (isWindowAvailable()) {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== AGENT_PANEL_STORAGE_KEY) return;
+    const next = loadPersisted();
+    const current = useAgentPanelStore.getState();
+    if (
+      current.isOpen === next.isOpen &&
+      current.width === next.width &&
+      current.activeSessionId === next.activeSessionId
+    ) {
+      return;
+    }
+    useAgentPanelStore.setState({
+      isOpen: next.isOpen,
+      width: next.width,
+      activeSessionId: next.activeSessionId,
+    });
+  });
+}

--- a/mcpjam-inspector/client/src/stores/agent-panel/agent-panel-store.ts
+++ b/mcpjam-inspector/client/src/stores/agent-panel/agent-panel-store.ts
@@ -1,14 +1,19 @@
 /**
  * MCPJam Agent side-panel state.
  *
- * Persists `isOpen`, `width`, and `activeSessionId` to localStorage so the
- * panel survives page reloads and stays open across navigation. A `storage`
- * listener mirrors changes from other tabs so opening the agent in one tab
- * is reflected in others (matches `recent-sessions.ts`).
+ * Persists `isOpen`, `width`, `activeSessionId`, and `activeSessionProjectId`
+ * to localStorage so the panel survives page reloads and stays open across
+ * navigation. A `storage` listener mirrors changes from other tabs so opening
+ * the agent in one tab is reflected in others (matches `recent-sessions.ts`).
  *
  * The active session id is a uuid minted client-side and also persisted
  * server-side via the existing chat-history flow — this store only owns the
  * "which session is selected in the panel" pointer, not the transcript.
+ *
+ * `activeSessionProjectId` carries the owning project so render and effect
+ * code can detect cross-project pointers (cross-tab sync, fresh reload into
+ * a different active project) and avoid hydrating a session against the
+ * wrong project.
  */
 import { create } from "zustand";
 
@@ -20,16 +25,18 @@ export interface AgentPanelState {
   isOpen: boolean;
   width: number;
   activeSessionId: string | null;
+  activeSessionProjectId: string | null;
   setOpen: (next: boolean) => void;
   toggle: () => void;
   setWidth: (next: number) => void;
-  setActiveSessionId: (id: string | null) => void;
+  setActiveSession: (id: string | null, projectId: string | null) => void;
 }
 
 interface PersistedShape {
   isOpen?: unknown;
   width?: unknown;
   activeSessionId?: unknown;
+  activeSessionProjectId?: unknown;
 }
 
 function isWindowAvailable(): boolean {
@@ -48,15 +55,19 @@ function clampWidth(raw: number): number {
   return Math.min(lowerBounded, max);
 }
 
-function loadPersisted(): {
+interface LoadedState {
   isOpen: boolean;
   width: number;
   activeSessionId: string | null;
-} {
-  const fallback = {
+  activeSessionProjectId: string | null;
+}
+
+function loadPersisted(): LoadedState {
+  const fallback: LoadedState = {
     isOpen: false,
     width: AGENT_PANEL_DEFAULT_WIDTH,
-    activeSessionId: null as string | null,
+    activeSessionId: null,
+    activeSessionProjectId: null,
   };
   if (!isWindowAvailable()) return fallback;
   let raw: string | null;
@@ -69,27 +80,32 @@ function loadPersisted(): {
   try {
     const parsed = JSON.parse(raw) as PersistedShape;
     if (!parsed || typeof parsed !== "object") return fallback;
+    const sessionId =
+      typeof parsed.activeSessionId === "string"
+        ? parsed.activeSessionId
+        : null;
+    const sessionProjectId =
+      typeof parsed.activeSessionProjectId === "string"
+        ? parsed.activeSessionProjectId
+        : null;
     return {
       isOpen: parsed.isOpen === true,
       width:
         typeof parsed.width === "number"
           ? clampWidth(parsed.width)
           : AGENT_PANEL_DEFAULT_WIDTH,
-      activeSessionId:
-        typeof parsed.activeSessionId === "string"
-          ? parsed.activeSessionId
-          : null,
+      // A v1-shape entry has a sessionId but no sessionProjectId. Treat that
+      // as a cross-project pointer (we don't know its project) and drop it
+      // rather than hydrate it against the wrong project.
+      activeSessionId: sessionProjectId ? sessionId : null,
+      activeSessionProjectId: sessionProjectId,
     };
   } catch {
     return fallback;
   }
 }
 
-function persist(state: {
-  isOpen: boolean;
-  width: number;
-  activeSessionId: string | null;
-}): void {
+function persist(state: LoadedState): void {
   if (!isWindowAvailable()) return;
   try {
     window.localStorage.setItem(
@@ -98,6 +114,7 @@ function persist(state: {
         isOpen: state.isOpen,
         width: state.width,
         activeSessionId: state.activeSessionId,
+        activeSessionProjectId: state.activeSessionProjectId,
       })
     );
   } catch {
@@ -111,30 +128,46 @@ export const useAgentPanelStore = create<AgentPanelState>((set, get) => ({
   isOpen: initial.isOpen,
   width: initial.width,
   activeSessionId: initial.activeSessionId,
+  activeSessionProjectId: initial.activeSessionProjectId,
   setOpen: (next) => {
     if (get().isOpen === next) return;
-    const state = { ...get(), isOpen: next };
-    persist(state);
+    const current = get();
+    persist({ ...current, isOpen: next });
     set({ isOpen: next });
   },
   toggle: () => {
     const next = !get().isOpen;
-    const state = { ...get(), isOpen: next };
-    persist(state);
+    const current = get();
+    persist({ ...current, isOpen: next });
     set({ isOpen: next });
   },
   setWidth: (next) => {
     const clamped = clampWidth(next);
     if (get().width === clamped) return;
-    const state = { ...get(), width: clamped };
-    persist(state);
+    const current = get();
+    persist({ ...current, width: clamped });
     set({ width: clamped });
   },
-  setActiveSessionId: (id) => {
-    if (get().activeSessionId === id) return;
-    const state = { ...get(), activeSessionId: id };
-    persist(state);
-    set({ activeSessionId: id });
+  setActiveSession: (id, projectId) => {
+    // Clearing collapses both fields so a stale projectId never lingers.
+    const nextId = id;
+    const nextProjectId = id === null ? null : projectId;
+    const current = get();
+    if (
+      current.activeSessionId === nextId &&
+      current.activeSessionProjectId === nextProjectId
+    ) {
+      return;
+    }
+    persist({
+      ...current,
+      activeSessionId: nextId,
+      activeSessionProjectId: nextProjectId,
+    });
+    set({
+      activeSessionId: nextId,
+      activeSessionProjectId: nextProjectId,
+    });
   },
 }));
 
@@ -146,7 +179,8 @@ if (isWindowAvailable()) {
     if (
       current.isOpen === next.isOpen &&
       current.width === next.width &&
-      current.activeSessionId === next.activeSessionId
+      current.activeSessionId === next.activeSessionId &&
+      current.activeSessionProjectId === next.activeSessionProjectId
     ) {
       return;
     }
@@ -154,6 +188,7 @@ if (isWindowAvailable()) {
       isOpen: next.isOpen,
       width: next.width,
       activeSessionId: next.activeSessionId,
+      activeSessionProjectId: next.activeSessionProjectId,
     });
   });
 


### PR DESCRIPTION
## Summary

- Surfaces the existing mcpjam-agent (docs MCP chat) as a persistent right-side panel reachable from every tab — PostHog / Attio pattern. New sparkle button in the top-right header opens an inline resizable panel; `⌘\` (`Ctrl+\`) toggles it.
- Gated by the same `home-page-enabled` PostHog flag that already gates the Home tab. When the flag is off the trigger hides and the shortcut no-ops.
- Sessions persist across navigation: active session id, panel open-state, and width all live in localStorage (`mcpjam:agent-panel:v1`) with cross-tab sync. The panel is mounted above `<Outlet>` inside `SidebarProvider` so route changes never unmount the streaming `useChat` instance.
- Home tab's existing full-bleed takeover is untouched — the panel is a parallel surface for v1.

## What's added

- `useAgentPanelStore` — Zustand singleton (open / width / activeSessionId), width clamped 360–50vw, persisted to localStorage with `storage` event sync.
- `AgentSidePanel` — desktop inline panel with bespoke left-edge drag handle; mobile (<768px) renders as `Sheet`. Header: Back / New chat / Close. Body swaps `McpjamAgentHero` ⇄ `McpjamAgentThread`. Kept mounted on close so in-flight streams aren't cancelled.
- `AgentSidePanelTrigger` — sparkle button in `AuthUpperArea`, hidden behind the flag.
- `AgentSidePanelMount` — owns the flag gate, the global `⌘\` shortcut (skips inputs/textareas/contentEditable), and resets `isOpen` when the flag flips off. Mounted at `SidebarProvider` scope.
- `McpjamAgentThread` gains `variant="sidebar"` — fills parent like `"full"` but drops the centered content column so the panel itself is the bounding chrome.
- Telemetry: `mcpjam_agent_panel_opened` (`{ via, tab }`), `mcpjam_agent_panel_closed` (`{ tab }`), `mcpjam_agent_panel_resized` (`{ width }`, debounced on `pointerup`).

## Horizontal-scaling notes

- No new server state. The existing `/api/web/mcpjam-agent` route is unchanged; transcripts persist to Convex (single source of truth across instances). Active session id is client-side.
- Streaming survives navigation because the panel lives above `<Outlet>` — the existing `useChat` instance keeps streaming through route changes.

## Known trade-offs

- **Mobile** uses Radix `Sheet`, which unmounts on close — so closing the drawer mid-stream cancels the in-flight turn. Matches every other mobile sheet in the app. Desktop keeps the panel mounted.
- **Home tab coexistence**: existing `?session=` takeover and the new side panel are two parallel surfaces on Home. Acceptable for v1; revisit if it confuses users.

## Test plan

- [ ] Flag off → no sparkle button, `⌘\` is a no-op
- [ ] Flag on → sparkle button visible in header; click opens panel; `⌘\` toggles
- [ ] Open on Playground, send message, navigate to Evaluate → conversation visible without remount flash
- [ ] Start a slow streaming response, navigate mid-stream → response continues
- [ ] Reload page → panel reopens at same width with active session hydrated from Convex
- [ ] Drag handle: below 360 snaps closed; above 50vw clamps; width persists across reload
- [ ] Mobile (<768px) renders as full-width sheet
- [ ] `⌘B` still toggles left sidebar (no conflict with `⌘\`)
- [ ] Three PostHog events fire (`mcpjam_agent_panel_opened` / `_closed` / `_resized`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and localStorage state reusing the existing agent API; main caveat is mobile Sheet unmount canceling mid-stream, which the PR documents as an accepted trade-off.
> 
> **Overview**
> Adds a **global MCPJam Agent side panel** so docs chat is available from any tab without leaving the current route. **`App.tsx`** mounts **`AgentSidePanelMount`** beside **`SidebarInset`** (outside **`Outlet`**) so navigation does not unmount an in-flight **`useChat`** stream.
> 
> **Entry & gating:** Header sparkle trigger in **`auth-upper-area.tsx`**; **`⌘\` / Ctrl+\** toggle (skipped in editable fields). All gated on **`home-page-enabled`**, with logic to avoid tearing down the panel during PostHog flag hydration and to force-close when the flag is off.
> 
> **State:** New **`useAgentPanelStore`** persists open state, width (360px–50vw), and active session + project id in **`localStorage`** with cross-tab sync; stale or cross-project session pointers are cleared after app bootstrap.
> 
> **UI:** **`AgentSidePanel`** swaps **`McpjamAgentHero`** and **`McpjamAgentThread`**; desktop uses a resizable inline panel (hidden via **`display: none`** when closed, still mounted); mobile uses a **`Sheet`**. **`McpjamAgentThread`** adds **`variant="sidebar"`** for full-height layout without the centered **`max-w-4xl`** column. PostHog events for open, close, and resize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10823bd87bebf397916154efdcf2b09fe36f0c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->