### PR TITLE
feat: WorkOS API Keys for v1 public API

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   UserPlus,
   ShieldCheck,
   Loader2,
+  Key,
 } from "lucide-react";
 import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { isPostHogBooleanFlagOn, standardEventProps } from "@/lib/PosthogUtils";
@@ -335,6 +336,11 @@ const navigationSections: NavSection[] = [
         title: "Support",
         url: "/support",
         icon: MessageCircleQuestionIcon,
+      },
+      {
+        title: "API Keys",
+        url: "/settings/api-keys",
+        icon: Key,
       },
       {
         title: "Settings",

--- a/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState } from "react";
+import { Key, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@mcpjam/design-system/button";
+import { SettingsSection } from "../setting/SettingsSection";
+import { CreateApiKeyDialog } from "./api-keys/CreateApiKeyDialog";
+import { RevealOnceDialog } from "./api-keys/RevealOnceDialog";
+import { RevokeApiKeyDialog } from "./api-keys/RevokeApiKeyDialog";
+import {
+  type ApiKey,
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+} from "@/lib/apis/web/api-keys";
+
+/**
+ * `/settings/api-keys` — manage WorkOS-issued `sk_…` API keys for the
+ * v1 public API.
+ *
+ * Server side gates this surface: the inspector's `/api/web/api-keys/*`
+ * sub-router refuses requests that themselves authenticated via a
+ * `sk_…` key. That means visiting this page over a session JWT is the
+ * only way to mint/revoke — there is no privilege escalation path here.
+ */
+export function ApiKeysRoute() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [revealValue, setRevealValue] = useState<string | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const items = await listApiKeys();
+      setKeys(items);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to load API keys";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleCreate = async ({ name }: { name: string }) => {
+    setIsCreating(true);
+    try {
+      const created = await createApiKey({ name });
+      setCreateOpen(false);
+      setRevealValue(created.value);
+      await refresh();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to create API key";
+      toast.error(message);
+      throw error;
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+    setIsRevoking(true);
+    try {
+      await revokeApiKey(revokeTarget.id);
+      toast.success(`Revoked ${revokeTarget.name}`);
+      setRevokeTarget(null);
+      await refresh();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to revoke API key";
+      toast.error(message);
+      throw error;
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-10 space-y-8 max-w-3xl">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">API keys</h1>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-2 size-4" aria-hidden /> Create API key
+          </Button>
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          Use these keys to call the MCPJam v1 public API from CI, scripts, or
+          other non-browser contexts. Keys carry your account's permissions
+          and can be revoked any time.
+        </p>
+
+        <SettingsSection title="Your keys">
+          {loading ? (
+            <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+              Loading…
+            </div>
+          ) : keys.length === 0 ? (
+            <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+              No API keys yet. Create one to start using the v1 API.
+            </div>
+          ) : (
+            keys.map((key) => (
+              <div
+                key={key.id}
+                className="flex items-center justify-between px-4 py-3 rounded-md border border-border/40 bg-muted/20 transition-colors"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
+                    <Key className="size-4 text-primary" aria-hidden />
+                  </div>
+                  <div className="flex flex-col min-w-0">
+                    <span className="text-sm font-medium truncate">
+                      {key.name}
+                    </span>
+                    <span className="text-xs text-muted-foreground font-mono truncate">
+                      {key.obfuscated_value}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+                    onClick={() => setRevokeTarget(key)}
+                    aria-label={`Revoke ${key.name}`}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </div>
+              </div>
+            ))
+          )}
+        </SettingsSection>
+
+        <CreateApiKeyDialog
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          isCreating={isCreating}
+          onCreate={handleCreate}
+        />
+
+        <RevealOnceDialog
+          open={revealValue !== null}
+          onOpenChange={(next) => {
+            if (!next) setRevealValue(null);
+          }}
+          value={revealValue}
+        />
+
+        <RevokeApiKeyDialog
+          open={revokeTarget !== null}
+          onOpenChange={(next) => {
+            if (!next) setRevokeTarget(null);
+          }}
+          keyName={revokeTarget?.name ?? ""}
+          isRevoking={isRevoking}
+          onConfirm={handleRevoke}
+        />
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/api-keys/CreateApiKeyDialog.tsx
+++ b/mcpjam-inspector/client/src/components/settings/api-keys/CreateApiKeyDialog.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+
+export interface CreateApiKeyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isCreating: boolean;
+  onCreate: (args: { name: string }) => Promise<void>;
+}
+
+export function CreateApiKeyDialog({
+  open,
+  onOpenChange,
+  isCreating,
+  onCreate,
+}: CreateApiKeyDialogProps) {
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (open) setName("");
+  }, [open]);
+
+  const trimmed = name.trim();
+  const canCreate = trimmed.length > 0 && !isCreating;
+
+  const handleSubmit = async () => {
+    if (!canCreate) return;
+    try {
+      await onCreate({ name: trimmed });
+    } catch {
+      /* Error toast handled by caller */
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && isCreating) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        showCloseButton={!isCreating}
+        className="gap-4 sm:max-w-md"
+      >
+        <DialogHeader className="gap-2 text-left">
+          <DialogTitle>Create API key</DialogTitle>
+          <DialogDescription>
+            Give this key a name so you can identify it later. The key value
+            will be shown only once after creation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="api-key-name-input">Name</Label>
+          <Input
+            id="api-key-name-input"
+            autoComplete="off"
+            placeholder="e.g. ci-pipeline, local-laptop"
+            value={name}
+            disabled={isCreating}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canCreate) {
+                e.preventDefault();
+                void handleSubmit();
+              }
+            }}
+          />
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isCreating}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!canCreate}
+            onClick={() => void handleSubmit()}
+          >
+            {isCreating ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                Creating…
+              </>
+            ) : (
+              "Create key"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/api-keys/RevealOnceDialog.tsx
+++ b/mcpjam-inspector/client/src/components/settings/api-keys/RevealOnceDialog.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { AlertTriangle, Check, Copy } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+
+export interface RevealOnceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: string | null;
+}
+
+/**
+ * One-shot reveal dialog for a freshly minted API key.
+ *
+ * The plaintext `sk_…` value is only ever in the WorkOS create response.
+ * We display it here, give the user a Copy button (with the
+ * Copy → Check feedback pattern from SkillsTab), and warn loudly that it
+ * won't be shown again. The `value` prop is dropped when the dialog closes.
+ */
+export function RevealOnceDialog({
+  open,
+  onOpenChange,
+  value,
+}: RevealOnceDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable — the user can still select + copy manually.
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setCopied(false);
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="gap-4 sm:max-w-lg">
+        <DialogHeader className="gap-2 text-left">
+          <DialogTitle>Copy your API key</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-foreground">
+                <AlertTriangle
+                  className="mt-0.5 size-4 shrink-0 text-warning"
+                  aria-hidden
+                />
+                <p className="text-sm">
+                  This key won't be shown again. Copy it now and store it
+                  somewhere safe. If you lose it, revoke it and create a new
+                  one.
+                </p>
+              </div>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-2">
+          <code className="flex-1 select-all overflow-x-auto whitespace-nowrap font-mono text-xs text-foreground">
+            {value ?? ""}
+          </code>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => void handleCopy()}
+            disabled={!value}
+            aria-label="Copy API key"
+          >
+            {copied ? (
+              <>
+                <Check className="mr-1.5 size-3.5" aria-hidden /> Copied
+              </>
+            ) : (
+              <>
+                <Copy className="mr-1.5 size-3.5" aria-hidden /> Copy
+              </>
+            )}
+          </Button>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button type="button" onClick={() => onOpenChange(false)}>
+            I've saved it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/api-keys/RevokeApiKeyDialog.tsx
+++ b/mcpjam-inspector/client/src/components/settings/api-keys/RevokeApiKeyDialog.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import { cn } from "@/lib/utils";
+
+export interface RevokeApiKeyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  keyName: string;
+  isRevoking: boolean;
+  onConfirm: () => Promise<void>;
+}
+
+/**
+ * Type-the-name-to-confirm pattern — mirrors `ChatboxDeleteConfirmDialog`.
+ * Revocation is immediate: once confirmed, any client still holding the
+ * key value gets 401 within seconds.
+ */
+export function RevokeApiKeyDialog({
+  open,
+  onOpenChange,
+  keyName,
+  isRevoking,
+  onConfirm,
+}: RevokeApiKeyDialogProps) {
+  const [confirmText, setConfirmText] = useState("");
+
+  useEffect(() => {
+    if (open) setConfirmText("");
+  }, [open]);
+
+  const phraseMatches = confirmText.trim() === keyName.trim();
+
+  const handleConfirm = async () => {
+    if (!phraseMatches || isRevoking) return;
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch {
+      /* Error toast is handled by the caller */
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && isRevoking) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        showCloseButton={!isRevoking}
+        className="gap-4 sm:max-w-md"
+      >
+        <DialogHeader className="gap-2 text-left">
+          <DialogTitle className="text-foreground">Revoke API key?</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                <span className="font-medium text-foreground">
+                  {keyName || "This key"}
+                </span>{" "}
+                will be revoked immediately. Any client still using it will
+                start receiving 401 errors.
+              </p>
+              <p>You cannot undo this.</p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="api-key-revoke-confirm-input">
+            Type the key name{" "}
+            <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-xs font-normal text-foreground">
+              {keyName}
+            </kbd>{" "}
+            to confirm
+          </Label>
+          <Input
+            id="api-key-revoke-confirm-input"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            placeholder={keyName}
+            value={confirmText}
+            disabled={isRevoking}
+            onChange={(e) => setConfirmText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && phraseMatches && !isRevoking) {
+                e.preventDefault();
+                void handleConfirm();
+              }
+            }}
+            className="font-mono"
+          />
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isRevoking}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className={cn(
+              "border-destructive/80 text-destructive shadow-none",
+              "hover:bg-destructive/10 hover:text-destructive",
+              "focus-visible:border-destructive focus-visible:ring-destructive/25",
+              "dark:hover:bg-destructive/15",
+            )}
+            disabled={!phraseMatches || isRevoking}
+            onClick={() => void handleConfirm()}
+          >
+            {isRevoking ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                Revoking…
+              </>
+            ) : (
+              "Revoke key"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/lib/apis/web/api-keys.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/api-keys.ts
@@ -1,0 +1,69 @@
+import { authFetch } from "@/lib/session-token";
+import { WebApiError } from "./base";
+
+/**
+ * Typed wrappers for the inspector's `/api/web/api-keys/*` management
+ * surface. Mint / list / revoke only — validation and rate limiting
+ * live server-side.
+ *
+ * `value` is only present on the create response; never persisted, never
+ * shown a second time.
+ */
+export interface ApiKey {
+  id: string;
+  name: string;
+  obfuscated_value: string;
+  created_at?: string;
+  last_used_at?: string | null;
+}
+
+export interface CreatedApiKey extends ApiKey {
+  /**
+   * Plaintext `sk_…` value. Returned ONCE from the create endpoint and
+   * surfaced via the RevealOnceDialog. Discarded as soon as the dialog
+   * closes — never written to localStorage / state stores.
+   */
+  value: string;
+}
+
+async function parseError(response: Response): Promise<never> {
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch {
+    // ignored
+  }
+  const message =
+    typeof body?.message === "string"
+      ? body.message
+      : `Request failed (${response.status})`;
+  const code = typeof body?.code === "string" ? body.code : null;
+  throw new WebApiError(response.status, code, message);
+}
+
+export async function listApiKeys(): Promise<ApiKey[]> {
+  const response = await authFetch("/api/web/api-keys", { method: "GET" });
+  if (!response.ok) await parseError(response);
+  const body = (await response.json()) as { items?: ApiKey[] };
+  return Array.isArray(body.items) ? body.items : [];
+}
+
+export async function createApiKey(args: {
+  name: string;
+}): Promise<CreatedApiKey> {
+  const response = await authFetch("/api/web/api-keys", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: args.name }),
+  });
+  if (!response.ok) await parseError(response);
+  return (await response.json()) as CreatedApiKey;
+}
+
+export async function revokeApiKey(id: string): Promise<void> {
+  const response = await authFetch(
+    `/api/web/api-keys/${encodeURIComponent(id)}`,
+    { method: "DELETE" },
+  );
+  if (!response.ok) await parseError(response);
+}

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -29,6 +29,7 @@ import App, {
   ViewsRoute,
   XAAFlowRoute,
 } from "./App";
+import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
 import { getAppRouter, setAppRouter } from "./router-ref";
 
 export { getAppRouter };
@@ -83,6 +84,7 @@ export function createAppRouter(): AppRouter {
         { path: "views", element: <ViewsRoute /> },
         { path: "support", element: <SupportRoute /> },
         { path: "settings", element: <SettingsRoute /> },
+        { path: "settings/api-keys", element: <ApiKeysRoute /> },
         { path: "profile", element: <ProfileRoute /> },
         { path: "project-settings", element: <ProjectSettingsRoute /> },
         { path: "client-config", element: <ServersRedirectRoute /> },

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -129,6 +129,7 @@
     "@sentry/vite-plugin": "^4.3.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@workos-inc/authkit-react": "^0.12.0",
+    "@workos-inc/node": "^10.2.0",
     "@xyflow/react": "^12.9.0",
     "ai": "^6.0.154",
     "ajv": "^8.18.0",

--- a/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Bearer Auth Middleware Tests
+ *
+ * Focus: the `sk_` (WorkOS API key) branch — the security-critical new code.
+ * Covers:
+ *   - missing / wrong-format bearer → 401
+ *   - `sk_` invalid → 401
+ *   - `sk_` valid → next() runs with context set
+ *   - request-local memoization (validate called once per request)
+ *   - per-key rate limit triggers 429 after burst
+ *   - cross-key rate limit isolation
+ *
+ * WorkOS SDK and identity helpers are mocked at module level via `vi.mock`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+
+// Mocks must be declared before importing the SUT.
+const validateApiKeyMock = vi.fn();
+vi.mock("../../services/workos-client.js", () => ({
+  getWorkOSClient: () => ({
+    apiKeys: { validateApiKey: validateApiKeyMock },
+  }),
+}));
+
+const resolveUserByExternalIdMock = vi.fn();
+vi.mock("../../services/identity.js", () => ({
+  resolveUserByExternalId: resolveUserByExternalIdMock,
+}));
+
+// Guest validation must always reject for these tests — only the sk_ branch is
+// exercised. The real guest validator does network calls we don't want here.
+vi.mock("../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: vi.fn(async () => ({
+    valid: false,
+    reason: "not_guest",
+  })),
+}));
+
+import {
+  bearerAuthMiddleware,
+  resetWorkOSRateLimitForTests,
+} from "../bearer-auth.js";
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.use("*", bearerAuthMiddleware);
+  app.get("/test", (c) =>
+    c.json({
+      ok: true,
+      authMethod: c.get("authMethod") ?? null,
+      workosApiKeyId: c.get("workosApiKeyId") ?? null,
+      workosUserId: c.get("workosUserId") ?? null,
+      mcpjamUserId: c.get("mcpjamUserId") ?? null,
+    }),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  validateApiKeyMock.mockReset();
+  resolveUserByExternalIdMock.mockReset();
+  resetWorkOSRateLimitForTests();
+});
+
+describe("bearerAuthMiddleware — header gate", () => {
+  it("rejects requests without an Authorization header", async () => {
+    const res = await createApp().request("/test");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects requests where the header isn't Bearer-prefixed", async () => {
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Basic abc" },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("bearerAuthMiddleware — sk_ WorkOS API key branch", () => {
+  it("returns 401 when WorkOS marks the key as invalid", async () => {
+    validateApiKeyMock.mockResolvedValueOnce({ apiKey: null });
+
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Bearer sk_invalid_value" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string; message?: string };
+    expect(body.code).toBe("UNAUTHORIZED");
+    expect(body.message).toMatch(/Invalid API key/i);
+    expect(validateApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(resolveUserByExternalIdMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when WorkOS validates but the MCPJam user is unknown", async () => {
+    validateApiKeyMock.mockResolvedValueOnce({
+      apiKey: { id: "api_key_x", owner: { id: "user_x" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValueOnce(null);
+
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Bearer sk_valid_but_unknown" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { message?: string };
+    expect(body.message).toMatch(/Unknown user/i);
+  });
+
+  it("sets identity context and calls next() on valid sk_ key", async () => {
+    validateApiKeyMock.mockResolvedValueOnce({
+      apiKey: { id: "api_key_42", owner: { id: "user_42" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValueOnce({
+      _id: "mcpjam_user_42",
+    });
+
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Bearer sk_live_abc" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.authMethod).toBe("workos_api_key");
+    expect(body.workosApiKeyId).toBe("api_key_42");
+    expect(body.workosUserId).toBe("user_42");
+    expect(body.mcpjamUserId).toBe("mcpjam_user_42");
+  });
+});
+
+describe("bearerAuthMiddleware — per-key rate limit", () => {
+  it("admits at least 10 burst requests for the same key, then rejects with 429", async () => {
+    validateApiKeyMock.mockResolvedValue({
+      apiKey: { id: "api_key_burst", owner: { id: "user_burst" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValue({ _id: "mcpjam_user_burst" });
+
+    const app = createApp();
+    const ok: number[] = [];
+    let throttled = 0;
+    let lastThrottledStatus = 0;
+    for (let i = 0; i < 12; i++) {
+      const res = await app.request("/test", {
+        headers: { authorization: "Bearer sk_burst" },
+      });
+      if (res.status === 200) {
+        ok.push(i);
+      } else {
+        throttled++;
+        lastThrottledStatus = res.status;
+      }
+    }
+    expect(ok.length).toBeGreaterThanOrEqual(10);
+    expect(throttled).toBeGreaterThanOrEqual(1);
+    expect(lastThrottledStatus).toBe(429);
+  });
+
+  it("isolates rate-limit buckets per WorkOS key id", async () => {
+    // Bucket A — drain it
+    validateApiKeyMock.mockImplementation(async ({ value }) => ({
+      apiKey: {
+        id: value === "sk_a" ? "api_key_a" : "api_key_b",
+        owner: { id: value === "sk_a" ? "user_a" : "user_b" },
+      },
+    }));
+    resolveUserByExternalIdMock.mockResolvedValue({ _id: "mcpjam_user" });
+
+    const app = createApp();
+    for (let i = 0; i < 11; i++) {
+      await app.request("/test", {
+        headers: { authorization: "Bearer sk_a" },
+      });
+    }
+    // Now sk_b should still succeed (separate bucket)
+    const res = await app.request("/test", {
+      headers: { authorization: "Bearer sk_b" },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("bearerAuthMiddleware — request-local memoization", () => {
+  it("only invokes WorkOS validate once per request even when bearer-auth runs multiple times", async () => {
+    validateApiKeyMock.mockResolvedValue({
+      apiKey: { id: "api_key_memo", owner: { id: "user_memo" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValue({ _id: "mcpjam_user_memo" });
+
+    // Simulate the real wiring: bearer-auth on a parent router AND on a
+    // sub-router (as `/api/web/api-keys/*` does explicitly).
+    const app = new Hono();
+    app.use("*", bearerAuthMiddleware);
+    app.use("*", bearerAuthMiddleware);
+    app.get("/double", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/double", {
+      headers: { authorization: "Bearer sk_memo" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(validateApiKeyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/middleware/bearer-auth.ts
+++ b/mcpjam-inspector/server/middleware/bearer-auth.ts
@@ -1,14 +1,103 @@
 import type { Context, Next } from "hono";
 import { ErrorCode } from "../routes/web/errors.js";
 import { validateGuestTokenDetailedAsync } from "../services/guest-token.js";
+import { getWorkOSClient } from "../services/workos-client.js";
+import { resolveUserByExternalId } from "../services/identity.js";
+import { getRequestLocal, setRequestLocal } from "./request-local.js";
+import { logger } from "../utils/logger.js";
 
 /**
  * Reusable Hono middleware that:
  * 1. Requires a Bearer token in the Authorization header (401 if missing).
- * 2. Attempts to validate it as a guest JWT.
- * 3. If valid guest token, sets c.set("guestId", guestId).
- * 4. If not a guest token, assumes WorkOS and passes through.
+ * 2. If the token starts with `sk_`, validates it as a WorkOS API key
+ *    (memoized per request) and resolves the owning MCPJam user.
+ * 3. Otherwise attempts to validate it as a guest JWT.
+ * 4. If valid guest token, sets `c.set("guestId", guestId)`.
+ * 5. If not a guest token, assumes WorkOS JWT and passes through.
+ *
+ * Prefix discrimination is sound: real WorkOS JWTs start with `eyJ`
+ * (base64 `{"`), so an `sk_` prefix is unambiguous and the branch
+ * never falls through to JWT validation.
  */
+
+/**
+ * Per-key token bucket for `sk_` validations. WorkOS validate is ~200ms
+ * and counts against our org-wide WorkOS rate budget; a misbehaving
+ * client should not be able to drain it. In-process Map — resets on
+ * deploy, which is fine for v1.
+ *
+ * Limits: 60 req/min sustained, burst 10. Buckets refill linearly.
+ */
+const WORKOS_RATE_LIMIT_PER_MIN = 60;
+const WORKOS_RATE_BURST = 10;
+const WORKOS_RATE_REFILL_PER_MS = WORKOS_RATE_LIMIT_PER_MIN / 60_000;
+
+interface TokenBucket {
+  /** Available tokens (fractional). */
+  tokens: number;
+  /** Last refill timestamp (ms). */
+  lastRefill: number;
+}
+
+const workosKeyBuckets = new Map<string, TokenBucket>();
+
+// Cleanup stale buckets every 5 minutes so revoked keys don't leak memory.
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, bucket] of workosKeyBuckets) {
+    if (now - bucket.lastRefill > 5 * 60_000) {
+      workosKeyBuckets.delete(id);
+    }
+  }
+}, 5 * 60_000).unref();
+
+/**
+ * Try to consume one token from the bucket for `keyId`. Returns the
+ * number of milliseconds the caller should wait before retrying, or
+ * `null` if the request was admitted. Rejecting BEFORE incrementing
+ * matches token-bucket semantics — a depleted bucket stays depleted
+ * until time passes.
+ */
+function consumeWorkOSToken(keyId: string): number | null {
+  const now = Date.now();
+  const existing = workosKeyBuckets.get(keyId);
+  if (!existing) {
+    workosKeyBuckets.set(keyId, {
+      tokens: WORKOS_RATE_BURST - 1,
+      lastRefill: now,
+    });
+    return null;
+  }
+
+  const elapsed = now - existing.lastRefill;
+  const refilled = Math.min(
+    WORKOS_RATE_BURST,
+    existing.tokens + elapsed * WORKOS_RATE_REFILL_PER_MS,
+  );
+  if (refilled < 1) {
+    existing.tokens = refilled;
+    existing.lastRefill = now;
+    const deficit = 1 - refilled;
+    const waitMs = Math.ceil(deficit / WORKOS_RATE_REFILL_PER_MS);
+    return Math.max(waitMs, 1);
+  }
+  existing.tokens = refilled - 1;
+  existing.lastRefill = now;
+  return null;
+}
+
+/** Test-only: clear all token buckets. */
+export function resetWorkOSRateLimitForTests(): void {
+  workosKeyBuckets.clear();
+}
+
+type ValidateApiKeyResult = {
+  apiKey: {
+    id: string;
+    owner: { id: string };
+  } | null;
+};
+
 export async function bearerAuthMiddleware(
   c: Context,
   next: Next,
@@ -22,6 +111,94 @@ export async function bearerAuthMiddleware(
   }
 
   const token = authHeader.slice("Bearer ".length);
+
+  // WorkOS API key branch. Real WorkOS JWTs begin with `eyJ`, so an
+  // `sk_` prefix is unambiguous; this branch never falls through.
+  if (token.startsWith("sk_")) {
+    // Request-local memoization: a single `/api/v1/...` call hits this
+    // middleware AND `authorizeBatch`, both of which would otherwise
+    // pay the ~200ms WorkOS validate cost. Cached per request only —
+    // no cross-request cache, so revocation stays immediate.
+    let validation = getRequestLocal(c, "workosApiKeyValidation") as
+      | ValidateApiKeyResult
+      | undefined;
+    if (!validation) {
+      try {
+        // ~200ms validate latency (single global WorkOS endpoint, no
+        // local JWKS path). Counts against our WorkOS rate budget.
+        validation = (await getWorkOSClient().apiKeys.createValidation({
+          value: token,
+        })) as unknown as ValidateApiKeyResult;
+      } catch (error) {
+        logger.warn("WorkOS API key validation threw", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return c.json(
+          { code: ErrorCode.UNAUTHORIZED, message: "Invalid API key" },
+          401,
+        );
+      }
+      setRequestLocal(c, "workosApiKeyValidation", validation);
+    }
+
+    if (!validation.apiKey) {
+      return c.json(
+        { code: ErrorCode.UNAUTHORIZED, message: "Invalid API key" },
+        401,
+      );
+    }
+
+    const workosKeyId = validation.apiKey.id;
+    const workosUserId = validation.apiKey.owner.id;
+
+    // Per-key rate limit. Reject BEFORE doing the Convex user lookup
+    // so a flood can't tie up the database either.
+    const waitMs = consumeWorkOSToken(workosKeyId);
+    if (waitMs !== null) {
+      return c.json(
+        {
+          code: ErrorCode.RATE_LIMITED,
+          message: "API key rate limit exceeded. Slow down and retry.",
+        },
+        429,
+        { "Retry-After": String(Math.ceil(waitMs / 1000)) },
+      );
+    }
+
+    let mcpjamUser;
+    try {
+      mcpjamUser = await resolveUserByExternalId(workosUserId);
+    } catch (error) {
+      logger.error("Failed to resolve MCPJam user from WorkOS externalId", {
+        workosUserId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return c.json(
+        { code: ErrorCode.INTERNAL_ERROR, message: "Identity lookup failed" },
+        500,
+      );
+    }
+    if (!mcpjamUser) {
+      return c.json(
+        { code: ErrorCode.UNAUTHORIZED, message: "Unknown user" },
+        401,
+      );
+    }
+
+    c.set("authMethod", "workos_api_key");
+    c.set("workosApiKeyId", workosKeyId);
+    c.set("workosUserId", workosUserId);
+    c.set("mcpjamUserId", mcpjamUser._id);
+
+    logger.info("WorkOS API key request", {
+      event: "auth.workos_api_key",
+      auth_method: "workos_api_key",
+      workos_key_id: workosKeyId,
+      mcpjam_user_id: mcpjamUser._id,
+    });
+
+    return next();
+  }
 
   // Try validating as a guest token
   try {

--- a/mcpjam-inspector/server/middleware/request-local.ts
+++ b/mcpjam-inspector/server/middleware/request-local.ts
@@ -1,0 +1,37 @@
+import type { Context } from "hono";
+
+/**
+ * Typed request-local store, layered over Hono's `c.set` / `c.get`.
+ *
+ * Hono already gives us per-request storage via the Context's variable
+ * map, but reaching for `c.set(key, value)` with an arbitrary string is
+ * untyped — typos slip through and every reader has to widen `unknown`.
+ *
+ * The WorkOS API key validation is the motivating use case: a single
+ * `/api/v1/...` request hits the bearer middleware AND `authorizeBatch`
+ * — without per-request memoization we would pay two ~200ms WorkOS
+ * validate round-trips for one user-visible request. The cache is
+ * intentionally request-local (no cross-request LRU) so revocation
+ * stays immediate.
+ */
+export interface RequestLocalMap {
+  workosApiKeyValidation: unknown;
+}
+
+export function getRequestLocal<K extends keyof RequestLocalMap>(
+  c: Context,
+  key: K
+): RequestLocalMap[K] | undefined {
+  // `c.get` is typed via Hono's ContextVariableMap; we deliberately bypass
+  // it here so callers don't have to extend that global map just to cache
+  // an opaque blob for one request.
+  return (c.get(key as string) as RequestLocalMap[K] | undefined) ?? undefined;
+}
+
+export function setRequestLocal<K extends keyof RequestLocalMap>(
+  c: Context,
+  key: K,
+  value: RequestLocalMap[K]
+): void {
+  c.set(key as string, value);
+}

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -1,0 +1,295 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
+import { logger } from "../../utils/logger.js";
+import {
+  ErrorCode,
+  WebRouteError,
+  webError,
+  assertBearerToken,
+  readJsonBody,
+  parseWithSchema,
+} from "./errors.js";
+import { handleRoute } from "./auth.js";
+
+/**
+ * `/api/web/api-keys/*` — WorkOS API Key management.
+ *
+ * Calls the WorkOS REST API directly with the server-side `WORKOS_API_KEY`
+ * (the Node SDK only exposes org-scoped helpers; the user-scoped endpoints
+ * we need for v1 are documented REST routes). MCPJam never stores the raw
+ * key value — `value` is in WorkOS's create response only, returned to the
+ * browser once, and never persisted or logged.
+ *
+ * Security notes for future contributors:
+ * - A user can only mint a key as powerful as their own session: the
+ *   create call routes through `/user_management/users/{userId}` and
+ *   `userId` is taken from the session JWT.
+ * - DELETE re-fetches the key and verifies `owner.id === sessionUserId`
+ *   before issuing the WorkOS delete, so passing another user's key id
+ *   fails before WorkOS sees the request.
+ * - `sk_…` keys cannot manage other `sk_…` keys (privilege isolation).
+ */
+
+const apiKeys = new Hono();
+
+// `sessionAuthMiddleware` bypasses `/api/web/*` entirely (session-auth.ts:103),
+// so this sub-router must explicitly require a bearer.
+apiKeys.use("*", bearerAuthMiddleware);
+
+// Privilege isolation: a WorkOS API key authenticates as the owning user
+// but it must NOT be able to mint or revoke other API keys (would create
+// a privilege loop). Session-only here.
+apiKeys.use("*", async (c, next) => {
+  if (c.get("authMethod") === "workos_api_key") {
+    return c.json(
+      {
+        code: ErrorCode.FORBIDDEN,
+        message: "API keys cannot manage other API keys",
+      },
+      403,
+    );
+  }
+  return next();
+});
+
+const WORKOS_BASE_URL = "https://api.workos.com";
+
+function getWorkOSRestKey(): string {
+  const key = process.env.WORKOS_API_KEY;
+  if (!key) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing WORKOS_API_KEY configuration",
+    );
+  }
+  return key;
+}
+
+interface JwtClaims {
+  sub?: string;
+  org_id?: string;
+}
+
+/**
+ * Decode the AuthKit JWT payload to read the WorkOS `sub` (user id) and
+ * `org_id`. Signature is NOT re-verified here — Convex enforces auth on
+ * downstream calls. We use the claims only to scope WorkOS REST requests
+ * to the session user.
+ */
+function decodeSessionClaims(token: string): JwtClaims {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Session JWT is malformed",
+    );
+  }
+  try {
+    return JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf-8"),
+    ) as JwtClaims;
+  } catch {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Session JWT payload is not valid JSON",
+    );
+  }
+}
+
+interface SessionContext {
+  userId: string;
+  organizationId?: string;
+}
+
+function resolveSessionContext(c: any): SessionContext {
+  const bearer = assertBearerToken(c);
+  const claims = decodeSessionClaims(bearer);
+  const userId = claims.sub;
+  if (!userId) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Session JWT is missing `sub` claim",
+    );
+  }
+  return { userId, organizationId: claims.org_id };
+}
+
+async function callWorkOS(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const key = getWorkOSRestKey();
+  const response = await fetch(`${WORKOS_BASE_URL}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  let parsed: any = null;
+  try {
+    parsed = await response.json();
+  } catch {
+    // Empty body (204) — leave null.
+  }
+  return { status: response.status, body: parsed };
+}
+
+function mapWorkOSError(status: number, body: any, fallback: string): never {
+  const safeMessage =
+    typeof body?.message === "string"
+      ? body.message
+      : typeof body?.error_description === "string"
+        ? body.error_description
+        : fallback;
+  if (status === 401) {
+    throw new WebRouteError(401, ErrorCode.UNAUTHORIZED, safeMessage);
+  }
+  if (status === 404) {
+    throw new WebRouteError(404, ErrorCode.NOT_FOUND, safeMessage);
+  }
+  if (status === 429) {
+    throw new WebRouteError(429, ErrorCode.RATE_LIMITED, safeMessage);
+  }
+  throw new WebRouteError(500, ErrorCode.INTERNAL_ERROR, safeMessage);
+}
+
+const createSchema = z.object({
+  name: z.string().min(1).max(120),
+});
+
+apiKeys.post("/", async (c) =>
+  handleRoute(c, async () => {
+    const raw = await readJsonBody<unknown>(c);
+    const { name } = parseWithSchema(createSchema, raw);
+    const session = resolveSessionContext(c);
+
+    const payload: Record<string, unknown> = { name };
+    if (session.organizationId) {
+      payload.organization_id = session.organizationId;
+    }
+
+    const { status, body } = await callWorkOS(
+      "POST",
+      `/user_management/users/${encodeURIComponent(session.userId)}/api_keys`,
+      payload,
+    );
+
+    if (status < 200 || status >= 300) {
+      mapWorkOSError(status, body, "Failed to create API key");
+    }
+
+    logger.info("API key minted", {
+      event: "api_key_created",
+      auth_method: "session",
+      workos_key_id: body?.id ?? null,
+      actor_user_id: session.userId,
+    });
+
+    return body;
+  }),
+);
+
+apiKeys.get("/", async (c) =>
+  handleRoute(c, async () => {
+    const session = resolveSessionContext(c);
+    const params = new URLSearchParams();
+    if (session.organizationId) {
+      params.set("organization_id", session.organizationId);
+    }
+    const qs = params.toString();
+    const { status, body } = await callWorkOS(
+      "GET",
+      `/user_management/users/${encodeURIComponent(session.userId)}/api_keys${
+        qs ? `?${qs}` : ""
+      }`,
+    );
+
+    if (status < 200 || status >= 300) {
+      mapWorkOSError(status, body, "Failed to list API keys");
+    }
+
+    // WorkOS returns `{ data: [...] }` or `{ data: [...], list_metadata: ... }`.
+    const items = Array.isArray(body?.data)
+      ? body.data
+      : Array.isArray(body)
+        ? body
+        : [];
+    return { items };
+  }),
+);
+
+apiKeys.delete("/:id", async (c) =>
+  handleRoute(c, async () => {
+    const id = c.req.param("id");
+    if (!id) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "Missing API key id",
+      );
+    }
+    const session = resolveSessionContext(c);
+
+    // Cross-user defense in depth: fetch the key first and confirm the
+    // owner matches the session user before deleting. WorkOS does not
+    // enforce per-user ownership for the org-level admin key.
+    const lookup = await callWorkOS(
+      "GET",
+      `/api_keys/${encodeURIComponent(id)}`,
+    );
+    if (lookup.status === 404) {
+      throw new WebRouteError(404, ErrorCode.NOT_FOUND, "API key not found");
+    }
+    if (lookup.status < 200 || lookup.status >= 300) {
+      mapWorkOSError(lookup.status, lookup.body, "Failed to load API key");
+    }
+    const ownerId = lookup.body?.owner?.id;
+    if (typeof ownerId !== "string" || ownerId !== session.userId) {
+      throw new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        "API key not found",
+      );
+    }
+
+    const { status, body } = await callWorkOS(
+      "DELETE",
+      `/api_keys/${encodeURIComponent(id)}`,
+    );
+    if (status !== 204 && (status < 200 || status >= 300)) {
+      mapWorkOSError(status, body, "Failed to revoke API key");
+    }
+
+    logger.info("API key revoked", {
+      event: "api_key_revoked",
+      auth_method: "session",
+      workos_key_id: id,
+      actor_user_id: session.userId,
+    });
+
+    return { ok: true };
+  }),
+);
+
+apiKeys.onError((error, c) => {
+  if (error instanceof WebRouteError) {
+    return webError(c, error.status, error.code, error.message, error.details);
+  }
+  return webError(
+    c,
+    500,
+    ErrorCode.INTERNAL_ERROR,
+    error instanceof Error ? error.message : "Internal error",
+  );
+});
+
+export default apiKeys;

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -295,6 +295,58 @@ function stripStdioFieldsFromHostedConfig<
   return { ...holder, serverConfig: cleaned };
 }
 
+/**
+ * Build the auth headers used by Inspector → Convex `/web/*` calls.
+ *
+ * - For session/guest JWTs (the default): forward the caller's bearer
+ *   verbatim. Convex sees the same identity it always has.
+ * - For WorkOS API keys (`authMethod === "workos_api_key"`): exchange
+ *   the bearer for `INSPECTOR_SERVICE_TOKEN` and add
+ *   `x-mcpjam-acting-as: <mcpjamUserId>`. Convex never sees the `sk_`
+ *   value — Inspector is the trust boundary that validated it once via
+ *   WorkOS and now vouches for the resolved user. The companion
+ *   backend PR teaches `requestIdentity` to honor this delegated mode.
+ *
+ * Keeping this in one helper so every `/web/*` callsite picks up the
+ * same exchange (currently `authorizeServer` and `authorizeBatch` in
+ * this file). Other Convex-forwarding helpers under `server/utils/*`
+ * (e.g. `chat-history.ts`, `hosted-oauth-refresh.ts`,
+ * `local-server-resolver.ts`) are NOT on the `/api/v1/*` path today
+ * and stay on the original-bearer path until they're either reached
+ * by an API key request or refactored to receive Context.
+ */
+function buildConvexAuthHeaders(
+  c: Context,
+  originalBearer: string
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (c.get("authMethod") === "workos_api_key") {
+    const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+    if (!serviceToken) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Server missing INSPECTOR_SERVICE_TOKEN for WorkOS API key auth"
+      );
+    }
+    const actingAs = c.get("mcpjamUserId");
+    if (!actingAs) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Missing mcpjamUserId for WorkOS API key auth exchange"
+      );
+    }
+    headers["Authorization"] = `Bearer ${serviceToken}`;
+    headers["x-mcpjam-acting-as"] = actingAs;
+    return headers;
+  }
+  headers["Authorization"] = `Bearer ${originalBearer}`;
+  return headers;
+}
+
 export async function authorizeServer(
   c: Context,
   bearerToken: string,
@@ -319,10 +371,7 @@ export async function authorizeServer(
   try {
     response = await fetch(`${convexUrl}/web/authorize`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${bearerToken}`,
-      },
+      headers: buildConvexAuthHeaders(c, bearerToken),
       body: JSON.stringify({
         projectId,
         serverId,
@@ -399,10 +448,7 @@ export async function authorizeBatch(
   try {
     response = await fetch(`${convexUrl}/web/authorize-batch`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${bearerToken}`,
-      },
+      headers: buildConvexAuthHeaders(c, bearerToken),
       body: JSON.stringify({
         projectId,
         serverIds,
@@ -788,6 +834,15 @@ export async function createAuthorizedManager(
                       accessScope: options?.accessScope,
                       chatboxId: options?.chatboxId,
                       accessVersion: options?.accessVersion,
+                      // When the caller authed via WorkOS API key, secret
+                      // reveal must use the same delegated-identity exchange
+                      // as `authorizeBatch` — otherwise Convex would see the
+                      // service token without an acting-as user.
+                      workosApiKeyActingAs:
+                        c.get("authMethod") === "workos_api_key" &&
+                        c.get("mcpjamUserId")
+                          ? { mcpjamUserId: c.get("mcpjamUserId")! }
+                          : undefined,
                     })
                   ).headers ?? {}),
                 },

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -20,6 +20,7 @@ import guestSession from "./guest-session.js";
 import chatHistory from "./chat-history.js";
 import conformanceWeb from "./conformance.js";
 import checks from "./checks.js";
+import apiKeys from "./api-keys.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -61,6 +62,11 @@ web.route("/guest-session", guestSession);
 web.route("/chat-history", chatHistory);
 web.route("/conformance", conformanceWeb);
 web.route("/checks", checks);
+// `/api-keys` carries its own bearer-auth `.use()` because
+// `sessionAuthMiddleware` bypasses `/api/web/*` entirely. Nothing on this
+// sub-router is reachable without a session JWT (WorkOS `sk_…` keys are
+// explicitly rejected with 403 inside the router).
+web.route("/api-keys", apiKeys);
 
 // Public guest JWKS compatibility endpoint.
 web.get("/guest-jwks", async (c) => {

--- a/mcpjam-inspector/server/services/identity.ts
+++ b/mcpjam-inspector/server/services/identity.ts
@@ -1,0 +1,42 @@
+import { ConvexHttpClient } from "convex/browser";
+
+/**
+ * Resolve an MCPJam user from a WorkOS user id (the user's `externalId`
+ * in Convex).
+ *
+ * Used by the bearer middleware when an `sk_` WorkOS API key is presented:
+ * after `WorkOS.apiKeys.createValidation` returns the owning WorkOS user,
+ * we map it to an MCPJam user id so Inspector can call Convex as that user
+ * via the service-token + acting-as exchange.
+ *
+ * Returns `null` when no matching user is found — the caller is
+ * responsible for translating that into a 401.
+ */
+export interface ResolvedMcpjamUser {
+  /** MCPJam user document id (Convex). */
+  _id: string;
+}
+
+export async function resolveUserByExternalId(
+  externalId: string
+): Promise<ResolvedMcpjamUser | null> {
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl) {
+    throw new Error("CONVEX_URL is not set");
+  }
+
+  const client = new ConvexHttpClient(convexUrl);
+
+  // TODO: remove `as any` cast after the backend PR `claude/workos-api-keys-backend`
+  // adds `api.users.getByExternalId`. Inspector calls Convex via string
+  // function paths (matches `local-server-resolver.ts:935` and
+  // `servers.ts:80`) — no codegen step pins the API surface here, so the
+  // cast is the documented escape hatch until the reader query lands.
+  const result = (await client.query(
+    "users:getByExternalId" as any,
+    { externalId }
+  )) as { _id: string } | null | undefined;
+
+  if (!result || typeof result._id !== "string") return null;
+  return { _id: result._id };
+}

--- a/mcpjam-inspector/server/services/workos-client.ts
+++ b/mcpjam-inspector/server/services/workos-client.ts
@@ -1,0 +1,39 @@
+import { WorkOS } from "@workos-inc/node";
+
+/**
+ * Server-side WorkOS Node SDK client.
+ *
+ * Memoized as a per-process singleton. Reads `WORKOS_API_KEY` from the
+ * environment on first call and throws if it is missing — the inspector
+ * server should fail loud rather than silently fall back to unauthenticated
+ * calls against WorkOS.
+ *
+ * This mirrors the backend factory pattern in
+ * `mcpjam-backend/convex/lib/vault.ts` (`createWorkOSClient()`). Both
+ * processes use the same `WORKOS_API_KEY` secret.
+ *
+ * Used today only by the WorkOS API Keys feature:
+ *   - `server/middleware/bearer-auth.ts` — validate `sk_` bearers via
+ *     `apiKeys.createValidation`.
+ *   - `server/routes/web/api-keys.ts` — mint / list / revoke management
+ *     endpoints (org-scoped operations only; user-scoped paths go through
+ *     direct REST since the SDK doesn't expose them yet).
+ */
+let cachedClient: WorkOS | undefined;
+
+export function getWorkOSClient(): WorkOS {
+  if (cachedClient) return cachedClient;
+  const apiKey = process.env.WORKOS_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "WORKOS_API_KEY is not set — required for WorkOS API key validation and management."
+    );
+  }
+  cachedClient = new WorkOS(apiKey);
+  return cachedClient;
+}
+
+/** Test-only: reset the memoized client (does not affect process env). */
+export function resetWorkOSClientForTests(): void {
+  cachedClient = undefined;
+}

--- a/mcpjam-inspector/server/types/hono.ts
+++ b/mcpjam-inspector/server/types/hono.ts
@@ -10,5 +10,22 @@ declare module "hono" {
   interface ContextVariableMap {
     guestId?: string;
     requestLogContext?: RequestLogContext;
+    /**
+     * Auth method used to resolve the caller. Set by `bearerAuthMiddleware`:
+     * - `"workos_api_key"` — caller presented a WorkOS `sk_…` API key
+     *   (validated via `WorkOS.apiKeys.createValidation`).
+     * - Absent — guest JWT (see `guestId`) or WorkOS AuthKit JWT.
+     *
+     * Downstream Convex callers (`authorizeBatch`) read this to decide
+     * between forwarding the original bearer (JWT/guest) and exchanging
+     * for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as` (API key).
+     */
+    authMethod?: "workos_api_key";
+    /** WorkOS API key id (e.g. `api_key_…`). Set with `authMethod`. */
+    workosApiKeyId?: string;
+    /** WorkOS user externalId. Set with `authMethod`. */
+    workosUserId?: string;
+    /** Resolved MCPJam user `_id` (Convex). Set with `authMethod`. */
+    mcpjamUserId?: string;
   }
 }

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -44,6 +44,17 @@ export async function fetchRuntimeServerSecrets(args: {
   accessScope?: "project_member" | "chat_v2";
   chatboxId?: string;
   accessVersion?: number;
+  /**
+   * When the caller authenticated via a WorkOS API key, Inspector exchanges
+   * the user bearer for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as`.
+   * Passed by `createAuthorizedManager` so secret reveals during the
+   * `/api/v1/*` flow follow the same trust model as `authorizeBatch`.
+   * The bearer middleware sets `authMethod="workos_api_key"`; callers
+   * just forward those Context values.
+   */
+  workosApiKeyActingAs?: {
+    mcpjamUserId: string;
+  };
 }): Promise<ServerSecretsResult> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   if (!convexUrl) {
@@ -62,12 +73,27 @@ export async function fetchRuntimeServerSecrets(args: {
 
   let response: Response;
   try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (args.workosApiKeyActingAs) {
+      const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+      if (!serviceToken) {
+        throw new WebRouteError(
+          500,
+          ErrorCode.INTERNAL_ERROR,
+          "Server missing INSPECTOR_SERVICE_TOKEN for WorkOS API key auth"
+        );
+      }
+      headers["Authorization"] = `Bearer ${serviceToken}`;
+      headers["x-mcpjam-acting-as"] = args.workosApiKeyActingAs.mcpjamUserId;
+    } else {
+      headers["Authorization"] = `Bearer ${args.bearerToken}`;
+    }
+
     response = await fetch(`${convexUrl}/web/server/reveal-secrets`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${args.bearerToken}`,
-      },
+      headers,
       body: JSON.stringify({
         purpose: "runtime",
         projectId: args.projectId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,6 +328,7 @@
         "@sentry/vite-plugin": "^4.3.0",
         "@tanstack/react-virtual": "^3.13.12",
         "@workos-inc/authkit-react": "^0.12.0",
+        "@workos-inc/node": "^10.2.0",
         "@xyflow/react": "^12.9.0",
         "ai": "^6.0.154",
         "ajv": "^8.18.0",
@@ -551,6 +552,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "mcpjam-inspector/node_modules/@workos-inc/node": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-10.2.0.tgz",
+      "integrity": "sha512-K7LmCvwu8fL7HN3drAvjb/dWceltlDNSs3u1QNNYx5goZaxxG4dgCXDkdlcDt6ZKm8VGv030WfkmL7DylXvdaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=22.11.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -20406,7 +20419,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {


### PR DESCRIPTION
**Depends on backend PR [mcpjam-backend#469](https://github.com/MCPJam/mcpjam-backend/pull/469)** — do NOT merge until that's deployed. The Inspector code here uses a `service-token + x-mcpjam-acting-as` exchange that backend #469 implements on the Convex identity resolver.

## Summary

Adds WorkOS API Keys as a third bearer-token type for the v1 public API. Developers can now mint long-lived `sk_…` keys via the new `/settings/api-keys` page and hit `/api/v1/*` from `curl` / Python / CI without a browser session.

Plan: `/Users/marcelojimenezrocabado/.claude/plans/can-you-create-a-golden-allen.md`.

## Commits

| Commit | What |
|---|---|
| `f6d11082c` | Add `@workos-inc/node` SDK + `workos-client.ts` singleton + `identity.ts` (`resolveUserByExternalId` via `ConvexHttpClient`) + `request-local.ts` typed wrappers over Hono context. |
| `a818c4fbb` | Bearer middleware accepts `sk_` keys. Validates via WorkOS, resolves MCPJam user, sets `authMethod="workos_api_key"`. Per-WorkOS-key-id token bucket (60 req/min sustained, burst 10) → 429 with `Retry-After`. Documents ~200ms validate latency. |
| `1e6fcde45` | `authorizeBatch` (`server/routes/web/auth.ts:378`) swaps the bearer when `authMethod === "workos_api_key"`: sends `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as: <userId>` instead of forwarding the raw `sk_` value. Convex side (PR #469) understands this. |
| `3fa79d6f4` | `/api/web/api-keys/*` mint/list/revoke endpoints — calls WorkOS REST with our server-side `WORKOS_API_KEY`. **Explicitly auth-gated** (the `/api/web/*` prefix is bypassed by `sessionAuthMiddleware`, so the sub-router applies `bearerAuthMiddleware` itself). `sk_` keys are rejected with 403 — privilege isolation, no minting of more keys. DELETE re-fetches the key and asserts `owner.id === sessionUserId` before forwarding. |
| `147e9aa0b` | Settings → API Keys page: table, Create dialog, Reveal-once dialog (copy-with-Check + "won't be shown again" warning), Revoke dialog (type key name to confirm). Sidebar "API Keys" entry under settings section with `Key` icon. |
| `5dbced562` | Tests for the bearer middleware `sk_` branch: validation success/failure, unknown-user rejection, rate-limit burst → 429, per-key bucket isolation, request-local memoization (validate called once per request). |

## Architecture notes

- **WorkOS is the source of truth for key material.** We never store the raw value. `value` is in WorkOS's create response only, returned to the browser once, then forgotten.
- **Trust boundary:** Inspector validates the `sk_` key once per request (memoized). For downstream Convex calls, Inspector uses its service token + `acting-as` header. Convex (PR #469) trusts Inspector's word on identity. Avoids double validation (~400ms → ~200ms) and keeps WorkOS coupling at one layer.
- **Privilege isolation:** `sk_` keys cannot manage other `sk_` keys. Management surface is session-only.
- **Rate limit:** per-key token bucket defends WorkOS validate quota against a misbehaving caller. In-process Map, resets on deploy — fine for v1.

## Critical files

**New (server):** `services/workos-client.ts`, `services/identity.ts`, `middleware/request-local.ts`, `routes/web/api-keys.ts`
**Modified (server):** `package.json` (`@workos-inc/node`), `middleware/bearer-auth.ts`, `routes/web/auth.ts` (`authorizeBatch`), `routes/web/index.ts`
**New (client):** `components/settings/ApiKeysRoute.tsx` + `api-keys/{Create,RevealOnce,Revoke}Dialog.tsx`, `lib/apis/web/api-keys.ts`
**Modified (client):** `router.tsx`, `components/mcp-sidebar.tsx`
**Tests:** `server/middleware/__tests__/bearer-auth.test.ts`

## Test plan

After backend PR #469 deploys to staging:

- [ ] Mint a key via `/settings/api-keys` — confirm reveal-once dialog, copy value
- [ ] `curl -H "Authorization: Bearer <sk_>" https://api.mcpjam.com/api/v1/me` → 200
- [ ] `curl … /api/v1/projects/<id>/servers/<id>/tools` → 200 (proves `authorizeBatch` swap)
- [ ] Curl with tampered value → 401
- [ ] Refresh `/settings/api-keys` → key visible with obfuscated value
- [ ] Revoke → confirm via type-name → curl with revoked value → 401 within seconds
- [ ] As another user, attempt `/api/web/api-keys` → see only own keys
- [ ] Authenticated with the `sk_` key, hit `/api/web/api-keys` → 403 "API keys cannot manage other API keys"
- [ ] Burst 30 requests → last few 429
- [ ] Latency: p50 `/api/v1/me` ~ 200ms (one WorkOS validate per request)

## Follow-ups

- Dedicated test suite for `/api/web/api-keys/*` routes (needs JWT-claim mocking + WorkOS REST stubbing) — deferred for review clarity.
- Org-scoped keys (requires adding `workosOrgId` to `organizations` schema).
- Optional cross-request validation cache (60s LRU) if p99 becomes hot. Trades against immediate revocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, delegated identity to Convex, and API key lifecycle; depends on a companion backend PR for acting-as identity. Privilege isolation (keys cannot manage keys) and owner checks on delete are in place.
> 
> **Overview**
> Adds **WorkOS `sk_…` API keys** as a machine-auth path for the v1 public API, plus a **session-only** settings UI to mint, list, and revoke keys.
> 
> **Server:** Bearer middleware now branches on `sk_` tokens—WorkOS validation (request-local memoization), Convex user lookup, per-key rate limits (429 + `Retry-After`), and Hono context (`authMethod`, `mcpjamUserId`, etc.). Convex calls from API-key requests use **`INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as`** instead of forwarding the raw key (`authorizeBatch`, `authorizeServer`, runtime secret reveal). New **`/api/web/api-keys/*`** proxies WorkOS REST for create/list/delete; **`sk_` bearers get 403** on that router. Adds `@workos-inc/node`, WorkOS client singleton, identity resolver, and bearer middleware tests.
> 
> **Client:** **`/settings/api-keys`** route with list/create/reveal-once/revoke flows, client API helpers, and sidebar **API Keys** nav entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dbced562a33bb6a7b0acc6f1329f992faa66413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->