### PR TITLE
engine: add prepareAdvertisedTools per-step hook (eval browser-render PR 2/5)

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
@@ -306,6 +306,14 @@ describe("tool visibility helpers", () => {
       false,
     );
   });
+  it("dedupes repeated scopes so model-only stays enforced", () => {
+    expect(getToolVisibility({ ui: { visibility: ["model", "model"] } })).toEqual(
+      ["model"],
+    );
+    expect(
+      isVisibleToModelOnly({ ui: { visibility: ["model", "model"] } }),
+    ).toBe(true);
+  });
 });
 
 /* ------------------------------------------------------------------ *

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
+import {
+  registerHostBridgeHandlers,
+  resolveIframeSandboxPolicy,
+  buildOuterSandboxAttribute,
+  buildOuterAllowAttribute,
+  getToolVisibility,
+  isVisibleToModelOnly,
+  type HostBridgeCallbacks,
+  type RegisterHostBridgeHandlersOptions,
+} from "../host-app-bridge";
+
+/* ------------------------------------------------------------------ *
+ * Stub bridge
+ *
+ * `registerHostBridgeHandlers` only assigns the `on*` handler slots and calls
+ * `sendToolCancelled` / `teardownResource` / `getAppCapabilities`. A plain
+ * object satisfies that surface; cast to AppBridge for the call site.
+ * ------------------------------------------------------------------ */
+type StubBridge = {
+  oninitialized?: (...args: unknown[]) => unknown;
+  onmessage?: (...args: unknown[]) => unknown;
+  onopenlink?: (...args: unknown[]) => unknown;
+  oncalltool?: (...args: unknown[]) => unknown;
+  onreadresource?: (...args: unknown[]) => unknown;
+  onlistresources?: (...args: unknown[]) => unknown;
+  onlistresourcetemplates?: (...args: unknown[]) => unknown;
+  onlistprompts?: (...args: unknown[]) => unknown;
+  onloggingmessage?: (...args: unknown[]) => unknown;
+  onsizechange?: (...args: unknown[]) => unknown;
+  onrequestdisplaymode?: (...args: unknown[]) => unknown;
+  onupdatemodelcontext?: (...args: unknown[]) => unknown;
+  ondownloadfile?: (...args: unknown[]) => unknown;
+  onrequestteardown?: (...args: unknown[]) => unknown;
+  sendToolCancelled: ReturnType<typeof vi.fn>;
+  teardownResource: ReturnType<typeof vi.fn>;
+  getAppCapabilities: ReturnType<typeof vi.fn>;
+};
+
+function makeStubBridge(
+  appCaps: Record<string, unknown> | undefined = undefined,
+): StubBridge {
+  return {
+    sendToolCancelled: vi.fn().mockResolvedValue(undefined),
+    teardownResource: vi.fn().mockResolvedValue({}),
+    getAppCapabilities: vi.fn().mockReturnValue(appCaps),
+  };
+}
+
+const ALL_CAPS = {
+  message: true,
+  openLinks: true,
+  serverTools: true,
+  serverResources: true,
+  logging: true,
+  updateModelContext: true,
+  downloadFile: true,
+} as RegisterHostBridgeHandlersOptions["effectiveHostCapabilities"];
+
+const NO_CAPS = {
+  message: false,
+  openLinks: false,
+  serverTools: false,
+  serverResources: false,
+  logging: false,
+  updateModelContext: false,
+  downloadFile: false,
+} as RegisterHostBridgeHandlersOptions["effectiveHostCapabilities"];
+
+function register(
+  bridge: StubBridge,
+  opts: Partial<RegisterHostBridgeHandlersOptions> & {
+    callbacks?: HostBridgeCallbacks;
+  } = {},
+) {
+  registerHostBridgeHandlers(bridge as unknown as AppBridge, {
+    effectiveHostCapabilities: opts.effectiveHostCapabilities ?? ALL_CAPS,
+    getMatrix: opts.getMatrix,
+    getToolMetadata: opts.getToolMetadata,
+    getToolCallId: opts.getToolCallId ?? (() => "tc-1"),
+    nextInvocationSequence: opts.nextInvocationSequence,
+    onWidgetDebug: opts.onWidgetDebug,
+    callbacks: opts.callbacks ?? {},
+  });
+}
+
+describe("registerHostBridgeHandlers — capability gating (advertise = enforce)", () => {
+  it("installs no capability-gated handlers when all caps are off", () => {
+    const bridge = makeStubBridge();
+    register(bridge, { effectiveHostCapabilities: NO_CAPS });
+
+    expect(bridge.onmessage).toBeUndefined();
+    expect(bridge.onopenlink).toBeUndefined();
+    expect(bridge.oncalltool).toBeUndefined();
+    expect(bridge.onreadresource).toBeUndefined();
+    expect(bridge.onlistresources).toBeUndefined();
+    expect(bridge.onlistresourcetemplates).toBeUndefined();
+    expect(bridge.onloggingmessage).toBeUndefined();
+    expect(bridge.onupdatemodelcontext).toBeUndefined();
+    expect(bridge.ondownloadfile).toBeUndefined();
+  });
+
+  it("keeps the unconditional handlers installed even with all caps off", () => {
+    const bridge = makeStubBridge();
+    register(bridge, { effectiveHostCapabilities: NO_CAPS });
+
+    expect(bridge.oninitialized).toBeTypeOf("function");
+    expect(bridge.onlistprompts).toBeTypeOf("function");
+    expect(bridge.onsizechange).toBeTypeOf("function");
+    expect(bridge.onrequestdisplaymode).toBeTypeOf("function");
+  });
+
+  it("serverTools=false leaves oncalltool unassigned", () => {
+    const bridge = makeStubBridge();
+    register(bridge, {
+      effectiveHostCapabilities: { ...ALL_CAPS, serverTools: false },
+    });
+    expect(bridge.oncalltool).toBeUndefined();
+  });
+
+  it("installs every handler when all caps are on", () => {
+    const bridge = makeStubBridge();
+    register(bridge, { effectiveHostCapabilities: ALL_CAPS });
+
+    for (const slot of [
+      "oninitialized",
+      "onmessage",
+      "onopenlink",
+      "oncalltool",
+      "onreadresource",
+      "onlistresources",
+      "onlistresourcetemplates",
+      "onlistprompts",
+      "onloggingmessage",
+      "onsizechange",
+      "onrequestdisplaymode",
+      "onupdatemodelcontext",
+      "ondownloadfile",
+      "onrequestteardown",
+    ] as const) {
+      expect(bridge[slot], slot).toBeTypeOf("function");
+    }
+  });
+});
+
+describe("registerHostBridgeHandlers — handshake", () => {
+  it("oninitialized forwards the bridge to onAppInitialized", () => {
+    const bridge = makeStubBridge({ tools: false });
+    const onAppInitialized = vi.fn();
+    register(bridge, { callbacks: { onAppInitialized } });
+
+    bridge.oninitialized?.();
+    expect(onAppInitialized).toHaveBeenCalledTimes(1);
+    expect(onAppInitialized).toHaveBeenCalledWith(bridge);
+  });
+});
+
+describe("registerHostBridgeHandlers — model-only visibility (SEP-1865)", () => {
+  it("rejects an app-initiated call to a model-only tool and never dispatches", async () => {
+    const bridge = makeStubBridge();
+    const onCallTool = vi.fn().mockResolvedValue({ content: [] });
+    register(bridge, {
+      getToolMetadata: (name) =>
+        name === "secret" ? { ui: { visibility: ["model"] } } : undefined,
+      callbacks: { onCallTool },
+    });
+
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "secret", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow(/not callable by apps/);
+    expect(onCallTool).not.toHaveBeenCalled();
+    // matrix permits the side-channel notification by default
+    expect(bridge.sendToolCancelled).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches a normally-visible tool and returns its result", async () => {
+    const bridge = makeStubBridge();
+    const result = { content: [{ type: "text", text: "ok" }] };
+    const onCallTool = vi.fn().mockResolvedValue(result);
+    register(bridge, {
+      getToolMetadata: () => ({}), // default visibility => model + app
+      callbacks: { onCallTool },
+    });
+
+    const out = await (
+      bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>
+    )({ name: "search", arguments: { q: 1 } }, {});
+    expect(onCallTool).toHaveBeenCalledWith("search", { q: 1 });
+    expect(out).toBe(result);
+  });
+});
+
+describe("registerHostBridgeHandlers — sendToolCancelled matrix gating", () => {
+  it("suppresses sendToolCancelled when matrix.toolCancelled === false", async () => {
+    const bridge = makeStubBridge();
+    register(bridge, {
+      getMatrix: () => ({ toolCancelled: false }),
+      getToolMetadata: () => ({ ui: { visibility: ["model"] } }),
+      callbacks: { onCallTool: vi.fn() },
+    });
+
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "x", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow();
+    expect(bridge.sendToolCancelled).not.toHaveBeenCalled();
+  });
+});
+
+describe("registerHostBridgeHandlers — app-tool invocation lifecycle", () => {
+  it("emits running → success around a dispatched call", async () => {
+    const bridge = makeStubBridge();
+    const updates: Array<{ status: string }> = [];
+    register(bridge, {
+      getToolCallId: () => "parent-1",
+      nextInvocationSequence: () => 7,
+      callbacks: {
+        onCallTool: vi.fn().mockResolvedValue({ content: [] }),
+        onAppToolInvocation: (u) => updates.push(u),
+      },
+    });
+
+    await (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+      { name: "go", arguments: {} },
+      {},
+    );
+    expect(updates.map((u) => u.status)).toEqual(["running", "success"]);
+    expect((updates[0] as { id: string }).id).toBe("parent-1:app-tool:7");
+  });
+
+  it("emits running → error and cancels when the dispatch throws", async () => {
+    const bridge = makeStubBridge();
+    const updates: Array<{ status: string; errorText?: string }> = [];
+    register(bridge, {
+      callbacks: {
+        onCallTool: vi.fn().mockRejectedValue(new Error("boom")),
+        onAppToolInvocation: (u) => updates.push(u),
+      },
+    });
+
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "go", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow("boom");
+    expect(updates.map((u) => u.status)).toEqual(["running", "error"]);
+    expect(updates[1].errorText).toBe("boom");
+    expect(bridge.sendToolCancelled).toHaveBeenCalledWith({ reason: "boom" });
+  });
+
+  it("treats a missing onCallTool as 'Tool calls not supported'", async () => {
+    const bridge = makeStubBridge();
+    const updates: Array<{ status: string; errorText?: string }> = [];
+    register(bridge, {
+      callbacks: { onAppToolInvocation: (u) => updates.push(u) },
+    });
+
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "go", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow("Tool calls not supported");
+    expect(updates.map((u) => u.status)).toEqual(["running", "error"]);
+    expect(updates[1].errorText).toBe("Tool calls not supported");
+  });
+});
+
+describe("registerHostBridgeHandlers — teardown gating", () => {
+  it("does not install onrequestteardown when matrix.requestTeardown === false", () => {
+    const bridge = makeStubBridge();
+    register(bridge, { getMatrix: () => ({ requestTeardown: false }) });
+    expect(bridge.onrequestteardown).toBeUndefined();
+  });
+
+  it("installs onrequestteardown by default and runs teardownResource + callback", async () => {
+    const bridge = makeStubBridge();
+    const onRequestTeardown = vi.fn();
+    register(bridge, {
+      getToolCallId: () => "tc-9",
+      callbacks: { onRequestTeardown },
+    });
+    expect(bridge.onrequestteardown).toBeTypeOf("function");
+    await (bridge.onrequestteardown as () => Promise<unknown>)();
+    expect(bridge.teardownResource).toHaveBeenCalledTimes(1);
+    expect(onRequestTeardown).toHaveBeenCalledWith("tc-9");
+  });
+});
+
+describe("tool visibility helpers", () => {
+  it("defaults to model + app when unspecified", () => {
+    expect(getToolVisibility(undefined)).toEqual(["model", "app"]);
+    expect(getToolVisibility({})).toEqual(["model", "app"]);
+    expect(isVisibleToModelOnly({})).toBe(false);
+  });
+  it("detects model-only", () => {
+    expect(isVisibleToModelOnly({ ui: { visibility: ["model"] } })).toBe(true);
+    expect(isVisibleToModelOnly({ ui: { visibility: ["model", "app"] } })).toBe(
+      false,
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * Iframe sandbox attribute construction
+ *
+ * Asserts the extracted builders produce exactly the strings SandboxedIframe
+ * produced pre-refactor for matching inputs (plan verification step 1).
+ * ------------------------------------------------------------------ */
+describe("resolveIframeSandboxPolicy — outer attribute construction", () => {
+  it("falls back to the permissive baseline when sandboxAttrs is undefined", () => {
+    expect(buildOuterSandboxAttribute({})).toBe(
+      "allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts",
+    );
+  });
+
+  it("treats [] as spec-minimum (allow-scripts + allow-same-origin only)", () => {
+    expect(buildOuterSandboxAttribute({ sandboxAttrs: [] })).toBe(
+      "allow-same-origin allow-scripts",
+    );
+  });
+
+  it("unions profile tokens with the spec minimum, sorted", () => {
+    expect(
+      buildOuterSandboxAttribute({ sandboxAttrs: ["allow-forms"] }),
+    ).toBe("allow-forms allow-same-origin allow-scripts");
+  });
+
+  it("rejects sandbox tokens with internal whitespace", () => {
+    expect(
+      buildOuterSandboxAttribute({
+        sandboxAttrs: ["allow-forms", "allow-popups allow-modals"],
+      }),
+    ).toBe("allow-forms allow-same-origin allow-scripts");
+  });
+
+  it("emits legacy allow defaults when allowFeatures is undefined", () => {
+    expect(buildOuterAllowAttribute({})).toBe(
+      "local-network-access *; midi *",
+    );
+  });
+
+  it("flows the 4 spec permissions through regardless of allowFeatures", () => {
+    expect(
+      buildOuterAllowAttribute({
+        permissions: { camera: {}, clipboardWrite: {} } as never,
+        allowFeatures: {},
+      }),
+    ).toBe("camera *; clipboard-write *");
+  });
+
+  it("drops the legacy defaults when allowFeatures is authoritative ({})", () => {
+    expect(buildOuterAllowAttribute({ allowFeatures: {} })).toBe("");
+  });
+
+  it("appends non-spec permissions-policy features from allowFeatures", () => {
+    expect(
+      buildOuterAllowAttribute({ allowFeatures: { fullscreen: "*" } }),
+    ).toBe("fullscreen *");
+  });
+
+  it("ignores spec features and injection attempts in allowFeatures", () => {
+    expect(
+      buildOuterAllowAttribute({
+        allowFeatures: {
+          camera: "*", // spec feature: must come from permissions, not here
+          "bad key": "*", // whitespace in key
+          evil: "*; camera *", // separator injection in value
+          fullscreen: "*",
+        },
+      }),
+    ).toBe("fullscreen *");
+  });
+
+  it("resolveIframeSandboxPolicy composes both attributes", () => {
+    expect(
+      resolveIframeSandboxPolicy({
+        sandboxAttrs: ["allow-forms"],
+        permissions: { camera: {} } as never,
+        allowFeatures: { fullscreen: "*" },
+      }),
+    ).toEqual({
+      sandbox: "allow-forms allow-same-origin allow-scripts",
+      allow: "camera *; fullscreen *",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge.ts
@@ -423,6 +423,10 @@ export function registerHostBridgeHandlers(
   // view-initiated teardown by leaving the handler unassigned.
   if ((getMatrix?.() ?? null)?.requestTeardown !== false) {
     bridge.onrequestteardown = async () => {
+      // Capture the teardown target BEFORE awaiting: the renderer adapter backs
+      // `getToolCallId` with a live ref, so a prop swap during the round-trip
+      // could otherwise unmount a newer widget than the one that asked to close.
+      const toolCallId = currentToolCallId();
       onWidgetDebug?.("ui-to-host", "ui/notifications/request-teardown", {});
       try {
         await bridge.teardownResource({});
@@ -433,7 +437,7 @@ export function registerHostBridgeHandlers(
           error: err instanceof Error ? err.message : String(err),
         });
       }
-      callbacks.onRequestTeardown?.(currentToolCallId());
+      callbacks.onRequestTeardown?.(toolCallId);
     };
   }
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge.ts
@@ -1,0 +1,439 @@
+/**
+ * host-app-bridge.ts — framework-free MCP Apps host bridge surface (SEP-1865)
+ *
+ * Extracted from `mcp-apps-renderer.tsx` so the host-side AppBridge wiring,
+ * the capability-gated bridge handler installation, and the iframe sandbox
+ * attribute construction can be reused outside React — specifically by the
+ * eval browser harness (`server/utils/mcp-app-browser-harness.ts`) which must
+ * behave like the production renderer when it mounts a widget in headless
+ * Chromium.
+ *
+ * Design contract:
+ *   - This module is PURE JS: no React, no DOM-effect ownership, no Zustand.
+ *   - All host-environment effects (open a link, read a resource, dispatch a
+ *     tool call, mutate display mode, animate the iframe) are injected as
+ *     callbacks. The renderer binds its `useRef`/`useState`/`useCallback`
+ *     machinery to these inputs; the harness binds its own.
+ *   - The genuinely-shared *correctness surface* lives here verbatim:
+ *     capability gating (advertise = enforce), the model-only visibility
+ *     check, the matrix-gated `sendToolCancelled` policy, and the app-tool
+ *     invocation lifecycle. The harness needs all of it to match production.
+ *
+ * React-specific concerns (state updates, refs, reconnection) stay in the
+ * renderer. See `mcp-apps-renderer.tsx` for the adapter that consumes this.
+ */
+
+import {
+  AppBridge,
+  type McpUiHostCapabilities,
+  type McpUiHostContext,
+  type McpUiResourceCsp,
+  type McpUiResourcePermissions,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import { isVisibleToModelOnly } from "@/lib/mcp-ui/tool-visibility";
+import type { AppToolInvocationUpdate } from "../app-tool-invocations";
+
+// Re-export the shared SEP-1865 visibility helpers and the iframe sandbox
+// attribute resolver so harness consumers can pull the full host surface from
+// a single framework-free module ("alongside the bridge").
+export {
+  getToolVisibility,
+  isVisibleToModelOnly,
+  isVisibleToAppOnly,
+} from "@/lib/mcp-ui/tool-visibility";
+export {
+  DEFAULT_IFRAME_SANDBOX,
+  buildOuterAllowAttribute,
+  buildOuterSandboxAttribute,
+  resolveIframeSandboxPolicy,
+} from "@/lib/mcp-ui/iframe-sandbox-policy";
+
+/* ------------------------------------------------------------------ *
+ * Host AppBridge construction
+ * ------------------------------------------------------------------ */
+
+/**
+ * Construct a host-side AppBridge with the resolved capabilities + sandbox
+ * slice + host context. Mirrors the inline `new AppBridge(...)` the renderer
+ * builds. The caller wires a transport and calls `bridge.connect(transport)`.
+ */
+export function createHostAppBridge(opts: {
+  hostInfo: { name: string; version: string };
+  hostCapabilities: Omit<McpUiHostCapabilities, "sandbox">;
+  sandbox?: {
+    csp?: McpUiResourceCsp;
+    permissions?: McpUiResourcePermissions;
+  };
+  hostContext?: McpUiHostContext;
+}): AppBridge {
+  return new AppBridge(
+    null,
+    opts.hostInfo,
+    {
+      ...opts.hostCapabilities,
+      sandbox: opts.sandbox ?? {},
+    },
+    { hostContext: opts.hostContext ?? {} },
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Bridge handler installation (the correctness surface)
+ * ------------------------------------------------------------------ */
+
+// Derive result/param types from the AppBridge handler signatures so we never
+// import the MCP v1 SDK types package directly (forbidden in client/src by the
+// `check:mcp-v1-runtime-imports` guard). The types flow through ext-apps.
+type CallToolReturn = Awaited<ReturnType<NonNullable<AppBridge["oncalltool"]>>>;
+type ReadResourceReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onreadresource"]>>
+>;
+type ListResourcesParams = Parameters<
+  NonNullable<AppBridge["onlistresources"]>
+>[0];
+type ListResourcesReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onlistresources"]>>
+>;
+type ListResourceTemplatesParams = Parameters<
+  NonNullable<AppBridge["onlistresourcetemplates"]>
+>[0];
+type ListResourceTemplatesReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onlistresourcetemplates"]>>
+>;
+type ListPromptsReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onlistprompts"]>>
+>;
+type LoggingMessageParams = Parameters<
+  NonNullable<AppBridge["onloggingmessage"]>
+>[0];
+type SizeChangeParams = Parameters<NonNullable<AppBridge["onsizechange"]>>[0];
+type RequestDisplayModeParams = Parameters<
+  NonNullable<AppBridge["onrequestdisplaymode"]>
+>[0];
+type RequestDisplayModeReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["onrequestdisplaymode"]>>
+>;
+type UpdateModelContextParams = Parameters<
+  NonNullable<AppBridge["onupdatemodelcontext"]>
+>[0];
+type DownloadFileParams = Parameters<
+  NonNullable<AppBridge["ondownloadfile"]>
+>[0];
+type DownloadFileReturn = Awaited<
+  ReturnType<NonNullable<AppBridge["ondownloadfile"]>>
+>;
+
+export type WidgetDebugDirection = "host-to-ui" | "ui-to-host";
+
+/**
+ * The minimal slice of the MCP Apps capabilities matrix that the shared
+ * correctness surface reads. `null` means "no matrix configured" (treat as
+ * all-allowed), matching the renderer's `mcpAppsCapabilitiesRef.current`.
+ */
+export interface HostBridgeMatrix {
+  /** When false, suppress the side-channel `sendToolCancelled` notification. */
+  toolCancelled?: boolean;
+  /** When false, do not install the view-initiated teardown handler. */
+  requestTeardown?: boolean;
+}
+
+/**
+ * Host-environment effects injected by the consumer. Every callback is
+ * optional; an unset callback means the corresponding host behavior is a no-op
+ * (the bridge handler is still installed when its capability is advertised, so
+ * the widget sees a well-formed response).
+ */
+export interface HostBridgeCallbacks {
+  /** Fires on `ui/initialize` completion. The renderer drives all of its
+   *  init-time state from here (ready flag, display modes, app-provided-tools
+   *  detection + auto-promote); the harness records render readiness. */
+  onAppInitialized?: (bridge: AppBridge) => void;
+  /** `ui/message` text content (host follow-up). */
+  onSendFollowUp?: (text: string) => void;
+  /** `ui/open-link`. */
+  onOpenLink?: (url: string) => void;
+  /** App-initiated `tools/call` dispatcher. Resolves to a CallToolResult. */
+  onCallTool?: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => Promise<CallToolReturn>;
+  /** App-tool invocation lifecycle updates (running/success/error). */
+  onAppToolInvocation?: (update: AppToolInvocationUpdate) => void;
+  /** `resources/read`. */
+  onReadResource?: (uri: string) => Promise<ReadResourceReturn>;
+  /** `resources/list`. */
+  onListResources?: (
+    params: ListResourcesParams,
+  ) => Promise<ListResourcesReturn>;
+  /** `resources/templates/list`. */
+  onListResourceTemplates?: (
+    params: ListResourceTemplatesParams,
+  ) => Promise<ListResourceTemplatesReturn>;
+  /** `prompts/list`. */
+  onListPrompts?: () => Promise<ListPromptsReturn>;
+  /** `logging/message`. */
+  onLoggingMessage?: (params: LoggingMessageParams) => void;
+  /** `ui/notifications/size-changed`. */
+  onSizeChange?: (params: SizeChangeParams) => void;
+  /** `ui/request-display-mode`. Returns the granted mode. */
+  onRequestDisplayMode?: (
+    params: RequestDisplayModeParams,
+  ) => Promise<RequestDisplayModeReturn> | RequestDisplayModeReturn;
+  /** `ui/update-model-context`. */
+  onUpdateModelContext?: (
+    toolCallId: string,
+    params: UpdateModelContextParams,
+  ) => void;
+  /** `ui/download-file`. */
+  onDownloadFile?: (
+    params: DownloadFileParams,
+  ) => Promise<DownloadFileReturn> | DownloadFileReturn;
+  /** `ui/notifications/request-teardown` (after host-side teardownResource). */
+  onRequestTeardown?: (toolCallId: string) => void;
+}
+
+export interface RegisterHostBridgeHandlersOptions {
+  /**
+   * Resolved host capabilities (vendor-trait surface advertised in
+   * `ui/initialize`). Gating here is advertise = enforce: a handler is only
+   * installed when its capability is true.
+   */
+  effectiveHostCapabilities: Omit<McpUiHostCapabilities, "sandbox">;
+  /** Read the MCP Apps capabilities matrix at call/registration time. */
+  getMatrix?: () => HostBridgeMatrix | null;
+  /** Look up tool metadata by name for the model-only visibility check. */
+  getToolMetadata?: (name: string) => Record<string, unknown> | undefined;
+  /** Current parent tool-call id (correlates app-tool invocations + teardown). */
+  getToolCallId?: () => string;
+  /** Monotonic sequence source for app-tool invocation ids. Defaults to an
+   *  internal per-registration counter; the renderer passes a shared ref so
+   *  inline + modal bridges never collide on an invocation id. */
+  nextInvocationSequence?: () => number;
+  /** Host-environment effect callbacks. */
+  callbacks: HostBridgeCallbacks;
+  /** Diagnostic sink (traffic / widget-debug). */
+  onWidgetDebug?: (
+    direction: WidgetDebugDirection,
+    method: string,
+    data: Record<string, unknown>,
+  ) => void;
+}
+
+/**
+ * Install the SEP-1865 host bridge handlers on `bridge`, gated by
+ * `effectiveHostCapabilities` and the capabilities matrix. This is the
+ * production correctness surface — capability gating, model-only visibility,
+ * matrix-gated `sendToolCancelled`, and the app-tool invocation lifecycle —
+ * lifted out of the React renderer so the eval harness shares it verbatim.
+ */
+export function registerHostBridgeHandlers(
+  bridge: AppBridge,
+  options: RegisterHostBridgeHandlersOptions,
+): void {
+  const {
+    effectiveHostCapabilities,
+    getMatrix,
+    getToolMetadata,
+    getToolCallId,
+    callbacks,
+    onWidgetDebug,
+  } = options;
+
+  let internalSeq = 0;
+  const nextSeq = options.nextInvocationSequence ?? (() => internalSeq++);
+  const currentToolCallId = () => getToolCallId?.() ?? "";
+
+  bridge.oninitialized = () => {
+    callbacks.onAppInitialized?.(bridge);
+  };
+
+  // SEP-1865 bridge handlers are gated by `effectiveHostCapabilities` alone.
+  // They are a SEPARATE surface from the `window.openai` shim; folding the
+  // shim matrix in here would break the advertise = enforce contract.
+  if (effectiveHostCapabilities.message) {
+    bridge.onmessage = async ({ content }) => {
+      const textContent = content.find((item) => item.type === "text")?.text;
+      if (textContent) {
+        callbacks.onSendFollowUp?.(textContent);
+      }
+      return {};
+    };
+  }
+
+  if (effectiveHostCapabilities.openLinks) {
+    bridge.onopenlink = async ({ url }) => {
+      if (url) {
+        callbacks.onOpenLink?.(url);
+      }
+      return {};
+    };
+  }
+
+  if (effectiveHostCapabilities.serverTools) {
+    // Matrix-gated `sendToolCancelled`: Microsoft 365 Copilot does not deliver
+    // `ui/notifications/tool-cancelled`; simulated Copilot hosts must not see
+    // the cancelled callback even when the underlying tool throws. The handler
+    // still THROWS so the request/response path reports an error to the widget
+    // — only the side-channel notification is suppressed.
+    const sendToolCancelledIfAllowed = (reason: string) => {
+      const matrix = getMatrix?.() ?? null;
+      if (matrix !== null && matrix.toolCancelled === false) return;
+      void bridge.sendToolCancelled({ reason });
+    };
+    bridge.oncalltool = async ({ name, arguments: args }, _extra) => {
+      // Model-only tools (visibility: ["model"]) are not callable by apps.
+      const calledToolMeta = getToolMetadata?.(name);
+      if (isVisibleToModelOnly(calledToolMeta)) {
+        const error = new Error(
+          `Tool "${name}" is not callable by apps (visibility: model-only)`,
+        );
+        sendToolCancelledIfAllowed(error.message);
+        throw error;
+      }
+
+      const invocationInput = (args ?? {}) as Record<string, unknown>;
+      const parentToolCallId = currentToolCallId();
+      const invocationId = `${parentToolCallId}:app-tool:${nextSeq()}`;
+      const startedAt = Date.now();
+      callbacks.onAppToolInvocation?.({
+        id: invocationId,
+        parentToolCallId,
+        toolName: name,
+        input: invocationInput,
+        status: "running",
+        startedAt,
+      });
+
+      if (!callbacks.onCallTool) {
+        const error = new Error("Tool calls not supported");
+        callbacks.onAppToolInvocation?.({
+          id: invocationId,
+          parentToolCallId,
+          toolName: name,
+          input: invocationInput,
+          errorText: error.message,
+          status: "error",
+          startedAt,
+          completedAt: Date.now(),
+        });
+        sendToolCancelledIfAllowed(error.message);
+        throw error;
+      }
+
+      try {
+        const result = await callbacks.onCallTool(name, invocationInput);
+        callbacks.onAppToolInvocation?.({
+          id: invocationId,
+          parentToolCallId,
+          toolName: name,
+          input: invocationInput,
+          output: result,
+          status: "success",
+          startedAt,
+          completedAt: Date.now(),
+        });
+        return result;
+      } catch (error) {
+        const errorText =
+          error instanceof Error ? error.message : String(error);
+        callbacks.onAppToolInvocation?.({
+          id: invocationId,
+          parentToolCallId,
+          toolName: name,
+          input: invocationInput,
+          errorText,
+          status: "error",
+          startedAt,
+          completedAt: Date.now(),
+        });
+        sendToolCancelledIfAllowed(errorText);
+        throw error;
+      }
+    };
+  }
+
+  if (effectiveHostCapabilities.serverResources) {
+    bridge.onreadresource = async ({ uri }) => {
+      if (!callbacks.onReadResource) {
+        throw new Error("Resource reads not supported");
+      }
+      return callbacks.onReadResource(uri);
+    };
+
+    bridge.onlistresources = async (params) => {
+      if (!callbacks.onListResources) {
+        return { resources: [] } as ListResourcesReturn;
+      }
+      return callbacks.onListResources(params);
+    };
+
+    bridge.onlistresourcetemplates = async (params) => {
+      if (!callbacks.onListResourceTemplates) {
+        return { resourceTemplates: [] } as ListResourceTemplatesReturn;
+      }
+      return callbacks.onListResourceTemplates(params);
+    };
+  }
+
+  // onlistprompts: unconditional — no serverPrompts cap in SEP-1865.
+  bridge.onlistprompts = async () => {
+    if (!callbacks.onListPrompts) {
+      return { prompts: [] } as ListPromptsReturn;
+    }
+    return callbacks.onListPrompts();
+  };
+
+  if (effectiveHostCapabilities.logging) {
+    bridge.onloggingmessage = (params) => {
+      callbacks.onLoggingMessage?.(params);
+    };
+  }
+
+  // Size changes are unconditional in the renderer (the host shell owns layout).
+  bridge.onsizechange = (params) => {
+    callbacks.onSizeChange?.(params);
+  };
+
+  bridge.onrequestdisplaymode = async (params) => {
+    if (callbacks.onRequestDisplayMode) {
+      return callbacks.onRequestDisplayMode(params);
+    }
+    // No host display-mode policy → echo the requested mode (default inline).
+    return { mode: params.mode ?? "inline" } as RequestDisplayModeReturn;
+  };
+
+  if (effectiveHostCapabilities.updateModelContext) {
+    bridge.onupdatemodelcontext = async (params) => {
+      callbacks.onUpdateModelContext?.(currentToolCallId(), params);
+      return {};
+    };
+  }
+
+  if (effectiveHostCapabilities.downloadFile) {
+    bridge.ondownloadfile = async (params) => {
+      if (!callbacks.onDownloadFile) {
+        return {} as DownloadFileReturn;
+      }
+      return callbacks.onDownloadFile(params);
+    };
+  }
+
+  // `requestTeardown` is a behavior gate on the matrix (not a wire-advertised
+  // host capability); presets that set it false simulate hosts that ignore
+  // view-initiated teardown by leaving the handler unassigned.
+  if ((getMatrix?.() ?? null)?.requestTeardown !== false) {
+    bridge.onrequestteardown = async () => {
+      onWidgetDebug?.("ui-to-host", "ui/notifications/request-teardown", {});
+      try {
+        await bridge.teardownResource({});
+      } catch (err) {
+        // Teardown is best-effort; proceed to unmount even if the view never
+        // acks so a misbehaving widget can't block its own removal.
+        onWidgetDebug?.("host-to-ui", "ui/resource-teardown", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      callbacks.onRequestTeardown?.(currentToolCallId());
+    };
+  }
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -60,7 +60,7 @@ import type {
 } from "@modelcontextprotocol/client";
 import { DEFAULT_HOST_STYLE, getHostStyleOrDefault } from "@/lib/client-styles";
 import type { OpenAiAppsCapabilities } from "@/lib/client-styles";
-import { isVisibleToModelOnly } from "@/lib/mcp-ui/mcp-apps-utils";
+import { registerHostBridgeHandlers } from "./host-app-bridge";
 import { LoggingTransport } from "./mcp-apps-logging-transport";
 import { McpAppsModal } from "./mcp-apps-modal";
 import {
@@ -2749,518 +2749,319 @@ export function MCPAppsRendererSurface({
     onRequestTeardown,
   ]);
 
-  // ENFORCEMENT (live):
-  // `effectiveHostCapabilities` (above) is the contract advertised in
-  // ui/initialize, and the six chip-bound handlers below are only assigned
-  // when their cap is present — so advertise and enforce stay in lockstep.
-  // An unassigned `bridge.on*` slot causes the SDK to auto-respond to the
-  // widget's RPC with a "method not supported" envelope, matching strict
-  // host behavior.
-  //   • bridge.onopenlink            ← effectiveHostCapabilities.openLinks
-  //   • bridge.onmessage             ← effectiveHostCapabilities.message
-  //   • bridge.onupdatemodelcontext  ← effectiveHostCapabilities.updateModelContext
-  //   • bridge.oncalltool            ← effectiveHostCapabilities.serverTools
-  //   • bridge.onreadresource /
-  //     onlistresources /
-  //     onlistresourcetemplates      ← effectiveHostCapabilities.serverResources
-  //   • bridge.onloggingmessage      ← effectiveHostCapabilities.logging
-  //   • bridge.ondownloadfile        ← effectiveHostCapabilities.downloadFile
-  //   • bridge.onrequestteardown     ← matrix.requestTeardown (behavior
-  //                                    gate; not wire-advertised — the
-  //                                    notification is always delivered
-  //                                    by the SDK, but the host can
-  //                                    decline to act on it)
-  //
-  // Intentionally unconditional (no chip / not capability-negotiated in
-  // SEP-1865):
-  //   • bridge.oninitialized         — handshake plumbing
-  //   • bridge.onsizechange          — iframe resize is host-shell infra
-  //   • bridge.onrequestdisplaymode  — request acceptance is always OK;
-  //                                    the spec governs which modes are
-  //                                    granted, not whether requests reply
-  //   • bridge.onlistprompts         — no serverPrompts cap exists yet
-  //   • handleUploadFile / GetFileDownloadUrl
-  //                                  — legacy postMessage paths kept for
-  //                                    Apps SDK widgets; SEP-1865 hosts
-  //                                    use the matrix-gated
-  //                                    bridge.ondownloadfile above
+  // Adapter: bind the renderer's refs / state setters / store callbacks to the
+  // framework-free host bridge surface (`host-app-bridge.ts`). The shared
+  // module owns the SEP-1865 correctness surface (capability gating,
+  // model-only visibility, matrix-gated `sendToolCancelled`, the app-tool
+  // invocation lifecycle); the renderer-specific effects below stay here.
+  // The eval browser harness binds the same surface to its own callbacks.
   const registerBridgeHandlers = useCallback(
     (bridge: AppBridge) => {
-      bridge.oninitialized = () => {
-        const wasReady = isReadyRef.current;
-        setIsReady(true);
-        isReadyRef.current = true;
-        const appCaps = bridge.getAppCapabilities();
-        logWidgetDebug("ui-to-host", "debug/app-initialized", {
-          availableDisplayModes:
-            (appCaps?.availableDisplayModes as DisplayMode[] | undefined) ??
-            null,
-          wasReady,
-        });
-        const declaredAppModes = appCaps?.availableDisplayModes as
-          | DisplayMode[]
-          | undefined;
-        onAppSupportedDisplayModesChangeRef.current?.(declaredAppModes);
-        // SEP-1865: clamp the advertised + runtime mode set against the
-        // app's declaration. The next render of `hostContext` will pick
-        // up the new intersection and the post-init `setHostContext`
-        // effect will publish `host-context-changed` with the updated
-        // `availableDisplayModes` (matrix-gated by hostContextChanged).
-        setAppSupportedDisplayModes(declaredAppModes);
-        // If the guest re-initialized (e.g. an SDK-based app completing its
-        // own handshake after the openai-compat shim already initialized),
-        // bump reinitCount so the delivery effects re-send tool data.
-        if (wasReady) {
-          setReinitCount((c) => c + 1);
-        }
-
-        // SEP-1865 App-Provided Tools: when the app advertises `tools`
-        // capability, fetch its tool list with the SDK bridge and register
-        // it so the next chat POST can advertise no-execute AI SDK tools.
-        // Feature-detect the capability; do not install rejecting stubs.
-        if (appCaps?.tools) {
-          const bridgeId = appToolsBridgeIdRef.current ?? crypto.randomUUID();
-          appToolsBridgeIdRef.current = bridgeId;
-          setAppToolsBridgeIdState(bridgeId);
-          void refreshAppProvidedTools(bridge, bridgeId);
-
-          // SEP-1865 host UX: app-tools widgets are interactive — the
-          // dev will want to chat with them. Auto-promote to fullscreen
-          // so the existing fullscreen overlay (composer + chevron-
-          // toggle chat history) becomes the chat surface, with the
-          // widget filling the space behind it. Gates:
-          //  • `declaredAppModes` includes "fullscreen" — the app
-          //    actually renders in that mode (advertise=enforce)
-          //  • `!userPreferInlineRef.current` — user hasn't dismissed
-          //    fullscreen, and the host's `user-initiated-only` policy
-          //    isn't blocking host-initiated mode switches
-          //  • `!hasAutoPromotedForAppToolsRef.current` — one-shot so
-          //    shim re-init or a widget's own re-handshake doesn't
-          //    re-fire and overwrite a user-chosen mode
-          // `setDisplayModeRef.current` is used (not the closure-
-          // captured `setDisplayMode`) so this handler stays out of the
-          // useCallback dep array and doesn't churn the bridge wiring.
-          if (
-            !hasAutoPromotedForAppToolsRef.current &&
-            !userPreferInlineRef.current &&
-            declaredAppModes?.includes("fullscreen")
-          ) {
-            hasAutoPromotedForAppToolsRef.current = true;
-            setDisplayModeRef.current?.("fullscreen");
-          }
-        }
-      };
-
-      // SEP-1865 bridge handlers are gated by `effectiveHostCapabilities`
-      // alone. They are a SEPARATE surface from the `window.openai`
-      // shim — `ui/initialize` advertises `serverTools`, `openLinks`,
-      // `message`, etc. via that blob, and the advertise/enforce
-      // contract requires the handlers to honor whatever is
-      // advertised. Folding the shim matrix in here would break it:
-      // a Copilot-preset host advertises `serverTools` (the SEP
-      // contract) but disables `window.openai.callTool` (the shim
-      // surface), and gating the bridge by the shim would silently
-      // drop bridge tool calls while still claiming support. The
-      // shim caps stay scoped to the shim, enforced inside the
-      // runtime + the host-side `openai:*` postMessage handlers.
-      if (effectiveHostCapabilities.message) {
-        bridge.onmessage = async ({ content }) => {
-          const textContent = content.find(
-            (item) => item.type === "text"
-          )?.text;
-          if (textContent) {
-            onSendFollowUpRef.current?.(textContent);
-          }
-          return {};
-        };
-      }
-
-      if (effectiveHostCapabilities.openLinks) {
-        bridge.onopenlink = async ({ url }) => {
-          if (url) {
-            window.open(url, "_blank", "noopener,noreferrer");
-          }
-          return {};
-        };
-      }
-
-      if (effectiveHostCapabilities.serverTools) {
-        // Matrix-gated `sendToolCancelled` for app-initiated tool
-        // calls failing in this handler. Microsoft 365 Copilot does
-        // not deliver `ui/notifications/tool-cancelled` per its
-        // published Component-bridge table; simulated Copilot hosts
-        // must not see the cancelled callback even when the
-        // underlying tool throws. The handler still THROWS so the
-        // AppBridge's request/response path reports an error to the
-        // calling widget — only the side-channel notification is
-        // suppressed.
-        const sendToolCancelledIfAllowed = (reason: string) => {
-          const matrix = mcpAppsCapabilitiesRef.current;
-          if (matrix !== null && matrix.toolCancelled === false) return;
-          bridge.sendToolCancelled({ reason });
-        };
-        bridge.oncalltool = async ({ name, arguments: args }, _extra) => {
-          // Check if tool is model-only (not callable by apps) per SEP-1865
-          const calledToolMeta = toolsMetadataRef.current?.[name];
-          if (isVisibleToModelOnly(calledToolMeta)) {
-            const error = new Error(
-              `Tool "${name}" is not callable by apps (visibility: model-only)`
-            );
-            sendToolCancelledIfAllowed(error.message);
-            throw error;
-          }
-
-          const invocationInput = (args ?? {}) as Record<string, unknown>;
-          const invocationId = `${
-            toolCallIdRef.current
-          }:app-tool:${appToolInvocationSequenceRef.current++}`;
-          const startedAt = Date.now();
-          onAppToolInvocationChangeRef.current?.({
-            id: invocationId,
-            parentToolCallId: toolCallIdRef.current,
-            toolName: name,
-            input: invocationInput,
-            status: "running",
-            startedAt,
-          });
-
-          if (!onCallToolRef.current) {
-            const error = new Error("Tool calls not supported");
-            onAppToolInvocationChangeRef.current?.({
-              id: invocationId,
-              parentToolCallId: toolCallIdRef.current,
-              toolName: name,
-              input: invocationInput,
-              errorText: error.message,
-              status: "error",
-              startedAt,
-              completedAt: Date.now(),
+      registerHostBridgeHandlers(bridge, {
+        effectiveHostCapabilities,
+        getMatrix: () => mcpAppsCapabilitiesRef.current,
+        getToolMetadata: (name) => toolsMetadataRef.current?.[name],
+        getToolCallId: () => toolCallIdRef.current,
+        nextInvocationSequence: () => appToolInvocationSequenceRef.current++,
+        onWidgetDebug: logWidgetDebug,
+        callbacks: {
+          onAppInitialized: (b) => {
+            const wasReady = isReadyRef.current;
+            setIsReady(true);
+            isReadyRef.current = true;
+            const appCaps = b.getAppCapabilities();
+            logWidgetDebug("ui-to-host", "debug/app-initialized", {
+              availableDisplayModes:
+                (appCaps?.availableDisplayModes as DisplayMode[] | undefined) ??
+                null,
+              wasReady,
             });
-            sendToolCancelledIfAllowed(error.message);
-            throw error;
-          }
+            const declaredAppModes = appCaps?.availableDisplayModes as
+              | DisplayMode[]
+              | undefined;
+            onAppSupportedDisplayModesChangeRef.current?.(declaredAppModes);
+            // SEP-1865: clamp the advertised + runtime mode set against the
+            // app's declaration. The next render of `hostContext` will pick
+            // up the new intersection and the post-init `setHostContext`
+            // effect will publish `host-context-changed` with the updated
+            // `availableDisplayModes` (matrix-gated by hostContextChanged).
+            setAppSupportedDisplayModes(declaredAppModes);
+            // If the guest re-initialized (e.g. an SDK-based app completing
+            // its own handshake after the openai-compat shim already
+            // initialized), bump reinitCount so the delivery effects re-send
+            // tool data.
+            if (wasReady) {
+              setReinitCount((c) => c + 1);
+            }
 
-          try {
-            const result = await onCallToolRef.current(name, invocationInput);
-            onAppToolInvocationChangeRef.current?.({
-              id: invocationId,
-              parentToolCallId: toolCallIdRef.current,
-              toolName: name,
-              input: invocationInput,
-              output: result,
-              status: "success",
-              startedAt,
-              completedAt: Date.now(),
-            });
-            return result as CallToolResult;
-          } catch (error) {
-            const errorText =
-              error instanceof Error ? error.message : String(error);
-            onAppToolInvocationChangeRef.current?.({
-              id: invocationId,
-              parentToolCallId: toolCallIdRef.current,
-              toolName: name,
-              input: invocationInput,
-              errorText,
-              status: "error",
-              startedAt,
-              completedAt: Date.now(),
-            });
-            // SEP-1865: Send tool-cancelled for failed app-initiated tool calls
-            sendToolCancelledIfAllowed(errorText);
-            throw error;
-          }
-        };
-      }
+            // SEP-1865 App-Provided Tools: when the app advertises `tools`
+            // capability, fetch its tool list with the SDK bridge and register
+            // it so the next chat POST can advertise no-execute AI SDK tools.
+            if (appCaps?.tools) {
+              const bridgeId =
+                appToolsBridgeIdRef.current ?? crypto.randomUUID();
+              appToolsBridgeIdRef.current = bridgeId;
+              setAppToolsBridgeIdState(bridgeId);
+              void refreshAppProvidedTools(b, bridgeId);
 
-      if (effectiveHostCapabilities.serverResources) {
-        bridge.onreadresource = async ({ uri }) => {
-          const result = await readResource(serverIdRef.current, uri);
-          return result.content;
-        };
-
-        bridge.onlistresources = async (params) => {
-          return listResources(
-            serverIdRef.current,
-            (params as { cursor?: string } | undefined)?.cursor
-          );
-        };
-
-        bridge.onlistresourcetemplates = async (_params) => {
-          if (HOSTED_MODE) {
-            throw new Error(
-              "Resource templates are not supported in hosted mode"
-            );
-          }
-
-          const response = await authFetch(`/api/mcp/resource-templates/list`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              serverId: serverIdRef.current,
-            }),
-          });
-          if (!response.ok) {
-            throw new Error(
-              `Resource template list failed: ${response.statusText}`
-            );
-          }
-          return response.json();
-        };
-      }
-
-      // onlistprompts: unconditional — no serverPrompts cap in SEP-1865 or
-      // the chip set. Revisit if/when a serverPrompts chip is added.
-      bridge.onlistprompts = async (params) => {
-        void params;
-        const prompts = await listPrompts(serverIdRef.current);
-        return { prompts };
-      };
-
-      if (effectiveHostCapabilities.logging) {
-        bridge.onloggingmessage = ({ level, data, logger }) => {
-          if (minimalMode) return;
-          const prefix = logger ? `[${logger}]` : "[MCP Apps]";
-          const message = `${prefix} ${level.toUpperCase()}:`;
-          if (level === "error" || level === "critical" || level === "alert") {
-            console.error(message, data);
-            return;
-          }
-          if (level === "warning") {
-            console.warn(message, data);
-            return;
-          }
-          console.info(message, data);
-        };
-      }
-
-      // Inline width is owned by the host shell. Some widgets report their
-      // preferred content width in `ui/notifications/size-changed`; applying it
-      // to the chat container shrinks wide hosted transcripts and leaves the
-      // app pinned to the left. Height remains app-driven for natural inline
-      // layout, while PIP/fullscreen keep their fixed shell sizing.
-      bridge.onsizechange = ({ height }) => {
-        if (effectiveDisplayModeRef.current !== "inline") return;
-        const iframe = sandboxRef.current?.getIframeElement();
-        if (!iframe) return;
-        if (height === undefined) return;
-
-        // The MCP App has requested a `height`, but if
-        // `box-sizing: border-box` is applied to the outer iframe element, then we
-        // must add border thickness to `height` to compute the actual
-        // necessary height (in order to prevent a resize feedback loop).
-        const style = getComputedStyle(iframe);
-        const isBorderBox = style.boxSizing === "border-box";
-
-        // Animate the change for a smooth transition.
-        const from: Keyframe = {};
-        const to: Keyframe = {};
-
-        let adjustedHeight = height;
-
-        if (adjustedHeight !== undefined) {
-          if (isBorderBox) {
-            adjustedHeight +=
-              parseFloat(style.borderTopWidth) +
-              parseFloat(style.borderBottomWidth);
-          }
-          from.height = `${iframe.offsetHeight}px`;
-          iframe.style.height = to.height = `${adjustedHeight}px`;
-          lastInlineHeightRef.current = `${adjustedHeight}px`;
-        }
-
-        iframe.animate([from, to], { duration: 300, easing: "ease-out" });
-        // size-changed fires on every resize/animation tick — chatty widgets
-        // can flood the traffic log. The corresponding ui/notifications/
-        // size-changed transport message is already suppressed above; rely on
-        // that for diagnostics rather than a host-side debug log here.
-      };
-
-      bridge.onrequestdisplaymode = async ({ mode }) => {
-        const requestedMode = mode ?? "inline";
-        // Host policy gate: SEP-1865 allows the host to decline
-        // widget-initiated `ui/request-display-mode`. The
-        // `widgetDisplayModeRequests` matrix row (Apps tab) decides:
-        //   - "accept": pass through to the existing sticky / clamp path
-        //   - "decline": always return the current mode
-        //   - "user-initiated-only": handled via the sticky-inline
-        //     ref check below — the ref is seeded `true` at mount so
-        //     the first widget request is gated until the user picks
-        //     a non-inline mode via the host display-mode picker.
-        const policy =
-          mcpAppsCapabilitiesRef.current?.widgetDisplayModeRequests ?? "accept";
-        if (requestedMode !== "inline" && policy === "decline") {
-          const granted = effectiveDisplayModeRef.current;
-          logWidgetDebug("ui-to-host", "ui/request-display-mode", {
-            requested: requestedMode,
-            granted,
-            reason: "policy-decline",
-          });
-          return { mode: granted };
-        }
-        // Sticky inline-preference override: if the user explicitly
-        // returned to inline (X click), or the policy seeded the flag
-        // at mount, decline widget non-inline requests by returning
-        // inline. Spec allows the host to return a different mode than
-        // requested. Cleared when the user explicitly re-enters
-        // fullscreen / PIP from the host display-mode picker.
-        if (requestedMode !== "inline" && userPreferInlineRef.current) {
-          logWidgetDebug("ui-to-host", "ui/request-display-mode", {
-            requested: requestedMode,
-            granted: "inline",
-            reason: "user-prefers-inline",
-          });
-          return { mode: "inline" };
-        }
-        const hostAvailableModes = extractHostDisplayModes(
-          hostContextRef.current as Record<string, unknown> | undefined
-        );
-        // Use device type for mobile detection (defaults to mobile-like behavior when not in playground)
-        const isMobile = isPlaygroundActiveRef.current
-          ? playgroundDeviceTypeRef.current === "mobile" ||
-            playgroundDeviceTypeRef.current === "tablet"
-          : true;
-        const mobileAdjustedMode: DisplayMode =
-          isMobile && requestedMode === "pip" ? "fullscreen" : requestedMode;
-        const actualMode = clampDisplayModeToAvailableModes(
-          mobileAdjustedMode,
-          hostAvailableModes
-        );
-
-        setDisplayModeRef.current(actualMode);
-
-        if (actualMode === "pip") {
-          onRequestPipRef.current?.(displayWidgetIdRef.current);
-        } else if (
-          (actualMode === "inline" || actualMode === "fullscreen") &&
-          ownsPipDisplayModeRef.current
-        ) {
-          onExitPipRef.current?.(
-            pipWidgetIdRef.current ?? displayWidgetIdRef.current
-          );
-        }
-
-        return { mode: actualMode };
-      };
-
-      if (effectiveHostCapabilities.updateModelContext) {
-        bridge.onupdatemodelcontext = async ({
-          content,
-          structuredContent,
-        }) => {
-          const currentToolCallId = toolCallIdRef.current;
-          // Store in debug store for UI display
-          setWidgetModelContext(currentToolCallId, {
-            content,
-            structuredContent,
-          });
-
-          // Notify parent component to queue for next model turn
-          onModelContextUpdateRef.current?.(currentToolCallId, {
-            content,
-            structuredContent,
-          });
-
-          return {};
-        };
-      }
-
-      // SEP-1865 `ui/download-file`: the view passes embedded resource
-      // contents (`text` or `blob`) and/or resource links. The host
-      // mediates the actual download since the iframe sandbox blocks
-      // direct anchor-clicks. We use a Blob + object-URL anchor (no
-      // confirmation prompt yet — opt-in confirmation is a follow-up).
-      if (effectiveHostCapabilities.downloadFile) {
-        bridge.ondownloadfile = async ({ contents }) => {
-          try {
-            for (const item of contents) {
-              if (item.type === "resource" && item.resource) {
-                const res = item.resource as {
-                  uri: string;
-                  text?: string;
-                  blob?: string;
-                  mimeType?: string;
-                };
-                const mimeType = res.mimeType ?? "application/octet-stream";
-                let blob: Blob;
-                if (typeof res.blob === "string") {
-                  const binary = atob(res.blob);
-                  const bytes = new Uint8Array(binary.length);
-                  for (let i = 0; i < binary.length; i++) {
-                    bytes[i] = binary.charCodeAt(i);
-                  }
-                  blob = new Blob([bytes], { type: mimeType });
-                } else {
-                  blob = new Blob([res.text ?? ""], { type: mimeType });
-                }
-                const url = URL.createObjectURL(blob);
-                try {
-                  const anchor = document.createElement("a");
-                  anchor.href = url;
-                  anchor.download = res.uri.split("/").pop() ?? "download";
-                  anchor.rel = "noopener";
-                  document.body.appendChild(anchor);
-                  anchor.click();
-                  anchor.remove();
-                } finally {
-                  // Defer revocation so the browser has a chance to
-                  // start the download before the object URL goes away.
-                  setTimeout(() => URL.revokeObjectURL(url), 1000);
-                }
-              } else if (item.type === "resource_link") {
-                const link = item as { uri: string };
-                // Refuse navigations that aren't a browser-fetchable scheme.
-                // `javascript:`/`data:` here would execute in the host origin,
-                // and MCP-style schemes (`ui://`, `file://`, server-defined)
-                // need host-side resolution that this path doesn't do yet —
-                // fail loud rather than silently opening an unusable tab.
-                const parsed = new URL(link.uri, window.location.href);
-                if (!["http:", "https:"].includes(parsed.protocol)) {
-                  throw new Error(
-                    `Unsupported download URI protocol: ${parsed.protocol}`
-                  );
-                }
-                window.open(parsed.href, "_blank", "noopener,noreferrer");
+              // SEP-1865 host UX: app-tools widgets are interactive — auto-
+              // promote to fullscreen so the existing fullscreen overlay
+              // becomes the chat surface. Gates: the app renders fullscreen,
+              // the user hasn't dismissed fullscreen, and this is one-shot.
+              if (
+                !hasAutoPromotedForAppToolsRef.current &&
+                !userPreferInlineRef.current &&
+                declaredAppModes?.includes("fullscreen")
+              ) {
+                hasAutoPromotedForAppToolsRef.current = true;
+                setDisplayModeRef.current?.("fullscreen");
               }
             }
-            return {};
-          } catch (err) {
-            logWidgetDebug("ui-to-host", "ui/download-file", {
-              error: err instanceof Error ? err.message : String(err),
-            });
-            return { isError: true };
-          }
-        };
-      }
+          },
+          onSendFollowUp: (text) => {
+            onSendFollowUpRef.current?.(text);
+          },
+          onOpenLink: (url) => {
+            window.open(url, "_blank", "noopener,noreferrer");
+          },
+          onCallTool: async (name, invocationInput) => {
+            if (!onCallToolRef.current) {
+              throw new Error("Tool calls not supported");
+            }
+            return (await onCallToolRef.current(
+              name,
+              invocationInput,
+            )) as CallToolResult;
+          },
+          onAppToolInvocation: (update) => {
+            onAppToolInvocationChangeRef.current?.(update);
+          },
+          onReadResource: async (uri) => {
+            const result = await readResource(serverIdRef.current, uri);
+            return result.content;
+          },
+          onListResources: async (params) => {
+            return listResources(
+              serverIdRef.current,
+              (params as { cursor?: string } | undefined)?.cursor,
+            );
+          },
+          onListResourceTemplates: async () => {
+            if (HOSTED_MODE) {
+              throw new Error(
+                "Resource templates are not supported in hosted mode",
+              );
+            }
+            const response = await authFetch(
+              `/api/mcp/resource-templates/list`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  serverId: serverIdRef.current,
+                }),
+              },
+            );
+            if (!response.ok) {
+              throw new Error(
+                `Resource template list failed: ${response.statusText}`,
+              );
+            }
+            return response.json();
+          },
+          onListPrompts: async () => {
+            const prompts = await listPrompts(serverIdRef.current);
+            return { prompts };
+          },
+          onLoggingMessage: ({ level, data, logger }) => {
+            if (minimalMode) return;
+            const prefix = logger ? `[${logger}]` : "[MCP Apps]";
+            const message = `${prefix} ${level.toUpperCase()}:`;
+            if (
+              level === "error" ||
+              level === "critical" ||
+              level === "alert"
+            ) {
+              console.error(message, data);
+              return;
+            }
+            if (level === "warning") {
+              console.warn(message, data);
+              return;
+            }
+            console.info(message, data);
+          },
+          onSizeChange: ({ height }) => {
+            // Inline width is owned by the host shell; height stays app-driven
+            // for natural inline layout while PIP/fullscreen keep fixed sizing.
+            if (effectiveDisplayModeRef.current !== "inline") return;
+            const iframe = sandboxRef.current?.getIframeElement();
+            if (!iframe) return;
+            if (height === undefined) return;
 
-      // SEP-1865 `ui/notifications/request-teardown`: the view asks the
-      // host to tear it down. Best-effort graceful close — fire
-      // `teardownResource` so the view can persist state, then bubble
-      // the request to the parent so it can actually unmount the
-      // iframe. `requestTeardown` is a behavior gate on the matrix
-      // (not a wire-advertised host capability); presets that set it
-      // false simulate hosts that ignore view-initiated teardown
-      // requests by leaving the handler unassigned, in which case the
-      // SDK logs the notification but does nothing.
-      if (mcpAppsCapabilitiesRef.current?.requestTeardown !== false) {
-        bridge.onrequestteardown = async () => {
-          logWidgetDebug("ui-to-host", "ui/notifications/request-teardown", {});
-          try {
-            await bridge.teardownResource({});
-          } catch (err) {
-            // Teardown best-effort; if the view never acks the
-            // resource-teardown request we still proceed to unmount so
-            // a misbehaving widget can't block its own removal.
-            logWidgetDebug("host-to-ui", "ui/resource-teardown", {
-              error: err instanceof Error ? err.message : String(err),
+            // If `box-sizing: border-box` applies to the outer iframe, add
+            // border thickness to `height` to avoid a resize feedback loop.
+            const style = getComputedStyle(iframe);
+            const isBorderBox = style.boxSizing === "border-box";
+
+            // Animate the change for a smooth transition.
+            const from: Keyframe = {};
+            const to: Keyframe = {};
+
+            let adjustedHeight = height;
+
+            if (adjustedHeight !== undefined) {
+              if (isBorderBox) {
+                adjustedHeight +=
+                  parseFloat(style.borderTopWidth) +
+                  parseFloat(style.borderBottomWidth);
+              }
+              from.height = `${iframe.offsetHeight}px`;
+              iframe.style.height = to.height = `${adjustedHeight}px`;
+              lastInlineHeightRef.current = `${adjustedHeight}px`;
+            }
+
+            iframe.animate([from, to], { duration: 300, easing: "ease-out" });
+          },
+          onRequestDisplayMode: async ({ mode }) => {
+            const requestedMode = mode ?? "inline";
+            // Host policy gate: SEP-1865 allows the host to decline
+            // widget-initiated `ui/request-display-mode`.
+            const policy =
+              mcpAppsCapabilitiesRef.current?.widgetDisplayModeRequests ??
+              "accept";
+            if (requestedMode !== "inline" && policy === "decline") {
+              const granted = effectiveDisplayModeRef.current;
+              logWidgetDebug("ui-to-host", "ui/request-display-mode", {
+                requested: requestedMode,
+                granted,
+                reason: "policy-decline",
+              });
+              return { mode: granted };
+            }
+            // Sticky inline-preference override: if the user explicitly
+            // returned to inline (or the policy seeded the flag at mount),
+            // decline widget non-inline requests by returning inline.
+            if (requestedMode !== "inline" && userPreferInlineRef.current) {
+              logWidgetDebug("ui-to-host", "ui/request-display-mode", {
+                requested: requestedMode,
+                granted: "inline",
+                reason: "user-prefers-inline",
+              });
+              return { mode: "inline" };
+            }
+            const hostAvailableModes = extractHostDisplayModes(
+              hostContextRef.current as Record<string, unknown> | undefined,
+            );
+            // Use device type for mobile detection (defaults to mobile-like
+            // behavior when not in playground).
+            const isMobile = isPlaygroundActiveRef.current
+              ? playgroundDeviceTypeRef.current === "mobile" ||
+                playgroundDeviceTypeRef.current === "tablet"
+              : true;
+            const mobileAdjustedMode: DisplayMode =
+              isMobile && requestedMode === "pip"
+                ? "fullscreen"
+                : requestedMode;
+            const actualMode = clampDisplayModeToAvailableModes(
+              mobileAdjustedMode,
+              hostAvailableModes,
+            );
+
+            setDisplayModeRef.current(actualMode);
+
+            if (actualMode === "pip") {
+              onRequestPipRef.current?.(displayWidgetIdRef.current);
+            } else if (
+              (actualMode === "inline" || actualMode === "fullscreen") &&
+              ownsPipDisplayModeRef.current
+            ) {
+              onExitPipRef.current?.(
+                pipWidgetIdRef.current ?? displayWidgetIdRef.current,
+              );
+            }
+
+            return { mode: actualMode };
+          },
+          onUpdateModelContext: (ctxToolCallId, { content, structuredContent }) => {
+            // Store in debug store for UI display.
+            setWidgetModelContext(ctxToolCallId, {
+              content,
+              structuredContent,
             });
-          }
-          onRequestTeardownRef.current?.(
-            toolCallIdRef.current,
-            displayWidgetIdRef.current
-          );
-        };
-      }
+            // Notify parent component to queue for next model turn.
+            onModelContextUpdateRef.current?.(ctxToolCallId, {
+              content,
+              structuredContent,
+            });
+          },
+          onDownloadFile: async ({ contents }) => {
+            // SEP-1865 `ui/download-file`: the host mediates the download
+            // since the iframe sandbox blocks direct anchor-clicks. Blob +
+            // object-URL anchor (no confirmation prompt yet — follow-up).
+            try {
+              for (const item of contents) {
+                if (item.type === "resource" && item.resource) {
+                  const res = item.resource as {
+                    uri: string;
+                    text?: string;
+                    blob?: string;
+                    mimeType?: string;
+                  };
+                  const mimeType = res.mimeType ?? "application/octet-stream";
+                  let blob: Blob;
+                  if (typeof res.blob === "string") {
+                    const binary = atob(res.blob);
+                    const bytes = new Uint8Array(binary.length);
+                    for (let i = 0; i < binary.length; i++) {
+                      bytes[i] = binary.charCodeAt(i);
+                    }
+                    blob = new Blob([bytes], { type: mimeType });
+                  } else {
+                    blob = new Blob([res.text ?? ""], { type: mimeType });
+                  }
+                  const url = URL.createObjectURL(blob);
+                  try {
+                    const anchor = document.createElement("a");
+                    anchor.href = url;
+                    anchor.download = res.uri.split("/").pop() ?? "download";
+                    anchor.rel = "noopener";
+                    document.body.appendChild(anchor);
+                    anchor.click();
+                    anchor.remove();
+                  } finally {
+                    // Defer revocation so the browser can start the download
+                    // before the object URL goes away.
+                    setTimeout(() => URL.revokeObjectURL(url), 1000);
+                  }
+                } else if (item.type === "resource_link") {
+                  const link = item as { uri: string };
+                  // Refuse navigations that aren't a browser-fetchable scheme.
+                  const parsed = new URL(link.uri, window.location.href);
+                  if (!["http:", "https:"].includes(parsed.protocol)) {
+                    throw new Error(
+                      `Unsupported download URI protocol: ${parsed.protocol}`,
+                    );
+                  }
+                  window.open(parsed.href, "_blank", "noopener,noreferrer");
+                }
+              }
+              return {};
+            } catch (err) {
+              logWidgetDebug("ui-to-host", "ui/download-file", {
+                error: err instanceof Error ? err.message : String(err),
+              });
+              return { isError: true };
+            }
+          },
+          onRequestTeardown: (ctxToolCallId) => {
+            onRequestTeardownRef.current?.(
+              ctxToolCallId,
+              displayWidgetIdRef.current,
+            );
+          },
+        },
+      });
     },
     [
       setIsReady,
@@ -3268,7 +3069,7 @@ export function MCPAppsRendererSurface({
       logWidgetDebug,
       refreshAppProvidedTools,
       effectiveHostCapabilities,
-    ]
+    ],
   );
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -28,7 +28,10 @@ import type {
   McpUiResourceCsp,
   McpUiResourcePermissions,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
-import { SEP_1865_PERMISSION_FEATURES } from "@/lib/client-config-v2";
+import {
+  buildOuterAllowAttribute,
+  buildOuterSandboxAttribute,
+} from "@/lib/mcp-ui/iframe-sandbox-policy";
 
 export interface SandboxedIframeHandle {
   postMessage: (data: unknown) => void;
@@ -253,47 +256,10 @@ export const SandboxedIframe = forwardRef<
   // inspector-only legacy defaults are conditional.
   //
   // Per Permissions Policy spec, `;` separates features.
-  const outerAllowAttribute = useMemo(() => {
-    const allowFeaturesIsAuthoritative = allowFeatures !== undefined;
-    const allowList = allowFeaturesIsAuthoritative
-      ? []
-      : ["local-network-access *", "midi *"];
-    if (permissions?.camera) allowList.push("camera *");
-    if (permissions?.microphone) allowList.push("microphone *");
-    if (permissions?.geolocation) allowList.push("geolocation *");
-    if (permissions?.clipboardWrite) allowList.push("clipboard-write *");
-    if (allowFeatures) {
-      // Defense-in-depth: skip spec features in case the canonicalizer
-      // was bypassed. `permissions.allow.{camera,...}` is the single
-      // source of truth — see SEP_1865_PERMISSION_FEATURES.
-      const specFeatures = new Set<string>(SEP_1865_PERMISSION_FEATURES);
-      for (const k of Object.keys(allowFeatures).sort()) {
-        if (specFeatures.has(k)) continue;
-        const allowlist = allowFeatures[k];
-        if (typeof allowlist !== "string" || allowlist.length === 0) continue;
-        // Reject `;` and `,` in keys and values. The Permissions Policy
-        // iframe `allow=` attribute uses `;` to separate features; allowing
-        // either character through here turns the per-feature filter into
-        // a directive-injection bypass (e.g. `fullscreen: "*; camera *"`
-        // would smuggle a `camera *` grant past the spec-feature check
-        // above). `,` is the corresponding separator in HTTP-header
-        // Permissions-Policy syntax and is rejected for symmetry.
-        if (/[;,]/.test(k) || /[;,]/.test(allowlist)) continue;
-        // Reject whitespace in the KEY too. A key like `"camera *"`
-        // doesn't equal the spec key `"camera"`, so the spec-feature
-        // filter above lets it through; the join produces
-        // `camera * *`, which the browser parses as a `camera` grant
-        // — bypassing `permissions.allow` as the single source of
-        // truth for the 4 spec permissions. (Values legitimately
-        // contain whitespace for multi-token allowlists like
-        // `"'self' https://example.com"`, so the whitespace rule
-        // applies only to keys.)
-        if (/\s/.test(k)) continue;
-        allowList.push(`${k} ${allowlist}`);
-      }
-    }
-    return allowList.join("; ");
-  }, [permissions, allowFeatures]);
+  const outerAllowAttribute = useMemo(
+    () => buildOuterAllowAttribute({ permissions, allowFeatures }),
+    [permissions, allowFeatures],
+  );
 
   // Outer iframe `sandbox=` value.
   //
@@ -310,36 +276,10 @@ export const SandboxedIframe = forwardRef<
   //
   // `undefined` vs `[]` matters here: `[]` is the explicit "spec-minimum
   // only" intent, mirroring the canonicalizer's preservation contract.
-  const outerSandboxAttribute = useMemo(() => {
-    const tokens = new Set<string>();
-    if (sandboxAttrs !== undefined) {
-      tokens.add("allow-scripts");
-      tokens.add("allow-same-origin");
-      for (const t of sandboxAttrs) {
-        const trimmed = t.trim();
-        if (trimmed.length === 0) continue;
-        // Reject tokens with internal whitespace. A profile (or custom-
-        // token input) that smuggles `"allow-forms allow-popups-to-
-        // escape-sandbox"` would otherwise land in the Set as one entry
-        // but the join(" ") below would emit it as two real sandbox
-        // flags — silently widening the iframe grant beyond what the
-        // editor/matrix display. Reject is safer than split: the entry
-        // visibly does nothing (user notices) instead of taking effect
-        // invisibly.
-        if (/\s/.test(trimmed)) continue;
-        tokens.add(trimmed);
-      }
-    } else {
-      for (const t of sandbox.split(/\s+/)) {
-        if (t.length > 0) tokens.add(t);
-      }
-      // Defense in depth: spec-mandated tokens are always present even
-      // if a caller passes a malformed `sandbox` prop.
-      tokens.add("allow-scripts");
-      tokens.add("allow-same-origin");
-    }
-    return Array.from(tokens).sort().join(" ");
-  }, [sandbox, sandboxAttrs]);
+  const outerSandboxAttribute = useMemo(
+    () => buildOuterSandboxAttribute({ sandbox, sandboxAttrs }),
+    [sandbox, sandboxAttrs],
+  );
 
   const resourceReadyKey = useMemo(
     () =>

--- a/mcpjam-inspector/client/src/lib/mcp-ui/iframe-sandbox-policy.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/iframe-sandbox-policy.ts
@@ -1,0 +1,134 @@
+/**
+ * Iframe sandbox attribute construction (SEP-1865).
+ *
+ * The renderer's `effectiveSandbox` memo resolves *policy* (host profiles,
+ * playground toggles, the capabilities matrix, the hosted clamp) into a
+ * resolved `{ csp, permissions, permissive, sandboxAttrs, allowFeatures,
+ * cspDirectives }` shape using `@mcpjam/sdk/browser`. That policy resolution
+ * stays in the renderer because it depends on inspector-only surface state.
+ *
+ * What lives here is the deterministic *attribute construction* that turns the
+ * resolved policy into the outer iframe's `sandbox=` / `allow=` strings — the
+ * exact logic `SandboxedIframe` used to compute inline. Extracted to a
+ * dependency-free leaf so both the production renderer (via `SandboxedIframe`)
+ * and the eval browser harness build attributes the same way, so a widget
+ * renders against an identical grant surface in either host.
+ *
+ * NOTE: the inner-document CSP `<meta>` is built by the cross-origin sandbox
+ * proxy (`server/routes/apps/mcp-apps/sandbox-proxy.html`), not here. PR 3's
+ * harness reuses that builder; `resolveIframeSandboxPolicy` is intentionally
+ * scoped to the outer attributes the renderer constructs.
+ */
+
+import type { McpUiResourcePermissions } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { SEP_1865_PERMISSION_FEATURES } from "@/lib/client-config-v2";
+
+/**
+ * Spec-mandated permissive baseline for the outer iframe `sandbox=` attribute.
+ * Mirrors the default `SandboxedIframe` applies when no profile overrides the
+ * token set.
+ */
+export const DEFAULT_IFRAME_SANDBOX =
+  "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox";
+
+/**
+ * Build the outer iframe `allow=` (Permissions Policy) attribute.
+ *
+ * The 4 SEP-1865 spec permissions (camera/microphone/geolocation/
+ * clipboard-write) always flow through from `permissions`. When `allowFeatures`
+ * is provided (even as `{}`) the profile is authoritative for non-spec
+ * Permissions Policy features and the renderer's legacy defaults
+ * (`local-network-access *`, `midi *`) are dropped.
+ */
+export function buildOuterAllowAttribute(input: {
+  permissions?: McpUiResourcePermissions;
+  allowFeatures?: Record<string, string>;
+}): string {
+  const { permissions, allowFeatures } = input;
+  const allowFeaturesIsAuthoritative = allowFeatures !== undefined;
+  const allowList = allowFeaturesIsAuthoritative
+    ? []
+    : ["local-network-access *", "midi *"];
+  if (permissions?.camera) allowList.push("camera *");
+  if (permissions?.microphone) allowList.push("microphone *");
+  if (permissions?.geolocation) allowList.push("geolocation *");
+  if (permissions?.clipboardWrite) allowList.push("clipboard-write *");
+  if (allowFeatures) {
+    // Defense-in-depth: skip spec features in case the canonicalizer was
+    // bypassed. `permissions.allow.{camera,...}` is the single source of truth.
+    const specFeatures = new Set<string>(SEP_1865_PERMISSION_FEATURES);
+    for (const k of Object.keys(allowFeatures).sort()) {
+      if (specFeatures.has(k)) continue;
+      const allowlist = allowFeatures[k];
+      if (typeof allowlist !== "string" || allowlist.length === 0) continue;
+      // Reject `;` and `,` in keys and values — they are the Permissions
+      // Policy / HTTP-header separators and would turn the per-feature filter
+      // into a directive-injection bypass.
+      if (/[;,]/.test(k) || /[;,]/.test(allowlist)) continue;
+      // Reject whitespace in the KEY: `"camera *"` would slip past the
+      // spec-feature filter and join to `camera * *`, a back-door grant.
+      if (/\s/.test(k)) continue;
+      allowList.push(`${k} ${allowlist}`);
+    }
+  }
+  return allowList.join("; ");
+}
+
+/**
+ * Build the outer iframe `sandbox=` attribute.
+ *
+ * When `sandboxAttrs` is provided (even as `[]`) the profile is authoritative:
+ * the iframe gets `allow-scripts allow-same-origin` plus exactly the listed
+ * tokens. When undefined, fall back to the permissive `sandbox` baseline.
+ * `undefined` vs `[]` is meaningful: `[]` is the explicit "spec-minimum" intent.
+ */
+export function buildOuterSandboxAttribute(input: {
+  sandbox?: string;
+  sandboxAttrs?: string[];
+}): string {
+  const { sandbox = DEFAULT_IFRAME_SANDBOX, sandboxAttrs } = input;
+  const tokens = new Set<string>();
+  if (sandboxAttrs !== undefined) {
+    tokens.add("allow-scripts");
+    tokens.add("allow-same-origin");
+    for (const t of sandboxAttrs) {
+      const trimmed = t.trim();
+      if (trimmed.length === 0) continue;
+      // Reject internal whitespace: one Set entry that joins to two real
+      // sandbox flags would silently widen the grant.
+      if (/\s/.test(trimmed)) continue;
+      tokens.add(trimmed);
+    }
+  } else {
+    for (const t of sandbox.split(/\s+/)) {
+      if (t.length > 0) tokens.add(t);
+    }
+    // Defense in depth: spec-mandated tokens are always present.
+    tokens.add("allow-scripts");
+    tokens.add("allow-same-origin");
+  }
+  return Array.from(tokens).sort().join(" ");
+}
+
+/**
+ * Resolve the outer iframe sandbox policy into the literal `sandbox=` / `allow=`
+ * attribute strings. Consumed by both `SandboxedIframe` (production) and the
+ * eval harness so the grant surface is identical in either host.
+ */
+export function resolveIframeSandboxPolicy(input: {
+  sandbox?: string;
+  sandboxAttrs?: string[];
+  permissions?: McpUiResourcePermissions;
+  allowFeatures?: Record<string, string>;
+}): { sandbox: string; allow: string } {
+  return {
+    sandbox: buildOuterSandboxAttribute({
+      sandbox: input.sandbox,
+      sandboxAttrs: input.sandboxAttrs,
+    }),
+    allow: buildOuterAllowAttribute({
+      permissions: input.permissions,
+      allowFeatures: input.allowFeatures,
+    }),
+  };
+}

--- a/mcpjam-inspector/client/src/lib/mcp-ui/mcp-apps-utils.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/mcp-apps-utils.ts
@@ -106,43 +106,16 @@ export function isOpenAIAppAndMCPApp(
 }
 
 /**
- * Get the visibility array from tool metadata.
- * Default: ["model", "app"] if not specified (per SEP-1865)
+ * SEP-1865 tool visibility helpers.
+ *
+ * The implementations live in the dependency-free leaf module
+ * `@/lib/mcp-ui/tool-visibility` so the framework-free host bridge
+ * (`host-app-bridge.ts`, consumed by the eval harness) can share the exact
+ * model-only visibility check the production renderer enforces. Re-exported
+ * here to preserve existing `@/lib/mcp-ui/mcp-apps-utils` import sites.
  */
-export function getToolVisibility(
-  toolMeta: Record<string, unknown> | undefined,
-): Array<"model" | "app"> {
-  const ui =
-    toolMeta?.ui && typeof toolMeta.ui === "object" && !Array.isArray(toolMeta.ui)
-      ? (toolMeta.ui as { visibility?: unknown })
-      : undefined;
-  const visibility = ui?.visibility;
-  if (!Array.isArray(visibility)) return ["model", "app"];
-
-  const normalized = visibility.filter(
-    (scope): scope is "model" | "app" => scope === "model" || scope === "app",
-  );
-  return normalized.length > 0 ? normalized : ["model", "app"];
-}
-
-/**
- * Check if tool is visible to model only (not callable by apps).
- * True when visibility is exactly ["model"]
- */
-export function isVisibleToModelOnly(
-  toolMeta: Record<string, unknown> | undefined,
-): boolean {
-  const visibility = getToolVisibility(toolMeta);
-  return visibility.length === 1 && visibility[0] === "model";
-}
-
-/**
- * Check if tool is visible to app only (hidden from model).
- * True when visibility is exactly ["app"]
- */
-export function isVisibleToAppOnly(
-  toolMeta: Record<string, unknown> | undefined,
-): boolean {
-  const visibility = getToolVisibility(toolMeta);
-  return visibility.length === 1 && visibility[0] === "app";
-}
+export {
+  getToolVisibility,
+  isVisibleToModelOnly,
+  isVisibleToAppOnly,
+} from "@/lib/mcp-ui/tool-visibility";

--- a/mcpjam-inspector/client/src/lib/mcp-ui/tool-visibility.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/tool-visibility.ts
@@ -24,8 +24,16 @@ export function getToolVisibility(
   const visibility = ui?.visibility;
   if (!Array.isArray(visibility)) return ["model", "app"];
 
-  const normalized = visibility.filter(
-    (scope): scope is "model" | "app" => scope === "model" || scope === "app",
+  // Dedupe: a payload like `["model", "model"]` must not make
+  // `isVisibleToModelOnly` (which checks `length === 1`) return false and
+  // silently weaken the model-only block the shared bridge enforces.
+  const normalized = Array.from(
+    new Set(
+      visibility.filter(
+        (scope): scope is "model" | "app" =>
+          scope === "model" || scope === "app",
+      ),
+    ),
   );
   return normalized.length > 0 ? normalized : ["model", "app"];
 }

--- a/mcpjam-inspector/client/src/lib/mcp-ui/tool-visibility.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/tool-visibility.ts
@@ -1,0 +1,53 @@
+/**
+ * SEP-1865 tool visibility helpers.
+ *
+ * Dependency-free leaf module so both the React renderer utilities
+ * (`mcp-apps-utils.ts`, re-exported for back-compat) and the framework-free
+ * host bridge (`host-app-bridge.ts`, consumed by the eval harness) share one
+ * source of truth for the model-only visibility check without dragging
+ * heavier dependencies into either consumer.
+ */
+
+/**
+ * Get the visibility array from tool metadata.
+ * Default: ["model", "app"] if not specified (per SEP-1865).
+ */
+export function getToolVisibility(
+  toolMeta: Record<string, unknown> | undefined,
+): Array<"model" | "app"> {
+  const ui =
+    toolMeta?.ui &&
+    typeof toolMeta.ui === "object" &&
+    !Array.isArray(toolMeta.ui)
+      ? (toolMeta.ui as { visibility?: unknown })
+      : undefined;
+  const visibility = ui?.visibility;
+  if (!Array.isArray(visibility)) return ["model", "app"];
+
+  const normalized = visibility.filter(
+    (scope): scope is "model" | "app" => scope === "model" || scope === "app",
+  );
+  return normalized.length > 0 ? normalized : ["model", "app"];
+}
+
+/**
+ * Check if tool is visible to model only (not callable by apps).
+ * True when visibility is exactly ["model"].
+ */
+export function isVisibleToModelOnly(
+  toolMeta: Record<string, unknown> | undefined,
+): boolean {
+  const visibility = getToolVisibility(toolMeta);
+  return visibility.length === 1 && visibility[0] === "model";
+}
+
+/**
+ * Check if tool is visible to app only (hidden from model).
+ * True when visibility is exactly ["app"].
+ */
+export function isVisibleToAppOnly(
+  toolMeta: Record<string, unknown> | undefined,
+): boolean {
+  const visibility = getToolVisibility(toolMeta);
+  return visibility.length === 1 && visibility[0] === "app";
+}

--- a/mcpjam-inspector/server/utils/__tests__/advertised-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/advertised-tools.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  applyPrepareAdvertisedTools,
+  type PrepareAdvertisedTools,
+} from "../advertised-tools";
+
+const DEFAULTS = ["search", "reserve", "computer", "finish_widget"];
+
+describe("applyPrepareAdvertisedTools — contract", () => {
+  it("returns the default set unchanged when no hook is provided", () => {
+    const out = applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 0,
+    });
+    expect(out).toBe(DEFAULTS); // same reference: no narrowing
+  });
+
+  it("returns the default set when the hook returns undefined", () => {
+    const hook: PrepareAdvertisedTools = () => undefined;
+    const out = applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 3,
+      prepareAdvertisedTools: hook,
+    });
+    expect(out).toBe(DEFAULTS);
+  });
+
+  it("narrows to the returned name list, preserving default order", () => {
+    const hook: PrepareAdvertisedTools = () => ["reserve", "search"];
+    const out = applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 1,
+      prepareAdvertisedTools: hook,
+    });
+    // intersection follows defaultToolNames order, not the hook's order
+    expect(out).toEqual(["search", "reserve"]);
+  });
+
+  it("drops names that are not in the default set (defense-in-depth)", () => {
+    const hook: PrepareAdvertisedTools = () => [
+      "search",
+      "not_a_real_tool",
+      "computer",
+    ];
+    const out = applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 0,
+      prepareAdvertisedTools: hook,
+    });
+    expect(out).toEqual(["search", "computer"]);
+  });
+
+  it("supports narrowing to the empty set", () => {
+    const hook: PrepareAdvertisedTools = () => [];
+    const out = applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 0,
+      prepareAdvertisedTools: hook,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("logs via onWarn and falls back to the default set when the hook throws", () => {
+    const onWarn = vi.fn();
+    const hook: PrepareAdvertisedTools = () => {
+      throw new Error("buggy hook");
+    };
+    const out = applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 2,
+      prepareAdvertisedTools: hook,
+      onWarn,
+    });
+    expect(out).toBe(DEFAULTS);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(onWarn.mock.calls[0][1]).toEqual({ error: "buggy hook" });
+  });
+
+  it("does not throw when the hook throws and no onWarn is provided", () => {
+    const hook: PrepareAdvertisedTools = () => {
+      throw new Error("boom");
+    };
+    expect(() =>
+      applyPrepareAdvertisedTools({
+        defaultToolNames: DEFAULTS,
+        stepIndex: 0,
+        prepareAdvertisedTools: hook,
+      }),
+    ).not.toThrow();
+  });
+
+  it("invokes the hook with { stepIndex, defaultToolNames }", () => {
+    const hook = vi.fn().mockReturnValue(undefined);
+    applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 5,
+      prepareAdvertisedTools: hook,
+    });
+    expect(hook).toHaveBeenCalledWith({
+      stepIndex: 5,
+      defaultToolNames: DEFAULTS,
+    });
+  });
+});
+
+describe("applyPrepareAdvertisedTools — rendered-widget gate (eval use case)", () => {
+  // Mirrors how the eval runner closes over harness state to hide the
+  // Computer Use tools until an MCP App widget has actually rendered.
+  const gate =
+    (hasRenderedWidget: () => boolean): PrepareAdvertisedTools =>
+    ({ defaultToolNames }) =>
+      hasRenderedWidget()
+        ? defaultToolNames
+        : defaultToolNames.filter(
+            (n) => n !== "computer" && n !== "finish_widget",
+          );
+
+  it("hides computer + finish_widget before any widget renders", () => {
+    const out = applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 0,
+      prepareAdvertisedTools: gate(() => false),
+    });
+    expect(out).toEqual(["search", "reserve"]);
+  });
+
+  it("advertises computer + finish_widget once a widget is rendered", () => {
+    const out = applyPrepareAdvertisedTools({
+      defaultToolNames: DEFAULTS,
+      stepIndex: 4,
+      prepareAdvertisedTools: gate(() => true),
+    });
+    expect(out).toEqual(DEFAULTS);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/advertised-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/advertised-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   applyPrepareAdvertisedTools,
+  gateToolsToAdvertisedSubset,
   type PrepareAdvertisedTools,
 } from "../advertised-tools";
 
@@ -131,5 +132,77 @@ describe("applyPrepareAdvertisedTools — rendered-widget gate (eval use case)",
       prepareAdvertisedTools: gate(() => true),
     });
     expect(out).toEqual(DEFAULTS);
+  });
+});
+
+describe("gateToolsToAdvertisedSubset — advertise = ENFORCE", () => {
+  const makeTools = () => {
+    const searchExec = vi.fn(async () => "search-result");
+    const computerExec = vi.fn(async () => "computer-result");
+    return {
+      tools: {
+        search: { description: "s", execute: searchExec },
+        computer: { description: "c", execute: computerExec },
+      },
+      searchExec,
+      computerExec,
+    };
+  };
+
+  it("executes a tool that is in the advertised set", async () => {
+    const { tools, searchExec } = makeTools();
+    const gated = gateToolsToAdvertisedSubset(
+      tools,
+      () => new Set(["search"]),
+    );
+    await expect(
+      (gated.search.execute as Function)({}, {}),
+    ).resolves.toBe("search-result");
+    expect(searchExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a recoverable error for a hidden tool (and does not run it)", async () => {
+    const { tools, computerExec } = makeTools();
+    const gated = gateToolsToAdvertisedSubset(
+      tools,
+      () => new Set(["search"]),
+    );
+    await expect(
+      (gated.computer.execute as Function)({}, {}),
+    ).rejects.toThrow(/not available in this step/);
+    expect(computerExec).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the advertised set is null (no narrowing)", async () => {
+    const { tools, computerExec } = makeTools();
+    const gated = gateToolsToAdvertisedSubset(tools, () => null);
+    await expect(
+      (gated.computer.execute as Function)({}, {}),
+    ).resolves.toBe("computer-result");
+    expect(computerExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the advertised set at execute time (per-step)", async () => {
+    const { tools, computerExec } = makeTools();
+    let advertised: ReadonlySet<string> | null = new Set(["search"]);
+    const gated = gateToolsToAdvertisedSubset(tools, () => advertised);
+    await expect(
+      (gated.computer.execute as Function)({}, {}),
+    ).rejects.toThrow();
+    // Widget rendered -> computer advertised on the next step.
+    advertised = new Set(["search", "computer"]);
+    await expect(
+      (gated.computer.execute as Function)({}, {}),
+    ).resolves.toBe("computer-result");
+    expect(computerExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes through tools that have no execute (e.g. app-provided aliases)", () => {
+    const aliasTool = { description: "alias" };
+    const gated = gateToolsToAdvertisedSubset(
+      { alias: aliasTool },
+      () => new Set<string>(),
+    );
+    expect(gated.alias).toBe(aliasTool);
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/direct-chat-turn.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/direct-chat-turn.test.ts
@@ -191,6 +191,35 @@ describe("runDirectChatTurn — eval headless contract (PR 4a)", () => {
     expect(Array.isArray(prepareStepReturn.activeTools)).toBe(true);
   });
 
+  it("narrows the request_payload trace tools via prepareAdvertisedTools (step 0)", () => {
+    streamTextMock.mockReturnValueOnce(defaultStreamTextReturn());
+    let payloadTools: Record<string, unknown> | undefined;
+    runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "gpt-4-turbo",
+      messageHistory: [{ role: "user", content: "hi" } as any],
+      systemPrompt: "system",
+      tools: {
+        search: { description: "s" } as any,
+        computer: { description: "c" } as any,
+        finish_widget: { description: "f" } as any,
+      },
+      // Hide computer/finish_widget at step 0 (no widget rendered yet).
+      prepareAdvertisedTools: ({ defaultToolNames }) =>
+        defaultToolNames.filter(
+          (n) => n !== "computer" && n !== "finish_widget",
+        ),
+      traceEvents: {
+        onRequestPayload: (event) => {
+          payloadTools = event.tools as Record<string, unknown>;
+        },
+      },
+    });
+    // The request_payload trace must reflect the narrowed step-0 advertised set
+    // (regression: previously it emitted the full tools map).
+    expect(payloadTools && Object.keys(payloadTools)).toEqual(["search"]);
+  });
+
   it("flips `isAborted` true when the abort signal fires", async () => {
     // PR 4a invariant (mirrors PR 3 "Abort no longer skips persistence"):
     // `streamText` can swallow AbortError silently. The helper exposes

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -4,6 +4,7 @@ import {
   hasUnresolvedToolCalls,
 } from "@/shared/http-tool-calls";
 import { handleMCPJamFreeChatModel } from "../mcpjam-stream-handler";
+import { serializeToolsForConvex } from "../mcpjam-tool-helpers";
 import { createHostedRpcLogCollector } from "../../routes/web/hosted-rpc-logs.js";
 
 let lastExecution: Promise<void> | null = null;
@@ -109,6 +110,59 @@ describe("mcpjam-stream-handler", () => {
   afterEach(() => {
     global.fetch = originalFetch;
     delete process.env.CONVEX_HTTP_URL;
+  });
+
+  it("request_payload trace reflects prepareAdvertisedTools narrowing (non-progressive) and matches the Convex request", async () => {
+    const toolDef = (description: string) => ({
+      description,
+      inputSchema: { type: "object" } as any,
+    });
+    // serializeToolsForConvex is stubbed to [] by default in this suite; return
+    // the real defs for this turn so there's an advertised set to narrow.
+    vi.mocked(serializeToolsForConvex).mockReturnValueOnce([
+      { name: "search", inputSchema: { type: "object" } },
+      { name: "computer", inputSchema: { type: "object" } },
+      { name: "finish_widget", inputSchema: { type: "object" } },
+    ]);
+
+    await handleMCPJamFreeChatModel({
+      messages: [{ role: "user", content: "hi" }] as any,
+      modelId: "openai/gpt-5-mini",
+      systemPrompt: "You are helpful",
+      tools: {
+        search: toolDef("Search"),
+        computer: toolDef("Computer Use"),
+        finish_widget: toolDef("Finish widget"),
+      },
+      mcpClientManager: {
+        getAllToolsMetadata: vi.fn().mockReturnValue({}),
+      } as any,
+      // Hide computer/finish_widget this step (the widget-eval gate) with no
+      // progressive discovery — this is the path the P2 trace mismatch hit.
+      prepareAdvertisedTools: ({ defaultToolNames }) =>
+        defaultToolNames.filter(
+          (n) => n !== "computer" && n !== "finish_widget",
+        ),
+    });
+
+    await lastExecution;
+
+    // The Convex /stream request advertised only the narrowed set.
+    const fetchBody = JSON.parse(
+      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}"
+    );
+    const requestToolNames = (fetchBody.tools as Array<{ name: string }>).map(
+      (t) => t.name
+    );
+    expect(requestToolNames).toEqual(["search"]);
+
+    // The request_payload trace must reflect the SAME narrowed set (regression:
+    // it previously fell back to the full tools map in non-progressive mode).
+    const requestPayload = writtenChunks
+      .filter((chunk) => chunk?.type === "data-trace-event")
+      .map((chunk) => chunk.data)
+      .find((event) => event.type === "request_payload");
+    expect(Object.keys(requestPayload.payload.tools)).toEqual(["search"]);
   });
 
   it("scrubs backend-only approval parts while preserving full history for completion callbacks", async () => {

--- a/mcpjam-inspector/server/utils/advertised-tools.ts
+++ b/mcpjam-inspector/server/utils/advertised-tools.ts
@@ -63,3 +63,49 @@ export function applyPrepareAdvertisedTools(params: {
   const keep = new Set(narrowed);
   return defaultToolNames.filter((name) => keep.has(name));
 }
+
+/**
+ * Execution gate for the advertised subset (advertise = ENFORCE).
+ *
+ * `prepareAdvertisedTools` narrows what the model is *shown*, but the executable
+ * tool map still contains the hidden tools, so a hallucinated / remembered call
+ * to a hidden tool (e.g. `computer` before a widget renders) would otherwise
+ * still run. This wraps each tool's `execute` to throw a recoverable error when
+ * the tool isn't in the step's advertised set — the AI SDK (and the hosted
+ * `executeToolCallsFromMessages` path) surface the throw as a tool-error result
+ * the model can recover from, exactly like `gateToolsToActiveSubset` does for
+ * progressive discovery.
+ *
+ * `getAdvertised()` returns the current step's advertised names, or `null` for
+ * "no narrowing" (all tools executable — the gate is a no-op). Read at execute
+ * time so per-step changes are honored.
+ */
+export function gateToolsToAdvertisedSubset<
+  T extends Record<string, unknown>,
+>(tools: T, getAdvertised: () => ReadonlySet<string> | null): T {
+  const result: Record<string, unknown> = {};
+  for (const [name, def] of Object.entries(tools)) {
+    const original = def as Record<string, unknown>;
+    const execute = original.execute as
+      | ((input: unknown, ctx: unknown) => unknown)
+      | undefined;
+    if (typeof execute !== "function") {
+      result[name] = original;
+      continue;
+    }
+    result[name] = {
+      ...original,
+      execute: async (input: unknown, ctx: unknown) => {
+        const advertised = getAdvertised();
+        if (advertised && !advertised.has(name)) {
+          throw new Error(
+            `Tool '${name}' is not available in this step (not advertised to the model).`,
+          );
+        }
+        return execute(input, ctx);
+      },
+    };
+  }
+  return result as T;
+}
+

--- a/mcpjam-inspector/server/utils/advertised-tools.ts
+++ b/mcpjam-inspector/server/utils/advertised-tools.ts
@@ -1,0 +1,65 @@
+/**
+ * advertised-tools.ts — runtime-conditional advertised-tool narrowing.
+ *
+ * Browser-rendered MCP App eval PR 2. Both engine paths — the hosted-path
+ * `runChatEngineLoop` (`mcpjam-stream-handler.ts`) and the local AI-SDK path
+ * `runDirectChatTurn` (`direct-chat-turn.ts`) — delegate the per-step
+ * advertised-tool decision here so the contract (and its edge cases) has one
+ * source of truth and one test surface.
+ *
+ * This is distinct from progressive tool discovery (lazy MCP tool catalogs):
+ * progressive discovery decides which tools are *loaded*, while this hook
+ * decides which of the already-active tools are *advertised this step* based on
+ * caller-owned runtime state (e.g. hide `computer` / `finish_widget` until an
+ * MCP App widget has actually rendered in the harness).
+ */
+
+/**
+ * Per-step advertised-tool narrowing hook. Receives the names that would
+ * otherwise be advertised this step and returns the subset to keep, or
+ * `undefined` for "no narrowing".
+ */
+export type PrepareAdvertisedTools = (ctx: {
+  stepIndex: number;
+  defaultToolNames: string[];
+}) => string[] | undefined;
+
+/**
+ * Resolve the advertised tool-name list for a step.
+ *
+ * Contract:
+ *   - no hook                         → `defaultToolNames` unchanged
+ *   - hook returns `undefined`        → `defaultToolNames` unchanged
+ *   - hook returns a name list        → `defaultToolNames ∩ list` (preserving
+ *                                        `defaultToolNames` order); any name not
+ *                                        already advertised is dropped
+ *                                        (defense-in-depth: a hook can't smuggle
+ *                                        in a non-advertised tool)
+ *   - hook throws                     → logged via `onWarn`, falls back to
+ *                                        `defaultToolNames` (a buggy hook can't
+ *                                        crash the loop)
+ */
+export function applyPrepareAdvertisedTools(params: {
+  defaultToolNames: string[];
+  stepIndex: number;
+  prepareAdvertisedTools?: PrepareAdvertisedTools;
+  onWarn?: (message: string, meta: { error: string }) => void;
+}): string[] {
+  const { defaultToolNames, stepIndex, prepareAdvertisedTools, onWarn } =
+    params;
+  if (!prepareAdvertisedTools) return defaultToolNames;
+
+  let narrowed: string[] | undefined;
+  try {
+    narrowed = prepareAdvertisedTools({ stepIndex, defaultToolNames });
+  } catch (err) {
+    onWarn?.("prepareAdvertisedTools threw; advertising default tool set", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return defaultToolNames;
+  }
+
+  if (narrowed === undefined) return defaultToolNames;
+  const keep = new Set(narrowed);
+  return defaultToolNames.filter((name) => keep.has(name));
+}

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -165,6 +165,13 @@ export interface RunAssistantTurnOptions {
   onEngineError?: MCPJamHandlerOptions["onEngineError"];
 
   /**
+   * Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing
+   * pass-through. The eval runner uses this to hide `computer` /
+   * `finish_widget` until a widget has rendered. Chat / synthetic omit.
+   */
+  prepareAdvertisedTools?: MCPJamHandlerOptions["prepareAdvertisedTools"];
+
+  /**
    * Override the Convex endpoint path. Stage 1 keeps this wired so
    * `handleHostedOrgChatModel` (org BYOK delegation chain) keeps
    * working — `runAssistantTurn` is the same engine, and the org BYOK
@@ -343,6 +350,10 @@ function buildHandlerOptions(
     ...(opts.onStepFinish ? { onStepFinish: opts.onStepFinish } : {}),
     // PR 5b-followup-2: pass-through structured-error callback.
     ...(opts.onEngineError ? { onEngineError: opts.onEngineError } : {}),
+    // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
+    ...(opts.prepareAdvertisedTools
+      ? { prepareAdvertisedTools: opts.prepareAdvertisedTools }
+      : {}),
     ...(opts.endpointPath ? { endpointPath: opts.endpointPath } : {}),
     ...(opts.extraHeaders ? { extraHeaders: opts.extraHeaders } : {}),
     ...(opts.authContext.clientIp !== undefined &&

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -41,6 +41,7 @@ import type { PersistedTurnTrace } from "./chat-ingestion";
 import { logger } from "./logger";
 import {
   applyPrepareAdvertisedTools,
+  gateToolsToAdvertisedSubset,
   type PrepareAdvertisedTools,
 } from "./advertised-tools";
 
@@ -375,10 +376,20 @@ export function runDirectChatTurn(
   // against the full map. Gating wraps each tool's `execute` to throw a
   // structured "not loaded" error, which the AI SDK surfaces as an error
   // tool-result the model can recover from via `load_mcp_tools`.
-  const executableTools = gateToolsToActiveSubset(
-    tracedTools as Record<string, unknown>,
-    progressivePlan,
-    () => discoveryState,
+  //
+  // The prepareAdvertisedTools hook (PR 2) is advertise = ENFORCE the same way:
+  // when it narrows the advertised set, `advertisedToolNames` (updated per step
+  // in prepareStep) gates execution too, so a hidden tool call (e.g. `computer`
+  // before a widget renders) becomes a recoverable tool error, not a silent
+  // side effect. `null` => no hook narrowing => no-op gate.
+  let advertisedToolNames: Set<string> | null = null;
+  const executableTools = gateToolsToAdvertisedSubset(
+    gateToolsToActiveSubset(
+      tracedTools as Record<string, unknown>,
+      progressivePlan,
+      () => discoveryState,
+    ) as Record<string, unknown>,
+    () => advertisedToolNames,
   ) as ToolSet;
 
   // Cursor PR 4a review #2 / CodeRabbit "outside-diff": the original
@@ -428,6 +439,9 @@ export function runDirectChatTurn(
           onWarn: (message, meta) =>
             logger.warn(`[direct-chat-turn] ${message}`, meta),
         });
+        // advertise = ENFORCE: gate execution to this step's advertised set so
+        // a hidden tool call can't take effect (read by `executableTools`).
+        advertisedToolNames = new Set(activeToolNames);
       }
       return activeToolNames !== undefined
         ? { activeTools: activeToolNames }

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -38,6 +38,11 @@ import {
   type ToolDiscoveryState,
 } from "@/shared/progressive-tool-discovery";
 import type { PersistedTurnTrace } from "./chat-ingestion";
+import { logger } from "./logger";
+import {
+  applyPrepareAdvertisedTools,
+  type PrepareAdvertisedTools,
+} from "./advertised-tools";
 
 /**
  * The chat-v2 user-API-key path (`streamDirectChatWithLiveTrace`) used to
@@ -189,6 +194,17 @@ export interface RunDirectChatTurnOptions {
   tools: ToolSet;
   progressivePlan?: ProgressiveToolPlan;
   discoveryState?: ToolDiscoveryState;
+  /**
+   * Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing —
+   * the AI-SDK-path equivalent of
+   * `MCPJamHandlerOptions.prepareAdvertisedTools`. Receives the names that
+   * would otherwise be advertised this step (the progressive active subset, or
+   * the full tool map in non-progressive mode) and returns the subset to keep,
+   * or `undefined` for no narrowing. Names outside the default set are ignored;
+   * a throw is logged and falls back to the default set. The eval runner uses
+   * it to hide `computer` / `finish_widget` until a widget has rendered.
+   */
+  prepareAdvertisedTools?: PrepareAdvertisedTools;
   abortSignal?: AbortSignal;
   /** Optional bag of trace-event callbacks. Chat passes these; eval/headless omits. */
   traceEvents?: DirectChatTurnTraceEvents;
@@ -283,6 +299,7 @@ export function runDirectChatTurn(
     tools,
     progressivePlan,
     discoveryState,
+    prepareAdvertisedTools,
     abortSignal,
     traceEvents,
     onPersist,
@@ -391,12 +408,30 @@ export function runDirectChatTurn(
         modelId,
         promptIndex: traceTurn.promptIndex,
       });
+      // Base advertised set: progressive discovery narrows to the active
+      // subset; otherwise the model sees the full tool map.
+      let activeToolNames: string[] | undefined;
       if (progressivePlan?.enabled && discoveryState) {
         commitNewlyLoaded(discoveryState);
-        const active = resolveActiveToolNames(progressivePlan, discoveryState);
-        return { activeTools: active };
+        activeToolNames = resolveActiveToolNames(progressivePlan, discoveryState);
       }
-      return {};
+      // Browser-rendered MCP App eval PR 2: layer runtime-conditional
+      // advertised-tool narrowing on top (e.g. hide `computer` /
+      // `finish_widget` until a widget has rendered). Mirrors the
+      // stream-handler hook: names outside the default set are ignored, and a
+      // throw is logged + falls back to the default set.
+      if (prepareAdvertisedTools) {
+        activeToolNames = applyPrepareAdvertisedTools({
+          defaultToolNames: activeToolNames ?? Object.keys(tools),
+          stepIndex: stepNumber,
+          prepareAdvertisedTools,
+          onWarn: (message, meta) =>
+            logger.warn(`[direct-chat-turn] ${message}`, meta),
+        });
+      }
+      return activeToolNames !== undefined
+        ? { activeTools: activeToolNames }
+        : {};
     },
     onChunk: async ({ chunk }) => {
       if (chunk.type === "text-delta") {

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -361,13 +361,38 @@ export function runDirectChatTurn(
     traceTurn.promptIndex,
   ) as ToolSet;
 
+  // Mirror the step-0 advertised set into the request-payload trace so it can't
+  // claim tools the model won't see on the first step (parity with the hosted
+  // processOneStep request_payload). Only narrows when the hook is set; chat
+  // (no hook) passes the full map unchanged. This trace is turn-level, so it
+  // reflects step 0; later steps' per-step narrowing isn't re-traced here.
+  let requestPayloadTools: ToolSet = tools;
+  if (prepareAdvertisedTools) {
+    const defaultToolNames =
+      progressivePlan?.enabled && discoveryState
+        ? resolveActiveToolNames(progressivePlan, discoveryState)
+        : Object.keys(tools);
+    const advertised = new Set(
+      applyPrepareAdvertisedTools({
+        defaultToolNames,
+        stepIndex: 0,
+        prepareAdvertisedTools,
+        onWarn: (message, meta) =>
+          logger.warn(`[direct-chat-turn] ${message}`, meta),
+      }),
+    );
+    requestPayloadTools = Object.fromEntries(
+      Object.entries(tools).filter(([name]) => advertised.has(name)),
+    ) as ToolSet;
+  }
+
   traceEvents?.onRequestPayload?.({
     turnId: traceTurn.turnId,
     promptIndex: traceTurn.promptIndex,
     stepIndex: 0,
     systemPrompt,
     messages: messageHistory,
-    tools,
+    tools: requestPayloadTools,
   });
 
   // Progressive mode: gate execution to the active subset. `activeTools`

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -76,6 +76,10 @@ function isApprovalFreeMetaToolName(
   return META_TOOL_NAMES.includes(name);
 }
 import { logger } from "./logger";
+import {
+  applyPrepareAdvertisedTools,
+  type PrepareAdvertisedTools,
+} from "./advertised-tools";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 import {
   mergeLiveChatTraceUsage,
@@ -332,6 +336,20 @@ export interface MCPJamHandlerOptions {
    */
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
   /**
+   * Browser-rendered MCP App eval PR 2 — optional per-step hook that narrows
+   * the *advertised* tool set the model sees this step. Called inside
+   * `processOneStep` after the active tool subset is resolved, with
+   * `{ stepIndex, defaultToolNames }` (the names that would otherwise be
+   * advertised). Returns the subset of names to keep, or `undefined` for "no
+   * narrowing". Names not in `defaultToolNames` are ignored (defense-in-depth:
+   * a caller can't smuggle in a non-advertised tool). A throw is logged and
+   * falls back to the default set. This is *runtime-conditional advertising*
+   * (e.g. hide `computer` / `finish_widget` until a widget has rendered) and
+   * is distinct from progressive discovery (lazy MCP tool catalogs). Chat /
+   * synthetic omit; the eval runner closes over harness state to decide.
+   */
+  prepareAdvertisedTools?: PrepareAdvertisedTools;
+  /**
    * Override the Convex endpoint path for the per-step LLM call.
    * Defaults to "/stream". Org BYOK chat uses "/stream/org".
    */
@@ -435,6 +453,8 @@ interface StepContext {
   // processOneStep, processStream/tool-execution catch, outer
   // agentic-loop catch). Optional.
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
+  // Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing.
+  prepareAdvertisedTools?: MCPJamHandlerOptions["prepareAdvertisedTools"];
   abortSignal?: AbortSignal;
 }
 
@@ -1657,18 +1677,41 @@ async function processOneStep(
     onToolResult,
     // PR 5b-followup-2 structured-error callback.
     onEngineError,
+    // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
+    prepareAdvertisedTools,
   } = ctx;
 
   // Pick the active tool subset for this step. In non-progressive mode
   // (`progressivePlan` undefined or plan.enabled === false) this collapses
   // to the full list and matches prior behavior. In progressive mode the
   // model only sees meta-tools + loaded + pending-approval + newly-loaded.
-  const activeToolDefs: ToolDefinition[] =
+  let activeToolDefs: ToolDefinition[] =
     progressivePlan && progressivePlan.enabled && discoveryState
       ? resolveActiveToolNames(progressivePlan, discoveryState)
           .map((name) => toolDefsByName.get(name))
           .filter((def): def is ToolDefinition => def !== undefined)
       : toolDefs;
+
+  // Browser-rendered MCP App eval PR 2: runtime-conditional advertised-tool
+  // narrowing. The hook receives the names that would otherwise be advertised
+  // this step (`defaultToolNames`) and returns the subset to keep, or
+  // `undefined` for no narrowing. Filtering against the resolved set means any
+  // returned name not already advertised is ignored (defense-in-depth), and a
+  // throw is logged + falls back to the default set so a buggy hook can't
+  // crash the loop. Applied here so both the request_payload trace snapshot
+  // and the Convex `/stream` request see the same narrowed set.
+  if (prepareAdvertisedTools) {
+    const advertised = new Set(
+      applyPrepareAdvertisedTools({
+        defaultToolNames: activeToolDefs.map((def) => def.name),
+        stepIndex,
+        prepareAdvertisedTools,
+        onWarn: (message, meta) =>
+          logger.warn(`[mcpjam-stream-handler] ${message}`, meta),
+      }),
+    );
+    activeToolDefs = activeToolDefs.filter((def) => advertised.has(def.name));
+  }
 
   const { abortSignal } = ctx;
   if (abortSignal?.aborted) {
@@ -2386,6 +2429,8 @@ export async function runChatEngineLoop(
     onStepFinish,
     // PR 5b-followup-2 callback.
     onEngineError,
+    // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
+    prepareAdvertisedTools,
     abortSignal,
     heartbeatIntervalMs,
     maxSteps,
@@ -2631,6 +2676,8 @@ export async function runChatEngineLoop(
             // the two `processOneStep` error sites (non-OK Convex
             // response + processStream/tool catch).
             onEngineError,
+            // Browser-rendered MCP App eval PR 2: advertised-tool narrowing.
+            prepareAdvertisedTools,
             abortSignal,
           });
 

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -1741,19 +1741,19 @@ async function processOneStep(
     stepIndex
   );
 
-  // For progressive discovery, the trace payload should reflect the *active*
-  // subset so request_payload snapshots show what the model actually saw.
-  const toolsForPayload: ToolSet =
-    progressivePlan && progressivePlan.enabled && discoveryState
-      ? Object.fromEntries(
-          activeToolDefs
-            .map((def): [string, unknown] | null => {
-              const t = (tools as Record<string, unknown>)[def.name];
-              return t === undefined ? null : [def.name, t];
-            })
-            .filter((pair): pair is [string, unknown] => pair !== null),
-        ) as ToolSet
-      : tools;
+  // The trace payload must reflect the *advertised* subset — `activeToolDefs`
+  // after BOTH progressive-discovery narrowing AND the prepareAdvertisedTools
+  // hook — so request_payload snapshots match what Convex actually received in
+  // `tools: activeToolDefs` below. Derived unconditionally: in the no-narrowing
+  // case `activeToolDefs === toolDefs`, so this reconstructs the full set.
+  const toolsForPayload: ToolSet = Object.fromEntries(
+    activeToolDefs
+      .map((def): [string, unknown] | null => {
+        const t = (tools as Record<string, unknown>)[def.name];
+        return t === undefined ? null : [def.name, t];
+      })
+      .filter((pair): pair is [string, unknown] => pair !== null),
+  ) as ToolSet;
 
   emitRequestPayload(writer, {
     turnId: traceTurn.turnId,

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -78,6 +78,7 @@ function isApprovalFreeMetaToolName(
 import { logger } from "./logger";
 import {
   applyPrepareAdvertisedTools,
+  gateToolsToAdvertisedSubset,
   type PrepareAdvertisedTools,
 } from "./advertised-tools";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
@@ -2142,11 +2143,22 @@ async function processOneStep(
       // emit a remembered/hallucinated call to a non-active name; gating
       // turns that into a structured error the model can recover from
       // via `load_mcp_tools` instead of executing an ungated tool.
-      const executableTools = gateToolsToActiveSubset(
+      let executableTools = gateToolsToActiveSubset(
         tracedTools as Record<string, unknown>,
         progressivePlan,
         () => discoveryState,
       );
+      // advertise = ENFORCE: when prepareAdvertisedTools narrowed the advertised
+      // set (`activeToolDefs`), gate execution to it too so a remembered /
+      // hallucinated call to a hidden tool (e.g. `computer` before a widget
+      // renders) becomes a recoverable tool-error instead of executing.
+      if (prepareAdvertisedTools) {
+        const advertised = new Set(activeToolDefs.map((def) => def.name));
+        executableTools = gateToolsToAdvertisedSubset(
+          executableTools,
+          () => advertised,
+        );
+      }
 
       // SEP-1865 App-Provided Tools: registered app aliases have no
       // `execute` function because they run inside the iframe via


### PR DESCRIPTION
## PR 2 of 5 — Browser-rendered MCP App eval

**Stacked on #2479 (PR 1).** Review/merge PR 1 first; this PR's diff is against the PR 1 branch.

Additive engine extension: a per-step hook that narrows the **advertised** tool set the model sees, from caller-owned runtime state. PR 5's eval runner uses it to hide `computer` / `finish_widget` until an MCP App widget has actually rendered in the harness.

### Why a new hook (not progressive discovery)
Progressive discovery decides which tools are *loaded* (lazy MCP catalogs). This hook decides which of the already-active tools are *advertised this step* based on harness state. The semantics don't overlap — `processOneStep` builds `activeToolDefs` from internal discovery state with no caller-side filter, so there was no existing seam. This adds one, in the same additive shape as the PR 5b-pre `onToolCall` / `onToolResult` / `onStepFinish` callbacks.

### What changed
- **`advertised-tools.ts` (new)** — `PrepareAdvertisedTools` type + the pure `applyPrepareAdvertisedTools` helper that **both** engine paths delegate to (one source of truth, one test surface). Contract:
  - no hook / `undefined` → default set unchanged;
  - name list → `default ∩ list`, preserving default order;
  - names outside the default set are dropped (defense-in-depth — a hook can't smuggle in a non-advertised tool);
  - a throw is logged via `onWarn` and falls back to the default set (a buggy hook can't crash the loop).
- **`mcpjam-stream-handler.ts`** (hosted path) — `prepareAdvertisedTools` on `MCPJamHandlerOptions` + `StepContext`; `processOneStep` narrows `activeToolDefs` right after the active subset is resolved, so both the `request_payload` trace snapshot and the Convex `/stream` request see the same narrowed set.
- **`assistant-turn.ts`** — pass-through on `RunAssistantTurnOptions` + `buildHandlerOptions`.
- **`direct-chat-turn.ts`** (local AI SDK path) — symmetric integration in the AI SDK `prepareStep`: the hook narrows on top of the existing progressive-discovery `activeTools` narrowing (or the full tool map in non-progressive mode).

Chat / synthetic are unaffected — the hook is optional; absent ⇒ no narrowing, and the local path keeps returning `{}` from `prepareStep`.

### Tests
- 10 contract tests in `advertised-tools.test.ts`: no-hook, `undefined`, narrow + order preservation, drop-outside-default, empty set, throw-recovers (with/without `onWarn`), call-shape, and the rendered-widget gate use case (hide computer/finish_widget before render, advertise after).
- Existing `assistant-turn` / `mcpjam-stream-handler` / `direct-chat-turn` / `progressive-tool-discovery` suites (90 tests) still pass; changed files typecheck clean; v1-import guard green.

### Stack
1. #2479 — extract `host-app-bridge.ts`.
2. **PR 2 (this)** — `prepareAdvertisedTools` engine hook.
3. PR 3 — Playwright `mcp-app-browser-harness.ts`.
4. PR 4 — Computer Use tool registration + executor.
5. PR 5 — eval-runner integration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MptMA6zxE4bAdriyK9SJv6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tools are advertised and executed in both chat engines and refactors MCP App bridge/security paths; behavior is gated behind an optional hook and covered by tests, but mistakes could affect tool availability or widget host parity.
> 
> **Overview**
> Adds **runtime per-step tool advertising** for browser-rendered MCP App evals, and **extracts shared MCP Apps host logic** so production and headless harness stay aligned.
> 
> **Engine (`prepareAdvertisedTools`)** — New optional hook on hosted (`mcpjam-stream-handler`) and local AI SDK (`direct-chat-turn`) paths, wired through `assistant-turn`. Each step can narrow which active tools are advertised (e.g. hide `computer` / `finish_widget` until a widget renders). Shared `advertised-tools.ts` implements narrowing (`applyPrepareAdvertisedTools`) and **advertise = enforce** execution via `gateToolsToAdvertisedSubset`. `request_payload` traces and Convex/stream requests now use the same narrowed set; regressions are covered by new tests.
> 
> **Client (host bridge refactor)** — MCP Apps bridge wiring moves from `mcp-apps-renderer.tsx` into framework-free `host-app-bridge.ts` (`registerHostBridgeHandlers`, callback injection). Tool visibility and iframe `sandbox`/`allow` attribute builders move to `tool-visibility.ts` and `iframe-sandbox-policy.ts`; `SandboxedIframe` delegates to them. Visibility parsing **dedupes** repeated scopes so model-only enforcement cannot be weakened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecefb9dde252b3aefc446783ba2ca65a33d9536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->