### PR TITLE
ui: rename hostConfig label "Client" → "Host"

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
@@ -226,10 +226,10 @@ export function ChatboxesTab({
             onClick={() => {
               navigate(buildClientsPath(previewedHostId));
             }}
-            title="Open this client's config in Connect"
+            title="Open this host's config in Connect"
           >
             <Settings2 className="mr-1.5 size-4" />
-            Edit client config
+            Edit host config
           </Button>
           {publishLink ? (
             <Button

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxHostCanvasPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxHostCanvasPanel.tsx
@@ -13,7 +13,7 @@ import {
 import { buildClientsPath, useAppNavigate } from "@/lib/app-navigation";
 
 /**
- * Read-only embedding of the Connect "Client" graph for the chatbox's
+ * Read-only embedding of the Connect "Host" graph for the chatbox's
  * bound host. Identity edits live on the Connect tab; clicking anywhere
  * in the canvas routes there via `onRequestEdit`.
  */

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxPublishClientBar.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxPublishClientBar.tsx
@@ -97,7 +97,7 @@ export function ChatboxPublishClientBar({
         type="button"
         onClick={() => navigate(buildClientsPath(hostId))}
         className="flex h-8 max-w-[260px] items-center gap-1.5 rounded-full border border-border/60 bg-muted/40 px-2.5 text-xs font-medium text-foreground transition hover:bg-muted/70"
-        title="Edit this client's identity in Connect"
+        title="Edit this host's identity in Connect"
       >
         {logoSrc ? (
           <img

--- a/mcpjam-inspector/client/src/components/clients/ClientOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/clients/ClientOverlayBar.tsx
@@ -166,7 +166,7 @@ export function ClientOverlayBar({
     setIsDeleting(true);
     try {
       await deleteHost({ hostId });
-      toast.success(`Client "${host.name}" deleted`);
+      toast.success(`Host "${host.name}" deleted`);
       // Telemetry is best-effort: a posthog throw must not bubble into the
       // shared catch and surface a delete-failure toast after the client
       // has already been removed.
@@ -180,7 +180,7 @@ export function ClientOverlayBar({
         // swallow — analytics must not block the success path
       }
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Failed to delete client";
+      const msg = err instanceof Error ? err.message : "Failed to delete host";
       if (msg.includes("consumer")) {
         toast.error(
           `${msg} — use force delete or remove dependent chatboxes/evals first`,
@@ -237,7 +237,7 @@ export function ClientOverlayBar({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                aria-label="Client used for preview"
+                aria-label="Host used for preview"
                 data-testid="host-overlay-current"
                 className={cn(
                   "flex h-8 min-w-[7rem] max-w-[14rem] items-center justify-center border-x border-border/40 bg-transparent px-3 text-sm font-medium text-foreground transition-colors outline-none",
@@ -308,7 +308,7 @@ export function ClientOverlayBar({
                 className="group pr-1.5"
               >
                 <Plus className="size-3.5" />
-                <span className="flex-1">Add client</span>
+                <span className="flex-1">Add host</span>
                 <span
                   className="ml-2 flex shrink-0 items-center gap-0.5"
                   onPointerDown={(e) => e.stopPropagation()}
@@ -320,7 +320,7 @@ export function ClientOverlayBar({
                       <button
                         key={id}
                         type="button"
-                        aria-label={`Add ${template.label} client`}
+                        aria-label={`Add ${template.label} host`}
                         title={`Add ${template.label}`}
                         data-testid={`host-overlay-quick-add-${id}`}
                         onClick={(e) => {
@@ -348,7 +348,7 @@ export function ClientOverlayBar({
 
           <button
             type="button"
-            aria-label="Next client"
+            aria-label="Next host"
             data-testid="host-overlay-next"
             disabled={arrowDisabled}
             onClick={() => cycle(1)}

--- a/mcpjam-inspector/client/src/components/clients/ConnectViewHeader.tsx
+++ b/mcpjam-inspector/client/src/components/clients/ConnectViewHeader.tsx
@@ -39,7 +39,7 @@ export function ConnectViewHeader({
               { value: "servers", label: "Servers" },
               {
                 value: "host",
-                label: "Client",
+                label: "Host",
                 disabled: !previewedHostId,
               },
               { value: "compare", label: "Compare" },

--- a/mcpjam-inspector/client/src/components/clients/CreateClientDialog.tsx
+++ b/mcpjam-inspector/client/src/components/clients/CreateClientDialog.tsx
@@ -97,7 +97,7 @@ export function CreateClientDialog({
         name: trimmed,
         input: { ...seed, serverIds: [] },
       });
-      toast.success(`Client "${trimmed}" created`);
+      toast.success(`Host "${trimmed}" created`);
       handleClose();
       onCreated(hostId);
       // Telemetry is best-effort: a posthog throw must not bubble into the
@@ -115,7 +115,7 @@ export function CreateClientDialog({
         // swallow — analytics must not block the success path
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to create client");
+      toast.error(err instanceof Error ? err.message : "Failed to create host");
     } finally {
       setIsSaving(false);
     }
@@ -125,7 +125,7 @@ export function CreateClientDialog({
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>New Client</DialogTitle>
+          <DialogTitle>New Host</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-4 py-2">
           <div className="flex flex-col gap-2">
@@ -163,7 +163,7 @@ export function CreateClientDialog({
             <Label htmlFor="host-name">Name</Label>
             <Input
               id="host-name"
-              placeholder="My Client"
+              placeholder="My Host"
               value={name}
               onChange={(e) => setName(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleCreate()}

--- a/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
@@ -288,7 +288,7 @@ export function MultiHostPicker({
         </TooltipTrigger>
         <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
           <p className="font-medium">
-            {isActiveCompareMode ? "Clients" : "Compare clients"}
+            {isActiveCompareMode ? "Hosts" : "Compare hosts"}
           </p>
           {isActiveCompareMode ? (
             <p className="text-xs font-light text-muted-foreground">
@@ -298,7 +298,7 @@ export function MultiHostPicker({
             </p>
           ) : (
             <p className="text-xs font-light text-muted-foreground">
-              Run multiple clients side by side
+              Run multiple hosts side by side
             </p>
           )}
         </TooltipContent>
@@ -306,12 +306,12 @@ export function MultiHostPicker({
 
       <PopoverContent align="start" className="w-[280px] p-0" sideOffset={8}>
         <Command shouldFilter={true}>
-          <CommandInput placeholder="Search clients" />
+          <CommandInput placeholder="Search hosts" />
 
           {effectiveSelectedHostIds.length > 1 ? (
             <div
               className="flex flex-wrap gap-1 border-b px-2.5 py-1.5"
-              title="First chip is the lead client. Click a chip to promote it."
+              title="First chip is the lead host. Click a chip to promote it."
               data-testid="multi-host-chip-strip"
             >
               {effectiveSelectedHostIds.map((hostId, index) => {
@@ -359,11 +359,11 @@ export function MultiHostPicker({
           ) : null}
 
           <CommandList className="max-h-[min(320px,45vh)]">
-            <CommandEmpty>No matching clients.</CommandEmpty>
+            <CommandEmpty>No matching hosts.</CommandEmpty>
 
             {!canUseMultiHost ? (
               <div className="px-2.5 py-2 text-[11px] text-muted-foreground">
-                Add a second client to start comparing.
+                Add a second host to start comparing.
               </div>
             ) : null}
 
@@ -373,7 +373,7 @@ export function MultiHostPicker({
                 !isSelected && selectedLimitReached;
               const isDisabled = isLimitedOut;
               const disabledReason = isLimitedOut
-                ? `You can compare up to ${maxSelectedHosts} clients at once`
+                ? `You can compare up to ${maxSelectedHosts} hosts at once`
                 : undefined;
 
               const row = (

--- a/mcpjam-inspector/client/src/components/clients/ServerConnectionOverrideSection.tsx
+++ b/mcpjam-inspector/client/src/components/clients/ServerConnectionOverrideSection.tsx
@@ -151,7 +151,7 @@ function ServerOverrideRow({
               }
             />
             <Label htmlFor={`override-${server.id}`} className="text-xs">
-              {hasOverride ? "Override active" : "Using client defaults"}
+              {hasOverride ? "Override active" : "Using host defaults"}
             </Label>
           </div>
           {hasOverride && (
@@ -166,7 +166,7 @@ function ServerOverrideRow({
                 <Label className="text-xs">Timeout override (ms)</Label>
                 <Input
                   type="number"
-                  placeholder="Using client default"
+                  placeholder="Using host default"
                   value={override?.requestTimeoutOverride ?? ""}
                   onChange={(e) => {
                     const val = e.target.value;

--- a/mcpjam-inspector/client/src/components/clients/__tests__/ClientOverlayBar.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/__tests__/ClientOverlayBar.test.tsx
@@ -110,7 +110,7 @@ describe("ClientOverlayBar", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Client used for preview" }),
+      screen.getByRole("button", { name: "Host used for preview" }),
     );
 
     await waitFor(() => {
@@ -184,7 +184,7 @@ describe("ClientOverlayBar", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Client used for preview" }),
+      screen.getByRole("button", { name: "Host used for preview" }),
     );
 
     const deleteBtn = await screen.findByTestId("host-overlay-delete-host-a");
@@ -209,7 +209,7 @@ describe("ClientOverlayBar", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Client used for preview" }),
+      screen.getByRole("button", { name: "Host used for preview" }),
     );
 
     const deleteBtn = await screen.findByTestId("host-overlay-delete-host-a");

--- a/mcpjam-inspector/client/src/components/clients/__tests__/MultiHostPicker.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/__tests__/MultiHostPicker.test.tsx
@@ -121,7 +121,7 @@ describe("MultiHostPicker", () => {
     await user.click(screen.getByTestId("multi-host-picker-trigger"));
 
     expect(
-      await screen.findByText("Add a second client to start comparing."),
+      await screen.findByText("Add a second host to start comparing."),
     ).toBeInTheDocument();
     // The old toggle is gone entirely.
     expect(screen.queryByTestId("multi-host-toggle")).toBeNull();

--- a/mcpjam-inspector/client/src/components/clients/clientCanvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/clientCanvasBuilder.ts
@@ -80,8 +80,8 @@ function resolveHostData(context: HostBuilderContext): HostBuilderNodeData {
     : "No model selected";
   return {
     kind: "host",
-    title: "Client",
-    subtitle: hostName.trim() || "Untitled client",
+    title: "Host",
+    subtitle: hostName.trim() || "Untitled host",
     detailLine: `Model · ${modelName}`,
     hostStyle: draft.hostStyle,
     chips: [],

--- a/mcpjam-inspector/client/src/components/clients/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/HostCompareSelector.tsx
@@ -175,9 +175,9 @@ function HostCompareOverflowMenu({
       </PopoverTrigger>
       <PopoverContent align="start" className="w-[240px] p-0">
         <Command shouldFilter>
-          <CommandInput placeholder="Search clients" />
+          <CommandInput placeholder="Search hosts" />
           <CommandList>
-            <CommandEmpty>No matching clients.</CommandEmpty>
+            <CommandEmpty>No matching hosts.</CommandEmpty>
             {hosts.map((host) => {
               const selected = selectedSet.has(host.hostId);
               const subject = subjectsByHost[host.hostId];

--- a/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/clients/comparison/HostConfigCompareView.tsx
@@ -186,7 +186,7 @@ export function HostConfigCompareView({
         ) : hosts.length === 0 ? (
           <div className="rounded-xl border border-border bg-card p-10 text-center">
             <p className="text-sm text-muted-foreground">
-              No hosts yet. Create one from the Clients tab to populate the
+              No hosts yet. Create one from the Host tab to populate the
               comparison.
             </p>
           </div>

--- a/mcpjam-inspector/client/src/components/clients/redesigned/ClientBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/ClientBuilderViewRedesigned.tsx
@@ -436,7 +436,7 @@ export function ClientBuilderViewRedesigned({
               }}
               options={[
                 { value: "servers", label: "Servers" },
-                { value: "host", label: "Client" },
+                { value: "host", label: "Host" },
                 { value: "compare", label: "Compare" },
               ]}
             />

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/ClientIdentityRow.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/ClientIdentityRow.tsx
@@ -24,8 +24,8 @@ export function ClientIdentityRow({
       <Input
         value={hostDisplayName}
         onChange={(event) => onHostDisplayNameChange(event.target.value)}
-        placeholder="Client name"
-        aria-label="Client name"
+        placeholder="Host name"
+        aria-label="Host name"
         className={cn(
           "h-8 min-w-0 flex-1 text-[13px]",
           hasNameIssue && "border-amber-500",

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/GeneralTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/GeneralTab.tsx
@@ -11,9 +11,9 @@ interface GeneralTabProps {
 export function GeneralTab(_: GeneralTabProps) {
   return (
     <div className="flex flex-col gap-4">
-      <FocusBlock title="General" subtitle="Client-wide settings.">
+      <FocusBlock title="General" subtitle="Host-wide settings.">
         <p className="text-[11.5px] text-muted-foreground">
-          Nothing here yet — client name and style live in the header above.
+          Nothing here yet — host name and style live in the header above.
         </p>
       </FocusBlock>
     </div>

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/ClientFocusPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/ClientFocusPanel.test.tsx
@@ -161,7 +161,7 @@ describe("ClientFocusPanel", () => {
     expect(screen.queryByRole("tab", { name: /^General$/ })).toBeNull();
     expect(screen.queryByRole("tab", { name: /^Appearance$/ })).toBeNull();
     // The host-name textbox lives in the always-visible identity header.
-    expect(screen.getByRole("textbox", { name: "Client name" })).toHaveValue(
+    expect(screen.getByRole("textbox", { name: "Host name" })).toHaveValue(
       "My Host",
     );
   });

--- a/mcpjam-inspector/client/src/components/evals/client-attachments-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/client-attachments-editor.tsx
@@ -98,8 +98,8 @@ export function ClientAttachmentsEditor({
               location="eval_runner"
               placeholder={
                 attachedIds.size === hosts.length && hosts.length > 0
-                  ? "All clients attached"
-                  : "Choose a client to attach"
+                  ? "All hosts attached"
+                  : "Choose a host to attach"
               }
               includeNone={false}
               disabled={

--- a/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
@@ -107,11 +107,11 @@ export function CreateSuiteDialog({
     if (name.trim().length === 0) return "Add a suite name first.";
     if (attachmentsRequired && serverAttachmentId === null) {
       return hostAttachments.length === 0
-        ? "Attach a server and at least one client first."
+        ? "Attach a server and at least one host first."
         : "Pick a server attachment first.";
     }
     if (attachmentsRequired && hostAttachments.length === 0) {
-      return "Attach at least one client first.";
+      return "Attach at least one host first.";
     }
     return null;
   })();
@@ -167,7 +167,7 @@ export function CreateSuiteDialog({
                     Servers
                   </h3>
                   <p className="text-xs text-muted-foreground">
-                    Server set all clients run against.
+                    Server set all hosts run against.
                   </p>
                 </div>
                 <div className="shrink-0">
@@ -182,10 +182,10 @@ export function CreateSuiteDialog({
               <div className="space-y-2 p-3">
                 <div className="space-y-0.5">
                   <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    Clients
+                    Hosts
                   </h3>
                   <p className="text-xs text-muted-foreground">
-                    Each attached client fans out into its own run.
+                    Each attached host fans out into its own run.
                   </p>
                 </div>
                 <ClientAttachmentsEditor

--- a/mcpjam-inspector/client/src/components/evals/cross-host/host-cell.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/host-cell.tsx
@@ -61,17 +61,17 @@ const METRIC_COPY: Record<
   p50: {
     title: "P50 latency",
     description: "Median completed-run latency for this test case.",
-    missing: "No completed latency sample for this client.",
+    missing: "No completed latency sample for this host.",
   },
   p95: {
     title: "P95 latency",
     description: "Tail latency for the slowest completed runs in this case.",
-    missing: "No completed tail-latency sample for this client.",
+    missing: "No completed tail-latency sample for this host.",
   },
   avgTokens: {
     title: "Average tokens",
     description: "Mean token usage per iteration in the latest run.",
-    missing: "No token usage sample for this client.",
+    missing: "No token usage sample for this host.",
   },
 };
 

--- a/mcpjam-inspector/client/src/components/evals/evals-empty-hero.tsx
+++ b/mcpjam-inspector/client/src/components/evals/evals-empty-hero.tsx
@@ -3,7 +3,7 @@ import { Button } from "@mcpjam/design-system/button";
 import { cn } from "@/lib/utils";
 
 const FIRST_SUITE_EMPTY_DESCRIPTION =
-  "A suite groups test cases with the MCP servers they use. Run it across clients to get insights into your design.";
+  "A suite groups test cases with the MCP servers they use. Run it across hosts to get insights into your design.";
 
 interface EvalsEmptyHeroProps {
   onCreateSuite: () => void;

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -600,10 +600,10 @@ export function SuiteIterationsView({
         hostAttachments: attachments,
       });
       toast.success(
-        attachments.length === 0 ? "Clients cleared" : "Clients updated"
+        attachments.length === 0 ? "Hosts cleared" : "Hosts updated"
       );
     } catch (error) {
-      toast.error(getBillingErrorMessage(error, "Failed to update clients"));
+      toast.error(getBillingErrorMessage(error, "Failed to update hosts"));
       console.error("Failed to update host attachments:", error);
       throw error;
     }

--- a/mcpjam-inspector/client/src/components/evals/suite-overview-client-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-overview-client-bar.tsx
@@ -143,18 +143,18 @@ export function SuiteOverviewClientBar({
         <button
           type="button"
           className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/60 bg-background text-foreground outline-none transition-colors hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-ring dark:bg-background"
-          aria-label="Compare attached clients"
+          aria-label="Compare attached hosts"
           onClick={handleOpenCompare}
         >
           <GitCompare className="h-3.5 w-3.5" />
         </button>
       </TooltipTrigger>
-      <TooltipContent>Compare attached clients side by side</TooltipContent>
+      <TooltipContent>Compare attached hosts side by side</TooltipContent>
     </Tooltip>
   ) : null;
 
   const triggerLabel = useMemo(() => {
-    if (attachments.length === 0) return "No clients · pick one";
+    if (attachments.length === 0) return "No hosts · pick one";
     const firstName =
       hostNameByAttachment.get(attachments[0]!.namedHostId) ??
       projectHosts.find((h) => h.hostId === attachments[0]!.namedHostId)
@@ -181,7 +181,7 @@ export function SuiteOverviewClientBar({
               : "border-border/60 bg-muted/40 hover:bg-muted/60",
             !editable && "cursor-not-allowed opacity-50",
           )}
-          aria-label="Attached clients"
+          aria-label="Attached hosts"
         >
           {triggerLogoLabel ? (
             <HostLogoMark label={triggerLogoLabel} />
@@ -203,13 +203,13 @@ export function SuiteOverviewClientBar({
         <div className="space-y-0.5">
           <div className="flex items-center justify-between gap-2 px-2 pb-1 pt-0.5">
             <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Clients
+              Hosts
             </span>
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  aria-label="What is a client attachment?"
+                  aria-label="What is a host attachment?"
                   className="rounded-full p-0.5 text-muted-foreground outline-none transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   <Info className="size-3" />
@@ -217,16 +217,16 @@ export function SuiteOverviewClientBar({
               </TooltipTrigger>
               <TooltipContent side="top" className="max-w-[240px]">
                 <p className="text-xs leading-snug">
-                  Clients are the MCP hosts this suite evaluates. Attach
-                  one or more to compare how each handles the same
-                  scenarios.
+                  Hosts are the configurations this suite evaluates.
+                  Attach one or more to compare how each handles the
+                  same scenarios.
                 </p>
               </TooltipContent>
             </Tooltip>
           </div>
           {projectHosts.length === 0 ? (
             <p className="px-2 py-1.5 text-xs text-muted-foreground">
-              No clients in this project yet — add one below.
+              No hosts in this project yet — add one below.
             </p>
           ) : null}
           {projectHosts.map((host) => {
@@ -267,7 +267,7 @@ export function SuiteOverviewClientBar({
                   {isLastAttached ? (
                     <TooltipContent side="right">
                       <p className="text-xs">
-                        Attach another client first
+                        Attach another host first
                       </p>
                     </TooltipContent>
                   ) : null}
@@ -308,7 +308,7 @@ export function SuiteOverviewClientBar({
               className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
             >
               <span className="size-3.5 shrink-0" aria-hidden />
-              <span>Manage clients…</span>
+              <span>Manage hosts…</span>
             </button>
           </div>
         </div>
@@ -374,7 +374,7 @@ export function SuiteOverviewClientBar({
               clientPicker
             ) : attachments.length === 0 ? (
               <span className="shrink-0 text-[13px] font-normal text-muted-foreground">
-                No clients attached
+                No hosts attached
               </span>
             ) : (
               attachments.map((attachment) => {

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -543,7 +543,7 @@ export function useEvalHandlers({
           await handleReplayRun(suite, rerunEligibility.replayableLatestRun);
           return;
         }
-        toast.error("Attach a client to this suite before running it.");
+        toast.error("Attach a host to this suite before running it.");
         return;
       }
 
@@ -834,7 +834,7 @@ export function useEvalHandlers({
       );
 
       if (suiteServers.length === 0) {
-        toast.error("Attach a client to this suite before running it.");
+        toast.error("Attach a host to this suite before running it.");
         return null;
       }
 


### PR DESCRIPTION
## What

Renames the user-facing **"Client" / "Clients"** labels for the `hostConfig` concept to **"Host" / "Hosts"** across the UI. This finishes a migration that was already done in code — the internal layer already uses `host` everywhere (tab value `"host"`, `hostDisplayName`, `kind: "host"`); only the visible display strings still said "Client".

Scope is **visible labels only** (~45 strings, 24 files), in three feature areas:

- **Connect view** — the tab label itself, host overlay bar (`Add host`, `Next host`, `Host used for preview`, create/delete toasts), `New Host` dialog, `Host name` field, canvas node title, `Search hosts`, multi-host picker tooltips.
- **Evals** — suite **Hosts** section, attach/compare affordances, cleared/updated toasts, empty states, cross-host metric messages.
- **Chatboxes** — `Edit host config` / `Open this host's config in Connect` buttons.

## Deliberately left unchanged (distinct concepts)

These say "client" but mean something different, so renaming them would be wrong:

- **`Client capabilities`** and **`clientInfo` name/version** — the MCP-protocol *client role*, shown alongside **Host capabilities** in the handshake view. Not the host config.
- **Sequence-diagram / "What is MCP" actors** ("The MCP Client", etc.) — protocol education.
- **Analytics event names** (`client_created`, `create_client_dialog`, `client_selected`) — keep dashboard continuity.
- **Route paths** (`/clients`) — these are URLs, not labels; changing them would break bookmarks/links.

## One wording change

The eval tooltip read *"Clients are the MCP hosts this suite evaluates"* — a literal swap gives the redundant *"Hosts are the MCP hosts…"*, so it's reworded to **"Hosts are the configurations this suite evaluates."**

## Note for reviewers

- The Connect tab now reads **"Host"** (singular), a 1:1 swap of the old "Client" — it shows one previewed host's config, consistent with `Servers` / `Compare`. Happy to make it "Hosts" if preferred.
- This is the UI-labels-only pass. Underlying *code* identifiers (folder `clients/`, `ClientOverlayBar`, `CreateClientDialog`, etc.) are intentionally untouched — a separate follow-up could rename those if desired.

## Verification

- `typecheck:client` → clean (exit 0)
- Touched clients components → 32/32 tests pass
- Evals + chatboxes test suites → 659/659 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and test assertion updates only; no logic, APIs, or routing changes.
> 
> **Overview**
> **User-facing copy** for the `hostConfig` concept is renamed from **Client/Clients** to **Host/Hosts** across Connect, evals, and chatboxes so UI wording matches the internal `host` model (tab value `"host"`, `hostId`, etc.). No routes, analytics event names, or component/file identifiers change.
> 
> In **Connect**, the view tab reads **Host**, the overlay bar and **New Host** dialog use host-centric labels and toasts, the canvas node title and defaults say **Host** / **Untitled host**, compare/search placeholders say **Search hosts**, and server override copy refers to **host defaults**.
> 
> **Evals** and **chatboxes** get the same treatment for suite attachments, compare affordances, run guard toasts, empty states, and publish actions (**Edit host config**, **Open this host's config in Connect**). The eval attachment tooltip is reworded to *"Hosts are the configurations this suite evaluates"* instead of the redundant *MCP hosts* phrasing.
> 
> Tests that assert accessible names and empty-state strings are updated to match. A few strings outside this diff (e.g. compare loading copy, **Attach a client** label, chatboxes empty state) may still say **client**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094a8c820b7f330c937315311d2358554845b739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->