### PR TITLE
Wire hostConfig builtInToolIds through chat, eval, and sessionSimulation engines

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -1226,6 +1226,70 @@ describe("POST /api/mcp/chat-v2", () => {
         global.fetch = originalFetch;
       }
     });
+
+    it("advertises built-in tools for MCPJam guest requests after resolving guest auth", async () => {
+      const originalFetch = global.fetch;
+      global.fetch = vi
+        .fn()
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
+          const url = String(input);
+          if (url === "https://test-convex.example.com/stream") {
+            return createSseResponse([
+              {
+                type: "finish",
+                finishReason: "stop",
+                messageMetadata: {
+                  inputTokens: 1,
+                  outputTokens: 1,
+                  totalTokens: 2,
+                },
+              },
+            ]);
+          }
+
+          if (url === "https://test-convex.example.com/ingest-chat") {
+            return new Response(null, { status: 200 });
+          }
+
+          throw new Error(`Unexpected fetch URL: ${url}`);
+        });
+
+      try {
+        const res = await postJson(app, "/api/mcp/chat-v2", {
+          messages: [{ role: "user", content: "Search for current docs" }],
+          model: { id: "anthropic/claude-haiku-4.5", provider: "anthropic" },
+          projectId: "project-1",
+          builtInToolIds: ["web_search"],
+        });
+
+        expect(res.status).toBe(200);
+        await lastStreamExecution;
+
+        const streamCall = vi
+          .mocked(global.fetch)
+          .mock.calls.find(([url]) => String(url).endsWith("/stream"));
+
+        expect(streamCall).toBeDefined();
+        const [, init] = streamCall!;
+        expect(init).toMatchObject({
+          headers: expect.objectContaining({
+            authorization: "Bearer guest-test-token",
+          }),
+        });
+
+        const streamBody = JSON.parse(
+          String((init as RequestInit).body ?? "{}"),
+        );
+        expect(streamBody.tools).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: "web_search" }),
+          ]),
+        );
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+
     it("uses a guest token for non-gated MCPJam guest requests", async () => {
       const { getProductionGuestAuthHeader } =
         await import("../../../utils/guest-auth.js");

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -461,9 +461,12 @@ chatV2.post("/", async (c) => {
     }
 
     const requestAuthHeader = c.req.header("authorization");
+    const isMcpJamProvidedModel = Boolean(
+      modelDefinition.id && isMCPJamProvidedModel(modelDefinition.id)
+    );
     if (
+      isMcpJamProvidedModel &&
       modelDefinition.id &&
-      isMCPJamProvidedModel(modelDefinition.id) &&
       !requestAuthHeader &&
       !isMCPJamGuestAllowedModel(modelDefinition.id)
     ) {
@@ -474,6 +477,27 @@ chatV2.post("/", async (c) => {
         },
         403
       );
+    }
+    let mcpJamAuthHeader = requestAuthHeader;
+    const resolveMcpJamAuthHeader = async () => {
+      if (mcpJamAuthHeader || !isMcpJamProvidedModel) return mcpJamAuthHeader;
+      try {
+        mcpJamAuthHeader = (await getProductionGuestAuthHeader()) ?? undefined;
+      } catch {
+        mcpJamAuthHeader = undefined;
+      }
+      return mcpJamAuthHeader;
+    };
+
+    // Guest MCPJam-model requests get their bearer lazily server-side. Resolve
+    // it before tool prep too, otherwise host-enabled built-ins are omitted
+    // even though the later MCPJam model path can authenticate the turn.
+    if (
+      isMcpJamProvidedModel &&
+      !mcpJamAuthHeader &&
+      process.env.CONVEX_HTTP_URL
+    ) {
+      await resolveMcpJamAuthHeader();
     }
 
     // Convert the inbound UI messages once so prepareChatV2 can replay
@@ -511,11 +535,12 @@ chatV2.post("/", async (c) => {
     // HTTP action, which needs a bearer + projectId to authorize. Local
     // requests without either (anonymous local mode, no project) omit the
     // tools — same degradation as a host that never enabled them.
+    const builtInAuthHeader = mcpJamAuthHeader ?? requestAuthHeader;
     const builtInTools = safeResolveBuiltInTools(
       resolvedExecution.builtInToolIds,
-      requestAuthHeader && typeof body.projectId === "string" && body.projectId
+      builtInAuthHeader && typeof body.projectId === "string" && body.projectId
         ? {
-            authHeader: requestAuthHeader,
+            authHeader: builtInAuthHeader,
             projectId: body.projectId,
             ...(body.chatSessionId
               ? { chatSessionId: body.chatSessionId }
@@ -599,9 +624,7 @@ chatV2.post("/", async (c) => {
     const authenticatedUserId = c.var.requestLogContext?.userId ?? null;
 
     // MCPJam-provided models: delegate to stream handler
-    if (modelDefinition.id && isMCPJamProvidedModel(modelDefinition.id)) {
-      let authHeader = requestAuthHeader;
-
+    if (isMcpJamProvidedModel && modelDefinition.id) {
       if (!process.env.CONVEX_HTTP_URL) {
         return c.json(
           { error: "Server missing CONVEX_HTTP_URL configuration" },
@@ -611,21 +634,15 @@ chatV2.post("/", async (c) => {
 
       // Resolve auth header: use client-provided token (WorkOS) if present,
       // otherwise fetch a production guest token for guest-allowed models.
+      const authHeader = await resolveMcpJamAuthHeader();
       if (!authHeader) {
-        try {
-          authHeader = (await getProductionGuestAuthHeader()) ?? undefined;
-        } catch {
-          authHeader = undefined;
-        }
-        if (!authHeader) {
-          return c.json(
-            {
-              error:
-                "Unable to authenticate with MCPJam servers. Please try again or sign in.",
-            },
-            503
-          );
-        }
+        return c.json(
+          {
+            error:
+              "Unable to authenticate with MCPJam servers. Please try again or sign in.",
+          },
+          503
+        );
       }
 
       const modelMessages = await convertToModelMessages(messages);

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -64,6 +64,7 @@ import {
 } from "../../utils/direct-chat-turn";
 import { buildDirectChatTraceCallbacks } from "../../utils/direct-chat-sse-callbacks";
 import { resolveExecutionContext } from "../../utils/host-execution-context";
+import { safeResolveBuiltInTools } from "../../utils/built-in-tools/registry.js";
 
 function formatStreamError(error: unknown, provider?: ModelProvider): string {
   if (!(error instanceof Error)) {
@@ -353,6 +354,7 @@ chatV2.post("/", async (c) => {
         requireToolApproval: bodyRequireToolApproval,
         respectToolVisibility: bodyRespectToolVisibility,
         progressiveToolDiscovery: body.progressiveToolDiscovery,
+        builtInToolIds: body.builtInToolIds,
       },
       precedence: "host-wins",
     });
@@ -505,6 +507,23 @@ chatV2.post("/", async (c) => {
       throw error;
     }
 
+    // Built-in tools (e.g. web_search) bill MCPJam credits via a Convex
+    // HTTP action, which needs a bearer + projectId to authorize. Local
+    // requests without either (anonymous local mode, no project) omit the
+    // tools — same degradation as a host that never enabled them.
+    const builtInTools = safeResolveBuiltInTools(
+      resolvedExecution.builtInToolIds,
+      requestAuthHeader && typeof body.projectId === "string" && body.projectId
+        ? {
+            authHeader: requestAuthHeader,
+            projectId: body.projectId,
+            ...(body.chatSessionId
+              ? { chatSessionId: body.chatSessionId }
+              : {}),
+          }
+        : null
+    );
+
     let prepared;
     try {
       prepared = await prepareChatV2({
@@ -517,6 +536,7 @@ chatV2.post("/", async (c) => {
         respectToolVisibility,
         customProviders: body.customProviders,
         priorMessages: priorModelMessages,
+        ...(builtInTools ? { builtInTools } : {}),
         // Body for direct chat (project default), host-re-resolved for
         // chatbox-bound sessions. undefined → auto policy.
         ...(resolvedProgressiveToolDiscovery !== undefined

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -27,6 +27,7 @@ import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
 import { resolveExecutionContext } from "../../utils/host-execution-context.js";
+import { safeResolveBuiltInTools } from "../../utils/built-in-tools/registry.js";
 import { logger } from "../../utils/logger.js";
 
 const chatV2 = new Hono();
@@ -142,6 +143,7 @@ chatV2.post("/", async (c) => {
         requireToolApproval: bodyRequireToolApproval,
         respectToolVisibility: bodyRespectToolVisibility,
         progressiveToolDiscovery: body.progressiveToolDiscovery,
+        builtInToolIds: body.builtInToolIds,
       },
       precedence: "host-wins",
     });
@@ -207,6 +209,17 @@ chatV2.post("/", async (c) => {
     const respectToolVisibility = resolvedExecution.respectToolVisibility;
     const resolvedProgressiveToolDiscovery =
       resolvedExecution.progressiveToolDiscovery;
+    // Built-in tools (e.g. web_search) bill MCPJam credits via Convex; the
+    // bearer is guaranteed by assertBearerToken above and projectId by the
+    // hosted schema, so the auth context is always constructible here.
+    const builtInTools = safeResolveBuiltInTools(
+      resolvedExecution.builtInToolIds,
+      {
+        authHeader: bearerToken,
+        projectId: hostedBody.projectId,
+        ...(body.chatSessionId ? { chatSessionId: body.chatSessionId } : {}),
+      }
+    );
 
     // Membership chat (no share/chatbox token) is the default — the backend
     // authorizes via project ownership for both guest and authed users.
@@ -289,6 +302,7 @@ chatV2.post("/", async (c) => {
             : {}),
           appTools: validatedAppTools,
           widgetModelContext: validatedWidgetModelContext,
+          ...(builtInTools ? { builtInTools } : {}),
         },
         persist: {
           chatSessionId: body.chatSessionId,

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -242,6 +242,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     const requireToolApproval = runtime.config.requireToolApproval;
     const respectToolVisibility = runtime.config.respectToolVisibility;
     const progressiveToolDiscovery = runtime.config.progressiveToolDiscovery;
+    const builtInToolIds = runtime.config.builtInToolIds;
     // `runtime.config.accessVersion` is the server-resolved value the
     // chatbox redeem produced (vs the client-supplied `body.accessVersion`,
     // which the generate-sessions dialog never sends). Use the runtime
@@ -266,6 +267,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
         requireToolApproval,
         respectToolVisibility,
         progressiveToolDiscovery,
+        ...(builtInToolIds ? { builtInToolIds } : {}),
         // Threaded into the runner's per-tool widget snapshot capture so
         // `chatSessions:createWidgetSnapshot` can authenticate against the
         // chatbox path. Without it the Sessions viewer can't render MCP App

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -27,10 +27,8 @@ import {
 } from "../../config.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { streamWebChatTurn } from "../../utils/web-chat-turn.js";
-import {
-  buildExaWebSearchTool,
-  WEB_SEARCH_TOOL_NAME,
-} from "../../utils/built-in-tools/exa-web-search.js";
+import { WEB_SEARCH_TOOL_NAME } from "../../utils/built-in-tools/exa-web-search.js";
+import { safeResolveBuiltInTools } from "../../utils/built-in-tools/registry.js";
 import {
   assertBearerToken,
   readJsonBody,
@@ -105,15 +103,15 @@ mcpjamAgent.post("/", async (c) => {
       // Bearer is guaranteed by assertBearerToken above; thread it (plus the
       // project + session) into the web_search built-in tool, whose execute
       // proxies to the Convex Exa route for billing + the external call.
+      // The agent always advertises web_search — it isn't hostConfig-gated
+      // like chat-v2 / eval surfaces, so the id list is fixed here.
       const authHeader = c.req.header("authorization");
       const builtInTools = authHeader
-        ? {
-            [WEB_SEARCH_TOOL_NAME]: buildExaWebSearchTool({
-              authHeader,
-              projectId: body.projectId,
-              chatSessionId: body.chatSessionId,
-            }),
-          }
+        ? safeResolveBuiltInTools([WEB_SEARCH_TOOL_NAME], {
+            authHeader,
+            projectId: body.projectId,
+            chatSessionId: body.chatSessionId,
+          })
         : undefined;
 
       return await streamWebChatTurn({

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -34,6 +34,7 @@ import {
 } from "../utils/direct-chat-turn";
 import { consumeFullStreamAsEvalEvents } from "./evals/stream-adapter";
 import { resolveExecutionContext } from "../utils/host-execution-context";
+import { safeResolveBuiltInTools } from "../utils/built-in-tools/registry.js";
 import { logger } from "../utils/logger";
 import { captureMcpAppWidgetSnapshots } from "../utils/mcp-app-widget-capture";
 import {
@@ -1098,6 +1099,13 @@ const runIterationWithAiSdk = async ({
     // missing skill tools, Anthropic name validation, and skills-prompt
     // assembly. Called inside the try so prep failures become a recorded
     // failed iteration rather than an uncaught setup error.
+    //
+    // `builtInTools` stays absent on this local-AI-SDK BYOK path: built-in
+    // tools (web_search) execute via a Convex HTTP action billed in MCPJam
+    // credits, and BYOK iterations carry no Convex auth — advertising a tool
+    // whose execute can only fail is worse than omitting it. The null-ctx
+    // helper call debug-logs when the suite hostConfig requested ids anyway.
+    safeResolveBuiltInTools(resolvedExecution.builtInToolIds, null);
     const prepared = await prepareChatV2({
       mcpClientManager,
       selectedServers,
@@ -1811,6 +1819,7 @@ const runIterationViaBackend = async ({
   hostPolicy,
   toolSignals,
   suiteHostConfig,
+  orgModelConfigTarget,
 }: RunIterationBackendParams) => {
   const resolvedTest = resolveEvalTestCase(test);
 
@@ -1939,6 +1948,19 @@ const runIterationViaBackend = async ({
   const backendCustomProviders = orgModelConfig
     ? buildLlmRuntimeConfigFromOrgConfig(orgModelConfig).customProviders
     : undefined;
+  // Suite hostConfig `builtInToolIds` (e.g. web_search) resolve to runnable
+  // tools the same way chat does. The tool's execute bills MCPJam credits
+  // via Convex, so the auth context reuses the iteration's bearer plus the
+  // same project target the org-BYOK/jam billing paths derive
+  // (`resolveOrgTargetForEval`). Org-level targets carry no projectId —
+  // the Exa route requires one — so those omit the tools.
+  const builtInTarget = resolveOrgTargetForEval(test, orgModelConfigTarget);
+  const builtInTools = safeResolveBuiltInTools(
+    resolvedExecution.builtInToolIds,
+    builtInTarget && "projectId" in builtInTarget
+      ? { authHeader: convexAuthToken, projectId: builtInTarget.projectId }
+      : null,
+  );
   // PR 4d review fix (Codex P2 / Cursor Medium): hoisted up-front (above
   // the `prepareChatV2` try) so the catch path and the assignment
   // inside the try are both in scope. Stays `undefined` if prepareChatV2
@@ -1958,6 +1980,7 @@ const runIterationViaBackend = async ({
         ? { customProviders: backendCustomProviders }
         : {}),
       priorMessages: [],
+      ...(builtInTools ? { builtInTools } : {}),
     });
     // PR 4d review fix (Codex P2 / Cursor Medium): stash the resolved
     // system prompt for the persistence prefix below. The engine
@@ -2553,6 +2576,7 @@ const runTestCase = async (params: {
         convexClient,
         modelApiKeys,
         orgModelConfig,
+        orgModelConfigTarget,
         runId,
         abortSignal,
         compareRunId,
@@ -3126,7 +3150,10 @@ const streamIterationWithAiSdk = async ({
 
   try {
     // See `runIterationWithAiSdk`: adopt the chat-side pipeline inside the try
-    // so prep failures become a recorded failed iteration.
+    // so prep failures become a recorded failed iteration. Like that runner,
+    // `builtInTools` stays absent on the local BYOK path (no Convex auth to
+    // bill web_search against) — the null-ctx call just debug-logs requests.
+    safeResolveBuiltInTools(resolvedExecution.builtInToolIds, null);
     const prepared = await prepareChatV2({
       mcpClientManager,
       selectedServers,
@@ -3958,6 +3985,7 @@ const streamIterationViaBackend = async ({
   hostPolicy,
   toolSignals,
   suiteHostConfig,
+  orgModelConfigTarget,
 }: RunIterationBackendParams & {
   emit: StreamEmit;
 }): Promise<EvalIterationOutcome> => {
@@ -4112,6 +4140,16 @@ const streamIterationViaBackend = async ({
           ...msgs,
         ]
       : msgs;
+  // Same shape as the non-stream backend runner: suite hostConfig
+  // `builtInToolIds` resolve via the shared registry, billed against the
+  // project target the org-BYOK/jam billing paths derive.
+  const builtInTarget = resolveOrgTargetForEval(test, orgModelConfigTarget);
+  const builtInTools = safeResolveBuiltInTools(
+    resolvedExecution.builtInToolIds,
+    builtInTarget && "projectId" in builtInTarget
+      ? { authHeader: convexAuthToken, projectId: builtInTarget.projectId }
+      : null,
+  );
   let prepared: PrepareChatV2Result;
   try {
     prepared = await prepareChatV2({
@@ -4125,6 +4163,7 @@ const streamIterationViaBackend = async ({
         ? { customProviders: backendCustomProviders }
         : {}),
       priorMessages: [],
+      ...(builtInTools ? { builtInTools } : {}),
     });
     // PR 4d review fix (Codex P2 / Cursor Medium): same persistence
     // prefix shape as the non-stream backend runner.
@@ -5065,6 +5104,7 @@ export const streamTestCase = async (params: {
         convexClient,
         modelApiKeys,
         orgModelConfig,
+        orgModelConfigTarget,
         runId,
         abortSignal,
         emit,

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -840,6 +840,178 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     );
   });
 
+  it("threads suiteHostConfig builtInToolIds into prepareChatV2 on the backend path", async () => {
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
+    const orchestration = await import("../../../utils/chat-v2-orchestration");
+    const prepareMock = vi.mocked(orchestration.prepareChatV2);
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Case",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: {},
+      // The web_search execute bills via Convex against a project — the
+      // runner derives it from the same target the jam/org billing paths
+      // use (`resolveOrgTargetForEval`).
+      orgModelConfigTarget: { projectId: "project-1" },
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+      suiteHostConfig: { builtInToolIds: ["web_search"] },
+    });
+
+    expect(prepareMock).toHaveBeenCalled();
+    const options = prepareMock.mock.calls[0]?.[0] as {
+      builtInTools?: Record<string, unknown>;
+    };
+    expect(options.builtInTools).toBeDefined();
+    expect(Object.keys(options.builtInTools!)).toEqual(["web_search"]);
+  });
+
+  it("omits builtInTools on the backend path when no project target exists", async () => {
+    // Org-level targets (or no target at all) carry no projectId; the Exa
+    // Convex route requires one, so the runner must omit the tool rather
+    // than advertise an execute that can only fail.
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
+    const orchestration = await import("../../../utils/chat-v2-orchestration");
+    const prepareMock = vi.mocked(orchestration.prepareChatV2);
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Case",
+            query: "Hello",
+            runs: 1,
+            model: "claude-haiku-4.5",
+            provider: "anthropic",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: {},
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+      suiteHostConfig: { builtInToolIds: ["web_search"] },
+    });
+
+    expect(prepareMock).toHaveBeenCalled();
+    const options = prepareMock.mock.calls[0]?.[0] as {
+      builtInTools?: Record<string, unknown>;
+    };
+    expect(options.builtInTools).toBeUndefined();
+  });
+
+  it("omits builtInTools on the local BYOK path even when the suite requests them", async () => {
+    // Local-AI-SDK iterations carry no Convex auth; web_search is billed in
+    // MCPJam credits via Convex, so the BYOK path never advertises it.
+    const orchestration = await import("../../../utils/chat-v2-orchestration");
+    const prepareMock = vi.mocked(orchestration.prepareChatV2);
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Case",
+            query: "Hello",
+            runs: 1,
+            model: "gpt-4-turbo",
+            provider: "openai",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: { openai: "sk-test" },
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+      suiteHostConfig: { builtInToolIds: ["web_search"] },
+    });
+
+    expect(prepareMock).toHaveBeenCalled();
+    const options = prepareMock.mock.calls[0]?.[0] as {
+      builtInTools?: Record<string, unknown>;
+    };
+    expect(options.builtInTools).toBeUndefined();
+  });
+
+  it("threads suiteHostConfig builtInToolIds into prepareChatV2 on the streamed backend path", async () => {
+    fetchMock.mockResolvedValue(createBackendStreamResponse());
+    const orchestration = await import("../../../utils/chat-v2-orchestration");
+    const prepareMock = vi.mocked(orchestration.prepareChatV2);
+
+    await streamTestCase({
+      test: {
+        title: "Case",
+        query: "Hello",
+        runs: 1,
+        model: "claude-haiku-4.5",
+        provider: "anthropic",
+        expectedToolCalls: [],
+        promptTurns: [{ id: "turn-1", prompt: "Hello", expectedToolCalls: [] }],
+        testCaseId: "case-1",
+      },
+      tools: {},
+      selectedServers: [],
+      mcpClientManager: mcpClientManager as any,
+      recorder: null,
+      modelApiKeys: {},
+      orgModelConfigTarget: { projectId: "project-1" },
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      testCaseId: "case-1",
+      suiteId: "suite-1",
+      runId: null,
+      emit: () => {},
+      suiteHostConfig: { builtInToolIds: ["web_search"] },
+    });
+
+    expect(prepareMock).toHaveBeenCalled();
+    const options = prepareMock.mock.calls[0]?.[0] as {
+      builtInTools?: Record<string, unknown>;
+    };
+    expect(options.builtInTools).toBeDefined();
+    expect(Object.keys(options.builtInTools!)).toEqual(["web_search"]);
+  });
+
   it("runs org BYOK cloud eval models through Convex without raw provider keys", async () => {
     // Same migration as the previous test: assert against the engine's
     // `mode:"stream"` SSE request, not the legacy `mode:"step"` JSON. The

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -22,6 +22,7 @@ import {
   type SyntheticModelSource,
 } from "../../utils/org-model-config.js";
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
+import { safeResolveBuiltInTools } from "../../utils/built-in-tools/registry.js";
 import {
   persistChatSessionToConvex,
   type PersistedTurnTrace,
@@ -145,6 +146,12 @@ export interface RunSimulationOptions {
    * visitor would get.
    */
   progressiveToolDiscovery?: boolean;
+  /**
+   * Built-in tool ids from the chatbox's pinned HostConfigV2 (e.g.
+   * `["web_search"]`). Resolved per session via the shared registry so a
+   * synthetic visitor sees the same tool set a real chatbox visitor gets.
+   */
+  builtInToolIds?: string[];
   /**
    * Optional hosted-chat access version. Forwarded into
    * `chatSessions:createWidgetSnapshot` so the optimistic-concurrency check
@@ -276,6 +283,7 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
     requireToolApproval,
     respectToolVisibility,
     progressiveToolDiscovery,
+    builtInToolIds,
     accessVersion,
     convexHttpUrl,
     convexAuthToken,
@@ -324,6 +332,7 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
           requireToolApproval,
           respectToolVisibility,
           progressiveToolDiscovery,
+          builtInToolIds,
           accessVersion,
           convexHttpUrl,
           convexAuthToken,
@@ -412,6 +421,7 @@ async function runOneSession(args: {
   requireToolApproval: boolean;
   respectToolVisibility?: boolean;
   progressiveToolDiscovery?: boolean;
+  builtInToolIds?: string[];
   accessVersion?: number;
   convexHttpUrl: string;
   convexAuthToken: string;
@@ -432,6 +442,7 @@ async function runOneSession(args: {
     requireToolApproval,
     respectToolVisibility,
     progressiveToolDiscovery,
+    builtInToolIds,
     accessVersion,
     convexHttpUrl,
     convexAuthToken,
@@ -468,6 +479,15 @@ async function runOneSession(args: {
           : selectedServerIds,
     };
 
+    // Built-in tools from the chatbox host config (e.g. web_search) resolve
+    // the same way a real visitor's chat-v2 turn would: billed via Convex
+    // against this project, namespaced under the synthetic session id.
+    const builtInTools = safeResolveBuiltInTools(builtInToolIds, {
+      authHeader,
+      projectId,
+      chatSessionId,
+    });
+
     const prepared = await prepareChatV2({
       mcpClientManager: manager,
       selectedServers: selectedServerIds,
@@ -483,6 +503,7 @@ async function runOneSession(args: {
             },
           }
         : {}),
+      ...(builtInTools ? { builtInTools } : {}),
     });
 
     let messageHistory: ModelMessage[] = [];

--- a/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
@@ -50,6 +50,17 @@ describe("safeResolveBuiltInTools", () => {
     expect(safeResolveBuiltInTools(["not_a_tool"], ctx)).toBeUndefined();
   });
 
+  it("does not double-prefix a lowercase bearer scheme", () => {
+    // RFC 7235 schemes are case-insensitive; "bearer x" must pass through
+    // instead of becoming "Bearer bearer x".
+    const tools = resolveBuiltInTools([WEB_SEARCH_TOOL_NAME], {
+      authHeader: "bearer token-123",
+      projectId: "project-1",
+    });
+
+    expect(Object.keys(tools)).toEqual([WEB_SEARCH_TOOL_NAME]);
+  });
+
   it("resolves with auth context, raw bearer accepted", () => {
     // Eval threads `convexAuthToken` without the "Bearer " prefix; the
     // registry normalizes, so the same call shape works for both.

--- a/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveBuiltInTools,
+  safeResolveBuiltInTools,
+} from "../built-in-tools/registry";
+import { WEB_SEARCH_TOOL_NAME } from "../built-in-tools/exa-web-search";
+
+const ctx = {
+  authHeader: "Bearer token-123",
+  projectId: "project-1",
+  chatSessionId: "session-1",
+};
+
+describe("resolveBuiltInTools", () => {
+  it("resolves web_search to a runnable tool", () => {
+    const tools = resolveBuiltInTools([WEB_SEARCH_TOOL_NAME], ctx);
+
+    expect(Object.keys(tools)).toEqual([WEB_SEARCH_TOOL_NAME]);
+    expect(typeof tools[WEB_SEARCH_TOOL_NAME].execute).toBe("function");
+  });
+
+  it("skips unknown ids instead of throwing", () => {
+    const tools = resolveBuiltInTools(
+      ["not_a_tool", WEB_SEARCH_TOOL_NAME],
+      ctx,
+    );
+
+    expect(Object.keys(tools)).toEqual([WEB_SEARCH_TOOL_NAME]);
+  });
+
+  it("returns an empty set for undefined / empty ids", () => {
+    expect(resolveBuiltInTools(undefined, ctx)).toEqual({});
+    expect(resolveBuiltInTools([], ctx)).toEqual({});
+  });
+});
+
+describe("safeResolveBuiltInTools", () => {
+  it("returns undefined when there is nothing to resolve", () => {
+    expect(safeResolveBuiltInTools(undefined, ctx)).toBeUndefined();
+    expect(safeResolveBuiltInTools([], ctx)).toBeUndefined();
+  });
+
+  it("returns undefined without auth context (local BYOK paths)", () => {
+    expect(
+      safeResolveBuiltInTools([WEB_SEARCH_TOOL_NAME], null),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when every requested id is unknown", () => {
+    expect(safeResolveBuiltInTools(["not_a_tool"], ctx)).toBeUndefined();
+  });
+
+  it("resolves with auth context, raw bearer accepted", () => {
+    // Eval threads `convexAuthToken` without the "Bearer " prefix; the
+    // registry normalizes, so the same call shape works for both.
+    const tools = safeResolveBuiltInTools([WEB_SEARCH_TOOL_NAME], {
+      authHeader: "raw-token",
+      projectId: "project-1",
+    });
+
+    expect(tools).toBeDefined();
+    expect(Object.keys(tools!)).toEqual([WEB_SEARCH_TOOL_NAME]);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/host-execution-context.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/host-execution-context.test.ts
@@ -335,6 +335,67 @@ describe("resolveExecutionContext — type coercion guards", () => {
 
     expect(result.selectedServerIds).toEqual(["fallback"]);
   });
+
+  it("ignores non-string-array builtInToolIds on hostConfig", () => {
+    const result = resolveExecutionContext({
+      hostConfig: { builtInToolIds: ["web_search", 7] },
+      precedence: "host-wins",
+    });
+
+    expect(result.builtInToolIds).toBeUndefined();
+  });
+});
+
+describe("resolveExecutionContext — builtInToolIds", () => {
+  it("reads builtInToolIds from the hostConfig record", () => {
+    const result = resolveExecutionContext({
+      hostConfig: { builtInToolIds: ["web_search"] },
+      precedence: "host-wins",
+    });
+
+    expect(result.builtInToolIds).toEqual(["web_search"]);
+  });
+
+  it("falls back to the override when the host omits the field", () => {
+    const result = resolveExecutionContext({
+      hostConfig: {},
+      overrides: { builtInToolIds: ["web_search"] },
+      precedence: "host-wins",
+    });
+
+    expect(result.builtInToolIds).toEqual(["web_search"]);
+  });
+
+  it("host wins under host-wins precedence when both define the field", () => {
+    // An explicit empty array on the host record is a real "no built-ins"
+    // opinion — it must beat a body that tries to opt in.
+    const result = resolveExecutionContext({
+      hostConfig: { builtInToolIds: [] },
+      overrides: { builtInToolIds: ["web_search"] },
+      precedence: "host-wins",
+    });
+
+    expect(result.builtInToolIds).toEqual([]);
+  });
+
+  it("returns the override on a null hostConfig (direct chat path)", () => {
+    const result = resolveExecutionContext({
+      hostConfig: null,
+      overrides: { builtInToolIds: ["web_search"] },
+      precedence: "host-wins",
+    });
+
+    expect(result.builtInToolIds).toEqual(["web_search"]);
+  });
+
+  it("is undefined when neither side defines it", () => {
+    const result = resolveExecutionContext({
+      hostConfig: {},
+      precedence: "host-wins",
+    });
+
+    expect(result.builtInToolIds).toBeUndefined();
+  });
 });
 
 describe("resolveExecutionContext — hostPolicy passthrough", () => {

--- a/mcpjam-inspector/server/utils/__tests__/host-execution-context.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/host-execution-context.test.ts
@@ -396,6 +396,40 @@ describe("resolveExecutionContext — builtInToolIds", () => {
 
     expect(result.builtInToolIds).toBeUndefined();
   });
+
+  it("does NOT report drift for array fields with equal contents", () => {
+    // Arrays arrive as fresh allocations on every request — drift must
+    // compare values, not references.
+    const result = resolveExecutionContext({
+      hostConfig: {
+        builtInToolIds: ["web_search"],
+        selectedServerIds: ["srv-1"],
+      },
+      overrides: {
+        builtInToolIds: ["web_search"],
+        selectedServerIds: ["srv-1"],
+      },
+      precedence: "host-wins",
+    });
+
+    expect(result.drift).toEqual([]);
+  });
+
+  it("reports drift for array fields with differing contents", () => {
+    const result = resolveExecutionContext({
+      hostConfig: { builtInToolIds: [] },
+      overrides: { builtInToolIds: ["web_search"] },
+      precedence: "host-wins",
+    });
+
+    expect(result.drift).toEqual([
+      {
+        field: "builtInToolIds",
+        overrideValue: ["web_search"],
+        hostValue: [],
+      },
+    ]);
+  });
 });
 
 describe("resolveExecutionContext — hostPolicy passthrough", () => {

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -35,7 +35,10 @@ export interface BuiltInToolContext {
 }
 
 function normalizeAuthHeader(raw: string): string {
-  return raw.startsWith("Bearer ") ? raw : `Bearer ${raw}`;
+  // Scheme matching is case-insensitive per RFC 7235 — a client may send
+  // "bearer x"; prefixing that again would produce "Bearer bearer x".
+  const value = raw.trim();
+  return /^bearer\s/i.test(value) ? value : `Bearer ${value}`;
 }
 
 /**

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -1,0 +1,86 @@
+/**
+ * Built-in tool registry: HostConfig v2 `builtInToolIds` → AI SDK ToolSet.
+ *
+ * Built-in tools are server-side tools the inspector defines itself (no MCP
+ * server involved) whose `execute` proxies to a Convex HTTP action that owns
+ * the external API key and the billing. Today that's just `web_search`
+ * (Exa, billed as MCPJam credits against the project's organization — see
+ * `exa-web-search.ts`).
+ *
+ * `resolveExecutionContext` surfaces the resolved id list off a hostConfig
+ * record; this module turns ids into runnable tools. The split keeps the
+ * resolver pure (no auth concerns) and gives every engine — chat-v2 routes,
+ * the eval runners, sessionSimulation — one construction path, so the tool
+ * the model sees is identical across surfaces.
+ *
+ * Auth context is required because every built-in tool bills via Convex:
+ * paths with no Convex auth (local BYOK eval runs) must omit the tools
+ * entirely rather than advertise a tool whose execute can only fail —
+ * that's what `safeResolveBuiltInTools(ids, null)` encodes.
+ */
+import type { ToolSet } from "ai";
+import { logger } from "../logger.js";
+import {
+  buildExaWebSearchTool,
+  WEB_SEARCH_TOOL_NAME,
+} from "./exa-web-search.js";
+
+export interface BuiltInToolContext {
+  /** Bearer authorization forwarded to Convex. "Bearer " prefix optional. */
+  authHeader: string;
+  /** Project the built-in tool's usage bills against. */
+  projectId: string;
+  /** Optional chat session, used by Convex for idempotency namespacing. */
+  chatSessionId?: string;
+}
+
+function normalizeAuthHeader(raw: string): string {
+  return raw.startsWith("Bearer ") ? raw : `Bearer ${raw}`;
+}
+
+/**
+ * Build the ToolSet for a resolved `builtInToolIds` list. Unknown ids are
+ * skipped with a warn (a newer backend catalog may advertise ids this
+ * inspector build doesn't implement yet — degrading to "tool absent" is the
+ * same behavior the model would see if the host never enabled it).
+ */
+export function resolveBuiltInTools(
+  ids: ReadonlyArray<string> | undefined,
+  ctx: BuiltInToolContext,
+): ToolSet {
+  const out: ToolSet = {};
+  for (const id of ids ?? []) {
+    if (id === WEB_SEARCH_TOOL_NAME) {
+      out[WEB_SEARCH_TOOL_NAME] = buildExaWebSearchTool({
+        authHeader: normalizeAuthHeader(ctx.authHeader),
+        projectId: ctx.projectId,
+        ...(ctx.chatSessionId ? { chatSessionId: ctx.chatSessionId } : {}),
+      });
+    } else {
+      logger.warn("[built-in-tools] unknown builtInToolId; skipping", { id });
+    }
+  }
+  return out;
+}
+
+/**
+ * Null-context-tolerant wrapper for call sites where Convex auth may be
+ * absent (e.g. local BYOK eval iterations). Returns `undefined` — i.e.
+ * "pass nothing to `prepareChatV2`" — when there's nothing to resolve or
+ * no auth to resolve it with.
+ */
+export function safeResolveBuiltInTools(
+  ids: ReadonlyArray<string> | undefined,
+  ctx: BuiltInToolContext | null,
+): ToolSet | undefined {
+  if (!ids || ids.length === 0) return undefined;
+  if (!ctx) {
+    logger.debug(
+      "[built-in-tools] builtInToolIds requested without Convex auth context; omitting",
+      { ids: [...ids] },
+    );
+    return undefined;
+  }
+  const tools = resolveBuiltInTools(ids, ctx);
+  return Object.keys(tools).length > 0 ? tools : undefined;
+}

--- a/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
@@ -31,6 +31,10 @@ export type ChatboxRuntimeConfig = {
   // mcpjam-backend PR #334 (which adds the field) returns omitted →
   // undefined and the inspector falls back to its auto policy.
   progressiveToolDiscovery?: boolean;
+  // Built-in tool ids from the pinned HostConfigV2 (e.g. ["web_search"]).
+  // Optional so a backend older than mcpjam-backend PR #484 (which adds
+  // the field to runtime-config) returns omitted → no built-in tools.
+  builtInToolIds?: string[];
 };
 
 export type ChatboxRuntimeConfigResult =

--- a/mcpjam-inspector/server/utils/host-execution-context.ts
+++ b/mcpjam-inspector/server/utils/host-execution-context.ts
@@ -174,6 +174,18 @@ function readProgressiveToolDiscovery(
 }
 
 /**
+ * Value equality for drift detection. Array fields (`selectedServerIds`,
+ * `builtInToolIds`) arrive as fresh allocations on every request — a
+ * reference compare would report drift for identical contents.
+ */
+function areEqualValues(a: unknown, b: unknown): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => v === b[i]);
+  }
+  return Object.is(a, b);
+}
+
+/**
  * Pick the winning value for a field given the resolver precedence.
  * Returns the winner AND, if both sides disagreed, a drift entry the
  * caller can log.
@@ -197,7 +209,7 @@ function pickField<T>(
   }
   // Both defined — apply precedence + record drift when they differ.
   const drift =
-    override !== host
+    !areEqualValues(override, host)
       ? {
           field,
           overrideValue: override as unknown,

--- a/mcpjam-inspector/server/utils/host-execution-context.ts
+++ b/mcpjam-inspector/server/utils/host-execution-context.ts
@@ -68,6 +68,7 @@ export interface ExecutionOverrides {
   progressiveToolDiscovery?: boolean;
   modelId?: string;
   selectedServerIds?: string[];
+  builtInToolIds?: string[];
 }
 
 /**
@@ -107,6 +108,13 @@ export interface ResolvedExecutionContext {
   progressiveToolDiscovery: boolean | undefined;
   modelId: string | undefined;
   selectedServerIds: string[] | undefined;
+  /**
+   * HostConfig v2 built-in tool ids (e.g. `["web_search"]`). The resolver
+   * only surfaces the resolved id list; turning ids into runnable AI SDK
+   * tools (and deciding whether auth context permits it) is owned by
+   * `built-in-tools/registry.ts` at the call site.
+   */
+  builtInToolIds: string[] | undefined;
   hostPolicy: HostExecutionPolicy;
   drift: ExecutionDriftEntry[];
 }
@@ -221,6 +229,7 @@ export function resolveExecutionContext(args: {
       progressiveToolDiscovery: overrides.progressiveToolDiscovery,
       modelId: overrides.modelId,
       selectedServerIds: overrides.selectedServerIds,
+      builtInToolIds: overrides.builtInToolIds,
       hostPolicy,
       drift,
     };
@@ -234,6 +243,7 @@ export function resolveExecutionContext(args: {
     progressiveToolDiscovery: readProgressiveToolDiscovery(hostConfig),
     modelId: readString(hostConfig, "modelId"),
     selectedServerIds: readStringArray(hostConfig, "selectedServerIds"),
+    builtInToolIds: readStringArray(hostConfig, "builtInToolIds"),
   };
 
   const systemPrompt = pickField(
@@ -292,6 +302,14 @@ export function resolveExecutionContext(args: {
   );
   if (selectedServerIds.drift) drift.push(selectedServerIds.drift);
 
+  const builtInToolIds = pickField(
+    "builtInToolIds",
+    overrides.builtInToolIds,
+    hostFields.builtInToolIds,
+    precedence,
+  );
+  if (builtInToolIds.drift) drift.push(builtInToolIds.drift);
+
   return {
     systemPrompt: systemPrompt.value,
     temperature: temperature.value,
@@ -301,6 +319,7 @@ export function resolveExecutionContext(args: {
     progressiveToolDiscovery: progressiveToolDiscovery.value,
     modelId: modelId.value,
     selectedServerIds: selectedServerIds.value,
+    builtInToolIds: builtInToolIds.value,
     hostPolicy,
     drift,
   };

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -37,6 +37,15 @@ export interface ChatV2Request {
   selectedServerIds?: string[];
   requireToolApproval?: boolean;
   /**
+   * HostConfig v2 built-in tool ids (e.g. `["web_search"]`) the client wants
+   * advertised this turn. For chatbox-bound requests the server re-resolves
+   * from the host's pinned config (host wins); for playground/direct chat the
+   * body value is used as-is. Billing authorization happens server-side in
+   * Convex (bearer + projectId), so a tampered body can't bill a project the
+   * caller isn't authorized on.
+   */
+  builtInToolIds?: string[];
+  /**
    * Host-level opt-in for progressive MCP tool discovery
    * (`search_mcp_tools` / `load_mcp_tools` meta-tools instead of sending
    * every tool definition every turn). Sourced from the project's default


### PR DESCRIPTION
## Summary

`builtInToolIds` is a HostConfig v2 dimension (SDK #2511), but nothing server-side consumed it — only the docs agent built the `web_search` tool, inline and unconditionally. This PR wires the dimension end-to-end so toggling `web_search` on a host config has runtime effect across every engine, with one shared construction path.

### Resolver
- `resolveExecutionContext` now extracts `builtInToolIds` from hostConfig records and accepts it as a per-call override, so chatbox-pinned configs, eval suite hostConfigs, and request bodies all resolve through the same precedence rules as the other execution fields.

### Registry (new)
- `server/utils/built-in-tools/registry.ts` turns resolved ids into runnable AI SDK tools (`web_search` → Exa via the Convex HTTP action that owns the key + billing). Unknown ids degrade to "tool absent" with a warn.
- `safeResolveBuiltInTools` encodes the no-Convex-auth case: paths that can't bill the tool omit it instead of advertising an execute that can only fail.

### Consumers
- **chat-v2 routes (web + mcp)**: resolve `builtInTools` off the resolved execution context and pass them to `prepareChatV2`, which already had the collision-guarded merge. The docs agent (`mcpjam-agent.ts`) now uses the registry instead of its inline construction.
- **Eval runners**: backend iteration runners derive the billing project from the same target the org-BYOK/jam billing paths use (`resolveOrgTargetForEval`) and thread `builtInTools` into `prepareChatV2` — non-stream and streamed variants. Local-AI-SDK BYOK paths omit them by design (no Convex auth to bill against); the omission is debug-logged.
- **sessionSimulation**: threads the chatbox runtime-config's `builtInToolIds` through to each synthetic session, so simulated visitors see the same tool set a real visitor gets.

Backend support (runtime-config returning `builtInToolIds`) landed in mcpjam-backend #484; older backends omit the field and resolve to no built-in tools.

## Tests
- Resolver: host/override/precedence/null-host/type-guard cases for `builtInToolIds`.
- Registry: known/unknown ids, empty ids, null auth context, raw-bearer normalization.
- Eval runners: `prepareChatV2` receives `web_search` on the backend path (suite + streamed), omits it when no project target exists, and omits it on the local BYOK path.

## Verification
- `vitest --project server`: 1353 passed; the only failures (11) are the pre-existing headless-Chromium-dependent harness/computer-use tests, which fail identically on the base branch in this environment.
- `tsc --noEmit -p server`: no new errors vs. base (same 10 pre-existing unused-import diagnostics).
- `typecheck:client`: clean.

End-to-end verification (attach `web_search` to an eval suite host config, run, confirm the Exa call + credit debit) needs a deployed backend with the seeded catalog and is left as a follow-up check.

https://claude.ai/code/session_01Cjw3u8k6z3Ykpa8kREm2M1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cjw3u8k6z3Ykpa8kREm2M1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span multiple chat/eval entry points and credit-billed Convex tool execution; guest auth timing for MCPJam models affects which tools appear on stream requests.
> 
> **Overview**
> HostConfig **`builtInToolIds`** (e.g. **`web_search`**) now drives runtime tool advertisement across chat, eval, and synthetic sessions instead of staying unused except on the docs agent.
> 
> **`resolveExecutionContext`** resolves **`builtInToolIds`** from host config and request overrides with the same host-wins precedence as other execution fields; array drift compares by value, not reference. A new **`built-in-tools/registry`** maps ids to runnable AI SDK tools (Convex-billed Exa search) via **`safeResolveBuiltInTools`**, which omits tools when auth/project context is missing rather than exposing broken executes.
> 
> **MCP and web chat-v2** pass resolved built-ins into **`prepareChatV2`**; **mcp/chat-v2** eagerly resolves guest MCPJam auth before tool prep so guest turns still get host-enabled built-ins on the Convex stream payload. **Eval backend runners** attach built-ins when a project billing target exists; local BYOK paths intentionally skip them. **Session simulation** threads chatbox runtime **`builtInToolIds`** into synthetic sessions; **mcpjam-agent** switches from inline Exa construction to the shared registry while still always enabling **`web_search`**.
> 
> Shared **`ChatV2Request`** and chatbox runtime config types gain optional **`builtInToolIds`**; tests cover registry behavior, resolver precedence, eval path branching, and guest MCPJam stream tool advertisement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53add0db99c1ceb952aa909c5b03763f8d5de43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->