### PR TITLE
feat(evals): browser-rendered MCP App artifacts on hosted runner paths (PR 14)

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -113,6 +113,10 @@ import type {
 } from "../utils/mcpjam-stream-handler.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
 import { finalizeEvalIteration } from "./evals/finalize-iteration.js";
+import {
+  createEvalBrowserContext,
+  type EvalBrowserContext,
+} from "./evals/browser-eval-context.js";
 import type {
   EvalStreamEvent,
   EvalStreamToolCall,
@@ -1779,39 +1783,61 @@ const runIterationWithAiSdk = async ({
   }
 };
 
-const runIterationViaBackend = async ({
-  test,
-  runIndex,
-  // Suite-level raw set retained for `toolSignals`; per-iteration tool prep
-  // is delegated to prepareChatV2 below.
-  tools: _suiteTools,
-  selectedServers,
-  mcpClientManager,
-  recorder,
-  testCaseId,
-  // `convexHttpUrl` is in the RunIterationBackendParams type because the
-  // streaming variant (`streamIterationViaBackend`) still uses it for
-  // its legacy per-step fetch loop (PR 5 collapses that). The non-stream
-  // path now drives `runAssistantTurn`, which reads
-  // `process.env.CONVEX_HTTP_URL` directly — so the runner-level param
-  // is dead here. Kept in the type signature (no API churn) but no
-  // longer destructured.
-  convexAuthToken,
-  modelId,
-  modelDefinition,
-  orgModelConfig,
-  endpointPath = "/stream",
-  extraBodyFields,
-  convexClient,
-  runId,
-  abortSignal,
-  compareRunId,
-  precreatedIterationId,
-  injectOpenAiCompat,
-  hostPolicy,
-  toolSignals,
-  suiteHostConfig,
-}: RunIterationBackendParams) => {
+const runIterationViaBackend = async (params: RunIterationBackendParams) => {
+  // Browser-rendered MCP App eval (PR 14): hosted-path harness context — the
+  // engine-attached equivalent of the local runners' inline harness wiring
+  // (computer tools, advertised-tool gate, render hook, artifact collectors).
+  // The wrapper owns disposal: try/finally guarantees a launched Chromium is
+  // torn down on EVERY exit (cancellation early-returns, setup failures,
+  // finalize throws), which per-exit dispose calls could miss.
+  const browser = createEvalBrowserContext({
+    model: params.test.model,
+    mcpClientManager: params.mcpClientManager,
+    injectOpenAiCompat: params.injectOpenAiCompat,
+  });
+  try {
+    return await runIterationViaBackendWithBrowser(params, browser);
+  } finally {
+    await browser.dispose();
+  }
+};
+
+const runIterationViaBackendWithBrowser = async (
+  {
+    test,
+    runIndex,
+    // Suite-level raw set retained for `toolSignals`; per-iteration tool prep
+    // is delegated to prepareChatV2 below.
+    tools: _suiteTools,
+    selectedServers,
+    mcpClientManager,
+    recorder,
+    testCaseId,
+    // `convexHttpUrl` is in the RunIterationBackendParams type because the
+    // streaming variant (`streamIterationViaBackend`) still uses it for
+    // its legacy per-step fetch loop (PR 5 collapses that). The non-stream
+    // path now drives `runAssistantTurn`, which reads
+    // `process.env.CONVEX_HTTP_URL` directly — so the runner-level param
+    // is dead here. Kept in the type signature (no API churn) but no
+    // longer destructured.
+    convexAuthToken,
+    modelId,
+    modelDefinition,
+    orgModelConfig,
+    endpointPath = "/stream",
+    extraBodyFields,
+    convexClient,
+    runId,
+    abortSignal,
+    compareRunId,
+    precreatedIterationId,
+    injectOpenAiCompat,
+    hostPolicy,
+    toolSignals,
+    suiteHostConfig,
+  }: RunIterationBackendParams,
+  browser: EvalBrowserContext,
+) => {
   const resolvedTest = resolveEvalTestCase(test);
 
   // Check if run was cancelled before starting iteration
@@ -2067,12 +2093,23 @@ const runIterationViaBackend = async ({
 
     const promptTurn = promptTurns[promptIndex]!;
 
+    // Browser-rendered MCP App eval (PR 14): stamp collected artifacts with
+    // this turn, and start the turn with a clean widget surface — a widget
+    // kept mounted by a previous prompt turn must not bleed into this one
+    // (otherwise Computer Use could be advertised against the prior turn's
+    // widget before this turn's own MCP App tool runs).
+    browser.setActivePromptIndex(promptIndex);
+    await browser.dismissCarriedWidget();
+
     // Per-turn span-capture context. `wrapToolSetForEvalTrace` instruments
     // each tool's `execute` to push to `traceCtx.recordedSpans`; we drain
     // into `capturedSpans` after the engine finishes.
     const traceCtx = createAiSdkEvalTraceContext(runStartedAt);
+    // PR 14: the Computer Use tools ride the same wrap so `computer` /
+    // `finish_widget` executions land as tool spans in the trace UI like
+    // every other locally-executed tool.
     const tracedTools = wrapToolSetForEvalTrace(
-      prepared.allTools,
+      { ...prepared.allTools, ...browser.computerWidgetTools },
       traceCtx,
       promptIndex,
     );
@@ -2140,6 +2177,16 @@ const runIterationViaBackend = async ({
         maxSteps: MAX_STEPS,
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
+        // Browser-rendered MCP App eval (PR 14): cache tool-call inputs for
+        // the widget shim, render MCP App tool results in the harness (the
+        // engine awaits the hook, so a mounted widget is visible to the next
+        // step's gate), and hide `computer` / `finish_widget` until a widget
+        // has actually rendered.
+        onToolCall: (event) => browser.noteToolCallInput(event),
+        onToolResult: (event) => browser.handleEngineToolResult(event),
+        ...(browser.prepareAdvertisedTools
+          ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
+          : {}),
       });
     } catch (error) {
       // Cancellation: bail without recording. AbortError can surface
@@ -2375,6 +2422,16 @@ const runIterationViaBackend = async ({
     ...(capturedSpans.length ? { spans: capturedSpans } : {}),
     ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
     ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
+    // Browser-rendered MCP App eval (PR 14): hosted-path browser artifacts.
+    // finalizeEvalIteration serializes them once (screenshot upload +
+    // sanitize) for both the W2 and W1 persistence paths — same machinery
+    // the local AI-SDK runners feed (PR 6b/9).
+    ...(browser.widgetRenderObservations.length
+      ? { widgetRenderObservations: browser.widgetRenderObservations }
+      : {}),
+    ...(browser.browserInteractionSteps.length
+      ? { browserInteractionSteps: browser.browserInteractionSteps }
+      : {}),
     status: "completed" as const,
     startedAt: runStartedAt,
     error: iterationError,
@@ -3926,41 +3983,64 @@ const streamIterationWithAiSdk = async ({
   }
 };
 
-const streamIterationViaBackend = async ({
-  test,
-  runIndex,
-  // Suite-level raw set retained for `toolSignals`; per-iteration tool prep
-  // is delegated to prepareChatV2 below.
-  tools: _suiteTools,
-  selectedServers,
-  mcpClientManager,
-  recorder,
-  testCaseId,
-  // PR 5b: `convexHttpUrl` is in the `RunIterationBackendParams` type
-  // (shared with the non-stream runner + the iterative path) but
-  // unused here — `runAssistantTurn` owns the Convex `/stream` fetch
-  // and reads its base URL from `CONVEX_HTTP_URL` env / the configured
-  // chat-orchestration helpers. Kept on the params type so the caller
-  // shape stays uniform across runners.
-  convexAuthToken,
-  modelId,
-  modelDefinition,
-  orgModelConfig,
-  endpointPath = "/stream",
-  extraBodyFields,
-  convexClient,
-  runId,
-  abortSignal,
-  emit,
-  compareRunId,
-  precreatedIterationId,
-  injectOpenAiCompat,
-  hostPolicy,
-  toolSignals,
-  suiteHostConfig,
-}: RunIterationBackendParams & {
-  emit: StreamEmit;
-}): Promise<EvalIterationOutcome> => {
+const streamIterationViaBackend = async (
+  params: RunIterationBackendParams & {
+    emit: StreamEmit;
+  },
+): Promise<EvalIterationOutcome> => {
+  // Browser-rendered MCP App eval (PR 14): hosted-path harness context for
+  // the streaming runner — same wiring as `runIterationViaBackend`; the
+  // wrapper's try/finally guarantees Chromium teardown on every exit.
+  const browser = createEvalBrowserContext({
+    model: params.test.model,
+    mcpClientManager: params.mcpClientManager,
+    injectOpenAiCompat: params.injectOpenAiCompat,
+  });
+  try {
+    return await streamIterationViaBackendWithBrowser(params, browser);
+  } finally {
+    await browser.dispose();
+  }
+};
+
+const streamIterationViaBackendWithBrowser = async (
+  {
+    test,
+    runIndex,
+    // Suite-level raw set retained for `toolSignals`; per-iteration tool prep
+    // is delegated to prepareChatV2 below.
+    tools: _suiteTools,
+    selectedServers,
+    mcpClientManager,
+    recorder,
+    testCaseId,
+    // PR 5b: `convexHttpUrl` is in the `RunIterationBackendParams` type
+    // (shared with the non-stream runner + the iterative path) but
+    // unused here — `runAssistantTurn` owns the Convex `/stream` fetch
+    // and reads its base URL from `CONVEX_HTTP_URL` env / the configured
+    // chat-orchestration helpers. Kept on the params type so the caller
+    // shape stays uniform across runners.
+    convexAuthToken,
+    modelId,
+    modelDefinition,
+    orgModelConfig,
+    endpointPath = "/stream",
+    extraBodyFields,
+    convexClient,
+    runId,
+    abortSignal,
+    emit,
+    compareRunId,
+    precreatedIterationId,
+    injectOpenAiCompat,
+    hostPolicy,
+    toolSignals,
+    suiteHostConfig,
+  }: RunIterationBackendParams & {
+    emit: StreamEmit;
+  },
+  browser: EvalBrowserContext,
+): Promise<EvalIterationOutcome> => {
   const resolvedTest = resolveEvalTestCase(test);
 
   // Check if run was cancelled before starting iteration
@@ -4228,6 +4308,12 @@ const streamIterationViaBackend = async ({
       content: promptTurn.prompt,
     });
 
+    // Browser-rendered MCP App eval (PR 14): stamp collected artifacts with
+    // this turn, and start the turn with a clean widget surface (a widget
+    // kept mounted by a previous prompt turn must not bleed into this one).
+    browser.setActivePromptIndex(promptIndex);
+    await browser.dismissCarriedWidget();
+
     emit({
       type: "turn_start",
       turnIndex: promptIndex,
@@ -4239,8 +4325,10 @@ const streamIterationViaBackend = async ({
     // `traceCtx.recordedSpans`; we drain into `capturedSpans` after the
     // engine finishes (same shape as the non-stream backend runner).
     const traceCtx = createAiSdkEvalTraceContext(runStartedAt);
+    // PR 14: Computer Use tools ride the same wrap (see the non-stream
+    // backend runner).
     const tracedTools = wrapToolSetForEvalTrace(
-      prepared.allTools,
+      { ...prepared.allTools, ...browser.computerWidgetTools },
       traceCtx,
       promptIndex,
     );
@@ -4343,6 +4431,9 @@ const streamIterationViaBackend = async ({
     };
     const onToolCall = (event: MCPJamToolCallEvent) => {
       if (!event.toolName) return;
+      // PR 14: cache the input so the widget render hook can feed the
+      // OpenAI-compat shim the real tool-call args.
+      browser.noteToolCallInput(event);
       const args = (event.input ?? {}) as Record<string, unknown>;
       promptToolsCalled.push({
         toolName: event.toolName,
@@ -4361,7 +4452,7 @@ const streamIterationViaBackend = async ({
         args,
       });
     };
-    const onToolResult = (event: MCPJamToolResultEvent) => {
+    const onToolResult = async (event: MCPJamToolResultEvent) => {
       partialToolResultMessages.push({
         role: "tool",
         content: [
@@ -4380,6 +4471,11 @@ const streamIterationViaBackend = async ({
         result: event.output,
         isError: event.isError,
       });
+      // PR 14: render MCP App tool results in the harness AFTER the SSE
+      // emit (live consumers shouldn't wait on Chromium). The engine awaits
+      // this callback, so the widget is mounted before the next step's
+      // advertised-tool gate runs.
+      await browser.handleEngineToolResult(event);
     };
     const onStepFinish = (event: MCPJamStepFinishEvent) => {
       // Marcelo's PR 5b-pre review caveat: only emit `step_finish` for
@@ -4534,6 +4630,11 @@ const streamIterationViaBackend = async ({
         onToolResult,
         onStepFinish,
         onEngineError,
+        // Browser-rendered MCP App eval (PR 14): hide `computer` /
+        // `finish_widget` until a widget has actually rendered.
+        ...(browser.prepareAdvertisedTools
+          ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
+          : {}),
       });
     } catch (error) {
       // Cancellation: bail without recording. AbortError can surface
@@ -4877,6 +4978,14 @@ const streamIterationViaBackend = async ({
     ...(capturedSpans.length ? { spans: capturedSpans } : {}),
     ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
     ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
+    // Browser-rendered MCP App eval (PR 14): hosted-path browser artifacts
+    // (see the non-stream backend runner).
+    ...(browser.widgetRenderObservations.length
+      ? { widgetRenderObservations: browser.widgetRenderObservations }
+      : {}),
+    ...(browser.browserInteractionSteps.length
+      ? { browserInteractionSteps: browser.browserInteractionSteps }
+      : {}),
     status: "completed" as const,
     startedAt: runStartedAt,
     error: iterationError,

--- a/mcpjam-inspector/server/services/evals/__tests__/browser-eval-context.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/browser-eval-context.test.ts
@@ -1,0 +1,378 @@
+/**
+ * browser-eval-context.test.ts — hosted-path browser eval context (PR 14).
+ *
+ * Covers the engine-attachment surface the hosted runners
+ * (`runIterationViaBackend` / `streamIterationViaBackend`) wire into
+ * `runAssistantTurn`: Computer Use tool construction (wire format), the
+ * advertised-tool gate, the render hook (engine `onToolResult`), input
+ * caching, prompt-index stamping, and disposal.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const renderMcpAppToolResult = vi.fn();
+const isRenderableMcpAppTool = vi.fn();
+
+vi.mock("../../../utils/mcp-app-render-observation", () => ({
+  renderMcpAppToolResult: (...args: unknown[]) =>
+    renderMcpAppToolResult(...args),
+  isRenderableMcpAppTool: (...args: unknown[]) =>
+    isRenderableMcpAppTool(...args),
+}));
+
+const harnessInstances: Array<{
+  getMountedWidgetId: ReturnType<typeof vi.fn>;
+  dismissWidget: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+  executeAction: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock("../../../utils/mcp-app-browser-harness", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/mcp-app-browser-harness")
+  >("../../../utils/mcp-app-browser-harness");
+  return {
+    ...actual,
+    McpAppBrowserHarness: vi.fn().mockImplementation(() => {
+      const instance = {
+        getMountedWidgetId: vi.fn().mockReturnValue(null),
+        dismissWidget: vi.fn().mockResolvedValue(undefined),
+        dispose: vi.fn().mockResolvedValue(undefined),
+        executeAction: vi.fn(),
+      };
+      harnessInstances.push(instance);
+      return instance;
+    }),
+  };
+});
+
+import { createEvalBrowserContext } from "../browser-eval-context";
+
+const CLAUDE_MODEL = "claude-haiku-4-5";
+const NON_CLAUDE_MODEL = "gpt-5-mini";
+
+function stubManager() {
+  return {
+    executeTool: vi.fn(),
+    getAllToolsMetadata: vi.fn().mockReturnValue({}),
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  harnessInstances.length = 0;
+  isRenderableMcpAppTool.mockReturnValue(false);
+});
+
+describe("createEvalBrowserContext — Computer Use surface", () => {
+  it("builds wire-format computer tools + gate for Claude drivers", () => {
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+
+    expect(ctx.computerUseVersion).toBe("20250124");
+    expect(Object.keys(ctx.computerWidgetTools).sort()).toEqual([
+      "computer",
+      "finish_widget",
+    ]);
+    // Wire format: NOT the provider-defined factory output.
+    expect(
+      (ctx.computerWidgetTools.computer as { id?: string }).id,
+    ).toBeUndefined();
+    expect(ctx.prepareAdvertisedTools).toBeDefined();
+  });
+
+  it("builds no computer tools and no gate for non-Claude drivers", () => {
+    const ctx = createEvalBrowserContext({
+      model: NON_CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+
+    expect(ctx.computerUseVersion).toBeNull();
+    expect(ctx.computerWidgetTools).toEqual({});
+    expect(ctx.prepareAdvertisedTools).toBeUndefined();
+    // No harness eagerly constructed either.
+    expect(harnessInstances).toHaveLength(0);
+  });
+
+  it("gate hides computer tools until a widget is mounted, then reveals", () => {
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+    const harness = harnessInstances[0]!;
+    const names = ["search", "computer", "finish_widget"];
+
+    expect(
+      ctx.prepareAdvertisedTools!({ stepIndex: 0, defaultToolNames: names }),
+    ).toEqual(["search"]);
+
+    harness.getMountedWidgetId.mockReturnValue("tc-1");
+    expect(
+      ctx.prepareAdvertisedTools!({ stepIndex: 1, defaultToolNames: names }),
+    ).toEqual(names);
+  });
+});
+
+describe("createEvalBrowserContext — render hook", () => {
+  const baseEvent = {
+    toolCallId: "tc-1",
+    toolName: "show_widget",
+    output: { type: "json", value: { scrubbed: true } },
+    rawResult: { content: [], structuredContent: { full: true } },
+    isError: false,
+    stepIndex: 0,
+    promptIndex: 0,
+    serverId: "srv-1",
+  };
+
+  it("renders renderable MCP App results with the raw output and caches input", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi
+        .fn()
+        .mockReturnValue({ show_widget: { "mcpjam/widget": true } }),
+    } as never;
+    isRenderableMcpAppTool.mockReturnValue(true);
+    renderMcpAppToolResult.mockResolvedValue({
+      toolCallId: "tc-1",
+      toolName: "show_widget",
+      serverId: "srv-1",
+      status: "rendered",
+      elapsedMs: 5,
+      ts: 123,
+    });
+
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: manager,
+      injectOpenAiCompat: true,
+    });
+    ctx.setActivePromptIndex(2);
+    ctx.noteToolCallInput({ toolCallId: "tc-1", input: { city: "lisbon" } });
+
+    await ctx.handleEngineToolResult(baseEvent);
+
+    expect(renderMcpAppToolResult).toHaveBeenCalledTimes(1);
+    const params = renderMcpAppToolResult.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    // Raw result (not the scrubbed LLM view) feeds the widget shim.
+    expect(params.output).toBe(baseEvent.rawResult);
+    expect(params.toolInput).toEqual({ city: "lisbon" });
+    expect(params.injectOpenAiCompat).toBe(true);
+    // Claude driver → keep the widget mounted for Computer Use.
+    expect(params.keepMounted).toBe(true);
+
+    expect(ctx.widgetRenderObservations).toEqual([
+      expect.objectContaining({
+        toolCallId: "tc-1",
+        status: "rendered",
+        // Stamped from setActivePromptIndex, not the engine event.
+        promptIndex: 2,
+      }),
+    ]);
+  });
+
+  it("skips events without serverId, error results, and non-renderable tools", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi.fn().mockReturnValue({ show_widget: {} }),
+    } as never;
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: manager,
+    });
+
+    await ctx.handleEngineToolResult({ ...baseEvent, serverId: undefined });
+    await ctx.handleEngineToolResult({ ...baseEvent, isError: true });
+    isRenderableMcpAppTool.mockReturnValue(false);
+    await ctx.handleEngineToolResult(baseEvent);
+
+    expect(renderMcpAppToolResult).not.toHaveBeenCalled();
+    expect(ctx.widgetRenderObservations).toEqual([]);
+  });
+
+  it("a throwing render is contained (no observation, no throw)", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi
+        .fn()
+        .mockReturnValue({ show_widget: { "mcpjam/widget": true } }),
+    } as never;
+    isRenderableMcpAppTool.mockReturnValue(true);
+    renderMcpAppToolResult.mockRejectedValue(new Error("chromium exploded"));
+
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: manager,
+    });
+
+    await expect(ctx.handleEngineToolResult(baseEvent)).resolves.toBeUndefined();
+    expect(ctx.widgetRenderObservations).toEqual([]);
+  });
+
+  it("renders for non-Claude drivers too (observations without Computer Use)", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi
+        .fn()
+        .mockReturnValue({ show_widget: { "mcpjam/widget": true } }),
+    } as never;
+    isRenderableMcpAppTool.mockReturnValue(true);
+    renderMcpAppToolResult.mockResolvedValue({
+      toolCallId: "tc-1",
+      toolName: "show_widget",
+      serverId: "srv-1",
+      status: "rendered",
+      elapsedMs: 5,
+      ts: 123,
+    });
+
+    const ctx = createEvalBrowserContext({
+      model: NON_CLAUDE_MODEL,
+      mcpClientManager: manager,
+    });
+    await ctx.handleEngineToolResult(baseEvent);
+
+    expect(ctx.widgetRenderObservations).toHaveLength(1);
+    // No Computer Use → don't keep the widget mounted.
+    expect(
+      (renderMcpAppToolResult.mock.calls[0]![0] as { keepMounted?: boolean })
+        .keepMounted,
+    ).toBe(false);
+  });
+});
+
+describe("createEvalBrowserContext — interaction steps", () => {
+  it("collects browserInteractionSteps from computer-tool actions with per-widget step ordinals", async () => {
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+    const harness = harnessInstances[0]!;
+    harness.getMountedWidgetId.mockReturnValue("tc-w");
+    harness.executeAction.mockResolvedValue({
+      action: { action: "left_click", coordinate: [10, 20] },
+      screenshotBase64: "img",
+      widgetToolCalls: [],
+      elapsedMs: 3,
+    });
+
+    ctx.setActivePromptIndex(1);
+    const computer = ctx.computerWidgetTools.computer as {
+      execute: (input: unknown, opts: unknown) => Promise<unknown>;
+    };
+    await computer.execute({ action: "left_click", coordinate: [10, 20] }, {});
+    await computer.execute({ action: "left_click", coordinate: [10, 20] }, {});
+
+    expect(ctx.browserInteractionSteps).toEqual([
+      expect.objectContaining({
+        toolCallId: "tc-w",
+        stepIndex: 0,
+        promptIndex: 1,
+        action: "left_click",
+        coordinateX: 10,
+        coordinateY: 20,
+        screenshotBase64: "img",
+      }),
+      expect.objectContaining({ stepIndex: 1 }),
+    ]);
+  });
+
+  it("narrows unknown harness notes instead of dropping the step", async () => {
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+    const harness = harnessInstances[0]!;
+    harness.getMountedWidgetId.mockReturnValue("tc-w");
+    harness.executeAction.mockResolvedValue({
+      action: { action: "screenshot" },
+      widgetToolCalls: [],
+      elapsedMs: 1,
+      note: "some_future_note_literal",
+    });
+
+    const computer = ctx.computerWidgetTools.computer as {
+      execute: (input: unknown, opts: unknown) => Promise<unknown>;
+    };
+    await computer.execute({ action: "screenshot" }, {});
+
+    expect(ctx.browserInteractionSteps).toHaveLength(1);
+    expect(ctx.browserInteractionSteps[0]!.note).toBeUndefined();
+  });
+});
+
+describe("createEvalBrowserContext — lifecycle", () => {
+  it("dismissCarriedWidget dismisses only when a widget is mounted", async () => {
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+    const harness = harnessInstances[0]!;
+
+    await ctx.dismissCarriedWidget();
+    expect(harness.dismissWidget).not.toHaveBeenCalled();
+
+    harness.getMountedWidgetId.mockReturnValue("tc-carried");
+    await ctx.dismissCarriedWidget();
+    expect(harness.dismissWidget).toHaveBeenCalledWith("tc-carried");
+  });
+
+  it("dispose tears down the harness; no-op when never constructed", async () => {
+    const claudeCtx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+    await claudeCtx.dispose();
+    expect(harnessInstances[0]!.dispose).toHaveBeenCalledTimes(1);
+
+    const plainCtx = createEvalBrowserContext({
+      model: NON_CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+    await expect(plainCtx.dispose()).resolves.toBeUndefined();
+  });
+
+  it("noteToolCallInput ignores non-object inputs", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi
+        .fn()
+        .mockReturnValue({ show_widget: { "mcpjam/widget": true } }),
+    } as never;
+    isRenderableMcpAppTool.mockReturnValue(true);
+    renderMcpAppToolResult.mockResolvedValue({
+      toolCallId: "tc-1",
+      toolName: "show_widget",
+      serverId: "srv-1",
+      status: "rendered",
+      elapsedMs: 5,
+      ts: 1,
+    });
+
+    const ctx = createEvalBrowserContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: manager,
+    });
+    ctx.noteToolCallInput({ toolCallId: "tc-1", input: "not-an-object" });
+
+    await ctx.handleEngineToolResult({
+      toolCallId: "tc-1",
+      toolName: "show_widget",
+      output: {},
+      rawResult: {},
+      isError: false,
+      stepIndex: 0,
+      promptIndex: 0,
+      serverId: "srv-1",
+    });
+
+    expect(
+      (renderMcpAppToolResult.mock.calls[0]![0] as { toolInput?: unknown })
+        .toolInput,
+    ).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -784,6 +784,142 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     expect(createLlmModelMock).not.toHaveBeenCalled();
   });
 
+  // Browser-rendered MCP App eval PR 14: the hosted (jam / org-BYOK) runners
+  // attach the harness via the engine's extension points.
+  it("PR 14: threads Computer Use tools + browser hooks into runAssistantTurn for Claude jam models", async () => {
+    const assistantTurnModule = await import("../../../utils/assistant-turn");
+    const runAssistantTurnSpy = vi
+      .spyOn(assistantTurnModule, "runAssistantTurn")
+      .mockImplementation(async (opts: any) => ({
+        messages: [
+          ...opts.messages,
+          { role: "assistant", content: [{ type: "text", text: "Done" }] },
+        ],
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+        turnTrace: { spans: [] } as any,
+      }));
+
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Widget case",
+              query: "Show the widget",
+              runs: 1,
+              model: "claude-haiku-4.5",
+              provider: "anthropic",
+              expectedToolCalls: [],
+              promptTurns: [
+                {
+                  id: "turn-1",
+                  prompt: "Show the widget",
+                  expectedToolCalls: [],
+                },
+              ],
+              testCaseId: "case-pr14",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-pr14",
+      });
+
+      expect(runAssistantTurnSpy).toHaveBeenCalledTimes(1);
+      const opts = runAssistantTurnSpy.mock.calls[0]![0] as any;
+      // Wire-format Computer Use tools merged into the engine tool map
+      // (trace-wrapped, so identity differs — names + executability matter).
+      expect(Object.keys(opts.tools)).toEqual(
+        expect.arrayContaining(["computer", "finish_widget"]),
+      );
+      expect(typeof opts.tools.computer.execute).toBe("function");
+      expect(typeof opts.tools.computer.toModelOutput).toBe("function");
+      // The advertised-tool gate + both browser hooks are attached.
+      expect(typeof opts.prepareAdvertisedTools).toBe("function");
+      expect(typeof opts.onToolCall).toBe("function");
+      expect(typeof opts.onToolResult).toBe("function");
+      // No widget mounted yet → the gate hides the computer tools.
+      expect(
+        opts.prepareAdvertisedTools({
+          stepIndex: 0,
+          defaultToolNames: ["search", "computer", "finish_widget"],
+        }),
+      ).toEqual(["search"]);
+    } finally {
+      runAssistantTurnSpy.mockRestore();
+    }
+  });
+
+  it("PR 14: non-Claude jam models get no Computer Use tools or gate (render hook still attached)", async () => {
+    const assistantTurnModule = await import("../../../utils/assistant-turn");
+    const runAssistantTurnSpy = vi
+      .spyOn(assistantTurnModule, "runAssistantTurn")
+      .mockImplementation(async (opts: any) => ({
+        messages: [
+          ...opts.messages,
+          { role: "assistant", content: [{ type: "text", text: "Done" }] },
+        ],
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+        turnTrace: { spans: [] } as any,
+      }));
+
+    try {
+      await runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Non-Claude widget case",
+              query: "Show the widget",
+              runs: 1,
+              model: "gpt-5-mini",
+              provider: "openai",
+              expectedToolCalls: [],
+              promptTurns: [
+                {
+                  id: "turn-1",
+                  prompt: "Show the widget",
+                  expectedToolCalls: [],
+                },
+              ],
+              testCaseId: "case-pr14-openai",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: {},
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-pr14-openai",
+      });
+
+      expect(runAssistantTurnSpy).toHaveBeenCalledTimes(1);
+      const opts = runAssistantTurnSpy.mock.calls[0]![0] as any;
+      expect(Object.keys(opts.tools)).not.toEqual(
+        expect.arrayContaining(["computer"]),
+      );
+      expect(opts.prepareAdvertisedTools).toBeUndefined();
+      // Render observations are model-agnostic — the hook stays attached.
+      expect(typeof opts.onToolResult).toBe("function");
+    } finally {
+      runAssistantTurnSpy.mockRestore();
+    }
+  });
+
   it("streams bare MCPJam Anthropic test cases through the backend without a BYOK key", async () => {
     const emitted: Array<Record<string, unknown>> = [];
     fetchMock.mockResolvedValue(createBackendStreamResponse());

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -909,9 +909,8 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
 
       expect(runAssistantTurnSpy).toHaveBeenCalledTimes(1);
       const opts = runAssistantTurnSpy.mock.calls[0]![0] as any;
-      expect(Object.keys(opts.tools)).not.toEqual(
-        expect.arrayContaining(["computer"]),
-      );
+      expect(opts.tools).not.toHaveProperty("computer");
+      expect(opts.tools).not.toHaveProperty("finish_widget");
       expect(opts.prepareAdvertisedTools).toBeUndefined();
       // Render observations are model-agnostic — the hook stays attached.
       expect(typeof opts.onToolResult).toBe("function");

--- a/mcpjam-inspector/server/services/evals/browser-eval-context.ts
+++ b/mcpjam-inspector/server/services/evals/browser-eval-context.ts
@@ -1,0 +1,266 @@
+/**
+ * browser-eval-context.ts — per-iteration browser-rendered MCP App context for
+ * the HOSTED eval runner paths (PR 14).
+ *
+ * `runIterationViaBackend` / `streamIterationViaBackend` drive their turns
+ * through the shared engine (`runAssistantTurn` → `runChatEngineLoop`), so the
+ * harness wiring that the local AI-SDK runners inline (PR 5/6b/9) attaches via
+ * the engine's extension points instead:
+ *
+ *   - `computerWidgetTools` — wire-format `computer` + `finish_widget` tools
+ *     (regular function tools; the provider-native factory's lazy schema
+ *     serializes to an empty object on the Convex `/stream` wire). Merged into
+ *     the tool map the runner passes to `runAssistantTurn`, executed locally by
+ *     `executeToolCallsFromMessages`, with screenshots reaching the model as
+ *     image content via the tool's `toModelOutput` (honored by the shared
+ *     executor since PR 14).
+ *   - `prepareAdvertisedTools` — hides both tools until a widget is actually
+ *     mounted in the harness (same gate the local runners use; the engine
+ *     additionally enforces execution against the advertised subset).
+ *   - `handleEngineToolResult` — the engine's `onToolResult` hook (awaited by
+ *     `emitToolResults` since PR 14, so a rendered widget is mounted before the
+ *     next step's gate runs). Renders MCP App tool results in the harness and
+ *     records `RunnerWidgetRenderObservation`s.
+ *   - `noteToolCallInput` — the engine's `onToolCall` hook; caches tool-call
+ *     inputs so the render hook can feed the OpenAI-compat shim the same
+ *     `toolInput` the live widget would have received.
+ *
+ * One context per iteration; `dispose()` MUST run (callers wrap the iteration
+ * body in try/finally) so a launched Chromium never outlives its iteration.
+ */
+
+import type { MCPClientManager } from "@mcpjam/sdk";
+import type { ToolSet } from "ai";
+import {
+  DEFAULT_VIEWPORT,
+  McpAppBrowserHarness,
+} from "../../utils/mcp-app-browser-harness";
+import {
+  buildComputerUseTools,
+  resolveComputerUseToolVersion,
+} from "../../utils/computer-use-tool";
+import {
+  isRenderableMcpAppTool,
+  renderMcpAppToolResult,
+} from "../../utils/mcp-app-render-observation";
+import type { MCPJamToolResultEvent } from "../../utils/mcpjam-stream-handler.js";
+import type { PrepareAdvertisedTools } from "../../utils/advertised-tools";
+import {
+  isEvalTraceBrowserStepNote,
+  type RunnerBrowserInteractionStep,
+  type RunnerWidgetRenderObservation,
+} from "@/shared/eval-trace";
+import { logger } from "../../utils/logger";
+
+export interface CreateEvalBrowserContextParams {
+  /** Driver model id (`test.model`) — decides Computer Use availability. */
+  model: string;
+  mcpClientManager: MCPClientManager;
+  injectOpenAiCompat?: boolean;
+}
+
+export interface EvalBrowserContext {
+  /** Non-null exactly when the driver model supports Computer Use. */
+  readonly computerUseVersion: ReturnType<typeof resolveComputerUseToolVersion>;
+  /** Wire-format `computer` + `finish_widget`, or `{}` for non-Claude drivers. */
+  readonly computerWidgetTools: ToolSet;
+  /** Collected render observations (promptIndex stamped at push time). */
+  readonly widgetRenderObservations: RunnerWidgetRenderObservation[];
+  /** Collected Computer Use steps (promptIndex/stepIndex stamped at push time). */
+  readonly browserInteractionSteps: RunnerBrowserInteractionStep[];
+  /** Advertised-tool gate: hide computer tools until a widget is mounted. */
+  readonly prepareAdvertisedTools: PrepareAdvertisedTools | undefined;
+  /** Runner loop bookkeeping: stamp artifacts with the active prompt turn. */
+  setActivePromptIndex(promptIndex: number): void;
+  /** Engine `onToolCall` hook — caches inputs for the render hook. */
+  noteToolCallInput(event: { toolCallId: string; input: unknown }): void;
+  /** Engine `onToolResult` hook — renders MCP App results in the harness. */
+  handleEngineToolResult(event: MCPJamToolResultEvent): Promise<void>;
+  /** Start-of-turn hygiene: a widget kept mounted by a previous prompt turn
+   *  must not bleed into this one. */
+  dismissCarriedWidget(): Promise<void>;
+  /** Tear down the harness (and Chromium, if launched). Always call. */
+  dispose(): Promise<void>;
+}
+
+export function createEvalBrowserContext(
+  params: CreateEvalBrowserContextParams,
+): EvalBrowserContext {
+  const { mcpClientManager, injectOpenAiCompat } = params;
+  const computerUseVersion = resolveComputerUseToolVersion(params.model);
+
+  const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
+    current: null,
+  };
+  const widgetRenderObservations: RunnerWidgetRenderObservation[] = [];
+  const browserInteractionSteps: RunnerBrowserInteractionStep[] = [];
+  const stepIndexByToolCallId = new Map<string, number>();
+  const inputByToolCallId = new Map<string, Record<string, unknown>>();
+  let activePromptIndex = 0;
+
+  const ensureWidgetHarness = (): McpAppBrowserHarness => {
+    if (!widgetHarnessRef.current) {
+      widgetHarnessRef.current = new McpAppBrowserHarness({
+        callTool: (sid, name, args) =>
+          mcpClientManager.executeTool(sid, name, args),
+        viewport: DEFAULT_VIEWPORT,
+      });
+    }
+    return widgetHarnessRef.current;
+  };
+  // Eager (cheap) construction when Computer Use is supported so the computer
+  // tools can reference the harness; Chromium still launches lazily on the
+  // first widget render.
+  if (computerUseVersion) ensureWidgetHarness();
+
+  const computerWidgetTools: ToolSet = computerUseVersion
+    ? buildComputerUseTools({
+        version: computerUseVersion,
+        harness: ensureWidgetHarness(),
+        // The harness keeps at most one widget mounted — it is the single
+        // source of truth for the active widget across turns and dismissals.
+        getActiveToolCallId: () =>
+          widgetHarnessRef.current?.getMountedWidgetId() ?? null,
+        viewport: DEFAULT_VIEWPORT,
+        // Hosted paths serialize tool defs to flat JSON for the Convex
+        // `/stream` request; the provider-native factory can't ride that wire.
+        wireFormat: true,
+        // One browserInteractionStep per executeAction. The screenshot stays
+        // base64 here; finalizeEvalIteration uploads it once for both the W2
+        // and W1 persistence paths.
+        onAction: (result, { toolCallId }) => {
+          const stepIndex = (stepIndexByToolCallId.get(toolCallId) ?? -1) + 1;
+          stepIndexByToolCallId.set(toolCallId, stepIndex);
+          // The harness types `note` as an open string; the backend union is
+          // closed and rejects the whole turn on an unknown literal. Narrow
+          // through the guard — keep the step, drop an unrecognized note.
+          let note: RunnerBrowserInteractionStep["note"];
+          if (result.note !== undefined) {
+            if (isEvalTraceBrowserStepNote(result.note)) {
+              note = result.note;
+            } else {
+              logger.warn("[evals] dropping unknown browser-step note", {
+                note: result.note,
+                toolCallId,
+              });
+            }
+          }
+          browserInteractionSteps.push({
+            toolCallId,
+            stepIndex,
+            promptIndex: activePromptIndex,
+            action: result.action.action,
+            coordinateX: result.action.coordinate?.[0],
+            coordinateY: result.action.coordinate?.[1],
+            text: result.action.text,
+            scrollDirection: result.action.scrollDirection,
+            scrollAmount: result.action.scrollAmount,
+            duration: result.action.duration,
+            screenshotBase64: result.screenshotBase64,
+            widgetToolCalls: result.widgetToolCalls,
+            elapsedMs: result.elapsedMs,
+            ...(note ? { note } : {}),
+            ts: Date.now(),
+          });
+        },
+      })
+    : {};
+
+  // Gate Computer Use tools on the harness's live mount — the SAME source
+  // `getActiveToolCallId` reads — so the model only sees `computer` /
+  // `finish_widget` when an action can actually target a widget.
+  const prepareAdvertisedTools: PrepareAdvertisedTools | undefined =
+    computerUseVersion
+      ? ({ defaultToolNames }) =>
+          widgetHarnessRef.current?.getMountedWidgetId()
+            ? defaultToolNames
+            : defaultToolNames.filter(
+                (n) => n !== "computer" && n !== "finish_widget",
+              )
+      : undefined;
+
+  const handleEngineToolResult = async (
+    event: MCPJamToolResultEvent,
+  ): Promise<void> => {
+    const { toolCallId, toolName, serverId } = event;
+    if (!serverId || !toolName) return;
+    if (event.isError) return;
+    const meta = mcpClientManager.getAllToolsMetadata(serverId)?.[toolName];
+    if (!isRenderableMcpAppTool(meta)) return;
+    try {
+      const obs = await renderMcpAppToolResult({
+        toolCallId,
+        toolName,
+        serverId,
+        toolMetadata: meta,
+        // Feed the real tool-call args to the widget shim so the hosted-path
+        // render matches what the local runners (and post-turn snapshot
+        // capture) inject.
+        toolInput: inputByToolCallId.get(toolCallId),
+        // `rawResult` is the unscrubbed implementation result; `output` on the
+        // event is the LLM-facing view with `_meta` / `structuredContent`
+        // scrubbed, which would starve the widget shim of its data.
+        output: event.rawResult ?? event.output,
+        mcpClientManager,
+        injectOpenAiCompat,
+        harness: ensureWidgetHarness(),
+        keepMounted: computerUseVersion !== null,
+      });
+      // Stamp promptIndex at push-time — the harness type stays pure; the
+      // runner loop is the single source of truth for promptIndex.
+      widgetRenderObservations.push({
+        ...obs,
+        promptIndex: activePromptIndex,
+      });
+      logger.debug("[evals] widget render observation (hosted path)", {
+        toolName,
+        status: obs.status,
+      });
+    } catch (err) {
+      logger.warn("[evals] widget render failed (hosted path)", {
+        toolName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  return {
+    computerUseVersion,
+    computerWidgetTools,
+    widgetRenderObservations,
+    browserInteractionSteps,
+    prepareAdvertisedTools,
+    setActivePromptIndex(promptIndex: number): void {
+      activePromptIndex = promptIndex;
+    },
+    noteToolCallInput(event: { toolCallId: string; input: unknown }): void {
+      if (
+        event.input &&
+        typeof event.input === "object" &&
+        !Array.isArray(event.input)
+      ) {
+        inputByToolCallId.set(
+          event.toolCallId,
+          event.input as Record<string, unknown>,
+        );
+      }
+    },
+    handleEngineToolResult,
+    async dismissCarriedWidget(): Promise<void> {
+      const carriedWidgetId =
+        widgetHarnessRef.current?.getMountedWidgetId() ?? null;
+      if (carriedWidgetId) {
+        await widgetHarnessRef.current!.dismissWidget(carriedWidgetId);
+      }
+    },
+    async dispose(): Promise<void> {
+      await widgetHarnessRef.current?.dispose();
+      if (widgetRenderObservations.length > 0) {
+        logger.debug("[evals] widget render observations (hosted path)", {
+          count: widgetRenderObservations.length,
+          statuses: widgetRenderObservations.map((o) => o.status),
+        });
+      }
+    },
+  };
+}

--- a/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computer-use-tool.test.ts
@@ -392,3 +392,135 @@ describe("buildComputerUseTools", () => {
     });
   });
 });
+
+describe("buildComputerUseTools — wireFormat (hosted paths, PR 14)", () => {
+  function stubHarness() {
+    const executeAction = vi.fn(
+      async ({ action }: { toolCallId: string; action: unknown }) => ({
+        action,
+        screenshotBase64: "iVBORscreenshot",
+        widgetToolCalls: [],
+        elapsedMs: 7,
+      }),
+    );
+    const dismissWidget = vi.fn(async () => {});
+    return {
+      harness: {
+        executeAction,
+        dismissWidget,
+      } as unknown as McpAppBrowserHarness,
+      executeAction,
+      dismissWidget,
+    };
+  }
+
+  it("emits `computer` as a regular function tool with a JSON-serializable schema", async () => {
+    const { harness } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => "tc-1",
+      viewport: { width: 1280, height: 800 },
+      wireFormat: true,
+    });
+
+    const computer = tools.computer as Record<string, unknown>;
+    // Not the provider-defined factory output: a plain function tool whose
+    // schema survives `serializeToolsForConvex` (the provider tool's lazy
+    // schema serializes to an empty object on the hosted wire).
+    expect(computer.type ?? "function").not.toBe("provider-defined");
+    expect(typeof computer.description).toBe("string");
+    const { serializeToolsForConvex } = await import("../mcpjam-tool-helpers");
+    const defs = serializeToolsForConvex(tools as never);
+    const computerDef = defs.find((d) => d.name === "computer");
+    expect(computerDef).toBeDefined();
+    const props = (computerDef!.inputSchema as { properties?: object })
+      .properties;
+    expect(Object.keys(props ?? {})).toEqual(
+      expect.arrayContaining(["action", "coordinate", "text"]),
+    );
+    const actionEnum = (
+      (props as Record<string, { enum?: string[] }>).action ?? {}
+    ).enum;
+    expect(actionEnum).toEqual(expect.arrayContaining(["screenshot", "left_click", "type", "key", "scroll", "wait"]));
+  });
+
+  it("wire `computer` drives the harness and maps output via toModelOutput like the native tool", async () => {
+    const { harness, executeAction } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => "tc-9",
+      viewport: { width: 1280, height: 800 },
+      wireFormat: true,
+    });
+
+    const computer = tools.computer as {
+      execute: Function;
+      toModelOutput: Function;
+    };
+    const implOut = await computer.execute(
+      { action: "left_click", coordinate: [10, 20] },
+      {},
+    );
+    expect(executeAction).toHaveBeenCalledWith({
+      toolCallId: "tc-9",
+      action: { action: "left_click", coordinate: [10, 20] },
+    });
+
+    const modelOut = computer.toModelOutput({ output: implOut });
+    expect(modelOut.type).toBe("content");
+    expect(modelOut.value[0]).toMatchObject({
+      type: "image-data",
+      data: "iVBORscreenshot",
+    });
+  });
+
+  it("wire mode still short-circuits with no_rendered_widget when nothing is mounted", async () => {
+    const { harness, executeAction } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => null,
+      viewport: { width: 1280, height: 800 },
+      wireFormat: true,
+    });
+
+    const computer = tools.computer as { execute: Function };
+    const out = await computer.execute({ action: "screenshot" }, {});
+    expect(executeAction).not.toHaveBeenCalled();
+    expect(out).toMatchObject({ note: "no_rendered_widget" });
+  });
+
+  it("wire mode fires onAction with the active toolCallId", async () => {
+    const { harness } = stubHarness();
+    const onAction = vi.fn();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => "tc-act",
+      viewport: { width: 1280, height: 800 },
+      wireFormat: true,
+      onAction,
+    });
+
+    await (tools.computer as { execute: Function }).execute(
+      { action: "screenshot" },
+      {},
+    );
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onAction.mock.calls[0][1]).toEqual({ toolCallId: "tc-act" });
+  });
+
+  it("default (no wireFormat) keeps the provider-native factory", () => {
+    const { harness } = stubHarness();
+    const tools = buildComputerUseTools({
+      version: "20250124",
+      harness,
+      getActiveToolCallId: () => null,
+      viewport: { width: 1280, height: 800 },
+    });
+    // Provider-defined tools carry the factory id; the wire tool must not.
+    expect((tools.computer as { id?: string }).id).toMatch(/anthropic\./);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1050,6 +1050,124 @@ describe("mcpjam-stream-handler", () => {
     });
   });
 
+  // Browser-rendered MCP App eval PR 14: the hosted eval runner's widget
+  // render hook rides `onToolResult` and must complete BEFORE the next
+  // step's `prepareAdvertisedTools` gate reads the harness mount state.
+  it("awaits an async onToolResult before the next step's prepareAdvertisedTools, and exposes rawResult", async () => {
+    let fetchCall = 0;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      fetchCall += 1;
+      if (fetchCall === 1) {
+        return createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-w1",
+            toolName: "show_widget",
+            input: { city: "lisbon" },
+          },
+          {
+            type: "finish",
+            finishReason: "stop",
+            totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ]);
+      }
+      return createSseResponse([
+        {
+          type: "finish",
+          finishReason: "stop",
+          totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ]);
+    });
+    vi.mocked(hasUnresolvedToolCalls).mockImplementation(
+      (messages) =>
+        messages.some(
+          (message: any) =>
+            message?.role === "assistant" &&
+            Array.isArray(message.content) &&
+            message.content.some((part: any) => part.type === "tool-call")
+        ) && !messages.some((message: any) => message?.role === "tool")
+    );
+    const rawWidgetResult = {
+      content: [{ type: "text", text: "ok" }],
+      structuredContent: { seats: [1, 2, 3] },
+      _meta: { "mcpjam/widget": true },
+    };
+    vi.mocked(executeToolCallsFromMessages).mockImplementation(
+      async (messages: any[]) => {
+        const toolResultMessage = {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-w1",
+              toolName: "show_widget",
+              // LLM-facing output is the SCRUBBED view…
+              output: {
+                type: "json",
+                value: { content: [{ type: "text", text: "ok" }] },
+              },
+              // …while `result` carries the raw, unscrubbed payload the
+              // render hook needs.
+              result: rawWidgetResult,
+              serverId: "widget-server",
+            },
+          ],
+        };
+        messages.splice(2, 0, toolResultMessage);
+        return [toolResultMessage] as any;
+      }
+    );
+
+    // Simulates the eval runner's harness state: the render hook "mounts"
+    // the widget only after an async delay; the next step's gate must
+    // observe the mounted state (i.e. the engine awaited the callback).
+    let widgetMounted = false;
+    const seenRawResults: unknown[] = [];
+    const mountStateAtGateCall: Array<{
+      stepIndex: number;
+      mounted: boolean;
+    }> = [];
+
+    await handleMCPJamFreeChatModel({
+      messages: [{ role: "user", content: "Show me the widget" }] as any,
+      modelId: "anthropic/claude-haiku-4.5",
+      systemPrompt: "You are helpful",
+      tools: {
+        show_widget: {
+          _serverId: "widget-server",
+        },
+      } as any,
+      mcpClientManager: {
+        getAllToolsMetadata: vi.fn().mockReturnValue({
+          show_widget: {},
+        }),
+      } as any,
+      prepareAdvertisedTools: ({ stepIndex, defaultToolNames }) => {
+        mountStateAtGateCall.push({ stepIndex, mounted: widgetMounted });
+        return defaultToolNames;
+      },
+      onToolResult: async (event) => {
+        seenRawResults.push(event.rawResult);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        widgetMounted = true;
+      },
+    });
+
+    await lastExecution;
+
+    // The raw (unscrubbed) result reached the callback.
+    expect(seenRawResults).toEqual([rawWidgetResult]);
+    // Step 0's gate ran before any render; step 1's gate ran AFTER the
+    // awaited async callback completed — ordering would break (mounted:
+    // false) if the engine fired the callback without awaiting it.
+    expect(mountStateAtGateCall).toEqual([
+      { stepIndex: 0, mounted: false },
+      { stepIndex: 1, mounted: true },
+    ]);
+  });
+
   describe("progressive discovery approval semantics", () => {
     // Minimal "plan enabled" — only the `enabled` flag is read on the
     // post-stream unresolved-tool detection + drain paths exercised here.

--- a/mcpjam-inspector/server/utils/computer-use-tool.ts
+++ b/mcpjam-inspector/server/utils/computer-use-tool.ts
@@ -229,6 +229,84 @@ export interface BuildComputerUseToolsOptions {
     result: BrowserActionResult,
     context: { toolCallId: string },
   ) => void;
+  /**
+   * PR 14 (hosted-path Computer Use): emit the `computer` tool as a REGULAR
+   * AI SDK tool with an explicit JSON-serializable input schema instead of
+   * the Anthropic provider-native factory. The hosted backend paths
+   * serialize the tool map to flat `{name, description, inputSchema}` defs
+   * for the Convex `/stream` request (`serializeToolsForConvex`), and the
+   * provider-native tool's lazy schema serializes to an EMPTY object there —
+   * the model would see a `computer` tool it can't call. Wire format trades
+   * the provider beta header (OpenRouter exposes function tools only) for a
+   * faithful hand-rolled schema covering exactly the harness-supported
+   * action set. Local AI-SDK paths keep the default (provider-native).
+   */
+  wireFormat?: boolean;
+}
+
+/**
+ * Actions the wire-format `computer` tool advertises. Mirrors the Anthropic
+ * native action vocabulary restricted to what the harness implements (plus
+ * `triple_click`, which maps to the closest analogue) — advertising actions
+ * that silently degrade to screenshots (drag, hold_key, …) would mislead the
+ * model on a function-tool surface that lacks the native harness prompt.
+ */
+const WIRE_FORMAT_ACTIONS = [
+  "screenshot",
+  "left_click",
+  "double_click",
+  "triple_click",
+  "right_click",
+  "mouse_move",
+  "type",
+  "key",
+  "scroll",
+  "wait",
+] as const;
+
+function buildWireFormatComputerInputSchema(viewport: {
+  width: number;
+  height: number;
+}) {
+  return z.object({
+    action: z
+      .enum(WIRE_FORMAT_ACTIONS)
+      .describe(
+        "The action to perform on the rendered widget. Take a screenshot " +
+          "first to see the current state before clicking or typing.",
+      ),
+    coordinate: z
+      .array(z.number().int().min(0))
+      .min(2)
+      .max(2)
+      .optional()
+      .describe(
+        `[x, y] pixel coordinate for click / mouse_move / scroll actions. ` +
+          `x is in [0, ${viewport.width}), y is in [0, ${viewport.height}).`,
+      ),
+    text: z
+      .string()
+      .optional()
+      .describe(
+        "Text to type (for `type`), or the key / key-combination to press " +
+          "(for `key`, e.g. 'Return', 'Tab', 'ctrl+a').",
+      ),
+    duration: z
+      .number()
+      .min(0)
+      .optional()
+      .describe("Seconds to pause (for `wait`)."),
+    scroll_amount: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Number of scroll wheel clicks (for `scroll`)."),
+    scroll_direction: z
+      .enum(["up", "down", "left", "right"])
+      .optional()
+      .describe("Direction to scroll (for `scroll`)."),
+  });
 }
 
 /**
@@ -285,8 +363,33 @@ export function buildComputerUseTools(
     toModelOutput,
   };
 
-  const computer =
-    opts.version === "20251124"
+  // Wire format (hosted backend paths): a regular function tool with an
+  // explicit, JSON-serializable schema. Same execute / toModelOutput
+  // implementation — only the model-facing surface differs (function tool
+  // vs. provider-native tool type + beta header). Built as an object literal
+  // rather than via `tool()`: the helper is a pure inference identity, and
+  // its overloads can't unify the zod-v4 schema with `toModelOutput`'s
+  // output type. The consumers are duck-typed (`serializeToolsForConvex`
+  // reads `inputSchema`, `executeToolCallsFromMessages` reads `execute` /
+  // `toModelOutput`), so the literal is a first-class tool.
+  const computer = opts.wireFormat
+    ? ({
+        description:
+          `A virtual ${viewport.width}x${viewport.height} browser viewport ` +
+          "showing the currently rendered MCP App widget. Use it to look at " +
+          "the widget (screenshot) and interact with it (click, type, " +
+          "scroll). Coordinates are pixels with (0, 0) at the top-left. " +
+          "Always take a screenshot first to see the widget before " +
+          "interacting, and after each action to verify its effect. When " +
+          "you are done interacting with the widget, call `finish_widget`.",
+        inputSchema: buildWireFormatComputerInputSchema(viewport),
+        // The wire schema types `coordinate` as number[] (tuple constraints
+        // ride as minItems/maxItems so the JSON round-trips through the
+        // backend's schema reconstruction); the impl type narrows it.
+        execute: (input: ComputerActionInput) => execute(input),
+        toModelOutput,
+      } as unknown as ToolSet[string])
+    : opts.version === "20251124"
       ? anthropic.tools.computer_20251124(factoryArgs)
       : anthropic.tools.computer_20250124(factoryArgs);
 

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -165,6 +165,17 @@ export interface MCPJamToolResultEvent {
   /** May be undefined when the chunk lacks toolName (older Convex versions). */
   toolName: string | undefined;
   output: unknown;
+  /**
+   * Browser-rendered MCP App eval PR 14: the raw, unscrubbed implementation
+   * result the tool's `execute` returned (the `result:` extra
+   * `executeToolCallsFromMessages` stamps on the part for UI hydration).
+   * `output` above is the LLM-facing view — for MCP App tools that view is
+   * scrubbed of `_meta` / `structuredContent`, which the eval runner's widget
+   * render hook needs to feed the OpenAI-compat shim with full fidelity.
+   * Undefined for tools that don't carry the raw extra (e.g. `toModelOutput`
+   * tools, denial results).
+   */
+  rawResult?: unknown;
   /** `true` when the tool execution returned an error result (vs. an OK output). */
   isError: boolean;
   stepIndex: number;
@@ -314,8 +325,15 @@ export interface MCPJamHandlerOptions {
    * UI chunk and the `tool_result` trace event. Eval's backend stream
    * runner uses this to emit the `tool_result` SSE event. Chat /
    * synthetic omit.
+   *
+   * Browser-rendered MCP App eval PR 14: a returned promise is AWAITED
+   * before the engine proceeds to the next step. The eval runner's widget
+   * render hook relies on this ordering — the harness must have the widget
+   * mounted before the next step's `prepareAdvertisedTools` gate decides
+   * whether to advertise `computer` / `finish_widget`. Sync callbacks
+   * (chat / eval SSE emitters) are unaffected.
    */
-  onToolResult?: (event: MCPJamToolResultEvent) => void;
+  onToolResult?: (event: MCPJamToolResultEvent) => void | Promise<void>;
   /**
    * Engine consolidation PR 5b-pre — fires from `runChatEngineLoop`
    * after each `processOneStep` returns and the step counter
@@ -447,7 +465,7 @@ interface StepContext {
   // chunk-processing switch (onToolCall / onToolResult) and to the
   // step loop (onStepFinish). All optional.
   onToolCall?: (event: MCPJamToolCallEvent) => void;
-  onToolResult?: (event: MCPJamToolResultEvent) => void;
+  onToolResult?: (event: MCPJamToolResultEvent) => void | Promise<void>;
   onStepFinish?: (event: MCPJamStepFinishEvent) => void;
   // PR 5b-followup-2: structured-error callback. Fires at every site
   // that emits a writer `error` UI chunk (non-OK Convex response in
@@ -1193,7 +1211,7 @@ async function processStream(
  * Emit tool results to the client stream.
  * Called after tools have been executed locally.
  */
-function emitToolResults(
+async function emitToolResults(
   writer: StepContext["writer"],
   mcpClientManager: MCPClientManager,
   newMessages: ModelMessage[],
@@ -1202,9 +1220,10 @@ function emitToolResults(
   // PR 5b-pre: optional chunk-level callback so eval's backend stream
   // runner (PR 5b) can emit the `tool_result` SSE event. Chat /
   // synthetic don't supply this callback — the UI writer + trace event
-  // still fire unchanged.
-  onToolResult?: (event: MCPJamToolResultEvent) => void
-) {
+  // still fire unchanged. PR 14: a returned promise is awaited so the
+  // eval render hook completes before the engine's next step.
+  onToolResult?: (event: MCPJamToolResultEvent) => void | Promise<void>
+): Promise<void> {
   for (const msg of newMessages) {
     if (msg?.role === "tool") {
       const toolMsg = msg as ToolModelMessage;
@@ -1275,10 +1294,14 @@ function emitToolResults(
             // PR 5a's adapter uses for its `tool_result` SSE event).
             if (onToolResult) {
               try {
-                onToolResult({
+                await onToolResult({
                   toolCallId: part.toolCallId,
                   toolName: toolName ?? part.toolName,
                   output: outputForUi,
+                  // PR 14: raw implementation result (unscrubbed) for the
+                  // eval widget render hook; absent on parts without the
+                  // `result:` UI-hydration extra.
+                  rawResult: (part as { result?: unknown }).result,
                   isError: part.output?.type === "error-text",
                   stepIndex,
                   promptIndex: traceTurn.promptIndex,
@@ -1398,7 +1421,7 @@ async function handlePendingApprovals(
   abortSignal?: AbortSignal,
   // PR 5b-pre: propagate the chunk-level callbacks so denial /
   // resumed-approval / approved-tool-result emissions all fire them.
-  onToolResult?: (event: MCPJamToolResultEvent) => void,
+  onToolResult?: (event: MCPJamToolResultEvent) => void | Promise<void>,
   // PR 5b-pre review fix (Cursor Medium): resumed-approval branch
   // emits `tool-input-available` UI chunks — `onToolCall` must fire
   // here too so PR 5b's wiring doesn't see orphan `tool_result`.
@@ -1510,7 +1533,7 @@ async function handlePendingApprovals(
         // denied tools on resumed approval turns.
         if (onToolResult) {
           try {
-            onToolResult({
+            await onToolResult({
               toolCallId,
               toolName,
               output: {
@@ -1629,7 +1652,7 @@ async function handlePendingApprovals(
       ...(abortSignal ? { abortSignal } : {}),
     });
 
-    emitToolResults(
+    await emitToolResults(
       writer,
       mcpClientManager,
       newMessages,
@@ -1685,12 +1708,33 @@ async function processOneStep(
   // Pick the active tool subset for this step. In non-progressive mode
   // (`progressivePlan` undefined or plan.enabled === false) this collapses
   // to the full list and matches prior behavior. In progressive mode the
-  // model only sees meta-tools + loaded + pending-approval + newly-loaded.
+  // model only sees meta-tools + loaded + pending-approval + newly-loaded —
+  // PLUS tools injected into the map after the catalog was built (e.g. the
+  // eval Computer Use tools, PR 14): they have no catalog toolId, so
+  // `load_mcp_tools` can never activate them and dropping them here would
+  // make them permanently invisible. Their per-step visibility stays
+  // governed by `prepareAdvertisedTools` below (parity with
+  // direct-chat-turn's `withInjectedTools`).
   let activeToolDefs: ToolDefinition[] =
     progressivePlan && progressivePlan.enabled && discoveryState
-      ? resolveActiveToolNames(progressivePlan, discoveryState)
-          .map((name) => toolDefsByName.get(name))
-          .filter((def): def is ToolDefinition => def !== undefined)
+      ? (() => {
+          const activeNames = resolveActiveToolNames(
+            progressivePlan,
+            discoveryState
+          );
+          const cataloged = new Set(
+            progressivePlan.catalog.map((entry) => entry.modelName)
+          );
+          const seen = new Set(activeNames);
+          for (const def of toolDefs) {
+            if (!cataloged.has(def.name) && !seen.has(def.name)) {
+              activeNames.push(def.name);
+            }
+          }
+          return activeNames
+            .map((name) => toolDefsByName.get(name))
+            .filter((def): def is ToolDefinition => def !== undefined);
+        })()
       : toolDefs;
 
   // Browser-rendered MCP App eval PR 2: runtime-conditional advertised-tool
@@ -2026,7 +2070,7 @@ async function processOneStep(
           messageHistory.splice(idx + 1, 0, denialMsg);
           denialMessages.push(denialMsg);
         }
-        emitToolResults(
+        await emitToolResults(
           writer,
           mcpClientManager,
           denialMessages,
@@ -2068,7 +2112,7 @@ async function processOneStep(
         ...(abortSignal ? { abortSignal } : {}),
       });
       if (metaMessages.length > 0) {
-        emitToolResults(
+        await emitToolResults(
           writer,
           mcpClientManager,
           metaMessages,
@@ -2235,7 +2279,7 @@ async function processOneStep(
       );
 
       // Emit results for newly executed tools
-      emitToolResults(
+      await emitToolResults(
         writer,
         mcpClientManager,
         newMessages,

--- a/mcpjam-inspector/shared/__tests__/http-tool-calls.test.ts
+++ b/mcpjam-inspector/shared/__tests__/http-tool-calls.test.ts
@@ -989,3 +989,142 @@ describe("executeToolCallsFromMessages", () => {
     });
   });
 });
+
+describe("executeToolCallsFromMessages — toModelOutput (browser-render PR 14)", () => {
+  const callMessage = (toolName: string): ModelMessage[] =>
+    [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-cu-1",
+            toolName,
+            input: { action: "screenshot" },
+          },
+        ],
+      },
+    ] as unknown as ModelMessage[];
+
+  it("uses the tool's toModelOutput mapping as the model-facing output", async () => {
+    const implResult = {
+      screenshotBase64: "aGVsbG8=",
+      widgetToolCalls: [],
+      elapsedMs: 12,
+    };
+    const tools = {
+      computer: {
+        execute: vi.fn().mockResolvedValue(implResult),
+        toModelOutput: vi.fn(({ output }: { output: unknown }) => ({
+          type: "content",
+          value: [
+            {
+              type: "image-data",
+              data: (output as { screenshotBase64: string }).screenshotBase64,
+              mediaType: "image/png",
+            },
+          ],
+        })),
+      },
+    };
+
+    const messages = callMessage("computer");
+    const newMessages = await executeToolCallsFromMessages(messages, {
+      tools,
+    });
+
+    expect(tools.computer.toModelOutput).toHaveBeenCalledWith({
+      output: implResult,
+    });
+    expect(newMessages).toHaveLength(1);
+    const part = (newMessages[0] as any).content[0];
+    expect(part.type).toBe("tool-result");
+    expect(part.toolCallId).toBe("call-cu-1");
+    expect(part.output).toEqual({
+      type: "content",
+      value: [
+        { type: "image-data", data: "aGVsbG8=", mediaType: "image/png" },
+      ],
+    });
+  });
+
+  it("does NOT duplicate the raw implementation result onto the part", async () => {
+    // Content outputs carry the full model-facing payload (screenshots);
+    // duplicating the raw result would double-ship the screenshot in every
+    // subsequent per-step request body on the hosted path.
+    const tools = {
+      computer: {
+        execute: async () => ({ screenshotBase64: "eA==" }),
+        toModelOutput: () => ({ type: "text", value: "ok" }),
+      },
+    };
+
+    const messages = callMessage("computer");
+    const newMessages = await executeToolCallsFromMessages(messages, {
+      tools,
+    });
+
+    const part = (newMessages[0] as any).content[0];
+    expect(part.output).toEqual({ type: "text", value: "ok" });
+    expect("result" in part).toBe(false);
+  });
+
+  it("awaits an async toModelOutput", async () => {
+    const tools = {
+      computer: {
+        execute: async () => ({ n: 1 }),
+        toModelOutput: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return { type: "text", value: "async-mapped" };
+        },
+      },
+    };
+
+    const messages = callMessage("computer");
+    const newMessages = await executeToolCallsFromMessages(messages, {
+      tools,
+    });
+
+    expect((newMessages[0] as any).content[0].output).toEqual({
+      type: "text",
+      value: "async-mapped",
+    });
+  });
+
+  it("a throwing toModelOutput records an error tool-result (not a crash)", async () => {
+    const tools = {
+      computer: {
+        execute: async () => ({ n: 1 }),
+        toModelOutput: () => {
+          throw new Error("mapping failed");
+        },
+      },
+    };
+
+    const messages = callMessage("computer");
+    const newMessages = await executeToolCallsFromMessages(messages, {
+      tools,
+    });
+
+    const part = (newMessages[0] as any).content[0];
+    expect(part.output.type).toBe("error-text");
+    expect(part.output.value).toMatch(/mapping failed/);
+  });
+
+  it("tools without toModelOutput keep the JSON serialization path", async () => {
+    const tools = {
+      regular: {
+        execute: async () => ({ ok: true }),
+      },
+    };
+
+    const messages = callMessage("regular");
+    const newMessages = await executeToolCallsFromMessages(messages, {
+      tools,
+    });
+
+    const part = (newMessages[0] as any).content[0];
+    expect(part.output).toEqual({ type: "json", value: { ok: true } });
+    expect(part.result).toEqual({ ok: true });
+  });
+});

--- a/mcpjam-inspector/shared/http-tool-calls.ts
+++ b/mcpjam-inspector/shared/http-tool-calls.ts
@@ -234,6 +234,42 @@ export async function executeToolCallsFromMessages(
               : Object.assign(new Error("Aborted"), { name: "AbortError" });
           }
 
+          // AI SDK tool contract: when a tool defines `toModelOutput`, the
+          // model-visible output is its mapping of the implementation result
+          // — e.g. the eval `computer` tool turns `{screenshotBase64}` into
+          // `{type:"content", value:[{type:"image-data",…}]}` so the model
+          // sees the screenshot as an image instead of a base64 JSON blob.
+          // The raw implementation result is NOT duplicated onto the part
+          // (`result:` below) in this branch: content outputs already carry
+          // the full model-facing payload, and double-shipping screenshots
+          // would bloat every subsequent per-step request body.
+          const toModelOutput = (
+            tool as {
+              toModelOutput?: (ctx: {
+                output: unknown;
+              }) => ToolResultPart | Promise<ToolResultPart>;
+            }
+          ).toModelOutput;
+          if (typeof toModelOutput === "function") {
+            const mappedOutput = await toModelOutput({ output: result });
+            const toolResultMessage: ModelMessage = {
+              role: "tool" as const,
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: content.toolCallId,
+                  toolName: toolName,
+                  output: mappedOutput,
+                  serverId: extractServerId(toolName),
+                },
+              ],
+            } as any;
+            if (!resultsByAssistantIdx.has(i)) resultsByAssistantIdx.set(i, []);
+            resultsByAssistantIdx.get(i)!.push(toolResultMessage);
+            allNewResults.push(toolResultMessage);
+            continue;
+          }
+
           let output: ToolResultPart;
           if (result !== undefined && result !== null) {
             if (typeof result === "object") {


### PR DESCRIPTION
# Browser tab for MCPJam-provided + org-BYOK evals (PR 14)

## Problem

The Browser tab (widget render observations + Computer Use timeline, PR 5–13) only fills in on the **local AI-SDK paths** — i.e. when the eval runs with an explicitly-pasted API key. MCPJam-provided models and org-stored BYOK keys dispatch through `runIterationViaBackend` / `streamIterationViaBackend`, which drive the shared engine (`runAssistantTurn` → `runChatEngineLoop`) and had **none of the harness wiring** — same Railway box, same Chromium, different code lane. Hosted iterations produced no browser artifacts.

## What this does

Wires the harness into the hosted lane via the engine's existing extension points (several of which were built for exactly this in PR 2/5b-pre). Both hosted runners now produce `widgetRenderObservations` + `browserInteractionSteps`, feeding the same finalize/persistence machinery as the local runners (PR 6b).

### Engine (`mcpjam-stream-handler.ts`)
- **`onToolResult` may return a promise and is awaited** (all `emitToolResults` call sites, incl. approval-denial paths). The eval render hook relies on this ordering: the widget must be mounted in the harness before the next step's `prepareAdvertisedTools` gate decides whether to advertise `computer` / `finish_widget`. Sync callbacks (chat, eval SSE emitters) unaffected.
- **`MCPJamToolResultEvent.rawResult`**: the unscrubbed implementation result. The event's `output` is the LLM-facing view with `_meta` / `structuredContent` scrubbed — the widget shim needs full fidelity.
- **Progressive-discovery fix**: non-cataloged injected tools (the Computer Use pair) stay advertised by default, mirroring `direct-chat-turn`'s `withInjectedTools`. They have no catalog `toolId`, so `load_mcp_tools` could never activate them — previously they'd be permanently invisible in progressive mode. No-op for chat (its catalog covers every real tool).

### Shared executor (`shared/http-tool-calls.ts`)
- **`executeToolCallsFromMessages` honors `tool.toModelOutput`** — the AI SDK contract the local path gets natively. Without this, the computer tool's screenshot would reach the model as a base64 JSON blob (token bomb, not an image). Content outputs skip the `result:` duplication so screenshots aren't double-shipped in every per-step request body.

### Computer Use tool (`computer-use-tool.ts`)
- **`wireFormat: true`** emits `computer` as a regular function tool with an explicit, JSON-serializable zod schema (harness-supported actions only) + a descriptive prompt. The provider-native factory's lazy schema serializes to an **empty object** through `serializeToolsForConvex` (verified — the model couldn't call it), and OpenRouter only exposes function tools anyway. Same `execute` / `toModelOutput` as the native tool.

### Runners (`evals-runner.ts` + new `browser-eval-context.ts`)
- `createEvalBrowserContext` bundles the harness lifecycle, wire-format tools, advertised-tool gate, render hook, tool-input cache, artifact collectors, and disposal — the engine-attachment mirror of the local runners' inline wiring.
- Both hosted runners delegate through a thin wrapper whose **try/finally guarantees Chromium teardown on every exit** (cancellation early-returns, setup failures, finalize throws).
- Per turn: prompt-index stamping + carried-widget dismissal; computer tools ride the existing trace wrap so their executions land as tool spans; `finishParams` thread both artifact arrays into the existing finalize path.

## What needs no changes

**The backend repo.** Verified end-to-end: `/stream` and `/stream/org` reconstruct flat `toolDefs` via `convertToAiSdkTools` (round-tripped the real serialized schema through it), `normalizeToolResultOrdering` passes tool-result parts through untouched, and both the OpenRouter provider (jam-paid; `image-data` → `image_url`, checked in the installed `@openrouter/ai-sdk-provider@2.9.0`) and `@ai-sdk/anthropic` (org BYOK) convert content-typed tool outputs with media for the model. Persistence schema + replay UI landed in PR 6/7.

## Behavior matrix after this PR

| Model selection | Render observations | Computer Use timeline |
|---|---|---|
| Explicit BYOK key (local paths) | ✅ (unchanged) | ✅ Claude only (unchanged) |
| MCPJam-provided model | ✅ **new** | ✅ **new**, Claude only (wire-format function tool via OpenRouter) |
| Org-stored BYOK | ✅ **new** | ✅ **new**, Claude only |

## Tests

- `http-tool-calls`: 5 new — `toModelOutput` mapping, no raw-result duplication, async mapping awaited, throwing mapper → error tool-result, JSON path untouched.
- `computer-use-tool`: 5 new — wire schema survives `serializeToolsForConvex` (action enum present), harness driving + `toModelOutput` parity, no-widget short-circuit, `onAction`, native default unchanged.
- `mcpjam-stream-handler`: ordering test — async `onToolResult` is awaited before the next step's `prepareAdvertisedTools` (gate observes the mount), `rawResult` carries the unscrubbed payload.
- `browser-eval-context` (new, 12): tool construction per driver, gate behavior, render hook (raw output, input cache, prompt-index stamping, error containment, non-Claude renders without keep-mounted), step collection + note narrowing, dismissal/disposal lifecycle.
- `evals-runner`: 2 new — Claude jam model gets tools + gate + hooks threaded into `runAssistantTurn`; non-Claude jam model gets render hook only.

Full suite: **5,383 passed / 0 failed** (516 files). Typecheck: no new errors vs. main baseline.

https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared chat engine loop, tool execution, and eval persistence with Chromium lifecycle; ordering and progressive-discovery fixes are subtle but covered by extensive tests.
> 
> **Overview**
> **Hosted eval paths** (MCPJam-provided and org BYOK via `runIterationViaBackend` / `streamIterationViaBackend`) now emit the same **Browser tab** artifacts as local AI-SDK runs: `widgetRenderObservations` and `browserInteractionSteps`, wired through a new **`createEvalBrowserContext`** wrapper with **try/finally Chromium disposal**.
> 
> Each iteration merges wire-format **`computer` / `finish_widget`** tools (Claude only), hooks **`onToolCall` / `onToolResult` / `prepareAdvertisedTools`** into `runAssistantTurn`, dismisses carried widgets per prompt turn, and passes collected artifacts into **`finalizeEvalIteration`**.
> 
> **Engine and executor changes** support this: **`onToolResult` is awaited** before the next step so the widget mounts before the Computer Use gate runs; tool events expose **`rawResult`** for widget rendering; progressive discovery keeps **non-catalog injected tools** visible; **`executeToolCallsFromMessages`** honors **`toModelOutput`** (screenshots as images, no duplicate raw payload on content outputs).
> 
> **`buildComputerUseTools({ wireFormat: true })`** adds a JSON-serializable function-tool `computer` schema for Convex `/stream` serialization instead of the empty provider-native schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742bd61f32215db3e15e65bc62be77340240c6c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->