### PR TITLE
feat(evals): per-iteration browser-eval metrics for budget tuning (PR 13)

### DIFF
--- a/mcpjam-inspector/server/services/evals/__tests__/browser-eval-metrics.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/browser-eval-metrics.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
+} from "@/shared/eval-trace";
+import {
+  emitBrowserEvalMetrics,
+  summarizeBrowserEvalMetrics,
+} from "../browser-eval-metrics";
+import { logger } from "../../../utils/logger";
+
+const obs = (
+  o: Partial<RunnerWidgetRenderObservation> = {},
+): RunnerWidgetRenderObservation => ({
+  toolCallId: "tc-a",
+  toolName: "show_seats",
+  serverId: "flights",
+  status: "rendered",
+  elapsedMs: 100,
+  ts: 1,
+  promptIndex: 0,
+  ...o,
+});
+
+const step = (
+  s: Partial<RunnerBrowserInteractionStep> = {},
+): RunnerBrowserInteractionStep => ({
+  toolCallId: "tc-a",
+  stepIndex: 0,
+  promptIndex: 0,
+  action: "left_click",
+  elapsedMs: 10,
+  ts: 1,
+  ...s,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("summarizeBrowserEvalMetrics", () => {
+  it("returns zeroed metrics for empty input", () => {
+    const m = summarizeBrowserEvalMetrics([], []);
+    expect(m).toMatchObject({
+      renderCount: 0,
+      renderedCount: 0,
+      browserUnavailable: false,
+      statusCounts: {},
+      widgetCount: 0,
+      totalSteps: 0,
+      maxStepsPerWidget: 0,
+      meanStepsPerWidget: 0,
+      screenshotCount: 0,
+      meanActionElapsedMs: 0,
+      maxActionElapsedMs: 0,
+      meanRenderElapsedMs: 0,
+    });
+  });
+
+  it("aggregates statuses, steps-per-widget, screenshots, budgets, and latency", () => {
+    const observations = [
+      obs({ status: "rendered", screenshotBase64: "x" }),
+      obs({ status: "rendered", screenshotBase64: "x", elapsedMs: 200 }),
+      obs({ status: "bridge_timeout", elapsedMs: 300 }),
+      obs({ status: "browser_unavailable", elapsedMs: 5 }),
+    ];
+    const steps = [
+      step({ toolCallId: "tc-a", stepIndex: 0, screenshotBase64: "x", elapsedMs: 10 }),
+      step({ toolCallId: "tc-a", stepIndex: 1, screenshotBase64: "x", elapsedMs: 20 }),
+      step({
+        toolCallId: "tc-a",
+        stepIndex: 2,
+        elapsedMs: 30,
+        note: "step_budget_exceeded",
+      }),
+      step({
+        toolCallId: "tc-b",
+        stepIndex: 0,
+        elapsedMs: 40,
+        note: "no_rendered_widget",
+      }),
+    ];
+
+    const m = summarizeBrowserEvalMetrics(observations, steps);
+
+    expect(m.renderCount).toBe(4);
+    expect(m.renderedCount).toBe(2);
+    expect(m.browserUnavailable).toBe(true);
+    expect(m.statusCounts).toEqual({
+      rendered: 2,
+      bridge_timeout: 1,
+      browser_unavailable: 1,
+    });
+    expect(m.widgetCount).toBe(2);
+    expect(m.totalSteps).toBe(4);
+    expect(m.maxStepsPerWidget).toBe(3); // tc-a has 3
+    expect(m.meanStepsPerWidget).toBe(2); // (3 + 1) / 2
+    expect(m.screenshotCount).toBe(4); // 2 obs + 2 steps with a shot
+    expect(m.stepBudgetExceededCount).toBe(1);
+    expect(m.screenshotBudgetExceededCount).toBe(0);
+    expect(m.noRenderedWidgetCount).toBe(1);
+    expect(m.meanActionElapsedMs).toBe(25); // (10+20+30+40)/4
+    expect(m.maxActionElapsedMs).toBe(40);
+    expect(m.meanRenderElapsedMs).toBe(151); // round((100+200+300+5)/4)
+  });
+});
+
+describe("emitBrowserEvalMetrics", () => {
+  it("does NOT emit when there are no browser artifacts", () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
+    emitBrowserEvalMetrics([], []);
+    emitBrowserEvalMetrics(undefined, undefined);
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits one structured metric record with the summary", () => {
+    const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
+    emitBrowserEvalMetrics([obs()], [step()]);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[evals-metric] browser_eval",
+      expect.objectContaining({ renderCount: 1, totalSteps: 1 }),
+    );
+  });
+
+  it("never throws if logging fails (best-effort)", () => {
+    vi.spyOn(logger, "info").mockImplementation(() => {
+      throw new Error("axiom down");
+    });
+    expect(() => emitBrowserEvalMetrics([obs()], [step()])).not.toThrow();
+  });
+});

--- a/mcpjam-inspector/server/services/evals/browser-eval-metrics.ts
+++ b/mcpjam-inspector/server/services/evals/browser-eval-metrics.ts
@@ -1,0 +1,126 @@
+import type {
+  EvalTraceWidgetRenderStatus,
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
+} from "@/shared/eval-trace";
+import { logger } from "../../utils/logger.js";
+
+/**
+ * PR 13 — observability for browser-rendered MCP App evals.
+ *
+ * Emits one structured `[evals-metric] browser_eval` record per iteration that
+ * exercised the headless-Chromium harness, computed entirely from the
+ * already-collected `widgetRenderObservations` + `browserInteractionSteps`
+ * arrays at the shared `finalizeEvalIteration` choke point (covers both the
+ * stream and non-stream paths). `logger.info` ingests to Axiom, so rates are
+ * aggregated downstream — this is the per-iteration sample those rates sum over.
+ *
+ * What the budget defaults can be defended with (HarnessBudgets):
+ *   - `maxStepsPerWidget` / `meanStepsPerWidget` → maxBrowserStepsPerWidget (12)
+ *   - `screenshotCount`                          → totalScreenshotsPerIteration (60)
+ *   - `stepBudgetExceededCount` /
+ *     `screenshotBudgetExceededCount`            → cap-hit rate
+ *   - `browserUnavailable`                       → browser_unavailable rate
+ *   - `statusCounts`                             → render status distribution
+ *   - `meanActionElapsedMs` / `maxActionElapsedMs` → Computer Use latency
+ */
+export type BrowserEvalMetrics = {
+  /** Total render attempts recorded this iteration. */
+  renderCount: number;
+  /** How many ended `rendered`. */
+  renderedCount: number;
+  /** True if any render fell back to `browser_unavailable` (Chromium missing). */
+  browserUnavailable: boolean;
+  /** Counts keyed by render status (only non-zero statuses present). */
+  statusCounts: Partial<Record<EvalTraceWidgetRenderStatus, number>>;
+  /** Distinct widgets (toolCallIds) the model interacted with. */
+  widgetCount: number;
+  /** Total Computer Use steps across all widgets. */
+  totalSteps: number;
+  maxStepsPerWidget: number;
+  meanStepsPerWidget: number;
+  /** Screenshots captured (render + step), the per-iteration budget signal. */
+  screenshotCount: number;
+  stepBudgetExceededCount: number;
+  screenshotBudgetExceededCount: number;
+  noRenderedWidgetCount: number;
+  meanActionElapsedMs: number;
+  maxActionElapsedMs: number;
+  meanRenderElapsedMs: number;
+};
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+}
+
+export function summarizeBrowserEvalMetrics(
+  observations: RunnerWidgetRenderObservation[],
+  steps: RunnerBrowserInteractionStep[],
+): BrowserEvalMetrics {
+  const statusCounts: Partial<Record<EvalTraceWidgetRenderStatus, number>> = {};
+  for (const obs of observations) {
+    statusCounts[obs.status] = (statusCounts[obs.status] ?? 0) + 1;
+  }
+
+  const stepsByWidget = new Map<string, number>();
+  for (const step of steps) {
+    stepsByWidget.set(
+      step.toolCallId,
+      (stepsByWidget.get(step.toolCallId) ?? 0) + 1,
+    );
+  }
+  const perWidgetCounts = [...stepsByWidget.values()];
+
+  const screenshotCount =
+    observations.filter((o) => Boolean(o.screenshotBase64)).length +
+    steps.filter((s) => Boolean(s.screenshotBase64)).length;
+
+  const stepElapsed = steps.map((s) => s.elapsedMs);
+
+  return {
+    renderCount: observations.length,
+    renderedCount: statusCounts.rendered ?? 0,
+    browserUnavailable: (statusCounts.browser_unavailable ?? 0) > 0,
+    statusCounts,
+    widgetCount: stepsByWidget.size,
+    totalSteps: steps.length,
+    maxStepsPerWidget:
+      perWidgetCounts.length > 0 ? Math.max(...perWidgetCounts) : 0,
+    meanStepsPerWidget: mean(perWidgetCounts),
+    screenshotCount,
+    stepBudgetExceededCount: steps.filter(
+      (s) => s.note === "step_budget_exceeded",
+    ).length,
+    screenshotBudgetExceededCount: steps.filter(
+      (s) => s.note === "screenshot_budget_exceeded",
+    ).length,
+    noRenderedWidgetCount: steps.filter((s) => s.note === "no_rendered_widget")
+      .length,
+    meanActionElapsedMs: mean(stepElapsed),
+    maxActionElapsedMs: stepElapsed.length > 0 ? Math.max(...stepElapsed) : 0,
+    meanRenderElapsedMs: mean(observations.map((o) => o.elapsedMs)),
+  };
+}
+
+/**
+ * Emit the per-iteration browser-eval metric. No-op when the iteration didn't
+ * touch the harness (no observations and no steps) so non-browser evals stay
+ * silent. Best-effort: never throws into the finalize path.
+ */
+export function emitBrowserEvalMetrics(
+  observations: RunnerWidgetRenderObservation[] | undefined,
+  steps: RunnerBrowserInteractionStep[] | undefined,
+): void {
+  const obs = observations ?? [];
+  const stp = steps ?? [];
+  if (obs.length === 0 && stp.length === 0) return;
+  try {
+    logger.info(
+      "[evals-metric] browser_eval",
+      summarizeBrowserEvalMetrics(obs, stp),
+    );
+  } catch {
+    /* metrics are best-effort; never break finalize */
+  }
+}

--- a/mcpjam-inspector/server/services/evals/finalize-iteration.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration.ts
@@ -10,6 +10,7 @@ import type {
 import { logger } from "../../utils/logger.js";
 import type { UsageTotals } from "./types.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+import { emitBrowserEvalMetrics } from "./browser-eval-metrics.js";
 import {
   serializeBrowserStepsForBackend,
   serializeRenderObservationsForBackend,
@@ -181,6 +182,11 @@ export async function finalizeEvalIteration(
       : isCycleFailure
         ? "eval_failed"
         : "eval_completed";
+
+  // PR 13: emit per-iteration browser-eval observability from the runner-local
+  // arrays (covers both the stream + non-stream paths via this shared choke
+  // point). Best-effort + no-op when the iteration didn't touch the harness.
+  emitBrowserEvalMetrics(widgetRenderObservations, browserInteractionSteps);
 
   // PR 6b: serialize browser artifacts ONCE here (upload screenshots + run
   // through the convex sanitizer) so the W2 fanout and the W1 fallback share a


### PR DESCRIPTION
## Summary

**PR 13** — observability for browser-rendered MCP App evals, so the harness budget defaults (12 steps/widget, 60 screenshots/iteration, 256 KiB/screenshot) can be defended from real data instead of vibes.

Emits **one structured `[evals-metric] browser_eval` record per iteration** that exercised the headless-Chromium harness. `logger.info` ingests to Axiom, so rates aggregate downstream — this is the per-iteration sample those rates sum over. Server-only, self-contained.

## What changed

- **`browser-eval-metrics.ts`** (new) — `summarizeBrowserEvalMetrics` (pure) computes, from the already-collected `widgetRenderObservations` + `browserInteractionSteps`:
  - render **status distribution** + `browser_unavailable` (Chromium-missing) flag
  - **steps-per-widget** (max / mean) → `maxBrowserStepsPerWidget` baseline
  - **screenshot count** → `totalScreenshotsPerIteration` baseline
  - **step / screenshot budget-exceeded** counts → cap-hit rate
  - Computer Use **action latency** (mean / max)

  `emitBrowserEvalMetrics` logs it — **no-op** when the iteration didn't touch the harness, **best-effort** (never throws into finalize).
- **`finalize-iteration.ts`** — call it from the runner-local arrays at the shared finalize choke point, so **both** the stream and non-stream paths emit through one site.

## Design notes

- Computed from the **already-collected arrays** at `finalizeEvalIteration` — no new harness plumbing, one emission point for every eval path (recorder + direct, stream + non-stream).
- `logger.info` → Axiom matches the handoff's "dashboard from logs is fine for v1" and the runner's existing `[evals]` logging style. No new heavyweight event type needed.

## Testing

`summarizeBrowserEvalMetrics` aggregation (statuses, per-widget steps, screenshots, budget-exceeded, latency) + `emitBrowserEvalMetrics` (no-op when empty / emits the summary / never throws). Full evals suite green (**175 tests**, no regression).

## Deferred

Per-action harness-callback emission (finer granularity) — the per-iteration aggregate already covers every metric the handoff named for v1.

https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only logging on the finalize path; no-op for non-browser evals and errors are swallowed so eval completion is unchanged.
> 
> **Overview**
> Adds **per-iteration observability** for headless-Chromium browser evals by aggregating existing `widgetRenderObservations` and `browserInteractionSteps` into one structured `[evals-metric] browser_eval` log (via `logger.info` → Axiom). Metrics cover render status counts, steps/screenshots per widget, budget-exceeded and `no_rendered_widget` notes, and action/render latency.
> 
> **`finalizeEvalIteration`** now calls **`emitBrowserEvalMetrics`** at the shared finalize choke point (before artifact serialization), so stream and non-stream eval paths emit the same way; non-browser iterations stay silent. Emission is **best-effort** (swallows logging failures) and does not alter persistence or fanout behavior.
> 
> New unit tests cover aggregation edge cases and emit no-op / single-record / never-throw behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48558fdcc59b211abc1be01a7cb7e2f78f8dfbff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->