### PR TITLE
Add builtInToolIds as a HostConfig v2 dimension (SDK)

### DIFF
--- a/.changeset/built-in-tool-ids-host-config.md
+++ b/.changeset/built-in-tool-ids-host-config.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Add `builtInToolIds` as a HostConfig v2 dimension. Host configs can now carry an opaque list of built-in tool catalog ids (a peer dimension to `serverIds`). The canonicalizer validates wire shape (array of non-empty strings), then dedupes and sorts; an absent or empty list is omitted from the canonical JSON, so every existing host config keeps a byte-identical `configHash`. IDs remain opaque to the SDK — existence and org-scope are enforced by the backend catalog, not an SDK enum.

--- a/sdk/scripts/gen-host-config-parity-fixture.mjs
+++ b/sdk/scripts/gen-host-config-parity-fixture.mjs
@@ -198,6 +198,17 @@ const inputs = [
     input: { ...base(), hostCapabilitiesOverride: {}, chatUiOverride: { logo: "x" } },
   },
   {
+    // Empty builtInToolIds collapses to absent → canonical JSON has no key,
+    // byte-identical to base-minimal for that dimension (hash-neutral default).
+    label: "builtin-tool-ids-empty-omitted",
+    input: { ...base(), builtInToolIds: [] },
+  },
+  {
+    // Unsorted + duplicate opaque ids → deduped + sorted in the canonical shape.
+    label: "builtin-tool-ids-unsorted-dupes",
+    input: { ...base(), builtInToolIds: ["web_search", "code_exec", "web_search"] },
+  },
+  {
     label: "adversarial-stray-deny-must-be-dropped",
     input: {
       ...base(),

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -144,6 +144,36 @@ function sortUniqueServerIds(ids: Array<ServerId> | undefined): Array<ServerId> 
   return Array.from(new Set(ids ?? [])).sort() as Array<ServerId>;
 }
 
+// Canonicalize built-in tool ids as a SET: validate wire shape, dedupe, sort.
+// IDs are OPAQUE to the SDK — there is NO enum/catalog check here (the backend
+// validates existence + org scope against the `builtInTools` table). Order is
+// not semantic, so we dedupe + sort like serverIds. Absent (undefined) OR empty
+// ([]) collapses to `undefined` so the key is dropped from the canonical JSON,
+// keeping every pre-feature row's hash byte-identical (precedent: the
+// allowFeatures / serverConnectionOverrides empty-collapse). Entries are stored
+// verbatim (never trimmed) so a malformed id like "web_search " is preserved
+// and rejected downstream by the catalog scope check rather than silently fixed.
+function canonicalizeBuiltInToolIds(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error("hostConfigV2: builtInToolIds must be a string[]");
+  }
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      throw new Error("hostConfigV2: builtInToolIds entries must be strings");
+    }
+    if (entry.trim() === "") {
+      throw new Error(
+        "hostConfigV2: builtInToolIds entries must be non-empty strings",
+      );
+    }
+    seen.add(entry);
+  }
+  if (seen.size === 0) return undefined;
+  return Array.from(seen).sort();
+}
+
 // Plain-object guard shared by hostCapabilitiesOverride and mcpProfile.
 // Arrays/null satisfy `typeof === 'object'`; the canonicalizer is the
 // chokepoint.
@@ -973,6 +1003,9 @@ export function canonicalizeHostConfigV2(
     // is identical for semantically equivalent server lists.
     serverIds,
     optionalServerIds,
+    // Opaque built-in tool ids. Helper returns undefined for absent/empty, so
+    // JSON.stringify drops the key and pre-feature rows hash byte-identically.
+    builtInToolIds: canonicalizeBuiltInToolIds(input.builtInToolIds),
     connectionDefaults: {
       headers: sortStringKeys(input.connectionDefaults.headers),
       requestTimeout: input.connectionDefaults.requestTimeout,

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -229,6 +229,14 @@ export type HostConfigInputV2 = {
   // array" case.
   serverIds?: Array<ServerId>;
   optionalServerIds?: Array<ServerId>;
+  // Catalog ids of host-managed built-in tools (e.g. "web_search") attached to
+  // this host config — a peer dimension to serverIds. The SDK treats these as
+  // OPAQUE strings: it validates wire shape (array of non-empty strings, then
+  // dedupe + sort) but does NOT check them against any enum or catalog.
+  // Existence / org-scope is enforced by the backend against the `builtInTools`
+  // table. undefined OR [] → omitted from the canonical hash so pre-feature
+  // rows stay byte-identical; a populated set dedupes + sorts before hashing.
+  builtInToolIds?: ReadonlyArray<string>;
   connectionDefaults: HostConfigConnectionDefaults;
   clientCapabilities: Record<string, unknown>;
   hostContext: Record<string, unknown>;
@@ -268,6 +276,9 @@ export type CanonicalHostConfigV2 = {
   respectToolVisibility?: boolean;
   serverIds: Array<ServerId>;
   optionalServerIds: Array<ServerId>;
+  // Mirrors HostConfigInputV2.builtInToolIds. Optional + omitted when absent or
+  // empty so pre-feature rows hash byte-identically; deduped + sorted when set.
+  builtInToolIds?: Array<string>;
   connectionDefaults: HostConfigConnectionDefaults;
   clientCapabilities: Record<string, unknown>;
   hostContext: Record<string, unknown>;

--- a/sdk/tests/fixtures/host-config-parity-fixtures.json
+++ b/sdk/tests/fixtures/host-config-parity-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "__inputHash": "32a8406b9ff8d090c2ba3e0c2f4093c3af06e9a54fb6f5913c24e72458ca29c4",
+  "__inputHash": "ce77ad7441fe0c6eb84ddfb0d224e243a5ad192d5db9472b866818bf349f775c",
   "rows": [
     {
       "label": "base-minimal",
@@ -373,6 +373,48 @@
       },
       "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"hostCapabilitiesOverride\":{},\"chatUiOverride\":{\"logo\":\"x\"}}",
       "sha256": "688fa1203c5197fe044ef781fbe5ca459cc963d3cb919310161fbc1179c05785"
+    },
+    {
+      "label": "builtin-tool-ids-empty-omitted",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "builtInToolIds": []
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{}}",
+      "sha256": "f6df30e89bb13c7b9fe2a098bcdd1e2778a0612d831cd4497471ca8ef2a4d729"
+    },
+    {
+      "label": "builtin-tool-ids-unsorted-dupes",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "builtInToolIds": [
+          "web_search",
+          "code_exec",
+          "web_search"
+        ]
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"builtInToolIds\":[\"code_exec\",\"web_search\"],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{}}",
+      "sha256": "f52dc644d170085356969ceb86f3a370cd7a9fc8648a53481b318ba478a72d7a"
     },
     {
       "label": "adversarial-stray-deny-must-be-dropped",

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -62,6 +62,74 @@ describe("canonicalizeHostConfigV2 — hash stability", () => {
   });
 });
 
+describe("canonicalizeHostConfigV2 — builtInToolIds", () => {
+  it("omits builtInToolIds when absent (pre-feature rows stay byte-identical)", () => {
+    const canonical = JSON.parse(JSON.stringify(canonicalizeHostConfigV2(base())));
+    expect("builtInToolIds" in canonical).toBe(false);
+  });
+
+  it("treats undefined and [] as identical (both omitted, same hash)", async () => {
+    expect(await hash(base())).toBe(await hash(base({ builtInToolIds: [] })));
+    const canonical = JSON.parse(
+      JSON.stringify(canonicalizeHostConfigV2(base({ builtInToolIds: [] }))),
+    );
+    expect("builtInToolIds" in canonical).toBe(false);
+  });
+
+  it("a populated set shifts the hash vs absent", async () => {
+    expect(await hash(base())).not.toBe(
+      await hash(base({ builtInToolIds: ["web_search"] })),
+    );
+  });
+
+  it("dedupes and sorts deterministically (order-insensitive)", async () => {
+    const c = canonicalizeHostConfigV2(
+      base({ builtInToolIds: ["web_search", "code_exec", "web_search"] }),
+    );
+    expect(c.builtInToolIds).toEqual(["code_exec", "web_search"]);
+    // Order + dupes do not affect the hash.
+    expect(
+      await hash(base({ builtInToolIds: ["web_search", "code_exec"] })),
+    ).toBe(
+      await hash(
+        base({ builtInToolIds: ["code_exec", "web_search", "code_exec"] }),
+      ),
+    );
+  });
+
+  it("preserves opaque ids verbatim (no trimming — backend rejects malformed)", () => {
+    const c = canonicalizeHostConfigV2(
+      base({ builtInToolIds: ["web_search "] }),
+    );
+    expect(c.builtInToolIds).toEqual(["web_search "]);
+  });
+
+  it("rejects a non-array builtInToolIds", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({ builtInToolIds: "web_search" as unknown as string[] }),
+      ),
+    ).toThrow(/builtInToolIds must be a string\[\]/);
+  });
+
+  it("rejects non-string entries", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({ builtInToolIds: [123 as unknown as string] }),
+      ),
+    ).toThrow(/builtInToolIds entries must be strings/);
+  });
+
+  it("rejects empty / whitespace-only entries", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(base({ builtInToolIds: [""] })),
+    ).toThrow(/builtInToolIds entries must be non-empty strings/);
+    expect(() =>
+      canonicalizeHostConfigV2(base({ builtInToolIds: ["   "] })),
+    ).toThrow(/builtInToolIds entries must be non-empty strings/);
+  });
+});
+
 describe("canonicalizeHostConfigV2 — undefined vs explicit", () => {
   it("distinguishes hostCapabilitiesOverride undefined from {}", async () => {
     const omitted = canonicalizeHostConfigV2(base());

--- a/sdk/tests/host-config-parity.test.ts
+++ b/sdk/tests/host-config-parity.test.ts
@@ -24,7 +24,7 @@ import type { HostConfigInputV2 } from "../src/host-config/internal";
  * directly, so the SDK-side constant is the single source of truth.
  */
 const EXPECTED_INPUT_HASH =
-  "32a8406b9ff8d090c2ba3e0c2f4093c3af06e9a54fb6f5913c24e72458ca29c4";
+  "ce77ad7441fe0c6eb84ddfb0d224e243a5ad192d5db9472b866818bf349f775c";
 
 type FixtureRow = {
   label: string;


### PR DESCRIPTION
## What

Adds `builtInToolIds` as a first-class **HostConfig v2 dimension** in the SDK — an opaque list of built-in tool catalog ids (e.g. `web_search`), a peer dimension to `serverIds`. This is the **foundation/gate** for making host-managed built-in tools a real hostConfig dimension instead of route-local glue.

## Why this is the gate

The backend (`mcpjam-backend`) consumes `@mcpjam/sdk` as a **published npm package** and delegates hostConfig canonicalization to it. It cannot validate/persist `builtInToolIds` (or have the field affect `configHash`) until this lands and `@mcpjam/sdk@1.14.0` is published. The backend PR depends on this release and stays in draft until then. The inspector app links the SDK via the workspace, so it picks the field up immediately.

## Changes

- **`sdk/src/host-config/types.ts`** — `builtInToolIds?` on `HostConfigInputV2` (`ReadonlyArray<string>`) and `CanonicalHostConfigV2` (`Array<string>`).
- **`sdk/src/host-config/canonicalize.ts`** — `canonicalizeBuiltInToolIds` helper: validates wire shape (array of non-empty strings), dedupes + sorts (order is not semantic). **Absent (`undefined`) or empty (`[]`) collapses to omitted**, reusing the established `allowFeatures` / `serverConnectionOverrides` empty-collapse idiom. IDs are stored **verbatim** (never trimmed) so a malformed id like `"web_search "` is preserved and rejected downstream by the backend catalog check rather than silently "fixed". IDs stay **opaque** — no SDK enum, no existence check.
- **Tests** — 8 new goldens in `host-config-canonicalize.test.ts`: `undefined === []` (both omitted, same hash), populated set shifts the hash, dedupe + sort is deterministic/order-insensitive, opaque ids preserved verbatim, malformed shapes rejected (non-array, non-string entry, empty/whitespace-only).
- **Parity** — 2 new battery rows (`builtin-tool-ids-empty-omitted`, `builtin-tool-ids-unsorted-dupes`); regenerated `host-config-parity-fixtures.json`; updated the pinned `__inputHash` in `host-config-parity.test.ts`.

## Hash stability (the important bit)

Schema version stays at **2** — this is an additive, hash-neutral change. The regenerated fixture diff is **purely additive**: the only removed line is the old `__inputHash`; every pre-existing row's `canonicalJson` and `sha256` are **byte-identical**. So every host config created before this change keeps its exact `configHash` (no dedupe-row churn). A populated `builtInToolIds` shifts the hash, as intended.

## Verification

- Full SDK suite: **84 files, 1373 passed / 1 skipped**.
- `host-config-canonicalize.test.ts` (33) + `host-config-parity.test.ts` (35) green.
- Fixture diff confirmed additive-only (existing goldens unchanged).

## Release

Includes a changeset (`@mcpjam/sdk`: **minor** → `1.14.0`). Merging this publishes the SDK and unblocks the backend PR.

https://claude.ai/code/session_01K2hufybViFTo65YHRyiwxs

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2hufybViFTo65YHRyiwxs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes host config canonicalization and `configHash` for configs that set built-in tool ids; incorrect rules could cause dedupe churn or backend/SDK parity drift, though pre-existing rows without the field remain hash-stable.
> 
> **Overview**
> Adds **`builtInToolIds`** as an optional HostConfig v2 field (peer to `serverIds`) so host configs can reference opaque built-in tool catalog ids. Types on `HostConfigInputV2` and `CanonicalHostConfigV2` are extended; **`canonicalizeBuiltInToolIds`** validates `string[]`, rejects empty/whitespace entries, dedupes and sorts, and omits the key when absent or `[]` so existing **`configHash`** values stay unchanged.
> 
> Eight unit tests cover hash neutrality, dedupe/sort, verbatim ids (no trim), and invalid wire shapes. The parity fixture gains two vectors and an updated pinned **`__inputHash`**; a **minor** changeset targets `@mcpjam/sdk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79221462eae14be401565787388a9bf85d94c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->