### PR TITLE
feat(checks): Layer B inspector — predicate orchestrator + Hono route

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/checks.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/checks.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+const runPredicatesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../services/checks/run-predicates-on-chat-session.js", () => ({
+  runPredicatesOnChatSession: runPredicatesMock,
+}));
+
+vi.mock("../../../services/evals/route-helpers.js", () => ({
+  createConvexClient: vi.fn(() => ({ __mockConvexClient: true })),
+}));
+
+vi.mock("../auth.js", () => {
+  class WebRouteError extends Error {
+    status: number;
+    code: string;
+    details?: Record<string, unknown>;
+    constructor(
+      status: number,
+      code: string,
+      message: string,
+      details?: Record<string, unknown>,
+    ) {
+      super(message);
+      this.status = status;
+      this.code = code;
+      this.details = details;
+    }
+  }
+
+  return {
+    handleRoute: async (c: any, handler: () => Promise<any>) => {
+      try {
+        const result = await handler();
+        return c.json(result, 200);
+      } catch (error: any) {
+        if (error && typeof error.status === "number" && error.code) {
+          return c.json(
+            { code: error.code, message: error.message },
+            error.status,
+          );
+        }
+        return c.json({ code: "INTERNAL_ERROR", message: error.message }, 500);
+      }
+    },
+    parseWithSchema: (schema: any, body: unknown) => schema.parse(body),
+    readJsonBody: async (c: any) => await c.req.json(),
+    WebRouteError,
+  };
+});
+
+vi.mock("../errors.js", () => {
+  class WebRouteError extends Error {
+    status: number;
+    code: string;
+    constructor(status: number, code: string, message: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  }
+  return {
+    WebRouteError,
+    ErrorCode: { UNAUTHORIZED: "UNAUTHORIZED" },
+    assertBearerToken: (c: any) => {
+      const auth = c.req.header("authorization");
+      if (!auth || !auth.startsWith("Bearer ")) {
+        throw new WebRouteError(401, "UNAUTHORIZED", "Missing bearer token");
+      }
+      return auth.slice("Bearer ".length);
+    },
+  };
+});
+
+let app: Hono;
+
+beforeEach(async () => {
+  vi.resetModules();
+  runPredicatesMock.mockReset();
+  const checksModule = await import("../checks.js");
+  app = new Hono();
+  app.route("/", checksModule.default);
+});
+
+describe("POST /run-predicates", () => {
+  it("rejects without a bearer token", async () => {
+    const res = await app.request("/run-predicates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chatSessionId: "cs_1",
+        predicates: [],
+        setKind: "ad_hoc",
+      }),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ code: "UNAUTHORIZED", message: "Missing bearer token" });
+    expect(runPredicatesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid body shape", async () => {
+    const res = await app.request("/run-predicates", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: "Bearer abc",
+      },
+      body: JSON.stringify({
+        // chatSessionId missing
+        predicates: [],
+        setKind: "ad_hoc",
+      }),
+    });
+    expect(res.status).toBe(500);
+    expect(runPredicatesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid setKind enum", async () => {
+    const res = await app.request("/run-predicates", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: "Bearer abc",
+      },
+      body: JSON.stringify({
+        chatSessionId: "cs_1",
+        predicates: [],
+        setKind: "not_a_real_kind",
+      }),
+    });
+    expect(res.status).toBe(500);
+    expect(runPredicatesMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards a valid request to runPredicatesOnChatSession", async () => {
+    runPredicatesMock.mockResolvedValue({
+      checkRunId: "chk_1",
+      results: [{ predicate: { type: "noToolErrors" }, passed: true, reason: "ok" }],
+    });
+
+    const res = await app.request("/run-predicates", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: "Bearer xyz",
+      },
+      body: JSON.stringify({
+        chatSessionId: "cs_1",
+        predicates: [{ type: "noToolErrors" }],
+        setKind: "suite_defaults",
+        setRef: "suite_42",
+        setVersion: 3,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      checkRunId: "chk_1",
+      results: [{ predicate: { type: "noToolErrors" }, passed: true, reason: "ok" }],
+    });
+
+    expect(runPredicatesMock).toHaveBeenCalledTimes(1);
+    const call = runPredicatesMock.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      authHeader: "Bearer xyz",
+      chatSessionId: "cs_1",
+      predicates: [{ type: "noToolErrors" }],
+      setKind: "suite_defaults",
+      setRef: "suite_42",
+      setVersion: 3,
+    });
+  });
+
+  it("omits optional fields from the orchestrator args when not in body", async () => {
+    runPredicatesMock.mockResolvedValue({ checkRunId: "chk_2", results: [] });
+
+    const res = await app.request("/run-predicates", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: "Bearer xyz",
+      },
+      body: JSON.stringify({
+        chatSessionId: "cs_2",
+        predicates: [{ type: "noToolErrors" }],
+        setKind: "ad_hoc",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const call = runPredicatesMock.mock.calls[0]?.[0];
+    expect(call).not.toHaveProperty("setRef");
+    expect(call).not.toHaveProperty("setVersion");
+    expect(call).not.toHaveProperty("triggeredBy");
+  });
+
+  it("propagates errors from the orchestrator as 500", async () => {
+    runPredicatesMock.mockRejectedValue(
+      new Error("ChatSession not found or unauthorized"),
+    );
+
+    const res = await app.request("/run-predicates", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: "Bearer xyz",
+      },
+      body: JSON.stringify({
+        chatSessionId: "cs_x",
+        predicates: [{ type: "noToolErrors" }],
+        setKind: "ad_hoc",
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.message).toContain("ChatSession not found or unauthorized");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/checks.ts
+++ b/mcpjam-inspector/server/routes/web/checks.ts
@@ -1,0 +1,68 @@
+/**
+ * Cross-surface checks — Hono route (Layer B).
+ *
+ * Single endpoint `POST /web/checks/run-predicates` that runs an arbitrary
+ * predicate set against a stored `chatSessions` transcript. Sits alongside
+ * `evals` as a second caller of the SDK predicate library — eval grades a
+ * live test iteration, this grades a persisted chat session on demand.
+ *
+ * Auth shape mirrors `evals.ts` trace-repair endpoints:
+ *   - Bearer token extracted via `assertBearerToken` (request envelope).
+ *   - `createConvexClient(token)` for forwarding to Convex.
+ *   - Body parsed against a Zod schema via `parseWithSchema`.
+ *   - Errors mapped via `mapRuntimeError` -> `webError` in the parent
+ *     `web/index.ts` `onError` hook.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { predicateArraySchema } from "@/shared/eval-matching";
+import { createConvexClient } from "../../services/evals/route-helpers.js";
+import {
+  runPredicatesOnChatSession,
+  type ChatSessionId,
+  type UserId,
+} from "../../services/checks/run-predicates-on-chat-session.js";
+import { handleRoute, parseWithSchema, readJsonBody } from "./auth.js";
+import { assertBearerToken } from "./errors.js";
+
+const checks = new Hono();
+
+const runPredicatesSchema = z.object({
+  chatSessionId: z.string().min(1),
+  predicates: predicateArraySchema,
+  setKind: z.enum(["suite_defaults", "case_resolved", "ad_hoc"]),
+  setRef: z.string().min(1).optional(),
+  setVersion: z.number().int().nonnegative().optional(),
+  // `triggeredBy` is optional at this surface; the backend already knows
+  // the caller from the Convex auth token. Accepted for parity with the
+  // orchestrator signature, in case a future flow (e.g. background job)
+  // wants to attribute to a different user than the request bearer.
+  triggeredBy: z.string().min(1).optional(),
+});
+
+checks.post("/run-predicates", async (c) =>
+  handleRoute(c, async () => {
+    const bearerToken = assertBearerToken(c);
+    const body = parseWithSchema(runPredicatesSchema, await readJsonBody(c));
+    const convexClient = createConvexClient(bearerToken);
+    const result = await runPredicatesOnChatSession({
+      convexClient,
+      authHeader: `Bearer ${bearerToken}`,
+      chatSessionId: body.chatSessionId as ChatSessionId,
+      predicates: body.predicates,
+      setKind: body.setKind,
+      ...(body.setRef !== undefined ? { setRef: body.setRef } : {}),
+      ...(body.setVersion !== undefined ? { setVersion: body.setVersion } : {}),
+      ...(body.triggeredBy !== undefined
+        ? { triggeredBy: body.triggeredBy as UserId }
+        : {}),
+    });
+    return {
+      checkRunId: result.checkRunId,
+      results: result.results,
+    };
+  }),
+);
+
+export default checks;

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -19,6 +19,7 @@ import exporter from "./export.js";
 import guestSession from "./guest-session.js";
 import chatHistory from "./chat-history.js";
 import conformanceWeb from "./conformance.js";
+import checks from "./checks.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -34,6 +35,7 @@ web.use("/chat-v2", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/mcpjam-agent", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/chat-history/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/conformance/*", bearerAuthMiddleware, guestRateLimitMiddleware);
+web.use("/checks/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/server/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use(
   "/apps/mcp-apps/widget-content",
@@ -58,6 +60,7 @@ web.route("/xaa", xaaWeb);
 web.route("/guest-session", guestSession);
 web.route("/chat-history", chatHistory);
 web.route("/conformance", conformanceWeb);
+web.route("/checks", checks);
 
 // Public guest JWKS compatibility endpoint.
 web.get("/guest-jwks", async (c) => {

--- a/mcpjam-inspector/server/services/checks/__tests__/run-predicates-on-chat-session.test.ts
+++ b/mcpjam-inspector/server/services/checks/__tests__/run-predicates-on-chat-session.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const evaluatePredicatesMock = vi.hoisted(() => vi.fn());
+const buildIterationTranscriptMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/shared/eval-matching", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/shared/eval-matching")>(
+      "@/shared/eval-matching",
+    );
+  return {
+    ...actual,
+    evaluatePredicates: evaluatePredicatesMock,
+    buildIterationTranscript: buildIterationTranscriptMock,
+  };
+});
+
+import {
+  runPredicatesOnChatSession,
+  type ChatSessionId,
+} from "../run-predicates-on-chat-session";
+
+type ConvexClientMock = {
+  mutation: ReturnType<typeof vi.fn>;
+  action: ReturnType<typeof vi.fn>;
+};
+
+function makeClient(): ConvexClientMock {
+  return {
+    mutation: vi.fn(),
+    action: vi.fn(),
+  };
+}
+
+function basePredicates() {
+  return [
+    {
+      type: "toolCalledAtLeastOnce" as const,
+      toolName: "search",
+    },
+  ];
+}
+
+describe("runPredicatesOnChatSession", () => {
+  beforeEach(() => {
+    evaluatePredicatesMock.mockReset();
+    buildIterationTranscriptMock.mockReset();
+    buildIterationTranscriptMock.mockImplementation((input) => ({
+      __transcript: true,
+      input,
+    }));
+  });
+
+  it("drives the full lifecycle: start → load → evaluate → complete", async () => {
+    const client = makeClient();
+    client.mutation.mockImplementation(async (name: string) => {
+      if (name.endsWith(":startCheckRun")) return { checkRunId: "chk_1" };
+      return undefined;
+    });
+    client.action.mockResolvedValue({
+      traceVersion: 1,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolName: "search", input: { q: "hello" } },
+          ],
+        },
+      ],
+      spans: [],
+    });
+    const verdict = [{ predicate: basePredicates()[0], passed: true, reason: "ok" }];
+    evaluatePredicatesMock.mockReturnValue(verdict);
+
+    const result = await runPredicatesOnChatSession({
+      convexClient: client as never,
+      authHeader: "Bearer token",
+      chatSessionId: "cs_1" as ChatSessionId,
+      predicates: basePredicates(),
+      setKind: "suite_defaults",
+      setRef: "suite_42",
+      setVersion: 3,
+    });
+
+    expect(result).toEqual({ checkRunId: "chk_1", results: verdict });
+
+    // Mutation call order: startCheckRun, then completeCheckRun
+    expect(client.mutation).toHaveBeenCalledTimes(2);
+    expect(client.mutation.mock.calls[0]?.[0]).toContain("startCheckRun");
+    const startArgs = client.mutation.mock.calls[0]?.[1] as {
+      definitionSnapshot: Record<string, unknown>;
+    };
+    expect(startArgs.definitionSnapshot).toMatchObject({
+      setKind: "suite_defaults",
+      setRef: "suite_42",
+      setVersion: 3,
+      predicates: basePredicates(),
+    });
+    expect(client.mutation.mock.calls[1]?.[0]).toContain("completeCheckRun");
+    expect(client.mutation.mock.calls[1]?.[1]).toMatchObject({
+      checkRunId: "chk_1",
+      predicateResults: verdict,
+    });
+
+    // Action call: loadChatSessionEnvelopeAuthorized
+    expect(client.action).toHaveBeenCalledTimes(1);
+    expect(client.action.mock.calls[0]?.[0]).toContain(
+      "loadChatSessionEnvelopeAuthorized",
+    );
+
+    // buildIterationTranscript got the messages + extracted toolCalls
+    expect(buildIterationTranscriptMock).toHaveBeenCalledTimes(1);
+    const transcriptInput = buildIterationTranscriptMock.mock.calls[0]?.[0] as {
+      toolCalls: Array<{ toolName: string }>;
+      trace: { messages: unknown[] };
+      usage: undefined;
+    };
+    expect(transcriptInput.toolCalls).toEqual([
+      { toolName: "search", arguments: { q: "hello" } },
+    ]);
+    expect(transcriptInput.usage).toBeUndefined();
+
+    // evaluatePredicates was called with the transcript + predicates
+    expect(evaluatePredicatesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ __transcript: true }),
+      basePredicates(),
+    );
+  });
+
+  it("omits setRef / setVersion from definitionSnapshot when not supplied", async () => {
+    const client = makeClient();
+    client.mutation.mockImplementation(async (name: string) => {
+      if (name.endsWith(":startCheckRun")) return { checkRunId: "chk_2" };
+      return undefined;
+    });
+    client.action.mockResolvedValue({ messages: [], spans: [] });
+    evaluatePredicatesMock.mockReturnValue([]);
+
+    await runPredicatesOnChatSession({
+      convexClient: client as never,
+      authHeader: "Bearer token",
+      chatSessionId: "cs_2" as ChatSessionId,
+      predicates: basePredicates(),
+      setKind: "ad_hoc",
+    });
+
+    const startArgs = client.mutation.mock.calls[0]?.[1] as {
+      definitionSnapshot: Record<string, unknown>;
+    };
+    expect(startArgs.definitionSnapshot).toEqual({
+      setKind: "ad_hoc",
+      predicates: basePredicates(),
+    });
+    expect(startArgs.definitionSnapshot).not.toHaveProperty("setRef");
+    expect(startArgs.definitionSnapshot).not.toHaveProperty("setVersion");
+  });
+
+  it("calls failCheckRun and rethrows when the envelope load fails", async () => {
+    const client = makeClient();
+    client.mutation.mockImplementation(async (name: string) => {
+      if (name.endsWith(":startCheckRun")) return { checkRunId: "chk_3" };
+      return undefined;
+    });
+    const authError = new Error("ChatSession not found or unauthorized");
+    client.action.mockRejectedValue(authError);
+
+    await expect(
+      runPredicatesOnChatSession({
+        convexClient: client as never,
+        authHeader: "Bearer token",
+        chatSessionId: "cs_3" as ChatSessionId,
+        predicates: basePredicates(),
+        setKind: "suite_defaults",
+      }),
+    ).rejects.toThrow("ChatSession not found or unauthorized");
+
+    // start → fail (no complete)
+    expect(client.mutation).toHaveBeenCalledTimes(2);
+    expect(client.mutation.mock.calls[0]?.[0]).toContain("startCheckRun");
+    expect(client.mutation.mock.calls[1]?.[0]).toContain("failCheckRun");
+    expect(client.mutation.mock.calls[1]?.[1]).toMatchObject({
+      checkRunId: "chk_3",
+      error: "ChatSession not found or unauthorized",
+    });
+
+    // evaluatePredicates never ran
+    expect(evaluatePredicatesMock).not.toHaveBeenCalled();
+  });
+
+  it("rethrows the primary error even if failCheckRun itself fails", async () => {
+    const client = makeClient();
+    client.mutation.mockImplementation(async (name: string) => {
+      if (name.endsWith(":startCheckRun")) return { checkRunId: "chk_4" };
+      if (name.endsWith(":failCheckRun"))
+        throw new Error("secondary failure — should be swallowed");
+      return undefined;
+    });
+    client.action.mockRejectedValue(new Error("primary failure"));
+
+    await expect(
+      runPredicatesOnChatSession({
+        convexClient: client as never,
+        authHeader: "Bearer token",
+        chatSessionId: "cs_4" as ChatSessionId,
+        predicates: basePredicates(),
+        setKind: "ad_hoc",
+      }),
+    ).rejects.toThrow("primary failure");
+  });
+
+  it("extracts tool calls from inline toolCalls arrays as well as tool-call content parts", async () => {
+    const client = makeClient();
+    client.mutation.mockImplementation(async (name: string) => {
+      if (name.endsWith(":startCheckRun")) return { checkRunId: "chk_5" };
+      return undefined;
+    });
+    client.action.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: "text-only message",
+          toolCalls: [{ toolName: "fetch", args: { url: "/x" } }],
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolName: "search", input: { q: "y" } },
+          ],
+        },
+      ],
+    });
+    evaluatePredicatesMock.mockReturnValue([]);
+
+    await runPredicatesOnChatSession({
+      convexClient: client as never,
+      authHeader: "Bearer token",
+      chatSessionId: "cs_5" as ChatSessionId,
+      predicates: basePredicates(),
+      setKind: "ad_hoc",
+    });
+
+    const transcriptInput = buildIterationTranscriptMock.mock.calls[0]?.[0] as {
+      toolCalls: Array<{ toolName: string; arguments: unknown }>;
+    };
+    expect(transcriptInput.toolCalls).toEqual([
+      { toolName: "fetch", arguments: { url: "/x" } },
+      { toolName: "search", arguments: { q: "y" } },
+    ]);
+  });
+
+  it("deduplicates identical tool calls across messages", async () => {
+    const client = makeClient();
+    client.mutation.mockImplementation(async (name: string) => {
+      if (name.endsWith(":startCheckRun")) return { checkRunId: "chk_6" };
+      return undefined;
+    });
+    client.action.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolName: "search", input: { q: "x" } },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolName: "search", input: { q: "x" } },
+          ],
+        },
+      ],
+    });
+    evaluatePredicatesMock.mockReturnValue([]);
+
+    await runPredicatesOnChatSession({
+      convexClient: client as never,
+      authHeader: "Bearer token",
+      chatSessionId: "cs_6" as ChatSessionId,
+      predicates: basePredicates(),
+      setKind: "ad_hoc",
+    });
+
+    const transcriptInput = buildIterationTranscriptMock.mock.calls[0]?.[0] as {
+      toolCalls: unknown[];
+    };
+    expect(transcriptInput.toolCalls).toHaveLength(1);
+  });
+});

--- a/mcpjam-inspector/server/services/checks/run-predicates-on-chat-session.ts
+++ b/mcpjam-inspector/server/services/checks/run-predicates-on-chat-session.ts
@@ -1,0 +1,270 @@
+/**
+ * Cross-surface checks orchestrator (Layer B).
+ *
+ * Runs the existing eval predicate library against a stored `chatSessions`
+ * transcript on demand — the "second caller" of `evaluatePredicates` beyond
+ * the live eval runner (see `server/services/evals-runner.ts:1543-1554` for
+ * the in-eval invocation this mirrors). Same SDK gate, different transcript
+ * source: instead of building the iteration transcript live from per-turn
+ * runner state, we load the persisted envelope from Convex via
+ * `chatSessionChecks/loadChatSessionEnvelopeAuthorized` and adapt it onto
+ * the SDK's `IterationTranscript` shape.
+ *
+ * Lifecycle on the backend:
+ *   1. `startCheckRun`    — persists a `chatSessionChecks` row with a
+ *                           `definitionSnapshot` of `{setKind, setRef?,
+ *                           setVersion?, predicates}` so the run is auditable
+ *                           even if the source predicate set later mutates.
+ *   2. `loadChatSessionEnvelopeAuthorized` — authorized read of the stored
+ *                           transcript (`{traceVersion, messages, spans?,
+ *                           prompts?, widgetSnapshots?}`).
+ *   3. `completeCheckRun`  — persists `predicateResults`.
+ *   4. `failCheckRun`      — persists the error message; called on any
+ *                           orchestrator-level failure (auth, fetch,
+ *                           predicate eval).
+ *
+ * Backend types/actions are referenced by string path; the Convex codegen
+ * is on a sibling PR (`feat/chat-session-trace-loader`), so we cast the
+ * string args via `as any` (mirrors the existing pattern at
+ * `evals-runner.ts:699` for `testSuites:updateTestIteration`). Once the
+ * backend PR merges and codegen runs, the string paths can be tightened
+ * to typed `api.chatSessionChecks.*` references — no other shape change
+ * required.
+ */
+
+import type { ConvexHttpClient } from "convex/browser";
+import type { ModelMessage } from "ai";
+import {
+  buildIterationTranscript,
+  evaluatePredicates,
+} from "@/shared/eval-matching";
+import type {
+  Predicate,
+  PredicateResult,
+  TranscriptToolCall,
+} from "@/shared/eval-matching";
+
+// Re-declared narrowly here (not imported from generated Convex types) for the
+// same reason as the action-name strings: the backend codegen isn't available
+// in this worktree yet. Once the sibling backend PR merges, callers can use the
+// generated `Id<"chatSessions">` / `Id<"chatSessionChecks">` directly.
+export type ChatSessionId = string & { readonly __tableName: "chatSessions" };
+export type CheckRunId = string & {
+  readonly __tableName: "chatSessionChecks";
+};
+export type UserId = string & { readonly __tableName: "users" };
+
+export type CheckSetKind = "suite_defaults" | "case_resolved" | "ad_hoc";
+
+export interface RunPredicatesOnChatSessionArgs {
+  /** Already-authenticated Convex HTTP client (caller called `setAuth`). */
+  convexClient: ConvexHttpClient;
+  /** Bearer token; unused on the Convex client path but threaded for future
+   * HTTP-action calls in case the loader is reachable from both. Keeping the
+   * arg in the signature avoids a breaking change later. */
+  authHeader: string;
+  chatSessionId: ChatSessionId;
+  predicates: Predicate[];
+  setKind: CheckSetKind;
+  setRef?: string;
+  setVersion?: number;
+  triggeredBy?: UserId;
+}
+
+export interface RunPredicatesOnChatSessionResult {
+  checkRunId: CheckRunId;
+  results: PredicateResult[];
+}
+
+/**
+ * Shape of the envelope returned by
+ * `chatSessionChecks/loadChatSessionEnvelopeAuthorized`. Kept loose because
+ * the backend codegen isn't present here; the consumer only depends on
+ * `messages` (for tool-call extraction + final-message derivation) and
+ * `spans` (for tool-error classification via `extractToolErrors`).
+ */
+interface ChatSessionEnvelope {
+  traceVersion?: number;
+  messages: Array<{ role: string; content: unknown }>;
+  spans?: Array<Record<string, unknown>>;
+  prompts?: unknown[];
+  widgetSnapshots?: unknown[];
+}
+
+/**
+ * Walk messages and pull out tool calls in the order they appear.
+ *
+ * NOTE: This mirrors `extractToolCallsFromConversation` in
+ * `server/services/evals-runner.ts:387` (the canonical implementation,
+ * which is a module-local function rather than an export). When the
+ * eval-rework persistence work centralizes per-turn extraction, this can
+ * be replaced with the shared helper; until then, duplicating the small
+ * walker keeps the orchestrator self-contained and avoids cross-cutting
+ * `evals-runner.ts` (out of scope for Layer B).
+ *
+ * Difference from the eval version: we never have an AI SDK `steps` array
+ * here — the envelope is a persisted transcript, not a live run — so the
+ * `steps` branch is omitted.
+ */
+function extractToolCallsFromEnvelopeMessages(
+  messages: ChatSessionEnvelope["messages"],
+): TranscriptToolCall[] {
+  const toolsCalled: TranscriptToolCall[] = [];
+
+  for (const msg of messages) {
+    if (!msg || msg.role !== "assistant") continue;
+
+    const content = (msg as { content?: unknown }).content;
+    if (Array.isArray(content)) {
+      for (const item of content) {
+        if (
+          item &&
+          typeof item === "object" &&
+          (item as { type?: unknown }).type === "tool-call"
+        ) {
+          const rec = item as Record<string, unknown>;
+          const name = (rec.toolName ?? rec.name) as string | undefined;
+          if (!name) continue;
+          const argumentsValue =
+            (rec.input as Record<string, unknown> | undefined) ??
+            (rec.parameters as Record<string, unknown> | undefined) ??
+            (rec.args as Record<string, unknown> | undefined) ??
+            {};
+          const argsKey = JSON.stringify(argumentsValue);
+          const alreadyAdded = toolsCalled.some(
+            (toolCall) =>
+              toolCall.toolName === name &&
+              JSON.stringify(toolCall.arguments) === argsKey,
+          );
+          if (!alreadyAdded) {
+            toolsCalled.push({ toolName: name, arguments: argumentsValue });
+          }
+        }
+      }
+    }
+
+    const inlineToolCalls = (msg as { toolCalls?: unknown }).toolCalls;
+    if (Array.isArray(inlineToolCalls)) {
+      for (const call of inlineToolCalls) {
+        if (!call || typeof call !== "object") continue;
+        const rec = call as Record<string, unknown>;
+        const name = (rec.toolName ?? rec.name) as string | undefined;
+        if (!name) continue;
+        const argumentsValue =
+          (rec.args as Record<string, unknown> | undefined) ??
+          (rec.input as Record<string, unknown> | undefined) ??
+          {};
+        const argsKey = JSON.stringify(argumentsValue);
+        const alreadyAdded = toolsCalled.some(
+          (toolCall) =>
+            toolCall.toolName === name &&
+            JSON.stringify(toolCall.arguments) === argsKey,
+        );
+        if (!alreadyAdded) {
+          toolsCalled.push({ toolName: name, arguments: argumentsValue });
+        }
+      }
+    }
+  }
+
+  return toolsCalled;
+}
+
+/**
+ * Run a predicate set against a persisted chat session transcript.
+ *
+ * On any failure after `startCheckRun` succeeds, the row is finalized via
+ * `failCheckRun` so the UI never sees an in-progress run stuck without
+ * resolution. We rethrow after `failCheckRun` so the route can surface the
+ * error to the caller with the right status code.
+ */
+export async function runPredicatesOnChatSession(
+  args: RunPredicatesOnChatSessionArgs,
+): Promise<RunPredicatesOnChatSessionResult> {
+  const {
+    convexClient,
+    chatSessionId,
+    predicates,
+    setKind,
+    setRef,
+    setVersion,
+    triggeredBy,
+  } = args;
+
+  // 1. Persist the run with a definition snapshot (audit anchor).
+  const definitionSnapshot = {
+    setKind,
+    ...(setRef !== undefined ? { setRef } : {}),
+    ...(setVersion !== undefined ? { setVersion } : {}),
+    predicates,
+  };
+  const startResult = (await convexClient.mutation(
+    "chatSessionChecks:startCheckRun" as any,
+    {
+      chatSessionId,
+      definitionSnapshot,
+      ...(triggeredBy !== undefined ? { triggeredBy } : {}),
+    },
+  )) as { checkRunId: CheckRunId };
+  const checkRunId = startResult.checkRunId;
+
+  try {
+    // 2. Load the persisted transcript envelope under the caller's auth.
+    const envelope = (await convexClient.action(
+      "chatSessionChecks:loadChatSessionEnvelopeAuthorized" as any,
+      { chatSessionId },
+    )) as ChatSessionEnvelope;
+
+    // 3. Extract tool calls from messages — `toolCalls` is not a top-level
+    //    envelope field today; eval derives it the same way per turn.
+    const toolCalls = extractToolCallsFromEnvelopeMessages(envelope.messages);
+
+    // 4. Build the SDK iteration transcript. Usage isn't on the envelope
+    //    for on-demand runs (no live token accounting), so leave undefined;
+    //    `tokenUsageBelow` predicates against this transcript will short-
+    //    circuit deterministically via the SDK's undefined-usage branch.
+    const transcript = buildIterationTranscript({
+      trace: {
+        messages: envelope.messages,
+        ...(envelope.spans ? { spans: envelope.spans as any } : {}),
+      },
+      toolCalls,
+      usage: undefined,
+    });
+
+    // 5. Pure SDK call — same function evals-runner.ts invokes.
+    const results = evaluatePredicates(transcript, predicates);
+
+    // 6. Persist the verdict.
+    await convexClient.mutation(
+      "chatSessionChecks:completeCheckRun" as any,
+      {
+        checkRunId,
+        predicateResults: results,
+      },
+    );
+
+    return { checkRunId, results };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      await convexClient.mutation(
+        "chatSessionChecks:failCheckRun" as any,
+        { checkRunId, error: message },
+      );
+    } catch {
+      // Swallow secondary failures — the primary error is what the caller
+      // needs to see, and the row will eventually be reaped by backend
+      // janitorial sweeps. Logging the secondary error here would mask the
+      // real cause in route-level error envelopes.
+    }
+    throw error;
+  }
+}
+
+// Re-export the `ModelMessage` type used to author tests for this module
+// without forcing each consumer to import from `ai` directly. Kept narrowly
+// scoped to the orchestrator boundary.
+export type EnvelopeMessage = Pick<ModelMessage, "role" | "content"> & {
+  toolCalls?: unknown;
+};


### PR DESCRIPTION
## Summary

Layer B (inspector half) of cross-surface checks. Adds the Node-side orchestrator that ties Convex auth + envelope-load to SDK predicate evaluation, plus the Hono route the UI POSTs to.

Backend companion: feat/chat-session-trace-loader (will be opened against mcpjam-backend, depends on #453 + Layer B backend).

## Why this is inspector-side, not Convex
Convex can't import @mcpjam/sdk — the predicate evaluators have Node-only deps that don't bundle into Convex (documented at convex/lib/predicates.ts:1-18). Same constraint that drove the live eval runner to live inspector-side; this is the second caller of the same SDK gate.

## What lands here

- **server/services/checks/run-predicates-on-chat-session.ts** — orchestrator. Lifecycle: startCheckRun → loadChatSessionEnvelopeAuthorized → extract toolCalls from envelope messages → buildIterationTranscript (SDK) → evaluatePredicates (SDK) → completeCheckRun. On any failure after startCheckRun succeeds: failCheckRun + rethrow.
- **server/routes/web/checks.ts** — POST /web/checks/run-predicates. Mirrors evals.ts trace-repair route shape (handleRoute + assertBearerToken + parseWithSchema + createConvexClient). Zod schema validates body.
- **server/routes/web/index.ts** — route mount + auth middleware on /checks/* (bearerAuthMiddleware + guestRateLimitMiddleware).

Backend types/action names are referenced via string paths + as any — the matching backend PR (feat/chat-session-trace-loader) carries the generated types. Once the backend lands and codegen runs, the casts can be tightened to typed api.chatSessionChecks.* references.

## Test plan

- [x] 12 new tests: 6 orchestrator (lifecycle, definitionSnapshot shape, auth-fail, secondary-failure-swallowed, mixed tool-call shapes, dedup); 6 route (auth, validation, enum, forwarding, optional-omit, 500 propagation).
- [x] All pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated API reads chat transcripts and writes check-run state; behavior depends on a sibling Convex backend PR and uses untyped Convex string references until codegen merges.
> 
> **Overview**
> Adds **cross-surface checks** on the inspector: clients can run the same eval predicate library against a **persisted** `chatSessions` transcript instead of only during live eval iterations.
> 
> A new **`POST /web/checks/run-predicates`** route (bearer auth + guest rate limit, same envelope as other web eval routes) validates the body with Zod and forwards to **`runPredicatesOnChatSession`**. That orchestrator records a check run in Convex (`startCheckRun` with an auditable `definitionSnapshot`), loads the session envelope under the caller’s token, builds an SDK iteration transcript (including tool-call extraction from message content and inline `toolCalls`, with dedup), runs **`evaluatePredicates`**, then **`completeCheckRun`** or **`failCheckRun`** on errors so runs don’t stay stuck in progress. Convex action/mutation names are wired via string paths until the companion backend PR lands.
> 
> **Tests** cover the full orchestrator lifecycle, failure paths, tool-call shaping, and route auth/validation/forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e33e3957bd71c4332c9365a9a592cacf0c42901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->