### PR TITLE
servers: add Snapshot view to History tab (Revision 1 now expandable)

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerHistoryContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerHistoryContent.tsx
@@ -36,12 +36,17 @@ interface SnapshotDiff {
   };
 }
 
-const SOURCE_LABEL: Record<RevisionSource, string> = {
-  connect: "Connect",
-  evalRun: "Eval run",
-  chatSession: "Chat",
-  traceRepair: "Trace repair",
-};
+interface SnapshotTool {
+  name: string;
+  description?: string;
+}
+
+interface RevisionSnapshot {
+  snapshot: {
+    tools?: SnapshotTool[];
+  };
+  counts: { tools: number };
+}
 
 function compactAgo(ms: number): string {
   const seconds = Math.max(0, Math.floor((Date.now() - ms) / 1000));
@@ -98,17 +103,15 @@ export function ServerHistoryContent({
       {revisions.map((rev, i) => {
         const prev = revisions[i + 1];
         const isLatest = i === 0;
-        const expandable = rev.revisionNumber > 1;
         const isOpen = expanded === rev.revisionNumber;
         return (
           <div key={rev.revisionNumber}>
             <button
               type="button"
-              disabled={!expandable}
               onClick={() =>
-                expandable && setExpanded(isOpen ? null : rev.revisionNumber)
+                setExpanded(isOpen ? null : rev.revisionNumber)
               }
-              className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left hover:bg-muted/50 disabled:cursor-default disabled:hover:bg-transparent"
+              className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left hover:bg-muted/50"
             >
               <span
                 className={`h-2 w-2 shrink-0 rounded-full ${
@@ -118,7 +121,6 @@ export function ServerHistoryContent({
               <span className="shrink-0 text-[13px] font-medium">
                 Revision {rev.revisionNumber}
               </span>
-              <SourceBadge source={rev.source} latest={isLatest} />
               <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted-foreground">
                 <DeltaLabel rev={rev} prev={prev} />
               </span>
@@ -127,16 +129,17 @@ export function ServerHistoryContent({
               </span>
               <ChevronRight
                 className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${
-                  expandable ? "" : "invisible"
-                } ${isOpen ? "rotate-90" : ""}`}
+                  isOpen ? "rotate-90" : ""
+                }`}
               />
             </button>
             {isOpen && (
               <div className="mb-1 ml-[18px]">
-                <RevisionDiff
+                <RevisionDetail
                   projectId={projectId}
                   serverId={serverId}
                   revisionNumber={rev.revisionNumber}
+                  hasPrev={!!prev}
                 />
               </div>
             )}
@@ -144,33 +147,6 @@ export function ServerHistoryContent({
         );
       })}
     </div>
-  );
-}
-
-function SourceBadge({
-  source,
-  latest,
-}: {
-  source: RevisionSource;
-  latest?: boolean;
-}) {
-  const tone =
-    source === "connect"
-      ? "bg-info/10 text-info"
-      : source === "evalRun"
-      ? "bg-primary/10 text-primary"
-      : "bg-muted text-muted-foreground";
-  return (
-    <span className="flex shrink-0 items-center gap-1.5">
-      {latest && (
-        <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
-          Latest
-        </span>
-      )}
-      <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tone}`}>
-        {SOURCE_LABEL[source]}
-      </span>
-    </span>
   );
 }
 
@@ -182,11 +158,7 @@ function DeltaLabel({
   prev?: RevisionSummary;
 }) {
   if (!prev) {
-    return rev.revisionNumber === 1 ? (
-      <>Initial snapshot · {rev.counts.tools} tools</>
-    ) : (
-      <>{rev.counts.tools} tools</>
-    );
+    return <>{rev.counts.tools} tools</>;
   }
   const delta = rev.counts.tools - prev.counts.tools;
   if (delta > 0)
@@ -204,7 +176,125 @@ function DeltaLabel({
   return <>Updated</>;
 }
 
-function RevisionDiff({
+function RevisionDetail({
+  projectId,
+  serverId,
+  revisionNumber,
+  hasPrev,
+}: {
+  projectId: string;
+  serverId: string;
+  revisionNumber: number;
+  hasPrev: boolean;
+}) {
+  const [mode, setMode] = useState<"diff" | "snapshot">(
+    hasPrev ? "diff" : "snapshot"
+  );
+  return (
+    <div className="space-y-3 rounded-lg bg-muted/30 p-3 text-[12.5px]">
+      {hasPrev && <ViewToggle mode={mode} onChange={setMode} />}
+      {mode === "diff" ? (
+        <DiffBody
+          projectId={projectId}
+          serverId={serverId}
+          revisionNumber={revisionNumber}
+        />
+      ) : (
+        <SnapshotBody
+          projectId={projectId}
+          serverId={serverId}
+          revisionNumber={revisionNumber}
+        />
+      )}
+    </div>
+  );
+}
+
+function ViewToggle({
+  mode,
+  onChange,
+}: {
+  mode: "diff" | "snapshot";
+  onChange: (next: "diff" | "snapshot") => void;
+}) {
+  return (
+    <div className="inline-flex rounded-md bg-muted/60 p-0.5 text-[11px] font-medium">
+      {(["diff", "snapshot"] as const).map((option) => {
+        const active = mode === option;
+        return (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            className={`rounded px-2 py-0.5 capitalize ${
+              active
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {option}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SnapshotBody({
+  projectId,
+  serverId,
+  revisionNumber,
+}: {
+  projectId: string;
+  serverId: string;
+  revisionNumber: number;
+}) {
+  const result = useQuery(
+    "serverInspections:getInspectionRevision" as never,
+    {
+      projectId,
+      serverId,
+      revisionNumber,
+    } as never
+  ) as RevisionSnapshot | null | undefined;
+
+  if (result === undefined) {
+    return <Skeleton className="h-4 w-40" />;
+  }
+  if (result === null) {
+    return (
+      <div className="text-[11.5px] text-muted-foreground">
+        Snapshot unavailable
+      </div>
+    );
+  }
+
+  const tools = result.snapshot.tools ?? [];
+  if (tools.length === 0) {
+    return (
+      <div className="text-[11.5px] text-muted-foreground">No tools</div>
+    );
+  }
+
+  return (
+    <DiffGroup
+      label={`Tools (${result.counts.tools})`}
+      tone="text-muted-foreground"
+    >
+      {tools.map((tool) => (
+        <DiffRow
+          key={tool.name}
+          sigil="·"
+          tone="text-muted-foreground"
+          name={tool.name}
+          note={tool.description}
+        />
+      ))}
+    </DiffGroup>
+  );
+}
+
+function DiffBody({
   projectId,
   serverId,
   revisionNumber,
@@ -224,15 +314,11 @@ function RevisionDiff({
   ) as { diff: SnapshotDiff } | null | undefined;
 
   if (result === undefined) {
-    return (
-      <div className="rounded-lg bg-muted/30 p-3">
-        <Skeleton className="h-4 w-40" />
-      </div>
-    );
+    return <Skeleton className="h-4 w-40" />;
   }
   if (result === null) {
     return (
-      <div className="rounded-lg bg-muted/30 p-3 text-[11.5px] text-muted-foreground">
+      <div className="text-[11.5px] text-muted-foreground">
         Diff unavailable
       </div>
     );
@@ -247,7 +333,7 @@ function RevisionDiff({
     !discovery?.changed;
 
   return (
-    <div className="space-y-3 rounded-lg bg-muted/30 p-3 text-[12.5px]">
+    <>
       {added.length > 0 && (
         <DiffGroup label={`Added (${added.length})`} tone="text-success">
           {added.map((tool) => (
@@ -301,7 +387,7 @@ function RevisionDiff({
           No tool changes
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/connection/ServerHistoryContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerHistoryContent.tsx
@@ -139,7 +139,7 @@ export function ServerHistoryContent({
                   projectId={projectId}
                   serverId={serverId}
                   revisionNumber={rev.revisionNumber}
-                  hasPrev={!!prev}
+                  hasPrev={rev.revisionNumber > 1}
                 />
               </div>
             )}


### PR DESCRIPTION
The History tab's expanded panel previously only rendered a diff against the previous revision, so Revision 1 had no clickable affordance and clicking did nothing. Adds a Diff/Snapshot toggle inside the expanded panel: Diff stays the default for revisions 2+, Snapshot lists the tools captured at that revision. Revision 1 expands straight into Snapshot (no toggle clutter when there's nothing to diff against).

Backend unchanged — reuses serverInspections.getInspectionRevision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI in ServerHistoryContent; reuses existing Convex queries with no auth or data-model changes.
> 
> **Overview**
> The **History** tab on server connection now lets every revision expand, including **Revision 1**, which previously had no working expand affordance because the panel only loaded a diff against the prior revision.
> 
> Expanded rows show a **Diff / Snapshot** toggle when a previous revision exists (**Diff** stays default). **Snapshot** loads `serverInspections:getInspectionRevision` and lists tools (name + description) for that revision. **Revision 1** opens directly in Snapshot with no toggle.
> 
> The timeline UI is simplified: **source badges** and the **Latest** label are removed, all revisions are clickable with a visible chevron, and the first-revision delta line no longer says “Initial snapshot”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0d70346ae003fb08c9273a0b7a991ca54f792b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->