### PR TITLE
feat(evals): browser-rendered MCP App replay UI — "Browser" tab (PR 7)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/browser-artifacts-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/browser-artifacts-view.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type {
+  EvalTraceBrowserInteractionStepView,
+  EvalTraceWidgetRenderObservationView,
+} from "@/shared/eval-trace";
+import {
+  BrowserArtifactsView,
+  formatBrowserAction,
+} from "../browser-artifacts-view";
+
+const obs = (
+  o: Partial<EvalTraceWidgetRenderObservationView> = {},
+): EvalTraceWidgetRenderObservationView => ({
+  toolCallId: "tc-show",
+  toolName: "show_seats",
+  promptIndex: 0,
+  status: "rendered",
+  screenshotUrl: "https://store.example/obs.png",
+  elapsedMs: 1200,
+  ts: 1,
+  ...o,
+});
+
+const step = (
+  s: Partial<EvalTraceBrowserInteractionStepView> = {},
+): EvalTraceBrowserInteractionStepView => ({
+  toolCallId: "tc-show",
+  stepIndex: 0,
+  promptIndex: 0,
+  action: "left_click",
+  coordinateX: 640,
+  coordinateY: 400,
+  elapsedMs: 7,
+  ts: 1,
+  ...s,
+});
+
+describe("BrowserArtifactsView", () => {
+  it("shows an empty state when there are no artifacts", () => {
+    render(<BrowserArtifactsView />);
+    expect(screen.getByTestId("browser-artifacts-empty")).toBeInTheDocument();
+  });
+
+  it("renders a render-observation card with status badge, turn, and screenshot", () => {
+    render(<BrowserArtifactsView observations={[obs()]} />);
+
+    const card = screen.getByTestId("render-observation-card");
+    expect(within(card).getByText("show_seats")).toBeInTheDocument();
+    expect(within(card).getByText("Rendered")).toBeInTheDocument();
+    // promptIndex is displayed 1-based.
+    expect(within(card).getByText(/turn 1/)).toBeInTheDocument();
+    const img = within(card).getByRole("img", { name: "show_seats render" });
+    expect(img).toHaveAttribute("src", "https://store.example/obs.png");
+  });
+
+  it("shows a 'No screenshot' placeholder + failure label for a failed render", () => {
+    render(
+      <BrowserArtifactsView
+        observations={[
+          obs({ status: "render_error", screenshotUrl: null }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Render error")).toBeInTheDocument();
+    expect(screen.getByText("No screenshot")).toBeInTheDocument();
+  });
+
+  it("surfaces console errors in a collapsible details element", () => {
+    render(
+      <BrowserArtifactsView
+        observations={[obs({ consoleErrors: ["boom", "kaboom"] })]}
+      />,
+    );
+    expect(screen.getByText("2 console errors")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("renders the Computer Use timeline grouped by widget, titled by tool name", () => {
+    render(
+      <BrowserArtifactsView
+        observations={[obs()]}
+        steps={[step({ stepIndex: 0 }), step({ stepIndex: 1, action: "screenshot" })]}
+      />,
+    );
+    const group = screen.getByTestId("interaction-step-group");
+    // Group titled by the matching observation's tool name.
+    expect(within(group).getByText("show_seats")).toBeInTheDocument();
+    expect(within(group).getByText("2 steps")).toBeInTheDocument();
+    expect(within(group).getAllByTestId("interaction-step-row")).toHaveLength(2);
+    expect(within(group).getByText("Left click (640, 400)")).toBeInTheDocument();
+    expect(within(group).getByText("Screenshot")).toBeInTheDocument();
+  });
+
+  it("renders widget-initiated tools/call and a budget note on a step", () => {
+    render(
+      <BrowserArtifactsView
+        steps={[
+          step({
+            note: "step_budget_exceeded",
+            widgetToolCalls: [
+              { name: "reserve", args: { seat: 12 }, ok: true, elapsedMs: 4 },
+              { name: "pay", args: {}, ok: false, error: "declined", elapsedMs: 9 },
+            ],
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Step budget exceeded")).toBeInTheDocument();
+    expect(screen.getByText(/reserve/)).toBeInTheDocument();
+    expect(screen.getByText(/pay — declined/)).toBeInTheDocument();
+  });
+
+  it("falls back to toolCallId when no observation names the group", () => {
+    render(<BrowserArtifactsView steps={[step({ toolCallId: "tc-orphan" })]} />);
+    expect(screen.getByText("tc-orphan")).toBeInTheDocument();
+  });
+});
+
+describe("formatBrowserAction", () => {
+  it("formats every action variant", () => {
+    expect(formatBrowserAction(step({ action: "left_click" }))).toBe(
+      "Left click (640, 400)",
+    );
+    expect(
+      formatBrowserAction(
+        step({ action: "type", text: "hello", coordinateX: undefined, coordinateY: undefined }),
+      ),
+    ).toBe('Type "hello"');
+    expect(
+      formatBrowserAction(step({ action: "key", text: "Enter" })),
+    ).toBe("Key Enter");
+    expect(
+      formatBrowserAction(
+        step({ action: "scroll", scrollDirection: "down", scrollAmount: 3 }),
+      ),
+    ).toBe("Scroll down ×3");
+    expect(formatBrowserAction(step({ action: "wait", duration: 250 }))).toBe(
+      "Wait 250ms",
+    );
+    expect(formatBrowserAction(step({ action: "screenshot" }))).toBe(
+      "Screenshot",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/browser-artifacts-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/browser-artifacts-view.test.tsx
@@ -66,6 +66,34 @@ describe("BrowserArtifactsView", () => {
     expect(screen.getByText("No screenshot")).toBeInTheDocument();
   });
 
+  it("shows diagnostic copy for failure statuses", () => {
+    render(
+      <BrowserArtifactsView
+        observations={[obs({ status: "bridge_timeout", screenshotUrl: null })]}
+      />,
+    );
+    expect(
+      screen.getByText(/Bridge handshake timed out/),
+    ).toBeInTheDocument();
+  });
+
+  it("prefers the first console error as the render_error description", () => {
+    render(
+      <BrowserArtifactsView
+        observations={[
+          obs({
+            status: "render_error",
+            screenshotUrl: null,
+            consoleErrors: ["TypeError: x is undefined"],
+          }),
+        ]}
+      />,
+    );
+    expect(
+      screen.getByTestId("render-observation-description"),
+    ).toHaveTextContent("TypeError: x is undefined");
+  });
+
   it("surfaces console errors in a collapsible details element", () => {
     render(
       <BrowserArtifactsView

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
@@ -33,4 +33,49 @@ describe("TraceViewModeTabs", () => {
       "text-sidebar-accent-foreground",
     );
   });
+
+  it("hides the Browser tab by default", () => {
+    render(
+      <TraceViewModeTabs
+        mode="timeline"
+        onModeChange={vi.fn()}
+        showToolsTab={false}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Browser" })).toBeNull();
+  });
+
+  it("shows the Browser tab when showBrowserTab is set", () => {
+    render(
+      <TraceViewModeTabs
+        mode="timeline"
+        onModeChange={vi.fn()}
+        showToolsTab={false}
+        showBrowserTab
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Browser" }),
+    ).toBeInTheDocument();
+  });
+
+  it("applies active styling to the Browser tab when browserActive is set", () => {
+    render(
+      <TraceViewModeTabs
+        mode="timeline"
+        onModeChange={vi.fn()}
+        showToolsTab={false}
+        showBrowserTab
+        browserActive
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Browser" })).toHaveClass(
+      "bg-sidebar-accent",
+      "text-sidebar-accent-foreground",
+    );
+    // With Browser active, no standard tab is highlighted.
+    expect(screen.getByRole("button", { name: "Trace" })).not.toHaveClass(
+      "bg-sidebar-accent",
+    );
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/browser-artifacts-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/browser-artifacts-view.tsx
@@ -75,6 +75,33 @@ const STATUS_META: Record<
   },
 };
 
+// Plain-language "why did it fail?" copy shown under the badge. `rendered` needs
+// no explanation; `render_error` prefers the first console error when present.
+const STATUS_DESCRIPTION: Record<
+  EvalTraceWidgetRenderStatus,
+  string | undefined
+> = {
+  rendered: undefined,
+  bridge_timeout:
+    "Bridge handshake timed out — the widget may have a slow init path.",
+  blank_screenshot: "Rendered but painted blank — check console errors.",
+  mount_failed: "Failed to mount in the browser.",
+  render_error: "Render error during mount.",
+  resource_read_failed: "Couldn't fetch the widget HTML.",
+  no_ui_resource: "No widget HTML in the tool response.",
+  screenshot_failed: "Rendered, but screenshot capture failed.",
+  browser_unavailable: "Browser sandbox unavailable (Chromium not installed).",
+};
+
+function statusDescription(
+  observation: EvalTraceWidgetRenderObservationView,
+): string | undefined {
+  if (observation.status === "render_error") {
+    return observation.consoleErrors?.[0] ?? STATUS_DESCRIPTION.render_error;
+  }
+  return STATUS_DESCRIPTION[observation.status];
+}
+
 const ACTION_ICON: Record<EvalTraceBrowserAction, LucideIcon> = {
   screenshot: Clock,
   left_click: MousePointerClick,
@@ -209,6 +236,7 @@ function RenderObservationCard({
     Icon: Ban,
   };
   const { Icon } = meta;
+  const description = statusDescription(observation);
   return (
     <div
       className="flex flex-col gap-2 rounded-md border border-border/40 bg-muted/10 p-3"
@@ -228,6 +256,15 @@ function RenderObservationCard({
           turn {observation.promptIndex + 1} · {observation.elapsedMs}ms
         </span>
       </div>
+
+      {description ? (
+        <p
+          className="text-[11px] text-muted-foreground"
+          data-testid="render-observation-description"
+        >
+          {description}
+        </p>
+      ) : null}
 
       <Screenshot
         url={observation.screenshotUrl}

--- a/mcpjam-inspector/client/src/components/evals/browser-artifacts-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/browser-artifacts-view.tsx
@@ -1,0 +1,409 @@
+import {
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  Clock,
+  Keyboard,
+  MonitorOff,
+  MousePointerClick,
+  Move,
+  ScrollText,
+  Type,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import type {
+  EvalTraceBrowserAction,
+  EvalTraceBrowserInteractionStepView,
+  EvalTraceBrowserStepNote,
+  EvalTraceWidgetRenderObservationView,
+  EvalTraceWidgetRenderStatus,
+  EvalTraceWidgetToolCall,
+} from "@/shared/eval-trace";
+
+/**
+ * PR 7 — eval replay "Browser" view. Renders what the headless-Chromium harness
+ * captured for an iteration:
+ *   - widgetRenderObservations: one status card per MCP App widget (the LATEST
+ *     render outcome — the backend upserts per toolCallId), with a screenshot.
+ *   - browserInteractionSteps: the model-driven Computer Use timeline, grouped
+ *     by widget, each step showing its action, screenshot, and any
+ *     widget-initiated tools/call.
+ */
+
+type Tone = "success" | "warning" | "danger" | "neutral";
+
+const TONE_CLASS: Record<Tone, string> = {
+  success:
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  warning:
+    "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  danger: "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400",
+  neutral: "border-border/50 bg-muted/40 text-muted-foreground",
+};
+
+const STATUS_META: Record<
+  EvalTraceWidgetRenderStatus,
+  { label: string; tone: Tone; Icon: LucideIcon }
+> = {
+  rendered: { label: "Rendered", tone: "success", Icon: CheckCircle2 },
+  blank_screenshot: {
+    label: "Blank screenshot",
+    tone: "warning",
+    Icon: AlertTriangle,
+  },
+  bridge_timeout: { label: "Bridge timeout", tone: "warning", Icon: Clock },
+  no_ui_resource: { label: "No UI resource", tone: "neutral", Icon: Ban },
+  resource_read_failed: {
+    label: "Resource read failed",
+    tone: "danger",
+    Icon: XCircle,
+  },
+  mount_failed: { label: "Mount failed", tone: "danger", Icon: XCircle },
+  render_error: { label: "Render error", tone: "danger", Icon: XCircle },
+  screenshot_failed: {
+    label: "Screenshot failed",
+    tone: "danger",
+    Icon: XCircle,
+  },
+  browser_unavailable: {
+    label: "Browser unavailable",
+    tone: "neutral",
+    Icon: MonitorOff,
+  },
+};
+
+const ACTION_ICON: Record<EvalTraceBrowserAction, LucideIcon> = {
+  screenshot: Clock,
+  left_click: MousePointerClick,
+  double_click: MousePointerClick,
+  right_click: MousePointerClick,
+  mouse_move: Move,
+  type: Type,
+  key: Keyboard,
+  scroll: ScrollText,
+  wait: Clock,
+};
+
+const NOTE_META: Record<EvalTraceBrowserStepNote, { label: string; tone: Tone }> =
+  {
+    no_rendered_widget: { label: "No rendered widget", tone: "neutral" },
+    step_budget_exceeded: { label: "Step budget exceeded", tone: "warning" },
+    screenshot_budget_exceeded: {
+      label: "Screenshot budget exceeded",
+      tone: "warning",
+    },
+  };
+
+function Badge({
+  tone,
+  className,
+  children,
+}: {
+  tone: Tone;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        TONE_CLASS[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function coordinateSuffix(
+  step: EvalTraceBrowserInteractionStepView,
+): string {
+  return step.coordinateX != null && step.coordinateY != null
+    ? ` (${step.coordinateX}, ${step.coordinateY})`
+    : "";
+}
+
+/** One-line human label for a Computer Use action. */
+export function formatBrowserAction(
+  step: EvalTraceBrowserInteractionStepView,
+): string {
+  switch (step.action) {
+    case "left_click":
+      return `Left click${coordinateSuffix(step)}`;
+    case "double_click":
+      return `Double click${coordinateSuffix(step)}`;
+    case "right_click":
+      return `Right click${coordinateSuffix(step)}`;
+    case "mouse_move":
+      return `Mouse move${coordinateSuffix(step)}`;
+    case "type":
+      return `Type ${JSON.stringify(step.text ?? "")}`;
+    case "key":
+      return `Key ${step.text ?? ""}`.trim();
+    case "scroll":
+      return `Scroll ${step.scrollDirection ?? "down"}${
+        step.scrollAmount ? ` ×${step.scrollAmount}` : ""
+      }`;
+    case "wait":
+      return `Wait${step.duration ? ` ${step.duration}ms` : ""}`;
+    case "screenshot":
+      return "Screenshot";
+    default:
+      return step.action;
+  }
+}
+
+function Screenshot({ url, alt }: { url?: string | null; alt: string }) {
+  if (!url) {
+    return (
+      <div className="flex h-24 w-full items-center justify-center rounded-md border border-dashed border-border/50 bg-muted/20 text-[11px] text-muted-foreground">
+        No screenshot
+      </div>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={url}
+      alt={alt}
+      loading="lazy"
+      className="max-h-64 w-full rounded-md border border-border/40 bg-background object-contain object-top"
+    />
+  );
+}
+
+function WidgetToolCallList({ calls }: { calls: EvalTraceWidgetToolCall[] }) {
+  if (calls.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1">
+      {calls.map((call, i) => (
+        <div
+          key={`${call.name}-${i}`}
+          className="flex items-start gap-1.5 text-[11px]"
+        >
+          <Badge tone={call.ok ? "success" : "danger"}>
+            {call.ok ? "OK" : "ERR"}
+          </Badge>
+          <span className="min-w-0 break-all font-mono text-muted-foreground">
+            {call.name}
+            {call.error ? ` — ${call.error}` : ""}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RenderObservationCard({
+  observation,
+}: {
+  observation: EvalTraceWidgetRenderObservationView;
+}) {
+  const meta = STATUS_META[observation.status] ?? {
+    label: observation.status,
+    tone: "neutral" as Tone,
+    Icon: Ban,
+  };
+  const { Icon } = meta;
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-md border border-border/40 bg-muted/10 p-3"
+      data-testid="render-observation-card"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-mono text-xs font-medium">
+            {observation.toolName}
+          </span>
+          <Badge tone={meta.tone}>
+            <Icon className="h-3 w-3" aria-hidden />
+            {meta.label}
+          </Badge>
+        </div>
+        <span className="text-[11px] text-muted-foreground">
+          turn {observation.promptIndex + 1} · {observation.elapsedMs}ms
+        </span>
+      </div>
+
+      <Screenshot
+        url={observation.screenshotUrl}
+        alt={`${observation.toolName} render`}
+      />
+
+      {observation.resourceUri ? (
+        <div className="truncate font-mono text-[11px] text-muted-foreground">
+          {observation.resourceUri}
+        </div>
+      ) : null}
+
+      {observation.consoleErrors && observation.consoleErrors.length > 0 ? (
+        <details className="text-[11px]">
+          <summary className="cursor-pointer text-red-500">
+            {observation.consoleErrors.length} console error
+            {observation.consoleErrors.length === 1 ? "" : "s"}
+          </summary>
+          <ul className="mt-1 flex flex-col gap-0.5 pl-3">
+            {observation.consoleErrors.map((err, i) => (
+              <li
+                key={i}
+                className="break-all font-mono text-muted-foreground"
+              >
+                {err}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+function InteractionStepRow({
+  step,
+}: {
+  step: EvalTraceBrowserInteractionStepView;
+}) {
+  const Icon = ACTION_ICON[step.action] ?? MousePointerClick;
+  const note = step.note ? NOTE_META[step.note] : undefined;
+  return (
+    <div className="flex gap-2" data-testid="interaction-step-row">
+      <div className="flex flex-col items-center">
+        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border/50 bg-background text-[10px] font-medium text-muted-foreground">
+          {step.stepIndex}
+        </div>
+        <div className="mt-1 w-px flex-1 bg-border/40" aria-hidden />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5 pb-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium">
+            <Icon className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+            {formatBrowserAction(step)}
+          </span>
+          <span className="text-[11px] text-muted-foreground">
+            {step.elapsedMs}ms
+          </span>
+          {note ? <Badge tone={note.tone}>{note.label}</Badge> : null}
+        </div>
+        {step.screenshotUrl ? (
+          <Screenshot
+            url={step.screenshotUrl}
+            alt={`step ${step.stepIndex} screenshot`}
+          />
+        ) : null}
+        {step.widgetToolCalls && step.widgetToolCalls.length > 0 ? (
+          <WidgetToolCallList calls={step.widgetToolCalls} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function BrowserArtifactsView({
+  observations = [],
+  steps = [],
+  className,
+}: {
+  observations?: EvalTraceWidgetRenderObservationView[];
+  steps?: EvalTraceBrowserInteractionStepView[];
+  className?: string;
+}) {
+  // Map toolCallId → display name so the step timeline can title each group.
+  const nameByToolCallId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const obs of observations) map.set(obs.toolCallId, obs.toolName);
+    return map;
+  }, [observations]);
+
+  // Group steps into per-widget timelines, preserving the backend's order.
+  const stepGroups = useMemo(() => {
+    const order: string[] = [];
+    const byTool = new Map<string, EvalTraceBrowserInteractionStepView[]>();
+    for (const step of steps) {
+      if (!byTool.has(step.toolCallId)) {
+        byTool.set(step.toolCallId, []);
+        order.push(step.toolCallId);
+      }
+      byTool.get(step.toolCallId)!.push(step);
+    }
+    return order.map((toolCallId) => ({
+      toolCallId,
+      steps: byTool.get(toolCallId)!,
+    }));
+  }, [steps]);
+
+  if (observations.length === 0 && steps.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-md border border-dashed border-border/40 py-8 text-xs text-muted-foreground"
+        data-testid="browser-artifacts-empty"
+      >
+        No browser-rendered widgets in this iteration.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("flex min-h-0 flex-col gap-4 overflow-auto", className)}
+      data-testid="browser-artifacts-view"
+    >
+      {observations.length > 0 ? (
+        <section className="flex flex-col gap-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Render observations
+            <span className="ml-1.5 font-normal normal-case text-muted-foreground/70">
+              latest render per widget
+            </span>
+          </h3>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {observations.map((obs) => (
+              <RenderObservationCard
+                key={`${obs.toolCallId}-${obs.ts}`}
+                observation={obs}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {stepGroups.length > 0 ? (
+        <section className="flex flex-col gap-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Computer Use timeline
+          </h3>
+          <div className="flex flex-col gap-3">
+            {stepGroups.map((group) => (
+              <div
+                key={group.toolCallId}
+                className="rounded-md border border-border/40 bg-muted/10 p-3"
+                data-testid="interaction-step-group"
+              >
+                <div className="mb-2 flex items-center gap-2">
+                  <span className="truncate font-mono text-xs font-medium">
+                    {nameByToolCallId.get(group.toolCallId) ?? group.toolCallId}
+                  </span>
+                  <span className="text-[11px] text-muted-foreground">
+                    {group.steps.length} step
+                    {group.steps.length === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <div className="flex flex-col">
+                  {group.steps.map((step) => (
+                    <InteractionStepRow
+                      key={`${step.toolCallId}-${step.stepIndex}`}
+                      step={step}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -1,4 +1,4 @@
-import { AlignLeft, Code2, MessageSquare, Wrench } from "lucide-react";
+import { AlignLeft, Code2, MessageSquare, Monitor, Wrench } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { cn } from "@/lib/utils";
 import { standardEventProps } from "@/lib/PosthogUtils";
@@ -8,23 +8,41 @@ export type TraceViewMode = "timeline" | "chat" | "raw" | "tools";
 /**
  * Mode switcher for {@link TraceViewer} — shared with compare playground so Runs / CI / compare
  * use identical controls.
+ *
+ * The eval-only "Browser" tab (PR 7) is intentionally NOT part of `TraceViewMode`:
+ * the chat / playground / compare surfaces that reuse this switcher never show it,
+ * so it rides its own `browserActive` / `onSelectBrowser` props instead of widening
+ * the shared union (which every consumer's narrower state would then have to guard).
  */
 export function TraceViewModeTabs({
   mode,
   onModeChange,
   showToolsTab,
+  showBrowserTab = false,
+  browserActive = false,
+  onSelectBrowser,
   layout = "default",
   className,
 }: {
   mode: TraceViewMode;
   onModeChange: (mode: TraceViewMode) => void;
   showToolsTab: boolean;
+  /** PR 7: show the "Browser" tab when the iteration has browser-rendered
+   *  MCP App artifacts (render observations / Computer Use steps). */
+  showBrowserTab?: boolean;
+  /** PR 7: highlight the Browser tab (the active mode lives outside the shared
+   *  `TraceViewMode` union, in the trace viewer's local state). */
+  browserActive?: boolean;
+  /** PR 7: fired when the Browser tab is selected. */
+  onSelectBrowser?: () => void;
   /** `fullWidth`: equal-width segments across the container (e.g. chat trace header). */
   layout?: "default" | "fullWidth";
   className?: string;
 }) {
   const fullWidth = layout === "fullWidth";
   const posthog = usePostHog();
+  // When the Browser tab is active no standard tab is highlighted.
+  const standardActive = (m: TraceViewMode) => !browserActive && mode === m;
 
   const handleModeChange = (nextMode: TraceViewMode) => {
     posthog.capture("trace_view_mode_changed", {
@@ -55,7 +73,7 @@ export function TraceViewModeTabs({
         <button
           type="button"
           onClick={() => handleModeChange("tools")}
-          className={tabClass(mode === "tools")}
+          className={tabClass(standardActive("tools"))}
           title="Expected vs actual tool calls"
           data-testid="trace-viewer-tools-tab"
         >
@@ -66,7 +84,7 @@ export function TraceViewModeTabs({
       <button
         type="button"
         onClick={() => handleModeChange("timeline")}
-        className={tabClass(mode === "timeline")}
+        className={tabClass(standardActive("timeline"))}
         title="Trace"
       >
         <AlignLeft className="h-3 w-3 shrink-0" />
@@ -75,16 +93,34 @@ export function TraceViewModeTabs({
       <button
         type="button"
         onClick={() => handleModeChange("chat")}
-        className={tabClass(mode === "chat")}
+        className={tabClass(standardActive("chat"))}
         title="Chat view"
       >
         <MessageSquare className="h-3 w-3 shrink-0" />
         <span className="truncate">Chat</span>
       </button>
+      {showBrowserTab ? (
+        <button
+          type="button"
+          onClick={() => {
+            posthog.capture("trace_view_mode_changed", {
+              ...standardEventProps("trace_view_mode_tabs"),
+              mode: "browser",
+            });
+            onSelectBrowser?.();
+          }}
+          className={tabClass(browserActive)}
+          title="Browser-rendered widgets & Computer Use"
+          data-testid="trace-viewer-browser-tab"
+        >
+          <Monitor className="h-3 w-3 shrink-0" />
+          <span className="truncate">Browser</span>
+        </button>
+      ) : null}
       <button
         type="button"
         onClick={() => handleModeChange("raw")}
-        className={tabClass(mode === "raw")}
+        className={tabClass(standardActive("raw"))}
         title="Raw JSON"
       >
         <Code2 className="h-3 w-3 shrink-0" />

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
@@ -27,7 +27,11 @@ import {
   readToolResultMeta,
   readToolResultServerId,
 } from "@/lib/tool-result-utils";
-import type { EvalTraceSpan } from "@/shared/eval-trace";
+import type {
+  EvalTraceBrowserInteractionStepView,
+  EvalTraceSpan,
+  EvalTraceWidgetRenderObservationView,
+} from "@/shared/eval-trace";
 
 export interface TraceContentPart {
   type: string;
@@ -188,6 +192,10 @@ export interface TraceEnvelope {
   messages?: TraceSourceMessage[];
   widgetSnapshots?: TraceWidgetSnapshot[];
   spans?: EvalTraceSpan[];
+  // PR 7: browser-rendered MCP App eval artifacts, surfaced by the backend
+  // trace envelope with screenshot blob ids resolved to `screenshotUrl`.
+  widgetRenderObservations?: EvalTraceWidgetRenderObservationView[];
+  browserInteractionSteps?: EvalTraceBrowserInteractionStepView[];
   traceStartedAtMs?: number;
   traceEndedAtMs?: number;
   [key: string]: unknown;

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -12,7 +12,11 @@ import { StickToBottom } from "use-stick-to-bottom";
 import { Button } from "@mcpjam/design-system/button";
 import { ScrollToBottomButton } from "@/components/chat-v2/shared/scroll-to-bottom-button";
 import type { ModelDefinition, ModelProvider } from "@/shared/types";
-import type { EvalTraceSpan } from "@/shared/eval-trace";
+import type {
+  EvalTraceBrowserInteractionStepView,
+  EvalTraceSpan,
+  EvalTraceWidgetRenderObservationView,
+} from "@/shared/eval-trace";
 import type { ToolServerMap } from "@/lib/apis/mcp-tools-api";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { Thread } from "@/components/chat-v2/thread";
@@ -33,6 +37,7 @@ import {
 } from "./recorded-trace-toolbar";
 import { cn } from "@/lib/utils";
 import { TraceViewModeTabs } from "./trace-view-mode-tabs";
+import { BrowserArtifactsView } from "./browser-artifacts-view";
 import { ToolCallsDiffView } from "./tool-calls-diff-view";
 import {
   TraceRawView,
@@ -85,7 +90,8 @@ interface TraceViewerProps {
   expectedToolCalls?: TraceViewerEvalToolCall[];
   /** Tool calls observed for this iteration; enables the Tools tab. */
   actualToolCalls?: TraceViewerEvalToolCall[];
-  /** Force a single mode (used when TraceViewer is embedded into a larger shell). */
+  /** Force a single mode (used when TraceViewer is embedded into a larger shell).
+   *  The eval-only "browser" mode is trace-viewer-local, never forced by shells. */
   forcedViewMode?: "timeline" | "chat" | "raw" | "tools";
   /** Hide the internal toolbar when the parent shell provides its own tabs. */
   hideToolbar?: boolean;
@@ -194,6 +200,23 @@ function getRecordedSpans(
   return raw as EvalTraceSpan[];
 }
 
+// PR 7: pull the browser-rendered MCP App artifacts off the trace envelope.
+function getBrowserObservations(
+  trace: TraceEnvelope | TraceMessage | TraceMessage[] | null,
+): EvalTraceWidgetRenderObservationView[] {
+  if (!trace || Array.isArray(trace) || typeof trace !== "object") return [];
+  const raw = (trace as TraceEnvelope).widgetRenderObservations;
+  return Array.isArray(raw) ? raw : [];
+}
+
+function getBrowserSteps(
+  trace: TraceEnvelope | TraceMessage | TraceMessage[] | null,
+): EvalTraceBrowserInteractionStepView[] {
+  if (!trace || Array.isArray(trace) || typeof trace !== "object") return [];
+  const raw = (trace as TraceEnvelope).browserInteractionSteps;
+  return Array.isArray(raw) ? raw : [];
+}
+
 export function TraceViewer({
   trace,
   model,
@@ -255,7 +278,7 @@ export function TraceViewer({
     hostStyle ?? DEFAULT_TRACE_HOST_STYLE_FALLBACK;
 
   const [viewMode, setViewMode] = useState<
-    "timeline" | "chat" | "raw" | "tools"
+    "timeline" | "chat" | "raw" | "tools" | "browser"
   >("timeline");
   const [toolsCompareLayout, setToolsCompareLayout] = useState<"diff" | "json">(
     "diff",
@@ -287,6 +310,16 @@ export function TraceViewer({
     expectedToolCalls.length > 0 || actualToolCalls.length > 0;
   const effectiveViewMode = forcedViewMode ?? viewMode;
   const recordedSpans = useMemo(() => getRecordedSpans(trace), [trace]);
+  // PR 7: browser-rendered MCP App eval artifacts (render observations +
+  // Computer Use steps). Only iterations driven through the headless-Chromium
+  // harness carry these, so the Browser tab is gated on their presence.
+  const browserObservations = useMemo(
+    () => getBrowserObservations(trace),
+    [trace],
+  );
+  const browserSteps = useMemo(() => getBrowserSteps(trace), [trace]);
+  const hasBrowserArtifacts =
+    browserObservations.length > 0 || browserSteps.length > 0;
   const promptGroups = useMemo(
     () => (recordedSpans?.length ? buildPromptGroups(recordedSpans) : []),
     [recordedSpans],
@@ -361,6 +394,12 @@ export function TraceViewer({
   }, [hasEvalToolCalls]);
 
   useEffect(() => {
+    if (!hasBrowserArtifacts) {
+      setViewMode((mode) => (mode === "browser" ? "timeline" : mode));
+    }
+  }, [hasBrowserArtifacts]);
+
+  useEffect(() => {
     if (effectiveViewMode !== "raw" && effectiveViewMode !== "chat") return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
@@ -430,6 +469,7 @@ export function TraceViewer({
   const flexFillChrome =
     fillContent ||
     effectiveViewMode === "raw" ||
+    effectiveViewMode === "browser" ||
     (effectiveViewMode === "tools" && hasEvalToolCalls);
 
   const toolsCompareLayoutToggle = (
@@ -567,9 +607,16 @@ export function TraceViewer({
               </div>
               {!forcedViewMode ? (
                 <TraceViewModeTabs
-                  mode={effectiveViewMode}
+                  mode={
+                    effectiveViewMode === "browser"
+                      ? "timeline"
+                      : effectiveViewMode
+                  }
                   onModeChange={setViewMode}
                   showToolsTab={hasEvalToolCalls}
+                  showBrowserTab={hasBrowserArtifacts}
+                  browserActive={effectiveViewMode === "browser"}
+                  onSelectBrowser={() => setViewMode("browser")}
                 />
               ) : null}
             </div>
@@ -608,6 +655,24 @@ export function TraceViewer({
               trace={trace}
               requestPayloadHistory={rawRequestPayloadHistory}
               growWithContent={rawGrowWithContent}
+            />
+          </div>
+        )}
+
+        {effectiveViewMode === "browser" && (
+          <div
+            className={cn(
+              "min-w-0 flex flex-col",
+              flexFillChrome
+                ? "min-h-0 flex-1"
+                : "min-h-0 max-h-[min(70vh,36rem)]",
+            )}
+            data-testid="trace-viewer-browser"
+          >
+            <BrowserArtifactsView
+              observations={browserObservations}
+              steps={browserSteps}
+              className={flexFillChrome ? "flex-1" : undefined}
             />
           </div>
         )}

--- a/mcpjam-inspector/shared/eval-trace.ts
+++ b/mcpjam-inspector/shared/eval-trace.ts
@@ -230,6 +230,47 @@ export type BrowserInteractionStepPayload = Omit<
   "promptIndex"
 >;
 
+// PR 7: shapes the backend trace envelope returns to the replay UI. The
+// backend (`getEvalTraceFromChatSession` + `addBrowserArtifactUrls`) collects
+// the PR 6b tables, keeps `promptIndex`, and resolves `screenshotBlobId` →
+// `screenshotUrl` (null when no blob). `serverId` arrives as the resolved
+// Convex doc id; the UI keys on `toolName` / `toolCallId` for display.
+
+export type EvalTraceWidgetRenderObservationView = {
+  toolCallId: string;
+  toolName: string;
+  serverId?: string;
+  promptIndex: number;
+  status: EvalTraceWidgetRenderStatus;
+  resourceUri?: string;
+  bridgeInitialized?: boolean;
+  screenshotBlobId?: string;
+  screenshotUrl?: string | null;
+  consoleErrors?: string[];
+  blockedRequests?: string[];
+  elapsedMs: number;
+  ts: number;
+};
+
+export type EvalTraceBrowserInteractionStepView = {
+  toolCallId: string;
+  stepIndex: number;
+  promptIndex: number;
+  action: EvalTraceBrowserAction;
+  coordinateX?: number;
+  coordinateY?: number;
+  text?: string;
+  scrollDirection?: "up" | "down" | "left" | "right";
+  scrollAmount?: number;
+  duration?: number;
+  screenshotBlobId?: string;
+  screenshotUrl?: string | null;
+  widgetToolCalls?: EvalTraceWidgetToolCall[];
+  elapsedMs: number;
+  note?: EvalTraceBrowserStepNote;
+  ts: number;
+};
+
 /** Versioned blob written by `testSuites:updateTestIteration` when messages are stored. */
 export type EvalTraceBlobV1 = {
   traceVersion: 1;


### PR DESCRIPTION
## Summary

Inspector‑side **PR 7** — the eval replay UI for browser‑rendered MCP Apps. Adds a dedicated **"Browser"** tab to the eval iteration trace viewer that surfaces what **PR 6b (#2499, merged)** persists and the backend (**mcpjam-backend#475**) exposes via the trace envelope.

> Requires backend **mcpjam-backend#475** deployed — it adds `widgetRenderObservations` / `browserInteractionSteps` (+ resolved `screenshotUrl`) to the `getTestIterationBlob` envelope.

## What's in the tab

- **Render observations** — one card per MCP App widget showing the **latest** render outcome: a status badge (`Rendered` / `Render error` / `Bridge timeout` / `Browser unavailable` / …), the screenshot, resource URI, timing, and collapsible console errors.
- **Computer Use timeline** — steps grouped per widget, each with its action (`Left click (640, 400)`, `Type "…"`, `Scroll down ×3`, …), screenshot, any widget‑initiated `tools/call` (OK/ERR), and budget notes.

## Design notes

- The eval‑only **"browser" mode is trace‑viewer‑local**: it rides dedicated `browserActive` / `onSelectBrowser` props on `TraceViewModeTabs` rather than widening the shared `TraceViewMode` union — so the chat / playground / compare surfaces that reuse the switcher are untouched (no guard churn across 5 files).
- The tab is **gated on artifact presence** (non‑browser evals never see it); if artifacts vanish, the viewer resets to the timeline.
- `promptIndex` is rendered as **"turn N"** = the latest turn a widget re‑rendered in (the backend upserts the observation row per `toolCallId`), not "first observed" — matching the PR 6b semantics.

## Testing

`262` trace / eval / chat / playground tests green; **client `tsc` clean**. New coverage:
- `BrowserArtifactsView` (8): empty state, render cards + status labels + screenshot, "No screenshot" placeholder on failure, console‑error disclosure, per‑widget timeline grouping/titling, widget tool calls + budget note, `toolCallId` fallback, and `formatBrowserAction` for every action variant.
- Browser‑tab visibility + active‑state, incl. "no standard tab highlighted while Browser is active" (5).

Verified no regressions across `ChatTabV2`, `PlaygroundMain`, multi‑model cards, `test-template-editor`, `iteration-details`, and `trace-viewer`/`-adapter`.

## Follow-ups

PR 13 metrics (status distribution / budget‑exceeded counts) can build on the same envelope. Inline status badges on tool calls in the existing Tools tab were intentionally deferred to keep this a clean first cut.

https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inspector-only eval UI and types; Browser tab is opt-in via artifact presence and does not widen shared trace mode unions used elsewhere.
> 
> **Overview**
> Adds an eval-only **Browser** tab to the iteration trace viewer so replay can show headless-Chromium harness output from the trace envelope (`widgetRenderObservations`, `browserInteractionSteps` with resolved `screenshotUrl`).
> 
> **`BrowserArtifactsView`** is new: render-observation cards (status badges, turn timing, screenshots, failure copy, console errors) and a **Computer Use** timeline grouped by widget with formatted actions, step screenshots, widget `tools/call` results, and budget notes.
> 
> **`TraceViewer`** reads those fields off `TraceEnvelope`, shows the tab only when artifacts exist, resets to timeline if they disappear, and keeps browser mode local (not in shared `TraceViewMode`). **`TraceViewModeTabs`** gains optional `showBrowserTab` / `browserActive` / `onSelectBrowser` so chat/playground/compare reuse stays unchanged. Shared **`EvalTraceWidgetRenderObservationView`** and **`EvalTraceBrowserInteractionStepView`** types document the backend envelope shape.
> 
> Tests cover **`BrowserArtifactsView`**, browser tab visibility/active styling, and **`formatBrowserAction`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cddb0a7438fd7e4d797aa86e1baa4fd9651cddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->