### PR TITLE
feat: WorkOS API keys for v1 public API, org-scoped (completes #2507)

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   UserPlus,
   ShieldCheck,
   Loader2,
+  Key,
 } from "lucide-react";
 import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { isPostHogBooleanFlagOn, standardEventProps } from "@/lib/PosthogUtils";
@@ -335,6 +336,11 @@ const navigationSections: NavSection[] = [
         title: "Support",
         url: "/support",
         icon: MessageCircleQuestionIcon,
+      },
+      {
+        title: "API Keys",
+        url: "/settings/api-keys",
+        icon: Key,
       },
       {
         title: "Settings",

--- a/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useConvexAuth } from "convex/react";
 import { Key, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
@@ -6,6 +7,7 @@ import { SettingsSection } from "../setting/SettingsSection";
 import { CreateApiKeyDialog } from "./api-keys/CreateApiKeyDialog";
 import { RevealOnceDialog } from "./api-keys/RevealOnceDialog";
 import { RevokeApiKeyDialog } from "./api-keys/RevokeApiKeyDialog";
+import { useOrganizationQueries } from "@/hooks/useOrganizations";
 import {
   type ApiKey,
   createApiKey,
@@ -31,6 +33,10 @@ export function ApiKeysRoute() {
   const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
   const [isRevoking, setIsRevoking] = useState(false);
 
+  const { isAuthenticated } = useConvexAuth();
+  const { sortedOrganizations, isLoading: orgsLoading } =
+    useOrganizationQueries({ isAuthenticated });
+
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
@@ -49,10 +55,16 @@ export function ApiKeysRoute() {
     void refresh();
   }, [refresh]);
 
-  const handleCreate = async ({ name }: { name: string }) => {
+  const handleCreate = async ({
+    name,
+    organizationId,
+  }: {
+    name: string;
+    organizationId: string;
+  }) => {
     setIsCreating(true);
     try {
-      const created = await createApiKey({ name });
+      const created = await createApiKey({ name, organizationId });
       setCreateOpen(false);
       setRevealValue(created.value);
       await refresh();
@@ -148,6 +160,8 @@ export function ApiKeysRoute() {
           open={createOpen}
           onOpenChange={setCreateOpen}
           isCreating={isCreating}
+          organizations={sortedOrganizations}
+          orgsLoading={orgsLoading}
           onCreate={handleCreate}
         />
 

--- a/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState } from "react";
+import { Key, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@mcpjam/design-system/button";
+import { SettingsSection } from "../setting/SettingsSection";
+import { CreateApiKeyDialog } from "./api-keys/CreateApiKeyDialog";
+import { RevealOnceDialog } from "./api-keys/RevealOnceDialog";
+import { RevokeApiKeyDialog } from "./api-keys/RevokeApiKeyDialog";
+import {
+  type ApiKey,
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+} from "@/lib/apis/web/api-keys";
+
+/**
+ * `/settings/api-keys` — manage WorkOS-issued `sk_…` API keys for the
+ * v1 public API.
+ *
+ * Server side gates this surface: the inspector's `/api/web/api-keys/*`
+ * sub-router refuses requests that themselves authenticated via a
+ * `sk_…` key. That means visiting this page over a session JWT is the
+ * only way to mint/revoke — there is no privilege escalation path here.
+ */
+export function ApiKeysRoute() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [revealValue, setRevealValue] = useState<string | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const items = await listApiKeys();
+      setKeys(items);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to load API keys";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleCreate = async ({ name }: { name: string }) => {
+    setIsCreating(true);
+    try {
+      const created = await createApiKey({ name });
+      setCreateOpen(false);
+      setRevealValue(created.value);
+      await refresh();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to create API key";
+      toast.error(message);
+      throw error;
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+    setIsRevoking(true);
+    try {
+      await revokeApiKey(revokeTarget.id);
+      toast.success(`Revoked ${revokeTarget.name}`);
+      setRevokeTarget(null);
+      await refresh();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to revoke API key";
+      toast.error(message);
+      throw error;
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-10 space-y-8 max-w-3xl">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">API keys</h1>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-2 size-4" aria-hidden /> Create API key
+          </Button>
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          Use these keys to call the MCPJam v1 public API from CI, scripts, or
+          other non-browser contexts. Keys carry your account's permissions
+          and can be revoked any time.
+        </p>
+
+        <SettingsSection title="Your keys">
+          {loading ? (
+            <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+              Loading…
+            </div>
+          ) : keys.length === 0 ? (
+            <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+              No API keys yet. Create one to start using the v1 API.
+            </div>
+          ) : (
+            keys.map((key) => (
+              <div
+                key={key.id}
+                className="flex items-center justify-between px-4 py-3 rounded-md border border-border/40 bg-muted/20 transition-colors"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
+                    <Key className="size-4 text-primary" aria-hidden />
+                  </div>
+                  <div className="flex flex-col min-w-0">
+                    <span className="text-sm font-medium truncate">
+                      {key.name}
+                    </span>
+                    <span className="text-xs text-muted-foreground font-mono truncate">
+                      {key.obfuscated_value}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+                    onClick={() => setRevokeTarget(key)}
+                    aria-label={`Revoke ${key.name}`}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </div>
+              </div>
+            ))
+          )}
+        </SettingsSection>
+
+        <CreateApiKeyDialog
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          isCreating={isCreating}
+          onCreate={handleCreate}
+        />
+
+        <RevealOnceDialog
+          open={revealValue !== null}
+          onOpenChange={(next) => {
+            if (!next) setRevealValue(null);
+          }}
+          value={revealValue}
+        />
+
+        <RevokeApiKeyDialog
+          open={revokeTarget !== null}
+          onOpenChange={(next) => {
+            if (!next) setRevokeTarget(null);
+          }}
+          keyName={revokeTarget?.name ?? ""}
+          isRevoking={isRevoking}
+          onConfirm={handleRevoke}
+        />
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/api-keys/CreateApiKeyDialog.tsx
+++ b/mcpjam-inspector/client/src/components/settings/api-keys/CreateApiKeyDialog.tsx
@@ -11,37 +11,67 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+
+export interface CreateApiKeyOrganization {
+  _id: string;
+  name: string;
+}
 
 export interface CreateApiKeyDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   isCreating: boolean;
-  onCreate: (args: { name: string }) => Promise<void>;
+  /** MCPJam orgs the user belongs to. The key is scoped to the selected one. */
+  organizations: CreateApiKeyOrganization[];
+  orgsLoading: boolean;
+  onCreate: (args: { name: string; organizationId: string }) => Promise<void>;
 }
 
 export function CreateApiKeyDialog({
   open,
   onOpenChange,
   isCreating,
+  organizations,
+  orgsLoading,
   onCreate,
 }: CreateApiKeyDialogProps) {
   const [name, setName] = useState("");
+  const [organizationId, setOrganizationId] = useState("");
 
+  // Reset name on open; auto-select the org when there's exactly one (and
+  // clear any stale selection that's no longer in the list).
   useEffect(() => {
-    if (open) setName("");
-  }, [open]);
+    if (!open) return;
+    setName("");
+    setOrganizationId((prev) => {
+      if (organizations.length === 1) return organizations[0]._id;
+      if (prev && organizations.some((o) => o._id === prev)) return prev;
+      return "";
+    });
+  }, [open, organizations]);
 
   const trimmed = name.trim();
-  const canCreate = trimmed.length > 0 && !isCreating;
+  const hasOrgs = organizations.length > 0;
+  const canCreate =
+    trimmed.length > 0 && organizationId.length > 0 && !isCreating;
 
   const handleSubmit = async () => {
     if (!canCreate) return;
     try {
-      await onCreate({ name: trimmed });
+      await onCreate({ name: trimmed, organizationId });
     } catch {
       /* Error toast handled by caller */
     }
   };
+
+  const singleOrg = organizations.length === 1;
 
   return (
     <Dialog
@@ -51,10 +81,7 @@ export function CreateApiKeyDialog({
         onOpenChange(next);
       }}
     >
-      <DialogContent
-        showCloseButton={!isCreating}
-        className="gap-4 sm:max-w-md"
-      >
+      <DialogContent showCloseButton={!isCreating} className="gap-4 sm:max-w-md">
         <DialogHeader className="gap-2 text-left">
           <DialogTitle>Create API key</DialogTitle>
           <DialogDescription>
@@ -79,6 +106,42 @@ export function CreateApiKeyDialog({
               }
             }}
           />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="api-key-org-select">Organization</Label>
+          {orgsLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+              Loading organizations…
+            </div>
+          ) : !hasOrgs ? (
+            <p className="text-sm text-muted-foreground">
+              You don't belong to any organization yet. Create one first to mint
+              an API key.
+            </p>
+          ) : (
+            <Select
+              value={organizationId}
+              onValueChange={setOrganizationId}
+              disabled={isCreating || singleOrg}
+            >
+              <SelectTrigger id="api-key-org-select">
+                <SelectValue placeholder="Select an organization" />
+              </SelectTrigger>
+              <SelectContent>
+                {organizations.map((org) => (
+                  <SelectItem key={org._id} value={org._id}>
+                    {org.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <p className="text-xs text-muted-foreground">
+            The key acts inside this organization. Requests are scoped to its
+            projects and servers.
+          </p>
         </div>
 
         <DialogFooter className="gap-2 sm:gap-2">

--- a/mcpjam-inspector/client/src/components/settings/api-keys/CreateApiKeyDialog.tsx
+++ b/mcpjam-inspector/client/src/components/settings/api-keys/CreateApiKeyDialog.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+
+export interface CreateApiKeyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isCreating: boolean;
+  onCreate: (args: { name: string }) => Promise<void>;
+}
+
+export function CreateApiKeyDialog({
+  open,
+  onOpenChange,
+  isCreating,
+  onCreate,
+}: CreateApiKeyDialogProps) {
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (open) setName("");
+  }, [open]);
+
+  const trimmed = name.trim();
+  const canCreate = trimmed.length > 0 && !isCreating;
+
+  const handleSubmit = async () => {
+    if (!canCreate) return;
+    try {
+      await onCreate({ name: trimmed });
+    } catch {
+      /* Error toast handled by caller */
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && isCreating) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        showCloseButton={!isCreating}
+        className="gap-4 sm:max-w-md"
+      >
+        <DialogHeader className="gap-2 text-left">
+          <DialogTitle>Create API key</DialogTitle>
+          <DialogDescription>
+            Give this key a name so you can identify it later. The key value
+            will be shown only once after creation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="api-key-name-input">Name</Label>
+          <Input
+            id="api-key-name-input"
+            autoComplete="off"
+            placeholder="e.g. ci-pipeline, local-laptop"
+            value={name}
+            disabled={isCreating}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canCreate) {
+                e.preventDefault();
+                void handleSubmit();
+              }
+            }}
+          />
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isCreating}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!canCreate}
+            onClick={() => void handleSubmit()}
+          >
+            {isCreating ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                Creating…
+              </>
+            ) : (
+              "Create key"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/api-keys/RevealOnceDialog.tsx
+++ b/mcpjam-inspector/client/src/components/settings/api-keys/RevealOnceDialog.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { AlertTriangle, Check, Copy } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+
+export interface RevealOnceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: string | null;
+}
+
+/**
+ * One-shot reveal dialog for a freshly minted API key.
+ *
+ * The plaintext `sk_…` value is only ever in the WorkOS create response.
+ * We display it here, give the user a Copy button (with the
+ * Copy → Check feedback pattern from SkillsTab), and warn loudly that it
+ * won't be shown again. The `value` prop is dropped when the dialog closes.
+ */
+export function RevealOnceDialog({
+  open,
+  onOpenChange,
+  value,
+}: RevealOnceDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable — the user can still select + copy manually.
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setCopied(false);
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="gap-4 sm:max-w-lg">
+        <DialogHeader className="gap-2 text-left">
+          <DialogTitle>Copy your API key</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-foreground">
+                <AlertTriangle
+                  className="mt-0.5 size-4 shrink-0 text-warning"
+                  aria-hidden
+                />
+                <p className="text-sm">
+                  This key won't be shown again. Copy it now and store it
+                  somewhere safe. If you lose it, revoke it and create a new
+                  one.
+                </p>
+              </div>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-2">
+          <code className="flex-1 select-all overflow-x-auto whitespace-nowrap font-mono text-xs text-foreground">
+            {value ?? ""}
+          </code>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => void handleCopy()}
+            disabled={!value}
+            aria-label="Copy API key"
+          >
+            {copied ? (
+              <>
+                <Check className="mr-1.5 size-3.5" aria-hidden /> Copied
+              </>
+            ) : (
+              <>
+                <Copy className="mr-1.5 size-3.5" aria-hidden /> Copy
+              </>
+            )}
+          </Button>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button type="button" onClick={() => onOpenChange(false)}>
+            I've saved it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/api-keys/RevokeApiKeyDialog.tsx
+++ b/mcpjam-inspector/client/src/components/settings/api-keys/RevokeApiKeyDialog.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import { cn } from "@/lib/utils";
+
+export interface RevokeApiKeyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  keyName: string;
+  isRevoking: boolean;
+  onConfirm: () => Promise<void>;
+}
+
+/**
+ * Type-the-name-to-confirm pattern — mirrors `ChatboxDeleteConfirmDialog`.
+ * Revocation is immediate: once confirmed, any client still holding the
+ * key value gets 401 within seconds.
+ */
+export function RevokeApiKeyDialog({
+  open,
+  onOpenChange,
+  keyName,
+  isRevoking,
+  onConfirm,
+}: RevokeApiKeyDialogProps) {
+  const [confirmText, setConfirmText] = useState("");
+
+  useEffect(() => {
+    if (open) setConfirmText("");
+  }, [open]);
+
+  const phraseMatches = confirmText.trim() === keyName.trim();
+
+  const handleConfirm = async () => {
+    if (!phraseMatches || isRevoking) return;
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch {
+      /* Error toast is handled by the caller */
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && isRevoking) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        showCloseButton={!isRevoking}
+        className="gap-4 sm:max-w-md"
+      >
+        <DialogHeader className="gap-2 text-left">
+          <DialogTitle className="text-foreground">Revoke API key?</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                <span className="font-medium text-foreground">
+                  {keyName || "This key"}
+                </span>{" "}
+                will be revoked immediately. Any client still using it will
+                start receiving 401 errors.
+              </p>
+              <p>You cannot undo this.</p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="api-key-revoke-confirm-input">
+            Type the key name{" "}
+            <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-xs font-normal text-foreground">
+              {keyName}
+            </kbd>{" "}
+            to confirm
+          </Label>
+          <Input
+            id="api-key-revoke-confirm-input"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            placeholder={keyName}
+            value={confirmText}
+            disabled={isRevoking}
+            onChange={(e) => setConfirmText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && phraseMatches && !isRevoking) {
+                e.preventDefault();
+                void handleConfirm();
+              }
+            }}
+            className="font-mono"
+          />
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isRevoking}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className={cn(
+              "border-destructive/80 text-destructive shadow-none",
+              "hover:bg-destructive/10 hover:text-destructive",
+              "focus-visible:border-destructive focus-visible:ring-destructive/25",
+              "dark:hover:bg-destructive/15",
+            )}
+            disabled={!phraseMatches || isRevoking}
+            onClick={() => void handleConfirm()}
+          >
+            {isRevoking ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                Revoking…
+              </>
+            ) : (
+              "Revoke key"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/lib/apis/web/api-keys.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/api-keys.ts
@@ -1,0 +1,69 @@
+import { authFetch } from "@/lib/session-token";
+import { WebApiError } from "./base";
+
+/**
+ * Typed wrappers for the inspector's `/api/web/api-keys/*` management
+ * surface. Mint / list / revoke only — validation and rate limiting
+ * live server-side.
+ *
+ * `value` is only present on the create response; never persisted, never
+ * shown a second time.
+ */
+export interface ApiKey {
+  id: string;
+  name: string;
+  obfuscated_value: string;
+  created_at?: string;
+  last_used_at?: string | null;
+}
+
+export interface CreatedApiKey extends ApiKey {
+  /**
+   * Plaintext `sk_…` value. Returned ONCE from the create endpoint and
+   * surfaced via the RevealOnceDialog. Discarded as soon as the dialog
+   * closes — never written to localStorage / state stores.
+   */
+  value: string;
+}
+
+async function parseError(response: Response): Promise<never> {
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch {
+    // ignored
+  }
+  const message =
+    typeof body?.message === "string"
+      ? body.message
+      : `Request failed (${response.status})`;
+  const code = typeof body?.code === "string" ? body.code : null;
+  throw new WebApiError(response.status, code, message);
+}
+
+export async function listApiKeys(): Promise<ApiKey[]> {
+  const response = await authFetch("/api/web/api-keys", { method: "GET" });
+  if (!response.ok) await parseError(response);
+  const body = (await response.json()) as { items?: ApiKey[] };
+  return Array.isArray(body.items) ? body.items : [];
+}
+
+export async function createApiKey(args: {
+  name: string;
+}): Promise<CreatedApiKey> {
+  const response = await authFetch("/api/web/api-keys", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: args.name }),
+  });
+  if (!response.ok) await parseError(response);
+  return (await response.json()) as CreatedApiKey;
+}
+
+export async function revokeApiKey(id: string): Promise<void> {
+  const response = await authFetch(
+    `/api/web/api-keys/${encodeURIComponent(id)}`,
+    { method: "DELETE" },
+  );
+  if (!response.ok) await parseError(response);
+}

--- a/mcpjam-inspector/client/src/lib/apis/web/api-keys.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/api-keys.ts
@@ -50,11 +50,16 @@ export async function listApiKeys(): Promise<ApiKey[]> {
 
 export async function createApiKey(args: {
   name: string;
+  /** MCPJam organization id (Convex) the key acts inside. Required. */
+  organizationId: string;
 }): Promise<CreatedApiKey> {
   const response = await authFetch("/api/web/api-keys", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: args.name }),
+    body: JSON.stringify({
+      name: args.name,
+      organizationId: args.organizationId,
+    }),
   });
   if (!response.ok) await parseError(response);
   return (await response.json()) as CreatedApiKey;

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -29,6 +29,7 @@ import App, {
   ViewsRoute,
   XAAFlowRoute,
 } from "./App";
+import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
 import { getAppRouter, setAppRouter } from "./router-ref";
 
 export { getAppRouter };
@@ -83,6 +84,7 @@ export function createAppRouter(): AppRouter {
         { path: "views", element: <ViewsRoute /> },
         { path: "support", element: <SupportRoute /> },
         { path: "settings", element: <SettingsRoute /> },
+        { path: "settings/api-keys", element: <ApiKeysRoute /> },
         { path: "profile", element: <ProfileRoute /> },
         { path: "project-settings", element: <ProjectSettingsRoute /> },
         { path: "client-config", element: <ServersRedirectRoute /> },

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -149,6 +149,7 @@
     "fuse.js": "^7.1.0",
     "gray-matter": "^4.0.3",
     "hono": "^4.11.7",
+    "jose": "^5.10.0",
     "lucide-react": "^0.525.0",
     "marked": "^16.4.1",
     "next-themes": "^0.4.6",

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -129,6 +129,7 @@
     "@sentry/vite-plugin": "^4.3.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@workos-inc/authkit-react": "^0.12.0",
+    "@workos-inc/node": "^10.2.0",
     "@xyflow/react": "^12.9.0",
     "ai": "^6.0.154",
     "ajv": "^8.18.0",

--- a/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Bearer Auth Middleware Tests
+ *
+ * Focus: the `sk_` (WorkOS API key) branch — the security-critical new code.
+ * Covers:
+ *   - missing / wrong-format bearer → 401
+ *   - `sk_` invalid → 401
+ *   - `sk_` valid → next() runs with context set
+ *   - request-local memoization (validate called once per request)
+ *   - per-key rate limit triggers 429 after burst
+ *   - cross-key rate limit isolation
+ *
+ * WorkOS SDK and identity helpers are mocked at module level via `vi.mock`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+
+// Mocks must be declared before importing the SUT.
+const validateApiKeyMock = vi.fn();
+vi.mock("../../services/workos-client.js", () => ({
+  getWorkOSClient: () => ({
+    apiKeys: { validateApiKey: validateApiKeyMock },
+  }),
+}));
+
+const resolveUserByExternalIdMock = vi.fn();
+vi.mock("../../services/identity.js", () => ({
+  resolveUserByExternalId: resolveUserByExternalIdMock,
+}));
+
+// Guest validation must always reject for these tests — only the sk_ branch is
+// exercised. The real guest validator does network calls we don't want here.
+vi.mock("../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: vi.fn(async () => ({
+    valid: false,
+    reason: "not_guest",
+  })),
+}));
+
+import {
+  bearerAuthMiddleware,
+  resetWorkOSRateLimitForTests,
+} from "../bearer-auth.js";
+
+function createApp(): Hono {
+  const app = new Hono();
+  app.use("*", bearerAuthMiddleware);
+  app.get("/test", (c) =>
+    c.json({
+      ok: true,
+      authMethod: c.get("authMethod") ?? null,
+      workosApiKeyId: c.get("workosApiKeyId") ?? null,
+      workosUserId: c.get("workosUserId") ?? null,
+      mcpjamUserId: c.get("mcpjamUserId") ?? null,
+    }),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  validateApiKeyMock.mockReset();
+  resolveUserByExternalIdMock.mockReset();
+  resetWorkOSRateLimitForTests();
+});
+
+describe("bearerAuthMiddleware — header gate", () => {
+  it("rejects requests without an Authorization header", async () => {
+    const res = await createApp().request("/test");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects requests where the header isn't Bearer-prefixed", async () => {
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Basic abc" },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("bearerAuthMiddleware — sk_ WorkOS API key branch", () => {
+  it("returns 401 when WorkOS marks the key as invalid", async () => {
+    validateApiKeyMock.mockResolvedValueOnce({ apiKey: null });
+
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Bearer sk_invalid_value" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string; message?: string };
+    expect(body.code).toBe("UNAUTHORIZED");
+    expect(body.message).toMatch(/Invalid API key/i);
+    expect(validateApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(resolveUserByExternalIdMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when WorkOS validates but the MCPJam user is unknown", async () => {
+    validateApiKeyMock.mockResolvedValueOnce({
+      apiKey: { id: "api_key_x", owner: { id: "user_x" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValueOnce(null);
+
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Bearer sk_valid_but_unknown" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { message?: string };
+    expect(body.message).toMatch(/Unknown user/i);
+  });
+
+  it("sets identity context and calls next() on valid sk_ key", async () => {
+    validateApiKeyMock.mockResolvedValueOnce({
+      apiKey: { id: "api_key_42", owner: { id: "user_42" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValueOnce({
+      _id: "mcpjam_user_42",
+    });
+
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Bearer sk_live_abc" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.authMethod).toBe("workos_api_key");
+    expect(body.workosApiKeyId).toBe("api_key_42");
+    expect(body.workosUserId).toBe("user_42");
+    expect(body.mcpjamUserId).toBe("mcpjam_user_42");
+  });
+});
+
+describe("bearerAuthMiddleware — per-key rate limit", () => {
+  it("admits at least 10 burst requests for the same key, then rejects with 429", async () => {
+    validateApiKeyMock.mockResolvedValue({
+      apiKey: { id: "api_key_burst", owner: { id: "user_burst" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValue({ _id: "mcpjam_user_burst" });
+
+    const app = createApp();
+    const ok: number[] = [];
+    let throttled = 0;
+    let lastThrottledStatus = 0;
+    for (let i = 0; i < 12; i++) {
+      const res = await app.request("/test", {
+        headers: { authorization: "Bearer sk_burst" },
+      });
+      if (res.status === 200) {
+        ok.push(i);
+      } else {
+        throttled++;
+        lastThrottledStatus = res.status;
+      }
+    }
+    expect(ok.length).toBeGreaterThanOrEqual(10);
+    expect(throttled).toBeGreaterThanOrEqual(1);
+    expect(lastThrottledStatus).toBe(429);
+  });
+
+  it("isolates rate-limit buckets per WorkOS key id", async () => {
+    // Bucket A — drain it
+    validateApiKeyMock.mockImplementation(async ({ value }) => ({
+      apiKey: {
+        id: value === "sk_a" ? "api_key_a" : "api_key_b",
+        owner: { id: value === "sk_a" ? "user_a" : "user_b" },
+      },
+    }));
+    resolveUserByExternalIdMock.mockResolvedValue({ _id: "mcpjam_user" });
+
+    const app = createApp();
+    for (let i = 0; i < 11; i++) {
+      await app.request("/test", {
+        headers: { authorization: "Bearer sk_a" },
+      });
+    }
+    // Now sk_b should still succeed (separate bucket)
+    const res = await app.request("/test", {
+      headers: { authorization: "Bearer sk_b" },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("bearerAuthMiddleware — request-local memoization", () => {
+  it("only invokes WorkOS validate once per request even when bearer-auth runs multiple times", async () => {
+    validateApiKeyMock.mockResolvedValue({
+      apiKey: { id: "api_key_memo", owner: { id: "user_memo" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValue({ _id: "mcpjam_user_memo" });
+
+    // Simulate the real wiring: bearer-auth on a parent router AND on a
+    // sub-router (as `/api/web/api-keys/*` does explicitly).
+    const app = new Hono();
+    app.use("*", bearerAuthMiddleware);
+    app.use("*", bearerAuthMiddleware);
+    app.get("/double", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/double", {
+      headers: { authorization: "Bearer sk_memo" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(validateApiKeyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
@@ -5,28 +5,42 @@
  * Covers:
  *   - missing / wrong-format bearer → 401
  *   - `sk_` invalid → 401
- *   - `sk_` valid → next() runs with context set
+ *   - `sk_` valid + bound → next() runs with identity AND org context set
+ *   - `sk_` valid but NO org binding → 401 ORPHANED_KEY
+ *   - binding lookup throws → 500
  *   - request-local memoization (validate called once per request)
  *   - per-key rate limit triggers 429 after burst
  *   - cross-key rate limit isolation
  *
- * WorkOS SDK and identity helpers are mocked at module level via `vi.mock`.
+ * WorkOS SDK, identity, and binding helpers are mocked at module level.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Hono } from "hono";
 
-// Mocks must be declared before importing the SUT.
-const validateApiKeyMock = vi.fn();
+// Mocks must be available to the `vi.mock` factories, which vitest hoists
+// above the imports. `vi.hoisted` is the supported way to initialize the mock
+// fns before those factories run (a plain `const fooMock = vi.fn()` lands in
+// the temporal dead zone when the factory executes at import time).
+const { validateApiKeyMock, resolveUserByExternalIdMock, lookupWorkosKeyBindingMock } =
+  vi.hoisted(() => ({
+    validateApiKeyMock: vi.fn(),
+    resolveUserByExternalIdMock: vi.fn(),
+    lookupWorkosKeyBindingMock: vi.fn(),
+  }));
+
 vi.mock("../../services/workos-client.js", () => ({
   getWorkOSClient: () => ({
-    apiKeys: { validateApiKey: validateApiKeyMock },
+    apiKeys: { createValidation: validateApiKeyMock },
   }),
 }));
 
-const resolveUserByExternalIdMock = vi.fn();
 vi.mock("../../services/identity.js", () => ({
   resolveUserByExternalId: resolveUserByExternalIdMock,
+}));
+
+vi.mock("../../services/workos-key-bindings.js", () => ({
+  lookupWorkosKeyBinding: lookupWorkosKeyBindingMock,
 }));
 
 // Guest validation must always reject for these tests — only the sk_ branch is
@@ -53,6 +67,7 @@ function createApp(): Hono {
       workosApiKeyId: c.get("workosApiKeyId") ?? null,
       workosUserId: c.get("workosUserId") ?? null,
       mcpjamUserId: c.get("mcpjamUserId") ?? null,
+      mcpjamOrganizationId: c.get("mcpjamOrganizationId") ?? null,
     }),
   );
   return app;
@@ -61,6 +76,11 @@ function createApp(): Hono {
 beforeEach(() => {
   validateApiKeyMock.mockReset();
   resolveUserByExternalIdMock.mockReset();
+  lookupWorkosKeyBindingMock.mockReset();
+  // Default: every valid key is bound to an org. Orphaned-key tests override.
+  lookupWorkosKeyBindingMock.mockResolvedValue({
+    mcpjamOrganizationId: "org_default",
+  });
   resetWorkOSRateLimitForTests();
 });
 
@@ -109,12 +129,15 @@ describe("bearerAuthMiddleware — sk_ WorkOS API key branch", () => {
     expect(body.message).toMatch(/Unknown user/i);
   });
 
-  it("sets identity context and calls next() on valid sk_ key", async () => {
+  it("sets identity AND org context and calls next() on a valid, bound sk_ key", async () => {
     validateApiKeyMock.mockResolvedValueOnce({
       apiKey: { id: "api_key_42", owner: { id: "user_42" } },
     });
     resolveUserByExternalIdMock.mockResolvedValueOnce({
       _id: "mcpjam_user_42",
+    });
+    lookupWorkosKeyBindingMock.mockResolvedValueOnce({
+      mcpjamOrganizationId: "org_42",
     });
 
     const res = await createApp().request("/test", {
@@ -128,6 +151,44 @@ describe("bearerAuthMiddleware — sk_ WorkOS API key branch", () => {
     expect(body.workosApiKeyId).toBe("api_key_42");
     expect(body.workosUserId).toBe("user_42");
     expect(body.mcpjamUserId).toBe("mcpjam_user_42");
+    // The org the key is bound to — what gets forwarded as
+    // `x-mcpjam-acting-in-org`.
+    expect(body.mcpjamOrganizationId).toBe("org_42");
+    expect(lookupWorkosKeyBindingMock).toHaveBeenCalledWith("api_key_42");
+  });
+
+  it("returns 401 ORPHANED_KEY when the key has no org binding", async () => {
+    validateApiKeyMock.mockResolvedValueOnce({
+      apiKey: { id: "api_key_orphan", owner: { id: "user_orphan" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValueOnce({ _id: "mcpjam_user" });
+    // 404 from the backend → null → orphaned.
+    lookupWorkosKeyBindingMock.mockResolvedValueOnce(null);
+
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Bearer sk_orphan" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string; message?: string };
+    expect(body.code).toBe("ORPHANED_KEY");
+    expect(body.message).toMatch(/not bound to an organization/i);
+  });
+
+  it("returns 500 when the org binding lookup throws", async () => {
+    validateApiKeyMock.mockResolvedValueOnce({
+      apiKey: { id: "api_key_err", owner: { id: "user_err" } },
+    });
+    resolveUserByExternalIdMock.mockResolvedValueOnce({ _id: "mcpjam_user" });
+    lookupWorkosKeyBindingMock.mockRejectedValueOnce(new Error("backend down"));
+
+    const res = await createApp().request("/test", {
+      headers: { authorization: "Bearer sk_err" },
+    });
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("INTERNAL_ERROR");
   });
 });
 
@@ -183,11 +244,14 @@ describe("bearerAuthMiddleware — per-key rate limit", () => {
 });
 
 describe("bearerAuthMiddleware — request-local memoization", () => {
-  it("only invokes WorkOS validate once per request even when bearer-auth runs multiple times", async () => {
+  it("only invokes WorkOS validate + binding lookup once per request even when bearer-auth runs multiple times", async () => {
     validateApiKeyMock.mockResolvedValue({
       apiKey: { id: "api_key_memo", owner: { id: "user_memo" } },
     });
     resolveUserByExternalIdMock.mockResolvedValue({ _id: "mcpjam_user_memo" });
+    lookupWorkosKeyBindingMock.mockResolvedValue({
+      mcpjamOrganizationId: "org_memo",
+    });
 
     // Simulate the real wiring: bearer-auth on a parent router AND on a
     // sub-router (as `/api/web/api-keys/*` does explicitly).
@@ -202,5 +266,6 @@ describe("bearerAuthMiddleware — request-local memoization", () => {
 
     expect(res.status).toBe(200);
     expect(validateApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(lookupWorkosKeyBindingMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
@@ -6,7 +6,7 @@
  *   - missing / wrong-format bearer → 401
  *   - `sk_` invalid → 401
  *   - `sk_` valid + bound → next() runs with identity AND org context set
- *   - `sk_` valid but NO org binding → 401 ORPHANED_KEY
+ *   - `sk_` valid but NO org binding → 401 UNAUTHORIZED (details.reason ORPHANED_KEY)
  *   - binding lookup throws → 500
  *   - request-local memoization (validate called once per request)
  *   - per-key rate limit triggers 429 after burst
@@ -157,7 +157,7 @@ describe("bearerAuthMiddleware — sk_ WorkOS API key branch", () => {
     expect(lookupWorkosKeyBindingMock).toHaveBeenCalledWith("api_key_42");
   });
 
-  it("returns 401 ORPHANED_KEY when the key has no org binding", async () => {
+  it("returns 401 UNAUTHORIZED with details.reason ORPHANED_KEY when the key has no org binding", async () => {
     validateApiKeyMock.mockResolvedValueOnce({
       apiKey: { id: "api_key_orphan", owner: { id: "user_orphan" } },
     });
@@ -170,8 +170,15 @@ describe("bearerAuthMiddleware — sk_ WorkOS API key branch", () => {
     });
 
     expect(res.status).toBe(401);
-    const body = (await res.json()) as { code?: string; message?: string };
-    expect(body.code).toBe("ORPHANED_KEY");
+    const body = (await res.json()) as {
+      code?: string;
+      message?: string;
+      details?: { reason?: string };
+    };
+    // Stays within the v1 contract's error-code union; the orphaned-key
+    // specifics live in the opaque `details` bag, not a new wire code.
+    expect(body.code).toBe("UNAUTHORIZED");
+    expect(body.details?.reason).toBe("ORPHANED_KEY");
     expect(body.message).toMatch(/not bound to an organization/i);
   });
 

--- a/mcpjam-inspector/server/middleware/bearer-auth.ts
+++ b/mcpjam-inspector/server/middleware/bearer-auth.ts
@@ -3,6 +3,7 @@ import { ErrorCode } from "../routes/web/errors.js";
 import { validateGuestTokenDetailedAsync } from "../services/guest-token.js";
 import { getWorkOSClient } from "../services/workos-client.js";
 import { resolveUserByExternalId } from "../services/identity.js";
+import { lookupWorkosKeyBinding } from "../services/workos-key-bindings.js";
 import { getRequestLocal, setRequestLocal } from "./request-local.js";
 import { logger } from "../utils/logger.js";
 
@@ -185,16 +186,57 @@ export async function bearerAuthMiddleware(
       );
     }
 
+    // Resolve which MCPJam org this key acts inside. WorkOS keys are not
+    // org-scoped natively, so the backend persists the binding at mint time
+    // and we look it up here (memoized per request, like the validation
+    // above). A missing binding means the key predates binding support or
+    // its scope was removed — it cannot be safely delegated, so reject it as
+    // orphaned rather than guessing an org.
+    let binding = getRequestLocal(c, "workosApiKeyBinding");
+    if (binding === undefined) {
+      try {
+        binding = await lookupWorkosKeyBinding(workosKeyId);
+      } catch (error) {
+        logger.error("Failed to look up WorkOS API key org binding", {
+          workos_key_id: workosKeyId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return c.json(
+          {
+            code: ErrorCode.INTERNAL_ERROR,
+            message: "Org binding lookup failed",
+          },
+          500,
+        );
+      }
+      setRequestLocal(c, "workosApiKeyBinding", binding);
+    }
+    if (!binding) {
+      logger.warn("Orphaned WorkOS API key (no org binding)", {
+        workos_key_id: workosKeyId,
+      });
+      return c.json(
+        {
+          code: ErrorCode.ORPHANED_KEY,
+          message:
+            "This API key is not bound to an organization. Re-create it from Settings → API keys.",
+        },
+        401,
+      );
+    }
+
     c.set("authMethod", "workos_api_key");
     c.set("workosApiKeyId", workosKeyId);
     c.set("workosUserId", workosUserId);
     c.set("mcpjamUserId", mcpjamUser._id);
+    c.set("mcpjamOrganizationId", binding.mcpjamOrganizationId);
 
     logger.info("WorkOS API key request", {
       event: "auth.workos_api_key",
       auth_method: "workos_api_key",
       workos_key_id: workosKeyId,
       mcpjam_user_id: mcpjamUser._id,
+      mcpjam_organization_id: binding.mcpjamOrganizationId,
     });
 
     return next();

--- a/mcpjam-inspector/server/middleware/bearer-auth.ts
+++ b/mcpjam-inspector/server/middleware/bearer-auth.ts
@@ -215,11 +215,17 @@ export async function bearerAuthMiddleware(
       logger.warn("Orphaned WorkOS API key (no org binding)", {
         workos_key_id: workosKeyId,
       });
+      // Stay within the v1 public error-code contract: the wire `code` is the
+      // canonical UNAUTHORIZED, with the specific reason carried in the opaque
+      // `details` bag (see routes/v1/contract.ts — `ORPHANED_KEY` is NOT a
+      // first-class v1 code). Clients that care can branch on
+      // `details.reason === "ORPHANED_KEY"`; everyone else sees a 401.
       return c.json(
         {
-          code: ErrorCode.ORPHANED_KEY,
+          code: ErrorCode.UNAUTHORIZED,
           message:
             "This API key is not bound to an organization. Re-create it from Settings → API keys.",
+          details: { reason: "ORPHANED_KEY" },
         },
         401,
       );

--- a/mcpjam-inspector/server/middleware/bearer-auth.ts
+++ b/mcpjam-inspector/server/middleware/bearer-auth.ts
@@ -1,14 +1,103 @@
 import type { Context, Next } from "hono";
 import { ErrorCode } from "../routes/web/errors.js";
 import { validateGuestTokenDetailedAsync } from "../services/guest-token.js";
+import { getWorkOSClient } from "../services/workos-client.js";
+import { resolveUserByExternalId } from "../services/identity.js";
+import { getRequestLocal, setRequestLocal } from "./request-local.js";
+import { logger } from "../utils/logger.js";
 
 /**
  * Reusable Hono middleware that:
  * 1. Requires a Bearer token in the Authorization header (401 if missing).
- * 2. Attempts to validate it as a guest JWT.
- * 3. If valid guest token, sets c.set("guestId", guestId).
- * 4. If not a guest token, assumes WorkOS and passes through.
+ * 2. If the token starts with `sk_`, validates it as a WorkOS API key
+ *    (memoized per request) and resolves the owning MCPJam user.
+ * 3. Otherwise attempts to validate it as a guest JWT.
+ * 4. If valid guest token, sets `c.set("guestId", guestId)`.
+ * 5. If not a guest token, assumes WorkOS JWT and passes through.
+ *
+ * Prefix discrimination is sound: real WorkOS JWTs start with `eyJ`
+ * (base64 `{"`), so an `sk_` prefix is unambiguous and the branch
+ * never falls through to JWT validation.
  */
+
+/**
+ * Per-key token bucket for `sk_` validations. WorkOS validate is ~200ms
+ * and counts against our org-wide WorkOS rate budget; a misbehaving
+ * client should not be able to drain it. In-process Map — resets on
+ * deploy, which is fine for v1.
+ *
+ * Limits: 60 req/min sustained, burst 10. Buckets refill linearly.
+ */
+const WORKOS_RATE_LIMIT_PER_MIN = 60;
+const WORKOS_RATE_BURST = 10;
+const WORKOS_RATE_REFILL_PER_MS = WORKOS_RATE_LIMIT_PER_MIN / 60_000;
+
+interface TokenBucket {
+  /** Available tokens (fractional). */
+  tokens: number;
+  /** Last refill timestamp (ms). */
+  lastRefill: number;
+}
+
+const workosKeyBuckets = new Map<string, TokenBucket>();
+
+// Cleanup stale buckets every 5 minutes so revoked keys don't leak memory.
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, bucket] of workosKeyBuckets) {
+    if (now - bucket.lastRefill > 5 * 60_000) {
+      workosKeyBuckets.delete(id);
+    }
+  }
+}, 5 * 60_000).unref();
+
+/**
+ * Try to consume one token from the bucket for `keyId`. Returns the
+ * number of milliseconds the caller should wait before retrying, or
+ * `null` if the request was admitted. Rejecting BEFORE incrementing
+ * matches token-bucket semantics — a depleted bucket stays depleted
+ * until time passes.
+ */
+function consumeWorkOSToken(keyId: string): number | null {
+  const now = Date.now();
+  const existing = workosKeyBuckets.get(keyId);
+  if (!existing) {
+    workosKeyBuckets.set(keyId, {
+      tokens: WORKOS_RATE_BURST - 1,
+      lastRefill: now,
+    });
+    return null;
+  }
+
+  const elapsed = now - existing.lastRefill;
+  const refilled = Math.min(
+    WORKOS_RATE_BURST,
+    existing.tokens + elapsed * WORKOS_RATE_REFILL_PER_MS,
+  );
+  if (refilled < 1) {
+    existing.tokens = refilled;
+    existing.lastRefill = now;
+    const deficit = 1 - refilled;
+    const waitMs = Math.ceil(deficit / WORKOS_RATE_REFILL_PER_MS);
+    return Math.max(waitMs, 1);
+  }
+  existing.tokens = refilled - 1;
+  existing.lastRefill = now;
+  return null;
+}
+
+/** Test-only: clear all token buckets. */
+export function resetWorkOSRateLimitForTests(): void {
+  workosKeyBuckets.clear();
+}
+
+type ValidateApiKeyResult = {
+  apiKey: {
+    id: string;
+    owner: { id: string };
+  } | null;
+};
+
 export async function bearerAuthMiddleware(
   c: Context,
   next: Next,
@@ -22,6 +111,94 @@ export async function bearerAuthMiddleware(
   }
 
   const token = authHeader.slice("Bearer ".length);
+
+  // WorkOS API key branch. Real WorkOS JWTs begin with `eyJ`, so an
+  // `sk_` prefix is unambiguous; this branch never falls through.
+  if (token.startsWith("sk_")) {
+    // Request-local memoization: a single `/api/v1/...` call hits this
+    // middleware AND `authorizeBatch`, both of which would otherwise
+    // pay the ~200ms WorkOS validate cost. Cached per request only —
+    // no cross-request cache, so revocation stays immediate.
+    let validation = getRequestLocal(c, "workosApiKeyValidation") as
+      | ValidateApiKeyResult
+      | undefined;
+    if (!validation) {
+      try {
+        // ~200ms validate latency (single global WorkOS endpoint, no
+        // local JWKS path). Counts against our WorkOS rate budget.
+        validation = (await getWorkOSClient().apiKeys.createValidation({
+          value: token,
+        })) as unknown as ValidateApiKeyResult;
+      } catch (error) {
+        logger.warn("WorkOS API key validation threw", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return c.json(
+          { code: ErrorCode.UNAUTHORIZED, message: "Invalid API key" },
+          401,
+        );
+      }
+      setRequestLocal(c, "workosApiKeyValidation", validation);
+    }
+
+    if (!validation.apiKey) {
+      return c.json(
+        { code: ErrorCode.UNAUTHORIZED, message: "Invalid API key" },
+        401,
+      );
+    }
+
+    const workosKeyId = validation.apiKey.id;
+    const workosUserId = validation.apiKey.owner.id;
+
+    // Per-key rate limit. Reject BEFORE doing the Convex user lookup
+    // so a flood can't tie up the database either.
+    const waitMs = consumeWorkOSToken(workosKeyId);
+    if (waitMs !== null) {
+      return c.json(
+        {
+          code: ErrorCode.RATE_LIMITED,
+          message: "API key rate limit exceeded. Slow down and retry.",
+        },
+        429,
+        { "Retry-After": String(Math.ceil(waitMs / 1000)) },
+      );
+    }
+
+    let mcpjamUser;
+    try {
+      mcpjamUser = await resolveUserByExternalId(workosUserId);
+    } catch (error) {
+      logger.error("Failed to resolve MCPJam user from WorkOS externalId", {
+        workosUserId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return c.json(
+        { code: ErrorCode.INTERNAL_ERROR, message: "Identity lookup failed" },
+        500,
+      );
+    }
+    if (!mcpjamUser) {
+      return c.json(
+        { code: ErrorCode.UNAUTHORIZED, message: "Unknown user" },
+        401,
+      );
+    }
+
+    c.set("authMethod", "workos_api_key");
+    c.set("workosApiKeyId", workosKeyId);
+    c.set("workosUserId", workosUserId);
+    c.set("mcpjamUserId", mcpjamUser._id);
+
+    logger.info("WorkOS API key request", {
+      event: "auth.workos_api_key",
+      auth_method: "workos_api_key",
+      workos_key_id: workosKeyId,
+      mcpjam_user_id: mcpjamUser._id,
+    });
+
+    return next();
+  }
 
   // Try validating as a guest token
   try {

--- a/mcpjam-inspector/server/middleware/bearer-auth.ts
+++ b/mcpjam-inspector/server/middleware/bearer-auth.ts
@@ -152,18 +152,23 @@ export async function bearerAuthMiddleware(
     const workosKeyId = validation.apiKey.id;
     const workosUserId = validation.apiKey.owner.id;
 
-    // Per-key rate limit. Reject BEFORE doing the Convex user lookup
-    // so a flood can't tie up the database either.
-    const waitMs = consumeWorkOSToken(workosKeyId);
-    if (waitMs !== null) {
-      return c.json(
-        {
-          code: ErrorCode.RATE_LIMITED,
-          message: "API key rate limit exceeded. Slow down and retry.",
-        },
-        429,
-        { "Retry-After": String(Math.ceil(waitMs / 1000)) },
-      );
+    // Per-key rate limit. Reject BEFORE doing the Convex user lookup so a
+    // flood can't tie up the database either. Debit once per request (memoized
+    // like the validation/binding lookups above) so the limit isn't double
+    // counted if the middleware ever runs on both a parent and child router.
+    if (!getRequestLocal(c, "workosRateLimitConsumed")) {
+      const waitMs = consumeWorkOSToken(workosKeyId);
+      if (waitMs !== null) {
+        return c.json(
+          {
+            code: ErrorCode.RATE_LIMITED,
+            message: "API key rate limit exceeded. Slow down and retry.",
+          },
+          429,
+          { "Retry-After": String(Math.ceil(waitMs / 1000)) },
+        );
+      }
+      setRequestLocal(c, "workosRateLimitConsumed", true);
     }
 
     let mcpjamUser;

--- a/mcpjam-inspector/server/middleware/request-local.ts
+++ b/mcpjam-inspector/server/middleware/request-local.ts
@@ -24,6 +24,14 @@ export interface RequestLocalMap {
    * key is orphaned); `undefined` means "not looked up yet".
    */
   workosApiKeyBinding: { mcpjamOrganizationId: string } | null;
+  /**
+   * Set once the per-key WorkOS rate-limit token has been debited for this
+   * request. The limit is per user-visible request, not per middleware
+   * invocation — this guards against double counting if `bearerAuthMiddleware`
+   * ever runs on both a parent and a child router (the same scenario the
+   * caches above defend against).
+   */
+  workosRateLimitConsumed: boolean;
 }
 
 export function getRequestLocal<K extends keyof RequestLocalMap>(

--- a/mcpjam-inspector/server/middleware/request-local.ts
+++ b/mcpjam-inspector/server/middleware/request-local.ts
@@ -1,0 +1,37 @@
+import type { Context } from "hono";
+
+/**
+ * Typed request-local store, layered over Hono's `c.set` / `c.get`.
+ *
+ * Hono already gives us per-request storage via the Context's variable
+ * map, but reaching for `c.set(key, value)` with an arbitrary string is
+ * untyped — typos slip through and every reader has to widen `unknown`.
+ *
+ * The WorkOS API key validation is the motivating use case: a single
+ * `/api/v1/...` request hits the bearer middleware AND `authorizeBatch`
+ * — without per-request memoization we would pay two ~200ms WorkOS
+ * validate round-trips for one user-visible request. The cache is
+ * intentionally request-local (no cross-request LRU) so revocation
+ * stays immediate.
+ */
+export interface RequestLocalMap {
+  workosApiKeyValidation: unknown;
+}
+
+export function getRequestLocal<K extends keyof RequestLocalMap>(
+  c: Context,
+  key: K
+): RequestLocalMap[K] | undefined {
+  // `c.get` is typed via Hono's ContextVariableMap; we deliberately bypass
+  // it here so callers don't have to extend that global map just to cache
+  // an opaque blob for one request.
+  return (c.get(key as string) as RequestLocalMap[K] | undefined) ?? undefined;
+}
+
+export function setRequestLocal<K extends keyof RequestLocalMap>(
+  c: Context,
+  key: K,
+  value: RequestLocalMap[K]
+): void {
+  c.set(key as string, value);
+}

--- a/mcpjam-inspector/server/middleware/request-local.ts
+++ b/mcpjam-inspector/server/middleware/request-local.ts
@@ -16,6 +16,14 @@ import type { Context } from "hono";
  */
 export interface RequestLocalMap {
   workosApiKeyValidation: unknown;
+  /**
+   * Memoized result of the org-binding lookup for an `sk_…` key. Like the
+   * validation cache, this keeps a single user-visible request to one backend
+   * round-trip even when `bearerAuthMiddleware` runs on both a parent router
+   * and a sub-router. `null` is a real cached value (the lookup ran and the
+   * key is orphaned); `undefined` means "not looked up yet".
+   */
+  workosApiKeyBinding: { mcpjamOrganizationId: string } | null;
 }
 
 export function getRequestLocal<K extends keyof RequestLocalMap>(

--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -21,9 +21,16 @@ import type { Context } from "hono";
 import { createAuthorizedManager } from "../auth.js";
 import { WebRouteError } from "../errors.js";
 
+// Faithful Hono Context stub: `get`, `var`, and `set` all read/write the same
+// store (in real Hono `c.get(k)` === `c.var[k]`). The delegated-auth header
+// builder reads `c.get("authMethod")`, so the mock must implement `get`.
+const mockVars: Record<string, unknown> = { requestLogContext: undefined };
 const mockContext = {
-  var: { requestLogContext: undefined },
-  set: vi.fn(),
+  var: mockVars,
+  get: (key: string) => mockVars[key],
+  set: vi.fn((key: string, value: unknown) => {
+    mockVars[key] = value;
+  }),
 } as unknown as Context;
 
 function fetchUrl(input: Parameters<typeof fetch>[0]): string {

--- a/mcpjam-inspector/server/routes/web/__tests__/authorize-batch.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/authorize-batch.test.ts
@@ -32,6 +32,9 @@ function makeContext(): { c: Context; vars: Record<string, unknown> } {
   const vars: Record<string, unknown> = { requestLogContext: { ...baseContext } };
   const c = {
     var: new Proxy(vars, { get: (t, p) => t[p as string] }),
+    // Faithful to Hono: `c.get(k)` mirrors `c.var[k]`. The delegated-auth
+    // header builder reads context via `c.get(...)`.
+    get: (key: string) => vars[key],
     set: (key: string, value: unknown) => {
       vars[key] = value;
     },

--- a/mcpjam-inspector/server/routes/web/__tests__/buildConvexAuthHeaders.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/buildConvexAuthHeaders.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the Convex auth-header exchange used by every Inspector → Convex
+ * `/web/*` call. The security-critical invariant: for WorkOS API key requests
+ * the delegated identity headers carry the WorkOS user id (Convex
+ * `externalId`) — NOT the Convex user `_id` — plus the bound org id. Sending
+ * the Convex id would be looked up by the backend resolver as an `externalId`
+ * and 404 as UNKNOWN_DELEGATED_USER.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Context } from "hono";
+import { buildConvexAuthHeaders } from "../auth.js";
+
+const SERVICE_TOKEN = "svc-token-test";
+const ORIGINAL_ENV = process.env.INSPECTOR_SERVICE_TOKEN;
+
+/** Minimal Context stub exposing only the `c.get(key)` the SUT reads. */
+function fakeContext(vars: Record<string, unknown>): Context {
+  return { get: (key: string) => vars[key] } as unknown as Context;
+}
+
+beforeEach(() => {
+  process.env.INSPECTOR_SERVICE_TOKEN = SERVICE_TOKEN;
+});
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) delete process.env.INSPECTOR_SERVICE_TOKEN;
+  else process.env.INSPECTOR_SERVICE_TOKEN = ORIGINAL_ENV;
+});
+
+describe("buildConvexAuthHeaders — WorkOS API key exchange", () => {
+  it("sends acting-as = WorkOS user id (not the Convex user id) and acting-in-org", () => {
+    const c = fakeContext({
+      authMethod: "workos_api_key",
+      workosUserId: "workos|user_42",
+      mcpjamUserId: "mcpjam_user_42", // Convex id — must NOT be the acting-as
+      mcpjamOrganizationId: "org_42",
+    });
+
+    const headers = buildConvexAuthHeaders(c, "sk_should_not_be_forwarded");
+
+    expect(headers["Authorization"]).toBe(`Bearer ${SERVICE_TOKEN}`);
+    expect(headers["x-mcpjam-acting-as"]).toBe("workos|user_42");
+    expect(headers["x-mcpjam-acting-as"]).not.toBe("mcpjam_user_42");
+    expect(headers["x-mcpjam-acting-in-org"]).toBe("org_42");
+    // The raw sk_ value is never forwarded to Convex.
+    expect(JSON.stringify(headers)).not.toContain("sk_should_not_be_forwarded");
+  });
+
+  it("throws when the WorkOS user id is missing", () => {
+    const c = fakeContext({
+      authMethod: "workos_api_key",
+      mcpjamOrganizationId: "org_42",
+    });
+    expect(() => buildConvexAuthHeaders(c, "sk_x")).toThrow(/workosUserId/);
+  });
+
+  it("throws when the bound org id is missing", () => {
+    const c = fakeContext({
+      authMethod: "workos_api_key",
+      workosUserId: "workos|user_42",
+    });
+    expect(() => buildConvexAuthHeaders(c, "sk_x")).toThrow(
+      /mcpjamOrganizationId/,
+    );
+  });
+});
+
+describe("buildConvexAuthHeaders — non-API-key path", () => {
+  it("forwards the original bearer verbatim and adds no delegation headers", () => {
+    const c = fakeContext({}); // no authMethod → session/guest JWT
+    const headers = buildConvexAuthHeaders(c, "eyJ-session-jwt");
+
+    expect(headers["Authorization"]).toBe("Bearer eyJ-session-jwt");
+    expect(headers["x-mcpjam-acting-as"]).toBeUndefined();
+    expect(headers["x-mcpjam-acting-in-org"]).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -17,6 +17,10 @@ import {
   removeWorkosKeyBinding,
   WorkosKeyBindingError,
 } from "../../services/workos-key-bindings.js";
+import {
+  verifyAuthKitToken,
+  AuthKitConfigError,
+} from "../../services/authkit-jwt.js";
 
 /**
  * `/api/web/api-keys/*` — WorkOS API Key management.
@@ -73,56 +77,45 @@ function getWorkOSRestKey(): string {
   return key;
 }
 
-interface JwtClaims {
-  sub?: string;
-  org_id?: string;
-}
-
-/**
- * Decode the AuthKit JWT payload to read the WorkOS `sub` (user id) and
- * `org_id`. Signature is NOT re-verified here — Convex enforces auth on
- * downstream calls. We use the claims only to scope WorkOS REST requests
- * to the session user.
- */
-function decodeSessionClaims(token: string): JwtClaims {
-  const parts = token.split(".");
-  if (parts.length !== 3) {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "Session JWT is malformed",
-    );
-  }
-  try {
-    return JSON.parse(
-      Buffer.from(parts[1], "base64url").toString("utf-8"),
-    ) as JwtClaims;
-  } catch {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "Session JWT payload is not valid JSON",
-    );
-  }
-}
-
 interface SessionContext {
   userId: string;
   organizationId?: string;
 }
 
-function resolveSessionContext(c: any): SessionContext {
+/**
+ * Authenticate a key-management request by VERIFYING the WorkOS AuthKit access
+ * token (signature, issuer, audience, exp/nbf) and returning only the trusted
+ * `sub` / `org_id`.
+ *
+ * These routes act on the caller's behalf using the server's admin
+ * `WORKOS_API_KEY` and write Convex org bindings, so the token MUST be verified
+ * here — unlike other `/api/web/*` routes, nothing downstream re-checks it.
+ * Verification (and the resulting 401) happens before any WorkOS or
+ * binding-endpoint side effect.
+ */
+async function resolveSessionContext(c: any): Promise<SessionContext> {
   const bearer = assertBearerToken(c);
-  const claims = decodeSessionClaims(bearer);
-  const userId = claims.sub;
-  if (!userId) {
+  let session;
+  try {
+    session = await verifyAuthKitToken(bearer);
+  } catch (error) {
+    if (error instanceof AuthKitConfigError) {
+      logger.error("AuthKit verification is misconfigured", {
+        error: error.message,
+      });
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Server auth verification is not configured",
+      );
+    }
     throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "Session JWT is missing `sub` claim",
+      401,
+      ErrorCode.UNAUTHORIZED,
+      "Invalid or expired session token",
     );
   }
-  return { userId, organizationId: claims.org_id };
+  return { userId: session.sub, organizationId: session.orgId };
 }
 
 async function callWorkOS(
@@ -180,7 +173,7 @@ apiKeys.post("/", async (c) =>
   handleRoute(c, async () => {
     const raw = await readJsonBody<unknown>(c);
     const { name, organizationId } = parseWithSchema(createSchema, raw);
-    const session = resolveSessionContext(c);
+    const session = await resolveSessionContext(c);
 
     // Resolve the MCPJam (Convex) user id for the binding. The session bearer
     // carries the WorkOS user id (`sub`); the binding records the Convex user
@@ -298,7 +291,7 @@ apiKeys.post("/", async (c) =>
 
 apiKeys.get("/", async (c) =>
   handleRoute(c, async () => {
-    const session = resolveSessionContext(c);
+    const session = await resolveSessionContext(c);
     const params = new URLSearchParams();
     if (session.organizationId) {
       params.set("organization_id", session.organizationId);
@@ -335,7 +328,7 @@ apiKeys.delete("/:id", async (c) =>
         "Missing API key id",
       );
     }
-    const session = resolveSessionContext(c);
+    const session = await resolveSessionContext(c);
 
     // Cross-user defense in depth: fetch the key first and confirm the
     // owner matches the session user before deleting. WorkOS does not

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -1,0 +1,295 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
+import { logger } from "../../utils/logger.js";
+import {
+  ErrorCode,
+  WebRouteError,
+  webError,
+  assertBearerToken,
+  readJsonBody,
+  parseWithSchema,
+} from "./errors.js";
+import { handleRoute } from "./auth.js";
+
+/**
+ * `/api/web/api-keys/*` — WorkOS API Key management.
+ *
+ * Calls the WorkOS REST API directly with the server-side `WORKOS_API_KEY`
+ * (the Node SDK only exposes org-scoped helpers; the user-scoped endpoints
+ * we need for v1 are documented REST routes). MCPJam never stores the raw
+ * key value — `value` is in WorkOS's create response only, returned to the
+ * browser once, and never persisted or logged.
+ *
+ * Security notes for future contributors:
+ * - A user can only mint a key as powerful as their own session: the
+ *   create call routes through `/user_management/users/{userId}` and
+ *   `userId` is taken from the session JWT.
+ * - DELETE re-fetches the key and verifies `owner.id === sessionUserId`
+ *   before issuing the WorkOS delete, so passing another user's key id
+ *   fails before WorkOS sees the request.
+ * - `sk_…` keys cannot manage other `sk_…` keys (privilege isolation).
+ */
+
+const apiKeys = new Hono();
+
+// `sessionAuthMiddleware` bypasses `/api/web/*` entirely (session-auth.ts:103),
+// so this sub-router must explicitly require a bearer.
+apiKeys.use("*", bearerAuthMiddleware);
+
+// Privilege isolation: a WorkOS API key authenticates as the owning user
+// but it must NOT be able to mint or revoke other API keys (would create
+// a privilege loop). Session-only here.
+apiKeys.use("*", async (c, next) => {
+  if (c.get("authMethod") === "workos_api_key") {
+    return c.json(
+      {
+        code: ErrorCode.FORBIDDEN,
+        message: "API keys cannot manage other API keys",
+      },
+      403,
+    );
+  }
+  return next();
+});
+
+const WORKOS_BASE_URL = "https://api.workos.com";
+
+function getWorkOSRestKey(): string {
+  const key = process.env.WORKOS_API_KEY;
+  if (!key) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing WORKOS_API_KEY configuration",
+    );
+  }
+  return key;
+}
+
+interface JwtClaims {
+  sub?: string;
+  org_id?: string;
+}
+
+/**
+ * Decode the AuthKit JWT payload to read the WorkOS `sub` (user id) and
+ * `org_id`. Signature is NOT re-verified here — Convex enforces auth on
+ * downstream calls. We use the claims only to scope WorkOS REST requests
+ * to the session user.
+ */
+function decodeSessionClaims(token: string): JwtClaims {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Session JWT is malformed",
+    );
+  }
+  try {
+    return JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf-8"),
+    ) as JwtClaims;
+  } catch {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Session JWT payload is not valid JSON",
+    );
+  }
+}
+
+interface SessionContext {
+  userId: string;
+  organizationId?: string;
+}
+
+function resolveSessionContext(c: any): SessionContext {
+  const bearer = assertBearerToken(c);
+  const claims = decodeSessionClaims(bearer);
+  const userId = claims.sub;
+  if (!userId) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Session JWT is missing `sub` claim",
+    );
+  }
+  return { userId, organizationId: claims.org_id };
+}
+
+async function callWorkOS(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const key = getWorkOSRestKey();
+  const response = await fetch(`${WORKOS_BASE_URL}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  let parsed: any = null;
+  try {
+    parsed = await response.json();
+  } catch {
+    // Empty body (204) — leave null.
+  }
+  return { status: response.status, body: parsed };
+}
+
+function mapWorkOSError(status: number, body: any, fallback: string): never {
+  const safeMessage =
+    typeof body?.message === "string"
+      ? body.message
+      : typeof body?.error_description === "string"
+        ? body.error_description
+        : fallback;
+  if (status === 401) {
+    throw new WebRouteError(401, ErrorCode.UNAUTHORIZED, safeMessage);
+  }
+  if (status === 404) {
+    throw new WebRouteError(404, ErrorCode.NOT_FOUND, safeMessage);
+  }
+  if (status === 429) {
+    throw new WebRouteError(429, ErrorCode.RATE_LIMITED, safeMessage);
+  }
+  throw new WebRouteError(500, ErrorCode.INTERNAL_ERROR, safeMessage);
+}
+
+const createSchema = z.object({
+  name: z.string().min(1).max(120),
+});
+
+apiKeys.post("/", async (c) =>
+  handleRoute(c, async () => {
+    const raw = await readJsonBody<unknown>(c);
+    const { name } = parseWithSchema(createSchema, raw);
+    const session = resolveSessionContext(c);
+
+    const payload: Record<string, unknown> = { name };
+    if (session.organizationId) {
+      payload.organization_id = session.organizationId;
+    }
+
+    const { status, body } = await callWorkOS(
+      "POST",
+      `/user_management/users/${encodeURIComponent(session.userId)}/api_keys`,
+      payload,
+    );
+
+    if (status < 200 || status >= 300) {
+      mapWorkOSError(status, body, "Failed to create API key");
+    }
+
+    logger.info("API key minted", {
+      event: "api_key_created",
+      auth_method: "session",
+      workos_key_id: body?.id ?? null,
+      actor_user_id: session.userId,
+    });
+
+    return body;
+  }),
+);
+
+apiKeys.get("/", async (c) =>
+  handleRoute(c, async () => {
+    const session = resolveSessionContext(c);
+    const params = new URLSearchParams();
+    if (session.organizationId) {
+      params.set("organization_id", session.organizationId);
+    }
+    const qs = params.toString();
+    const { status, body } = await callWorkOS(
+      "GET",
+      `/user_management/users/${encodeURIComponent(session.userId)}/api_keys${
+        qs ? `?${qs}` : ""
+      }`,
+    );
+
+    if (status < 200 || status >= 300) {
+      mapWorkOSError(status, body, "Failed to list API keys");
+    }
+
+    // WorkOS returns `{ data: [...] }` or `{ data: [...], list_metadata: ... }`.
+    const items = Array.isArray(body?.data)
+      ? body.data
+      : Array.isArray(body)
+        ? body
+        : [];
+    return { items };
+  }),
+);
+
+apiKeys.delete("/:id", async (c) =>
+  handleRoute(c, async () => {
+    const id = c.req.param("id");
+    if (!id) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "Missing API key id",
+      );
+    }
+    const session = resolveSessionContext(c);
+
+    // Cross-user defense in depth: fetch the key first and confirm the
+    // owner matches the session user before deleting. WorkOS does not
+    // enforce per-user ownership for the org-level admin key.
+    const lookup = await callWorkOS(
+      "GET",
+      `/api_keys/${encodeURIComponent(id)}`,
+    );
+    if (lookup.status === 404) {
+      throw new WebRouteError(404, ErrorCode.NOT_FOUND, "API key not found");
+    }
+    if (lookup.status < 200 || lookup.status >= 300) {
+      mapWorkOSError(lookup.status, lookup.body, "Failed to load API key");
+    }
+    const ownerId = lookup.body?.owner?.id;
+    if (typeof ownerId !== "string" || ownerId !== session.userId) {
+      throw new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        "API key not found",
+      );
+    }
+
+    const { status, body } = await callWorkOS(
+      "DELETE",
+      `/api_keys/${encodeURIComponent(id)}`,
+    );
+    if (status !== 204 && (status < 200 || status >= 300)) {
+      mapWorkOSError(status, body, "Failed to revoke API key");
+    }
+
+    logger.info("API key revoked", {
+      event: "api_key_revoked",
+      auth_method: "session",
+      workos_key_id: id,
+      actor_user_id: session.userId,
+    });
+
+    return { ok: true };
+  }),
+);
+
+apiKeys.onError((error, c) => {
+  if (error instanceof WebRouteError) {
+    return webError(c, error.status, error.code, error.message, error.details);
+  }
+  return webError(
+    c,
+    500,
+    ErrorCode.INTERNAL_ERROR,
+    error instanceof Error ? error.message : "Internal error",
+  );
+});
+
+export default apiKeys;

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -43,15 +43,17 @@ import {
 
 const apiKeys = new Hono();
 
-// `sessionAuthMiddleware` bypasses `/api/web/*` entirely (session-auth.ts:103),
-// so this sub-router must explicitly require a bearer.
-apiKeys.use("*", bearerAuthMiddleware);
-
-// Privilege isolation: a WorkOS API key authenticates as the owning user
-// but it must NOT be able to mint or revoke other API keys (would create
-// a privilege loop). Session-only here.
+// Privilege isolation: a WorkOS API key authenticates as the owning user but
+// it must NOT mint or revoke other API keys (would create a privilege loop).
+// Reject `sk_…` BEFORE bearerAuthMiddleware validates it — `sk_` is the same
+// unambiguous discriminator the middleware uses (bearer-auth.ts), so this is
+// equivalent to a post-validation `authMethod` check while skipping a ~200ms
+// WorkOS validate plus Convex identity/binding lookups on a request that always
+// ends in 403. (Bonus: invalid/revoked keys get the same 403, not a 401, so the
+// endpoint can't be used to probe key validity.)
 apiKeys.use("*", async (c, next) => {
-  if (c.get("authMethod") === "workos_api_key") {
+  const auth = c.req.header("authorization") ?? "";
+  if (auth.startsWith("Bearer sk_")) {
     return c.json(
       {
         code: ErrorCode.FORBIDDEN,
@@ -62,6 +64,10 @@ apiKeys.use("*", async (c, next) => {
   }
   return next();
 });
+
+// `sessionAuthMiddleware` bypasses `/api/web/*` entirely (session-auth.ts:103),
+// so this sub-router must explicitly require a bearer.
+apiKeys.use("*", bearerAuthMiddleware);
 
 const WORKOS_BASE_URL = "https://api.workos.com";
 

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -11,6 +11,12 @@ import {
   parseWithSchema,
 } from "./errors.js";
 import { handleRoute } from "./auth.js";
+import { resolveUserByExternalId } from "../../services/identity.js";
+import {
+  createWorkosKeyBinding,
+  removeWorkosKeyBinding,
+  WorkosKeyBindingError,
+} from "../../services/workos-key-bindings.js";
 
 /**
  * `/api/web/api-keys/*` — WorkOS API Key management.
@@ -164,13 +170,29 @@ function mapWorkOSError(status: number, body: any, fallback: string): never {
 
 const createSchema = z.object({
   name: z.string().min(1).max(120),
+  // MCPJam organization id (Convex `Id<'organizations'>`) the key acts inside.
+  // The dialog requires an explicit selection (auto-selected when the user
+  // has exactly one org). This is NOT the WorkOS org id.
+  organizationId: z.string().min(1),
 });
 
 apiKeys.post("/", async (c) =>
   handleRoute(c, async () => {
     const raw = await readJsonBody<unknown>(c);
-    const { name } = parseWithSchema(createSchema, raw);
+    const { name, organizationId } = parseWithSchema(createSchema, raw);
     const session = resolveSessionContext(c);
+
+    // Resolve the MCPJam (Convex) user id for the binding. The session bearer
+    // carries the WorkOS user id (`sub`); the binding records the Convex user
+    // id so the backend can verify org membership at mint time.
+    const mcpjamUser = await resolveUserByExternalId(session.userId);
+    if (!mcpjamUser) {
+      throw new WebRouteError(
+        401,
+        ErrorCode.UNAUTHORIZED,
+        "Could not resolve your MCPJam account",
+      );
+    }
 
     const payload: Record<string, unknown> = { name };
     if (session.organizationId) {
@@ -187,11 +209,87 @@ apiKeys.post("/", async (c) =>
       mapWorkOSError(status, body, "Failed to create API key");
     }
 
+    const workosKeyId = typeof body?.id === "string" ? body.id : null;
+    if (!workosKeyId) {
+      // WorkOS always returns an id on 2xx; without one we can neither bind
+      // nor later revoke the key, so fail loud rather than ship a dead key.
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "WorkOS did not return an API key id",
+      );
+    }
+
+    // Bind the key to the selected MCPJam org. A key with no binding is
+    // orphaned (rejected on /api/v1/* with 401 ORPHANED_KEY), so if the bind
+    // fails we revoke the WorkOS key immediately and report the failure —
+    // never leave an unusable key behind.
+    try {
+      await createWorkosKeyBinding({
+        workosApiKeyId: workosKeyId,
+        mcpjamOrganizationId: organizationId,
+        mintedByUserId: mcpjamUser._id,
+      });
+    } catch (bindingError) {
+      logger.error("API key org binding failed; revoking WorkOS key", {
+        workos_key_id: workosKeyId,
+        error:
+          bindingError instanceof Error
+            ? bindingError.message
+            : String(bindingError),
+      });
+      try {
+        await callWorkOS(
+          "DELETE",
+          `/api_keys/${encodeURIComponent(workosKeyId)}`,
+        );
+      } catch (revokeError) {
+        // Best-effort cleanup. If this also fails the WorkOS key lingers with
+        // no binding — not a security hole (the bearer middleware rejects
+        // orphaned keys) but litter worth flagging.
+        logger.error("Failed to revoke WorkOS key after binding failure", {
+          workos_key_id: workosKeyId,
+          error:
+            revokeError instanceof Error
+              ? revokeError.message
+              : String(revokeError),
+        });
+      }
+
+      const message =
+        bindingError instanceof Error
+          ? bindingError.message
+          : "Failed to bind API key";
+      if (bindingError instanceof WorkosKeyBindingError) {
+        // Surface a client-fault rejection as itself; the key was not created.
+        if (bindingError.status === 400) {
+          throw new WebRouteError(
+            400,
+            ErrorCode.VALIDATION_ERROR,
+            `${message} (API key not created)`,
+          );
+        }
+        if (bindingError.status === 403) {
+          throw new WebRouteError(
+            403,
+            ErrorCode.FORBIDDEN,
+            `${message} (API key not created)`,
+          );
+        }
+      }
+      throw new WebRouteError(
+        502,
+        ErrorCode.SERVER_UNREACHABLE,
+        "Could not bind the API key to your organization. The key was not created.",
+      );
+    }
+
     logger.info("API key minted", {
       event: "api_key_created",
       auth_method: "session",
-      workos_key_id: body?.id ?? null,
+      workos_key_id: workosKeyId,
       actor_user_id: session.userId,
+      mcpjam_organization_id: organizationId,
     });
 
     return body;
@@ -267,6 +365,18 @@ apiKeys.delete("/:id", async (c) =>
     );
     if (status !== 204 && (status < 200 || status >= 300)) {
       mapWorkOSError(status, body, "Failed to revoke API key");
+    }
+
+    // Remove the org binding. Best-effort: the backend delete is idempotent
+    // and the WorkOS key is already gone, so a cleanup failure (including a
+    // binding that was never written) must not fail the user-facing revoke.
+    try {
+      await removeWorkosKeyBinding(id);
+    } catch (error) {
+      logger.warn("Failed to remove API key org binding during revoke", {
+        workos_key_id: id,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
 
     logger.info("API key revoked", {

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -221,9 +221,9 @@ apiKeys.post("/", async (c) =>
     }
 
     // Bind the key to the selected MCPJam org. A key with no binding is
-    // orphaned (rejected on /api/v1/* with 401 ORPHANED_KEY), so if the bind
-    // fails we revoke the WorkOS key immediately and report the failure —
-    // never leave an unusable key behind.
+    // orphaned (rejected on /api/v1/* with 401 UNAUTHORIZED, details.reason
+    // "ORPHANED_KEY"), so if the bind fails we revoke the WorkOS key
+    // immediately and report the failure — never leave an unusable key behind.
     try {
       await createWorkosKeyBinding({
         workosApiKeyId: workosKeyId,

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -302,10 +302,13 @@ function stripStdioFieldsFromHostedConfig<
  *   verbatim. Convex sees the same identity it always has.
  * - For WorkOS API keys (`authMethod === "workos_api_key"`): exchange
  *   the bearer for `INSPECTOR_SERVICE_TOKEN` and add
- *   `x-mcpjam-acting-as: <mcpjamUserId>`. Convex never sees the `sk_`
- *   value — Inspector is the trust boundary that validated it once via
- *   WorkOS and now vouches for the resolved user. The companion
- *   backend PR teaches `requestIdentity` to honor this delegated mode.
+ *   `x-mcpjam-acting-as: <workosUserId>` (the user's Convex `externalId`)
+ *   plus `x-mcpjam-acting-in-org: <mcpjamOrganizationId>` (the org the key
+ *   is bound to). Convex never sees the `sk_` value — Inspector is the
+ *   trust boundary that validated it once via WorkOS and now vouches for
+ *   the resolved user, scoped to the key's organization. The backend
+ *   `requestIdentity` resolver requires BOTH headers and re-checks that the
+ *   user is a member of that org.
  *
  * Keeping this in one helper so every `/web/*` callsite picks up the
  * same exchange (currently `authorizeServer` and `authorizeBatch` in
@@ -315,7 +318,7 @@ function stripStdioFieldsFromHostedConfig<
  * and stay on the original-bearer path until they're either reached
  * by an API key request or refactored to receive Context.
  */
-function buildConvexAuthHeaders(
+export function buildConvexAuthHeaders(
   c: Context,
   originalBearer: string
 ): Record<string, string> {
@@ -331,16 +334,28 @@ function buildConvexAuthHeaders(
         "Server missing INSPECTOR_SERVICE_TOKEN for WorkOS API key auth"
       );
     }
-    const actingAs = c.get("mcpjamUserId");
+    // `acting-as` is the WorkOS user id (the user's Convex `externalId`),
+    // NOT the Convex user `_id`: the backend resolves the delegated user by
+    // externalId. Sending the Convex id here would 404 as UNKNOWN_DELEGATED_USER.
+    const actingAs = c.get("workosUserId");
     if (!actingAs) {
       throw new WebRouteError(
         500,
         ErrorCode.INTERNAL_ERROR,
-        "Missing mcpjamUserId for WorkOS API key auth exchange"
+        "Missing workosUserId for WorkOS API key auth exchange"
+      );
+    }
+    const actingInOrg = c.get("mcpjamOrganizationId");
+    if (!actingInOrg) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Missing mcpjamOrganizationId for WorkOS API key auth exchange"
       );
     }
     headers["Authorization"] = `Bearer ${serviceToken}`;
     headers["x-mcpjam-acting-as"] = actingAs;
+    headers["x-mcpjam-acting-in-org"] = actingInOrg;
     return headers;
   }
   headers["Authorization"] = `Bearer ${originalBearer}`;
@@ -840,8 +855,13 @@ export async function createAuthorizedManager(
                       // service token without an acting-as user.
                       workosApiKeyActingAs:
                         c.get("authMethod") === "workos_api_key" &&
-                        c.get("mcpjamUserId")
-                          ? { mcpjamUserId: c.get("mcpjamUserId")! }
+                        c.get("workosUserId") &&
+                        c.get("mcpjamOrganizationId")
+                          ? {
+                              workosUserId: c.get("workosUserId")!,
+                              mcpjamOrganizationId:
+                                c.get("mcpjamOrganizationId")!,
+                            }
                           : undefined,
                     })
                   ).headers ?? {}),

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -295,6 +295,58 @@ function stripStdioFieldsFromHostedConfig<
   return { ...holder, serverConfig: cleaned };
 }
 
+/**
+ * Build the auth headers used by Inspector → Convex `/web/*` calls.
+ *
+ * - For session/guest JWTs (the default): forward the caller's bearer
+ *   verbatim. Convex sees the same identity it always has.
+ * - For WorkOS API keys (`authMethod === "workos_api_key"`): exchange
+ *   the bearer for `INSPECTOR_SERVICE_TOKEN` and add
+ *   `x-mcpjam-acting-as: <mcpjamUserId>`. Convex never sees the `sk_`
+ *   value — Inspector is the trust boundary that validated it once via
+ *   WorkOS and now vouches for the resolved user. The companion
+ *   backend PR teaches `requestIdentity` to honor this delegated mode.
+ *
+ * Keeping this in one helper so every `/web/*` callsite picks up the
+ * same exchange (currently `authorizeServer` and `authorizeBatch` in
+ * this file). Other Convex-forwarding helpers under `server/utils/*`
+ * (e.g. `chat-history.ts`, `hosted-oauth-refresh.ts`,
+ * `local-server-resolver.ts`) are NOT on the `/api/v1/*` path today
+ * and stay on the original-bearer path until they're either reached
+ * by an API key request or refactored to receive Context.
+ */
+function buildConvexAuthHeaders(
+  c: Context,
+  originalBearer: string
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (c.get("authMethod") === "workos_api_key") {
+    const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+    if (!serviceToken) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Server missing INSPECTOR_SERVICE_TOKEN for WorkOS API key auth"
+      );
+    }
+    const actingAs = c.get("mcpjamUserId");
+    if (!actingAs) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Missing mcpjamUserId for WorkOS API key auth exchange"
+      );
+    }
+    headers["Authorization"] = `Bearer ${serviceToken}`;
+    headers["x-mcpjam-acting-as"] = actingAs;
+    return headers;
+  }
+  headers["Authorization"] = `Bearer ${originalBearer}`;
+  return headers;
+}
+
 export async function authorizeServer(
   c: Context,
   bearerToken: string,
@@ -319,10 +371,7 @@ export async function authorizeServer(
   try {
     response = await fetch(`${convexUrl}/web/authorize`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${bearerToken}`,
-      },
+      headers: buildConvexAuthHeaders(c, bearerToken),
       body: JSON.stringify({
         projectId,
         serverId,
@@ -399,10 +448,7 @@ export async function authorizeBatch(
   try {
     response = await fetch(`${convexUrl}/web/authorize-batch`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${bearerToken}`,
-      },
+      headers: buildConvexAuthHeaders(c, bearerToken),
       body: JSON.stringify({
         projectId,
         serverIds,
@@ -788,6 +834,15 @@ export async function createAuthorizedManager(
                       accessScope: options?.accessScope,
                       chatboxId: options?.chatboxId,
                       accessVersion: options?.accessVersion,
+                      // When the caller authed via WorkOS API key, secret
+                      // reveal must use the same delegated-identity exchange
+                      // as `authorizeBatch` — otherwise Convex would see the
+                      // service token without an acting-as user.
+                      workosApiKeyActingAs:
+                        c.get("authMethod") === "workos_api_key" &&
+                        c.get("mcpjamUserId")
+                          ? { mcpjamUserId: c.get("mcpjamUserId")! }
+                          : undefined,
                     })
                   ).headers ?? {}),
                 },

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -3,6 +3,11 @@ import { describeError, type NormalizedError } from "@mcpjam/sdk";
 
 export const ErrorCode = {
   UNAUTHORIZED: "UNAUTHORIZED",
+  // A valid WorkOS `sk_…` key that has no MCPJam org binding. Returned as 401
+  // so the caller knows the credential itself is unusable and must be
+  // re-created (bindings are written at mint time; pre-binding keys are
+  // orphaned). Distinct from UNAUTHORIZED so clients can message it precisely.
+  ORPHANED_KEY: "ORPHANED_KEY",
   FORBIDDEN: "FORBIDDEN",
   NOT_FOUND: "NOT_FOUND",
   VALIDATION_ERROR: "VALIDATION_ERROR",

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -3,11 +3,6 @@ import { describeError, type NormalizedError } from "@mcpjam/sdk";
 
 export const ErrorCode = {
   UNAUTHORIZED: "UNAUTHORIZED",
-  // A valid WorkOS `sk_…` key that has no MCPJam org binding. Returned as 401
-  // so the caller knows the credential itself is unusable and must be
-  // re-created (bindings are written at mint time; pre-binding keys are
-  // orphaned). Distinct from UNAUTHORIZED so clients can message it precisely.
-  ORPHANED_KEY: "ORPHANED_KEY",
   FORBIDDEN: "FORBIDDEN",
   NOT_FOUND: "NOT_FOUND",
   VALIDATION_ERROR: "VALIDATION_ERROR",

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -20,6 +20,7 @@ import guestSession from "./guest-session.js";
 import chatHistory from "./chat-history.js";
 import conformanceWeb from "./conformance.js";
 import checks from "./checks.js";
+import apiKeys from "./api-keys.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -61,6 +62,11 @@ web.route("/guest-session", guestSession);
 web.route("/chat-history", chatHistory);
 web.route("/conformance", conformanceWeb);
 web.route("/checks", checks);
+// `/api-keys` carries its own bearer-auth `.use()` because
+// `sessionAuthMiddleware` bypasses `/api/web/*` entirely. Nothing on this
+// sub-router is reachable without a session JWT (WorkOS `sk_…` keys are
+// explicitly rejected with 403 inside the router).
+web.route("/api-keys", apiKeys);
 
 // Public guest JWKS compatibility endpoint.
 web.get("/guest-jwks", async (c) => {

--- a/mcpjam-inspector/server/services/__tests__/authkit-jwt.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/authkit-jwt.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for AuthKit access-token verification on the key-management surface.
+ * The bar (per review): reject forged/unsigned, wrong-issuer, wrong-audience,
+ * and expired tokens; accept a valid one and surface only `sub`/`org_id`.
+ *
+ * JWKS is injected via `deps` so these run offline with locally generated keys.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { SignJWT, generateKeyPair, type KeyLike } from "jose";
+import {
+  verifyAuthKitToken,
+  AuthKitVerificationError,
+  type AuthKitVerifyDeps,
+} from "../authkit-jwt.js";
+
+const ISSUER = "https://login.mcpjam.com";
+const CLIENT_ID = "client_test_123";
+const SUB = "user_workos_42";
+
+let trustedPrivate: KeyLike;
+let trustedPublic: KeyLike;
+let attackerPrivate: KeyLike;
+
+beforeAll(async () => {
+  const trusted = await generateKeyPair("RS256");
+  trustedPrivate = trusted.privateKey;
+  trustedPublic = trusted.publicKey;
+  const attacker = await generateKeyPair("RS256");
+  attackerPrivate = attacker.privateKey;
+});
+
+// Trust only ISSUER, verified against the trusted public key.
+function deps(): AuthKitVerifyDeps {
+  return {
+    clientId: CLIENT_ID,
+    resolveKey: (iss) => (iss === ISSUER ? trustedPublic : null),
+  };
+}
+
+async function sign(
+  key: KeyLike,
+  opts: {
+    iss?: string;
+    aud?: string;
+    sub?: string;
+    expSecondsFromNow?: number;
+    orgId?: string | null;
+  } = {},
+): Promise<string> {
+  const payload: Record<string, unknown> = {};
+  if (opts.orgId !== null) payload.org_id = opts.orgId ?? "org_active";
+  const builder = new SignJWT(payload)
+    .setProtectedHeader({ alg: "RS256" })
+    .setSubject(opts.sub ?? SUB)
+    .setIssuer(opts.iss ?? ISSUER)
+    .setAudience(opts.aud ?? CLIENT_ID)
+    .setIssuedAt();
+  const exp = Math.floor(Date.now() / 1000) + (opts.expSecondsFromNow ?? 300);
+  builder.setExpirationTime(exp);
+  return builder.sign(key);
+}
+
+describe("verifyAuthKitToken", () => {
+  it("accepts a valid token and returns only sub + org_id", async () => {
+    const token = await sign(trustedPrivate, { orgId: "org_active" });
+    const result = await verifyAuthKitToken(token, deps());
+    expect(result).toEqual({ sub: SUB, orgId: "org_active" });
+  });
+
+  it("returns orgId undefined when the token has no org_id", async () => {
+    const token = await sign(trustedPrivate, { orgId: null });
+    const result = await verifyAuthKitToken(token, deps());
+    expect(result).toEqual({ sub: SUB, orgId: undefined });
+  });
+
+  it("rejects a forged token signed with an untrusted key", async () => {
+    // Attacker controls the payload (valid-looking iss/aud/sub) but not the key.
+    const token = await sign(attackerPrivate, { sub: "victim_workos_id" });
+    await expect(verifyAuthKitToken(token, deps())).rejects.toBeInstanceOf(
+      AuthKitVerificationError,
+    );
+  });
+
+  it("rejects an unsigned (alg: none) token", async () => {
+    const b64 = (o: unknown) =>
+      Buffer.from(JSON.stringify(o)).toString("base64url");
+    const unsigned =
+      `${b64({ alg: "none", typ: "JWT" })}.` +
+      `${b64({ iss: ISSUER, aud: CLIENT_ID, sub: "victim_workos_id" })}.`;
+    await expect(verifyAuthKitToken(unsigned, deps())).rejects.toBeInstanceOf(
+      AuthKitVerificationError,
+    );
+  });
+
+  it("rejects a token from an untrusted issuer", async () => {
+    const token = await sign(trustedPrivate, { iss: "https://evil.example.com" });
+    await expect(
+      verifyAuthKitToken(token, deps()),
+    ).rejects.toThrow(/issuer/i);
+  });
+
+  it("rejects a token with the wrong audience", async () => {
+    const token = await sign(trustedPrivate, { aud: "client_other" });
+    await expect(verifyAuthKitToken(token, deps())).rejects.toBeInstanceOf(
+      AuthKitVerificationError,
+    );
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await sign(trustedPrivate, { expSecondsFromNow: -60 });
+    await expect(verifyAuthKitToken(token, deps())).rejects.toBeInstanceOf(
+      AuthKitVerificationError,
+    );
+  });
+
+  it("rejects a malformed token", async () => {
+    await expect(
+      verifyAuthKitToken("not-a-jwt", deps()),
+    ).rejects.toBeInstanceOf(AuthKitVerificationError);
+  });
+});

--- a/mcpjam-inspector/server/services/authkit-jwt.ts
+++ b/mcpjam-inspector/server/services/authkit-jwt.ts
@@ -1,0 +1,214 @@
+import {
+  createRemoteJWKSet,
+  decodeJwt,
+  jwtVerify,
+  type JWTVerifyGetKey,
+  type KeyLike,
+} from "jose";
+
+/**
+ * WorkOS AuthKit access-token verification for the `/api/web/api-keys`
+ * management surface.
+ *
+ * Why this exists: those routes perform privileged side effects (mint / list /
+ * revoke WorkOS API keys with the server-side admin `WORKOS_API_KEY`, and
+ * create/remove Convex org bindings) scoped to the caller's `sub`. Every other
+ * `/api/web/*` route forwards the bearer to Convex, which verifies the AuthKit
+ * JWT signature — but these routes call WorkOS/Convex-bindings directly and so
+ * MUST verify the token themselves before trusting any claim. Decoding the
+ * payload without signature verification (the previous behaviour) let a forged
+ * bearer drive key lifecycle operations against another user's `sub`.
+ *
+ * The issuer/JWKS/audience set is mirrored byte-for-byte from the backend's
+ * `convex/auth.config.ts` so Inspector accepts exactly the tokens Convex
+ * already accepts — verifying here never rejects a token Convex would honor.
+ * Client ids are public identifiers, not secrets.
+ */
+
+// Mirrors mcpjam-backend/convex/lib/authkit.ts.
+const PRODUCTION_WORKOS_CLIENT_ID = "client_01K4C1TVPBE7JTBFQJF9SDW9P9";
+const STAGING_WORKOS_CLIENT_ID = "client_01K4C1TVA6CMQ3G32F1P301A9G";
+const DEVELOPMENT_WORKOS_CLIENT_ID = "client_01KTN2EWHHJCKRB8RSR307X4SG";
+const PRODUCTION_AUTHKIT_DOMAIN = "login.mcpjam.com";
+const STAGING_AUTHKIT_DOMAIN = "dynamic-echo-14-staging.authkit.app";
+const DEVELOPMENT_AUTHKIT_DOMAIN = "deep-vanilla-68-test.authkit.app";
+
+/** Raised when the server is missing the config needed to verify (→ 500). */
+export class AuthKitConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthKitConfigError";
+  }
+}
+
+/** Raised when a token fails verification (→ 401). Never leaks the token. */
+export class AuthKitVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthKitVerificationError";
+  }
+}
+
+function normalizeDomain(domain: string | undefined): string | undefined {
+  if (!domain) return undefined;
+  return domain.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+}
+
+export function resolveWorkosClientId(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  // Inspector ships the client id to the browser as VITE_WORKOS_CLIENT_ID;
+  // it's the same id AuthKit issues tokens for. WORKOS_CLIENT_ID overrides.
+  return env.WORKOS_CLIENT_ID || env.VITE_WORKOS_CLIENT_ID || undefined;
+}
+
+function deriveAuthkitDomain(clientId: string): string | undefined {
+  switch (clientId) {
+    case PRODUCTION_WORKOS_CLIENT_ID:
+      return PRODUCTION_AUTHKIT_DOMAIN;
+    case STAGING_WORKOS_CLIENT_ID:
+      return STAGING_AUTHKIT_DOMAIN;
+    case DEVELOPMENT_WORKOS_CLIENT_ID:
+      return DEVELOPMENT_AUTHKIT_DOMAIN;
+    default:
+      return undefined;
+  }
+}
+
+function resolveAuthkitIssuer(
+  clientId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const domain = normalizeDomain(
+    env.AUTHKIT_DOMAIN || deriveAuthkitDomain(clientId),
+  );
+  return domain ? `https://${domain}` : undefined;
+}
+
+/**
+ * Allowed issuer → JWKS URL, mirroring `convex/auth.config.ts`. The token's
+ * `iss` selects the JWKS; an issuer absent from this map is rejected. The guest
+ * issuer is intentionally excluded — API-key management is JWT-only and guests
+ * cannot manage keys.
+ */
+export function authkitIssuerJwks(
+  clientId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  const workosJwks = `https://api.workos.com/sso/jwks/${clientId}`;
+  const mcpjamJwks = `https://api.mcpjam.com/sso/jwks/${clientId}`;
+  const authJwks = `https://auth.mcpjam.com/sso/jwks/${clientId}`;
+  map.set("https://api.workos.com/", workosJwks);
+  map.set(`https://api.workos.com/user_management/${clientId}`, workosJwks);
+  map.set("https://api.mcpjam.com/", mcpjamJwks);
+  map.set(`https://api.mcpjam.com/user_management/${clientId}`, mcpjamJwks);
+  map.set("https://auth.mcpjam.com/", authJwks);
+  map.set(`https://auth.mcpjam.com/user_management/${clientId}`, authJwks);
+  const authkitIssuer = resolveAuthkitIssuer(clientId, env);
+  if (authkitIssuer) {
+    map.set(authkitIssuer, `${authkitIssuer}/oauth2/jwks`);
+  }
+  return map;
+}
+
+// One remote JWKS per URL (jose caches the fetched keys internally per set).
+const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+function remoteJwks(url: string): ReturnType<typeof createRemoteJWKSet> {
+  let set = jwksCache.get(url);
+  if (!set) {
+    set = createRemoteJWKSet(new URL(url));
+    jwksCache.set(url, set);
+  }
+  return set;
+}
+
+export interface VerifiedSession {
+  /** WorkOS user id (the user's Convex `externalId`). */
+  sub: string;
+  /** Active WorkOS organization id, if present on the token. */
+  orgId?: string;
+}
+
+type KeyResolver = ReturnType<typeof createRemoteJWKSet> | KeyLike;
+
+export interface AuthKitVerifyDeps {
+  /** Expected `aud` of the access token. */
+  clientId: string;
+  /** Key/JWKS for an allowed issuer, or `null` to reject the issuer. */
+  resolveKey: (issuer: string) => KeyResolver | null;
+}
+
+function defaultDeps(): AuthKitVerifyDeps {
+  const clientId = resolveWorkosClientId();
+  if (!clientId) {
+    throw new AuthKitConfigError(
+      "WORKOS_CLIENT_ID (or VITE_WORKOS_CLIENT_ID) is not configured",
+    );
+  }
+  const issuers = authkitIssuerJwks(clientId);
+  return {
+    clientId,
+    resolveKey: (issuer) => {
+      const jwksUrl = issuers.get(issuer);
+      return jwksUrl ? remoteJwks(jwksUrl) : null;
+    },
+  };
+}
+
+/**
+ * Verify a WorkOS AuthKit access token and return only the claims we trust
+ * (`sub`, `org_id`). Throws `AuthKitVerificationError` on any failure
+ * (malformed, untrusted issuer, bad signature, wrong audience, expired/nbf).
+ *
+ * `deps` is injectable for tests; production uses the env-derived issuer set.
+ */
+export async function verifyAuthKitToken(
+  token: string,
+  deps: AuthKitVerifyDeps = defaultDeps(),
+): Promise<VerifiedSession> {
+  // Read the (unverified) issuer ONLY to pick the matching JWKS. The actual
+  // trust decision is `jwtVerify` below — signature + issuer pin + audience +
+  // exp/nbf — so a spoofed `iss` cannot grant access (it must also be in the
+  // allow-list AND be signed by that issuer's keys).
+  let unverifiedIssuer: string | undefined;
+  try {
+    unverifiedIssuer = decodeJwt(token).iss;
+  } catch {
+    throw new AuthKitVerificationError("Malformed session token");
+  }
+  if (!unverifiedIssuer) {
+    throw new AuthKitVerificationError("Session token missing issuer");
+  }
+
+  const key = deps.resolveKey(unverifiedIssuer);
+  if (!key) {
+    throw new AuthKitVerificationError("Untrusted session token issuer");
+  }
+  // Normalize to a key-getter so the overload is unambiguous: a remote JWKS is
+  // already a function; a static key (tests / injected deps) is wrapped.
+  const getKey: JWTVerifyGetKey =
+    typeof key === "function" ? (key as JWTVerifyGetKey) : async () => key;
+
+  let payload;
+  try {
+    ({ payload } = await jwtVerify(token, getKey, {
+      issuer: unverifiedIssuer,
+      audience: deps.clientId,
+      algorithms: ["RS256"],
+      clockTolerance: 5,
+    }));
+  } catch (error) {
+    throw new AuthKitVerificationError(
+      error instanceof Error ? error.message : "Token verification failed",
+    );
+  }
+
+  const sub = typeof payload.sub === "string" ? payload.sub : undefined;
+  if (!sub) {
+    throw new AuthKitVerificationError("Verified token is missing `sub`");
+  }
+  const orgIdClaim = (payload as { org_id?: unknown }).org_id;
+  const orgId = typeof orgIdClaim === "string" ? orgIdClaim : undefined;
+  return { sub, orgId };
+}

--- a/mcpjam-inspector/server/services/identity.ts
+++ b/mcpjam-inspector/server/services/identity.ts
@@ -1,0 +1,42 @@
+import { ConvexHttpClient } from "convex/browser";
+
+/**
+ * Resolve an MCPJam user from a WorkOS user id (the user's `externalId`
+ * in Convex).
+ *
+ * Used by the bearer middleware when an `sk_` WorkOS API key is presented:
+ * after `WorkOS.apiKeys.createValidation` returns the owning WorkOS user,
+ * we map it to an MCPJam user id so Inspector can call Convex as that user
+ * via the service-token + acting-as exchange.
+ *
+ * Returns `null` when no matching user is found — the caller is
+ * responsible for translating that into a 401.
+ */
+export interface ResolvedMcpjamUser {
+  /** MCPJam user document id (Convex). */
+  _id: string;
+}
+
+export async function resolveUserByExternalId(
+  externalId: string
+): Promise<ResolvedMcpjamUser | null> {
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl) {
+    throw new Error("CONVEX_URL is not set");
+  }
+
+  const client = new ConvexHttpClient(convexUrl);
+
+  // TODO: remove `as any` cast after the backend PR `claude/workos-api-keys-backend`
+  // adds `api.users.getByExternalId`. Inspector calls Convex via string
+  // function paths (matches `local-server-resolver.ts:935` and
+  // `servers.ts:80`) — no codegen step pins the API surface here, so the
+  // cast is the documented escape hatch until the reader query lands.
+  const result = (await client.query(
+    "users:getByExternalId" as any,
+    { externalId }
+  )) as { _id: string } | null | undefined;
+
+  if (!result || typeof result._id !== "string") return null;
+  return { _id: result._id };
+}

--- a/mcpjam-inspector/server/services/identity.ts
+++ b/mcpjam-inspector/server/services/identity.ts
@@ -1,4 +1,5 @@
 import { ConvexHttpClient } from "convex/browser";
+import { getInspectorClientRuntimeConfig } from "../env.js";
 
 /**
  * Resolve an MCPJam user from a WorkOS user id (the user's `externalId`
@@ -20,9 +21,19 @@ export interface ResolvedMcpjamUser {
 export async function resolveUserByExternalId(
   externalId: string
 ): Promise<ResolvedMcpjamUser | null> {
-  const convexUrl = process.env.CONVEX_URL;
+  // ConvexHttpClient needs the deployment (`.convex.cloud`) URL. Inspector
+  // boot only *requires* CONVEX_HTTP_URL (the `.convex.site` HTTP-actions
+  // origin), and `getInspectorClientRuntimeConfig()` derives the `.convex.cloud`
+  // query URL from it — so a deployment that sets only CONVEX_HTTP_URL still
+  // resolves identity here (previously this threw "CONVEX_URL is not set",
+  // 500-ing all sk_ auth and API-key minting). Fall back to an explicit
+  // CONVEX_URL if the derivation can't produce one.
+  const convexUrl =
+    getInspectorClientRuntimeConfig().convexUrl ?? process.env.CONVEX_URL;
   if (!convexUrl) {
-    throw new Error("CONVEX_URL is not set");
+    throw new Error(
+      "Convex deployment URL is not configured (set CONVEX_HTTP_URL or CONVEX_URL)",
+    );
   }
 
   const client = new ConvexHttpClient(convexUrl);
@@ -37,6 +48,7 @@ export async function resolveUserByExternalId(
     { externalId }
   )) as { _id: string } | null | undefined;
 
-  if (!result || typeof result._id !== "string") return null;
+  if (!result || typeof result !== "object" || typeof result._id !== "string")
+    return null;
   return { _id: result._id };
 }

--- a/mcpjam-inspector/server/services/workos-client.ts
+++ b/mcpjam-inspector/server/services/workos-client.ts
@@ -1,0 +1,39 @@
+import { WorkOS } from "@workos-inc/node";
+
+/**
+ * Server-side WorkOS Node SDK client.
+ *
+ * Memoized as a per-process singleton. Reads `WORKOS_API_KEY` from the
+ * environment on first call and throws if it is missing — the inspector
+ * server should fail loud rather than silently fall back to unauthenticated
+ * calls against WorkOS.
+ *
+ * This mirrors the backend factory pattern in
+ * `mcpjam-backend/convex/lib/vault.ts` (`createWorkOSClient()`). Both
+ * processes use the same `WORKOS_API_KEY` secret.
+ *
+ * Used today only by the WorkOS API Keys feature:
+ *   - `server/middleware/bearer-auth.ts` — validate `sk_` bearers via
+ *     `apiKeys.createValidation`.
+ *   - `server/routes/web/api-keys.ts` — mint / list / revoke management
+ *     endpoints (org-scoped operations only; user-scoped paths go through
+ *     direct REST since the SDK doesn't expose them yet).
+ */
+let cachedClient: WorkOS | undefined;
+
+export function getWorkOSClient(): WorkOS {
+  if (cachedClient) return cachedClient;
+  const apiKey = process.env.WORKOS_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "WORKOS_API_KEY is not set — required for WorkOS API key validation and management."
+    );
+  }
+  cachedClient = new WorkOS(apiKey);
+  return cachedClient;
+}
+
+/** Test-only: reset the memoized client (does not affect process env). */
+export function resetWorkOSClientForTests(): void {
+  cachedClient = undefined;
+}

--- a/mcpjam-inspector/server/services/workos-key-bindings.ts
+++ b/mcpjam-inspector/server/services/workos-key-bindings.ts
@@ -1,0 +1,126 @@
+/**
+ * Inspector-side client for the backend's service-token-gated
+ * WorkOS-API-key → MCPJam-org binding endpoints
+ * (`/internal/v1/workos-api-key-bindings`; see mcpjam-backend `convex/http.ts`).
+ *
+ * WorkOS has no native org binding for API keys, so the backend persists the
+ * scope and Inspector reads it here to attach `x-mcpjam-acting-in-org` to
+ * delegated `/api/v1/*` calls. Authenticated with `INSPECTOR_SERVICE_TOKEN`
+ * via the `x-inspector-service-token` header — the dedicated header these
+ * routes gate on (they do NOT accept `Authorization: Bearer`, unlike the
+ * delegated-identity resolver).
+ */
+
+const BINDINGS_PATH = "/internal/v1/workos-api-key-bindings";
+
+export interface WorkosKeyBinding {
+  /** MCPJam organization id (Convex `Id<'organizations'>`). */
+  mcpjamOrganizationId: string;
+}
+
+/**
+ * Carries the backend HTTP status so the mint handler can map a
+ * non-member (403) or malformed-id (400) rejection to the right client
+ * status instead of flattening everything to a 502.
+ */
+export class WorkosKeyBindingError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "WorkosKeyBindingError";
+    this.status = status;
+  }
+}
+
+function getConfig(): { convexUrl: string; serviceToken: string } {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new Error("CONVEX_HTTP_URL is not set");
+  }
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!serviceToken) {
+    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
+  }
+  return { convexUrl, serviceToken };
+}
+
+/**
+ * Look up the org a WorkOS API key is bound to. Returns `null` when the
+ * backend reports 404 (no binding) — the caller treats that as an orphaned
+ * key (401). Throws on transport / unexpected status so the caller can 500.
+ */
+export async function lookupWorkosKeyBinding(
+  workosApiKeyId: string,
+): Promise<WorkosKeyBinding | null> {
+  const { convexUrl, serviceToken } = getConfig();
+  const url = `${convexUrl}${BINDINGS_PATH}?workosApiKeyId=${encodeURIComponent(
+    workosApiKeyId,
+  )}`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "x-inspector-service-token": serviceToken },
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Binding lookup failed (${response.status})`);
+  }
+  const body = (await response.json()) as { mcpjamOrganizationId?: unknown };
+  if (typeof body?.mcpjamOrganizationId !== "string") {
+    throw new Error("Binding lookup returned an invalid body");
+  }
+  return { mcpjamOrganizationId: body.mcpjamOrganizationId };
+}
+
+/**
+ * Persist the org binding for a freshly minted WorkOS key. Throws on any
+ * non-2xx — the mint handler revokes the WorkOS key when this fails so we
+ * never leave an unscoped (orphaned) key alive.
+ */
+export async function createWorkosKeyBinding(args: {
+  workosApiKeyId: string;
+  mcpjamOrganizationId: string;
+  mintedByUserId: string;
+}): Promise<void> {
+  const { convexUrl, serviceToken } = getConfig();
+  const response = await fetch(`${convexUrl}${BINDINGS_PATH}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-inspector-service-token": serviceToken,
+    },
+    body: JSON.stringify(args),
+  });
+  if (!response.ok) {
+    let message = `Binding create failed (${response.status})`;
+    try {
+      const body = (await response.json()) as { error?: unknown };
+      if (typeof body?.error === "string") message = body.error;
+    } catch {
+      // keep the status-only message
+    }
+    throw new WorkosKeyBindingError(response.status, message);
+  }
+}
+
+/**
+ * Remove the org binding for a revoked WorkOS key. The backend delete is
+ * idempotent (200 whether or not a row existed); the caller treats a thrown
+ * error as best-effort and does not fail the user-facing revoke.
+ */
+export async function removeWorkosKeyBinding(
+  workosApiKeyId: string,
+): Promise<void> {
+  const { convexUrl, serviceToken } = getConfig();
+  const url = `${convexUrl}${BINDINGS_PATH}?workosApiKeyId=${encodeURIComponent(
+    workosApiKeyId,
+  )}`;
+  const response = await fetch(url, {
+    method: "DELETE",
+    headers: { "x-inspector-service-token": serviceToken },
+  });
+  if (!response.ok) {
+    throw new Error(`Binding remove failed (${response.status})`);
+  }
+}

--- a/mcpjam-inspector/server/types/hono.ts
+++ b/mcpjam-inspector/server/types/hono.ts
@@ -10,5 +10,22 @@ declare module "hono" {
   interface ContextVariableMap {
     guestId?: string;
     requestLogContext?: RequestLogContext;
+    /**
+     * Auth method used to resolve the caller. Set by `bearerAuthMiddleware`:
+     * - `"workos_api_key"` — caller presented a WorkOS `sk_…` API key
+     *   (validated via `WorkOS.apiKeys.createValidation`).
+     * - Absent — guest JWT (see `guestId`) or WorkOS AuthKit JWT.
+     *
+     * Downstream Convex callers (`authorizeBatch`) read this to decide
+     * between forwarding the original bearer (JWT/guest) and exchanging
+     * for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as` (API key).
+     */
+    authMethod?: "workos_api_key";
+    /** WorkOS API key id (e.g. `api_key_…`). Set with `authMethod`. */
+    workosApiKeyId?: string;
+    /** WorkOS user externalId. Set with `authMethod`. */
+    workosUserId?: string;
+    /** Resolved MCPJam user `_id` (Convex). Set with `authMethod`. */
+    mcpjamUserId?: string;
   }
 }

--- a/mcpjam-inspector/server/types/hono.ts
+++ b/mcpjam-inspector/server/types/hono.ts
@@ -27,5 +27,12 @@ declare module "hono" {
     workosUserId?: string;
     /** Resolved MCPJam user `_id` (Convex). Set with `authMethod`. */
     mcpjamUserId?: string;
+    /**
+     * MCPJam organization id (Convex `Id<'organizations'>`) the WorkOS API
+     * key is bound to. Set with `authMethod` by `bearerAuthMiddleware` after
+     * looking up the key's org binding. Forwarded to Convex as
+     * `x-mcpjam-acting-in-org` by the delegated-identity exchange.
+     */
+    mcpjamOrganizationId?: string;
   }
 }

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -44,6 +44,17 @@ export async function fetchRuntimeServerSecrets(args: {
   accessScope?: "project_member" | "chat_v2";
   chatboxId?: string;
   accessVersion?: number;
+  /**
+   * When the caller authenticated via a WorkOS API key, Inspector exchanges
+   * the user bearer for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as`.
+   * Passed by `createAuthorizedManager` so secret reveals during the
+   * `/api/v1/*` flow follow the same trust model as `authorizeBatch`.
+   * The bearer middleware sets `authMethod="workos_api_key"`; callers
+   * just forward those Context values.
+   */
+  workosApiKeyActingAs?: {
+    mcpjamUserId: string;
+  };
 }): Promise<ServerSecretsResult> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   if (!convexUrl) {
@@ -62,12 +73,27 @@ export async function fetchRuntimeServerSecrets(args: {
 
   let response: Response;
   try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (args.workosApiKeyActingAs) {
+      const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+      if (!serviceToken) {
+        throw new WebRouteError(
+          500,
+          ErrorCode.INTERNAL_ERROR,
+          "Server missing INSPECTOR_SERVICE_TOKEN for WorkOS API key auth"
+        );
+      }
+      headers["Authorization"] = `Bearer ${serviceToken}`;
+      headers["x-mcpjam-acting-as"] = args.workosApiKeyActingAs.mcpjamUserId;
+    } else {
+      headers["Authorization"] = `Bearer ${args.bearerToken}`;
+    }
+
     response = await fetch(`${convexUrl}/web/server/reveal-secrets`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${args.bearerToken}`,
-      },
+      headers,
       body: JSON.stringify({
         purpose: "runtime",
         projectId: args.projectId,

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -46,14 +46,16 @@ export async function fetchRuntimeServerSecrets(args: {
   accessVersion?: number;
   /**
    * When the caller authenticated via a WorkOS API key, Inspector exchanges
-   * the user bearer for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as`.
-   * Passed by `createAuthorizedManager` so secret reveals during the
-   * `/api/v1/*` flow follow the same trust model as `authorizeBatch`.
-   * The bearer middleware sets `authMethod="workos_api_key"`; callers
-   * just forward those Context values.
+   * the user bearer for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as`
+   * (the WorkOS user id / Convex `externalId`) + `x-mcpjam-acting-in-org`
+   * (the org the key is bound to). Passed by `createAuthorizedManager` so
+   * secret reveals during the `/api/v1/*` flow follow the same trust model
+   * as `authorizeBatch`. The bearer middleware sets
+   * `authMethod="workos_api_key"`; callers just forward those Context values.
    */
   workosApiKeyActingAs?: {
-    mcpjamUserId: string;
+    workosUserId: string;
+    mcpjamOrganizationId: string;
   };
 }): Promise<ServerSecretsResult> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
@@ -86,7 +88,9 @@ export async function fetchRuntimeServerSecrets(args: {
         );
       }
       headers["Authorization"] = `Bearer ${serviceToken}`;
-      headers["x-mcpjam-acting-as"] = args.workosApiKeyActingAs.mcpjamUserId;
+      headers["x-mcpjam-acting-as"] = args.workosApiKeyActingAs.workosUserId;
+      headers["x-mcpjam-acting-in-org"] =
+        args.workosApiKeyActingAs.mcpjamOrganizationId;
     } else {
       headers["Authorization"] = `Bearer ${args.bearerToken}`;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,6 +328,7 @@
         "@sentry/vite-plugin": "^4.3.0",
         "@tanstack/react-virtual": "^3.13.12",
         "@workos-inc/authkit-react": "^0.12.0",
+        "@workos-inc/node": "^10.2.0",
         "@xyflow/react": "^12.9.0",
         "ai": "^6.0.154",
         "ajv": "^8.18.0",
@@ -551,6 +552,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "mcpjam-inspector/node_modules/@workos-inc/node": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-10.2.0.tgz",
+      "integrity": "sha512-K7LmCvwu8fL7HN3drAvjb/dWceltlDNSs3u1QNNYx5goZaxxG4dgCXDkdlcDt6ZKm8VGv030WfkmL7DylXvdaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=22.11.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -20406,7 +20419,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,6 +348,7 @@
         "fuse.js": "^7.1.0",
         "gray-matter": "^4.0.3",
         "hono": "^4.11.7",
+        "jose": "^5.10.0",
         "lucide-react": "^0.525.0",
         "marked": "^16.4.1",
         "next-themes": "^0.4.6",
@@ -570,7 +571,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -1060,7 +1061,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -1074,7 +1075,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1084,7 +1085,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1098,7 +1099,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1108,7 +1109,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@axiomhq/js": {
@@ -2222,7 +2223,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2242,7 +2243,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2266,7 +2267,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2294,7 +2295,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2317,7 +2318,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2342,7 +2343,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4582,7 +4583,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -6069,7 +6070,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -8504,7 +8505,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -13750,7 +13751,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -13760,7 +13760,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -16236,7 +16236,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -16458,7 +16458,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -17565,7 +17565,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -17586,7 +17586,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -17602,7 +17602,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -18173,7 +18173,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -18187,7 +18187,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -18284,7 +18284,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -19441,7 +19441,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -19452,7 +19451,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -22234,7 +22232,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -22301,7 +22299,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -22315,7 +22313,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -23128,7 +23126,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -24531,7 +24529,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -24571,7 +24569,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -24581,7 +24579,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -24595,7 +24593,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -24990,7 +24988,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -25023,7 +25021,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25044,7 +25041,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25065,7 +25061,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25086,7 +25081,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25107,7 +25101,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25128,7 +25121,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25149,7 +25141,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25170,7 +25161,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25191,7 +25181,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25212,7 +25201,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25233,7 +25221,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26152,7 +26139,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -28888,7 +28875,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -29798,7 +29785,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -31212,7 +31199,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -31304,7 +31291,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -31978,7 +31965,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -31997,7 +31984,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -32694,7 +32681,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -32841,7 +32828,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -32925,7 +32912,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -33183,7 +33170,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
       "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -33196,7 +33183,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -33300,7 +33287,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -33313,7 +33300,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -33661,7 +33648,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -33844,7 +33831,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -34857,7 +34844,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -34933,7 +34920,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -35038,7 +35025,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -35048,7 +35035,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -35896,7 +35883,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -35916,7 +35903,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {


### PR DESCRIPTION
## Summary

Finishes the WorkOS `sk_…` API-key path for the v1 public API so external developers can call production `/api/v1/*` from curl / CI. This branch **incorporates the work from #2507** (merged in) and adds the org-scoping the merged backend now requires, so it supersedes #2507 — close that one in favor of this.

**Pairs with backend [mcpjam-backend#479](https://github.com/MCPJam/mcpjam-backend/pull/479)** (the WorkOS-key → org binding endpoints). Backend #469 (delegated identity) is already merged and now requires **both** `x-mcpjam-acting-as` (a WorkOS `externalId`) and `x-mcpjam-acting-in-org` (a Convex org id) — #2507 as written sent neither correctly, which is what this PR fixes.

## What changed on top of #2507

### The bug #2507 shipped with
`buildConvexAuthHeaders` sent `x-mcpjam-acting-as: <mcpjamUserId>` (the **Convex** user id) and no org header. Against the merged backend that 404s as `UNKNOWN_DELEGATED_USER` and fails the required org check. Now:
- `x-mcpjam-acting-as` = **WorkOS user id** (the user's Convex `externalId`).
- `x-mcpjam-acting-in-org` = the **MCPJam org id** the key is bound to.
- Both fixed in `routes/web/auth.ts` **and** `utils/server-secrets.ts` (runtime secret reveal uses the same exchange).

### Org binding (the new requirement)
- **`services/workos-key-bindings.ts`** (new): service-token client for backend #479's `/internal/v1/workos-api-key-bindings` (create / lookup / remove), via `x-inspector-service-token`.
- **Bearer middleware**: after resolving the MCPJam user, look up the key's org binding (memoized per request). **Missing binding → `401 ORPHANED_KEY`**; otherwise store `mcpjamOrganizationId` in context.
- **Mint** (`routes/web/api-keys.ts`): accepts `{ name, organizationId }`, resolves the Convex user id, creates the backend binding, and **revokes the WorkOS key immediately if the binding write fails** (never leaves an orphaned key).
- **Revoke**: deletes the WorkOS key, then removes the binding best-effort (logs, never fails the user-facing revoke).
- **Client**: Create dialog adds MCPJam org selection — auto-selects when the user has one org, requires an explicit choice when there are several; posts `organizationId`.

## Tests

- `middleware/__tests__/bearer-auth.test.ts` (10): invalid/unknown-user 401, valid key sets identity **and** org context, **orphaned key → 401 ORPHANED_KEY**, binding-lookup throw → 500, rate-limit burst, per-request memoization of validate **and** binding lookup. (Also fixed the `sk_` validate mock — it called `validateApiKey` but the SDK method is `createValidation`.)
- `routes/web/__tests__/buildConvexAuthHeaders.test.ts` (new, 4): **asserts `x-mcpjam-acting-as` is the WorkOS user id, not the Convex id**, both delegation headers present, raw `sk_` never forwarded, non-API-key path forwards the bearer verbatim.
- Made the `auth-manager` / `authorize-batch` Context test mocks faithful to Hono (`c.get`), fixing 12 pre-existing failures introduced by #2507's `c.get` usage.
- Full server suite: **1365 pass**; the only residual failures are headless-Chromium browser-harness tests (no Chromium in CI sandbox), unrelated to this change. Client + server typecheck clean for all touched files.

## Production ops (cannot be done from here — needs prod access)

- Deploy backend #479 **before** this; set production `INSPECTOR_SERVICE_TOKEN` identically on backend + Inspector, and `WORKOS_API_KEY` on Inspector.
- Revoke any WorkOS keys minted before binding support — they're orphaned and will 401.
- Smoke: mint for org A → `/api/v1/*` against org A = 200, against org B = 403, revoke → 401; confirm backend logs `delegated_identity.resolved` with `targetOrganizationId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011asM4GkyWv5TQp35PAC3cC

---
_Generated by [Claude Code](https://claude.ai/code/session_011asM4GkyWv5TQp35PAC3cC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, delegated identity to Convex, and API key lifecycle; incorrect headers or binding logic would break v1 API access or widen scope. Mitigated by explicit org binding, session-only key management, and focused tests.
> 
> **Overview**
> This PR completes the **WorkOS `sk_…` API key** path for calling **`/api/v1/*`** from CI and scripts, with **MCPJam org scoping** and a fix for delegated auth to Convex.
> 
> **Client:** New **`/settings/api-keys`** route (sidebar link), list/create/revoke flow, org picker on mint, one-time reveal dialog, and typed **`/api/web/api-keys`** client helpers.
> 
> **Server — `sk_` auth:** **`bearerAuthMiddleware`** validates WorkOS keys, resolves the MCPJam user, loads an **org binding** (memoized per request), applies **per-key rate limits**, and rejects **orphaned** keys with **`401`** and **`details.reason: ORPHANED_KEY`**. **`buildConvexAuthHeaders`** now sends **`x-mcpjam-acting-as`** as the **WorkOS user id** (not Convex `_id`) plus **`x-mcpjam-acting-in-org`**; the same exchange applies to runtime **secret reveal**.
> 
> **Key management:** **`/api/web/api-keys`** verifies **AuthKit JWTs** (new **`authkit-jwt`**), proxies WorkOS REST for mint/list/revoke, persists bindings via **`workos-key-bindings`**, rolls back WorkOS on bind failure, and returns **403** when a **`sk_`** bearer tries to manage keys.
> 
> **Deps/tests:** Adds **`@workos-inc/node`**, **`jose`**, request-local memoization, and tests for bearer auth, header exchange, and AuthKit verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1b89645fd71aa0cd1c79f9f22d26007333d5360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->