### PR TITLE
home: prefer preview MP4 over YouTube iframe in update modal

### DIFF
--- a/mcpjam-inspector/client/src/components/home/ProductUpdateExpandedPanel.tsx
+++ b/mcpjam-inspector/client/src/components/home/ProductUpdateExpandedPanel.tsx
@@ -34,6 +34,24 @@ function getPanelLayout(viewWidth: number, viewHeight: number) {
 }
 
 function ExpandedVideo({ entry }: { entry: ProductUpdateEntry }) {
+  if (entry.previewVideoUrl) {
+    return (
+      <div className="aspect-video w-full overflow-hidden rounded-lg bg-black">
+        <video
+          src={entry.previewVideoUrl}
+          poster={entry.videoPosterUrl}
+          className="h-full w-full"
+          autoPlay
+          loop
+          muted
+          playsInline
+          preload="auto"
+          controls
+        />
+      </div>
+    );
+  }
+
   const embed = entry.videoUrl ? parseVideoEmbed(entry.videoUrl) : null;
   const youtubeId =
     embed?.provider === "youtube"
@@ -41,26 +59,7 @@ function ExpandedVideo({ entry }: { entry: ProductUpdateEntry }) {
       : null;
   const isInlineEmbeddable = embed && embed.provider !== "raw";
 
-  // No embeddable full video: show the preview MP4 (if present) or a
-  // placeholder. Clicking through to a raw URL stays an out-of-modal action.
   if (!isInlineEmbeddable) {
-    if (entry.previewVideoUrl) {
-      return (
-        <div className="aspect-video w-full overflow-hidden rounded-lg bg-black">
-          <video
-            src={entry.previewVideoUrl}
-            poster={entry.videoPosterUrl}
-            className="h-full w-full"
-            autoPlay
-            loop
-            muted
-            playsInline
-            preload="auto"
-            controls
-          />
-        </div>
-      );
-    }
     return (
       <div className="aspect-video w-full bg-muted flex items-center justify-center rounded-lg">
         <p className="text-muted-foreground text-sm">No video available</p>


### PR DESCRIPTION
## Summary
- The expanded \"What's new\" modal embedded the YouTube iframe whenever an entry had a `videoUrl`, even if a `previewVideoUrl` (MP4 thumbnail/loop) was set.
- The hover card already preferred the preview MP4; the modal now matches and falls back to the YouTube iframe only when no preview MP4 is available.

## Test plan
- [ ] Open the home page, click a What's new entry that has both `previewVideoUrl` and a YouTube `videoUrl` (e.g. "MCPJam Evals is GA"); modal shows the looping preview, not the YouTube player chrome.
- [ ] Confirm entries with only a YouTube `videoUrl` still render the iframe + "Watch on YouTube" affordance.
- [ ] Confirm entries with neither still render the "No video available" placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to video display order in the product updates modal; no auth, data, or API impact.
> 
> **Overview**
> The expanded **What's new** modal now shows the **`previewVideoUrl` MP4** whenever it is set, instead of defaulting to the YouTube iframe when **`videoUrl`** is present.
> 
> **`ExpandedVideo`** in `ProductUpdateExpandedPanel` checks for a preview first (same priority as the hover card). YouTube embed and the "No video available" placeholder are used only when there is no preview MP4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7b5ffab3d7678dd69f5169cb3d98d22f0ce695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->