### PR TITLE
posthog: instrument Ask MCPJam agent lifecycle

### DIFF
--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, type ReactNode } from "react";
 import { useQuery } from "convex/react";
 import { useSearchParams } from "react-router";
 import { useAuth } from "@workos-inc/authkit-react";
+import { usePostHog } from "posthog-js/react";
 import { ArrowLeft, Plus } from "lucide-react";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { Button } from "@mcpjam/design-system/button";
@@ -93,6 +94,7 @@ function clearPendingForSession(sessionId: string | null | undefined) {
 
 export function HomeTab({ organizationId, projectId }: HomeTabProps) {
   const navigate = useAppNavigate();
+  const posthog = usePostHog();
   const [searchParams, setSearchParams] = useSearchParams();
   const sessionParam = searchParams.get("session");
   const composeParam = searchParams.get("compose") === "1";
@@ -154,6 +156,10 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
         // otherwise a later resume of the same id replays the prompt and
         // re-renders the optimistic bubble over the hydrated transcript.
         clearPendingForSession(prev.get("session"));
+        posthog?.capture("mcpjam_agent_back", {
+          surface: "home",
+          had_session: Boolean(prev.get("session")),
+        });
         const next = new URLSearchParams(prev);
         next.delete("session");
         next.delete("compose");
@@ -161,7 +167,7 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
       },
       { replace: false }
     );
-  }, [setSearchParams]);
+  }, [posthog, setSearchParams]);
 
   // "New chat" inside the takeover keeps the user on the agent surface and
   // swaps the thread for an empty composer (Hero). A session id is minted
@@ -173,6 +179,10 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
         // Same rationale as handleBackToHome — drop the leaving session's
         // unconsumed pending payload so a later resume doesn't double-send.
         clearPendingForSession(prev.get("session"));
+        posthog?.capture("mcpjam_agent_new_chat", {
+          surface: "home",
+          had_session: Boolean(prev.get("session")),
+        });
         const next = new URLSearchParams(prev);
         next.delete("session");
         next.set("compose", "1");
@@ -180,7 +190,7 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
       },
       { replace: false }
     );
-  }, [setSearchParams]);
+  }, [posthog, setSearchParams]);
   const { user } = useAuth();
   const convexUser = useQuery("users:getCurrentUser" as any) as
     | { name?: string }

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -54,7 +54,7 @@ export function McpjamAgentThread({
   sessionId,
   projectId,
   organizationId,
-  surface: _surface,
+  surface,
   variant = "card",
   className,
 }: McpjamAgentThreadProps) {
@@ -62,6 +62,7 @@ export function McpjamAgentThread({
     chatSessionId: sessionId,
     projectId,
     organizationId,
+    surface,
   });
 
   const [draft, setDraft] = useState("");

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -13,6 +13,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useChat, type UIMessage } from "@ai-sdk/react";
 import { DefaultChatTransport, generateId } from "ai";
+import { usePostHog } from "posthog-js/react";
 import { authFetch } from "@/lib/session-token";
 import { useHostedOrgModelConfig } from "@/hooks/use-hosted-org-model-config";
 import { usePersistedModel } from "@/hooks/use-persisted-model";
@@ -43,6 +44,11 @@ export interface UseMcpjamAgentSessionArgs {
   organizationId?: string | null;
   /** Optional override to override the persisted default model. */
   modelOverride?: ModelDefinition;
+  /**
+   * Telemetry surface — passed into PostHog lifecycle events so we can split
+   * engagement/error/latency by home vs. side-panel vs. future bubble.
+   */
+  surface?: string;
 }
 
 export interface UseMcpjamAgentSessionResult {
@@ -66,6 +72,8 @@ export function useMcpjamAgentSession(
   args: UseMcpjamAgentSessionArgs
 ): UseMcpjamAgentSessionResult {
   const { projectId, organizationId, chatSessionId: providedSessionId } = args;
+  const posthog = usePostHog();
+  const surface = args.surface ?? "unknown";
 
   const [chatSessionId, setChatSessionId] = useState<string>(
     () => providedSessionId ?? generateId()
@@ -179,6 +187,50 @@ export function useMcpjamAgentSession(
     transport,
   });
 
+  // Lifecycle telemetry — track each user message round-trip so we can read
+  // engagement (message_sent), latency (response_finished.duration_ms), tool
+  // usage (response_finished.tool_call_count), and reliability
+  // (response_error). Uses status edge transitions instead of a non-existent
+  // useChat `onFinish` callback in this @ai-sdk/react version.
+  const turnStartedAtRef = useRef<number | null>(null);
+  const turnIndexRef = useRef<number>(0);
+  const prevStatusRef = useRef(status);
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = status;
+    if (prev === status) return;
+    if ((prev === "submitted" || prev === "streaming") && status === "ready") {
+      const startedAt = turnStartedAtRef.current;
+      turnStartedAtRef.current = null;
+      const last = messages[messages.length - 1];
+      let toolCallCount = 0;
+      if (last && last.role === "assistant" && Array.isArray(last.parts)) {
+        toolCallCount = last.parts.filter((p) =>
+          typeof (p as { type?: unknown }).type === "string" &&
+          (p as { type: string }).type.startsWith("tool-")
+        ).length;
+      }
+      posthog?.capture("mcpjam_agent_response_finished", {
+        surface,
+        session_id: chatSessionId,
+        message_index: turnIndexRef.current,
+        duration_ms: startedAt != null ? Date.now() - startedAt : null,
+        tool_call_count: toolCallCount,
+        message_count: messages.length,
+      });
+    } else if (status === "error") {
+      const startedAt = turnStartedAtRef.current;
+      turnStartedAtRef.current = null;
+      posthog?.capture("mcpjam_agent_response_error", {
+        surface,
+        session_id: chatSessionId,
+        message_index: turnIndexRef.current,
+        duration_ms: startedAt != null ? Date.now() - startedAt : null,
+        error_message: error?.message ?? null,
+      });
+    }
+  }, [chatSessionId, error, messages, posthog, status, surface]);
+
   // Seed `useChat` with hydrated history once it arrives.
   const seededForRef = useRef<string | null>(null);
   useEffect(() => {
@@ -198,9 +250,19 @@ export function useMcpjamAgentSession(
       if (!providedSessionId && seededForRef.current === null) {
         seededForRef.current = chatSessionId;
       }
+      turnIndexRef.current += 1;
+      turnStartedAtRef.current = Date.now();
+      posthog?.capture("mcpjam_agent_message_sent", {
+        surface,
+        session_id: chatSessionId,
+        message_index: turnIndexRef.current,
+        prompt_length: trimmed.length,
+        model_id: modelRef.current?.id ?? null,
+        provider: modelRef.current?.provider ?? null,
+      });
       void sendMessage({ text: trimmed });
     },
-    [chatSessionId, providedSessionId, sendMessage]
+    [chatSessionId, posthog, providedSessionId, sendMessage, surface]
   );
 
   return {


### PR DESCRIPTION
## Summary

Adds client-side PostHog events so we can read engagement, latency, tool usage, and reliability for the home-page Ask MCPJam agent. Three existing events (`mcpjam_agent_submit` / `_suggested_prompt` / `_resume`) stay; this fills in the rest of the funnel.

| Event | Where | Properties |
|---|---|---|
| `mcpjam_agent_message_sent` | `use-mcpjam-agent-session.ts:submit` | surface, session_id, message_index, prompt_length, model_id, provider |
| `mcpjam_agent_response_finished` | status `submitted/streaming → ready` edge | surface, session_id, message_index, duration_ms, tool_call_count, message_count |
| `mcpjam_agent_response_error` | status `→ error` edge | surface, session_id, message_index, duration_ms, error_message |
| `mcpjam_agent_back` | HomeTab back button | surface, had_session |
| `mcpjam_agent_new_chat` | HomeTab + New chat button | surface, had_session |

`useMcpjamAgentSession` takes a new optional `surface` arg threaded from `McpjamAgentThread`, so lifecycle events carry `surface: "home"` instead of `"unknown"`. `tool_call_count` is derived from the last assistant message's `parts` (filtering entries whose `type` starts with `tool-`).

No server-side emission — `posthog-node` isn't wired anywhere in this repo, and the existing server pattern is internal `log-events`.

## Caveats

- `mcpjam_agent_submit` already fires from the hero, and the autosubmit pipes that same first prompt back through the hook's `submit()`, so on the home page the first message produces **both** `submit` and `message_sent`. That's intentional (submit = user engaged the hero; message_sent = actually hit the wire), but it means `message_sent ≥ submit` rather than equal.
- Latency uses `useChat` status edges (`submitted/streaming → ready`) rather than an `onFinish` callback — `@ai-sdk/react@^3.0.156` in this repo doesn't expose one, and `use-chat-session.ts` already uses the same pattern.

## Dashboard

Pre-built dashboard with 7 insights pointing at the new events:

- [Ask MCPJam dashboard](https://us.posthog.com/project/212744/dashboard/1689351)
- [Messages sent per day](https://us.posthog.com/project/212744/insights/SkZvW3Xb)
- [Daily active users](https://us.posthog.com/project/212744/insights/CvyRzG4p)
- [Suggested-prompt clicks by prompt](https://us.posthog.com/project/212744/insights/35yXpprT)
- [Response latency p50/p95/p99](https://us.posthog.com/project/212744/insights/D6KsKZek)
- [Error rate %](https://us.posthog.com/project/212744/insights/tjMJVyMi)
- [Avg tool calls per response](https://us.posthog.com/project/212744/insights/BypcFRIG)
- [Submit vs resume vs new chat](https://us.posthog.com/project/212744/insights/3dcS4EGj)

Charts will be empty until this ships; PostHog backfills automatically once events start flowing.

## Test plan

- [ ] `npm run typecheck:client` passes (verified locally)
- [ ] On the home page, type a prompt → confirm `mcpjam_agent_message_sent` then `mcpjam_agent_response_finished` fire in the PostHog live view, both with `surface: "home"`
- [ ] Send a follow-up message in the takeover → confirm `message_index: 2` on `message_sent`
- [ ] Click the back button and the `+ New chat` button → confirm `mcpjam_agent_back` and `mcpjam_agent_new_chat` with the right `had_session` value
- [ ] Force an error (e.g. revoke bearer / disconnect docs MCP) → confirm `mcpjam_agent_response_error` fires with `error_message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only client changes with optional PostHog capture; no auth, API, or persistence behavior changes.
> 
> **Overview**
> Adds **client-side PostHog events** so the home Ask MCPJam agent funnel can be measured for engagement, latency, tool usage, and errors, alongside existing hero events (`submit`, suggested prompt, resume).
> 
> **`useMcpjamAgentSession`** now accepts optional **`surface`** (threaded from **`McpjamAgentThread`**, e.g. `home`) and emits **`mcpjam_agent_message_sent`** on each **`submit`**, plus **`mcpjam_agent_response_finished`** / **`mcpjam_agent_response_error`** on **`useChat` status edges** (with **`duration_ms`**, **`tool_call_count`**, model metadata). **`HomeTab`** fires **`mcpjam_agent_back`** and **`mcpjam_agent_new_chat`** when leaving or resetting the takeover, each with **`had_session`**.
> 
> The first home message may log both hero **`submit`** and hook **`message_sent`** by design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9addbf5a33c18aaac64634fc57dac44e9d064321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->