### PR TITLE
fix(server): resolve externalId via service-token route, not anon Convex query

### DIFF
--- a/mcpjam-inspector/server/services/__tests__/identity.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/identity.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the externalId → MCPJam user resolver, focused on 404
+ * disambiguation: the backend route's own "User not found" 404 must map to
+ * `null` (caller 401s), while a routing-level 404 — the route not deployed
+ * or CONVEX_HTTP_URL pointing at the wrong deployment — must throw so the
+ * misconfiguration surfaces as a 500 instead of silent "Unknown user" 401s.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resolveUserByExternalId } from "../identity.js";
+
+const CONVEX_HTTP_URL = "https://example.convex.site";
+const SERVICE_TOKEN = "test-service-token";
+
+function mockFetchResponse(status: number, body: string | null) {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(body, { status }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("resolveUserByExternalId", () => {
+  beforeEach(() => {
+    vi.stubEnv("CONVEX_HTTP_URL", CONVEX_HTTP_URL);
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", SERVICE_TOKEN);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves { _id } from a 200 and sends the service token", async () => {
+    const fetchMock = mockFetchResponse(
+      200,
+      JSON.stringify({ ok: true, userId: "users_abc123" })
+    );
+
+    const result = await resolveUserByExternalId("workos|user_1");
+
+    expect(result).toEqual({ _id: "users_abc123" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      `${CONVEX_HTTP_URL}/internal/v1/users/lookup-by-external-id?externalId=workos%7Cuser_1`
+    );
+    expect(init.headers["x-inspector-service-token"]).toBe(SERVICE_TOKEN);
+  });
+
+  it("returns null on the route's own 'User not found' 404", async () => {
+    mockFetchResponse(
+      404,
+      JSON.stringify({ ok: false, error: "User not found" })
+    );
+
+    await expect(resolveUserByExternalId("workos|missing")).resolves.toBeNull();
+  });
+
+  it("throws on a routing-level 404 (route not deployed)", async () => {
+    // Convex's own 404 for an unknown path is not the route's JSON shape.
+    mockFetchResponse(404, "No matching routes found");
+
+    await expect(resolveUserByExternalId("workos|user_1")).rejects.toThrow(
+      /route not found/
+    );
+  });
+
+  it("throws on other non-OK statuses", async () => {
+    mockFetchResponse(
+      401,
+      JSON.stringify({ ok: false, error: "Unauthorized" })
+    );
+
+    await expect(resolveUserByExternalId("workos|user_1")).rejects.toThrow(
+      /User lookup failed \(401\)/
+    );
+  });
+
+  it("throws when the 200 body is missing a string userId", async () => {
+    mockFetchResponse(200, JSON.stringify({ ok: true }));
+
+    await expect(resolveUserByExternalId("workos|user_1")).rejects.toThrow(
+      /invalid body/
+    );
+  });
+
+  it("throws when config is missing", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "");
+
+    await expect(resolveUserByExternalId("workos|user_1")).rejects.toThrow(
+      /CONVEX_HTTP_URL/
+    );
+  });
+});

--- a/mcpjam-inspector/server/services/identity.ts
+++ b/mcpjam-inspector/server/services/identity.ts
@@ -10,9 +10,16 @@
  * (`GET /internal/v1/users/lookup-by-external-id`; see mcpjam-backend
  * `convex/http.ts`). Authenticated with `INSPECTOR_SERVICE_TOKEN` via the
  * `x-inspector-service-token` header — the same channel `workos-key-bindings.ts`
- * uses for its sibling routes. Returns `null` on 404 (no matching user) so
- * the caller can translate to a 401; throws on transport / unexpected status.
+ * uses for its sibling routes. Returns `null` only on the route's own
+ * "User not found" 404 so the caller can translate to a 401; throws on
+ * transport errors, unexpected statuses, and routing-level 404s (route not
+ * deployed / wrong `CONVEX_HTTP_URL`).
  */
+
+import {
+  getInternalBackendConfig,
+  isEntityNotFound,
+} from "./internal-backend.js";
 
 const USERS_LOOKUP_PATH = "/internal/v1/users/lookup-by-external-id";
 
@@ -21,22 +28,10 @@ export interface ResolvedMcpjamUser {
   _id: string;
 }
 
-function getConfig(): { convexUrl: string; serviceToken: string } {
-  const convexUrl = process.env.CONVEX_HTTP_URL;
-  if (!convexUrl) {
-    throw new Error("CONVEX_HTTP_URL is not set");
-  }
-  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  if (!serviceToken) {
-    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
-  }
-  return { convexUrl, serviceToken };
-}
-
 export async function resolveUserByExternalId(
   externalId: string
 ): Promise<ResolvedMcpjamUser | null> {
-  const { convexUrl, serviceToken } = getConfig();
+  const { convexUrl, serviceToken } = getInternalBackendConfig();
   const url = `${convexUrl}${USERS_LOOKUP_PATH}?externalId=${encodeURIComponent(
     externalId
   )}`;
@@ -45,7 +40,12 @@ export async function resolveUserByExternalId(
     headers: { "x-inspector-service-token": serviceToken },
   });
   if (response.status === 404) {
-    return null;
+    if (await isEntityNotFound(response, "User not found")) {
+      return null;
+    }
+    throw new Error(
+      `User lookup route not found at ${convexUrl}${USERS_LOOKUP_PATH} — is the backend lookup route deployed?`
+    );
   }
   if (!response.ok) {
     throw new Error(`User lookup failed (${response.status})`);

--- a/mcpjam-inspector/server/services/identity.ts
+++ b/mcpjam-inspector/server/services/identity.ts
@@ -1,54 +1,58 @@
-import { ConvexHttpClient } from "convex/browser";
-import { getInspectorClientRuntimeConfig } from "../env.js";
-
 /**
  * Resolve an MCPJam user from a WorkOS user id (the user's `externalId`
  * in Convex).
  *
- * Used by the bearer middleware when an `sk_` WorkOS API key is presented:
- * after `WorkOS.apiKeys.createValidation` returns the owning WorkOS user,
- * we map it to an MCPJam user id so Inspector can call Convex as that user
- * via the service-token + acting-as exchange.
+ * Used by the bearer middleware when an `sk_` WorkOS API key is presented,
+ * and by the API-key mint route to record the minting user's Convex id on
+ * the new `workosApiKeyBindings` row.
  *
- * Returns `null` when no matching user is found — the caller is
- * responsible for translating that into a 401.
+ * Calls the backend's service-token-gated resolver
+ * (`GET /internal/v1/users/lookup-by-external-id`; see mcpjam-backend
+ * `convex/http.ts`). Authenticated with `INSPECTOR_SERVICE_TOKEN` via the
+ * `x-inspector-service-token` header — the same channel `workos-key-bindings.ts`
+ * uses for its sibling routes. Returns `null` on 404 (no matching user) so
+ * the caller can translate to a 401; throws on transport / unexpected status.
  */
+
+const USERS_LOOKUP_PATH = "/internal/v1/users/lookup-by-external-id";
+
 export interface ResolvedMcpjamUser {
   /** MCPJam user document id (Convex). */
   _id: string;
 }
 
+function getConfig(): { convexUrl: string; serviceToken: string } {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new Error("CONVEX_HTTP_URL is not set");
+  }
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!serviceToken) {
+    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
+  }
+  return { convexUrl, serviceToken };
+}
+
 export async function resolveUserByExternalId(
   externalId: string
 ): Promise<ResolvedMcpjamUser | null> {
-  // ConvexHttpClient needs the deployment (`.convex.cloud`) URL. Inspector
-  // boot only *requires* CONVEX_HTTP_URL (the `.convex.site` HTTP-actions
-  // origin), and `getInspectorClientRuntimeConfig()` derives the `.convex.cloud`
-  // query URL from it — so a deployment that sets only CONVEX_HTTP_URL still
-  // resolves identity here (previously this threw "CONVEX_URL is not set",
-  // 500-ing all sk_ auth and API-key minting). Fall back to an explicit
-  // CONVEX_URL if the derivation can't produce one.
-  const convexUrl =
-    getInspectorClientRuntimeConfig().convexUrl ?? process.env.CONVEX_URL;
-  if (!convexUrl) {
-    throw new Error(
-      "Convex deployment URL is not configured (set CONVEX_HTTP_URL or CONVEX_URL)",
-    );
-  }
-
-  const client = new ConvexHttpClient(convexUrl);
-
-  // TODO: remove `as any` cast after the backend PR `claude/workos-api-keys-backend`
-  // adds `api.users.getByExternalId`. Inspector calls Convex via string
-  // function paths (matches `local-server-resolver.ts:935` and
-  // `servers.ts:80`) — no codegen step pins the API surface here, so the
-  // cast is the documented escape hatch until the reader query lands.
-  const result = (await client.query(
-    "users:getByExternalId" as any,
-    { externalId }
-  )) as { _id: string } | null | undefined;
-
-  if (!result || typeof result !== "object" || typeof result._id !== "string")
+  const { convexUrl, serviceToken } = getConfig();
+  const url = `${convexUrl}${USERS_LOOKUP_PATH}?externalId=${encodeURIComponent(
+    externalId
+  )}`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "x-inspector-service-token": serviceToken },
+  });
+  if (response.status === 404) {
     return null;
-  return { _id: result._id };
+  }
+  if (!response.ok) {
+    throw new Error(`User lookup failed (${response.status})`);
+  }
+  const body = (await response.json()) as { userId?: unknown };
+  if (typeof body?.userId !== "string") {
+    throw new Error("User lookup returned an invalid body");
+  }
+  return { _id: body.userId };
 }

--- a/mcpjam-inspector/server/services/internal-backend.ts
+++ b/mcpjam-inspector/server/services/internal-backend.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared plumbing for the backend's service-token-gated `/internal/v1/*`
+ * routes (see mcpjam-backend `convex/http.ts`). Inspector authenticates to
+ * them with `INSPECTOR_SERVICE_TOKEN` via the `x-inspector-service-token`
+ * header; `CONVEX_HTTP_URL` is the `.convex.site` HTTP-actions origin those
+ * routes are mounted on.
+ */
+
+export function getInternalBackendConfig(): {
+  convexUrl: string;
+  serviceToken: string;
+} {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new Error("CONVEX_HTTP_URL is not set");
+  }
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!serviceToken) {
+    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
+  }
+  return { convexUrl, serviceToken };
+}
+
+/**
+ * Distinguish an entity-level 404 (the backend route ran and reported the
+ * entity missing, body `{ ok: false, error: <expectedError> }`) from a 404
+ * produced by Convex routing itself when the path doesn't exist — e.g. the
+ * backend route isn't deployed yet, or `CONVEX_HTTP_URL` points at the wrong
+ * deployment. Convex's routing 404 is not this JSON shape, so callers can
+ * throw on it instead of mapping a config error to "entity missing" (which
+ * would surface downstream as silent 401s).
+ */
+export async function isEntityNotFound(
+  response: Response,
+  expectedError: string
+): Promise<boolean> {
+  const body = (await response.json().catch(() => null)) as {
+    ok?: unknown;
+    error?: unknown;
+  } | null;
+  return body?.ok === false && body?.error === expectedError;
+}

--- a/mcpjam-inspector/server/services/workos-key-bindings.ts
+++ b/mcpjam-inspector/server/services/workos-key-bindings.ts
@@ -11,6 +11,11 @@
  * delegated-identity resolver).
  */
 
+import {
+  getInternalBackendConfig,
+  isEntityNotFound,
+} from "./internal-backend.js";
+
 const BINDINGS_PATH = "/internal/v1/workos-api-key-bindings";
 
 export interface WorkosKeyBinding {
@@ -32,36 +37,31 @@ export class WorkosKeyBindingError extends Error {
   }
 }
 
-function getConfig(): { convexUrl: string; serviceToken: string } {
-  const convexUrl = process.env.CONVEX_HTTP_URL;
-  if (!convexUrl) {
-    throw new Error("CONVEX_HTTP_URL is not set");
-  }
-  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  if (!serviceToken) {
-    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
-  }
-  return { convexUrl, serviceToken };
-}
-
 /**
- * Look up the org a WorkOS API key is bound to. Returns `null` when the
- * backend reports 404 (no binding) — the caller treats that as an orphaned
- * key (401). Throws on transport / unexpected status so the caller can 500.
+ * Look up the org a WorkOS API key is bound to. Returns `null` only on the
+ * route's own "Binding not found" 404 — the caller treats that as an
+ * orphaned key (401). Throws on transport / unexpected status, and on a
+ * routing-level 404 (route not deployed / wrong `CONVEX_HTTP_URL`), so the
+ * caller can 500 instead of mis-reporting a config error as an orphaned key.
  */
 export async function lookupWorkosKeyBinding(
-  workosApiKeyId: string,
+  workosApiKeyId: string
 ): Promise<WorkosKeyBinding | null> {
-  const { convexUrl, serviceToken } = getConfig();
+  const { convexUrl, serviceToken } = getInternalBackendConfig();
   const url = `${convexUrl}${BINDINGS_PATH}?workosApiKeyId=${encodeURIComponent(
-    workosApiKeyId,
+    workosApiKeyId
   )}`;
   const response = await fetch(url, {
     method: "GET",
     headers: { "x-inspector-service-token": serviceToken },
   });
   if (response.status === 404) {
-    return null;
+    if (await isEntityNotFound(response, "Binding not found")) {
+      return null;
+    }
+    throw new Error(
+      `Binding lookup route not found at ${convexUrl}${BINDINGS_PATH} — is the backend bindings route deployed?`
+    );
   }
   if (!response.ok) {
     throw new Error(`Binding lookup failed (${response.status})`);
@@ -83,7 +83,7 @@ export async function createWorkosKeyBinding(args: {
   mcpjamOrganizationId: string;
   mintedByUserId: string;
 }): Promise<void> {
-  const { convexUrl, serviceToken } = getConfig();
+  const { convexUrl, serviceToken } = getInternalBackendConfig();
   const response = await fetch(`${convexUrl}${BINDINGS_PATH}`, {
     method: "POST",
     headers: {
@@ -110,11 +110,11 @@ export async function createWorkosKeyBinding(args: {
  * error as best-effort and does not fail the user-facing revoke.
  */
 export async function removeWorkosKeyBinding(
-  workosApiKeyId: string,
+  workosApiKeyId: string
 ): Promise<void> {
-  const { convexUrl, serviceToken } = getConfig();
+  const { convexUrl, serviceToken } = getInternalBackendConfig();
   const url = `${convexUrl}${BINDINGS_PATH}?workosApiKeyId=${encodeURIComponent(
-    workosApiKeyId,
+    workosApiKeyId
   )}`;
   const response = await fetch(url, {
     method: "DELETE",


### PR DESCRIPTION
## Summary

- Switches `server/services/identity.ts` from an unauthenticated `ConvexHttpClient.query("users:getByExternalId")` call to a `fetch` against the new `GET /internal/v1/users/lookup-by-external-id` route added in [mcpjam-backend#487](https://github.com/MCPJam/mcpjam-backend/pull/487), gated by `INSPECTOR_SERVICE_TOKEN` via the `x-inspector-service-token` header.
- Mirrors the existing `server/services/workos-key-bindings.ts` pattern that already talks to the sibling `/internal/v1/workos-api-key-bindings` routes.

## Why

The previous code called a public Convex query that was never landed on the backend, so every \`sk_\` API-key mint 500'd with:

\`\`\`
Could not find public function for 'users:getByExternalId'.
\`\`\`

Going through the service-token route is the robust mirror of how Inspector reads/writes WorkOS-key org bindings today, and avoids putting an externalId→userId resolver on the unauthenticated public Convex surface.

The exported function name, signature, and return shape are unchanged, so the two callers (`server/middleware/bearer-auth.ts:176` and `server/routes/web/api-keys.ts:187`) need no edits.

## Dependency

Requires [mcpjam-backend#487](https://github.com/MCPJam/mcpjam-backend/pull/487) to be deployed first. Until then, this branch's `resolveUserByExternalId` will 404. After both land, the \`sk_\` mint flow goes end-to-end.

## Test plan

- [x] \`vitest run server/middleware/__tests__/bearer-auth.test.ts\` — all 10 tests green (the suite mocks `resolveUserByExternalId`, so the refactor is transparent to it)
- [x] \`prettier --check\` clean on the touched file
- [ ] Manual: with backend#487 deployed and `INSPECTOR_SERVICE_TOKEN` + `CONVEX_HTTP_URL` set, hit \`Create API key\` and confirm the binding row writes successfully with \`mintedByUserId\` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sk_ API-key auth and mint identity resolution; depends on backend route deployment and correct CONVEX_HTTP_URL, but behavior for callers is unchanged when configured correctly.
> 
> **Overview**
> **`resolveUserByExternalId`** no longer calls an unauthenticated Convex `users:getByExternalId` query. It now **GETs** `CONVEX_HTTP_URL/internal/v1/users/lookup-by-external-id` with **`x-inspector-service-token`**, maps **`userId`** to **`{ _id }`**, and keeps the same public contract for bearer auth and API-key minting.
> 
> New **`internal-backend.ts`** centralizes **`CONVEX_HTTP_URL` + `INSPECTOR_SERVICE_TOKEN`** and **`isEntityNotFound`**, which tells a route’s JSON **404** (“User not found” / “Binding not found”) from Convex’s routing **404**. **`workos-key-bindings`** uses the same helper so a missing backend route or wrong URL **throws** instead of being treated as “no binding / unknown user” (**401**).
> 
> Adds **`identity.test.ts`** covering success, entity 404 → **`null`**, routing 404, bad status/body, and missing config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3869829b2b39c0d0e63922e00be9c426fe341bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->