### PR TITLE
docs: let readers create an API key straight from the public API docs

### DIFF
--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -14,7 +14,7 @@ icon: "key"
 
 The key for the **[MCPJam API](/reference/public-api)** — programmatic access to live MCP server diagnostics at `https://app.mcpjam.com/api/v1/...`. This is the one to reach for whenever you mean "the MCPJam API key."
 
-**Where it lives:** **Settings → API keys** in the hosted app. Shown **exactly once** at creation — store it in your own secret manager or an environment variable.
+**Where it lives:** [**Settings → API keys**](https://app.mcpjam.com/settings/api-keys) in the hosted app — that link takes you straight to key creation (sign in if prompted; you'll land back on the page). Shown **exactly once** at creation — store it in your own secret manager or an environment variable.
 
 **When it's used:** Every `Authorization: Bearer sk_…` request to `/api/v1/*` — validating servers, running the doctor, listing tools/prompts/resources, reading resources, exporting snapshots.
 
@@ -60,7 +60,7 @@ A project-scoped token for `@mcpjam/sdk` / CLI traffic to the hosted backend, ge
 
 | Key | Format | Issued by | Use it for |
 | --- | --- | --- | --- |
-| **MCPJam API key** | `sk_…` | Settings → API keys | The [MCPJam API](/reference/public-api) (`/api/v1/*`) |
+| **MCPJam API key** | `sk_…` | [Settings → API keys](https://app.mcpjam.com/settings/api-keys) | The [MCPJam API](/reference/public-api) (`/api/v1/*`) |
 | LLM provider key | provider-specific | the LLM provider | Playground chat — *third-party* |
 | Playground BYOK | server-specific | your MCP server | Authenticating to one MCP server — *third-party* |
 | Project API Key | `mcpjam_…` | Settings (legacy) | **Deprecated** — `@mcpjam/sdk` / CLI |

--- a/docs/reference/public-api.mdx
+++ b/docs/reference/public-api.mdx
@@ -55,8 +55,19 @@ curl -X POST \
 
 ### Creating a key
 
-1. Open [app.mcpjam.com](https://app.mcpjam.com) and go to **Settings → API keys**.
-2. Click **Create key**, name it, and pick the **organization** it will act in.
+<Card
+  title="Create an API key"
+  icon="key"
+  href="https://app.mcpjam.com/settings/api-keys"
+  horizontal
+>
+  Go straight to key management in the hosted app. If you're signed out,
+  you'll be asked to sign in and then land right back on this page.
+</Card>
+
+1. Open [**Settings → API keys**](https://app.mcpjam.com/settings/api-keys)
+   in the hosted app (the card above takes you there directly).
+2. Click **Create API key**, name it, and pick the **organization** it will act in.
 3. Copy the key (`sk_…`) immediately — **it is shown exactly once** and never
    stored by MCPJam in retrievable form.
 
@@ -87,11 +98,12 @@ Treat an API key like a password:
   source control or ship it in client-side code.
 - Scope keys narrowly: one key per integration, named so you can tell them apart.
 - Rotate by creating a replacement key, switching traffic, then revoking the old one.
-- If a key leaks, revoke it immediately in **Settings → API keys**.
+- If a key leaks, revoke it immediately in
+  [**Settings → API keys**](https://app.mcpjam.com/settings/api-keys).
 
 If you see `401 UNAUTHORIZED` with `details.reason: "ORPHANED_KEY"`, the key
 is no longer bound to an organization and cannot be used — create a new key
-from Settings.
+from [Settings](https://app.mcpjam.com/settings/api-keys).
 
 ## Conventions
 

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -179,6 +179,10 @@ import {
   readCliSignInReturnPath,
 } from "./lib/cli-signin-return-path";
 import {
+  clearApiKeysSignInReturnPath,
+  readApiKeysSignInReturnPath,
+} from "./lib/api-keys-signin-return-path";
+import {
   sanitizeHostedOAuthErrorMessage,
   clearHostedOAuthResumeMarker,
   writeHostedOAuthResumeMarker,
@@ -1492,13 +1496,19 @@ export default function App() {
         ? readBillingSignInReturnPath()
         : null;
       const cliReturnPath = readCliSignInReturnPath();
+      const apiKeysReturnPath = readApiKeysSignInReturnPath();
       clearChatboxSignInReturnPath();
       clearBillingSignInReturnPath();
       clearCliSignInReturnPath();
+      clearApiKeysSignInReturnPath();
       window.history.replaceState(
         {},
         "",
-        chatboxReturnPath ?? billingReturnPath ?? cliReturnPath ?? "/"
+        chatboxReturnPath ??
+          billingReturnPath ??
+          cliReturnPath ??
+          apiKeysReturnPath ??
+          "/"
       );
       setCallbackCompleted(true);
       setCallbackRecoveryExpired(false);

--- a/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useConvexAuth } from "convex/react";
+import { useAuth } from "@workos-inc/authkit-react";
 import { Key, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
@@ -14,6 +15,7 @@ import {
   listApiKeys,
   revokeApiKey,
 } from "@/lib/apis/web/api-keys";
+import { writeApiKeysSignInReturnPath } from "@/lib/api-keys-signin-return-path";
 
 /**
  * `/settings/api-keys` — manage WorkOS-issued `sk_…` API keys for the
@@ -34,6 +36,10 @@ export function ApiKeysRoute() {
   const [isRevoking, setIsRevoking] = useState(false);
 
   const { isAuthenticated } = useConvexAuth();
+  // Guests authenticate to Convex too, so gate this surface on the WorkOS
+  // user: the key-management API rejects guest sessions outright.
+  const { user, signIn, isLoading: isAuthLoading } = useAuth();
+  const isSignedIn = Boolean(user);
   const { sortedOrganizations, isLoading: orgsLoading } =
     useOrganizationQueries({ isAuthenticated });
 
@@ -52,8 +58,14 @@ export function ApiKeysRoute() {
   }, []);
 
   useEffect(() => {
+    if (!isSignedIn) return;
     void refresh();
-  }, [refresh]);
+  }, [refresh, isSignedIn]);
+
+  const handleSignIn = useCallback(() => {
+    writeApiKeysSignInReturnPath("/settings/api-keys");
+    signIn();
+  }, [signIn]);
 
   const handleCreate = async ({
     name,
@@ -95,6 +107,32 @@ export function ApiKeysRoute() {
       setIsRevoking(false);
     }
   };
+
+  if (isAuthLoading) {
+    return (
+      <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+        Loading…
+      </div>
+    );
+  }
+
+  if (!isSignedIn) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-8">
+        <div className="text-center space-y-4 max-w-md">
+          <h2 className="text-2xl font-bold">Sign in to manage API keys</h2>
+          <p className="text-sm text-muted-foreground">
+            API keys for the MCPJam API are tied to your account. Sign in (or
+            create a free account) and you'll come right back here to create
+            one.
+          </p>
+          <Button onClick={handleSignIn} size="lg">
+            Sign In
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full overflow-y-auto">

--- a/mcpjam-inspector/client/src/lib/__tests__/api-keys-signin-return-path.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/api-keys-signin-return-path.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearApiKeysSignInReturnPath,
+  readApiKeysSignInReturnPath,
+  writeApiKeysSignInReturnPath,
+} from "../api-keys-signin-return-path";
+
+describe("api-keys-signin-return-path", () => {
+  afterEach(() => {
+    clearApiKeysSignInReturnPath();
+  });
+
+  it("round-trips the API keys settings route", () => {
+    writeApiKeysSignInReturnPath("/settings/api-keys");
+
+    expect(readApiKeysSignInReturnPath()).toBe("/settings/api-keys");
+  });
+
+  it("falls back to root for empty or unknown routes", () => {
+    writeApiKeysSignInReturnPath("/not-an-app-route");
+
+    expect(readApiKeysSignInReturnPath()).toBe("/");
+
+    clearApiKeysSignInReturnPath();
+    writeApiKeysSignInReturnPath("");
+
+    expect(readApiKeysSignInReturnPath()).toBe("/");
+  });
+
+  it("clears the stored path", () => {
+    writeApiKeysSignInReturnPath("/settings/api-keys");
+    clearApiKeysSignInReturnPath();
+
+    expect(readApiKeysSignInReturnPath()).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/api-keys-signin-return-path.ts
+++ b/mcpjam-inspector/client/src/lib/api-keys-signin-return-path.ts
@@ -1,0 +1,68 @@
+import { normalizeReturnTargetPath, routePaths } from "./app-navigation";
+
+/**
+ * Sign-in return path for the `/settings/api-keys` surface.
+ *
+ * The docs deep-link signed-out readers straight to the API keys page;
+ * persisting the path across the AuthKit redirect lands them back on key
+ * management instead of the app root after they sign in. Same pattern as
+ * the chatbox/billing/CLI return paths consumed by the `/callback` handler
+ * in `App.tsx`.
+ */
+
+const API_KEYS_SIGN_IN_RETURN_PATH_STORAGE_KEY =
+  "mcpjam_api_keys_signin_return_path_v1";
+
+function normalizeApiKeysReturnPath(path: string | null | undefined): string {
+  const trimmed = path?.trim() ?? "";
+  if (!trimmed || trimmed === routePaths.root || trimmed.startsWith("/?")) {
+    return routePaths.root;
+  }
+  return normalizeReturnTargetPath(trimmed, routePaths.root);
+}
+
+export function writeApiKeysSignInReturnPath(
+  path: string | null | undefined
+): void {
+  if (typeof sessionStorage === "undefined") {
+    return;
+  }
+
+  const normalizedPath = normalizeApiKeysReturnPath(path);
+  try {
+    sessionStorage.setItem(
+      API_KEYS_SIGN_IN_RETURN_PATH_STORAGE_KEY,
+      normalizedPath
+    );
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+export function readApiKeysSignInReturnPath(): string | null {
+  if (typeof sessionStorage === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = sessionStorage.getItem(
+      API_KEYS_SIGN_IN_RETURN_PATH_STORAGE_KEY
+    );
+    if (!raw) return null;
+    return normalizeApiKeysReturnPath(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function clearApiKeysSignInReturnPath(): void {
+  if (typeof sessionStorage === "undefined") {
+    return;
+  }
+
+  try {
+    sessionStorage.removeItem(API_KEYS_SIGN_IN_RETURN_PATH_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}


### PR DESCRIPTION
## Summary

The [public API reference](https://docs.mcpjam.com/reference/public-api) told readers to "open app.mcpjam.com and go to **Settings → API keys**" but gave them nothing to click — and the deep link it implied didn't actually work for the docs audience: a signed-out visitor landing on `/settings/api-keys` got failing request toasts, and after signing in they were dumped back at the app root instead of the key page.

This makes "get an API key from the docs" a one-click flow:

### Docs
- Add a **Create an API key** card in `reference/public-api.mdx` linking straight to `https://app.mcpjam.com/settings/api-keys`, and turn the remaining "Settings → API keys" mentions (here and in `reference/api-keys.mdx`) into direct links.

### App
- `/settings/api-keys` now has a proper signed-out state: a sign-in prompt instead of firing key-list requests that 401 into error toasts. The gate is the WorkOS user (not Convex auth), since guest sessions authenticate to Convex but can't mint keys.
- Sign-in from that page persists `/settings/api-keys` as a return path (same sessionStorage pattern as the existing chatbox/billing/CLI return paths), and the `/callback` handler restores it — so docs readers land back on key management after auth instead of `/`.

## Testing
- `npm run typecheck:client` passes
- New unit test `api-keys-signin-return-path.test.ts` (round-trip, unknown-route fallback, clear) passes
- Existing `App.hosted-oauth.test.tsx` callback-flow suite (58 tests) passes

https://claude.ai/code/session_01UPwRqcbzvFpydt5gAEtae1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPwRqcbzvFpydt5gAEtae1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and sign-in redirect UX only; no changes to API key issuance, revocation, or authorization on the server.
> 
> **Overview**
> **Docs** now deep-link to `https://app.mcpjam.com/settings/api-keys` — a **Create an API key** card on the public API reference plus clickable **Settings → API keys** links in `api-keys.mdx` and `public-api.mdx`, so readers can jump straight to key management.
> 
> **Hosted app** fixes the signed-out experience on `/settings/api-keys`: instead of firing list requests that 401 into toasts, the page shows a **Sign in to manage API keys** prompt gated on the **WorkOS user** (not Convex auth, since guests can authenticate to Convex but cannot mint keys). Sign-in stores `/settings/api-keys` in sessionStorage and the **`/callback`** handler restores that path after auth (same pattern as chatbox/billing/CLI return paths), so doc deep-links land back on key management instead of `/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdabc01e75b0feed375fcedc151d40e37ce34be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->