### PR TITLE
Add Playwright E2E framework with app-level smoke test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   NODE_VERSION: "24.14.0"
+  # This workflow typechecks, builds, and boots the server in Node — it never
+  # launches Electron, so skip the (occasionally flaky) Electron binary download.
+  ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
 jobs:
   build:

--- a/.github/workflows/post-deploy-staging.yml
+++ b/.github/workflows/post-deploy-staging.yml
@@ -14,9 +14,14 @@ on:
         required: false
         type: string
 
+env:
+  NODE_VERSION: "24.14.0"
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    outputs:
+      base_url: ${{ steps.target.outputs.base_url }}
     steps:
       - name: Resolve staging URL
         id: target
@@ -65,3 +70,45 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Target: \`$BASE_URL\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Checked: \`/health\`, \`/api/mcp/health\`, \`/api/apps/health\`, unauthenticated \`/api/web/tools/list\`" >> "$GITHUB_STEP_SUMMARY"
+
+  e2e:
+    needs: smoke
+    runs-on: ubuntu-latest
+    # Non-gating during the initial soak. deploy-staging.yml calls this workflow
+    # and release.yml polls deploy-staging.yml success as the release gate, so a
+    # hard failure here would gate releases. Remove once the suite is promoted.
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install workspace dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke against staging
+        # PLAYWRIGHT_BASE_URL makes the config skip the local webServer and drive
+        # the deployed URL, so no inspector build is needed here. Sourced from the
+        # smoke job's output because step outputs are job-local.
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ needs.smoke.outputs.base_url }}
+        run: npm run test:e2e -w @mcpjam/inspector
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-staging
+          path: |
+            mcpjam-inspector/playwright-report/
+            mcpjam-inspector/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/post-deploy-staging.yml
+++ b/.github/workflows/post-deploy-staging.yml
@@ -78,6 +78,9 @@ jobs:
     # and release.yml polls deploy-staging.yml success as the release gate, so a
     # hard failure here would gate releases. Remove once the suite is promoted.
     continue-on-error: true
+    # Drives a deployed URL; never launches Electron, so skip its binary download.
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,41 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=6144"
         run: npm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    name: E2E Smoke (Playwright)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install workspace dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build inspector
+        # Playwright's webServer boots `npm run start`, which serves built artifacts.
+        run: npm run build -w @mcpjam/inspector
+
+      - name: Run Playwright smoke
+        run: npm run test:e2e -w @mcpjam/inspector
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            mcpjam-inspector/playwright-report/
+            mcpjam-inspector/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   NODE_VERSION: "24.14.0"
+  # No CI job in this workflow launches Electron, so skip the (occasionally
+  # flaky) Electron binary download during npm ci.
+  ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
 jobs:
   test:
@@ -41,11 +44,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     name: E2E Smoke (Playwright)
-    # This lane builds the web client/server and drives a browser; it never
-    # launches Electron, so skip the (occasionally flaky) Electron binary
-    # download during npm ci.
-    env:
-      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,11 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     name: E2E Smoke (Playwright)
+    # This lane builds the web client/server and drives a browser; it never
+    # launches Electron, so skip the (occasionally flaky) Electron binary
+    # download during npm ci.
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
     steps:
       - name: Checkout code

--- a/mcpjam-inspector/.gitignore
+++ b/mcpjam-inspector/.gitignore
@@ -15,8 +15,13 @@ node_modules/
 # testing
 /coverage
 
+# playwright
+playwright-report/
+test-results/
+.playwright/
 
-# production  
+
+# production
 /build
 /dist
 cli/build/

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3157,6 +3157,7 @@ export default function App() {
           <Toaster />
           <MCPJamLimitDialog />
           <div
+            data-testid="app-shell"
             aria-hidden={shouldShowBillingHandoffOverlay || undefined}
             className={
               shouldShowBillingHandoffOverlay

--- a/mcpjam-inspector/e2e/README.md
+++ b/mcpjam-inspector/e2e/README.md
@@ -1,0 +1,31 @@
+# End-to-end tests (Playwright)
+
+App-level Playwright smoke tests for the inspector. These are separate from the
+vitest unit/integration suite (`npm test`) and from the widget browser-render
+eval harness — this layer drives the real app in a browser.
+
+## Run locally
+
+```bash
+npm run test:e2e -w @mcpjam/inspector
+```
+
+Playwright boots the inspector in production mode via its `webServer` config
+(`npm run start -- --no-open` on `http://localhost:6274`), runs the specs, and
+shuts the server down. The build artifacts must exist first — run
+`npm run build -w @mcpjam/inspector` once if you have not built recently.
+
+## Run against a deployed URL
+
+Set `PLAYWRIGHT_BASE_URL` to skip the local server and drive a deployed target:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://staging.mcpjam.com npm run test:e2e -w @mcpjam/inspector
+```
+
+## Reports & artifacts
+
+- HTML report: `mcpjam-inspector/playwright-report/index.html`
+- Traces / screenshots / videos (retained on failure): `mcpjam-inspector/test-results/`
+
+In CI these are uploaded as the `playwright-report` artifact when a run fails.

--- a/mcpjam-inspector/e2e/smoke.spec.ts
+++ b/mcpjam-inspector/e2e/smoke.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+// App-level smoke only: prove the framework works end-to-end and that the app
+// actually serves a mounted shell, without coupling to any specific feature UI,
+// route, feature flag, or auth state. Build more specific specs from here.
+test("home route serves a mounted app shell", async ({ page }) => {
+  const response = await page.goto("/");
+
+  expect(response, "navigation to / should return a response").not.toBeNull();
+  expect(
+    response?.ok(),
+    `expected a 2xx response from /, got ${response?.status()}`,
+  ).toBe(true);
+
+  // `data-testid="app-shell"` marks the top-level mounted chrome wrapper in
+  // client/src/App.tsx. It renders outside the auth/billing gates, so this
+  // holds for guest and authed users and across local/hosted builds.
+  await expect(page.getByTestId("app-shell")).toBeVisible({ timeout: 30_000 });
+});

--- a/mcpjam-inspector/playwright.config.ts
+++ b/mcpjam-inspector/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+// When PLAYWRIGHT_BASE_URL is set (e.g. the post-deploy staging lane), tests run
+// against that deployed URL and no local server is booted. Otherwise we boot the
+// inspector in production mode and drive it on the default port.
+const deployedBaseUrl = process.env.PLAYWRIGHT_BASE_URL;
+const baseURL = deployedBaseUrl ?? "http://localhost:6274";
+
+// Resolve to the inspector package root (this config's directory) so the booted
+// webServer runs the workspace's `npm run start` regardless of the invoking cwd.
+const packageRoot = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    // One browser for now; the array leaves room for firefox/webkit later.
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  // Boot a local production server only when not targeting a deployed URL.
+  webServer: deployedBaseUrl
+    ? undefined
+    : {
+        command: "npm run start -- --no-open",
+        url: baseURL,
+        cwd: packageRoot,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        env: {
+          NODE_ENV: "production",
+          MCPJAM_INSPECTOR_SUPPRESS_AUTO_OPEN: "1",
+        },
+      },
+});


### PR DESCRIPTION
## Summary

Inspector had no app-level end-to-end coverage — CI ran vitest unit/integration tests and the post-deploy staging lane only did HTTP curl probes (no proof the app actually serves a page). This stands up **Playwright as a real app-level E2E framework** with one smoke spec and wires it into CI in two lanes: pre-merge (against a locally-booted production build) and post-deploy-staging (against the deployed URL).

This is distinct from the existing `playwright` dep used by the widget browser-render eval harness (`server/utils/mcp-app-browser-harness.ts`) — that's the wrong layer for app E2E. This uses the already-present `@playwright/test` dev dependency and the stub `test:e2e` script.

## What changed

- **`mcpjam-inspector/playwright.config.ts`** (new) — `testDir: ./e2e`, one chromium project (room for firefox/webkit later). `baseURL` resolves from `PLAYWRIGHT_BASE_URL`, falling back to `http://localhost:6274`. When that env is unset it boots the inspector via `npm run start -- --no-open` (production mode, auto-open suppressed) as the `webServer`; when set, `webServer` is omitted so Playwright drives the deployed URL. `retries`/`workers`/`forbidOnly` gate on `CI`; `list` + `html` reporters; screenshot/video/trace retained on failure.
- **`mcpjam-inspector/e2e/smoke.spec.ts`** (new) — app-level smoke only: `goto("/")`, assert a 2xx response, assert the mounted app shell (`data-testid="app-shell"`) is visible. Deliberately avoids route-, feature-flag-, auth-, or copy-dependent assertions so it doesn't churn.
- **`mcpjam-inspector/client/src/App.tsx`** — adds `data-testid="app-shell"` to the top-level chrome wrapper. It sits **outside** the auth/billing gate, so the marker holds for guest and authed users and across the local (`npm run start`) and hosted (staging) builds, which render the unauthenticated `/` differently.
- **`.github/workflows/test.yml`** — new `e2e` job (sibling to the vitest `test` job, kept separate so the unit lane stays fast): install deps → install chromium → build inspector → run smoke → upload the Playwright report on failure (7-day retention). **Not a required check yet** — soak first, then promote.
- **`.github/workflows/post-deploy-staging.yml`** — new `e2e` job (`needs: smoke`) that drives the deployed staging URL. The existing curl probes stay. The `smoke` job now exposes its resolved URL as a **job output** (step outputs are job-local), consumed via `needs.smoke.outputs.base_url`. The job is **`continue-on-error: true`** during the soak: `deploy-staging.yml` calls this workflow and `release.yml` polls `deploy-staging.yml` success as the release gate, so a hard failure here would gate releases.
- **`mcpjam-inspector/e2e/README.md`**, **`mcpjam-inspector/.gitignore`** — usage docs and ignore `playwright-report/`, `test-results/`, `.playwright/`.

## Verification

- Local: `npm run test:e2e -w @mcpjam/inspector` boots the production webServer and runs the smoke.
- Local against a deployed URL: `PLAYWRIGHT_BASE_URL=https://staging.mcpjam.com npm run test:e2e -w @mcpjam/inspector` (no webServer).
- This PR's own `test.yml` `e2e` job exercises the full pre-merge path (build + boot + smoke).
- Staging: dispatch `post-deploy-staging.yml` with a `base_url` override to run both jobs.

## Out of scope (follow-ups)

More specs (Servers/Tools/Chat) one at a time; authenticated WorkOS/Convex flows; multi-browser projects; visual regression; and promoting the suite to a hard release gate (removing the staging `continue-on-error` / wiring a required check into `release.yml`) once it has soaked.

https://claude.ai/code/session_017xVbCCKjs8tsApqekg2VQE

---
_Generated by [Claude Code](https://claude.ai/code/session_017xVbCCKjs8tsApqekg2VQE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CI, test infra, and a test-only DOM attribute; staging E2E is explicitly non-gating during soak.
> 
> **Overview**
> Adds **app-level Playwright E2E** for the inspector: `playwright.config.ts` boots a local production server (or uses `PLAYWRIGHT_BASE_URL` for deployed targets), plus a minimal `e2e/smoke.spec.ts` that checks `/` returns 2xx and **`data-testid="app-shell"`** is visible.
> 
> **`App.tsx`** gets that test id on the top-level chrome wrapper (outside auth/billing gates) so the smoke stays stable across guest/authed and local/hosted builds.
> 
> **CI:** New **`e2e`** jobs in `test.yml` (build inspector, run smoke, upload report on failure) and in `post-deploy-staging.yml` (after HTTP smoke, Playwright against staging via job output `base_url`; **`continue-on-error: true`** during soak so releases stay gated on deploy success only). **`lint.yml`** and **`test.yml`** set **`ELECTRON_SKIP_BINARY_DOWNLOAD=1`** where Electron is never launched.
> 
> Docs (`e2e/README.md`) and `.gitignore` entries for Playwright artifacts complete the setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13dc10501fed30553656b8d23e65bd3b36e4027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->