### PR TITLE
harness: snake_case BrowserActionResult note literal

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
@@ -255,7 +255,7 @@ describe("buildComputerUseTools", () => {
     );
   });
 
-  it("computer.execute returns 'no rendered widget' when none is active", async () => {
+  it("computer.execute returns 'no_rendered_widget' when none is active", async () => {
     const { harness, executeAction } = stubHarness();
     const tools = buildComputerUseTools({
       version: "20250124",
@@ -265,7 +265,7 @@ describe("buildComputerUseTools", () => {
     });
     const exec = (tools.computer as { execute: Function }).execute;
     const impl = (await exec({ action: "screenshot" }, {})) as ComputerImplOutput;
-    expect(impl.note).toBe("no rendered widget");
+    expect(impl.note).toBe("no_rendered_widget");
     expect(executeAction).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
@@ -241,7 +241,7 @@ describe("McpAppBrowserHarness — interaction", () => {
     expect(h.calls).toEqual([{ name: "reserve", args: { seat: 12 } }]);
   }, 30_000);
 
-  it("returns 'no rendered widget' when acting on an unmounted tool call", async () => {
+  it("returns 'no_rendered_widget' when acting on an unmounted tool call", async () => {
     const h = makeHarness();
     // Launch via a cheap render so the page exists, but don't keep it mounted.
     await h.renderWidget({
@@ -254,7 +254,7 @@ describe("McpAppBrowserHarness — interaction", () => {
       toolCallId: "tc-gone",
       action: { action: "screenshot" },
     });
-    expect(result.note).toBe("no rendered widget");
+    expect(result.note).toBe("no_rendered_widget");
     expect(result.widgetToolCalls).toEqual([]);
   }, 30_000);
 
@@ -279,7 +279,7 @@ describe("McpAppBrowserHarness — interaction", () => {
       toolCallId: "kept-1",
       action: { action: "left_click", coordinate: [640, 400] },
     });
-    expect(stale.note).toBe("no rendered widget");
+    expect(stale.note).toBe("no_rendered_widget");
     // kept-2 is the live widget.
     const live = await h.executeAction({
       toolCallId: "kept-2",
@@ -327,6 +327,6 @@ describe("McpAppBrowserHarness — interaction", () => {
       toolCallId: "cap-1",
       action: { action: "screenshot" },
     });
-    expect(third.note).toBe("no rendered widget");
+    expect(third.note).toBe("no_rendered_widget");
   }, 30_000);
 });

--- a/mcpjam-inspector/server/utils/computer-use-tool.ts
+++ b/mcpjam-inspector/server/utils/computer-use-tool.ts
@@ -113,7 +113,7 @@ export interface ComputerImplOutput {
   widgetToolCalls: WidgetToolCall[];
   action: ComputerActionInput;
   elapsedMs: number;
-  /** Harness note (e.g. "budget_exceeded", "no rendered widget"). */
+  /** Harness note (e.g. "step_budget_exceeded", "no_rendered_widget"). */
   note?: string;
 }
 
@@ -235,7 +235,7 @@ export function buildComputerUseTools(
         widgetToolCalls: [],
         action: input,
         elapsedMs: 0,
-        note: "no rendered widget",
+        note: "no_rendered_widget",
       };
     }
     const result = await harness.executeAction({

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -90,7 +90,7 @@ export interface BrowserActionResult {
   widgetToolCalls: WidgetToolCall[];
   elapsedMs: number;
   /**
-   * Set when a budget/limit forced a no-op. One of `"no rendered widget"`,
+   * Set when a budget/limit forced a no-op. One of `"no_rendered_widget"`,
    * `"step_budget_exceeded"` (per-widget step cap hit — widget force-dismissed),
    * or `"screenshot_budget_exceeded"` (per-iteration screenshot cap hit — widget
    * left mounted).
@@ -551,7 +551,7 @@ export class McpAppBrowserHarness {
         action: input.action,
         widgetToolCalls: [],
         elapsedMs: 0,
-        note: "no rendered widget",
+        note: "no_rendered_widget",
       };
     }
     // The step cap is per-widget and terminal: once a widget exhausts it, the


### PR DESCRIPTION
## Summary

Tiny stylistic consistency fix. The harness's `BrowserActionResult.note` field had one literal with spaces (`"no rendered widget"`) and two snake_case siblings (`"step_budget_exceeded"`, `"screenshot_budget_exceeded"`). Normalizes the odd one to match.

No consumer branches on the literal today. Pure cosmetic correctness.

## Why now

Backend persistence PR https://github.com/MCPJam/mcpjam-backend/pull/460 (browser-rendered MCP App eval — PR 6) adds a `browserInteractionSteps.note` enum that needs to either accept the harness's emit verbatim or normalize through an adapter. Fixing the harness here means the persistence path stays clean snake_case end-to-end — no two-form-translation layer, no future "why is one literal different?" question.

## What changed

- `server/utils/mcp-app-browser-harness.ts` — emit site + doc comment
- `server/utils/computer-use-tool.ts` — emit site (short-circuit when no active toolCallId) + doc comment
- `server/utils/__tests__/mcp-app-browser-harness.test.ts` — 3 assertions + 1 description
- `server/utils/__tests__/computer-use-tool.test.ts` — 1 assertion + 1 description

10 insertions, 10 deletions.

## Test plan

- [x] `npx vitest run server/utils/__tests__/mcp-app-browser-harness.test.ts server/utils/__tests__/computer-use-tool.test.ts` — 33 tests pass.
- [x] `grep -rn "no rendered widget"` returns zero hits across `mcpjam-inspector` after the change.

## Coordination with PR #460 (backend persistence)

The backend PR's `browserInteractionSteps.note` validator accepts the snake_case form (`'no_rendered_widget'`). With this PR merged, backend ↔ inspector agree end-to-end. No backend change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String literal rename only; no logic changes and no known consumers branching on the old form.
> 
> **Overview**
> Renames the browser harness **`note`** value from `"no rendered widget"` to **`"no_rendered_widget"`** so it matches the existing snake_case siblings (`step_budget_exceeded`, `screenshot_budget_exceeded`).
> 
> Emit sites in **`mcp-app-browser-harness.ts`** (`executeAction` when nothing is mounted) and **`computer-use-tool.ts`** (short-circuit when there is no active tool call id) are updated, along with JSDoc examples. Unit tests in **`mcp-app-browser-harness.test.ts`** and **`computer-use-tool.test.ts`** assert the new string.
> 
> Behavior is unchanged aside from the literal string; this aligns inspector output with backend persistence enums for browser interaction steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8cd33ae4cb8aa87fc4e4d4c6fbd6d438f752d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->