### PR TITLE
fix(evals): honor widget-declared CSP in the browser harness network gate

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
@@ -4,6 +4,7 @@ import {
   McpAppBrowserHarness,
   ChromiumNotInstalledError,
   cspSourceMatchesUrl,
+  injectCspMeta,
   type McpAppBrowserHarnessOptions,
 } from "../mcp-app-browser-harness";
 
@@ -396,6 +397,33 @@ describe("cspSourceMatchesUrl — CSP host-source matching", () => {
     ).toBe(true);
   });
 
+  it("treats an omitted source port as the scheme default only (not any port)", () => {
+    // CSP: a source without a port matches only the URL scheme's default port.
+    expect(
+      cspSourceMatchesUrl(
+        "https://api.example.com",
+        u("https://api.example.com/x")
+      )
+    ).toBe(true);
+    expect(
+      cspSourceMatchesUrl(
+        "https://api.example.com",
+        u("https://api.example.com:443/x")
+      )
+    ).toBe(true);
+    expect(
+      cspSourceMatchesUrl(
+        "https://api.example.com",
+        u("https://api.example.com:8443/x")
+      )
+    ).toBe(false);
+    // http default is 80.
+    expect(cspSourceMatchesUrl("http://h.io", u("http://h.io/x"))).toBe(true);
+    expect(cspSourceMatchesUrl("http://h.io", u("http://h.io:8080/x"))).toBe(
+      false
+    );
+  });
+
   it("ignores paths in host-sources (origin-granular gate)", () => {
     expect(
       cspSourceMatchesUrl(
@@ -414,70 +442,137 @@ describe("cspSourceMatchesUrl — CSP host-source matching", () => {
   });
 });
 
-describe("McpAppBrowserHarness — widget-declared network policy", () => {
-  // Guest that handshakes, paints, and probes two origins. `.invalid` is a
-  // reserved TLD (RFC 2606): the allowed probe fails DNS (a net error, fine)
-  // while never leaving the machine; only the GATE-aborted probe must land in
-  // blockedRequests.
-  const FETCHING_GUEST_SRC = `
+describe("injectCspMeta", () => {
+  it("inserts the policy as the first child of <head>", () => {
+    const out = injectCspMeta(
+      "<!doctype html><html><head><title>x</title></head><body></body></html>",
+      "default-src 'self'"
+    );
+    expect(out).toContain(
+      `<head><meta http-equiv="Content-Security-Policy" content="default-src 'self'">`
+    );
+    // Must precede any resource-bearing tag it governs.
+    expect(out.indexOf("Content-Security-Policy")).toBeLessThan(
+      out.indexOf("<title>")
+    );
+  });
+
+  it("synthesizes a <head> when the document omits one", () => {
+    expect(
+      injectCspMeta("<html><body>x</body></html>", "default-src 'none'")
+    ).toContain(
+      `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'"></head>`
+    );
+    // No <html> at all: prepend so document.write still parses it first.
+    expect(injectCspMeta("<p>x</p>", "default-src 'none'")).toBe(
+      `<meta http-equiv="Content-Security-Policy" content="default-src 'none'"><p>x</p>`
+    );
+  });
+});
+
+describe("McpAppBrowserHarness — widget-declared CSP enforcement", () => {
+  // Guest that probes three origins via fetch (a connect-src concern) the
+  // instant it parses — before the bridge — so the injected <meta> CSP (first
+  // in <head>) governs them. `.invalid` is a reserved TLD (RFC 2606): a
+  // CSP-allowed probe leaves the machine and merely fails DNS, while a
+  // CSP-blocked probe never makes a network attempt and logs a violation.
+  const PROBE_GUEST_SRC = `
+fetch("https://conn-ok.invalid/a").catch(() => {});
+fetch("https://res-only.invalid/b").catch(() => {});
+fetch("https://nope.invalid/c").catch(() => {});
 import { App } from "@modelcontextprotocol/ext-apps";
-const app = new App({ name: "fixture-fetch", version: "1.0.0" });
+const app = new App({ name: "fixture-csp", version: "1.0.0" });
 (async () => {
   await app.connect();
   const d = document.createElement("div");
-  d.textContent = "fetch fixture";
+  d.textContent = "csp fixture";
   d.style.cssText = "font-size:32px;padding:40px";
   document.body.appendChild(d);
-  fetch("https://allowed-cdn.invalid/app.js").catch(() => {});
-  fetch("https://blocked-cdn.invalid/app.js").catch(() => {});
 })();
 `;
 
-  let fetchingHtml = "";
+  // Single-origin probe used for the undeclared-default and reset cases.
+  const ONE_PROBE_GUEST_SRC = `
+fetch("https://anywhere.invalid/x").catch(() => {});
+import { App } from "@modelcontextprotocol/ext-apps";
+const app = new App({ name: "fixture-csp1", version: "1.0.0" });
+(async () => {
+  await app.connect();
+  const d = document.createElement("div");
+  d.textContent = "csp1 fixture";
+  d.style.cssText = "font-size:32px;padding:40px";
+  document.body.appendChild(d);
+})();
+`;
+
+  let probeHtml = "";
+  let oneProbeHtml = "";
   beforeAll(async () => {
-    fetchingHtml = guestHtml(await bundleGuest(FETCHING_GUEST_SRC));
+    probeHtml = guestHtml(await bundleGuest(PROBE_GUEST_SRC));
+    oneProbeHtml = guestHtml(await bundleGuest(ONE_PROBE_GUEST_SRC));
   }, 60_000);
 
-  it("lets declared CSP origins through the gate and blocks the rest", async () => {
+  it("enforces directive separation: fetch obeys connect_domains, not resource_domains", async () => {
     const h = makeHarness();
     const obs = await h.renderWidget({
       toolCallId: "csp-1",
       toolName: "show_widget",
       serverId: "srv",
-      html: fetchingHtml,
-      cspMeta: { resource_domains: ["https://allowed-cdn.invalid"] },
+      html: probeHtml,
+      cspMeta: {
+        connect_domains: ["https://conn-ok.invalid"],
+        resource_domains: ["https://res-only.invalid"],
+      },
     });
     expect(obs.status).toBe("rendered");
-    const blocked = obs.blockedRequests ?? [];
-    expect(blocked.some((u) => u.includes("blocked-cdn.invalid"))).toBe(true);
-    expect(blocked.some((u) => u.includes("allowed-cdn.invalid"))).toBe(false);
+    const errs = (obs.consoleErrors ?? []).join("\n");
+    // The "Refused to connect to '<url>'" prefix names the BLOCKED url itself
+    // (so it can't be confused with conn-ok appearing in the echoed directive).
+    expect(errs).toMatch(/Connecting to 'https:\/\/res-only\.invalid/);
+    expect(errs).toMatch(/Connecting to 'https:\/\/nope\.invalid/);
+    // connect_domains origin is permitted by connect-src -> no CSP violation.
+    expect(errs).not.toMatch(/Connecting to 'https:\/\/conn-ok\.invalid/);
   }, 30_000);
 
-  it("resets the allowlist per widget: undeclared next widget is blocked again", async () => {
+  it("policies undeclared widgets with the SEP restrictive default", async () => {
+    const h = makeHarness();
+    const obs = await h.renderWidget({
+      toolCallId: "csp-default",
+      toolName: "show_widget",
+      serverId: "srv",
+      html: oneProbeHtml,
+      // no cspMeta -> widget-declared default: connect-src 'self' + loopback.
+    });
+    expect(obs.status).toBe("rendered");
+    const errs = (obs.consoleErrors ?? []).join("\n");
+    expect(errs).toMatch(/Connecting to 'https:\/\/anywhere\.invalid/);
+  }, 30_000);
+
+  it("re-derives the policy per widget: a later undeclared widget loses the grant", async () => {
     const h = makeHarness();
     const first = await h.renderWidget({
       toolCallId: "csp-2a",
       toolName: "show_widget",
       serverId: "srv",
-      html: fetchingHtml,
-      cspMeta: { connect_domains: ["https://allowed-cdn.invalid"] },
+      html: oneProbeHtml,
+      cspMeta: { connect_domains: ["https://anywhere.invalid"] },
     });
-    expect(
-      (first.blockedRequests ?? []).some((u) =>
-        u.includes("allowed-cdn.invalid")
-      )
-    ).toBe(false);
+    expect(first.status).toBe("rendered");
+    expect((first.consoleErrors ?? []).join("\n")).not.toMatch(
+      /Connecting to 'https:\/\/anywhere\.invalid/
+    );
 
-    // Same harness, same fetches — but THIS widget declares nothing.
+    // Same harness, same probe — but THIS widget declares nothing, so the
+    // injected CSP reverts to the restrictive default and blocks the fetch.
     const second = await h.renderWidget({
       toolCallId: "csp-2b",
       toolName: "show_widget",
       serverId: "srv",
-      html: fetchingHtml,
+      html: oneProbeHtml,
     });
     expect(second.status).toBe("rendered");
-    const blocked = second.blockedRequests ?? [];
-    expect(blocked.some((u) => u.includes("allowed-cdn.invalid"))).toBe(true);
-    expect(blocked.some((u) => u.includes("blocked-cdn.invalid"))).toBe(true);
+    expect((second.consoleErrors ?? []).join("\n")).toMatch(
+      /Connecting to 'https:\/\/anywhere\.invalid/
+    );
   }, 45_000);
 });

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
@@ -336,6 +336,37 @@ describe("McpAppBrowserHarness — interaction", () => {
   }, 30_000);
 });
 
+describe("McpAppBrowserHarness — unmount network-allowance lifecycle", () => {
+  const sourcesOf = (h: McpAppBrowserHarness) =>
+    (h as unknown as { widgetCspSources: string[] }).widgetCspSources;
+
+  it("keeps the live widget's declared origins when a STALE tool-call is dismissed", async () => {
+    const h = makeHarness();
+    await h.renderWidget({
+      toolCallId: "live-1",
+      toolName: "show",
+      serverId: "srv",
+      html: buttonHtml,
+      cspMeta: { connect_domains: ["https://api.allowed.invalid"] },
+      keepMounted: true,
+    });
+    expect(h.getMountedWidgetId()).toBe("live-1");
+    expect(sourcesOf(h)).toContain("https://api.allowed.invalid");
+
+    // Dismissing a tool-call that is NOT the live mount (e.g. a carried id that
+    // was already replaced) must not strip the current widget's allowances —
+    // otherwise its subsequent subresource fetches abort at the route gate.
+    await h.dismissWidget("stale-never-mounted");
+    expect(h.getMountedWidgetId()).toBe("live-1");
+    expect(sourcesOf(h)).toContain("https://api.allowed.invalid");
+
+    // Dismissing the actual live widget DOES clear them (fail closed).
+    await h.dismissWidget("live-1");
+    expect(h.getMountedWidgetId()).toBeNull();
+    expect(sourcesOf(h)).toEqual([]);
+  }, 30_000);
+});
+
 describe("cspSourceMatchesUrl — CSP host-source matching", () => {
   const u = (s: string) => new URL(s);
 

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
@@ -468,6 +468,21 @@ describe("injectCspMeta", () => {
       `<meta http-equiv="Content-Security-Policy" content="default-src 'none'"><p>x</p>`
     );
   });
+
+  it("escapes attribute-breaking chars so widget metadata can't corrupt the policy", () => {
+    // A `"` in widget-derived CSP content must not break out of content="…"
+    // and truncate/disable the injected policy (or inject sibling markup).
+    const out = injectCspMeta(
+      "<!doctype html><html><head></head><body></body></html>",
+      `connect-src 'self' https://x"></head><script>alert(1)</script>`
+    );
+    expect(out).not.toContain(`x"></head>`); // no real breakout
+    expect(out).not.toContain("<script>alert(1)</script>"); // not injected as markup
+    expect(out).toContain("&quot;");
+    expect(out).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    // Single quotes are valid inside a double-quoted attribute -> left as-is.
+    expect(out).toContain("connect-src 'self'");
+  });
 });
 
 describe("McpAppBrowserHarness — widget-declared CSP enforcement", () => {

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
@@ -3,6 +3,7 @@ import { build } from "esbuild";
 import {
   McpAppBrowserHarness,
   ChromiumNotInstalledError,
+  cspSourceMatchesUrl,
   type McpAppBrowserHarnessOptions,
 } from "../mcp-app-browser-harness";
 
@@ -67,14 +68,14 @@ beforeAll(async () => {
 
 const harnesses: McpAppBrowserHarness[] = [];
 function makeHarness(
-  overrides: Partial<McpAppBrowserHarnessOptions> = {},
+  overrides: Partial<McpAppBrowserHarnessOptions> = {}
 ): McpAppBrowserHarness & { calls: Array<{ name: string }> } {
   const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
   const callTool = vi.fn(
     async (_serverId: string, name: string, args: Record<string, unknown>) => {
       calls.push({ name, args });
       return { content: [{ type: "text", text: "ok" }] };
-    },
+    }
   );
   const h = new McpAppBrowserHarness({
     callTool,
@@ -133,7 +134,7 @@ describe("McpAppBrowserHarness — render classification", () => {
     expect(obs.status).toBe("rendered");
     expect(obs.bridgeInitialized).toBe(true);
     expect(obs.screenshotBase64 && obs.screenshotBase64.length).toBeGreaterThan(
-      0,
+      0
     );
     // screenshot within the byte budget (256 KiB default).
     const bytes = Buffer.from(obs.screenshotBase64!, "base64").byteLength;
@@ -233,10 +234,13 @@ describe("McpAppBrowserHarness — interaction", () => {
     });
 
     expect(result.widgetToolCalls.length).toBe(1);
-    expect(result.widgetToolCalls[0]).toMatchObject({ name: "reserve", ok: true });
-    expect(result.screenshotBase64 && result.screenshotBase64.length).toBeGreaterThan(
-      0,
-    );
+    expect(result.widgetToolCalls[0]).toMatchObject({
+      name: "reserve",
+      ok: true,
+    });
+    expect(
+      result.screenshotBase64 && result.screenshotBase64.length
+    ).toBeGreaterThan(0);
     // dispatched through the injected callTool with the widget's serverId.
     expect(h.calls).toEqual([{ name: "reserve", args: { seat: 12 } }]);
   }, 30_000);
@@ -329,4 +333,151 @@ describe("McpAppBrowserHarness — interaction", () => {
     });
     expect(third.note).toBe("no_rendered_widget");
   }, 30_000);
+});
+
+describe("cspSourceMatchesUrl — CSP host-source matching", () => {
+  const u = (s: string) => new URL(s);
+
+  it("matches exact origins and rejects scheme/host mismatches", () => {
+    expect(
+      cspSourceMatchesUrl("https://esm.sh", u("https://esm.sh/react"))
+    ).toBe(true);
+    expect(
+      cspSourceMatchesUrl("https://esm.sh", u("http://esm.sh/react"))
+    ).toBe(false);
+    expect(
+      cspSourceMatchesUrl("https://esm.sh", u("https://evil.sh/react"))
+    ).toBe(false);
+  });
+
+  it("matches wildcard subdomains but not the bare apex", () => {
+    const src = "https://*.excalidraw.com";
+    expect(
+      cspSourceMatchesUrl(src, u("https://cdn.excalidraw.com/a.woff2"))
+    ).toBe(true);
+    expect(cspSourceMatchesUrl(src, u("https://a.b.excalidraw.com/x"))).toBe(
+      true
+    );
+    expect(cspSourceMatchesUrl(src, u("https://excalidraw.com/x"))).toBe(false);
+    expect(cspSourceMatchesUrl(src, u("https://notexcalidraw.com/x"))).toBe(
+      false
+    );
+  });
+
+  it("scheme-less host-sources match http(s)/ws(s) on that host only", () => {
+    expect(cspSourceMatchesUrl("esm.sh", u("https://esm.sh/x"))).toBe(true);
+    expect(cspSourceMatchesUrl("esm.sh", u("http://esm.sh/x"))).toBe(true);
+    expect(cspSourceMatchesUrl("esm.sh", u("wss://esm.sh/socket"))).toBe(true);
+    expect(cspSourceMatchesUrl("esm.sh", u("ftp://esm.sh/x"))).toBe(false);
+    expect(cspSourceMatchesUrl("esm.sh", u("https://other.sh/x"))).toBe(false);
+  });
+
+  it("scheme-only sources allow any host on that scheme", () => {
+    expect(cspSourceMatchesUrl("https:", u("https://anything.example/x"))).toBe(
+      true
+    );
+    expect(cspSourceMatchesUrl("https:", u("http://anything.example/x"))).toBe(
+      false
+    );
+  });
+
+  it("honors ports (explicit, wildcard, and scheme defaults)", () => {
+    expect(
+      cspSourceMatchesUrl("https://cdn.x.io:8443", u("https://cdn.x.io:8443/a"))
+    ).toBe(true);
+    expect(
+      cspSourceMatchesUrl("https://cdn.x.io:8443", u("https://cdn.x.io/a"))
+    ).toBe(false);
+    expect(
+      cspSourceMatchesUrl("https://cdn.x.io:443", u("https://cdn.x.io/a"))
+    ).toBe(true);
+    expect(
+      cspSourceMatchesUrl("https://cdn.x.io:*", u("https://cdn.x.io:9999/a"))
+    ).toBe(true);
+  });
+
+  it("ignores paths in host-sources (origin-granular gate)", () => {
+    expect(
+      cspSourceMatchesUrl(
+        "https://cdn.x.io/assets/",
+        u("https://cdn.x.io/other/file.js")
+      )
+    ).toBe(true);
+  });
+
+  it("never matches quoted keywords or empty sources", () => {
+    expect(cspSourceMatchesUrl("'self'", u("https://esm.sh/x"))).toBe(false);
+    expect(cspSourceMatchesUrl("'unsafe-inline'", u("https://esm.sh/x"))).toBe(
+      false
+    );
+    expect(cspSourceMatchesUrl("", u("https://esm.sh/x"))).toBe(false);
+  });
+});
+
+describe("McpAppBrowserHarness — widget-declared network policy", () => {
+  // Guest that handshakes, paints, and probes two origins. `.invalid` is a
+  // reserved TLD (RFC 2606): the allowed probe fails DNS (a net error, fine)
+  // while never leaving the machine; only the GATE-aborted probe must land in
+  // blockedRequests.
+  const FETCHING_GUEST_SRC = `
+import { App } from "@modelcontextprotocol/ext-apps";
+const app = new App({ name: "fixture-fetch", version: "1.0.0" });
+(async () => {
+  await app.connect();
+  const d = document.createElement("div");
+  d.textContent = "fetch fixture";
+  d.style.cssText = "font-size:32px;padding:40px";
+  document.body.appendChild(d);
+  fetch("https://allowed-cdn.invalid/app.js").catch(() => {});
+  fetch("https://blocked-cdn.invalid/app.js").catch(() => {});
+})();
+`;
+
+  let fetchingHtml = "";
+  beforeAll(async () => {
+    fetchingHtml = guestHtml(await bundleGuest(FETCHING_GUEST_SRC));
+  }, 60_000);
+
+  it("lets declared CSP origins through the gate and blocks the rest", async () => {
+    const h = makeHarness();
+    const obs = await h.renderWidget({
+      toolCallId: "csp-1",
+      toolName: "show_widget",
+      serverId: "srv",
+      html: fetchingHtml,
+      cspMeta: { resource_domains: ["https://allowed-cdn.invalid"] },
+    });
+    expect(obs.status).toBe("rendered");
+    const blocked = obs.blockedRequests ?? [];
+    expect(blocked.some((u) => u.includes("blocked-cdn.invalid"))).toBe(true);
+    expect(blocked.some((u) => u.includes("allowed-cdn.invalid"))).toBe(false);
+  }, 30_000);
+
+  it("resets the allowlist per widget: undeclared next widget is blocked again", async () => {
+    const h = makeHarness();
+    const first = await h.renderWidget({
+      toolCallId: "csp-2a",
+      toolName: "show_widget",
+      serverId: "srv",
+      html: fetchingHtml,
+      cspMeta: { connect_domains: ["https://allowed-cdn.invalid"] },
+    });
+    expect(
+      (first.blockedRequests ?? []).some((u) =>
+        u.includes("allowed-cdn.invalid")
+      )
+    ).toBe(false);
+
+    // Same harness, same fetches — but THIS widget declares nothing.
+    const second = await h.renderWidget({
+      toolCallId: "csp-2b",
+      toolName: "show_widget",
+      serverId: "srv",
+      html: fetchingHtml,
+    });
+    expect(second.status).toBe("rendered");
+    const blocked = second.blockedRequests ?? [];
+    expect(blocked.some((u) => u.includes("allowed-cdn.invalid"))).toBe(true);
+    expect(blocked.some((u) => u.includes("blocked-cdn.invalid"))).toBe(true);
+  }, 45_000);
 });

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-render-observation.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-render-observation.test.ts
@@ -22,7 +22,7 @@ describe("isRenderableMcpAppTool", () => {
 
 describe("renderMcpAppToolResult — short-circuits", () => {
   const stubHarness = () =>
-    ({ renderWidget: vi.fn() }) as unknown as McpAppBrowserHarness;
+    ({ renderWidget: vi.fn() } as unknown as McpAppBrowserHarness);
 
   it("returns no_ui_resource without touching the harness", async () => {
     const harness = stubHarness();
@@ -35,7 +35,9 @@ describe("renderMcpAppToolResult — short-circuits", () => {
       harness,
     });
     expect(obs.status).toBe("no_ui_resource");
-    expect((harness.renderWidget as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect(
+      harness.renderWidget as ReturnType<typeof vi.fn>
+    ).not.toHaveBeenCalled();
   });
 
   it("returns resource_read_failed when readResource throws", async () => {
@@ -68,7 +70,7 @@ describe("renderMcpAppToolResult — reads resource + delegates to harness", () 
         elapsedMs: 1,
         ts: Date.now(),
         _html: input.html,
-      }),
+      })
     );
     const harness = { renderWidget } as unknown as McpAppBrowserHarness;
     const mcpClientManager = {
@@ -93,7 +95,10 @@ describe("renderMcpAppToolResult — reads resource + delegates to harness", () 
       keepMounted: true,
     });
     expect(obs.status).toBe("rendered");
-    const arg = renderWidget.mock.calls[0][0] as { html: string; keepMounted?: boolean };
+    const arg = renderWidget.mock.calls[0][0] as {
+      html: string;
+      keepMounted?: boolean;
+    };
     expect(arg.html).toBe(html);
     expect(arg.keepMounted).toBe(true);
   });
@@ -117,6 +122,84 @@ describe("renderMcpAppToolResult — reads resource + delegates to harness", () 
     expect(arg.html).not.toBe(html);
     expect(arg.html.length).toBeGreaterThan(html.length);
     expect(arg.html).toContain("openai");
+  });
+
+  function setupWithMeta(meta: Record<string, unknown>) {
+    const renderWidget = vi.fn(async () => ({
+      toolCallId: "tc",
+      toolName: "t",
+      serverId: "s",
+      status: "rendered" as const,
+      elapsedMs: 1,
+      ts: Date.now(),
+    }));
+    const harness = { renderWidget } as unknown as McpAppBrowserHarness;
+    const mcpClientManager = {
+      readResource: vi.fn().mockResolvedValue({
+        contents: [{ text: "<html><body>w</body></html>", _meta: meta }],
+      }),
+    } as unknown as MCPClientManager;
+    return { harness, renderWidget, mcpClientManager };
+  }
+
+  it("normalizes SEP-1865 _meta.ui.csp into the harness cspMeta (Excalidraw shape)", async () => {
+    // Mirrors the live Excalidraw widget resource: camelCase domains under
+    // `_meta.ui.csp` — the declaration the network gate must honor for the
+    // widget's esm.sh bundle to load instead of blank-painting.
+    const { harness, renderWidget, mcpClientManager } = setupWithMeta({
+      ui: {
+        csp: {
+          resourceDomains: ["https://esm.sh"],
+          connectDomains: ["https://esm.sh"],
+        },
+        permissions: {},
+      },
+    });
+    await renderMcpAppToolResult({
+      toolCallId: "tc-csp",
+      toolName: "create_view",
+      serverId: "excalidraw",
+      toolMetadata: MCP_APP_META,
+      mcpClientManager,
+      harness,
+    });
+    const arg = renderWidget.mock.calls[0][0] as {
+      cspMeta?: { connect_domains?: string[]; resource_domains?: string[] };
+    };
+    expect(arg.cspMeta).toEqual({
+      connect_domains: ["https://esm.sh"],
+      resource_domains: ["https://esm.sh"],
+    });
+  });
+
+  it("normalizes legacy openai/widgetCSP and omits cspMeta when undeclared", async () => {
+    const legacy = setupWithMeta({
+      "openai/widgetCSP": { connect_domains: ["https://api.example.com"] },
+    });
+    await renderMcpAppToolResult({
+      toolCallId: "tc-legacy",
+      toolName: "t",
+      serverId: "s",
+      toolMetadata: MCP_APP_META,
+      mcpClientManager: legacy.mcpClientManager,
+      harness: legacy.harness,
+    });
+    expect(
+      (legacy.renderWidget.mock.calls[0][0] as { cspMeta?: unknown }).cspMeta
+    ).toEqual({ connect_domains: ["https://api.example.com"] });
+
+    const bare = setupWithMeta({ ui: { permissions: {} } });
+    await renderMcpAppToolResult({
+      toolCallId: "tc-bare",
+      toolName: "t",
+      serverId: "s",
+      toolMetadata: MCP_APP_META,
+      mcpClientManager: bare.mcpClientManager,
+      harness: bare.harness,
+    });
+    expect(
+      (bare.renderWidget.mock.calls[0][0] as { cspMeta?: unknown }).cspMeta
+    ).toBeUndefined();
   });
 });
 
@@ -182,7 +265,9 @@ describe("renderMcpAppToolResult — real harness integration", () => {
     });
     expect(obs.status).toBe("rendered");
     expect(obs.bridgeInitialized).toBe(true);
-    expect(obs.screenshotBase64 && obs.screenshotBase64.length).toBeGreaterThan(0);
+    expect(obs.screenshotBase64 && obs.screenshotBase64.length).toBeGreaterThan(
+      0
+    );
     expect(harness.hasRenderedWidget()).toBe(true);
   }, 30_000);
 });

--- a/mcpjam-inspector/server/utils/__tests__/sandbox-proxy-csp.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/sandbox-proxy-csp.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Parity test: `buildSandboxProxyWidgetCsp` (Node) MUST produce byte-identical
+ * output to the production `buildCSP` widget-declared branch that ships inline
+ * in `sandbox-proxy.html`. This is what lets the eval harness inject the real
+ * production policy; if the two ever drift, the harness silently regains the
+ * false-positive class this guards against (e.g. allowing `eval()`).
+ *
+ * Same extraction approach as `server/__tests__/sandbox-proxy-buildCSP.test.ts`:
+ * pull `sanitizeDomain` + `buildCSP` out of the HTML and evaluate them, so the
+ * canonical function stays physically in the document it ships in.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { buildSandboxProxyWidgetCsp } from "../sandbox-proxy-csp";
+import type { WidgetCspMeta } from "../widget-helpers";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const html = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "routes",
+    "apps",
+    "mcp-apps",
+    "sandbox-proxy.html"
+  ),
+  "utf8"
+);
+
+// Extract a named function body from the inline <script>, brace-walking so
+// reformatting of the HTML doesn't break the test.
+function extract(name: string): string {
+  const sig = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`);
+  const m = sig.exec(html);
+  if (!m) throw new Error(`Could not extract function ${name}`);
+  let i = m.index + m[0].length;
+  let depth = 1;
+  while (i < html.length && depth > 0) {
+    const ch = html[i++];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+  }
+  if (depth !== 0) throw new Error(`Unbalanced braces in ${name}`);
+  return html.slice(m.index, i);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const proxyBuildCSP = new Function(
+  "csp",
+  "cspDirectives",
+  `${extract("sanitizeDomain")}\n${extract(
+    "buildCSP"
+  )}\nreturn buildCSP(csp, cspDirectives);`
+) as (csp: unknown, cspDirectives?: Record<string, string[]>) => string;
+
+// The proxy's widget-declared branch reads camelCase domain arrays; map the
+// SDK's snake_case WidgetCspMeta onto it (no base-uri in WidgetCspMeta).
+function proxyWidgetCsp(meta: WidgetCspMeta): string {
+  return proxyBuildCSP(
+    {
+      connectDomains: meta.connect_domains ?? [],
+      resourceDomains: meta.resource_domains ?? [],
+      frameDomains: meta.frame_domains ?? [],
+      baseUriDomains: [],
+    },
+    undefined
+  );
+}
+
+describe("buildSandboxProxyWidgetCsp — parity with sandbox-proxy.html", () => {
+  const cases: Array<[string, WidgetCspMeta]> = [
+    ["no declared domains", {}],
+    ["connect only", { connect_domains: ["https://api.example.com"] }],
+    ["resource only", { resource_domains: ["https://cdn.example.com"] }],
+    ["frame only", { frame_domains: ["https://embed.example.com"] }],
+    [
+      "all three directives",
+      {
+        connect_domains: ["https://api.example.com", "wss://rt.example.com"],
+        resource_domains: ["https://cdn.example.com"],
+        frame_domains: ["https://embed.example.com"],
+      },
+    ],
+  ];
+
+  it.each(cases)(
+    "matches the production policy byte-for-byte (%s)",
+    (_label, meta) => {
+      expect(buildSandboxProxyWidgetCsp(meta)).toBe(proxyWidgetCsp(meta));
+    }
+  );
+
+  it("is strictly the production policy: no unsafe-eval, no self, default-src 'none'", () => {
+    const csp = buildSandboxProxyWidgetCsp({
+      connect_domains: ["https://api.example.com"],
+      resource_domains: ["https://cdn.example.com"],
+    });
+    // The exact false-positive vectors the harness must not reintroduce:
+    expect(csp).not.toContain("unsafe-eval");
+    expect(csp).not.toContain("'self'");
+    expect(csp).not.toContain("worker-src");
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    // Inline scripts/styles still run; declared/inline resources still load.
+    expect(csp).toContain(
+      "script-src 'unsafe-inline' data: blob: https://cdn.example.com"
+    );
+    // connect is scoped to declared origins only.
+    expect(csp).toContain("connect-src https://api.example.com");
+  });
+
+  it("falls back to 'none' for every undeclared directive (but keeps inline + data/blob)", () => {
+    const csp = buildSandboxProxyWidgetCsp({});
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("frame-src 'none'");
+    // With no declared resource domains, inline content still works via
+    // data:/blob: — but nothing external loads.
+    expect(csp).toContain("script-src 'unsafe-inline' data: blob:");
+    expect(csp).toContain("img-src data: blob:");
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/sandbox-proxy-csp.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/sandbox-proxy-csp.test.ts
@@ -84,6 +84,20 @@ describe("buildSandboxProxyWidgetCsp — parity with sandbox-proxy.html", () => 
         frame_domains: ["https://embed.example.com"],
       },
     ],
+    // Malformed/adversarial metadata must sanitize identically to the proxy.
+    [
+      "domain attempting CSP directive injection",
+      { connect_domains: ["https://x; script-src 'unsafe-eval'"] },
+    ],
+    [
+      "domain with attribute-breaking chars",
+      {
+        resource_domains: [
+          'https://cdn.example.com"><s',
+          "https://ok.example.com",
+        ],
+      },
+    ],
   ];
 
   it.each(cases)(
@@ -111,6 +125,19 @@ describe("buildSandboxProxyWidgetCsp — parity with sandbox-proxy.html", () => 
     );
     // connect is scoped to declared origins only.
     expect(csp).toContain("connect-src https://api.example.com");
+  });
+
+  it("strips CSP-breaking chars from domains so they can't inject a directive", () => {
+    // Without sanitization, the ';' would start a real `script-src 'unsafe-eval'`
+    // directive — re-enabling eval and producing a false-positive render.
+    const csp = buildSandboxProxyWidgetCsp({
+      connect_domains: ["https://x; script-src 'unsafe-eval'"],
+    });
+    expect(csp).not.toContain("'unsafe-eval'"); // quotes stripped → not the keyword
+    // Exactly the 10-directive set: no extra ';' leaked from the domain.
+    expect(csp.split(";")).toHaveLength(10);
+    // The sanitized remnants stay INSIDE connect-src, not as their own directive.
+    expect(csp).toContain("connect-src https://x script-src unsafe-eval");
   });
 
   it("falls back to 'none' for every undeclared directive (but keeps inline + data/blob)", () => {

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -24,7 +24,10 @@
 
 import { existsSync } from "fs";
 import type { Browser, BrowserContext, Page } from "playwright";
-import { buildSandboxProxyWidgetCsp } from "./sandbox-proxy-csp";
+import {
+  buildSandboxProxyWidgetCsp,
+  sanitizeProxyDomain,
+} from "./sandbox-proxy-csp";
 import { HARNESS_PAGE_BUNDLE } from "./browser-harness/HarnessPageBundle.generated";
 
 /* ------------------------------------------------------------------ *
@@ -576,7 +579,9 @@ export class McpAppBrowserHarness {
       ...(input.cspMeta?.connect_domains ?? []),
       ...(input.cspMeta?.resource_domains ?? []),
       ...(input.cspMeta?.frame_domains ?? []),
-    ];
+    ]
+      .map(sanitizeProxyDomain)
+      .filter(Boolean);
 
     // Enforce the widget's declared CSP IN the iframe with the SAME policy the
     // production sandbox proxy injects (see sandbox-proxy-csp.ts, pinned to
@@ -876,9 +881,15 @@ export class McpAppBrowserHarness {
         .catch(() => {});
     }
     this.mounted.delete(toolCallId);
-    // The widget is gone; its network allowances go with it (fail closed for
-    // any straggling in-flight or leaked requests).
-    this.widgetCspSources = [];
+    // Only drop network allowances once NO widget remains mounted. Clearing
+    // them whenever unmount runs — even for a stale tool-call id that was never
+    // (or is no longer) the live mount — would strip the CURRENT widget's
+    // declared origins out from under it, so its in-flight/subsequent
+    // subresource fetches abort at the route gate (net::ERR_FAILED) until
+    // teardown. Fail closed only when the page truly has no live widget.
+    if (this.mounted.size === 0) {
+      this.widgetCspSources = [];
+    }
   }
 
   async dispose(): Promise<void> {

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -252,9 +252,20 @@ export function cspSourceMatchesUrl(source: string, url: URL): boolean {
  *
  * Falls back to creating a `<head>` (or prepending) when the document omits
  * one, so even minimal widget HTML is governed rather than running unpoliced.
+ *
+ * `cspContent` is derived from widget-controlled metadata (the declared domain
+ * arrays are joined verbatim into the policy), so it is HTML-attribute-escaped
+ * before interpolation: a stray `"` must not be able to break out of
+ * `content="…"` and truncate or disable the policy we are injecting. A
+ * well-formed CSP never contains `&"<>`, so this is a no-op for real policies.
  */
 export function injectCspMeta(html: string, cspContent: string): string {
-  const tag = `<meta http-equiv="Content-Security-Policy" content="${cspContent}">`;
+  const escaped = cspContent
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  const tag = `<meta http-equiv="Content-Security-Policy" content="${escaped}">`;
   const headOpen = /<head\b[^>]*>/i.exec(html);
   if (headOpen) {
     const at = headOpen.index + headOpen[0].length;

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -24,6 +24,7 @@
 
 import { existsSync } from "fs";
 import type { Browser, BrowserContext, Page } from "playwright";
+import { buildCspHeader, buildCspMetaContent } from "./widget-helpers";
 import { HARNESS_PAGE_BUNDLE } from "./browser-harness/HarnessPageBundle.generated";
 
 /* ------------------------------------------------------------------ *
@@ -147,10 +148,12 @@ export interface RenderWidgetInput {
   /**
    * Widget-declared CSP (normalized from the UI resource's `_meta.ui.csp` /
    * legacy `_meta["openai/widgetCSP"]`, same shape as the SDK's
-   * `WidgetCspMeta`). The network gate honors these sources for this widget's
-   * mount lifetime — the headless analog of the sandbox proxy's
-   * `widget-declared` CSP mode. Omitted/empty means the widget gets only the
-   * standing allowances (loopback, data:/blob:, configured `allowOrigins`).
+   * `WidgetCspMeta`). Enforced two ways for this widget's mount lifetime: the
+   * harness injects the `widget-declared` policy as an in-iframe `<meta>` CSP
+   * (directive-precise — fetch vs script/font/img vs frame — exactly as the
+   * production sandbox proxy does), and the network route additionally treats
+   * these origins as a coarse "may egress" allowlist. Omitted/empty yields the
+   * SEP restrictive default (self + data:/blob: + loopback).
    */
   cspMeta?: {
     connect_domains?: string[];
@@ -223,11 +226,14 @@ export function cspSourceMatchesUrl(source: string, url: URL): boolean {
     return false;
   }
 
-  if (port && port !== "*") {
-    const urlPort =
-      url.port ||
-      (url.protocol === "https:" || url.protocol === "wss:" ? "443" : "80");
-    if (urlPort !== port) return false;
+  // Port matching (CSP semantics): `*` = any port; an explicit port must equal
+  // the URL's port; an OMITTED source port matches only the scheme's default
+  // port (so `https://api.example.com` matches `:443`/default but not `:8443`).
+  if (port !== "*") {
+    const defaultPort =
+      url.protocol === "https:" || url.protocol === "wss:" ? "443" : "80";
+    const urlPort = url.port || defaultPort;
+    if (urlPort !== (port ?? defaultPort)) return false;
   }
 
   const host = url.hostname.toLowerCase();
@@ -235,6 +241,31 @@ export function cspSourceMatchesUrl(source: string, url: URL): boolean {
   if (pattern === "*") return true;
   if (pattern.startsWith("*.")) return host.endsWith(pattern.slice(1));
   return host === pattern;
+}
+
+/**
+ * Inject a `<meta http-equiv="Content-Security-Policy">` as the FIRST child of
+ * `<head>` so the browser enforces the widget's declared policy at directive
+ * granularity inside the iframe — the headless analog of the sandbox proxy's
+ * CSP injection. First-in-head matters: a meta CSP only governs resources
+ * parsed after it, and `guestDoc.write(html)` parses top-down.
+ *
+ * Falls back to creating a `<head>` (or prepending) when the document omits
+ * one, so even minimal widget HTML is governed rather than running unpoliced.
+ */
+export function injectCspMeta(html: string, cspContent: string): string {
+  const tag = `<meta http-equiv="Content-Security-Policy" content="${cspContent}">`;
+  const headOpen = /<head\b[^>]*>/i.exec(html);
+  if (headOpen) {
+    const at = headOpen.index + headOpen[0].length;
+    return html.slice(0, at) + tag + html.slice(at);
+  }
+  const htmlOpen = /<html\b[^>]*>/i.exec(html);
+  if (htmlOpen) {
+    const at = htmlOpen.index + htmlOpen[0].length;
+    return html.slice(0, at) + `<head>${tag}</head>` + html.slice(at);
+  }
+  return tag + html;
 }
 
 // SEP-1865 host capabilities are declared as OBJECTS (an empty `{}` means
@@ -364,9 +395,12 @@ export class McpAppBrowserHarness {
       permissions: [],
     });
 
-    // Default-deny network with an allowlist: loopback + configured origins
+    // COARSE default-deny egress backstop: loopback + configured origins
     // (static for the harness lifetime) + the mounted widget's declared CSP
-    // sources (per-widget, see `widgetCspSources`). Non-network schemes
+    // origins as one flat union (per-widget, see `widgetCspSources`). This is
+    // intentionally directive-blind — the injected in-iframe `<meta>` CSP does
+    // the connect/resource/frame separation; the route just decides whether a
+    // request may leave the machine, and records the rest. Non-network schemes
     // (data:, blob:, about:) pass through.
     const allowOrigins = new Set(this.opts.allowOrigins ?? []);
     await this.context.route("**/*", (route) => {
@@ -521,15 +555,30 @@ export class McpAppBrowserHarness {
       serverId: input.serverId,
       actionCount: 0,
     });
-    // Arm the network gate with this widget's declared CSP sources BEFORE the
-    // in-page mount, so the iframe's initial subresource fetches (scripts,
-    // fonts, XHR) are judged against the widget's own policy instead of
-    // aborting with net::ERR_FAILED and a blank first paint.
+    // Arm the network route's COARSE egress backstop with this widget's
+    // declared origins (union of all directives) BEFORE the in-page mount. The
+    // route only decides "may a request leave the machine at all"; the injected
+    // in-iframe CSP below does the directive-precise enforcement (connect vs
+    // resource vs frame). Set before mount so first subresource fetches are
+    // judged against the widget's own policy, not aborted into a blank paint.
     this.widgetCspSources = [
       ...(input.cspMeta?.connect_domains ?? []),
       ...(input.cspMeta?.resource_domains ?? []),
       ...(input.cspMeta?.frame_domains ?? []),
     ];
+
+    // Enforce the widget's declared CSP IN the iframe, the same way the sandbox
+    // proxy does in production: build the `widget-declared` policy from the
+    // resource's CSP metadata and inject it as a <meta http-equiv> before mount.
+    // The browser then applies real directive semantics — e.g. a `fetch()` only
+    // succeeds to a `connect_domains` origin, a script/font/img only to a
+    // `resource_domains` origin. With no declared CSP this yields the SEP
+    // restrictive default (self + data:/blob: + loopback), so undeclared widgets
+    // run policed rather than open.
+    const cspContent = buildCspMetaContent(
+      buildCspHeader("widget-declared", input.cspMeta).headerString
+    );
+    const policedHtml = injectCspMeta(input.html, cspContent);
 
     let pageResult: {
       mounted: boolean;
@@ -545,7 +594,7 @@ export class McpAppBrowserHarness {
           ).__mcpjamHarness.renderWidget(opts),
         {
           widgetId: input.toolCallId,
-          html: input.html,
+          html: policedHtml,
           hostCapabilities:
             this.opts.hostCapabilities ?? DEFAULT_HOST_CAPABILITIES,
           hostInfo: this.opts.hostInfo ?? {

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -144,6 +144,19 @@ export interface RenderWidgetInput {
   permissions?: Record<string, unknown>;
   sandboxAttrs?: string[];
   allowFeatures?: Record<string, string>;
+  /**
+   * Widget-declared CSP (normalized from the UI resource's `_meta.ui.csp` /
+   * legacy `_meta["openai/widgetCSP"]`, same shape as the SDK's
+   * `WidgetCspMeta`). The network gate honors these sources for this widget's
+   * mount lifetime — the headless analog of the sandbox proxy's
+   * `widget-declared` CSP mode. Omitted/empty means the widget gets only the
+   * standing allowances (loopback, data:/blob:, configured `allowOrigins`).
+   */
+  cspMeta?: {
+    connect_domains?: string[];
+    resource_domains?: string[];
+    frame_domains?: string[];
+  };
   /** Keep the widget mounted for subsequent executeAction calls. */
   keepMounted?: boolean;
 }
@@ -153,7 +166,7 @@ export interface McpAppBrowserHarnessOptions {
   callTool: (
     serverId: string,
     name: string,
-    args: Record<string, unknown>,
+    args: Record<string, unknown>
   ) => Promise<unknown>;
   /** Host capabilities advertised in ui/initialize. Sensible default below. */
   hostCapabilities?: Record<string, unknown>;
@@ -162,6 +175,66 @@ export interface McpAppBrowserHarnessOptions {
   budgets?: Partial<HarnessBudgets>;
   /** Extra http(s) origins to allow through the default-deny network route. */
   allowOrigins?: string[];
+}
+
+/**
+ * Match a URL against one CSP host-source expression, at origin granularity:
+ * scheme (when given), host (with `*.` wildcard subdomains), and port. Paths
+ * in host-sources are deliberately ignored — the real CSP inside the widget
+ * iframe still enforces them; this gate only decides whether the request may
+ * leave the harness at all. Quoted keywords (`'self'`, `'unsafe-inline'`, …)
+ * never match: "self" for a srcdoc widget is the loopback host page, which
+ * the gate's standing rules already cover.
+ *
+ * Scheme handling mirrors CSP: a scheme-only source (`https:`) allows any
+ * host on that scheme; a scheme-less host-source matches http(s)/ws(s).
+ */
+export function cspSourceMatchesUrl(source: string, url: URL): boolean {
+  const src = source.trim();
+  if (!src || src.startsWith("'")) return false;
+
+  // Scheme-only source, e.g. "https:".
+  if (/^[a-z][a-z0-9+.-]*:$/i.test(src)) {
+    return url.protocol.toLowerCase() === src.toLowerCase();
+  }
+
+  let scheme: string | undefined;
+  let rest = src;
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):\/\//i.exec(src);
+  if (schemeMatch) {
+    scheme = `${schemeMatch[1].toLowerCase()}:`;
+    rest = src.slice(schemeMatch[0].length);
+  }
+  const slash = rest.indexOf("/");
+  if (slash !== -1) rest = rest.slice(0, slash);
+  if (!rest) return false;
+
+  let port: string | undefined;
+  let hostPattern = rest;
+  const portMatch = /^(.+):(\d+|\*)$/.exec(rest);
+  if (portMatch) {
+    hostPattern = portMatch[1];
+    port = portMatch[2];
+  }
+
+  if (scheme) {
+    if (url.protocol.toLowerCase() !== scheme) return false;
+  } else if (!/^(https?:|wss?:)$/.test(url.protocol)) {
+    return false;
+  }
+
+  if (port && port !== "*") {
+    const urlPort =
+      url.port ||
+      (url.protocol === "https:" || url.protocol === "wss:" ? "443" : "80");
+    if (urlPort !== port) return false;
+  }
+
+  const host = url.hostname.toLowerCase();
+  const pattern = hostPattern.toLowerCase();
+  if (pattern === "*") return true;
+  if (pattern.startsWith("*.")) return host.endsWith(pattern.slice(1));
+  return host === pattern;
 }
 
 // SEP-1865 host capabilities are declared as OBJECTS (an empty `{}` means
@@ -193,6 +266,14 @@ export class McpAppBrowserHarness {
   private page: Page | null = null;
 
   private readonly mounted = new Map<string, MountedWidget>();
+  /**
+   * CSP sources declared by the CURRENTLY mounted widget (renderWidget sets,
+   * unmount/dispose clear). Lives on the instance — not closed over at launch —
+   * because the network route outlives any single widget while the allowlist
+   * must follow the widget. Fail-closed: between widgets this is empty and the
+   * gate falls back to loopback + configured `allowOrigins` only.
+   */
+  private widgetCspSources: string[] = [];
   private consoleErrors: string[] = [];
   private blockedRequests: string[] = [];
   private toolCallBuffer: WidgetToolCall[] = [];
@@ -231,10 +312,7 @@ export class McpAppBrowserHarness {
   // `playwright-core` (present transitively).
   protected async loadChromium(): Promise<{
     executablePath: () => string;
-    launch: (opts: {
-      headless: boolean;
-      args?: string[];
-    }) => Promise<Browser>;
+    launch: (opts: { headless: boolean; args?: string[] }) => Promise<Browser>;
   }> {
     try {
       return (await import("playwright")).chromium;
@@ -255,7 +333,7 @@ export class McpAppBrowserHarness {
     }
     if (!executablePath || !existsSync(executablePath)) {
       throw new ChromiumNotInstalledError(
-        "Chromium is not installed for Playwright. Run `npx playwright install chromium`.",
+        "Chromium is not installed for Playwright. Run `npx playwright install chromium`."
       );
     }
 
@@ -286,8 +364,10 @@ export class McpAppBrowserHarness {
       permissions: [],
     });
 
-    // Default-deny network with a small allowlist (loopback + configured
-    // origins). Non-network schemes (data:, blob:, about:) pass through.
+    // Default-deny network with an allowlist: loopback + configured origins
+    // (static for the harness lifetime) + the mounted widget's declared CSP
+    // sources (per-widget, see `widgetCspSources`). Non-network schemes
+    // (data:, blob:, about:) pass through.
     const allowOrigins = new Set(this.opts.allowOrigins ?? []);
     await this.context.route("**/*", (route) => {
       const url = route.request().url();
@@ -299,11 +379,17 @@ export class McpAppBrowserHarness {
         return route.continue();
       }
       try {
-        const origin = new URL(url).origin;
-        const host = new URL(url).hostname;
+        const parsed = new URL(url);
+        const host = parsed.hostname;
         const isLoopback =
           host === "127.0.0.1" || host === "localhost" || host === "[::1]";
-        if (isLoopback || allowOrigins.has(origin)) return route.continue();
+        if (
+          isLoopback ||
+          allowOrigins.has(parsed.origin) ||
+          this.widgetCspSources.some((s) => cspSourceMatchesUrl(s, parsed))
+        ) {
+          return route.continue();
+        }
       } catch {
         /* fall through to abort */
       }
@@ -334,7 +420,7 @@ export class McpAppBrowserHarness {
           widgetId: string;
           name: string;
           args: Record<string, unknown>;
-        },
+        }
       ) => {
         const widget = this.mounted.get(payload.widgetId);
         // Fail closed: a tools/call from a widget that isn't (or is no longer)
@@ -353,7 +439,7 @@ export class McpAppBrowserHarness {
           const result = await this.opts.callTool(
             serverId,
             payload.name,
-            payload.args,
+            payload.args
           );
           this.toolCallBuffer.push({
             name: payload.name,
@@ -375,11 +461,11 @@ export class McpAppBrowserHarness {
         } finally {
           this.pendingRpcCount -= 1;
         }
-      },
+      }
     );
 
     await this.page.setContent(
-      "<!doctype html><html><head><meta charset='utf-8'></head><body></body></html>",
+      "<!doctype html><html><head><meta charset='utf-8'></head><body></body></html>"
     );
     await this.page.addScriptTag({ content: HARNESS_PAGE_BUNDLE });
   }
@@ -387,7 +473,7 @@ export class McpAppBrowserHarness {
   /* ---- render ---- */
 
   async renderWidget(
-    input: RenderWidgetInput,
+    input: RenderWidgetInput
   ): Promise<WidgetRenderObservation> {
     const ts = Date.now();
     const started = ts;
@@ -414,7 +500,11 @@ export class McpAppBrowserHarness {
     const page = this.page!;
 
     if (!input.html || input.html.trim().length === 0) {
-      return { ...base, status: "no_ui_resource", elapsedMs: Date.now() - started };
+      return {
+        ...base,
+        status: "no_ui_resource",
+        elapsedMs: Date.now() - started,
+      };
     }
 
     // Capture only this render's console errors + blocked requests (otherwise
@@ -431,6 +521,15 @@ export class McpAppBrowserHarness {
       serverId: input.serverId,
       actionCount: 0,
     });
+    // Arm the network gate with this widget's declared CSP sources BEFORE the
+    // in-page mount, so the iframe's initial subresource fetches (scripts,
+    // fonts, XHR) are judged against the widget's own policy instead of
+    // aborting with net::ERR_FAILED and a blank first paint.
+    this.widgetCspSources = [
+      ...(input.cspMeta?.connect_domains ?? []),
+      ...(input.cspMeta?.resource_domains ?? []),
+      ...(input.cspMeta?.frame_domains ?? []),
+    ];
 
     let pageResult: {
       mounted: boolean;
@@ -459,7 +558,7 @@ export class McpAppBrowserHarness {
           toolInput: input.toolInput,
           toolOutput: input.toolOutput,
           renderTimeoutMs: this.budgets.renderTimeoutMs,
-        },
+        }
       );
     } catch (err) {
       await this.unmount(input.toolCallId);
@@ -634,7 +733,7 @@ export class McpAppBrowserHarness {
       }
       case "wait":
         await page.waitForTimeout(
-          Math.min(action.duration ?? 250, this.budgets.settleTimeoutMs),
+          Math.min(action.duration ?? 250, this.budgets.settleTimeoutMs)
         );
         break;
       case "screenshot":
@@ -645,7 +744,9 @@ export class McpAppBrowserHarness {
   private async settle(): Promise<void> {
     const page = this.page!;
     await page
-      .waitForLoadState("networkidle", { timeout: this.budgets.settleTimeoutMs })
+      .waitForLoadState("networkidle", {
+        timeout: this.budgets.settleTimeoutMs,
+      })
       .catch(() => {});
     await page.waitForTimeout(50);
   }
@@ -691,7 +792,7 @@ export class McpAppBrowserHarness {
     const jpeg = await page.screenshot({ type: "jpeg", quality: 20 });
     throw new Error(
       `screenshot exceeds byte budget after re-encoding ` +
-        `(${jpeg.byteLength} > ${this.budgets.screenshotMaxBytes} bytes)`,
+        `(${jpeg.byteLength} > ${this.budgets.screenshotMaxBytes} bytes)`
     );
   }
 
@@ -711,11 +812,14 @@ export class McpAppBrowserHarness {
             (
               globalThis as unknown as { __mcpjamHarness: HarnessPageApi }
             ).__mcpjamHarness.dismissWidget(id),
-          toolCallId,
+          toolCallId
         )
         .catch(() => {});
     }
     this.mounted.delete(toolCallId);
+    // The widget is gone; its network allowances go with it (fail closed for
+    // any straggling in-flight or leaked requests).
+    this.widgetCspSources = [];
   }
 
   async dispose(): Promise<void> {
@@ -733,6 +837,7 @@ export class McpAppBrowserHarness {
     this.browser = null;
     this.page = null;
     this.mounted.clear();
+    this.widgetCspSources = [];
   }
 }
 

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -24,7 +24,7 @@
 
 import { existsSync } from "fs";
 import type { Browser, BrowserContext, Page } from "playwright";
-import { buildCspHeader, buildCspMetaContent } from "./widget-helpers";
+import { buildSandboxProxyWidgetCsp } from "./sandbox-proxy-csp";
 import { HARNESS_PAGE_BUNDLE } from "./browser-harness/HarnessPageBundle.generated";
 
 /* ------------------------------------------------------------------ *
@@ -149,11 +149,11 @@ export interface RenderWidgetInput {
    * Widget-declared CSP (normalized from the UI resource's `_meta.ui.csp` /
    * legacy `_meta["openai/widgetCSP"]`, same shape as the SDK's
    * `WidgetCspMeta`). Enforced two ways for this widget's mount lifetime: the
-   * harness injects the `widget-declared` policy as an in-iframe `<meta>` CSP
-   * (directive-precise — fetch vs script/font/img vs frame — exactly as the
-   * production sandbox proxy does), and the network route additionally treats
-   * these origins as a coarse "may egress" allowlist. Omitted/empty yields the
-   * SEP restrictive default (self + data:/blob: + loopback).
+   * harness injects the production sandbox proxy's exact widget-declared policy
+   * as an in-iframe `<meta>` CSP (directive-precise — fetch vs script/font/img
+   * vs frame; see {@link buildSandboxProxyWidgetCsp}), and the network route
+   * additionally treats these origins as a coarse "may egress" allowlist.
+   * Omitted/empty yields the SEP restrictive default (`default-src 'none'`).
    */
   cspMeta?: {
     connect_domains?: string[];
@@ -578,17 +578,16 @@ export class McpAppBrowserHarness {
       ...(input.cspMeta?.frame_domains ?? []),
     ];
 
-    // Enforce the widget's declared CSP IN the iframe, the same way the sandbox
-    // proxy does in production: build the `widget-declared` policy from the
-    // resource's CSP metadata and inject it as a <meta http-equiv> before mount.
-    // The browser then applies real directive semantics — e.g. a `fetch()` only
-    // succeeds to a `connect_domains` origin, a script/font/img only to a
-    // `resource_domains` origin. With no declared CSP this yields the SEP
-    // restrictive default (self + data:/blob: + loopback), so undeclared widgets
-    // run policed rather than open.
-    const cspContent = buildCspMetaContent(
-      buildCspHeader("widget-declared", input.cspMeta).headerString
-    );
+    // Enforce the widget's declared CSP IN the iframe with the SAME policy the
+    // production sandbox proxy injects (see sandbox-proxy-csp.ts, pinned to
+    // sandbox-proxy.html by a parity test). A more permissive policy would make
+    // render observations false positives — a widget needing eval()/<object>/
+    // base-uri or 'self' egress could "render" here yet be blocked by the real
+    // sandbox. The browser then applies real directive semantics: a `fetch()`
+    // only reaches a `connect_domains` origin, a script/font/img only a
+    // `resource_domains` origin; an undeclared widget gets the SEP restrictive
+    // default (`default-src 'none'`) instead of running open.
+    const cspContent = buildSandboxProxyWidgetCsp(input.cspMeta);
     const policedHtml = injectCspMeta(input.html, cspContent);
 
     let pageResult: {

--- a/mcpjam-inspector/server/utils/mcp-app-render-observation.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-render-observation.ts
@@ -12,7 +12,8 @@
 
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
 import { isMcpAppTool, type MCPClientManager } from "@mcpjam/sdk";
-import { injectOpenAICompat } from "./widget-helpers";
+import { injectOpenAICompat, normalizeWidgetCspMeta } from "./widget-helpers";
+import type { WidgetCspMeta } from "./widget-helpers";
 import {
   extractHtmlFromResourceContent,
   isRecord,
@@ -46,7 +47,7 @@ export interface RenderMcpAppToolResultParams {
  * declares a UI resource — i.e. a tool result worth render-checking.
  */
 export function isRenderableMcpAppTool(
-  toolMetadata: unknown,
+  toolMetadata: unknown
 ): toolMetadata is Record<string, unknown> {
   if (!isRecord(toolMetadata) || !isMcpAppTool(toolMetadata)) return false;
   return Boolean(getToolUiResourceUri({ _meta: toolMetadata }));
@@ -58,7 +59,7 @@ export function isRenderableMcpAppTool(
  * with `no_ui_resource` / `resource_read_failed` without launching the browser.
  */
 export async function renderMcpAppToolResult(
-  params: RenderMcpAppToolResultParams,
+  params: RenderMcpAppToolResultParams
 ): Promise<WidgetRenderObservation> {
   const { toolCallId, toolName, serverId, toolMetadata, mcpClientManager } =
     params;
@@ -72,22 +73,29 @@ export async function renderMcpAppToolResult(
 
   let html: string | undefined;
   let permissions: Record<string, unknown> | undefined;
+  let cspMeta: WidgetCspMeta | undefined;
   try {
     const resourceResult = await mcpClientManager.readResource(serverId, {
       uri: resourceUri,
     });
     const contents = Array.isArray(
-      (resourceResult as { contents?: unknown[] })?.contents,
+      (resourceResult as { contents?: unknown[] })?.contents
     )
       ? ((resourceResult as { contents: unknown[] }).contents as unknown[])
       : [];
     const content = contents[0];
     if (isRecord(content)) {
+      const contentMeta = isRecord(content._meta) ? content._meta : undefined;
       const uiMeta =
-        isRecord(content._meta) && isRecord(content._meta.ui)
-          ? (content._meta.ui as Record<string, unknown>)
+        contentMeta && isRecord(contentMeta.ui)
+          ? (contentMeta.ui as Record<string, unknown>)
           : undefined;
-      permissions = normalizeWidgetPermissions(uiMeta?.permissions) ?? undefined;
+      permissions =
+        normalizeWidgetPermissions(uiMeta?.permissions) ?? undefined;
+      // Widget-declared network policy (`_meta.ui.csp`, legacy
+      // `openai/widgetCSP`) — the harness network gate honors it per-widget,
+      // matching the sandbox proxy's `widget-declared` CSP mode.
+      cspMeta = normalizeWidgetCspMeta(contentMeta);
       html = extractHtmlFromResourceContent(content);
     }
   } catch {
@@ -126,6 +134,7 @@ export async function renderMcpAppToolResult(
     toolInput: params.toolInput,
     toolOutput: params.output,
     permissions,
+    cspMeta,
     keepMounted: params.keepMounted,
   });
 }

--- a/mcpjam-inspector/server/utils/sandbox-proxy-csp.ts
+++ b/mcpjam-inspector/server/utils/sandbox-proxy-csp.ts
@@ -1,0 +1,79 @@
+/**
+ * sandbox-proxy-csp.ts — the production widget-declared CSP, available in Node.
+ *
+ * The MCP App eval harness mounts a widget in a headless iframe and must apply
+ * the EXACT Content-Security-Policy the production sandbox proxy applies. If it
+ * applies a more permissive policy, a render observation becomes a false
+ * positive: a widget that relies on `eval()`, `<object>`, `base-uri`, or egress
+ * to `'self'`/localhost could "render" in the harness yet be blocked by the
+ * real widget-declared sandbox in production.
+ *
+ * The canonical policy lives inline in `routes/apps/mcp-apps/sandbox-proxy.html`
+ * (`buildCSP`, the widget-declared branch) because it ships to the browser as
+ * part of the proxy document. This module is the Node-side twin of that branch;
+ * `__tests__/sandbox-proxy-csp.test.ts` extracts the real `buildCSP` from the
+ * HTML and asserts this function is byte-identical, so the two cannot drift.
+ *
+ * Versus the SDK's `buildCspHeader("widget-declared", …)` (which is intentionally
+ * looser, e.g. for response headers): this is `default-src 'none'`, NO
+ * `'unsafe-eval'`, NO `'self'`/localhost, with explicit `object-src 'none'` and
+ * `base-uri`, and no `worker-src`/`child-src`.
+ */
+import type { WidgetCspMeta } from "./widget-helpers";
+
+/**
+ * Mirror of `sandbox-proxy.html`'s `mergeDirective` with no inspector-override
+ * (`cspDirectives`) tokens: order-preserving de-duplication, drop `'none'` once
+ * any real token is present, and emit `<name> 'none'` for an empty token set.
+ */
+function directive(name: string, tokens: string[]): string {
+  const merged: string[] = [];
+  for (const t of tokens) {
+    if (typeof t === "string" && t.length > 0 && !merged.includes(t)) {
+      merged.push(t);
+    }
+  }
+  if (merged.length > 1) {
+    const noneAt = merged.indexOf("'none'");
+    if (noneAt !== -1) merged.splice(noneAt, 1);
+  }
+  return merged.length === 0 ? `${name} 'none'` : `${name} ${merged.join(" ")}`;
+}
+
+/**
+ * Build the widget-declared CSP string the production sandbox proxy injects for
+ * a widget with this declared CSP metadata. Domains are assumed already
+ * normalized (the harness receives them via `normalizeWidgetCspMeta`), matching
+ * the proxy's `sanitizeDomain` for well-formed origins.
+ */
+export function buildSandboxProxyWidgetCsp(
+  cspMeta?: WidgetCspMeta | null
+): string {
+  const connect = cspMeta?.connect_domains ?? [];
+  const resource = cspMeta?.resource_domains ?? [];
+  const frame = cspMeta?.frame_domains ?? [];
+
+  // data:/blob: are always allowed for inline content; declared resource
+  // domains add to them. No forced CDNs and no 'self' (SEP-1865).
+  const resourceTokens =
+    resource.length > 0 ? ["data:", "blob:", ...resource] : ["data:", "blob:"];
+  const connectTokens = connect.length > 0 ? connect : ["'none'"];
+  const frameTokens = frame.length > 0 ? frame : ["'none'"];
+  // WidgetCspMeta does not model base-uri, so it is always 'none' here. That
+  // matches the proxy for widgets that declare no base-uri, and is otherwise
+  // the strict direction — never more permissive than production.
+  const baseUriTokens = ["'none'"];
+
+  return [
+    directive("default-src", ["'none'"]),
+    directive("script-src", ["'unsafe-inline'", ...resourceTokens]),
+    directive("style-src", ["'unsafe-inline'", ...resourceTokens]),
+    directive("img-src", resourceTokens),
+    directive("font-src", resourceTokens),
+    directive("media-src", resourceTokens),
+    directive("connect-src", connectTokens),
+    directive("frame-src", frameTokens),
+    directive("object-src", ["'none'"]),
+    directive("base-uri", baseUriTokens),
+  ].join("; ");
+}

--- a/mcpjam-inspector/server/utils/sandbox-proxy-csp.ts
+++ b/mcpjam-inspector/server/utils/sandbox-proxy-csp.ts
@@ -41,17 +41,36 @@ function directive(name: string, tokens: string[]): string {
 }
 
 /**
+ * Strip characters that could break out of a CSP directive or the HTML
+ * attribute it is injected into — an exact mirror of `sanitizeDomain` in
+ * `sandbox-proxy.html`. Crucially this removes `;`: an unsanitized declared
+ * origin like `https://x; connect-src *` would otherwise inject a second,
+ * more-permissive directive (the upstream `normalizeWidgetCspMeta` does NOT
+ * strip these). Applied to every domain so the harness can never end up more
+ * permissive than production for malformed metadata.
+ */
+export function sanitizeProxyDomain(domain: string): string {
+  if (typeof domain !== "string") return "";
+  return domain.replace(/['"<>;]/g, "").trim();
+}
+
+/**
  * Build the widget-declared CSP string the production sandbox proxy injects for
- * a widget with this declared CSP metadata. Domains are assumed already
- * normalized (the harness receives them via `normalizeWidgetCspMeta`), matching
- * the proxy's `sanitizeDomain` for well-formed origins.
+ * a widget with this declared CSP metadata. Each domain is run through
+ * {@link sanitizeProxyDomain} exactly as the proxy does at build time.
  */
 export function buildSandboxProxyWidgetCsp(
   cspMeta?: WidgetCspMeta | null
 ): string {
-  const connect = cspMeta?.connect_domains ?? [];
-  const resource = cspMeta?.resource_domains ?? [];
-  const frame = cspMeta?.frame_domains ?? [];
+  const connect = (cspMeta?.connect_domains ?? [])
+    .map(sanitizeProxyDomain)
+    .filter(Boolean);
+  const resource = (cspMeta?.resource_domains ?? [])
+    .map(sanitizeProxyDomain)
+    .filter(Boolean);
+  const frame = (cspMeta?.frame_domains ?? [])
+    .map(sanitizeProxyDomain)
+    .filter(Boolean);
 
   // data:/blob: are always allowed for inline content; declared resource
   // domains add to them. No forced CDNs and no 'self' (SEP-1865).


### PR DESCRIPTION
## Summary

Widget render observations in eval runs were coming back **`Blank screenshot`** with `net::ERR_FAILED` console errors for any MCP App that loads assets from its own declared CSP origins. Repro: the Excalidraw MCP App declares `_meta.ui.csp = { resourceDomains: ["https://esm.sh"], connectDomains: ["https://esm.sh"] }` and loads its entire bundle from esm.sh — the harness's default-deny network route (loopback + statically configured origins only) aborted those fetches, so the widget handshook but painted blank.

- `renderMcpAppToolResult` now extracts the UI resource's CSP via the SDK's `normalizeWidgetCspMeta` (SEP-1865 `_meta.ui.csp` camelCase + legacy `openai/widgetCSP` snake_case) and passes it to the harness.
- The harness network gate honors those sources for the widget's **mount lifetime**: armed before the in-page mount (so first subresource fetches pass), cleared on unmount/dispose (allowances never outlive their widget). This is the headless analog of the sandbox proxy's `widget-declared` CSP mode.
- Matching follows CSP host-source semantics at origin granularity: exact origins, `*.wildcard` subdomains, scheme-less hosts, scheme-only sources, ports. Paths are ignored here (the real CSP inside the iframe still enforces them); quoted keywords (`'self'`, …) never match.
- Widgets that declare nothing keep today's fail-closed default-deny.

## Verification

Ran the full extraction → normalization → gate path against the **live Excalidraw MCP server** (real resource `_meta`, real `create_view` output, real esm.sh fetches in headless Chromium): observation went from `blank_screenshot` + 6 blocked requests to `rendered` with `bridgeInitialized: true`, zero blocked requests, and a screenshot of the painted Start→End scene.

## Test plan

- `cspSourceMatchesUrl` unit tests: exact origin, wildcard-subdomain (not bare apex), scheme-less, scheme-only, ports (explicit/wildcard/defaults), path-insensitivity, quoted keywords.
- Harness integration (real Chromium, `.invalid` TLD so nothing leaves the machine): declared origins pass the gate while undeclared ones land in `blockedRequests`; allowlist resets per widget so the next undeclared widget is blocked again.
- `renderMcpAppToolResult` tests: SEP-1865 camelCase meta (exact Excalidraw shape) and legacy `openai/widgetCSP` normalize into `cspMeta`; undeclared resources pass `undefined`.
- Full affected suites green: 28/28 (19 harness + 9 render-observation).

https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox/network egress and CSP injection for headless eval rendering; misalignment could cause false positives/negatives, but policy is pinned to production and fail-closed with broad test coverage.
> 
> **Overview**
> Fixes eval **blank renders** when MCP Apps load from declared CSP origins (e.g. esm.sh): the harness default-deny route no longer aborts those fetches for the widget’s mount lifetime.
> 
> **`renderMcpAppToolResult`** now reads `_meta.ui.csp` / legacy `openai/widgetCSP` via `normalizeWidgetCspMeta` and passes **`cspMeta`** into the harness.
> 
> **`McpAppBrowserHarness`** applies widget policy in two layers: injects the **same widget-declared CSP** as production (`buildSandboxProxyWidgetCsp` + first-in-`<head>` **`injectCspMeta`**) for directive-accurate enforcement in the iframe, and extends the Playwright network route with a per-mount **`widgetCspSources`** allowlist using **`cspSourceMatchesUrl`**. Allowances clear only when **no** widget remains mounted (dismissing a stale tool-call id no longer strips the live widget’s origins).
> 
> New **`sandbox-proxy-csp.ts`** is byte-for-byte parity with `sandbox-proxy.html`, plus tests for CSP matching, meta injection, lifecycle, and end-to-end CSP probes in Chromium.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58cca82f486d617eac7284f8c0fd1bae0835211e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->