### PR TITLE
web_search built-in tool for the MCPJam agent

### DIFF
--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -28,6 +28,10 @@ import {
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { streamWebChatTurn } from "../../utils/web-chat-turn.js";
 import {
+  buildExaWebSearchTool,
+  WEB_SEARCH_TOOL_NAME,
+} from "../../utils/built-in-tools/exa-web-search.js";
+import {
   assertBearerToken,
   readJsonBody,
   parseWithSchema,
@@ -98,6 +102,20 @@ mcpjamAgent.post("/", async (c) => {
     );
 
     try {
+      // Bearer is guaranteed by assertBearerToken above; thread it (plus the
+      // project + session) into the web_search built-in tool, whose execute
+      // proxies to the Convex Exa route for billing + the external call.
+      const authHeader = c.req.header("authorization");
+      const builtInTools = authHeader
+        ? {
+            [WEB_SEARCH_TOOL_NAME]: buildExaWebSearchTool({
+              authHeader,
+              projectId: body.projectId,
+              chatSessionId: body.chatSessionId,
+            }),
+          }
+        : undefined;
+
       return await streamWebChatTurn({
         manager,
         prepare: {
@@ -108,6 +126,7 @@ mcpjamAgent.post("/", async (c) => {
           requireToolApproval: body.requireToolApproval,
           respectToolVisibility: body.respectToolVisibility,
           uiMessages: body.messages,
+          builtInTools,
         },
         persist: {
           chatSessionId: body.chatSessionId,
@@ -136,7 +155,7 @@ mcpjamAgent.post("/", async (c) => {
           captureToolSnapshot: false,
         },
         runtime: {
-          authHeader: c.req.header("authorization"),
+          authHeader,
           clientIp: getClientIp(c),
           abortSignal: c.req.raw.signal as AbortSignal | undefined,
           rpcCollector,

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -25,6 +25,10 @@ import {
 } from "../chat-v2-orchestration";
 import { getSkillToolsAndPrompt } from "../skill-tools";
 import {
+  buildExaWebSearchTool,
+  WEB_SEARCH_TOOL_NAME,
+} from "../built-in-tools/exa-web-search";
+import {
   commitNewlyLoaded,
   gateToolsToActiveSubset,
   resolveActiveToolNames,
@@ -484,6 +488,106 @@ describe("prepareChatV2", () => {
         }),
       ).rejects.toThrow(/search_mcp_tools/);
     });
+  });
+});
+
+describe("prepareChatV2 built-in tools", () => {
+  const baseArgs = {
+    selectedServers: ["srv"],
+    modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+    systemPrompt: "Base prompt.",
+  };
+
+  function webSearchBuiltIn() {
+    return {
+      [WEB_SEARCH_TOOL_NAME]: buildExaWebSearchTool({
+        authHeader: "Bearer test",
+        projectId: "proj_1",
+        chatSessionId: "sess_1",
+      }),
+    };
+  }
+
+  it("merges a built-in tool into the model tool set with its execute intact", async () => {
+    const manager = mockManager({
+      some_mcp_tool: { description: "mcp", _serverId: "srv" },
+    });
+
+    const result = await prepareChatV2({
+      ...baseArgs,
+      mcpClientManager: manager,
+      builtInTools: webSearchBuiltIn(),
+    });
+
+    expect(Object.keys(result.allTools)).toContain(WEB_SEARCH_TOOL_NAME);
+    // Built-ins execute server-side (unlike the no-execute app-tool path).
+    const entry = result.allTools[WEB_SEARCH_TOOL_NAME] as {
+      execute?: unknown;
+    };
+    expect(typeof entry.execute).toBe("function");
+  });
+
+  it("fails closed when a built-in name collides with an MCP tool", async () => {
+    const manager = mockManager({
+      [WEB_SEARCH_TOOL_NAME]: {
+        description: "mcp web search",
+        _serverId: "srv",
+      },
+    });
+
+    await expect(
+      prepareChatV2({
+        ...baseArgs,
+        mcpClientManager: manager,
+        builtInTools: webSearchBuiltIn(),
+      }),
+    ).rejects.toThrow(/web_search.*collides/);
+  });
+
+  it("fails closed when a built-in name collides with a skill tool", async () => {
+    vi.mocked(getSkillToolsAndPrompt).mockResolvedValue({
+      tools: {
+        [WEB_SEARCH_TOOL_NAME]: {
+          description: "skill web search",
+          execute: async () => ({}),
+        },
+      } as any,
+      systemPromptSection: "",
+    });
+    const manager = mockManager({});
+
+    await expect(
+      prepareChatV2({
+        ...baseArgs,
+        mcpClientManager: manager,
+        builtInTools: webSearchBuiltIn(),
+      }),
+    ).rejects.toThrow(/web_search.*collides/);
+  });
+
+  it("fails closed when a built-in name collides with an app tool", async () => {
+    const manager = mockManager({});
+    const appTools: AppToolEntry[] = [
+      {
+        alias: WEB_SEARCH_TOOL_NAME,
+        appName: "Shadow",
+        serverId: "srv",
+        parentToolCallId: "call-1",
+        rawName: "web_search",
+        description: "shadow tool",
+        inputSchema: { type: "object", properties: {} },
+        readOnly: true,
+      },
+    ];
+
+    await expect(
+      prepareChatV2({
+        ...baseArgs,
+        mcpClientManager: manager,
+        appTools,
+        builtInTools: webSearchBuiltIn(),
+      }),
+    ).rejects.toThrow(/web_search.*collides/);
   });
 });
 

--- a/mcpjam-inspector/server/utils/built-in-tools/exa-web-search.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/exa-web-search.ts
@@ -1,0 +1,90 @@
+/**
+ * Exa `web_search` built-in tool.
+ *
+ * Server-side tool the MCPJam agent exposes so the model can answer questions
+ * that aren't in the docs. Inspector defines the tool *shape* (so the model
+ * sees it like any other tool) but holds no Exa key: `execute` proxies to the
+ * Convex HTTP action at `/tools/exa/search`, which owns the key, billing, and
+ * the external call. The bearer token, current `projectId`, and `chatSessionId`
+ * are threaded through so Convex can authorize the call and meter MCPJam
+ * credits against the project's organization.
+ *
+ * `execute` returns a structured `{ error }` string instead of throwing so the
+ * model can relay the problem to the user instead of breaking the turn.
+ */
+import { tool, type ToolSet } from "ai";
+import { z } from "zod";
+
+export const WEB_SEARCH_TOOL_NAME = "web_search";
+
+export interface ExaWebSearchToolOptions {
+  /** Bearer authorization header forwarded to Convex (already in scope). */
+  authHeader: string;
+  /** Current project — required by Convex for billing authorization. */
+  projectId: string;
+  /** Optional chat session, used by Convex for idempotency namespacing. */
+  chatSessionId?: string;
+}
+
+interface ExaWebSearchResult {
+  title: string | null;
+  url: string;
+  content: string;
+  publishedDate: string | null;
+}
+
+export function buildExaWebSearchTool(
+  opts: ExaWebSearchToolOptions
+): ToolSet[string] {
+  return tool({
+    description:
+      "Search the web for current information. Use this for questions outside " +
+      "the MCPJam docs — recent news, current library/package versions, dev " +
+      "tooling, or anything that may have changed recently. Returns up to 5 " +
+      "results, each with a title, URL, and content excerpt.",
+    inputSchema: z.object({
+      query: z
+        .string()
+        .min(1)
+        .max(400)
+        .describe("Natural-language web search query"),
+    }),
+    execute: async ({ query }, { toolCallId, abortSignal }) => {
+      const convexUrl = process.env.CONVEX_HTTP_URL;
+      if (!convexUrl) {
+        return { error: "Web search is not configured." };
+      }
+      try {
+        const res = await fetch(`${convexUrl}/tools/exa/search`, {
+          method: "POST",
+          headers: {
+            Authorization: opts.authHeader,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            projectId: opts.projectId,
+            chatSessionId: opts.chatSessionId,
+            toolCallId,
+            query,
+          }),
+          signal: abortSignal,
+        });
+        if (res.status === 402) {
+          return { error: "Out of MCPJam credits. Top up to use web search." };
+        }
+        if (!res.ok) {
+          return { error: `Web search failed (${res.status}).` };
+        }
+        const data = (await res.json()) as {
+          results?: ExaWebSearchResult[];
+        };
+        return { results: data.results ?? [] };
+      } catch (error) {
+        if (abortSignal?.aborted) {
+          return { error: "Web search was cancelled." };
+        }
+        return { error: "Web search failed. Please try again." };
+      }
+    },
+  });
+}

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -438,6 +438,8 @@ export interface PrepareChatV2Options {
    */
   priorMessages?: ReadonlyArray<ModelMessage>;
   appTools?: AppToolEntry[];
+  /** Server-side built-in tools (e.g. web_search) with their own execute. */
+  builtInTools?: ToolSet;
 }
 
 /**
@@ -503,6 +505,7 @@ export async function prepareChatV2(
     respectToolVisibility,
     customProviders,
     appTools,
+    builtInTools,
   } = options;
 
   // Drop ids the manager hasn't registered (server disabled/disconnected, or
@@ -565,10 +568,28 @@ export async function prepareChatV2(
   // before skills so an app alias never collides with either (the
   // `app_<8hex>` namespace is opaque and disjoint from both).
   const appToolEntries = buildAppTools(appTools);
+  const builtInToolEntries = builtInTools ?? {};
+  // Collision guard: a built-in tool must not shadow — or be shadowed by — an
+  // MCP, app, or skill tool. Fail closed before streaming so `web_search` never
+  // silently resolves to a different tool (or vice versa).
+  for (const name of Object.keys(builtInToolEntries)) {
+    if (
+      Object.prototype.hasOwnProperty.call(mcpTools, name) ||
+      Object.prototype.hasOwnProperty.call(appToolEntries, name) ||
+      Object.prototype.hasOwnProperty.call(finalSkillTools, name)
+    ) {
+      throw new Error(
+        `Built-in tool '${name}' collides with an existing MCP, app, or skill tool.`,
+      );
+    }
+  }
+  // Built-ins merge last so an explicit built-in wins, but the guard above
+  // means there is never actually a collision to resolve.
   const realTools = {
     ...mcpTools,
     ...appToolEntries,
     ...finalSkillTools,
+    ...builtInToolEntries,
   } as ToolSet;
 
   // 2. Decide whether progressive discovery applies, then mint meta-tools if

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -143,6 +143,8 @@ export interface WebChatTurnPrepareInputs {
   /** Optional progressive-discovery override. */
   progressiveToolDiscovery?: { enabled: boolean };
   appTools?: AppToolEntry[];
+  /** Server-side built-in tools (e.g. web_search) to merge into the tool set. */
+  builtInTools?: ToolSet;
   widgetModelContext?: WidgetModelContextEntry[];
 }
 
@@ -210,6 +212,7 @@ export async function streamWebChatTurn(
         ? { progressiveToolDiscovery: prepare.progressiveToolDiscovery }
         : {}),
       appTools: prepare.appTools,
+      builtInTools: prepare.builtInTools,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
Adds a `web_search` built-in tool to the MCPJam docs agent (`/api/web/mcpjam-agent`) so it can answer questions outside the docs — recent news, current library/package versions, dev tooling. Inspector defines the tool **shape** the model sees; `execute` proxies to the Convex `/tools/exa/search` route, which owns the Exa key + billing. Inspector never holds the key.

Pairs with the **mcpjam-backend** PR on branch `claude/dreamy-pascal-82lVb` (the route + metering). Requires that change deployed with `EXA_API_KEY` set.

## What it does
- **`server/utils/built-in-tools/exa-web-search.ts`** — the tool factory. `execute(input, { toolCallId, abortSignal })` POSTs `{ projectId, chatSessionId, toolCallId, query }` to `${CONVEX_HTTP_URL}/tools/exa/search` with the bearer header, and returns `{ results }` or a structured `{ error }` string — so the model relays the problem instead of breaking the turn (e.g. `402` → "Out of MCPJam credits").
- **Pipeline plumbing** — a new optional `builtInTools` field flows `mcpjam-agent.ts → web-chat-turn.ts → chat-v2-orchestration.ts`, merged into the tool set alongside MCP / app / skill tools. A **collision guard** fails closed before streaming if a built-in name clashes with any existing tool.
- **`mcpjam-agent.ts`** builds the tool with the in-scope auth header + `projectId` + `chatSessionId` and threads it through `prepare.builtInTools`.

No frontend changes — tool-result rendering is already generic. `web_search` (snake_case) passes the Anthropic tool-name validator.

## Tests
`server/utils/__tests__/chat-v2-orchestration.test.ts`: the built-in merges into the model tool set with its `execute` intact (vs. the no-execute app-tool path), and a name collision with an MCP / app / skill tool fails closed before streaming.

https://claude.ai/code/session_01Sti6pVq9J5vbJwNFMJ3zyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sti6pVq9J5vbJwNFMJ3zyB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New billed external search path and auth forwarding to Convex; scope is limited to the agent route and fails closed on tool-name collisions.
> 
> **Overview**
> Adds a server-side **`web_search`** built-in for the MCPJam docs agent so the model can look up information outside the docs. A new **`buildExaWebSearchTool`** factory defines the tool shape; **`execute`** POSTs to Convex **`/tools/exa/search`** with bearer auth, **`projectId`**, and **`chatSessionId`** for authorization and billing, and returns **`{ results }`** or structured **`{ error }`** (including **402** credit exhaustion) instead of throwing.
> 
> Optional **`builtInTools`** is threaded **`mcpjam-agent` → `web-chat-turn` → `prepareChatV2`**, merged after MCP, app, and skill tools with a **collision guard** that errors before streaming if a built-in name clashes. The agent registers **`web_search`** when an Authorization header is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db9ef1f81e510d350dbf1dbd6a99a9a9d2027826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->