### PR TITLE
feat(evals): wire browser-rendered MCP App eval into the streamed path (PR 9)

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -3101,6 +3101,29 @@ const streamIterationWithAiSdk = async ({
         ]
       : msgs;
 
+  // Browser-rendered MCP App eval (PR 9): mirror runIterationWithAiSdk on the
+  // streamed path — render MCP App tool results in the headless-Chromium harness
+  // and (for Claude drivers) drive them with Computer Use. Declared BEFORE the
+  // try so the finally can dispose even on a mid-stream abort.
+  const computerUseVersion = resolveComputerUseToolVersion(test.model);
+  const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
+    current: null,
+  };
+  const widgetRenderObservations: RunnerWidgetRenderObservation[] = [];
+  const browserInteractionSteps: RunnerBrowserInteractionStep[] = [];
+  const stepIndexByToolCallId = new Map<string, number>();
+  const ensureWidgetHarness = (): McpAppBrowserHarness => {
+    if (!widgetHarnessRef.current) {
+      widgetHarnessRef.current = new McpAppBrowserHarness({
+        callTool: (sid, name, args) =>
+          mcpClientManager.executeTool(sid, name, args),
+        viewport: DEFAULT_VIEWPORT,
+      });
+    }
+    return widgetHarnessRef.current;
+  };
+  if (computerUseVersion) ensureWidgetHarness();
+
   try {
     // See `runIterationWithAiSdk`: adopt the chat-side pipeline inside the try
     // so prep failures become a recorded failed iteration.
@@ -3126,6 +3149,54 @@ const streamIterationWithAiSdk = async ({
     // time (mirroring the non-stream runner's PR 4d Codex P2 fix).
     streamEnhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
 
+    // Computer Use tools (Claude drivers only). Gated per step by
+    // `prepareAdvertisedTools` below so they only appear once a widget renders.
+    const computerWidgetTools = computerUseVersion
+      ? buildComputerUseTools({
+          version: computerUseVersion,
+          harness: ensureWidgetHarness(),
+          getActiveToolCallId: () =>
+            widgetHarnessRef.current?.getMountedWidgetId() ?? null,
+          viewport: DEFAULT_VIEWPORT,
+          // PR 9: collect one browserInteractionStep per executeAction; the
+          // screenshot stays base64 here (finalizeEvalIteration uploads once).
+          onAction: (result, { toolCallId }) => {
+            const stepIndex = (stepIndexByToolCallId.get(toolCallId) ?? -1) + 1;
+            stepIndexByToolCallId.set(toolCallId, stepIndex);
+            // Narrow the harness's open-string note through the guard (the
+            // backend union is closed) — keep the step, drop an unknown note.
+            let note: RunnerBrowserInteractionStep["note"];
+            if (result.note !== undefined) {
+              if (isEvalTraceBrowserStepNote(result.note)) {
+                note = result.note;
+              } else {
+                logger.warn("[evals] dropping unknown browser-step note", {
+                  note: result.note,
+                  toolCallId,
+                });
+              }
+            }
+            browserInteractionSteps.push({
+              toolCallId,
+              stepIndex,
+              promptIndex: activePromptIndex,
+              action: result.action.action,
+              coordinateX: result.action.coordinate?.[0],
+              coordinateY: result.action.coordinate?.[1],
+              text: result.action.text,
+              scrollDirection: result.action.scrollDirection,
+              scrollAmount: result.action.scrollAmount,
+              duration: result.action.duration,
+              screenshotBase64: result.screenshotBase64,
+              widgetToolCalls: result.widgetToolCalls,
+              elapsedMs: result.elapsedMs,
+              ...(note ? { note } : {}),
+              ts: Date.now(),
+            });
+          },
+        })
+      : {};
+
     const llmModel = createLlmModel(
       modelDefinition,
       modelRuntime.apiKey,
@@ -3136,7 +3207,10 @@ const streamIterationWithAiSdk = async ({
     if (
       toolChoice &&
       typeof toolChoice === "object" &&
-      !Object.hasOwn(prepared.allTools, toolChoice.toolName)
+      !Object.hasOwn(prepared.allTools, toolChoice.toolName) &&
+      // `computer` / `finish_widget` are merged into the tool map below, so a
+      // forced tool choice naming one of them is valid on Claude drivers.
+      !Object.hasOwn(computerWidgetTools, toolChoice.toolName)
     ) {
       throw new Error(
         `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`,
@@ -3161,6 +3235,14 @@ const streamIterationWithAiSdk = async ({
       if (localIsAborted()) return returnLocalCancelled();
       const promptTurn = promptTurns[promptIndex]!;
       activePromptIndex = promptIndex;
+      // PR 9 (mirror PR 5): start each turn with a clean widget surface so a
+      // widget kept mounted by a previous turn can't be advertised/targeted
+      // before this turn's own MCP App tool runs.
+      const carriedWidgetId =
+        widgetHarnessRef.current?.getMountedWidgetId() ?? null;
+      if (carriedWidgetId) {
+        await widgetHarnessRef.current!.dismissWidget(carriedWidgetId);
+      }
       // PR 5a invariant (mirror PR 4b round 2): push the user prompt to
       // `conversationMessages` BEFORE the driver call so a failed turn
       // still records the prompt in the persisted transcript. Without
@@ -3212,9 +3294,27 @@ const streamIterationWithAiSdk = async ({
         ...(prepared.resolvedTemperature == null
           ? {}
           : { temperature: prepared.resolvedTemperature }),
-        tools: prepared.allTools,
+        tools: { ...prepared.allTools, ...computerWidgetTools },
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
+        // PR 9 (mirror PR 5): gate Computer Use tools so the model only sees
+        // `computer` / `finish_widget` once a widget has actually rendered in
+        // the harness (the same live-widget source `getActiveToolCallId` reads).
+        ...(computerUseVersion
+          ? {
+              prepareAdvertisedTools: ({
+                defaultToolNames,
+              }: {
+                stepIndex: number;
+                defaultToolNames: string[];
+              }) =>
+                widgetHarnessRef.current?.getMountedWidgetId()
+                  ? defaultToolNames
+                  : defaultToolNames.filter(
+                      (n) => n !== "computer" && n !== "finish_widget",
+                    ),
+            }
+          : {}),
         ...(abortSignal ? { abortSignal } : {}),
         ...(toolChoice
           ? { toolChoice: toolChoice as ToolChoice<Record<string, AiTool>> }
@@ -3280,6 +3380,51 @@ const streamIterationWithAiSdk = async ({
                 usage: accumulatedUsage,
               }),
             );
+          },
+          // PR 9 (mirror PR 5): render each MCP App tool result in the harness
+          // and record an observation. `onToolResultChunk` fires on the stream
+          // path too; awaited so a rendered widget is mounted before the next
+          // step's Computer Use gate runs.
+          onToolResultChunk: async ({
+            toolCallId,
+            toolName,
+            input,
+            output,
+            serverId,
+          }) => {
+            if (!serverId) return;
+            const meta = mcpClientManager.getAllToolsMetadata(serverId)?.[
+              toolName
+            ];
+            if (!isRenderableMcpAppTool(meta)) return;
+            try {
+              const obs = await renderMcpAppToolResult({
+                toolCallId,
+                toolName,
+                serverId,
+                toolMetadata: meta,
+                toolInput: input,
+                output,
+                mcpClientManager,
+                injectOpenAiCompat,
+                harness: ensureWidgetHarness(),
+                keepMounted: computerUseVersion !== null,
+              });
+              // Stamp promptIndex at push-time (runner is the source of truth).
+              widgetRenderObservations.push({
+                ...obs,
+                promptIndex: activePromptIndex,
+              });
+              logger.debug("[evals] widget render observation", {
+                toolName,
+                status: obs.status,
+              });
+            } catch (err) {
+              logger.warn("[evals] widget render failed", {
+                toolName,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
           },
         },
       });
@@ -3581,6 +3726,9 @@ const streamIterationWithAiSdk = async ({
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
+      // PR 9: browser artifacts from the streamed Computer Use path.
+      ...(widgetRenderObservations.length ? { widgetRenderObservations } : {}),
+      ...(browserInteractionSteps.length ? { browserInteractionSteps } : {}),
       status: "completed" as const,
       startedAt: runStartedAt,
       // PR 5a (mirror PR 4b): if the per-turn loop set `iterationError`
@@ -3734,6 +3882,9 @@ const streamIterationWithAiSdk = async ({
       ...(recordedSpans.length ? { spans: recordedSpans } : {}),
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
+      // PR 9: browser artifacts collected before the failure still persist.
+      ...(widgetRenderObservations.length ? { widgetRenderObservations } : {}),
+      ...(browserInteractionSteps.length ? { browserInteractionSteps } : {}),
       status: "failed" as const,
       startedAt: runStartedAt,
       error: errorMessage,
@@ -3762,6 +3913,16 @@ const streamIterationWithAiSdk = async ({
       evaluation,
       iterationId: iterationId ?? undefined,
     };
+  } finally {
+    // PR 9: tear down the harness (and its headless Chromium, if launched) on
+    // success, failure, OR mid-stream abort. No-op when never constructed.
+    await widgetHarnessRef.current?.dispose();
+    if (widgetRenderObservations.length > 0) {
+      logger.debug("[evals] widget render observations (stream)", {
+        count: widgetRenderObservations.length,
+        statuses: widgetRenderObservations.map((o) => o.status),
+      });
+    }
   }
 };
 

--- a/mcpjam-inspector/server/services/evals/__tests__/computer-use-loop-stream.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/computer-use-loop-stream.test.ts
@@ -1,0 +1,344 @@
+/**
+ * PR 9 — End-to-end smoke test for the model-driven Computer Use loop on the
+ * STREAMED Anthropic AI-SDK eval path (`streamIterationWithAiSdk`, reached via
+ * `streamTestCase`).
+ *
+ * Sibling to `computer-use-loop.test.ts` (the non-stream PR 8 smoke test). Proves
+ * PR 9's port: the streamed path mounts the widget, drives a Computer Use click
+ * through the real headless-Chromium harness, and forwards exactly one render
+ * observation + one interaction step into the persistence fanout — same as the
+ * non-stream path. Uses the same fixture + mock model; only the runner entry and
+ * the stream consumer differ.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { build } from "esbuild";
+import type {
+  LanguageModelV3CallOptions,
+  LanguageModelV3StreamPart,
+  LanguageModelV3StreamResult,
+} from "@ai-sdk/provider";
+
+const createLlmModelMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../utils/chat-helpers", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../../utils/chat-helpers")>(
+      "../../../utils/chat-helpers",
+    );
+  return {
+    ...actual,
+    createLlmModel: (...args: unknown[]) =>
+      createLlmModelMock(...(args as Parameters<typeof createLlmModelMock>)),
+  };
+});
+
+const preparedToolsRef = vi.hoisted(() => ({
+  tools: {} as Record<string, unknown>,
+}));
+
+vi.mock("../../../utils/chat-v2-orchestration", () => ({
+  prepareChatV2: vi.fn(async (options: any) => ({
+    allTools: preparedToolsRef.tools,
+    enhancedSystemPrompt: options?.systemPrompt ?? "",
+    resolvedTemperature: options?.temperature,
+    scrubMessages: (msgs: unknown[]) => msgs,
+    progressivePlan: { enabled: false },
+    discoveryState: { loadedToolIds: new Set<string>(), catalogVersion: 0 },
+  })),
+}));
+
+// Skip persistence — assert in-memory collection via the fanout call args.
+const persistEvalTraceFanoutMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ turnsWritten: 0, locked: false }),
+);
+vi.mock("../persist-eval-trace", () => ({
+  persistEvalTraceFanout: persistEvalTraceFanoutMock,
+  lockEvalSessionAfterUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@mcpjam/sdk", async () => {
+  const actual =
+    await vi.importActual<typeof import("@mcpjam/sdk")>("@mcpjam/sdk");
+  return {
+    ...actual,
+    finalizePassedForEval: ({ matchPassed }: { matchPassed: boolean }) =>
+      matchPassed,
+  };
+});
+
+import { streamTestCase } from "../../evals-runner";
+import { tool } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { z } from "zod";
+import * as computerUseModule from "../../../utils/computer-use-tool";
+import {
+  McpAppBrowserHarness,
+  DEFAULT_VIEWPORT,
+} from "../../../utils/mcp-app-browser-harness";
+
+const BUTTON_GUEST_SRC = `
+import { App } from "@modelcontextprotocol/ext-apps";
+const app = new App({ name: "fixture-button", version: "1.0.0" });
+(async () => {
+  await app.connect();
+  const b = document.createElement("button");
+  b.id = "ok";
+  b.textContent = "Reserve seat";
+  b.style.cssText = "position:absolute;left:540px;top:370px;width:200px;height:60px;font-size:18px";
+  b.addEventListener("click", () => {
+    app.callServerTool({ name: "reserve", arguments: { seat: 12 } }).catch(() => {});
+  });
+  document.body.appendChild(b);
+})();
+`;
+
+async function bundleGuest(source: string): Promise<string> {
+  const r = await build({
+    stdin: { contents: source, resolveDir: process.cwd(), loader: "ts" },
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "es2022",
+    write: false,
+    logLevel: "silent",
+  });
+  return r.outputFiles[0].text;
+}
+
+function guestHtml(js: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"></head><body><script>${js}</script></body></html>`;
+}
+
+let buttonHtml = "";
+beforeAll(async () => {
+  buttonHtml = guestHtml(await bundleGuest(BUTTON_GUEST_SRC));
+}, 60_000);
+
+function streamPartsAsResult(
+  parts: LanguageModelV3StreamPart[],
+): LanguageModelV3StreamResult {
+  return {
+    stream: new ReadableStream<LanguageModelV3StreamPart>({
+      start(controller) {
+        for (const p of parts) controller.enqueue(p);
+        controller.close();
+      },
+    }),
+  };
+}
+
+const USAGE = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+
+function streamForShowSeatsCall(): LanguageModelV3StreamResult {
+  return streamPartsAsResult([
+    { type: "stream-start", warnings: [] },
+    { type: "tool-input-start", id: "tc-show", toolName: "show_seats" },
+    { type: "tool-input-end", id: "tc-show" },
+    { type: "tool-call", toolCallId: "tc-show", toolName: "show_seats", input: "{}" },
+    { type: "finish", finishReason: "tool-calls", usage: USAGE },
+  ]);
+}
+function streamForComputerLeftClick(
+  coordinate: [number, number],
+): LanguageModelV3StreamResult {
+  return streamPartsAsResult([
+    { type: "stream-start", warnings: [] },
+    { type: "tool-input-start", id: "tc-click", toolName: "computer" },
+    { type: "tool-input-end", id: "tc-click" },
+    {
+      type: "tool-call",
+      toolCallId: "tc-click",
+      toolName: "computer",
+      input: JSON.stringify({ action: "left_click", coordinate }),
+    },
+    { type: "finish", finishReason: "tool-calls", usage: USAGE },
+  ]);
+}
+function streamForFinishWidget(): LanguageModelV3StreamResult {
+  return streamPartsAsResult([
+    { type: "stream-start", warnings: [] },
+    { type: "tool-input-start", id: "tc-fin", toolName: "finish_widget" },
+    { type: "tool-input-end", id: "tc-fin" },
+    {
+      type: "tool-call",
+      toolCallId: "tc-fin",
+      toolName: "finish_widget",
+      input: JSON.stringify({ toolCallId: "tc-show" }),
+    },
+    { type: "finish", finishReason: "tool-calls", usage: USAGE },
+  ]);
+}
+function streamForFinalText(): LanguageModelV3StreamResult {
+  return streamPartsAsResult([
+    { type: "stream-start", warnings: [] },
+    { type: "text-start", id: "t1" },
+    { type: "text-delta", id: "t1", delta: "Done." },
+    { type: "text-end", id: "t1" },
+    { type: "finish", finishReason: "stop", usage: USAGE },
+  ]);
+}
+
+describe("PR 9 — model-driven Computer Use loop, streamed path (smoke)", () => {
+  const executeToolCalls: Array<{
+    sid: string;
+    name: string;
+    args: Record<string, unknown>;
+  }> = [];
+
+  const convexClient = {
+    mutation: vi.fn().mockResolvedValue({ iterationId: "iter-1" }),
+    query: vi.fn().mockResolvedValue({ status: "running" }),
+    action: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const mcpClientManager = {
+    listServers: vi.fn().mockReturnValue(["flights"]),
+    getToolsForAiSdk: vi.fn().mockResolvedValue({}),
+    getAllToolsMetadata: vi.fn((sid: string) =>
+      sid === "flights"
+        ? { show_seats: { ui: { resourceUri: "ui://widget/seats" } } }
+        : {},
+    ),
+    readResource: vi.fn(async () => ({
+      contents: [{ text: buttonHtml, _meta: { ui: {} } }],
+    })),
+    executeTool: vi.fn(async (sid: string, name: string, args: any) => {
+      executeToolCalls.push({ sid, name, args });
+      return { content: [{ type: "text", text: "reserved" }] };
+    }),
+    hasServer: vi.fn(() => true),
+  };
+
+  let buildCuToolsSpy: ReturnType<typeof vi.spyOn>;
+  let renderWidgetSpy: ReturnType<typeof vi.spyOn>;
+  let executeActionSpy: ReturnType<typeof vi.spyOn>;
+  let disposeSpy: ReturnType<typeof vi.spyOn>;
+  let mockModel: MockLanguageModelV3;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executeToolCalls.length = 0;
+    persistEvalTraceFanoutMock.mockResolvedValue({ turnsWritten: 0, locked: false });
+    convexClient.mutation.mockResolvedValue({ iterationId: "iter-1" });
+    convexClient.query.mockResolvedValue({ status: "running" });
+    convexClient.action.mockResolvedValue(undefined);
+    mcpClientManager.getAllToolsMetadata.mockImplementation((sid: string) =>
+      sid === "flights"
+        ? { show_seats: { ui: { resourceUri: "ui://widget/seats" } } }
+        : {},
+    );
+    mcpClientManager.readResource.mockResolvedValue({
+      contents: [{ text: buttonHtml, _meta: { ui: {} } }],
+    });
+    mcpClientManager.executeTool.mockImplementation(
+      async (sid: string, name: string, args: any) => {
+        executeToolCalls.push({ sid, name, args });
+        return { content: [{ type: "text", text: "reserved" }] };
+      },
+    );
+
+    const showSeatsTool = tool({
+      description: "Show the seat selector widget",
+      inputSchema: z.object({}).passthrough(),
+      execute: async () => ({ content: [{ type: "text", text: "showing seats" }] }),
+    }) as any;
+    showSeatsTool._serverId = "flights";
+    preparedToolsRef.tools = { show_seats: showSeatsTool };
+
+    const streams = [
+      streamForShowSeatsCall(),
+      streamForComputerLeftClick([640, 400]),
+      streamForFinishWidget(),
+      streamForFinalText(),
+    ];
+    let streamIndex = 0;
+    mockModel = new MockLanguageModelV3({
+      provider: "anthropic",
+      modelId: "claude-haiku-4-5",
+      doStream: async (_opts: LanguageModelV3CallOptions) => {
+        const next = streams[streamIndex];
+        streamIndex += 1;
+        if (!next) {
+          throw new Error(
+            `MockLanguageModelV3 called more than ${streams.length} times`,
+          );
+        }
+        return next;
+      },
+    });
+    createLlmModelMock.mockReturnValue(mockModel);
+
+    buildCuToolsSpy = vi.spyOn(computerUseModule, "buildComputerUseTools");
+    renderWidgetSpy = vi.spyOn(McpAppBrowserHarness.prototype, "renderWidget");
+    executeActionSpy = vi.spyOn(McpAppBrowserHarness.prototype, "executeAction");
+    disposeSpy = vi.spyOn(McpAppBrowserHarness.prototype, "dispose");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("streamed path renders, drives a click, collects one obs + one step, disposes", async () => {
+    await streamTestCase({
+      test: {
+        title: "Computer Use stream smoke",
+        query: "Reserve seat 12",
+        model: "claude-haiku-4-5",
+        provider: "anthropic",
+        runs: 1,
+        expectedToolCalls: [],
+        promptTurns: [
+          { id: "turn-1", prompt: "Reserve seat 12", expectedToolCalls: [] },
+        ],
+        testCaseId: "case-smoke",
+      } as any,
+      tools: {},
+      selectedServers: ["flights"],
+      mcpClientManager: mcpClientManager as any,
+      recorder: null,
+      modelApiKeys: { anthropic: "sk-test" },
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      convexClient: convexClient as any,
+      testCaseId: "case-smoke",
+      runId: null,
+      emit: () => {},
+    });
+
+    // Harness lifecycle ran on the streamed path.
+    expect(buildCuToolsSpy).toHaveBeenCalledTimes(1);
+    expect(buildCuToolsSpy.mock.calls[0]![0].viewport).toEqual(DEFAULT_VIEWPORT);
+    expect(renderWidgetSpy).toHaveBeenCalledTimes(1);
+    expect(renderWidgetSpy.mock.calls[0]![0]).toMatchObject({
+      toolCallId: "tc-show",
+      serverId: "flights",
+      keepMounted: true,
+    });
+    expect(executeActionSpy).toHaveBeenCalledTimes(1);
+    // The fixture widget's tools/call reached executeTool through the harness.
+    expect(executeToolCalls).toEqual([
+      { sid: "flights", name: "reserve", args: { seat: 12 } },
+    ]);
+    // Harness disposed in the finally (PR 9's outer try/finally).
+    expect(disposeSpy).toHaveBeenCalled();
+
+    // PR 9 deliverable: one render observation + one step forwarded to the
+    // fanout from the streamed iteration.
+    expect(persistEvalTraceFanoutMock).toHaveBeenCalledTimes(1);
+    const fanoutArgs = persistEvalTraceFanoutMock.mock.calls[0]![0];
+    expect(fanoutArgs.widgetRenderObservations).toHaveLength(1);
+    expect(fanoutArgs.browserInteractionSteps).toHaveLength(1);
+    expect(fanoutArgs.widgetRenderObservations[0]).toMatchObject({
+      toolCallId: "tc-show",
+      status: "rendered",
+      promptIndex: 0,
+    });
+    expect(fanoutArgs.browserInteractionSteps[0]).toMatchObject({
+      toolCallId: "tc-show",
+      stepIndex: 0,
+      promptIndex: 0,
+      action: "left_click",
+    });
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

**PR 9** — stream-variant parity for browser-rendered MCP App evals. Ports the render-check + Computer Use collection + persistence wiring from `runIterationWithAiSdk` into `streamIterationWithAiSdk`, so streamed evals (the path most production traffic uses) populate the same `widgetRenderObservations` + `browserInteractionSteps` tables as the non-stream path landed in PR 6b.

Server-only; no schema or cross-repo changes. Builds on the shared finalize/fanout pipeline already in `main`.

## What changed (`server/services/evals-runner.ts`)

All mirrors of the non-stream template:

- **Harness lifecycle** — lazy `ensureWidgetHarness` declared *before* the `try` (so the `finally` can dispose), eager-constructed for Claude drivers.
- **Computer Use tools** merged into the streamed `runDirectChatTurn` call and **gated per-step** by `prepareAdvertisedTools` (only advertised once a widget is actually mounted).
- **`onToolResultChunk`** collects render observations (stamping `promptIndex`); **`onAction`** collects browser steps (same closed-`note` type guard as the non-stream path — unknown notes are dropped, not fatal).
- Both arrays threaded into the **success + failure** `finishParams`.
- **Outer `try/finally`** disposes the harness on success, failure, **or mid-stream abort** — the streamed path can `return` mid-stream on cancellation, which a plain try/catch would skip.

## Testing

New **streamed Computer Use smoke test** (`computer-use-loop-stream.test.ts`) — drives a `MockLanguageModelV3` through real headless Chromium via `streamTestCase`: asserts render → `left_click` → widget-initiated `tools/call` → `finish_widget` dispose, and that **exactly one render observation + one interaction step** are forwarded to the fanout from the streamed iteration.

Full evals suite green (**207 tests**, incl. both Chromium smoke tests and the existing **59** `evals-runner` tests — no regression). Same Chromium-graceful-degrade behavior (missing Chromium → `browser_unavailable`, no crash).

## Follow-ups

PR 10 (hosted/non-Claude render-after-turn) and PR 13 (metrics) remain. PR 13 is up next.

https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production streamed eval loop and headless Chromium lifecycle; behavior is mirrored from an existing path but adds async render hooks and new persisted artifacts on failure/abort paths.
> 
> **Overview**
> **Streamed local-BYOK evals** (`streamIterationWithAiSdk`) now match the non-stream runner for **browser-rendered MCP App tools** and **Claude Computer Use**: headless `McpAppBrowserHarness`, merged `computer` / `finish_widget` tools, per-step gating via `prepareAdvertisedTools`, MCP App rendering on `onToolResultChunk`, and interaction steps via `onAction`.
> 
> Collected **`widgetRenderObservations`** and **`browserInteractionSteps`** are included on success and failure persistence; an outer **`try/finally`** disposes Chromium even on mid-stream cancel. Each prompt turn **dismisses** a carried widget so Computer Use cannot target a prior turn’s mount.
> 
> Adds **`computer-use-loop-stream.test.ts`**, a Chromium smoke test through `streamTestCase` that asserts one render observation and one browser step reach the trace fanout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4fbe9f3f43ab4ee9c0a9dd558058ce6330e9025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->