### PR TITLE
fix(oauth): send client_secret on token exchange with static preregistered creds

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -1248,6 +1248,63 @@ describe("mcp-oauth", () => {
       ).toBe(false);
     });
 
+    it("drops stored token_endpoint_auth_method when a static client_secret is supplied", async () => {
+      // Regression: when DCR previously registered this server, the stored
+      // client info carries `token_endpoint_auth_method: "none"` (echoed
+      // back from our DCR metadata). On a later attempt the user provides
+      // a static client_id + client_secret. The upstream SDK honors the
+      // stored `"none"` hint and skips client auth on token exchange,
+      // surfacing as `invalid_client` from the server. The fix: when a
+      // static secret is configured, strip the inherited hint so the SDK
+      // auto-picks client_secret_basic / _post from server metadata.
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      localStorage.setItem(
+        "mcp-client-asana",
+        JSON.stringify({
+          client_id: "dcr-registered-id",
+          token_endpoint_auth_method: "none",
+        })
+      );
+
+      const provider = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+        "static-client-id",
+        "static-client-secret"
+      );
+
+      const info = provider.clientInformation() as Record<string, unknown>;
+      expect(info.client_id).toBe("static-client-id");
+      expect(info.client_secret).toBe("static-client-secret");
+      expect(info).not.toHaveProperty("token_endpoint_auth_method");
+    });
+
+    it("advertises client_secret_basic in clientMetadata when a static secret is configured", async () => {
+      // The DCR metadata advertises `token_endpoint_auth_method`. Hard-coding
+      // "none" while we hold a confidential client secret tells the server
+      // to expect a public (PKCE-only) client and is the root cause of the
+      // stored hint that pollutes later token exchanges.
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      const providerNoSecret = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+        "static-client-id"
+      );
+      expect(providerNoSecret.clientMetadata.token_endpoint_auth_method).toBe(
+        "none"
+      );
+
+      const providerWithSecret = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+        "static-client-id",
+        "static-client-secret"
+      );
+      expect(
+        providerWithSecret.clientMetadata.token_endpoint_auth_method
+      ).toBe("client_secret_basic");
+    });
+
     it("round-trips discovery state for the matching server URL", async () => {
       const { MCPOAuthProvider } = await import("../mcp-oauth");
       const discoveryState = createDiscoveryState();

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -1279,6 +1279,35 @@ describe("mcp-oauth", () => {
       expect(info).not.toHaveProperty("token_endpoint_auth_method");
     });
 
+    it("preserves stored client_secret_post / _basic when merging static credentials", async () => {
+      // Companion to the "none" strip: the heal is intentionally narrow.
+      // A legitimately-registered confidential client may have
+      // token_endpoint_auth_method = "client_secret_post" (or "_basic")
+      // in stored info. Dropping it would let the SDK auto-pick — which
+      // prefers basic when both are listed in server metadata — and
+      // could downgrade a post-configured client. Both values still
+      // result in the secret being sent, so honoring them is correct.
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      localStorage.setItem(
+        "mcp-client-asana",
+        JSON.stringify({
+          client_id: "dcr-registered-id",
+          token_endpoint_auth_method: "client_secret_post",
+        })
+      );
+
+      const provider = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+        "static-client-id",
+        "static-client-secret"
+      );
+
+      const info = provider.clientInformation() as Record<string, unknown>;
+      expect(info.token_endpoint_auth_method).toBe("client_secret_post");
+      expect(info.client_secret).toBe("static-client-secret");
+    });
+
     it("advertises client_secret_basic in clientMetadata when a static secret is configured", async () => {
       // The DCR metadata advertises `token_endpoint_auth_method`. Hard-coding
       // "none" while we hold a confidential client secret tells the server

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1938,6 +1938,12 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 
   get clientMetadata() {
+    // When the user has supplied a static client_secret we register as a
+    // confidential client; otherwise PKCE-only ("none"). Advertising "none"
+    // with a secret would tell the server to expect no creds at the token
+    // endpoint and the SDK would honor that hint on later exchanges,
+    // silently dropping the secret and producing `invalid_client`.
+    const hasSecret = Boolean(this.customClientSecret);
     return {
       client_name: `MCPJam - ${this.serverName}`,
       client_uri: "https://github.com/mcpjam/inspector",
@@ -1945,7 +1951,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       redirect_uris: [this.redirectUri],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
-      token_endpoint_auth_method: "none",
+      token_endpoint_auth_method: hasSecret ? "client_secret_basic" : "none",
     };
   }
 
@@ -1965,13 +1971,23 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     if (this.customClientId) {
       if (storedClientInformation) {
         // If there's stored information, merge with custom client credentials
-        const result = {
+        const result: any = {
           ...storedClientInformation,
           client_id: this.customClientId,
         };
         // Add client secret if provided
         if (this.customClientSecret) {
           result.client_secret = this.customClientSecret;
+          // Drop any inherited `token_endpoint_auth_method` from a prior
+          // DCR registration. Our DCR metadata advertises "none" when no
+          // secret is set, and servers echo that back into the stored
+          // client info. The upstream SDK's `selectClientAuthMethod`
+          // honors the field when present, so leaving it here would
+          // silently bypass the secret on token exchange and surface as
+          // `invalid_client`. Letting the SDK auto-pick (client_secret_basic
+          // or _post) from the auth server's metadata is the right default
+          // once a secret is configured.
+          delete result.token_endpoint_auth_method;
         }
         return result;
       } else {

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1978,16 +1978,18 @@ export class MCPOAuthProvider implements OAuthClientProvider {
         // Add client secret if provided
         if (this.customClientSecret) {
           result.client_secret = this.customClientSecret;
-          // Drop any inherited `token_endpoint_auth_method` from a prior
+          // Drop only the specific `"none"` hint inherited from a prior
           // DCR registration. Our DCR metadata advertises "none" when no
           // secret is set, and servers echo that back into the stored
           // client info. The upstream SDK's `selectClientAuthMethod`
-          // honors the field when present, so leaving it here would
+          // honors the field when present, so leaving "none" here would
           // silently bypass the secret on token exchange and surface as
-          // `invalid_client`. Letting the SDK auto-pick (client_secret_basic
-          // or _post) from the auth server's metadata is the right default
-          // once a secret is configured.
-          delete result.token_endpoint_auth_method;
+          // `invalid_client`. Stored `client_secret_basic` / `_post` are
+          // left intact — they may be a legitimate per-client registration
+          // value, and either still results in the secret being sent.
+          if (result.token_endpoint_auth_method === "none") {
+            delete result.token_endpoint_auth_method;
+          }
         }
         return result;
       } else {


### PR DESCRIPTION
## Summary

Fixes `Error completing OAuth flow: Invalid client ID during token exchange` reported in the follow-up on #2504 when connecting an OAuth server with **static `client_id` + `client_secret`**.

Two changes in `client/src/lib/oauth/mcp-oauth.ts`:

1. **Core fix — `clientInformation()`:** when a `customClientSecret` is configured, strip an inherited `token_endpoint_auth_method: "none"` from the merged result so the SDK actually sends the secret on token exchange.
2. **Defense-in-depth — `clientMetadata`:** advertise `client_secret_basic` instead of hard-coded `"none"` when a static secret is configured. The static-creds flow goes through `registrationStrategy: "preregistered"` and skips DCR, so this change does not affect the reported user — but it stops the same pollution from being created at the DCR boundary for any future flow that does DCR with a secret.

## Root cause

The upstream MCP SDK's `selectClientAuthMethod` honors any `token_endpoint_auth_method` field present on the `clientInformation` object before falling back to method auto-selection:

```js
// node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js:29-38
if ('token_endpoint_auth_method' in clientInformation &&
    clientInformation.token_endpoint_auth_method &&
    isClientAuthMethod(clientInformation.token_endpoint_auth_method) && ...) {
  return clientInformation.token_endpoint_auth_method;
}
```

Our DCR metadata hard-codes `token_endpoint_auth_method: "none"`. Servers echo that back during DCR registration, and `saveClientInformation` persists it into `localStorage[mcp-client-<serverName>]`. On a later attempt with static creds, `initiateOAuth` does:

```js
const updatedClientInfo: any = { ...existingJson };
if (options.clientId) updatedClientInfo.client_id = options.clientId;
if (!HOSTED_MODE && options.clientSecret) updatedClientInfo.client_secret = options.clientSecret;
```

`token_endpoint_auth_method: "none"` survives the merge. The SDK then returns `"none"` from `selectClientAuthMethod`; `applyClientAuthentication` for `"none"` is a no-op, so the token exchange goes out **without** client credentials → server replies `invalid_client`.

## The fix

Heal the specific pollution at read time (1), and stop creating new pollution at the DCR boundary (2):

```ts
// (1) clientInformation() — narrow strip
if (this.customClientSecret) {
  result.client_secret = this.customClientSecret;
  if (result.token_endpoint_auth_method === "none") {
    delete result.token_endpoint_auth_method;
  }
}

// (2) clientMetadata
const hasSecret = Boolean(this.customClientSecret);
return {
  ...
  token_endpoint_auth_method: hasSecret ? "client_secret_basic" : "none",
};
```

The strip is intentionally narrowed to `=== "none"`: stored `client_secret_basic` / `_post` may be a legitimate per-client registration value, and either still results in the secret being sent — dropping them would silently let the SDK auto-pick (and downgrade a `_post`-configured client to `_basic` when both are listed in metadata).

(1) means existing users hit by the bug don't need to clear browser/desktop storage to recover.

## Test plan

- [x] `npx vitest run client/src/lib/oauth/__tests__/mcp-oauth.test.ts` — 47/47 pass (3 new regression tests).
- [x] `npm run typecheck:client` — clean.
- [ ] Manual: connect an OAuth server in static-creds mode with `localStorage[mcp-client-<name>]` pre-populated with `token_endpoint_auth_method: "none"` — token exchange should now succeed and the request should carry `Authorization: Basic <...>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)