### PR TITLE
pricing(compare): RBAC Basic on Free, drop click-through DPA on Team

### DIFF
--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -289,7 +289,7 @@ const COMPARE_PLAN_ROW_LABEL_TOOLTIPS: Record<
   "Role-based access control (RBAC)": {
     ariaLabel: "About RBAC",
     content:
-      "Basic Admin/Member-style access on Team; customizable roles and fine-grained permissions on Enterprise.",
+      "Basic Admin/Member-style access on Free and Team; customizable roles and fine-grained permissions on Enterprise.",
     contentClassName: "max-w-[22rem]",
   },
   "Data processing agreement (DPA)": {

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -74,7 +74,7 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     rows: [
       {
         label: "Role-based access control (RBAC)",
-        free: x,
+        free: t("Basic"),
         team: t("Basic", true),
         enterprise: t("Custom", true),
       },
@@ -93,7 +93,7 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
       {
         label: "Data processing agreement (DPA)",
         free: x,
-        team: t("Click-through", true),
+        team: x,
         enterprise: t("Custom", true),
       },
       {


### PR DESCRIPTION
## Summary
- RBAC row in the in-app compare-plans table now shows Basic on Free (matches Team) — Free already gets Admin/Member-style access
- DPA row drops the "Click-through" treatment on Team; DPAs are Enterprise-only
- RBAC tooltip updated: "Basic Admin/Member-style access on Free and Team; customizable roles and fine-grained permissions on Enterprise"

Mirrors the same edits on the marketing pricing page (MCPJam/mcpjam-webapp#174).

## Test plan
- [ ] `npx vitest run client/src/components/organization/__tests__/compare-plan-marketing.test.ts` passes
- [ ] In-app billing compare table renders RBAC as Basic / Basic / Custom
- [ ] In-app billing compare table renders DPA as – / – / Custom
- [ ] RBAC info tooltip text reflects Basic on Free + Team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and static compare-table cell changes only; no billing logic or entitlements code.
> 
> **Overview**
> Updates the in-app **Plans & Billing** compare table and RBAC tooltip so marketing matches product reality.
> 
> **RBAC** now shows **Basic** on Free (same as Team); Enterprise stays **Custom**. The RBAC info tooltip says basic Admin/Member access applies on **Free and Team**, not Team only.
> 
> **DPA** no longer shows a Team **Click-through** cell—Free and Team render as not included; Enterprise remains **Custom** (DPA treated as Enterprise-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b0a8cfdcada9a878fc0bd30cf9eae9fa51a2355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->