### PR TITLE
byok: route Settings provider config to the org path

### DIFF
--- a/mcpjam-inspector/client/src/components/SettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SettingsTab.tsx
@@ -1,32 +1,16 @@
-import { useAiProviderKeys } from "@/hooks/use-ai-provider-keys";
-import { useCustomProviders } from "@/hooks/use-custom-providers";
-import { useState } from "react";
-import { ProviderConfigDialog } from "./setting/ProviderConfigDialog";
-import { OllamaConfigDialog } from "./setting/OllamaConfigDialog";
-import { CustomProviderConfigDialog } from "./setting/CustomProviderConfigDialog";
-import { OpenRouterConfigDialog } from "./setting/OpenRouterConfigDialog";
-import { AzureOpenAIConfigDialog } from "./setting/AzureOpenAIConfigDialog";
+import { useByokAllowed } from "@/hooks/use-byok-allowed";
+import { useAuth } from "@workos-inc/authkit-react";
+import { usePostHog } from "posthog-js/react";
 import { SettingsSection } from "./setting/SettingsSection";
 import { SettingsRow } from "./setting/SettingsRow";
-import { ProviderRow } from "./setting/ProviderRow";
+import { EmptyState } from "./ui/empty-state";
 import { Switch } from "@mcpjam/design-system/switch";
 import { Button } from "@mcpjam/design-system/button";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { updateThemeMode } from "@/lib/theme-utils";
-import { Plus, Pencil, Trash2, Info } from "lucide-react";
+import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
+import { Info, KeyRound } from "lucide-react";
 import { HOSTED_MODE } from "@/lib/config";
-
-import type { CustomProvider } from "@mcpjam/sdk/browser";
-
-interface ProviderConfig {
-  id: string;
-  name: string;
-  logo: string;
-  logoAlt: string;
-  description: string;
-  placeholder: string;
-  getApiKeyUrl: string;
-}
 
 interface SettingsTabProps {
   activeOrganizationId?: string;
@@ -39,234 +23,21 @@ export function SettingsTab({
 }: SettingsTabProps = {}) {
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const setThemeMode = usePreferencesStore((s) => s.setThemeMode);
-  const {
-    tokens,
-    setToken,
-    clearToken,
-    hasToken,
-    getOllamaBaseUrl,
-    setOllamaBaseUrl,
-    getOpenRouterSelectedModels,
-    setOpenRouterSelectedModels,
-    getAzureBaseUrl,
-    setAzureBaseUrl,
-  } = useAiProviderKeys();
-  const {
-    customProviders,
-    addCustomProvider,
-    updateCustomProvider,
-    removeCustomProvider,
-  } = useCustomProviders();
+  const byokAllowed = useByokAllowed();
+  const { signIn } = useAuth();
+  const posthog = usePostHog();
 
-  // When the user is in an org-backed context, LLM provider configuration is
-  // managed at the organization level, not per-user in local storage.
+  // Model providers are tied to organizations. The Settings tab only points
+  // users at the right place to configure them — it does not store keys
+  // locally. Hosted mode hides the section entirely (the surface lives in
+  // the org dashboard); local OSS either signs the user in, points them at
+  // their active org, or nudges them to create one.
   const isOrgBacked = !!activeOrganizationId;
-
-  const [editingValue, setEditingValue] = useState("");
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [selectedProvider, setSelectedProvider] =
-    useState<ProviderConfig | null>(null);
-  const [ollamaDialogOpen, setOllamaDialogOpen] = useState(false);
-  const [ollamaUrl, setOllamaUrl] = useState("");
-  const [openRouterDialogOpen, setOpenRouterDialogOpen] = useState(false);
-  const [openRouterApiKeyInput, setOpenRouterApiKeyInput] = useState("");
-  const [openRouterSelectedModelsInput, setOpenRouterSelectedModelsInput] =
-    useState<string[]>([]);
-  const [azureDialogOpen, setAzureDialogOpen] = useState(false);
-  const [azureUrl, setAzureUrl] = useState("");
-  const [azureApiKey, setAzureApiKey] = useState("");
-
-  // Custom provider dialog state
-  const [customProviderDialogOpen, setCustomProviderDialogOpen] =
-    useState(false);
-  const [editingCustomProviderIndex, setEditingCustomProviderIndex] = useState<
-    number | null
-  >(null);
-
-  const providerConfigs: ProviderConfig[] = [
-    {
-      id: "openai",
-      name: "OpenAI",
-      logo: "/openai_logo.png",
-      logoAlt: "OpenAI",
-      description: "GPT-4, GPT-4o, GPT-4o-mini, GPT-4.1, GPT-5",
-      placeholder: "sk-...",
-      getApiKeyUrl: "https://platform.openai.com/api-keys",
-    },
-    {
-      id: "anthropic",
-      name: "Anthropic",
-      logo: "/claude_logo.png",
-      logoAlt: "Claude",
-      description: "Claude 3.5, Claude 3.7, Claude Opus 4",
-      placeholder: "sk-ant-...",
-      getApiKeyUrl: "https://console.anthropic.com/",
-    },
-    {
-      id: "google",
-      name: "Google AI",
-      logo: "/google_logo.png",
-      logoAlt: "Google AI",
-      description: "Gemini 2.5, Gemini 2.5 Flash",
-      placeholder: "AI...",
-      getApiKeyUrl: "https://aistudio.google.com/app/apikey",
-    },
-    {
-      id: "deepseek",
-      name: "DeepSeek",
-      logo: "/deepseek_logo.svg",
-      logoAlt: "DeepSeek",
-      description: "DeepSeek Chat, DeepSeek Reasoner",
-      placeholder: "sk-...",
-      getApiKeyUrl: "https://platform.deepseek.com/api_keys",
-    },
-    {
-      id: "mistral",
-      name: "Mistral AI",
-      logo: "/mistral_logo.png",
-      logoAlt: "Mistral AI",
-      description: "Mistral Large, Mistral Small, Codestral",
-      placeholder: "...",
-      getApiKeyUrl: "https://console.mistral.ai/api-keys/",
-    },
-    {
-      id: "xai",
-      name: "xAI",
-      logo: "/xai_logo.png",
-      logoAlt: "xAI Grok",
-      description: "Grok 3, Grok 3 Mini",
-      placeholder: "xai-...",
-      getApiKeyUrl: "https://console.x.ai/",
-    },
-  ];
-
-  const selfHostedProviders: Array<{
-    id: string;
-    name: string;
-    logo: string;
-    isConfigured: boolean;
-    onEdit: () => void;
-    configType?: "api-key" | "base-url";
-  }> = [
-    {
-      id: "ollama",
-      name: "Ollama",
-      logo: "/ollama_logo.svg",
-      isConfigured: Boolean(getOllamaBaseUrl()),
-      configType: "base-url",
-      onEdit: () => {
-        setOllamaUrl(getOllamaBaseUrl());
-        setOllamaDialogOpen(true);
-      },
-    },
-    {
-      id: "openrouter",
-      name: "OpenRouter",
-      logo: "/openrouter_logo.png",
-      isConfigured: Boolean(tokens.openrouter),
-      onEdit: () => {
-        setOpenRouterApiKeyInput(tokens.openrouter || "");
-        setOpenRouterSelectedModelsInput(getOpenRouterSelectedModels());
-        setOpenRouterDialogOpen(true);
-      },
-    },
-    {
-      id: "azure",
-      name: "Azure OpenAI",
-      logo: "/azure_logo.png",
-      isConfigured: Boolean(getAzureBaseUrl()),
-      configType: "base-url",
-      onEdit: () => {
-        setAzureUrl(getAzureBaseUrl());
-        setAzureApiKey(tokens.azure || "");
-        setAzureDialogOpen(true);
-      },
-    },
-  ];
-
-  const handleEdit = (providerId: string) => {
-    const provider = providerConfigs.find((p) => p.id === providerId);
-    if (provider) {
-      setSelectedProvider(provider);
-      const tokenValue = tokens[providerId as keyof typeof tokens];
-      setEditingValue(
-        Array.isArray(tokenValue) ? tokenValue.join(", ") : tokenValue || "",
-      );
-      setDialogOpen(true);
-    }
-  };
-
-  const handleSave = () => {
-    if (selectedProvider) {
-      setToken(selectedProvider.id as keyof typeof tokens, editingValue);
-      setDialogOpen(false);
-      setSelectedProvider(null);
-      setEditingValue("");
-    }
-  };
-
-  const handleCancel = () => {
-    setDialogOpen(false);
-    setSelectedProvider(null);
-    setEditingValue("");
-  };
-
-  const handleOllamaSave = () => {
-    setOllamaBaseUrl(ollamaUrl);
-    setOllamaDialogOpen(false);
-    setOllamaUrl("");
-  };
-
-  const handleOllamaCancel = () => {
-    setOllamaDialogOpen(false);
-    setOllamaUrl("");
-  };
-
-  const handleOpenRouterSave = (apiKey: string, selectedModels: string[]) => {
-    setToken("openrouter", apiKey);
-    setOpenRouterSelectedModels(selectedModels);
-    setOpenRouterDialogOpen(false);
-  };
-
-  const handleOpenRouterCancel = () => {
-    setOpenRouterDialogOpen(false);
-    setOpenRouterApiKeyInput("");
-    setOpenRouterSelectedModelsInput([]);
-  };
-
-  const handleAzureSave = () => {
-    setAzureBaseUrl(azureUrl);
-    setToken("azure", azureApiKey);
-    setAzureDialogOpen(false);
-    setAzureUrl("");
-    setAzureApiKey("");
-  };
-
-  const handleAzureCancel = () => {
-    setAzureDialogOpen(false);
-    setAzureUrl("");
-    setAzureApiKey("");
-  };
 
   const handleThemeToggle = (checked: boolean) => {
     const newTheme = checked ? "dark" : "light";
     updateThemeMode(newTheme);
     setThemeMode(newTheme);
-  };
-
-  const handleCustomProviderSave = (provider: CustomProvider) => {
-    if (editingCustomProviderIndex !== null) {
-      updateCustomProvider(editingCustomProviderIndex, provider);
-    } else {
-      addCustomProvider(provider);
-    }
-    setCustomProviderDialogOpen(false);
-    setEditingCustomProviderIndex(null);
-  };
-
-  const handleCustomProviderCancel = () => {
-    setCustomProviderDialogOpen(false);
-    setEditingCustomProviderIndex(null);
   };
 
   return (
@@ -298,7 +69,33 @@ export function SettingsTab({
           />
         </SettingsSection>
 
-        {!HOSTED_MODE && isOrgBacked && (
+        {!HOSTED_MODE && !byokAllowed && (
+          <SettingsSection title="LLM Providers">
+            <EmptyState
+              icon={KeyRound}
+              title="Sign in to configure model providers"
+              description="Provider keys are managed at the organization level. Sign in to set up your organization's models and use them in chat, evals, and the playground."
+              className="py-10"
+            >
+              <Button
+                type="button"
+                onClick={() => {
+                  posthog.capture("login_button_clicked", {
+                    location: "byok_signin_gate",
+                    platform: detectPlatform(),
+                    environment: detectEnvironment(),
+                  });
+                  signIn();
+                }}
+                size="sm"
+              >
+                Sign in
+              </Button>
+            </EmptyState>
+          </SettingsSection>
+        )}
+
+        {!HOSTED_MODE && byokAllowed && isOrgBacked && (
           <SettingsSection title="LLM Providers">
             <div className="flex items-start gap-3 px-4 py-3 rounded-md border border-border/40 bg-muted/30">
               <Info className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
@@ -322,164 +119,28 @@ export function SettingsTab({
           </SettingsSection>
         )}
 
-        {!HOSTED_MODE && !isOrgBacked && (
-          <>
-            {/* LLM Providers */}
-            <SettingsSection title="LLM Providers">
-              {providerConfigs.map((config) => (
-                <ProviderRow
-                  key={config.id}
-                  logo={config.logo}
-                  logoAlt={config.logoAlt}
-                  name={config.name}
-                  isConfigured={hasToken(config.id as keyof typeof tokens)}
-                  onEdit={() => handleEdit(config.id)}
-                />
-              ))}
-              {selfHostedProviders.map((provider) => (
-                <ProviderRow
-                  key={provider.id}
-                  logo={provider.logo}
-                  logoAlt={provider.name}
-                  name={provider.name}
-                  isConfigured={provider.isConfigured}
-                  onEdit={provider.onEdit}
-                  configType={provider.configType}
-                />
-              ))}
-            </SettingsSection>
-
-            {/* Custom Providers */}
-            <SettingsSection title="Custom Providers">
-              {customProviders.map((cp, index) => (
-                <div
-                  key={`${cp.name}-${index}`}
-                  className="flex items-center justify-between px-4 py-3 rounded-md border border-success/30 transition-colors"
+        {!HOSTED_MODE && byokAllowed && !isOrgBacked && (
+          <SettingsSection title="LLM Providers">
+            <div className="flex items-start gap-3 px-4 py-3 rounded-md border border-border/40 bg-muted/30">
+              <Info className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
+              <div className="flex flex-col gap-1">
+                <span className="text-sm text-muted-foreground">
+                  Model providers are configured at the organization level.
+                  Create or join an organization on mcpjam.com to set them up.
+                </span>
+                <Button
+                  variant="link"
+                  className="h-auto p-0 text-sm justify-start"
+                  onClick={() =>
+                    window.open("https://mcpjam.com/organizations", "_blank")
+                  }
                 >
-                  <div className="flex items-center gap-3">
-                    <div className="size-5 rounded-sm bg-primary/10 flex items-center justify-center">
-                      <span className="text-xs font-bold text-primary">
-                        {cp.name[0]?.toUpperCase()}
-                      </span>
-                    </div>
-                    <div>
-                      <span className="text-sm font-medium">{cp.name}</span>
-                      <span className="text-xs text-muted-foreground ml-2">
-                        {cp.modelIds.length} model
-                        {cp.modelIds.length !== 1 ? "s" : ""}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8"
-                      onClick={() => {
-                        setEditingCustomProviderIndex(index);
-                        setCustomProviderDialogOpen(true);
-                      }}
-                    >
-                      <Pencil className="size-3.5" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8 text-destructive hover:text-destructive hover:bg-destructive/10"
-                      onClick={() => removeCustomProvider(index)}
-                    >
-                      <Trash2 className="size-3.5" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
-              <Button
-                variant="outline"
-                className="w-full"
-                onClick={() => {
-                  setEditingCustomProviderIndex(null);
-                  setCustomProviderDialogOpen(true);
-                }}
-              >
-                <Plus className="size-4 mr-2" />
-                Add Custom Provider
-              </Button>
-            </SettingsSection>
-          </>
+                  Open mcpjam.com
+                </Button>
+              </div>
+            </div>
+          </SettingsSection>
         )}
-
-        {/* Dialogs */}
-        <ProviderConfigDialog
-          open={dialogOpen}
-          onOpenChange={setDialogOpen}
-          provider={selectedProvider}
-          value={editingValue}
-          onValueChange={setEditingValue}
-          onSave={handleSave}
-          onCancel={handleCancel}
-          onRemove={() => {
-            if (selectedProvider) {
-              clearToken(selectedProvider.id as keyof typeof tokens);
-              setDialogOpen(false);
-              setSelectedProvider(null);
-              setEditingValue("");
-            }
-          }}
-          isConfigured={
-            selectedProvider
-              ? hasToken(selectedProvider.id as keyof typeof tokens)
-              : false
-          }
-        />
-
-        <OllamaConfigDialog
-          open={ollamaDialogOpen}
-          onOpenChange={setOllamaDialogOpen}
-          value={ollamaUrl}
-          onValueChange={setOllamaUrl}
-          onSave={handleOllamaSave}
-          onCancel={handleOllamaCancel}
-        />
-
-        <AzureOpenAIConfigDialog
-          open={azureDialogOpen}
-          onOpenChange={setAzureDialogOpen}
-          baseUrl={azureUrl}
-          apiKey={azureApiKey}
-          onBaseUrlChange={setAzureUrl}
-          onApiKeyChange={setAzureApiKey}
-          onSave={handleAzureSave}
-          onCancel={handleAzureCancel}
-        />
-
-        <OpenRouterConfigDialog
-          open={openRouterDialogOpen}
-          onOpenChange={setOpenRouterDialogOpen}
-          apiKey={openRouterApiKeyInput}
-          selectedModels={openRouterSelectedModelsInput}
-          onApiKeyChange={setOpenRouterApiKeyInput}
-          onSelectedModelsChange={setOpenRouterSelectedModelsInput}
-          onSave={handleOpenRouterSave}
-          onCancel={handleOpenRouterCancel}
-          onRemove={() => {
-            clearToken("openrouter");
-            setOpenRouterSelectedModels([]);
-            setOpenRouterDialogOpen(false);
-          }}
-          isConfigured={Boolean(tokens.openrouter)}
-        />
-
-        <CustomProviderConfigDialog
-          open={customProviderDialogOpen}
-          onOpenChange={setCustomProviderDialogOpen}
-          editProvider={
-            editingCustomProviderIndex !== null
-              ? customProviders[editingCustomProviderIndex]
-              : undefined
-          }
-          onSave={handleCustomProviderSave}
-          onCancel={handleCustomProviderCancel}
-        />
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/SettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SettingsTab.tsx
@@ -135,6 +135,7 @@ export function SettingsTab({
                     window.open(
                       "https://app.mcpjam.com/organizations",
                       "_blank",
+                      "noopener,noreferrer",
                     )
                   }
                 >

--- a/mcpjam-inspector/client/src/components/SettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SettingsTab.tsx
@@ -132,7 +132,10 @@ export function SettingsTab({
                   variant="link"
                   className="h-auto p-0 text-sm justify-start"
                   onClick={() =>
-                    window.open("https://mcpjam.com/organizations", "_blank")
+                    window.open(
+                      "https://app.mcpjam.com/organizations",
+                      "_blank",
+                    )
                   }
                 >
                   Open mcpjam.com

--- a/mcpjam-inspector/client/src/components/__tests__/SettingsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SettingsTab.test.tsx
@@ -38,6 +38,18 @@ vi.mock("@/hooks/use-custom-providers", () => ({
   }),
 }));
 
+vi.mock("@/hooks/use-byok-allowed", () => ({
+  useByokAllowed: () => true,
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ signIn: vi.fn(), user: null }),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: true,
 }));

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -7,6 +7,10 @@ vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: false, isLoading: false }),
 }));
 
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: null, isLoading: false, signIn: vi.fn() }),
+}));
+
 const mockIsHostedMode = vi.fn(() => false);
 vi.mock("@/lib/apis/mode-client", () => ({
   isHostedMode: () => mockIsHostedMode(),

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-master-detail.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-master-detail.test.tsx
@@ -17,6 +17,10 @@ vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: false, isLoading: false }),
 }));
 
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: null, isLoading: false, signIn: vi.fn() }),
+}));
+
 vi.mock("../use-suite-data", () => ({
   useSuiteData: () => ({
     runTrendData: [],

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -43,7 +43,6 @@ import {
 import { useMutation } from "convex/react";
 import { toast } from "sonner";
 
-import { isMCPJamProvidedModel } from "@/shared/types";
 import { CiMetadataDisplay } from "./ci-metadata-display";
 import { PassCriteriaBadge } from "./pass-criteria-badge";
 import { ValidatorsSection } from "./validators-section";
@@ -54,10 +53,6 @@ import {
 import { RunHeaderCompactStats } from "./run-header-compact-stats";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { getSuiteReplayEligibility } from "./replay-eligibility";
-import {
-  useAiProviderKeys,
-  type ProviderTokens,
-} from "@/hooks/use-ai-provider-keys";
 import { RunDetailPlaygroundActions } from "./run-detail-playground-actions";
 import { cn } from "@/lib/utils";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -287,23 +282,6 @@ export function SuiteHeader(props: SuiteHeaderProps) {
   const replayableLatestRun = replayEligibility.replayableLatestRun;
   const isReplayingLatestRun =
     replayableLatestRun != null && replayingRunId === replayableLatestRun._id;
-
-  // Check which provider API keys are missing for replay
-  const { hasToken } = useAiProviderKeys();
-  const missingReplayProviderKeys = useMemo(() => {
-    if (!replayableLatestRun || !testCases || testCases.length === 0) return [];
-    const providers = new Set<string>();
-    for (const tc of testCases) {
-      for (const m of tc.models ?? []) {
-        if (!isMCPJamProvidedModel(m.model, m.provider)) {
-          providers.add(m.provider);
-        }
-      }
-    }
-    return [...providers].filter(
-      (p) => !hasToken(p.toLowerCase() as keyof ProviderTokens)
-    );
-  }, [replayableLatestRun, testCases, hasToken]);
 
   const isMobile = useIsMobile();
 
@@ -921,8 +899,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                         replayableLatestRun
                           ? isReplayingLatestRun ||
                             !onReplayRun ||
-                            Boolean(evalRunsDisabledReason) ||
-                            missingReplayProviderKeys.length > 0
+                            Boolean(evalRunsDisabledReason)
                           : !canTriggerLiveRun ||
                             isRerunning ||
                             Boolean(evalRunsDisabledReason)
@@ -956,12 +933,6 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                   {replayableLatestRun
                     ? evalRunsDisabledReason
                       ? evalRunsDisabledReason
-                      : missingReplayProviderKeys.length > 0
-                      ? `Add your ${missingReplayProviderKeys.join(
-                          ", "
-                        )} API key${
-                          missingReplayProviderKeys.length > 1 ? "s" : ""
-                        } in Settings to replay`
                       : "Replay the latest CI run"
                     : evalRunsDisabledReason
                     ? evalRunsDisabledReason

--- a/mcpjam-inspector/client/src/components/evals/suite-hero-stats.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-hero-stats.tsx
@@ -6,11 +6,6 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import { Button } from "@mcpjam/design-system/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@mcpjam/design-system/tooltip";
 import { Area, AreaChart, PieChart, Pie, Label } from "recharts";
 import { computeIterationResult } from "./pass-criteria";
 import type { EvalIteration, EvalSuiteRun } from "./types";
@@ -36,7 +31,6 @@ interface SuiteHeroStatsProps {
   onRunClick?: (runId: string) => void;
   onReplayLatestRun?: (run: EvalSuiteRun) => void;
   isReplayingLatestRun?: boolean;
-  missingReplayProviderKeys?: string[];
 }
 
 export function SuiteHeroStats({
@@ -49,7 +43,6 @@ export function SuiteHeroStats({
   onRunClick,
   onReplayLatestRun,
   isReplayingLatestRun = false,
-  missingReplayProviderKeys = [],
 }: SuiteHeroStatsProps) {
   const stats = useMemo(() => {
     if (runs.length === 0) return null;
@@ -257,34 +250,18 @@ export function SuiteHeroStats({
 
         {latestReplayableRun && onReplayLatestRun && (
           <div className="shrink-0">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => onReplayLatestRun(latestReplayableRun)}
-                    disabled={
-                      isReplayingLatestRun ||
-                      missingReplayProviderKeys.length > 0
-                    }
-                    className="gap-2"
-                  >
-                    <RotateCw
-                      className={`h-4 w-4 ${isReplayingLatestRun ? "animate-spin" : ""}`}
-                    />
-                    {isReplayingLatestRun
-                      ? "Replaying..."
-                      : "Replay latest run"}
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              {missingReplayProviderKeys.length > 0 && (
-                <TooltipContent>
-                  {`Add your ${missingReplayProviderKeys.join(", ")} API key${missingReplayProviderKeys.length > 1 ? "s" : ""} in Settings to replay`}
-                </TooltipContent>
-              )}
-            </Tooltip>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onReplayLatestRun(latestReplayableRun)}
+              disabled={isReplayingLatestRun}
+              className="gap-2"
+            >
+              <RotateCw
+                className={`h-4 w-4 ${isReplayingLatestRun ? "animate-spin" : ""}`}
+              />
+              {isReplayingLatestRun ? "Replaying..." : "Replay latest run"}
+            </Button>
           </div>
         )}
 

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -44,11 +44,6 @@ import type {
 import type { EvalRoute, SuiteOverviewView } from "@/lib/eval-route-types";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { useSharedAppState } from "@/state/app-state-context";
-import { isMCPJamProvidedModel } from "@/shared/types";
-import {
-  useAiProviderKeys,
-  type ProviderTokens,
-} from "@/hooks/use-ai-provider-keys";
 import { Button } from "@mcpjam/design-system/button";
 import { Loader2, Trash2 } from "lucide-react";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
@@ -651,22 +646,6 @@ export function SuiteIterationsView({
     });
   }, []);
 
-  const { hasToken } = useAiProviderKeys();
-  const missingReplayProviderKeys = useMemo(() => {
-    if (!cases || cases.length === 0) return [];
-    const providers = new Set<string>();
-    for (const tc of cases) {
-      for (const m of tc.models ?? []) {
-        if (!isMCPJamProvidedModel(m.model, m.provider)) {
-          providers.add(m.provider);
-        }
-      }
-    }
-    return [...providers].filter(
-      (p) => !hasToken(p.toLowerCase() as keyof ProviderTokens)
-    );
-  }, [cases, hasToken]);
-
   const isReplayingLatestRun = useMemo(
     () =>
       replayingRunId != null &&
@@ -960,7 +939,6 @@ export function SuiteIterationsView({
                               : undefined
                           }
                           isReplayingLatestRun={isReplayingLatestRun}
-                          missingReplayProviderKeys={missingReplayProviderKeys}
                         />
                         <div className="rounded-xl border bg-card px-4 py-10 text-center text-sm text-muted-foreground">
                           <p>

--- a/mcpjam-inspector/client/src/hooks/use-ai-provider-keys.ts
+++ b/mcpjam-inspector/client/src/hooks/use-ai-provider-keys.ts
@@ -78,8 +78,20 @@ export function useAiProviderKeys(): useAiProviderKeysReturn {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (stored) {
-        const parsedTokens = JSON.parse(stored) as ProviderTokens;
-        setTokens(parsedTokens);
+        // Merge a (possibly legacy/partial) payload onto defaults so missing
+        // or malformed fields can't leave the state ill-shaped — e.g. an
+        // absent openRouterSelectedModels would otherwise make
+        // hasToken("openrouter") throw on `.length`.
+        const parsed = JSON.parse(stored) as Partial<ProviderTokens>;
+        setTokens({
+          ...defaultTokens,
+          ...parsed,
+          openRouterSelectedModels: Array.isArray(
+            parsed.openRouterSelectedModels,
+          )
+            ? parsed.openRouterSelectedModels
+            : defaultTokens.openRouterSelectedModels,
+        });
       }
     } catch (error) {
       console.warn(

--- a/mcpjam-inspector/client/src/hooks/use-ai-provider-keys.ts
+++ b/mcpjam-inspector/client/src/hooks/use-ai-provider-keys.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useByokAllowed } from "@/hooks/use-byok-allowed";
 
 export interface ProviderTokens {
   anthropic: string;
@@ -48,59 +49,71 @@ const defaultTokens: ProviderTokens = {
 };
 
 export function useAiProviderKeys(): useAiProviderKeysReturn {
+  // BYOK is sign-in only: guests see empty tokens and no-op setters. When the
+  // user signs in mid-session the load effect re-runs and rehydrates from
+  // localStorage; on sign-out the same effect resets state back to defaults.
+  const allowed = useByokAllowed();
   const [tokens, setTokens] = useState<ProviderTokens>(defaultTokens);
   const [isInitialized, setIsInitialized] = useState(false);
 
-  // Load tokens from localStorage on mount
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored) {
-          const parsedTokens = JSON.parse(stored) as ProviderTokens;
-          setTokens(parsedTokens);
-        }
-      } catch (error) {
-        console.warn(
-          "Failed to load provider tokens from localStorage:",
-          error,
-        );
-      }
+    if (typeof window === "undefined") return;
+    if (!allowed) {
+      setTokens(defaultTokens);
       setIsInitialized(true);
+      return;
     }
-  }, []);
-
-  // Save tokens to localStorage whenever they change
-  useEffect(() => {
-    if (isInitialized && typeof window !== "undefined") {
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens));
-      } catch (error) {
-        console.warn("Failed to save provider tokens to localStorage:", error);
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsedTokens = JSON.parse(stored) as ProviderTokens;
+        setTokens(parsedTokens);
       }
+    } catch (error) {
+      console.warn(
+        "Failed to load provider tokens from localStorage:",
+        error,
+      );
     }
-  }, [tokens, isInitialized]);
+    setIsInitialized(true);
+  }, [allowed]);
+
+  useEffect(() => {
+    if (!isInitialized || typeof window === "undefined") return;
+    if (!allowed) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens));
+    } catch (error) {
+      console.warn("Failed to save provider tokens to localStorage:", error);
+    }
+  }, [tokens, isInitialized, allowed]);
 
   const setToken = useCallback(
     (provider: keyof ProviderTokens, token: string) => {
+      if (!allowed) return;
       setTokens((prev) => ({
         ...prev,
         [provider]: token,
       }));
     },
-    [],
+    [allowed],
   );
 
-  const clearToken = useCallback((provider: keyof ProviderTokens) => {
-    setTokens((prev) => ({
-      ...prev,
-      [provider]: "",
-    }));
-  }, []);
+  const clearToken = useCallback(
+    (provider: keyof ProviderTokens) => {
+      if (!allowed) return;
+      setTokens((prev) => ({
+        ...prev,
+        [provider]: "",
+      }));
+    },
+    [allowed],
+  );
 
   const clearAllTokens = useCallback(() => {
+    if (!allowed) return;
     setTokens(defaultTokens);
-  }, []);
+  }, [allowed]);
 
   const hasToken = useCallback(
     (provider: keyof ProviderTokens) => {
@@ -135,23 +148,31 @@ export function useAiProviderKeys(): useAiProviderKeysReturn {
     return tokens.ollamaBaseUrl || defaultTokens.ollamaBaseUrl;
   }, [tokens.ollamaBaseUrl]);
 
-  const setOllamaBaseUrl = useCallback((url: string) => {
-    setTokens((prev) => ({
-      ...prev,
-      ollamaBaseUrl: url,
-    }));
-  }, []);
+  const setOllamaBaseUrl = useCallback(
+    (url: string) => {
+      if (!allowed) return;
+      setTokens((prev) => ({
+        ...prev,
+        ollamaBaseUrl: url,
+      }));
+    },
+    [allowed],
+  );
 
   const getAzureBaseUrl = useCallback(() => {
     return tokens.azureBaseUrl || defaultTokens.azureBaseUrl;
   }, [tokens.azureBaseUrl]);
 
-  const setAzureBaseUrl = useCallback((url: string) => {
-    setTokens((prev) => ({
-      ...prev,
-      azureBaseUrl: url,
-    }));
-  }, []);
+  const setAzureBaseUrl = useCallback(
+    (url: string) => {
+      if (!allowed) return;
+      setTokens((prev) => ({
+        ...prev,
+        azureBaseUrl: url,
+      }));
+    },
+    [allowed],
+  );
 
   const getOpenRouterSelectedModels = useCallback(() => {
     return (
@@ -159,12 +180,16 @@ export function useAiProviderKeys(): useAiProviderKeysReturn {
     );
   }, [tokens.openRouterSelectedModels]);
 
-  const setOpenRouterSelectedModels = useCallback((models: string[]) => {
-    setTokens((prev) => ({
-      ...prev,
-      openRouterSelectedModels: models,
-    }));
-  }, []);
+  const setOpenRouterSelectedModels = useCallback(
+    (models: string[]) => {
+      if (!allowed) return;
+      setTokens((prev) => ({
+        ...prev,
+        openRouterSelectedModels: models,
+      }));
+    },
+    [allowed],
+  );
 
   return {
     tokens,

--- a/mcpjam-inspector/client/src/hooks/use-ai-provider-keys.ts
+++ b/mcpjam-inspector/client/src/hooks/use-ai-provider-keys.ts
@@ -59,7 +59,19 @@ export function useAiProviderKeys(): useAiProviderKeysReturn {
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!allowed) {
+      // Sign-out (or initial guest load) clears both in-memory state AND
+      // localStorage so the next sign-in on the same browser — possibly a
+      // different WorkOS user — cannot silently rehydrate the previous
+      // user's keys.
       setTokens(defaultTokens);
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch (error) {
+        console.warn(
+          "Failed to clear provider tokens from localStorage:",
+          error,
+        );
+      }
       setIsInitialized(true);
       return;
     }

--- a/mcpjam-inspector/client/src/hooks/use-byok-allowed.ts
+++ b/mcpjam-inspector/client/src/hooks/use-byok-allowed.ts
@@ -1,0 +1,17 @@
+import { useAuth } from "@workos-inc/authkit-react";
+
+/**
+ * Gate for "bring your own key" features. Returns true when the current
+ * session has a signed-in WorkOS identity. Anonymous sessions (direct
+ * guests, hosted guest JWTs) are blocked from saving or reading provider
+ * keys.
+ *
+ * Optimistic during auth loading: returns true so saved keys don't flash
+ * out for signed-in users on first paint. Resolves to the real value once
+ * isLoading is false.
+ */
+export function useByokAllowed(): boolean {
+  const { user, isLoading } = useAuth();
+  if (isLoading) return true;
+  return !!user;
+}

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -632,7 +632,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const result = JSON.parse(onError(error));
       expect(result.code).toBe("auth_error");
       expect(result.message).toBe(
-        "Invalid API key for openai. Please check your key under LLM Providers in Settings.",
+        "Invalid API key for openai. Check your organization's model providers configuration.",
       );
       expect(result.statusCode).toBe(401);
     });
@@ -649,7 +649,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const result = JSON.parse(onError(error));
       expect(result.code).toBe("auth_error");
       expect(result.message).toBe(
-        "Invalid API key for anthropic. Please check your key under LLM Providers in Settings.",
+        "Invalid API key for anthropic. Check your organization's model providers configuration.",
       );
     });
 
@@ -667,7 +667,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const result = JSON.parse(onError(error));
       expect(result.code).toBe("auth_error");
       expect(result.message).toBe(
-        "Invalid API key for deepseek. Please check your key under LLM Providers in Settings.",
+        "Invalid API key for deepseek. Check your organization's model providers configuration.",
       );
       expect(result.statusCode).toBe(401);
     });
@@ -686,7 +686,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const result = JSON.parse(onError(error));
       expect(result.code).toBe("auth_error");
       expect(result.message).toBe(
-        "Invalid API key for xai. Please check your key under LLM Providers in Settings.",
+        "Invalid API key for xai. Check your organization's model providers configuration.",
       );
     });
 
@@ -704,7 +704,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const result = JSON.parse(onError(error));
       expect(result.code).toBe("auth_error");
       expect(result.message).toBe(
-        "Invalid API key for google. Please check your key under LLM Providers in Settings.",
+        "Invalid API key for google. Check your organization's model providers configuration.",
       );
     });
 
@@ -824,7 +824,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const result = JSON.parse(onError(error));
       expect(result.code).toBe("auth_error");
       expect(result.message).toBe(
-        "Invalid API key for openai. Please check your key under LLM Providers in Settings.",
+        "Invalid API key for openai. Check your organization's model providers configuration.",
       );
     });
   });
@@ -867,7 +867,7 @@ describe("POST /api/mcp/chat-v2", () => {
       }>(res);
 
       expect(status).toBe(401);
-      expect(data.code).toBe("byok_requires_signin");
+      expect(data.code).toBe("personal_byok_unsupported");
     });
 
     it("401s a cloud apiKey even with a bearer (no personal BYOK)", async () => {
@@ -877,7 +877,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const { status, data } = await expectJson<{ code: string }>(res);
 
       expect(status).toBe(401);
-      expect(data.code).toBe("byok_requires_signin");
+      expect(data.code).toBe("personal_byok_unsupported");
     });
 
     it("never gates Ollama (local daemon, not a cloud account)", async () => {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -9,6 +9,7 @@ import {
 import type { Hono } from "hono";
 import { APICallError } from "@ai-sdk/provider";
 import type { ModelMessage } from "ai";
+import { validateGuestTokenDetailedAsync } from "../../../services/guest-token.js";
 
 // Track stream events for testing
 let capturedStreamEvents: any[] = [];
@@ -174,6 +175,10 @@ vi.mock("../../../utils/guest-auth.js", () => ({
   getProductionGuestAuthHeader: vi
     .fn()
     .mockResolvedValue("Bearer guest-test-token"),
+}));
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: vi.fn(),
 }));
 
 // Mock http-tool-calls for testing unresolved tool calls scenario
@@ -826,6 +831,96 @@ describe("POST /api/mcp/chat-v2", () => {
       expect(result.message).toBe(
         "Invalid API key for openai. Please check your key under LLM Providers in Settings.",
       );
+    });
+  });
+
+  describe("BYOK sign-in gate (Convex-attached)", () => {
+    // The gate only arms when the inspector is attached to Convex. Cloud
+    // BYOK from a guest (guest JWT, or no bearer) is rejected; a signed-in
+    // WorkOS caller falls through to the normal direct-key path.
+    beforeEach(() => {
+      process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
+    });
+    afterEach(() => {
+      delete process.env.CONVEX_HTTP_URL;
+    });
+
+    const postWithAuth = (
+      body: Record<string, unknown>,
+      authHeader?: string,
+    ) =>
+      app.request("/api/mcp/chat-v2", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(authHeader ? { Authorization: authHeader } : {}),
+        },
+        body: JSON.stringify(body),
+      });
+
+    const cloudByokBody = {
+      messages: [{ role: "user", content: "Hello" }],
+      model: { id: "gpt-4", provider: "openai" },
+      apiKey: "sk-user-supplied-key",
+    };
+
+    it("401s a guest (guest JWT) using a cloud provider key", async () => {
+      vi.mocked(validateGuestTokenDetailedAsync).mockResolvedValue({
+        valid: true,
+        guestId: "guest_1",
+      });
+
+      const res = await postWithAuth(cloudByokBody, "Bearer guest-jwt");
+      const { status, data } = await expectJson<{
+        error: string;
+        code: string;
+      }>(res);
+
+      expect(status).toBe(401);
+      expect(data.code).toBe("byok_requires_signin");
+    });
+
+    it("401s a caller with no bearer at all", async () => {
+      const res = await postWithAuth(cloudByokBody);
+      const { status, data } = await expectJson<{ code: string }>(res);
+
+      expect(status).toBe(401);
+      expect(data.code).toBe("byok_requires_signin");
+      // No bearer ⇒ guest, decided without consulting the verifier.
+      expect(
+        vi.mocked(validateGuestTokenDetailedAsync),
+      ).not.toHaveBeenCalled();
+    });
+
+    it("lets a signed-in (WorkOS) caller through to the direct path", async () => {
+      // A WorkOS token is not a guest JWT, so the verifier reports invalid.
+      vi.mocked(validateGuestTokenDetailedAsync).mockResolvedValue({
+        valid: false,
+        reason: "issuer_mismatch",
+      });
+
+      const res = await postWithAuth(cloudByokBody, "Bearer workos-token");
+
+      expect(res.status).toBe(200);
+    });
+
+    it("never gates Ollama, even for a guest (no shared cloud account)", async () => {
+      vi.mocked(validateGuestTokenDetailedAsync).mockResolvedValue({
+        valid: true,
+        guestId: "guest_1",
+      });
+
+      const res = await postWithAuth(
+        {
+          messages: [{ role: "user", content: "Hello" }],
+          model: { id: "llama3", provider: "ollama" },
+          apiKey: "local",
+          ollamaBaseUrl: "http://localhost:11434",
+        },
+        "Bearer guest-jwt",
+      );
+
+      expect(res.status).toBe(200);
     });
   });
 

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -9,7 +9,6 @@ import {
 import type { Hono } from "hono";
 import { APICallError } from "@ai-sdk/provider";
 import type { ModelMessage } from "ai";
-import { validateGuestTokenDetailedAsync } from "../../../services/guest-token.js";
 
 // Track stream events for testing
 let capturedStreamEvents: any[] = [];
@@ -175,10 +174,6 @@ vi.mock("../../../utils/guest-auth.js", () => ({
   getProductionGuestAuthHeader: vi
     .fn()
     .mockResolvedValue("Bearer guest-test-token"),
-}));
-
-vi.mock("../../../services/guest-token.js", () => ({
-  validateGuestTokenDetailedAsync: vi.fn(),
 }));
 
 // Mock http-tool-calls for testing unresolved tool calls scenario
@@ -834,10 +829,10 @@ describe("POST /api/mcp/chat-v2", () => {
     });
   });
 
-  describe("BYOK sign-in gate (Convex-attached)", () => {
-    // The gate only arms when the inspector is attached to Convex. Cloud
-    // BYOK from a guest (guest JWT, or no bearer) is rejected; a signed-in
-    // WorkOS caller falls through to the normal direct-key path.
+  describe("Cloud BYOK is org-based (Convex-attached)", () => {
+    // BYOK keys come from the org's Convex config. On a Convex-attached
+    // deployment a client-supplied apiKey for a cloud provider is a personal
+    // BYOK attempt, which isn't supported — rejected regardless of caller.
     beforeEach(() => {
       process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
     });
@@ -864,13 +859,8 @@ describe("POST /api/mcp/chat-v2", () => {
       apiKey: "sk-user-supplied-key",
     };
 
-    it("401s a guest (guest JWT) using a cloud provider key", async () => {
-      vi.mocked(validateGuestTokenDetailedAsync).mockResolvedValue({
-        valid: true,
-        guestId: "guest_1",
-      });
-
-      const res = await postWithAuth(cloudByokBody, "Bearer guest-jwt");
+    it("401s a cloud apiKey with no bearer", async () => {
+      const res = await postWithAuth(cloudByokBody);
       const { status, data } = await expectJson<{
         error: string;
         code: string;
@@ -880,36 +870,17 @@ describe("POST /api/mcp/chat-v2", () => {
       expect(data.code).toBe("byok_requires_signin");
     });
 
-    it("401s a caller with no bearer at all", async () => {
-      const res = await postWithAuth(cloudByokBody);
+    it("401s a cloud apiKey even with a bearer (no personal BYOK)", async () => {
+      // Org-based: identity is irrelevant — a client apiKey for a cloud
+      // provider is never honored on a Convex-attached deployment.
+      const res = await postWithAuth(cloudByokBody, "Bearer any-token");
       const { status, data } = await expectJson<{ code: string }>(res);
 
       expect(status).toBe(401);
       expect(data.code).toBe("byok_requires_signin");
-      // No bearer ⇒ guest, decided without consulting the verifier.
-      expect(
-        vi.mocked(validateGuestTokenDetailedAsync),
-      ).not.toHaveBeenCalled();
     });
 
-    it("lets a signed-in (WorkOS) caller through to the direct path", async () => {
-      // A WorkOS token is not a guest JWT, so the verifier reports invalid.
-      vi.mocked(validateGuestTokenDetailedAsync).mockResolvedValue({
-        valid: false,
-        reason: "issuer_mismatch",
-      });
-
-      const res = await postWithAuth(cloudByokBody, "Bearer workos-token");
-
-      expect(res.status).toBe(200);
-    });
-
-    it("never gates Ollama, even for a guest (no shared cloud account)", async () => {
-      vi.mocked(validateGuestTokenDetailedAsync).mockResolvedValue({
-        valid: true,
-        guestId: "guest_1",
-      });
-
+    it("never gates Ollama (local daemon, not a cloud account)", async () => {
       const res = await postWithAuth(
         {
           messages: [{ role: "user", content: "Hello" }],
@@ -917,8 +888,16 @@ describe("POST /api/mcp/chat-v2", () => {
           apiKey: "local",
           ollamaBaseUrl: "http://localhost:11434",
         },
-        "Bearer guest-jwt",
+        "Bearer any-token",
       );
+
+      expect(res.status).toBe(200);
+    });
+
+    it("does not gate when not Convex-attached (local OSS)", async () => {
+      delete process.env.CONVEX_HTTP_URL;
+
+      const res = await postWithAuth(cloudByokBody, "Bearer any-token");
 
       expect(res.status).toBe(200);
     });

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -806,18 +806,30 @@ chatV2.post("/", async (c) => {
       });
     }
 
-    // Personal BYOK is not a supported path. Provider keys are an
+    // Personal cloud BYOK is not a supported path. Provider keys are an
     // organization-level concept: hosted clients hit /api/web/chat-v2
     // with a projectId and no client apiKey, and the org BYOK branch
     // above (~line 684) resolves the key from Convex. Reject any inbound
     // request that tries to bypass that on a Convex-attached deployment
-    // by hand-crafting an apiKey-bearing call to this route. Local OSS
-    // (no CONVEX_HTTP_URL) keeps the legacy user-apiKey path so existing
-    // localStorage keys still work until they're migrated out.
+    // by hand-crafting an apiKey-bearing call for a CLOUD provider.
+    //
+    // Ollama (local daemon, "local" placeholder apiKey) and `custom`
+    // (self-hosted OpenAI-compatible endpoints) are explicitly skipped:
+    // they have no shared cloud account to gate behind sign-in, and the
+    // org BYOK surface doesn't model them. Local OSS (no CONVEX_HTTP_URL)
+    // also bypasses — the frontend hook is the only enforcement on `npx`.
+    //
+    // projectId is checked with `typeof === "string"` to match the
+    // sibling org branch (~line 686); a non-string truthy projectId
+    // would otherwise sail past both guards.
+    const isCloudByokProvider =
+      modelDefinition.provider !== "ollama" &&
+      modelDefinition.provider !== "custom";
     if (
       process.env.CONVEX_HTTP_URL &&
+      isCloudByokProvider &&
       apiKey &&
-      !body.projectId
+      !(typeof body.projectId === "string" && body.projectId)
     ) {
       return c.json(
         { error: "BYOK requires sign-in", code: "byok_requires_signin" },

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -15,7 +15,6 @@ import {
 import type { ModelProvider } from "@/shared/types";
 import { getClientIp } from "../../utils/client-ip.js";
 import { getProductionGuestAuthHeader } from "../../utils/guest-auth.js";
-import { validateGuestTokenDetailedAsync } from "../../services/guest-token.js";
 import { logger } from "../../utils/logger";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config";
 import {
@@ -151,34 +150,6 @@ function toPersistedUsage(
     inputTokens: usage.inputTokens,
     outputTokens: usage.outputTokens,
   };
-}
-
-/**
- * BYOK sign-in check for the local/mcp chat route.
- *
- * Unlike `/api/web/chat-v2`, this route mounts no auth middleware that
- * resolves a WorkOS identity into the request context, so there is no
- * `userId` to read here. Both signed-in and guest clients send an
- * `Authorization: Bearer …` header (guests carry a guest JWT — see the
- * client `use-chat-session.ts`), so presence alone can't tell them apart.
- *
- * Mirror `bearerAuthMiddleware`: a token that validates as a guest JWT is a
- * guest; anything else (a WorkOS token) is signed in. No bearer at all is a
- * guest. Fails open (treats as signed in) only when the guest-token service
- * itself errors, matching the middleware so a verifier blip can't 401 real
- * signed-in users.
- */
-async function isGuestByokCaller(
-  authHeader: string | undefined
-): Promise<boolean> {
-  if (!authHeader?.startsWith("Bearer ")) return true;
-  const token = authHeader.slice("Bearer ".length);
-  try {
-    const result = await validateGuestTokenDetailedAsync(token);
-    return result.valid && !!result.guestId;
-  } catch {
-    return false;
-  }
 }
 
 /**
@@ -835,35 +806,22 @@ chatV2.post("/", async (c) => {
       });
     }
 
-    // Personal cloud BYOK is not a supported path. Provider keys are an
-    // organization-level concept: hosted clients hit /api/web/chat-v2
-    // with a projectId and no client apiKey, and the org BYOK branch
-    // above (~line 684) resolves the key from Convex. Reject any inbound
-    // request that tries to bypass that on a Convex-attached deployment
-    // by hand-crafting an apiKey-bearing call for a CLOUD provider while
-    // signed out.
-    //
-    // "Signed out" is decided from the bearer token via `isGuestByokCaller`,
-    // not from the request body. This route has no auth middleware that
-    // resolves a WorkOS identity into the request context, so there is no
-    // userId to read here (an earlier revision read `requestLogContext.userId`
-    // and was always-null on this path, 401-ing signed-in users too). A guest
-    // JWT — or no bearer — is signed out; a WorkOS token is signed in.
+    // BYOK is organization-based: cloud provider keys come from the org's
+    // Convex config, never from a client-supplied apiKey. On a Convex-attached
+    // deployment the only supported cloud paths are MCPJam-provided models and
+    // org BYOK (projectId, no apiKey) — both handled above. So a request that
+    // still carries a client apiKey for a CLOUD provider is a personal-BYOK
+    // attempt we don't support; reject it regardless of the caller's identity.
     //
     // Ollama (local daemon, "local" placeholder apiKey) and `custom`
-    // (self-hosted OpenAI-compatible endpoints) are explicitly skipped:
-    // they have no shared cloud account to gate behind sign-in, and the
-    // org BYOK surface doesn't model them. Local OSS (no CONVEX_HTTP_URL)
-    // also bypasses — the frontend hook is the only enforcement on `npx`.
+    // (self-hosted OpenAI-compatible endpoints) are exempt — they're local /
+    // self-hosted, not a shared cloud account, and the org surface doesn't
+    // model them. Local OSS (no CONVEX_HTTP_URL) is exempt too; the frontend
+    // hook is the only enforcement on `npx`.
     const isCloudByokProvider =
       modelDefinition.provider !== "ollama" &&
       modelDefinition.provider !== "custom";
-    if (
-      process.env.CONVEX_HTTP_URL &&
-      isCloudByokProvider &&
-      apiKey &&
-      (await isGuestByokCaller(requestAuthHeader))
-    ) {
+    if (process.env.CONVEX_HTTP_URL && isCloudByokProvider && apiKey) {
       return c.json(
         { error: "BYOK requires sign-in", code: "byok_requires_signin" },
         401

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -811,17 +811,21 @@ chatV2.post("/", async (c) => {
     // with a projectId and no client apiKey, and the org BYOK branch
     // above (~line 684) resolves the key from Convex. Reject any inbound
     // request that tries to bypass that on a Convex-attached deployment
-    // by hand-crafting an apiKey-bearing call for a CLOUD provider.
+    // by hand-crafting an apiKey-bearing call for a CLOUD provider while
+    // signed out.
+    //
+    // The gate keys off `authenticatedUserId` — the verified WorkOS
+    // identity resolved server-side from the request context (~line 579),
+    // never anything in the request body. An earlier revision gated on the
+    // presence of a client-supplied `projectId`; a signed-out caller could
+    // forge that value to sail past both this guard and the org branch
+    // above, defeating the sign-in requirement.
     //
     // Ollama (local daemon, "local" placeholder apiKey) and `custom`
     // (self-hosted OpenAI-compatible endpoints) are explicitly skipped:
     // they have no shared cloud account to gate behind sign-in, and the
     // org BYOK surface doesn't model them. Local OSS (no CONVEX_HTTP_URL)
     // also bypasses — the frontend hook is the only enforcement on `npx`.
-    //
-    // projectId is checked with `typeof === "string"` to match the
-    // sibling org branch (~line 686); a non-string truthy projectId
-    // would otherwise sail past both guards.
     const isCloudByokProvider =
       modelDefinition.provider !== "ollama" &&
       modelDefinition.provider !== "custom";
@@ -829,7 +833,7 @@ chatV2.post("/", async (c) => {
       process.env.CONVEX_HTTP_URL &&
       isCloudByokProvider &&
       apiKey &&
-      !(typeof body.projectId === "string" && body.projectId)
+      !authenticatedUserId
     ) {
       return c.json(
         { error: "BYOK requires sign-in", code: "byok_requires_signin" },

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -113,7 +113,7 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
 
     return JSON.stringify({
       code: "auth_error",
-      message: `Invalid API key for ${providerName}. Please check your key under LLM Providers in Settings.`,
+      message: `Invalid API key for ${providerName}. Check your organization's model providers configuration.`,
       statusCode,
       normalized: providerNormalized,
     });
@@ -823,7 +823,11 @@ chatV2.post("/", async (c) => {
       modelDefinition.provider !== "custom";
     if (process.env.CONVEX_HTTP_URL && isCloudByokProvider && apiKey) {
       return c.json(
-        { error: "BYOK requires sign-in", code: "byok_requires_signin" },
+        {
+          error:
+            "Personal provider keys aren't supported. Configure cloud models in your organization's settings (Organization Models).",
+          code: "personal_byok_unsupported",
+        },
         401
       );
     }

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -15,6 +15,7 @@ import {
 import type { ModelProvider } from "@/shared/types";
 import { getClientIp } from "../../utils/client-ip.js";
 import { getProductionGuestAuthHeader } from "../../utils/guest-auth.js";
+import { validateGuestTokenDetailedAsync } from "../../services/guest-token.js";
 import { logger } from "../../utils/logger";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config";
 import {
@@ -150,6 +151,34 @@ function toPersistedUsage(
     inputTokens: usage.inputTokens,
     outputTokens: usage.outputTokens,
   };
+}
+
+/**
+ * BYOK sign-in check for the local/mcp chat route.
+ *
+ * Unlike `/api/web/chat-v2`, this route mounts no auth middleware that
+ * resolves a WorkOS identity into the request context, so there is no
+ * `userId` to read here. Both signed-in and guest clients send an
+ * `Authorization: Bearer …` header (guests carry a guest JWT — see the
+ * client `use-chat-session.ts`), so presence alone can't tell them apart.
+ *
+ * Mirror `bearerAuthMiddleware`: a token that validates as a guest JWT is a
+ * guest; anything else (a WorkOS token) is signed in. No bearer at all is a
+ * guest. Fails open (treats as signed in) only when the guest-token service
+ * itself errors, matching the middleware so a verifier blip can't 401 real
+ * signed-in users.
+ */
+async function isGuestByokCaller(
+  authHeader: string | undefined
+): Promise<boolean> {
+  if (!authHeader?.startsWith("Bearer ")) return true;
+  const token = authHeader.slice("Bearer ".length);
+  try {
+    const result = await validateGuestTokenDetailedAsync(token);
+    return result.valid && !!result.guestId;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -814,12 +843,12 @@ chatV2.post("/", async (c) => {
     // by hand-crafting an apiKey-bearing call for a CLOUD provider while
     // signed out.
     //
-    // The gate keys off `authenticatedUserId` — the verified WorkOS
-    // identity resolved server-side from the request context (~line 579),
-    // never anything in the request body. An earlier revision gated on the
-    // presence of a client-supplied `projectId`; a signed-out caller could
-    // forge that value to sail past both this guard and the org branch
-    // above, defeating the sign-in requirement.
+    // "Signed out" is decided from the bearer token via `isGuestByokCaller`,
+    // not from the request body. This route has no auth middleware that
+    // resolves a WorkOS identity into the request context, so there is no
+    // userId to read here (an earlier revision read `requestLogContext.userId`
+    // and was always-null on this path, 401-ing signed-in users too). A guest
+    // JWT — or no bearer — is signed out; a WorkOS token is signed in.
     //
     // Ollama (local daemon, "local" placeholder apiKey) and `custom`
     // (self-hosted OpenAI-compatible endpoints) are explicitly skipped:
@@ -833,7 +862,7 @@ chatV2.post("/", async (c) => {
       process.env.CONVEX_HTTP_URL &&
       isCloudByokProvider &&
       apiKey &&
-      !authenticatedUserId
+      (await isGuestByokCaller(requestAuthHeader))
     ) {
       return c.json(
         { error: "BYOK requires sign-in", code: "byok_requires_signin" },

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -806,6 +806,25 @@ chatV2.post("/", async (c) => {
       });
     }
 
+    // Personal BYOK is not a supported path. Provider keys are an
+    // organization-level concept: hosted clients hit /api/web/chat-v2
+    // with a projectId and no client apiKey, and the org BYOK branch
+    // above (~line 684) resolves the key from Convex. Reject any inbound
+    // request that tries to bypass that on a Convex-attached deployment
+    // by hand-crafting an apiKey-bearing call to this route. Local OSS
+    // (no CONVEX_HTTP_URL) keeps the legacy user-apiKey path so existing
+    // localStorage keys still work until they're migrated out.
+    if (
+      process.env.CONVEX_HTTP_URL &&
+      apiKey &&
+      !body.projectId
+    ) {
+      return c.json(
+        { error: "BYOK requires sign-in", code: "byok_requires_signin" },
+        401
+      );
+    }
+
     // User-provided models: direct streamText
     const llmModel = createLlmModel(
       modelDefinition,


### PR DESCRIPTION
Personal localStorage BYOK is no longer offered from the Settings tab. Provider keys are an organization-level concept, so Settings becomes a router into the org dashboard.

The Settings "LLM Providers" section now shows one of three states:
- Not signed in: "Sign in to configure model providers" CTA → WorkOS sign-in (existing flow).
- Signed in with an active org: "Managed in your organization settings" + Go to Organization Models link (unchanged from prior isOrgBacked path).
- Signed in without an active org: "Create or join an organization on mcpjam.com" link.

Hosted mode is unchanged — the section is hidden in HOSTED_MODE and the dashboard owns the surface.

Underlying useAiProviderKeys hook still exists and is read by chat / eval / playground selectors; the gate added to it keeps any pre-existing localStorage keys inert for guests. Chat-v2 route's hosted-mode rejection of client-supplied apiKey from unauthenticated callers stays in place as defense in depth.

Test mocks updated where rendered components now reach useByokAllowed (SettingsTab, SuiteHeader, SuiteIterationsView).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication-adjacent BYOK behavior (localStorage clearing, server rejection of client apiKeys) and removes a large Settings surface; misconfiguration could block chat or surprise users with cleared keys after sign-out.
> 
> **Overview**
> **Settings no longer stores or edits LLM provider keys locally.** The LLM Providers section is reduced to routing: guests get a sign-in CTA (PostHog `byok_signin_gate`), signed-in users with an org link to Organization Models, and signed-in users without an org are sent to mcpjam.com. All provider/custom-provider dialogs and `useAiProviderKeys` wiring are removed from this tab.
> 
> **BYOK is gated on WorkOS sign-in** via new `useByokAllowed`. `useAiProviderKeys` treats guests as empty tokens with no-op mutators, clears `localStorage` on sign-out/guest load, and merges stored payloads onto defaults to avoid malformed state.
> 
> **Eval replay UX** drops client-side “missing Settings API key” checks; replay buttons no longer disable or tooltip based on local `hasToken`.
> 
> **On Convex-attached deployments**, `chat-v2` **401s** requests that include a client `apiKey` for cloud providers (`personal_byok_unsupported`), while Ollama/custom and non-Convex OSS remain exempt. LLM auth error copy now points at **organization model providers** instead of Settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ec56ef18aae0524a9d2b5b400f76195b373476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->