### PR TITLE
chat-engine: add onToolCall / onToolResult / onStepFinish callbacks (engine consolidation PR 5b-pre)

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1828,8 +1828,19 @@ describe("mcpjam-stream-handler", () => {
       // derives per-step deltas across successive invocations.
       const first = onStepFinish.mock.calls[0]?.[0];
       const second = onStepFinish.mock.calls[1]?.[0];
-      expect(first).toMatchObject({ stepIndex: 0, promptIndex: 0 });
-      expect(second).toMatchObject({ stepIndex: 1, promptIndex: 0 });
+      expect(first).toMatchObject({
+        stepIndex: 0,
+        promptIndex: 0,
+        // PR 5b-pre review caveat (Marcelo): both successful steps
+        // settle without error. PR 5b should rely on this flag to
+        // gate eval `step_finish` SSE event emission.
+        settledWithError: false,
+      });
+      expect(second).toMatchObject({
+        stepIndex: 1,
+        promptIndex: 0,
+        settledWithError: false,
+      });
       // Engine aggregates usage across steps; the second call sees the
       // sum (3+1, 4+2, 7+3).
       expect(second.turnUsage).toMatchObject({
@@ -1837,6 +1848,55 @@ describe("mcpjam-stream-handler", () => {
         outputTokens: 6,
         totalTokens: 10,
       });
+    });
+
+    it("fires `onStepFinish` with `settledWithError: true` on backend failure paths (PR 5b-pre review — Marcelo caveat)", async () => {
+      // Marcelo's review caveat: `onStepFinish` fires after every
+      // `processOneStep` return — including the non-OK / no-body
+      // branches at mcpjam-stream-handler.ts:1558. Those return
+      // `didEmitFinish: false` after writing an error UI chunk. If
+      // PR 5b maps `onStepFinish` directly to eval `step_finish` SSE,
+      // failed backend steps would emit `step_finish` where the
+      // pre-collapse runner only emitted error/failure trace.
+      //
+      // Fix is "step settled, not step succeeded" semantics: the engine
+      // surfaces the settle state via `settledWithError` so PR 5b's
+      // wire-up gates correctly. This test locks the failure shape:
+      // a non-OK HTTP response from Convex MUST fire `onStepFinish`
+      // exactly once with `settledWithError: true`.
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response("upstream broke", {
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+      );
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+
+      const onStepFinish = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "Fail me" }] as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        onStepFinish,
+      });
+
+      await lastExecution;
+
+      // Failure step fires the callback once. `settledWithError: true`
+      // signals to PR 5b's wire-up to NOT emit eval `step_finish` SSE.
+      expect(onStepFinish).toHaveBeenCalledTimes(1);
+      expect(onStepFinish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stepIndex: 0,
+          promptIndex: 0,
+          settledWithError: true,
+        }),
+      );
     });
 
     it("fires `onToolResult` for denied tools on resumed approval turns (PR 5b-pre review fix — Cursor Medium)", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -75,6 +75,13 @@ vi.mock("../mcpjam-tool-helpers", () => ({
 vi.mock("../logger", () => ({
   logger: {
     error: vi.fn(),
+    // PR 5b-pre review fix (CodeRabbit Minor): the callback try/catch
+    // path calls `logger.warn` on a callback throw. The mock must
+    // include `warn` so the path is faithfully exercised (without
+    // this, calling `logger.warn` would have thrown TypeError and the
+    // catch-block-doesn't-propagate test would have validated against
+    // a mock-shape side effect instead of the real behavior).
+    warn: vi.fn(),
   },
 }));
 
@@ -1829,6 +1836,128 @@ describe("mcpjam-stream-handler", () => {
         inputTokens: 4,
         outputTokens: 6,
         totalTokens: 10,
+      });
+    });
+
+    it("fires `onToolResult` for denied tools on resumed approval turns (PR 5b-pre review fix — Cursor Medium)", async () => {
+      // Cursor PR 5b-pre review fix: `handlePendingApprovals` writes a
+      // `tool_result` trace event inline (not via `emitToolResults`)
+      // when the user denies a tool call on a resumed approval turn.
+      // Pre-fix the inline path skipped `onToolResult` even though the
+      // emitToolResults path fired it for approved + auto-deny cases —
+      // PR 5b eval wiring would miss SSE events for denied tools on
+      // resumed turns. Fixed in this PR by mirroring the callback
+      // invocation at the inline trace event site.
+      const stepOne = [
+        {
+          type: "tool-input-available",
+          toolCallId: "call-denied-1",
+          toolName: "delete_things",
+          input: { id: 42 },
+        },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      const stepTwo = [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "ok denied" },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      let call = 0;
+      global.fetch = vi.fn().mockImplementation(async () => {
+        const events = call === 0 ? stepOne : stepTwo;
+        call += 1;
+        return createSseResponse(events);
+      });
+
+      // The resumed-approval shape: client sends back an assistant
+      // message with a `tool-approval-request` part + a corresponding
+      // `tool-approval-response` part marked denied. `handlePendingApprovals`
+      // processes this BEFORE the per-step loop runs, so the
+      // `emitToolResults` path isn't hit — the denial trace event +
+      // callback fire from inside `handlePendingApprovals` itself.
+      // Same resumed-approval shape as the existing "preserves spliced
+      // denial tool results" test in this file: the approval-response
+      // lives in a tool-role message, not bundled into the assistant
+      // message (mirrors how the client posts the approval response on
+      // the next round trip).
+      const resumedMessages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-denied-1",
+              toolName: "delete_things",
+              input: { id: 42 },
+            },
+            {
+              type: "tool-approval-request",
+              approvalId: "approval-1",
+              toolCallId: "call-denied-1",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-approval-response",
+              approvalId: "approval-1",
+              approved: false,
+            },
+          ],
+        },
+      ];
+
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+      vi.mocked(executeToolCallsFromMessages).mockResolvedValue([]);
+
+      const onToolResult = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: resumedMessages as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {
+          delete_things: { _serverId: "destructive-server" },
+        } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({
+            delete_things: {},
+          }),
+        } as any,
+        requireToolApproval: true,
+        onToolResult,
+      });
+
+      await lastExecution;
+
+      // The denial path fired `onToolResult` with the
+      // user-denied-by-user error shape.
+      expect(onToolResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolCallId: "call-denied-1",
+          toolName: "delete_things",
+          isError: true,
+          stepIndex: expect.any(Number),
+          promptIndex: 0,
+        }),
+      );
+      const deniedCall = onToolResult.mock.calls.find(
+        (c) => c[0]?.toolCallId === "call-denied-1",
+      );
+      expect(deniedCall?.[0]?.output).toEqual({
+        type: "error-text",
+        value: "Tool execution denied by user.",
       });
     });
 

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1541,4 +1541,383 @@ describe("mcpjam-stream-handler", () => {
       delete process.env.GUEST_SESSION_HASH_PEPPER;
     });
   });
+
+  describe("PR 5b-pre — chunk + step callback contract", () => {
+    // Engine consolidation PR 5b-pre
+    // (`~/mcpjam-docs/unification.md`): new optional callbacks on
+    // `MCPJamHandlerOptions` so eval's PR 5b backend stream runner can
+    // emit SSE events from engine signals. Locks the callback timing +
+    // shape so PR 5b's wire-up trusts the contract. Chat + synthetic
+    // (which don't supply these callbacks) are unaffected — covered by
+    // the omit-callbacks-and-still-work assertions on every existing
+    // test in this file.
+
+    it("fires `onToolCall` with the chunk fields when a tool-input-available chunk arrives", async () => {
+      // Step 1: model returns a tool call. Step 2: tool result fed in,
+      // model finishes. Asserts `onToolCall` fires once with the
+      // chunk's toolName/toolCallId/input plus stepIndex + promptIndex.
+      const stepOne = [
+        {
+          type: "tool-input-available",
+          toolCallId: "call-1",
+          toolName: "read_docs",
+          input: { topic: "latency" },
+        },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 3, outputTokens: 4, totalTokens: 7 },
+        },
+      ];
+      const stepTwo = [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "ok" },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      let call = 0;
+      global.fetch = vi.fn().mockImplementation(async () => {
+        const events = call === 0 ? stepOne : stepTwo;
+        call += 1;
+        return createSseResponse(events);
+      });
+      vi.mocked(hasUnresolvedToolCalls).mockImplementation(
+        (messages) =>
+          messages.some(
+            (message: any) =>
+              message?.role === "assistant" &&
+              Array.isArray(message.content) &&
+              message.content.some((part: any) => part.type === "tool-call"),
+          ) && !messages.some((message: any) => message?.role === "tool"),
+      );
+      vi.mocked(executeToolCallsFromMessages).mockImplementation(
+        async (messages: any[]) => {
+          const toolResultMessage = {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call-1",
+                toolName: "read_docs",
+                output: { type: "json", value: { ok: true } },
+                result: { ok: true },
+                serverId: "docs-server",
+              },
+            ],
+          };
+          messages.splice(2, 0, toolResultMessage);
+          return [toolResultMessage] as any;
+        },
+      );
+
+      const onToolCall = vi.fn();
+      const onToolResult = vi.fn();
+      const onStepFinish = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "Fetch the docs" }] as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {
+          read_docs: { _serverId: "docs-server" },
+        } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({ read_docs: {} }),
+        } as any,
+        onToolCall,
+        onToolResult,
+        onStepFinish,
+      });
+
+      await lastExecution;
+
+      // `onToolCall` fires once for the single tool call, before
+      // execution. Shape includes stepIndex and promptIndex from
+      // engine bookkeeping.
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(onToolCall).toHaveBeenCalledWith({
+        toolCallId: "call-1",
+        toolName: "read_docs",
+        input: { topic: "latency" },
+        stepIndex: 0,
+        promptIndex: 0,
+        serverId: "docs-server",
+      });
+    });
+
+    it("fires `onToolResult` after local tool execution with isError flag", async () => {
+      const stepOne = [
+        {
+          type: "tool-input-available",
+          toolCallId: "call-1",
+          toolName: "read_docs",
+          input: {},
+        },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      const stepTwo = [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "done" },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      let call = 0;
+      global.fetch = vi.fn().mockImplementation(async () => {
+        const events = call === 0 ? stepOne : stepTwo;
+        call += 1;
+        return createSseResponse(events);
+      });
+      vi.mocked(hasUnresolvedToolCalls).mockImplementation(
+        (messages) =>
+          messages.some(
+            (message: any) =>
+              message?.role === "assistant" &&
+              Array.isArray(message.content) &&
+              message.content.some((part: any) => part.type === "tool-call"),
+          ) && !messages.some((message: any) => message?.role === "tool"),
+      );
+      vi.mocked(executeToolCallsFromMessages).mockImplementation(
+        async (messages: any[]) => {
+          const toolResultMessage = {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call-1",
+                toolName: "read_docs",
+                // Error result — locks `isError: true` mapping.
+                output: { type: "error-text", value: "boom" },
+                result: { error: "boom" },
+                serverId: "docs-server",
+              },
+            ],
+          };
+          messages.splice(2, 0, toolResultMessage);
+          return [toolResultMessage] as any;
+        },
+      );
+
+      const onToolResult = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "Run it" }] as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {
+          read_docs: { _serverId: "docs-server" },
+        } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({ read_docs: {} }),
+        } as any,
+        onToolResult,
+      });
+
+      await lastExecution;
+
+      expect(onToolResult).toHaveBeenCalledTimes(1);
+      expect(onToolResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolCallId: "call-1",
+          toolName: "read_docs",
+          isError: true,
+          stepIndex: 0,
+          promptIndex: 0,
+          serverId: "docs-server",
+        }),
+      );
+    });
+
+    it("fires `onStepFinish` once per completed step with cumulative turnUsage", async () => {
+      const stepOne = [
+        {
+          type: "tool-input-available",
+          toolCallId: "call-1",
+          toolName: "read_docs",
+          input: {},
+        },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 3, outputTokens: 4, totalTokens: 7 },
+        },
+      ];
+      const stepTwo = [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "done" },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+        },
+      ];
+      let call = 0;
+      global.fetch = vi.fn().mockImplementation(async () => {
+        const events = call === 0 ? stepOne : stepTwo;
+        call += 1;
+        return createSseResponse(events);
+      });
+      vi.mocked(hasUnresolvedToolCalls).mockImplementation(
+        (messages) =>
+          messages.some(
+            (message: any) =>
+              message?.role === "assistant" &&
+              Array.isArray(message.content) &&
+              message.content.some((part: any) => part.type === "tool-call"),
+          ) && !messages.some((message: any) => message?.role === "tool"),
+      );
+      vi.mocked(executeToolCallsFromMessages).mockImplementation(
+        async (messages: any[]) => {
+          const toolResultMessage = {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call-1",
+                toolName: "read_docs",
+                output: { type: "json", value: { ok: true } },
+                result: { ok: true },
+                serverId: "docs-server",
+              },
+            ],
+          };
+          messages.splice(2, 0, toolResultMessage);
+          return [toolResultMessage] as any;
+        },
+      );
+
+      const onStepFinish = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "Two steps" }] as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {
+          read_docs: { _serverId: "docs-server" },
+        } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({ read_docs: {} }),
+        } as any,
+        onStepFinish,
+      });
+
+      await lastExecution;
+
+      // Two steps completed: tool-call step + final text step.
+      expect(onStepFinish).toHaveBeenCalledTimes(2);
+      // stepIndex increments. turnUsage is CUMULATIVE per turn — caller
+      // derives per-step deltas across successive invocations.
+      const first = onStepFinish.mock.calls[0]?.[0];
+      const second = onStepFinish.mock.calls[1]?.[0];
+      expect(first).toMatchObject({ stepIndex: 0, promptIndex: 0 });
+      expect(second).toMatchObject({ stepIndex: 1, promptIndex: 0 });
+      // Engine aggregates usage across steps; the second call sees the
+      // sum (3+1, 4+2, 7+3).
+      expect(second.turnUsage).toMatchObject({
+        inputTokens: 4,
+        outputTokens: 6,
+        totalTokens: 10,
+      });
+    });
+
+    it("does not throw when callback omitted — chat / synthetic compatibility", async () => {
+      // Defensive regression: every existing chat / synthetic call site
+      // omits the new callbacks. The engine MUST stay no-op-equivalent
+      // for those callers.
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          { type: "text-start", id: "text-1" },
+          { type: "text-delta", id: "text-1", delta: "hi" },
+          { type: "text-end", id: "text-1" },
+          {
+            type: "finish",
+            finishReason: "stop",
+            totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ]),
+      );
+
+      // No callbacks supplied — same as every existing chat call site.
+      await expect(
+        handleMCPJamFreeChatModel({
+          messages: [{ role: "user", content: "Say hi" }] as any,
+          modelId: "openai/gpt-5-mini",
+          systemPrompt: "You are helpful",
+          tools: {},
+          mcpClientManager: {
+            getAllToolsMetadata: vi.fn().mockReturnValue({}),
+          } as any,
+        }),
+      ).resolves.toBeDefined();
+
+      await lastExecution;
+    });
+
+    it("catches callback throws without aborting the turn", async () => {
+      // Eval callers' code might throw. The engine catches per-callback
+      // and logs a warning so a buggy SSE emitter doesn't crash the
+      // entire iteration.
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-1",
+            toolName: "read_docs",
+            input: {},
+          },
+          {
+            type: "finish",
+            finishReason: "stop",
+            messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ]),
+      );
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+
+      const onToolCall = vi.fn(() => {
+        throw new Error("callback boom");
+      });
+      const onStepFinish = vi.fn();
+
+      await expect(
+        handleMCPJamFreeChatModel({
+          messages: [{ role: "user", content: "Run" }] as any,
+          modelId: "openai/gpt-5-mini",
+          systemPrompt: "You are helpful",
+          tools: {
+            read_docs: { _serverId: "docs-server" },
+          } as any,
+          mcpClientManager: {
+            getAllToolsMetadata: vi.fn().mockReturnValue({ read_docs: {} }),
+          } as any,
+          onToolCall,
+          onStepFinish,
+        }),
+      ).resolves.toBeDefined();
+
+      await lastExecution;
+
+      // Even though `onToolCall` threw, the engine kept running and
+      // wrote chunks to the UI stream (proving the throw was caught
+      // and didn't propagate). Don't strictly require `onStepFinish`
+      // — depending on `hasUnresolvedToolCalls`'s response the engine
+      // may short-circuit before a full step completes; the
+      // load-bearing assertion is that `onToolCall` did fire AND the
+      // overall promise resolved (i.e., no unhandled throw).
+      expect(onToolCall).toHaveBeenCalled();
+      expect(writtenChunks.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -138,6 +138,16 @@ export interface RunAssistantTurnOptions {
   onStreamComplete?: MCPJamHandlerOptions["onStreamComplete"];
   onStreamWriterReady?: MCPJamHandlerOptions["onStreamWriterReady"];
   onLiveTextDelta?: MCPJamHandlerOptions["onLiveTextDelta"];
+  /**
+   * PR 5b-pre: chunk-level + step-level callbacks. Pass-throughs to
+   * `MCPJamHandlerOptions`. Eval's PR 5b backend stream runner uses
+   * these to emit SSE events from engine signals; chat / synthetic
+   * omit. See `MCPJamHandlerOptions.onToolCall` etc. for shape +
+   * timing.
+   */
+  onToolCall?: MCPJamHandlerOptions["onToolCall"];
+  onToolResult?: MCPJamHandlerOptions["onToolResult"];
+  onStepFinish?: MCPJamHandlerOptions["onStepFinish"];
 
   /**
    * Override the Convex endpoint path. Stage 1 keeps this wired so
@@ -312,6 +322,10 @@ function buildHandlerOptions(
     ...(opts.onLiveTextDelta
       ? { onLiveTextDelta: opts.onLiveTextDelta }
       : {}),
+    // PR 5b-pre: pass-through chunk-level + step-level callbacks.
+    ...(opts.onToolCall ? { onToolCall: opts.onToolCall } : {}),
+    ...(opts.onToolResult ? { onToolResult: opts.onToolResult } : {}),
+    ...(opts.onStepFinish ? { onStepFinish: opts.onStepFinish } : {}),
     ...(opts.endpointPath ? { endpointPath: opts.endpointPath } : {}),
     ...(opts.extraHeaders ? { extraHeaders: opts.extraHeaders } : {}),
     ...(opts.authContext.clientIp !== undefined &&

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -182,6 +182,24 @@ export interface MCPJamStepFinishEvent {
     outputTokens?: number;
     totalTokens?: number;
   };
+  /**
+   * **Step SETTLED, not necessarily successful.** `onStepFinish` fires
+   * once per `processOneStep` return, regardless of outcome — including
+   * the non-OK HTTP / no-body / decode-error branches that emit an
+   * `error` UI chunk + failure trace event and return
+   * `didEmitFinish: false`. Callers that map this to a higher-level
+   * "step succeeded" SSE event (eval's `step_finish`) MUST gate on
+   * `settledWithError === false`, OR consume failure events from the
+   * UI/trace stream and treat `onStepFinish` as a settle-once
+   * notification.
+   *
+   * Marcelo's PR 5b-pre review caveat: if PR 5b wires this directly to
+   * eval `step_finish` SSE, failed backend steps would emit
+   * `step_finish` where the pre-collapse runner only emitted error /
+   * failure trace. Surfacing the settle state on the event lets the
+   * wire-up decide.
+   */
+  settledWithError: boolean;
 }
 
 export interface MCPJamHandlerOptions {
@@ -2366,6 +2384,17 @@ export async function runChatEngineLoop(
           // callbacks' shape.
           if (onStepFinish) {
             try {
+              // Marcelo's PR 5b-pre review caveat: the engine's
+              // failure branches return `shouldContinue: false` +
+              // `didEmitFinish: false` after emitting an error UI
+              // chunk. We surface this on `settledWithError` so PR 5b's
+              // wire-up can decide whether to map to eval's
+              // `step_finish` SSE event (success-only) or treat the
+              // settle as terminal. The shape: a step that produced a
+              // UI `finish` chunk OR `shouldContinue: true` is a
+              // success; the only failure shape today is
+              // `shouldContinue: false && !didEmitFinish`.
+              const settledWithError = !didEmitFinish && !shouldContinue;
               onStepFinish({
                 stepIndex: effectiveSteps() - 1,
                 promptIndex: traceTurn.promptIndex,
@@ -2376,6 +2405,7 @@ export async function runChatEngineLoop(
                       totalTokens: traceTurn.turnUsage.totalTokens,
                     }
                   : undefined,
+                settledWithError,
               });
             } catch (error) {
               logger.warn(

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -1266,6 +1266,39 @@ async function handlePendingApprovals(
           },
           errorText: "Tool execution denied by user.",
         });
+        // PR 5b-pre review fix (Cursor Medium "Denied approval skips
+        // onToolResult"): the denial path writes the trace event
+        // inline without going through `emitToolResults`, so the
+        // `onToolResult` callback wasn't firing. Auto-deny via
+        // `processOneStep` does fire it through the
+        // `emitToolResults` → callback chain; denial via
+        // `handlePendingApprovals` needs the symmetric call here so
+        // PR 5b's eval wiring sees `tool_result` SSE events for
+        // denied tools on resumed approval turns.
+        if (onToolResult) {
+          try {
+            onToolResult({
+              toolCallId,
+              toolName,
+              output: {
+                type: "error-text",
+                value: "Tool execution denied by user.",
+              },
+              isError: true,
+              stepIndex,
+              promptIndex: traceTurn.promptIndex,
+              serverId: undefined,
+            });
+          } catch (error) {
+            logger.warn(
+              "[mcpjam-stream-handler] onToolResult callback failed (denial path)",
+              {
+                error:
+                  error instanceof Error ? error.message : String(error),
+              },
+            );
+          }
+        }
       }
 
       const part: ToolResultPart = {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -135,6 +135,55 @@ export function warnIfChatAbortSignalMissing(
   );
 }
 
+/**
+ * Event payloads for the chunk-level + step-level callbacks exposed by
+ * the chat engine to its callers. Engine consolidation PR 5b-pre
+ * (`~/mcpjam-docs/unification.md`) adds these so eval's backend stream
+ * runner can wire SSE events from engine signals when PR 5b collapses
+ * `streamIterationViaBackend` onto the shared engine. Chat + synthetic
+ * pass nothing today and are unaffected.
+ *
+ * `promptIndex` mirrors `traceTurn.promptIndex` — eval needs it for
+ * trace span correlation; chat / synthetic ignore it.
+ */
+export interface MCPJamToolCallEvent {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  stepIndex: number;
+  promptIndex: number;
+  serverId: string | undefined;
+}
+
+export interface MCPJamToolResultEvent {
+  toolCallId: string;
+  /** May be undefined when the chunk lacks toolName (older Convex versions). */
+  toolName: string | undefined;
+  output: unknown;
+  /** `true` when the tool execution returned an error result (vs. an OK output). */
+  isError: boolean;
+  stepIndex: number;
+  promptIndex: number;
+  serverId: string | undefined;
+}
+
+export interface MCPJamStepFinishEvent {
+  stepIndex: number;
+  promptIndex: number;
+  /**
+   * Cumulative usage for this TURN as of step completion (the engine
+   * tracks per-turn aggregates, not per-step deltas). Callers compute
+   * per-step deltas across successive `onStepFinish` invocations if
+   * they need them. Undefined when the engine has no usage signal for
+   * this step.
+   */
+  turnUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+}
+
 export interface MCPJamHandlerOptions {
   messages: ModelMessage[];
   modelId: string;
@@ -170,6 +219,30 @@ export interface MCPJamHandlerOptions {
     write: (chunk: UIMessageChunk) => void;
   }) => void;
   onLiveTextDelta?: (delta: string) => void;
+  /**
+   * Engine consolidation PR 5b-pre — fires from the chunk-processing
+   * switch when Convex emits a `tool-input-available` chunk (the AI
+   * SDK v6 equivalent of `tool-call`). Eval's backend stream runner
+   * uses this to emit the `tool_call` SSE event. Chat / synthetic
+   * omit; the engine writer still writes the `tool-input-available`
+   * UI chunk verbatim regardless.
+   */
+  onToolCall?: (event: MCPJamToolCallEvent) => void;
+  /**
+   * Engine consolidation PR 5b-pre — fires from the local tool-result
+   * persistence path AFTER the engine writes the `tool-output-available`
+   * UI chunk and the `tool_result` trace event. Eval's backend stream
+   * runner uses this to emit the `tool_result` SSE event. Chat /
+   * synthetic omit.
+   */
+  onToolResult?: (event: MCPJamToolResultEvent) => void;
+  /**
+   * Engine consolidation PR 5b-pre — fires from `runChatEngineLoop`
+   * after each `processOneStep` returns and the step counter
+   * increments. Eval's backend stream runner uses this to emit the
+   * `step_finish` SSE event. Chat / synthetic omit.
+   */
+  onStepFinish?: (event: MCPJamStepFinishEvent) => void;
   /**
    * Override the Convex endpoint path for the per-step LLM call.
    * Defaults to "/stream". Org BYOK chat uses "/stream/org".
@@ -263,6 +336,12 @@ interface StepContext {
   extraBodyFields?: Record<string, unknown>;
   clientIp?: string | null;
   onLiveTextDelta?: (delta: string) => void;
+  // PR 5b-pre: chunk-level + step-level callbacks. Threaded to the
+  // chunk-processing switch (onToolCall / onToolResult) and to the
+  // step loop (onStepFinish). All optional.
+  onToolCall?: (event: MCPJamToolCallEvent) => void;
+  onToolResult?: (event: MCPJamToolResultEvent) => void;
+  onStepFinish?: (event: MCPJamStepFinishEvent) => void;
   abortSignal?: AbortSignal;
 }
 
@@ -674,7 +753,11 @@ async function processStream(
   requireToolApproval?: boolean,
   onLiveTextDelta?: (delta: string) => void,
   abortSignal?: AbortSignal,
-  progressivePlan?: ProgressiveToolPlan
+  progressivePlan?: ProgressiveToolPlan,
+  // PR 5b-pre: chunk-level callbacks. Optional; only fired when
+  // supplied. Chat / synthetic omit (handler still writes the UI
+  // chunk + trace event unchanged).
+  onToolCall?: (event: MCPJamToolCallEvent) => void
 ): Promise<StreamResult> {
   const contentParts: PersistedAssistantPart[] = [];
   let pendingText = "";
@@ -832,6 +915,7 @@ async function processStream(
           });
           hasToolCalls = true;
           writer.write({ ...chunk, toolCallId });
+          const serverIdForToolCall = readToolServerId(tools, chunk.toolName);
           writeTraceEvent(writer, {
             type: "tool_call",
             turnId: traceTurn.turnId,
@@ -840,8 +924,28 @@ async function processStream(
             toolCallId,
             toolName: chunk.toolName,
             input: toTraceRecord(chunk.input),
-            serverId: readToolServerId(tools, chunk.toolName),
+            serverId: serverIdForToolCall,
           });
+          // PR 5b-pre: fire chunk-level callback so eval's backend
+          // stream runner (PR 5b) can emit the `tool_call` SSE event.
+          // Chat / synthetic don't supply this callback.
+          if (onToolCall) {
+            try {
+              onToolCall({
+                toolCallId,
+                toolName: chunk.toolName,
+                input: chunk.input,
+                stepIndex,
+                promptIndex: traceTurn.promptIndex,
+                serverId: serverIdForToolCall,
+              });
+            } catch (error) {
+              logger.warn(
+                "[mcpjam-stream-handler] onToolCall callback failed",
+                { error: error instanceof Error ? error.message : String(error) },
+              );
+            }
+          }
 
           if (
             requireToolApproval &&
@@ -900,7 +1004,12 @@ function emitToolResults(
   mcpClientManager: MCPClientManager,
   newMessages: ModelMessage[],
   traceTurn?: LiveTraceTurnContext,
-  stepIndex?: number
+  stepIndex?: number,
+  // PR 5b-pre: optional chunk-level callback so eval's backend stream
+  // runner (PR 5b) can emit the `tool_result` SSE event. Chat /
+  // synthetic don't supply this callback — the UI writer + trace event
+  // still fire unchanged.
+  onToolResult?: (event: MCPJamToolResultEvent) => void
 ) {
   for (const msg of newMessages) {
     if (msg?.role === "tool") {
@@ -967,6 +1076,30 @@ function emitToolResults(
               errorText,
               serverId,
             });
+            // PR 5b-pre: fire chunk-level callback. `isError` matches
+            // the AI SDK's error-text output discriminator (same shape
+            // PR 5a's adapter uses for its `tool_result` SSE event).
+            if (onToolResult) {
+              try {
+                onToolResult({
+                  toolCallId: part.toolCallId,
+                  toolName: toolName ?? part.toolName,
+                  output: outputForUi,
+                  isError: part.output?.type === "error-text",
+                  stepIndex,
+                  promptIndex: traceTurn.promptIndex,
+                  serverId,
+                });
+              } catch (error) {
+                logger.warn(
+                  "[mcpjam-stream-handler] onToolResult callback failed",
+                  {
+                    error:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                );
+              }
+            }
           }
         }
       }
@@ -1033,7 +1166,10 @@ async function handlePendingApprovals(
   mcpClientManager: MCPClientManager,
   traceTurn?: LiveTraceTurnContext,
   stepIndex?: number,
-  abortSignal?: AbortSignal
+  abortSignal?: AbortSignal,
+  // PR 5b-pre: propagate the chunk-level callback so denial /
+  // approved-tool-result emissions also fire it.
+  onToolResult?: (event: MCPJamToolResultEvent) => void
 ): Promise<boolean> {
   // Build approvalId → toolCallId map, toolCallId → toolName map,
   // and toolCallId → assistant message index map from assistant messages
@@ -1208,7 +1344,8 @@ async function handlePendingApprovals(
       mcpClientManager,
       newMessages,
       traceTurn,
-      stepIndex
+      stepIndex,
+      onToolResult
     );
     didHandle = true;
   }
@@ -1245,6 +1382,10 @@ async function processOneStep(
     traceTurn,
     progressivePlan,
     discoveryState,
+    // PR 5b-pre chunk-level callbacks (optional, propagated from
+    // MCPJamHandlerOptions through runChatEngineLoop).
+    onToolCall,
+    onToolResult,
   } = ctx;
 
   // Pick the active tool subset for this step. In non-progressive mode
@@ -1437,7 +1578,8 @@ async function processOneStep(
     requireToolApproval,
     onLiveTextDelta,
     abortSignal,
-    progressivePlan
+    progressivePlan,
+    onToolCall
   );
   const llmEndAbs = Date.now();
   traceTurn.turnUsage = mergeLiveChatTraceUsage(
@@ -1557,7 +1699,8 @@ async function processOneStep(
           mcpClientManager,
           denialMessages,
           traceTurn,
-          stepIndex
+          stepIndex,
+          onToolResult
         );
       }
       // Fall through to the normal tool-execution branch below so
@@ -1598,7 +1741,8 @@ async function processOneStep(
           mcpClientManager,
           metaMessages,
           traceTurn,
-          stepIndex
+          stepIndex,
+          onToolResult
         );
         // Promote any ids the model just loaded so a subsequent
         // resumed-after-approval step sees them as loaded.
@@ -1745,7 +1889,8 @@ async function processOneStep(
         mcpClientManager,
         newMessages,
         traceTurn,
-        stepIndex
+        stepIndex,
+        onToolResult
       );
       emitTraceSnapshot(writer, messageHistory, tools, traceTurn);
 
@@ -1928,6 +2073,10 @@ export async function runChatEngineLoop(
     sourceType,
     clientIp,
     onLiveTextDelta,
+    // PR 5b-pre callbacks.
+    onToolCall,
+    onToolResult,
+    onStepFinish,
     abortSignal,
     heartbeatIntervalMs,
     maxSteps,
@@ -2122,7 +2271,8 @@ export async function runChatEngineLoop(
             mcpClientManager,
             traceTurn,
             effectiveSteps(),
-            abortSignal
+            abortSignal,
+            onToolResult
           );
           if (handled) {
             // Approvals were processed — if there are still unresolved tool
@@ -2162,12 +2312,47 @@ export async function runChatEngineLoop(
             extraBodyFields,
             clientIp,
             onLiveTextDelta,
+            // PR 5b-pre: chunk-level callbacks. Passed through to the
+            // step processor where the chunk-switch (onToolCall) +
+            // tool-result emission (onToolResult) sites fire them.
+            onToolCall,
+            onToolResult,
             abortSignal,
           });
 
           steps++;
           if (didEmitFinish) {
             finishEmitted = true;
+          }
+
+          // PR 5b-pre: step-level callback. Fires after each
+          // `processOneStep` returns and the step counter increments,
+          // so the runner sees one event per completed step in order.
+          // `turnUsage` reads from `traceTurn` so callers can compute
+          // per-step deltas. Wrapped in try/catch to match the chunk
+          // callbacks' shape.
+          if (onStepFinish) {
+            try {
+              onStepFinish({
+                stepIndex: effectiveSteps() - 1,
+                promptIndex: traceTurn.promptIndex,
+                turnUsage: traceTurn.turnUsage
+                  ? {
+                      inputTokens: traceTurn.turnUsage.inputTokens,
+                      outputTokens: traceTurn.turnUsage.outputTokens,
+                      totalTokens: traceTurn.turnUsage.totalTokens,
+                    }
+                  : undefined,
+              });
+            } catch (error) {
+              logger.warn(
+                "[mcpjam-stream-handler] onStepFinish callback failed",
+                {
+                  error:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
+            }
           }
 
           if (!shouldContinue) {


### PR DESCRIPTION
## Summary

Pure additive engine extension preparing for PR 5b's `streamIterationViaBackend` runner collapse. The shared chat engine (`runChatEngineLoop` → `processOneStep` → `processStream` / `emitToolResults`) now exposes three optional callbacks on `MCPJamHandlerOptions` so callers can wire chunk-level + step-level signals into their own SSE event vocabulary.

PR 5a (#2468) wired `streamIterationWithAiSdk` onto the local streamText driver + the PR-5-pre adapter (#2466). PR 5b will wire `streamIterationViaBackend` onto `runAssistantTurn` (which forwards to the chat engine for paths 1+2). The eval SSE event vocabulary needs `tool_call` / `tool_result` / `step_finish` events that the chat engine doesn't surface via callbacks today — `onLiveTextDelta` was the only existing chunk-level callback. This PR adds the missing surface without touching the runner; chat / synthetic call sites are unaffected (callbacks are optional).

## What this PR adds

New types on `MCPJamHandlerOptions`:

- **`MCPJamToolCallEvent`** `{ toolCallId, toolName, input, stepIndex, promptIndex, serverId }` — fires from the `tool-input-available` case in `processStream`'s chunk switch (the AI SDK v6 equivalent of `tool-call`).
- **`MCPJamToolResultEvent`** `{ toolCallId, toolName, output, isError, stepIndex, promptIndex, serverId }` — fires from `emitToolResults` after the engine writes the `tool-output-available` UI chunk + the `tool_result` trace event. `isError` maps the `error-text`-output discriminator.
- **`MCPJamStepFinishEvent`** `{ stepIndex, promptIndex, turnUsage? }` — fires from the step loop after each `processOneStep` returns and the step counter increments. `turnUsage` is CUMULATIVE per turn (the engine tracks aggregate, not per-step deltas); callers compute step deltas across successive invocations.

Threaded through `RunAssistantTurnOptions` as pass-throughs to `MCPJamHandlerOptions`. Synthetic + chat omit them.

## Why these specific shapes

- `promptIndex` mirrors `traceTurn.promptIndex` — eval needs it for trace span correlation; chat / synthetic ignore it.
- Callbacks are invoked with `try/catch` and a `logger.warn` on throw so a buggy emitter doesn't crash the agentic loop. Matches the existing `onLiveTextDelta` pattern.
- Tool-result `isError` uses the existing `part.output?.type === "error-text"` discriminator already used at the trace event site, so callers see the same error semantics the trace + UI already assume.
- `onStepFinish` fires AFTER `processOneStep` returns and the step counter increments — so the runner sees one event per completed step in arrival order, matching PR 5-pre's adapter contract.

## What this PR explicitly does NOT touch

- `streamIterationViaBackend` rewrite stays for PR 5b. The new callbacks are exercised only by the contract tests in this PR; the eval runner still uses its inline Convex `/stream` loop on `main`.
- Chat (`handleMCPJamFreeChatModel`) + synthetic (`drainAssistantTurn` → `runAssistantTurn`) call sites unchanged — they don't supply the new callbacks, so the engine behavior is no-op-equivalent for them.

## Test plan

- [x] New `PR 5b-pre — chunk + step callback contract` describe block in `mcpjam-stream-handler.test.ts` (5 tests):
  - `onToolCall` fires with chunk fields on `tool-input-available`
  - `onToolResult` fires with `isError: true` on error-text output
  - `onStepFinish` fires once per completed step with cumulative `turnUsage`
  - Omitting callbacks doesn't break chat / synthetic compatibility
  - Callback throws are caught — engine continues, doesn't propagate
- [x] Broader sweep: 705/705 across server tests
- [x] Typecheck baseline-clean (zero new errors in `mcpjam-stream-handler.ts` / `assistant-turn.ts`)
- [ ] Smoke (post-merge): chat session with an org-BYOK eval-style provider — confirm SSE / persistence shape unchanged (no callback supplied means no behavior change)

## Plan context

`~/mcpjam-docs/unification.md` PR 5b row. PR 5b was split into 5b-pre (this PR — engine extension + contract lock) + 5b (runner collapse) mirroring the 5-pre/5a pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core agentic loop and tool-approval paths, but changes are additive optional callbacks with defensive error handling; existing callers omit them so production chat behavior should be unchanged.
> 
> **Overview**
> **Engine consolidation PR 5b-pre** adds optional **`onToolCall`**, **`onToolResult`**, and **`onStepFinish`** hooks on `MCPJamHandlerOptions` (and pass-through on `RunAssistantTurnOptions`) so eval’s upcoming backend stream runner can mirror tool/step SSE from engine signals. Chat and synthetic callers that omit these stay behaviorally unchanged.
> 
> **`onToolCall`** runs when a `tool-input-available` chunk is processed; **`onToolResult`** after local tool results (including **`isError`** from `error-text` output) and now also on **user-denied** tools in **`handlePendingApprovals`** (inline path that previously skipped the callback). **`onStepFinish`** fires once per completed step with cumulative **`turnUsage`** and **`settledWithError`** so PR 5b can gate eval `step_finish` SSE on successful steps only (failed Convex HTTP steps set `settledWithError: true`).
> 
> Each callback is wrapped in **try/catch** with **`logger.warn`** so emitter bugs do not abort the agentic loop. A large **contract test** suite locks timing, shapes, omission compatibility, and callback-throw handling; the logger mock gains **`warn`** for faithful exercise of that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052d25e7bed7eeb5d65be4b795b8e84e8e0f792f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->