### PR TITLE
fix(evals): load trace via chatSessionId, not just legacy blob

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/use-eval-trace-blob.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-trace-blob.ts
@@ -34,7 +34,7 @@ export function useEvalTraceBlob({
         return;
       }
 
-      if (!iteration?.blob) {
+      if (!iteration?.blob && !iteration?.chatSessionId) {
         setBlob(null);
         setLoading(false);
         setError(null);
@@ -46,9 +46,10 @@ export function useEvalTraceBlob({
       setError(null);
 
       try {
-        // Backend authorizes via the iteration's testSuite and derives the
-        // blob id server-side. We still gate on `iteration.blob` above to
-        // skip the roundtrip for blobless iterations.
+        // Backend authorizes via the iteration's testSuite and resolves the
+        // trace server-side from either the legacy blob or the unified
+        // chatSessions path. Gate skips the roundtrip only when neither
+        // source is present.
         const data = await getBlob({ iterationId: iteration._id });
         if (!cancelled) {
           setBlob(data);
@@ -71,7 +72,7 @@ export function useEvalTraceBlob({
     return () => {
       cancelled = true;
     };
-  }, [enabled, getBlob, iteration?.blob]);
+  }, [enabled, getBlob, iteration?.blob, iteration?.chatSessionId]);
 
   return {
     blob,


### PR DESCRIPTION
## Summary
- The eval→chatSessions unification (mcpjam-backend PR-6) dropped the legacy `storeTraceBlob` writer. New iterations are created with `chatSessionId` set and `blob` unset, and the backend `getTestIterationBlob` action (`convex/testSuites.ts:7554-7570`) resolves the trace via `chatSessionId` server-side.
- `use-eval-trace-blob.ts` still gated the round-trip on `iteration.blob`, so for any post-unification run the backend was never called — the trace surface rendered the empty state at `eval-trace-surface.tsx:168` even though the iteration row had tokens and tool-call counts populated.
- Fix: gate on either `blob` or `chatSessionId`, and add `chatSessionId` to the effect's dep array so it re-fires when the field resolves on a freshly-completed run.

## Symptom
A Claude Haiku 4.5 (Free) failed iteration in the Excalidraw quickstart suite showed `Latency 12s · Tokens 26,261 · Tools 2 tool calls` next to "No trace data is available for this run."

## Test plan
- [ ] Open a failed eval iteration created after the unification — Runs → Trace tab should populate (no more "No trace data is available for this run.")
- [ ] Open a successful post-unification iteration — trace renders as before
- [ ] Open a pre-unification iteration that still has \`iteration.blob\` set (pre-PR-7 cleanup) — still renders
- [ ] An in-progress run that transitions from no-trace → has-\`chatSessionId\` re-fires the effect (dep array change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ddc911bfdc7b849d20c8bcb523806f60ec799ac9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->