### PR TITLE
eval-runner: render checks + local Computer Use integration (eval browser-render PR 5/5)

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -37,6 +37,19 @@ import { resolveExecutionContext } from "../utils/host-execution-context";
 import { logger } from "../utils/logger";
 import { captureMcpAppWidgetSnapshots } from "../utils/mcp-app-widget-capture";
 import {
+  McpAppBrowserHarness,
+  DEFAULT_VIEWPORT,
+  type WidgetRenderObservation,
+} from "../utils/mcp-app-browser-harness";
+import {
+  buildComputerUseTools,
+  resolveComputerUseToolVersion,
+} from "../utils/computer-use-tool";
+import {
+  renderMcpAppToolResult,
+  isRenderableMcpAppTool,
+} from "../utils/mcp-app-render-observation";
+import {
   buildLlmRuntimeConfigFromOrgConfig,
   deriveOrgProviderKey,
   isLocalRuntimeEligible,
@@ -1232,6 +1245,33 @@ const runIterationWithAiSdk = async ({
   // `messages`) while the wire shape stays chat-aligned.
   let enhancedSystemPromptForPersist: string | undefined = undefined;
 
+  // Browser-rendered MCP App eval (PR 5): render MCP App tool results in the
+  // headless-Chromium harness and (for Claude drivers) drive them with
+  // Computer Use. Harness construction is cheap; Chromium launches lazily on
+  // the first widget render, so prompt-only / no-widget iterations pay nothing.
+  const computerUseVersion = resolveComputerUseToolVersion(test.model);
+  // Ref-object (not a bare `let`): the only assignments happen inside the
+  // closures below, which TS control-flow analysis can't see — a bare `let`
+  // would stay narrowed to its `null` initializer in the outer `finally`.
+  const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
+    current: null,
+  };
+  let activeWidgetToolCallId: string | null = null;
+  const widgetRenderObservations: WidgetRenderObservation[] = [];
+  const ensureWidgetHarness = (): McpAppBrowserHarness => {
+    if (!widgetHarnessRef.current) {
+      widgetHarnessRef.current = new McpAppBrowserHarness({
+        callTool: (sid, name, args) =>
+          mcpClientManager.executeTool(sid, name, args),
+        viewport: DEFAULT_VIEWPORT,
+      });
+    }
+    return widgetHarnessRef.current;
+  };
+  // Eager (cheap) construction when Computer Use is supported so the computer
+  // tools can reference the harness; Chromium still launches lazily.
+  if (computerUseVersion) ensureWidgetHarness();
+
   try {
     // Adopt the chat-side tool/system/temperature pipeline. Eval used to skip
     // this and call `getToolsForAiSdk` + an inline system/temperature wiring,
@@ -1264,6 +1304,18 @@ const runIterationWithAiSdk = async ({
     // array at persistence time, since eval's wire shape to Convex
     // (`appendEvalTurnTrace`) has no dedicated `systemPrompt` slot.
     enhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
+
+    // Computer Use tools (Claude drivers only). Included in the tool map so the
+    // AI SDK Anthropic provider auto-attaches the beta header; gated per step by
+    // `prepareAdvertisedTools` so they only appear once a widget has rendered.
+    const computerWidgetTools = computerUseVersion
+      ? buildComputerUseTools({
+          version: computerUseVersion,
+          harness: ensureWidgetHarness(),
+          getActiveToolCallId: () => activeWidgetToolCallId,
+          viewport: DEFAULT_VIEWPORT,
+        })
+      : {};
 
     const llmModel = createLlmModel(
       modelDefinition,
@@ -1351,9 +1403,27 @@ const runIterationWithAiSdk = async ({
         ...(prepared.resolvedTemperature == null
           ? {}
           : { temperature: prepared.resolvedTemperature }),
-        tools: prepared.allTools,
+        tools: { ...prepared.allTools, ...computerWidgetTools },
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
+        // Browser-rendered MCP App eval (PR 5): gate Computer Use tools so the
+        // model only sees `computer` / `finish_widget` once a widget has
+        // actually rendered in the harness (PR 2's prepareAdvertisedTools hook).
+        ...(computerUseVersion
+          ? {
+              prepareAdvertisedTools: ({
+                defaultToolNames,
+              }: {
+                stepIndex: number;
+                defaultToolNames: string[];
+              }) =>
+                widgetHarnessRef.current?.hasRenderedWidget()
+                  ? defaultToolNames
+                  : defaultToolNames.filter(
+                      (n) => n !== "computer" && n !== "finish_widget",
+                    ),
+            }
+          : {}),
         ...(abortSignal ? { abortSignal } : {}),
         ...(toolChoice
           ? { toolChoice: toolChoice as ToolChoice<Record<string, AiTool>> }
@@ -1384,6 +1454,43 @@ const runIterationWithAiSdk = async ({
             activePartialResponseMessages = traceHistory.slice(
               promptInputLength,
             ) as ModelMessage[];
+          },
+          // Browser-rendered MCP App eval (PR 5): render each MCP App tool
+          // result in the harness and record a WidgetRenderObservation. Awaited
+          // (direct-chat-turn awaits this callback) so a rendered widget is
+          // mounted before the next step's Computer Use gate runs.
+          onToolResultChunk: async ({ toolCallId, toolName, output, serverId }) => {
+            if (!serverId) return;
+            const meta = mcpClientManager.getAllToolsMetadata(serverId)?.[
+              toolName
+            ];
+            if (!isRenderableMcpAppTool(meta)) return;
+            try {
+              const obs = await renderMcpAppToolResult({
+                toolCallId,
+                toolName,
+                serverId,
+                toolMetadata: meta,
+                output,
+                mcpClientManager,
+                injectOpenAiCompat,
+                harness: ensureWidgetHarness(),
+                keepMounted: computerUseVersion !== null,
+              });
+              widgetRenderObservations.push(obs);
+              if (obs.status === "rendered" && computerUseVersion) {
+                activeWidgetToolCallId = toolCallId;
+              }
+              logger.debug("[evals] widget render observation", {
+                toolName,
+                status: obs.status,
+              });
+            } catch (err) {
+              logger.warn("[evals] widget render failed", {
+                toolName,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
           },
         },
       });
@@ -1755,6 +1862,17 @@ const runIterationWithAiSdk = async ({
       evaluation,
       iterationId: iterationId ?? undefined,
     };
+  } finally {
+    // Browser-rendered MCP App eval (PR 5): tear down the harness (and its
+    // headless Chromium, if launched) regardless of success/failure. No-op
+    // when the harness was never constructed or never launched.
+    await widgetHarnessRef.current?.dispose();
+    if (widgetRenderObservations.length > 0) {
+      logger.debug("[evals] widget render observations", {
+        count: widgetRenderObservations.length,
+        statuses: widgetRenderObservations.map((o) => o.status),
+      });
+    }
   }
 };
 

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-render-observation.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-render-observation.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { build } from "esbuild";
+import {
+  renderMcpAppToolResult,
+  isRenderableMcpAppTool,
+} from "../mcp-app-render-observation";
+import { McpAppBrowserHarness } from "../mcp-app-browser-harness";
+import type { MCPClientManager } from "@mcpjam/sdk";
+
+const MCP_APP_META = { ui: { resourceUri: "ui://widget/seats" } };
+
+describe("isRenderableMcpAppTool", () => {
+  it("accepts MCP App tools that declare a UI resource", () => {
+    expect(isRenderableMcpAppTool(MCP_APP_META)).toBe(true);
+  });
+  it("rejects non-MCP-App / resource-less metadata", () => {
+    expect(isRenderableMcpAppTool({})).toBe(false);
+    expect(isRenderableMcpAppTool({ ui: {} })).toBe(false);
+    expect(isRenderableMcpAppTool(undefined)).toBe(false);
+  });
+});
+
+describe("renderMcpAppToolResult — short-circuits", () => {
+  const stubHarness = () =>
+    ({ renderWidget: vi.fn() }) as unknown as McpAppBrowserHarness;
+
+  it("returns no_ui_resource without touching the harness", async () => {
+    const harness = stubHarness();
+    const obs = await renderMcpAppToolResult({
+      toolCallId: "tc",
+      toolName: "t",
+      serverId: "s",
+      toolMetadata: {},
+      mcpClientManager: {} as MCPClientManager,
+      harness,
+    });
+    expect(obs.status).toBe("no_ui_resource");
+    expect((harness.renderWidget as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it("returns resource_read_failed when readResource throws", async () => {
+    const harness = stubHarness();
+    const mcpClientManager = {
+      readResource: vi.fn().mockRejectedValue(new Error("nope")),
+    } as unknown as MCPClientManager;
+    const obs = await renderMcpAppToolResult({
+      toolCallId: "tc",
+      toolName: "t",
+      serverId: "s",
+      toolMetadata: MCP_APP_META,
+      mcpClientManager,
+      harness,
+    });
+    expect(obs.status).toBe("resource_read_failed");
+    expect(obs.resourceUri).toBe("ui://widget/seats");
+  });
+});
+
+describe("renderMcpAppToolResult — reads resource + delegates to harness", () => {
+  function setup(html: string) {
+    const renderWidget = vi.fn(
+      async (input: { toolCallId: string; html: string }) => ({
+        toolCallId: input.toolCallId,
+        toolName: "t",
+        serverId: "s",
+        status: "rendered" as const,
+        bridgeInitialized: true,
+        elapsedMs: 1,
+        ts: Date.now(),
+        _html: input.html,
+      }),
+    );
+    const harness = { renderWidget } as unknown as McpAppBrowserHarness;
+    const mcpClientManager = {
+      readResource: vi.fn().mockResolvedValue({
+        contents: [{ text: html, _meta: { ui: { permissions: {} } } }],
+      }),
+    } as unknown as MCPClientManager;
+    return { harness, renderWidget, mcpClientManager };
+  }
+
+  it("passes the raw widget HTML through when the shim is off", async () => {
+    const html = "<html><body>seats</body></html>";
+    const { harness, renderWidget, mcpClientManager } = setup(html);
+    const obs = await renderMcpAppToolResult({
+      toolCallId: "tc1",
+      toolName: "show_seats",
+      serverId: "flights",
+      toolMetadata: MCP_APP_META,
+      output: { content: [] },
+      mcpClientManager,
+      harness,
+      keepMounted: true,
+    });
+    expect(obs.status).toBe("rendered");
+    const arg = renderWidget.mock.calls[0][0] as { html: string; keepMounted?: boolean };
+    expect(arg.html).toBe(html);
+    expect(arg.keepMounted).toBe(true);
+  });
+
+  it("injects the OpenAI compat shim when enabled", async () => {
+    const html = "<html><body>seats</body></html>";
+    const { harness, renderWidget, mcpClientManager } = setup(html);
+    await renderMcpAppToolResult({
+      toolCallId: "tc1",
+      toolName: "show_seats",
+      serverId: "flights",
+      toolMetadata: MCP_APP_META,
+      output: { content: [] },
+      mcpClientManager,
+      harness,
+      injectOpenAiCompat: true,
+    });
+    const arg = renderWidget.mock.calls[0][0] as { html: string };
+    // The shim injects the OpenAI Apps runtime (defines window.openai), so the
+    // HTML grows and references the openai surface.
+    expect(arg.html).not.toBe(html);
+    expect(arg.html.length).toBeGreaterThan(html.length);
+    expect(arg.html).toContain("openai");
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * Integration: real harness end-to-end (renders a handshaking widget).
+ * ------------------------------------------------------------------ */
+const harnesses: McpAppBrowserHarness[] = [];
+afterEach(async () => {
+  while (harnesses.length) await harnesses.pop()!.dispose();
+});
+
+async function bundleGuestHtml(): Promise<string> {
+  const src = `
+    import { App } from "@modelcontextprotocol/ext-apps";
+    const app = new App({ name: "render-obs-fixture", version: "1.0.0" });
+    (async () => {
+      await app.connect();
+      const p = document.createElement("p");
+      p.textContent = "Seat map";
+      p.style.cssText = "font-size:20px;padding:16px";
+      document.body.appendChild(p);
+    })();
+  `;
+  const r = await build({
+    stdin: { contents: src, resolveDir: process.cwd(), loader: "ts" },
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "es2022",
+    write: false,
+    logLevel: "silent",
+  });
+  return `<!doctype html><html><head><meta charset="utf-8"></head><body><script>${r.outputFiles[0].text}</script></body></html>`;
+}
+
+describe("renderMcpAppToolResult — real harness integration", () => {
+  it("reads the resource and renders the widget in headless Chromium", async () => {
+    const html = await bundleGuestHtml();
+    const harness = new McpAppBrowserHarness({
+      callTool: async () => ({ content: [] }),
+      budgets: { renderTimeoutMs: 1500 },
+    });
+    harnesses.push(harness);
+    const mcpClientManager = {
+      readResource: vi.fn().mockResolvedValue({
+        contents: [{ text: html, _meta: { ui: {} } }],
+      }),
+    } as unknown as MCPClientManager;
+
+    const obs = await renderMcpAppToolResult({
+      toolCallId: "tc-real",
+      toolName: "show_seats",
+      serverId: "flights",
+      toolMetadata: MCP_APP_META,
+      output: { content: [{ type: "text", text: "ok" }] },
+      mcpClientManager,
+      harness,
+      keepMounted: true,
+    });
+
+    expect(mcpClientManager.readResource).toHaveBeenCalledWith("flights", {
+      uri: "ui://widget/seats",
+    });
+    expect(obs.status).toBe("rendered");
+    expect(obs.bridgeInitialized).toBe(true);
+    expect(obs.screenshotBase64 && obs.screenshotBase64.length).toBeGreaterThan(0);
+    expect(harness.hasRenderedWidget()).toBe(true);
+  }, 30_000);
+});

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -167,7 +167,9 @@ export interface DirectChatTurnTraceEvents {
   /** Fired for every tool-call chunk. */
   onToolCallChunk?: (event: DirectChatTurnToolCallChunk) => void;
   /** Fired for every tool-result chunk. */
-  onToolResultChunk?: (event: DirectChatTurnToolResultChunk) => void;
+  onToolResultChunk?: (
+    event: DirectChatTurnToolResultChunk,
+  ) => void | Promise<void>;
   /**
    * Fired after each step finishes — after spans have been emitted into
    * `traceContext` and `traceHistory` has been updated. Chat uses this to
@@ -495,7 +497,11 @@ export function runDirectChatTurn(
         return;
       }
       if (chunk.type === "tool-result") {
-        traceEvents?.onToolResultChunk?.({
+        // Awaited (the callback may be async — the eval runner renders the MCP
+        // App widget here so a rendered widget is mounted before the next
+        // step's `prepareStep` decides whether to advertise Computer Use).
+        // Existing void-returning consumers (chat trace) are unaffected.
+        await traceEvents?.onToolResultChunk?.({
           turnId: traceTurn.turnId,
           promptIndex: traceTurn.promptIndex,
           stepIndex: currentStepIndex,

--- a/mcpjam-inspector/server/utils/mcp-app-render-observation.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-render-observation.ts
@@ -1,0 +1,131 @@
+/**
+ * mcp-app-render-observation.ts — read an MCP App tool result's UI resource and
+ * render it in the browser harness, producing a WidgetRenderObservation.
+ *
+ * Browser-rendered MCP App eval PR 5. Shared helper used by the eval runner's
+ * render-check path: it reads the widget HTML the same way
+ * `captureMcpAppWidgetSnapshots` does (resource read + OpenAI-compat shim +
+ * `_meta.ui` policy), then hands it to the harness (PR 3). Keeping this in one
+ * place means render observations and the legacy HTML snapshots agree on what
+ * a widget tool result resolves to.
+ */
+
+import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { isMcpAppTool, type MCPClientManager } from "@mcpjam/sdk";
+import { injectOpenAICompat } from "./widget-helpers";
+import {
+  extractHtmlFromResourceContent,
+  isRecord,
+  normalizeWidgetPermissions,
+} from "./mcp-app-widget-capture";
+import type {
+  McpAppBrowserHarness,
+  WidgetRenderObservation,
+} from "./mcp-app-browser-harness";
+
+export interface RenderMcpAppToolResultParams {
+  toolCallId: string;
+  toolName: string;
+  serverId: string;
+  /** Tool metadata (from `mcpClientManager.getAllToolsMetadata`). */
+  toolMetadata: Record<string, unknown>;
+  /** The tool result output (delivered to the widget as toolOutput). */
+  output?: unknown;
+  /** The tool-call input (delivered to the widget as toolInput), if known. */
+  toolInput?: Record<string, unknown>;
+  mcpClientManager: MCPClientManager;
+  /** Inject the OpenAI Apps SDK `window.openai` shim (host-config resolved). */
+  injectOpenAiCompat?: boolean;
+  harness: McpAppBrowserHarness;
+  /** Keep the widget mounted for subsequent Computer Use actions. */
+  keepMounted?: boolean;
+}
+
+/**
+ * Returns `true` when the tool's metadata marks it as an MCP App (SEP-1865) and
+ * declares a UI resource — i.e. a tool result worth render-checking.
+ */
+export function isRenderableMcpAppTool(
+  toolMetadata: unknown,
+): toolMetadata is Record<string, unknown> {
+  if (!isRecord(toolMetadata) || !isMcpAppTool(toolMetadata)) return false;
+  return Boolean(getToolUiResourceUri({ _meta: toolMetadata }));
+}
+
+/**
+ * Read the widget HTML for an MCP App tool result and render it in the harness.
+ * Returns a WidgetRenderObservation; on resource problems it short-circuits
+ * with `no_ui_resource` / `resource_read_failed` without launching the browser.
+ */
+export async function renderMcpAppToolResult(
+  params: RenderMcpAppToolResultParams,
+): Promise<WidgetRenderObservation> {
+  const { toolCallId, toolName, serverId, toolMetadata, mcpClientManager } =
+    params;
+  const ts = Date.now();
+  const base = { toolCallId, toolName, serverId, ts };
+
+  const resourceUri = getToolUiResourceUri({ _meta: toolMetadata });
+  if (!resourceUri) {
+    return { ...base, status: "no_ui_resource", elapsedMs: 0 };
+  }
+
+  let html: string | undefined;
+  let permissions: Record<string, unknown> | undefined;
+  try {
+    const resourceResult = await mcpClientManager.readResource(serverId, {
+      uri: resourceUri,
+    });
+    const contents = Array.isArray(
+      (resourceResult as { contents?: unknown[] })?.contents,
+    )
+      ? ((resourceResult as { contents: unknown[] }).contents as unknown[])
+      : [];
+    const content = contents[0];
+    if (isRecord(content)) {
+      const uiMeta =
+        isRecord(content._meta) && isRecord(content._meta.ui)
+          ? (content._meta.ui as Record<string, unknown>)
+          : undefined;
+      permissions = normalizeWidgetPermissions(uiMeta?.permissions) ?? undefined;
+      html = extractHtmlFromResourceContent(content);
+    }
+  } catch {
+    return {
+      ...base,
+      status: "resource_read_failed",
+      resourceUri,
+      elapsedMs: Date.now() - ts,
+    };
+  }
+
+  if (!html) {
+    return {
+      ...base,
+      status: "no_ui_resource",
+      resourceUri,
+      elapsedMs: Date.now() - ts,
+    };
+  }
+
+  const widgetHtml = params.injectOpenAiCompat
+    ? injectOpenAICompat(html, {
+        toolId: toolCallId,
+        toolName,
+        toolInput: params.toolInput ?? {},
+        toolOutput: params.output,
+      })
+    : html;
+
+  return params.harness.renderWidget({
+    toolCallId,
+    toolName,
+    serverId,
+    html: widgetHtml,
+    resourceUri,
+    toolInput: params.toolInput,
+    toolOutput: params.output,
+    permissions,
+    keepMounted: params.keepMounted,
+  });
+}

--- a/mcpjam-inspector/server/utils/mcp-app-widget-capture.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-widget-capture.ts
@@ -16,7 +16,7 @@ type ToolSnapshotSource = {
   serverId: string;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
@@ -67,7 +67,7 @@ function readServerIdFromToolOutput(value: unknown): string | undefined {
   return undefined;
 }
 
-function extractHtmlFromResourceContent(content: unknown): string {
+export function extractHtmlFromResourceContent(content: unknown): string {
   if (!isRecord(content)) {
     return "";
   }
@@ -126,7 +126,7 @@ function normalizeWidgetCsp(value: unknown): Record<string, unknown> | null {
   return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
-function normalizeWidgetPermissions(
+export function normalizeWidgetPermissions(
   value: unknown,
 ): Record<string, unknown> | null {
   return isRecord(value) ? value : null;


### PR DESCRIPTION
## PR 5 of 5 — Browser-rendered MCP App eval

**Stacked on #2483 (PR 4) → #2482 → #2480 → #2479.** Review/merge the lower PRs first. This is the **behavior change** that ties the stack together.

Wires the browser harness (PR 3), Computer Use tools (PR 4), and the `prepareAdvertisedTools` gate (PR 2) into the local Anthropic AI-SDK eval path (`runIterationWithAiSdk` → `runDirectChatTurn`).

### What changed
- **`mcp-app-render-observation.ts` (new)** — `renderMcpAppToolResult` reads an MCP App tool result's UI resource (resource read + OpenAI-compat shim + `_meta.ui` policy — the same way `captureMcpAppWidgetSnapshots` does) and renders it in the harness, returning a `WidgetRenderObservation`. `isRenderableMcpAppTool` gates on MCP-App + UI-resource. Reuses helpers now exported from `mcp-app-widget-capture.ts` (`extractHtmlFromResourceContent`, `isRecord`, `normalizeWidgetPermissions`) so render observations and the legacy HTML snapshots agree on what a tool result resolves to.
- **`evals-runner.ts` (`runIterationWithAiSdk`)** — lazily constructs a per-iteration harness (cheap; Chromium launches on first render, so prompt-only iterations pay nothing). For Claude drivers (`resolveComputerUseToolVersion != null`) it composes `computer` + `finish_widget` into the AI SDK tool map (provider auto-attaches the beta header) and gates them per step via `prepareAdvertisedTools` so they only appear **once a widget has rendered**. `traceEvents.onToolResultChunk` render-checks each MCP App tool result and, for Claude drivers, keeps the widget mounted + tracks the active widget so `computer` actions target it. Harness disposed in a `finally`. **`captureMcpAppWidgetSnapshots` keeps running unchanged** (data continuity).
- **`direct-chat-turn.ts`** — `onToolResultChunk` may now return a `Promise` and is awaited, so a rendered widget is mounted before the next step's Computer Use gate runs. Backward compatible (chat's sync handler is unaffected).

### Scope (v1) + follow-ups
- **In this PR:** the local **non-stream** AI-SDK path (`runIterationWithAiSdk`) — render checks for any driver + interactive Computer Use for Claude drivers.
- **Follow-ups (reuse the same helper):** the stream variant (`streamIterationWithAiSdk`) and the hosted / non-Claude render-after-turn paths (transcript-walk via the to-be-extracted `captureMcpAppWidgetSnapshots` source discovery).
- **Persistence of `WidgetRenderObservation` + `BrowserInteractionStep` is PR 6** (cross-repo, `mcpjam-backend`). Today observations are computed + logged; the full eval-CLI end-to-end is the post-PR-6 manual check (per the plan).

### Tests (7)
`renderMcpAppToolResult` short-circuits (`no_ui_resource`, `resource_read_failed`), resource-read + harness delegation, shim injection, and a **real-headless-Chromium integration** that reads the resource and renders a handshaking widget to `rendered`. Existing `evals-runner` (59) + `direct-chat-turn` (7) suites still pass; **no new tsc errors vs. base** (verified by stash-compare; the file is built via tsup/vitest, not `tsc`).

### Stack (complete)
1. #2479 — `host-app-bridge.ts` shared module.
2. #2480 — `prepareAdvertisedTools` engine hook.
3. #2482 — Playwright `mcp-app-browser-harness.ts`.
4. #2483 — Computer Use tool registration + executor.
5. **PR 5 (this)** — eval-runner integration.

PR 6 (persistence, cross-repo) and PR 7 (replay UI) are named follow-ups, not in this stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MptMA6zxE4bAdriyK9SJv6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval iteration timing and tool advertisement (async render + headless Chromium) on the local AI-SDK path; scope is limited to that runner and failures are mostly logged, but resource reads and browser lifecycle add operational complexity.
> 
> **Overview**
> **Browser-rendered MCP App eval (PR 5)** wires the Playwright harness and Computer Use stack into the **local non-stream** `runIterationWithAiSdk` path.
> 
> Each iteration can lazily create an `McpAppBrowserHarness` (Chromium starts on first widget render). On every MCP App tool result, an async `onToolResultChunk` handler calls new **`renderMcpAppToolResult`**, which reads the UI resource (aligned with legacy widget snapshot helpers), optionally injects the OpenAI compat shim, and renders in the harness, producing **`WidgetRenderObservation`** records (logged today; persistence is a follow-up).
> 
> For **Claude** drivers, **`computer`** / **`finish_widget`** are merged into the tool map and **`prepareAdvertisedTools`** hides them until **`hasRenderedWidget()`** is true; successful renders set the active widget for Computer Use. The harness is **`dispose()`d in `finally`**. Existing **`captureMcpAppWidgetSnapshots`** behavior is unchanged.
> 
> **`direct-chat-turn`** now allows **`onToolResultChunk`** to return a **`Promise`** and **awaits** it so rendering finishes before the next step’s tool advertisement. **`mcp-app-widget-capture`** exports shared HTML/permission helpers for the new module. **Vitest** covers short-circuits, shim injection, and a real headless integration case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d83756bdba99269e094ff298ffc80cc369b144b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->