### PR TITLE
servers: add snapshot History tab + tools-changed drift chip

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -620,7 +620,7 @@ export function ServerDetailModal({
                 <ServerHistoryDriftChip
                   projectId={projectId}
                   serverId={serverId}
-                  isViewing={activeTab === "history"}
+                  isViewing={isOpen && activeTab === "history"}
                   onClick={() => setActiveTab("history")}
                 />
               )}

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -191,6 +191,7 @@ export function ServerDetailModal({
   // form control inside `EditServerFormContent` can stay a pure prop
   // consumer.
   const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
+  const serverHistoryEnabled = useFeatureFlagEnabled("server-history-tab");
   const projectServerConfigDto = useQuery(
     "projectServerConfig:getConfig" as never,
     projectId ? ({ projectId } as never) : "skip"
@@ -208,9 +209,11 @@ export function ServerDetailModal({
   // `sharedProjectServersRecord[name]?._id` and passes it down as
   // `hostedServerId`.
   const serverId = hostedServerId ?? undefined;
-  // The History tab surfaces persisted snapshot revisions, which only exist
-  // for project-scoped (hosted) servers. Hidden entirely in local mode.
-  const showHistory = Boolean(projectId && serverId);
+  // The History tab + drift chip surface persisted snapshot revisions, which
+  // only exist for project-scoped (hosted) servers. Gated behind the
+  // `server-history-tab` PostHog flag (@mcpjam.com only) and hidden in local
+  // mode. Both surfaces key off `showHistory`, so this is the single gate.
+  const showHistory = Boolean(projectId && serverId && serverHistoryEnabled);
   const currentMcpProtocolVersionOverride = useMemo<
     McpProtocolVersion | undefined
   >(

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -37,6 +37,8 @@ import { useServerForm } from "./hooks/use-server-form";
 import { ServerInfoContent } from "./ServerInfoContent";
 import { ServerInfoToolsMetadataContent } from "./ServerInfoToolsMetadataContent";
 import { EditServerFormContent } from "./EditServerFormContent";
+import { ServerHistoryContent } from "./ServerHistoryContent";
+import { ServerHistoryDriftChip } from "./ServerHistoryDriftChip";
 import type { McpProtocolVersion } from "@/lib/client-config-v2";
 import type {
   ProjectServerConfigDto,
@@ -47,7 +49,11 @@ import { EffectiveProtocolVersionChip } from "./shared/EffectiveProtocolVersionC
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 
-export type ServerDetailTab = "overview" | "configuration" | "tools-metadata";
+export type ServerDetailTab =
+  | "overview"
+  | "configuration"
+  | "tools-metadata"
+  | "history";
 
 interface ServerDetailModalProps {
   isOpen: boolean;
@@ -202,6 +208,9 @@ export function ServerDetailModal({
   // `sharedProjectServersRecord[name]?._id` and passes it down as
   // `hostedServerId`.
   const serverId = hostedServerId ?? undefined;
+  // The History tab surfaces persisted snapshot revisions, which only exist
+  // for project-scoped (hosted) servers. Hidden entirely in local mode.
+  const showHistory = Boolean(projectId && serverId);
   const currentMcpProtocolVersionOverride = useMemo<
     McpProtocolVersion | undefined
   >(
@@ -311,10 +320,7 @@ export function ServerDetailModal({
     // If this control enrolls the server only to save the protocol pin, remember
     // that provenance so clearing the pin can undo the implicit enrollment
     // without removing servers that were already explicitly auto-connected.
-    const autoEnrollKey = getProtocolOverrideAutoEnrollKey(
-      projectId,
-      serverId
-    );
+    const autoEnrollKey = getProtocolOverrideAutoEnrollKey(projectId, serverId);
     const autoEnrollRecord =
       protocolOverrideAutoEnrolledRef.current.get(autoEnrollKey) ??
       readProtocolOverrideAutoEnrollRecord(autoEnrollKey);
@@ -331,10 +337,10 @@ export function ServerDetailModal({
     const nextServerIds = shouldAutoEnrollForOverride
       ? [...currentServerIds, serverId]
       : shouldUndoAutoEnroll
-        ? currentServerIds.filter(
-            (currentServerId) => currentServerId !== serverId
-          )
-        : currentServerIds;
+      ? currentServerIds.filter(
+          (currentServerId) => currentServerId !== serverId
+        )
+      : currentServerIds;
     try {
       await setProjectServerConfigMutation({
         projectId,
@@ -556,7 +562,9 @@ export function ServerDetailModal({
     }
   };
 
-  const tabGridClass = "grid w-full grid-cols-3";
+  const tabGridClass = showHistory
+    ? "grid w-full grid-cols-4"
+    : "grid w-full grid-cols-3";
   const isConfigurationTab = activeTab === "configuration";
 
   const handleConfigurationSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -605,6 +613,14 @@ export function ServerDetailModal({
               )}
             </div>
             <div className="flex items-center gap-1.5 flex-shrink-0 mr-6">
+              {showHistory && projectId && serverId && (
+                <ServerHistoryDriftChip
+                  projectId={projectId}
+                  serverId={serverId}
+                  isViewing={activeTab === "history"}
+                  onClick={() => setActiveTab("history")}
+                />
+              )}
               <EffectiveProtocolVersionChip
                 hostDefault={resolvedHostDefaultMcpProtocolVersion}
                 serverOverride={currentMcpProtocolVersionOverride}
@@ -663,6 +679,9 @@ export function ServerDetailModal({
               <TabsTrigger value="configuration">Configuration</TabsTrigger>
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="tools-metadata">Tools Metadata</TabsTrigger>
+              {showHistory && (
+                <TabsTrigger value="history">History</TabsTrigger>
+              )}
             </TabsList>
 
             <div className="relative mt-4 -mr-6 -ml-1">
@@ -782,6 +801,21 @@ export function ServerDetailModal({
                   )}
                 </div>
               </TabsContent>
+
+              {/* History: persisted snapshot revisions; works while disconnected */}
+              {showHistory && projectId && serverId && (
+                <TabsContent
+                  value="history"
+                  className="mt-0 flex-none absolute inset-0 overflow-y-auto bg-background"
+                >
+                  <div className="pl-1 pr-6">
+                    <ServerHistoryContent
+                      projectId={projectId}
+                      serverId={serverId}
+                    />
+                  </div>
+                </TabsContent>
+              )}
             </div>
           </Tabs>
         </form>

--- a/mcpjam-inspector/client/src/components/connection/ServerHistoryContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerHistoryContent.tsx
@@ -1,0 +1,351 @@
+import { useState, type ReactNode } from "react";
+import { useQuery } from "convex/react";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
+import { ChevronRight } from "lucide-react";
+
+/**
+ * Server snapshot history. Each revision is an immutable capture of this
+ * server's tool/capability contract, minted server-side only when the
+ * contract actually changes (see `serverInspections.recordFromConnect`).
+ * Reads persisted Convex data, so it works while the server is disconnected.
+ *
+ * DTOs are mirrored from the backend by hand (two-repo layout) and kept
+ * narrow to what we render — the source of truth is
+ * `mcpjam-backend/convex/serverInspections.ts`.
+ */
+type RevisionSource = "connect" | "evalRun" | "traceRepair" | "chatSession";
+
+interface RevisionSummary {
+  revisionNumber: number;
+  capturedAt: number;
+  source: RevisionSource;
+  counts: {
+    tools: number;
+    prompts?: number;
+    resources?: number;
+    resourceTemplates?: number;
+  };
+}
+
+interface SnapshotDiff {
+  discovery?: { changed: boolean; changedFields: string[] };
+  tools: {
+    added: Array<{ name: string; description?: string }>;
+    removed: Array<{ name: string }>;
+    changed: Array<{ name: string; changedFields: string[] }>;
+  };
+}
+
+const SOURCE_LABEL: Record<RevisionSource, string> = {
+  connect: "Connect",
+  evalRun: "Eval run",
+  chatSession: "Chat",
+  traceRepair: "Trace repair",
+};
+
+function compactAgo(ms: number): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+export function ServerHistoryContent({
+  projectId,
+  serverId,
+}: {
+  projectId: string;
+  serverId: string;
+}) {
+  const revisions = useQuery(
+    "serverInspections:listInspectionRevisions" as never,
+    {
+      projectId,
+      serverId,
+      limit: 50,
+    } as never
+  ) as RevisionSummary[] | undefined;
+
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  if (revisions === undefined) {
+    return (
+      <div className="space-y-2 py-2">
+        {[0, 1, 2].map((i) => (
+          <Skeleton key={i} className="h-9 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (revisions.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        No snapshots captured yet
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-0.5 py-1">
+      {revisions.map((rev, i) => {
+        const prev = revisions[i + 1];
+        const isLatest = i === 0;
+        const expandable = rev.revisionNumber > 1;
+        const isOpen = expanded === rev.revisionNumber;
+        return (
+          <div key={rev.revisionNumber}>
+            <button
+              type="button"
+              disabled={!expandable}
+              onClick={() =>
+                expandable && setExpanded(isOpen ? null : rev.revisionNumber)
+              }
+              className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left hover:bg-muted/50 disabled:cursor-default disabled:hover:bg-transparent"
+            >
+              <span
+                className={`h-2 w-2 shrink-0 rounded-full ${
+                  isLatest ? "bg-primary" : "bg-muted-foreground/40"
+                }`}
+              />
+              <span className="shrink-0 text-[13px] font-medium">
+                Revision {rev.revisionNumber}
+              </span>
+              <SourceBadge source={rev.source} latest={isLatest} />
+              <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted-foreground">
+                <DeltaLabel rev={rev} prev={prev} />
+              </span>
+              <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+                {compactAgo(rev.capturedAt)}
+              </span>
+              <ChevronRight
+                className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${
+                  expandable ? "" : "invisible"
+                } ${isOpen ? "rotate-90" : ""}`}
+              />
+            </button>
+            {isOpen && (
+              <div className="mb-1 ml-[18px]">
+                <RevisionDiff
+                  projectId={projectId}
+                  serverId={serverId}
+                  revisionNumber={rev.revisionNumber}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SourceBadge({
+  source,
+  latest,
+}: {
+  source: RevisionSource;
+  latest?: boolean;
+}) {
+  const tone =
+    source === "connect"
+      ? "bg-info/10 text-info"
+      : source === "evalRun"
+      ? "bg-primary/10 text-primary"
+      : "bg-muted text-muted-foreground";
+  return (
+    <span className="flex shrink-0 items-center gap-1.5">
+      {latest && (
+        <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+          Latest
+        </span>
+      )}
+      <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tone}`}>
+        {SOURCE_LABEL[source]}
+      </span>
+    </span>
+  );
+}
+
+function DeltaLabel({
+  rev,
+  prev,
+}: {
+  rev: RevisionSummary;
+  prev?: RevisionSummary;
+}) {
+  if (!prev) {
+    return rev.revisionNumber === 1 ? (
+      <>Initial snapshot · {rev.counts.tools} tools</>
+    ) : (
+      <>{rev.counts.tools} tools</>
+    );
+  }
+  const delta = rev.counts.tools - prev.counts.tools;
+  if (delta > 0)
+    return (
+      <span className="text-success">
+        +{delta} tool{delta > 1 ? "s" : ""}
+      </span>
+    );
+  if (delta < 0)
+    return (
+      <span className="text-destructive">
+        −{-delta} tool{-delta > 1 ? "s" : ""}
+      </span>
+    );
+  return <>Updated</>;
+}
+
+function RevisionDiff({
+  projectId,
+  serverId,
+  revisionNumber,
+}: {
+  projectId: string;
+  serverId: string;
+  revisionNumber: number;
+}) {
+  const result = useQuery(
+    "serverInspections:diffInspectionRevisions" as never,
+    {
+      projectId,
+      serverId,
+      fromRevisionNumber: revisionNumber - 1,
+      toRevisionNumber: revisionNumber,
+    } as never
+  ) as { diff: SnapshotDiff } | null | undefined;
+
+  if (result === undefined) {
+    return (
+      <div className="rounded-lg bg-muted/30 p-3">
+        <Skeleton className="h-4 w-40" />
+      </div>
+    );
+  }
+  if (result === null) {
+    return (
+      <div className="rounded-lg bg-muted/30 p-3 text-[11.5px] text-muted-foreground">
+        Diff unavailable
+      </div>
+    );
+  }
+
+  const { added, removed, changed } = result.diff.tools;
+  const discovery = result.diff.discovery;
+  const empty =
+    added.length === 0 &&
+    removed.length === 0 &&
+    changed.length === 0 &&
+    !discovery?.changed;
+
+  return (
+    <div className="space-y-3 rounded-lg bg-muted/30 p-3 text-[12.5px]">
+      {added.length > 0 && (
+        <DiffGroup label={`Added (${added.length})`} tone="text-success">
+          {added.map((tool) => (
+            <DiffRow
+              key={tool.name}
+              sigil="+"
+              tone="text-success"
+              name={tool.name}
+              note={tool.description}
+            />
+          ))}
+        </DiffGroup>
+      )}
+      {removed.length > 0 && (
+        <DiffGroup
+          label={`Removed (${removed.length})`}
+          tone="text-destructive"
+        >
+          {removed.map((tool) => (
+            <DiffRow
+              key={tool.name}
+              sigil="−"
+              tone="text-destructive"
+              name={tool.name}
+            />
+          ))}
+        </DiffGroup>
+      )}
+      {changed.length > 0 && (
+        <DiffGroup label={`Changed (${changed.length})`} tone="text-warning">
+          {changed.map((tool) => (
+            <DiffRow
+              key={tool.name}
+              sigil="~"
+              tone="text-warning"
+              name={tool.name}
+              note={tool.changedFields.join(", ")}
+            />
+          ))}
+        </DiffGroup>
+      )}
+      {discovery?.changed && (
+        <DiffGroup label="Server info" tone="text-warning">
+          <div className="text-[11.5px] text-muted-foreground">
+            {discovery.changedFields.join(", ")}
+          </div>
+        </DiffGroup>
+      )}
+      {empty && (
+        <div className="text-[11.5px] text-muted-foreground">
+          No tool changes
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffGroup({
+  label,
+  tone,
+  children,
+}: {
+  label: string;
+  tone: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div
+        className={`mb-1.5 text-[10px] font-semibold uppercase tracking-wide ${tone}`}
+      >
+        {label}
+      </div>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function DiffRow({
+  sigil,
+  tone,
+  name,
+  note,
+}: {
+  sigil: string;
+  tone: string;
+  name: string;
+  note?: string;
+}) {
+  return (
+    <div className="flex min-w-0 items-baseline gap-2">
+      <span className={`font-mono font-semibold ${tone}`}>{sigil}</span>
+      <code className="shrink-0 font-mono text-[12px] font-medium">{name}</code>
+      {note && (
+        <span className="truncate text-[11.5px] text-muted-foreground">
+          {note}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/connection/ServerHistoryDriftChip.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerHistoryDriftChip.tsx
@@ -47,7 +47,12 @@ export function ServerHistoryDriftChip({
 }: {
   projectId: string;
   serverId: string;
-  /** True while the History tab is the active tab — advances the baseline. */
+  /**
+   * True only while the modal is open AND History is the active tab —
+   * advances the "seen" baseline. Caller must gate on `isOpen` so a closed
+   * modal that lingers mounted (e.g. exit animation, or a future
+   * `forceMount`) can't silently advance the baseline.
+   */
   isViewing: boolean;
   onClick: () => void;
 }) {

--- a/mcpjam-inspector/client/src/components/connection/ServerHistoryDriftChip.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerHistoryDriftChip.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "convex/react";
+import { Clock } from "lucide-react";
+
+/**
+ * Quiet "this server's tools changed" signal for the server detail modal
+ * header. Drift = the latest persisted revision is newer than the one this
+ * user last saw. The baseline is seeded on first sight (no chip the first
+ * time you open a server) and advanced whenever the History tab is viewed,
+ * so the chip only appears for a genuine post-baseline change — never noisy.
+ *
+ * Per-user, local-only (localStorage). The richer "changed since the last
+ * eval/chat run that used it" signal would read `listInspectionObservations`;
+ * deferred to keep v1 backend-free.
+ */
+const SEEN_PREFIX = "mcpjam:server-history-seen";
+
+const seenKey = (projectId: string, serverId: string) =>
+  `${SEEN_PREFIX}:${projectId}:${serverId}`;
+
+function readSeen(key: string): number | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return undefined;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeSeen(key: string, value: number) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, String(value));
+  } catch {
+    // Losing the marker only means the chip may re-surface once; harmless.
+  }
+}
+
+export function ServerHistoryDriftChip({
+  projectId,
+  serverId,
+  isViewing,
+  onClick,
+}: {
+  projectId: string;
+  serverId: string;
+  /** True while the History tab is the active tab — advances the baseline. */
+  isViewing: boolean;
+  onClick: () => void;
+}) {
+  const latest = useQuery(
+    "serverInspections:getLatestInspection" as never,
+    {
+      projectId,
+      serverId,
+    } as never
+  ) as { currentRevisionNumber: number } | null | undefined;
+
+  const latestRevision = latest?.currentRevisionNumber;
+  const key = seenKey(projectId, serverId);
+  const [seen, setSeen] = useState<number | undefined>(() => readSeen(key));
+
+  // Reset the baseline when the modal is reused for a different server.
+  useEffect(() => {
+    setSeen(readSeen(key));
+  }, [key]);
+
+  // Seed on first sight, advance while viewing history.
+  useEffect(() => {
+    if (latestRevision === undefined) return;
+    if ((seen === undefined || isViewing) && seen !== latestRevision) {
+      writeSeen(key, latestRevision);
+      setSeen(latestRevision);
+    }
+  }, [latestRevision, seen, isViewing, key]);
+
+  const hasDrift =
+    latestRevision !== undefined && seen !== undefined && latestRevision > seen;
+
+  if (!hasDrift) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="This server's tools changed since you last viewed its history"
+      className="inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-[11px] font-medium text-warning"
+    >
+      <Clock className="h-3 w-3" />
+      Tools changed
+    </button>
+  );
+}


### PR DESCRIPTION
## What

Adds a **History** tab to the server detail modal that surfaces a server's snapshot/version history — the immutable revisions of its tool/capability contract the backend already captures — plus a quiet **"Tools changed"** drift chip in the header.

This is the config/snapshot-versioning surface we scoped: per-server *tool-contract* revisions, which are the only thing versioned per-server today. (A server's connection config is mutated in place and isn't versioned, so it's intentionally out of scope.)

## How it works

- **History tab** — revisions newest-first: revision number, source (`Connect` / `Eval run` / `Chat` / `Trace repair`), relative time, and a tool-count delta. Expanding a row fetches the diff and shows tools added / removed / changed (with the changed field names) in place.
- **Drift chip** — appears in the header only when the latest revision is newer than the one you last viewed (per-user `localStorage` baseline, seeded on first open, advanced when you open the tab). Click jumps to the tab. Silent on first encounter — never noisy.
- **Frontend-only.** Backed entirely by existing `serverInspections` Convex queries (`listInspectionRevisions`, `diffInspectionRevisions`, `getLatestInspection`). No schema or backend change.
- **Gating** — behind the `server-history-tab` PostHog flag (see below) **and** project-scoped servers (`projectId` + `serverId`); hidden in local mode (tab list stays 3-wide). The tab reads persisted data, so it works while the server is disconnected.

## Feature flag

Gated behind **`server-history-tab`** ([id 709593](https://us.posthog.com/project/212744/feature_flags/709593)) — active, targeting `email icontains @mcpjam.com` at 100% (parallels the existing `chat-history-rail` internal flag). Off for everyone else, so this ships dark and we can dogfood it on @mcpjam accounts before any wider rollout.

## Design notes

- Kept deliberately minimal — no header caption, no per-row prose; specifics live behind the expand. Uses the existing design tokens and chip idioms.
- **Drift semantics (v1):** "new since you last viewed." The richer "changed since the last eval/chat run that used it" signal would read `listInspectionObservations`; deferred to keep v1 backend-free, and easy to swap in later.

## Files

- `ServerHistoryContent.tsx` (new) — the tab body (revision list + lazy expand-to-diff).
- `ServerHistoryDriftChip.tsx` (new) — the header drift signal.
- `ServerDetailModal.tsx` — wires the 4th tab + chip behind `showHistory`.

## Verification

- `typecheck:client` clean; prettier clean.
- Existing tests pass: `ServerDetailModal` (18) + hosted (3) + `ServersTab` (33) = **54**.
- Visual reviewed against the design system (warm theme, coral primary, source/Latest chips, expand-to-diff).
- ⚠️ **Manual QA still needed for the live data path**: the `serverInspections` queries are backend-tested, but the new UI hasn't been exercised against a real project with ≥2 captured revisions. Worth a quick look in a hosted project before/after merge.

## No changeset

Client-only UI; no releasable package API changed. Happy to add one if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI over read-only Convex queries; gated by feature flag and scoped to hosted project servers with no auth or data mutation paths.
> 
> **Overview**
> Adds a **History** tab to the server detail modal for **project-scoped hosted servers**, surfacing persisted tool/capability snapshot revisions from existing `serverInspections` Convex queries. The tab works while disconnected and lists revisions with source, time, and tool-count deltas; expanding a row loads an add/remove/change diff.
> 
> A **Tools changed** header chip appears when the latest revision is newer than the user’s last-seen baseline (`localStorage`, seeded on first open and advanced while the History tab is active). Clicking the chip switches to History.
> 
> Both surfaces are gated by **`server-history-tab`** (PostHog) plus `projectId` and `serverId`; local mode keeps a three-tab layout. No backend or schema changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf486bda7a4eca1ceb3a643ceda948c342b19308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->