### PR TITLE
feat(evals): persist browser-rendered MCP App observations + steps (PR 6b)

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -39,7 +39,6 @@ import { captureMcpAppWidgetSnapshots } from "../utils/mcp-app-widget-capture";
 import {
   McpAppBrowserHarness,
   DEFAULT_VIEWPORT,
-  type WidgetRenderObservation,
 } from "../utils/mcp-app-browser-harness";
 import {
   buildComputerUseTools,
@@ -86,8 +85,13 @@ import type {
   EvalTraceSpan,
   PromptTraceSummary,
   EvalTraceWidgetSnapshot,
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
 } from "@/shared/eval-trace";
-import { appendDedupedModelMessages } from "@/shared/eval-trace";
+import {
+  appendDedupedModelMessages,
+  isEvalTraceBrowserStepNote,
+} from "@/shared/eval-trace";
 import {
   deriveLegacyPromptFields,
   resolvePromptTurns,
@@ -1066,7 +1070,14 @@ const runIterationWithAiSdk = async ({
   const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
     current: null,
   };
-  const widgetRenderObservations: WidgetRenderObservation[] = [];
+  const widgetRenderObservations: RunnerWidgetRenderObservation[] = [];
+  // PR 6b: Computer Use interaction steps, collected via the harness `onAction`
+  // callback wired into buildComputerUseTools below. This local AI-SDK path is
+  // the only place Computer Use runs, so it is the only place the array is
+  // non-empty (hosted + streaming paths land in PR 9/PR 10).
+  // `stepIndexByToolCallId` stamps a monotonic per-widget step ordinal.
+  const browserInteractionSteps: RunnerBrowserInteractionStep[] = [];
+  const stepIndexByToolCallId = new Map<string, number>();
   const ensureWidgetHarness = (): McpAppBrowserHarness => {
     if (!widgetHarnessRef.current) {
       widgetHarnessRef.current = new McpAppBrowserHarness({
@@ -1128,6 +1139,44 @@ const runIterationWithAiSdk = async ({
           getActiveToolCallId: () =>
             widgetHarnessRef.current?.getMountedWidgetId() ?? null,
           viewport: DEFAULT_VIEWPORT,
+          // PR 6b: collect one browserInteractionStep per executeAction. The
+          // screenshot stays base64 here; finalizeEvalIteration uploads it once
+          // for both the W2 and W1 persistence paths.
+          onAction: (result, { toolCallId }) => {
+            const stepIndex = (stepIndexByToolCallId.get(toolCallId) ?? -1) + 1;
+            stepIndexByToolCallId.set(toolCallId, stepIndex);
+            // The harness types `note` as an open string; the backend union is
+            // closed and rejects the whole turn on an unknown literal. Narrow
+            // through the guard — keep the step, drop an unrecognized note.
+            let note: RunnerBrowserInteractionStep["note"];
+            if (result.note !== undefined) {
+              if (isEvalTraceBrowserStepNote(result.note)) {
+                note = result.note;
+              } else {
+                logger.warn("[evals] dropping unknown browser-step note", {
+                  note: result.note,
+                  toolCallId,
+                });
+              }
+            }
+            browserInteractionSteps.push({
+              toolCallId,
+              stepIndex,
+              promptIndex: activePromptIndex,
+              action: result.action.action,
+              coordinateX: result.action.coordinate?.[0],
+              coordinateY: result.action.coordinate?.[1],
+              text: result.action.text,
+              scrollDirection: result.action.scrollDirection,
+              scrollAmount: result.action.scrollAmount,
+              duration: result.action.duration,
+              screenshotBase64: result.screenshotBase64,
+              widgetToolCalls: result.widgetToolCalls,
+              elapsedMs: result.elapsedMs,
+              ...(note ? { note } : {}),
+              ts: Date.now(),
+            });
+          },
         })
       : {};
 
@@ -1317,7 +1366,12 @@ const runIterationWithAiSdk = async ({
                 harness: ensureWidgetHarness(),
                 keepMounted: computerUseVersion !== null,
               });
-              widgetRenderObservations.push(obs);
+              // Stamp promptIndex at push-time — the harness type stays pure;
+              // the runner is the single source of truth for promptIndex.
+              widgetRenderObservations.push({
+                ...obs,
+                promptIndex: activePromptIndex,
+              });
               // No separate active-widget bookkeeping: a `rendered` + kept widget
               // stays in the harness mount (the single source of truth that the
               // gate and getActiveToolCallId both read); every other outcome is
@@ -1549,6 +1603,11 @@ const runIterationWithAiSdk = async ({
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
+      // PR 6b: per-iteration browser artifacts, non-empty only on this local
+      // AI-SDK Computer Use path. finalizeEvalIteration serializes them once
+      // (screenshot upload + sanitize) for both the W2 and W1 persistence paths.
+      ...(widgetRenderObservations.length ? { widgetRenderObservations } : {}),
+      ...(browserInteractionSteps.length ? { browserInteractionSteps } : {}),
       status: "completed" as const,
       startedAt: runStartedAt,
       ...(iterationError ? { error: iterationError } : {}),
@@ -1675,6 +1734,9 @@ const runIterationWithAiSdk = async ({
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
+      // PR 6b: browser artifacts collected before the failure still persist.
+      ...(widgetRenderObservations.length ? { widgetRenderObservations } : {}),
+      ...(browserInteractionSteps.length ? { browserInteractionSteps } : {}),
       status: "failed" as const,
       startedAt: runStartedAt,
       error: errorMessage,

--- a/mcpjam-inspector/server/services/evals/__tests__/computer-use-loop.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/computer-use-loop.test.ts
@@ -68,10 +68,13 @@ vi.mock("../../../utils/chat-v2-orchestration", () => ({
 }));
 
 // Skip persistence — we want to assert in-memory state, not exercise Convex.
+// Hoisted so the test can read the serialized artifacts the real
+// finalizeEvalIteration forwards into the fanout (PR 6b).
+const persistEvalTraceFanoutMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ turnsWritten: 0, locked: false }),
+);
 vi.mock("../persist-eval-trace", () => ({
-  persistEvalTraceFanout: vi
-    .fn()
-    .mockResolvedValue({ turnsWritten: 0, locked: false }),
+  persistEvalTraceFanout: persistEvalTraceFanoutMock,
   lockEvalSessionAfterUpdate: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -471,5 +474,31 @@ describe("PR 8 — model-driven Computer Use loop (smoke)", () => {
       expect(finalToolNames).not.toContain("computer");
       expect(finalToolNames).not.toContain("finish_widget");
     }
+
+    // 8. PR 6b: the runner collected exactly one render observation and one
+    //    interaction step, and finalizeEvalIteration forwarded them (serialized)
+    //    into the fanout. The fixture produces exactly one of each: one
+    //    show_seats render + one computer left_click.
+    expect(persistEvalTraceFanoutMock).toHaveBeenCalledTimes(1);
+    const fanoutArgs = persistEvalTraceFanoutMock.mock.calls[0]![0];
+    expect(fanoutArgs.widgetRenderObservations).toHaveLength(1);
+    expect(fanoutArgs.browserInteractionSteps).toHaveLength(1);
+    expect(fanoutArgs.widgetRenderObservations[0]).toMatchObject({
+      toolCallId: "tc-show",
+      status: "rendered",
+      promptIndex: 0,
+    });
+    expect(fanoutArgs.browserInteractionSteps[0]).toMatchObject({
+      toolCallId: "tc-show",
+      stepIndex: 0,
+      promptIndex: 0,
+      action: "left_click",
+      coordinateX: 640,
+      coordinateY: 400,
+    });
+    // The widget→host tools/call was captured on the step.
+    expect(fanoutArgs.browserInteractionSteps[0].widgetToolCalls).toEqual([
+      expect.objectContaining({ name: "reserve", ok: true }),
+    ]);
   }, 60_000);
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/finalize-iteration-browser-artifacts.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/finalize-iteration-browser-artifacts.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { ConvexHttpClient } from "convex/browser";
+import type {
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
+} from "@/shared/eval-trace";
+
+// Mock the upload helper so the serializers never hit Convex storage. Use
+// vi.hoisted so the spy exists when vi.mock's factory runs (hoisted above imports).
+const { uploadScreenshotBlob } = vi.hoisted(() => ({
+  uploadScreenshotBlob: vi.fn(),
+}));
+vi.mock("../../../utils/mcp-app-widget-capture.js", () => ({
+  uploadScreenshotBlob,
+}));
+
+import {
+  serializeBrowserStepsForBackend,
+  serializeRenderObservationsForBackend,
+  toBrowserStepPayload,
+  toObservationPayload,
+} from "../finalize-iteration-browser-artifacts.js";
+
+const client = {} as ConvexHttpClient;
+
+const makeObs = (
+  overrides: Partial<RunnerWidgetRenderObservation> = {},
+): RunnerWidgetRenderObservation => ({
+  toolCallId: "tc-0",
+  toolName: "create_view",
+  serverId: "excalidraw",
+  status: "rendered",
+  screenshotBase64: "c2hvdA==",
+  elapsedMs: 5,
+  ts: 1,
+  promptIndex: 0,
+  ...overrides,
+});
+
+const makeStep = (
+  overrides: Partial<RunnerBrowserInteractionStep> = {},
+): RunnerBrowserInteractionStep => ({
+  toolCallId: "tc-0",
+  stepIndex: 0,
+  promptIndex: 0,
+  action: "left_click",
+  coordinateX: 1,
+  coordinateY: 2,
+  screenshotBase64: "c2hvdA==",
+  elapsedMs: 3,
+  ts: 1,
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("serializeRenderObservationsForBackend", () => {
+  test("returns [] for empty/undefined input without uploading", async () => {
+    expect(
+      await serializeRenderObservationsForBackend(undefined, client),
+    ).toEqual([]);
+    expect(await serializeRenderObservationsForBackend([], client)).toEqual([]);
+    expect(uploadScreenshotBlob).not.toHaveBeenCalled();
+  });
+
+  test("uploads one screenshot per row and swaps base64 → screenshotBlobId", async () => {
+    uploadScreenshotBlob.mockResolvedValue("blob-xyz");
+
+    const out = await serializeRenderObservationsForBackend(
+      [makeObs(), makeObs({ toolCallId: "tc-1", promptIndex: 1 })],
+      client,
+    );
+
+    expect(uploadScreenshotBlob).toHaveBeenCalledTimes(2);
+    expect(uploadScreenshotBlob).toHaveBeenCalledWith(client, "c2hvdA==");
+    expect(out).toHaveLength(2);
+    expect(out[0]!.screenshotBlobId).toBe("blob-xyz");
+    expect(out[0]).not.toHaveProperty("screenshotBase64");
+    // promptIndex retained for per-turn bucketing in the fanout.
+    expect(out[0]!.promptIndex).toBe(0);
+    expect(out[1]!.promptIndex).toBe(1);
+  });
+
+  test("never uploads when a row has no screenshot", async () => {
+    const out = await serializeRenderObservationsForBackend(
+      [makeObs({ screenshotBase64: undefined, status: "no_ui_resource" })],
+      client,
+    );
+    expect(uploadScreenshotBlob).not.toHaveBeenCalled();
+    expect(out[0]).not.toHaveProperty("screenshotBlobId");
+    expect(out[0]!.status).toBe("no_ui_resource");
+  });
+
+  test("drops screenshotBlobId but KEEPS the row when upload throws", async () => {
+    uploadScreenshotBlob.mockRejectedValue(new Error("convex down"));
+
+    const out = await serializeRenderObservationsForBackend(
+      [makeObs({ consoleErrors: ["boom"] })],
+      client,
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).not.toHaveProperty("screenshotBlobId");
+    // Status / diagnostics stay useful for replay even without the image.
+    expect(out[0]!.status).toBe("rendered");
+    expect(out[0]!.consoleErrors).toEqual(["boom"]);
+  });
+});
+
+describe("serializeBrowserStepsForBackend", () => {
+  test("returns [] for empty/undefined input without uploading", async () => {
+    expect(await serializeBrowserStepsForBackend(undefined, client)).toEqual([]);
+    expect(await serializeBrowserStepsForBackend([], client)).toEqual([]);
+    expect(uploadScreenshotBlob).not.toHaveBeenCalled();
+  });
+
+  test("uploads one screenshot per step and swaps base64 → screenshotBlobId", async () => {
+    uploadScreenshotBlob.mockResolvedValue("blob-step");
+
+    const out = await serializeBrowserStepsForBackend(
+      [makeStep(), makeStep({ stepIndex: 1 })],
+      client,
+    );
+
+    expect(uploadScreenshotBlob).toHaveBeenCalledTimes(2);
+    expect(out[0]!.screenshotBlobId).toBe("blob-step");
+    expect(out[0]).not.toHaveProperty("screenshotBase64");
+  });
+
+  test("sanitizes $-prefixed keys inside widgetToolCalls[].args", async () => {
+    uploadScreenshotBlob.mockResolvedValue(undefined);
+
+    const out = await serializeBrowserStepsForBackend(
+      [
+        makeStep({
+          screenshotBase64: undefined,
+          widgetToolCalls: [
+            {
+              name: "reserve",
+              // A JSON-Schema-shaped arg — `$ref` would be rejected by Convex's
+              // validator and collapse the whole appendEvalTurnTrace call.
+              args: { $ref: "#/x", nested: { $schema: "s" } },
+              ok: true,
+              elapsedMs: 2,
+            },
+          ],
+        }),
+      ],
+      client,
+    );
+
+    const args = out[0]!.widgetToolCalls![0]!.args as Record<string, unknown>;
+    expect(args.$ref).toBeUndefined();
+    expect(args.__convexReserved__ref).toBe("#/x");
+    expect((args.nested as Record<string, unknown>).$schema).toBeUndefined();
+    expect((args.nested as Record<string, unknown>).__convexReserved__schema).toBe(
+      "s",
+    );
+  });
+});
+
+describe("payload converters", () => {
+  test("toObservationPayload strips promptIndex, keeps the rest", () => {
+    const payload = toObservationPayload({
+      toolCallId: "tc-0",
+      toolName: "create_view",
+      serverId: "excalidraw",
+      status: "rendered",
+      screenshotBlobId: "blob",
+      elapsedMs: 5,
+      ts: 1,
+      promptIndex: 3,
+    });
+    expect(payload).not.toHaveProperty("promptIndex");
+    expect(payload.screenshotBlobId).toBe("blob");
+    expect(payload.status).toBe("rendered");
+  });
+
+  test("toBrowserStepPayload strips promptIndex, keeps the rest", () => {
+    const payload = toBrowserStepPayload({
+      toolCallId: "tc-0",
+      stepIndex: 2,
+      promptIndex: 3,
+      action: "scroll",
+      elapsedMs: 3,
+      ts: 1,
+    });
+    expect(payload).not.toHaveProperty("promptIndex");
+    expect(payload.stepIndex).toBe(2);
+    expect(payload.action).toBe("scroll");
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/finalize-iteration.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/finalize-iteration.test.ts
@@ -4,7 +4,19 @@ import type { ModelMessage } from "ai";
 import type {
   EvalTraceSpan,
   PromptTraceSummary,
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
 } from "@/shared/eval-trace";
+
+// Mock screenshot upload so the serializers don't hit Convex storage. Tests
+// that pass no browser artifacts never call it (the serializers short-circuit).
+const { uploadScreenshotBlob } = vi.hoisted(() => ({
+  uploadScreenshotBlob: vi.fn(),
+}));
+vi.mock("../../../utils/mcp-app-widget-capture.js", () => ({
+  uploadScreenshotBlob,
+}));
+
 import { finalizeEvalIteration } from "../finalize-iteration.js";
 
 type Call = { ref: string; args: Record<string, unknown> };
@@ -429,5 +441,112 @@ describe("finalizeEvalIteration", () => {
     });
     const lock = calls.find((c) => c.ref === "testSuites:lockEvalSession");
     expect(lock).toBeDefined();
+  });
+
+  describe("browser artifacts (PR 6b)", () => {
+    const obs: RunnerWidgetRenderObservation = {
+      toolCallId: "tc-0",
+      toolName: "create_view",
+      serverId: "excalidraw",
+      status: "rendered",
+      screenshotBase64: "c2hvdA==",
+      elapsedMs: 5,
+      ts: 1,
+      promptIndex: 0,
+    };
+    const step: RunnerBrowserInteractionStep = {
+      toolCallId: "tc-0",
+      stepIndex: 0,
+      promptIndex: 0,
+      action: "left_click",
+      screenshotBase64: "c2hvdA==",
+      elapsedMs: 3,
+      ts: 1,
+    };
+
+    test("W1 fallback carries artifacts — uploaded once, base64 dropped, promptIndex stripped", async () => {
+      uploadScreenshotBlob.mockResolvedValue("blob-1");
+      const { client, calls } = makeClient({
+        appendThrows: new Error("fanout pre-turn failure"),
+      });
+
+      await finalizeEvalIteration({
+        convexClient: client,
+        iterationId: "iter1",
+        passed: true,
+        toolsCalled: [],
+        usage: usageZero,
+        messages,
+        widgetRenderObservations: [obs],
+        browserInteractionSteps: [step],
+      });
+
+      const update = calls.find(
+        (c) => c.ref === "testSuites:updateTestIteration",
+      );
+      expect(update).toBeDefined();
+      const obsOut = update!.args.widgetRenderObservations as any[];
+      const stepsOut = update!.args.browserInteractionSteps as any[];
+      expect(obsOut).toHaveLength(1);
+      expect(obsOut[0].screenshotBlobId).toBe("blob-1");
+      expect(obsOut[0]).not.toHaveProperty("screenshotBase64");
+      // Backend stamps promptIndex from the W1 turn (promptIndex:0).
+      expect(obsOut[0]).not.toHaveProperty("promptIndex");
+      expect(stepsOut).toHaveLength(1);
+      expect(stepsOut[0].screenshotBlobId).toBe("blob-1");
+      expect(stepsOut[0]).not.toHaveProperty("promptIndex");
+
+      // Serialize-once: one upload per artifact total, even though the same
+      // serialized records feed BOTH the (failed) W2 fanout and the W1 fallback.
+      expect(uploadScreenshotBlob).toHaveBeenCalledTimes(2);
+    });
+
+    test("W1 fallback omits browser arrays when none were collected", async () => {
+      const { client, calls } = makeClient({
+        appendThrows: new Error("fanout pre-turn failure"),
+      });
+
+      await finalizeEvalIteration({
+        convexClient: client,
+        iterationId: "iter1",
+        passed: true,
+        toolsCalled: [],
+        usage: usageZero,
+        messages,
+      });
+
+      const update = calls.find(
+        (c) => c.ref === "testSuites:updateTestIteration",
+      );
+      expect("widgetRenderObservations" in update!.args).toBe(false);
+      expect("browserInteractionSteps" in update!.args).toBe(false);
+      expect(uploadScreenshotBlob).not.toHaveBeenCalled();
+    });
+
+    test("happy path (fanout persists) does NOT W1-spread artifacts to updateTestIteration", async () => {
+      uploadScreenshotBlob.mockResolvedValue("blob-1");
+      const { client, calls } = makeClient({});
+
+      await finalizeEvalIteration({
+        convexClient: client,
+        iterationId: "iter1",
+        passed: true,
+        toolsCalled: [],
+        usage: usageZero,
+        messages,
+        widgetRenderObservations: [obs],
+        browserInteractionSteps: [step],
+      });
+
+      // Artifacts rode the per-turn appendEvalTurnTrace call (W2); the
+      // updateTestIteration call must NOT also carry them.
+      const update = calls.find(
+        (c) => c.ref === "testSuites:updateTestIteration",
+      );
+      expect("widgetRenderObservations" in update!.args).toBe(false);
+      expect("browserInteractionSteps" in update!.args).toBe(false);
+      // Still serialized exactly once.
+      expect(uploadScreenshotBlob).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/persist-eval-trace.test.ts
@@ -5,6 +5,8 @@ import type {
   EvalTraceSpan,
   EvalTraceWidgetSnapshot,
   PromptTraceSummary,
+  SerializedBrowserInteractionStep,
+  SerializedWidgetRenderObservation,
 } from "@/shared/eval-trace";
 import {
   lockEvalSessionAfterUpdate,
@@ -638,5 +640,142 @@ describe("persistEvalTraceFanout — widget serialization", () => {
       resourceDomains: ["good.com"],
     });
     expect(csp.unrelatedField).toBeUndefined();
+  });
+});
+
+describe("persistEvalTraceFanout — browser artifact fanout (PR 6b)", () => {
+  const twoPrompts: PromptTraceSummary[] = [0, 1].map((promptIndex) => ({
+    promptIndex,
+    prompt: `p${promptIndex}`,
+    expectedToolCalls: [],
+    actualToolCalls: [],
+    passed: true,
+    missing: [],
+    unexpected: [],
+    argumentMismatches: [],
+  }));
+  const twoTurnMessages: ModelMessage[] = [
+    { role: "user", content: "q0" } as ModelMessage,
+    { role: "assistant", content: "a0" } as ModelMessage,
+    { role: "user", content: "q1" } as ModelMessage,
+    { role: "assistant", content: "a1" } as ModelMessage,
+  ];
+
+  const obs = (
+    promptIndex: number,
+    toolCallId: string,
+  ): SerializedWidgetRenderObservation => ({
+    toolCallId,
+    toolName: "create_view",
+    serverId: "excalidraw",
+    status: "rendered",
+    screenshotBlobId: `blob-${toolCallId}`,
+    elapsedMs: 5,
+    ts: 1,
+    promptIndex,
+  });
+  const step = (
+    promptIndex: number,
+    stepIndex: number,
+  ): SerializedBrowserInteractionStep => ({
+    toolCallId: `tc-${promptIndex}`,
+    stepIndex,
+    promptIndex,
+    action: "left_click",
+    coordinateX: stepIndex,
+    coordinateY: stepIndex,
+    elapsedMs: 3,
+    ts: 1,
+  });
+
+  test("observations + steps bucket PER turn (not last-turn-batched like widgets)", async () => {
+    const { client, calls } = makeMockClient();
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: twoTurnMessages,
+      spans: undefined,
+      prompts: twoPrompts,
+      widgetRenderObservations: [obs(0, "tc-0"), obs(1, "tc-1")],
+      browserInteractionSteps: [step(0, 0), step(0, 1), step(1, 0)],
+    });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    expect(appendCalls).toHaveLength(2);
+
+    const turn0 = appendCalls[0]!.args.turn as {
+      widgetRenderObservations?: Array<{ toolCallId: string }>;
+      browserInteractionSteps?: Array<{ stepIndex: number }>;
+    };
+    const turn1 = appendCalls[1]!.args.turn as {
+      widgetRenderObservations?: Array<{ toolCallId: string }>;
+      browserInteractionSteps?: Array<{ stepIndex: number }>;
+    };
+
+    // Turn 0 sees ONLY its own observation + steps.
+    expect(turn0.widgetRenderObservations?.map((o) => o.toolCallId)).toEqual([
+      "tc-0",
+    ]);
+    expect(turn0.browserInteractionSteps?.map((s) => s.stepIndex)).toEqual([
+      0, 1,
+    ]);
+    // Turn 1 sees ONLY its own.
+    expect(turn1.widgetRenderObservations?.map((o) => o.toolCallId)).toEqual([
+      "tc-1",
+    ]);
+    expect(turn1.browserInteractionSteps?.map((s) => s.stepIndex)).toEqual([0]);
+  });
+
+  test("strips per-entry promptIndex (backend stamps it from turn.promptIndex)", async () => {
+    const { client, calls } = makeMockClient();
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: twoTurnMessages,
+      spans: undefined,
+      prompts: twoPrompts,
+      widgetRenderObservations: [obs(0, "tc-0")],
+      browserInteractionSteps: [step(0, 0)],
+    });
+
+    const turn0 = calls.find(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    )!.args.turn as {
+      widgetRenderObservations: Array<Record<string, unknown>>;
+      browserInteractionSteps: Array<Record<string, unknown>>;
+    };
+    expect(turn0.widgetRenderObservations[0]).not.toHaveProperty("promptIndex");
+    expect(turn0.browserInteractionSteps[0]).not.toHaveProperty("promptIndex");
+    // The blob id (already uploaded by finalize) rides through verbatim.
+    expect(turn0.widgetRenderObservations[0]!.screenshotBlobId).toBe("blob-tc-0");
+  });
+
+  test("omits the arrays entirely on turns with no artifacts (non-CU evals untouched)", async () => {
+    const { client, calls } = makeMockClient();
+
+    await persistEvalTraceFanout({
+      convexClient: client,
+      iterationId: "iter1",
+      messages: twoTurnMessages,
+      spans: undefined,
+      prompts: twoPrompts,
+      // Only turn 1 has a step; turn 0 has nothing.
+      browserInteractionSteps: [step(1, 0)],
+    });
+
+    const appendCalls = calls.filter(
+      (c) => c.ref === "testSuites:appendEvalTurnTrace",
+    );
+    const turn0 = appendCalls[0]!.args.turn as Record<string, unknown>;
+    const turn1 = appendCalls[1]!.args.turn as Record<string, unknown>;
+    // Absent (not []), so the wire shape of artifact-free turns is unchanged.
+    expect(turn0).not.toHaveProperty("widgetRenderObservations");
+    expect(turn0).not.toHaveProperty("browserInteractionSteps");
+    expect(turn1).not.toHaveProperty("widgetRenderObservations");
+    expect(turn1).toHaveProperty("browserInteractionSteps");
   });
 });

--- a/mcpjam-inspector/server/services/evals/finalize-iteration-browser-artifacts.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration-browser-artifacts.ts
@@ -1,0 +1,115 @@
+import type { ConvexHttpClient } from "convex/browser";
+import type {
+  BrowserInteractionStepPayload,
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
+  SerializedBrowserInteractionStep,
+  SerializedWidgetRenderObservation,
+  WidgetRenderObservationPayload,
+} from "@/shared/eval-trace";
+import { logger } from "../../utils/logger.js";
+import { uploadScreenshotBlob } from "../../utils/mcp-app-widget-capture.js";
+import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+
+/**
+ * PR 6b: serialize browser-rendered MCP App eval artifacts for the backend.
+ *
+ * These run inside `finalizeEvalIteration` exactly ONCE per iteration, BEFORE
+ * the W2 per-turn fanout or the W1 single-call fallback consume the result, so
+ * a screenshot blob is never uploaded twice. Each helper:
+ *   - uploads the transient base64 screenshot (`screenshotBase64` →
+ *     `screenshotBlobId`) — best-effort: a failed upload drops the blob id but
+ *     KEEPS the row (status / timings / console errors stay useful for replay),
+ *   - runs the record through `sanitizeForConvexTransport` ($-key escaping is
+ *     required for the `widgetToolCalls[].args: v.any()` field on steps),
+ *   - retains `promptIndex` so the fanout can bucket per turn.
+ *
+ * Uploads are sequential (not `Promise.all`): under the harness budgets
+ * (≤ 12 steps + a few observations per iteration) the wall-clock cost is dwarfed
+ * by the rest of the fanout, and the convex-test storage mock expects serial
+ * writes. Batch only if real evals show latency (see PR plan risks).
+ */
+export async function serializeRenderObservationsForBackend(
+  observations: RunnerWidgetRenderObservation[] | undefined,
+  convexClient: ConvexHttpClient,
+): Promise<SerializedWidgetRenderObservation[]> {
+  if (!observations?.length) return [];
+  const out: SerializedWidgetRenderObservation[] = [];
+  for (const obs of observations) {
+    let screenshotBlobId: string | undefined;
+    if (obs.screenshotBase64) {
+      try {
+        screenshotBlobId = await uploadScreenshotBlob(
+          convexClient,
+          obs.screenshotBase64,
+        );
+      } catch (err) {
+        logger.warn("[eval-persist] dropped render-obs screenshot upload", {
+          toolCallId: obs.toolCallId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    // Drop the transient base64; keep every other field (incl. promptIndex).
+    const { screenshotBase64: _screenshotBase64, ...rest } = obs;
+    const serialized: SerializedWidgetRenderObservation = {
+      ...rest,
+      ...(screenshotBlobId ? { screenshotBlobId } : {}),
+    };
+    // No $-key risk on observations (no v.any fields), but stay consistent with
+    // widgets and route through the sanitizer regardless.
+    out.push(sanitizeForConvexTransport(serialized));
+  }
+  return out;
+}
+
+export async function serializeBrowserStepsForBackend(
+  steps: RunnerBrowserInteractionStep[] | undefined,
+  convexClient: ConvexHttpClient,
+): Promise<SerializedBrowserInteractionStep[]> {
+  if (!steps?.length) return [];
+  const out: SerializedBrowserInteractionStep[] = [];
+  for (const step of steps) {
+    let screenshotBlobId: string | undefined;
+    if (step.screenshotBase64) {
+      try {
+        screenshotBlobId = await uploadScreenshotBlob(
+          convexClient,
+          step.screenshotBase64,
+        );
+      } catch (err) {
+        logger.warn("[eval-persist] dropped browser-step screenshot upload", {
+          toolCallId: step.toolCallId,
+          stepIndex: step.stepIndex,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    // Drop the transient base64; keep every other field (incl. promptIndex).
+    const { screenshotBase64: _screenshotBase64, ...rest } = step;
+    const serialized: SerializedBrowserInteractionStep = {
+      ...rest,
+      ...(screenshotBlobId ? { screenshotBlobId } : {}),
+    };
+    // $-keys can appear inside widgetToolCalls[].args (v.any() on the backend
+    // validator). sanitizeForConvexTransport handles the escape.
+    out.push(sanitizeForConvexTransport(serialized));
+  }
+  return out;
+}
+
+/** Strip `promptIndex` for the backend turn payload — the backend stamps it
+ *  from `turn.promptIndex` server-side. */
+export function toObservationPayload(
+  obs: SerializedWidgetRenderObservation,
+): WidgetRenderObservationPayload {
+  const { promptIndex: _promptIndex, ...payload } = obs;
+  return payload;
+}
+
+export function toBrowserStepPayload(
+  step: SerializedBrowserInteractionStep,
+): BrowserInteractionStepPayload {
+  const { promptIndex: _promptIndex, ...payload } = step;
+  return payload;
+}

--- a/mcpjam-inspector/server/services/evals/finalize-iteration.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration.ts
@@ -4,10 +4,18 @@ import type {
   EvalTraceSpan,
   EvalTraceWidgetSnapshot,
   PromptTraceSummary,
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
 } from "@/shared/eval-trace";
 import { logger } from "../../utils/logger.js";
 import type { UsageTotals } from "./types.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+import {
+  serializeBrowserStepsForBackend,
+  serializeRenderObservationsForBackend,
+  toBrowserStepPayload,
+  toObservationPayload,
+} from "./finalize-iteration-browser-artifacts.js";
 import { buildIterationUsageMetadata } from "./iteration-usage-metadata.js";
 import {
   lockEvalSessionAfterUpdate,
@@ -37,6 +45,14 @@ export type FinalizeEvalIterationParams = {
    * fanout failed before any turn wrote.
    */
   systemPrompt?: string;
+  /**
+   * PR 6b: browser-rendered MCP App eval artifacts collected by the runner
+   * (runner-local shape, screenshots still base64). Serialized ONCE here —
+   * screenshots uploaded, records sanitized — then forwarded to the W2 fanout
+   * and reused on the W1 fallback so neither path re-uploads.
+   */
+  widgetRenderObservations?: RunnerWidgetRenderObservation[];
+  browserInteractionSteps?: RunnerBrowserInteractionStep[];
   status?: IterationStatus;
   startedAt?: number;
   error?: string;
@@ -93,6 +109,8 @@ export async function finalizeEvalIteration(
     prompts,
     widgetSnapshots,
     systemPrompt,
+    widgetRenderObservations,
+    browserInteractionSteps,
     status,
     startedAt,
     error,
@@ -164,6 +182,21 @@ export async function finalizeEvalIteration(
         ? "eval_failed"
         : "eval_completed";
 
+  // PR 6b: serialize browser artifacts ONCE here (upload screenshots + run
+  // through the convex sanitizer) so the W2 fanout and the W1 fallback share a
+  // single upload pass. Owning this in the shared finalize step is what keeps
+  // recorder + direct quick-run callers from double-uploading.
+  const serializedWidgetRenderObservations =
+    await serializeRenderObservationsForBackend(
+      widgetRenderObservations,
+      convexClient,
+    );
+  const serializedBrowserInteractionSteps =
+    await serializeBrowserStepsForBackend(
+      browserInteractionSteps,
+      convexClient,
+    );
+
   const fanout = await persistEvalTraceFanout({
     convexClient,
     iterationId,
@@ -173,6 +206,8 @@ export async function finalizeEvalIteration(
     prompts,
     widgetSnapshots,
     systemPrompt,
+    widgetRenderObservations: serializedWidgetRenderObservations,
+    browserInteractionSteps: serializedBrowserInteractionSteps,
   });
   // Fall back to the W1 single-call path ONLY when the fanout failed
   // before any turn landed. With turns already written, re-sending
@@ -227,6 +262,24 @@ export async function finalizeEvalIteration(
               ? {
                   widgetSnapshots:
                     sanitizeForConvexTransport(widgetSnapshots),
+                }
+              : {}),
+            // PR 6b: browser artifacts already uploaded + sanitized above;
+            // strip `promptIndex` (the backend stamps it from the W1 turn's
+            // promptIndex: 0). All artifacts land under that single fallback
+            // turn — lossy but acceptable, mirroring W1's transcript fallback.
+            ...(serializedWidgetRenderObservations.length
+              ? {
+                  widgetRenderObservations:
+                    serializedWidgetRenderObservations.map(
+                      toObservationPayload,
+                    ),
+                }
+              : {}),
+            ...(serializedBrowserInteractionSteps.length
+              ? {
+                  browserInteractionSteps:
+                    serializedBrowserInteractionSteps.map(toBrowserStepPayload),
                 }
               : {}),
           }

--- a/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
+++ b/mcpjam-inspector/server/services/evals/persist-eval-trace.ts
@@ -1,12 +1,20 @@
 import type { ConvexHttpClient } from "convex/browser";
 import type { ModelMessage } from "ai";
 import type {
+  BrowserInteractionStepPayload,
   EvalTraceSpan,
   EvalTraceWidgetSnapshot,
   PromptTraceSummary,
+  SerializedBrowserInteractionStep,
+  SerializedWidgetRenderObservation,
+  WidgetRenderObservationPayload,
 } from "@/shared/eval-trace";
 import { logger } from "../../utils/logger.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+import {
+  toBrowserStepPayload,
+  toObservationPayload,
+} from "./finalize-iteration-browser-artifacts.js";
 import {
   evalTraceSnapshotToPayload,
   sanitizeWidgetForBackend,
@@ -202,12 +210,39 @@ export async function persistEvalTraceFanout(args: {
    * used to splice into `messages` at finalize.
    */
   systemPrompt?: string;
+  /**
+   * PR 6b: browser-rendered MCP App render observations + interaction steps,
+   * ALREADY uploaded + sanitized by `finalizeEvalIteration`. This function
+   * must NOT upload screenshots. Each record keeps `promptIndex` so it buckets
+   * onto its own turn (their natural emission cadence — unlike widgets, which
+   * attach to the last turn only). `promptIndex` is stripped before the backend
+   * turn payload; the backend re-stamps it from `turn.promptIndex`.
+   */
+  widgetRenderObservations?: SerializedWidgetRenderObservation[];
+  browserInteractionSteps?: SerializedBrowserInteractionStep[];
 }): Promise<FanoutResult> {
   const turns = sliceTraceIntoTurns({
     messages: args.messages,
     spans: args.spans ?? [],
     prompts: args.prompts ?? [],
   });
+
+  // Bucket the (already-serialized) browser artifacts by promptIndex so each
+  // turn carries only its own observations/steps. The backend dedups
+  // observations by (sessionId, toolCallId) and steps by
+  // (sessionId, toolCallId, stepIndex), so a same-turn retry is idempotent.
+  const obsByPromptIndex = new Map<number, WidgetRenderObservationPayload[]>();
+  for (const obs of args.widgetRenderObservations ?? []) {
+    const arr = obsByPromptIndex.get(obs.promptIndex) ?? [];
+    arr.push(toObservationPayload(obs));
+    obsByPromptIndex.set(obs.promptIndex, arr);
+  }
+  const stepsByPromptIndex = new Map<number, BrowserInteractionStepPayload[]>();
+  for (const step of args.browserInteractionSteps ?? []) {
+    const arr = stepsByPromptIndex.get(step.promptIndex) ?? [];
+    arr.push(toBrowserStepPayload(step));
+    stepsByPromptIndex.set(step.promptIndex, arr);
+  }
 
   // Convert inspector-shape widgets to the backend `appendEvalTurnTrace`
   // shape. Inspector snapshots optionally carry the HTML blob id;
@@ -240,6 +275,11 @@ export async function persistEvalTraceFanout(args: {
       // finalize, so we attach the full set to the last turn call. Earlier
       // turns send `widgets: []` to keep per-turn payloads light.
       const widgetsForThisTurn = isLastTurn ? lastTurnWidgets : [];
+      // Observations + steps attach PER turn (their natural emission cadence),
+      // unlike last-turn-only widgets. Omitted entirely when empty so the
+      // wire shape of non-Computer-Use evals is unchanged.
+      const obsForThisTurn = obsByPromptIndex.get(turn.promptIndex) ?? [];
+      const stepsForThisTurn = stepsByPromptIndex.get(turn.promptIndex) ?? [];
       const result = (await args.convexClient.action(
         "testSuites:appendEvalTurnTrace" as any,
         {
@@ -265,6 +305,12 @@ export async function persistEvalTraceFanout(args: {
               ? { prompts: sanitizeForConvexTransport(turn.prompts) }
               : {}),
             widgets: widgetsForThisTurn,
+            ...(obsForThisTurn.length
+              ? { widgetRenderObservations: obsForThisTurn }
+              : {}),
+            ...(stepsForThisTurn.length
+              ? { browserInteractionSteps: stepsForThisTurn }
+              : {}),
           },
         },
       )) as { skipped?: boolean } | undefined;

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -3,6 +3,10 @@ import type { ConvexHttpClient } from "convex/browser";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 import type { PromptTraceSummary } from "@/shared/eval-trace";
 import type { EvalTraceWidgetSnapshot } from "@/shared/eval-trace";
+import type {
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
+} from "@/shared/eval-trace";
 import type { PromptTurn } from "@/shared/prompt-turns";
 import type { UsageTotals } from "./types";
 import { logger } from "../../utils/logger";
@@ -66,6 +70,13 @@ export type SuiteRunRecorder = {
      * `messages`.
      */
     systemPrompt?: string;
+    /**
+     * PR 6b: browser-rendered MCP App eval artifacts (runner-local shape).
+     * Pure pass-through — `finishIteration` forwards them to
+     * `finalizeEvalIteration`, which owns screenshot upload + serialization.
+     */
+    widgetRenderObservations?: RunnerWidgetRenderObservation[];
+    browserInteractionSteps?: RunnerBrowserInteractionStep[];
     status?: IterationStatus;
     startedAt?: number;
     error?: string;

--- a/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
@@ -10,6 +10,7 @@ import {
   type ComputerImplOutput,
 } from "../computer-use-tool";
 import type { McpAppBrowserHarness } from "../mcp-app-browser-harness";
+import { logger } from "../logger";
 
 describe("resolveComputerUseToolVersion", () => {
   it("resolves every mapped model id to its version", () => {
@@ -267,6 +268,78 @@ describe("buildComputerUseTools", () => {
     const impl = (await exec({ action: "screenshot" }, {})) as ComputerImplOutput;
     expect(impl.note).toBe("no_rendered_widget");
     expect(executeAction).not.toHaveBeenCalled();
+  });
+
+  it("onAction fires once per real action with the harness result + toolCallId", async () => {
+    const { harness } = stubHarness();
+    const onAction = vi.fn();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => "tc-active",
+      viewport: { width: 1280, height: 800 },
+      onAction,
+    });
+    const exec = (tools.computer as { execute: Function }).execute;
+    await exec({ action: "left_click", coordinate: [10, 20] }, {});
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    const [result, context] = onAction.mock.calls[0]!;
+    // The raw harness BrowserActionResult — not the model-facing impl output.
+    expect(result).toMatchObject({
+      screenshotBase64: "iVBORscreenshot",
+      widgetToolCalls: [
+        { name: "reserve", args: { seat: 12 }, ok: true, elapsedMs: 4 },
+      ],
+      elapsedMs: 7,
+    });
+    expect(context).toEqual({ toolCallId: "tc-active" });
+  });
+
+  it("onAction does NOT fire on the no-widget short-circuit", async () => {
+    const { harness, executeAction } = stubHarness();
+    const onAction = vi.fn();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => null,
+      viewport: { width: 1280, height: 800 },
+      onAction,
+    });
+    const exec = (tools.computer as { execute: Function }).execute;
+    const impl = (await exec({ action: "screenshot" }, {})) as ComputerImplOutput;
+
+    expect(impl.note).toBe("no_rendered_widget");
+    expect(executeAction).not.toHaveBeenCalled();
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("a throwing onAction is caught + logged; execute still returns the result", async () => {
+    const { harness } = stubHarness();
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const onAction = vi.fn(() => {
+      throw new Error("emitter boom");
+    });
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => "tc-active",
+      viewport: { width: 1280, height: 800 },
+      onAction,
+    });
+    const exec = (tools.computer as { execute: Function }).execute;
+    const impl = (await exec(
+      { action: "left_click", coordinate: [1, 2] },
+      {},
+    )) as ComputerImplOutput;
+
+    // A buggy emitter must not crash the agent loop.
+    expect(impl.widgetToolCalls).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[computer-use] onAction callback threw",
+      expect.objectContaining({ error: "emitter boom" }),
+    );
+    warnSpy.mockRestore();
   });
 
   it("finish_widget.execute dismisses the named widget", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-widget-capture.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-widget-capture.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { ConvexHttpClient } from "convex/browser";
+import { uploadScreenshotBlob } from "../mcp-app-widget-capture.js";
+
+function makeClient(uploadUrl: unknown): {
+  client: ConvexHttpClient;
+  mutation: ReturnType<typeof vi.fn>;
+} {
+  const mutation = vi.fn(async () => uploadUrl);
+  return { client: { mutation } as unknown as ConvexHttpClient, mutation };
+}
+
+// Duck-typed Response so the test doesn't depend on a global `Response`.
+const okJson = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
+const errStatus = (status: number) => ({
+  ok: false,
+  status,
+  json: async () => null,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("uploadScreenshotBlob", () => {
+  test("POSTs an image/png blob and returns the storageId", async () => {
+    const { client, mutation } = makeClient("https://convex.example/upload");
+    const fetchMock = vi.fn(async () => okJson({ storageId: "store-1" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // PNG base64 begins with "iVBOR"; not "/9j/" so it's detected as PNG.
+    const id = await uploadScreenshotBlob(client, "iVBORw0KGgo");
+
+    expect(id).toBe("store-1");
+    expect(mutation).toHaveBeenCalledWith(
+      "chatSessions:generateSnapshotUploadUrl",
+      {},
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]! as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("https://convex.example/upload");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "image/png",
+    );
+    expect((init.body as Blob).type).toBe("image/png");
+  });
+
+  test("detects image/jpeg from the base64 header", async () => {
+    const { client } = makeClient("https://convex.example/upload");
+    const fetchMock = vi.fn(async () => okJson({ storageId: "store-2" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await uploadScreenshotBlob(client, "/9j/4AAQSkZJRg");
+
+    const [, init] = fetchMock.mock.calls[0]! as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "image/jpeg",
+    );
+  });
+
+  test("returns undefined when the upload URL can't be generated (no fetch)", async () => {
+    const { client } = makeClient("");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await uploadScreenshotBlob(client, "iVBORw0")).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("throws on a non-2xx upload response", async () => {
+    const { client } = makeClient("https://convex.example/upload");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => errStatus(500)),
+    );
+
+    await expect(uploadScreenshotBlob(client, "iVBORw0")).rejects.toThrow(/500/);
+  });
+
+  test("returns undefined when the response body lacks a storageId", async () => {
+    const { client } = makeClient("https://convex.example/upload");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => okJson({})),
+    );
+
+    expect(await uploadScreenshotBlob(client, "iVBORw0")).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/utils/computer-use-tool.ts
+++ b/mcpjam-inspector/server/utils/computer-use-tool.ts
@@ -21,10 +21,12 @@ import { tool, type ToolSet } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
 import type {
+  BrowserActionResult,
   BrowserActionSpec,
   McpAppBrowserHarness,
   WidgetToolCall,
 } from "./mcp-app-browser-harness";
+import { logger } from "./logger";
 
 export type ComputerUseToolVersion = "20250124" | "20251124";
 
@@ -214,6 +216,19 @@ export interface BuildComputerUseToolsOptions {
   getActiveToolCallId: () => string | null;
   /** Viewport == screenshot pixel space == the model's coordinate space. */
   viewport: { width: number; height: number };
+  /**
+   * PR 6b: fires after every `harness.executeAction()` returns. Receives the
+   * raw `BrowserActionResult` plus the toolCallId of the active widget the
+   * action targeted. The eval runner uses this to collect
+   * `browserInteractionSteps` for persistence. It does NOT fire on the
+   * no-widget short-circuit (that path is already represented in
+   * `widgetRenderObservations` + the model loop), and never touches the
+   * model-side `toModelOutput` path.
+   */
+  onAction?: (
+    result: BrowserActionResult,
+    context: { toolCallId: string },
+  ) => void;
 }
 
 /**
@@ -242,6 +257,15 @@ export function buildComputerUseTools(
       toolCallId,
       action: mapToBrowserAction(input),
     });
+    try {
+      opts.onAction?.(result, { toolCallId });
+    } catch (err) {
+      // Engine-callback contract: a buggy emitter must not crash the agent
+      // loop. Surface and continue (mirrors the stream handler's onToolCall).
+      logger.warn("[computer-use] onAction callback threw", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     return {
       screenshotBase64: result.screenshotBase64,
       widgetToolCalls: result.widgetToolCalls,

--- a/mcpjam-inspector/server/utils/mcp-app-widget-capture.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-widget-capture.ts
@@ -266,6 +266,52 @@ async function uploadWidgetHtmlBlob(
 }
 
 /**
+ * PR 6b sibling to `uploadWidgetHtmlBlob`. Same content-agnostic upload mutation
+ * (`chatSessions:generateSnapshotUploadUrl` → `ctx.storage.generateUploadUrl()`);
+ * only the Blob mime type changes. The caller hands base64 from the harness —
+ * decode → Blob → POST → return the storageId. Exported (unlike its HTML
+ * sibling) because `finalize-iteration.ts` serializes browser artifacts.
+ */
+export async function uploadScreenshotBlob(
+  convexClient: ConvexHttpClient,
+  base64: string,
+): Promise<string | undefined> {
+  const uploadUrl = await convexClient.mutation(
+    "chatSessions:generateSnapshotUploadUrl" as any,
+    {},
+  );
+
+  if (typeof uploadUrl !== "string" || uploadUrl.length === 0) {
+    return undefined;
+  }
+
+  const mediaType = detectScreenshotMediaType(base64);
+  const bytes = Buffer.from(base64, "base64");
+  const response = await fetch(uploadUrl, {
+    method: "POST",
+    headers: { "Content-Type": mediaType },
+    body: new Blob([bytes], { type: mediaType }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to upload screenshot (${response.status})`);
+  }
+
+  const body = (await response.json().catch(() => null)) as
+    | { storageId?: string }
+    | null;
+  return typeof body?.storageId === "string" ? body.storageId : undefined;
+}
+
+// Mirrors `detectImageMediaType` in computer-use-tool.ts but kept local so
+// widget-capture stays the single owner of screenshot upload concerns. The
+// harness emits PNG by default and JPEG only after re-encoding to fit the byte
+// budget; JPEG base64 begins with "/9j/".
+function detectScreenshotMediaType(base64: string): "image/jpeg" | "image/png" {
+  return base64.startsWith("/9j/") ? "image/jpeg" : "image/png";
+}
+
+/**
  * Walk an AI SDK message transcript, find every tool result whose tool
  * metadata identifies an MCP App, fetch the widget HTML via
  * `MCPClientManager.readResource()`, upload it to Convex, and return one

--- a/mcpjam-inspector/shared/eval-trace.ts
+++ b/mcpjam-inspector/shared/eval-trace.ts
@@ -94,6 +94,142 @@ export type EvalTraceWidgetSnapshot = {
   };
 };
 
+// PR 6b: browser-rendered MCP App eval — render observations + interaction
+// steps. Runner records carry base64 screenshots until `finalizeEvalIteration`
+// uploads them via `chatSessions:generateSnapshotUploadUrl`; serialized records
+// replace that field with `screenshotBlobId`. These never enter
+// `EvalTraceBlobV1` — they fan out to the sibling `widgetRenderObservations` /
+// `browserInteractionSteps` Convex tables via `appendEvalTurnTrace`, which has
+// its own server-side validators, so no Zod mirror lives here.
+
+export type EvalTraceWidgetRenderStatus =
+  | "rendered"
+  | "no_ui_resource"
+  | "resource_read_failed"
+  | "mount_failed"
+  | "bridge_timeout"
+  | "render_error"
+  | "blank_screenshot"
+  | "screenshot_failed"
+  | "browser_unavailable";
+
+export type EvalTraceBrowserAction =
+  | "screenshot"
+  | "left_click"
+  | "double_click"
+  | "right_click"
+  | "mouse_move"
+  | "type"
+  | "key"
+  | "scroll"
+  | "wait";
+
+export type EvalTraceBrowserStepNote =
+  | "no_rendered_widget"
+  | "step_budget_exceeded"
+  | "screenshot_budget_exceeded";
+
+const EVAL_TRACE_BROWSER_STEP_NOTES: ReadonlySet<string> = new Set([
+  "no_rendered_widget",
+  "step_budget_exceeded",
+  "screenshot_budget_exceeded",
+]);
+
+/**
+ * The harness types `BrowserActionResult.note` as an open `string`, but the
+ * backend step validator is a CLOSED union and rejects the whole turn write on
+ * an unknown literal. The runner narrows through this guard so a future harness
+ * note can never cost an entire turn's worth of steps — keep the step, drop the
+ * unrecognized note.
+ */
+export function isEvalTraceBrowserStepNote(
+  value: unknown,
+): value is EvalTraceBrowserStepNote {
+  return typeof value === "string" && EVAL_TRACE_BROWSER_STEP_NOTES.has(value);
+}
+
+export type EvalTraceWidgetToolCall = {
+  name: string;
+  args: unknown; // sanitized at the boundary; sanitizer handles `$`-keys
+  ok: boolean;
+  error?: string;
+  elapsedMs: number;
+};
+
+/**
+ * Runner-local render observation: carries `promptIndex` (stamped by the runner)
+ * plus the transient base64 screenshot until finalize uploads it.
+ */
+export type RunnerWidgetRenderObservation = {
+  toolCallId: string;
+  toolName: string;
+  serverId: string; // friendly MCP server name; backend resolves to Id<'servers'>
+  status: EvalTraceWidgetRenderStatus;
+  resourceUri?: string;
+  bridgeInitialized?: boolean;
+  screenshotBase64?: string; // transient; uploaded in finalizeEvalIteration
+  consoleErrors?: string[];
+  blockedRequests?: string[];
+  elapsedMs: number;
+  ts: number;
+  promptIndex: number; // stamped by the runner
+};
+
+/**
+ * Runner-local interaction step: carries `promptIndex` + `stepIndex` (both
+ * stamped by the runner) plus the transient base64 screenshot until finalize
+ * uploads it.
+ */
+export type RunnerBrowserInteractionStep = {
+  toolCallId: string;
+  stepIndex: number; // monotonic per (toolCallId), stamped by the runner
+  promptIndex: number; // stamped by the runner
+  action: EvalTraceBrowserAction;
+  coordinateX?: number;
+  coordinateY?: number;
+  text?: string;
+  scrollDirection?: "up" | "down" | "left" | "right";
+  scrollAmount?: number;
+  duration?: number;
+  screenshotBase64?: string; // transient; uploaded in finalizeEvalIteration
+  widgetToolCalls?: EvalTraceWidgetToolCall[];
+  elapsedMs: number;
+  note?: EvalTraceBrowserStepNote;
+  ts: number;
+};
+
+/**
+ * Serialized render observation: screenshot already uploaded
+ * (`screenshotBase64` → `screenshotBlobId`), `promptIndex` retained so the W2
+ * fanout can bucket per turn.
+ */
+export type SerializedWidgetRenderObservation = Omit<
+  RunnerWidgetRenderObservation,
+  "screenshotBase64"
+> & {
+  screenshotBlobId?: string;
+};
+
+/** Serialized interaction step — same screenshot-upload swap as above. */
+export type SerializedBrowserInteractionStep = Omit<
+  RunnerBrowserInteractionStep,
+  "screenshotBase64"
+> & {
+  screenshotBlobId?: string;
+};
+
+// Payloads sent inside one `appendEvalTurnTrace` turn. These deliberately OMIT
+// `promptIndex`: the backend stamps it from `turn.promptIndex` server-side.
+export type WidgetRenderObservationPayload = Omit<
+  SerializedWidgetRenderObservation,
+  "promptIndex"
+>;
+
+export type BrowserInteractionStepPayload = Omit<
+  SerializedBrowserInteractionStep,
+  "promptIndex"
+>;
+
 /** Versioned blob written by `testSuites:updateTestIteration` when messages are stored. */
 export type EvalTraceBlobV1 = {
   traceVersion: 1;


### PR DESCRIPTION
## Summary

Inspector companion to **mcpjam-backend#460**. Populates the new `widgetRenderObservations` + `browserInteractionSteps` Convex tables end-to-end so the eval UI (PR 7) can show render statuses and Computer Use timelines. Until this lands, those tables sit empty.

Data flows from the local AI‑SDK Computer Use path through the existing shared finalize choke point:

```
runIterationWithAiSdk  ──(runner-local records, base64 screenshots)──▶  finalizeEvalIteration
   • onAction → browserInteractionSteps[]        serialize ONCE (upload screenshots + sanitize)
   • onToolResultChunk → render observations            │
                                          ┌──────────────┴───────────────┐
                                   W2 persistEvalTraceFanout        W1 updateTestIteration
                                   (bucket per promptIndex)         (fallback, promptIndex:0)
```

## What changed

- **`shared/eval-trace.ts`** — runner-local / serialized / backend-payload types for render observations + interaction steps, plus `isEvalTraceBrowserStepNote` (the harness types `note` as an open `string`; the backend union is closed).
- **`computer-use-tool.ts`** — `onAction?` option on `buildComputerUseTools`, fired after each `harness.executeAction()` and wrapped so a buggy emitter can't crash the agent loop. Not fired on the no‑widget short‑circuit.
- **`mcp-app-widget-capture.ts`** — exported `uploadScreenshotBlob`, sibling to `uploadWidgetHtmlBlob` (same content‑agnostic `generateSnapshotUploadUrl` mutation; only the mime type changes).
- **`evals-runner.ts`** — collect `browserInteractionSteps` + stamp `promptIndex` on observations in `runIterationWithAiSdk`; thread both (non‑empty) into the success **and** failure `finishParams`.
- **`finalize-iteration.ts`** — serialize **once** (upload screenshots + sanitize) at the shared finalize step, then forward the serialized records to the W2 fanout and reuse them on the W1 fallback so neither path double‑uploads.
- **`persist-eval-trace.ts`** — bucket artifacts by `promptIndex` and attach **per turn** (stripping per‑entry `promptIndex`; backend stamps from `turn.promptIndex`), omitting the arrays entirely when empty.
- **`recorder.ts`** — type‑only pass‑through (already spreads `...params`).

## Decisions

- **Scope confined to `runIterationWithAiSdk`** — the only path that runs Computer Use today. The hosted (`runIterationViaBackend`) and streaming (`streamIterationWithAiSdk`/`ViaBackend`) paths are untouched; they pick up the same generic finalize/fanout plumbing when their data sources land (PR 9 stream, PR 10 hosted render‑after‑turn). No always‑empty scaffolding.
- **Unknown `note` is dropped, not fatal** — `result.note` is narrowed through a type guard; an unrecognized literal keeps the step (minus `note`) and logs a warning rather than failing the whole turn write.

## Testing

`211/211` eval tests green, incl. real‑Chromium harness + the PR 8 smoke test:

- `onAction` fires once per real action / not on short‑circuit / survives a throwing emitter (×3)
- `uploadScreenshotBlob` content‑type, storageId, URL‑gen failure, non‑2xx (×5)
- serializers: empty→`[]`, one upload per row, drop‑blob‑keep‑row on failure, `$`‑key sanitize (×9)
- fanout: per‑turn bucketing, `promptIndex` stripped, arrays omitted when empty (×3)
- finalize: W1 carries artifacts (uploaded once, base64 dropped, `promptIndex` stripped), serialize‑once, no W1 spread on happy path (×3)
- PR 8 smoke test asserts exactly one observation + one step flow through the collection

Non‑Computer‑Use evals are unchanged end‑to‑end (empty arrays → no extra Convex args, no Chromium launch).

## Follow-ups (not in this PR)

PR 7 replay UI · PR 9 stream variant · PR 10 hosted render‑after‑turn · PR 13 metrics.

https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval persistence and Convex boundary validation (sanitization, closed `note` union, W1 vs W2 artifact routing); behavior is gated to Computer Use runs and heavily tested, but mistakes could drop or mis-bucket turn traces.
> 
> **Overview**
> Wires **widget render observations** and **Computer Use browser interaction steps** from the local AI-SDK eval path into Convex via the existing finalize/fanout pipeline (companion to backend table support).
> 
> The runner now stamps **`promptIndex`** on observations, collects **`browserInteractionSteps`** through a new **`onAction`** hook on `buildComputerUseTools` (with safe handling for unknown step `note` values and throwing emitters), and passes both artifacts on success and failure. **`finalizeEvalIteration`** serializes them **once**—uploading base64 screenshots to storage, sanitizing for Convex, then feeding **W2** per-turn `appendEvalTurnTrace` (bucketed by prompt) or **W1** fallback without double-upload or duplicate fields on the happy path. Shared types live in **`eval-trace.ts`**; **`uploadScreenshotBlob`** is added for screenshot persistence.
> 
> Scope is **`runIterationWithAiSdk` only** (the path that runs Computer Use today); hosted/streaming eval paths are unchanged. Non–Computer-Use runs omit the new arrays entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f68111243441a96502ae9467d92950ea043fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->