### PR TITLE
Fix flaky ServerDetailModal test (clear reconnect fallback timer on unmount)

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -239,6 +239,11 @@ export function ServerDetailModal({
   const pendingReconnectRef = useRef<{
     target: McpProtocolVersion | undefined;
   } | null>(null);
+  // Id of the 1.5s reconnect fallback timer (set in
+  // `handleMcpProtocolVersionOverrideChange`). Tracked so it can be
+  // cleared on unmount — otherwise it can fire after the modal closes,
+  // calling `onReconnect` on a torn-down component.
+  const reconnectFallbackTimeoutRef = useRef<number | null>(null);
   const [pendingReconnectTick, setPendingReconnectTick] = useState(0);
   useEffect(() => {
     const pending = pendingReconnectRef.current;
@@ -256,6 +261,19 @@ export function ServerDetailModal({
     server.name,
     pendingReconnectTick,
   ]);
+
+  // Clear the reconnect fallback timer on unmount so it can't fire after
+  // the modal closes — which would call `onReconnect` on a torn-down
+  // component (and reject in tests after the environment is torn down).
+  useEffect(
+    () => () => {
+      if (reconnectFallbackTimeoutRef.current !== null) {
+        window.clearTimeout(reconnectFallbackTimeoutRef.current);
+        reconnectFallbackTimeoutRef.current = null;
+      }
+    },
+    []
+  );
 
   const handleMcpProtocolVersionOverrideChange = async (
     next: McpProtocolVersion | undefined
@@ -374,7 +392,8 @@ export function ServerDetailModal({
       // Fallback: if the reactive refetch is delayed (network blip,
       // backend slow), trigger reconnect after 1.5s anyway. The watcher
       // effect short-circuits if it already fired.
-      window.setTimeout(() => {
+      reconnectFallbackTimeoutRef.current = window.setTimeout(() => {
+        reconnectFallbackTimeoutRef.current = null;
         if (pendingReconnectRef.current?.target === next) {
           pendingReconnectRef.current = null;
           void onReconnect(server.name, {


### PR DESCRIPTION
## Summary

Fixes a flaky failure in the **Run Tests** CI job. `ServerDetailModal`'s `handleMcpProtocolVersionOverrideChange` schedules a 1.5s `setTimeout` fallback that calls `onReconnect(...)`, but the timer id was never stored or cleared. When the modal unmounts before the timer fires, the callback still runs on a torn-down component.

In the test suite this surfaced as an unhandled rejection caught **after** the test environment was torn down:

```
⎯ Uncaught Exception ⎯
TypeError: Cannot read properties of undefined (reading 'catch')
 ❯ Timeout._onTimeout client/src/components/connection/ServerDetailModal.tsx:382
This error was caught after test environment was torn down.
```

All assertions passed (5351/5351), but the stray rejection still failed the job — and only intermittently, depending on timing, which is why it passed on some commits and failed on others.

## Fix
- Track the fallback timer id in `reconnectFallbackTimeoutRef`.
- Clear it on unmount via a cleanup effect, so it can't fire after the modal closes.
- Null the ref when the timer fires normally.

This also prevents a real production edge case: a reconnect firing ~1.5s after the modal was closed.

## Testing
- `ServerDetailModal.test.tsx` → 18/18 pass, **no unhandled errors**, across 3 consecutive runs (previously produced "1 error" post-teardown).
- `tsc --noEmit -p client/tsconfig.typecheck.json` → clean.

## Context
This flake is unrelated to any feature change — it surfaced on the Claude Fable 5 PR (#2532), but the root cause is pre-existing in this component. Filing as a standalone fix so it unblocks `Run Tests` for all PRs.

https://claude.ai/code/session_0186kAd4svNWzwiDQQGd8WvD

---
_Generated by [Claude Code](https://claude.ai/code/session_0186kAd4svNWzwiDQQGd8WvD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix around an existing timeout; no change to reconnect or override save logic beyond preventing orphaned callbacks.
> 
> **Overview**
> **ServerDetailModal** now keeps the 1.5s reconnect fallback timer id in `reconnectFallbackTimeoutRef` when saving an MCP wire-mode override, and **clears that timer on unmount** so the callback cannot call `onReconnect` after the dialog closes.
> 
> The fallback `setTimeout` behavior is unchanged; only lifecycle handling is added (ref assignment when scheduling, nulling when the timer runs). This addresses intermittent CI failures from post-teardown rejections and avoids a stray reconnect ~1.5s after closing the modal in the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed58ab6d166db862fda3bf082c204997dd5f27f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->