### PR TITLE
feat(synthetic): enable BYOK chatbox models for synthetic runs

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -112,11 +112,12 @@ export function GenerateSessionsDialog({
   // render the rough cost preview below.
   const isByokChatbox = !isMCPJamProvidedModel(chatbox.modelId);
 
-  // Rough upper-bound cost preview. There's no per-model cost catalog
-  // on the client today (SUPPORTED_MODELS doesn't expose pricing), so
-  // this uses a coarse average tokens-per-turn × an average per-token
-  // rate. Marked as an estimate in the UI; follow-up should swap in
-  // per-model pricing from a shared catalog once one exists.
+  // Rough cost estimate (not an upper bound — uses a single blended
+  // midpoint rate with no safety multiplier, so it can under-estimate
+  // real spend if the model is on the expensive end). There's no
+  // per-model cost catalog on the client today (SUPPORTED_MODELS doesn't
+  // expose pricing); follow-up should swap in per-model pricing from a
+  // shared catalog once one exists.
   const ESTIMATED_TOKENS_PER_TURN = 4000; // input + output combined
   const ESTIMATED_USD_PER_1K_TOKENS = 0.005; // coarse blended midpoint
   const totalTurnsUpperBound = personaCount * sessionsPerPersona * maxTurns;
@@ -383,29 +384,32 @@ export function GenerateSessionsDialog({
             </div>
 
             {isByokChatbox ? (
-              <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
-                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-                <span>
-                  This chatbox uses your organization&apos;s model key.
-                  Running synthetic sessions will consume your provider
-                  credits.
-                </span>
-              </div>
-            ) : null}
+              <>
+                <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+                  <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                  <span>
+                    This chatbox uses your organization&apos;s model key.
+                    Running synthetic sessions will consume your provider
+                    credits.
+                  </span>
+                </div>
 
-            <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
-              <div className="flex items-center justify-between gap-2">
-                <span>Estimated upper-bound cost</span>
-                <span className="font-medium text-foreground">
-                  {formatUsd(estimatedCostUsd)}
-                </span>
-              </div>
-              <div className="mt-1 text-[11px] opacity-80">
-                {totalTurnsUpperBound} turns ({personaCount} ×{" "}
-                {sessionsPerPersona} × {maxTurns}). Estimate may vary —
-                actuals depend on the model and conversation length.
-              </div>
-            </div>
+                <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+                  <div className="flex items-center justify-between gap-2">
+                    <span>Rough cost estimate</span>
+                    <span className="font-medium text-foreground">
+                      {formatUsd(estimatedCostUsd)}
+                    </span>
+                  </div>
+                  <div className="mt-1 text-[11px] opacity-80">
+                    {totalTurnsUpperBound} turns ({personaCount} ×{" "}
+                    {sessionsPerPersona} × {maxTurns}) at a coarse blended
+                    rate. Actuals depend on the model and conversation
+                    length and can vary above this number.
+                  </div>
+                </div>
+              </>
+            ) : null}
 
             {chatbox.requireToolApproval ? (
               <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -104,14 +104,31 @@ export function GenerateSessionsDialog({
   }));
   const hasRequiredServers = serversPayload.some((s) => !s.optional);
 
-  // BYOK guard (plan v4 §H). The synthesis worker threads
-  // `synthesisRunId` into the MCPJam `/stream` usage record so
-  // per-run spend lands on `chatboxSynthesisRuns.spendUsdActual`. Org
-  // BYOK chats route through `/stream/org` instead, which isn't yet
-  // wired into the synthesis usage path. The server route is the
-  // load-bearing guard; this is the UI affordance so the button
-  // doesn't hand the user a 400 they have to debug.
+  // BYOK is now supported on synthetic runs — the runner dispatches
+  // org-BYOK models through /stream/org (or local-usage writeback) and
+  // the backend forwarder stamps synthesisRunId onto the resulting
+  // llmUsageRecord. The flag is kept to (a) show a spend-warning
+  // notice so users know provider credits will be consumed, and (b)
+  // render the rough cost preview below.
   const isByokChatbox = !isMCPJamProvidedModel(chatbox.modelId);
+
+  // Rough upper-bound cost preview. There's no per-model cost catalog
+  // on the client today (SUPPORTED_MODELS doesn't expose pricing), so
+  // this uses a coarse average tokens-per-turn × an average per-token
+  // rate. Marked as an estimate in the UI; follow-up should swap in
+  // per-model pricing from a shared catalog once one exists.
+  const ESTIMATED_TOKENS_PER_TURN = 4000; // input + output combined
+  const ESTIMATED_USD_PER_1K_TOKENS = 0.005; // coarse blended midpoint
+  const totalTurnsUpperBound = personaCount * sessionsPerPersona * maxTurns;
+  const estimatedCostUsd =
+    (totalTurnsUpperBound * ESTIMATED_TOKENS_PER_TURN *
+      ESTIMATED_USD_PER_1K_TOKENS) /
+    1000;
+  const formatUsd = (value: number): string => {
+    if (value < 0.01) return "< $0.01";
+    if (value < 1) return `$${value.toFixed(2)}`;
+    return `$${value.toFixed(2)}`;
+  };
 
   async function authHeader(): Promise<Record<string, string>> {
     const token = await getAccessToken();
@@ -369,11 +386,26 @@ export function GenerateSessionsDialog({
               <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
                 <AlertTriangle className="mt-0.5 size-4 shrink-0" />
                 <span>
-                  Synthetic sessions are not yet supported for chatboxes using
-                  your own model keys. Coming soon.
+                  This chatbox uses your organization&apos;s model key.
+                  Running synthetic sessions will consume your provider
+                  credits.
                 </span>
               </div>
             ) : null}
+
+            <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+              <div className="flex items-center justify-between gap-2">
+                <span>Estimated upper-bound cost</span>
+                <span className="font-medium text-foreground">
+                  {formatUsd(estimatedCostUsd)}
+                </span>
+              </div>
+              <div className="mt-1 text-[11px] opacity-80">
+                {totalTurnsUpperBound} turns ({personaCount} ×{" "}
+                {sessionsPerPersona} × {maxTurns}). Estimate may vary —
+                actuals depend on the model and conversation length.
+              </div>
+            </div>
 
             {chatbox.requireToolApproval ? (
               <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
@@ -392,7 +424,7 @@ export function GenerateSessionsDialog({
               <Button
                 size="sm"
                 onClick={handleGenerate}
-                disabled={!hasRequiredServers || isByokChatbox || generating}
+                disabled={!hasRequiredServers || generating}
               >
                 {generating ? (
                   <>

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/GenerateSessionsDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/GenerateSessionsDialog.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Tests for `GenerateSessionsDialog` plan v4 §J affordances:
- *   - BYOK chatbox: warning visible, Generate disabled.
+ *   - BYOK chatbox: spend warning + rough cost estimate visible; Generate
+ *     button is enabled (BYOK synthetic shipped — see PR #2486).
+ *   - MCPJam-provided chatbox: no BYOK warning, no cost estimate.
  *   - requireToolApproval chatbox: rewritten warning visible.
  *   - rate_limited run status: shows the "Rate-limited — budget reached"
  *     label with the amber treatment.
@@ -57,7 +59,7 @@ afterEach(() => {
 });
 
 describe("GenerateSessionsDialog — plan v4 §J affordances", () => {
-  it("shows the BYOK disabled state when modelId is a BYOK provider", () => {
+  it("shows the BYOK spend warning + rough cost estimate when modelId is a BYOK provider; Generate stays enabled", () => {
     const byokChatbox = {
       ...baseChatbox,
       modelId: "ollama/llama-3:8b",
@@ -69,15 +71,39 @@ describe("GenerateSessionsDialog — plan v4 §J affordances", () => {
         chatbox={byokChatbox}
       />,
     );
+    // Spend warning surfaces so the user knows provider credits will burn.
     expect(
       screen.getByText(
-        /Synthetic sessions are not yet supported for chatboxes using your own model keys/,
+        /will consume your provider credits/i,
       ),
     ).toBeInTheDocument();
+    // Rough cost estimate tile renders for BYOK chatboxes.
+    expect(screen.getByText(/Rough cost estimate/i)).toBeInTheDocument();
+    // Button is enabled — BYOK synthetic is supported.
     expect(
       (screen.getByRole("button", { name: "Generate personas" }) as HTMLButtonElement)
         .disabled,
-    ).toBe(true);
+    ).toBe(false);
+    // Old blocked-state copy must no longer appear (regression guard).
+    expect(
+      screen.queryByText(
+        /Synthetic sessions are not yet supported for chatboxes using your own model keys/i,
+      ),
+    ).toBeNull();
+  });
+
+  it("hides the BYOK warning + cost estimate for an MCPJam-provided model", () => {
+    render(
+      <GenerateSessionsDialog
+        isOpen
+        onClose={() => {}}
+        chatbox={baseChatbox}
+      />,
+    );
+    expect(
+      screen.queryByText(/will consume your provider credits/i),
+    ).toBeNull();
+    expect(screen.queryByText(/Rough cost estimate/i)).toBeNull();
   });
 
   it("shows the approval-mode warning when requireToolApproval is set", () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.byok.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.byok.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebTestApp, postJson, expectJson } from "./helpers/test-app.js";
+
+const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
+
+const fetchChatboxRuntimeConfigMock = vi.fn();
+const createRunMock = vi.fn();
+const startSimulationMock = vi.fn();
+
+vi.mock("../../../utils/chatbox-runtime-config.js", () => ({
+  fetchChatboxRuntimeConfig: (...args: unknown[]) =>
+    fetchChatboxRuntimeConfigMock(...args),
+}));
+
+vi.mock("../../../services/session-agent.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/session-agent.js")
+  >("../../../services/session-agent.js");
+  return {
+    ...actual,
+    createRun: (...args: unknown[]) => createRunMock(...args),
+  };
+});
+
+vi.mock("../../../services/sessionSimulation/runner.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/sessionSimulation/runner.js")
+  >("../../../services/sessionSimulation/runner.js");
+  return {
+    ...actual,
+    startSimulation: (...args: unknown[]) => startSimulationMock(...args),
+  };
+});
+
+describe("web routes — chatbox-sessions BYOK gate removed", () => {
+  const { app, token } = createWebTestApp();
+
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "https://test-deployment.convex.site";
+    fetchChatboxRuntimeConfigMock.mockReset();
+    createRunMock.mockReset();
+    startSimulationMock.mockReset();
+    createRunMock.mockResolvedValue({ runId: "run-1" });
+    startSimulationMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (ORIGINAL_CONVEX_HTTP_URL === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = ORIGINAL_CONVEX_HTTP_URL;
+    }
+  });
+
+  const validBody = {
+    projectId: "proj-1",
+    servers: [{ serverId: "srv-1", serverName: "srv-1" }],
+    personas: [
+      { id: "p-1", name: "Alice", role: "user", notes: "tries the feature" },
+    ],
+    sessionsPerPersona: 1,
+    maxTurns: 3,
+  };
+
+  it("no longer returns 400 byok_unsupported for a chatbox whose modelId is not MCPJam-provided", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-1",
+        accessVersion: 0,
+        // Bare gpt-4o (no openai/ prefix) is BYOK, not MCPJam-provided.
+        modelId: "gpt-4o",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-1/simulate-sessions/start",
+      validBody,
+      token,
+    );
+    const { status, data } = await expectJson<{
+      runId?: string;
+      code?: string;
+      errorCode?: string;
+    }>(response);
+
+    expect(status).toBe(200);
+    expect(data.runId).toBe("run-1");
+    expect(createRunMock).toHaveBeenCalledTimes(1);
+    // Specifically: the old byok_unsupported error must not appear.
+    expect(data.errorCode).toBeUndefined();
+  });
+
+  it("still accepts MCPJam-provided modelIds (regression)", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-2",
+        accessVersion: 0,
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-2/simulate-sessions/start",
+      validBody,
+      token,
+    );
+    const { status, data } = await expectJson<{ runId?: string }>(response);
+
+    expect(status).toBe(200);
+    expect(data.runId).toBe("run-1");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -242,6 +242,15 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     const requireToolApproval = runtime.config.requireToolApproval;
     const respectToolVisibility = runtime.config.respectToolVisibility;
     const progressiveToolDiscovery = runtime.config.progressiveToolDiscovery;
+    // `runtime.config.accessVersion` is the server-resolved value the
+    // chatbox redeem produced (vs the client-supplied `body.accessVersion`,
+    // which the generate-sessions dialog never sends). Use the runtime
+    // value so the runner's /stream/org/resolve and /stream/org body
+    // payloads authorize against the right chatbox version. Falling back
+    // to body.accessVersion keeps the door open for an explicit client
+    // override should the dialog ever start sending one.
+    const accessVersion =
+      runtime.config.accessVersion ?? body.accessVersion;
 
     setImmediate(() => {
       startSimulation({
@@ -261,9 +270,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
         // `chatSessions:createWidgetSnapshot` can authenticate against the
         // chatbox path. Without it the Sessions viewer can't render MCP App
         // widgets (e.g. Excalidraw) for synthetic threads.
-        ...(body.accessVersion !== undefined
-          ? { accessVersion: body.accessVersion }
-          : {}),
+        ...(accessVersion !== undefined ? { accessVersion } : {}),
         convexHttpUrl,
         convexAuthToken: bearerToken,
         authHeader,
@@ -279,7 +286,11 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
             {
               accessScope: "chat_v2",
               chatboxId,
-              accessVersion: body.accessVersion,
+              // Same reason as the runner-arg fix above: use the
+              // server-resolved accessVersion (the dialog doesn't send
+              // body.accessVersion) so the manager factory's chatbox
+              // access is authorized against the current version.
+              accessVersion,
               serverNames: selectedServerNames,
             },
           );

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -21,8 +21,6 @@ import {
 } from "../../services/session-agent.js";
 import { startSimulation } from "../../services/sessionSimulation/runner.js";
 import { logger } from "../../utils/logger.js";
-import { isMCPJamProvidedModel } from "@/shared/types";
-
 const chatboxSessions = new Hono();
 
 function requireConvexHttpUrl(): string {
@@ -209,19 +207,20 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       );
     }
 
-    // BYOK guard (plan v4 §H): synthetic runs require an MCPJam-provided
-    // model so per-run spend can be attributed to chatboxSynthesisRuns
-    // via the /stream usage-record path. Org BYOK chats route through
-    // /stream/org with the provider key, which the worker can't
-    // re-resolve without the user bearer.
-    if (!isMCPJamProvidedModel(runtime.config.modelId)) {
-      throw new WebRouteError(
-        400,
-        ErrorCode.FEATURE_NOT_SUPPORTED,
-        "Synthetic sessions are not yet supported for chatboxes using your own model keys. Coming soon.",
-        { errorCode: "byok_unsupported" },
-      );
-    }
+    // BYOK is now supported on synthetic runs: the runner's
+    // `drainAssistantTurn` dispatches MCPJam-provided models through
+    // `/stream` and org-BYOK models (both cloud and local) through
+    // `/stream/org` (or local-usage writeback). The synthesisRunId is
+    // stamped onto the resulting llmUsageRecord by each path's backend
+    // forwarder so per-run spend rolls up via a query on
+    // `llmUsageRecord.synthesisRunId` regardless of model source.
+    //
+    // The only remaining unsupported case is user-API-key direct (where
+    // the request would carry the user's own provider key in the body
+    // instead of resolving via org settings). That path doesn't make
+    // product sense for synthetic — there's no "visitor" whose key to
+    // use — and the chatbox runtime never produces it, so there's no
+    // route-level gate to add here.
 
     const { runId } = await createRun(
       convexHttpUrl,

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -178,6 +178,57 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
     expect(opts.synthesisRunId).toBe("run-xyz");
   });
 
+  it("refuses local-runtime org BYOK + requireToolApproval=true with non-empty tools (no auto-deny loop on the local path yet)", async () => {
+    resolveOrgProviderRuntimeMock.mockResolvedValue({
+      runtimeLocation: "local",
+      provider: { providerKey: "openai" } as any,
+    });
+
+    await expect(
+      drainAssistantTurn(
+        baseArgs({
+          modelId: "llama3",
+          modelDefinition: {
+            id: "llama3",
+            name: "Llama3 local",
+            provider: "ollama",
+          } as ModelDefinition,
+          requireToolApproval: true,
+          tools: { search: { description: "noop" } } as any,
+        }) as Parameters<typeof drainAssistantTurn>[0],
+      ),
+    ).rejects.toThrow(
+      /approval-required tool calls.*Disable tool approval/i,
+    );
+
+    // Refusal happens before the handler is invoked.
+    expect(handleLocalOrgChatModelMock).not.toHaveBeenCalled();
+  });
+
+  it("still dispatches local-runtime org BYOK when requireToolApproval is false", async () => {
+    const calls: unknown[] = [];
+    handleLocalOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
+    resolveOrgProviderRuntimeMock.mockResolvedValue({
+      runtimeLocation: "local",
+      provider: { providerKey: "openai" } as any,
+    });
+
+    await drainAssistantTurn(
+      baseArgs({
+        modelId: "llama3",
+        modelDefinition: {
+          id: "llama3",
+          name: "Llama3 local",
+          provider: "ollama",
+        } as ModelDefinition,
+        requireToolApproval: false,
+        tools: { search: { description: "noop" } } as any,
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+
+    expect(handleLocalOrgChatModelMock).toHaveBeenCalledTimes(1);
+  });
+
   it("throws with a clear message when org-BYOK derivation fails (custom provider without a name)", async () => {
     await expect(
       drainAssistantTurn(

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ModelDefinition } from "@/shared/types";
+
+const handleMCPJamFreeChatModelMock = vi.fn();
+const handleHostedOrgChatModelMock = vi.fn();
+const handleLocalOrgChatModelMock = vi.fn();
+const resolveOrgProviderRuntimeMock = vi.fn();
+
+vi.mock("../../../utils/mcpjam-stream-handler.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/mcpjam-stream-handler.js")
+  >("../../../utils/mcpjam-stream-handler.js");
+  return {
+    ...actual,
+    handleMCPJamFreeChatModel: (...args: unknown[]) =>
+      handleMCPJamFreeChatModelMock(...args),
+  };
+});
+
+vi.mock("../../../utils/org-model-stream-handler.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/org-model-stream-handler.js")
+  >("../../../utils/org-model-stream-handler.js");
+  return {
+    ...actual,
+    handleHostedOrgChatModel: (...args: unknown[]) =>
+      handleHostedOrgChatModelMock(...args),
+    handleLocalOrgChatModel: (...args: unknown[]) =>
+      handleLocalOrgChatModelMock(...args),
+  };
+});
+
+vi.mock("../../../utils/org-model-config.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/org-model-config.js")
+  >("../../../utils/org-model-config.js");
+  return {
+    ...actual,
+    resolveOrgProviderRuntime: (...args: unknown[]) =>
+      resolveOrgProviderRuntimeMock(...args),
+  };
+});
+
+import { drainAssistantTurn } from "../runner.js";
+
+/**
+ * The runner's drainAssistantTurn awaits handler responses and then reads
+ * `response.body` to drain the SSE stream before returning. The handler
+ * also fires `onConversationComplete` synchronously inside the handler
+ * (in production via the AI SDK stream's onFinish). For dispatch tests we
+ * return an empty Response and invoke onConversationComplete before
+ * returning so the captured history flows through.
+ */
+function buildHandlerStub(captureCalls: unknown[]) {
+  return vi.fn(async (opts: any) => {
+    captureCalls.push(opts);
+    // Synchronously invoke onConversationComplete with a captured history
+    // so the runner has something to return.
+    opts.onConversationComplete?.(opts.messages, {
+      turnId: "test-turn",
+      promptIndex: 0,
+      startedAt: 0,
+      endedAt: 0,
+      spans: [],
+    });
+    return new Response(null, { status: 200 });
+  });
+}
+
+const baseArgs = (overrides: Record<string, unknown> = {}) => ({
+  messages: [{ role: "user", content: "hi" }],
+  modelId: "openai/gpt-4o-mini",
+  systemPrompt: "system",
+  tools: {} as any,
+  mcpClientManager: {} as any,
+  chatSessionId: "sess_1",
+  selectedServers: ["server-a"],
+  projectId: "proj-1",
+  authHeader: "Bearer abc",
+  synthesisRunId: "run-xyz",
+  modelDefinition: {
+    id: "openai/gpt-4o-mini",
+    name: "GPT-4o mini",
+    provider: "openai",
+  } as ModelDefinition,
+  ...overrides,
+});
+
+describe("drainAssistantTurn — model-aware dispatch", () => {
+  beforeEach(() => {
+    handleMCPJamFreeChatModelMock.mockReset();
+    handleHostedOrgChatModelMock.mockReset();
+    handleLocalOrgChatModelMock.mockReset();
+    resolveOrgProviderRuntimeMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches MCPJam-provided models through handleMCPJamFreeChatModel and threads synthesisRunId via extraBodyFields", async () => {
+    const calls: unknown[] = [];
+    handleMCPJamFreeChatModelMock.mockImplementation(buildHandlerStub(calls));
+
+    const result = await drainAssistantTurn(
+      baseArgs() as Parameters<typeof drainAssistantTurn>[0],
+    );
+
+    expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledTimes(1);
+    expect(handleHostedOrgChatModelMock).not.toHaveBeenCalled();
+    expect(handleLocalOrgChatModelMock).not.toHaveBeenCalled();
+    expect(result.modelSource).toBe("mcpjam");
+    const opts = calls[0] as any;
+    expect(opts.extraBodyFields).toMatchObject({ synthesisRunId: "run-xyz" });
+    expect(opts.approvalMode).toBe("auto-deny");
+  });
+
+  it("dispatches non-MCPJam models with cloud runtime through handleHostedOrgChatModel and threads synthesisRunId via extraBodyFields", async () => {
+    const calls: unknown[] = [];
+    handleHostedOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
+    resolveOrgProviderRuntimeMock.mockResolvedValue({
+      runtimeLocation: "cloud",
+      providerKey: "anthropic",
+    });
+
+    const result = await drainAssistantTurn(
+      baseArgs({
+        modelId: "claude-3-5-sonnet-latest",
+        modelDefinition: {
+          id: "claude-3-5-sonnet-latest",
+          name: "Claude",
+          provider: "anthropic",
+        } as ModelDefinition,
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+
+    expect(handleHostedOrgChatModelMock).toHaveBeenCalledTimes(1);
+    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+    expect(handleLocalOrgChatModelMock).not.toHaveBeenCalled();
+    expect(result.modelSource).toBe("byok");
+    const opts = calls[0] as any;
+    expect(opts.extraBodyFields).toMatchObject({ synthesisRunId: "run-xyz" });
+    expect(opts.providerKey).toBe("anthropic");
+  });
+
+  it("dispatches non-MCPJam models with local runtime through handleLocalOrgChatModel and threads synthesisRunId as a typed option", async () => {
+    const calls: unknown[] = [];
+    handleLocalOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
+    resolveOrgProviderRuntimeMock.mockResolvedValue({
+      runtimeLocation: "local",
+      provider: {
+        providerKey: "openai",
+        // local providers carry resolved config including apiKey
+      } as any,
+    });
+
+    const result = await drainAssistantTurn(
+      baseArgs({
+        // ollama is in isLocalRuntimeEligible's allow-list (custom: also is).
+        modelId: "llama3",
+        modelDefinition: {
+          id: "llama3",
+          name: "Llama3 local",
+          provider: "ollama",
+        } as ModelDefinition,
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+
+    expect(handleLocalOrgChatModelMock).toHaveBeenCalledTimes(1);
+    expect(handleHostedOrgChatModelMock).not.toHaveBeenCalled();
+    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+    expect(result.modelSource).toBe("local_byok");
+    const opts = calls[0] as any;
+    expect(opts.synthesisRunId).toBe("run-xyz");
+  });
+
+  it("throws with a clear message when org-BYOK derivation fails (custom provider without a name)", async () => {
+    await expect(
+      drainAssistantTurn(
+        baseArgs({
+          modelId: "custom-thing",
+          modelDefinition: {
+            id: "custom-thing",
+            name: "Custom",
+            provider: "custom",
+            // intentionally no customProviderName — forces deriveOrgProviderKey error
+          } as ModelDefinition,
+        }) as Parameters<typeof drainAssistantTurn>[0],
+      ),
+    ).rejects.toThrow(/derive org provider key/i);
+  });
+});

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -5,7 +5,14 @@ import type { ModelDefinition } from "@/shared/types";
 const handleMCPJamFreeChatModelMock = vi.fn();
 const handleHostedOrgChatModelMock = vi.fn();
 const handleLocalOrgChatModelMock = vi.fn();
-const resolveOrgProviderRuntimeMock = vi.fn();
+// The runner calls the shared `resolveSyntheticModelSource` helper which
+// internally calls `resolveOrgProviderRuntime`. Mocking the latter via
+// module mocking doesn't intercept the call because both functions live
+// in the SAME module (vitest module mocks only intercept cross-module
+// imports). Mock the public entry point instead — that's also the
+// boundary the empty-session fallback uses, so the test naturally
+// exercises the same surface as production.
+const resolveSyntheticModelSourceMock = vi.fn();
 
 vi.mock("../../../utils/mcpjam-stream-handler.js", async () => {
   const actual = await vi.importActual<
@@ -37,8 +44,8 @@ vi.mock("../../../utils/org-model-config.js", async () => {
   >("../../../utils/org-model-config.js");
   return {
     ...actual,
-    resolveOrgProviderRuntime: (...args: unknown[]) =>
-      resolveOrgProviderRuntimeMock(...args),
+    resolveSyntheticModelSource: (...args: unknown[]) =>
+      resolveSyntheticModelSourceMock(...args),
   };
 });
 
@@ -92,7 +99,7 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
     handleMCPJamFreeChatModelMock.mockReset();
     handleHostedOrgChatModelMock.mockReset();
     handleLocalOrgChatModelMock.mockReset();
-    resolveOrgProviderRuntimeMock.mockReset();
+    resolveSyntheticModelSourceMock.mockReset();
   });
 
   afterEach(() => {
@@ -102,6 +109,7 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
   it("dispatches MCPJam-provided models through handleMCPJamFreeChatModel and threads synthesisRunId via extraBodyFields", async () => {
     const calls: unknown[] = [];
     handleMCPJamFreeChatModelMock.mockImplementation(buildHandlerStub(calls));
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
 
     const result = await drainAssistantTurn(
       baseArgs() as Parameters<typeof drainAssistantTurn>[0],
@@ -119,9 +127,9 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
   it("dispatches non-MCPJam models with cloud runtime through handleHostedOrgChatModel and threads synthesisRunId via extraBodyFields", async () => {
     const calls: unknown[] = [];
     handleHostedOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
-    resolveOrgProviderRuntimeMock.mockResolvedValue({
-      runtimeLocation: "cloud",
-      providerKey: "anthropic",
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "byok",
+      orgRuntime: { runtimeLocation: "cloud", providerKey: "anthropic" },
     });
 
     const result = await drainAssistantTurn(
@@ -150,12 +158,12 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
   it("dispatches non-MCPJam models with local runtime through handleLocalOrgChatModel and threads synthesisRunId as a typed option", async () => {
     const calls: unknown[] = [];
     handleLocalOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
-    resolveOrgProviderRuntimeMock.mockResolvedValue({
-      runtimeLocation: "local",
-      provider: {
-        providerKey: "openai",
-        // local providers carry resolved config including apiKey
-      } as any,
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as any,
+      },
     });
 
     const result = await drainAssistantTurn(
@@ -179,9 +187,12 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
   });
 
   it("refuses local-runtime org BYOK + requireToolApproval=true with non-empty tools (no auto-deny loop on the local path yet)", async () => {
-    resolveOrgProviderRuntimeMock.mockResolvedValue({
-      runtimeLocation: "local",
-      provider: { providerKey: "openai" } as any,
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as any,
+      },
     });
 
     await expect(
@@ -208,9 +219,12 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
   it("still dispatches local-runtime org BYOK when requireToolApproval is false", async () => {
     const calls: unknown[] = [];
     handleLocalOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
-    resolveOrgProviderRuntimeMock.mockResolvedValue({
-      runtimeLocation: "local",
-      provider: { providerKey: "openai" } as any,
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as any,
+      },
     });
 
     await drainAssistantTurn(
@@ -230,6 +244,14 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
   });
 
   it("throws with a clear message when org-BYOK derivation fails (custom provider without a name)", async () => {
+    // The resolver throws on deriveOrgProviderKey failure; runner propagates
+    // the same message it threw before the refactor.
+    resolveSyntheticModelSourceMock.mockRejectedValue(
+      new Error(
+        "Synthetic dispatch failed to derive org provider key: missing customProviderName",
+      ),
+    );
+
     await expect(
       drainAssistantTurn(
         baseArgs({

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -142,6 +142,9 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
     const opts = calls[0] as any;
     expect(opts.extraBodyFields).toMatchObject({ synthesisRunId: "run-xyz" });
     expect(opts.providerKey).toBe("anthropic");
+    // Synthetic runs must auto-deny approval-required tool calls — there
+    // is no human in the loop. Regression guard for #2486 PR review.
+    expect(opts.approvalMode).toBe("auto-deny");
   });
 
   it("dispatches non-MCPJam models with local runtime through handleLocalOrgChatModel and threads synthesisRunId as a typed option", async () => {

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -932,6 +932,26 @@ export async function drainAssistantTurn(
 
     if (orgRuntime.runtimeLocation === "local") {
       modelSource = "local_byok";
+      // Local-runtime org providers don't have an approval loop today —
+      // handleLocalOrgChatModel rejects synchronously with
+      // `tool_approval_unsupported` when requireToolApproval is true and
+      // any tools are exposed. Cloud BYOK paths handle this via
+      // `approvalMode: "auto-deny"` (the loop denies each call and
+      // continues); the local path has no equivalent yet, so a synthetic
+      // run on an approval-required chatbox would have every turn fail
+      // with the same error. Refuse upfront with a clear message rather
+      // than letting the per-turn errors stack up silently. Disable
+      // approval on the chatbox or switch the provider to cloud runtime
+      // to unblock.
+      if (
+        args.requireToolApproval === true &&
+        args.tools &&
+        Object.keys(args.tools as Record<string, unknown>).length > 0
+      ) {
+        throw new Error(
+          "Synthetic runs on local-runtime org BYOK models don't yet support approval-required tool calls. Disable tool approval on this chatbox or switch the provider to cloud runtime.",
+        );
+      }
       response = handleLocalOrgChatModel({
         provider: orgRuntime.provider,
         projectId: args.projectId ?? "",

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -1,13 +1,24 @@
 import type { ModelMessage } from "@ai-sdk/provider-utils";
+import type { ToolSet } from "ai";
 import type { MCPClientManager } from "@mcpjam/sdk";
 import { ConvexHttpClient } from "convex/browser";
 import type { ModelDefinition } from "@/shared/types";
-import { getModelById } from "@/shared/types";
+import { getModelById, isMCPJamProvidedModel } from "@/shared/types";
 import { logger } from "../../utils/logger.js";
 import {
   handleMCPJamFreeChatModel,
   type MCPJamHandlerOptions,
 } from "../../utils/mcpjam-stream-handler.js";
+import {
+  handleHostedOrgChatModel,
+  handleLocalOrgChatModel,
+} from "../../utils/org-model-stream-handler.js";
+import {
+  deriveOrgProviderKey,
+  isLocalRuntimeEligible,
+  resolveOrgProviderRuntime,
+  type OrgProviderRuntime,
+} from "../../utils/org-model-config.js";
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
 import {
   persistChatSessionToConvex,
@@ -483,6 +494,11 @@ async function runOneSession(args: {
     let lastTranscript: Array<{ role: "user" | "assistant"; content: string }> =
       [];
     let anyTurnPersisted = false;
+    // Captured from the first drained turn so per-session persist calls
+    // (including the empty-history fallback below) stamp the correct
+    // modelSource on chatSessions. The chatbox modelId is pinned at start,
+    // so this is stable across turns.
+    let sessionModelSource: SyntheticModelSource | undefined;
 
     for (let turn = 0; turn < maxTurns; turn++) {
       if (abortSignal?.aborted) return "failed";
@@ -504,9 +520,14 @@ async function runOneSession(args: {
       } as ModelMessage);
       lastTranscript.push({ role: "user", content: next.message });
 
-      const { history: updatedHistory, turnTrace } = await drainAssistantTurn({
+      const {
+        history: updatedHistory,
+        turnTrace,
+        modelSource: turnModelSource,
+      } = await drainAssistantTurn({
         messages: messageHistory,
         modelId: String(modelDefinition.id),
+        modelDefinition,
         chatSessionId,
         sourceType: "chatbox",
         systemPrompt: prepared.enhancedSystemPrompt,
@@ -522,11 +543,18 @@ async function runOneSession(args: {
         projectId,
         authHeader,
         abortSignal,
-        // Tag the /stream usage record with the synthesis run so spend lands
-        // on `chatboxSynthesisRuns.spendUsdActual`. The BYOK guard at the
-        // route ensures we're on the /stream (MCPJam-provided) path here.
-        extraBodyFields: { synthesisRunId: runId },
+        // Threaded into the per-step /stream (or /stream/org) body and the
+        // /stream/org/local-usage writeback so the backend BYOK and
+        // JAM-paid writers can stamp synthesisRunId onto llmUsageRecord
+        // for per-run spend attribution.
+        synthesisRunId: runId,
       });
+      // Track the first turn's modelSource for the per-session persist
+      // calls. modelSource is stable across turns within a session because
+      // chatbox modelId is pinned by `fetchChatboxRuntimeConfig` at start.
+      if (sessionModelSource === undefined) {
+        sessionModelSource = turnModelSource;
+      }
 
       messageHistory = updatedHistory;
       const assistantText = extractAssistantText(updatedHistory);
@@ -559,7 +587,7 @@ async function runOneSession(args: {
       await persistChatSessionToConvex({
         chatSessionId,
         modelId: String(modelDefinition.id),
-        modelSource: "mcpjam",
+        modelSource: sessionModelSource ?? "mcpjam",
         authHeader,
         projectId,
         sourceType: "chatbox",
@@ -604,10 +632,18 @@ async function runOneSession(args: {
       // Session ended before any assistant turn completed (persona returned
       // endSession on turn 0, or every turn aborted). Persist once with no
       // trace so the chatSessions row exists and the run summary lines up.
+      // No turn ever ran, so sessionModelSource is undefined. The empty
+      // session is attributed to the originally-resolved chatbox model
+      // class — derive it lazily from modelId so this fallback row's
+      // modelSource matches what real turns would have written.
+      const emptySessionModelSource: SyntheticModelSource =
+        isMCPJamProvidedModel(String(modelDefinition.id))
+          ? "mcpjam"
+          : "byok";
       await persistChatSessionToConvex({
         chatSessionId,
         modelId: String(modelDefinition.id),
-        modelSource: "mcpjam",
+        modelSource: emptySessionModelSource,
         authHeader,
         projectId,
         sourceType: "chatbox",
@@ -767,34 +803,158 @@ async function captureAndPersistWidgetSnapshotsForSession(args: {
   );
 }
 
+type SyntheticModelSource = "mcpjam" | "byok" | "local_byok";
+
 /**
- * Drive one assistant turn through `handleMCPJamFreeChatModel`, returning the
- * post-turn message history and the per-turn trace captured by
- * `onConversationComplete`. The caller persists each successful turn through
- * the same `chat-ingestion.ts` path Playground uses, so synthetic sessions
- * look identical to normal Playground sessions in the Trace tab and the
- * Convex `chatSessionTurnTraces` table.
+ * Drive one assistant turn through the appropriate model handler:
+ *   - MCPJam-provided modelId → `handleMCPJamFreeChatModel` (JAM-paid)
+ *   - Org-BYOK cloud runtime → `handleHostedOrgChatModel`
+ *   - Org-BYOK local runtime → `handleLocalOrgChatModel`
  *
- * Drains the SSE response body (`createUIMessageStreamResponse` requires the
- * consumer to read the stream before `onFinish` runs).
+ * Mirrors `web-chat-turn.ts`'s three-way dispatch but re-implements the
+ * minimum branch logic here because the shared dispatcher's surface is
+ * UIMessage-shaped and bakes in persist/SSE concerns that synthetic runs
+ * own themselves (per-turn `persistChatSessionToConvex` from
+ * `runOneSession` with `synthetic: true`, `personaId`, `synthesisRunId`).
+ *
+ * User-API-key direct chats are NOT supported on the synthetic path —
+ * there's no "visitor" whose key to use. Such chatboxes are rejected at
+ * the route boundary; this dispatcher's only fallthrough is for an
+ * unexpected `resolveOrgProviderRuntime` shape, which throws.
+ *
+ * Returns the post-turn message history, the per-turn trace captured by
+ * `onConversationComplete`, and the resolved `modelSource` so the caller
+ * can stamp `persistChatSessionToConvex` correctly.
+ *
+ * Drains the SSE response body (`createUIMessageStreamResponse` requires
+ * the consumer to read the stream before `onFinish` runs).
  */
-async function drainAssistantTurn(
+export async function drainAssistantTurn(
   args: Omit<MCPJamHandlerOptions, "onConversationComplete" | "onStreamComplete"> & {
     chatSessionId: string;
+    /** Resolved provider info for org-BYOK dispatch. Falls back to lookup. */
+    modelDefinition: ModelDefinition;
+    /** Synthesis run id — stamped onto BYOK usage records for attribution. */
+    synthesisRunId: string;
   },
-): Promise<{ history: ModelMessage[]; turnTrace: PersistedTurnTrace | undefined }> {
+): Promise<{
+  history: ModelMessage[];
+  turnTrace: PersistedTurnTrace | undefined;
+  modelSource: SyntheticModelSource;
+}> {
   let captured: ModelMessage[] = [];
   let capturedTurnTrace: PersistedTurnTrace | undefined;
-  const { chatSessionId: _omit, ...rest } = args;
-  const options: MCPJamHandlerOptions = {
-    ...rest,
-    approvalMode: "auto-deny",
-    onConversationComplete: (fullHistory, turnTrace) => {
-      captured = [...fullHistory];
-      capturedTurnTrace = turnTrace;
-    },
+  const {
+    chatSessionId: _omitSession,
+    modelDefinition,
+    synthesisRunId,
+    extraBodyFields,
+    ...rest
+  } = args;
+
+  const modelIdStr = String(modelDefinition.id);
+  const onConversationComplete = (
+    fullHistory: ModelMessage[],
+    turnTrace: PersistedTurnTrace,
+  ) => {
+    captured = [...fullHistory];
+    capturedTurnTrace = turnTrace;
   };
-  const response = await handleMCPJamFreeChatModel(options);
+
+  let response: Response;
+  let modelSource: SyntheticModelSource;
+
+  if (isMCPJamProvidedModel(modelIdStr)) {
+    // MCPJam-paid path: synthesisRunId rides via extraBodyFields on /stream
+    // so the JAM-paid forwarder stamps it onto the llmUsageRecord.
+    modelSource = "mcpjam";
+    const options: MCPJamHandlerOptions = {
+      ...rest,
+      approvalMode: "auto-deny",
+      extraBodyFields: { ...(extraBodyFields ?? {}), synthesisRunId },
+      onConversationComplete,
+    };
+    response = await handleMCPJamFreeChatModel(options);
+  } else {
+    // Org-BYOK path: derive providerKey from the model definition, then
+    // resolve the runtime location (cloud vs local) the same way
+    // web-chat-turn does for real chats.
+    const providerKeyResult = deriveOrgProviderKey(modelDefinition);
+    if (!providerKeyResult.ok) {
+      throw new Error(
+        `Synthetic dispatch failed to derive org provider key: ${providerKeyResult.error}`,
+      );
+    }
+    const providerKey = providerKeyResult.key;
+
+    const orgRuntime: OrgProviderRuntime = isLocalRuntimeEligible(providerKey)
+      ? await resolveOrgProviderRuntime(
+          args.projectId ?? "",
+          providerKey,
+          modelIdStr,
+          {
+            authHeader: args.authHeader,
+            chatboxId: args.chatboxId,
+            accessVersion: args.accessVersion,
+            serverIds: args.selectedServers,
+          },
+        )
+      : { runtimeLocation: "cloud", providerKey };
+
+    if (orgRuntime.runtimeLocation === "local") {
+      modelSource = "local_byok";
+      response = handleLocalOrgChatModel({
+        provider: orgRuntime.provider,
+        projectId: args.projectId ?? "",
+        modelId: modelIdStr,
+        chatSessionId: args.chatSessionId,
+        sourceType: args.sourceType,
+        messages: args.messages,
+        systemPrompt: args.systemPrompt,
+        temperature: args.temperature,
+        tools: args.tools as ToolSet,
+        progressivePlan: args.progressivePlan,
+        discoveryState: args.discoveryState,
+        authHeader: args.authHeader,
+        chatboxId: args.chatboxId,
+        accessVersion: args.accessVersion,
+        selectedServers: args.selectedServers,
+        serverIds: args.selectedServers,
+        requireToolApproval: args.requireToolApproval,
+        onConversationComplete,
+        abortSignal: args.abortSignal,
+        synthesisRunId,
+      });
+    } else {
+      modelSource = "byok";
+      response = await handleHostedOrgChatModel({
+        projectId: args.projectId ?? "",
+        providerKey: orgRuntime.providerKey,
+        modelId: modelIdStr,
+        chatSessionId: args.chatSessionId,
+        sourceType: args.sourceType,
+        messages: args.messages,
+        systemPrompt: args.systemPrompt,
+        temperature: args.temperature,
+        tools: args.tools as ToolSet,
+        progressivePlan: args.progressivePlan,
+        discoveryState: args.discoveryState,
+        authHeader: args.authHeader,
+        chatboxId: args.chatboxId,
+        accessVersion: args.accessVersion,
+        mcpClientManager: args.mcpClientManager,
+        selectedServers: args.selectedServers,
+        serverIds: args.selectedServers,
+        requireToolApproval: args.requireToolApproval,
+        onConversationComplete,
+        abortSignal: args.abortSignal,
+        // Threaded through to /stream/org so the BYOK forwarder stamps
+        // synthesisRunId onto the resulting llmUsageRecord.
+        extraBodyFields: { ...(extraBodyFields ?? {}), synthesisRunId },
+      });
+    }
+  }
+
   if (response.body) {
     const reader = response.body.getReader();
     while (true) {
@@ -805,6 +965,7 @@ async function drainAssistantTurn(
   return {
     history: captured.length > 0 ? captured : args.messages,
     turnTrace: capturedTurnTrace,
+    modelSource,
   };
 }
 

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -3,7 +3,7 @@ import type { ToolSet } from "ai";
 import type { MCPClientManager } from "@mcpjam/sdk";
 import { ConvexHttpClient } from "convex/browser";
 import type { ModelDefinition } from "@/shared/types";
-import { getModelById, isMCPJamProvidedModel } from "@/shared/types";
+import { getModelById } from "@/shared/types";
 import { logger } from "../../utils/logger.js";
 import {
   handleMCPJamFreeChatModel,
@@ -14,10 +14,8 @@ import {
   handleLocalOrgChatModel,
 } from "../../utils/org-model-stream-handler.js";
 import {
-  deriveOrgProviderKey,
-  isLocalRuntimeEligible,
-  resolveOrgProviderRuntime,
-  type OrgProviderRuntime,
+  resolveSyntheticModelSource,
+  type SyntheticModelSource,
 } from "../../utils/org-model-config.js";
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
 import {
@@ -636,38 +634,26 @@ async function runOneSession(args: {
       // Session ended before any assistant turn completed (persona returned
       // endSession on turn 0, or every turn aborted). Persist once with no
       // trace so the chatSessions row exists and the run summary lines up.
-      // No turn ever ran, so sessionModelSource is undefined. Derive it
-      // from the same dispatch shape `drainAssistantTurn` uses so a local-
-      // runtime org-BYOK chatbox doesn't get mis-attributed as cloud
-      // byok on the fallback row.
+      // No turn ever ran, so sessionModelSource is undefined. Use the same
+      // resolver `drainAssistantTurn` uses so a local-runtime org-BYOK
+      // chatbox doesn't get mis-attributed as cloud byok on the fallback
+      // row. Soft-fall-back to "byok" on resolver failure — real turns
+      // would have errored before reaching this persist; we're best-effort
+      // labeling an attribution row that exists only because the run
+      // ended before any turn ran.
       let emptySessionModelSource: SyntheticModelSource;
-      const modelIdForEmpty = String(modelDefinition.id);
-      if (isMCPJamProvidedModel(modelIdForEmpty)) {
-        emptySessionModelSource = "mcpjam";
-      } else {
-        const keyResult = deriveOrgProviderKey(modelDefinition);
-        if (!keyResult.ok) {
-          // Couldn't derive a key — fall back to cloud byok rather than
-          // crashing this attribution path. Real turns would have failed
-          // before reaching the persist.
-          emptySessionModelSource = "byok";
-        } else if (isLocalRuntimeEligible(keyResult.key)) {
-          const runtime = await resolveOrgProviderRuntime(
-            projectId,
-            keyResult.key,
-            modelIdForEmpty,
-            {
-              authHeader,
-              chatboxId,
-              accessVersion,
-              serverIds: selectedServerIds,
-            },
-          );
-          emptySessionModelSource =
-            runtime.runtimeLocation === "local" ? "local_byok" : "byok";
-        } else {
-          emptySessionModelSource = "byok";
-        }
+      try {
+        const resolution = await resolveSyntheticModelSource({
+          modelDefinition,
+          projectId,
+          authHeader,
+          chatboxId,
+          accessVersion,
+          serverIds: selectedServerIds,
+        });
+        emptySessionModelSource = resolution.source;
+      } catch {
+        emptySessionModelSource = "byok";
       }
       await persistChatSessionToConvex({
         chatSessionId,
@@ -832,7 +818,8 @@ async function captureAndPersistWidgetSnapshotsForSession(args: {
   );
 }
 
-type SyntheticModelSource = "mcpjam" | "byok" | "local_byok";
+// `SyntheticModelSource` is imported from `org-model-config.ts` so the
+// runner and the shared resolver stay in lockstep.
 
 /**
  * Drive one assistant turn through the appropriate model handler:
@@ -893,7 +880,20 @@ export async function drainAssistantTurn(
   let response: Response;
   let modelSource: SyntheticModelSource;
 
-  if (isMCPJamProvidedModel(modelIdStr)) {
+  // Classify once, dispatch off the result. The same resolver is used by
+  // the empty-session fallback persist so the two attribution paths can't
+  // drift (e.g. if isLocalRuntimeEligible's allow-list ever changes, both
+  // sites pick it up automatically).
+  const resolution = await resolveSyntheticModelSource({
+    modelDefinition,
+    projectId: args.projectId ?? "",
+    authHeader: args.authHeader,
+    chatboxId: args.chatboxId,
+    accessVersion: args.accessVersion,
+    serverIds: args.selectedServers,
+  });
+
+  if (resolution.source === "mcpjam") {
     // MCPJam-paid path: synthesisRunId rides via extraBodyFields on /stream
     // so the JAM-paid forwarder stamps it onto the llmUsageRecord.
     modelSource = "mcpjam";
@@ -905,30 +905,11 @@ export async function drainAssistantTurn(
     };
     response = await handleMCPJamFreeChatModel(options);
   } else {
-    // Org-BYOK path: derive providerKey from the model definition, then
-    // resolve the runtime location (cloud vs local) the same way
-    // web-chat-turn does for real chats.
-    const providerKeyResult = deriveOrgProviderKey(modelDefinition);
-    if (!providerKeyResult.ok) {
-      throw new Error(
-        `Synthetic dispatch failed to derive org provider key: ${providerKeyResult.error}`,
-      );
-    }
-    const providerKey = providerKeyResult.key;
-
-    const orgRuntime: OrgProviderRuntime = isLocalRuntimeEligible(providerKey)
-      ? await resolveOrgProviderRuntime(
-          args.projectId ?? "",
-          providerKey,
-          modelIdStr,
-          {
-            authHeader: args.authHeader,
-            chatboxId: args.chatboxId,
-            accessVersion: args.accessVersion,
-            serverIds: args.selectedServers,
-          },
-        )
-      : { runtimeLocation: "cloud", providerKey };
+    // resolution.orgRuntime is guaranteed defined for non-"mcpjam" sources
+    // (the resolver only omits it when source === "mcpjam"). The type
+    // narrows after the explicit check below; cast comment + check keeps
+    // strict mode happy without weakening the contract.
+    const orgRuntime = resolution.orgRuntime!;
 
     if (orgRuntime.runtimeLocation === "local") {
       modelSource = "local_byok";

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -539,7 +539,11 @@ async function runOneSession(args: {
         selectedServers: selectedServerIds,
         requireToolApproval,
         chatboxId,
-        accessVersion: undefined,
+        // The chatbox runtime-config redeem returns an accessVersion that
+        // /stream/org/resolve uses to authorize the actor against the
+        // versioned chatbox; threading the value (instead of undefined)
+        // matches what real-visitor synthetic-equivalent chats send.
+        accessVersion,
         projectId,
         authHeader,
         abortSignal,
@@ -632,14 +636,39 @@ async function runOneSession(args: {
       // Session ended before any assistant turn completed (persona returned
       // endSession on turn 0, or every turn aborted). Persist once with no
       // trace so the chatSessions row exists and the run summary lines up.
-      // No turn ever ran, so sessionModelSource is undefined. The empty
-      // session is attributed to the originally-resolved chatbox model
-      // class — derive it lazily from modelId so this fallback row's
-      // modelSource matches what real turns would have written.
-      const emptySessionModelSource: SyntheticModelSource =
-        isMCPJamProvidedModel(String(modelDefinition.id))
-          ? "mcpjam"
-          : "byok";
+      // No turn ever ran, so sessionModelSource is undefined. Derive it
+      // from the same dispatch shape `drainAssistantTurn` uses so a local-
+      // runtime org-BYOK chatbox doesn't get mis-attributed as cloud
+      // byok on the fallback row.
+      let emptySessionModelSource: SyntheticModelSource;
+      const modelIdForEmpty = String(modelDefinition.id);
+      if (isMCPJamProvidedModel(modelIdForEmpty)) {
+        emptySessionModelSource = "mcpjam";
+      } else {
+        const keyResult = deriveOrgProviderKey(modelDefinition);
+        if (!keyResult.ok) {
+          // Couldn't derive a key — fall back to cloud byok rather than
+          // crashing this attribution path. Real turns would have failed
+          // before reaching the persist.
+          emptySessionModelSource = "byok";
+        } else if (isLocalRuntimeEligible(keyResult.key)) {
+          const runtime = await resolveOrgProviderRuntime(
+            projectId,
+            keyResult.key,
+            modelIdForEmpty,
+            {
+              authHeader,
+              chatboxId,
+              accessVersion,
+              serverIds: selectedServerIds,
+            },
+          );
+          emptySessionModelSource =
+            runtime.runtimeLocation === "local" ? "local_byok" : "byok";
+        } else {
+          emptySessionModelSource = "byok";
+        }
+      }
       await persistChatSessionToConvex({
         chatSessionId,
         modelId: String(modelDefinition.id),
@@ -946,6 +975,12 @@ export async function drainAssistantTurn(
         selectedServers: args.selectedServers,
         serverIds: args.selectedServers,
         requireToolApproval: args.requireToolApproval,
+        // Synthetic runs have no human-in-the-loop. Auto-deny any
+        // approval-required tool call inside the loop so the run can
+        // make forward progress instead of pausing forever waiting for
+        // an approval that will never arrive. Matches the MCPJam-paid
+        // branch above.
+        approvalMode: "auto-deny",
         onConversationComplete,
         abortSignal: args.abortSignal,
         // Threaded through to /stream/org so the BYOK forwarder stamps

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -3,7 +3,10 @@ import type { ToolSet } from "ai";
 import type { MCPClientManager } from "@mcpjam/sdk";
 import { ConvexHttpClient } from "convex/browser";
 import type { ModelDefinition } from "@/shared/types";
-import { getModelById } from "@/shared/types";
+// `getModelById` lookup is now wrapped by `buildSyntheticModelDefinition`
+// (org-model-config.ts) — that helper falls back to BYOK provider parsing
+// when the chatbox modelId isn't in SUPPORTED_MODELS, which is the common
+// case for org-BYOK chatboxes (Ollama, custom: providers, OpenRouter ids).
 import { logger } from "../../utils/logger.js";
 import {
   handleMCPJamFreeChatModel,
@@ -14,6 +17,7 @@ import {
   handleLocalOrgChatModel,
 } from "../../utils/org-model-stream-handler.js";
 import {
+  buildSyntheticModelDefinition,
   resolveSyntheticModelSource,
   type SyntheticModelSource,
 } from "../../utils/org-model-config.js";
@@ -280,19 +284,12 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
     abortSignal,
   } = opts;
 
-  const modelDefinition = getModelById(modelId);
-  if (!modelDefinition) {
-    await tryUpdateRunWithRetry(
-      convexHttpUrl,
-      convexAuthToken,
-      projectId,
-      runId,
-      {},
-      "failed",
-      "unknown-model",
-    );
-    throw new Error(`Unknown modelId for simulation: ${modelId}`);
-  }
+  // Resolve a ModelDefinition for the chatbox modelId. Catalog hits return
+  // unchanged; BYOK shapes (Ollama, custom: providers, OpenRouter-style
+  // ids) get a derived provider so the BYOK dispatch can run. Pre-fix this
+  // was a hard `Unknown modelId for simulation` failure before any BYOK
+  // dispatch ran.
+  const modelDefinition = buildSyntheticModelDefinition(modelId);
 
   let totalSucceeded = 0;
   let totalFailed = 0;

--- a/mcpjam-inspector/server/utils/__tests__/resolve-synthetic-model-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-synthetic-model-source.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Contract tests for `resolveSyntheticModelSource` — the synthetic
+ * runner's single source of truth for the three-way MCPJam vs cloud-BYOK
+ * vs local-BYOK decision.
+ *
+ * Both `drainAssistantTurn` (turn dispatch) and the synthetic empty-session
+ * persist fallback call this helper. Locking the shape here so the two
+ * call sites can't drift.
+ *
+ * Scope: branches that DON'T require the Convex runtime resolver.
+ * The local-runtime path (`resolveOrgProviderRuntime` Convex call) lives
+ * in the same module as `resolveSyntheticModelSource`, so vitest's module
+ * mock can't intercept the internal call (same-module calls bypass the
+ * mock). That path is covered transitively by
+ * `runner.dispatch.test.ts`, which mocks `resolveSyntheticModelSource`
+ * itself.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ModelDefinition } from "@/shared/types";
+import { resolveSyntheticModelSource } from "../org-model-config";
+
+describe("resolveSyntheticModelSource", () => {
+  it("returns `mcpjam` source with no orgRuntime for MCPJam-catalog models", async () => {
+    const result = await resolveSyntheticModelSource({
+      modelDefinition: {
+        id: "openai/gpt-oss-120b",
+        name: "JAM model",
+        provider: "openai",
+      } as ModelDefinition,
+      projectId: "proj-1",
+    });
+
+    expect(result).toEqual({ source: "mcpjam" });
+  });
+
+  it("returns `byok` + cloud orgRuntime for non-MCPJam providers that aren't local-runtime-eligible (no Convex round-trip)", async () => {
+    // anthropic isn't in LOCAL_RUNTIME_ELIGIBLE_PROVIDERS and doesn't start
+    // with `custom:`, so the resolver short-circuits to cloud without
+    // hitting Convex. The test runs without CONVEX_HTTP_URL set on purpose
+    // — if the short-circuit ever regresses, the test will fail with
+    // "CONVEX_HTTP_URL is not set" rather than a silent behavior change.
+    const result = await resolveSyntheticModelSource({
+      modelDefinition: {
+        id: "claude-3-5-sonnet-latest",
+        name: "Claude",
+        provider: "anthropic",
+      } as ModelDefinition,
+      projectId: "proj-1",
+    });
+
+    expect(result.source).toBe("byok");
+    expect(result.orgRuntime).toEqual({
+      runtimeLocation: "cloud",
+      providerKey: "anthropic",
+    });
+  });
+
+  it("throws on deriveOrgProviderKey failure (e.g. custom provider missing customProviderName)", async () => {
+    await expect(
+      resolveSyntheticModelSource({
+        modelDefinition: {
+          id: "custom-thing",
+          name: "Custom",
+          provider: "custom",
+          // intentionally no customProviderName
+        } as ModelDefinition,
+        projectId: "proj-1",
+      }),
+    ).rejects.toThrow(/derive org provider key/i);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/resolve-synthetic-model-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/resolve-synthetic-model-source.test.ts
@@ -18,7 +18,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { ModelDefinition } from "@/shared/types";
-import { resolveSyntheticModelSource } from "../org-model-config";
+import {
+  buildSyntheticModelDefinition,
+  resolveSyntheticModelSource,
+} from "../org-model-config";
 
 describe("resolveSyntheticModelSource", () => {
   it("returns `mcpjam` source with no orgRuntime for MCPJam-catalog models", async () => {
@@ -68,5 +71,63 @@ describe("resolveSyntheticModelSource", () => {
         projectId: "proj-1",
       }),
     ).rejects.toThrow(/derive org provider key/i);
+  });
+});
+
+describe("buildSyntheticModelDefinition", () => {
+  it("returns the catalog definition unchanged for a SUPPORTED_MODELS id", () => {
+    const result = buildSyntheticModelDefinition("openai/gpt-oss-120b");
+    expect(result.id).toBe("openai/gpt-oss-120b");
+    expect(result.provider).toBe("openai");
+    // Catalog hits carry contextLength and other fields the BYOK fallbacks
+    // can't derive — locking that round-trip stays intact.
+    expect(result.contextLength).toBeDefined();
+  });
+
+  it("parses custom:NAME/... into provider='custom' + customProviderName", () => {
+    const result = buildSyntheticModelDefinition(
+      "custom:my-provider/some-model",
+    );
+    expect(result).toEqual({
+      id: "custom:my-provider/some-model",
+      name: "custom:my-provider/some-model",
+      provider: "custom",
+      customProviderName: "my-provider",
+    });
+  });
+
+  it("derives provider from prefix for non-catalog known prefixes", () => {
+    expect(
+      buildSyntheticModelDefinition("anthropic/claude-3.5-sonnet").provider,
+    ).toBe("anthropic");
+    expect(
+      buildSyntheticModelDefinition("meta-llama/llama-3.1-405b").provider,
+    ).toBe("meta");
+    expect(
+      buildSyntheticModelDefinition("x-ai/grok-4").provider,
+    ).toBe("xai");
+    expect(
+      buildSyntheticModelDefinition("ollama/llama-3:8b").provider,
+    ).toBe("ollama");
+  });
+
+  it("falls back to provider='ollama' for bare ids (no slash, no recognized prefix)", () => {
+    // Catalog never carries bare ids today, so the realistic BYOK case is
+    // an Ollama-style local model stored on a chatbox runtime config.
+    const result = buildSyntheticModelDefinition("llama-3:8b");
+    expect(result).toEqual({
+      id: "llama-3:8b",
+      name: "llama-3:8b",
+      provider: "ollama",
+    });
+  });
+
+  it("falls back to provider='ollama' when the prefix isn't in the catalog map", () => {
+    // Unknown-prefix BYOK ids are vanishingly rare in practice but still
+    // get a sensible default that deriveOrgProviderKey can act on.
+    const result = buildSyntheticModelDefinition(
+      "experimentalprovider/some-model",
+    );
+    expect(result.provider).toBe("ollama");
   });
 });

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import dns from "node:dns/promises";
-import type { ModelDefinition } from "@/shared/types";
+import { isMCPJamProvidedModel, type ModelDefinition } from "@/shared/types";
 import type { OrgProviderResolvedConfig } from "@mcpjam/sdk/model-factory";
 import type { BaseUrls, CustomProviderConfig } from "./chat-helpers";
 import { HOSTED_MODE } from "../config.js";
@@ -655,4 +655,84 @@ export async function resolveOrgProviderRuntimeForTarget(
     expiresAt: writeNow + RUNTIME_CACHE_TTL_MS,
   });
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic model-source classification — single source of truth for the
+// three-way MCPJam / cloud-BYOK / local-BYOK decision the synthetic runner
+// makes per session.
+// ---------------------------------------------------------------------------
+
+/** Persisted attribution label on chatSessions / llmUsageRecord rows. */
+export type SyntheticModelSource = "mcpjam" | "byok" | "local_byok";
+
+/**
+ * Result of {@link resolveSyntheticModelSource}.
+ *
+ * `orgRuntime` is present when `source !== "mcpjam"` so the synthetic
+ * dispatcher can reuse the resolved runtime (cloud providerKey OR local
+ * `OrgProviderResolvedConfig`) for the actual handler call — no
+ * duplicate `resolveOrgProviderRuntime` round-trip.
+ */
+export interface SyntheticModelResolution {
+  source: SyntheticModelSource;
+  orgRuntime?: OrgProviderRuntime;
+}
+
+/**
+ * Single source of truth for "what model-source class is this chatbox?"
+ * Mirrors the three-way split the chat path does in `web-chat-turn.ts`,
+ * narrowed to the surfaces synthetic can target (no user-API-key direct).
+ *
+ * Two callers in this PR:
+ *   1. `drainAssistantTurn` (turn dispatch) — uses both `source` and
+ *      `orgRuntime` to pick the handler.
+ *   2. The empty-session fallback persist — uses `source` only for
+ *      attribution.
+ *
+ * Pre-extraction, both encoded the same chain inline; this helper keeps
+ * them aligned so adding a runtime location (or changing
+ * `isLocalRuntimeEligible`'s allow-list) updates both call sites at once.
+ *
+ * Throws on `deriveOrgProviderKey` failure. Callers that need a soft
+ * fallback (empty-session attribution) should wrap in try/catch and
+ * default to `"byok"` — the failure means the real turns would have
+ * failed too; we're best-effort labeling a row that exists only because
+ * the run ended before any turn completed.
+ */
+export async function resolveSyntheticModelSource(args: {
+  modelDefinition: ModelDefinition;
+  projectId: string;
+  authHeader?: string;
+  chatboxId?: string;
+  accessVersion?: number;
+  serverIds?: string[];
+}): Promise<SyntheticModelResolution> {
+  const modelIdStr = String(args.modelDefinition.id);
+  if (isMCPJamProvidedModel(modelIdStr)) {
+    return { source: "mcpjam" };
+  }
+  const keyResult = deriveOrgProviderKey(args.modelDefinition);
+  if (!keyResult.ok) {
+    throw new Error(
+      `Synthetic dispatch failed to derive org provider key: ${keyResult.error}`,
+    );
+  }
+  const orgRuntime: OrgProviderRuntime = isLocalRuntimeEligible(keyResult.key)
+    ? await resolveOrgProviderRuntime(
+        args.projectId,
+        keyResult.key,
+        modelIdStr,
+        {
+          authHeader: args.authHeader,
+          chatboxId: args.chatboxId,
+          accessVersion: args.accessVersion,
+          serverIds: args.serverIds,
+        },
+      )
+    : { runtimeLocation: "cloud", providerKey: keyResult.key };
+  return {
+    source: orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok",
+    orgRuntime,
+  };
 }

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -1,6 +1,11 @@
 import { createHash } from "node:crypto";
 import dns from "node:dns/promises";
-import { isMCPJamProvidedModel, type ModelDefinition } from "@/shared/types";
+import {
+  getModelById,
+  isMCPJamProvidedModel,
+  type ModelDefinition,
+  type ModelProvider,
+} from "@/shared/types";
 import type { OrgProviderResolvedConfig } from "@mcpjam/sdk/model-factory";
 import type { BaseUrls, CustomProviderConfig } from "./chat-helpers";
 import { HOSTED_MODE } from "../config.js";
@@ -734,5 +739,101 @@ export async function resolveSyntheticModelSource(args: {
   return {
     source: orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok",
     orgRuntime,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic model-definition builder — used by the synthetic runner when
+// the chatbox is on a BYOK model that isn't in the static SUPPORTED_MODELS
+// catalog (Ollama BYOK, custom: providers, OpenRouter-style ids, etc.).
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a model-id prefix to a ModelProvider. The catalog uses
+ * provider/model ids where the prefix is the canonical provider name
+ * with one quirk: `meta-llama/...` lives under provider `meta`, and
+ * `x-ai/...` lives under provider `xai`. Mirrors the catalog entries in
+ * `shared/types.ts::SUPPORTED_MODELS`.
+ */
+const ID_PREFIX_TO_PROVIDER: Record<string, ModelProvider> = {
+  anthropic: "anthropic",
+  azure: "azure",
+  deepseek: "deepseek",
+  google: "google",
+  "meta-llama": "meta",
+  minimax: "minimax",
+  moonshotai: "moonshotai",
+  openai: "openai",
+  ollama: "ollama",
+  openrouter: "openrouter",
+  qwen: "qwen",
+  mistral: "mistral",
+  "x-ai": "xai",
+  "z-ai": "z-ai",
+};
+
+/**
+ * Build a `ModelDefinition` from a bare modelId string (e.g. the value
+ * `runtime.config.modelId` returns from `fetchChatboxRuntimeConfig`).
+ *
+ * Resolution order:
+ *   1. `getModelById(modelId)` — MCPJam catalog hit returns the full
+ *      definition unchanged (correct provider, contextLength, etc.).
+ *   2. `custom:NAME/...` prefix — provider="custom", customProviderName
+ *      parsed from the segment after `custom:`. Matches the
+ *      `deriveOrgProviderKey` shape for custom providers.
+ *   3. Known catalog-prefix shape (`anthropic/...`, `meta-llama/...`,
+ *      `ollama/...`, etc.) — provider is derived from the prefix via
+ *      ID_PREFIX_TO_PROVIDER.
+ *   4. Bare id with no recognized prefix — fall back to "ollama" since
+ *      bare ids are how Ollama BYOK models are typically stored on
+ *      chatbox runtime configs (no catalog ID uses a bare shape).
+ *
+ * This is **synthetic-runner-specific** — real chat callers always have
+ * a client-supplied ModelDefinition with the provider set. Synthetic
+ * only has `runtime.config.modelId` (the chatbox runtime endpoint
+ * doesn't expose provider today). Hoisting the runner's catalog-only
+ * lookup into a function with BYOK fallbacks makes the previously-fatal
+ * `Unknown modelId for simulation` cases dispatchable.
+ */
+export function buildSyntheticModelDefinition(
+  modelId: string,
+): ModelDefinition {
+  const supported = getModelById(modelId);
+  if (supported) return supported;
+
+  if (modelId.startsWith("custom:")) {
+    const rest = modelId.slice("custom:".length);
+    const customProviderName = rest.split("/")[0];
+    return {
+      id: modelId,
+      name: modelId,
+      provider: "custom",
+      customProviderName: customProviderName || undefined,
+    };
+  }
+
+  const slashIdx = modelId.indexOf("/");
+  if (slashIdx > 0) {
+    const prefix = modelId.slice(0, slashIdx);
+    const provider = ID_PREFIX_TO_PROVIDER[prefix];
+    if (provider) {
+      return {
+        id: modelId,
+        name: modelId,
+        provider,
+      };
+    }
+  }
+
+  // Bare id (no `/`) — Ollama BYOK is the only realistic case today since
+  // no catalog id is bare. If the org has a different bare-id provider in
+  // the future, deriveOrgProviderKey will produce "ollama" and the
+  // resolver round-trip will fail with a clearer error than the
+  // previously-fatal catalog-miss path.
+  return {
+    id: modelId,
+    name: modelId,
+    provider: "ollama",
   };
 }

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -97,6 +97,13 @@ export interface OrgModelHandlerOptions {
   selectedServers?: string[];
   serverIds?: string[];
   requireToolApproval?: boolean;
+  /**
+   * Approval mode forwarded into the wrapped MCPJam handler. Synthetic
+   * callers pass `"auto-deny"` so approval-required tool calls auto-deny
+   * inside the loop instead of pausing for a human (there is no visitor
+   * in a synthetic run). Direct chatters omit or pass `"prompt"`.
+   */
+  approvalMode?: "prompt" | "auto-deny";
   onConversationComplete?: (
     fullHistory: ModelMessage[],
     turnTrace: PersistedTurnTrace
@@ -790,6 +797,9 @@ export async function handleHostedOrgChatModel(
     mcpClientManager: options.mcpClientManager,
     selectedServers: options.selectedServers,
     requireToolApproval: options.requireToolApproval,
+    ...(options.approvalMode !== undefined
+      ? { approvalMode: options.approvalMode }
+      : {}),
     onConversationComplete: options.onConversationComplete,
     onStreamComplete: options.onStreamComplete,
     onStreamWriterReady: options.onStreamWriterReady,

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -133,6 +133,14 @@ export interface OrgModelHandlerOptions {
    * See MCPJamHandlerOptions.maxSteps. Forwarded as-is.
    */
   maxSteps?: number;
+  /**
+   * Extra body fields merged into the per-step Convex `/stream/org` POST.
+   * Synthetic chatbox runs use this to thread `synthesisRunId` so the
+   * backend BYOK writer can stamp it onto `llmUsageRecord` for per-run
+   * spend attribution. Sibling fields from the handler (providerKey,
+   * serverIds) take precedence on collision.
+   */
+  extraBodyFields?: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -279,6 +287,13 @@ export interface OrgLocalModelHandlerOptions {
    */
   progressivePlan?: ProgressiveToolPlan;
   discoveryState?: ToolDiscoveryState;
+  /**
+   * Synthesis run id for chatbox-session simulation runs. Forwarded to
+   * `/stream/org/local-usage` so the backend BYOK writer can stamp it
+   * onto the resulting `llmUsageRecord` for per-run spend attribution.
+   * Omitted for real chat traffic.
+   */
+  synthesisRunId?: string;
 }
 
 export function handleLocalOrgChatModel(
@@ -302,6 +317,7 @@ export function handleLocalOrgChatModel(
     onStreamComplete,
     onStreamWriterReady,
     onLiveTextDelta,
+    synthesisRunId,
   } = options;
 
   if (requireToolApproval && Object.keys(tools).length > 0) {
@@ -626,6 +642,7 @@ export function handleLocalOrgChatModel(
             accessVersion,
             selectedServers: options.selectedServers,
             serverIds: options.serverIds,
+            synthesisRunId,
           }).catch((err) => {
             logger.warn("[org/local] Failed to post local usage", {
               error: err instanceof Error ? err.message : String(err),
@@ -688,6 +705,12 @@ async function postLocalUsage(params: {
   accessVersion?: number;
   selectedServers?: string[];
   serverIds?: string[];
+  /**
+   * Synthesis run id for chatbox-session simulation runs. Backend BYOK
+   * writer stamps it onto `llmUsageRecord` so dashboards can query
+   * "all spend for synthesisRunId X" in one hop. Omitted for real chat.
+   */
+  synthesisRunId?: string;
 }): Promise<void> {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
   if (!convexHttpUrl) return;
@@ -722,6 +745,9 @@ async function postLocalUsage(params: {
           : {}),
         ...((params.serverIds ?? params.selectedServers)?.length
           ? { serverIds: params.serverIds ?? params.selectedServers }
+          : {}),
+        ...(params.synthesisRunId
+          ? { synthesisRunId: params.synthesisRunId }
           : {}),
       }),
       signal: controller.signal,
@@ -776,6 +802,10 @@ export async function handleHostedOrgChatModel(
     discoveryState: options.discoveryState,
     endpointPath: "/stream/org",
     extraBodyFields: {
+      // Caller-provided fields first; sibling fields from this handler
+      // (providerKey, serverIds) override on collision so the hosted
+      // contract can't be silently broken by a downstream caller.
+      ...(options.extraBodyFields ?? {}),
       providerKey: options.providerKey,
       // chatboxId / accessVersion are set on the body by
       // handleMCPJamFreeChatModel itself.


### PR DESCRIPTION
## Summary

Lifts the byok_unsupported guard on POST /web/chatboxes/:id/simulate-sessions/start so synthetic chatbox runs work with org-BYOK models (both hosted and local runtimes). User-API-key direct stays blocked with a clearer error (no visitor whose key to use in a synthetic run).

Depends on backend forwarders shipping the synthesisRunId field through /stream, /stream/org, /stream/local-byok writers (#454 + the BYOK forwarders PR). Until backend lands, BYOK spend won't be attributed by-run; UI works.

## What lands here

- **server/services/sessionSimulation/runner.ts** — drainAssistantTurn becomes model-aware:
  - MCPJam-provided → handleMCPJamFreeChatModel (existing).
  - Org-BYOK cloud → handleHostedOrgChatModel.
  - Org-BYOK local → handleLocalOrgChatModel (ollama / custom: providers).
  - synthesisRunId threaded to each handler via extraBodyFields so backend writers can stamp llmUsageRecord.synthesisRunId.
- **server/utils/org-model-stream-handler.ts** — handleHostedOrgChatModel accepts optional extraBodyFields (sibling fields take precedence on collision); handleLocalOrgChatModel + postLocalUsage accept typed synthesisRunId.
- **server/routes/web/chatbox-sessions.ts** — removed byok_unsupported 400 guard; user-API-key direct case is not producible from chatbox runtime config (resolveOrgProviderRuntime always returns either cloud or local for stored provider keys).
- **client/src/components/chatboxes/GenerateSessionsDialog.tsx** — Generate button enabled on BYOK chatboxes; spend warning + coarse cost preview tile rendered for BYOK.

### Re-implemented synthetic dispatch (not shared with web-chat-turn)

Justified inline: streamWebChatTurn's surface is UIMessage-shaped and bakes in persist/SSE concerns the synthetic runner owns itself (per-turn persistChatSessionToConvex with synthetic: true / personaId / synthesisRunId). Sharing would have required pushing synthesis-specific concerns through the dispatcher.

### Cost preview is coarse

4000 tokens/turn × \$0.005/1k blended. SUPPORTED_MODELS has no per-model pricing exposed client-side; flagged in code as estimate with disclaimer. Per-model catalog is a follow-up.

## Test plan

- [x] 6 new tests: 4 dispatch (MCPJam vs hosted-BYOK vs local-BYOK routing, synthesisRunId threading, custom-provider name-derivation error); 2 route (BYOK chatbox no longer 400, MCPJam regression).
- [x] 46 adjacent tests still green (org-model-config, chat-v2.hosted, chatboxes).
- [x] Server typecheck + client typecheck clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM routing, org provider resolution, and usage attribution for synthetic runs; real org API spend can occur once BYOK is enabled, with partial dependency on backend forwarders stamping synthesisRunId.
> 
> **Overview**
> **Synthetic chatbox runs now support org-BYOK models** — the simulate-sessions start route no longer returns `byok_unsupported`, and the generate dialog enables **Generate personas** for BYOK chatboxes with a provider-credit warning and a coarse cost estimate instead of a hard block.
> 
> On the server, **`drainAssistantTurn`** routes each turn through MCPJam `/stream`, hosted **`/stream/org`**, or local org BYOK (with **`approvalMode: auto-deny`** on cloud/MCPJam paths). Shared helpers **`buildSyntheticModelDefinition`** and **`resolveSyntheticModelSource`** replace catalog-only model lookup so Ollama/custom ids dispatch; **`synthesisRunId`** is threaded through stream bodies and local-usage writeback for per-run spend. The start route passes **server-resolved `accessVersion`** into the runner and manager factory for `/stream/org` auth.
> 
> **Local-runtime BYOK + tool approval + tools** fails upfront with a clear error (no auto-deny on the local path yet). Session persistence stamps the correct **`modelSource`** (`mcpjam` / `byok` / `local_byok`), including empty-session fallback via the same resolver.
> 
> New tests cover route BYOK acceptance, dispatch routing, and resolver/buildSynthetic contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1cc341104a90e95f3364def06a84b03cd1c188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->