### PR TITLE
evals: collapse finishIterationDirectly + recorder.finishIteration into shared finalize

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -108,10 +108,7 @@ import type {
   MCPJamToolResultEvent,
 } from "../utils/mcpjam-stream-handler.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
-import {
-  lockEvalSessionAfterUpdate,
-  persistEvalTraceFanout,
-} from "./evals/persist-eval-trace.js";
+import { finalizeEvalIteration } from "./evals/finalize-iteration.js";
 import type {
   EvalStreamEvent,
   EvalStreamToolCall,
@@ -603,196 +600,6 @@ async function createIterationDirectly(
   }
 }
 
-// Helper to finish iteration directly (for quick runs without a recorder)
-async function finishIterationDirectly(
-  convexClient: ConvexHttpClient,
-  params: {
-    iterationId?: string;
-    passed: boolean;
-    toolsCalled: Array<{ toolName: string; arguments: Record<string, any> }>;
-    usage: UsageTotals;
-    messages: ModelMessage[];
-    spans?: EvalTraceSpan[];
-    prompts?: PromptTraceSummary[];
-    widgetSnapshots?: EvalTraceWidgetSnapshot[];
-    /**
-     * Resolved system prompt for the eval session. Forwarded to
-     * `persistEvalTraceFanout` → `appendEvalTurnTrace.systemPrompt`,
-     * which the backend persists to `chatSessions.systemPrompt` with
-     * first-write-wins semantics.
-     */
-    systemPrompt?: string;
-    status?: "completed" | "failed" | "cancelled";
-    startedAt?: number;
-    error?: string;
-    errorDetails?: string;
-    resultSource?: "reported" | "derived";
-    metadata?: Record<string, string | number | boolean>;
-  },
-): Promise<void> {
-  if (!params.iterationId) return;
-
-  // Check if iteration was cancelled before trying to update
-  try {
-    const iteration = await convexClient.query(
-      "testSuites:getTestIteration" as any,
-      { iterationId: params.iterationId },
-    );
-    if (iteration?.status === "cancelled") {
-      logger.debug(
-        "[evals] Skipping update for cancelled iteration:",
-        params.iterationId,
-      );
-      return;
-    }
-  } catch (error) {
-    // If we can't check status, continue anyway
-  }
-
-  const iterationStatus =
-    params.status ?? (params.passed ? "completed" : "failed");
-  const result = params.passed ? "passed" : "failed";
-
-  // PR-2 eval→chatSessions fanout. Mirrors recorder.finishIteration —
-  // see persist-eval-trace.ts for the contract. Fanout writes per-turn
-  // rows BEFORE updateTestIteration; the chatSessions lock fires AFTER
-  // updateTestIteration succeeds (PR-2 review fix #2). When the
-  // backend flag is off, today's legacy behavior runs unchanged.
-  // lockReason describes the transcript LIFECYCLE, not the verdict —
-  // see recorder.ts for the full rationale. A failed-verdict iteration
-  // that ran cleanly still gets eval_completed; eval_failed is reserved
-  // for cycle failures (provider errors, transport crashes, etc.).
-  //
-  // The `params.error` check covers a runner quirk (Codex review on
-  // #2446): some backend eval paths set `iterationError` but still
-  // pass `status: "completed"` to finishIteration (see
-  // evals-runner.ts:2079-2082 / :3962-3965). Treating those as
-  // eval_completed would lock an error transcript with the wrong reason.
-  const isCycleFailure =
-    iterationStatus === "failed" ||
-    (params.error !== undefined && params.error !== "");
-  const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
-    iterationStatus === "cancelled"
-      ? "eval_cancelled"
-      : isCycleFailure
-        ? "eval_failed"
-        : "eval_completed";
-  const fanout = await persistEvalTraceFanout({
-    convexClient,
-    iterationId: params.iterationId,
-    iterationStartedAt: params.startedAt,
-    messages: params.messages,
-    spans: params.spans,
-    prompts: params.prompts,
-    widgetSnapshots: params.widgetSnapshots,
-    systemPrompt: params.systemPrompt,
-  });
-  // Fall back to the W1 single-call path ONLY when the fanout failed
-  // before any turn landed. See recorder.ts / persist-eval-trace.ts.
-  const useW1Fallback =
-    fanout.persisted === false && fanout.turnsWritten === 0;
-  if (fanout.persisted === false) {
-    logger.warn(
-      useW1Fallback
-        ? "[evals] persistEvalTraceFanout failed before any turn landed (quick run); falling back to W1 single-call save"
-        : "[evals] persistEvalTraceFanout failed mid-stream (quick run); iteration finalized without re-attempting (would orphan partial turns)",
-      {
-        iterationId: params.iterationId,
-        turnsWritten: fanout.turnsWritten,
-        error: fanout.error.message,
-      },
-    );
-  }
-
-  // PR-2 review #5 (Cursor "Update failure after successful fanout"):
-  // track iteration-gone state so the lock can fire even when the
-  // update throws a transient error. Mirrors recorder.finishIteration.
-  let iterationGoneOrCancelled = false;
-  try {
-    await convexClient.action("testSuites:updateTestIteration" as any, {
-      iterationId: params.iterationId,
-      result,
-      status: iterationStatus,
-      actualToolCalls: sanitizeForConvexTransport(params.toolsCalled),
-      tokensUsed: params.usage.totalTokens ?? 0,
-      ...(useW1Fallback
-        ? {
-            messages: sanitizeForConvexTransport(params.messages),
-            // Mirrors `appendEvalTurnTrace.systemPrompt` (Cursor follow-up
-            // on PR-2481): after dropping the persistence-side prepend,
-            // this W1 single-call path would otherwise persist a
-            // transcript with no resolved system prompt. Backend PR #448
-            // adds `systemPrompt` to `updateTestIteration` with the same
-            // first-write-wins semantics as the per-turn append.
-            ...(params.systemPrompt
-              ? { systemPrompt: params.systemPrompt }
-              : {}),
-            ...(params.spans?.length
-              ? { spans: sanitizeForConvexTransport(params.spans) }
-              : {}),
-            ...(params.prompts?.length
-              ? { prompts: sanitizeForConvexTransport(params.prompts) }
-              : {}),
-            ...(params.widgetSnapshots?.length
-              ? {
-                  widgetSnapshots: sanitizeForConvexTransport(
-                    params.widgetSnapshots,
-                  ),
-                }
-              : {}),
-          }
-        : {}),
-      error: params.error,
-      errorDetails: params.errorDetails,
-      resultSource: params.resultSource,
-      // Merge user-provided metadata with token usage breakdown, then
-      // sanitize: metadata can carry nested predicate rows whose authored
-      // args may contain $-prefixed keys Convex rejects at the boundary.
-      metadata: sanitizeForConvexTransport({
-        ...(params.metadata ?? {}),
-        ...buildIterationUsageMetadata(params.usage),
-      }),
-    });
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
-    // Silently skip if iteration was deleted or cancelled
-    if (
-      errorMessage.includes("not found") ||
-      errorMessage.includes("unauthorized") ||
-      errorMessage.includes("cancelled")
-    ) {
-      iterationGoneOrCancelled = true;
-    } else {
-      logger.error(
-        "[evals] Failed to finish iteration:",
-        new Error(errorMessage),
-      );
-      // Fall through to the lock step. See recorder.ts for the
-      // rationale: chatSessions transcript is complete from the
-      // fanout's perspective; locking prevents partial writes on a
-      // retry. Iteration row's terminal status may stay stale until
-      // a retry/cron sweep — acceptable because the chatSessions
-      // layer is consistent.
-    }
-  }
-
-  // Lock the chatSession when fanout succeeded. Runs in BOTH the
-  // success branch and the transient-failure branch; skipped only
-  // when the iteration is gone. Mirrors recorder.finishIteration's
-  // pattern — see there for full rationale.
-  if (
-    fanout?.persisted === true &&
-    params.iterationId &&
-    !iterationGoneOrCancelled
-  ) {
-    await lockEvalSessionAfterUpdate({
-      convexClient,
-      iterationId: params.iterationId,
-      reason: terminalReason,
-    });
-  }
-}
 
 /**
  * Persist a failed iteration row when iteration setup throws BEFORE the
@@ -823,7 +630,10 @@ async function persistSetupFailedIteration(args: {
   if (args.recorder) {
     await args.recorder.finishIteration(failParams);
   } else {
-    await finishIterationDirectly(args.convexClient, failParams);
+    await finalizeEvalIteration({
+      ...failParams,
+      convexClient: args.convexClient,
+    });
   }
 }
 
@@ -1762,7 +1572,7 @@ const runIterationWithAiSdk = async ({
     if (recorder) {
       await recorder.finishIteration(finishParams);
     } else {
-      await finishIterationDirectly(convexClient, finishParams);
+      await finalizeEvalIteration({ ...finishParams, convexClient });
     }
 
     return {
@@ -1887,7 +1697,7 @@ const runIterationWithAiSdk = async ({
     if (recorder) {
       await recorder.finishIteration(failParams);
     } else {
-      await finishIterationDirectly(convexClient, failParams);
+      await finalizeEvalIteration({ ...failParams, convexClient });
     }
     return {
       evaluation,
@@ -2526,7 +2336,7 @@ const runIterationViaBackend = async ({
   if (recorder) {
     await recorder.finishIteration(finishParams);
   } else {
-    await finishIterationDirectly(convexClient, finishParams);
+    await finalizeEvalIteration({ ...finishParams, convexClient });
   }
 
   return {
@@ -3736,7 +3546,7 @@ const streamIterationWithAiSdk = async ({
     if (recorder) {
       await recorder.finishIteration(finishParams);
     } else {
-      await finishIterationDirectly(convexClient, finishParams);
+      await finalizeEvalIteration({ ...finishParams, convexClient });
     }
 
     return {
@@ -3884,7 +3694,7 @@ const streamIterationWithAiSdk = async ({
     if (recorder) {
       await recorder.finishIteration(failParams);
     } else {
-      await finishIterationDirectly(convexClient, failParams);
+      await finalizeEvalIteration({ ...failParams, convexClient });
     }
     return {
       evaluation,
@@ -4867,7 +4677,7 @@ const streamIterationViaBackend = async ({
   if (recorder) {
     await recorder.finishIteration(finishParams);
   } else {
-    await finishIterationDirectly(convexClient, finishParams);
+    await finalizeEvalIteration({ ...finishParams, convexClient });
   }
 
   return {

--- a/mcpjam-inspector/server/services/evals/__tests__/finalize-iteration.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/finalize-iteration.test.ts
@@ -1,0 +1,433 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { ConvexHttpClient } from "convex/browser";
+import type { ModelMessage } from "ai";
+import type {
+  EvalTraceSpan,
+  PromptTraceSummary,
+} from "@/shared/eval-trace";
+import { finalizeEvalIteration } from "../finalize-iteration.js";
+
+type Call = { ref: string; args: Record<string, unknown> };
+
+function makeClient(opts: {
+  /** When set, the first call to `testSuites:updateTestIteration` throws. */
+  updateThrows?: Error;
+  /** When set, ALL calls to `testSuites:appendEvalTurnTrace` throw (fanout
+   *  fails before any turn lands → triggers the W1 fallback). */
+  appendThrows?: Error;
+  /** When set, returns this `status` from `testSuites:getTestIteration`. */
+  iterationStatus?: string;
+}): {
+  client: ConvexHttpClient;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const query = vi.fn(async (ref: string, args: Record<string, unknown>) => {
+    calls.push({ ref, args });
+    if (ref === "testSuites:getTestIteration") {
+      if (opts.iterationStatus) {
+        return { status: opts.iterationStatus };
+      }
+      return { status: "running" };
+    }
+    throw new Error(`unexpected query ${ref}`);
+  });
+  const action = vi.fn(async (ref: string, args: Record<string, unknown>) => {
+    calls.push({ ref, args });
+    if (ref === "testSuites:appendEvalTurnTrace") {
+      if (opts.appendThrows) throw opts.appendThrows;
+      return { skipped: false };
+    }
+    if (ref === "testSuites:updateTestIteration") {
+      if (opts.updateThrows) throw opts.updateThrows;
+      return undefined;
+    }
+    if (ref === "testSuites:lockEvalSession") {
+      return { skipped: false, locked: true, alreadyLocked: false };
+    }
+    throw new Error(`unexpected action ${ref}`);
+  });
+  return {
+    client: { query, action } as unknown as ConvexHttpClient,
+    calls,
+  };
+}
+
+const messages: ModelMessage[] = [
+  { role: "user", content: "q0" } as ModelMessage,
+  { role: "assistant", content: "a0" } as ModelMessage,
+];
+const usageZero = {
+  inputTokens: 0,
+  outputTokens: 0,
+  totalTokens: 0,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("finalizeEvalIteration", () => {
+  test("early-returns when iterationId is absent", async () => {
+    const { client, calls } = makeClient({});
+    await finalizeEvalIteration({
+      convexClient: client,
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("skips update when the iteration is already cancelled", async () => {
+    const { client, calls } = makeClient({ iterationStatus: "cancelled" });
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+    });
+    // Only the pre-check `getTestIteration` query should have happened.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.ref).toBe("testSuites:getTestIteration");
+  });
+
+  test("W1 fallback includes systemPrompt when set (regression: systemPrompt-slot)", async () => {
+    // Fanout fails before any turn lands → W1 fallback path. systemPrompt
+    // must round-trip into `updateTestIteration` so the resolved system
+    // prompt isn't dropped. This is the load-bearing bug class this PR
+    // prevents (the Cursor follow-ups had to fix it in BOTH paths).
+    const { client, calls } = makeClient({
+      appendThrows: new Error("fanout pre-turn failure"),
+    });
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      systemPrompt: "You are a careful assistant.",
+    });
+    const update = calls.find(
+      (c) => c.ref === "testSuites:updateTestIteration",
+    );
+    expect(update).toBeDefined();
+    expect(update!.args.systemPrompt).toBe("You are a careful assistant.");
+    // Messages forwarded too (W1 single-call save).
+    expect(update!.args.messages).toBeDefined();
+  });
+
+  test("W1 fallback omits systemPrompt when unset", async () => {
+    const { client, calls } = makeClient({
+      appendThrows: new Error("fanout pre-turn failure"),
+    });
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+    });
+    const update = calls.find(
+      (c) => c.ref === "testSuites:updateTestIteration",
+    );
+    expect(update).toBeDefined();
+    expect("systemPrompt" in update!.args).toBe(false);
+  });
+
+  test("W1 fallback omits empty spans/prompts/widgetSnapshots", async () => {
+    const { client, calls } = makeClient({
+      appendThrows: new Error("fanout pre-turn failure"),
+    });
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      spans: [],
+      prompts: [],
+      widgetSnapshots: [],
+    });
+    const update = calls.find(
+      (c) => c.ref === "testSuites:updateTestIteration",
+    );
+    expect(update).toBeDefined();
+    expect("spans" in update!.args).toBe(false);
+    expect("prompts" in update!.args).toBe(false);
+    expect("widgetSnapshots" in update!.args).toBe(false);
+  });
+
+  test("terminalReason: completed + passed:false → eval_completed (verdict-only failure is not a cycle failure)", async () => {
+    const { client, calls } = makeClient({});
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: false,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      status: "completed",
+    });
+    const lock = calls.find((c) => c.ref === "testSuites:lockEvalSession");
+    expect(lock).toBeDefined();
+    expect(lock!.args.reason).toBe("eval_completed");
+  });
+
+  test("terminalReason: completed + error set → eval_failed (cycle failure)", async () => {
+    const { client, calls } = makeClient({});
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: false,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      status: "completed",
+      error: "provider rejected request",
+    });
+    const lock = calls.find((c) => c.ref === "testSuites:lockEvalSession");
+    expect(lock).toBeDefined();
+    expect(lock!.args.reason).toBe("eval_failed");
+  });
+
+  test("terminalReason: cancelled → eval_cancelled", async () => {
+    const { client, calls } = makeClient({});
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: false,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      status: "cancelled",
+    });
+    const lock = calls.find((c) => c.ref === "testSuites:lockEvalSession");
+    expect(lock).toBeDefined();
+    expect(lock!.args.reason).toBe("eval_cancelled");
+  });
+
+  test("fanout-mid-stream-fail (persisted:false, turnsWritten>0) → no W1 spread, no re-attempt", async () => {
+    // Turn 0 succeeds, turn 1 throws. `turnsWritten > 0` so we must NOT
+    // re-send trace fields to `updateTestIteration` — would overwrite
+    // turn 0 and orphan later turns.
+    let appendCount = 0;
+    const calls: Call[] = [];
+    const query = vi.fn(async (ref: string, args: Record<string, unknown>) => {
+      calls.push({ ref, args });
+      return { status: "running" };
+    });
+    const action = vi.fn(async (ref: string, args: Record<string, unknown>) => {
+      calls.push({ ref, args });
+      if (ref === "testSuites:appendEvalTurnTrace") {
+        appendCount += 1;
+        if (appendCount === 2) throw new Error("network blip on turn 1");
+        return { skipped: false };
+      }
+      if (ref === "testSuites:updateTestIteration") return undefined;
+      if (ref === "testSuites:lockEvalSession") {
+        return { skipped: false, locked: true, alreadyLocked: false };
+      }
+      throw new Error(`unexpected ${ref}`);
+    });
+    const client = { query, action } as unknown as ConvexHttpClient;
+
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "s0",
+        name: "step",
+        category: "step",
+        startMs: 1,
+        endMs: 2,
+        promptIndex: 0,
+      },
+      {
+        id: "s1",
+        name: "step",
+        category: "step",
+        startMs: 3,
+        endMs: 4,
+        promptIndex: 1,
+      },
+    ];
+    const prompts: PromptTraceSummary[] = [
+      {
+        promptIndex: 0,
+        prompt: "p0",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+      {
+        promptIndex: 1,
+        prompt: "p1",
+        expectedToolCalls: [],
+        actualToolCalls: [],
+        passed: true,
+        missing: [],
+        unexpected: [],
+        argumentMismatches: [],
+      },
+    ];
+
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages: [
+        { role: "user", content: "q0" } as ModelMessage,
+        { role: "assistant", content: "a0" } as ModelMessage,
+        { role: "user", content: "q1" } as ModelMessage,
+        { role: "assistant", content: "a1" } as ModelMessage,
+      ],
+      spans,
+      prompts,
+      systemPrompt: "sys",
+    });
+
+    const update = calls.find(
+      (c) => c.ref === "testSuites:updateTestIteration",
+    );
+    expect(update).toBeDefined();
+    // No W1 spread because turnsWritten > 0.
+    expect("messages" in update!.args).toBe(false);
+    expect("systemPrompt" in update!.args).toBe(false);
+    expect("spans" in update!.args).toBe(false);
+    expect("prompts" in update!.args).toBe(false);
+    // Lock skipped because fanout.persisted === false.
+    const lock = calls.find((c) => c.ref === "testSuites:lockEvalSession");
+    expect(lock).toBeUndefined();
+  });
+
+  test("onRunDeleted invoked when updateTestIteration throws 'not found'", async () => {
+    const { client } = makeClient({
+      updateThrows: new Error("iteration not found"),
+    });
+    const onRunDeleted = vi.fn();
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      onRunDeleted,
+    });
+    expect(onRunDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  test("onRunDeleted invoked when updateTestIteration throws 'unauthorized'", async () => {
+    const { client } = makeClient({
+      updateThrows: new Error("unauthorized"),
+    });
+    const onRunDeleted = vi.fn();
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      onRunDeleted,
+    });
+    expect(onRunDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  test("onRunDeleted invoked when updateTestIteration throws 'cancelled'", async () => {
+    const { client } = makeClient({
+      updateThrows: new Error("iteration cancelled"),
+    });
+    const onRunDeleted = vi.fn();
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      onRunDeleted,
+    });
+    expect(onRunDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  test("onRunDeleted NOT invoked on transient update failures", async () => {
+    const { client } = makeClient({
+      updateThrows: new Error("connection reset"),
+    });
+    const onRunDeleted = vi.fn();
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+      onRunDeleted,
+    });
+    expect(onRunDeleted).not.toHaveBeenCalled();
+  });
+
+  test("lock fires when fanout persisted + update succeeds", async () => {
+    const { client, calls } = makeClient({});
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+    });
+    const lock = calls.find((c) => c.ref === "testSuites:lockEvalSession");
+    expect(lock).toBeDefined();
+    expect(lock!.args).toMatchObject({
+      iterationId: "iter1",
+      reason: "eval_completed",
+    });
+  });
+
+  test("lock SKIPS when iteration is gone (onRunDeleted branch)", async () => {
+    const { client, calls } = makeClient({
+      updateThrows: new Error("iteration not found"),
+    });
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+    });
+    const lock = calls.find((c) => c.ref === "testSuites:lockEvalSession");
+    expect(lock).toBeUndefined();
+  });
+
+  test("lock STILL fires on transient update failure when fanout persisted", async () => {
+    // PR-2 review #5: transient (non-cancellation) update failures must
+    // still trigger the lock so retries don't accumulate partial writes
+    // against a row whose chatSessions transcript is already complete.
+    const { client, calls } = makeClient({
+      updateThrows: new Error("connection reset"),
+    });
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: usageZero,
+      messages,
+    });
+    const lock = calls.find((c) => c.ref === "testSuites:lockEvalSession");
+    expect(lock).toBeDefined();
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { startSuiteRunWithRecorder } from "../recorder.js";
+import type { ModelMessage } from "ai";
+import { createSuiteRunRecorder, startSuiteRunWithRecorder } from "../recorder.js";
 
 describe("startSuiteRunWithRecorder", () => {
   it("forwards tool snapshot metadata when creating a suite run", async () => {
@@ -191,5 +192,62 @@ describe("startSuiteRunWithRecorder", () => {
     });
 
     expect(result.config.environment).toEqual(snapshotEnvironment);
+  });
+});
+
+describe("createSuiteRunRecorder", () => {
+  it("flips runDeleted when finishIteration's shared finalize sees 'not found', short-circuiting subsequent startIteration", async () => {
+    // Pre-check getTestIteration returns running; updateTestIteration throws
+    // "not found" → shared finalizeEvalIteration fires `onRunDeleted` →
+    // recorder's `runDeleted` flag flips → next `startIteration` no-ops
+    // without ever querying Convex.
+    const query = vi.fn(async (ref: string) => {
+      if (ref === "testSuites:getTestIteration") {
+        return { status: "running" };
+      }
+      throw new Error(`unexpected query ${ref}`);
+    });
+    const action = vi.fn(async (ref: string) => {
+      if (ref === "testSuites:appendEvalTurnTrace") {
+        return { skipped: false };
+      }
+      if (ref === "testSuites:updateTestIteration") {
+        throw new Error("iteration not found");
+      }
+      if (ref === "testSuites:lockEvalSession") {
+        return { skipped: false, locked: true, alreadyLocked: false };
+      }
+      throw new Error(`unexpected action ${ref}`);
+    });
+    const mutation = vi.fn();
+    const convexClient = { query, action, mutation } as any;
+
+    const recorder = createSuiteRunRecorder({
+      convexClient,
+      suiteId: "suite-1",
+      runId: "run-1",
+    });
+
+    await recorder.finishIteration({
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      messages: [{ role: "user", content: "hi" } as ModelMessage],
+    });
+
+    // The action threw "not found"; the runDeleted callback should have
+    // fired. Confirm by calling startIteration and asserting it
+    // short-circuits (no Convex calls).
+    const queryCallsBefore = query.mock.calls.length;
+    const mutationCallsBefore = mutation.mock.calls.length;
+    const result = await recorder.startIteration({
+      testCaseId: "tc1",
+      iterationNumber: 1,
+      startedAt: Date.now(),
+    });
+    expect(result).toBeUndefined();
+    expect(query.mock.calls.length).toBe(queryCallsBefore);
+    expect(mutation.mock.calls.length).toBe(mutationCallsBefore);
   });
 });

--- a/mcpjam-inspector/server/services/evals/finalize-iteration.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration.ts
@@ -1,0 +1,287 @@
+import type { ModelMessage } from "ai";
+import type { ConvexHttpClient } from "convex/browser";
+import type {
+  EvalTraceSpan,
+  EvalTraceWidgetSnapshot,
+  PromptTraceSummary,
+} from "@/shared/eval-trace";
+import { logger } from "../../utils/logger.js";
+import type { UsageTotals } from "./types.js";
+import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+import { buildIterationUsageMetadata } from "./iteration-usage-metadata.js";
+import {
+  lockEvalSessionAfterUpdate,
+  persistEvalTraceFanout,
+} from "./persist-eval-trace.js";
+
+type IterationStatus = "completed" | "failed" | "cancelled";
+
+const DEFAULT_ITERATION_STATUS: IterationStatus = "completed";
+
+export type FinalizeEvalIterationParams = {
+  convexClient: ConvexHttpClient;
+  iterationId?: string;
+  passed: boolean;
+  toolsCalled: Array<{ toolName: string; arguments: Record<string, any> }>;
+  usage: UsageTotals;
+  messages: ModelMessage[];
+  spans?: EvalTraceSpan[];
+  prompts?: PromptTraceSummary[];
+  widgetSnapshots?: EvalTraceWidgetSnapshot[];
+  /**
+   * Resolved system prompt for the eval session. Forwarded to
+   * `persistEvalTraceFanout` → `appendEvalTurnTrace.systemPrompt`,
+   * which the backend persists to `chatSessions.systemPrompt` with
+   * first-write-wins semantics. Also forwarded on the W1 fallback
+   * `updateTestIteration` call so the prompt lands even when the
+   * fanout failed before any turn wrote.
+   */
+  systemPrompt?: string;
+  status?: IterationStatus;
+  startedAt?: number;
+  error?: string;
+  errorDetails?: string;
+  resultSource?: "reported" | "derived";
+  // Scalar signals (argumentMismatchCount, host exposure counts, …) plus the
+  // nested `predicates: PredicateResult[]` rows. Persisted to
+  // `testIteration.metadata`; the Convex validator accepts nested values.
+  metadata?: Record<string, unknown>;
+  /**
+   * Recorder hook: called when the iteration update returns a
+   * "not found" / "unauthorized" / "cancelled" error so the caller can
+   * short-circuit further calls on this run. Direct callers (no recorder)
+   * pass nothing.
+   */
+  onRunDeleted?: () => void;
+};
+
+/**
+ * Shared finalize step for both the multi-iteration suite-run recorder
+ * (`SuiteRunRecorder.finishIteration`) and the quick-run direct path
+ * (where `runId === null`). Owns:
+ *   - early bail when there is no `iterationId`
+ *   - cancellation pre-check via `getTestIteration`
+ *   - status / result / terminalReason derivation
+ *   - per-turn fanout via `persistEvalTraceFanout`
+ *   - W1 single-call fallback (`messages` + optional trace fields) when
+ *     the fanout failed before any turn landed
+ *   - `updateTestIteration` call with sanitized metadata
+ *   - terminal lock via `lockEvalSessionAfterUpdate` (post-update)
+ *
+ * The two paths used to be near byte-identical (`recorder.ts` vs
+ * `evals-runner.ts:finishIterationDirectly`). The systemPrompt-slot PR
+ * series (mcpjam-backend #448 + #449, inspector #2481) had to fix the
+ * same W1 fallback bug — `systemPrompt` was dropped — in BOTH paths.
+ * This collapse prevents the next instance of that bug class.
+ *
+ * Suite-run-scoped state (the recorder's `runDeleted` short-circuit
+ * flag) stays in the recorder; it surfaces here as the `onRunDeleted`
+ * callback fired in the same error branches the recorder used to flip
+ * `runDeleted` in directly.
+ */
+export async function finalizeEvalIteration(
+  params: FinalizeEvalIterationParams,
+): Promise<void> {
+  const {
+    convexClient,
+    iterationId,
+    passed,
+    toolsCalled,
+    usage,
+    messages,
+    spans,
+    prompts,
+    widgetSnapshots,
+    systemPrompt,
+    status,
+    startedAt,
+    error,
+    errorDetails,
+    resultSource,
+    metadata,
+    onRunDeleted,
+  } = params;
+
+  if (!iterationId) {
+    return;
+  }
+
+  // Check if iteration was cancelled before trying to update.
+  try {
+    const iteration = await convexClient.query(
+      "testSuites:getTestIteration" as any,
+      { iterationId },
+    );
+    if (iteration?.status === "cancelled") {
+      logger.debug(
+        "[evals] Skipping update for cancelled iteration:",
+        iterationId,
+      );
+      return;
+    }
+  } catch {
+    // If we can't check status, continue anyway.
+  }
+
+  const iterationStatus =
+    status ?? (passed ? DEFAULT_ITERATION_STATUS : "failed");
+  const result = passed ? "passed" : "failed";
+
+  // PR-2 eval→chatSessions fanout: write the transcript as per-turn rows
+  // BEFORE calling updateTestIteration. The fanout no longer fires the
+  // terminal lock — that happens AFTER updateTestIteration succeeds so
+  // a downstream iteration-row failure cannot leave a locked transcript
+  // without a finalized iteration (PR-2 review fix #2, Cursor
+  // #ed44ef40). Idempotent on retry.
+  //
+  // Fanout result drives whether we still pass trace fields to
+  // updateTestIteration:
+  //   - persisted:true  → trace lives in chatSessions; updateTestIteration
+  //                       called WITHOUT trace fields (no double-persist)
+  //   - persisted:false → fanout failed before any turn landed; fall
+  //                       back to the legacy single-call path so the
+  //                       iteration is still complete and replayable.
+  //
+  // lockReason describes the transcript LIFECYCLE (did the eval cycle
+  // run to completion?), NOT the verdict. A failed-verdict iteration
+  // that ran cleanly (status: "completed", result: "failed") still gets
+  // eval_completed; eval_failed is reserved for cycle failures like
+  // provider errors, MCP transport crashes, etc. The verdict lives on
+  // testIteration.result (passed | failed | pending).
+  //
+  // The `error != null` check covers a runner quirk (Codex review on
+  // #2446): the backend eval paths sometimes set `iterationError` while
+  // still calling finishIteration with `status: "completed"` (see
+  // evals-runner.ts). Treating those as eval_completed would lock an
+  // error transcript with the wrong reason. Presence of `error` is the
+  // cycle-failure signal we already have in scope.
+  const isCycleFailure =
+    iterationStatus === "failed" || (error !== undefined && error !== "");
+  const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
+    iterationStatus === "cancelled"
+      ? "eval_cancelled"
+      : isCycleFailure
+        ? "eval_failed"
+        : "eval_completed";
+
+  const fanout = await persistEvalTraceFanout({
+    convexClient,
+    iterationId,
+    iterationStartedAt: startedAt,
+    messages,
+    spans,
+    prompts,
+    widgetSnapshots,
+    systemPrompt,
+  });
+  // Fall back to the W1 single-call path ONLY when the fanout failed
+  // before any turn landed. With turns already written, re-sending
+  // would overwrite turn 0 (W1 always writes at promptIndex: 0) and
+  // orphan turns 1..N. See persist-eval-trace.ts for the contract.
+  const useW1Fallback =
+    fanout.persisted === false && fanout.turnsWritten === 0;
+  if (fanout.persisted === false) {
+    logger.warn(
+      useW1Fallback
+        ? "[evals] persistEvalTraceFanout failed before any turn landed; falling back to W1 single-call save"
+        : "[evals] persistEvalTraceFanout failed mid-stream; iteration finalized without re-attempting (would orphan partial turns)",
+      {
+        iterationId,
+        turnsWritten: fanout.turnsWritten,
+        error: fanout.error.message,
+      },
+    );
+  }
+
+  // PR-2 review #5 (Cursor "Update failure after successful fanout"):
+  // track whether the iteration is gone so we don't waste a lock
+  // call on a deleted session, AND so the lock fires even when
+  // the iteration update threw a transient error.
+  let iterationGoneOrCancelled = false;
+  try {
+    await convexClient.action("testSuites:updateTestIteration" as any, {
+      iterationId,
+      status: iterationStatus === "completed" ? "completed" : iterationStatus,
+      result,
+      actualToolCalls: sanitizeForConvexTransport(toolsCalled),
+      tokensUsed: usage.totalTokens ?? 0,
+      ...(useW1Fallback
+        ? {
+            messages: sanitizeForConvexTransport(messages),
+            // Mirrors `appendEvalTurnTrace.systemPrompt`. Cursor Bugbot
+            // follow-up "W1 omits systemPrompt": without this the W1
+            // fallback persists a transcript with no resolved system
+            // prompt — the prepend was dropped earlier in the
+            // systemPrompt-slot PR series. Backend `updateTestIteration`
+            // accepts the slot (mcpjam-backend #449); first-write-wins
+            // semantics apply, no risk of clobbering a value already
+            // set by an earlier `appendEvalTurnTrace`.
+            ...(systemPrompt ? { systemPrompt } : {}),
+            ...(spans?.length
+              ? { spans: sanitizeForConvexTransport(spans) }
+              : {}),
+            ...(prompts?.length
+              ? { prompts: sanitizeForConvexTransport(prompts) }
+              : {}),
+            ...(widgetSnapshots?.length
+              ? {
+                  widgetSnapshots:
+                    sanitizeForConvexTransport(widgetSnapshots),
+                }
+              : {}),
+          }
+        : {}),
+      error,
+      errorDetails,
+      resultSource,
+      // Merge user-provided metadata with token usage breakdown, then
+      // sanitize: metadata can carry nested predicate rows whose
+      // authored args may contain $-prefixed keys Convex rejects at
+      // the boundary.
+      metadata: sanitizeForConvexTransport({
+        ...(metadata ?? {}),
+        ...buildIterationUsageMetadata(usage),
+      }),
+    });
+  } catch (caught) {
+    const errorMessage =
+      caught instanceof Error ? caught.message : String(caught);
+
+    // Check if run was deleted/not found or iteration was cancelled.
+    if (
+      errorMessage.includes("not found") ||
+      errorMessage.includes("unauthorized") ||
+      errorMessage.includes("cancelled")
+    ) {
+      iterationGoneOrCancelled = true;
+      onRunDeleted?.();
+    } else {
+      logger.error(
+        "[evals] Failed to record iteration result:",
+        new Error(errorMessage),
+      );
+      // Transient (non-cancellation) failure: fall through to the lock
+      // step. The chatSessions transcript is complete from the fanout's
+      // perspective; locking prevents a retry from accumulating partial
+      // writes against a row whose data already represents the final
+      // state. The iteration row's terminal status remains stale until
+      // a retry/cron sweep finalizes it — that's acceptable because
+      // the data is consistent at the chatSessions layer.
+    }
+  }
+
+  // Lock the chatSession when fanout succeeded — runs in BOTH the
+  // success branch (updateTestIteration succeeded → defense + UI hint)
+  // and the transient-failure branch (updateTestIteration threw a
+  // non-cancellation error → prevents partial writes on retry).
+  // Skipped only when the iteration is gone, where locking a deleted
+  // session is wasted work. Best-effort: lockEvalSessionAfterUpdate
+  // swallows its own failures.
+  if (fanout?.persisted === true && !iterationGoneOrCancelled) {
+    await lockEvalSessionAfterUpdate({
+      convexClient,
+      iterationId,
+      reason: terminalReason,
+    });
+  }
+}

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -8,11 +8,7 @@ import type { UsageTotals } from "./types";
 import { logger } from "../../utils/logger";
 import type { ServerToolSnapshot } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
-import { buildIterationUsageMetadata } from "./iteration-usage-metadata.js";
-import {
-  lockEvalSessionAfterUpdate,
-  persistEvalTraceFanout,
-} from "./persist-eval-trace.js";
+import { finalizeEvalIteration } from "./finalize-iteration.js";
 import { resolveCaseSuccessPredicates } from "@/shared/eval-matching";
 
 type IterationStatus = "completed" | "failed" | "cancelled";
@@ -91,8 +87,6 @@ export type SuiteRunRecorder = {
     notes?: string;
   }): Promise<void>;
 };
-
-const DEFAULT_ITERATION_STATUS: IterationStatus = "completed";
 
 function isSuiteRunEnvironmentSnapshot(
   value: unknown,
@@ -203,217 +197,22 @@ export const createSuiteRunRecorder = ({
         return undefined;
       }
     },
-    async finishIteration({
-      iterationId,
-      passed,
-      toolsCalled,
-      usage,
-      messages,
-      spans,
-      prompts,
-      widgetSnapshots,
-      systemPrompt,
-      status,
-      startedAt,
-      error,
-      errorDetails,
-      resultSource,
-      metadata,
-    }) {
-      if (!iterationId || runDeleted) {
+    async finishIteration(params) {
+      if (runDeleted) {
         return;
       }
-
-      // Check if iteration was cancelled before trying to update
-      try {
-        const iteration = await convexClient.query(
-          "testSuites:getTestIteration" as any,
-          { iterationId },
-        );
-        if (iteration?.status === "cancelled") {
-          logger.debug(
-            "[evals] Skipping update for cancelled iteration:",
-            iterationId,
-          );
-          return;
-        }
-      } catch (error) {
-        // If we can't check status, continue anyway
-      }
-
-      const iterationStatus =
-        status ?? (passed ? DEFAULT_ITERATION_STATUS : "failed");
-      const result = passed ? "passed" : "failed";
-
-      // PR-2 eval→chatSessions fanout: when the backend flag is on,
-      // write the transcript as per-turn rows in the chatSessions path
-      // BEFORE calling updateTestIteration. The fanout no longer fires
-      // the terminal lock — that happens AFTER updateTestIteration
-      // succeeds so a downstream iteration-row failure cannot leave a
-      // locked transcript without a finalized iteration (PR-2 review
-      // fix #2, Cursor #ed44ef40). Idempotent on retry.
-      //
-      // Fanout result drives whether we still pass trace fields to
-      // updateTestIteration:
-      //   - null            → flag off; today's legacy behavior runs
-      //   - persisted:true  → trace lives in chatSessions; updateTestIteration
-      //                       called WITHOUT trace fields (no double-persist)
-      //   - persisted:false → fanout failed mid-stream; fall back to
-      //                       the legacy single-call path so the iteration
-      //                       is still complete and replayable.
-      // lockReason describes the transcript LIFECYCLE (did the eval cycle
-      // run to completion?), NOT the verdict. A failed-verdict iteration
-      // that ran cleanly (status: "completed", result: "failed") still
-      // gets eval_completed; eval_failed is reserved for cycle failures
-      // like provider errors, MCP transport crashes, etc. The verdict
-      // lives on testIteration.result (passed | failed | pending).
-      //
-      // The `error != null` check covers a runner quirk (Codex review on
-      // #2446): the backend eval paths sometimes set
-      // `iterationError` while still calling finishIteration with
-      // `status: "completed"` (see evals-runner.ts:2079-2082 and
-      // :3962-3965). Treating those as eval_completed would lock an
-      // error transcript with the wrong reason. Presence of `error`
-      // is the cycle-failure signal we already have in scope.
-      //
-      // Today this is defense-in-depth: the backend's
-      // internalUpdateTestIteration auto-lock (W1) fires first with the
-      // same status-based derivation, and internalLockEvalSession is
-      // "first lock wins" — so this recorder-side lock call no-ops. But
-      // if W1 ever doesn't run (iteration finalized without status
-      // patches) the wrong `passed`-based reason would land.
-      const isCycleFailure =
-        iterationStatus === "failed" || (error !== undefined && error !== "");
-      const terminalReason: "eval_completed" | "eval_failed" | "eval_cancelled" =
-        iterationStatus === "cancelled"
-          ? "eval_cancelled"
-          : isCycleFailure
-            ? "eval_failed"
-            : "eval_completed";
-      const fanout = await persistEvalTraceFanout({
+      await finalizeEvalIteration({
         convexClient,
-        iterationId,
-        iterationStartedAt: startedAt,
-        messages,
-        spans,
-        prompts,
-        widgetSnapshots,
-        systemPrompt,
-      });
-      // Fall back to the W1 single-call path ONLY when the fanout failed
-      // before any turn landed. With turns already written, re-sending
-      // would overwrite turn 0 (W1 always writes at promptIndex: 0) and
-      // orphan turns 1..N. See persist-eval-trace.ts for the contract.
-      const useW1Fallback =
-        fanout.persisted === false && fanout.turnsWritten === 0;
-      if (fanout.persisted === false) {
-        logger.warn(
-          useW1Fallback
-            ? "[evals] persistEvalTraceFanout failed before any turn landed; falling back to W1 single-call save"
-            : "[evals] persistEvalTraceFanout failed mid-stream; iteration finalized without re-attempting (would orphan partial turns)",
-          {
-            iterationId,
-            turnsWritten: fanout.turnsWritten,
-            error: fanout.error.message,
-          },
-        );
-      }
-
-      // PR-2 review #5 (Cursor "Update failure after successful fanout"):
-      // track whether the iteration is gone so we don't waste a lock
-      // call on a deleted session, AND so the lock fires even when
-      // the iteration update threw a transient error.
-      let iterationGoneOrCancelled = false;
-      try {
-        await convexClient.action("testSuites:updateTestIteration" as any, {
-          iterationId,
-          status:
-            iterationStatus === "completed" ? "completed" : iterationStatus,
-          result,
-          actualToolCalls: sanitizeForConvexTransport(toolsCalled),
-          tokensUsed: usage.totalTokens ?? 0,
-          ...(useW1Fallback
-            ? {
-                messages: sanitizeForConvexTransport(messages),
-                // Mirrors `appendEvalTurnTrace.systemPrompt` + the
-                // parallel fix in `finishIterationDirectly`. Cursor
-                // Bugbot follow-up "Recorder W1 omits systemPrompt":
-                // without this, suite runs that use the recorder
-                // (not the direct `finishIterationDirectly` path) and
-                // hit the W1 fallback persist a transcript with no
-                // resolved system prompt — the prepend was dropped
-                // earlier in this PR. Backend `updateTestIteration`
-                // accepts the slot (mcpjam-backend #449); first-write-
-                // wins semantics apply, no risk of clobbering a value
-                // already set by an earlier `appendEvalTurnTrace`.
-                ...(systemPrompt ? { systemPrompt } : {}),
-                ...(spans?.length
-                  ? { spans: sanitizeForConvexTransport(spans) }
-                  : {}),
-                ...(prompts?.length
-                  ? { prompts: sanitizeForConvexTransport(prompts) }
-                  : {}),
-                ...(widgetSnapshots?.length
-                  ? {
-                      widgetSnapshots:
-                        sanitizeForConvexTransport(widgetSnapshots),
-                    }
-                  : {}),
-              }
-            : {}),
-          error,
-          errorDetails,
-          resultSource,
-          // Merge user-provided metadata with token usage breakdown, then
-          // sanitize: metadata can carry nested predicate rows whose authored
-          // args may contain $-prefixed keys Convex rejects at the boundary.
-          metadata: sanitizeForConvexTransport({
-            ...(metadata ?? {}),
-            ...buildIterationUsageMetadata(usage),
-          }),
-        });
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-
-        // Check if run was deleted/not found or iteration was cancelled
-        if (
-          errorMessage.includes("not found") ||
-          errorMessage.includes("unauthorized") ||
-          errorMessage.includes("cancelled")
-        ) {
+        ...params,
+        // Suite-run-scoped short-circuit: flip the recorder's
+        // `runDeleted` flag when the shared finalize step sees a
+        // "not found" / "unauthorized" / "cancelled" update error so
+        // subsequent calls on this recorder no-op. The quick-run
+        // direct path (no recorder) passes no callback.
+        onRunDeleted: () => {
           runDeleted = true;
-          iterationGoneOrCancelled = true;
-        } else {
-          logger.error(
-            "[evals] Failed to record iteration result:",
-            new Error(errorMessage),
-          );
-          // Transient (non-cancellation) failure: fall through to the
-          // lock step. The chatSessions transcript is complete from
-          // the fanout's perspective; locking prevents a retry from
-          // accumulating partial writes against a row whose data
-          // already represents the final state. The iteration row's
-          // terminal status remains stale until a retry/cron sweep
-          // finalizes it — that's acceptable because the data is
-          // consistent at the chatSessions layer.
-        }
-      }
-
-      // Lock the chatSession when fanout succeeded — runs in BOTH the
-      // success branch (updateTestIteration succeeded → defense + UI
-      // hint) and the transient-failure branch (updateTestIteration
-      // threw a non-cancellation error → prevents partial writes on
-      // retry). Skipped only when the iteration is gone, where
-      // locking a deleted session is wasted work. Best-effort:
-      // lockEvalSessionAfterUpdate swallows its own failures.
-      if (fanout?.persisted === true && !iterationGoneOrCancelled) {
-        await lockEvalSessionAfterUpdate({
-          convexClient,
-          iterationId,
-          reason: terminalReason,
-        });
-      }
+        },
+      });
     },
     async finalize({ status, summary, notes }) {
       if (runDeleted) {


### PR DESCRIPTION
## Summary

- Collapses eval's two near-byte-identical finalize paths (`SuiteRunRecorder.finishIteration` + `finishIterationDirectly`) into one shared `finalizeEvalIteration` function
- Prevents the next instance of the bug class the systemPrompt-slot PR series ([backend #448](https://github.com/MCPJam/mcpjam-backend/pull/448), [backend #449](https://github.com/MCPJam/mcpjam-backend/pull/449), [inspector #2481](https://github.com/MCPJam/inspector/pull/2481)) caught Cursor Bugbot finding in BOTH paths — `systemPrompt` dropped from the W1-single-call `updateTestIteration` fallback. Two separate fix commits, same bug.
- Inspector-only. No backend changes. No public signature changes.

## Motivation

The two paths drifted independently for months but converged on the same shape: per-turn fanout (W2) → optional W1 single-call fallback → `updateTestIteration` → terminal lock. The systemPrompt slot was direct evidence of the duplicate-bug-surface cost: a new persistence concern needed to be wired through two near-identical implementations, and the bot found the same gap in both.

After this PR: new finalize-class concerns get added once in `finalizeEvalIteration`. The recorder retains its legitimate suite-run-scoped state (`runDeleted` flag, `startIteration` query, `finalize` run-row update) and delegates `finishIteration` via an `onRunDeleted` hook.

## Shape

**New**: `mcpjam-inspector/server/services/evals/finalize-iteration.ts` — exports `finalizeEvalIteration(params)`. Owns the full finalize pipeline (early bail → cancellation pre-check → status/result/terminalReason → fanout → W1 fallback → updateTestIteration → lock).

**Modified**:
- `mcpjam-inspector/server/services/evals/recorder.ts` — `SuiteRunRecorder.finishIteration` becomes a thin wrapper passing an `onRunDeleted` hook to flip the recorder-scoped `runDeleted` short-circuit flag. `startIteration` and `finalize` untouched.
- `mcpjam-inspector/server/services/evals-runner.ts` — `finishIterationDirectly` deleted entirely (193 LOC). The 7 inline `recorder ? : direct` call sites now route the direct branch through `finalizeEvalIteration({ ...params, convexClient })`.

**Unchanged**:
- Backend signatures: `updateTestIteration`, `appendEvalTurnTrace`, `lockEvalSession`
- `persistEvalTraceFanout` body (just a collaborator)
- Lock-after-update sequencing (`fanout.persisted === true && !iterationGoneOrCancelled`)
- All existing eval-runner end-to-end tests pass unchanged — they assert observable Convex calls, not function names

## Test plan

- [x] `npx tsc --noEmit` — baseline-matched (4 pre-existing finishParams errors in evals-runner.ts unchanged; 2 pre-existing implicit-any test errors unchanged)
- [x] `npm run test:once -- finalize-iteration` — new unit tests cover: W1 fallback systemPrompt threading, empty-array omission, terminalReason derivation, mid-stream-fail behavior, `onRunDeleted` invocation, lock fire conditions
- [x] `npm run test:once -- evals-runner` — existing end-to-end tests pass unchanged
- [x] `npm run test:once -- recorder` — extended with one test asserting `onRunDeleted` flip + subsequent `startIteration` short-circuit
- [x] `npm run test -- --run server` — full server suite green
- [ ] Smoke: run one quick eval (BYOK key) → assert iteration row reaches `status:"completed"` and chatSessions transcript is locked
- [ ] Smoke: run one suite eval (2+ iterations) → assert all iterations finalize, suite-run row reaches `status:"completed"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval persistence, fanout/W1 fallback, and chatSession locking on many runner call sites; behavior is intended to be equivalent and is heavily unit-tested, but regressions would affect stored transcripts and iteration rows.
> 
> **Overview**
> **Unifies eval iteration persistence** by replacing duplicated `finishIterationDirectly` (~190 LOC in `evals-runner.ts`) and the bulk of `SuiteRunRecorder.finishIteration` with a single **`finalizeEvalIteration`** module.
> 
> Quick runs (no recorder) and suite runs now share one pipeline: cancellation pre-check → trace fanout → optional W1 fallback (including **`systemPrompt`**) → `updateTestIteration` → post-update session lock. The recorder keeps suite-scoped behavior via an **`onRunDeleted`** callback that sets **`runDeleted`** so later iterations short-circuit after a gone/cancelled iteration.
> 
> Adds focused unit tests for W1 fallback, terminal lock reasons, mid-stream fanout failure, and lock/update edge cases; extends recorder tests for the **`onRunDeleted`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd059900e58843ca9c6c4a035cd29bdf9207f25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->