### PR TITLE
chore: add .railwayignore for broken editor symlinks

### DIFF
--- a/mcpjam-inspector/.railwayignore
+++ b/mcpjam-inspector/.railwayignore
@@ -1,0 +1,3 @@
+.mcpjam/
+.agents/
+.claude/


### PR DESCRIPTION
## Summary
- Adds `mcpjam-inspector/.railwayignore` that excludes `.mcpjam/`, `.agents/`, `.claude/` from `railway up` uploads.

## Why
`railway up` walks the working tree and aborts with an `IO error … No such file or directory` when it hits a broken symlink. Several editor/agent scaffolds (Claude Code, internal `.mcpjam/skills/*`) drop symlinks under those directories that point at user-relative paths that don't always resolve. None of it is deployed code, so blacklisting the directories is safe and unblocks ad-hoc deploys from local machines.

Encountered this trying to push a staging hotfix earlier today — Railway's existing deploy workflow (`deploy-staging.yml`) wasn't affected because it runs in a clean CI checkout with no editor scaffolds, but local `railway up` couldn't even start uploading.

## Test plan
- [x] `railway up --detach --service mcp-inspector` from local successfully built and deployed (commit prior to this PR; deploy id `60aeac75`)
- [ ] No impact expected on CI deploys (CI workspaces don't have these directories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy packaging only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds **`mcpjam-inspector/.railwayignore`** so local **`railway up`** uploads skip **`.mcpjam/`**, **`.agents/`**, and **`.claude/`**.
> 
> Those folders often contain editor/agent scaffold symlinks that point at paths that do not resolve on the machine running the deploy. Railway’s upload walk then fails with an IO error on broken symlinks. The paths are not part of the deployed app, so excluding them unblocks ad-hoc deploys from developer machines without changing CI (clean checkouts typically lack these dirs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a6158e1be072a02f5424e12f6ab703ab4f788f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->