### PR TITLE
evals: rewire streamIterationViaBackend onto runAssistantTurn + engine callbacks (engine consolidation PR 5b)

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -3765,7 +3765,12 @@ const streamIterationViaBackend = async ({
   mcpClientManager,
   recorder,
   testCaseId,
-  convexHttpUrl,
+  // PR 5b: `convexHttpUrl` is in the `RunIterationBackendParams` type
+  // (shared with the non-stream runner + the iterative path) but
+  // unused here — `runAssistantTurn` owns the Convex `/stream` fetch
+  // and reads its base URL from `CONVEX_HTTP_URL` env / the configured
+  // chat-orchestration helpers. Kept on the params type so the caller
+  // shape stays uniform across runners.
   convexAuthToken,
   modelId,
   modelDefinition,
@@ -4258,13 +4263,17 @@ const streamIterationViaBackend = async ({
           usage: accumulatedUsage,
         }),
       );
-      // Reset partial-response accumulators for the next step so the
-      // next step_finish snapshot doesn't double-count this step's
-      // assistant/tool content (which will land in `messageHistory`
-      // via `turnResult.messages` after the turn settles).
-      partialAssistantText = "";
-      partialAssistantToolCalls.length = 0;
-      partialToolResultMessages.length = 0;
+      // NO per-step reset of partial-response accumulators. The
+      // earlier version of this PR cleared them here, which corrupted
+      // step N's snapshot by dropping step 1..N-1's assistant/tool
+      // content — `messageHistory` doesn't roll forward from
+      // `turnResult.messages` until AFTER `runAssistantTurn` returns,
+      // so during the turn the accumulators are the ONLY source of
+      // in-flight content for snapshot fidelity. The accumulators are
+      // per-turn `let`s scoped to this `for` body, so they reset
+      // naturally on the next prompt-turn iteration; no double-count
+      // risk because `messageHistory` is replaced with the engine's
+      // canonical post-turn transcript below before the next iteration.
     };
 
     // `runAssistantTurn` call shape mirrors `runIterationViaBackend`

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -51,11 +51,6 @@ import {
   type ModelDefinition,
   type ModelProvider,
 } from "@/shared/types";
-import { z } from "zod";
-import {
-  executeToolCallsFromMessages,
-  hasUnresolvedToolCalls,
-} from "@/shared/http-tool-calls";
 import {
   buildIterationTranscript,
   evaluatePredicates,
@@ -66,10 +61,6 @@ import {
   type SuiteRunRecorder,
 } from "./evals/recorder";
 import {
-  pushBackendStepLlmFailureSpans,
-  pushBackendStepSuccessSpans,
-  pushBackendStepToolFailureSpans,
-  wrapBackendToolsForTrace,
   createAiSdkEvalTraceContext,
   emitAiSdkOnStepFinish,
   finalizeAiSdkTraceOnFailure,
@@ -97,6 +88,11 @@ import {
   type PrepareChatV2Result,
 } from "../utils/chat-v2-orchestration.js";
 import { runAssistantTurn } from "../utils/assistant-turn.js";
+import type {
+  MCPJamStepFinishEvent,
+  MCPJamToolCallEvent,
+  MCPJamToolResultEvent,
+} from "../utils/mcpjam-stream-handler.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
 import {
   lockEvalSessionAfterUpdate,
@@ -107,36 +103,6 @@ import type {
   EvalStreamToolCall,
 } from "@/shared/eval-stream-events";
 
-/**
- * Turn a non-OK backend stream response into a human-readable message. The
- * Convex stream endpoint returns structured JSON for guardrails like the daily
- * spend cap — e.g. { code: "user_rate_limit", error: "Daily MCPJam model limit
- * reached. Use BYOK or try again tomorrow.", details: "Try again in N minutes." }.
- * Surface that instead of the bare HTTP status text ("Too Many Requests"), and
- * flag 429s as expected guardrails (not faults) so callers can log them quietly.
- */
-function describeBackendStreamError(
-  status: number,
-  bodyText: string,
-): { message: string; code?: string; expected: boolean } {
-  const expected = status === 429;
-  try {
-    const body = JSON.parse(bodyText) as {
-      code?: string;
-      error?: string;
-      details?: string;
-    };
-    if (body?.error) {
-      const message = body.details
-        ? `${body.error} ${body.details}`
-        : body.error;
-      return { message, code: body.code, expected };
-    }
-  } catch {
-    // body wasn't JSON — fall through to the generic shape
-  }
-  return { message: `Backend stream error: ${status} ${bodyText}`, expected };
-}
 
 export type EvalTestCase = {
   title: string;
@@ -545,58 +511,6 @@ function toStreamToolCalls(toolCalls: ToolCall[]): EvalStreamToolCall[] {
   }));
 }
 
-/**
- * Parse the backend's UI Message Stream (SSE format produced by
- * `toUIMessageStreamResponse()` in AI SDK v6) into chunk objects.
- *
- * Wire format: `data: <JSON>\n\n` per event, terminated by `data: [DONE]\n\n`.
- */
-async function* parseBackendUIMessageSSE(
-  body: ReadableStream<Uint8Array>,
-): AsyncGenerator<{ type: string; [key: string]: unknown }> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-
-      let boundary: number;
-      while ((boundary = buffer.indexOf("\n\n")) !== -1) {
-        const event = buffer.slice(0, boundary);
-        buffer = buffer.slice(boundary + 2);
-        for (const line of event.split("\n")) {
-          if (!line.startsWith("data: ")) continue;
-          const data = line.slice(6);
-          if (data === "[DONE]") return;
-          try {
-            yield JSON.parse(data);
-          } catch {
-            /* ignore malformed JSON */
-          }
-        }
-      }
-    }
-    // Flush remaining buffer
-    if (buffer.trim()) {
-      for (const line of buffer.split("\n")) {
-        if (!line.startsWith("data: ")) continue;
-        const data = line.slice(6);
-        if (data === "[DONE]") return;
-        try {
-          yield JSON.parse(data);
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-}
 
 function buildTraceSnapshotEvent(params: {
   turnIndex: number;
@@ -4077,46 +3991,39 @@ const streamIterationViaBackend = async ({
     };
   }
 
-  const toolDefs = Object.entries(prepared.allTools).map(([name, tool]) => {
-    const schema = (tool as any)?.inputSchema;
-    let serializedSchema: Record<string, unknown> | undefined;
-    if (schema) {
-      if (
-        typeof schema === "object" &&
-        schema !== null &&
-        "jsonSchema" in (schema as Record<string, unknown>)
-      ) {
-        serializedSchema = (schema as any).jsonSchema as Record<
-          string,
-          unknown
-        >;
-      } else if (typeof schema === "object" && "safeParse" in (schema as any)) {
-        try {
-          serializedSchema = z.toJSONSchema(schema) as Record<string, unknown>;
-        } catch {
-          serializedSchema = undefined;
-        }
-      } else {
-        serializedSchema = schema as Record<string, unknown>;
-      }
-    }
+  // PR 5b: drive the per-turn loop through `runAssistantTurn` (the same
+  // engine chat / playground / synthetic / non-stream eval already use).
+  // Engine owns the Convex `/stream` per-step loop, tool execution,
+  // trace persistence, abort plumbing, progressive discovery, and
+  // approval handling. Eval owns the per-turn `runAssistantTurn` call,
+  // SSE callback wiring (text deltas via `onLiveTextDelta`, tool
+  // call/result/step events via the PR 5b-pre callbacks), failure
+  // detection, persistence, and grading.
+  //
+  // `runAssistantTurn` reads `authContext.token` and forwards it as the
+  // Authorization header on the per-step Convex fetch — same shape used
+  // by `runIterationViaBackend` above (PR 3/4d).
+  const evalAuthContext = {
+    kind: "user_bearer" as const,
+    token: `Bearer ${convexAuthToken}`,
+  };
 
-    return {
-      name,
-      description: (tool as any)?.description,
-      inputSchema:
-        serializedSchema ??
-        ({
-          type: "object",
-          properties: {},
-          additionalProperties: false,
-        } as Record<string, unknown>),
-    };
+  // Cursor review fix (mirrors PR 4b for the non-stream backend
+  // runner): the engine swallows AbortError internally (sets its
+  // `aborted` flag, omits `turnTrace`, doesn't throw out of
+  // `runAssistantTurn`). Read `abortSignal.aborted` directly as the
+  // authoritative cancellation signal, used at the top of each
+  // iteration AND after every per-turn call (success or catch).
+  const isAborted = () => abortSignal?.aborted === true;
+  const returnCancelled = () => ({
+    evaluation: evaluateMultiTurnResults(
+      promptTurns,
+      toolsCalledByPrompt,
+      test.isNegativeTest,
+      test.matchOptions,
+    ),
+    iterationId: undefined,
   });
-
-  const authHeader = convexAuthToken
-    ? { Authorization: `Bearer ${convexAuthToken}` }
-    : ({} as Record<string, string>);
 
   let accumulatedUsage: UsageTotals = {
     inputTokens: 0,
@@ -4130,6 +4037,13 @@ const streamIterationViaBackend = async ({
   // PR 4d review fix (Codex P2 / Cursor Medium): see hoist above the
   // `prepareChatV2` try.
   for (let promptIndex = 0; promptIndex < promptTurns.length; promptIndex++) {
+    if (isAborted()) {
+      logger.debug(
+        "[evals] backend streaming iteration aborted between turns; skipping record",
+      );
+      return returnCancelled();
+    }
+
     const promptTurn = promptTurns[promptIndex]!;
     const promptToolsCalled: ToolCall[] = [];
     toolsCalledByPrompt.push(promptToolsCalled);
@@ -4144,526 +4058,388 @@ const streamIterationViaBackend = async ({
       prompt: promptTurn.prompt,
     });
 
-    let steps = 0;
-    while (steps < MAX_STEPS) {
-      const stepStartAbs = Date.now();
-      const stepIndex = steps;
-      const llmStartAbs = stepStartAbs;
-      const stepMessageStartIndex = messageHistory.length;
-      try {
-        const res = await fetch(`${convexHttpUrl}${endpointPath}`, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            ...(authHeader ? { ...authHeader } : {}),
-          },
-          body: JSON.stringify({
-            skipChatIngestion: true,
-            messages: JSON.stringify(messageHistory),
-            model: modelId,
-            ...(prepared.enhancedSystemPrompt
-              ? { systemPrompt: prepared.enhancedSystemPrompt }
-              : {}),
-            ...(prepared.resolvedTemperature == null
-              ? {}
-              : { temperature: prepared.resolvedTemperature }),
-            ...(toolChoice ? { toolChoice } : {}),
-            tools: toolDefs,
-            maxOutputTokens: 16384,
-            ...(extraBodyFields ?? {}),
-          }),
-          ...(abortSignal ? { signal: abortSignal } : {}),
-        });
+    // Per-turn span-capture context. `wrapToolSetForEvalTrace`
+    // instruments each tool's `execute` to push to
+    // `traceCtx.recordedSpans`; we drain into `capturedSpans` after the
+    // engine finishes (same shape as the non-stream backend runner).
+    const traceCtx = createAiSdkEvalTraceContext(runStartedAt);
+    const tracedTools = wrapToolSetForEvalTrace(
+      prepared.allTools,
+      traceCtx,
+      promptIndex,
+    );
 
-        if (!res.ok) {
-          const errorText = await res.text().catch(() => res.statusText);
-          const { message, expected } = describeBackendStreamError(
-            res.status,
-            errorText,
-          );
-          iterationError = message;
-          iterationErrorDetails = errorText;
-          if (expected) {
-            // Daily spend cap / concurrency guardrail — expected, and with N
-            // cases running concurrently it fires once per case. Log a single
-            // quiet line with the real reason, not an alarming per-case stack.
-            logger.warn(`[evals] run halted: ${message}`);
-          } else {
-            logger.error("[evals] backend stream error", new Error(message));
-          }
-          const failAbs = Date.now();
-          pushBackendStepLlmFailureSpans(
-            capturedSpans,
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            stepStartAbs,
-            llmStartAbs,
-            failAbs,
-          );
-          emit(
-            buildTraceSnapshotEvent({
-              turnIndex: promptIndex,
-              stepIndex,
-              snapshotKind: "failure",
-              messages: withSystemPrefix(messageHistory),
-              spans: capturedSpans,
-              actualToolCalls: extractToolCallsFromConversation({
-                messages: messageHistory,
-              }),
-              usage: accumulatedUsage,
-            }),
-          );
-          emit({
-            type: "error",
-            message: iterationError,
-            details: iterationErrorDetails,
-          });
-          break;
-        }
+    const messageCountBeforeTurn = messageHistory.length;
+    const inputMessages: ModelMessage[] = [...messageHistory];
+    const accumulatedUsageBeforeTurn = {
+      inputTokens: accumulatedUsage.inputTokens ?? 0,
+      outputTokens: accumulatedUsage.outputTokens ?? 0,
+      totalTokens: accumulatedUsage.totalTokens ?? 0,
+    };
+    // Track engine-emitted step events so the post-turn `turn_finish`
+    // trace_snapshot has a stable last-step index, and so failure
+    // branches can carry stepIndex when available.
+    let activeCompletedStepCount = 0;
+    let lastSettledStepIndex: number | undefined;
 
-        if (!res.body) {
-          iterationError = "No response body from backend stream";
-          const failAbs = Date.now();
-          pushBackendStepLlmFailureSpans(
-            capturedSpans,
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            stepStartAbs,
-            llmStartAbs,
-            failAbs,
-            { modelId },
-          );
-          emit(
-            buildTraceSnapshotEvent({
-              turnIndex: promptIndex,
-              stepIndex,
-              snapshotKind: "failure",
-              messages: withSystemPrefix(messageHistory),
-              spans: capturedSpans,
-              actualToolCalls: extractToolCallsFromConversation({
-                messages: messageHistory,
-              }),
-              usage: accumulatedUsage,
-            }),
-          );
-          emit({
-            type: "error",
-            message: iterationError,
-          });
-          break;
-        }
-
-        // Consume SSE stream from the backend (real-time text deltas)
-        let stepText = "";
-        const stepToolCalls: Array<{
-          toolCallId: string;
-          toolName: string;
-          input: unknown;
-        }> = [];
-        let stepFinishReason: string | undefined;
-        let stepUsage: {
-          inputTokens?: number;
-          outputTokens?: number;
-          totalTokens?: number;
-        } = {};
-
-        for await (const chunk of parseBackendUIMessageSSE(res.body)) {
-          switch (chunk.type) {
-            case "text-delta":
-              stepText += (chunk.delta as string) ?? "";
-              emit({
-                type: "text_delta",
-                content: (chunk.delta as string) ?? "",
-              });
-              break;
-            case "tool-input-available": {
-              const tcId =
-                (chunk.toolCallId as string) ??
-                `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-              const tcName = chunk.toolName as string;
-              const tcInput = (chunk.input ?? {}) as Record<string, unknown>;
-              stepToolCalls.push({
-                toolCallId: tcId,
-                toolName: tcName,
-                input: tcInput,
-              });
-              if (tcName) {
-                emit({
-                  type: "tool_call",
-                  toolName: tcName,
-                  toolCallId: tcId,
-                  args: tcInput,
-                });
-              }
-              break;
-            }
-            case "finish": {
-              stepFinishReason = chunk.finishReason as string | undefined;
-              const metadata = chunk.messageMetadata as
-                | Record<string, number>
-                | undefined;
-              if (metadata) {
-                stepUsage = {
-                  inputTokens: metadata.inputTokens,
-                  outputTokens: metadata.outputTokens,
-                  totalTokens: metadata.totalTokens,
-                };
-              }
-              break;
-            }
-            case "error":
-              iterationError =
-                (chunk.errorText as string) ?? "Backend stream error";
-              break;
-          }
-        }
-
-        if (iterationError) {
-          const failAbs = Date.now();
-          pushBackendStepLlmFailureSpans(
-            capturedSpans,
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            stepStartAbs,
-            llmStartAbs,
-            failAbs,
-            { modelId },
-          );
-          emit(
-            buildTraceSnapshotEvent({
-              turnIndex: promptIndex,
-              stepIndex,
-              snapshotKind: "failure",
-              messages: withSystemPrefix(messageHistory),
-              spans: capturedSpans,
-              actualToolCalls: extractToolCallsFromConversation({
-                messages: messageHistory,
-              }),
-              usage: accumulatedUsage,
-            }),
-          );
-          emit({
-            type: "error",
-            message: iterationError,
-            details: iterationErrorDetails,
-          });
-          break;
-        }
-
-        const llmEndAbs = Date.now();
-
-        // Update accumulated usage from stream metadata
-        accumulatedUsage.inputTokens =
-          (accumulatedUsage.inputTokens || 0) +
-          (stepUsage.inputTokens || 0);
-        accumulatedUsage.outputTokens =
-          (accumulatedUsage.outputTokens || 0) +
-          (stepUsage.outputTokens || 0);
-        accumulatedUsage.totalTokens =
-          (accumulatedUsage.totalTokens || 0) +
-          (stepUsage.totalTokens || 0);
-
-        // Reconstruct assistant message from stream chunks
-        const assistantContent: unknown[] = [];
-        if (stepText) {
-          assistantContent.push({ type: "text", text: stepText });
-        }
-        for (const tc of stepToolCalls) {
-          assistantContent.push({
-            type: "tool-call",
-            toolCallId: tc.toolCallId,
-            toolName: tc.toolName,
-            input: tc.input ?? {},
-          });
-          promptToolsCalled.push({
-            toolName: tc.toolName,
-            arguments: (tc.input ?? {}) as Record<string, any>,
-          });
-        }
-        if (assistantContent.length > 0) {
-          messageHistory.push({
-            role: "assistant",
-            content: assistantContent,
-          } as ModelMessage);
-        }
-
-        if (hasUnresolvedToolCalls(messageHistory as any)) {
-          const toolsStartAbs = Date.now();
-          const tracedBackendTools = wrapBackendToolsForTrace(prepared.allTools as any, {
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            spans: capturedSpans,
-          });
-          try {
-            const newToolMessages = await executeToolCallsFromMessages(
-              messageHistory as any,
-              {
-                tools: tracedBackendTools as any,
-              },
-            );
-            const toolsEndAbs = Date.now();
-
-            // Emit tool_result events for each tool result message
-            for (const toolMsg of newToolMessages) {
-              if (
-                (toolMsg as any)?.role === "tool" &&
-                Array.isArray((toolMsg as any).content)
-              ) {
-                for (const part of (toolMsg as any).content) {
-                  if (
-                    part?.type === "tool-result" &&
-                    typeof part.toolCallId === "string"
-                  ) {
-                    emit({
-                      type: "tool_result",
-                      toolCallId: part.toolCallId,
-                      result: part.result,
-                      isError: part.isError,
-                    });
-                  }
-                }
-              }
-            }
-
-            const toolMessageIndexByCallId = new Map<string, number>();
-            for (let index = 0; index < messageHistory.length; index++) {
-              const msg = messageHistory[index] as any;
-              if (msg?.role !== "tool" || !Array.isArray(msg.content)) {
-                continue;
-              }
-              for (const part of msg.content) {
-                if (
-                  part?.type === "tool-result" &&
-                  typeof part.toolCallId === "string"
-                ) {
-                  toolMessageIndexByCallId.set(part.toolCallId, index);
-                }
-              }
-            }
-            for (const span of capturedSpans) {
-              if (
-                span.stepIndex !== stepIndex ||
-                (span.promptIndex ?? 0) !== promptIndex ||
-                typeof span.toolCallId !== "string" ||
-                typeof span.messageStartIndex === "number"
-              ) {
-                continue;
-              }
-              const toolMessageIndex = toolMessageIndexByCallId.get(
-                span.toolCallId,
-              );
-              if (typeof toolMessageIndex === "number") {
-                span.messageStartIndex = toolMessageIndex;
-                span.messageEndIndex = toolMessageIndex;
-              }
-            }
-            const stepMessageEndIndex =
-              messageHistory.length > stepMessageStartIndex
-                ? messageHistory.length - 1
-                : undefined;
-            pushBackendStepSuccessSpans(
-              capturedSpans,
-              runStartedAt,
-              promptIndex,
-              stepIndex,
-              stepStartAbs,
-              { startAbs: llmStartAbs, endAbs: llmEndAbs },
-              {
-                startAbs: toolsStartAbs,
-                endAbs: toolsEndAbs,
-                pushAggregateSpan: newToolMessages.length === 0,
-              },
-              {
-                modelId,
-                inputTokens: stepUsage.inputTokens,
-                outputTokens: stepUsage.outputTokens,
-                totalTokens: stepUsage.totalTokens,
-                messageStartIndex:
-                  stepMessageEndIndex != null
-                    ? stepMessageStartIndex
-                    : undefined,
-                messageEndIndex: stepMessageEndIndex,
-                status: "ok",
-              },
-            );
-          } catch (toolErr) {
-            const failAbs = Date.now();
-            const stepMessageEndIndex =
-              messageHistory.length > stepMessageStartIndex
-                ? messageHistory.length - 1
-                : undefined;
-            pushBackendStepToolFailureSpans(
-              capturedSpans,
-              runStartedAt,
-              promptIndex,
-              stepIndex,
-              stepStartAbs,
-              { startAbs: llmStartAbs, endAbs: llmEndAbs },
-              toolsStartAbs,
-              failAbs,
-              {
-                modelId,
-                inputTokens: stepUsage.inputTokens,
-                outputTokens: stepUsage.outputTokens,
-                totalTokens: stepUsage.totalTokens,
-                messageStartIndex:
-                  stepMessageEndIndex != null
-                    ? stepMessageStartIndex
-                    : undefined,
-                messageEndIndex: stepMessageEndIndex,
-                pushAggregateSpan: false,
-              },
-            );
-            iterationError =
-              toolErr instanceof Error ? toolErr.message : String(toolErr);
-            logger.error("[evals] tool execution failed", toolErr);
-            emit(
-              buildTraceSnapshotEvent({
-                turnIndex: promptIndex,
-                stepIndex,
-                snapshotKind: "failure",
-                messages: withSystemPrefix(messageHistory),
-                spans: capturedSpans,
-                actualToolCalls: extractToolCallsFromConversation({
-                  messages: messageHistory,
-                }),
-                usage: accumulatedUsage,
-              }),
-            );
-            emit({
-              type: "error",
-              message: iterationError,
-              details: iterationErrorDetails,
-            });
-            break;
-          }
-        } else {
-          const stepMessageEndIndex =
-            messageHistory.length > stepMessageStartIndex
-              ? messageHistory.length - 1
-              : undefined;
-          pushBackendStepSuccessSpans(
-            capturedSpans,
-            runStartedAt,
-            promptIndex,
-            stepIndex,
-            stepStartAbs,
-            { startAbs: llmStartAbs, endAbs: llmEndAbs },
-            undefined,
-            {
-              modelId,
-              inputTokens: stepUsage.inputTokens,
-              outputTokens: stepUsage.outputTokens,
-              totalTokens: stepUsage.totalTokens,
-              messageStartIndex:
-                stepMessageEndIndex != null ? stepMessageStartIndex : undefined,
-              messageEndIndex: stepMessageEndIndex,
-              status: "ok",
-            },
-          );
-        }
-
-        steps += 1;
-
-        emit({
-          type: "step_finish",
-          stepNumber: steps,
-          usage: {
-            inputTokens: stepUsage.inputTokens ?? 0,
-            outputTokens: stepUsage.outputTokens ?? 0,
-          },
-        });
-        emit(
-          buildTraceSnapshotEvent({
-            turnIndex: promptIndex,
-            stepIndex,
-            snapshotKind: "step_finish",
-            messages: withSystemPrefix(messageHistory),
-            spans: capturedSpans,
-            actualToolCalls: extractToolCallsFromConversation({
-              messages: messageHistory,
-            }),
-            usage: accumulatedUsage,
-          }),
-        );
-
-        if (stepFinishReason && stepFinishReason !== "tool-calls") {
-          break;
-        }
-      } catch (error) {
-        if (error instanceof Error && error.name === "AbortError") {
-          logger.debug(
-            "[evals] backend streaming iteration aborted due to cancellation",
-          );
-          return {
-            evaluation: evaluateMultiTurnResults(
-              promptTurns,
-              toolsCalledByPrompt,
-              test.isNegativeTest,
-              test.matchOptions,
-            ),
-            iterationId: undefined,
-          };
-        }
-
-        if (error instanceof Error) {
-          iterationError = error.message || error.toString();
-
-          const responseBody = (error as any).responseBody;
-          if (responseBody && typeof responseBody === "string") {
-            iterationErrorDetails = responseBody;
-          }
-        } else if (typeof error === "string") {
-          iterationError = error;
-        } else {
-          iterationError = String(error);
-        }
-
-        if (iterationError && iterationError.length > 500) {
-          iterationError = iterationError.substring(0, 497) + "...";
-        }
-
-        logger.error("[evals] backend fetch failed", error);
-        const failAbs = Date.now();
-        pushBackendStepLlmFailureSpans(
-          capturedSpans,
-          runStartedAt,
-          promptIndex,
-          stepIndex,
-          stepStartAbs,
-          llmStartAbs,
-          failAbs,
-          {
-            modelId,
-          },
-        );
-        emit(
-          buildTraceSnapshotEvent({
-            turnIndex: promptIndex,
-            stepIndex,
-            snapshotKind: "failure",
-            messages: withSystemPrefix(messageHistory),
-            spans: capturedSpans,
-            actualToolCalls: extractToolCallsFromConversation({
-              messages: messageHistory,
-            }),
-            usage: accumulatedUsage,
-          }),
-        );
-        emit({
-          type: "error",
-          message: iterationError,
-          details: iterationErrorDetails,
-        });
-        break;
+    // Engine callbacks → SSE events. These mirror the events the old
+    // inline backend stream loop emitted from its chunk-processing
+    // switch:
+    //  - `onToolCall`     → `tool_call` SSE (was `tool-input-available`
+    //                       chunk branch).
+    //  - `onToolResult`   → `tool_result` SSE (was post-tool-execution
+    //                       loop over new tool messages).
+    //  - `onStepFinish`   → `step_finish` SSE + step_finish trace
+    //                       snapshot, gated on `settledWithError ===
+    //                       false` per Marcelo's PR 5b-pre review
+    //                       caveat. Failed backend steps surface via
+    //                       the failure detection branches below; we
+    //                       don't emit `step_finish` for them.
+    // `onLiveTextDelta`  → `text_delta` SSE (was the `text-delta`
+    //                       chunk branch).
+    //
+    // `promptToolsCalled` mirrors the legacy local accumulator; the
+    // engine's `messageHistory` is the source of truth post-turn, so
+    // we also rebuild from there for the eval grader (see
+    // `extractToolCallsFromConversation` below). Pushing into
+    // `promptToolsCalled` here keeps the SSE consumer's running view
+    // aligned with the trace snapshot's `actualToolCalls`.
+    const onLiveTextDelta = (delta: string) => {
+      if (typeof delta === "string" && delta.length > 0) {
+        emit({ type: "text_delta", content: delta });
       }
+    };
+    const onToolCall = (event: MCPJamToolCallEvent) => {
+      if (!event.toolName) return;
+      const args = (event.input ?? {}) as Record<string, unknown>;
+      promptToolsCalled.push({
+        toolName: event.toolName,
+        arguments: args as Record<string, any>,
+      });
+      emit({
+        type: "tool_call",
+        toolName: event.toolName,
+        toolCallId: event.toolCallId,
+        args,
+      });
+    };
+    const onToolResult = (event: MCPJamToolResultEvent) => {
+      emit({
+        type: "tool_result",
+        toolCallId: event.toolCallId,
+        result: event.output,
+        isError: event.isError,
+      });
+    };
+    const onStepFinish = (event: MCPJamStepFinishEvent) => {
+      // Marcelo's PR 5b-pre review caveat: only emit `step_finish` for
+      // settled-OK steps; failed backend steps surface through the
+      // post-turn failure detection (no `turnTrace`, error span, etc).
+      if (event.settledWithError) return;
+      activeCompletedStepCount += 1;
+      lastSettledStepIndex = event.stepIndex;
+      // Per-step usage delta = current cumulative - pre-turn baseline +
+      // last step's running total. The engine reports turn-cumulative
+      // usage on each onStepFinish; recompute accumulated usage from
+      // the snapshot taken at turn start so mid-run trace_snapshot
+      // events show the right running total even when this is step N
+      // of a multi-step turn.
+      accumulatedUsage.inputTokens =
+        accumulatedUsageBeforeTurn.inputTokens +
+        (event.turnUsage?.inputTokens ?? 0);
+      accumulatedUsage.outputTokens =
+        accumulatedUsageBeforeTurn.outputTokens +
+        (event.turnUsage?.outputTokens ?? 0);
+      accumulatedUsage.totalTokens =
+        accumulatedUsageBeforeTurn.totalTokens +
+        (event.turnUsage?.totalTokens ?? 0);
+      emit({
+        type: "step_finish",
+        stepNumber: activeCompletedStepCount,
+        usage: {
+          inputTokens: event.turnUsage?.inputTokens ?? 0,
+          outputTokens: event.turnUsage?.outputTokens ?? 0,
+        },
+      });
+      // Live trace snapshot for the step. Spans accumulate on
+      // `traceCtx.recordedSpans` (tool spans) + the engine's own LLM
+      // step spans (delivered on `turnResult.turnTrace.spans` AFTER
+      // the turn finishes). Mid-turn we only have the tool spans; the
+      // engine's LLM-step spans land at `turn_finish`.
+      const snapshotMessages = [...messageHistory];
+      emit(
+        buildTraceSnapshotEvent({
+          turnIndex: promptIndex,
+          stepIndex: event.stepIndex,
+          snapshotKind: "step_finish",
+          messages: withSystemPrefix(snapshotMessages),
+          spans: [...capturedSpans, ...traceCtx.recordedSpans],
+          actualToolCalls: extractToolCallsFromConversation({
+            messages: snapshotMessages,
+          }),
+          usage: accumulatedUsage,
+        }),
+      );
+    };
+
+    // `runAssistantTurn` call shape mirrors `runIterationViaBackend`
+    // (the non-stream backend runner) with SSE callback wires added.
+    // The contract bullets carried since PR 5a:
+    //  - Wire shape: `systemPrompt:` arg (engine sends `system:` field
+    //    to Convex `/stream`).
+    //  - Persistence prefix: `backendEnhancedSystemPromptForPersist`
+    //    prepended at finishParams (see post-loop section).
+    //  - SSE prefix: `withSystemPrefix` applied at every
+    //    `buildTraceSnapshotEvent` call site.
+    //  - Eval correctness invariants: progressive discovery, skill
+    //    tools, anthropic name validation flow from `prepareChatV2`.
+    //  - Resolver wire-up: `resolveExecutionContext` + suite
+    //    hostConfig already in place (PR 4d).
+    //  - UI event contract preserved: text_delta / tool_call /
+    //    tool_result / step_finish / turn_finish / trace_snapshot all
+    //    still emit in the same order as the legacy inline loop.
+    const mergedExtraBodyFields: Record<string, unknown> = {
+      maxOutputTokens: 16384,
+      ...(extraBodyFields ?? {}),
+      ...(toolChoice ? { toolChoice } : {}),
+    };
+
+    let turnResult: Awaited<ReturnType<typeof runAssistantTurn>>;
+    try {
+      turnResult = await runAssistantTurn({
+        messages: inputMessages,
+        modelDefinition: { ...modelDefinition, id: modelId },
+        systemPrompt: prepared.enhancedSystemPrompt,
+        ...(prepared.resolvedTemperature != null
+          ? { temperature: prepared.resolvedTemperature }
+          : {}),
+        tools: tracedTools,
+        ...(selectedServers.length
+          ? { selectedServerIds: selectedServers }
+          : {}),
+        mcpClientManager,
+        authContext: evalAuthContext,
+        sourceType: "eval",
+        origin: "eval",
+        streamSink: "none",
+        persistMode: "caller",
+        approvalMode: "auto-deny",
+        endpointPath,
+        extraBodyFields: mergedExtraBodyFields,
+        ...(abortSignal ? { abortSignal } : {}),
+        maxSteps: MAX_STEPS,
+        progressivePlan: prepared.progressivePlan,
+        discoveryState: prepared.discoveryState,
+        onLiveTextDelta,
+        onToolCall,
+        onToolResult,
+        onStepFinish,
+      });
+    } catch (error) {
+      // Cancellation: bail without recording. AbortError can surface
+      // either as a thrown exception or as the engine's internal
+      // silent-cancellation path; check `isAborted()` to catch both.
+      if (
+        isAborted() ||
+        (error instanceof Error && error.name === "AbortError")
+      ) {
+        logger.debug(
+          "[evals] backend streaming iteration aborted due to cancellation",
+        );
+        return returnCancelled();
+      }
+
+      if (error instanceof Error) {
+        iterationError = error.message || error.toString();
+        const responseBody = (error as { responseBody?: unknown })
+          .responseBody;
+        if (responseBody && typeof responseBody === "string") {
+          iterationErrorDetails = responseBody;
+        }
+      } else if (typeof error === "string") {
+        iterationError = error;
+      } else {
+        iterationError = String(error);
+      }
+      if (iterationError && iterationError.length > 500) {
+        iterationError = iterationError.substring(0, 497) + "...";
+      }
+      logger.error("[evals] runAssistantTurn (stream) failed", error);
+      // Mirror the in-stream failure signal the legacy inline loop
+      // emitted: failure trace_snapshot + error event before `break`
+      // so live SSE consumers don't see a silent end.
+      emit(
+        buildTraceSnapshotEvent({
+          turnIndex: promptIndex,
+          ...(lastSettledStepIndex != null
+            ? { stepIndex: lastSettledStepIndex }
+            : {}),
+          snapshotKind: "failure",
+          messages: withSystemPrefix(messageHistory),
+          spans: capturedSpans,
+          actualToolCalls: extractToolCallsFromConversation({
+            messages: messageHistory,
+          }),
+          usage: accumulatedUsage,
+        }),
+      );
+      emit({
+        type: "error",
+        message: iterationError,
+        details: iterationErrorDetails,
+      });
+      break;
     }
 
-    if (iterationError) {
+    // Cancellation that fired DURING `runAssistantTurn` without
+    // surfacing as a throw (engine catches AbortError, sets internal
+    // `aborted` flag, omits `turnTrace`, returns normally).
+    if (isAborted()) {
+      logger.debug(
+        "[evals] backend streaming iteration aborted mid-turn; skipping record",
+      );
+      return returnCancelled();
+    }
+
+    // Drain per-turn outputs into iteration-level accumulators BEFORE
+    // failure checks. Same shape as `runIterationViaBackend` (PR 3/4d).
+    //
+    // Tool spans from `wrapToolSetForEvalTrace` land in
+    // `traceCtx.recordedSpans` with `stepIndex: -1` (no `prepareStep`
+    // bridge to the engine yet); the engine's own LLM-step spans land
+    // on `turnResult.turnTrace.spans` with correct per-step indices.
+    // Merge both for the persisted run.
+    capturedSpans.push(...traceCtx.recordedSpans);
+    if (turnResult.turnTrace?.spans?.length) {
+      capturedSpans.push(...turnResult.turnTrace.spans);
+    }
+    // Reconcile accumulated usage to the engine's canonical post-turn
+    // total. The per-step `onStepFinish` callback already updates
+    // `accumulatedUsage` for each completed step, but if the engine
+    // resolved with zero settled-OK steps (no-content failure path),
+    // the baseline is the only source of truth — fold in `turnTrace.usage`
+    // to match the non-stream runner's "totalUsage merged BEFORE
+    // failure branches" invariant from PR 4b.
+    if (turnResult.usage) {
+      accumulatedUsage.inputTokens =
+        accumulatedUsageBeforeTurn.inputTokens +
+        (turnResult.usage.inputTokens ?? 0);
+      accumulatedUsage.outputTokens =
+        accumulatedUsageBeforeTurn.outputTokens +
+        (turnResult.usage.outputTokens ?? 0);
+      accumulatedUsage.totalTokens =
+        accumulatedUsageBeforeTurn.totalTokens +
+        (turnResult.usage.totalTokens ?? 0);
+    }
+
+    // Per-turn tool calls — rebuild from the new messages only so
+    // prior turns' calls aren't double-counted. The engine returns
+    // the full transcript; slice from `messageCountBeforeTurn`.
+    const newMessages = turnResult.messages.slice(messageCountBeforeTurn);
+    // `promptToolsCalled` was already populated via the `onToolCall`
+    // callback during the run. Reconcile against the engine's
+    // transcript so the grader sees the canonical post-turn shape
+    // (handles cases where `onToolCall` arguments were `undefined`).
+    const canonicalPromptToolsCalled = extractToolCallsFromConversation({
+      messages: newMessages,
+    });
+    promptToolsCalled.length = 0;
+    promptToolsCalled.push(...canonicalPromptToolsCalled);
+
+    // Roll the engine's transcript forward as the next turn's input.
+    messageHistory.length = 0;
+    messageHistory.push(...turnResult.messages);
+
+    // Failure detection — same three-signal shape as the non-stream
+    // backend runner (PR 3/4d):
+    //   (a) Engine catch fired mid-turn (`!turnTrace`) — engine
+    //       runSucceeded=false, partial messages may exist.
+    //   (b) Engine succeeded but produced no new content
+    //       (`newMessages.length === 0`).
+    //   (c) Engine succeeded and produced content, but a later step
+    //       errored (non-tool error span on `turnTrace.spans`).
+    if (!turnResult.turnTrace) {
+      iterationError =
+        "Backend stream failed during iteration (engine caught an error mid-turn)";
+      logger.error(
+        `[evals] runAssistantTurn (stream) returned no turnTrace (engine runSucceeded=false); treating as cycle failure (messagesGrew=${newMessages.length > 0})`,
+      );
+      emit(
+        buildTraceSnapshotEvent({
+          turnIndex: promptIndex,
+          ...(lastSettledStepIndex != null
+            ? { stepIndex: lastSettledStepIndex }
+            : {}),
+          snapshotKind: "failure",
+          messages: withSystemPrefix(messageHistory),
+          spans: capturedSpans,
+          actualToolCalls: extractToolCallsFromConversation({
+            messages: messageHistory,
+          }),
+          usage: accumulatedUsage,
+        }),
+      );
+      emit({ type: "error", message: iterationError });
+      break;
+    }
+    if (newMessages.length === 0) {
+      iterationError =
+        "Backend step returned no content (stream error or empty response)";
+      logger.error(
+        "[evals] runAssistantTurn (stream) produced no new messages this turn; treating as cycle failure",
+      );
+      emit(
+        buildTraceSnapshotEvent({
+          turnIndex: promptIndex,
+          ...(lastSettledStepIndex != null
+            ? { stepIndex: lastSettledStepIndex }
+            : {}),
+          snapshotKind: "failure",
+          messages: withSystemPrefix(messageHistory),
+          spans: capturedSpans,
+          actualToolCalls: extractToolCallsFromConversation({
+            messages: messageHistory,
+          }),
+          usage: accumulatedUsage,
+        }),
+      );
+      emit({ type: "error", message: iterationError });
+      break;
+    }
+    // Cursor / Codex PR 5a review fix applied here too: filter to
+    // backend step / LLM failure spans only (exclude `category: "tool"`
+    // AND any span carrying a `toolCallId` — the child error span that
+    // `wrapToolSetForEvalTrace` emits alongside a failed tool span).
+    // Tool-category error spans flow through the `failOnToolError`
+    // gate below; treating them as cycle failures here would defeat
+    // that policy.
+    const stepErrorSpan = turnResult.turnTrace.spans.find(
+      (span) =>
+        span.status === "error" &&
+        span.category !== "tool" &&
+        !(span as { toolCallId?: string }).toolCallId,
+    );
+    if (stepErrorSpan) {
+      iterationError = `Backend step failed mid-turn: ${stepErrorSpan.name}`;
+      logger.error(
+        `[evals] runAssistantTurn (stream) turnTrace has non-tool error-status span; treating as cycle failure (span=${stepErrorSpan.name} category=${stepErrorSpan.category})`,
+      );
+      emit(
+        buildTraceSnapshotEvent({
+          turnIndex: promptIndex,
+          ...(lastSettledStepIndex != null
+            ? { stepIndex: lastSettledStepIndex }
+            : {}),
+          snapshotKind: "failure",
+          messages: withSystemPrefix(messageHistory),
+          spans: capturedSpans,
+          actualToolCalls: extractToolCallsFromConversation({
+            messages: messageHistory,
+          }),
+          usage: accumulatedUsage,
+        }),
+      );
+      emit({ type: "error", message: iterationError });
       break;
     }
 
@@ -4681,6 +4457,7 @@ const streamIterationViaBackend = async ({
     );
     emit({ type: "turn_finish", turnIndex: promptIndex });
   }
+
 
   const evaluation = evaluateMultiTurnResults(
     promptTurns,

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -4081,22 +4081,64 @@ const streamIterationViaBackend = async ({
     // branches can carry stepIndex when available.
     let activeCompletedStepCount = 0;
     let lastSettledStepIndex: number | undefined;
+    // Engine reports turn-cumulative usage on each `onStepFinish`. The
+    // legacy inline loop emitted PER-STEP token counts on
+    // `step_finish` SSE, so we track the previous step's cumulative
+    // and emit the delta. (Cursor PR 5b review fix: "Step finish
+    // reports cumulative usage" — multi-step hosted eval turns
+    // otherwise show inflated per-step counts vs the local-BYOK
+    // stream path / consumeFullStreamAsEvalEvents.)
+    let prevStepCumulativeInput = 0;
+    let prevStepCumulativeOutput = 0;
+
+    // In-flight partial-response accumulator. Mid-turn `step_finish`
+    // trace_snapshot needs to carry the assistant/tool content that
+    // already streamed within the turn — the engine doesn't roll its
+    // own `messageHistory` ref forward into `runAssistantTurn`'s
+    // return value until the turn settles, so `messageHistory` here
+    // is stale (only contains prior turns' history + this turn's user
+    // prompt). Mirror PR 5a's `activePartialResponseMessages` shape:
+    // synthesize one rolling assistant message from text deltas + tool
+    // calls, and append synthetic tool-result messages from tool
+    // results. (Cursor PR 5b review fix: "Step snapshots omit in-turn
+    // messages" — without this, live UI consumers watching SSE see
+    // empty assistant transcripts mid-turn even though tool_call /
+    // text_delta SSE already fired.)
+    let partialAssistantText = "";
+    const partialAssistantToolCalls: Array<{
+      type: "tool-call";
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+    }> = [];
+    const partialToolResultMessages: ModelMessage[] = [];
+    const buildPartialResponseMessages = (): ModelMessage[] => {
+      const content: unknown[] = [];
+      if (partialAssistantText) {
+        content.push({ type: "text", text: partialAssistantText });
+      }
+      content.push(...partialAssistantToolCalls);
+      const out: ModelMessage[] = [];
+      if (content.length > 0) {
+        out.push({ role: "assistant", content } as ModelMessage);
+      }
+      out.push(...partialToolResultMessages);
+      return out;
+    };
 
     // Engine callbacks → SSE events. These mirror the events the old
     // inline backend stream loop emitted from its chunk-processing
     // switch:
-    //  - `onToolCall`     → `tool_call` SSE (was `tool-input-available`
-    //                       chunk branch).
-    //  - `onToolResult`   → `tool_result` SSE (was post-tool-execution
-    //                       loop over new tool messages).
-    //  - `onStepFinish`   → `step_finish` SSE + step_finish trace
-    //                       snapshot, gated on `settledWithError ===
-    //                       false` per Marcelo's PR 5b-pre review
-    //                       caveat. Failed backend steps surface via
-    //                       the failure detection branches below; we
-    //                       don't emit `step_finish` for them.
-    // `onLiveTextDelta`  → `text_delta` SSE (was the `text-delta`
-    //                       chunk branch).
+    //  - `onLiveTextDelta` → `text_delta` SSE + rolling assistant text
+    //  - `onToolCall`      → `tool_call` SSE + push to partial assistant
+    //  - `onToolResult`    → `tool_result` SSE + append synthetic tool msg
+    //  - `onStepFinish`    → `step_finish` SSE (with per-step usage
+    //                        DELTA, not cumulative) + step_finish trace
+    //                        snapshot. Gated on `settledWithError ===
+    //                        false` per Marcelo's PR 5b-pre review
+    //                        caveat. After firing, the partial-response
+    //                        accumulators reset so the next step starts
+    //                        fresh.
     //
     // `promptToolsCalled` mirrors the legacy local accumulator; the
     // engine's `messageHistory` is the source of truth post-turn, so
@@ -4105,9 +4147,9 @@ const streamIterationViaBackend = async ({
     // `promptToolsCalled` here keeps the SSE consumer's running view
     // aligned with the trace snapshot's `actualToolCalls`.
     const onLiveTextDelta = (delta: string) => {
-      if (typeof delta === "string" && delta.length > 0) {
-        emit({ type: "text_delta", content: delta });
-      }
+      if (typeof delta !== "string" || delta.length === 0) return;
+      partialAssistantText += delta;
+      emit({ type: "text_delta", content: delta });
     };
     const onToolCall = (event: MCPJamToolCallEvent) => {
       if (!event.toolName) return;
@@ -4115,6 +4157,12 @@ const streamIterationViaBackend = async ({
       promptToolsCalled.push({
         toolName: event.toolName,
         arguments: args as Record<string, any>,
+      });
+      partialAssistantToolCalls.push({
+        type: "tool-call",
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        input: args,
       });
       emit({
         type: "tool_call",
@@ -4124,6 +4172,18 @@ const streamIterationViaBackend = async ({
       });
     };
     const onToolResult = (event: MCPJamToolResultEvent) => {
+      partialToolResultMessages.push({
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: event.toolCallId,
+            ...(event.toolName ? { toolName: event.toolName } : {}),
+            output: event.output,
+            ...(event.isError ? { isError: true } : {}),
+          },
+        ],
+      } as ModelMessage);
       emit({
         type: "tool_result",
         toolCallId: event.toolCallId,
@@ -4138,35 +4198,53 @@ const streamIterationViaBackend = async ({
       if (event.settledWithError) return;
       activeCompletedStepCount += 1;
       lastSettledStepIndex = event.stepIndex;
-      // Per-step usage delta = current cumulative - pre-turn baseline +
-      // last step's running total. The engine reports turn-cumulative
-      // usage on each onStepFinish; recompute accumulated usage from
-      // the snapshot taken at turn start so mid-run trace_snapshot
-      // events show the right running total even when this is step N
-      // of a multi-step turn.
+      // Per-step delta = cumulative-now − cumulative-at-prev-step.
+      // Engine reports turn-cumulative on `event.turnUsage`; emit just
+      // this step's contribution on the SSE `step_finish.usage` field
+      // so the wire shape matches the legacy inline loop (which
+      // forwarded each step's own `messageMetadata` totals).
+      const cumulativeInput = event.turnUsage?.inputTokens ?? 0;
+      const cumulativeOutput = event.turnUsage?.outputTokens ?? 0;
+      const cumulativeTotal = event.turnUsage?.totalTokens ?? 0;
+      const stepDeltaInput = Math.max(
+        0,
+        cumulativeInput - prevStepCumulativeInput,
+      );
+      const stepDeltaOutput = Math.max(
+        0,
+        cumulativeOutput - prevStepCumulativeOutput,
+      );
+      prevStepCumulativeInput = cumulativeInput;
+      prevStepCumulativeOutput = cumulativeOutput;
+      // Roll `accumulatedUsage` forward to the engine's reported
+      // turn-cumulative + the pre-turn baseline (multi-turn runs).
       accumulatedUsage.inputTokens =
-        accumulatedUsageBeforeTurn.inputTokens +
-        (event.turnUsage?.inputTokens ?? 0);
+        accumulatedUsageBeforeTurn.inputTokens + cumulativeInput;
       accumulatedUsage.outputTokens =
-        accumulatedUsageBeforeTurn.outputTokens +
-        (event.turnUsage?.outputTokens ?? 0);
+        accumulatedUsageBeforeTurn.outputTokens + cumulativeOutput;
       accumulatedUsage.totalTokens =
-        accumulatedUsageBeforeTurn.totalTokens +
-        (event.turnUsage?.totalTokens ?? 0);
+        accumulatedUsageBeforeTurn.totalTokens + cumulativeTotal;
       emit({
         type: "step_finish",
         stepNumber: activeCompletedStepCount,
         usage: {
-          inputTokens: event.turnUsage?.inputTokens ?? 0,
-          outputTokens: event.turnUsage?.outputTokens ?? 0,
+          inputTokens: stepDeltaInput,
+          outputTokens: stepDeltaOutput,
         },
       });
-      // Live trace snapshot for the step. Spans accumulate on
+      // Live trace snapshot for the step. Compose snapshot messages
+      // from the stale `messageHistory` (prior turns + this turn's
+      // user prompt) PLUS the in-flight partial response built from
+      // the chunk-event accumulators — without this, mid-turn step
+      // snapshots show only the user prompt even though `tool_call` /
+      // `text_delta` SSE already fired. Spans accumulate on
       // `traceCtx.recordedSpans` (tool spans) + the engine's own LLM
       // step spans (delivered on `turnResult.turnTrace.spans` AFTER
-      // the turn finishes). Mid-turn we only have the tool spans; the
-      // engine's LLM-step spans land at `turn_finish`.
-      const snapshotMessages = [...messageHistory];
+      // the turn finishes).
+      const snapshotMessages = [
+        ...messageHistory,
+        ...buildPartialResponseMessages(),
+      ];
       emit(
         buildTraceSnapshotEvent({
           turnIndex: promptIndex,
@@ -4180,6 +4258,13 @@ const streamIterationViaBackend = async ({
           usage: accumulatedUsage,
         }),
       );
+      // Reset partial-response accumulators for the next step so the
+      // next step_finish snapshot doesn't double-count this step's
+      // assistant/tool content (which will land in `messageHistory`
+      // via `turnResult.messages` after the turn settles).
+      partialAssistantText = "";
+      partialAssistantToolCalls.length = 0;
+      partialToolResultMessages.length = 0;
     };
 
     // `runAssistantTurn` call shape mirrors `runIterationViaBackend`

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -3315,4 +3315,286 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       );
     });
   });
+
+  describe("PR 5b — streamIterationViaBackend on runAssistantTurn + engine callbacks", () => {
+    // PR 5b replaces the inline `while (steps < MAX_STEPS)` Convex
+    // /stream loop in `streamIterationViaBackend` with a single
+    // `runAssistantTurn` call per turn, wired to the engine callbacks
+    // added in PR 5b-pre (onToolCall / onToolResult / onStepFinish)
+    // plus the existing `onLiveTextDelta` for text deltas. The legacy
+    // event vocabulary (text_delta / tool_call / tool_result /
+    // step_finish / trace_snapshot / turn_finish) is preserved so
+    // streamTestCase SSE consumers see the same byte shape.
+
+    it("emits the canonical SSE event vocabulary from engine callbacks (PR 5b)", async () => {
+      // Lock the byte-shape contract for the backend variant: the
+      // runner threads `onLiveTextDelta`, `onToolCall`, `onToolResult`,
+      // and `onStepFinish` into `runAssistantTurn`. The engine fires
+      // them in-order during the turn; the runner emits the matching
+      // SSE events. After the turn finishes, the runner emits
+      // turn_finish + trace_snapshot.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockImplementationOnce(async (opts: any) => {
+          // Fire the engine callbacks in the order the real engine
+          // would, then return the assembled turnResult.
+          opts.onLiveTextDelta?.("Working");
+          opts.onToolCall?.({
+            toolCallId: "call-1",
+            toolName: "search",
+            input: { q: "status" },
+            stepIndex: 0,
+            promptIndex: 0,
+            serverId: undefined,
+          });
+          opts.onToolResult?.({
+            toolCallId: "call-1",
+            toolName: "search",
+            output: { ok: true },
+            isError: false,
+            stepIndex: 0,
+            promptIndex: 0,
+            serverId: undefined,
+          });
+          opts.onStepFinish?.({
+            stepIndex: 0,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+            settledWithError: false,
+          });
+          return {
+            messages: [
+              { role: "user", content: "Hello" } as any,
+              { role: "assistant", content: "Done" } as any,
+            ],
+            assistantMessages: [],
+            toolCalls: [],
+            toolResults: [],
+            turnTrace: {
+              turnId: "t_1",
+              promptIndex: 0,
+              startedAt: 0,
+              endedAt: 10,
+              modelId: "anthropic/claude-haiku-4.5",
+              spans: [],
+            },
+            usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+          } as any;
+        });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b SSE vocabulary",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-pr5b-vocab",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-pr5b-vocab",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event) => emitted.push(event as Record<string, unknown>),
+        } as any);
+
+        expect(emitted).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ type: "turn_start" }),
+            expect.objectContaining({
+              type: "text_delta",
+              content: "Working",
+            }),
+            expect.objectContaining({
+              type: "tool_call",
+              toolName: "search",
+              toolCallId: "call-1",
+            }),
+            expect.objectContaining({
+              type: "tool_result",
+              toolCallId: "call-1",
+              isError: false,
+            }),
+            expect.objectContaining({ type: "step_finish" }),
+            expect.objectContaining({ type: "trace_snapshot" }),
+            expect.objectContaining({ type: "turn_finish" }),
+          ]),
+        );
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
+    it("does NOT emit step_finish SSE when onStepFinish fires with settledWithError=true (PR 5b — Marcelo caveat)", async () => {
+      // Marcelo's PR 5b-pre review caveat: `MCPJamStepFinishEvent`
+      // settles with `settledWithError` carrying the engine's
+      // step-level OK/error state. The runner must NOT translate a
+      // failed-step settle into a `step_finish` SSE event — failed
+      // backend steps already surface via the failure detection paths
+      // (no `turnTrace`, error span on turnTrace, etc). Emitting
+      // step_finish for failed steps would surface a "step succeeded"
+      // SSE event to live UI consumers when the step actually failed.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockImplementationOnce(async (opts: any) => {
+          // Engine settled with error — runner must NOT emit
+          // step_finish SSE for this step.
+          opts.onStepFinish?.({
+            stepIndex: 0,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 },
+            settledWithError: true,
+          });
+          return {
+            messages: [
+              { role: "user", content: "Hello" } as any,
+              { role: "assistant", content: "" } as any,
+            ],
+            assistantMessages: [],
+            toolCalls: [],
+            toolResults: [],
+            turnTrace: {
+              turnId: "t_1",
+              promptIndex: 0,
+              startedAt: 0,
+              endedAt: 10,
+              modelId: "anthropic/claude-haiku-4.5",
+              spans: [],
+            },
+            usage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 },
+          } as any;
+        });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b settledWithError gate",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-pr5b-settle-gate",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-pr5b-settle-gate",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event) => emitted.push(event as Record<string, unknown>),
+        } as any);
+
+        const stepFinishEvents = emitted.filter(
+          (e) => e.type === "step_finish",
+        );
+        expect(stepFinishEvents).toHaveLength(0);
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
+    it("passes `streamSink: 'none'` and `persistMode: 'caller'` to runAssistantTurn (PR 5b contract)", async () => {
+      // PR 5b contract bullet: the backend stream runner drives the
+      // engine in headless mode and owns its own caller-side
+      // persistence (recorder + verdict + locking semantics). This
+      // locks the call shape so a future refactor doesn't
+      // accidentally flip it to `streamSink: "ui"` or
+      // `persistMode: "handler"`, which would double-persist or
+      // wedge the SSE writer.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockResolvedValueOnce({
+          messages: [
+            { role: "user", content: "Hello" } as any,
+            { role: "assistant", content: "Done" } as any,
+          ],
+          assistantMessages: [],
+          toolCalls: [],
+          toolResults: [],
+          turnTrace: {
+            turnId: "t_1",
+            promptIndex: 0,
+            startedAt: 0,
+            endedAt: 10,
+            modelId: "anthropic/claude-haiku-4.5",
+            spans: [],
+          },
+        } as any);
+
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b call shape",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-pr5b-callshape",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-pr5b-callshape",
+          suiteId: "suite-1",
+          runId: null,
+          emit: () => {},
+        } as any);
+
+        expect(runAssistantTurnSpy).toHaveBeenCalledTimes(1);
+        const call = runAssistantTurnSpy.mock.calls[0]![0]!;
+        expect(call.streamSink).toBe("none");
+        expect(call.persistMode).toBe("caller");
+        expect(call.sourceType).toBe("eval");
+        expect(call.approvalMode).toBe("auto-deny");
+        // The four engine-callback wires that PR 5b adds.
+        expect(typeof call.onLiveTextDelta).toBe("function");
+        expect(typeof call.onToolCall).toBe("function");
+        expect(typeof call.onToolResult).toBe("function");
+        expect(typeof call.onStepFinish).toBe("function");
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -3411,12 +3411,37 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
           testCaseId: "case-pr5b-vocab",
           suiteId: "suite-1",
           runId: null,
-          emit: (event) => emitted.push(event as Record<string, unknown>),
+          emit: (event: unknown) => emitted.push(event as Record<string, unknown>),
         } as any);
 
+        // CodeRabbit PR 5b review (nit): use ordered-index assertions,
+        // not arrayContaining — the latter accepts out-of-order
+        // regressions, but this test is supposed to lock the SSE event
+        // SEQUENCE the legacy inline loop emitted.
+        const types = emitted.map((e) => e.type as string);
+        const firstIndex = (t: string) => types.indexOf(t);
+        expect(firstIndex("turn_start")).toBeGreaterThanOrEqual(0);
+        expect(firstIndex("text_delta")).toBeGreaterThan(
+          firstIndex("turn_start"),
+        );
+        expect(firstIndex("tool_call")).toBeGreaterThan(
+          firstIndex("text_delta"),
+        );
+        expect(firstIndex("tool_result")).toBeGreaterThan(
+          firstIndex("tool_call"),
+        );
+        expect(firstIndex("step_finish")).toBeGreaterThan(
+          firstIndex("tool_result"),
+        );
+        expect(firstIndex("trace_snapshot")).toBeGreaterThan(
+          firstIndex("step_finish"),
+        );
+        expect(firstIndex("turn_finish")).toBeGreaterThan(
+          firstIndex("trace_snapshot"),
+        );
+        // Spot-check the data shapes carried on the events.
         expect(emitted).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ type: "turn_start" }),
             expect.objectContaining({
               type: "text_delta",
               content: "Working",
@@ -3431,9 +3456,251 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
               toolCallId: "call-1",
               isError: false,
             }),
-            expect.objectContaining({ type: "step_finish" }),
-            expect.objectContaining({ type: "trace_snapshot" }),
-            expect.objectContaining({ type: "turn_finish" }),
+          ]),
+        );
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
+    it("emits per-step usage delta on step_finish SSE, not cumulative (PR 5b review — Cursor Medium #1)", async () => {
+      // Cursor PR 5b review fix: the engine reports turn-cumulative
+      // usage on each `onStepFinish` (`event.turnUsage`), but the
+      // legacy inline loop emitted PER-STEP token counts on
+      // `step_finish` SSE. Mid-turn step_finish SSEs from a multi-step
+      // hosted eval turn would otherwise show inflated counts vs the
+      // local-BYOK stream path / `consumeFullStreamAsEvalEvents`.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockImplementationOnce(async (opts: any) => {
+          // Two settled-OK steps. Step 1: 10 in / 5 out cumulative.
+          // Step 2: 25 in / 13 out cumulative (i.e. step 2 contributed
+          // +15 in / +8 out). Emitted step_finish SSEs must show the
+          // PER-STEP deltas, not the cumulative.
+          opts.onStepFinish?.({
+            stepIndex: 0,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            settledWithError: false,
+          });
+          opts.onStepFinish?.({
+            stepIndex: 1,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 25, outputTokens: 13, totalTokens: 38 },
+            settledWithError: false,
+          });
+          return {
+            messages: [
+              { role: "user", content: "Hello" } as any,
+              { role: "assistant", content: "Done" } as any,
+            ],
+            assistantMessages: [],
+            toolCalls: [],
+            toolResults: [],
+            turnTrace: {
+              turnId: "t_1",
+              promptIndex: 0,
+              startedAt: 0,
+              endedAt: 10,
+              modelId: "anthropic/claude-haiku-4.5",
+              spans: [],
+            },
+            usage: { inputTokens: 25, outputTokens: 13, totalTokens: 38 },
+          } as any;
+        });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b step usage delta",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-pr5b-usage-delta",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-pr5b-usage-delta",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event: unknown) => emitted.push(event as Record<string, unknown>),
+        } as any);
+
+        const stepFinishEvents = emitted.filter(
+          (e) => e.type === "step_finish",
+        ) as Array<{
+          stepNumber: number;
+          usage: { inputTokens: number; outputTokens: number };
+        }>;
+        expect(stepFinishEvents).toHaveLength(2);
+        // Step 1 delta = cumulative-step-1 (no prior).
+        expect(stepFinishEvents[0]!.usage).toEqual({
+          inputTokens: 10,
+          outputTokens: 5,
+        });
+        // Step 2 delta = cumulative-step-2 − cumulative-step-1.
+        expect(stepFinishEvents[1]!.usage).toEqual({
+          inputTokens: 15,
+          outputTokens: 8,
+        });
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
+    it("includes in-flight assistant + tool content on mid-turn step_finish trace_snapshot (PR 5b review — Cursor Medium #2)", async () => {
+      // Cursor PR 5b review fix: mid-turn `step_finish` trace_snapshot
+      // would otherwise copy only `messageHistory`, which doesn't roll
+      // forward from `turnResult.messages` until AFTER `runAssistantTurn`
+      // returns. Live UI consumers watching SSE would see empty
+      // assistant transcripts mid-turn even though `tool_call` /
+      // `text_delta` SSE already fired. Mirror PR 5a's
+      // `activePartialResponseMessages` pattern: synthesize the
+      // partial response from chunk-event accumulators and stitch into
+      // mid-turn snapshots.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockImplementationOnce(async (opts: any) => {
+          // Stream text + tool call + tool result, then settle the
+          // step. The step_finish trace_snapshot must include the
+          // in-flight assistant text + tool-call + tool-result content.
+          opts.onLiveTextDelta?.("Looking up status");
+          opts.onToolCall?.({
+            toolCallId: "call-1",
+            toolName: "search",
+            input: { q: "status" },
+            stepIndex: 0,
+            promptIndex: 0,
+            serverId: undefined,
+          });
+          opts.onToolResult?.({
+            toolCallId: "call-1",
+            toolName: "search",
+            output: { ok: true, items: 3 },
+            isError: false,
+            stepIndex: 0,
+            promptIndex: 0,
+            serverId: undefined,
+          });
+          opts.onStepFinish?.({
+            stepIndex: 0,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+            settledWithError: false,
+          });
+          return {
+            messages: [
+              { role: "user", content: "Hello" } as any,
+              { role: "assistant", content: "Done" } as any,
+            ],
+            assistantMessages: [],
+            toolCalls: [],
+            toolResults: [],
+            turnTrace: {
+              turnId: "t_1",
+              promptIndex: 0,
+              startedAt: 0,
+              endedAt: 10,
+              modelId: "anthropic/claude-haiku-4.5",
+              spans: [],
+            },
+            usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+          } as any;
+        });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b mid-turn snapshot fidelity",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-pr5b-snap-fidelity",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-pr5b-snap-fidelity",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event: unknown) => emitted.push(event as Record<string, unknown>),
+        } as any);
+
+        // The mid-turn step_finish trace_snapshot must carry the
+        // in-flight assistant content (text + tool-call) AND the
+        // synthetic tool-result message.
+        const stepFinishSnapshots = emitted.filter(
+          (e) =>
+            e.type === "trace_snapshot" &&
+            (e as { snapshotKind?: string }).snapshotKind === "step_finish",
+        );
+        expect(stepFinishSnapshots.length).toBeGreaterThan(0);
+        const snap = stepFinishSnapshots[0] as {
+          trace: { messages: Array<{ role: string; content: unknown }> };
+        };
+        const messages = snap.trace.messages;
+        const assistantMsg = messages.find((m) => m.role === "assistant");
+        expect(assistantMsg).toBeDefined();
+        const assistantContent = assistantMsg!.content as Array<{
+          type: string;
+          text?: string;
+          toolCallId?: string;
+          toolName?: string;
+        }>;
+        expect(assistantContent).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "text",
+              text: "Looking up status",
+            }),
+            expect.objectContaining({
+              type: "tool-call",
+              toolCallId: "call-1",
+              toolName: "search",
+            }),
+          ]),
+        );
+        const toolMsg = messages.find((m) => m.role === "tool");
+        expect(toolMsg).toBeDefined();
+        const toolContent = toolMsg!.content as Array<{
+          type: string;
+          toolCallId?: string;
+        }>;
+        expect(toolContent).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "tool-result",
+              toolCallId: "call-1",
+            }),
           ]),
         );
       } finally {
@@ -3510,7 +3777,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
           testCaseId: "case-pr5b-settle-gate",
           suiteId: "suite-1",
           runId: null,
-          emit: (event) => emitted.push(event as Record<string, unknown>),
+          emit: (event: unknown) => emitted.push(event as Record<string, unknown>),
         } as any);
 
         const stepFinishEvents = emitted.filter(

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -3708,6 +3708,178 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       }
     });
 
+    it("accumulates partial response across multi-step turns; step 2 snapshot retains step 1 content (PR 5b review followup)", async () => {
+      // Original PR 5b fix for Cursor #2 reset the partial-response
+      // accumulators inside `onStepFinish`, which corrupted step N's
+      // snapshot by dropping step 1..N-1's assistant/tool content
+      // (`messageHistory` doesn't roll forward from `turnResult.messages`
+      // until AFTER `runAssistantTurn` returns, so during the turn the
+      // accumulators are the ONLY source of in-flight content).
+      // Lock the followup fix: a step-2 snapshot must carry BOTH
+      // step-1 AND step-2 partial assistant + tool content.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockImplementationOnce(async (opts: any) => {
+          // Step 1: model says "Step1 text", calls tool A, gets a result.
+          opts.onLiveTextDelta?.("Step1 text");
+          opts.onToolCall?.({
+            toolCallId: "call-a",
+            toolName: "search",
+            input: { q: "first" },
+            stepIndex: 0,
+            promptIndex: 0,
+            serverId: undefined,
+          });
+          opts.onToolResult?.({
+            toolCallId: "call-a",
+            toolName: "search",
+            output: { ok: true, step: 1 },
+            isError: false,
+            stepIndex: 0,
+            promptIndex: 0,
+            serverId: undefined,
+          });
+          opts.onStepFinish?.({
+            stepIndex: 0,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+            settledWithError: false,
+          });
+          // Step 2: model says "Step2 text", calls tool B, gets a result.
+          opts.onLiveTextDelta?.("Step2 text");
+          opts.onToolCall?.({
+            toolCallId: "call-b",
+            toolName: "lookup",
+            input: { q: "second" },
+            stepIndex: 1,
+            promptIndex: 0,
+            serverId: undefined,
+          });
+          opts.onToolResult?.({
+            toolCallId: "call-b",
+            toolName: "lookup",
+            output: { ok: true, step: 2 },
+            isError: false,
+            stepIndex: 1,
+            promptIndex: 0,
+            serverId: undefined,
+          });
+          opts.onStepFinish?.({
+            stepIndex: 1,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 12, outputTokens: 7, totalTokens: 19 },
+            settledWithError: false,
+          });
+          return {
+            messages: [
+              { role: "user", content: "Hello" } as any,
+              { role: "assistant", content: "Done" } as any,
+            ],
+            assistantMessages: [],
+            toolCalls: [],
+            toolResults: [],
+            turnTrace: {
+              turnId: "t_1",
+              promptIndex: 0,
+              startedAt: 0,
+              endedAt: 10,
+              modelId: "anthropic/claude-haiku-4.5",
+              spans: [],
+            },
+            usage: { inputTokens: 12, outputTokens: 7, totalTokens: 19 },
+          } as any;
+        });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b cumulative partials across steps",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-pr5b-multistep-snap",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-pr5b-multistep-snap",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event: unknown) =>
+            emitted.push(event as Record<string, unknown>),
+        } as any);
+
+        const stepFinishSnapshots = emitted.filter(
+          (e) =>
+            e.type === "trace_snapshot" &&
+            (e as { snapshotKind?: string }).snapshotKind === "step_finish",
+        ) as Array<{
+          stepIndex?: number;
+          trace: { messages: Array<{ role: string; content: unknown }> };
+        }>;
+        // Exactly one step_finish snapshot per settled-OK step.
+        expect(stepFinishSnapshots).toHaveLength(2);
+
+        // Step 2 snapshot must carry BOTH step 1 + step 2 partials.
+        const step2Snap = stepFinishSnapshots.find(
+          (s) => s.stepIndex === 1,
+        );
+        expect(step2Snap).toBeDefined();
+        const step2Messages = step2Snap!.trace.messages;
+
+        // Find the assistant message — should be a single rolling
+        // assistant with text + 2 tool-call parts (both steps' calls).
+        const assistantMsg = step2Messages.find((m) => m.role === "assistant");
+        expect(assistantMsg).toBeDefined();
+        const assistantContent = assistantMsg!.content as Array<{
+          type: string;
+          text?: string;
+          toolCallId?: string;
+          toolName?: string;
+        }>;
+        // Text from both steps must be present (concatenated rolling
+        // assistant text).
+        const textParts = assistantContent.filter((p) => p.type === "text");
+        expect(textParts.length).toBeGreaterThan(0);
+        const combinedText = textParts.map((p) => p.text ?? "").join("");
+        expect(combinedText).toContain("Step1 text");
+        expect(combinedText).toContain("Step2 text");
+        // Both tool calls must be present.
+        const toolCallParts = assistantContent.filter(
+          (p) => p.type === "tool-call",
+        );
+        expect(toolCallParts.map((p) => p.toolCallId).sort()).toEqual([
+          "call-a",
+          "call-b",
+        ]);
+
+        // Both tool-result messages must be present (one per call).
+        const toolMessages = step2Messages.filter((m) => m.role === "tool");
+        const allToolResultCallIds = toolMessages.flatMap((m) =>
+          (m.content as Array<{ type: string; toolCallId?: string }>)
+            .filter((p) => p.type === "tool-result")
+            .map((p) => p.toolCallId),
+        );
+        expect(allToolResultCallIds.sort()).toEqual(["call-a", "call-b"]);
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
     it("does NOT emit step_finish SSE when onStepFinish fires with settledWithError=true (PR 5b — Marcelo caveat)", async () => {
       // Marcelo's PR 5b-pre review caveat: `MCPJamStepFinishEvent`
       // settles with `settledWithError` carrying the engine's


### PR DESCRIPTION
## Summary

PR 5b of the eval engine consolidation. Replaces the inline `while (steps < MAX_STEPS)` Convex `/stream` loop in `streamIterationViaBackend` with a **single `runAssistantTurn` call per turn**, wired to the engine callbacks added in PR 5b-pre (#2472) and follow-up (#2473).

The backend stream runner now rides on the same engine chat / playground / synthetic / non-stream eval (PR 3/4d) already use.

**Net diff: −223 LOC.** Largest is the inline `while`-loop removal (~542 lines of chunk-switch / partial-tool-call reconstruction / per-step span pushes / failure trace re-emit), replaced by ~320 lines of `runAssistantTurn` driver + callback wiring + failure detection.

## Engine surface (already shipped — no new engine code in this PR)

- `onLiveTextDelta`  → `text_delta` SSE
- `onToolCall`       → `tool_call` SSE + `promptToolsCalled` push
- `onToolResult`     → `tool_result` SSE
- `onStepFinish`     → `step_finish` SSE + step_finish trace snapshot, gated on `settledWithError === false` per Marcelo's PR 5b-pre review caveat

## Contract bullets carried since PR 5a (all honored, locked by tests)

1. **Wire shape:** `systemPrompt:` arg (engine sends `system:` field, not a `role:system` msg).
2. **Persistence prefix:** `backendEnhancedSystemPromptForPersist` prepended at `finishParams`.
3. **SSE prefix:** `withSystemPrefix` applied at every `buildTraceSnapshotEvent` site (including all failure branches).
4. **Eval correctness invariants:** progressive discovery, skill tools, Anthropic name validation flow from `prepareChatV2`.
5. **Resolver wire-up:** `resolveExecutionContext` + suite hostConfig (PR 4d shape preserved).
6. **UI event contract preserved:** text_delta / tool_call / tool_result / step_finish / turn_finish / trace_snapshot all emit in the same order as the legacy inline loop.

## Failure detection

Mirrors the non-stream backend runner's three-signal shape:

- `!turnTrace` → engine catch fired mid-turn
- zero new messages → no-content cycle failure
- non-tool error span on `turnTrace.spans` → step error

Each branch emits a failure trace_snapshot + error SSE before breaking, so live SSE consumers never see a `turn_start` without a terminal event (PR 5a Cursor Medium fix applied here too).

## Token tracking + tool-error filter

- Per-turn anchor (`accumulatedUsageBeforeTurn`) + `onStepFinish` delta-update + post-turn reconcile against `turnResult.usage` — keeps "totalUsage merged BEFORE failure branches" invariant from PR 4b on the zero-completed-steps path.
- Tool-error-span filter excludes `category === "tool"` AND any span carrying `toolCallId` (PR 5a review fix applied symmetrically).

## Dead-code sweep

Removed legacy helpers used only by the inline loop:
- `describeBackendStreamError`, `parseBackendUIMessageSSE` (private to evals-runner)
- `authHeader`, `toolDefs` locals
- `zod` import + `executeToolCallsFromMessages` / `hasUnresolvedToolCalls` / `pushBackendStep*Spans` / `wrapBackendToolsForTrace` imports

The helpers themselves remain exported (used by `mcpjam-stream-handler.ts` on the chat path).

## Tests

- All 50 existing evals-runner tests still pass — contract-preserving rewrite.
- 3 new PR 5b-targeted tests:
  - canonical SSE event vocabulary flows from engine callbacks
  - `step_finish` SSE suppressed when `settledWithError: true` (Marcelo caveat)
  - `runAssistantTurn` call shape locked: `streamSink: "none"`, `persistMode: "caller"`, `sourceType: "eval"`, `approvalMode: "auto-deny"`, all four engine callbacks wired

## Test plan

- [x] All 53 evals-runner tests pass (50 existing + 3 new)
- [x] `npm run test -- --run server` — 1469 pass / 5 skipped (no regressions)
- [x] `tsc --noEmit` — no new type errors (pre-existing `finishParams.toolsCalled` mismatch present on main in all 4 iteration variants)
- [ ] Smoke: streamTestCase against a JAM-paid Anthropic model — confirm SSE events flow + iteration persists with correct verdict
- [ ] Smoke: streamTestCase against hosted-org BYOK + `endpointPath: "/stream/org"` — confirm same shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral swap in hosted eval streaming (SSE, traces, failures, abort) with broad test coverage but high integration risk if engine callbacks diverge from the old loop.
> 
> **Overview**
> **Backend streaming eval iterations** no longer implement their own Convex `/stream` fetch + SSE parse + tool-execution loop. Each prompt turn now goes through **`runAssistantTurn`** (same engine as chat and non-stream evals), with **`streamSink: 'none'`** and **`persistMode: 'caller'`**, and maps engine callbacks to the existing eval SSE vocabulary (`text_delta`, `tool_call`, `tool_result`, `step_finish`, trace snapshots, failures).
> 
> The rewrite **drops** the inline helpers and imports tied to that loop (`parseBackendUIMessageSSE`, `describeBackendStreamError`, direct `executeToolCallsFromMessages`, backend step span push helpers). **Failure handling, abort checks, usage reconciliation, and grading** are aligned with the non-stream backend runner, including **per-step usage deltas** on `step_finish`, **in-flight partial messages** on mid-turn snapshots, and **no `step_finish` when `settledWithError`**.
> 
> **Tests** add a PR 5b block that locks event ordering, usage deltas, snapshot fidelity across multi-step turns, and the `runAssistantTurn` call contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56c821f5fa84776998dcfe811bdedafd990f9008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->