### PR TITLE
mcp-apps: extract framework-free host-app-bridge shared module (eval browser-render PR 1/5)

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
@@ -306,6 +306,14 @@ describe("tool visibility helpers", () => {
       false,
     );
   });
+  it("dedupes repeated scopes so model-only stays enforced", () => {
+    expect(getToolVisibility({ ui: { visibility: ["model", "model"] } })).toEqual(
+      ["model"],
+    );
+    expect(
+      isVisibleToModelOnly({ ui: { visibility: ["model", "model"] } }),
+    ).toBe(true);
+  });
 });
 
 /* ------------------------------------------------------------------ *

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
+import {
+  registerHostBridgeHandlers,
+  resolveIframeSandboxPolicy,
+  buildOuterSandboxAttribute,
+  buildOuterAllowAttribute,
+  getToolVisibility,
+  isVisibleToModelOnly,
+  type HostBridgeCallbacks,
+  type RegisterHostBridgeHandlersOptions,
+} from "../host-app-bridge";
+
+/* ------------------------------------------------------------------ *
+ * Stub bridge
+ *
+ * `registerHostBridgeHandlers` only assigns the `on*` handler slots and calls
+ * `sendToolCancelled` / `teardownResource` / `getAppCapabilities`. A plain
+ * object satisfies that surface; cast to AppBridge for the call site.
+ * ------------------------------------------------------------------ */
+type StubBridge = {
+  oninitialized?: (...args: unknown[]) => unknown;
+  onmessage?: (...args: unknown[]) => unknown;
+  onopenlink?: (...args: unknown[]) => unknown;
+  oncalltool?: (...args: unknown[]) => unknown;
+  onreadresource?: (...args: unknown[]) => unknown;
+  onlistresources?: (...args: unknown[]) => unknown;
+  onlistresourcetemplates?: (...args: unknown[]) => unknown;
+  onlistprompts?: (...args: unknown[]) => unknown;
+  onloggingmessage?: (...args: unknown[]) => unknown;
+  onsizechange?: (...args: unknown[]) => unknown;
+  onrequestdisplaymode?: (...args: unknown[]) => unknown;
+  onupdatemodelcontext?: (...args: unknown[]) => unknown;
+  ondownloadfile?: (...args: unknown[]) => unknown;
+  onrequestteardown?: (...args: unknown[]) => unknown;
+  sendToolCancelled: ReturnType<typeof vi.fn>;
+  teardownResource: ReturnType<typeof vi.fn>;
+  getAppCapabilities: ReturnType<typeof vi.fn>;
+};
+
+function makeStubBridge(
+  appCaps: Record<string, unknown> | undefined = undefined,
+): StubBridge {
+  return {
+    sendToolCancelled: vi.fn().mockResolvedValue(undefined),
+    teardownResource: vi.fn().mockResolvedValue({}),
+    getAppCapabilities: vi.fn().mockReturnValue(appCaps),
+  };
+}
+
+const ALL_CAPS = {
+  message: true,
+  openLinks: true,
+  serverTools: true,
+  serverResources: true,
+  logging: true,
+  updateModelContext: true,
+  downloadFile: true,
+} as RegisterHostBridgeHandlersOptions["effectiveHostCapabilities"];
+
+const NO_CAPS = {
+  message: false,
+  openLinks: false,
+  serverTools: false,
+  serverResources: false,
+  logging: false,
+  updateModelContext: false,
+  downloadFile: false,
+} as RegisterHostBridgeHandlersOptions["effectiveHostCapabilities"];
+
+function register(
+  bridge: StubBridge,
+  opts: Partial<RegisterHostBridgeHandlersOptions> & {
+    callbacks?: HostBridgeCallbacks;
+  } = {},
+) {
+  registerHostBridgeHandlers(bridge as unknown as AppBridge, {
+    effectiveHostCapabilities: opts.effectiveHostCapabilities ?? ALL_CAPS,
+    getMatrix: opts.getMatrix,
+    getToolMetadata: opts.getToolMetadata,
+    getToolCallId: opts.getToolCallId ?? (() => "tc-1"),
+    nextInvocationSequence: opts.nextInvocationSequence,
+    onWidgetDebug: opts.onWidgetDebug,
+    callbacks: opts.callbacks ?? {},
+  });
+}
+
+describe("registerHostBridgeHandlers — capability gating (advertise = enforce)", () => {
+  it("installs no capability-gated handlers when all caps are off", () => {
+    const bridge = makeStubBridge();
+    register(bridge, { effectiveHostCapabilities: NO_CAPS });
+
+    expect(bridge.onmessage).toBeUndefined();
+    expect(bridge.onopenlink).toBeUndefined();
+    expect(bridge.oncalltool).toBeUndefined();
+    expect(bridge.onreadresource).toBeUndefined();
+    expect(bridge.onlistresources).toBeUndefined();
+    expect(bridge.onlistresourcetemplates).toBeUndefined();
+    expect(bridge.onloggingmessage).toBeUndefined();
+    expect(bridge.onupdatemodelcontext).toBeUndefined();
+    expect(bridge.ondownloadfile).toBeUndefined();
+  });
+
+  it("keeps the unconditional handlers installed even with all caps off", () => {
+    const bridge = makeStubBridge();
+    register(bridge, { effectiveHostCapabilities: NO_CAPS });
+
+    expect(bridge.oninitialized).toBeTypeOf("function");
+    expect(bridge.onlistprompts).toBeTypeOf("function");
+    expect(bridge.onsizechange).toBeTypeOf("function");
+    expect(bridge.onrequestdisplaymode).toBeTypeOf("function");
+  });
+
+  it("serverTools=false leaves oncalltool unassigned", () => {
+    const bridge = makeStubBridge();
+    register(bridge, {
+      effectiveHostCapabilities: { ...ALL_CAPS, serverTools: false },
+    });
+    expect(bridge.oncalltool).toBeUndefined();
+  });
+
+  it("installs every handler when all caps are on", () => {
+    const bridge = makeStubBridge();
+    register(bridge, { effectiveHostCapabilities: ALL_CAPS });
+
+    for (const slot of [
+      "oninitialized",
+      "onmessage",
+      "onopenlink",
+      "oncalltool",
+      "onreadresource",
+      "onlistresources",
+      "onlistresourcetemplates",
+      "onlistprompts",
+      "onloggingmessage",
+      "onsizechange",
+      "onrequestdisplaymode",
+      "onupdatemodelcontext",
+      "ondownloadfile",
+      "onrequestteardown",
+    ] as const) {
+      expect(bridge[slot], slot).toBeTypeOf("function");
+    }
+  });
+});
+
+describe("registerHostBridgeHandlers — handshake", () => {
+  it("oninitialized forwards the bridge to onAppInitialized", () => {
+    const bridge = makeStubBridge({ tools: false });
+    const onAppInitialized = vi.fn();
+    register(bridge, { callbacks: { onAppInitialized } });
+
+    bridge.oninitialized?.();
+    expect(onAppInitialized).toHaveBeenCalledTimes(1);
+    expect(onAppInitialized).toHaveBeenCalledWith(bridge);
+  });
+});
+
+describe("registerHostBridgeHandlers — model-only visibility (SEP-1865)", () => {
+  it("rejects an app-initiated call to a model-only tool and never dispatches", async () => {
+    const bridge = makeStubBridge();
+    const onCallTool = vi.fn().mockResolvedValue({ content: [] });
+    register(bridge, {
+      getToolMetadata: (name) =>
+        name === "secret" ? { ui: { visibility: ["model"] } } : undefined,
+      callbacks: { onCallTool },
+    });
+
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "secret", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow(/not callable by apps/);
+    expect(onCallTool).not.toHaveBeenCalled();
+    // matrix permits the side-channel notification by default
+    expect(bridge.sendToolCancelled).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches a normally-visible tool and returns its result", async () => {
+    const bridge = makeStubBridge();
+    const result = { content: [{ type: "text", text: "ok" }] };
+    const onCallTool = vi.fn().mockResolvedValue(result);
+    register(bridge, {
+      getToolMetadata: () => ({}), // default visibility => model + app
+      callbacks: { onCallTool },
+    });
+
+    const out = await (
+      bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>
+    )({ name: "search", arguments: { q: 1 } }, {});
+    expect(onCallTool).toHaveBeenCalledWith("search", { q: 1 });
+    expect(out).toBe(result);
+  });
+});
+
+describe("registerHostBridgeHandlers — sendToolCancelled matrix gating", () => {
+  it("suppresses sendToolCancelled when matrix.toolCancelled === false", async () => {
+    const bridge = makeStubBridge();
+    register(bridge, {
+      getMatrix: () => ({ toolCancelled: false }),
+      getToolMetadata: () => ({ ui: { visibility: ["model"] } }),
+      callbacks: { onCallTool: vi.fn() },
+    });
+
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "x", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow();
+    expect(bridge.sendToolCancelled).not.toHaveBeenCalled();
+  });
+});
+
+describe("registerHostBridgeHandlers — app-tool invocation lifecycle", () => {
+  it("emits running → success around a dispatched call", async () => {
+    const bridge = makeStubBridge();
+    const updates: Array<{ status: string }> = [];
+    register(bridge, {
+      getToolCallId: () => "parent-1",
+      nextInvocationSequence: () => 7,
+      callbacks: {
+        onCallTool: vi.fn().mockResolvedValue({ content: [] }),
+        onAppToolInvocation: (u) => updates.push(u),
+      },
+    });
+
+    await (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+      { name: "go", arguments: {} },
+      {},
+    );
+    expect(updates.map((u) => u.status)).toEqual(["running", "success"]);
+    expect((updates[0] as { id: string }).id).toBe("parent-1:app-tool:7");
+  });
+
+  it("emits running → error and cancels when the dispatch throws", async () => {
+    const bridge = makeStubBridge();
+    const updates: Array<{ status: string; errorText?: string }> = [];
+    register(bridge, {
+      callbacks: {
+        onCallTool: vi.fn().mockRejectedValue(new Error("boom")),
+        onAppToolInvocation: (u) => updates.push(u),
+      },
+    });
+
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "go", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow("boom");
+    expect(updates.map((u) => u.status)).toEqual(["running", "error"]);
+    expect(updates[1].errorText).toBe("boom");
+    expect(bridge.sendToolCancelled).toHaveBeenCalledWith({ reason: "boom" });
+  });
+
+  it("treats a missing onCallTool as 'Tool calls not supported'", async () => {
+    const bridge = makeStubBridge();
+    const updates: Array<{ status: string; errorText?: string }> = [];
+    register(bridge, {
+      callbacks: { onAppToolInvocation: (u) => updates.push(u) },
+    });
+
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "go", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow("Tool calls not supported");
+    expect(updates.map((u) => u.status)).toEqual(["running", "error"]);
+    expect(updates[1].errorText).toBe("Tool calls not supported");
+  });
+});
+
+describe("registerHostBridgeHandlers — teardown gating", () => {
+  it("does not install onrequestteardown when matrix.requestTeardown === false", () => {
+    const bridge = makeStubBridge();
+    register(bridge, { getMatrix: () => ({ requestTeardown: false }) });
+    expect(bridge.onrequestteardown).toBeUndefined();
+  });
+
+  it("installs onrequestteardown by default and runs teardownResource + callback", async () => {
+    const bridge = makeStubBridge();
+    const onRequestTeardown = vi.fn();
+    register(bridge, {
+      getToolCallId: () => "tc-9",
+      callbacks: { onRequestTeardown },
+    });
+    expect(bridge.onrequestteardown).toBeTypeOf("function");
+    await (bridge.onrequestteardown as () => Promise<unknown>)();
+    expect(bridge.teardownResource).toHaveBeenCalledTimes(1);
+    expect(onRequestTeardown).toHaveBeenCalledWith("tc-9");
+  });
+});
+
+describe("tool visibility helpers", () => {
+  it("defaults to model + app when unspecified", () => {
+    expect(getToolVisibility(undefined)).toEqual(["model", "app"]);
+    expect(getToolVisibility({})).toEqual(["model", "app"]);
+    expect(isVisibleToModelOnly({})).toBe(false);
+  });
+  it("detects model-only", () => {
+    expect(isVisibleToModelOnly({ ui: { visibility: ["model"] } })).toBe(true);
+    expect(isVisibleToModelOnly({ ui: { visibility: ["model", "app"] } })).toBe(
+      false,
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * Iframe sandbox attribute construction
+ *
+ * Asserts the extracted builders produce exactly the strings SandboxedIframe
+ * produced pre-refactor for matching inputs (plan verification step 1).
+ * ------------------------------------------------------------------ */
+describe("resolveIframeSandboxPolicy — outer attribute construction", () => {
+  it("falls back to the permissive baseline when sandboxAttrs is undefined", () => {
+    expect(buildOuterSandboxAttribute({})).toBe(
+      "allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts",
+    );
+  });
+
+  it("treats [] as spec-minimum (allow-scripts + allow-same-origin only)", () => {
+    expect(buildOuterSandboxAttribute({ sandboxAttrs: [] })).toBe(
+      "allow-same-origin allow-scripts",
+    );
+  });
+
+  it("unions profile tokens with the spec minimum, sorted", () => {
+    expect(
+      buildOuterSandboxAttribute({ sandboxAttrs: ["allow-forms"] }),
+    ).toBe("allow-forms allow-same-origin allow-scripts");
+  });
+
+  it("rejects sandbox tokens with internal whitespace", () => {
+    expect(
+      buildOuterSandboxAttribute({
+        sandboxAttrs: ["allow-forms", "allow-popups allow-modals"],
+      }),
+    ).toBe("allow-forms allow-same-origin allow-scripts");
+  });
+
+  it("emits legacy allow defaults when allowFeatures is undefined", () => {
+    expect(buildOuterAllowAttribute({})).toBe(
+      "local-network-access *; midi *",
+    );
+  });
+
+  it("flows the 4 spec permissions through regardless of allowFeatures", () => {
+    expect(
+      buildOuterAllowAttribute({
+        permissions: { camera: {}, clipboardWrite: {} } as never,
+        allowFeatures: {},
+      }),
+    ).toBe("camera *; clipboard-write *");
+  });
+
+  it("drops the legacy defaults when allowFeatures is authoritative ({})", () => {
+    expect(buildOuterAllowAttribute({ allowFeatures: {} })).toBe("");
+  });
+
+  it("appends non-spec permissions-policy features from allowFeatures", () => {
+    expect(
+      buildOuterAllowAttribute({ allowFeatures: { fullscreen: "*" } }),
+    ).toBe("fullscreen *");
+  });
+
+  it("ignores spec features and injection attempts in allowFeatures", () => {
+    expect(
+      buildOuterAllowAttribute({
+        allowFeatures: {
+          camera: "*", // spec feature: must come from permissions, not here
+          "bad key": "*", // whitespace in key
+          evil: "*; camera *", // separator injection in value
+          fullscreen: "*",
+        },
+      }),
+    ).toBe("fullscreen *");
+  });
+
+  it("resolveIframeSandboxPolicy composes both attributes", () => {
+    expect(
+      resolveIframeSandboxPolicy({
+        sandboxAttrs: ["allow-forms"],
+        permissions: { camera: {} } as never,
+        allowFeatures: { fullscreen: "*" },
+      }),
+    ).toEqual({
+      sandbox: "allow-forms allow-same-origin allow-scripts",
+      allow: "camera *; fullscreen *",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge.ts
@@ -423,6 +423,10 @@ export function registerHostBridgeHandlers(
   // view-initiated teardown by leaving the handler unassigned.
   if ((getMatrix?.() ?? null)?.requestTeardown !== false) {
     bridge.onrequestteardown = async () => {
+      // Capture the teardown target BEFORE awaiting: the renderer adapter backs
+      // `getToolCallId` with a live ref, so a prop swap during the round-trip
+      // could otherwise unmount a newer widget than the one that asked to close.
+      const toolCallId = currentToolCallId();
       onWidgetDebug?.("ui-to-host", "ui/notifications/request-teardown", {});
       try {
         await bridge.teardownResource({});
@@ -433,7 +437,7 @@ export function registerHostBridgeHandlers(
           error: err instanceof Error ? err.message : String(err),
         });
       }
-      callbacks.onRequestTeardown?.(currentToolCallId());
+      callbacks.onRequestTeardown?.(toolCallId);
     };
   }
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge.ts
@@ -1,0 +1,439 @@
+/**
+ * host-app-bridge.ts — framework-free MCP Apps host bridge surface (SEP-1865)
+ *
+ * Extracted from `mcp-apps-renderer.tsx` so the host-side AppBridge wiring,
+ * the capability-gated bridge handler installation, and the iframe sandbox
+ * attribute construction can be reused outside React — specifically by the
+ * eval browser harness (`server/utils/mcp-app-browser-harness.ts`) which must
+ * behave like the production renderer when it mounts a widget in headless
+ * Chromium.
+ *
+ * Design contract:
+ *   - This module is PURE JS: no React, no DOM-effect ownership, no Zustand.
+ *   - All host-environment effects (open a link, read a resource, dispatch a
+ *     tool call, mutate display mode, animate the iframe) are injected as
+ *     callbacks. The renderer binds its `useRef`/`useState`/`useCallback`
+ *     machinery to these inputs; the harness binds its own.
+ *   - The genuinely-shared *correctness surface* lives here verbatim:
+ *     capability gating (advertise = enforce), the model-only visibility
+ *     check, the matrix-gated `sendToolCancelled` policy, and the app-tool
+ *     invocation lifecycle. The harness needs all of it to match production.
+ *
+ * React-specific concerns (state updates, refs, reconnection) stay in the
+ * renderer. See `mcp-apps-renderer.tsx` for the adapter that consumes this.
+ */
+
+import {
+  AppBridge,
+  type McpUiHostCapabilities,
+  type McpUiHostContext,
+  type McpUiResourceCsp,
+  type McpUiResourcePermissions,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import { isVisibleToModelOnly } from "@/lib/mcp-ui/tool-visibility";
+import type { AppToolInvocationUpdate } from "../app-tool-invocations";
+
+// Re-export the shared SEP-1865 visibility helpers and the iframe sandbox
+// attribute resolver so harness consumers can pull the full host surface from
+// a single framework-free module ("alongside the bridge").
+export {
+  getToolVisibility,
+  isVisibleToModelOnly,
+  isVisibleToAppOnly,
+} from "@/lib/mcp-ui/tool-visibility";
+export {
+  DEFAULT_IFRAME_SANDBOX,
+  buildOuterAllowAttribute,
+  buildOuterSandboxAttribute,
+  resolveIframeSandboxPolicy,
+} from "@/lib/mcp-ui/iframe-sandbox-policy";
+
+/* ------------------------------------------------------------------ *
+ * Host AppBridge construction
+ * ------------------------------------------------------------------ */
+
+/**
+ * Construct a host-side AppBridge with the resolved capabilities + sandbox
+ * slice + host context. Mirrors the inline `new AppBridge(...)` the renderer
+ * builds. The caller wires a transport and calls `bridge.connect(transport)`.
+ */
+export function createHostAppBridge(opts: {
+  hostInfo: { name: string; version: string };
+  hostCapabilities: Omit<McpUiHostCapabilities, "sandbox">;
+  sandbox?: {
+    csp?: McpUiResourceCsp;
+    permissions?: McpUiResourcePermissions;
+  };
+  hostContext?: McpUiHostContext;
+}): AppBridge {
+  return new AppBridge(
+    null,
+    opts.hostInfo,
+    {
+      ...opts.hostCapabilities,
+      sandbox: opts.sandbox ?? {},
+    },
+    { hostContext: opts.hostContext ?? {} },
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Bridge handler installation (the correctness surface)
+ * ------------------------------------------------------------------ */
+
+// Derive result/param types from the AppBridge handler signatures so we never
+// import the MCP v1 SDK types package directly (forbidden in client/src by the
+// `check:mcp-v1-runtime-imports` guard). The types flow through ext-apps.
+type CallToolReturn = Awaited<ReturnType<NonNullable<AppBridge["oncalltool"]>>>;
+type ReadResourceReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onreadresource"]>>
+>;
+type ListResourcesParams = Parameters<
+  NonNullable<AppBridge["onlistresources"]>
+>[0];
+type ListResourcesReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onlistresources"]>>
+>;
+type ListResourceTemplatesParams = Parameters<
+  NonNullable<AppBridge["onlistresourcetemplates"]>
+>[0];
+type ListResourceTemplatesReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onlistresourcetemplates"]>>
+>;
+type ListPromptsReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onlistprompts"]>>
+>;
+type LoggingMessageParams = Parameters<
+  NonNullable<AppBridge["onloggingmessage"]>
+>[0];
+type SizeChangeParams = Parameters<NonNullable<AppBridge["onsizechange"]>>[0];
+type RequestDisplayModeParams = Parameters<
+  NonNullable<AppBridge["onrequestdisplaymode"]>
+>[0];
+type RequestDisplayModeReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onrequestdisplaymode"]>>
+>;
+type UpdateModelContextParams = Parameters<
+  NonNullable<AppBridge["onupdatemodelcontext"]>
+>[0];
+type DownloadFileParams = Parameters<
+  NonNullable<AppBridge["ondownloadfile"]>
+>[0];
+type DownloadFileReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["ondownloadfile"]>>
+>;
+
+export type WidgetDebugDirection = "host-to-ui" | "ui-to-host";
+
+/**
+ * The minimal slice of the MCP Apps capabilities matrix that the shared
+ * correctness surface reads. `null` means "no matrix configured" (treat as
+ * all-allowed), matching the renderer's `mcpAppsCapabilitiesRef.current`.
+ */
+export interface HostBridgeMatrix {
+  /** When false, suppress the side-channel `sendToolCancelled` notification. */
+  toolCancelled?: boolean;
+  /** When false, do not install the view-initiated teardown handler. */
+  requestTeardown?: boolean;
+}
+
+/**
+ * Host-environment effects injected by the consumer. Every callback is
+ * optional; an unset callback means the corresponding host behavior is a no-op
+ * (the bridge handler is still installed when its capability is advertised, so
+ * the widget sees a well-formed response).
+ */
+export interface HostBridgeCallbacks {
+  /** Fires on `ui/initialize` completion. The renderer drives all of its
+   *  init-time state from here (ready flag, display modes, app-provided-tools
+   *  detection + auto-promote); the harness records render readiness. */
+  onAppInitialized?: (bridge: AppBridge) => void;
+  /** `ui/message` text content (host follow-up). */
+  onSendFollowUp?: (text: string) => void;
+  /** `ui/open-link`. */
+  onOpenLink?: (url: string) => void;
+  /** App-initiated `tools/call` dispatcher. Resolves to a CallToolResult. */
+  onCallTool?: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => Promise<CallToolReturn>;
+  /** App-tool invocation lifecycle updates (running/success/error). */
+  onAppToolInvocation?: (update: AppToolInvocationUpdate) => void;
+  /** `resources/read`. */
+  onReadResource?: (uri: string) => Promise<ReadResourceReturn>;
+  /** `resources/list`. */
+  onListResources?: (
+    params: ListResourcesParams,
+  ) => Promise<ListResourcesReturn>;
+  /** `resources/templates/list`. */
+  onListResourceTemplates?: (
+    params: ListResourceTemplatesParams,
+  ) => Promise<ListResourceTemplatesReturn>;
+  /** `prompts/list`. */
+  onListPrompts?: () => Promise<ListPromptsReturn>;
+  /** `logging/message`. */
+  onLoggingMessage?: (params: LoggingMessageParams) => void;
+  /** `ui/notifications/size-changed`. */
+  onSizeChange?: (params: SizeChangeParams) => void;
+  /** `ui/request-display-mode`. Returns the granted mode. */
+  onRequestDisplayMode?: (
+    params: RequestDisplayModeParams,
+  ) => Promise<RequestDisplayModeReturn> | RequestDisplayModeReturn;
+  /** `ui/update-model-context`. */
+  onUpdateModelContext?: (
+    toolCallId: string,
+    params: UpdateModelContextParams,
+  ) => void;
+  /** `ui/download-file`. */
+  onDownloadFile?: (
+    params: DownloadFileParams,
+  ) => Promise<DownloadFileReturn> | DownloadFileReturn;
+  /** `ui/notifications/request-teardown` (after host-side teardownResource). */
+  onRequestTeardown?: (toolCallId: string) => void;
+}
+
+export interface RegisterHostBridgeHandlersOptions {
+  /**
+   * Resolved host capabilities (vendor-trait surface advertised in
+   * `ui/initialize`). Gating here is advertise = enforce: a handler is only
+   * installed when its capability is true.
+   */
+  effectiveHostCapabilities: Omit<McpUiHostCapabilities, "sandbox">;
+  /** Read the MCP Apps capabilities matrix at call/registration time. */
+  getMatrix?: () => HostBridgeMatrix | null;
+  /** Look up tool metadata by name for the model-only visibility check. */
+  getToolMetadata?: (name: string) => Record<string, unknown> | undefined;
+  /** Current parent tool-call id (correlates app-tool invocations + teardown). */
+  getToolCallId?: () => string;
+  /** Monotonic sequence source for app-tool invocation ids. Defaults to an
+   *  internal per-registration counter; the renderer passes a shared ref so
+   *  inline + modal bridges never collide on an invocation id. */
+  nextInvocationSequence?: () => number;
+  /** Host-environment effect callbacks. */
+  callbacks: HostBridgeCallbacks;
+  /** Diagnostic sink (traffic / widget-debug). */
+  onWidgetDebug?: (
+    direction: WidgetDebugDirection,
+    method: string,
+    data: Record<string, unknown>,
+  ) => void;
+}
+
+/**
+ * Install the SEP-1865 host bridge handlers on `bridge`, gated by
+ * `effectiveHostCapabilities` and the capabilities matrix. This is the
+ * production correctness surface — capability gating, model-only visibility,
+ * matrix-gated `sendToolCancelled`, and the app-tool invocation lifecycle —
+ * lifted out of the React renderer so the eval harness shares it verbatim.
+ */
+export function registerHostBridgeHandlers(
+  bridge: AppBridge,
+  options: RegisterHostBridgeHandlersOptions,
+): void {
+  const {
+    effectiveHostCapabilities,
+    getMatrix,
+    getToolMetadata,
+    getToolCallId,
+    callbacks,
+    onWidgetDebug,
+  } = options;
+
+  let internalSeq = 0;
+  const nextSeq = options.nextInvocationSequence ?? (() => internalSeq++);
+  const currentToolCallId = () => getToolCallId?.() ?? "";
+
+  bridge.oninitialized = () => {
+    callbacks.onAppInitialized?.(bridge);
+  };
+
+  // SEP-1865 bridge handlers are gated by `effectiveHostCapabilities` alone.
+  // They are a SEPARATE surface from the `window.openai` shim; folding the
+  // shim matrix in here would break the advertise = enforce contract.
+  if (effectiveHostCapabilities.message) {
+    bridge.onmessage = async ({ content }) => {
+      const textContent = content.find((item) => item.type === "text")?.text;
+      if (textContent) {
+        callbacks.onSendFollowUp?.(textContent);
+      }
+      return {};
+    };
+  }
+
+  if (effectiveHostCapabilities.openLinks) {
+    bridge.onopenlink = async ({ url }) => {
+      if (url) {
+        callbacks.onOpenLink?.(url);
+      }
+      return {};
+    };
+  }
+
+  if (effectiveHostCapabilities.serverTools) {
+    // Matrix-gated `sendToolCancelled`: Microsoft 365 Copilot does not deliver
+    // `ui/notifications/tool-cancelled`; simulated Copilot hosts must not see
+    // the cancelled callback even when the underlying tool throws. The handler
+    // still THROWS so the request/response path reports an error to the widget
+    // — only the side-channel notification is suppressed.
+    const sendToolCancelledIfAllowed = (reason: string) => {
+      const matrix = getMatrix?.() ?? null;
+      if (matrix !== null && matrix.toolCancelled === false) return;
+      void bridge.sendToolCancelled({ reason });
+    };
+    bridge.oncalltool = async ({ name, arguments: args }, _extra) => {
+      // Model-only tools (visibility: ["model"]) are not callable by apps.
+      const calledToolMeta = getToolMetadata?.(name);
+      if (isVisibleToModelOnly(calledToolMeta)) {
+        const error = new Error(
+          `Tool "${name}" is not callable by apps (visibility: model-only)`,
+        );
+        sendToolCancelledIfAllowed(error.message);
+        throw error;
+      }
+
+      const invocationInput = (args ?? {}) as Record<string, unknown>;
+      const parentToolCallId = currentToolCallId();
+      const invocationId = `${parentToolCallId}:app-tool:${nextSeq()}`;
+      const startedAt = Date.now();
+      callbacks.onAppToolInvocation?.({
+        id: invocationId,
+        parentToolCallId,
+        toolName: name,
+        input: invocationInput,
+        status: "running",
+        startedAt,
+      });
+
+      if (!callbacks.onCallTool) {
+        const error = new Error("Tool calls not supported");
+        callbacks.onAppToolInvocation?.({
+          id: invocationId,
+          parentToolCallId,
+          toolName: name,
+          input: invocationInput,
+          errorText: error.message,
+          status: "error",
+          startedAt,
+          completedAt: Date.now(),
+        });
+        sendToolCancelledIfAllowed(error.message);
+        throw error;
+      }
+
+      try {
+        const result = await callbacks.onCallTool(name, invocationInput);
+        callbacks.onAppToolInvocation?.({
+          id: invocationId,
+          parentToolCallId,
+          toolName: name,
+          input: invocationInput,
+          output: result,
+          status: "success",
+          startedAt,
+          completedAt: Date.now(),
+        });
+        return result;
+      } catch (error) {
+        const errorText =
+          error instanceof Error ? error.message : String(error);
+        callbacks.onAppToolInvocation?.({
+          id: invocationId,
+          parentToolCallId,
+          toolName: name,
+          input: invocationInput,
+          errorText,
+          status: "error",
+          startedAt,
+          completedAt: Date.now(),
+        });
+        sendToolCancelledIfAllowed(errorText);
+        throw error;
+      }
+    };
+  }
+
+  if (effectiveHostCapabilities.serverResources) {
+    bridge.onreadresource = async ({ uri }) => {
+      if (!callbacks.onReadResource) {
+        throw new Error("Resource reads not supported");
+      }
+      return callbacks.onReadResource(uri);
+    };
+
+    bridge.onlistresources = async (params) => {
+      if (!callbacks.onListResources) {
+        return { resources: [] } as ListResourcesReturn;
+      }
+      return callbacks.onListResources(params);
+    };
+
+    bridge.onlistresourcetemplates = async (params) => {
+      if (!callbacks.onListResourceTemplates) {
+        return { resourceTemplates: [] } as ListResourceTemplatesReturn;
+      }
+      return callbacks.onListResourceTemplates(params);
+    };
+  }
+
+  // onlistprompts: unconditional — no serverPrompts cap in SEP-1865.
+  bridge.onlistprompts = async () => {
+    if (!callbacks.onListPrompts) {
+      return { prompts: [] } as ListPromptsReturn;
+    }
+    return callbacks.onListPrompts();
+  };
+
+  if (effectiveHostCapabilities.logging) {
+    bridge.onloggingmessage = (params) => {
+      callbacks.onLoggingMessage?.(params);
+    };
+  }
+
+  // Size changes are unconditional in the renderer (the host shell owns layout).
+  bridge.onsizechange = (params) => {
+    callbacks.onSizeChange?.(params);
+  };
+
+  bridge.onrequestdisplaymode = async (params) => {
+    if (callbacks.onRequestDisplayMode) {
+      return callbacks.onRequestDisplayMode(params);
+    }
+    // No host display-mode policy → echo the requested mode (default inline).
+    return { mode: params.mode ?? "inline" } as RequestDisplayModeReturn;
+  };
+
+  if (effectiveHostCapabilities.updateModelContext) {
+    bridge.onupdatemodelcontext = async (params) => {
+      callbacks.onUpdateModelContext?.(currentToolCallId(), params);
+      return {};
+    };
+  }
+
+  if (effectiveHostCapabilities.downloadFile) {
+    bridge.ondownloadfile = async (params) => {
+      if (!callbacks.onDownloadFile) {
+        return {} as DownloadFileReturn;
+      }
+      return callbacks.onDownloadFile(params);
+    };
+  }
+
+  // `requestTeardown` is a behavior gate on the matrix (not a wire-advertised
+  // host capability); presets that set it false simulate hosts that ignore
+  // view-initiated teardown by leaving the handler unassigned.
+  if ((getMatrix?.() ?? null)?.requestTeardown !== false) {
+    bridge.onrequestteardown = async () => {
+      onWidgetDebug?.("ui-to-host", "ui/notifications/request-teardown", {});
+      try {
+        await bridge.teardownResource({});
+      } catch (err) {
+        // Teardown is best-effort; proceed to unmount even if the view never
+        // acks so a misbehaving widget can't block its own removal.
+        onWidgetDebug?.("host-to-ui", "ui/resource-teardown", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      callbacks.onRequestTeardown?.(currentToolCallId());
+    };
+  }
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -60,7 +60,7 @@ import type {
 } from "@modelcontextprotocol/client";
 import { DEFAULT_HOST_STYLE, getHostStyleOrDefault } from "@/lib/client-styles";
 import type { OpenAiAppsCapabilities } from "@/lib/client-styles";
-import { isVisibleToModelOnly } from "@/lib/mcp-ui/mcp-apps-utils";
+import { registerHostBridgeHandlers } from "./host-app-bridge";
 import { LoggingTransport } from "./mcp-apps-logging-transport";
 import { McpAppsModal } from "./mcp-apps-modal";
 import {
@@ -2749,518 +2749,319 @@ export function MCPAppsRendererSurface({
     onRequestTeardown,
   ]);
 
-  // ENFORCEMENT (live):
-  // `effectiveHostCapabilities` (above) is the contract advertised in
-  // ui/initialize, and the six chip-bound handlers below are only assigned
-  // when their cap is present — so advertise and enforce stay in lockstep.
-  // An unassigned `bridge.on*` slot causes the SDK to auto-respond to the
-  // widget's RPC with a "method not supported" envelope, matching strict
-  // host behavior.
-  //   • bridge.onopenlink            ← effectiveHostCapabilities.openLinks
-  //   • bridge.onmessage             ← effectiveHostCapabilities.message
-  //   • bridge.onupdatemodelcontext  ← effectiveHostCapabilities.updateModelContext
-  //   • bridge.oncalltool            ← effectiveHostCapabilities.serverTools
-  //   • bridge.onreadresource /
-  //     onlistresources /
-  //     onlistresourcetemplates      ← effectiveHostCapabilities.serverResources
-  //   • bridge.onloggingmessage      ← effectiveHostCapabilities.logging
-  //   • bridge.ondownloadfile        ← effectiveHostCapabilities.downloadFile
-  //   • bridge.onrequestteardown     ← matrix.requestTeardown (behavior
-  //                                    gate; not wire-advertised — the
-  //                                    notification is always delivered
-  //                                    by the SDK, but the host can
-  //                                    decline to act on it)
-  //
-  // Intentionally unconditional (no chip / not capability-negotiated in
-  // SEP-1865):
-  //   • bridge.oninitialized         — handshake plumbing
-  //   • bridge.onsizechange          — iframe resize is host-shell infra
-  //   • bridge.onrequestdisplaymode  — request acceptance is always OK;
-  //                                    the spec governs which modes are
-  //                                    granted, not whether requests reply
-  //   • bridge.onlistprompts         — no serverPrompts cap exists yet
-  //   • handleUploadFile / GetFileDownloadUrl
-  //                                  — legacy postMessage paths kept for
-  //                                    Apps SDK widgets; SEP-1865 hosts
-  //                                    use the matrix-gated
-  //                                    bridge.ondownloadfile above
+  // Adapter: bind the renderer's refs / state setters / store callbacks to the
+  // framework-free host bridge surface (`host-app-bridge.ts`). The shared
+  // module owns the SEP-1865 correctness surface (capability gating,
+  // model-only visibility, matrix-gated `sendToolCancelled`, the app-tool
+  // invocation lifecycle); the renderer-specific effects below stay here.
+  // The eval browser harness binds the same surface to its own callbacks.
   const registerBridgeHandlers = useCallback(
     (bridge: AppBridge) => {
-      bridge.oninitialized = () => {
-        const wasReady = isReadyRef.current;
-        setIsReady(true);
-        isReadyRef.current = true;
-        const appCaps = bridge.getAppCapabilities();
-        logWidgetDebug("ui-to-host", "debug/app-initialized", {
-          availableDisplayModes:
-            (appCaps?.availableDisplayModes as DisplayMode[] | undefined) ??
-            null,
-          wasReady,
-        });
-        const declaredAppModes = appCaps?.availableDisplayModes as
-          | DisplayMode[]
-          | undefined;
-        onAppSupportedDisplayModesChangeRef.current?.(declaredAppModes);
-        // SEP-1865: clamp the advertised + runtime mode set against the
-        // app's declaration. The next render of `hostContext` will pick
-        // up the new intersection and the post-init `setHostContext`
-        // effect will publish `host-context-changed` with the updated
-        // `availableDisplayModes` (matrix-gated by hostContextChanged).
-        setAppSupportedDisplayModes(declaredAppModes);
-        // If the guest re-initialized (e.g. an SDK-based app completing its
-        // own handshake after the openai-compat shim already initialized),
-        // bump reinitCount so the delivery effects re-send tool data.
-        if (wasReady) {
-          setReinitCount((c) => c + 1);
-        }
-
-        // SEP-1865 App-Provided Tools: when the app advertises `tools`
-        // capability, fetch its tool list with the SDK bridge and register
-        // it so the next chat POST can advertise no-execute AI SDK tools.
-        // Feature-detect the capability; do not install rejecting stubs.
-        if (appCaps?.tools) {
-          const bridgeId = appToolsBridgeIdRef.current ?? crypto.randomUUID();
-          appToolsBridgeIdRef.current = bridgeId;
-          setAppToolsBridgeIdState(bridgeId);
-          void refreshAppProvidedTools(bridge, bridgeId);
-
-          // SEP-1865 host UX: app-tools widgets are interactive — the
-          // dev will want to chat with them. Auto-promote to fullscreen
-          // so the existing fullscreen overlay (composer + chevron-
-          // toggle chat history) becomes the chat surface, with the
-          // widget filling the space behind it. Gates:
-          //  • `declaredAppModes` includes "fullscreen" — the app
-          //    actually renders in that mode (advertise=enforce)
-          //  • `!userPreferInlineRef.current` — user hasn't dismissed
-          //    fullscreen, and the host's `user-initiated-only` policy
-          //    isn't blocking host-initiated mode switches
-          //  • `!hasAutoPromotedForAppToolsRef.current` — one-shot so
-          //    shim re-init or a widget's own re-handshake doesn't
-          //    re-fire and overwrite a user-chosen mode
-          // `setDisplayModeRef.current` is used (not the closure-
-          // captured `setDisplayMode`) so this handler stays out of the
-          // useCallback dep array and doesn't churn the bridge wiring.
-          if (
-            !hasAutoPromotedForAppToolsRef.current &&
-            !userPreferInlineRef.current &&
-            declaredAppModes?.includes("fullscreen")
-          ) {
-            hasAutoPromotedForAppToolsRef.current = true;
-            setDisplayModeRef.current?.("fullscreen");
-          }
-        }
-      };
-
-      // SEP-1865 bridge handlers are gated by `effectiveHostCapabilities`
-      // alone. They are a SEPARATE surface from the `window.openai`
-      // shim — `ui/initialize` advertises `serverTools`, `openLinks`,
-      // `message`, etc. via that blob, and the advertise/enforce
-      // contract requires the handlers to honor whatever is
-      // advertised. Folding the shim matrix in here would break it:
-      // a Copilot-preset host advertises `serverTools` (the SEP
-      // contract) but disables `window.openai.callTool` (the shim
-      // surface), and gating the bridge by the shim would silently
-      // drop bridge tool calls while still claiming support. The
-      // shim caps stay scoped to the shim, enforced inside the
-      // runtime + the host-side `openai:*` postMessage handlers.
-      if (effectiveHostCapabilities.message) {
-        bridge.onmessage = async ({ content }) => {
-          const textContent = content.find(
-            (item) => item.type === "text"
-          )?.text;
-          if (textContent) {
-            onSendFollowUpRef.current?.(textContent);
-          }
-          return {};
-        };
-      }
-
-      if (effectiveHostCapabilities.openLinks) {
-        bridge.onopenlink = async ({ url }) => {
-          if (url) {
-            window.open(url, "_blank", "noopener,noreferrer");
-          }
-          return {};
-        };
-      }
-
-      if (effectiveHostCapabilities.serverTools) {
-        // Matrix-gated `sendToolCancelled` for app-initiated tool
-        // calls failing in this handler. Microsoft 365 Copilot does
-        // not deliver `ui/notifications/tool-cancelled` per its
-        // published Component-bridge table; simulated Copilot hosts
-        // must not see the cancelled callback even when the
-        // underlying tool throws. The handler still THROWS so the
-        // AppBridge's request/response path reports an error to the
-        // calling widget — only the side-channel notification is
-        // suppressed.
-        const sendToolCancelledIfAllowed = (reason: string) => {
-          const matrix = mcpAppsCapabilitiesRef.current;
-          if (matrix !== null && matrix.toolCancelled === false) return;
-          bridge.sendToolCancelled({ reason });
-        };
-        bridge.oncalltool = async ({ name, arguments: args }, _extra) => {
-          // Check if tool is model-only (not callable by apps) per SEP-1865
-          const calledToolMeta = toolsMetadataRef.current?.[name];
-          if (isVisibleToModelOnly(calledToolMeta)) {
-            const error = new Error(
-              `Tool "${name}" is not callable by apps (visibility: model-only)`
-            );
-            sendToolCancelledIfAllowed(error.message);
-            throw error;
-          }
-
-          const invocationInput = (args ?? {}) as Record<string, unknown>;
-          const invocationId = `${
-            toolCallIdRef.current
-          }:app-tool:${appToolInvocationSequenceRef.current++}`;
-          const startedAt = Date.now();
-          onAppToolInvocationChangeRef.current?.({
-            id: invocationId,
-            parentToolCallId: toolCallIdRef.current,
-            toolName: name,
-            input: invocationInput,
-            status: "running",
-            startedAt,
-          });
-
-          if (!onCallToolRef.current) {
-            const error = new Error("Tool calls not supported");
-            onAppToolInvocationChangeRef.current?.({
-              id: invocationId,
-              parentToolCallId: toolCallIdRef.current,
-              toolName: name,
-              input: invocationInput,
-              errorText: error.message,
-              status: "error",
-              startedAt,
-              completedAt: Date.now(),
+      registerHostBridgeHandlers(bridge, {
+        effectiveHostCapabilities,
+        getMatrix: () => mcpAppsCapabilitiesRef.current,
+        getToolMetadata: (name) => toolsMetadataRef.current?.[name],
+        getToolCallId: () => toolCallIdRef.current,
+        nextInvocationSequence: () => appToolInvocationSequenceRef.current++,
+        onWidgetDebug: logWidgetDebug,
+        callbacks: {
+          onAppInitialized: (b) => {
+            const wasReady = isReadyRef.current;
+            setIsReady(true);
+            isReadyRef.current = true;
+            const appCaps = b.getAppCapabilities();
+            logWidgetDebug("ui-to-host", "debug/app-initialized", {
+              availableDisplayModes:
+                (appCaps?.availableDisplayModes as DisplayMode[] | undefined) ??
+                null,
+              wasReady,
             });
-            sendToolCancelledIfAllowed(error.message);
-            throw error;
-          }
+            const declaredAppModes = appCaps?.availableDisplayModes as
+              | DisplayMode[]
+              | undefined;
+            onAppSupportedDisplayModesChangeRef.current?.(declaredAppModes);
+            // SEP-1865: clamp the advertised + runtime mode set against the
+            // app's declaration. The next render of `hostContext` will pick
+            // up the new intersection and the post-init `setHostContext`
+            // effect will publish `host-context-changed` with the updated
+            // `availableDisplayModes` (matrix-gated by hostContextChanged).
+            setAppSupportedDisplayModes(declaredAppModes);
+            // If the guest re-initialized (e.g. an SDK-based app completing
+            // its own handshake after the openai-compat shim already
+            // initialized), bump reinitCount so the delivery effects re-send
+            // tool data.
+            if (wasReady) {
+              setReinitCount((c) => c + 1);
+            }
 
-          try {
-            const result = await onCallToolRef.current(name, invocationInput);
-            onAppToolInvocationChangeRef.current?.({
-              id: invocationId,
-              parentToolCallId: toolCallIdRef.current,
-              toolName: name,
-              input: invocationInput,
-              output: result,
-              status: "success",
-              startedAt,
-              completedAt: Date.now(),
-            });
-            return result as CallToolResult;
-          } catch (error) {
-            const errorText =
-              error instanceof Error ? error.message : String(error);
-            onAppToolInvocationChangeRef.current?.({
-              id: invocationId,
-              parentToolCallId: toolCallIdRef.current,
-              toolName: name,
-              input: invocationInput,
-              errorText,
-              status: "error",
-              startedAt,
-              completedAt: Date.now(),
-            });
-            // SEP-1865: Send tool-cancelled for failed app-initiated tool calls
-            sendToolCancelledIfAllowed(errorText);
-            throw error;
-          }
-        };
-      }
+            // SEP-1865 App-Provided Tools: when the app advertises `tools`
+            // capability, fetch its tool list with the SDK bridge and register
+            // it so the next chat POST can advertise no-execute AI SDK tools.
+            if (appCaps?.tools) {
+              const bridgeId =
+                appToolsBridgeIdRef.current ?? crypto.randomUUID();
+              appToolsBridgeIdRef.current = bridgeId;
+              setAppToolsBridgeIdState(bridgeId);
+              void refreshAppProvidedTools(b, bridgeId);
 
-      if (effectiveHostCapabilities.serverResources) {
-        bridge.onreadresource = async ({ uri }) => {
-          const result = await readResource(serverIdRef.current, uri);
-          return result.content;
-        };
-
-        bridge.onlistresources = async (params) => {
-          return listResources(
-            serverIdRef.current,
-            (params as { cursor?: string } | undefined)?.cursor
-          );
-        };
-
-        bridge.onlistresourcetemplates = async (_params) => {
-          if (HOSTED_MODE) {
-            throw new Error(
-              "Resource templates are not supported in hosted mode"
-            );
-          }
-
-          const response = await authFetch(`/api/mcp/resource-templates/list`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              serverId: serverIdRef.current,
-            }),
-          });
-          if (!response.ok) {
-            throw new Error(
-              `Resource template list failed: ${response.statusText}`
-            );
-          }
-          return response.json();
-        };
-      }
-
-      // onlistprompts: unconditional — no serverPrompts cap in SEP-1865 or
-      // the chip set. Revisit if/when a serverPrompts chip is added.
-      bridge.onlistprompts = async (params) => {
-        void params;
-        const prompts = await listPrompts(serverIdRef.current);
-        return { prompts };
-      };
-
-      if (effectiveHostCapabilities.logging) {
-        bridge.onloggingmessage = ({ level, data, logger }) => {
-          if (minimalMode) return;
-          const prefix = logger ? `[${logger}]` : "[MCP Apps]";
-          const message = `${prefix} ${level.toUpperCase()}:`;
-          if (level === "error" || level === "critical" || level === "alert") {
-            console.error(message, data);
-            return;
-          }
-          if (level === "warning") {
-            console.warn(message, data);
-            return;
-          }
-          console.info(message, data);
-        };
-      }
-
-      // Inline width is owned by the host shell. Some widgets report their
-      // preferred content width in `ui/notifications/size-changed`; applying it
-      // to the chat container shrinks wide hosted transcripts and leaves the
-      // app pinned to the left. Height remains app-driven for natural inline
-      // layout, while PIP/fullscreen keep their fixed shell sizing.
-      bridge.onsizechange = ({ height }) => {
-        if (effectiveDisplayModeRef.current !== "inline") return;
-        const iframe = sandboxRef.current?.getIframeElement();
-        if (!iframe) return;
-        if (height === undefined) return;
-
-        // The MCP App has requested a `height`, but if
-        // `box-sizing: border-box` is applied to the outer iframe element, then we
-        // must add border thickness to `height` to compute the actual
-        // necessary height (in order to prevent a resize feedback loop).
-        const style = getComputedStyle(iframe);
-        const isBorderBox = style.boxSizing === "border-box";
-
-        // Animate the change for a smooth transition.
-        const from: Keyframe = {};
-        const to: Keyframe = {};
-
-        let adjustedHeight = height;
-
-        if (adjustedHeight !== undefined) {
-          if (isBorderBox) {
-            adjustedHeight +=
-              parseFloat(style.borderTopWidth) +
-              parseFloat(style.borderBottomWidth);
-          }
-          from.height = `${iframe.offsetHeight}px`;
-          iframe.style.height = to.height = `${adjustedHeight}px`;
-          lastInlineHeightRef.current = `${adjustedHeight}px`;
-        }
-
-        iframe.animate([from, to], { duration: 300, easing: "ease-out" });
-        // size-changed fires on every resize/animation tick — chatty widgets
-        // can flood the traffic log. The corresponding ui/notifications/
-        // size-changed transport message is already suppressed above; rely on
-        // that for diagnostics rather than a host-side debug log here.
-      };
-
-      bridge.onrequestdisplaymode = async ({ mode }) => {
-        const requestedMode = mode ?? "inline";
-        // Host policy gate: SEP-1865 allows the host to decline
-        // widget-initiated `ui/request-display-mode`. The
-        // `widgetDisplayModeRequests` matrix row (Apps tab) decides:
-        //   - "accept": pass through to the existing sticky / clamp path
-        //   - "decline": always return the current mode
-        //   - "user-initiated-only": handled via the sticky-inline
-        //     ref check below — the ref is seeded `true` at mount so
-        //     the first widget request is gated until the user picks
-        //     a non-inline mode via the host display-mode picker.
-        const policy =
-          mcpAppsCapabilitiesRef.current?.widgetDisplayModeRequests ?? "accept";
-        if (requestedMode !== "inline" && policy === "decline") {
-          const granted = effectiveDisplayModeRef.current;
-          logWidgetDebug("ui-to-host", "ui/request-display-mode", {
-            requested: requestedMode,
-            granted,
-            reason: "policy-decline",
-          });
-          return { mode: granted };
-        }
-        // Sticky inline-preference override: if the user explicitly
-        // returned to inline (X click), or the policy seeded the flag
-        // at mount, decline widget non-inline requests by returning
-        // inline. Spec allows the host to return a different mode than
-        // requested. Cleared when the user explicitly re-enters
-        // fullscreen / PIP from the host display-mode picker.
-        if (requestedMode !== "inline" && userPreferInlineRef.current) {
-          logWidgetDebug("ui-to-host", "ui/request-display-mode", {
-            requested: requestedMode,
-            granted: "inline",
-            reason: "user-prefers-inline",
-          });
-          return { mode: "inline" };
-        }
-        const hostAvailableModes = extractHostDisplayModes(
-          hostContextRef.current as Record<string, unknown> | undefined
-        );
-        // Use device type for mobile detection (defaults to mobile-like behavior when not in playground)
-        const isMobile = isPlaygroundActiveRef.current
-          ? playgroundDeviceTypeRef.current === "mobile" ||
-            playgroundDeviceTypeRef.current === "tablet"
-          : true;
-        const mobileAdjustedMode: DisplayMode =
-          isMobile && requestedMode === "pip" ? "fullscreen" : requestedMode;
-        const actualMode = clampDisplayModeToAvailableModes(
-          mobileAdjustedMode,
-          hostAvailableModes
-        );
-
-        setDisplayModeRef.current(actualMode);
-
-        if (actualMode === "pip") {
-          onRequestPipRef.current?.(displayWidgetIdRef.current);
-        } else if (
-          (actualMode === "inline" || actualMode === "fullscreen") &&
-          ownsPipDisplayModeRef.current
-        ) {
-          onExitPipRef.current?.(
-            pipWidgetIdRef.current ?? displayWidgetIdRef.current
-          );
-        }
-
-        return { mode: actualMode };
-      };
-
-      if (effectiveHostCapabilities.updateModelContext) {
-        bridge.onupdatemodelcontext = async ({
-          content,
-          structuredContent,
-        }) => {
-          const currentToolCallId = toolCallIdRef.current;
-          // Store in debug store for UI display
-          setWidgetModelContext(currentToolCallId, {
-            content,
-            structuredContent,
-          });
-
-          // Notify parent component to queue for next model turn
-          onModelContextUpdateRef.current?.(currentToolCallId, {
-            content,
-            structuredContent,
-          });
-
-          return {};
-        };
-      }
-
-      // SEP-1865 `ui/download-file`: the view passes embedded resource
-      // contents (`text` or `blob`) and/or resource links. The host
-      // mediates the actual download since the iframe sandbox blocks
-      // direct anchor-clicks. We use a Blob + object-URL anchor (no
-      // confirmation prompt yet — opt-in confirmation is a follow-up).
-      if (effectiveHostCapabilities.downloadFile) {
-        bridge.ondownloadfile = async ({ contents }) => {
-          try {
-            for (const item of contents) {
-              if (item.type === "resource" && item.resource) {
-                const res = item.resource as {
-                  uri: string;
-                  text?: string;
-                  blob?: string;
-                  mimeType?: string;
-                };
-                const mimeType = res.mimeType ?? "application/octet-stream";
-                let blob: Blob;
-                if (typeof res.blob === "string") {
-                  const binary = atob(res.blob);
-                  const bytes = new Uint8Array(binary.length);
-                  for (let i = 0; i < binary.length; i++) {
-                    bytes[i] = binary.charCodeAt(i);
-                  }
-                  blob = new Blob([bytes], { type: mimeType });
-                } else {
-                  blob = new Blob([res.text ?? ""], { type: mimeType });
-                }
-                const url = URL.createObjectURL(blob);
-                try {
-                  const anchor = document.createElement("a");
-                  anchor.href = url;
-                  anchor.download = res.uri.split("/").pop() ?? "download";
-                  anchor.rel = "noopener";
-                  document.body.appendChild(anchor);
-                  anchor.click();
-                  anchor.remove();
-                } finally {
-                  // Defer revocation so the browser has a chance to
-                  // start the download before the object URL goes away.
-                  setTimeout(() => URL.revokeObjectURL(url), 1000);
-                }
-              } else if (item.type === "resource_link") {
-                const link = item as { uri: string };
-                // Refuse navigations that aren't a browser-fetchable scheme.
-                // `javascript:`/`data:` here would execute in the host origin,
-                // and MCP-style schemes (`ui://`, `file://`, server-defined)
-                // need host-side resolution that this path doesn't do yet —
-                // fail loud rather than silently opening an unusable tab.
-                const parsed = new URL(link.uri, window.location.href);
-                if (!["http:", "https:"].includes(parsed.protocol)) {
-                  throw new Error(
-                    `Unsupported download URI protocol: ${parsed.protocol}`
-                  );
-                }
-                window.open(parsed.href, "_blank", "noopener,noreferrer");
+              // SEP-1865 host UX: app-tools widgets are interactive — auto-
+              // promote to fullscreen so the existing fullscreen overlay
+              // becomes the chat surface. Gates: the app renders fullscreen,
+              // the user hasn't dismissed fullscreen, and this is one-shot.
+              if (
+                !hasAutoPromotedForAppToolsRef.current &&
+                !userPreferInlineRef.current &&
+                declaredAppModes?.includes("fullscreen")
+              ) {
+                hasAutoPromotedForAppToolsRef.current = true;
+                setDisplayModeRef.current?.("fullscreen");
               }
             }
-            return {};
-          } catch (err) {
-            logWidgetDebug("ui-to-host", "ui/download-file", {
-              error: err instanceof Error ? err.message : String(err),
-            });
-            return { isError: true };
-          }
-        };
-      }
+          },
+          onSendFollowUp: (text) => {
+            onSendFollowUpRef.current?.(text);
+          },
+          onOpenLink: (url) => {
+            window.open(url, "_blank", "noopener,noreferrer");
+          },
+          onCallTool: async (name, invocationInput) => {
+            if (!onCallToolRef.current) {
+              throw new Error("Tool calls not supported");
+            }
+            return (await onCallToolRef.current(
+              name,
+              invocationInput,
+            )) as CallToolResult;
+          },
+          onAppToolInvocation: (update) => {
+            onAppToolInvocationChangeRef.current?.(update);
+          },
+          onReadResource: async (uri) => {
+            const result = await readResource(serverIdRef.current, uri);
+            return result.content;
+          },
+          onListResources: async (params) => {
+            return listResources(
+              serverIdRef.current,
+              (params as { cursor?: string } | undefined)?.cursor,
+            );
+          },
+          onListResourceTemplates: async () => {
+            if (HOSTED_MODE) {
+              throw new Error(
+                "Resource templates are not supported in hosted mode",
+              );
+            }
+            const response = await authFetch(
+              `/api/mcp/resource-templates/list`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  serverId: serverIdRef.current,
+                }),
+              },
+            );
+            if (!response.ok) {
+              throw new Error(
+                `Resource template list failed: ${response.statusText}`,
+              );
+            }
+            return response.json();
+          },
+          onListPrompts: async () => {
+            const prompts = await listPrompts(serverIdRef.current);
+            return { prompts };
+          },
+          onLoggingMessage: ({ level, data, logger }) => {
+            if (minimalMode) return;
+            const prefix = logger ? `[${logger}]` : "[MCP Apps]";
+            const message = `${prefix} ${level.toUpperCase()}:`;
+            if (
+              level === "error" ||
+              level === "critical" ||
+              level === "alert"
+            ) {
+              console.error(message, data);
+              return;
+            }
+            if (level === "warning") {
+              console.warn(message, data);
+              return;
+            }
+            console.info(message, data);
+          },
+          onSizeChange: ({ height }) => {
+            // Inline width is owned by the host shell; height stays app-driven
+            // for natural inline layout while PIP/fullscreen keep fixed sizing.
+            if (effectiveDisplayModeRef.current !== "inline") return;
+            const iframe = sandboxRef.current?.getIframeElement();
+            if (!iframe) return;
+            if (height === undefined) return;
 
-      // SEP-1865 `ui/notifications/request-teardown`: the view asks the
-      // host to tear it down. Best-effort graceful close — fire
-      // `teardownResource` so the view can persist state, then bubble
-      // the request to the parent so it can actually unmount the
-      // iframe. `requestTeardown` is a behavior gate on the matrix
-      // (not a wire-advertised host capability); presets that set it
-      // false simulate hosts that ignore view-initiated teardown
-      // requests by leaving the handler unassigned, in which case the
-      // SDK logs the notification but does nothing.
-      if (mcpAppsCapabilitiesRef.current?.requestTeardown !== false) {
-        bridge.onrequestteardown = async () => {
-          logWidgetDebug("ui-to-host", "ui/notifications/request-teardown", {});
-          try {
-            await bridge.teardownResource({});
-          } catch (err) {
-            // Teardown best-effort; if the view never acks the
-            // resource-teardown request we still proceed to unmount so
-            // a misbehaving widget can't block its own removal.
-            logWidgetDebug("host-to-ui", "ui/resource-teardown", {
-              error: err instanceof Error ? err.message : String(err),
+            // If `box-sizing: border-box` applies to the outer iframe, add
+            // border thickness to `height` to avoid a resize feedback loop.
+            const style = getComputedStyle(iframe);
+            const isBorderBox = style.boxSizing === "border-box";
+
+            // Animate the change for a smooth transition.
+            const from: Keyframe = {};
+            const to: Keyframe = {};
+
+            let adjustedHeight = height;
+
+            if (adjustedHeight !== undefined) {
+              if (isBorderBox) {
+                adjustedHeight +=
+                  parseFloat(style.borderTopWidth) +
+                  parseFloat(style.borderBottomWidth);
+              }
+              from.height = `${iframe.offsetHeight}px`;
+              iframe.style.height = to.height = `${adjustedHeight}px`;
+              lastInlineHeightRef.current = `${adjustedHeight}px`;
+            }
+
+            iframe.animate([from, to], { duration: 300, easing: "ease-out" });
+          },
+          onRequestDisplayMode: async ({ mode }) => {
+            const requestedMode = mode ?? "inline";
+            // Host policy gate: SEP-1865 allows the host to decline
+            // widget-initiated `ui/request-display-mode`.
+            const policy =
+              mcpAppsCapabilitiesRef.current?.widgetDisplayModeRequests ??
+              "accept";
+            if (requestedMode !== "inline" && policy === "decline") {
+              const granted = effectiveDisplayModeRef.current;
+              logWidgetDebug("ui-to-host", "ui/request-display-mode", {
+                requested: requestedMode,
+                granted,
+                reason: "policy-decline",
+              });
+              return { mode: granted };
+            }
+            // Sticky inline-preference override: if the user explicitly
+            // returned to inline (or the policy seeded the flag at mount),
+            // decline widget non-inline requests by returning inline.
+            if (requestedMode !== "inline" && userPreferInlineRef.current) {
+              logWidgetDebug("ui-to-host", "ui/request-display-mode", {
+                requested: requestedMode,
+                granted: "inline",
+                reason: "user-prefers-inline",
+              });
+              return { mode: "inline" };
+            }
+            const hostAvailableModes = extractHostDisplayModes(
+              hostContextRef.current as Record<string, unknown> | undefined,
+            );
+            // Use device type for mobile detection (defaults to mobile-like
+            // behavior when not in playground).
+            const isMobile = isPlaygroundActiveRef.current
+              ? playgroundDeviceTypeRef.current === "mobile" ||
+                playgroundDeviceTypeRef.current === "tablet"
+              : true;
+            const mobileAdjustedMode: DisplayMode =
+              isMobile && requestedMode === "pip"
+                ? "fullscreen"
+                : requestedMode;
+            const actualMode = clampDisplayModeToAvailableModes(
+              mobileAdjustedMode,
+              hostAvailableModes,
+            );
+
+            setDisplayModeRef.current(actualMode);
+
+            if (actualMode === "pip") {
+              onRequestPipRef.current?.(displayWidgetIdRef.current);
+            } else if (
+              (actualMode === "inline" || actualMode === "fullscreen") &&
+              ownsPipDisplayModeRef.current
+            ) {
+              onExitPipRef.current?.(
+                pipWidgetIdRef.current ?? displayWidgetIdRef.current,
+              );
+            }
+
+            return { mode: actualMode };
+          },
+          onUpdateModelContext: (ctxToolCallId, { content, structuredContent }) => {
+            // Store in debug store for UI display.
+            setWidgetModelContext(ctxToolCallId, {
+              content,
+              structuredContent,
             });
-          }
-          onRequestTeardownRef.current?.(
-            toolCallIdRef.current,
-            displayWidgetIdRef.current
-          );
-        };
-      }
+            // Notify parent component to queue for next model turn.
+            onModelContextUpdateRef.current?.(ctxToolCallId, {
+              content,
+              structuredContent,
+            });
+          },
+          onDownloadFile: async ({ contents }) => {
+            // SEP-1865 `ui/download-file`: the host mediates the download
+            // since the iframe sandbox blocks direct anchor-clicks. Blob +
+            // object-URL anchor (no confirmation prompt yet — follow-up).
+            try {
+              for (const item of contents) {
+                if (item.type === "resource" && item.resource) {
+                  const res = item.resource as {
+                    uri: string;
+                    text?: string;
+                    blob?: string;
+                    mimeType?: string;
+                  };
+                  const mimeType = res.mimeType ?? "application/octet-stream";
+                  let blob: Blob;
+                  if (typeof res.blob === "string") {
+                    const binary = atob(res.blob);
+                    const bytes = new Uint8Array(binary.length);
+                    for (let i = 0; i < binary.length; i++) {
+                      bytes[i] = binary.charCodeAt(i);
+                    }
+                    blob = new Blob([bytes], { type: mimeType });
+                  } else {
+                    blob = new Blob([res.text ?? ""], { type: mimeType });
+                  }
+                  const url = URL.createObjectURL(blob);
+                  try {
+                    const anchor = document.createElement("a");
+                    anchor.href = url;
+                    anchor.download = res.uri.split("/").pop() ?? "download";
+                    anchor.rel = "noopener";
+                    document.body.appendChild(anchor);
+                    anchor.click();
+                    anchor.remove();
+                  } finally {
+                    // Defer revocation so the browser can start the download
+                    // before the object URL goes away.
+                    setTimeout(() => URL.revokeObjectURL(url), 1000);
+                  }
+                } else if (item.type === "resource_link") {
+                  const link = item as { uri: string };
+                  // Refuse navigations that aren't a browser-fetchable scheme.
+                  const parsed = new URL(link.uri, window.location.href);
+                  if (!["http:", "https:"].includes(parsed.protocol)) {
+                    throw new Error(
+                      `Unsupported download URI protocol: ${parsed.protocol}`,
+                    );
+                  }
+                  window.open(parsed.href, "_blank", "noopener,noreferrer");
+                }
+              }
+              return {};
+            } catch (err) {
+              logWidgetDebug("ui-to-host", "ui/download-file", {
+                error: err instanceof Error ? err.message : String(err),
+              });
+              return { isError: true };
+            }
+          },
+          onRequestTeardown: (ctxToolCallId) => {
+            onRequestTeardownRef.current?.(
+              ctxToolCallId,
+              displayWidgetIdRef.current,
+            );
+          },
+        },
+      });
     },
     [
       setIsReady,
@@ -3268,7 +3069,7 @@ export function MCPAppsRendererSurface({
       logWidgetDebug,
       refreshAppProvidedTools,
       effectiveHostCapabilities,
-    ]
+    ],
   );
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -28,7 +28,10 @@ import type {
   McpUiResourceCsp,
   McpUiResourcePermissions,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
-import { SEP_1865_PERMISSION_FEATURES } from "@/lib/client-config-v2";
+import {
+  buildOuterAllowAttribute,
+  buildOuterSandboxAttribute,
+} from "@/lib/mcp-ui/iframe-sandbox-policy";
 
 export interface SandboxedIframeHandle {
   postMessage: (data: unknown) => void;
@@ -253,47 +256,10 @@ export const SandboxedIframe = forwardRef<
   // inspector-only legacy defaults are conditional.
   //
   // Per Permissions Policy spec, `;` separates features.
-  const outerAllowAttribute = useMemo(() => {
-    const allowFeaturesIsAuthoritative = allowFeatures !== undefined;
-    const allowList = allowFeaturesIsAuthoritative
-      ? []
-      : ["local-network-access *", "midi *"];
-    if (permissions?.camera) allowList.push("camera *");
-    if (permissions?.microphone) allowList.push("microphone *");
-    if (permissions?.geolocation) allowList.push("geolocation *");
-    if (permissions?.clipboardWrite) allowList.push("clipboard-write *");
-    if (allowFeatures) {
-      // Defense-in-depth: skip spec features in case the canonicalizer
-      // was bypassed. `permissions.allow.{camera,...}` is the single
-      // source of truth — see SEP_1865_PERMISSION_FEATURES.
-      const specFeatures = new Set<string>(SEP_1865_PERMISSION_FEATURES);
-      for (const k of Object.keys(allowFeatures).sort()) {
-        if (specFeatures.has(k)) continue;
-        const allowlist = allowFeatures[k];
-        if (typeof allowlist !== "string" || allowlist.length === 0) continue;
-        // Reject `;` and `,` in keys and values. The Permissions Policy
-        // iframe `allow=` attribute uses `;` to separate features; allowing
-        // either character through here turns the per-feature filter into
-        // a directive-injection bypass (e.g. `fullscreen: "*; camera *"`
-        // would smuggle a `camera *` grant past the spec-feature check
-        // above). `,` is the corresponding separator in HTTP-header
-        // Permissions-Policy syntax and is rejected for symmetry.
-        if (/[;,]/.test(k) || /[;,]/.test(allowlist)) continue;
-        // Reject whitespace in the KEY too. A key like `"camera *"`
-        // doesn't equal the spec key `"camera"`, so the spec-feature
-        // filter above lets it through; the join produces
-        // `camera * *`, which the browser parses as a `camera` grant
-        // — bypassing `permissions.allow` as the single source of
-        // truth for the 4 spec permissions. (Values legitimately
-        // contain whitespace for multi-token allowlists like
-        // `"'self' https://example.com"`, so the whitespace rule
-        // applies only to keys.)
-        if (/\s/.test(k)) continue;
-        allowList.push(`${k} ${allowlist}`);
-      }
-    }
-    return allowList.join("; ");
-  }, [permissions, allowFeatures]);
+  const outerAllowAttribute = useMemo(
+    () => buildOuterAllowAttribute({ permissions, allowFeatures }),
+    [permissions, allowFeatures],
+  );
 
   // Outer iframe `sandbox=` value.
   //
@@ -310,36 +276,10 @@ export const SandboxedIframe = forwardRef<
   //
   // `undefined` vs `[]` matters here: `[]` is the explicit "spec-minimum
   // only" intent, mirroring the canonicalizer's preservation contract.
-  const outerSandboxAttribute = useMemo(() => {
-    const tokens = new Set<string>();
-    if (sandboxAttrs !== undefined) {
-      tokens.add("allow-scripts");
-      tokens.add("allow-same-origin");
-      for (const t of sandboxAttrs) {
-        const trimmed = t.trim();
-        if (trimmed.length === 0) continue;
-        // Reject tokens with internal whitespace. A profile (or custom-
-        // token input) that smuggles `"allow-forms allow-popups-to-
-        // escape-sandbox"` would otherwise land in the Set as one entry
-        // but the join(" ") below would emit it as two real sandbox
-        // flags — silently widening the iframe grant beyond what the
-        // editor/matrix display. Reject is safer than split: the entry
-        // visibly does nothing (user notices) instead of taking effect
-        // invisibly.
-        if (/\s/.test(trimmed)) continue;
-        tokens.add(trimmed);
-      }
-    } else {
-      for (const t of sandbox.split(/\s+/)) {
-        if (t.length > 0) tokens.add(t);
-      }
-      // Defense in depth: spec-mandated tokens are always present even
-      // if a caller passes a malformed `sandbox` prop.
-      tokens.add("allow-scripts");
-      tokens.add("allow-same-origin");
-    }
-    return Array.from(tokens).sort().join(" ");
-  }, [sandbox, sandboxAttrs]);
+  const outerSandboxAttribute = useMemo(
+    () => buildOuterSandboxAttribute({ sandbox, sandboxAttrs }),
+    [sandbox, sandboxAttrs],
+  );
 
   const resourceReadyKey = useMemo(
     () =>

--- a/mcpjam-inspector/client/src/lib/mcp-ui/iframe-sandbox-policy.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/iframe-sandbox-policy.ts
@@ -1,0 +1,134 @@
+/**
+ * Iframe sandbox attribute construction (SEP-1865).
+ *
+ * The renderer's `effectiveSandbox` memo resolves *policy* (host profiles,
+ * playground toggles, the capabilities matrix, the hosted clamp) into a
+ * resolved `{ csp, permissions, permissive, sandboxAttrs, allowFeatures,
+ * cspDirectives }` shape using `@mcpjam/sdk/browser`. That policy resolution
+ * stays in the renderer because it depends on inspector-only surface state.
+ *
+ * What lives here is the deterministic *attribute construction* that turns the
+ * resolved policy into the outer iframe's `sandbox=` / `allow=` strings — the
+ * exact logic `SandboxedIframe` used to compute inline. Extracted to a
+ * dependency-free leaf so both the production renderer (via `SandboxedIframe`)
+ * and the eval browser harness build attributes the same way, so a widget
+ * renders against an identical grant surface in either host.
+ *
+ * NOTE: the inner-document CSP `<meta>` is built by the cross-origin sandbox
+ * proxy (`server/routes/apps/mcp-apps/sandbox-proxy.html`), not here. PR 3's
+ * harness reuses that builder; `resolveIframeSandboxPolicy` is intentionally
+ * scoped to the outer attributes the renderer constructs.
+ */
+
+import type { McpUiResourcePermissions } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { SEP_1865_PERMISSION_FEATURES } from "@/lib/client-config-v2";
+
+/**
+ * Spec-mandated permissive baseline for the outer iframe `sandbox=` attribute.
+ * Mirrors the default `SandboxedIframe` applies when no profile overrides the
+ * token set.
+ */
+export const DEFAULT_IFRAME_SANDBOX =
+  "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox";
+
+/**
+ * Build the outer iframe `allow=` (Permissions Policy) attribute.
+ *
+ * The 4 SEP-1865 spec permissions (camera/microphone/geolocation/
+ * clipboard-write) always flow through from `permissions`. When `allowFeatures`
+ * is provided (even as `{}`) the profile is authoritative for non-spec
+ * Permissions Policy features and the renderer's legacy defaults
+ * (`local-network-access *`, `midi *`) are dropped.
+ */
+export function buildOuterAllowAttribute(input: {
+  permissions?: McpUiResourcePermissions;
+  allowFeatures?: Record<string, string>;
+}): string {
+  const { permissions, allowFeatures } = input;
+  const allowFeaturesIsAuthoritative = allowFeatures !== undefined;
+  const allowList = allowFeaturesIsAuthoritative
+    ? []
+    : ["local-network-access *", "midi *"];
+  if (permissions?.camera) allowList.push("camera *");
+  if (permissions?.microphone) allowList.push("microphone *");
+  if (permissions?.geolocation) allowList.push("geolocation *");
+  if (permissions?.clipboardWrite) allowList.push("clipboard-write *");
+  if (allowFeatures) {
+    // Defense-in-depth: skip spec features in case the canonicalizer was
+    // bypassed. `permissions.allow.{camera,...}` is the single source of truth.
+    const specFeatures = new Set<string>(SEP_1865_PERMISSION_FEATURES);
+    for (const k of Object.keys(allowFeatures).sort()) {
+      if (specFeatures.has(k)) continue;
+      const allowlist = allowFeatures[k];
+      if (typeof allowlist !== "string" || allowlist.length === 0) continue;
+      // Reject `;` and `,` in keys and values — they are the Permissions
+      // Policy / HTTP-header separators and would turn the per-feature filter
+      // into a directive-injection bypass.
+      if (/[;,]/.test(k) || /[;,]/.test(allowlist)) continue;
+      // Reject whitespace in the KEY: `"camera *"` would slip past the
+      // spec-feature filter and join to `camera * *`, a back-door grant.
+      if (/\s/.test(k)) continue;
+      allowList.push(`${k} ${allowlist}`);
+    }
+  }
+  return allowList.join("; ");
+}
+
+/**
+ * Build the outer iframe `sandbox=` attribute.
+ *
+ * When `sandboxAttrs` is provided (even as `[]`) the profile is authoritative:
+ * the iframe gets `allow-scripts allow-same-origin` plus exactly the listed
+ * tokens. When undefined, fall back to the permissive `sandbox` baseline.
+ * `undefined` vs `[]` is meaningful: `[]` is the explicit "spec-minimum" intent.
+ */
+export function buildOuterSandboxAttribute(input: {
+  sandbox?: string;
+  sandboxAttrs?: string[];
+}): string {
+  const { sandbox = DEFAULT_IFRAME_SANDBOX, sandboxAttrs } = input;
+  const tokens = new Set<string>();
+  if (sandboxAttrs !== undefined) {
+    tokens.add("allow-scripts");
+    tokens.add("allow-same-origin");
+    for (const t of sandboxAttrs) {
+      const trimmed = t.trim();
+      if (trimmed.length === 0) continue;
+      // Reject internal whitespace: one Set entry that joins to two real
+      // sandbox flags would silently widen the grant.
+      if (/\s/.test(trimmed)) continue;
+      tokens.add(trimmed);
+    }
+  } else {
+    for (const t of sandbox.split(/\s+/)) {
+      if (t.length > 0) tokens.add(t);
+    }
+    // Defense in depth: spec-mandated tokens are always present.
+    tokens.add("allow-scripts");
+    tokens.add("allow-same-origin");
+  }
+  return Array.from(tokens).sort().join(" ");
+}
+
+/**
+ * Resolve the outer iframe sandbox policy into the literal `sandbox=` / `allow=`
+ * attribute strings. Consumed by both `SandboxedIframe` (production) and the
+ * eval harness so the grant surface is identical in either host.
+ */
+export function resolveIframeSandboxPolicy(input: {
+  sandbox?: string;
+  sandboxAttrs?: string[];
+  permissions?: McpUiResourcePermissions;
+  allowFeatures?: Record<string, string>;
+}): { sandbox: string; allow: string } {
+  return {
+    sandbox: buildOuterSandboxAttribute({
+      sandbox: input.sandbox,
+      sandboxAttrs: input.sandboxAttrs,
+    }),
+    allow: buildOuterAllowAttribute({
+      permissions: input.permissions,
+      allowFeatures: input.allowFeatures,
+    }),
+  };
+}

--- a/mcpjam-inspector/client/src/lib/mcp-ui/mcp-apps-utils.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/mcp-apps-utils.ts
@@ -106,43 +106,16 @@ export function isOpenAIAppAndMCPApp(
 }
 
 /**
- * Get the visibility array from tool metadata.
- * Default: ["model", "app"] if not specified (per SEP-1865)
+ * SEP-1865 tool visibility helpers.
+ *
+ * The implementations live in the dependency-free leaf module
+ * `@/lib/mcp-ui/tool-visibility` so the framework-free host bridge
+ * (`host-app-bridge.ts`, consumed by the eval harness) can share the exact
+ * model-only visibility check the production renderer enforces. Re-exported
+ * here to preserve existing `@/lib/mcp-ui/mcp-apps-utils` import sites.
  */
-export function getToolVisibility(
-  toolMeta: Record<string, unknown> | undefined,
-): Array<"model" | "app"> {
-  const ui =
-    toolMeta?.ui && typeof toolMeta.ui === "object" && !Array.isArray(toolMeta.ui)
-      ? (toolMeta.ui as { visibility?: unknown })
-      : undefined;
-  const visibility = ui?.visibility;
-  if (!Array.isArray(visibility)) return ["model", "app"];
-
-  const normalized = visibility.filter(
-    (scope): scope is "model" | "app" => scope === "model" || scope === "app",
-  );
-  return normalized.length > 0 ? normalized : ["model", "app"];
-}
-
-/**
- * Check if tool is visible to model only (not callable by apps).
- * True when visibility is exactly ["model"]
- */
-export function isVisibleToModelOnly(
-  toolMeta: Record<string, unknown> | undefined,
-): boolean {
-  const visibility = getToolVisibility(toolMeta);
-  return visibility.length === 1 && visibility[0] === "model";
-}
-
-/**
- * Check if tool is visible to app only (hidden from model).
- * True when visibility is exactly ["app"]
- */
-export function isVisibleToAppOnly(
-  toolMeta: Record<string, unknown> | undefined,
-): boolean {
-  const visibility = getToolVisibility(toolMeta);
-  return visibility.length === 1 && visibility[0] === "app";
-}
+export {
+  getToolVisibility,
+  isVisibleToModelOnly,
+  isVisibleToAppOnly,
+} from "@/lib/mcp-ui/tool-visibility";

--- a/mcpjam-inspector/client/src/lib/mcp-ui/tool-visibility.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/tool-visibility.ts
@@ -24,8 +24,16 @@ export function getToolVisibility(
   const visibility = ui?.visibility;
   if (!Array.isArray(visibility)) return ["model", "app"];
 
-  const normalized = visibility.filter(
-    (scope): scope is "model" | "app" => scope === "model" || scope === "app",
+  // Dedupe: a payload like `["model", "model"]` must not make
+  // `isVisibleToModelOnly` (which checks `length === 1`) return false and
+  // silently weaken the model-only block the shared bridge enforces.
+  const normalized = Array.from(
+    new Set(
+      visibility.filter(
+        (scope): scope is "model" | "app" =>
+          scope === "model" || scope === "app",
+      ),
+    ),
   );
   return normalized.length > 0 ? normalized : ["model", "app"];
 }

--- a/mcpjam-inspector/client/src/lib/mcp-ui/tool-visibility.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/tool-visibility.ts
@@ -1,0 +1,53 @@
+/**
+ * SEP-1865 tool visibility helpers.
+ *
+ * Dependency-free leaf module so both the React renderer utilities
+ * (`mcp-apps-utils.ts`, re-exported for back-compat) and the framework-free
+ * host bridge (`host-app-bridge.ts`, consumed by the eval harness) share one
+ * source of truth for the model-only visibility check without dragging
+ * heavier dependencies into either consumer.
+ */
+
+/**
+ * Get the visibility array from tool metadata.
+ * Default: ["model", "app"] if not specified (per SEP-1865).
+ */
+export function getToolVisibility(
+  toolMeta: Record<string, unknown> | undefined,
+): Array<"model" | "app"> {
+  const ui =
+    toolMeta?.ui &&
+    typeof toolMeta.ui === "object" &&
+    !Array.isArray(toolMeta.ui)
+      ? (toolMeta.ui as { visibility?: unknown })
+      : undefined;
+  const visibility = ui?.visibility;
+  if (!Array.isArray(visibility)) return ["model", "app"];
+
+  const normalized = visibility.filter(
+    (scope): scope is "model" | "app" => scope === "model" || scope === "app",
+  );
+  return normalized.length > 0 ? normalized : ["model", "app"];
+}
+
+/**
+ * Check if tool is visible to model only (not callable by apps).
+ * True when visibility is exactly ["model"].
+ */
+export function isVisibleToModelOnly(
+  toolMeta: Record<string, unknown> | undefined,
+): boolean {
+  const visibility = getToolVisibility(toolMeta);
+  return visibility.length === 1 && visibility[0] === "model";
+}
+
+/**
+ * Check if tool is visible to app only (hidden from model).
+ * True when visibility is exactly ["app"].
+ */
+export function isVisibleToAppOnly(
+  toolMeta: Record<string, unknown> | undefined,
+): boolean {
+  const visibility = getToolVisibility(toolMeta);
+  return visibility.length === 1 && visibility[0] === "app";
+}


### PR DESCRIPTION
## PR 1 of 5 — Browser-rendered MCP App eval (render checks + Computer Use)

This is the **base of a 5-PR stack** that teaches the stateless eval runner to actually mount MCP App tool results in a production-equivalent host harness (headless Playwright) and record whether the widget rendered, plus drive it with Anthropic Computer Use on the local AI SDK path. This PR is a **pure refactor with no behavior change** — it lifts the host bridge surface out of the React renderer so the eval harness (PR 3) can reuse it verbatim.

### What changed

**New `host-app-bridge.ts` (framework-free).** `registerHostBridgeHandlers(bridge, options)` installs the capability-gated SEP-1865 bridge handlers and owns the *correctness surface* that the harness needs to behave like production:
- capability gating (advertise = enforce — a handler is only installed when its cap is advertised);
- the model-only visibility check (`isVisibleToModelOnly`);
- the matrix-gated `sendToolCancelled` policy (M365 Copilot suppresses the side-channel notification);
- the app-tool invocation lifecycle (running → success/error).

All host-environment effects (open a link, read a resource, dispatch a tool call, animate the iframe, change display mode, teardown) are **injected as callbacks**. The renderer binds its `useRef`/`useState`/store machinery to them; the harness will bind its own. Also exports `createHostAppBridge`.

**New leaf modules (single source of truth, dependency-light):**
- `tool-visibility.ts` — `getToolVisibility` / `isVisibleToModelOnly` / `isVisibleToAppOnly` (re-exported by `mcp-apps-utils.ts`, so existing import sites are unchanged).
- `iframe-sandbox-policy.ts` — `buildOuterSandboxAttribute` / `buildOuterAllowAttribute` / `resolveIframeSandboxPolicy`, the outer iframe `sandbox=` / `allow=` construction that `SandboxedIframe` used inline. Now shared so the harness builds an identical grant surface.

**Consumers rewired:**
- `mcp-apps-renderer.tsx` — `registerBridgeHandlers` becomes a thin adapter (the ~480-line `useCallback` collapses). The modal path is **untouched** — it still receives the same `(bridge) => void` adapter and overrides `oninitialized` / `onsizechange` after registration.
- `sandboxed-iframe.tsx` — consumes the extracted attribute builders.

### Notes for review
- SDK result/param types are **derived through `AppBridge`** (ext-apps) rather than imported from `@modelcontextprotocol/sdk`, to satisfy the `check:mcp-v1-runtime-imports` guard.
- The inner-document CSP `<meta>` stays in the cross-origin sandbox proxy (`sandbox-proxy.html`); `resolveIframeSandboxPolicy` is intentionally scoped to the **outer** attributes. PR 3's harness reuses the proxy's CSP builder.
- `registerBridgeHandlers`'s span was ~486 LOC (not ~250 as originally scoped) and tightly bound to ~30 refs — the extraction parameterizes each as a callback/getter.

### Tests
- 25 new framework-free unit tests: handshake, capability gating (`serverTools=false ⇒ oncalltool unassigned`), model-only filtering, `sendToolCancelled` matrix gating, app-tool lifecycle, teardown gating, and `sandbox=` / `allow=` string equivalence with the pre-refactor output.
- Existing suites still pass: `mcp-apps-renderer` (86), `cross-matrix-isolation`, `sandboxed-iframe`, `sandbox-proxy-buildCSP`/`routes`/`bundle-fresh`. Client typecheck + the v1-import guard are green.

### Stack
1. **PR 1 (this)** — extract `host-app-bridge.ts` shared module.
2. PR 2 — `prepareAdvertisedTools` engine hook.
3. PR 3 — Playwright `mcp-app-browser-harness.ts`.
4. PR 4 — Computer Use tool registration + executor adapter.
5. PR 5 — eval-runner integration (render checks + local Computer Use).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MptMA6zxE4bAdriyK9SJv6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive MCP Apps host behavior (tool visibility, sandbox grants, capability enforcement); intended as a no-op refactor but regressions would affect widget isolation and app-initiated tool calls.
> 
> **Overview**
> This PR **extracts** MCP Apps host bridge logic from `mcp-apps-renderer.tsx` into reusable, non-React modules so a future Playwright eval harness can match production behavior.
> 
> **`host-app-bridge.ts`** adds `registerHostBridgeHandlers` and `createHostAppBridge`, centralizing capability gating (advertise = enforce), model-only tool blocking, matrix-gated `sendToolCancelled`, app-tool invocation lifecycle, and teardown handling. Host effects (links, resources, display mode, downloads, etc.) are **injected via callbacks**; the renderer now binds refs/state to those callbacks instead of inlining ~480 lines of handler code.
> 
> **Leaf modules:** `tool-visibility.ts` holds SEP-1865 visibility helpers (with deduping for repeated scopes); `iframe-sandbox-policy.ts` holds outer iframe `sandbox=` / `allow=` construction. **`SandboxedIframe`** and **`mcp-apps-utils`** consume or re-export these instead of duplicating logic.
> 
> **Tests:** ~25 Vitest cases cover bridge gating, model-only rejection, lifecycle, teardown, and sandbox string parity with pre-refactor output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb0fa1c117e57760c8b856875d0d6bfbdc14237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->