### PR TITLE
docs: promote API reference to a top-level header tab

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -154,12 +154,16 @@
               "sdk/reference/llm-providers",
               "sdk/reference/protocol-conformance",
               "sdk/reference/oauth-conformance",
-              "sdk/reference/apps-conformance",
-              "reference/public-api",
-              "reference/api-keys"
+              "sdk/reference/apps-conformance"
             ]
           }
         ]
+      },
+      {
+        "tab": "API",
+        "icon": "webhook",
+        "tag": "Preview",
+        "pages": ["reference/public-api", "reference/api-keys"]
       }
     ],
     "global": {


### PR DESCRIPTION
## Summary

Follow-up to #2536: the MCPJam API reference was merged **nested under the SDK tab → Reference group**, so it didn't show up in the docs header nav. This promotes it to its own top-level **API** header tab.

## Change

`docs.json` only:
- New top-level `API` tab in the header, with a **`Preview`** chip (matches the page's preview framing and the convention already used by the `SDK` tab's `v1` chip).
- Moves `reference/public-api` and `reference/api-keys` into it, and removes them from the SDK → Reference group so they don't appear in two places.

Header now reads: **Get Started · Inspector · CLI · SDK `v1` · API `Preview`**

Page URLs are unchanged (Mintlify routes by file path, not nav position), so existing links — including the `public-api` ↔ `api-keys` cross-links — keep working. `docs.json` validates as JSON.

https://claude.ai/code/session_011asM4GkyWv5TQp35PAC3cC

---
_Generated by [Claude Code](https://claude.ai/code/session_011asM4GkyWv5TQp35PAC3cC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs site navigation config only; no application code or URL changes.
> 
> **Overview**
> **Mintlify navigation only:** adds a top-level **API** header tab (icon `webhook`, **`Preview`** tag, same pattern as SDK’s `v1` chip) with `reference/public-api` and `reference/api-keys`.
> 
> Those two pages are **removed** from **SDK → Reference** so they no longer appear nested under SDK and aren’t duplicated in the sidebar. Page paths are unchanged, so existing links and cross-links keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3350c4d4e6a73f536cc11b06a81c6fe0007bf8d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->