### PR TITLE
fix(docker): copy workspace-local node_modules into runtime image

### DIFF
--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -87,6 +87,10 @@ COPY cli/package.json /usr/src/app/cli/package.json
 COPY mcpjam-inspector/package.json ./package.json
 
 COPY --from=deps /usr/src/app/node_modules /usr/src/app/node_modules
+# Workspace-local deps that can't hoist to root (e.g. @workos-inc/node@^10
+# while @convex-dev/workos transitively pins @workos-inc/node@^7) land under
+# mcpjam-inspector/node_modules and must be carried into the runtime image.
+COPY --from=deps /usr/src/app/mcpjam-inspector/node_modules ./node_modules
 COPY --from=build /usr/src/app/mcpjam-inspector/bin ./bin
 COPY --from=build /usr/src/app/mcpjam-inspector/dist ./dist
 COPY --from=build /usr/src/app/mcpjam-inspector/.env.production ./.env.production


### PR DESCRIPTION
## Summary

- **staging.mcpjam.com is currently down (502)** — the inspector container has been crash-looping since #2523 merged.
- Runtime error from the crashed deploy (Railway env \`staging\`, deploy \`60c6b6e6\`):
  \`\`\`
  Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@workos-inc/node'
    imported from /usr/src/app/mcpjam-inspector/dist/server/index.js
  \`\`\`
- 5 consecutive \`Deploy Staging\` GH Actions runs have failed since #2523.

## Root cause

PR #2523 added \`"@workos-inc/node": "^10.2.0"\` to \`mcpjam-inspector/package.json\` and imports it from \`server/services/workos-client.ts\`.

\`@convex-dev/workos\` (already in the root) transitively pins \`@workos-inc/node@^7\`. npm therefore cannot hoist v10 to the root \`node_modules\` — the lockfile installs it at \`mcpjam-inspector/node_modules/@workos-inc/node@10.2.0\`.

The runtime stage of \`mcpjam-inspector/Dockerfile\` only copied \`/usr/src/app/node_modules\` from the deps stage. \`mcpjam-inspector/node_modules\` (where v10 lives) was left behind, so the production image is missing \`@workos-inc/node\` entirely and the server crashes on boot.

## Fix

Add one \`COPY\` in the runtime stage to bring \`mcpjam-inspector/node_modules\` into the image. Smallest possible change to unblock staging — no dep-graph surgery, no version realignment.

## Test plan

- [ ] CI \`Build and Test\` passes (image builds clean).
- [ ] On merge → \`Deploy Staging\` succeeds and smoke job's \`curl staging.mcpjam.com/health\` returns 200.
- [ ] \`curl https://staging.mcpjam.com/\` returns app HTML (no 502).
- [ ] Manual check: WorkOS API Keys bearer-auth path (\`server/middleware/bearer-auth.ts\`) responds without \`ERR_MODULE_NOT_FOUND\`.

## Follow-up (not in this PR)

Worth aligning \`@workos-inc/node\` versions across the repo so the dep hoists naturally — either bump \`@convex-dev/workos\` (or use a resolution override) so only one major lives in the tree. That would let us drop this extra COPY.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single runtime-stage COPY in the inspector Dockerfile; no auth or app logic changes, only restores missing npm packages for deploy.
> 
> **Overview**
> Fixes staging/production inspector **502 / crash-loop** after `@workos-inc/node@^10` was added to the inspector workspace while `@convex-dev/workos` still pulls `@workos-inc/node@^7`, so npm installs v10 under **`mcpjam-inspector/node_modules`** instead of hoisting to the root.
> 
> The runtime stage previously only copied root **`node_modules`**, so the built server could not resolve `@workos-inc/node` at boot (`ERR_MODULE_NOT_FOUND`).
> 
> **Change:** copy **`mcpjam-inspector/node_modules`** from the deps stage into the final image (with a short comment explaining the hoisting conflict). No dependency or application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed300f19a5c1c6e2d6c23174c7acda65ede1cc2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->