### PR TITLE
chat-engine: fire onToolCall on resumed approval + inherited paths (PR 5b-pre review follow-up)

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1899,6 +1899,128 @@ describe("mcpjam-stream-handler", () => {
       );
     });
 
+    it("fires `onToolCall` for approved tools on resumed approval turns (PR 5b-pre review fix — Cursor Medium)", async () => {
+      // Cursor PR 5b-pre review fix: `handlePendingApprovals` writes
+      // `tool-input-available` UI chunks for resumed APPROVED tools
+      // and `emitToolResults` fires `onToolResult` after local
+      // execution. Pre-fix `onToolCall` only fired from
+      // `processStream`'s chunk switch, so eval's PR 5b wiring would
+      // emit `tool_result` SSE without a matching `tool_call`. Fixed
+      // by firing `onToolCall` at the resumed-approval emit site.
+      const stepTwo = [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "ok approved" },
+        { type: "text-end", id: "text-1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      global.fetch = vi.fn().mockResolvedValue(createSseResponse(stepTwo));
+
+      // Resumed-approval shape with `approved: true` — the matching
+      // tool-call lives on the assistant message. handlePendingApprovals
+      // walks both, emits `tool-input-available`, executes the tool,
+      // then `emitToolResults` runs.
+      const resumedMessages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-approved-1",
+              toolName: "search",
+              input: { q: "approved" },
+            },
+            {
+              type: "tool-approval-request",
+              approvalId: "approval-1",
+              toolCallId: "call-approved-1",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-approval-response",
+              approvalId: "approval-1",
+              approved: true,
+            },
+          ],
+        },
+      ];
+
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+      vi.mocked(executeToolCallsFromMessages).mockImplementation(
+        async (messages: any[]) => {
+          const toolResultMessage = {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call-approved-1",
+                toolName: "search",
+                output: { type: "json", value: { hit: true } },
+                result: { hit: true },
+                serverId: "search-server",
+              },
+            ],
+          };
+          messages.push(toolResultMessage);
+          return [toolResultMessage] as any;
+        },
+      );
+
+      const onToolCall = vi.fn();
+      const onToolResult = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: resumedMessages as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {
+          search: { _serverId: "search-server" },
+        } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({ search: {} }),
+        } as any,
+        requireToolApproval: true,
+        onToolCall,
+        onToolResult,
+      });
+
+      await lastExecution;
+
+      // `onToolCall` MUST have fired for the approved tool before any
+      // `onToolResult` — eval's PR 5b wiring relies on the ordering.
+      const approvedCallIdx = onToolCall.mock.calls.findIndex(
+        (c) => c[0]?.toolCallId === "call-approved-1",
+      );
+      expect(approvedCallIdx).toBeGreaterThanOrEqual(0);
+      expect(onToolCall.mock.calls[approvedCallIdx]?.[0]).toMatchObject({
+        toolCallId: "call-approved-1",
+        toolName: "search",
+        input: { q: "approved" },
+        promptIndex: 0,
+        serverId: "search-server",
+      });
+    });
+
+    // NOTE: `emitInheritedToolCalls` also fires `onToolCall` after the
+    // PR 5b fix (the function's signature gained `tools` / `traceTurn`
+    // / `stepIndex` / `onToolCall` params, and the loop body now
+    // invokes the callback alongside the existing `writer.write({type:
+    // "tool-input-available", ...})`). That path is harder to trigger
+    // in isolation than the resumed-approval branch covered above —
+    // it requires the per-step path to reach the local tool-execution
+    // branch with prior unresolved tool-calls in scope, a
+    // multi-fixture setup that doesn't fit cleanly into the
+    // single-handler-call test shape used here. The code fix is
+    // covered by the same `tools` + `traceTurn` plumbing pattern as
+    // the approved-tools site above, which IS tested.
+
     it("fires `onToolResult` for denied tools on resumed approval turns (PR 5b-pre review fix — Cursor Medium)", async () => {
       // Cursor PR 5b-pre review fix: `handlePendingApprovals` writes a
       // `tool_result` trace event inline (not via `emitToolResults`)

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -1132,7 +1132,17 @@ function emitToolResults(
 function emitInheritedToolCalls(
   writer: StepContext["writer"],
   messageHistory: ModelMessage[],
-  beforeStepLength: number
+  beforeStepLength: number,
+  // PR 5b-pre review fix (Cursor Medium "Resumed approvals skip
+  // onToolCall"): symmetric counterpart of the denial-path
+  // `onToolResult` fix. This path writes `tool-input-available` UI
+  // chunks for inherited unresolved calls — eval's PR 5b wiring needs
+  // `onToolCall` to fire here too, otherwise it would see orphan
+  // `tool_result` events later without a matching `tool_call`.
+  tools?: ToolSet,
+  traceTurn?: LiveTraceTurnContext,
+  stepIndex?: number,
+  onToolCall?: (event: MCPJamToolCallEvent) => void
 ) {
   // Collect existing tool result IDs
   const existingResultIds = new Set<string>();
@@ -1164,6 +1174,31 @@ function emitInheritedToolCalls(
             toolName: part.toolName,
             input: part.input ?? {},
           });
+          // PR 5b-pre review fix (Cursor Medium): fire `onToolCall`
+          // for inherited unresolved calls so PR 5b's eval wiring
+          // sees a matching `tool_call` before any `tool_result`.
+          if (onToolCall && traceTurn && typeof stepIndex === "number") {
+            try {
+              onToolCall({
+                toolCallId: part.toolCallId,
+                toolName: part.toolName,
+                input: part.input,
+                stepIndex,
+                promptIndex: traceTurn.promptIndex,
+                serverId: tools
+                  ? readToolServerId(tools, part.toolName)
+                  : undefined,
+              });
+            } catch (error) {
+              logger.warn(
+                "[mcpjam-stream-handler] onToolCall callback failed (inherited)",
+                {
+                  error:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
+            }
+          }
         }
       }
     }
@@ -1185,9 +1220,13 @@ async function handlePendingApprovals(
   traceTurn?: LiveTraceTurnContext,
   stepIndex?: number,
   abortSignal?: AbortSignal,
-  // PR 5b-pre: propagate the chunk-level callback so denial /
-  // approved-tool-result emissions also fire it.
-  onToolResult?: (event: MCPJamToolResultEvent) => void
+  // PR 5b-pre: propagate the chunk-level callbacks so denial /
+  // resumed-approval / approved-tool-result emissions all fire them.
+  onToolResult?: (event: MCPJamToolResultEvent) => void,
+  // PR 5b-pre review fix (Cursor Medium): resumed-approval branch
+  // emits `tool-input-available` UI chunks — `onToolCall` must fire
+  // here too so PR 5b's wiring doesn't see orphan `tool_result`.
+  onToolCall?: (event: MCPJamToolCallEvent) => void
 ): Promise<boolean> {
   // Build approvalId → toolCallId map, toolCallId → toolName map,
   // and toolCallId → assistant message index map from assistant messages
@@ -1380,6 +1419,30 @@ async function handlePendingApprovals(
             toolName: part.toolName,
             input: part.input ?? {},
           });
+          // PR 5b-pre review fix (Cursor Medium "Resumed approvals
+          // skip onToolCall"): fire `onToolCall` for resumed approved
+          // tools so PR 5b's eval wiring sees a matching `tool_call`
+          // before the `tool_result` `emitToolResults` produces below.
+          if (onToolCall && traceTurn && typeof stepIndex === "number") {
+            try {
+              onToolCall({
+                toolCallId: part.toolCallId,
+                toolName: part.toolName,
+                input: part.input,
+                stepIndex,
+                promptIndex: traceTurn.promptIndex,
+                serverId: readToolServerId(tools, part.toolName),
+              });
+            } catch (error) {
+              logger.warn(
+                "[mcpjam-stream-handler] onToolCall callback failed (approval)",
+                {
+                  error:
+                    error instanceof Error ? error.message : String(error),
+                },
+              );
+            }
+          }
           break;
         }
       }
@@ -1835,7 +1898,15 @@ async function processOneStep(
     }
 
     // Emit inherited tool calls that need execution
-    emitInheritedToolCalls(writer, messageHistory, beforeStepLength);
+    emitInheritedToolCalls(
+      writer,
+      messageHistory,
+      beforeStepLength,
+      tools,
+      traceTurn,
+      stepIndex,
+      onToolCall,
+    );
 
     const toolsStartAbs = Date.now();
     try {
@@ -2323,7 +2394,8 @@ export async function runChatEngineLoop(
             traceTurn,
             effectiveSteps(),
             abortSignal,
-            onToolResult
+            onToolResult,
+            onToolCall
           );
           if (handled) {
             // Approvals were processed — if there are still unresolved tool


### PR DESCRIPTION
## Summary

Slim follow-up to PR 5b-pre (#2472). Folds in Cursor Medium "Resumed approvals skip onToolCall" — flagged after merge. The runner wire-up in PR 5b depends on `onToolCall` firing for every `tool-input-available` UI write, not just the `processStream` chunk-switch site that PR 5b-pre covered.

## Three sites in the engine write `tool-input-available` UI chunks

1. **`processStream` chunk switch** — covered by PR 5b-pre, fires `onToolCall`. ✅
2. **`emitInheritedToolCalls`** — re-emits chunks for inherited unresolved tool calls from prior assistant messages when the per-step path reaches the local tool-execution branch. Pre-fix didn't fire `onToolCall`. ⛔ → ✅
3. **`handlePendingApprovals`** — re-emits chunks for resumed APPROVED tools so the client sees them on the resumed turn. Pre-fix didn't fire `onToolCall`. ⛔ → ✅

Pre-fix sites #2 + #3 would later fire `onToolResult` (via `emitToolResults` callback chain landed in PR 5b-pre + the resumed-approval `onToolResult` fix in PR 5b-pre review round 1) WITHOUT a matching `onToolCall`. PR 5b's eval wiring would see orphan `tool_result` SSE events.

## Fix

Thread `onToolCall` into `handlePendingApprovals` and `emitInheritedToolCalls`. Invoke at each `tool-input-available` writer.write site with the same chunk-payload shape PR 5b-pre uses (`toolCallId`, `toolName`, `input`, `stepIndex`, `promptIndex`, `serverId` via `readToolServerId`). Wrapped in try/catch + `logger.warn` to match the rest of the callback pattern.

## Test plan

- [x] 33 → 34 in `mcpjam-stream-handler.test.ts`: new regression locks the resumed-approval `onToolCall` invocation shape. `emitInheritedToolCalls` covered by the same plumbing pattern; an isolated-branch test requires multi-step fixture setup that doesn't fit the single-handler-call shape used here — documented with a comment.
- [x] Broader sweep: 708/708 across server tests
- [x] Typecheck baseline-clean (zero new errors)
- [ ] Smoke (post-merge): chat session with a resumed approval cycle — confirm SSE/persistence shape unchanged (no callback supplied = no behavior change for chat/synthetic)

## Plan context

`~/mcpjam-docs/unification.md` Phase 2 PR 5b row. Slim review follow-up; the substantive PR 5b runner-rewrite will land separately in its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional callback wiring with existing try/catch pattern; no change when callbacks are omitted (chat/synthetic).
> 
> **Overview**
> Follow-up to PR 5b-pre: **`onToolCall`** now runs anywhere the engine writes **`tool-input-available`**, not only in **`processStream`**. That keeps eval PR 5b wiring from emitting **`tool_result`** SSE without a prior **`tool_call`**.
> 
> **`handlePendingApprovals`** invokes **`onToolCall`** when re-emitting UI chunks for **resumed approved** tools (before local execution and **`onToolResult`**). **`emitInheritedToolCalls`** does the same for **inherited unresolved** tool calls from earlier assistant messages. Both use the same payload as the stream path (`toolCallId`, `toolName`, `input`, `stepIndex`, `promptIndex`, `serverId` via **`readToolServerId`**), with try/catch + **`logger.warn`** on failure.
> 
> **`onToolCall`** is threaded from **`runChatEngineLoop`** into those helpers. A new regression test covers the resumed-approval approved-tools case; the inherited path shares the same plumbing (not isolated in this PR’s tests).
> 
> Callers that omit callbacks (chat/synthetic) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30ba5f82a87793a8dc6f48feb7df40b34f32614b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->