### PR TITLE
billing: rework compare-plans around credits & eval iterations

### DIFF
--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -256,34 +256,29 @@ const COMPARE_PLAN_ROW_LABEL_TOOLTIPS: Record<
   string,
   { ariaLabel: string; content: string; contentClassName?: string }
 > = {
-  "Triage Insights": {
-    ariaLabel: "About Triage Insights",
-    content: "Recommendations for how to improve your server.",
-    contentClassName: "max-w-[20rem]",
-  },
-  "Evaluation traces": {
-    ariaLabel: "What are evaluation traces?",
+  "Included credits": {
+    ariaLabel: "About included credits",
     content:
-      "Traces for evaluations: configured user prompts, tool execution, agent reasoning, errors, and latency breakdown for playground and CI/CD runs.",
-    contentClassName: "max-w-[26rem]",
-  },
-  "Insights Data Export": {
-    ariaLabel: "About insights data export",
-    content:
-      "Export triage and evaluation insights for analysis outside MCPJam.",
+      "Model credits for playground, chat, and agent usage. Free resets daily; Team is allocated per seat each month.",
     contentClassName: "max-w-[22rem]",
-  },
-  Projects: {
-    ariaLabel: "What is a project?",
-    content:
-      "Projects are containers for your MCP servers and related objects.",
-    contentClassName: "max-w-[16rem]",
   },
   "Seat limit": {
     ariaLabel: "About seat limits",
     content:
       "You're charged only for active members. Pending invites are free until accepted.",
     contentClassName: "max-w-[18rem]",
+  },
+  "Eval iterations": {
+    ariaLabel: "About eval iterations",
+    content:
+      "Suite and quick eval runs count toward your plan's iteration allowance. Free resets daily; Team resets monthly.",
+    contentClassName: "max-w-[22rem]",
+  },
+  "Evaluation traces": {
+    ariaLabel: "What are evaluation traces?",
+    content:
+      "Traces for evaluations: configured user prompts, tool execution, agent reasoning, errors, and latency breakdown for playground and CI/CD runs.",
+    contentClassName: "max-w-[26rem]",
   },
   "SSO / SAML": {
     ariaLabel: "About SSO",
@@ -347,6 +342,12 @@ function ComparePlanRowLabel({
   );
 }
 
+const COMPARE_PLAN_PERIOD_SUFFIXES = [
+  "/ seat / mo",
+  "/ day",
+  "/ mo",
+] as const;
+
 function ComparePlanMatrixCell({ cell }: { cell: ComparePlanCell }) {
   if (cell.kind === "check") {
     return (
@@ -364,6 +365,22 @@ function ComparePlanMatrixCell({ cell }: { cell: ComparePlanCell }) {
       </span>
     );
   }
+
+  const periodSuffix = COMPARE_PLAN_PERIOD_SUFFIXES.find((suffix) =>
+    cell.text.endsWith(suffix),
+  );
+  if (periodSuffix) {
+    const amount = cell.text.slice(0, -periodSuffix.length).trimEnd();
+    return (
+      <span className="flex w-full items-baseline justify-center gap-x-1 text-sm">
+        <span className="font-semibold tabular-nums text-foreground">
+          {amount}
+        </span>
+        <span className="font-normal text-muted-foreground">{periodSuffix}</span>
+      </span>
+    );
+  }
+
   return (
     <span
       className={cn(
@@ -982,16 +999,18 @@ export function OrganizationBillingSection({
                       <TableBody>
                         {(compareSections ?? []).map((section) => (
                           <Fragment key={section.title}>
-                            <TableRow className="border-b hover:bg-transparent">
-                              <TableCell
-                                className="bg-muted/40 py-2.5 pl-4"
-                                colSpan={PLAN_ORDER.length + 1}
-                              >
-                                <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                                  {section.title}
-                                </div>
-                              </TableCell>
-                            </TableRow>
+                            {!section.hideTitle ? (
+                              <TableRow className="border-b hover:bg-transparent">
+                                <TableCell
+                                  className="bg-muted/40 py-2.5 pl-4"
+                                  colSpan={PLAN_ORDER.length + 1}
+                                >
+                                  <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                                    {section.title}
+                                  </div>
+                                </TableCell>
+                              </TableRow>
+                            ) : null}
                             {section.rows.map((row, rowIndex) => {
                               const cells: ComparePlanCell[] = [
                                 row.free,

--- a/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { COMPARE_PLAN_MARKETING_SECTIONS } from "@/components/organization/compare-plan-marketing";
 import { buildComparePlanSectionsFromCatalog } from "@/components/organization/billing-compare-view-model";
 import type { PlanCatalog } from "@/hooks/useOrganizationBilling";
 
@@ -52,40 +53,17 @@ function createPlanCatalog(): PlanCatalog {
   };
 }
 
-function findRow(
-  sections: ReturnType<typeof buildComparePlanSectionsFromCatalog>,
-  label: string,
-) {
-  for (const section of sections) {
-    const row = section.rows.find((r) => r.label === label);
-    if (row) return row;
-  }
-  throw new Error(`${label} row not found`);
-}
-
 describe("buildComparePlanSectionsFromCatalog", () => {
-  it("renders uncapped Free and Team org/project limits from the catalog", () => {
+  it("returns the static marketing compare sections", () => {
     const sections = buildComparePlanSectionsFromCatalog(createPlanCatalog());
-    const seatLimit = findRow(sections, "Seat limit");
-    const projects = findRow(sections, "Projects");
 
-    expect(seatLimit.free).toMatchObject({
-      kind: "text",
-      text: "Unlimited",
-    });
-    expect(seatLimit.team).toEqual({
-      kind: "text",
-      text: "Unlimited",
-      emphasize: true,
-    });
-    expect(projects.free).toMatchObject({
-      kind: "text",
-      text: "Unlimited",
-    });
-    expect(projects.team).toEqual({
-      kind: "text",
-      text: "Unlimited",
-      emphasize: true,
-    });
+    expect(sections).toBe(COMPARE_PLAN_MARKETING_SECTIONS);
+    expect(sections.map((section) => section.title)).toEqual([
+      "Credits & seats",
+      "Evaluations",
+      "Security & Compliance",
+      "Support",
+      "Standard features",
+    ]);
   });
 });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -4,9 +4,8 @@ import { COMPARE_PLAN_MARKETING_SECTIONS } from "../compare-plan-marketing";
 describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
   it("mirrors the marketing compare table sections and row coverage", () => {
     expect(COMPARE_PLAN_MARKETING_SECTIONS.map((s) => s.title)).toEqual([
-      "Organization & projects",
+      "Credits & seats",
       "Evaluations",
-      "LLM Usage",
       "Security & Compliance",
       "Support",
       "Standard features",
@@ -26,7 +25,7 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
       (n, s) => n + s.rows.length,
       0,
     );
-    expect(rowCount).toBe(22);
+    expect(rowCount).toBe(15);
 
     const standardFeatures = COMPARE_PLAN_MARKETING_SECTIONS.find(
       (s) => s.title === "Standard features",
@@ -40,63 +39,65 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     ]);
   });
 
-  it("includes representative product and org/project cells", () => {
-    const evaluations = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Evaluations",
-    );
-    expect(
-      evaluations?.rows.some((r) => r.label === "Eval iteration cap"),
-    ).toBe(false);
-    expect(
-      evaluations?.rows.some((r) => r.label === "Eval iteration overage"),
-    ).toBe(false);
-    expect(
-      evaluations?.rows.find((r) => r.label === "Triage Insights")?.free,
-    ).toEqual({ kind: "check" });
+  it("leads the table with credits and seat limits before Evaluations", () => {
+    const creditsAndSeats = COMPARE_PLAN_MARKETING_SECTIONS[0];
 
-    const orgProjects = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Organization & projects",
-    );
-    expect(
-      orgProjects?.rows.find((r) => r.label === "Seat limit")?.free,
-    ).toEqual({
+    expect(creditsAndSeats?.hideTitle).toBe(true);
+    expect(creditsAndSeats?.rows.map((row) => row.label)).toEqual([
+      "Included credits",
+      "Seat limit",
+    ]);
+    expect(creditsAndSeats?.rows[0]?.free).toEqual({
+      kind: "text",
+      text: "200 / day",
+    });
+    expect(creditsAndSeats?.rows[0]?.team).toEqual({
+      kind: "text",
+      text: "6,000 / seat / mo",
+      emphasize: true,
+    });
+    expect(creditsAndSeats?.rows[1]?.team).toEqual({
       kind: "text",
       text: "Unlimited",
-    });
-    const security = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Security & Compliance",
-    );
-    expect(
-      security?.rows.find((r) => r.label === "SSO / SAML")?.enterprise,
-    ).toEqual({ kind: "check" });
-  });
-
-  it("keeps the LLM usage copy aligned to the daily per-user rate limit", () => {
-    const llmUsage = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "LLM Usage",
-    );
-    const rateLimitRow = llmUsage?.rows.find(
-      (r) => r.label === "Free daily credits / user",
-    );
-
-    expect(rateLimitRow?.team).toEqual({
-      kind: "text",
-      text: "$5",
       emphasize: true,
     });
   });
 
-  it("keeps insights data export on Enterprise only", () => {
+  it("leads Evaluations with eval iteration allowances", () => {
     const evaluations = COMPARE_PLAN_MARKETING_SECTIONS.find(
       (s) => s.title === "Evaluations",
     );
-    const exportRow = evaluations?.rows.find(
-      (r) => r.label === "Insights Data Export",
+    const evalIterations = evaluations?.rows[0];
+
+    expect(evalIterations?.label).toBe("Eval iterations");
+    expect(evalIterations?.free).toEqual({
+      kind: "text",
+      text: "25 / day",
+    });
+    expect(evalIterations?.team).toEqual({
+      kind: "text",
+      text: "5,000 / mo",
+      emphasize: true,
+    });
+    expect(evalIterations?.enterprise).toEqual({
+      kind: "text",
+      text: "Custom",
+      emphasize: true,
+    });
+  });
+
+  it("keeps Evaluations focused on iteration limits and traces", () => {
+    const evaluations = COMPARE_PLAN_MARKETING_SECTIONS.find(
+      (s) => s.title === "Evaluations",
     );
 
-    expect(exportRow?.free).toEqual({ kind: "x" });
-    expect(exportRow?.team).toEqual({ kind: "x" });
-    expect(exportRow?.enterprise).toEqual({ kind: "check" });
+    expect(evaluations?.rows.map((row) => row.label)).toEqual([
+      "Eval iterations",
+      "Traces",
+    ]);
+    expect(
+      evaluations?.rows.find((r) => r.label === "Traces")?.enterprise,
+    ).toEqual({ kind: "check" });
   });
 
   it("keeps audit logs positioned on Enterprise only", () => {
@@ -115,24 +116,4 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     });
   });
 
-  it("advertises unlimited servers per project across every tier (matches backend entitlement)", () => {
-    const orgProjects = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Organization & projects",
-    );
-    const serversRow = orgProjects?.rows.find(
-      (r) => r.label === "Servers per project",
-    );
-
-    expect(serversRow?.free).toEqual({ kind: "text", text: "Unlimited" });
-    expect(serversRow?.team).toEqual({
-      kind: "text",
-      text: "Unlimited",
-      emphasize: true,
-    });
-    expect(serversRow?.enterprise).toEqual({
-      kind: "text",
-      text: "Unlimited",
-      emphasize: true,
-    });
-  });
 });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -53,7 +53,7 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     });
     expect(creditsAndSeats?.rows[0]?.team).toEqual({
       kind: "text",
-      text: "6,000 / seat / mo",
+      text: "10,000 / seat / mo",
       emphasize: true,
     });
     expect(creditsAndSeats?.rows[1]?.team).toEqual({

--- a/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
+++ b/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
@@ -1,93 +1,11 @@
 import {
   COMPARE_PLAN_MARKETING_SECTIONS,
-  type ComparePlanCell,
   type ComparePlanSection,
 } from "@/components/organization/compare-plan-marketing";
-import type {
-  OrganizationPlan,
-  PlanCatalog,
-  PlanCatalogEntry,
-} from "@/hooks/useOrganizationBilling";
-
-function t(text: string, emphasize?: boolean): ComparePlanCell {
-  return { kind: "text", text, emphasize };
-}
-
-function getEntry(
-  planCatalog: PlanCatalog,
-  plan: OrganizationPlan,
-): PlanCatalogEntry {
-  return planCatalog.plans[plan];
-}
-
-function formatSeatLimit(
-  plan: OrganizationPlan,
-  entry: PlanCatalogEntry,
-): ComparePlanCell {
-  if (plan === "enterprise") {
-    return t("Custom", true);
-  }
-  const value = entry.limits.maxMembers;
-  if (value == null) {
-    return t("Unlimited", plan === "team");
-  }
-  return t(`${value}`, plan === "team");
-}
-
-function formatLimitValue(
-  value: number | null,
-  emphasize?: boolean,
-): ComparePlanCell {
-  if (value == null) {
-    return t("Unlimited", emphasize);
-  }
-  return t(value.toLocaleString(), emphasize);
-}
+import type { PlanCatalog } from "@/hooks/useOrganizationBilling";
 
 export function buildComparePlanSectionsFromCatalog(
-  planCatalog: PlanCatalog,
+  _planCatalog: PlanCatalog,
 ): ComparePlanSection[] {
-  return COMPARE_PLAN_MARKETING_SECTIONS.map((section) => ({
-    ...section,
-    rows: section.rows.map((row) => {
-      switch (row.label) {
-        case "Seat limit":
-          return {
-            ...row,
-            free: formatSeatLimit("free", getEntry(planCatalog, "free")),
-            team: formatSeatLimit("team", getEntry(planCatalog, "team")),
-            enterprise: formatSeatLimit(
-              "enterprise",
-              getEntry(planCatalog, "enterprise"),
-            ),
-          };
-        case "Projects":
-          return {
-            ...row,
-            free: formatLimitValue(
-              getEntry(planCatalog, "free").limits.maxProjects,
-            ),
-            team: formatLimitValue(
-              getEntry(planCatalog, "team").limits.maxProjects,
-              true,
-            ),
-            enterprise: t("Custom", true),
-          };
-        case "Servers per project":
-          return {
-            ...row,
-            free: formatLimitValue(
-              getEntry(planCatalog, "free").limits.maxServersPerProject,
-            ),
-            team: formatLimitValue(
-              getEntry(planCatalog, "team").limits.maxServersPerProject,
-              true,
-            ),
-            enterprise: t("Unlimited", true),
-          };
-        default:
-          return row;
-      }
-    }),
-  }));
+  return COMPARE_PLAN_MARKETING_SECTIONS;
 }

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -1,7 +1,7 @@
 /**
  * Marketing compare-plans table: product rows mirror `mcpjam_pricing_page.html`;
- * org/project counts are uncapped, while eval caps, credits, and enterprise
- * security features carry the remaining commercial distinctions.
+ * eval caps and enterprise security features carry the commercial
+ * distinctions.
  */
 
 export type ComparePlanCell =
@@ -20,6 +20,8 @@ export type ComparePlanRow = {
 
 export type ComparePlanSection = {
   title: string;
+  /** When true, rows render without the uppercase section header row. */
+  hideTitle?: boolean;
   rows: ComparePlanRow[];
 };
 
@@ -29,31 +31,20 @@ function t(text: string, emphasize?: boolean): ComparePlanCell {
   return { kind: "text", text, emphasize };
 }
 
-/** Section order: organization & projects, evaluations, LLM usage, security, support, standard features. */
+/** Section order: credits & seats, evaluations, security, support, standard features. */
 export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
   {
-    title: "Organization & projects",
+    title: "Credits & seats",
+    hideTitle: true,
     rows: [
       {
+        label: "Included credits",
+        free: t("200 / day"),
+        team: t("6,000 / seat / mo", true),
+        enterprise: t("Custom", true),
+      },
+      {
         label: "Seat limit",
-        free: t("Unlimited"),
-        team: t("Unlimited", true),
-        enterprise: t("Custom", true),
-      },
-      {
-        label: "Projects",
-        free: t("Unlimited"),
-        team: t("Unlimited", true),
-        enterprise: t("Custom", true),
-      },
-      {
-        label: "Project access levels",
-        free: x,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Servers per project",
         free: t("Unlimited"),
         team: t("Unlimited", true),
         enterprise: t("Unlimited", true),
@@ -64,52 +55,17 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     title: "Evaluations",
     rows: [
       {
+        label: "Eval iterations",
+        free: t("25 / day"),
+        team: t("5,000 / mo", true),
+        enterprise: t("Custom", true),
+      },
+      {
         label: "Traces",
         tooltipKey: "Evaluation traces",
         free: c,
         team: c,
         enterprise: c,
-      },
-      {
-        label: "Playground",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Triage Insights",
-        free: c,
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Insights Data Export",
-        free: x,
-        team: x,
-        enterprise: c,
-      },
-    ],
-  },
-  {
-    title: "LLM Usage",
-    rows: [
-      {
-        label: "Open models",
-        free: t("Rate limited"),
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Frontier models",
-        free: t("Rate limited"),
-        team: c,
-        enterprise: c,
-      },
-      {
-        label: "Free daily credits / user",
-        free: x,
-        team: t("$5", true),
-        enterprise: t("Custom", true),
       },
     ],
   },
@@ -117,16 +73,16 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     title: "Security & Compliance",
     rows: [
       {
-        label: "SSO / SAML",
-        free: x,
-        team: x,
-        enterprise: c,
-      },
-      {
         label: "Role-based access control (RBAC)",
         free: x,
         team: t("Basic", true),
         enterprise: t("Custom", true),
+      },
+      {
+        label: "SSO / SAML",
+        free: x,
+        team: x,
+        enterprise: c,
       },
       {
         label: "Audit log retention",

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -40,7 +40,7 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
       {
         label: "Included credits",
         free: t("200 / day"),
-        team: t("6,000 / seat / mo", true),
+        team: t("10,000 / seat / mo", true),
         enterprise: t("Custom", true),
       },
       {


### PR DESCRIPTION
## Summary
- Collapse `Organization & projects` + `LLM Usage` into a single headerless `Credits & seats` lead section with `Included credits` (200 / day on Free, 6,000 / seat / mo on Team) and `Seat limit`.
- Lead `Evaluations` with a new `Eval iterations` row (25 / day, 5,000 / mo, Custom on Enterprise) and drop derived org/project rows (Projects, Project access levels, Servers per project) and the legacy LLM-usage rows.
- Render `/ seat / mo`, `/ day`, `/ mo` period suffixes with muted styling so the amount stays prominent; add a `hideTitle` flag on `ComparePlanSection` for the lead section.
- View model now returns the static marketing sections directly since no rows are catalog-derived anymore.

## Test plan
- [ ] `npm run test -- billing-compare-view-model compare-plan-marketing` in `mcpjam-inspector/client`
- [ ] Visually verify the compare table on the billing page: Credits & seats leads without a section header, period suffixes render muted, Evaluations leads with Eval iterations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Compare limits are now fixed marketing strings instead of plan-catalog limits, so the UI can diverge from live entitlements if catalog or backend caps change without updating compare-plan-marketing.
> 
> **Overview**
> **Reworks the org billing compare table** so marketing copy leads with **Included credits** and **Seat limit** (headerless **Credits & seats** section), then **Eval iterations** and **Traces** under **Evaluations**. Removes the old **Organization & projects**, **LLM Usage**, and related rows (projects, servers, triage insights, insights export, frontier/open models, etc.)—**15 rows** down from **22**.
> 
> **`buildComparePlanSectionsFromCatalog`** no longer merges catalog limits into seat/project/server rows; it returns the static **`COMPARE_PLAN_MARKETING_SECTIONS`** only. Compare cells with **`/ day`**, **`/ mo`**, or **`/ seat / mo`** now split amount vs period styling; sections can set **`hideTitle`** to skip the section header row. Row tooltips were updated for credits and eval iterations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c048491e2b394d7c1a19ffa9280d7b3fa32225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->