### PR TITLE
eval: Computer Use + eval-runner integration, with review fixes (browser-render PR 4–5/5)

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -37,6 +37,19 @@ import { resolveExecutionContext } from "../utils/host-execution-context";
 import { logger } from "../utils/logger";
 import { captureMcpAppWidgetSnapshots } from "../utils/mcp-app-widget-capture";
 import {
+  McpAppBrowserHarness,
+  DEFAULT_VIEWPORT,
+  type WidgetRenderObservation,
+} from "../utils/mcp-app-browser-harness";
+import {
+  buildComputerUseTools,
+  resolveComputerUseToolVersion,
+} from "../utils/computer-use-tool";
+import {
+  renderMcpAppToolResult,
+  isRenderableMcpAppTool,
+} from "../utils/mcp-app-render-observation";
+import {
   buildLlmRuntimeConfigFromOrgConfig,
   deriveOrgProviderKey,
   isLocalRuntimeEligible,
@@ -1232,6 +1245,33 @@ const runIterationWithAiSdk = async ({
   // `messages`) while the wire shape stays chat-aligned.
   let enhancedSystemPromptForPersist: string | undefined = undefined;
 
+  // Browser-rendered MCP App eval (PR 5): render MCP App tool results in the
+  // headless-Chromium harness and (for Claude drivers) drive them with
+  // Computer Use. Harness construction is cheap; Chromium launches lazily on
+  // the first widget render, so prompt-only / no-widget iterations pay nothing.
+  const computerUseVersion = resolveComputerUseToolVersion(test.model);
+  // Ref-object (not a bare `let`): the only assignments happen inside the
+  // closures below, which TS control-flow analysis can't see — a bare `let`
+  // would stay narrowed to its `null` initializer in the outer `finally`.
+  const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
+    current: null,
+  };
+  let activeWidgetToolCallId: string | null = null;
+  const widgetRenderObservations: WidgetRenderObservation[] = [];
+  const ensureWidgetHarness = (): McpAppBrowserHarness => {
+    if (!widgetHarnessRef.current) {
+      widgetHarnessRef.current = new McpAppBrowserHarness({
+        callTool: (sid, name, args) =>
+          mcpClientManager.executeTool(sid, name, args),
+        viewport: DEFAULT_VIEWPORT,
+      });
+    }
+    return widgetHarnessRef.current;
+  };
+  // Eager (cheap) construction when Computer Use is supported so the computer
+  // tools can reference the harness; Chromium still launches lazily.
+  if (computerUseVersion) ensureWidgetHarness();
+
   try {
     // Adopt the chat-side tool/system/temperature pipeline. Eval used to skip
     // this and call `getToolsForAiSdk` + an inline system/temperature wiring,
@@ -1264,6 +1304,18 @@ const runIterationWithAiSdk = async ({
     // array at persistence time, since eval's wire shape to Convex
     // (`appendEvalTurnTrace`) has no dedicated `systemPrompt` slot.
     enhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
+
+    // Computer Use tools (Claude drivers only). Included in the tool map so the
+    // AI SDK Anthropic provider auto-attaches the beta header; gated per step by
+    // `prepareAdvertisedTools` so they only appear once a widget has rendered.
+    const computerWidgetTools = computerUseVersion
+      ? buildComputerUseTools({
+          version: computerUseVersion,
+          harness: ensureWidgetHarness(),
+          getActiveToolCallId: () => activeWidgetToolCallId,
+          viewport: DEFAULT_VIEWPORT,
+        })
+      : {};
 
     const llmModel = createLlmModel(
       modelDefinition,
@@ -1351,9 +1403,27 @@ const runIterationWithAiSdk = async ({
         ...(prepared.resolvedTemperature == null
           ? {}
           : { temperature: prepared.resolvedTemperature }),
-        tools: prepared.allTools,
+        tools: { ...prepared.allTools, ...computerWidgetTools },
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
+        // Browser-rendered MCP App eval (PR 5): gate Computer Use tools so the
+        // model only sees `computer` / `finish_widget` once a widget has
+        // actually rendered in the harness (PR 2's prepareAdvertisedTools hook).
+        ...(computerUseVersion
+          ? {
+              prepareAdvertisedTools: ({
+                defaultToolNames,
+              }: {
+                stepIndex: number;
+                defaultToolNames: string[];
+              }) =>
+                widgetHarnessRef.current?.hasRenderedWidget()
+                  ? defaultToolNames
+                  : defaultToolNames.filter(
+                      (n) => n !== "computer" && n !== "finish_widget",
+                    ),
+            }
+          : {}),
         ...(abortSignal ? { abortSignal } : {}),
         ...(toolChoice
           ? { toolChoice: toolChoice as ToolChoice<Record<string, AiTool>> }
@@ -1384,6 +1454,43 @@ const runIterationWithAiSdk = async ({
             activePartialResponseMessages = traceHistory.slice(
               promptInputLength,
             ) as ModelMessage[];
+          },
+          // Browser-rendered MCP App eval (PR 5): render each MCP App tool
+          // result in the harness and record a WidgetRenderObservation. Awaited
+          // (direct-chat-turn awaits this callback) so a rendered widget is
+          // mounted before the next step's Computer Use gate runs.
+          onToolResultChunk: async ({ toolCallId, toolName, output, serverId }) => {
+            if (!serverId) return;
+            const meta = mcpClientManager.getAllToolsMetadata(serverId)?.[
+              toolName
+            ];
+            if (!isRenderableMcpAppTool(meta)) return;
+            try {
+              const obs = await renderMcpAppToolResult({
+                toolCallId,
+                toolName,
+                serverId,
+                toolMetadata: meta,
+                output,
+                mcpClientManager,
+                injectOpenAiCompat,
+                harness: ensureWidgetHarness(),
+                keepMounted: computerUseVersion !== null,
+              });
+              widgetRenderObservations.push(obs);
+              if (obs.status === "rendered" && computerUseVersion) {
+                activeWidgetToolCallId = toolCallId;
+              }
+              logger.debug("[evals] widget render observation", {
+                toolName,
+                status: obs.status,
+              });
+            } catch (err) {
+              logger.warn("[evals] widget render failed", {
+                toolName,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
           },
         },
       });
@@ -1755,6 +1862,17 @@ const runIterationWithAiSdk = async ({
       evaluation,
       iterationId: iterationId ?? undefined,
     };
+  } finally {
+    // Browser-rendered MCP App eval (PR 5): tear down the harness (and its
+    // headless Chromium, if launched) regardless of success/failure. No-op
+    // when the harness was never constructed or never launched.
+    await widgetHarnessRef.current?.dispose();
+    if (widgetRenderObservations.length > 0) {
+      logger.debug("[evals] widget render observations", {
+        count: widgetRenderObservations.length,
+        statuses: widgetRenderObservations.map((o) => o.status),
+      });
+    }
   }
 };
 

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1256,7 +1256,6 @@ const runIterationWithAiSdk = async ({
   const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
     current: null,
   };
-  let activeWidgetToolCallId: string | null = null;
   const widgetRenderObservations: WidgetRenderObservation[] = [];
   const ensureWidgetHarness = (): McpAppBrowserHarness => {
     if (!widgetHarnessRef.current) {
@@ -1312,7 +1311,12 @@ const runIterationWithAiSdk = async ({
       ? buildComputerUseTools({
           version: computerUseVersion,
           harness: ensureWidgetHarness(),
-          getActiveToolCallId: () => activeWidgetToolCallId,
+          // The harness keeps at most one widget mounted and drops it on
+          // dismiss / re-render / screenshot failure, so it is the single
+          // source of truth for the active widget — no separate id to track
+          // (and drift) across turns or after a finish_widget dismiss.
+          getActiveToolCallId: () =>
+            widgetHarnessRef.current?.getMountedWidgetId() ?? null,
           viewport: DEFAULT_VIEWPORT,
         })
       : {};
@@ -1327,7 +1331,10 @@ const runIterationWithAiSdk = async ({
     if (
       toolChoice &&
       typeof toolChoice === "object" &&
-      !Object.hasOwn(prepared.allTools, toolChoice.toolName)
+      !Object.hasOwn(prepared.allTools, toolChoice.toolName) &&
+      // `computer` / `finish_widget` are merged into the tool map below, so a
+      // forced tool choice naming one of them is valid on Claude drivers.
+      !Object.hasOwn(computerWidgetTools, toolChoice.toolName)
     ) {
       throw new Error(
         `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`,
@@ -1353,6 +1360,16 @@ const runIterationWithAiSdk = async ({
       if (localIsAborted()) return returnLocalCancelled();
       const promptTurn = promptTurns[promptIndex]!;
       activePromptIndex = promptIndex;
+      // Browser-rendered MCP App eval (PR 5): start each prompt turn with a
+      // clean widget surface. A widget kept mounted by a previous turn must not
+      // bleed into this one — otherwise Computer Use could be advertised (and
+      // `computer` actions routed) against the prior turn's widget before this
+      // turn's own MCP App tool runs.
+      const carriedWidgetId =
+        widgetHarnessRef.current?.getMountedWidgetId() ?? null;
+      if (carriedWidgetId) {
+        await widgetHarnessRef.current!.dismissWidget(carriedWidgetId);
+      }
       // PR 4b invariant (carried from closed #2458, originally PR 3 round 2):
       // push the user prompt to `conversationMessages` BEFORE the driver
       // call so a failed turn still records the prompt in the persisted
@@ -1417,7 +1434,11 @@ const runIterationWithAiSdk = async ({
                 stepIndex: number;
                 defaultToolNames: string[];
               }) =>
-                widgetHarnessRef.current?.hasRenderedWidget()
+                // Gate on the harness's live widget — the SAME source
+                // `getActiveToolCallId` reads — so the tools are only advertised
+                // when a Computer Use action can actually target a mount (avoids
+                // advertising while the active id would resolve to null).
+                widgetHarnessRef.current?.getMountedWidgetId()
                   ? defaultToolNames
                   : defaultToolNames.filter(
                       (n) => n !== "computer" && n !== "finish_widget",
@@ -1459,7 +1480,13 @@ const runIterationWithAiSdk = async ({
           // result in the harness and record a WidgetRenderObservation. Awaited
           // (direct-chat-turn awaits this callback) so a rendered widget is
           // mounted before the next step's Computer Use gate runs.
-          onToolResultChunk: async ({ toolCallId, toolName, output, serverId }) => {
+          onToolResultChunk: async ({
+            toolCallId,
+            toolName,
+            input,
+            output,
+            serverId,
+          }) => {
             if (!serverId) return;
             const meta = mcpClientManager.getAllToolsMetadata(serverId)?.[
               toolName
@@ -1471,6 +1498,9 @@ const runIterationWithAiSdk = async ({
                 toolName,
                 serverId,
                 toolMetadata: meta,
+                // Feed the real tool-call args to the widget shim so the live
+                // render matches what post-turn snapshot capture injects.
+                toolInput: input,
                 output,
                 mcpClientManager,
                 injectOpenAiCompat,
@@ -1478,9 +1508,10 @@ const runIterationWithAiSdk = async ({
                 keepMounted: computerUseVersion !== null,
               });
               widgetRenderObservations.push(obs);
-              if (obs.status === "rendered" && computerUseVersion) {
-                activeWidgetToolCallId = toolCallId;
-              }
+              // No separate active-widget bookkeeping: a `rendered` + kept widget
+              // stays in the harness mount (the single source of truth that the
+              // gate and getActiveToolCallId both read); every other outcome is
+              // already unmounted by renderWidget.
               logger.debug("[evals] widget render observation", {
                 toolName,
                 status: obs.status,

--- a/mcpjam-inspector/server/tsup.config.ts
+++ b/mcpjam-inspector/server/tsup.config.ts
@@ -38,6 +38,13 @@ export default defineConfig({
     // Packages with dynamic requires
     "chalk",
     "supports-color",
+    // Headless-browser harness deps (eval browser-render): resolved at runtime,
+    // never bundled. `playwright` is a direct dep (auto-external); `playwright-core`
+    // is its transitive fallback (`await import("playwright-core")`) and must be
+    // listed explicitly, otherwise esbuild follows it into `bidiOverCdp` and
+    // fails on the optional `chromium-bidi` dependency.
+    "playwright",
+    "playwright-core",
   ],
   noExternal: [
     // Force bundling of problematic packages

--- a/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
@@ -50,6 +50,23 @@ describe("resolveComputerUseToolVersion", () => {
     );
   });
 
+  it("normalizes dotted MCPJam version ids to hyphenated map keys", () => {
+    // The default eval model id is dotted (`anthropic/claude-haiku-4.5`); the
+    // map keys are hyphenated, so the dot must normalize or Computer Use is
+    // silently dropped for the default model.
+    expect(resolveComputerUseToolVersion("anthropic/claude-haiku-4.5")).toBe(
+      "20250124",
+    );
+    expect(resolveComputerUseToolVersion("claude-sonnet-4.5")).toBe("20250124");
+    expect(resolveComputerUseToolVersion("anthropic/claude-opus-4.6")).toBe(
+      "20251124",
+    );
+    // dotted + dated suffix still resolves by longest prefix.
+    expect(
+      resolveComputerUseToolVersion("anthropic/claude-haiku-4.5-20251001"),
+    ).toBe("20250124");
+  });
+
   it("returns null for non-Claude / unmapped / empty models", () => {
     expect(resolveComputerUseToolVersion("gpt-4o")).toBeNull();
     expect(resolveComputerUseToolVersion("gemini-2.5-pro")).toBeNull();

--- a/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi } from "vitest";
+import { anthropic } from "@ai-sdk/anthropic";
+import {
+  COMPUTER_USE_TOOL_VERSIONS,
+  resolveComputerUseToolVersion,
+  buildComputerUseTools,
+  mapToBrowserAction,
+  summarizeWidgetToolCalls,
+  toComputerModelOutput,
+  type ComputerImplOutput,
+} from "../computer-use-tool";
+import type { McpAppBrowserHarness } from "../mcp-app-browser-harness";
+
+describe("resolveComputerUseToolVersion", () => {
+  it("resolves every mapped model id to its version", () => {
+    for (const [model, version] of Object.entries(COMPUTER_USE_TOOL_VERSIONS)) {
+      expect(resolveComputerUseToolVersion(model)).toBe(version);
+    }
+  });
+
+  it("every mapped version exists as an AI SDK provider-tool factory (drift guard)", () => {
+    const seen = new Set(Object.values(COMPUTER_USE_TOOL_VERSIONS));
+    for (const version of seen) {
+      expect(
+        typeof (anthropic.tools as Record<string, unknown>)[
+          `computer_${version}`
+        ],
+      ).toBe("function");
+    }
+  });
+
+  it("matches dated / suffixed ids by longest prefix", () => {
+    expect(resolveComputerUseToolVersion("claude-sonnet-4-5-20250929")).toBe(
+      "20250124",
+    );
+    expect(resolveComputerUseToolVersion("claude-opus-4-8-20260115")).toBe(
+      "20251124",
+    );
+    // longest-prefix: -4-8 wins over -4
+    expect(resolveComputerUseToolVersion("claude-opus-4-8")).toBe("20251124");
+    expect(resolveComputerUseToolVersion("claude-opus-4")).toBe("20250124");
+  });
+
+  it("strips provider prefixes", () => {
+    expect(resolveComputerUseToolVersion("anthropic/claude-opus-4-8")).toBe(
+      "20251124",
+    );
+    expect(resolveComputerUseToolVersion({ id: "anthropic.claude-sonnet-4" })).toBe(
+      "20250124",
+    );
+  });
+
+  it("returns null for non-Claude / unmapped / empty models", () => {
+    expect(resolveComputerUseToolVersion("gpt-4o")).toBeNull();
+    expect(resolveComputerUseToolVersion("gemini-2.5-pro")).toBeNull();
+    expect(resolveComputerUseToolVersion("claude-2.1")).toBeNull();
+    expect(resolveComputerUseToolVersion(undefined)).toBeNull();
+    expect(resolveComputerUseToolVersion(null)).toBeNull();
+    expect(resolveComputerUseToolVersion("")).toBeNull();
+  });
+});
+
+describe("mapToBrowserAction", () => {
+  it("maps clicks and movement with coordinates", () => {
+    expect(
+      mapToBrowserAction({ action: "left_click", coordinate: [1, 2] }),
+    ).toEqual({ action: "left_click", coordinate: [1, 2] });
+    expect(mapToBrowserAction({ action: "triple_click", coordinate: [3, 4] })).toEqual(
+      { action: "double_click", coordinate: [3, 4] },
+    );
+  });
+  it("maps scroll with amount + direction", () => {
+    expect(
+      mapToBrowserAction({
+        action: "scroll",
+        coordinate: [5, 6],
+        scroll_amount: 3,
+        scroll_direction: "down",
+      }),
+    ).toEqual({
+      action: "scroll",
+      coordinate: [5, 6],
+      scrollAmount: 3,
+      scrollDirection: "down",
+    });
+  });
+  it("maps type/key text", () => {
+    expect(mapToBrowserAction({ action: "type", text: "hi" })).toEqual({
+      action: "type",
+      text: "hi",
+    });
+    expect(mapToBrowserAction({ action: "key", text: "Enter" })).toEqual({
+      action: "key",
+      text: "Enter",
+    });
+  });
+  it("falls back to screenshot for unsupported actions", () => {
+    expect(mapToBrowserAction({ action: "zoom" })).toEqual({
+      action: "screenshot",
+    });
+    expect(mapToBrowserAction({ action: "left_click_drag" })).toEqual({
+      action: "screenshot",
+    });
+  });
+});
+
+describe("summarizeWidgetToolCalls", () => {
+  it("returns null for no calls", () => {
+    expect(summarizeWidgetToolCalls([])).toBeNull();
+  });
+  it("formats ok and error calls", () => {
+    const s = summarizeWidgetToolCalls([
+      { name: "get_flights", args: { date: "2026-01-01" }, ok: true, elapsedMs: 1 },
+      { name: "reserve", args: { seat: 12 }, ok: false, error: "sold out", elapsedMs: 2 },
+    ]);
+    expect(s).toContain("get_flights(date=2026-01-01) → OK");
+    expect(s).toContain("reserve(seat=12) → ERROR(sold out)");
+  });
+});
+
+describe("toComputerModelOutput", () => {
+  const base: ComputerImplOutput = {
+    widgetToolCalls: [],
+    action: { action: "left_click" },
+    elapsedMs: 1,
+  };
+
+  it("empty tool calls + screenshot => single image part", () => {
+    const out = toComputerModelOutput({
+      ...base,
+      screenshotBase64: "iVBORw0KGgoSCREEN",
+    });
+    expect(out.type).toBe("content");
+    expect(out.value).toHaveLength(1);
+    expect(out.value[0]).toMatchObject({
+      type: "image-data",
+      mediaType: "image/png",
+    });
+  });
+
+  it("detects jpeg media type from base64 header", () => {
+    const out = toComputerModelOutput({ ...base, screenshotBase64: "/9j/4AAQ" });
+    expect(out.value[0]).toMatchObject({ mediaType: "image/jpeg" });
+  });
+
+  it("one tool call => image + summary text", () => {
+    const out = toComputerModelOutput({
+      ...base,
+      screenshotBase64: "iVBORshot",
+      widgetToolCalls: [
+        { name: "reserve", args: { seat: 12 }, ok: true, elapsedMs: 3 },
+      ],
+    });
+    expect(out.value.some((p) => p.type === "image-data")).toBe(true);
+    expect(
+      out.value.some((p) => p.type === "text" && p.text.includes("reserve(seat=12)")),
+    ).toBe(true);
+  });
+
+  it("budget-exceeded note surfaces to the model", () => {
+    const out = toComputerModelOutput({ ...base, note: "budget_exceeded" });
+    expect(
+      out.value.some(
+        (p) => p.type === "text" && p.text.includes("budget_exceeded"),
+      ),
+    ).toBe(true);
+  });
+
+  it("no screenshot + no calls => a textual placeholder (never empty)", () => {
+    const out = toComputerModelOutput(base);
+    expect(out.value).toHaveLength(1);
+    expect(out.value[0]).toMatchObject({ type: "text" });
+  });
+});
+
+describe("buildComputerUseTools", () => {
+  function stubHarness() {
+    const executeAction = vi.fn(
+      async ({ action }: { toolCallId: string; action: unknown }) => ({
+        action,
+        screenshotBase64: "iVBORscreenshot",
+        widgetToolCalls: [
+          { name: "reserve", args: { seat: 12 }, ok: true, elapsedMs: 4 },
+        ],
+        elapsedMs: 7,
+      }),
+    );
+    const dismissWidget = vi.fn(async () => {});
+    return {
+      harness: { executeAction, dismissWidget } as unknown as McpAppBrowserHarness,
+      executeAction,
+      dismissWidget,
+    };
+  }
+
+  it("returns a provider-native computer tool and a regular finish_widget tool", () => {
+    const { harness } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => "tc-1",
+      viewport: { width: 1280, height: 800 },
+    });
+    expect(tools.computer).toBeDefined();
+    expect(tools.finish_widget).toBeDefined();
+    // finish_widget is a plain AI SDK tool with an input schema (no provider id).
+    expect(
+      (tools.finish_widget as { inputSchema?: unknown }).inputSchema,
+    ).toBeDefined();
+  });
+
+  it("computer.execute drives the harness and toModelOutput renders the result", async () => {
+    const { harness, executeAction } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20251124",
+      harness,
+      getActiveToolCallId: () => "tc-active",
+      viewport: { width: 1024, height: 768 },
+    });
+    const exec = (tools.computer as { execute: Function }).execute;
+    const impl = (await exec(
+      { action: "left_click", coordinate: [512, 384] },
+      {},
+    )) as ComputerImplOutput;
+
+    expect(executeAction).toHaveBeenCalledWith({
+      toolCallId: "tc-active",
+      action: { action: "left_click", coordinate: [512, 384] },
+    });
+    expect(impl.widgetToolCalls).toHaveLength(1);
+
+    const toModelOutput = (tools.computer as { toModelOutput: Function })
+      .toModelOutput;
+    const mo = toModelOutput({ output: impl });
+    expect(mo.type).toBe("content");
+    expect(mo.value.some((p: { type: string }) => p.type === "image-data")).toBe(
+      true,
+    );
+  });
+
+  it("computer.execute returns 'no rendered widget' when none is active", async () => {
+    const { harness, executeAction } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => null,
+      viewport: { width: 1280, height: 800 },
+    });
+    const exec = (tools.computer as { execute: Function }).execute;
+    const impl = (await exec({ action: "screenshot" }, {})) as ComputerImplOutput;
+    expect(impl.note).toBe("no rendered widget");
+    expect(executeAction).not.toHaveBeenCalled();
+  });
+
+  it("finish_widget.execute dismisses the named widget", async () => {
+    const { harness, dismissWidget } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => "tc-1",
+      viewport: { width: 1280, height: 800 },
+    });
+    const exec = (tools.finish_widget as { execute: Function }).execute;
+    const out = await exec({ toolCallId: "tc-1" }, {});
+    expect(dismissWidget).toHaveBeenCalledWith("tc-1");
+    expect(out).toMatchObject({ ok: true, dismissed: "tc-1" });
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
@@ -282,4 +282,40 @@ describe("buildComputerUseTools", () => {
     expect(dismissWidget).toHaveBeenCalledWith("tc-1");
     expect(out).toMatchObject({ ok: true, dismissed: "tc-1" });
   });
+
+  it("finish_widget.execute reports no dismissal when no widget is active", async () => {
+    const { harness, dismissWidget } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => null,
+      viewport: { width: 1280, height: 800 },
+    });
+    const exec = (tools.finish_widget as { execute: Function }).execute;
+    const out = await exec({ toolCallId: "tc-stale" }, {});
+    // No live widget -> don't claim success, and don't call dismiss.
+    expect(dismissWidget).not.toHaveBeenCalled();
+    expect(out).toMatchObject({ ok: false, dismissed: null });
+  });
+
+  it("finish_widget.execute dismisses the live widget even when the model passes a stale id", async () => {
+    const { harness, dismissWidget } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => "tc-live",
+      viewport: { width: 1280, height: 800 },
+    });
+    const exec = (tools.finish_widget as { execute: Function }).execute;
+    const out = await exec({ toolCallId: "tc-stale" }, {});
+    // Dismisses the actually-mounted widget, not the (wrong) requested id...
+    expect(dismissWidget).toHaveBeenCalledWith("tc-live");
+    expect(dismissWidget).not.toHaveBeenCalledWith("tc-stale");
+    // ...and reports the truth: what was dismissed vs. what was requested.
+    expect(out).toMatchObject({
+      ok: true,
+      dismissed: "tc-live",
+      requested: "tc-stale",
+    });
+  });
 });

--- a/mcpjam-inspector/server/utils/__tests__/direct-chat-turn.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/direct-chat-turn.test.ts
@@ -191,6 +191,76 @@ describe("runDirectChatTurn — eval headless contract (PR 4a)", () => {
     expect(Array.isArray(prepareStepReturn.activeTools)).toBe(true);
   });
 
+  it("keeps non-cataloged injected tools advertisable under progressive discovery", async () => {
+    // Regression: progressive discovery narrows the default set to the cataloged
+    // active subset, which never contains tools injected after plan-build (the
+    // eval `computer` / `finish_widget`). `prepareAdvertisedTools` can only KEEP
+    // names already in the default set, so without the injected-tools union
+    // those tools could never be advertised even once a widget mounts.
+    let prepareStepReturn: any;
+    let seenDefaultNames: string[] = [];
+    streamTextMock.mockImplementationOnce((options: any) => {
+      prepareStepReturn = options.prepareStep({ stepNumber: 0 });
+      return defaultStreamTextReturn();
+    });
+
+    const handle = runDirectChatTurn({
+      llmModel: { id: "mock" } as any,
+      modelId: "claude-opus-4-8",
+      messageHistory: [{ role: "user", content: "Hi" } as any],
+      systemPrompt: "s",
+      tools: {
+        search_tools: { description: "", execute: async () => ({}) },
+        computer: { description: "c", execute: async () => ({}) },
+        finish_widget: { description: "f", execute: async () => ({}) },
+      } as any,
+      progressivePlan: {
+        enabled: true,
+        reasons: [],
+        policy: {
+          thresholdPct: 0.03,
+          maxToolTokens: 10_000,
+          maxToolCount: 30,
+          searchLimit: 8,
+        },
+        catalog: [
+          {
+            toolId: "srv::search_tools",
+            modelName: "search_tools",
+            serverId: "srv",
+            originalName: "search_tools",
+            description: "",
+            fields: [],
+            inputSchema: {},
+            tokenEstimate: 100,
+          },
+        ],
+        totalTokenEstimate: 100,
+      } as any,
+      discoveryState: {
+        loadedToolIds: new Set(["srv::search_tools"]),
+        newlyLoadedToolIds: new Set<string>(),
+        pendingApprovalToolIds: new Set<string>(),
+      } as any,
+      // Simulate a mounted widget: keep the full default set (no narrowing).
+      prepareAdvertisedTools: ({ defaultToolNames }) => {
+        seenDefaultNames = defaultToolNames;
+        return defaultToolNames;
+      },
+    });
+
+    await consumeDirectChatTurnHeadless(handle);
+
+    // The injected tools reach the hook's default set...
+    expect(seenDefaultNames).toEqual(
+      expect.arrayContaining(["computer", "finish_widget"]),
+    );
+    // ...and survive into the advertised activeTools for the step.
+    expect(prepareStepReturn.activeTools).toEqual(
+      expect.arrayContaining(["computer", "finish_widget", "search_tools"]),
+    );
+  });
+
   it("narrows the request_payload trace tools via prepareAdvertisedTools (step 0)", () => {
     streamTextMock.mockReturnValueOnce(defaultStreamTextReturn());
     let payloadTools: Record<string, unknown> | undefined;

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
@@ -187,6 +187,31 @@ describe("McpAppBrowserHarness — render classification", () => {
     expect(second.status).toBe("rendered");
     expect(h.hasRenderedWidget()).toBe(true);
   }, 30_000);
+
+  it("reports screenshot_failed when the frame can't fit the byte budget", async () => {
+    // A 1-byte cap is unsatisfiable even at the lowest JPEG quality, so
+    // captureScreenshot throws and the render fails closed rather than emit an
+    // oversized image.
+    const h = makeHarness({
+      budgets: {
+        renderTimeoutMs: 1200,
+        settleTimeoutMs: 600,
+        screenshotMaxBytes: 1,
+      },
+    });
+    const obs = await h.renderWidget({
+      toolCallId: "tiny-1",
+      toolName: "show_seats",
+      serverId: "flights",
+      html: buttonHtml,
+      keepMounted: true,
+    });
+    expect(obs.status).toBe("screenshot_failed");
+    expect(obs.screenshotBase64).toBeUndefined();
+    // A failed render is not kept mounted.
+    expect(h.getMountedWidgetId()).toBeNull();
+    expect(h.hasRenderedWidget()).toBe(false);
+  }, 30_000);
 });
 
 describe("McpAppBrowserHarness — interaction", () => {
@@ -261,5 +286,47 @@ describe("McpAppBrowserHarness — interaction", () => {
       action: { action: "left_click", coordinate: [640, 400] },
     });
     expect(live.widgetToolCalls.map((c) => c.name)).toEqual(["reserve"]);
+  }, 30_000);
+
+  it("force-dismisses the widget once the per-widget step cap is reached", async () => {
+    const h = makeHarness({
+      budgets: {
+        renderTimeoutMs: 1200,
+        settleTimeoutMs: 600,
+        maxBrowserStepsPerWidget: 1,
+      },
+    });
+    const render = await h.renderWidget({
+      toolCallId: "cap-1",
+      toolName: "show_seats",
+      serverId: "flights",
+      html: buttonHtml,
+      keepMounted: true,
+    });
+    expect(render.status).toBe("rendered");
+    // getMountedWidgetId is the single source of truth for the live widget.
+    expect(h.getMountedWidgetId()).toBe("cap-1");
+
+    // First action consumes the only allowed step.
+    const first = await h.executeAction({
+      toolCallId: "cap-1",
+      action: { action: "left_click", coordinate: [640, 400] },
+    });
+    expect(first.note).toBeUndefined();
+
+    // Second action is over the step cap -> force-dismiss + distinct note.
+    const second = await h.executeAction({
+      toolCallId: "cap-1",
+      action: { action: "screenshot" },
+    });
+    expect(second.note).toBe("step_budget_exceeded");
+    // The widget is torn down: no longer live, and further actions no-op.
+    expect(h.getMountedWidgetId()).toBeNull();
+    expect(h.hasRenderedWidget()).toBe(false);
+    const third = await h.executeAction({
+      toolCallId: "cap-1",
+      action: { action: "screenshot" },
+    });
+    expect(third.note).toBe("no rendered widget");
   }, 30_000);
 });

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-render-observation.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-render-observation.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { build } from "esbuild";
+import {
+  renderMcpAppToolResult,
+  isRenderableMcpAppTool,
+} from "../mcp-app-render-observation";
+import { McpAppBrowserHarness } from "../mcp-app-browser-harness";
+import type { MCPClientManager } from "@mcpjam/sdk";
+
+const MCP_APP_META = { ui: { resourceUri: "ui://widget/seats" } };
+
+describe("isRenderableMcpAppTool", () => {
+  it("accepts MCP App tools that declare a UI resource", () => {
+    expect(isRenderableMcpAppTool(MCP_APP_META)).toBe(true);
+  });
+  it("rejects non-MCP-App / resource-less metadata", () => {
+    expect(isRenderableMcpAppTool({})).toBe(false);
+    expect(isRenderableMcpAppTool({ ui: {} })).toBe(false);
+    expect(isRenderableMcpAppTool(undefined)).toBe(false);
+  });
+});
+
+describe("renderMcpAppToolResult — short-circuits", () => {
+  const stubHarness = () =>
+    ({ renderWidget: vi.fn() }) as unknown as McpAppBrowserHarness;
+
+  it("returns no_ui_resource without touching the harness", async () => {
+    const harness = stubHarness();
+    const obs = await renderMcpAppToolResult({
+      toolCallId: "tc",
+      toolName: "t",
+      serverId: "s",
+      toolMetadata: {},
+      mcpClientManager: {} as MCPClientManager,
+      harness,
+    });
+    expect(obs.status).toBe("no_ui_resource");
+    expect((harness.renderWidget as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it("returns resource_read_failed when readResource throws", async () => {
+    const harness = stubHarness();
+    const mcpClientManager = {
+      readResource: vi.fn().mockRejectedValue(new Error("nope")),
+    } as unknown as MCPClientManager;
+    const obs = await renderMcpAppToolResult({
+      toolCallId: "tc",
+      toolName: "t",
+      serverId: "s",
+      toolMetadata: MCP_APP_META,
+      mcpClientManager,
+      harness,
+    });
+    expect(obs.status).toBe("resource_read_failed");
+    expect(obs.resourceUri).toBe("ui://widget/seats");
+  });
+});
+
+describe("renderMcpAppToolResult — reads resource + delegates to harness", () => {
+  function setup(html: string) {
+    const renderWidget = vi.fn(
+      async (input: { toolCallId: string; html: string }) => ({
+        toolCallId: input.toolCallId,
+        toolName: "t",
+        serverId: "s",
+        status: "rendered" as const,
+        bridgeInitialized: true,
+        elapsedMs: 1,
+        ts: Date.now(),
+        _html: input.html,
+      }),
+    );
+    const harness = { renderWidget } as unknown as McpAppBrowserHarness;
+    const mcpClientManager = {
+      readResource: vi.fn().mockResolvedValue({
+        contents: [{ text: html, _meta: { ui: { permissions: {} } } }],
+      }),
+    } as unknown as MCPClientManager;
+    return { harness, renderWidget, mcpClientManager };
+  }
+
+  it("passes the raw widget HTML through when the shim is off", async () => {
+    const html = "<html><body>seats</body></html>";
+    const { harness, renderWidget, mcpClientManager } = setup(html);
+    const obs = await renderMcpAppToolResult({
+      toolCallId: "tc1",
+      toolName: "show_seats",
+      serverId: "flights",
+      toolMetadata: MCP_APP_META,
+      output: { content: [] },
+      mcpClientManager,
+      harness,
+      keepMounted: true,
+    });
+    expect(obs.status).toBe("rendered");
+    const arg = renderWidget.mock.calls[0][0] as { html: string; keepMounted?: boolean };
+    expect(arg.html).toBe(html);
+    expect(arg.keepMounted).toBe(true);
+  });
+
+  it("injects the OpenAI compat shim when enabled", async () => {
+    const html = "<html><body>seats</body></html>";
+    const { harness, renderWidget, mcpClientManager } = setup(html);
+    await renderMcpAppToolResult({
+      toolCallId: "tc1",
+      toolName: "show_seats",
+      serverId: "flights",
+      toolMetadata: MCP_APP_META,
+      output: { content: [] },
+      mcpClientManager,
+      harness,
+      injectOpenAiCompat: true,
+    });
+    const arg = renderWidget.mock.calls[0][0] as { html: string };
+    // The shim injects the OpenAI Apps runtime (defines window.openai), so the
+    // HTML grows and references the openai surface.
+    expect(arg.html).not.toBe(html);
+    expect(arg.html.length).toBeGreaterThan(html.length);
+    expect(arg.html).toContain("openai");
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * Integration: real harness end-to-end (renders a handshaking widget).
+ * ------------------------------------------------------------------ */
+const harnesses: McpAppBrowserHarness[] = [];
+afterEach(async () => {
+  while (harnesses.length) await harnesses.pop()!.dispose();
+});
+
+async function bundleGuestHtml(): Promise<string> {
+  const src = `
+    import { App } from "@modelcontextprotocol/ext-apps";
+    const app = new App({ name: "render-obs-fixture", version: "1.0.0" });
+    (async () => {
+      await app.connect();
+      const p = document.createElement("p");
+      p.textContent = "Seat map";
+      p.style.cssText = "font-size:20px;padding:16px";
+      document.body.appendChild(p);
+    })();
+  `;
+  const r = await build({
+    stdin: { contents: src, resolveDir: process.cwd(), loader: "ts" },
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "es2022",
+    write: false,
+    logLevel: "silent",
+  });
+  return `<!doctype html><html><head><meta charset="utf-8"></head><body><script>${r.outputFiles[0].text}</script></body></html>`;
+}
+
+describe("renderMcpAppToolResult — real harness integration", () => {
+  it("reads the resource and renders the widget in headless Chromium", async () => {
+    const html = await bundleGuestHtml();
+    const harness = new McpAppBrowserHarness({
+      callTool: async () => ({ content: [] }),
+      budgets: { renderTimeoutMs: 1500 },
+    });
+    harnesses.push(harness);
+    const mcpClientManager = {
+      readResource: vi.fn().mockResolvedValue({
+        contents: [{ text: html, _meta: { ui: {} } }],
+      }),
+    } as unknown as MCPClientManager;
+
+    const obs = await renderMcpAppToolResult({
+      toolCallId: "tc-real",
+      toolName: "show_seats",
+      serverId: "flights",
+      toolMetadata: MCP_APP_META,
+      output: { content: [{ type: "text", text: "ok" }] },
+      mcpClientManager,
+      harness,
+      keepMounted: true,
+    });
+
+    expect(mcpClientManager.readResource).toHaveBeenCalledWith("flights", {
+      uri: "ui://widget/seats",
+    });
+    expect(obs.status).toBe("rendered");
+    expect(obs.bridgeInitialized).toBe(true);
+    expect(obs.screenshotBase64 && obs.screenshotBase64.length).toBeGreaterThan(0);
+    expect(harness.hasRenderedWidget()).toBe(true);
+  }, 30_000);
+});

--- a/mcpjam-inspector/server/utils/computer-use-tool.ts
+++ b/mcpjam-inspector/server/utils/computer-use-tool.ts
@@ -276,8 +276,18 @@ export function buildComputerUseTools(
         .describe("The tool call id of the rendered widget to dismiss."),
     }),
     execute: async ({ toolCallId }: { toolCallId: string }) => {
-      await harness.dismissWidget(toolCallId);
-      return { ok: true as const, dismissed: toolCallId };
+      // Dismiss the widget that is actually mounted (the harness keeps at most
+      // one, exposed via the same getActiveToolCallId the `computer` tool
+      // targets) rather than blindly the id the model passed. A stale or
+      // mistaken toolCallId must not report success while leaving the live
+      // widget mounted — otherwise Computer Use keeps targeting a widget the
+      // model believes is gone.
+      const active = getActiveToolCallId();
+      if (!active) {
+        return { ok: false as const, dismissed: null, requested: toolCallId };
+      }
+      await harness.dismissWidget(active);
+      return { ok: true as const, dismissed: active, requested: toolCallId };
     },
   });
 

--- a/mcpjam-inspector/server/utils/computer-use-tool.ts
+++ b/mcpjam-inspector/server/utils/computer-use-tool.ts
@@ -66,8 +66,14 @@ function normalizeModelId(
       ? model
       : (model?.id ?? model?.modelId ?? undefined);
   if (!raw) return undefined;
-  // Strip a provider prefix (`anthropic/`, `anthropic.`) and lowercase.
-  return raw.toLowerCase().replace(/^anthropic[./]/, "");
+  // Strip a provider prefix (`anthropic/`, `anthropic.`), lowercase, and
+  // convert version dots to hyphens so dotted MCPJam ids
+  // (`anthropic/claude-haiku-4.5` — the default eval model) match the
+  // hyphenated keys in COMPUTER_USE_TOOL_VERSIONS (`claude-haiku-4-5`).
+  return raw
+    .toLowerCase()
+    .replace(/^anthropic[./]/, "")
+    .replace(/\./g, "-");
 }
 
 /**

--- a/mcpjam-inspector/server/utils/computer-use-tool.ts
+++ b/mcpjam-inspector/server/utils/computer-use-tool.ts
@@ -1,0 +1,279 @@
+/**
+ * computer-use-tool.ts — Anthropic Computer Use tools for the local AI-SDK eval
+ * path, backed by the headless-Chromium harness (PR 3).
+ *
+ * Browser-rendered MCP App eval PR 4. Registers two AI SDK tools:
+ *   - `computer` — the Anthropic provider-native computer tool
+ *     (`anthropic.tools.computer_20250124` / `computer_20251124`). Including the
+ *     factory in the tool map is what makes the AI SDK Anthropic provider
+ *     auto-attach the matching beta header (`computer-use-2025-01-24` /
+ *     `-11-24`) — no providerOptions / extraHeaders plumbing. Its `execute`
+ *     drives the harness; `toModelOutput` turns the implementation result into a
+ *     model-visible screenshot + a summary of any widget-initiated tools/call.
+ *   - `finish_widget` — a regular AI SDK tool the model calls to dismiss a
+ *     rendered widget when it's done interacting.
+ *
+ * Computer Use is Claude-only; `resolveComputerUseToolVersion` returns `null`
+ * for unsupported driver models so the caller drops both tools.
+ */
+
+import { tool, type ToolSet } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+import type {
+  BrowserActionSpec,
+  McpAppBrowserHarness,
+  WidgetToolCall,
+} from "./mcp-app-browser-harness";
+
+export type ComputerUseToolVersion = "20250124" | "20251124";
+
+/**
+ * Model id → computer-tool version. A single source of truth so the unit test
+ * can enumerate every entry against the AI SDK provider-tool registry and catch
+ * drift on SDK upgrades. Matched by longest id prefix (so dated/suffixed ids
+ * like `claude-sonnet-4-5-20250929` resolve correctly). Updated whenever a new
+ * Claude model with Computer Use ships.
+ */
+export const COMPUTER_USE_TOOL_VERSIONS: Record<string, ComputerUseToolVersion> =
+  {
+    // computer_20251124 (Opus 4.5+ generation / newest)
+    "claude-opus-4-8": "20251124",
+    "claude-opus-4-7": "20251124",
+    "claude-opus-4-6": "20251124",
+    "claude-sonnet-4-7": "20251124",
+    "claude-sonnet-4-6": "20251124",
+    "claude-haiku-4-6": "20251124",
+    // computer_20250124 (4.x generation)
+    "claude-sonnet-4-5": "20250124",
+    "claude-haiku-4-5": "20250124",
+    "claude-opus-4-5": "20250124",
+    "claude-sonnet-4": "20250124",
+    "claude-opus-4": "20250124",
+    "claude-haiku-4": "20250124",
+  };
+
+// Longest-prefix order so e.g. `claude-opus-4-8` wins over `claude-opus-4`.
+const VERSION_KEYS_BY_LENGTH = Object.keys(COMPUTER_USE_TOOL_VERSIONS).sort(
+  (a, b) => b.length - a.length,
+);
+
+function normalizeModelId(
+  model: string | { id?: string; modelId?: string } | null | undefined,
+): string | undefined {
+  const raw =
+    typeof model === "string"
+      ? model
+      : (model?.id ?? model?.modelId ?? undefined);
+  if (!raw) return undefined;
+  // Strip a provider prefix (`anthropic/`, `anthropic.`) and lowercase.
+  return raw.toLowerCase().replace(/^anthropic[./]/, "");
+}
+
+/**
+ * Resolve the computer-tool version for a driver model, or `null` if the model
+ * doesn't support Computer Use (non-Claude, or an unmapped Claude id) — in
+ * which case the caller must not advertise the `computer` / `finish_widget`
+ * tools.
+ */
+export function resolveComputerUseToolVersion(
+  model: string | { id?: string; modelId?: string } | null | undefined,
+): ComputerUseToolVersion | null {
+  const id = normalizeModelId(model);
+  if (!id) return null;
+  for (const key of VERSION_KEYS_BY_LENGTH) {
+    if (id === key || id.startsWith(`${key}-`)) {
+      return COMPUTER_USE_TOOL_VERSIONS[key];
+    }
+  }
+  return null;
+}
+
+/** Broad structural type covering both versions' action inputs. */
+export interface ComputerActionInput {
+  action: string;
+  coordinate?: [number, number];
+  start_coordinate?: [number, number];
+  text?: string;
+  duration?: number;
+  scroll_amount?: number;
+  scroll_direction?: "up" | "down" | "left" | "right";
+  region?: [number, number, number, number];
+}
+
+/** Implementation output of the `computer` tool (not model-visible directly). */
+export interface ComputerImplOutput {
+  screenshotBase64?: string;
+  widgetToolCalls: WidgetToolCall[];
+  action: ComputerActionInput;
+  elapsedMs: number;
+  /** Harness note (e.g. "budget_exceeded", "no rendered widget"). */
+  note?: string;
+}
+
+type ComputerModelOutput = {
+  type: "content";
+  value: Array<
+    | { type: "text"; text: string }
+    | { type: "image-data"; data: string; mediaType: string }
+  >;
+};
+
+/** Map the AI SDK computer action to the harness's supported action subset. */
+export function mapToBrowserAction(input: ComputerActionInput): BrowserActionSpec {
+  switch (input.action) {
+    case "left_click":
+    case "double_click":
+    case "right_click":
+    case "mouse_move":
+      return { action: input.action, coordinate: input.coordinate };
+    case "triple_click":
+      // No triple-click in the harness; double_click is the closest analogue.
+      return { action: "double_click", coordinate: input.coordinate };
+    case "type":
+      return { action: "type", text: input.text };
+    case "key":
+      return { action: "key", text: input.text };
+    case "scroll":
+      return {
+        action: "scroll",
+        coordinate: input.coordinate,
+        scrollAmount: input.scroll_amount,
+        scrollDirection: input.scroll_direction,
+      };
+    case "wait":
+      return { action: "wait", duration: input.duration };
+    case "screenshot":
+    case "cursor_position":
+      return { action: "screenshot" };
+    default:
+      // hold_key, left_mouse_down/up, left_click_drag, middle_click, zoom, …
+      // are not modeled by the harness — return current state via a screenshot.
+      return { action: "screenshot" };
+  }
+}
+
+function detectImageMediaType(base64: string): string {
+  // JPEG base64 begins with "/9j/"; PNG with "iVBOR".
+  return base64.startsWith("/9j/") ? "image/jpeg" : "image/png";
+}
+
+/** Human-readable summary of widget-initiated tools/call for the model. */
+export function summarizeWidgetToolCalls(calls: WidgetToolCall[]): string | null {
+  if (!calls.length) return null;
+  const parts = calls.map((c) => {
+    const argStr = Object.entries(c.args ?? {})
+      .map(([k, v]) => `${k}=${formatArg(v)}`)
+      .join(", ");
+    const status = c.ok ? "OK" : `ERROR(${c.error ?? "unknown"})`;
+    return `${c.name}(${argStr}) → ${status}`;
+  });
+  return `During this action the widget invoked: ${parts.join("; ")}`;
+}
+
+function formatArg(v: unknown): string {
+  if (typeof v === "string") return v.length > 40 ? `${v.slice(0, 37)}…` : v;
+  if (v === null || typeof v !== "object") return String(v);
+  return "…";
+}
+
+/** Translate the implementation output into model-visible content parts. */
+export function toComputerModelOutput(
+  output: ComputerImplOutput,
+): ComputerModelOutput {
+  const value: ComputerModelOutput["value"] = [];
+  if (output.screenshotBase64) {
+    value.push({
+      type: "image-data",
+      data: output.screenshotBase64,
+      mediaType: detectImageMediaType(output.screenshotBase64),
+    });
+  }
+  const summary = summarizeWidgetToolCalls(output.widgetToolCalls);
+  if (summary) value.push({ type: "text", text: summary });
+  if (output.note) {
+    value.push({ type: "text", text: `[harness: ${output.note}]` });
+  }
+  if (value.length === 0) {
+    value.push({ type: "text", text: "No visible change." });
+  }
+  return { type: "content", value };
+}
+
+export interface BuildComputerUseToolsOptions {
+  version: ComputerUseToolVersion;
+  harness: McpAppBrowserHarness;
+  /** The tool-call id of the widget that `computer` actions target (the active
+   *  rendered widget). Returns null when no widget is mounted. */
+  getActiveToolCallId: () => string | null;
+  /** Viewport == screenshot pixel space == the model's coordinate space. */
+  viewport: { width: number; height: number };
+}
+
+/**
+ * Build the `computer` (Anthropic provider-native) + `finish_widget` tools.
+ * Including the resolved provider-tool factory in the returned set is what makes
+ * the AI SDK Anthropic provider attach the matching beta header.
+ */
+export function buildComputerUseTools(
+  opts: BuildComputerUseToolsOptions,
+): ToolSet {
+  const { harness, getActiveToolCallId, viewport } = opts;
+
+  const execute = async (
+    input: ComputerActionInput,
+  ): Promise<ComputerImplOutput> => {
+    const toolCallId = getActiveToolCallId();
+    if (!toolCallId) {
+      return {
+        widgetToolCalls: [],
+        action: input,
+        elapsedMs: 0,
+        note: "no rendered widget",
+      };
+    }
+    const result = await harness.executeAction({
+      toolCallId,
+      action: mapToBrowserAction(input),
+    });
+    return {
+      screenshotBase64: result.screenshotBase64,
+      widgetToolCalls: result.widgetToolCalls,
+      action: input,
+      elapsedMs: result.elapsedMs,
+      note: result.note,
+    };
+  };
+
+  const toModelOutput = ({ output }: { output: ComputerImplOutput }) =>
+    toComputerModelOutput(output);
+
+  const factoryArgs = {
+    displayWidthPx: viewport.width,
+    displayHeightPx: viewport.height,
+    execute,
+    toModelOutput,
+  };
+
+  const computer =
+    opts.version === "20251124"
+      ? anthropic.tools.computer_20251124(factoryArgs)
+      : anthropic.tools.computer_20250124(factoryArgs);
+
+  const finish_widget = tool({
+    description:
+      "Call this when you are done interacting with the currently rendered " +
+      "MCP App widget. Dismisses the widget so the conversation can continue.",
+    inputSchema: z.object({
+      toolCallId: z
+        .string()
+        .describe("The tool call id of the rendered widget to dismiss."),
+    }),
+    execute: async ({ toolCallId }: { toolCallId: string }) => {
+      await harness.dismissWidget(toolCallId);
+      return { ok: true as const, dismissed: toolCallId };
+    },
+  });
+
+  return { computer, finish_widget };
+}

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -111,6 +111,10 @@ export interface DirectChatTurnToolResultChunk {
   stepIndex: number;
   toolCallId: string;
   toolName: string;
+  /** The tool-call arguments (already normalized via `toTraceRecord`). Lets an
+   *  async consumer (the eval render-check) feed the real toolInput into the
+   *  widget shim, matching what post-turn snapshot capture injects. */
+  input: Record<string, unknown>;
   output: unknown;
   serverId: string | undefined;
 }
@@ -507,6 +511,7 @@ export function runDirectChatTurn(
           stepIndex: currentStepIndex,
           toolCallId: chunk.toolCallId,
           toolName: chunk.toolName,
+          input: toTraceRecord(chunk.input),
           output: chunk.output,
           serverId: readToolServerId(tracedTools, chunk.toolName),
         });

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -367,6 +367,28 @@ export function runDirectChatTurn(
     traceTurn.promptIndex,
   ) as ToolSet;
 
+  // Progressive discovery narrows the cataloged MCP tools, but tools injected
+  // into the map *after* the catalog was built (e.g. the eval Computer Use
+  // tools) aren't part of discovery and must stay in the advertised default set
+  // — otherwise the prepareAdvertisedTools hook below could never surface them
+  // (it can only keep names already in the default set). This appends those
+  // non-cataloged extras to a progressive active-subset list; their per-step
+  // visibility stays governed by the hook (and execution by the
+  // advertised-subset gate). Returns the list unchanged when there are none
+  // (chat / hosted, where every tool is cataloged).
+  const withInjectedTools = (activeNames: string[]): string[] => {
+    if (!progressivePlan) return activeNames;
+    const cataloged = new Set(
+      progressivePlan.catalog.map((entry) => entry.modelName),
+    );
+    const seen = new Set(activeNames);
+    const out = [...activeNames];
+    for (const name of Object.keys(tools)) {
+      if (!cataloged.has(name) && !seen.has(name)) out.push(name);
+    }
+    return out;
+  };
+
   // Mirror the step-0 advertised set into the request-payload trace so it can't
   // claim tools the model won't see on the first step (parity with the hosted
   // processOneStep request_payload). Only narrows when the hook is set; chat
@@ -376,7 +398,9 @@ export function runDirectChatTurn(
   if (prepareAdvertisedTools) {
     const defaultToolNames =
       progressivePlan?.enabled && discoveryState
-        ? resolveActiveToolNames(progressivePlan, discoveryState)
+        ? withInjectedTools(
+            resolveActiveToolNames(progressivePlan, discoveryState),
+          )
         : Object.keys(tools);
     const advertised = new Set(
       applyPrepareAdvertisedTools({
@@ -455,7 +479,9 @@ export function runDirectChatTurn(
       let activeToolNames: string[] | undefined;
       if (progressivePlan?.enabled && discoveryState) {
         commitNewlyLoaded(discoveryState);
-        activeToolNames = resolveActiveToolNames(progressivePlan, discoveryState);
+        activeToolNames = withInjectedTools(
+          resolveActiveToolNames(progressivePlan, discoveryState),
+        );
       }
       // Browser-rendered MCP App eval PR 2: layer runtime-conditional
       // advertised-tool narrowing on top (e.g. hide `computer` /

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -167,7 +167,9 @@ export interface DirectChatTurnTraceEvents {
   /** Fired for every tool-call chunk. */
   onToolCallChunk?: (event: DirectChatTurnToolCallChunk) => void;
   /** Fired for every tool-result chunk. */
-  onToolResultChunk?: (event: DirectChatTurnToolResultChunk) => void;
+  onToolResultChunk?: (
+    event: DirectChatTurnToolResultChunk,
+  ) => void | Promise<void>;
   /**
    * Fired after each step finishes — after spans have been emitted into
    * `traceContext` and `traceHistory` has been updated. Chat uses this to
@@ -495,7 +497,11 @@ export function runDirectChatTurn(
         return;
       }
       if (chunk.type === "tool-result") {
-        traceEvents?.onToolResultChunk?.({
+        // Awaited (the callback may be async — the eval runner renders the MCP
+        // App widget here so a rendered widget is mounted before the next
+        // step's `prepareStep` decides whether to advertise Computer Use).
+        // Existing void-returning consumers (chat trace) are unaffected.
+        await traceEvents?.onToolResultChunk?.({
           turnId: traceTurn.turnId,
           promptIndex: traceTurn.promptIndex,
           stepIndex: currentStepIndex,

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -89,7 +89,12 @@ export interface BrowserActionResult {
   screenshotBase64?: string;
   widgetToolCalls: WidgetToolCall[];
   elapsedMs: number;
-  /** Set when a budget/limit forced a no-op (e.g. "budget_exceeded"). */
+  /**
+   * Set when a budget/limit forced a no-op. One of `"no rendered widget"`,
+   * `"step_budget_exceeded"` (per-widget step cap hit — widget force-dismissed),
+   * or `"screenshot_budget_exceeded"` (per-iteration screenshot cap hit — widget
+   * left mounted).
+   */
   note?: string;
 }
 
@@ -205,6 +210,20 @@ export class McpAppBrowserHarness {
     return this.mounted.size > 0;
   }
 
+  /**
+   * The tool-call id of the single currently-mounted widget, or `null`.
+   *
+   * The harness keeps at most one widget mounted at a time (`renderWidget`
+   * clears any prior mount before mounting the next), so this is the single
+   * source of truth for "which widget is live". Callers (the eval runner) gate
+   * Computer Use on this instead of tracking their own active-widget id, which
+   * could drift across prompt turns or after a `finish_widget` dismiss.
+   */
+  getMountedWidgetId(): string | null {
+    const first = this.mounted.keys().next();
+    return first.done ? null : first.value;
+  }
+
   /* ---- launch ---- */
 
   // Overridable for tests (force the binary-missing path without uninstalling
@@ -318,7 +337,13 @@ export class McpAppBrowserHarness {
         },
       ) => {
         const widget = this.mounted.get(payload.widgetId);
-        const serverId = widget?.serverId ?? "";
+        // Fail closed: a tools/call from a widget that isn't (or is no longer)
+        // mounted Node-side has no server to route to. Dispatching with an empty
+        // serverId would misroute to whatever resolves "" — refuse instead.
+        if (!widget) {
+          return { error: "widget not mounted" };
+        }
+        const serverId = widget.serverId;
         const startedAt = Date.now();
         // Count the RPC as in-flight BEFORE awaiting so `drainAfterAction` waits
         // for slow tool calls instead of returning before they land (and
@@ -467,8 +492,15 @@ export class McpAppBrowserHarness {
     try {
       screenshotBase64 = await this.captureScreenshot();
     } catch {
-      // mounted but couldn't screenshot — keep mount state consistent.
-      if (!input.keepMounted) await this.unmount(input.toolCallId);
+      // A widget we can't screenshot is useless for screenshot-driven Computer
+      // Use, so unmount it even when keepMounted was requested — keeping
+      // getMountedWidgetId() == "a usable, rendered widget" (the single source
+      // of truth the eval runner gates on). This includes the by-design
+      // oversized-screenshot case: `captureScreenshot` throws rather than emit
+      // an image over the byte budget, so a widget that renders but produces an
+      // unencodable-within-budget frame is reported as `screenshot_failed`
+      // (fail closed; at 1280×800 @ JPEG q20 effectively unreachable).
+      await this.unmount(input.toolCallId);
       return {
         ...base,
         status: "screenshot_failed",
@@ -522,15 +554,26 @@ export class McpAppBrowserHarness {
         note: "no rendered widget",
       };
     }
-    if (
-      widget.actionCount >= this.budgets.maxBrowserStepsPerWidget ||
-      this.screenshotCount >= this.budgets.totalScreenshotsPerIteration
-    ) {
+    // The step cap is per-widget and terminal: once a widget exhausts it, the
+    // contract ("…before forced dismiss") is to tear it down so a runaway widget
+    // can't keep being driven and the next render starts clean. The screenshot
+    // cap is per-ITERATION (shared across widgets), so don't dismiss this widget
+    // for it — just refuse further actions on it.
+    const stepBudgetExceeded =
+      widget.actionCount >= this.budgets.maxBrowserStepsPerWidget;
+    const screenshotBudgetExceeded =
+      this.screenshotCount >= this.budgets.totalScreenshotsPerIteration;
+    if (stepBudgetExceeded) {
+      await this.unmount(input.toolCallId);
+    }
+    if (stepBudgetExceeded || screenshotBudgetExceeded) {
       return {
         action: input.action,
         widgetToolCalls: [],
         elapsedMs: Date.now() - started,
-        note: "budget_exceeded",
+        note: stepBudgetExceeded
+          ? "step_budget_exceeded"
+          : "screenshot_budget_exceeded",
       };
     }
     widget.actionCount += 1;
@@ -642,9 +685,14 @@ export class McpAppBrowserHarness {
         return jpeg.toString("base64");
       }
     }
-    // Still over budget: return the smallest attempt.
+    // Still over the byte budget even at the lowest quality: fail closed rather
+    // than hand back an oversized image (callers treat a screenshot throw as
+    // `screenshot_failed` on render, or leave the action screenshot unset).
     const jpeg = await page.screenshot({ type: "jpeg", quality: 20 });
-    return jpeg.toString("base64");
+    throw new Error(
+      `screenshot exceeds byte budget after re-encoding ` +
+        `(${jpeg.byteLength} > ${this.budgets.screenshotMaxBytes} bytes)`,
+    );
   }
 
   /* ---- teardown ---- */

--- a/mcpjam-inspector/server/utils/mcp-app-render-observation.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-render-observation.ts
@@ -1,0 +1,131 @@
+/**
+ * mcp-app-render-observation.ts — read an MCP App tool result's UI resource and
+ * render it in the browser harness, producing a WidgetRenderObservation.
+ *
+ * Browser-rendered MCP App eval PR 5. Shared helper used by the eval runner's
+ * render-check path: it reads the widget HTML the same way
+ * `captureMcpAppWidgetSnapshots` does (resource read + OpenAI-compat shim +
+ * `_meta.ui` policy), then hands it to the harness (PR 3). Keeping this in one
+ * place means render observations and the legacy HTML snapshots agree on what
+ * a widget tool result resolves to.
+ */
+
+import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { isMcpAppTool, type MCPClientManager } from "@mcpjam/sdk";
+import { injectOpenAICompat } from "./widget-helpers";
+import {
+  extractHtmlFromResourceContent,
+  isRecord,
+  normalizeWidgetPermissions,
+} from "./mcp-app-widget-capture";
+import type {
+  McpAppBrowserHarness,
+  WidgetRenderObservation,
+} from "./mcp-app-browser-harness";
+
+export interface RenderMcpAppToolResultParams {
+  toolCallId: string;
+  toolName: string;
+  serverId: string;
+  /** Tool metadata (from `mcpClientManager.getAllToolsMetadata`). */
+  toolMetadata: Record<string, unknown>;
+  /** The tool result output (delivered to the widget as toolOutput). */
+  output?: unknown;
+  /** The tool-call input (delivered to the widget as toolInput), if known. */
+  toolInput?: Record<string, unknown>;
+  mcpClientManager: MCPClientManager;
+  /** Inject the OpenAI Apps SDK `window.openai` shim (host-config resolved). */
+  injectOpenAiCompat?: boolean;
+  harness: McpAppBrowserHarness;
+  /** Keep the widget mounted for subsequent Computer Use actions. */
+  keepMounted?: boolean;
+}
+
+/**
+ * Returns `true` when the tool's metadata marks it as an MCP App (SEP-1865) and
+ * declares a UI resource — i.e. a tool result worth render-checking.
+ */
+export function isRenderableMcpAppTool(
+  toolMetadata: unknown,
+): toolMetadata is Record<string, unknown> {
+  if (!isRecord(toolMetadata) || !isMcpAppTool(toolMetadata)) return false;
+  return Boolean(getToolUiResourceUri({ _meta: toolMetadata }));
+}
+
+/**
+ * Read the widget HTML for an MCP App tool result and render it in the harness.
+ * Returns a WidgetRenderObservation; on resource problems it short-circuits
+ * with `no_ui_resource` / `resource_read_failed` without launching the browser.
+ */
+export async function renderMcpAppToolResult(
+  params: RenderMcpAppToolResultParams,
+): Promise<WidgetRenderObservation> {
+  const { toolCallId, toolName, serverId, toolMetadata, mcpClientManager } =
+    params;
+  const ts = Date.now();
+  const base = { toolCallId, toolName, serverId, ts };
+
+  const resourceUri = getToolUiResourceUri({ _meta: toolMetadata });
+  if (!resourceUri) {
+    return { ...base, status: "no_ui_resource", elapsedMs: 0 };
+  }
+
+  let html: string | undefined;
+  let permissions: Record<string, unknown> | undefined;
+  try {
+    const resourceResult = await mcpClientManager.readResource(serverId, {
+      uri: resourceUri,
+    });
+    const contents = Array.isArray(
+      (resourceResult as { contents?: unknown[] })?.contents,
+    )
+      ? ((resourceResult as { contents: unknown[] }).contents as unknown[])
+      : [];
+    const content = contents[0];
+    if (isRecord(content)) {
+      const uiMeta =
+        isRecord(content._meta) && isRecord(content._meta.ui)
+          ? (content._meta.ui as Record<string, unknown>)
+          : undefined;
+      permissions = normalizeWidgetPermissions(uiMeta?.permissions) ?? undefined;
+      html = extractHtmlFromResourceContent(content);
+    }
+  } catch {
+    return {
+      ...base,
+      status: "resource_read_failed",
+      resourceUri,
+      elapsedMs: Date.now() - ts,
+    };
+  }
+
+  if (!html) {
+    return {
+      ...base,
+      status: "no_ui_resource",
+      resourceUri,
+      elapsedMs: Date.now() - ts,
+    };
+  }
+
+  const widgetHtml = params.injectOpenAiCompat
+    ? injectOpenAICompat(html, {
+        toolId: toolCallId,
+        toolName,
+        toolInput: params.toolInput ?? {},
+        toolOutput: params.output,
+      })
+    : html;
+
+  return params.harness.renderWidget({
+    toolCallId,
+    toolName,
+    serverId,
+    html: widgetHtml,
+    resourceUri,
+    toolInput: params.toolInput,
+    toolOutput: params.output,
+    permissions,
+    keepMounted: params.keepMounted,
+  });
+}

--- a/mcpjam-inspector/server/utils/mcp-app-widget-capture.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-widget-capture.ts
@@ -16,7 +16,7 @@ type ToolSnapshotSource = {
   serverId: string;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
@@ -67,7 +67,7 @@ function readServerIdFromToolOutput(value: unknown): string | undefined {
   return undefined;
 }
 
-function extractHtmlFromResourceContent(content: unknown): string {
+export function extractHtmlFromResourceContent(content: unknown): string {
   if (!isRecord(content)) {
     return "";
   }
@@ -126,7 +126,7 @@ function normalizeWidgetCsp(value: unknown): Record<string, unknown> | null {
   return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
-function normalizeWidgetPermissions(
+export function normalizeWidgetPermissions(
   value: unknown,
 ): Record<string, unknown> | null {
   return isRecord(value) ? value : null;

--- a/mcpjam-inspector/shared/__tests__/progressive-tool-discovery.test.ts
+++ b/mcpjam-inspector/shared/__tests__/progressive-tool-discovery.test.ts
@@ -7,6 +7,7 @@ import {
   createDiscoveryState,
   decideProgressivePlan,
   estimateTokens,
+  gateToolsToActiveSubset,
   lookupToolIdByModelName,
   META_TOOL_LOAD,
   META_TOOL_NAMES,
@@ -388,5 +389,65 @@ describe("commitNewlyLoaded", () => {
     state.newlyLoadedToolIds.add("a");
     const promoted = commitNewlyLoaded(state);
     expect(promoted).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gateToolsToActiveSubset (execution gate)
+// ---------------------------------------------------------------------------
+
+describe("gateToolsToActiveSubset", () => {
+  // Cataloged MCP tools plus tools injected AFTER the catalog was built (an
+  // eval-style `computer` tool, and a meta-tool) — mirrors the eval Computer Use
+  // wiring where the harness tools are merged in downstream of plan creation.
+  const cataloged: ToolSet = {
+    asana_create_task: makeMcpTool({ serverId: "asana", fields: {} }),
+    asana_get_task: makeMcpTool({ serverId: "asana", fields: {} }),
+  } as unknown as ToolSet;
+  const catalog = buildToolCatalog(cataloged);
+  const fullTools = {
+    ...cataloged,
+    [META_TOOL_SEARCH]: { execute: async () => ({ meta: true }) },
+    computer: { execute: async () => ({ ran: "computer" }) },
+  } as unknown as ToolSet;
+
+  it("returns the tool map unchanged when progressive is disabled", () => {
+    const plan = decideProgressivePlan({ catalog, envOverride: false });
+    const gated = gateToolsToActiveSubset(fullTools, plan, () =>
+      createDiscoveryState(),
+    );
+    expect(gated).toBe(fullTools);
+  });
+
+  it("throws for a cataloged tool that isn't loaded yet", async () => {
+    const plan = decideProgressivePlan({ catalog, envOverride: true });
+    const state = createDiscoveryState();
+    const gated = gateToolsToActiveSubset(fullTools, plan, () => state);
+    const exec = (gated.asana_create_task as { execute: Function }).execute;
+    await expect(exec({}, {})).rejects.toThrow(/not loaded in this step/);
+  });
+
+  it("executes a cataloged tool once it is loaded", async () => {
+    const plan = decideProgressivePlan({ catalog, envOverride: true });
+    const state = createDiscoveryState();
+    state.loadedToolIds.add(
+      lookupToolIdByModelName(plan.catalog, "asana_create_task")!,
+    );
+    const gated = gateToolsToActiveSubset(fullTools, plan, () => state);
+    const exec = (gated.asana_create_task as { execute: Function }).execute;
+    await expect(exec({}, {})).resolves.toEqual({});
+  });
+
+  it("never gates tools outside the catalog (injected `computer`, meta-tools)", async () => {
+    // The regression: `computer` is injected after plan-build, so it has no
+    // catalog toolId and could never be load_mcp_tools'd. Gating it would make
+    // it permanently uncallable under progressive discovery. It must execute.
+    const plan = decideProgressivePlan({ catalog, envOverride: true });
+    const state = createDiscoveryState(); // nothing loaded
+    const gated = gateToolsToActiveSubset(fullTools, plan, () => state);
+    const computer = (gated.computer as { execute: Function }).execute;
+    await expect(computer({}, {})).resolves.toEqual({ ran: "computer" });
+    const meta = (gated[META_TOOL_SEARCH] as { execute: Function }).execute;
+    await expect(meta({}, {})).resolves.toEqual({ meta: true });
   });
 });

--- a/mcpjam-inspector/shared/progressive-tool-discovery.ts
+++ b/mcpjam-inspector/shared/progressive-tool-discovery.ts
@@ -590,6 +590,13 @@ export function gateToolsToActiveSubset<T extends Record<string, unknown>>(
   getState: () => ToolDiscoveryState | undefined,
 ): T {
   if (!plan?.enabled) return tools;
+  // Only tools the plan actually catalogs are subject to lazy loading. Tools
+  // outside the catalog — meta-tools, or tools injected into the map after the
+  // catalog was built (e.g. the eval Computer Use tools) — can't be activated
+  // via load_mcp_tools (they have no catalog toolId), so gating them here would
+  // make them permanently uncallable. They're always executable; any per-step
+  // visibility gating happens in the advertised-subset layer instead.
+  const catalogNames = new Set(plan.catalog.map((entry) => entry.modelName));
   const result: Record<string, unknown> = {};
   for (const [name, def] of Object.entries(tools)) {
     const original = def as Record<string, unknown>;
@@ -604,7 +611,7 @@ export function gateToolsToActiveSubset<T extends Record<string, unknown>>(
       ...original,
       execute: async (input: unknown, ctx: unknown) => {
         const state = getState();
-        if (state) {
+        if (state && catalogNames.has(name)) {
           const activeNames = new Set(resolveActiveToolNames(plan, state));
           if (!activeNames.has(name)) {
             const toolId = lookupToolIdByModelName(plan.catalog, name);


### PR DESCRIPTION
## PR 4 + 5 of 5 — Browser-rendered MCP App eval

> **Scope note (stack collapsed).** The lower stack was merged non-linearly while this was in review:
> - **#2479 (PR 1)**, **#2480 (PR 2)** and **#2482 (PR 3, the headless-Chromium harness)** are **merged to `main`**.
> - **#2484 (PR 5, eval-runner integration)** was merged **into this branch**.
>
> So this PR has been **rebased onto `main`** (dropping the now-merged PR 3 commits) and now carries **PR 4 (Computer Use tools) + PR 5 (eval-runner integration) + the post-merge review fixes**. It is the final piece of the stack; merging it lands the behavior change.

### What's included
- **`server/utils/computer-use-tool.ts` (PR 4)** — `buildComputerUseTools → { computer, finish_widget }`. `computer` is the Anthropic provider-native factory (so the AI SDK auto-attaches the beta header), using the `execute` + `toModelOutput` split to drive the harness and return a screenshot + a text summary of widget-initiated `tools/call`. `resolveComputerUseToolVersion` matches by longest id prefix (handles dated/suffixed and `anthropic/`-prefixed, dotted ids).
- **`server/utils/mcp-app-render-observation.ts` + `evals-runner.ts` + `direct-chat-turn.ts` (PR 5)** — lazy per-iteration harness; render-check each MCP App tool result; for Claude drivers, compose `computer` / `finish_widget` and gate them with `prepareAdvertisedTools` so they only appear once a widget has rendered; harness disposed in `finally`.

### Post-merge review fixes (this PR's new commits)
**Harness (findings on #2482):**
- Force-dismiss on the per-widget step cap; split the per-widget **step** budget from the per-iteration **screenshot** budget (distinct `step_budget_exceeded` / `screenshot_budget_exceeded` notes).
- Fail closed on a `tools/call` from an unknown/unmounted widget (no dispatch with an empty `serverId`).
- Enforce the screenshot byte cap: `captureScreenshot` throws rather than return an oversized image; a widget that can't be screenshotted is unmounted (never kept).
- New `getMountedWidgetId()` — single source of truth for the live widget.

**Eval-runner (findings on #2484):**
- Drop the drifting `activeWidgetToolCallId`; the Computer Use gate **and** `getActiveToolCallId` now both read `getMountedWidgetId()`, so they can't disagree (fixes "tools advertised while the active id is null" and the stale-after-`finish_widget`-dismiss case).
- Reset between prompt turns: each turn dismisses any widget carried from a previous turn.
- `toolChoice` validation now accepts `computer` / `finish_widget`.
- Forward the tool-call `input` on the result chunk so the widget shim sees the real `toolInput` (matching post-turn snapshot capture).

### Validation
Affected suites pass locally: harness (10, real Chromium incl. step-cap force-dismiss + oversized-screenshot), render-observation (7, real Chromium), computer-use-tool (21), direct-chat-turn (8), advertised-tools (15), evals-runner (59). `check:mcp-v1-runtime-imports` clean; no new `tsc` errors vs. base (the server builds via tsup).

### Follow-ups (named, not in this PR)
- **PR 6** — persistence of `WidgetRenderObservation` + `BrowserInteractionStep` (cross-repo, `mcpjam-backend`).
- **PR 7** — replay UI.
- The stream variant (`streamIterationWithAiSdk`) and hosted / non-Claude render-after-turn paths reuse the same helper.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MptMA6zxE4bAdriyK9SJv6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds headless browser + Computer Use to the eval path with budget and gating logic; progressive-discovery changes affect which tools can run when discovery is enabled, but scope is eval-local and covered by extensive tests.
> 
> **Overview**
> **Eval runner** now renders MCP App tool results in a lazy headless-Chromium harness during local eval iterations. For Claude drivers it adds **`computer`** and **`finish_widget`** (Anthropic Computer Use), advertises them only after a widget is mounted via **`prepareAdvertisedTools`**, and renders widgets on **`onToolResultChunk`** (async, with real tool input for the shim). Prompt turns dismiss carried widgets; harness teardown runs in **`finally`**. **`toolChoice`** validation accepts the new tools.
> 
> New **`computer-use-tool`** maps model ids to provider computer-tool versions and drives the harness; **`mcp-app-render-observation`** reads UI resources and delegates to the harness (shared with snapshot capture helpers).
> 
> **Harness** gains **`getMountedWidgetId()`** as the live-widget source of truth; stricter budgets (**`step_budget_exceeded`** vs **`screenshot_budget_exceeded`**), fail-closed screenshot byte limits and unmount on capture failure, and no RPC dispatch for unmounted widgets.
> 
> **Progressive discovery** / **`direct-chat-turn`**: non-catalog tools (e.g. **`computer`**) stay in the advertised default set and are not execution-gated; tool-result callbacks can be async and include **`input`**. **`tsup`** keeps **`playwright`** / **`playwright-core`** external.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b84f6ca62bddfd4d55d9716c905bd24de79c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->