### PR TITLE
chat-engine + evals: PR 5b-followup-2 — turnSpans on onStepFinish + onEngineError callback

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -4530,10 +4530,26 @@ const streamIterationViaBackend = async ({
       break;
     }
     if (newMessages.length === 0) {
-      iterationError =
-        "Backend step returned no content (stream error or empty response)";
+      // PR 5b-followup-2 review fix (Cursor High "Guardrail errors
+      // ignore captured engine"): non-OK Convex `/stream` responses
+      // make `processOneStep` return `{shouldContinue: false}` — the
+      // engine breaks the loop, fires a synthetic finish chunk, sets
+      // `runSucceeded = true`, and surfaces a populated `turnTrace`.
+      // 429-shaped guardrail turns also add no assistant messages, so
+      // this branch fires (NOT the `!turnTrace` branch above). The
+      // captured `lastEngineError` is the actual reason ("Daily
+      // MCPJam model limit reached…"); the generic "Backend step
+      // returned no content" message loses it. Prefer the engine
+      // event here too.
+      if (lastEngineError) {
+        iterationError = lastEngineError.message;
+        iterationErrorDetails = lastEngineError.rawText;
+      } else {
+        iterationError =
+          "Backend step returned no content (stream error or empty response)";
+      }
       logger.error(
-        "[evals] runAssistantTurn (stream) produced no new messages this turn; treating as cycle failure",
+        `[evals] runAssistantTurn (stream) produced no new messages this turn; treating as cycle failure (engineError=${lastEngineError ? lastEngineError.code ?? "uncoded" : "none"})`,
       );
       emit(
         buildTraceSnapshotEvent({
@@ -4550,7 +4566,11 @@ const streamIterationViaBackend = async ({
           usage: accumulatedUsage,
         }),
       );
-      emit({ type: "error", message: iterationError });
+      emit({
+        type: "error",
+        message: iterationError,
+        ...(iterationErrorDetails ? { details: iterationErrorDetails } : {}),
+      });
       break;
     }
     // Cursor / Codex PR 5a review fix applied here too: filter to
@@ -4567,9 +4587,20 @@ const streamIterationViaBackend = async ({
         !(span as { toolCallId?: string }).toolCallId,
     );
     if (stepErrorSpan) {
-      iterationError = `Backend step failed mid-turn: ${stepErrorSpan.name}`;
+      // PR 5b-followup-2 review fix: same shape as the no-content
+      // branch above — a captured engine error is more informative
+      // than the span-name fallback. The error-span case fires for
+      // later-step failures after partial success (engine logged an
+      // `error`-category span via `pushAiSdkTrailingErrorSpan` or
+      // similar); if `onEngineError` also fired, prefer it.
+      if (lastEngineError) {
+        iterationError = lastEngineError.message;
+        iterationErrorDetails = lastEngineError.rawText;
+      } else {
+        iterationError = `Backend step failed mid-turn: ${stepErrorSpan.name}`;
+      }
       logger.error(
-        `[evals] runAssistantTurn (stream) turnTrace has non-tool error-status span; treating as cycle failure (span=${stepErrorSpan.name} category=${stepErrorSpan.category})`,
+        `[evals] runAssistantTurn (stream) turnTrace has non-tool error-status span; treating as cycle failure (span=${stepErrorSpan.name} category=${stepErrorSpan.category} engineError=${lastEngineError ? lastEngineError.code ?? "uncoded" : "none"})`,
       );
       emit(
         buildTraceSnapshotEvent({
@@ -4586,7 +4617,11 @@ const streamIterationViaBackend = async ({
           usage: accumulatedUsage,
         }),
       );
-      emit({ type: "error", message: iterationError });
+      emit({
+        type: "error",
+        message: iterationError,
+        ...(iterationErrorDetails ? { details: iterationErrorDetails } : {}),
+      });
       break;
     }
 

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -89,6 +89,7 @@ import {
 } from "../utils/chat-v2-orchestration.js";
 import { runAssistantTurn } from "../utils/assistant-turn.js";
 import type {
+  MCPJamEngineErrorEvent,
   MCPJamStepFinishEvent,
   MCPJamToolCallEvent,
   MCPJamToolResultEvent,
@@ -4131,6 +4132,17 @@ const streamIterationViaBackend = async ({
       return out;
     };
 
+    // PR 5b-followup-2: capture the engine's structured-error event
+    // when the Convex `/stream` response is non-OK (429 daily-cap,
+    // hosted-model errors, ...) or when an in-stream catch fires. The
+    // engine writes a generic `error` UI chunk to the no-op writer
+    // (because `streamSink: "none"`); the callback gives us the
+    // parsed `{ code?, message, details? }` shape so failure-detection
+    // branches below can surface the actual reason on the eval SSE
+    // error event instead of dropping the detail with the generic
+    // "Backend stream failed during iteration" fallback.
+    let lastEngineError: MCPJamEngineErrorEvent | undefined;
+
     // Engine callbacks → SSE events. These mirror the events the old
     // inline backend stream loop emitted from its chunk-processing
     // switch:
@@ -4144,6 +4156,9 @@ const streamIterationViaBackend = async ({
     //                        caveat. After firing, the partial-response
     //                        accumulators reset so the next step starts
     //                        fresh.
+    //  - `onEngineError`   → captures the structured guardrail error
+    //                        body for use in the failure-detection
+    //                        fallback (PR 5b-followup-2).
     //
     // `promptToolsCalled` mirrors the legacy local accumulator; the
     // engine's `messageHistory` is the source of truth post-turn, so
@@ -4242,10 +4257,18 @@ const streamIterationViaBackend = async ({
       // user prompt) PLUS the in-flight partial response built from
       // the chunk-event accumulators — without this, mid-turn step
       // snapshots show only the user prompt even though `tool_call` /
-      // `text_delta` SSE already fired. Spans accumulate on
-      // `traceCtx.recordedSpans` (tool spans) + the engine's own LLM
-      // step spans (delivered on `turnResult.turnTrace.spans` AFTER
-      // the turn finishes).
+      // `text_delta` SSE already fired. Spans:
+      //  - `capturedSpans`        — prior turns' merged spans.
+      //  - `traceCtx.recordedSpans` — this turn's tool-instrumentation
+      //                              spans from `wrapToolSetForEvalTrace`.
+      //  - `event.turnSpans`      — PR 5b-followup-2: this turn's
+      //                              engine-recorded LLM-step + tool
+      //                              spans, snapshot at step settlement
+      //                              (closes Cursor PR 5b "Step
+      //                              snapshots omit LLM spans"). Without
+      //                              this the live trace UI lost
+      //                              per-step LLM timing for
+      //                              multi-step hosted streaming evals.
       const snapshotMessages = [
         ...messageHistory,
         ...buildPartialResponseMessages(),
@@ -4256,7 +4279,11 @@ const streamIterationViaBackend = async ({
           stepIndex: event.stepIndex,
           snapshotKind: "step_finish",
           messages: withSystemPrefix(snapshotMessages),
-          spans: [...capturedSpans, ...traceCtx.recordedSpans],
+          spans: [
+            ...capturedSpans,
+            ...traceCtx.recordedSpans,
+            ...event.turnSpans,
+          ],
           actualToolCalls: extractToolCallsFromConversation({
             messages: snapshotMessages,
           }),
@@ -4274,6 +4301,14 @@ const streamIterationViaBackend = async ({
       // naturally on the next prompt-turn iteration; no double-count
       // risk because `messageHistory` is replaced with the engine's
       // canonical post-turn transcript below before the next iteration.
+    };
+    // PR 5b-followup-2: capture the engine's structured-error event.
+    // The callback fires at the same site that emits the writer-side
+    // `error` UI chunk; capturing here lets the failure-detection
+    // branches below surface guardrail detail (429 daily-cap text,
+    // hosted-model setup errors, ...) on the eval SSE error event.
+    const onEngineError = (event: MCPJamEngineErrorEvent) => {
+      lastEngineError = event;
     };
 
     // `runAssistantTurn` call shape mirrors `runIterationViaBackend`
@@ -4328,6 +4363,7 @@ const streamIterationViaBackend = async ({
         onToolCall,
         onToolResult,
         onStepFinish,
+        onEngineError,
       });
     } catch (error) {
       // Cancellation: bail without recording. AbortError can surface
@@ -4453,10 +4489,23 @@ const streamIterationViaBackend = async ({
     //   (c) Engine succeeded and produced content, but a later step
     //       errored (non-tool error span on `turnTrace.spans`).
     if (!turnResult.turnTrace) {
-      iterationError =
-        "Backend stream failed during iteration (engine caught an error mid-turn)";
+      // PR 5b-followup-2: prefer the engine's captured structured
+      // error when present. Closes Cursor PR 5b "Stream guardrail
+      // errors lose detail" — without this, 429 daily-cap users saw
+      // the generic fallback below instead of the actual reason
+      // ("Daily MCPJam model limit reached. Use BYOK or try again
+      // tomorrow."). When no engine error was captured (true engine
+      // catch shape vs. a missed `onEngineError` site), keep the
+      // generic fallback for diagnostic clarity.
+      if (lastEngineError) {
+        iterationError = lastEngineError.message;
+        iterationErrorDetails = lastEngineError.rawText;
+      } else {
+        iterationError =
+          "Backend stream failed during iteration (engine caught an error mid-turn)";
+      }
       logger.error(
-        `[evals] runAssistantTurn (stream) returned no turnTrace (engine runSucceeded=false); treating as cycle failure (messagesGrew=${newMessages.length > 0})`,
+        `[evals] runAssistantTurn (stream) returned no turnTrace (engine runSucceeded=false); treating as cycle failure (messagesGrew=${newMessages.length > 0}, engineError=${lastEngineError ? lastEngineError.code ?? "uncoded" : "none"})`,
       );
       emit(
         buildTraceSnapshotEvent({
@@ -4473,7 +4522,11 @@ const streamIterationViaBackend = async ({
           usage: accumulatedUsage,
         }),
       );
-      emit({ type: "error", message: iterationError });
+      emit({
+        type: "error",
+        message: iterationError,
+        ...(iterationErrorDetails ? { details: iterationErrorDetails } : {}),
+      });
       break;
     }
     if (newMessages.length === 0) {

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -3363,6 +3363,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             stepIndex: 0,
             promptIndex: 0,
             turnUsage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+            turnSpans: [],
             settledWithError: false,
           });
           return {
@@ -3484,12 +3485,14 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             stepIndex: 0,
             promptIndex: 0,
             turnUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            turnSpans: [],
             settledWithError: false,
           });
           opts.onStepFinish?.({
             stepIndex: 1,
             promptIndex: 0,
             turnUsage: { inputTokens: 25, outputTokens: 13, totalTokens: 38 },
+            turnSpans: [],
             settledWithError: false,
           });
           return {
@@ -3604,6 +3607,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             stepIndex: 0,
             promptIndex: 0,
             turnUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+            turnSpans: [],
             settledWithError: false,
           });
           return {
@@ -3746,6 +3750,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             stepIndex: 0,
             promptIndex: 0,
             turnUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+            turnSpans: [],
             settledWithError: false,
           });
           // Step 2: model says "Step2 text", calls tool B, gets a result.
@@ -3771,6 +3776,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             stepIndex: 1,
             promptIndex: 0,
             turnUsage: { inputTokens: 12, outputTokens: 7, totalTokens: 19 },
+            turnSpans: [],
             settledWithError: false,
           });
           return {
@@ -3880,6 +3886,238 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       }
     });
 
+    it("stitches engine turnSpans into mid-turn step_finish trace_snapshot (PR 5b-followup-2 — Cursor 'Step snapshots omit LLM spans')", async () => {
+      // PR 5b-followup-2 closes Cursor's PR 5b-round-3 finding: mid-turn
+      // `step_finish` `trace_snapshot` events would otherwise show only
+      // prior-turn `capturedSpans` + the runner's tool-instrumentation
+      // spans, dropping the active turn's engine-recorded per-step LLM
+      // spans (engine puts them on `turnTrace.spans` but eval only drains
+      // post-turn). Engine surface fix: `MCPJamStepFinishEvent.turnSpans`
+      // carries a defensive-copy snapshot at step settlement. Runner
+      // stitches it into the snapshot's spans alongside capturedSpans +
+      // traceCtx.recordedSpans.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockImplementationOnce(async (opts: any) => {
+          // Engine fires onStepFinish with two per-step LLM spans.
+          opts.onStepFinish?.({
+            stepIndex: 0,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+            settledWithError: false,
+            turnSpans: [
+              {
+                category: "step",
+                status: "ok",
+                name: "llm-step-0",
+                stepIndex: 0,
+                promptIndex: 0,
+                startMs: 100,
+                endMs: 150,
+              } as any,
+            ],
+          });
+          opts.onStepFinish?.({
+            stepIndex: 1,
+            promptIndex: 0,
+            turnUsage: { inputTokens: 12, outputTokens: 7, totalTokens: 19 },
+            settledWithError: false,
+            turnSpans: [
+              {
+                category: "step",
+                status: "ok",
+                name: "llm-step-0",
+                stepIndex: 0,
+                promptIndex: 0,
+                startMs: 100,
+                endMs: 150,
+              } as any,
+              {
+                category: "step",
+                status: "ok",
+                name: "llm-step-1",
+                stepIndex: 1,
+                promptIndex: 0,
+                startMs: 200,
+                endMs: 250,
+              } as any,
+            ],
+          });
+          return {
+            messages: [
+              { role: "user", content: "Hello" } as any,
+              { role: "assistant", content: "Done" } as any,
+            ],
+            assistantMessages: [],
+            toolCalls: [],
+            toolResults: [],
+            turnTrace: {
+              turnId: "t_1",
+              promptIndex: 0,
+              startedAt: 0,
+              endedAt: 10,
+              modelId: "anthropic/claude-haiku-4.5",
+              spans: [],
+            },
+            usage: { inputTokens: 12, outputTokens: 7, totalTokens: 19 },
+          } as any;
+        });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b-followup-2 turnSpans",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-followup2-spans",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-followup2-spans",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event: unknown) =>
+            emitted.push(event as Record<string, unknown>),
+        } as any);
+
+        const stepFinishSnapshots = emitted.filter(
+          (e) =>
+            e.type === "trace_snapshot" &&
+            (e as { snapshotKind?: string }).snapshotKind === "step_finish",
+        ) as Array<{
+          stepIndex?: number;
+          trace: { spans?: Array<{ name?: string; category?: string }> };
+        }>;
+        expect(stepFinishSnapshots).toHaveLength(2);
+
+        // Step 1 snapshot must carry the step-0 LLM span the engine
+        // surfaced via turnSpans.
+        const step1Spans = stepFinishSnapshots[0]!.trace.spans ?? [];
+        expect(step1Spans.some((s) => s.name === "llm-step-0")).toBe(true);
+
+        // Step 2 snapshot must carry BOTH the step-0 + step-1 LLM
+        // spans (engine accumulates them on traceTurn.turnSpans;
+        // defensive copy means each snapshot carries the running set
+        // as of that step).
+        const step2Spans = stepFinishSnapshots[1]!.trace.spans ?? [];
+        expect(step2Spans.some((s) => s.name === "llm-step-0")).toBe(true);
+        expect(step2Spans.some((s) => s.name === "llm-step-1")).toBe(true);
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
+    it("surfaces engine guardrail detail on error SSE via onEngineError (PR 5b-followup-2 — Cursor 'Stream guardrail errors lose detail')", async () => {
+      // PR 5b-followup-2 closes Cursor's PR 5b-round-3 finding: when the
+      // Convex `/stream` endpoint returns a non-OK with a structured
+      // guardrail body (e.g. 429 `{ code: "user_rate_limit", error:
+      // "Daily MCPJam model limit reached…", details: "Try again in N
+      // minutes." }`), the engine catches internally and emits an
+      // `error` UI chunk to the no-op writer (because `streamSink:
+      // "none"`). Before the followup, eval's runner mapped the missing
+      // `turnTrace` to a generic "Backend stream failed during
+      // iteration" — losing the actual reason. Engine surface fix:
+      // `onEngineError({code, message, details, httpStatus, rawText})`
+      // fires at the same site; runner captures the event and prefers
+      // its message over the generic fallback.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockImplementationOnce(async (opts: any) => {
+          // Engine catches a 429 and fires onEngineError with the
+          // parsed structured body, then returns with NO turnTrace
+          // (runSucceeded=false shape — what the runner detects as
+          // "engine catch fired mid-turn").
+          opts.onEngineError?.({
+            message:
+              "Daily MCPJam model limit reached. Use BYOK or try again tomorrow. Try again in 30 minutes.",
+            code: "user_rate_limit",
+            details: "Try again in 30 minutes.",
+            httpStatus: 429,
+            rawText:
+              '{"code":"user_rate_limit","error":"Daily MCPJam model limit reached. Use BYOK or try again tomorrow.","details":"Try again in 30 minutes."}',
+            promptIndex: 0,
+            stepIndex: 0,
+          });
+          return {
+            // No turnTrace → runner enters the failure-detection branch.
+            messages: [{ role: "user", content: "Hello" } as any],
+            assistantMessages: [],
+            toolCalls: [],
+            toolResults: [],
+          } as any;
+        });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b-followup-2 guardrail detail",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-followup2-guardrail",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-followup2-guardrail",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event: unknown) =>
+            emitted.push(event as Record<string, unknown>),
+        } as any);
+
+        const errorEvents = emitted.filter((e) => e.type === "error") as Array<{
+          message: string;
+          details?: string;
+        }>;
+        expect(errorEvents).toHaveLength(1);
+        // The eval SSE error event carries the structured guardrail
+        // message — NOT the generic "Backend stream failed during
+        // iteration (engine caught an error mid-turn)" fallback.
+        expect(errorEvents[0]!.message).toContain(
+          "Daily MCPJam model limit reached",
+        );
+        expect(errorEvents[0]!.message).not.toContain(
+          "Backend stream failed during iteration",
+        );
+        // The raw body is forwarded on `details` so the live UI can
+        // show the full JSON when an operator wants to inspect it.
+        expect(errorEvents[0]!.details).toContain('"code":"user_rate_limit"');
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
     it("does NOT emit step_finish SSE when onStepFinish fires with settledWithError=true (PR 5b — Marcelo caveat)", async () => {
       // Marcelo's PR 5b-pre review caveat: `MCPJamStepFinishEvent`
       // settles with `settledWithError` carrying the engine's
@@ -3901,6 +4139,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             stepIndex: 0,
             promptIndex: 0,
             turnUsage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 },
+            turnSpans: [],
             settledWithError: true,
           });
           return {

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -4057,12 +4057,31 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             promptIndex: 0,
             stepIndex: 0,
           });
+          // PR 5b-followup-2 review fix (Cursor High "Guardrail
+          // errors ignore captured engine"): after a non-OK Convex
+          // `/stream` response, `processOneStep` returns
+          // `{shouldContinue: false}` — the engine BREAKS the loop,
+          // fires a synthetic finish, sets `runSucceeded = true`, and
+          // returns with `turnTrace` POPULATED. Typical 429 guardrail
+          // turns add no assistant messages either, so the runner
+          // hits the `newMessages.length === 0` branch, NOT the
+          // `!turnTrace` branch. This mock mirrors the real shape so
+          // the test catches the regression where the no-content
+          // branch ignored `lastEngineError`.
           return {
-            // No turnTrace → runner enters the failure-detection branch.
+            // turnTrace populated — runSucceeded=true on the 429 path.
             messages: [{ role: "user", content: "Hello" } as any],
             assistantMessages: [],
             toolCalls: [],
             toolResults: [],
+            turnTrace: {
+              turnId: "t_1",
+              promptIndex: 0,
+              startedAt: 0,
+              endedAt: 10,
+              modelId: "anthropic/claude-haiku-4.5",
+              spans: [],
+            },
           } as any;
         });
 
@@ -4102,16 +4121,126 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
         }>;
         expect(errorEvents).toHaveLength(1);
         // The eval SSE error event carries the structured guardrail
-        // message — NOT the generic "Backend stream failed during
-        // iteration (engine caught an error mid-turn)" fallback.
+        // message — NOT any of the runner's generic fallbacks for the
+        // three failure branches (`!turnTrace`, no-content, error-span).
         expect(errorEvents[0]!.message).toContain(
           "Daily MCPJam model limit reached",
         );
         expect(errorEvents[0]!.message).not.toContain(
           "Backend stream failed during iteration",
         );
+        expect(errorEvents[0]!.message).not.toContain(
+          "Backend step returned no content",
+        );
+        expect(errorEvents[0]!.message).not.toContain(
+          "Backend step failed mid-turn",
+        );
         // The raw body is forwarded on `details` so the live UI can
         // show the full JSON when an operator wants to inspect it.
+        expect(errorEvents[0]!.details).toContain('"code":"user_rate_limit"');
+      } finally {
+        runAssistantTurnSpy.mockRestore();
+      }
+    });
+
+    it("prefers captured engine error in the error-span failure branch (PR 5b-followup-2 review fix — Cursor High)", async () => {
+      // PR 5b-followup-2 review fix: same shape as the no-content
+      // branch, but for the third failure path — `turnTrace` has a
+      // non-tool error-status span. Without this fix the runner used
+      // the span-name fallback ("Backend step failed mid-turn: <span
+      // name>"), losing the engine's captured guardrail detail.
+      const assistantTurnModule = await import(
+        "../../../utils/assistant-turn"
+      );
+      const runAssistantTurnSpy = vi
+        .spyOn(assistantTurnModule, "runAssistantTurn")
+        .mockImplementationOnce(async (opts: any) => {
+          opts.onEngineError?.({
+            message:
+              "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+            code: "user_rate_limit",
+            details: "Try again in 30 minutes.",
+            httpStatus: 429,
+            rawText:
+              '{"code":"user_rate_limit","error":"Daily MCPJam model limit reached. Use BYOK or try again tomorrow.","details":"Try again in 30 minutes."}',
+            promptIndex: 0,
+            stepIndex: 1,
+          });
+          // Engine produced one good step, then a later step errored.
+          // turnTrace.spans includes a non-tool error span; runner's
+          // error-span branch fires.
+          return {
+            messages: [
+              { role: "user", content: "Hello" } as any,
+              { role: "assistant", content: "Partial" } as any,
+            ],
+            assistantMessages: [],
+            toolCalls: [],
+            toolResults: [],
+            turnTrace: {
+              turnId: "t_1",
+              promptIndex: 0,
+              startedAt: 0,
+              endedAt: 10,
+              modelId: "anthropic/claude-haiku-4.5",
+              spans: [
+                {
+                  category: "step",
+                  status: "error",
+                  name: "llm-step-1",
+                  stepIndex: 1,
+                  promptIndex: 0,
+                  startMs: 200,
+                  endMs: 250,
+                } as any,
+              ],
+            },
+            usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+          } as any;
+        });
+
+      const emitted: Array<Record<string, unknown>> = [];
+      try {
+        await streamTestCase({
+          test: {
+            title: "PR 5b-followup-2 error-span engine error",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-followup2-errspan-engineerror",
+          },
+          tools: {},
+          selectedServers: [],
+          mcpClientManager: mcpClientManager as any,
+          recorder: null,
+          modelApiKeys: {},
+          convexClient: convexClient as any,
+          convexHttpUrl: "https://example.convex.site",
+          convexAuthToken: "token",
+          testCaseId: "case-followup2-errspan-engineerror",
+          suiteId: "suite-1",
+          runId: null,
+          emit: (event: unknown) =>
+            emitted.push(event as Record<string, unknown>),
+        } as any);
+
+        const errorEvents = emitted.filter((e) => e.type === "error") as Array<{
+          message: string;
+          details?: string;
+        }>;
+        expect(errorEvents).toHaveLength(1);
+        expect(errorEvents[0]!.message).toContain(
+          "Daily MCPJam model limit reached",
+        );
+        // Specifically NOT the span-name fallback.
+        expect(errorEvents[0]!.message).not.toContain(
+          "Backend step failed mid-turn",
+        );
         expect(errorEvents[0]!.details).toContain('"code":"user_rate_limit"');
       } finally {
         runAssistantTurnSpy.mockRestore();

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1899,6 +1899,158 @@ describe("mcpjam-stream-handler", () => {
       );
     });
 
+    it("includes `turnSpans` snapshot on each `onStepFinish` invocation (PR 5b-followup-2 — Cursor 'Step snapshots omit LLM spans')", async () => {
+      // PR 5b-followup-2: the engine accumulates LLM-step + tool spans
+      // on `traceTurn.turnSpans` during the agentic loop but only
+      // surfaced them post-turn via `PersistedTurnTrace.spans`. The
+      // followup exposes a defensive-copy snapshot on
+      // `MCPJamStepFinishEvent.turnSpans` so eval's mid-turn step
+      // snapshots can include the active turn's per-step LLM timing.
+      // Lock the engine surface: every `onStepFinish` invocation
+      // carries `turnSpans: EvalTraceSpan[]`, and successive
+      // invocations see the running set grow (defensive copy means
+      // earlier event snapshots stay frozen).
+      const stepOne = [
+        { type: "text-start", id: "text-0" },
+        { type: "text-delta", id: "text-0", delta: "step1" },
+        { type: "text-end", id: "text-0" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          messageMetadata: { inputTokens: 3, outputTokens: 4, totalTokens: 7 },
+        },
+      ];
+      let fetchCall = 0;
+      global.fetch = vi.fn().mockImplementation(async () => {
+        fetchCall += 1;
+        return createSseResponse(stepOne);
+      });
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+
+      const onStepFinish = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "Hi" }] as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        onStepFinish,
+      });
+
+      await lastExecution;
+
+      expect(onStepFinish).toHaveBeenCalledTimes(1);
+      const event = onStepFinish.mock.calls[0]?.[0];
+      // `turnSpans` is REQUIRED — always present, even when the engine
+      // hasn't recorded any spans for this turn yet (the LLM-step span
+      // for the completed step IS recorded though, so we expect at
+      // least one entry).
+      expect(Array.isArray(event.turnSpans)).toBe(true);
+      expect(event.turnSpans.length).toBeGreaterThan(0);
+      // Defensive copy: mutating the event's array must not affect
+      // the engine's internal traceTurn.turnSpans on subsequent steps.
+      const originalLength = event.turnSpans.length;
+      event.turnSpans.push({ name: "intruder" } as any);
+      // Engine wouldn't be running anymore, but the contract holds:
+      // the array we received was a fresh copy.
+      expect(event.turnSpans.length).toBe(originalLength + 1);
+      void fetchCall;
+    });
+
+    it("fires `onEngineError` with structured guardrail body on non-OK Convex response (PR 5b-followup-2 — Cursor 'Stream guardrail errors lose detail')", async () => {
+      // PR 5b-followup-2: before this followup, `streamSink: "none"`
+      // consumers (eval backend stream runner) lost structured 429 /
+      // daily-cap / hosted-model setup error detail because the
+      // writer-side `error` UI chunk went to the no-op writer. Engine
+      // now also fires `onEngineError({code, message, details,
+      // httpStatus, rawText})` at the same site with the parsed
+      // `{ code?, error, details? }` body so eval can surface the
+      // actual guardrail reason on its own error SSE event.
+      const structuredBody = JSON.stringify({
+        code: "user_rate_limit",
+        error: "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+        details: "Try again in 30 minutes.",
+      });
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(structuredBody, {
+          status: 429,
+          statusText: "Too Many Requests",
+        }),
+      );
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+
+      const onEngineError = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "Rate-limit me" }] as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        onEngineError,
+      });
+
+      await lastExecution;
+
+      expect(onEngineError).toHaveBeenCalledTimes(1);
+      const event = onEngineError.mock.calls[0]?.[0];
+      // Display message is the parsed "error + details" shape (matches
+      // the legacy describeBackendStreamError output that lived in
+      // evals-runner before PR 5b's collapse).
+      expect(event.message).toContain("Daily MCPJam model limit reached");
+      expect(event.message).toContain("Try again in 30 minutes");
+      // Structured fields populated from the parsed body.
+      expect(event.code).toBe("user_rate_limit");
+      expect(event.details).toBe("Try again in 30 minutes.");
+      expect(event.httpStatus).toBe(429);
+      // Raw body is always present for debugging.
+      expect(event.rawText).toBe(structuredBody);
+      // Correlation fields.
+      expect(event.promptIndex).toBe(0);
+      expect(event.stepIndex).toBe(0);
+    });
+
+    it("fires `onEngineError` with raw text on non-OK response with non-JSON body (PR 5b-followup-2)", async () => {
+      // The parser falls back to a generic `Backend stream error: <status> <text>`
+      // when the body isn't structured JSON. `code` and `details` are
+      // omitted; `rawText` carries the original body for diagnostic use.
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response("upstream broke", {
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+      );
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+
+      const onEngineError = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "Fail me" }] as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        onEngineError,
+      });
+
+      await lastExecution;
+
+      expect(onEngineError).toHaveBeenCalledTimes(1);
+      const event = onEngineError.mock.calls[0]?.[0];
+      expect(event.message).toBe("Backend stream error: 500 upstream broke");
+      expect(event.code).toBeUndefined();
+      expect(event.details).toBeUndefined();
+      expect(event.httpStatus).toBe(500);
+      expect(event.rawText).toBe("upstream broke");
+    });
+
     it("fires `onToolCall` for approved tools on resumed approval turns (PR 5b-pre review fix — Cursor Medium)", async () => {
       // Cursor PR 5b-pre review fix: `handlePendingApprovals` writes
       // `tool-input-available` UI chunks for resumed APPROVED tools

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -2051,6 +2051,68 @@ describe("mcpjam-stream-handler", () => {
       expect(event.rawText).toBe("upstream broke");
     });
 
+    it("fires `onEngineError` (via outer catch) when SSE parser fails mid-stream (PR 5b-followup-2 review — CodeRabbit Major 'Parser failures bypass onEngineError')", async () => {
+      // CodeRabbit followup-2 review fix: the pre-fix
+      // `if (!value?.success)` branch in processStream wrote an error
+      // chunk and broke the read loop, then returned NORMALLY — so
+      // the outer agentic loop synthesized a finish and marked the
+      // turn successful (`runSucceeded = true`), and `onEngineError`
+      // never fired. Eval consumers lost the failure signal entirely.
+      //
+      // Fix: throw from the parse-failure branch so it lands in
+      // runChatEngineLoop's outer catch, which fires `onEngineError`
+      // (site #3) and writes the error+turn_finish trace events.
+      //
+      // Lock: feed a stream that decodes successfully (200 OK) but
+      // emits a chunk the schema rejects. Assert `onEngineError`
+      // fires once with the parser's message.
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          // Valid SSE framing, but the data payload is not parseable
+          // JSON. `parseJsonEventStream` surfaces this as
+          // `{ success: false, error: SyntaxError | ZodError }`.
+          `data: not-json-at-all-{{{\n\n`,
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+      );
+      vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+
+      const onEngineError = vi.fn();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "parse-fail me" }] as any,
+        modelId: "openai/gpt-5-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        onEngineError,
+      });
+
+      await lastExecution;
+
+      // The fix: parse failures now route through site #3
+      // (outer agentic-loop catch) instead of silently breaking the
+      // read loop. `onEngineError` MUST fire — pre-fix this was zero.
+      expect(onEngineError).toHaveBeenCalledTimes(1);
+      const event = onEngineError.mock.calls[0]?.[0];
+      // Outer-catch site doesn't carry httpStatus / code / details —
+      // those only populate at site #1 (non-OK Convex response).
+      expect(event.httpStatus).toBeUndefined();
+      expect(event.code).toBeUndefined();
+      expect(event.details).toBeUndefined();
+      expect(event.stepIndex).toBeUndefined();
+      // The parser's message is preserved (Zod or whatever the
+      // schema validator reports). Either way, NOT the success path.
+      expect(typeof event.message).toBe("string");
+      expect(event.message.length).toBeGreaterThan(0);
+      expect(event.rawText).toBe(event.message);
+    });
+
     it("fires `onToolCall` for approved tools on resumed approval turns (PR 5b-pre review fix — Cursor Medium)", async () => {
       // Cursor PR 5b-pre review fix: `handlePendingApprovals` writes
       // `tool-input-available` UI chunks for resumed APPROVED tools

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -154,6 +154,15 @@ export interface RunAssistantTurnOptions {
   onToolCall?: MCPJamHandlerOptions["onToolCall"];
   onToolResult?: MCPJamHandlerOptions["onToolResult"];
   onStepFinish?: MCPJamHandlerOptions["onStepFinish"];
+  /**
+   * PR 5b-followup-2: structured-error pass-through. Eval's backend
+   * stream runner uses this to surface guardrail detail (429
+   * daily-cap, hosted-model setup errors, etc.) on its `error` SSE
+   * event — `streamSink: "none"` consumers don't otherwise see the
+   * structured Convex `/stream` response body because the writer-side
+   * `error` chunk goes to the no-op writer. Chat / synthetic omit.
+   */
+  onEngineError?: MCPJamHandlerOptions["onEngineError"];
 
   /**
    * Override the Convex endpoint path. Stage 1 keeps this wired so
@@ -332,6 +341,8 @@ function buildHandlerOptions(
     ...(opts.onToolCall ? { onToolCall: opts.onToolCall } : {}),
     ...(opts.onToolResult ? { onToolResult: opts.onToolResult } : {}),
     ...(opts.onStepFinish ? { onStepFinish: opts.onStepFinish } : {}),
+    // PR 5b-followup-2: pass-through structured-error callback.
+    ...(opts.onEngineError ? { onEngineError: opts.onEngineError } : {}),
     ...(opts.endpointPath ? { endpointPath: opts.endpointPath } : {}),
     ...(opts.extraHeaders ? { extraHeaders: opts.extraHeaders } : {}),
     ...(opts.authContext.clientIp !== undefined &&

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -965,11 +965,31 @@ async function processStream(
       if (done) break;
 
       if (!value?.success) {
-        writer.write({
-          type: "error",
-          errorText: value?.error?.message ?? "stream parse failed",
-        });
-        break;
+        // PR 5b-followup-2 review fix (CodeRabbit Major "Parser failures
+        // still bypass onEngineError and the real failure path"): the
+        // pre-fix shape wrote an error UI chunk and `break`'d out of
+        // the loop. processStream then returned NORMALLY with whatever
+        // contentParts had accumulated, processOneStep ran its
+        // post-stream epilogue, and the outer agentic loop marked the
+        // turn successful (runSucceeded = true) — `onEngineError`
+        // never fired and the eval runner's failure detection didn't
+        // trip. Throw instead so the failure lands in
+        // `runChatEngineLoop`'s outer catch, which fires
+        // `onEngineError` (site #3), writes the error+turn_finish
+        // trace events, and skips the success epilogue. The thrown
+        // Error carries the parser's message so the engine-error
+        // contract stays consistent.
+        const parseErr = (value as { error?: unknown })?.error;
+        throw parseErr instanceof Error
+          ? parseErr
+          : new Error(
+              typeof parseErr === "object" &&
+              parseErr !== null &&
+              "message" in parseErr &&
+              typeof (parseErr as { message?: unknown }).message === "string"
+                ? (parseErr as { message: string }).message
+                : "stream parse failed",
+            );
       }
 
       const chunk = value.value as UIMessageChunk & {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -200,6 +200,63 @@ export interface MCPJamStepFinishEvent {
    * wire-up decide.
    */
   settledWithError: boolean;
+  /**
+   * PR 5b-followup-2: snapshot of the engine's per-turn spans as of
+   * step settlement. The engine accumulates LLM-step + tool spans on
+   * `traceTurn.turnSpans` while the agentic loop runs but only
+   * surfaces them post-turn via `PersistedTurnTrace.spans`. Eval's
+   * mid-turn `step_finish` `trace_snapshot` (Cursor #5b "Step
+   * snapshots omit LLM spans") would otherwise show only prior-turn
+   * spans + the runner's local tool-instrumentation spans, dropping
+   * the active turn's engine-recorded per-step LLM timing. The shape
+   * is a SNAPSHOT (defensive copy) — callers may retain it across
+   * step boundaries without race risk against the engine's continued
+   * mutation of `traceTurn.turnSpans`. Empty array when the engine
+   * has no spans yet for this turn (failed first step, etc).
+   */
+  turnSpans: EvalTraceSpan[];
+}
+
+/**
+ * PR 5b-followup-2: structured error event fired when the engine
+ * catches an error mid-step and routes it through the writer as an
+ * `error` UI chunk. Eval's backend stream runner consumes this to
+ * surface guardrail detail (e.g. 429 daily-cap "Daily MCPJam model
+ * limit reached. Use BYOK or try again tomorrow.") on its `error`
+ * SSE event — without the callback, `streamSink: "none"` consumers
+ * only see the engine's generic fallback message because the UI
+ * chunk goes to the no-op writer.
+ *
+ * Three fire sites in the engine:
+ *  1. Non-OK Convex `/stream` HTTP response in `processOneStep` —
+ *     structured fields populated when the body parsed as
+ *     `{ code?, error, details? }` (the standard guardrail shape).
+ *  2. `processStream` / tool-execution catch in `processOneStep` —
+ *     `message` only (decode / tool-throw error).
+ *  3. Outer agentic-loop catch in `runChatEngineLoop` — `message`
+ *     only (anything else that escaped the per-step handlers).
+ */
+export interface MCPJamEngineErrorEvent {
+  /**
+   * Human-readable display message. For site (1) when the body
+   * parsed structured, this is `"<error> <details>"`; otherwise the
+   * raw response text or the Error.message.
+   */
+  message: string;
+  /** Structured error code when the body parsed as a guardrail response. */
+  code?: string;
+  /** Structured details string when the body parsed as a guardrail response. */
+  details?: string;
+  /** HTTP status when the error came from a non-OK response (site 1 only). */
+  httpStatus?: number;
+  /**
+   * Raw response body / `Error.message` text — always present for
+   * logging / debugging. Callers should prefer `message` for display.
+   */
+  rawText: string;
+  promptIndex: number;
+  /** Step index when fired inside `processOneStep`; omitted for site (3). */
+  stepIndex?: number;
 }
 
 export interface MCPJamHandlerOptions {
@@ -261,6 +318,19 @@ export interface MCPJamHandlerOptions {
    * `step_finish` SSE event. Chat / synthetic omit.
    */
   onStepFinish?: (event: MCPJamStepFinishEvent) => void;
+  /**
+   * PR 5b-followup-2: structured-error callback. Fires when the
+   * engine catches a non-OK Convex `/stream` response (e.g. 429 daily
+   * spend cap), a `processStream` / tool-execution throw, or any
+   * outer agentic-loop error — i.e. every site that emits a writer
+   * `error` UI chunk + a trace `error` event. For non-OK responses,
+   * the structured `{ code?, error, details? }` body is parsed and
+   * populated on the event so `streamSink: "none"` consumers (eval's
+   * backend stream runner) can surface guardrail detail on their own
+   * error SSE event instead of dropping the actual reason. Chat /
+   * synthetic omit; the writer-side error chunk still fires regardless.
+   */
+  onEngineError?: (event: MCPJamEngineErrorEvent) => void;
   /**
    * Override the Convex endpoint path for the per-step LLM call.
    * Defaults to "/stream". Org BYOK chat uses "/stream/org".
@@ -360,6 +430,11 @@ interface StepContext {
   onToolCall?: (event: MCPJamToolCallEvent) => void;
   onToolResult?: (event: MCPJamToolResultEvent) => void;
   onStepFinish?: (event: MCPJamStepFinishEvent) => void;
+  // PR 5b-followup-2: structured-error callback. Fires at every site
+  // that emits a writer `error` UI chunk (non-OK Convex response in
+  // processOneStep, processStream/tool-execution catch, outer
+  // agentic-loop catch). Optional.
+  onEngineError?: (event: MCPJamEngineErrorEvent) => void;
   abortSignal?: AbortSignal;
 }
 
@@ -752,6 +827,66 @@ function safelyEmitLiveTextDelta(
     });
   } catch (error) {
     logger.warn("[mcpjam-stream-handler] onLiveTextDelta callback failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * PR 5b-followup-2: parse a Convex `/stream` non-OK response body as
+ * the standard guardrail JSON shape `{ code?, error, details? }`.
+ * Falls back to a generic `<status> <text>` message when the body
+ * isn't structured. Mirrors the legacy
+ * `describeBackendStreamError` shape that lived in
+ * evals-runner before PR 5b's collapse — moved into the engine here
+ * so `onEngineError` consumers see the same parsed display message.
+ */
+function parseEngineErrorBody(
+  status: number | undefined,
+  bodyText: string
+): { message: string; code?: string; details?: string } {
+  try {
+    const body = JSON.parse(bodyText) as {
+      code?: string;
+      error?: string;
+      details?: string;
+    };
+    if (body?.error) {
+      return {
+        message: body.details ? `${body.error} ${body.details}` : body.error,
+        ...(body.code ? { code: body.code } : {}),
+        ...(body.details ? { details: body.details } : {}),
+      };
+    }
+  } catch {
+    // body wasn't JSON — fall through to generic shape
+  }
+  return {
+    message:
+      status !== undefined
+        ? `Backend stream error: ${status} ${bodyText}`
+        : bodyText,
+  };
+}
+
+/**
+ * PR 5b-followup-2: safe-fire wrapper for `onEngineError`. Mirrors
+ * the chunk-callback shape (try/catch + `logger.warn`) so a buggy
+ * eval emitter can't crash the agentic loop.
+ */
+function safelyEmitEngineError(
+  onEngineError: ((event: MCPJamEngineErrorEvent) => void) | undefined,
+  event: MCPJamEngineErrorEvent
+) {
+  if (!onEngineError) return;
+  try {
+    void Promise.resolve(onEngineError(event)).catch((error) => {
+      logger.warn("[mcpjam-stream-handler] onEngineError callback failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  } catch (error) {
+    logger.warn("[mcpjam-stream-handler] onEngineError callback failed", {
       error: error instanceof Error ? error.message : String(error),
     });
   }
@@ -1500,6 +1635,8 @@ async function processOneStep(
     // MCPJamHandlerOptions through runChatEngineLoop).
     onToolCall,
     onToolResult,
+    // PR 5b-followup-2 structured-error callback.
+    onEngineError,
   } = ctx;
 
   // Pick the active tool subset for this step. In non-progressive mode
@@ -1678,6 +1815,23 @@ async function processOneStep(
       errorText,
     });
     writer.write({ type: "error", errorText });
+    // PR 5b-followup-2: surface the structured guardrail body to
+    // `streamSink: "none"` consumers (eval backend stream runner). The
+    // writer-side `error` chunk above is fire-and-forget here; the
+    // callback gives the eval runner the parsed
+    // `{ code?, error, details? }` shape so it can show the actual
+    // 429 reason on its SSE error event instead of the generic
+    // "Backend stream failed during iteration" fallback.
+    const parsed = parseEngineErrorBody(res.status, errorText);
+    safelyEmitEngineError(onEngineError, {
+      message: parsed.message,
+      ...(parsed.code ? { code: parsed.code } : {}),
+      ...(parsed.details ? { details: parsed.details } : {}),
+      httpStatus: res.status,
+      rawText: errorText,
+      promptIndex: traceTurn.promptIndex,
+      stepIndex,
+    });
     return { shouldContinue: false, didEmitFinish: false };
   }
 
@@ -2080,6 +2234,17 @@ async function processOneStep(
         errorText,
       });
       writer.write({ type: "error", errorText });
+      // PR 5b-followup-2: surface the error to `streamSink: "none"`
+      // consumers (eval backend stream runner). The processStream /
+      // tool-execution catch path doesn't have a structured body, so
+      // `message` is just the error text; `code` / `details` /
+      // `httpStatus` are omitted.
+      safelyEmitEngineError(onEngineError, {
+        message: errorText,
+        rawText: errorText,
+        promptIndex: traceTurn.promptIndex,
+        stepIndex,
+      });
       return { shouldContinue: false, didEmitFinish: false };
     }
 
@@ -2199,6 +2364,8 @@ export async function runChatEngineLoop(
     onToolCall,
     onToolResult,
     onStepFinish,
+    // PR 5b-followup-2 callback.
+    onEngineError,
     abortSignal,
     heartbeatIntervalMs,
     maxSteps,
@@ -2440,6 +2607,10 @@ export async function runChatEngineLoop(
             // tool-result emission (onToolResult) sites fire them.
             onToolCall,
             onToolResult,
+            // PR 5b-followup-2: structured-error callback. Fires from
+            // the two `processOneStep` error sites (non-OK Convex
+            // response + processStream/tool catch).
+            onEngineError,
             abortSignal,
           });
 
@@ -2478,6 +2649,11 @@ export async function runChatEngineLoop(
                     }
                   : undefined,
                 settledWithError,
+                // PR 5b-followup-2: defensive copy so callers can
+                // retain the snapshot across step boundaries without
+                // racing against engine mutation of traceTurn.turnSpans
+                // on the next step.
+                turnSpans: [...traceTurn.turnSpans],
               });
             } catch (error) {
               logger.warn(
@@ -2579,6 +2755,14 @@ export async function runChatEngineLoop(
           safeWriter.write({
             type: "error",
             errorText,
+          });
+          // PR 5b-followup-2: surface to `streamSink: "none"` consumers.
+          // Site (3) — outer agentic-loop catch. No structured body,
+          // no stepIndex.
+          safelyEmitEngineError(onEngineError, {
+            message: errorText,
+            rawText: errorText,
+            promptIndex: traceTurn.promptIndex,
           });
         }
       } finally {


### PR DESCRIPTION
## Summary

Closes the two engine-surface gaps Cursor Bugbot caught on PR 5b (#2474). Same shape as PR 5b-pre: extend the chat-engine surface with optional fields, fire from where the data exists, eval consumes via the existing callback path. Chat / synthetic unaffected.

## (1) `turnSpans` on `MCPJamStepFinishEvent` — closes Cursor "Step snapshots omit LLM spans"

The engine accumulates per-step LLM + tool spans on `traceTurn.turnSpans` while the agentic loop runs but only surfaced them post-turn via `turnResult.turnTrace.spans`. Eval's mid-turn `step_finish` `trace_snapshot` events were missing the active turn's per-step LLM timing — live trace UI during multi-step hosted streaming evals lost step-level granularity that the removed inline loop + `streamIterationWithAiSdk` still attach.

Fix: `MCPJamStepFinishEvent.turnSpans: EvalTraceSpan[]` is a **defensive-copy snapshot** at step settlement. Eval's `onStepFinish` consumer stitches into the snapshot's `spans:` alongside `capturedSpans` + `traceCtx.recordedSpans`. The copy means callers may retain the snapshot across step boundaries without race risk against engine mutation.

## (2) `onEngineError` callback — closes Cursor "Stream guardrail errors lose detail"

Convex `/stream` HTTP failures (e.g. 429 daily-cap with structured `{ code, error, details }` body) no longer surfaced on eval SSE — the engine catches internally, emits an `error` UI chunk to the no-op writer (`streamSink: "none"`), and returns with `turnTrace: undefined`. PR 5b's runner mapped the missing trace to a generic "Backend stream failed during iteration" fallback, dropping the actual reason ("Daily MCPJam model limit reached. Use BYOK or try again tomorrow.").

Fix: new `MCPJamEngineErrorEvent` type + `onEngineError?: (event) => void` on `MCPJamHandlerOptions`. Engine fires at **all three** error-emit sites:
  1. Non-OK `/stream` HTTP response — structured fields populated when body parses as `{ code?, error, details? }`.
  2. `processStream` / tool-execution catch — `message` only.
  3. Outer agentic-loop catch — `message` only.

Structured-body parser (`parseEngineErrorBody`) moved into the engine — mirrors the legacy `describeBackendStreamError` shape that lived in `evals-runner` before PR 5b's collapse. Eval runner captures into `lastEngineError`, then the `!turnResult.turnTrace` branch prefers `lastEngineError.message` over the generic fallback when present. Raw body forwarded on the eval SSE `error.details` field.

## Diff shape

- `mcpjam-stream-handler.ts`: `turnSpans` field on event + defensive copy at fire site; new `MCPJamEngineErrorEvent` + `onEngineError` field + `parseEngineErrorBody` + `safelyEmitEngineError`; threaded through `StepContext`; fired at all 3 error sites.
- `assistant-turn.ts`: 2 pass-through fields.
- `evals-runner.ts`: `event.turnSpans` spread into snapshot spans; `lastEngineError` capture + use in `!turnTrace` failure branch.
- Tests: +4 engine-surface tests (turnSpans presence + defensive copy + onEngineError structured + onEngineError raw); +2 eval-runner integration tests (snapshot stitching + guardrail-detail surfacing).

## Test plan

- [x] Engine suite: 37/37 pass
- [x] Eval-runner suite: 58/58 pass (53 → 58: +2 new + the +3 existing still pass)
- [x] Full server suite: 1477 / 5 skipped, no regressions
- [x] `tsc --noEmit` baseline-matched (only 4 pre-existing finishParams errors)
- [ ] Smoke: hosted JAM-paid eval that hits the daily-cap — confirm 429 detail surfaces on the SSE error event
- [ ] Smoke: multi-step hosted eval — confirm mid-turn step_finish trace_snapshot carries per-step LLM spans in the trace UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval streaming failure detection and mid-turn trace payloads; behavior fixes are user-visible but scoped to hosted eval SSE/trace paths, not auth or persistence core.
> 
> **Overview**
> Extends the hosted streaming eval path so **mid-turn trace snapshots** and **failure SSE events** match what the old inline loop exposed after PR 5b.
> 
> **Mid-turn LLM spans:** `onStepFinish` now carries a defensive-copy **`turnSpans`** snapshot from the chat engine. The eval runner merges those spans into `step_finish` `trace_snapshot` events (alongside prior-turn and tool-instrumentation spans) so multi-step hosted evals show per-step LLM timing in the live trace UI before the turn completes.
> 
> **Structured guardrail errors:** Adds **`onEngineError`** / `MCPJamEngineErrorEvent` on the engine surface, fired at non-OK Convex `/stream` responses (parsed `{ code, error, details }`), per-step catches, and the outer agentic-loop catch. **`assistant-turn`** passes the callback through; the eval runner stores **`lastEngineError`** and prefers it over generic messages in all three stream failure branches (`!turnTrace`, empty new messages, non-tool error span), forwarding **`details`** on the eval `error` SSE event. SSE parse failures now **throw** instead of silently finishing the turn so `onEngineError` and failure detection still run.
> 
> Tests cover engine callbacks and eval-runner integration for span stitching and 429-style guardrail surfacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9ea32f23e957c1b063f23307413e2b7529d96e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->