### PR TITLE
chore(authkit): drop VITE_WORKOS_API_HOSTNAME to free api.mcpjam.com

### DIFF
--- a/mcpjam-inspector/.env.production
+++ b/mcpjam-inspector/.env.production
@@ -5,4 +5,3 @@ VITE_WORKOS_REDIRECT_URI=mcpjam://oauth/callback
 CONVEX_HTTP_URL=https://outstanding-fennec-304.convex.site
 ENVIRONMENT=production
 VITE_DISABLE_POSTHOG_LOCAL=false
-VITE_WORKOS_API_HOSTNAME=api.mcpjam.com


### PR DESCRIPTION
## Summary
- Removes `VITE_WORKOS_API_HOSTNAME` from `mcpjam-inspector/.env.production`. AuthKit now talks to `api.workos.com` directly.
- Decouples the frontend from the WorkOS Authentication API custom domain so `api.mcpjam.com` can be released and re-pointed at Inspector Node for the new public API (`/api/v1/*`, branch `claude/v1-worker-tools`).
- No code changes — env-file only. Local dev (`.env.local`) is unchanged.

## Why this approach (and not `auth.mcpjam.com` directly)
WorkOS only supports **one** custom Authentication API domain at a time — there's no "add a second domain, then switch." So a true zero-downtime cutover via the dashboard alone isn't possible. Instead we route through `api.workos.com` (which WorkOS always serves regardless of dashboard config) as the interstitial. Once `api.mcpjam.com` is released, a follow-up can add `auth.mcpjam.com` for branding.

## Cutover order
1. **First**: merge MCPJam/mcpjam-backend#464 so Convex already accepts JWTs whose `iss` ends up as `api.workos.com` (it does, but PR #464 adds the future `auth.mcpjam.com` issuer too).
2. **Then**: merge + deploy this PR. AuthKit routes through `api.workos.com`. WorkOS still stamps `iss=https://api.mcpjam.com/...` on tokens (custom domain in dashboard hasn't changed yet), which `auth.config.ts` accepts.
3. **Then**: delete `api.mcpjam.com` in WorkOS dashboard. WorkOS reverts to `iss=https://api.workos.com/...`. Already-accepted by backend.
4. **Then**: re-point `api.mcpjam.com` DNS at the Inspector Node deployment, ship `claude/v1-worker-tools`.
5. **Later (optional, cosmetic)**: add `auth.mcpjam.com` as a branded Authentication API domain in WorkOS, then set `VITE_WORKOS_API_HOSTNAME=auth.mcpjam.com`. Backend already accepts those tokens (PR #464).

## User-visible change during steps 3-4
The brief AuthKit redirect URL will show `api.workos.com` instead of a branded domain. Functional, but cosmetic regression until step 5 ships.

## Test plan
- [ ] After deploy: hard refresh prod, confirm login flow works end-to-end.
- [ ] Decode resulting WorkOS access token in devtools — confirm Convex queries still succeed.
- [ ] After dashboard deletion of `api.mcpjam.com`: log out + log back in, confirm new tokens have `iss=https://api.workos.com/...` and Convex auth still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Production login routing depends on build-time env and a strict cutover order; merging or deploying out of sequence can break AuthKit or leave tokens rejected by Convex.
> 
> **Overview**
> Removes **`VITE_WORKOS_API_HOSTNAME=api.mcpjam.com`** from `mcpjam-inspector/.env.production` as part of moving AuthKit off `api.mcpjam.com` so that hostname can serve the Inspector public API instead.
> 
> Production AuthKit reads `VITE_WORKOS_API_HOSTNAME` at client build time (`main.tsx` → `apiHostname`); with the file entry gone, the hostname must come from the Docker **`VITE_WORKOS_API_HOSTNAME` build arg** (or login falls back to WorkOS defaults). **Deploy only after** Convex accepts `auth.mcpjam.com` JWT issuers and WorkOS has that domain verified as the default Authentication API host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309b294269877e73819d1cb576b34c9394d47261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->