### PR TITLE
shared+client: dedupe OpenAiApps / InjectedOpenAiCompat capabilities type

### DIFF
--- a/mcpjam-inspector/client/src/lib/client-styles/types.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/types.ts
@@ -4,6 +4,7 @@ import type {
   McpUiStyles,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
+import type { InjectedOpenAiCompatCapabilities } from "@/shared/widget-snapshot";
 
 /**
  * Persistable shape for a custom loading indicator. Built-in hosts ship
@@ -173,22 +174,13 @@ export interface HostMcpProfile {
  * widgets that test `if (window.openai.selectFiles)` must see
  * `undefined` to take their fallback path). `setOpenInAppUrl` is typed
  * and implemented by the OpenAI-compatible runtime.
+ *
+ * Re-exports the wire-shape definition from `shared/widget-snapshot.ts`
+ * (`InjectedOpenAiCompatCapabilities`) so client + server agree on a
+ * single structural type. The local `OpenAiAppsCapabilities` name is
+ * preserved for client-side call sites that group the matrix by app type.
  */
-export type OpenAiAppsCapabilities = {
-  callTool?: boolean;
-  sendFollowUpMessage?: boolean;
-  setWidgetState?: boolean;
-  requestDisplayMode?: "all" | "fullscreen-only" | "none";
-  notifyIntrinsicHeight?: boolean;
-  openExternal?: boolean;
-  setOpenInAppUrl?: boolean;
-  requestModal?: boolean;
-  uploadFile?: boolean;
-  selectFiles?: boolean;
-  getFileDownloadUrl?: boolean;
-  requestCheckout?: boolean;
-  requestClose?: boolean;
-};
+export type OpenAiAppsCapabilities = InjectedOpenAiCompatCapabilities;
 
 /**
  * Fully-resolved per-method surface — preset merged with user overrides,

--- a/mcpjam-inspector/shared/widget-snapshot.ts
+++ b/mcpjam-inspector/shared/widget-snapshot.ts
@@ -82,13 +82,14 @@ export type SharedChatWidgetSnapshotPayload = {
 };
 
 /**
- * Structurally identical to `OpenAiAppsCapabilities` in
- * `client/src/lib/client-styles/types.ts` (and to the matching shape on
- * `EvalTraceWidgetSnapshot`). All three are wire-level mirrors of the
- * Convex `injectedOpenAiCompatCapabilitiesValidator` — kept separate
- * because the client-styles file lives in `client/` and can't be
- * imported from shared/. A future cleanup could move the canonical
- * definition here and have the client-side alias re-export.
+ * Wire shape for the `window.openai` shim capability matrix persisted
+ * with a widget snapshot. Mirrors the Convex
+ * `injectedOpenAiCompatCapabilitiesValidator`.
+ *
+ * Canonical structural type for this matrix across the inspector:
+ * `client/src/lib/client-styles/types.ts` re-exports it as
+ * `OpenAiAppsCapabilities` (the name used by the widget-debug UI, which
+ * groups capabilities by app type) so client + server agree on one shape.
  */
 export type InjectedOpenAiCompatCapabilities = {
   callTool?: boolean;


### PR DESCRIPTION
## Summary

- Promote `InjectedOpenAiCompatCapabilities` (in `shared/widget-snapshot.ts`) as the canonical structural type for the `window.openai` shim per-method capability matrix.
- `OpenAiAppsCapabilities` (in `client/src/lib/client-styles/types.ts`) becomes a single-line `type` alias re-export. All existing client call sites keep their import path and exported name unchanged.
- Resolves the cross-link "future cleanup" comment that flagged the parallel definition.

## Verification that the two shapes were identical

Field-by-field comparison of the two `export type` blocks before this PR:

| field | `InjectedOpenAiCompatCapabilities` | `OpenAiAppsCapabilities` |
|---|---|---|
| `callTool` | `boolean?` | `boolean?` |
| `sendFollowUpMessage` | `boolean?` | `boolean?` |
| `setWidgetState` | `boolean?` | `boolean?` |
| `requestDisplayMode` | `"all" \| "fullscreen-only" \| "none"?` | same |
| `notifyIntrinsicHeight` | `boolean?` | `boolean?` |
| `openExternal` | `boolean?` | `boolean?` |
| `setOpenInAppUrl` | `boolean?` | `boolean?` |
| `requestModal` | `boolean?` | `boolean?` |
| `uploadFile` | `boolean?` | `boolean?` |
| `selectFiles` | `boolean?` | `boolean?` |
| `getFileDownloadUrl` | `boolean?` | `boolean?` |
| `requestCheckout` | `boolean?` | `boolean?` |
| `requestClose` | `boolean?` | `boolean?` |

Identical: same 13 fields, same types, same optionality (all `?`). No drift.

## Where the canonical definition now lives

`mcpjam-inspector/shared/widget-snapshot.ts` — `export type InjectedOpenAiCompatCapabilities`. The comment was updated to remove the "future cleanup" note and to record that `client-styles/types.ts` re-exports it as `OpenAiAppsCapabilities` for the widget-debug UI.

`client/src/lib/client-styles/types.ts` retains:

```ts
export type OpenAiAppsCapabilities = InjectedOpenAiCompatCapabilities;
```

…so `ResolvedOpenAiAppsCapabilities = Required<OpenAiAppsCapabilities>`, the `client-styles/index.ts` barrel, and every downstream `import { OpenAiAppsCapabilities }` continue to work unchanged.

## Call-site impact

**Zero consumer files needed updating.** The client-side public name is preserved via the alias; no call site to `OpenAiAppsCapabilities`, `ResolvedOpenAiAppsCapabilities`, or `InjectedOpenAiCompatCapabilities` changed.

Two files touched:
- `mcpjam-inspector/shared/widget-snapshot.ts` (comment update only, definition unchanged)
- `mcpjam-inspector/client/src/lib/client-styles/types.ts` (interface body replaced by alias + import)

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — same 3154-error baseline as `main` (pre-existing `evals-runner.ts`, `trace-repair-runner`, `guest-token-verifier`, `export-helpers.test`, `http-tool-calls.test` errors), no new errors introduced.
- [x] `npm run test -- --run client/src/lib/client-styles client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts` — 73/73 pass.
- [x] `npm run test -- --run shared/__tests__/widget-snapshot.test.ts` — 15/15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with preserved public client type names; no runtime or API behavior changes.
> 
> **Overview**
> **Deduplicates** the `window.openai` per-method capability matrix so client and shared code share one structural type instead of two parallel copies.
> 
> `InjectedOpenAiCompatCapabilities` in **`shared/widget-snapshot.ts`** is documented as the **canonical** wire shape (aligned with Convex validators and snapshot persistence). In **`client/src/lib/client-styles/types.ts`**, the inline **`OpenAiAppsCapabilities`** object type is **replaced** with `export type OpenAiAppsCapabilities = InjectedOpenAiCompatCapabilities` plus an import from shared. **`ResolvedOpenAiAppsCapabilities`** and all existing **`OpenAiAppsCapabilities`** imports keep the same names and paths—no call-site updates.
> 
> Comments drop the old “future cleanup” note and describe the alias relationship for widget-debug vs snapshot wire naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dcacda34c4e6379184cf1ef4dc5197898370bc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->