### PR TITLE
fix(api-v1): mount /api/v1 in production server entry

### DIFF
--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -100,6 +100,7 @@ function logBox(content: string, title?: string) {
 import mcpRoutes from "./routes/mcp/index";
 import appsRoutes from "./routes/apps/index";
 import webRoutes from "./routes/web/index";
+import v1Routes from "./routes/v1/index";
 import { rpcLogBus } from "./services/rpc-log-bus";
 import { tunnelManager } from "./services/tunnel-manager";
 import { shutdownRunningSimulations } from "./services/sessionSimulation/runner";
@@ -349,6 +350,25 @@ if (!HOSTED_MODE) {
   );
 }
 app.route("/api/web", webRoutes);
+
+// Hosted public API (v1). Same 1MB JSON cap as /api/web; routes wrap the same
+// core helpers and emit the canonical v1 envelope. Mirror of the mount in
+// server/app.ts::createHonoApp — both production entries must wire this up.
+app.use(
+  "/api/v1/*",
+  bodyLimit({
+    maxSize: 1024 * 1024,
+    onError: (c) =>
+      c.json(
+        {
+          code: "VALIDATION_ERROR",
+          message: "Request body exceeds 1MB limit",
+        },
+        400,
+      ),
+  }),
+);
+app.route("/api/v1", v1Routes);
 
 // Fallback for clients that post to "/sse/message" instead of the rewritten proxy messages URL.
 // We resolve the upstream messages endpoint via sessionId and forward with any injected auth.


### PR DESCRIPTION
## Summary

PR #2500 added the `/api/v1` live-MCP router and mounted it in `server/app.ts::createHonoApp`, but `createHonoApp` is only used by the Electron CLI entry (`src/main.ts`). The Railway/hosted production server runs `bin/start.js` → `node dist/server/index.js`, which tsup bundles from `server/index.ts`. That entry mounts `/api/apps`, `/api/mcp`, `/api/web` but never imported or mounted `v1Routes`, so every `/api/v1/*` request on staging and prod returns the default Hono text/plain 404 — including inside a freshly-built image with #2500's source.

The integration suite at `server/routes/v1/__tests__/routes.test.ts` builds its own Hono app inline, so CI on #2500 stayed green without exercising the bundled prod entry.

## Diagnosis (staging)

```
$ curl -s -X POST -o /dev/null -w "%{http_code} %header{content-type}\n" \
    https://staging.mcpjam.com/api/v1/projects/abc/servers/xyz/validate
404 text/plain; charset=UTF-8
```

`/api/v1` (bare) returns 401 from `sessionAuthMiddleware` (path doesn't start with the trailing-slash bypass) — confirming the request reaches the app but no v1 route is registered. Forcing a fresh Railway build (digest `sha256:ef053c88`, built from `origin/main` post-#2500) reproduces the same 404, proving it's not a stale-image issue.

## Fix

Mirror the `app.ts` mount in `server/index.ts`:

- import `v1Routes`
- install the same 1MB `bodyLimit` guard on `/api/v1/*`
- `app.route("/api/v1", v1Routes)` right after `/api/web`

`sessionAuthMiddleware` already bypasses `/api/v1/*` paths and the v1 router runs its own `bearerAuthMiddleware`, so no other wiring changes are needed.

## Follow-up (separate PR)

`server/index.ts` and `server/app.ts::createHonoApp` are now drifting siblings. The right durable fix is to collapse them into a single app factory consumed by both entries — leaving that out of scope here to keep this PR a single-file, minimal hotfix that prod can ship today.

A regression test that hits `/api/v1/.../validate` against `dist/server/index.js` (or `createHonoApp` exercised through the prod entry path) would have caught this — also a follow-up.

## Test plan

- [ ] CI green (vitest, including `routes/v1/__tests__/routes.test.ts`)
- [ ] After deploy to staging: `curl -X POST https://staging.mcpjam.com/api/v1/projects/<p>/servers/<s>/validate` with a valid bearer returns the v1 envelope (not text/plain 404)
- [ ] `curl https://staging.mcpjam.com/api/v1` still 401s from sessionAuthMiddleware (unchanged)
- [ ] `/api/web/*` and `/api/mcp/*` continue to work (no middleware ordering regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file wiring parity with an existing mount; session auth already skips `/api/v1/` and v1 handles its own bearer auth.
> 
> **Overview**
> The hosted/Railway server boots from **`server/index.ts`**, not `createHonoApp` in `app.ts`, so **`/api/v1/*` was never registered** in staging/prod and returned Hono’s text/plain 404 despite v1 existing in the Electron path.
> 
> This change **imports `v1Routes`**, applies the same **1MB `bodyLimit`** on `/api/v1/*` as `/api/web`, and **`app.route("/api/v1", v1Routes)`** immediately after `/api/web`, matching the wiring already in `server/app.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02bb10ce76d50cdcd097eb2931bae9c9f3a253b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->