### PR TITLE
fix(xaa): advertise https issuer/JWKS behind TLS-terminating proxy

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -73,6 +73,27 @@ describe("mcp xaa routes", () => {
     );
   });
 
+  it("ignores forwarded proxy headers for the local router", async () => {
+    // The local desktop router has no proxy in front of it, so a spoofed
+    // X-Forwarded-Proto must not flip the issuer to https.
+    const response = await app.request(
+      "http://localhost/api/mcp/xaa/.well-known/openid-configuration",
+      {
+        headers: {
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "evil.example.com",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.issuer).toBe("http://localhost/api/mcp/xaa");
+    expect(body.jwks_uri).toBe(
+      "http://localhost/api/mcp/xaa/.well-known/jwks.json",
+    );
+  });
+
   it("requires a session token for protected endpoints", async () => {
     const response = await app.request("/api/mcp/xaa/authenticate", {
       method: "POST",

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -50,10 +50,10 @@ const proxyTokenSchema = z.object({
 interface CreateXaaRouterOptions {
   issuerBasePath: "/api/mcp" | "/api/web";
   httpsOnlyProxy: boolean;
-  // When behind a TLS-terminating proxy (hosted mode), the issuer must be
-  // reconstructed from X-Forwarded-Proto/Host because c.req.url uses the
-  // internal http:// scheme. Leave false for local (no proxy) so the headers
-  // can't be spoofed into advertising https for a plain-http localhost run.
+  // When behind a TLS-terminating proxy (hosted mode), the issuer scheme must
+  // be reconstructed from X-Forwarded-Proto because c.req.url is http://
+  // internally. Leave false for local (no proxy) so the header can't be
+  // spoofed into advertising https for a plain-http localhost run.
   trustForwardedHeaders?: boolean;
   protectedMiddlewares?: MiddlewareHandler[];
 }
@@ -101,10 +101,16 @@ function getIssuerForRequest(
   const parsed = new URL(c.req.url);
 
   if (trustForwardedHeaders) {
+    // Only the scheme is reconstructed from a forwarded header: the edge
+    // terminates TLS so c.req.url is http:// internally. The host already
+    // comes from the validated Host header in c.req.url, so we do NOT trust
+    // X-Forwarded-Host — honoring it would let a client inject an arbitrary
+    // issuer/jwks_uri (and a forged `iss` on the signed ID-JAG). Restrict to
+    // a known scheme so a forwarded value can't switch to another protocol.
     const proto = c.req.header("x-forwarded-proto")?.split(",")[0]?.trim();
-    const host = c.req.header("x-forwarded-host")?.split(",")[0]?.trim();
-    if (proto) parsed.protocol = proto;
-    if (host) parsed.host = host;
+    if (proto === "https" || proto === "http") {
+      parsed.protocol = proto;
+    }
   }
 
   return getXAAIssuerUrl(`${parsed.origin}${issuerBasePath}`);

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { z } from "zod";
 import {
   DEFAULT_NEGATIVE_TEST_MODE,
@@ -50,6 +50,11 @@ const proxyTokenSchema = z.object({
 interface CreateXaaRouterOptions {
   issuerBasePath: "/api/mcp" | "/api/web";
   httpsOnlyProxy: boolean;
+  // When behind a TLS-terminating proxy (hosted mode), the issuer must be
+  // reconstructed from X-Forwarded-Proto/Host because c.req.url uses the
+  // internal http:// scheme. Leave false for local (no proxy) so the headers
+  // can't be spoofed into advertising https for a plain-http localhost run.
+  trustForwardedHeaders?: boolean;
   protectedMiddlewares?: MiddlewareHandler[];
 }
 
@@ -88,9 +93,21 @@ function parseRequest<T>(schema: z.ZodSchema<T>, data: unknown): T {
   return parsed.data;
 }
 
-function getIssuerForRequest(requestUrl: string, issuerBasePath: string): string {
-  const origin = new URL(requestUrl).origin;
-  return getXAAIssuerUrl(`${origin}${issuerBasePath}`);
+function getIssuerForRequest(
+  c: Context,
+  issuerBasePath: string,
+  trustForwardedHeaders: boolean,
+): string {
+  const parsed = new URL(c.req.url);
+
+  if (trustForwardedHeaders) {
+    const proto = c.req.header("x-forwarded-proto")?.split(",")[0]?.trim();
+    const host = c.req.header("x-forwarded-host")?.split(",")[0]?.trim();
+    if (proto) parsed.protocol = proto;
+    if (host) parsed.host = host;
+  }
+
+  return getXAAIssuerUrl(`${parsed.origin}${issuerBasePath}`);
 }
 
 function decodeJwtPayloadUnsafe(token: string): ParsedJwtPayload {
@@ -126,6 +143,7 @@ function resolveNegativeTestMode(value?: string): NegativeTestMode {
 export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
   const router = new Hono();
   const protectedMiddlewares = options.protectedMiddlewares ?? [];
+  const trustForwardedHeaders = options.trustForwardedHeaders ?? false;
 
   if (protectedMiddlewares.length > 0) {
     router.use("/authenticate", ...protectedMiddlewares);
@@ -142,7 +160,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
 
   router.get("/.well-known/openid-configuration", (c) => {
     initXAAIdpKeyPair();
-    const issuer = getIssuerForRequest(c.req.url, options.issuerBasePath);
+    const issuer = getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
 
     return c.json(
       {
@@ -172,7 +190,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     try {
       const body = await c.req.json();
       const { userId, email, audience } = parseRequest(authenticateSchema, body);
-      const issuer = getIssuerForRequest(c.req.url, options.issuerBasePath);
+      const issuer = getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
       const subject = userId || "user-12345";
       const resolvedEmail = email || "demo.user@example.com";
       const issued = issueMockIdToken({
@@ -207,7 +225,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       const body = await c.req.json();
       const parsed = parseRequest(tokenExchangeSchema, body);
       const negativeTestMode = resolveNegativeTestMode(parsed.negativeTestMode);
-      const issuer = getIssuerForRequest(c.req.url, options.issuerBasePath);
+      const issuer = getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
       const identityPayload = decodeJwtPayloadUnsafe(parsed.identityAssertion);
       const subject = identityPayload.sub || "user-12345";
 

--- a/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
@@ -51,6 +51,65 @@ describe("web xaa routes", () => {
     expect(discoveryBody.issuer).toBe("https://www.mcpjam.com/api/web/xaa");
   });
 
+  it("reconstructs an https issuer from forwarded proxy headers", async () => {
+    // Behind a TLS-terminating proxy the internal request is http://, but
+    // X-Forwarded-Proto/Host carry the public-facing https origin.
+    const discoveryResponse = await app.request(
+      "http://internal.local/api/web/xaa/.well-known/openid-configuration",
+      {
+        headers: {
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "app.mcpjam.com",
+        },
+      },
+    );
+
+    expect(discoveryResponse.status).toBe(200);
+    const discoveryBody = await discoveryResponse.json();
+    expect(discoveryBody.issuer).toBe("https://app.mcpjam.com/api/web/xaa");
+    expect(discoveryBody.jwks_uri).toBe(
+      "https://app.mcpjam.com/api/web/xaa/.well-known/jwks.json",
+    );
+  });
+
+  it("signs the ID-JAG iss with the forwarded https origin", async () => {
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: "Bearer workos-token",
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "app.mcpjam.com",
+    };
+
+    const authenticateResponse = await app.request(
+      "http://internal.local/api/web/xaa/authenticate",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ userId: "user-12345" }),
+      },
+    );
+    const authenticateBody = await authenticateResponse.json();
+
+    const tokenExchangeResponse = await app.request(
+      "http://internal.local/api/web/xaa/token-exchange",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          identityAssertion: authenticateBody.id_token,
+          audience: "https://auth.example.com",
+          resource: "https://mcp.example.com",
+          clientId: "mcpjam-debugger",
+        }),
+      },
+    );
+
+    expect(tokenExchangeResponse.status).toBe(200);
+    const tokenExchangeBody = await tokenExchangeResponse.json();
+    const payload = decodeJwtPayload(tokenExchangeBody.id_jag);
+    expect(payload.iss).toBe("https://app.mcpjam.com/api/web/xaa");
+  });
+
   it("requires a bearer token for protected endpoints", async () => {
     const response = await app.request("/api/web/xaa/authenticate", {
       method: "POST",

--- a/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
@@ -51,15 +51,17 @@ describe("web xaa routes", () => {
     expect(discoveryBody.issuer).toBe("https://www.mcpjam.com/api/web/xaa");
   });
 
-  it("reconstructs an https issuer from forwarded proxy headers", async () => {
-    // Behind a TLS-terminating proxy the internal request is http://, but
-    // X-Forwarded-Proto/Host carry the public-facing https origin.
+  it("reconstructs an https issuer from X-Forwarded-Proto, ignoring X-Forwarded-Host", async () => {
+    // Behind a TLS-terminating proxy the internal request is http://; only the
+    // scheme is taken from X-Forwarded-Proto. The host comes from the request's
+    // Host header (here app.mcpjam.com), NOT from X-Forwarded-Host, which an
+    // attacker could spoof to forge the issuer/jwks_uri.
     const discoveryResponse = await app.request(
-      "http://internal.local/api/web/xaa/.well-known/openid-configuration",
+      "http://app.mcpjam.com/api/web/xaa/.well-known/openid-configuration",
       {
         headers: {
           "x-forwarded-proto": "https",
-          "x-forwarded-host": "app.mcpjam.com",
+          "x-forwarded-host": "evil.example.com",
         },
       },
     );
@@ -72,16 +74,16 @@ describe("web xaa routes", () => {
     );
   });
 
-  it("signs the ID-JAG iss with the forwarded https origin", async () => {
+  it("signs the ID-JAG iss with the forwarded https scheme and validated host", async () => {
     const headers = {
       "Content-Type": "application/json",
       Authorization: "Bearer workos-token",
       "x-forwarded-proto": "https",
-      "x-forwarded-host": "app.mcpjam.com",
+      "x-forwarded-host": "evil.example.com",
     };
 
     const authenticateResponse = await app.request(
-      "http://internal.local/api/web/xaa/authenticate",
+      "http://app.mcpjam.com/api/web/xaa/authenticate",
       {
         method: "POST",
         headers,
@@ -91,7 +93,7 @@ describe("web xaa routes", () => {
     const authenticateBody = await authenticateResponse.json();
 
     const tokenExchangeResponse = await app.request(
-      "http://internal.local/api/web/xaa/token-exchange",
+      "http://app.mcpjam.com/api/web/xaa/token-exchange",
       {
         method: "POST",
         headers,

--- a/mcpjam-inspector/server/routes/web/xaa.ts
+++ b/mcpjam-inspector/server/routes/web/xaa.ts
@@ -5,6 +5,7 @@ import { createXaaRouter } from "../mcp/xaa.js";
 const xaaWeb = createXaaRouter({
   issuerBasePath: "/api/web",
   httpsOnlyProxy: true,
+  trustForwardedHeaders: true,
   protectedMiddlewares: [bearerAuthMiddleware, guestRateLimitMiddleware],
 });
 


### PR DESCRIPTION
## TL;DR

The hosted XAA IdP advertises an **`http://` issuer and `jwks_uri`** (and signs ID-JAGs with an `http://` `iss`) because the issuer is derived from the internal request URL, which is plain `http` after the edge terminates TLS. This forces a fragile `http`/`https` split when wiring a downstream authorization server. Fix: reconstruct the scheme from `X-Forwarded-Proto` (the host still comes from the validated `Host` header, **not** `X-Forwarded-Host`), gated so the local desktop router is unaffected.

## Before / after

`GET https://app.mcpjam.com/api/web/xaa/.well-known/openid-configuration`

| Field | Before | After |
|---|---|---|
| `issuer` | `http://app.mcpjam.com/api/web/xaa` | `https://app.mcpjam.com/api/web/xaa` |
| `jwks_uri` | `http://app.mcpjam.com/api/web/xaa/.well-known/jwks.json` | `https://…` |
| signed ID-JAG `iss` | `http://…` | `https://…` |

Local desktop router is unchanged: `http://localhost:6274/api/mcp/xaa`.

## Root cause

The issuer was built from `new URL(c.req.url).origin`. Behind a TLS-terminating proxy, `c.req.url` carries the **internal** `http://` hop, so every issuer surface came out `http://`. The same reverse-proxy reconstruction already exists in `in-app-browser.ts` — the XAA route never got it.

## What changed

- `getIssuerForRequest` now takes the request context and reconstructs **only the scheme** from `X-Forwarded-Proto` (allowlisted to `http`/`https`). The host keeps coming from the validated `Host` header in `c.req.url` — `X-Forwarded-Host` is deliberately ignored, since honoring it would let a client forge the `issuer`/`jwks_uri` (and the signed `iss`).
- Gated on a new per-router `trustForwardedHeaders` flag:
  - hosted web router → `true`
  - local desktop router → `false` (no proxy in front of it, so a spoofed header must not flip the issuer to `https`)
- Tests: https-under-proxy for issuer/jwks_uri **and** the signed `iss`; headers ignored for the local router.

## Risk register

| Concern | Answer |
|---|---|
| Could a client spoof the header on the local router? | No — local router leaves `trustForwardedHeaders` off, so forwarded headers are ignored (test covers this). |
| Does this break local desktop mode? | No — local still derives the origin from `c.req.url` (`http://localhost`). |
| Does the signed `iss` change for existing hosted users? | Yes, intentionally — it becomes `https://…`. Anyone who configured a downstream auth server to trust the `http://` issuer must update to `https://` (the correct value). |
| Comma-separated forwarded values? | First value is taken and trimmed. |

## Test plan

- `vitest run` on both xaa route test files — 10 passed (3 new).
