### PR TITLE
billing: limit users to 1 self-created organization

### DIFF
--- a/.changeset/inspector-rollup-pre-soundcheck-deploy.md
+++ b/.changeset/inspector-rollup-pre-soundcheck-deploy.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Inspector rollup since the last release:
+
+- Chatbox OAuth: attach the WorkOS bearer token on `/oauth/callback` to fix the 403 some users hit when finishing the chatbox auth flow.
+- Sidebar credit usage: clicking the progress bar now sends the user to billing.
+- Compare-plans table: removed the team seat-minimum label and finished the Projects row in the plan comparison.
+- Chatbox builder: removed the unused `allowGuestAccess` toggle.

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
@@ -292,7 +292,7 @@ export function SidebarContextSwitcher({
                     <TooltipContent side="top" sideOffset={6}>
                       {canCreateOrganization
                         ? "New organization"
-                        : "You can only create up to 2 organizations."}
+                        : "You can only create one organization. Ask to be invited to others."}
                     </TooltipContent>
                   </Tooltip>
                 </div>

--- a/mcpjam-inspector/client/src/hooks/useOrganizations.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizations.ts
@@ -16,7 +16,7 @@ export interface Organization {
   isCreator?: boolean;
 }
 
-export const ORGANIZATION_CREATION_LIMIT = 2;
+export const ORGANIZATION_CREATION_LIMIT = 1;
 
 export interface OrganizationMember {
   _id: string;


### PR DESCRIPTION
## Summary
- Lowers `ORGANIZATION_CREATION_LIMIT` from 2 → 1 in `client/src/hooks/useOrganizations.ts`
- Updates the create-org tooltip copy to direct users to ask for invitations
- Membership via invitation remains uncapped — only self-created orgs count toward the limit (existing filter on `isCreator`)

Pairs with the backend PR that lowers the server-side cap to match.

## Test plan
- [ ] Authed user with 0 self-created orgs sees the "New organization" tooltip and the + button is enabled
- [ ] After creating 1 org, the + button is disabled and the tooltip reads "You can only create one organization. Ask to be invited to others."
- [ ] User invited to additional orgs (not creator) can still join unlimited orgs
- [ ] Existing users with 2 self-created orgs keep both (grandfathered; no migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small product-policy UI change with no auth or data migration; existing users with two creator orgs remain grandfathered per test plan.
> 
> **Overview**
> **Lowers the client-side cap on self-created organizations from 2 to 1** by changing `ORGANIZATION_CREATION_LIMIT` in `useOrganizations.ts`. `canCreateOrganization` still only counts orgs where the user is the creator (`isCreator`), so invited memberships are unchanged.
> 
> When the limit is hit, the sidebar **“New organization”** tooltip now tells users they can only create one org and should **ask to be invited** to others.
> 
> Also adds a patch **changeset** rollup for `@mcpjam/inspector` (OAuth callback bearer token, billing link on credit bar, compare-plans tweaks, chatbox builder toggle removal)—separate from the org limit but shipped in the same changeset file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44c9a2eef1b3be0cac7e40575f85610f62c65c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->