### PR TITLE
fix(docker): copy client/ before bundle:browser-harness

### DIFF
--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -50,13 +50,18 @@ COPY mcpjam-inspector/server ./mcpjam-inspector/server
 COPY mcpjam-inspector/scripts ./mcpjam-inspector/scripts
 RUN npm run bundle:chatgpt -w @mcpjam/inspector && \
     npm run bundle:mcp-apps -w @mcpjam/inspector && \
-    npm run bundle:sandbox-proxies -w @mcpjam/inspector && \
-    npm run bundle:browser-harness -w @mcpjam/inspector && \
-    npm run build:server -w @mcpjam/inspector
+    npm run bundle:sandbox-proxies -w @mcpjam/inspector
 
+# `bundle:browser-harness` esbuilds `server/utils/browser-harness/host-page.ts`,
+# which imports `@/components/chat-v2/thread/mcp-apps/host-app-bridge` from the
+# client tree. It therefore has to run AFTER `mcpjam-inspector/client` is on
+# disk; `build:server` consumes the generated harness bundle so it runs in the
+# same step.
 COPY design-system ./design-system
 COPY mcpjam-inspector/client ./mcpjam-inspector/client
 COPY mcpjam-inspector/.env.production ./mcpjam-inspector/
+RUN npm run bundle:browser-harness -w @mcpjam/inspector && \
+    npm run build:server -w @mcpjam/inspector
 RUN if [ -n "$VITE_MCPJAM_HOSTED_MODE" ]; then export VITE_MCPJAM_HOSTED_MODE; fi; \
     if [ -n "$VITE_MCPJAM_NONPROD_LOCKDOWN" ]; then export VITE_MCPJAM_NONPROD_LOCKDOWN; fi; \
     if [ -n "$VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS" ]; then export VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS; fi; \


### PR DESCRIPTION
## Summary

Fixes a Dockerfile layer-ordering bug introduced by #2482 that broke every Deploy Staging and PR Preview build on `main`.

`scripts/bundle-browser-harness.mjs` esbuilds `server/utils/browser-harness/host-page.ts`, whose import graph reaches into the client tree (`@/components/chat-v2/thread/mcp-apps/host-app-bridge`, `@/lib/mcp-ui/...`). The Dockerfile ran `bundle:browser-harness` at line 54, but `COPY mcpjam-inspector/client` didn't happen until line 58 — so the bundle ran against a tree without `client/` and failed with:

```
✘ Could not resolve "/usr/src/app/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/host-app-bridge"
   server/utils/browser-harness/host-page.ts:33:7
```

(See failed run https://github.com/MCPJam/inspector/actions/runs/27122186271/job/80041720407.)

Fix: split the bundle `RUN` so the three client-independent bundles (`chatgpt`, `mcp-apps`, `sandbox-proxies`) keep their cache-friendly position before the client COPY, and move `bundle:browser-harness` + `build:server` (which consumes the generated harness bundle) into a new `RUN` after `COPY mcpjam-inspector/client`.

## Test plan

- [x] `npm run bundle:browser-harness -w @mcpjam/inspector` succeeds locally (847.7 KiB output).
- [ ] CI's PR Preview job builds the inspector image off this branch.
- [ ] After merge, Deploy Staging on `main` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-pipeline ordering only; no runtime, auth, or application code changes.
> 
> **Overview**
> Repairs **inspector Docker build ordering** so staging and PR preview images compile again after a regression where `bundle:browser-harness` ran before `mcpjam-inspector/client` was copied into the image.
> 
> The build step is **split into two `RUN` layers**: `bundle:chatgpt`, `bundle:mcp-apps`, and `bundle:sandbox-proxies` still run right after server/scripts are copied (unchanged cache behavior). **`bundle:browser-harness` and `build:server` move to a new step** after `COPY design-system`, `COPY mcpjam-inspector/client`, and `.env.production`, because the harness esbuild pulls client paths such as `host-app-bridge`. Inline comments document that dependency.
> 
> No application logic changes—only **when** those npm scripts execute relative to the client tree on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9ff6d659e3778eeb0b35e79c6899c24087e0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->