### PR TITLE
evals: pass systemPrompt to appendEvalTurnTrace, drop persistence-side prepends

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -705,6 +705,15 @@ async function finishIterationDirectly(
       ...(useW1Fallback
         ? {
             messages: sanitizeForConvexTransport(params.messages),
+            // Mirrors `appendEvalTurnTrace.systemPrompt` (Cursor follow-up
+            // on PR-2481): after dropping the persistence-side prepend,
+            // this W1 single-call path would otherwise persist a
+            // transcript with no resolved system prompt. Backend PR #448
+            // adds `systemPrompt` to `updateTestIteration` with the same
+            // first-write-wins semantics as the per-turn append.
+            ...(params.systemPrompt
+              ? { systemPrompt: params.systemPrompt }
+              : {}),
             ...(params.spans?.length
               ? { spans: sanitizeForConvexTransport(params.spans) }
               : {}),

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -602,6 +602,13 @@ async function finishIterationDirectly(
     spans?: EvalTraceSpan[];
     prompts?: PromptTraceSummary[];
     widgetSnapshots?: EvalTraceWidgetSnapshot[];
+    /**
+     * Resolved system prompt for the eval session. Forwarded to
+     * `persistEvalTraceFanout` → `appendEvalTurnTrace.systemPrompt`,
+     * which the backend persists to `chatSessions.systemPrompt` with
+     * first-write-wins semantics.
+     */
+    systemPrompt?: string;
     status?: "completed" | "failed" | "cancelled";
     startedAt?: number;
     error?: string;
@@ -665,6 +672,7 @@ async function finishIterationDirectly(
     spans: params.spans,
     prompts: params.prompts,
     widgetSnapshots: params.widgetSnapshots,
+    systemPrompt: params.systemPrompt,
   });
   // Fall back to the W1 single-call path ONLY when the fanout failed
   // before any turn landed. See recorder.ts / persist-eval-trace.ts.
@@ -1563,25 +1571,24 @@ const runIterationWithAiSdk = async ({
       convexClient,
     });
 
-    // PR 4d review fix (Codex P2): prepend the resolved system prompt
-    // so persisted eval transcripts carry it. The streamText `system:`
-    // field already covered the wire shape to the model; this restores
-    // the pre-4d persistence shape (first message is `role: "system"`)
-    // for downstream consumers of `appendEvalTurnTrace.sessionMessages`
-    // and the legacy `testIteration.blob` fallback.
-    const persistedMessages: ModelMessage[] = enhancedSystemPromptForPersist
-      ? [
-          { role: "system", content: enhancedSystemPromptForPersist },
-          ...conversationMessages,
-        ]
-      : conversationMessages;
-
+    // PR (this change): the resolved system prompt now flows through
+    // `appendEvalTurnTrace.systemPrompt` (persisted to
+    // `chatSessions.systemPrompt`, first-write-wins). The
+    // persistence-side `{role:"system",...}` prepend on `messages` was
+    // removed — the wire shape and the persisted shape now agree on
+    // "system carried out-of-band". Live SSE `trace_snapshot` events
+    // still apply the prefix via `withSystemPrefix` closures in the
+    // streaming runners (different consumer: live test-runner UI vs.
+    // stored transcript).
     const finishParams = {
       iterationId,
       passed,
       toolsCalled: evaluation.toolsCalled,
       usage,
-      messages: persistedMessages,
+      messages: conversationMessages,
+      ...(enhancedSystemPromptForPersist
+        ? { systemPrompt: enhancedSystemPromptForPersist }
+        : {}),
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -1690,21 +1697,11 @@ const runIterationWithAiSdk = async ({
       mcpClientManager,
       convexClient,
     });
-    // PR 4d review fix (Codex P2): same prefix as the success path — if
-    // `prepared` ran far enough to populate
-    // `enhancedSystemPromptForPersist`, surface the resolved system in
-    // the persisted failure transcript. Catches that fire BEFORE
-    // `prepareChatV2` returned leave the prefix empty (no system to
-    // persist anyway). Applied only in `runIterationWithAiSdk`; the
-    // streaming variant still pushes the system into
-    // `conversationMessages` itself (PR 5 territory).
-    const persistedFailMessages: ModelMessage[] = enhancedSystemPromptForPersist
-      ? [
-          { role: "system", content: enhancedSystemPromptForPersist },
-          ...failMessages,
-        ]
-      : failMessages;
-
+    // PR (this change): the resolved system prompt now flows through
+    // `appendEvalTurnTrace.systemPrompt`. Same threading as the success
+    // path. Catches that fire BEFORE `prepareChatV2` returned leave the
+    // value `undefined` — backend's first-write-wins tolerates a never-
+    // set systemPrompt cleanly.
     const failParams = {
       iterationId,
       passed: false,
@@ -1714,7 +1711,10 @@ const runIterationWithAiSdk = async ({
         outputTokens: accumulatedUsage.outputTokens,
         totalTokens: accumulatedUsage.totalTokens,
       },
-      messages: persistedFailMessages,
+      messages: failMessages,
+      ...(enhancedSystemPromptForPersist
+        ? { systemPrompt: enhancedSystemPromptForPersist }
+        : {}),
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -2329,26 +2329,19 @@ const runIterationViaBackend = async ({
     mcpClientManager,
     convexClient,
   });
-  // PR 4d review fix (Codex P2 / Cursor Medium): prepend the resolved
-  // system at persistence so the backend's transcript carries it.
-  // Engine sent it via `runAssistantTurn`'s `systemPrompt:` arg.
-  const persistedBackendMessages: ModelMessage[] =
-    backendEnhancedSystemPromptForPersist
-      ? [
-          {
-            role: "system",
-            content: backendEnhancedSystemPromptForPersist,
-          },
-          ...messageHistory,
-        ]
-      : messageHistory;
-
+  // PR (this change): the resolved system prompt now flows through
+  // `appendEvalTurnTrace.systemPrompt` (persisted to
+  // `chatSessions.systemPrompt`, first-write-wins). Engine still sends
+  // it via `runAssistantTurn`'s `systemPrompt:` arg for the model wire.
   const finishParams = {
     iterationId,
     passed,
     toolsCalled: evaluation.toolsCalled,
     usage: accumulatedUsage,
-    messages: persistedBackendMessages,
+    messages: messageHistory,
+    ...(backendEnhancedSystemPromptForPersist
+      ? { systemPrompt: backendEnhancedSystemPromptForPersist }
+      : {}),
     ...(capturedSpans.length ? { spans: capturedSpans } : {}),
     ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
     ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -3541,26 +3534,20 @@ const streamIterationWithAiSdk = async ({
       mcpClientManager,
       convexClient,
     });
-    // PR 4d review fix (CodeRabbit): prepend the resolved system at
-    // persistence time so the streamed eval's transcript matches the
-    // non-stream runner's shape (`role: "system"` first entry).
-    const persistedStreamMessages: ModelMessage[] =
-      streamEnhancedSystemPromptForPersist
-        ? [
-            {
-              role: "system",
-              content: streamEnhancedSystemPromptForPersist,
-            },
-            ...conversationMessages,
-          ]
-        : conversationMessages;
-
+    // PR (this change): the resolved system prompt now flows through
+    // `appendEvalTurnTrace.systemPrompt`. The `withSystemPrefix`
+    // closure above still applies the prefix to LIVE SSE
+    // `trace_snapshot` events for the test-runner UI (different
+    // consumer than the stored transcript).
     const finishParams = {
       iterationId,
       passed,
       toolsCalled: evaluation.toolsCalled,
       usage: usageFinal,
-      messages: persistedStreamMessages,
+      messages: conversationMessages,
+      ...(streamEnhancedSystemPromptForPersist
+        ? { systemPrompt: streamEnhancedSystemPromptForPersist }
+        : {}),
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -3698,20 +3685,9 @@ const streamIterationWithAiSdk = async ({
       details: errorDetails,
     });
 
-    // PR 4d review fix (CodeRabbit): mirror the non-stream runner — if
-    // `prepared` populated the resolved system prompt before the throw,
-    // prepend it to the persisted failure transcript.
-    const persistedStreamFailMessages: ModelMessage[] =
-      streamEnhancedSystemPromptForPersist
-        ? [
-            {
-              role: "system",
-              content: streamEnhancedSystemPromptForPersist,
-            },
-            ...failMessages,
-          ]
-        : failMessages;
-
+    // PR (this change): the resolved system prompt now flows through
+    // `appendEvalTurnTrace.systemPrompt`. Same threading as the
+    // success path.
     const failParams = {
       iterationId,
       passed: false,
@@ -3721,7 +3697,10 @@ const streamIterationWithAiSdk = async ({
         outputTokens: accumulatedUsage.outputTokens,
         totalTokens: accumulatedUsage.totalTokens,
       },
-      messages: persistedStreamFailMessages,
+      messages: failMessages,
+      ...(streamEnhancedSystemPromptForPersist
+        ? { systemPrompt: streamEnhancedSystemPromptForPersist }
+        : {}),
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
@@ -4690,26 +4669,20 @@ const streamIterationViaBackend = async ({
     mcpClientManager,
     convexClient,
   });
-  // PR 4d review fix (Codex P2 / Cursor Medium): prepend the resolved
-  // system at persistence so the backend's transcript carries it.
-  // Engine sent it via `runAssistantTurn`'s `systemPrompt:` arg.
-  const persistedBackendMessages: ModelMessage[] =
-    backendEnhancedSystemPromptForPersist
-      ? [
-          {
-            role: "system",
-            content: backendEnhancedSystemPromptForPersist,
-          },
-          ...messageHistory,
-        ]
-      : messageHistory;
-
+  // PR (this change): the resolved system prompt now flows through
+  // `appendEvalTurnTrace.systemPrompt`. The `withSystemPrefix` closure
+  // above still applies the prefix to LIVE SSE `trace_snapshot` events
+  // for the test-runner UI (different consumer than the stored
+  // transcript).
   const finishParams = {
     iterationId,
     passed,
     toolsCalled: evaluation.toolsCalled,
     usage: accumulatedUsage,
-    messages: persistedBackendMessages,
+    messages: messageHistory,
+    ...(backendEnhancedSystemPromptForPersist
+      ? { systemPrompt: backendEnhancedSystemPromptForPersist }
+      : {}),
     ...(capturedSpans.length ? { spans: capturedSpans } : {}),
     ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
     ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -2530,60 +2530,51 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       expect(hasSystemEntry).toBe(false);
     });
 
-    it("prepends the resolved system prompt to persisted messages (PR 4d review — Codex P2)", async () => {
-      // Codex P2 review fix: pre-4d the system rode along as the first
-      // entry in `conversationMessages` and was naturally persisted via
-      // the messages-array path. PR 4d dropped that push to align the
-      // streamText wire shape with chat-v2; persistence had no
-      // dedicated `systemPrompt` slot on `appendEvalTurnTrace`, so the
-      // resolved system prompt was lost from the persisted transcript.
-      //
-      // Fix: prepend the resolved value as a `role: "system"` message
-      // at PERSISTENCE TIME (not in `conversationMessages` — the wire
-      // shape stays chat-aligned, no double-send). This restores the
-      // pre-4d persistence shape exactly: first message is
-      // `role: "system"` with the resolved content.
+    it("passes the resolved system prompt to appendEvalTurnTrace.systemPrompt (chatSessions.systemPrompt)", async () => {
+      // Pre-this-PR: the resolved system was spliced into the persisted
+      // `messages` array as a leading `{role:"system",...}` entry,
+      // because `appendEvalTurnTrace` had no dedicated `systemPrompt`
+      // slot. This PR adds the slot (backend-side) and threads the
+      // value through as a top-level arg on the action call, persisted
+      // to `chatSessions.systemPrompt` with first-write-wins semantics.
+      // The persisted `messages` array no longer carries a leading
+      // system entry (the wire shape and the persisted shape now agree
+      // on "system carried out-of-band").
       await runWithSuiteHostConfig({
         systemPrompt: "Resolved system prompt for persistence",
       });
 
-      const hasSystemPrefix = (msgs: unknown): boolean => {
-        if (!Array.isArray(msgs) || msgs.length === 0) return false;
-        const first = msgs[0] as { role?: string; content?: unknown };
-        if (first?.role !== "system") return false;
-        if (typeof first.content === "string") {
-          return first.content === "Resolved system prompt for persistence";
-        }
-        if (Array.isArray(first.content)) {
-          return first.content.some(
-            (part: any) =>
-              part?.type === "text" &&
-              part.text === "Resolved system prompt for persistence",
-          );
-        }
-        return false;
-      };
       const anyCallCarriesIt = convexClient.action.mock.calls.some((call) => {
+        if (call[0] !== "testSuites:appendEvalTurnTrace") return false;
         const payload = call[1] as Record<string, unknown> | undefined;
-        if (!payload) return false;
-        if (hasSystemPrefix(payload.messages)) return true;
-        const turn = payload.turn as
-          | { sessionMessages?: unknown }
-          | undefined;
-        if (turn && hasSystemPrefix(turn.sessionMessages)) return true;
-        return false;
+        return (
+          payload?.systemPrompt === "Resolved system prompt for persistence"
+        );
       });
       expect(anyCallCarriesIt).toBe(true);
+
+      // And the persisted `turn.sessionMessages` no longer carries the
+      // system as a leading message — the new wire shape moved it to
+      // the top-level field.
+      const appendCalls = convexClient.action.mock.calls.filter(
+        (call) => call[0] === "testSuites:appendEvalTurnTrace",
+      );
+      for (const call of appendCalls) {
+        const payload = call[1] as Record<string, unknown> | undefined;
+        const turn = payload?.turn as
+          | { sessionMessages?: Array<{ role?: string }> }
+          | undefined;
+        const first = turn?.sessionMessages?.[0];
+        expect(first?.role).not.toBe("system");
+      }
     });
 
-    it("prepends the resolved system to the backend runner's persisted transcript (PR 4d review — Codex P2 / Cursor Medium)", async () => {
-      // Codex P2 / Cursor Medium: `runIterationViaBackend` sends the
-      // resolved system to the model via `runAssistantTurn`'s
-      // `systemPrompt:` arg, but the engine's returned message history
-      // doesn't carry a system entry. `appendEvalTurnTrace` has no
-      // dedicated `systemPrompt` slot, so the persisted transcript
-      // omits a prompt that affected the model. Fix: prepend at
-      // persistence time, mirroring the local runner's fix.
+    it("passes the resolved system to appendEvalTurnTrace.systemPrompt in the backend runner", async () => {
+      // `runIterationViaBackend` sends the resolved system to the model
+      // via `runAssistantTurn`'s `systemPrompt:` arg. With the new
+      // dedicated slot on `appendEvalTurnTrace`, the persisted
+      // transcript carries it via `chatSessions.systemPrompt` (no
+      // leading `{role:"system",...}` entry in the messages array).
       const assistantTurnModule = await import("../../../utils/assistant-turn");
       const runAssistantTurnSpy = vi
         .spyOn(assistantTurnModule, "runAssistantTurn")
@@ -2640,32 +2631,11 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
           },
         });
 
-        const hasSystemPrefix = (msgs: unknown): boolean => {
-          if (!Array.isArray(msgs) || msgs.length === 0) return false;
-          const first = msgs[0] as { role?: string; content?: unknown };
-          if (first?.role !== "system") return false;
-          if (typeof first.content === "string") {
-            return first.content === "Backend suite default";
-          }
-          if (Array.isArray(first.content)) {
-            return first.content.some(
-              (part: any) =>
-                part?.type === "text" &&
-                part.text === "Backend suite default",
-            );
-          }
-          return false;
-        };
         const anyCallCarriesIt = convexClient.action.mock.calls.some(
           (call) => {
+            if (call[0] !== "testSuites:appendEvalTurnTrace") return false;
             const payload = call[1] as Record<string, unknown> | undefined;
-            if (!payload) return false;
-            if (hasSystemPrefix(payload.messages)) return true;
-            const turn = payload.turn as
-              | { sessionMessages?: unknown }
-              | undefined;
-            if (turn && hasSystemPrefix(turn.sessionMessages)) return true;
-            return false;
+            return payload?.systemPrompt === "Backend suite default";
           },
         );
         expect(anyCallCarriesIt).toBe(true);
@@ -2729,34 +2699,15 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       const wireMessages = streamCall.messages as Array<{ role: string }>;
       expect(wireMessages.some((m) => m.role === "system")).toBe(false);
 
-      // Persistence shape: first message is the resolved system,
-      // matching the non-stream runner's prefix.
-      const hasSystemPrefix = (msgs: unknown): boolean => {
-        if (!Array.isArray(msgs) || msgs.length === 0) return false;
-        const first = msgs[0] as { role?: string; content?: unknown };
-        if (first?.role !== "system") return false;
-        if (typeof first.content === "string") {
-          return first.content === "Stream-runner suite default";
-        }
-        if (Array.isArray(first.content)) {
-          return first.content.some(
-            (part: any) =>
-              part?.type === "text" &&
-              part.text === "Stream-runner suite default",
-          );
-        }
-        return false;
-      };
+      // Persistence shape: the resolved system flows through
+      // `appendEvalTurnTrace.systemPrompt` (persisted to
+      // `chatSessions.systemPrompt`), not as a leading system entry
+      // in the messages array.
       const persistedCarriesIt = convexClient.action.mock.calls.some(
         (call) => {
+          if (call[0] !== "testSuites:appendEvalTurnTrace") return false;
           const payload = call[1] as Record<string, unknown> | undefined;
-          if (!payload) return false;
-          if (hasSystemPrefix(payload.messages)) return true;
-          const turn = payload.turn as
-            | { sessionMessages?: unknown }
-            | undefined;
-          if (turn && hasSystemPrefix(turn.sessionMessages)) return true;
-          return false;
+          return payload?.systemPrompt === "Stream-runner suite default";
         },
       );
       expect(persistedCarriesIt).toBe(true);

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -193,6 +193,15 @@ export async function persistEvalTraceFanout(args: {
    * server-side, not here.
    */
   widgetSnapshots?: EvalTraceWidgetSnapshot[];
+  /**
+   * Resolved system prompt for the eval session. Persisted to
+   * `chatSessions.systemPrompt` by the backend with **first-write-wins**
+   * semantics — the value is invariant per eval session, so subsequent
+   * per-turn calls carrying the same field are ignored. Replaces the
+   * pre-PR persistence-side `{role:"system", ...}` prepend each runner
+   * used to splice into `messages` at finalize.
+   */
+  systemPrompt?: string;
 }): Promise<FanoutResult> {
   const turns = sliceTraceIntoTurns({
     messages: args.messages,
@@ -240,6 +249,12 @@ export async function persistEvalTraceFanout(args: {
           ...(args.displayLabel ? { displayLabel: args.displayLabel } : {}),
           startedAt,
           lastActivityAt: now,
+          // First-write-wins on the backend; safe to send on every turn
+          // call. Replaces the pre-PR persistence-side prepend each
+          // runner used to splice into `messages` at finalize.
+          ...(args.systemPrompt !== undefined
+            ? { systemPrompt: args.systemPrompt }
+            : {}),
           turn: {
             promptIndex: turn.promptIndex,
             turnStartedAt: now,

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -61,6 +61,15 @@ export type SuiteRunRecorder = {
     spans?: EvalTraceSpan[];
     prompts?: PromptTraceSummary[];
     widgetSnapshots?: EvalTraceWidgetSnapshot[];
+    /**
+     * Resolved system prompt for the eval session. Forwarded to
+     * `persistEvalTraceFanout` → `appendEvalTurnTrace.systemPrompt`,
+     * which the backend persists to `chatSessions.systemPrompt` with
+     * first-write-wins semantics. Replaces the persistence-side
+     * `{role:"system", ...}` prepend each runner used to splice into
+     * `messages`.
+     */
+    systemPrompt?: string;
     status?: IterationStatus;
     startedAt?: number;
     error?: string;
@@ -203,6 +212,7 @@ export const createSuiteRunRecorder = ({
       spans,
       prompts,
       widgetSnapshots,
+      systemPrompt,
       status,
       startedAt,
       error,
@@ -288,6 +298,7 @@ export const createSuiteRunRecorder = ({
         spans,
         prompts,
         widgetSnapshots,
+        systemPrompt,
       });
       // Fall back to the W1 single-call path ONLY when the fanout failed
       // before any turn landed. With turns already written, re-sending

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -335,6 +335,18 @@ export const createSuiteRunRecorder = ({
           ...(useW1Fallback
             ? {
                 messages: sanitizeForConvexTransport(messages),
+                // Mirrors `appendEvalTurnTrace.systemPrompt` + the
+                // parallel fix in `finishIterationDirectly`. Cursor
+                // Bugbot follow-up "Recorder W1 omits systemPrompt":
+                // without this, suite runs that use the recorder
+                // (not the direct `finishIterationDirectly` path) and
+                // hit the W1 fallback persist a transcript with no
+                // resolved system prompt — the prepend was dropped
+                // earlier in this PR. Backend `updateTestIteration`
+                // accepts the slot (mcpjam-backend #449); first-write-
+                // wins semantics apply, no risk of clobbering a value
+                // already set by an earlier `appendEvalTurnTrace`.
+                ...(systemPrompt ? { systemPrompt } : {}),
                 ...(spans?.length
                   ? { spans: sanitizeForConvexTransport(spans) }
                   : {}),


### PR DESCRIPTION
## Summary

- Backend PR (parallel, in `MCPJam/mcpjam-backend`) adds an optional top-level `systemPrompt: v.optional(v.string())` arg to `appendEvalTurnTrace`, persisted to a new `chatSessions.systemPrompt` column with **first-write-wins** semantics.
- Inspector half: thread the resolved system prompt through `recorder.finishIteration` / `finishIterationDirectly` / `persistEvalTraceFanout` to the action call, and delete the six PR-4d persistence-side `{role:"system",...}` prepends each runner used to splice into `messages` at finalize.
- The two `withSystemPrefix` SSE closures stay — they serve a different consumer (live test-runner UI `trace_snapshot` events, not the stored transcript). Trace-render UI cleanup (reader-side: read `systemPrompt` from chatSession metadata instead of `messages[0]`) is a separate future PR.

## Wire shape

| | Before | After |
|---|---|---|
| Model wire (chat-aligned) | `streamText({system, messages})` / `runAssistantTurn({systemPrompt, ...})` | unchanged |
| Persisted transcript (chatSessions) | `chatSessions.messages[0] = {role:"system", content:<enhanced>}` (spliced inspector-side) | `chatSessions.systemPrompt = <enhanced>` (sent inspector-side, persisted backend-side, first-write-wins) |
| Persisted `messages[]` shape | leading `{role:"system",...}` followed by conversation | conversation only — no system entry |
| Live SSE `trace_snapshot` (test-runner UI) | `withSystemPrefix` closures prefix snapshots | unchanged (closures preserved at `evals-runner.ts:3070` and `:3935`) |

## Cross-repo dependency

**:warning: DO NOT MERGE until the backend PR is in prod.** The backend PR must merge AND deploy first; otherwise the new `systemPrompt` arg arrives at an old backend (silently ignored — Convex validators accept extra fields? no — Convex args validator REJECTS unknown args, so this would actually throw `ArgumentValidationError` on the action call). Either way: the prepend is gone, so persistence would lose the system entirely (best case) or hard-fail every eval iteration (worst case).

Depends on `MCPJam/mcpjam-backend` PR — see Phase 2 eval consolidation plan.

## Sites changed

**Call-site add** (one logical site, threaded through 3 layers):
- `server/services/evals/persist-eval-trace.ts` — `persistEvalTraceFanout` accepts `systemPrompt?`, forwards on every per-turn `appendEvalTurnTrace` call (backend dedupes via first-write-wins)
- `server/services/evals/recorder.ts` — `SuiteRunRecorder.finishIteration` interface + impl accept and forward `systemPrompt`
- `server/services/evals-runner.ts` — `finishIterationDirectly` params accept and forward `systemPrompt`

**Prepend deletions** (six in `evals-runner.ts`):
- `:1572` — `runIterationWithAiSdk` success finalize (`persistedMessages`, `enhancedSystemPromptForPersist`)
- `:1701` — `runIterationWithAiSdk` soft-fail finalize (`persistedFailMessages`)
- `:2335` — `runIterationViaBackend` finalize (`persistedBackendMessages`, `backendEnhancedSystemPromptForPersist`)
- `:3547` — `streamIterationWithAiSdk` success finalize (`persistedStreamMessages`, `streamEnhancedSystemPromptForPersist`)
- `:3704` — `streamIterationWithAiSdk` soft-fail finalize (`persistedStreamFailMessages`)
- `:4696` — `streamIterationViaBackend` finalize (`persistedBackendMessages`)

Each `finishParams`/`failParams` now passes `systemPrompt: <theEnhancedVariable>` instead of a spliced `messages` array. The `*EnhancedSystemPromptForPersist` variable declarations stay — the two `withSystemPrefix` SSE closures still read them.

## What was preserved

- `streamIterationWithAiSdk`'s `withSystemPrefix` closure at `evals-runner.ts:3070` — prefixes live `trace_snapshot` SSE events
- `streamIterationViaBackend`'s `withSystemPrefix` closure at `evals-runner.ts:3935` — same, for the backend variant
- All `*EnhancedSystemPromptForPersist` variable declarations and assignments — still read by the closures and the new fanout call arg

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — baseline-matched (4 pre-existing `finishParams` errors at `:1618/:2371/:3581/:4712` + 2 pre-existing implicit-any errors in tests; **no new errors**)
- [x] `npm run test -- --run server/services/evals` — 137/137 passed (11 files)
- [x] `npm run test -- --run server` — 1479 passed, 5 skipped (matches baseline)
- [x] Tests updated: three PR-4d "prepends the resolved system prompt …" assertions rewritten to check the new shape (`appendEvalTurnTrace.systemPrompt` arg + no leading `role:"system"` in `turn.sessionMessages`). The fourth PR-5a test (live SSE prefix) untouched — closure behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cross-repo deploy ordering is required, and persisted transcript shape changes for anything that still reads system from `messages[0]` instead of `chatSessions.systemPrompt`.
> 
> **Overview**
> Eval persistence now stores the **resolved system prompt** on `appendEvalTurnTrace` / `updateTestIteration` as a top-level **`systemPrompt`** field (backend maps it to `chatSessions.systemPrompt` with first-write-wins), instead of splicing a leading `{role:"system",...}` message into persisted **`messages`**.
> 
> The change threads **`systemPrompt?`** through **`finishIterationDirectly`**, **`SuiteRunRecorder.finishIteration`**, and **`persistEvalTraceFanout`**, and updates all eval runners (local AI SDK, backend, streaming success/failure finalize paths) to pass conversation-only **`messages`** plus optional **`systemPrompt`**. The **W1 fallback** path when fanout fails before any turn also forwards **`systemPrompt`** so transcripts are not left without a system after the prepend removal.
> 
> **Live SSE** `trace_snapshot` behavior is unchanged: streaming runners still use **`withSystemPrefix`** for the test-runner UI. Tests now assert **`appendEvalTurnTrace.systemPrompt`** and that **`turn.sessionMessages`** no longer start with a system role.
> 
> **Merge note:** depends on the parallel backend PR adding the Convex args; deploying inspector first can reject unknown args or drop the system from storage entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802f34964c3615661c4ee5fe2f4a986b361ed2f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


## Update (follow-up commit `c76b43190`) — Cursor "W1 fallback drops system prompt"

Cursor flagged that the W1 fallback path (`evals-runner.ts:705-714`, fires when `persistEvalTraceFanout` fails before any turn lands) sends `messages` to `updateTestIteration` but no `systemPrompt`. After the prepend deletions, that path would persist a transcript with no resolved system prompt.

Fix: thread `systemPrompt: params.systemPrompt` through the `useW1Fallback` conditional spread (mirrors the spans/prompts/widgetSnapshots present-only spread pattern). Backend PR [#449](https://github.com/MCPJam/mcpjam-backend/pull/449) has a companion commit (`04067a59`) adding `systemPrompt: v.optional(v.string())` to `updateTestIteration` with the same first-write-wins semantics as `appendEvalTurnTrace`.

The cross-repo "DO NOT MERGE until backend in prod" warning still applies — it now also covers `updateTestIteration`'s new arg.

