### PR TITLE
feat(api/v1): write operations — tools/call, prompts/get, async eval runs, OAuth token import

### DIFF
--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -6,7 +6,10 @@ import {
   convertToEvalTestCases,
   generateNegativeTestCases,
 } from "../../services/negative-test-agent";
-import { startSuiteRunWithRecorder } from "../../services/evals/recorder";
+import {
+  startSuiteRunWithRecorder,
+  type SuiteRunRecorder,
+} from "../../services/evals/recorder";
 import {
   captureToolSnapshotForEvalAuthoring,
   storeReplayConfig,
@@ -165,6 +168,8 @@ export const RunEvalsRequestSchema = z.object({
 export type RunEvalsRequest = z.infer<typeof RunEvalsRequestSchema>;
 type RunEvalsWithManagerRequest = RunEvalsRequest & {
   orgModelConfig?: ResolvedOrgModelConfig;
+  /** Run origin persisted on `testSuiteRun.source`; /api/v1 passes 'api'. */
+  source?: "ui" | "api";
 };
 
 export const RunTestCaseRequestSchema = z.object({
@@ -512,10 +517,37 @@ function buildPersistedSuiteEnvironment(args: {
   };
 }
 
-export async function runEvalsWithManager(
+export type PreparedEvalRun = {
+  suiteId: string;
+  runId: string;
+  caseUpsert: {
+    committed: Array<{ id?: string; name: string }>;
+    failed: Array<{ id?: string; name: string; error: string }>;
+  };
+  recorder: SuiteRunRecorder;
+  /**
+   * Execute the prepared run to completion. `runEvalSuiteWithAiSdk` owns
+   * terminal run status (completed/failed/cancelled); callers that detach
+   * this (the async /api/v1 route) should still catch and defensively
+   * finalize via `recorder` for errors thrown outside the runner's own
+   * try.
+   */
+  execute: () => Promise<void>;
+};
+
+/**
+ * Prepare phase of a suite run: validate, upsert suite + cases, create the
+ * run record (status 'running'), store replay configs, and resolve model
+ * credentials. Returns an `execute` closure over `runEvalSuiteWithAiSdk` so
+ * callers choose whether to await execution inline (`runEvalsWithManager`,
+ * the /api/web path) or detach it and respond immediately with the runId
+ * (the async public /api/v1 path). All request/quota validation errors
+ * surface here, synchronously, before any caller responds.
+ */
+export async function prepareEvalRun(
   clientManager: MCPClientManager,
   request: RunEvalsWithManagerRequest,
-) {
+): Promise<PreparedEvalRun> {
   const {
     suiteId,
     projectId,
@@ -538,6 +570,7 @@ export async function runEvalsWithManager(
     namedHostId,
     refreshSnapshot,
     runGroupId,
+    source,
   } = request;
 
   if (!suiteId && (!suiteName || suiteName.trim().length === 0)) {
@@ -877,6 +910,7 @@ export async function runEvalsWithManager(
     matchOptionsOverride,
     namedHostId,
     runGroupId,
+    source,
   });
   const suiteHostConfig =
     runHostConfigSnapshot ??
@@ -950,36 +984,54 @@ export async function runEvalsWithManager(
     }
   }
 
-  await runEvalSuiteWithAiSdk({
-    suiteId: resolvedSuiteId,
-    runId,
-    config,
-    modelApiKeys: resolvedModelApiKeys ?? undefined,
-    orgModelConfig: resolvedOrgModelConfig,
-    orgModelConfigTarget: resolvedOrgModelConfigTarget,
-    convexClient,
-    convexHttpUrl,
-    convexAuthToken,
-    mcpClientManager: clientManager,
-    recorder,
-    suiteInjectOpenAiCompat,
-    hostExecutionPolicy: suiteHostPolicy,
-    // PR 4d: thread the raw suite hostConfig record into the runner so
-    // it can resolve CONFIG fields (`systemPrompt` / `temperature` /
-    // `selectedServerIds`) via `resolveExecutionContext`. `hostPolicy`
-    // is the POLICY subset extracted upstream; this is the rest.
-    suiteHostConfig,
-  });
+  const execute = async () => {
+    await runEvalSuiteWithAiSdk({
+      suiteId: resolvedSuiteId,
+      runId,
+      config,
+      modelApiKeys: resolvedModelApiKeys ?? undefined,
+      orgModelConfig: resolvedOrgModelConfig,
+      orgModelConfigTarget: resolvedOrgModelConfigTarget,
+      convexClient,
+      convexHttpUrl,
+      convexAuthToken,
+      mcpClientManager: clientManager,
+      recorder,
+      suiteInjectOpenAiCompat,
+      hostExecutionPolicy: suiteHostPolicy,
+      // PR 4d: thread the raw suite hostConfig record into the runner so
+      // it can resolve CONFIG fields (`systemPrompt` / `temperature` /
+      // `selectedServerIds`) via `resolveExecutionContext`. `hostPolicy`
+      // is the POLICY subset extracted upstream; this is the rest.
+      suiteHostConfig,
+    });
+  };
 
   return {
-    success: true,
     suiteId: resolvedSuiteId,
     runId,
-    message: "Evals completed successfully. Check the Evals tab for results.",
     caseUpsert: {
       committed: committedCases,
       failed: failedCases,
     },
+    recorder,
+    execute,
+  };
+}
+
+export async function runEvalsWithManager(
+  clientManager: MCPClientManager,
+  request: RunEvalsWithManagerRequest,
+) {
+  const prepared = await prepareEvalRun(clientManager, request);
+  await prepared.execute();
+
+  return {
+    success: true,
+    suiteId: prepared.suiteId,
+    runId: prepared.runId,
+    message: "Evals completed successfully. Check the Evals tab for results.",
+    caseUpsert: prepared.caseUpsert,
   };
 }
 

--- a/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
@@ -11,16 +11,39 @@ const {
   createAuthorizedManagerMock,
   convexQueryMock,
   convexActionMock,
+  validateApiKeyMock,
+  resolveUserByExternalIdMock,
+  lookupWorkosKeyBindingMock,
 } = vi.hoisted(() => ({
   validateGuestTokenMock: vi.fn(),
   prepareEvalRunMock: vi.fn(),
   createAuthorizedManagerMock: vi.fn(),
   convexQueryMock: vi.fn(),
   convexActionMock: vi.fn(),
+  validateApiKeyMock: vi.fn(),
+  resolveUserByExternalIdMock: vi.fn(),
+  lookupWorkosKeyBindingMock: vi.fn(),
 }));
 
 vi.mock("../../../services/guest-token.js", () => ({
   validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+// WorkOS API-key middleware seams — same pattern as bearer-auth.test.ts.
+// Only exercised by tests that send an `sk_` bearer; JWT-bearer tests never
+// reach these.
+vi.mock("../../../services/workos-client.js", () => ({
+  getWorkOSClient: () => ({
+    apiKeys: { createValidation: validateApiKeyMock },
+  }),
+}));
+
+vi.mock("../../../services/identity.js", () => ({
+  resolveUserByExternalId: resolveUserByExternalIdMock,
+}));
+
+vi.mock("../../../services/workos-key-bindings.js", () => ({
+  lookupWorkosKeyBinding: lookupWorkosKeyBindingMock,
 }));
 
 vi.mock("../../shared/evals.js", async () => {
@@ -46,6 +69,7 @@ vi.mock("convex/browser", () => ({
 }));
 
 import v1Routes from "../index.js";
+import { parseMaxConcurrentRuns } from "../evals.js";
 
 function makeApp(): Hono {
   const app = new Hono();
@@ -57,14 +81,15 @@ function request(
   app: Hono,
   method: string,
   path: string,
-  body?: Record<string, unknown>
+  body?: Record<string, unknown>,
+  token = "tok"
 ): Promise<Response> {
   return Promise.resolve(
     app.request(path, {
       method,
       headers: {
         "Content-Type": "application/json",
-        Authorization: "Bearer tok",
+        Authorization: `Bearer ${token}`,
       },
       ...(body ? { body: JSON.stringify(body) } : {}),
     })
@@ -88,6 +113,7 @@ describe("v1 write routes", () => {
   const originalEnv = {
     CONVEX_URL: process.env.CONVEX_URL,
     CONVEX_HTTP_URL: process.env.CONVEX_HTTP_URL,
+    INSPECTOR_SERVICE_TOKEN: process.env.INSPECTOR_SERVICE_TOKEN,
   };
   const originalFetch = global.fetch;
 
@@ -245,6 +271,210 @@ describe("v1 write routes", () => {
       );
       expect(res.status).toBe(500);
       expect(disconnectAllServers).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes the delegated Convex JWT — not the sk_ key — to the manager for API-key callers", async () => {
+      process.env.INSPECTOR_SERVICE_TOKEN = "svc_token";
+      validateApiKeyMock.mockResolvedValue({
+        apiKey: { id: "key_1", owner: { id: "workos_user_1" } },
+      });
+      resolveUserByExternalIdMock.mockResolvedValue({ _id: "convex_user_1" });
+      lookupWorkosKeyBindingMock.mockResolvedValue({
+        mcpjamOrganizationId: "org_1",
+      });
+      // The only fetch on this path is the delegated-token mint.
+      global.fetch = vi.fn(async (input: any, init: any) => {
+        expect(String(input)).toBe(
+          "https://convex-http.example.com/web/delegated-token"
+        );
+        expect(init?.headers?.["x-mcpjam-acting-as"]).toBe("workos_user_1");
+        expect(init?.headers?.["x-mcpjam-acting-in-org"]).toBe("org_1");
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            token: "delegated-jwt",
+            expiresAt: Date.now() + 2 * 60 * 60 * 1000,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }) as typeof fetch;
+
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers },
+        oauthServerUrls: {},
+        authenticatedUserId: null,
+      });
+      prepareEvalRunMock.mockResolvedValue({
+        suiteId: "suite_1",
+        runId: "run_1",
+        caseUpsert: { committed: [], failed: [] },
+        recorder: { finalize: vi.fn() },
+        execute: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-runs",
+        { suiteId: "suite_1", serverIds: ["s1"] },
+        "sk_live_secret"
+      );
+      expect(res.status).toBe(202);
+
+      // The manager bearer feeds the hosted OAuth force-refresh closure and
+      // secret reveal — both JWT-only Convex surfaces where the raw API key
+      // would 401. Both seams must see the minted JWT.
+      expect(createAuthorizedManagerMock.mock.calls[0][1]).toBe(
+        "delegated-jwt"
+      );
+      expect(prepareEvalRunMock.mock.calls[0][1]).toMatchObject({
+        convexAuthToken: "delegated-jwt",
+        source: "api",
+      });
+      await vi.waitFor(() =>
+        expect(disconnectAllServers).toHaveBeenCalledTimes(1)
+      );
+    });
+
+    it("forces suiteRerun on a bare suiteId rerun even when the caller sends false", async () => {
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers },
+        oauthServerUrls: {},
+        authenticatedUserId: null,
+      });
+      prepareEvalRunMock.mockResolvedValue({
+        suiteId: "suite_1",
+        runId: "run_1",
+        caseUpsert: { committed: [], failed: [] },
+        recorder: { finalize: vi.fn() },
+        execute: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-runs",
+        { suiteId: "suite_1", serverIds: ["s1"], suiteRerun: false }
+      );
+      expect(res.status).toBe(202);
+      expect(prepareEvalRunMock.mock.calls[0][1]).toMatchObject({
+        suiteRerun: true,
+      });
+      await vi.waitFor(() =>
+        expect(disconnectAllServers).toHaveBeenCalledTimes(1)
+      );
+    });
+
+    it("keeps suiteRerun false when inline tests are supplied", async () => {
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers },
+        oauthServerUrls: {},
+        authenticatedUserId: null,
+      });
+      prepareEvalRunMock.mockResolvedValue({
+        suiteId: "suite_1",
+        runId: "run_1",
+        caseUpsert: { committed: [], failed: [] },
+        recorder: { finalize: vi.fn() },
+        execute: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-runs",
+        {
+          suiteId: "suite_1",
+          serverIds: ["s1"],
+          tests: [
+            {
+              title: "case",
+              query: "do it",
+              runs: 1,
+              model: "m",
+              provider: "anthropic",
+              expectedToolCalls: [],
+            },
+          ],
+        }
+      );
+      expect(res.status).toBe(202);
+      expect(prepareEvalRunMock.mock.calls[0][1]).toMatchObject({
+        suiteRerun: false,
+      });
+      await vi.waitFor(() =>
+        expect(disconnectAllServers).toHaveBeenCalledTimes(1)
+      );
+    });
+  });
+
+  describe("eval-run concurrency gate", () => {
+    it("parses V1_MAX_CONCURRENT_EVAL_RUNS defensively", () => {
+      expect(parseMaxConcurrentRuns(undefined)).toBe(2);
+      expect(parseMaxConcurrentRuns("bad")).toBe(2); // NaN must not disable the gate
+      expect(parseMaxConcurrentRuns("0")).toBe(2);
+      expect(parseMaxConcurrentRuns("-3")).toBe(2);
+      expect(parseMaxConcurrentRuns("2.5")).toBe(2);
+      expect(parseMaxConcurrentRuns("5")).toBe(5);
+    });
+
+    it("gates a caller at the limit, isolates other bearers, and frees slots on completion", async () => {
+      const app = makeApp();
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers },
+        oauthServerUrls: {},
+        authenticatedUserId: null,
+      });
+      const releaseGates: Array<() => void> = [];
+      prepareEvalRunMock.mockImplementation(async () => ({
+        suiteId: "suite_1",
+        runId: "run_1",
+        caseUpsert: { committed: [], failed: [] },
+        recorder: { finalize: vi.fn() },
+        execute: vi.fn(
+          () => new Promise<void>((resolve) => releaseGates.push(resolve))
+        ),
+      }));
+      const post = (token: string) =>
+        request(
+          app,
+          "POST",
+          "/api/v1/projects/p1/eval-runs",
+          { suiteId: "suite_1", serverIds: ["s1"] },
+          token
+        );
+
+      // Default limit is 2 (env unset in tests).
+      expect((await post("tok")).status).toBe(202);
+      expect((await post("tok")).status).toBe(202);
+
+      const gated = await post("tok");
+      expect(gated.status).toBe(429);
+      expect(await gated.json()).toMatchObject({
+        code: "RATE_LIMITED",
+        details: { reason: "CONCURRENT_RUN_LIMIT" },
+      });
+
+      // A different JWT bearer is a different caller — it must not share
+      // the saturated bucket (regression: all JWT callers keyed "anonymous").
+      expect((await post("other-tok")).status).toBe(202);
+
+      // Finishing runs releases slots for the gated caller.
+      for (const release of releaseGates.splice(0)) release();
+      await vi.waitFor(() =>
+        expect(disconnectAllServers).toHaveBeenCalledTimes(3)
+      );
+      expect((await post("tok")).status).toBe(202);
+
+      // Drain so later tests start with empty buckets.
+      for (const release of releaseGates.splice(0)) release();
+      await vi.waitFor(() =>
+        expect(disconnectAllServers).toHaveBeenCalledTimes(4)
+      );
     });
   });
 

--- a/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
@@ -1,0 +1,415 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Covers the v1 WRITE surface: tools/call + prompts/get schema validation,
+// the async eval-run POST (mocked prepare/execute seam), the eval read
+// proxies (mocked ConvexHttpClient), and the OAuth import-tokens proxy.
+
+const {
+  validateGuestTokenMock,
+  prepareEvalRunMock,
+  createAuthorizedManagerMock,
+  convexQueryMock,
+  convexActionMock,
+} = vi.hoisted(() => ({
+  validateGuestTokenMock: vi.fn(),
+  prepareEvalRunMock: vi.fn(),
+  createAuthorizedManagerMock: vi.fn(),
+  convexQueryMock: vi.fn(),
+  convexActionMock: vi.fn(),
+}));
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+vi.mock("../../shared/evals.js", async () => {
+  const actual = await vi.importActual<typeof import("../../shared/evals.js")>(
+    "../../shared/evals.js"
+  );
+  return { ...actual, prepareEvalRun: prepareEvalRunMock };
+});
+
+vi.mock("../../web/auth.js", async () => {
+  const actual = await vi.importActual<typeof import("../../web/auth.js")>(
+    "../../web/auth.js"
+  );
+  return { ...actual, createAuthorizedManager: createAuthorizedManagerMock };
+});
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+    action: convexActionMock,
+  })),
+}));
+
+import v1Routes from "../index.js";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+function request(
+  app: Hono,
+  method: string,
+  path: string,
+  body?: Record<string, unknown>
+): Promise<Response> {
+  return Promise.resolve(
+    app.request(path, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer tok",
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    })
+  );
+}
+
+const RUN_DOC = {
+  _id: "run_1",
+  suiteId: "suite_1",
+  projectId: "p1",
+  runNumber: 3,
+  status: "completed",
+  result: "passed",
+  summary: { total: 2, passed: 2, failed: 0, passRate: 1 },
+  source: "api",
+  createdAt: 1,
+  completedAt: 2,
+};
+
+describe("v1 write routes", () => {
+  const originalEnv = {
+    CONVEX_URL: process.env.CONVEX_URL,
+    CONVEX_HTTP_URL: process.env.CONVEX_HTTP_URL,
+  };
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_URL = "https://convex.example.com";
+    process.env.CONVEX_HTTP_URL = "https://convex-http.example.com";
+    validateGuestTokenMock.mockResolvedValue({ valid: false });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value) process.env[key] = value;
+      else delete process.env[key];
+    }
+  });
+
+  describe("tools/call and prompts/get validation", () => {
+    it("rejects tools/call without toolName (400 VALIDATION_ERROR)", async () => {
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/servers/s1/tools/call",
+        { parameters: {} }
+      );
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR"
+      );
+    });
+
+    it("rejects prompts/get without promptName (400 VALIDATION_ERROR)", async () => {
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/servers/s1/prompts/get",
+        {}
+      );
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR"
+      );
+    });
+  });
+
+  describe("POST /eval-runs", () => {
+    it("rejects a body with neither suiteId nor tests (400)", async () => {
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-runs",
+        { serverIds: ["s1"] }
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string; message?: string };
+      expect(body.code).toBe("VALIDATION_ERROR");
+      expect(prepareEvalRunMock).not.toHaveBeenCalled();
+    });
+
+    it("responds 202 with runId and detaches execution", async () => {
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers },
+        oauthServerUrls: {},
+        authenticatedUserId: null,
+      });
+      let resolveExecute!: () => void;
+      const executeGate = new Promise<void>((resolve) => {
+        resolveExecute = resolve;
+      });
+      prepareEvalRunMock.mockResolvedValue({
+        suiteId: "suite_1",
+        runId: "run_1",
+        caseUpsert: { committed: [{ name: "case" }], failed: [] },
+        recorder: { finalize: vi.fn() },
+        execute: vi.fn(() => executeGate),
+      });
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-runs",
+        { suiteId: "suite_1", serverIds: ["s1"] }
+      );
+
+      expect(res.status).toBe(202);
+      expect(await res.json()).toEqual({
+        runId: "run_1",
+        suiteId: "suite_1",
+        status: "running",
+        caseUpsert: { committed: [{ name: "case" }], failed: [] },
+      });
+      // The request resolved while execute was still pending — async run.
+      expect(disconnectAllServers).not.toHaveBeenCalled();
+      // prepareEvalRun received the public->internal request mapping.
+      const prepareArgs = prepareEvalRunMock.mock.calls[0][1];
+      expect(prepareArgs).toMatchObject({
+        projectId: "p1",
+        suiteRerun: true,
+        source: "api",
+        convexAuthToken: "tok",
+      });
+
+      resolveExecute();
+      await vi.waitFor(() =>
+        expect(disconnectAllServers).toHaveBeenCalledTimes(1)
+      );
+    });
+
+    it("marks the run failed when detached execution rejects", async () => {
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      const finalize = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers },
+        oauthServerUrls: {},
+        authenticatedUserId: null,
+      });
+      prepareEvalRunMock.mockResolvedValue({
+        suiteId: "suite_1",
+        runId: "run_1",
+        caseUpsert: { committed: [], failed: [] },
+        recorder: { finalize },
+        execute: vi.fn().mockRejectedValue(new Error("provider exploded")),
+      });
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-runs",
+        { suiteId: "suite_1", serverIds: ["s1"] }
+      );
+      expect(res.status).toBe(202);
+      await vi.waitFor(() => expect(finalize).toHaveBeenCalledTimes(1));
+      expect(finalize).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "failed" })
+      );
+      expect(disconnectAllServers).toHaveBeenCalledTimes(1);
+    });
+
+    it("disconnects and rethrows when prepare fails (no orphan manager)", async () => {
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers },
+        oauthServerUrls: {},
+        authenticatedUserId: null,
+      });
+      prepareEvalRunMock.mockRejectedValue(new Error("quota exceeded"));
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-runs",
+        { suiteId: "suite_1", serverIds: ["s1"] }
+      );
+      expect(res.status).toBe(500);
+      expect(disconnectAllServers).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("eval read proxies", () => {
+    it("returns the run DTO for a project-matched run", async () => {
+      convexQueryMock.mockResolvedValueOnce(RUN_DOC);
+      const res = await request(
+        makeApp(),
+        "GET",
+        "/api/v1/projects/p1/eval-runs/run_1"
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        id: "run_1",
+        suiteId: "suite_1",
+        runNumber: 3,
+        status: "completed",
+        result: "passed",
+        summary: { total: 2, passed: 2, failed: 0, passRate: 1 },
+        source: "api",
+        notes: null,
+        createdAt: 1,
+        completedAt: 2,
+      });
+    });
+
+    it("404s when the run belongs to a different project", async () => {
+      convexQueryMock.mockResolvedValueOnce({ ...RUN_DOC, projectId: "p2" });
+      const res = await request(
+        makeApp(),
+        "GET",
+        "/api/v1/projects/p1/eval-runs/run_1"
+      );
+      expect(res.status).toBe(404);
+      expect(((await res.json()) as { code?: string }).code).toBe("NOT_FOUND");
+    });
+
+    it("404s when Convex reports the run as not visible", async () => {
+      convexQueryMock.mockRejectedValueOnce(
+        new Error("Test suite run not found or unauthorized")
+      );
+      const res = await request(
+        makeApp(),
+        "GET",
+        "/api/v1/projects/p1/eval-runs/run_1"
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("maps iterations onto the page envelope with usage and latency", async () => {
+      convexQueryMock
+        .mockResolvedValueOnce(RUN_DOC)
+        .mockResolvedValueOnce({
+          page: [
+            {
+              _id: "iter_1",
+              testCaseId: "case_1",
+              suiteRunId: "run_1",
+              iterationNumber: 1,
+              status: "completed",
+              result: "passed",
+              startedAt: 100,
+              updatedAt: 5330,
+              tokensUsed: 1342,
+              usage: { inputTokens: 1100, outputTokens: 242 },
+              actualToolCalls: [{ toolName: "echo", arguments: { a: 1 } }],
+              testCaseSnapshot: {
+                title: "case",
+                model: "m",
+                provider: "anthropic",
+                expectedToolCalls: [{ toolName: "echo" }],
+              },
+            },
+          ],
+          isDone: false,
+          continueCursor: "cursor_2",
+        });
+
+      const res = await request(
+        makeApp(),
+        "GET",
+        "/api/v1/projects/p1/eval-runs/run_1/iterations?limit=1"
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        items: Array<Record<string, unknown>>;
+        nextCursor?: string;
+      };
+      expect(body.nextCursor).toBe("cursor_2");
+      expect(body.items[0]).toMatchObject({
+        id: "iter_1",
+        title: "case",
+        model: "m",
+        provider: "anthropic",
+        durationMs: 5230,
+        tokensUsed: 1342,
+        usage: { inputTokens: 1100, outputTokens: 242 },
+        actualToolCalls: [{ toolName: "echo", arguments: { a: 1 } }],
+      });
+    });
+
+    it("returns the trace blob and 404s with TRACE_NOT_AVAILABLE when missing", async () => {
+      convexQueryMock
+        .mockResolvedValueOnce(RUN_DOC)
+        .mockResolvedValueOnce({ _id: "iter_1", suiteRunId: "run_1" });
+      convexActionMock.mockResolvedValueOnce(null);
+      const res = await request(
+        makeApp(),
+        "GET",
+        "/api/v1/projects/p1/eval-runs/run_1/iterations/iter_1/trace"
+      );
+      expect(res.status).toBe(404);
+      expect(await res.json()).toMatchObject({
+        code: "NOT_FOUND",
+        details: { reason: "TRACE_NOT_AVAILABLE" },
+      });
+    });
+  });
+
+  describe("POST oauth/import-tokens", () => {
+    it("forwards to Convex and returns { imported: true }", async () => {
+      global.fetch = vi.fn(async (input: any) => {
+        expect(String(input)).toBe(
+          "https://convex-http.example.com/web/oauth/import-tokens"
+        );
+        return new Response(JSON.stringify({ expiresAt: 123 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/servers/s1/oauth/import-tokens",
+        {
+          serverUrl: "https://server.example.com/mcp",
+          tokens: { access_token: "at", refresh_token: "rt" },
+        }
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ imported: true, expiresAt: 123 });
+      const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock
+        .calls[0] as [string, RequestInit];
+      const forwarded = JSON.parse(String(init.body));
+      // Path params win over the body; kind pinned to generic.
+      expect(forwarded).toMatchObject({
+        projectId: "p1",
+        serverId: "s1",
+        kind: "generic",
+        tokens: { access_token: "at" },
+      });
+    });
+
+    it("rejects a body without tokens (400 VALIDATION_ERROR)", async () => {
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/servers/s1/oauth/import-tokens",
+        { serverUrl: "https://server.example.com/mcp" }
+      );
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR"
+      );
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
@@ -14,16 +14,22 @@ const {
   validateApiKeyMock,
   resolveUserByExternalIdMock,
   lookupWorkosKeyBindingMock,
-} = vi.hoisted(() => ({
-  validateGuestTokenMock: vi.fn(),
-  prepareEvalRunMock: vi.fn(),
-  createAuthorizedManagerMock: vi.fn(),
-  convexQueryMock: vi.fn(),
-  convexActionMock: vi.fn(),
-  validateApiKeyMock: vi.fn(),
-  resolveUserByExternalIdMock: vi.fn(),
-  lookupWorkosKeyBindingMock: vi.fn(),
-}));
+} = vi.hoisted(() => {
+  // The evals route resolves its concurrency limit at import time; pin the
+  // env BEFORE the hoisted imports run so a V1_MAX_CONCURRENT_EVAL_RUNS in
+  // the local/CI environment can't skew the gate tests.
+  process.env.V1_MAX_CONCURRENT_EVAL_RUNS = "2";
+  return {
+    validateGuestTokenMock: vi.fn(),
+    prepareEvalRunMock: vi.fn(),
+    createAuthorizedManagerMock: vi.fn(),
+    convexQueryMock: vi.fn(),
+    convexActionMock: vi.fn(),
+    validateApiKeyMock: vi.fn(),
+    resolveUserByExternalIdMock: vi.fn(),
+    lookupWorkosKeyBindingMock: vi.fn(),
+  };
+});
 
 vi.mock("../../../services/guest-token.js", () => ({
   validateGuestTokenDetailedAsync: validateGuestTokenMock,
@@ -224,7 +230,7 @@ describe("v1 write routes", () => {
       );
     });
 
-    it("marks the run failed when detached execution rejects", async () => {
+    it("marks the run failed when detached execution rejects before the runner finalizes", async () => {
       const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
       const finalize = vi.fn().mockResolvedValue(undefined);
       createAuthorizedManagerMock.mockResolvedValue({
@@ -239,6 +245,9 @@ describe("v1 write routes", () => {
         recorder: { finalize },
         execute: vi.fn().mockRejectedValue(new Error("provider exploded")),
       });
+      // The catch's terminal-status probe sees the run still running —
+      // the error escaped before the runner's own finalize.
+      convexQueryMock.mockResolvedValueOnce({ ...RUN_DOC, status: "running" });
 
       const res = await request(
         makeApp(),
@@ -252,6 +261,38 @@ describe("v1 write routes", () => {
         expect.objectContaining({ status: "failed" })
       );
       expect(disconnectAllServers).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-finalize when the runner already finalized the failed run", async () => {
+      const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+      const finalize = vi.fn().mockResolvedValue(undefined);
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers },
+        oauthServerUrls: {},
+        authenticatedUserId: null,
+      });
+      prepareEvalRunMock.mockResolvedValue({
+        suiteId: "suite_1",
+        runId: "run_1",
+        caseUpsert: { committed: [], failed: [] },
+        recorder: { finalize },
+        // runEvalSuiteWithAiSdk semantics: finalize as failed, then rethrow.
+        execute: vi.fn().mockRejectedValue(new Error("execution failed")),
+      });
+      convexQueryMock.mockResolvedValueOnce({ ...RUN_DOC, status: "failed" });
+
+      const res = await request(
+        makeApp(),
+        "POST",
+        "/api/v1/projects/p1/eval-runs",
+        { suiteId: "suite_1", serverIds: ["s1"] }
+      );
+      expect(res.status).toBe(202);
+      // The teardown still runs, but no second terminal write happens.
+      await vi.waitFor(() =>
+        expect(disconnectAllServers).toHaveBeenCalledTimes(1)
+      );
+      expect(finalize).not.toHaveBeenCalled();
     });
 
     it("disconnects and rethrows when prepare fails (no orphan manager)", async () => {
@@ -448,7 +489,7 @@ describe("v1 write routes", () => {
           token
         );
 
-      // Default limit is 2 (env unset in tests).
+      // Limit pinned to 2 by the hoisted V1_MAX_CONCURRENT_EVAL_RUNS stub.
       expect((await post("tok")).status).toBe(202);
       expect((await post("tok")).status).toBe(202);
 

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -15,10 +15,10 @@
  * the resource's projectId against the path so a valid id from another
  * project reads as NOT_FOUND.
  */
+import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { ConvexHttpClient } from "convex/browser";
 import {
-  assertBearerToken,
   parseWithSchema,
   ErrorCode,
   WebRouteError,
@@ -64,13 +64,31 @@ const createEvalRunSchema = RunEvalsRequestSchema.omit({
 // Per-org cap on detached runs in THIS process. Railway runs a single
 // Inspector instance today; if that changes this becomes per-instance,
 // which is acceptable (the backend run/iteration quotas remain global).
-const MAX_CONCURRENT_RUNS = Number(
-  process.env.V1_MAX_CONCURRENT_EVAL_RUNS ?? 2
+//
+// Exported for tests. A malformed env value (`Number("bad")` → NaN) must
+// fall back to the default rather than disabling the gate: every `>=`
+// comparison against NaN is false, which would admit unlimited runs.
+export function parseMaxConcurrentRuns(raw: string | undefined): number {
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : 2;
+}
+const MAX_CONCURRENT_RUNS = parseMaxConcurrentRuns(
+  process.env.V1_MAX_CONCURRENT_EVAL_RUNS
 );
 const activeRunsByOrg = new Map<string, number>();
 
 function orgConcurrencyKey(c: any): string {
-  return c.get("mcpjamOrganizationId") ?? c.get("workosUserId") ?? "anonymous";
+  const orgOrUser = c.get("mcpjamOrganizationId") ?? c.get("workosUserId");
+  if (orgOrUser) {
+    return orgOrUser;
+  }
+  // Only the API-key middleware sets WorkOS/org context; JWT callers would
+  // otherwise all share one "anonymous" bucket. Key them by a digest of the
+  // bearer instead — per-caller, without holding the raw token in the map.
+  const authHeader = c.req.header("authorization");
+  return authHeader
+    ? createHash("sha256").update(authHeader).digest("hex")
+    : "anonymous";
 }
 
 function tryAcquireRunSlot(key: string): boolean {
@@ -187,16 +205,19 @@ function toIterationDto(iteration: IterationDoc) {
 evals.post("/projects/:projectId/eval-runs", async (c) => {
   const projectId = c.req.param("projectId");
   const rawBody = await synthesizeServerBody(c);
-  const bearerToken = assertBearerToken(c);
   const body = parseWithSchema(createEvalRunSchema, {
     ...rawBody,
     projectId,
   });
 
-  // `suiteRerun` semantics from the web surface: don't re-upsert per-case
-  // fields when rerunning a configured suite without inline tests.
+  // `suiteRerun` semantics from the web surface: a bare `suiteId` rerun has
+  // no inline tests to upsert, so it is ALWAYS a rerun — forcing true here
+  // (even over an explicit `suiteRerun: false`) keeps a caller from baking
+  // suite defaults into per-case overrides on a plain rerun.
   const suiteRerun =
-    body.suiteRerun ?? (Boolean(body.suiteId) && body.tests.length === 0);
+    Boolean(body.suiteId) && body.tests.length === 0
+      ? true
+      : (body.suiteRerun ?? false);
 
   const slotKey = orgConcurrencyKey(c);
   if (!tryAcquireRunSlot(slotKey)) {
@@ -222,11 +243,15 @@ evals.post("/projects/:projectId/eval-runs", async (c) => {
   try {
     // Resolved once, synchronously: the background task captures this token
     // in its closure (its TTL covers a capped run; see v1-convex-token.ts).
+    // It is ALSO the bearer handed to the manager: the manager's
+    // bearer-forwarding paths (hosted OAuth force-refresh, secret reveal)
+    // hit Convex's JWT-only surfaces, where an `sk_` API key is useless —
+    // same swap `runEphemeralConnection` does for the synchronous routes.
     const convexAuthToken = await getConvexBearerForRequest(c);
 
     const { manager } = await createAuthorizedManager(
       c,
-      bearerToken,
+      convexAuthToken,
       projectId,
       body.serverIds,
       WEB_CALL_TIMEOUT_MS,

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -1,0 +1,429 @@
+/**
+ * Public v1 eval surface: async suite runs + polling reads.
+ *
+ * POST creates the run (suite/case upsert + run record, all synchronous so
+ * validation and quota errors surface as normal v1 errors), then DETACHES
+ * execution and responds 202 with the runId. Agents poll the GET routes for
+ * status, per-iteration results (tool calls, token usage, latency), and full
+ * traces. Runs land in the same Convex tables the hosted UI Runs/Cases tabs
+ * read, so a human can watch the run live while the agent polls.
+ *
+ * Reads are thin proxies over the same Convex queries the UI uses, called
+ * with the request's Convex bearer (the caller's JWT, or the short-lived
+ * delegated JWT minted for WorkOS API-key callers). Convex enforces
+ * membership + the delegated org scope; the routes additionally cross-check
+ * the resource's projectId against the path so a valid id from another
+ * project reads as NOT_FOUND.
+ */
+import { Hono } from "hono";
+import { ConvexHttpClient } from "convex/browser";
+import {
+  assertBearerToken,
+  parseWithSchema,
+  ErrorCode,
+  WebRouteError,
+} from "../web/errors.js";
+import { createAuthorizedManager } from "../web/auth.js";
+import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
+import {
+  RunEvalsRequestSchema,
+  prepareEvalRun,
+  type PreparedEvalRun,
+} from "../shared/evals.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { logger } from "../../utils/logger.js";
+import { v1Error, v1PageJson, v1Resource } from "./envelope.js";
+import { synthesizeServerBody } from "./adapter.js";
+
+const evals = new Hono();
+
+// ── Request schema ───────────────────────────────────────────────────
+
+const MAX_V1_TESTS = 100;
+
+// Public shape: the web RunEvalsRequestSchema minus hosted-app plumbing the
+// public surface must not accept (`convexAuthToken` comes from the bearer;
+// chatbox/access/storage fields are hosted-client concerns).
+const createEvalRunSchema = RunEvalsRequestSchema.omit({
+  convexAuthToken: true,
+  chatboxId: true,
+  accessVersion: true,
+  storageServerIds: true,
+})
+  .extend({
+    // Inline tests are optional on the public surface: a bare `suiteId`
+    // rerun is the simplest possible call.
+    tests: RunEvalsRequestSchema.shape.tests.max(MAX_V1_TESTS).default([]),
+  })
+  .refine((body) => body.suiteId || (body.tests?.length ?? 0) > 0, {
+    message: "Provide suiteId (rerun) and/or inline tests",
+  });
+
+// ── Concurrency gate ─────────────────────────────────────────────────
+
+// Per-org cap on detached runs in THIS process. Railway runs a single
+// Inspector instance today; if that changes this becomes per-instance,
+// which is acceptable (the backend run/iteration quotas remain global).
+const MAX_CONCURRENT_RUNS = Number(
+  process.env.V1_MAX_CONCURRENT_EVAL_RUNS ?? 2
+);
+const activeRunsByOrg = new Map<string, number>();
+
+function orgConcurrencyKey(c: any): string {
+  return c.get("mcpjamOrganizationId") ?? c.get("workosUserId") ?? "anonymous";
+}
+
+function tryAcquireRunSlot(key: string): boolean {
+  const active = activeRunsByOrg.get(key) ?? 0;
+  if (active >= MAX_CONCURRENT_RUNS) {
+    return false;
+  }
+  activeRunsByOrg.set(key, active + 1);
+  return true;
+}
+
+function releaseRunSlot(key: string): void {
+  const active = activeRunsByOrg.get(key) ?? 0;
+  if (active <= 1) {
+    activeRunsByOrg.delete(key);
+  } else {
+    activeRunsByOrg.set(key, active - 1);
+  }
+}
+
+// ── Convex read client ───────────────────────────────────────────────
+
+function createConvexReadClient(convexAuthToken: string): ConvexHttpClient {
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_URL configuration"
+    );
+  }
+  const client = new ConvexHttpClient(convexUrl);
+  client.setAuth(convexAuthToken);
+  return client;
+}
+
+/**
+ * Convex throws generic Errors from queries; the common authorization
+ * failures ("not found", "unauthorized", "Not a member") all mean the same
+ * thing to a v1 caller: this run/suite is not visible to you.
+ */
+function isConvexNotVisibleError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /not found|unauthorized|not a member/i.test(message);
+}
+
+function requireProjectMatch(
+  resource: { projectId?: unknown } | null | undefined,
+  projectId: string,
+  what: string
+): void {
+  if (!resource || String(resource.projectId ?? "") !== projectId) {
+    throw new WebRouteError(404, ErrorCode.NOT_FOUND, `${what} not found`);
+  }
+}
+
+// ── DTO mapping ──────────────────────────────────────────────────────
+
+type RunDoc = Record<string, any>;
+type IterationDoc = Record<string, any>;
+
+function toRunDto(run: RunDoc) {
+  return {
+    id: String(run._id),
+    suiteId: String(run.suiteId),
+    runNumber: run.runNumber ?? null,
+    status: run.status,
+    result: run.result,
+    summary: run.summary ?? null,
+    source: run.source ?? "ui",
+    notes: run.notes ?? null,
+    createdAt: run.createdAt,
+    completedAt: run.completedAt ?? null,
+  };
+}
+
+function toIterationDto(iteration: IterationDoc) {
+  const snapshot = iteration.testCaseSnapshot ?? {};
+  const startedAt =
+    typeof iteration.startedAt === "number" ? iteration.startedAt : null;
+  const isTerminal =
+    iteration.status === "completed" ||
+    iteration.status === "failed" ||
+    iteration.status === "cancelled";
+  const durationMs =
+    isTerminal && startedAt !== null && typeof iteration.updatedAt === "number"
+      ? Math.max(iteration.updatedAt - startedAt, 0)
+      : null;
+  return {
+    id: String(iteration._id),
+    testCaseId: iteration.testCaseId ? String(iteration.testCaseId) : null,
+    title: snapshot.title ?? null,
+    iterationNumber: iteration.iterationNumber,
+    status: iteration.status,
+    result: iteration.result,
+    model: snapshot.model ?? null,
+    provider: snapshot.provider ?? null,
+    startedAt,
+    durationMs,
+    tokensUsed: iteration.tokensUsed ?? null,
+    usage: iteration.usage ?? null,
+    actualToolCalls: iteration.actualToolCalls ?? [],
+    expectedToolCalls: snapshot.expectedToolCalls ?? [],
+    error: iteration.error ?? null,
+  };
+}
+
+// ── Routes ───────────────────────────────────────────────────────────
+
+// POST /v1/projects/:projectId/eval-runs
+// Create a suite run (existing suiteId rerun and/or inline tests) and start
+// executing it in the background. Responds 202 with the runId immediately;
+// poll GET /eval-runs/:runId for progress.
+evals.post("/projects/:projectId/eval-runs", async (c) => {
+  const projectId = c.req.param("projectId");
+  const rawBody = await synthesizeServerBody(c);
+  const bearerToken = assertBearerToken(c);
+  const body = parseWithSchema(createEvalRunSchema, {
+    ...rawBody,
+    projectId,
+  });
+
+  // `suiteRerun` semantics from the web surface: don't re-upsert per-case
+  // fields when rerunning a configured suite without inline tests.
+  const suiteRerun =
+    body.suiteRerun ?? (Boolean(body.suiteId) && body.tests.length === 0);
+
+  const slotKey = orgConcurrencyKey(c);
+  if (!tryAcquireRunSlot(slotKey)) {
+    return v1Error(
+      c,
+      "RATE_LIMITED",
+      `Too many concurrent eval runs (max ${MAX_CONCURRENT_RUNS}). Wait for an active run to finish.`,
+      { reason: "CONCURRENT_RUN_LIMIT", maxConcurrentRuns: MAX_CONCURRENT_RUNS }
+    );
+  }
+
+  // Manual connection lifecycle (mirrors the web stream-test-case route):
+  // the manager must outlive this request — it is the background task's MCP
+  // transport — so `withManager`'s request-scoped teardown can't be used.
+  let released = false;
+  const releaseSlotOnce = () => {
+    if (!released) {
+      released = true;
+      releaseRunSlot(slotKey);
+    }
+  };
+
+  try {
+    // Resolved once, synchronously: the background task captures this token
+    // in its closure (its TTL covers a capped run; see v1-convex-token.ts).
+    const convexAuthToken = await getConvexBearerForRequest(c);
+
+    const { manager } = await createAuthorizedManager(
+      c,
+      bearerToken,
+      projectId,
+      body.serverIds,
+      WEB_CALL_TIMEOUT_MS,
+      undefined,
+      undefined,
+      { serverNames: body.serverNames }
+    );
+
+    let prepared: PreparedEvalRun;
+    try {
+      prepared = await prepareEvalRun(manager, {
+        ...body,
+        projectId,
+        suiteRerun,
+        convexAuthToken,
+        source: "api",
+      });
+    } catch (error) {
+      await manager.disconnectAllServers().catch(() => {});
+      throw error;
+    }
+
+    // Detach: the runner owns terminal run status; the catch is defense for
+    // errors thrown outside its own try (provider construction, etc.).
+    void prepared
+      .execute()
+      .catch(async (error) => {
+        logger.error("[v1 evals] background eval run failed", error, {
+          runId: prepared.runId,
+          suiteId: prepared.suiteId,
+          projectId,
+        });
+        await prepared.recorder
+          .finalize({
+            status: "failed",
+            notes:
+              error instanceof Error
+                ? error.message.slice(0, 500)
+                : String(error).slice(0, 500),
+          })
+          .catch(() => {});
+      })
+      .finally(() => {
+        releaseSlotOnce();
+        void manager.disconnectAllServers().catch(() => {});
+      });
+
+    return v1Resource(
+      c,
+      {
+        runId: prepared.runId,
+        suiteId: prepared.suiteId,
+        status: "running",
+        caseUpsert: prepared.caseUpsert,
+      },
+      202
+    );
+  } catch (error) {
+    releaseSlotOnce();
+    throw error;
+  }
+});
+
+// GET /v1/projects/:projectId/eval-runs/:runId
+// Run status + summary. Poll this until status is terminal
+// (completed | failed | cancelled).
+evals.get("/projects/:projectId/eval-runs/:runId", async (c) => {
+  const projectId = c.req.param("projectId");
+  const runId = c.req.param("runId");
+  const convex = createConvexReadClient(await getConvexBearerForRequest(c));
+
+  let run: RunDoc | null;
+  try {
+    run = await convex.query("testSuites:getTestSuiteRun" as any, { runId });
+  } catch (error) {
+    if (isConvexNotVisibleError(error)) {
+      throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Eval run not found");
+    }
+    throw error;
+  }
+  requireProjectMatch(run, projectId, "Eval run");
+  return v1Resource(c, toRunDto(run!));
+});
+
+// GET /v1/projects/:projectId/eval-runs/:runId/iterations?cursor=&limit=
+// Per-iteration results: tool calls, structured token usage, latency.
+evals.get("/projects/:projectId/eval-runs/:runId/iterations", async (c) => {
+  const projectId = c.req.param("projectId");
+  const runId = c.req.param("runId");
+  const limit = Math.min(
+    Math.max(Number(c.req.query("limit") ?? 50) || 50, 1),
+    200
+  );
+  const cursor = c.req.query("cursor") ?? null;
+  const convex = createConvexReadClient(await getConvexBearerForRequest(c));
+
+  let run: RunDoc | null;
+  let page: { page: IterationDoc[]; isDone: boolean; continueCursor: string };
+  try {
+    run = await convex.query("testSuites:getTestSuiteRun" as any, { runId });
+    requireProjectMatch(run, projectId, "Eval run");
+    page = await convex.query(
+      "testSuites:listTestSuiteRunIterations" as any,
+      { runId, paginationOpts: { numItems: limit, cursor } }
+    );
+  } catch (error) {
+    if (isConvexNotVisibleError(error)) {
+      throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Eval run not found");
+    }
+    throw error;
+  }
+  return v1PageJson(
+    c,
+    (page.page ?? []).map(toIterationDto),
+    page.isDone ? undefined : page.continueCursor
+  );
+});
+
+// GET /v1/projects/:projectId/eval-runs/:runId/iterations/:iterationId/trace
+// Full trace envelope (messages + spans) for one iteration.
+evals.get(
+  "/projects/:projectId/eval-runs/:runId/iterations/:iterationId/trace",
+  async (c) => {
+    const projectId = c.req.param("projectId");
+    const runId = c.req.param("runId");
+    const iterationId = c.req.param("iterationId");
+    const convex = createConvexReadClient(await getConvexBearerForRequest(c));
+
+    let trace: unknown;
+    try {
+      const [run, iteration] = await Promise.all([
+        convex.query("testSuites:getTestSuiteRun" as any, { runId }),
+        convex.query("testSuites:getTestIteration" as any, { iterationId }),
+      ]);
+      requireProjectMatch(run, projectId, "Eval run");
+      if (
+        !iteration ||
+        String((iteration as IterationDoc).suiteRunId ?? "") !== runId
+      ) {
+        throw new WebRouteError(
+          404,
+          ErrorCode.NOT_FOUND,
+          "Eval iteration not found"
+        );
+      }
+      trace = await convex.action("testSuites:getTestIterationBlob" as any, {
+        iterationId,
+      });
+    } catch (error) {
+      if (isConvexNotVisibleError(error)) {
+        throw new WebRouteError(
+          404,
+          ErrorCode.NOT_FOUND,
+          "Eval iteration not found"
+        );
+      }
+      throw error;
+    }
+    if (trace === null || trace === undefined) {
+      throw new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        "Trace is not available for this iteration",
+        { reason: "TRACE_NOT_AVAILABLE" }
+      );
+    }
+    return v1Resource(c, trace);
+  }
+);
+
+// GET /v1/projects/:projectId/eval-suites/:suiteId/runs?limit=
+// Recent runs for a suite, newest first.
+evals.get("/projects/:projectId/eval-suites/:suiteId/runs", async (c) => {
+  const projectId = c.req.param("projectId");
+  const suiteId = c.req.param("suiteId");
+  const limit = Math.min(
+    Math.max(Number(c.req.query("limit") ?? 25) || 25, 1),
+    100
+  );
+  const convex = createConvexReadClient(await getConvexBearerForRequest(c));
+
+  let runs: RunDoc[];
+  let suite: { projectId?: unknown } | null;
+  try {
+    suite = await convex.query("testSuites:getTestSuite" as any, { suiteId });
+    requireProjectMatch(suite, projectId, "Eval suite");
+    runs = await convex.query("testSuites:listTestSuiteRuns" as any, {
+      suiteId,
+      limit,
+    });
+  } catch (error) {
+    if (isConvexNotVisibleError(error)) {
+      throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Eval suite not found");
+    }
+    throw error;
+  }
+  return v1PageJson(c, (runs ?? []).map(toRunDto));
+});
+
+export default evals;

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -145,6 +145,32 @@ function requireProjectMatch(
   }
 }
 
+const TERMINAL_RUN_STATUSES = new Set(["completed", "failed", "cancelled"]);
+
+/**
+ * Whether the run record already reached a terminal status. Used by the
+ * detached-execution catch: `runEvalSuiteWithAiSdk` finalizes a failed run
+ * itself before rethrowing, so a rejected `execute()` usually means the
+ * terminal write already happened — re-finalizing would restamp
+ * `completedAt` and overwrite the runner's notes.
+ */
+async function isRunAlreadyTerminal(
+  convexAuthToken: string,
+  runId: string
+): Promise<boolean> {
+  try {
+    const run: RunDoc | null = await createConvexReadClient(
+      convexAuthToken
+    ).query("testSuites:getTestSuiteRun" as any, { runId });
+    return TERMINAL_RUN_STATUSES.has(String(run?.status));
+  } catch {
+    // Can't tell — let the defensive finalize proceed. recorder.finalize
+    // tolerates deleted/unauthorized runs, so the worst case is the
+    // duplicate terminal write we'd have done unconditionally before.
+    return false;
+  }
+}
+
 // ── DTO mapping ──────────────────────────────────────────────────────
 
 type RunDoc = Record<string, any>;
@@ -274,8 +300,11 @@ evals.post("/projects/:projectId/eval-runs", async (c) => {
       throw error;
     }
 
-    // Detach: the runner owns terminal run status; the catch is defense for
-    // errors thrown outside its own try (provider construction, etc.).
+    // Detach: the runner owns terminal run status (it finalizes a failed
+    // run itself, then rethrows). The catch is defense for errors thrown
+    // outside the runner's own try (provider construction, etc.) — it only
+    // finalizes when the run record is still non-terminal, so the runner's
+    // completedAt/notes are never restamped by a second terminal write.
     void prepared
       .execute()
       .catch(async (error) => {
@@ -284,6 +313,9 @@ evals.post("/projects/:projectId/eval-runs", async (c) => {
           suiteId: prepared.suiteId,
           projectId,
         });
+        if (await isRunAlreadyTerminal(convexAuthToken, prepared.runId)) {
+          return;
+        }
         await prepared.recorder
           .finalize({
             status: "failed",

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -3,9 +3,10 @@
  *
  * Mounted at `/api/v1`. Resource-oriented, project-scoped routes that wrap the
  * same core helpers as `/api/web/*` (no forked handler logic) and emit the
- * canonical v1 envelope. Read-only diagnostics ship first; mutating operations
- * (tools/execute, evals/run, generate-tests) are deferred to a follow-up that
- * adds the X-MCPJam-Approval flow.
+ * canonical v1 envelope. Covers read diagnostics (validate/doctor/lists) and
+ * write operations: tools/call, prompts/get, resources/read, OAuth token
+ * import, and async eval runs (POST creates + detaches; agents poll the GET
+ * routes for status, iteration results, and traces).
  */
 import { Hono } from "hono";
 import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
@@ -15,6 +16,8 @@ import tools from "./tools.js";
 import prompts from "./prompts.js";
 import resources from "./resources.js";
 import exporter from "./export.js";
+import evals from "./evals.js";
+import oauth from "./oauth.js";
 import { v1Error, v1OnError } from "./envelope.js";
 
 const v1 = new Hono();
@@ -44,6 +47,8 @@ v1.route("/", tools);
 v1.route("/", prompts);
 v1.route("/", resources);
 v1.route("/", exporter);
+v1.route("/", evals);
+v1.route("/", oauth);
 
 v1.onError((error, c) => v1OnError(error, c));
 

--- a/mcpjam-inspector/server/routes/v1/oauth.ts
+++ b/mcpjam-inspector/server/routes/v1/oauth.ts
@@ -28,6 +28,8 @@ import { v1Resource } from "./envelope.js";
 
 const oauth = new Hono();
 
+const IMPORT_TIMEOUT_MS = 15_000;
+
 const importTokensSchema = z.object({
   projectId: z.string().min(1),
   serverId: z.string().min(1),
@@ -68,6 +70,8 @@ oauth.post(
       );
     }
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), IMPORT_TIMEOUT_MS);
     let response: Response;
     try {
       response = await fetch(`${convexUrl}/web/oauth/import-tokens`, {
@@ -76,13 +80,22 @@ oauth.post(
         // `kind: "generic"` — the registry OAuth-proxy variant is a hosted
         // client concern, not part of the public surface.
         body: JSON.stringify({ ...body, kind: "generic" }),
+        signal: controller.signal,
       });
-    } catch {
+    } catch (error) {
+      const isAbort =
+        error instanceof Error &&
+        (error.name === "AbortError" ||
+          (error as { code?: string }).code === "ABORT_ERR");
       throw new WebRouteError(
-        502,
-        ErrorCode.SERVER_UNREACHABLE,
-        "Failed to reach the token import service"
+        isAbort ? 504 : 502,
+        isAbort ? ErrorCode.TIMEOUT : ErrorCode.SERVER_UNREACHABLE,
+        isAbort
+          ? `Token import timed out after ${IMPORT_TIMEOUT_MS}ms`
+          : "Failed to reach the token import service"
       );
+    } finally {
+      clearTimeout(timeoutId);
     }
 
     type ImportTokensPayload = {

--- a/mcpjam-inspector/server/routes/v1/oauth.ts
+++ b/mcpjam-inspector/server/routes/v1/oauth.ts
@@ -1,0 +1,126 @@
+/**
+ * Public v1 OAuth surface.
+ *
+ * When a v1 operation hits an OAuth-protected server without a stored grant,
+ * the caller gets `OAUTH_REQUIRED` with `{ serverId, serverUrl }` details.
+ * This route closes the loop: an agent completes the OAuth flow itself
+ * (e.g. SDK `runOAuthLogin` — interactive loopback, headless, or
+ * client-credentials) and imports the resulting tokens here. The backend
+ * stores them scoped to (user, project, server); every subsequent v1 connect
+ * injects the stored access token automatically and 401s trigger a
+ * server-side refresh — no further caller involvement.
+ *
+ * Unlike the hosted `/api/web/oauth/*` proxies (which forward the raw
+ * Authorization header), this route builds delegation-aware Convex headers so
+ * WorkOS API-key callers work.
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  assertBearerToken,
+  parseWithSchema,
+  ErrorCode,
+  WebRouteError,
+} from "../web/errors.js";
+import { buildConvexAuthHeaders } from "../web/auth.js";
+import { synthesizeServerBody } from "./adapter.js";
+import { v1Resource } from "./envelope.js";
+
+const oauth = new Hono();
+
+const importTokensSchema = z.object({
+  projectId: z.string().min(1),
+  serverId: z.string().min(1),
+  serverUrl: z.string().min(1),
+  oauthResourceUrl: z.string().optional(),
+  clientInformation: z
+    .object({
+      clientId: z.string().min(1),
+      clientSecret: z.string().optional(),
+    })
+    .optional(),
+  tokens: z.object({
+    access_token: z.string().min(1),
+    refresh_token: z.string().optional(),
+    expires_in: z.number().optional(),
+    token_type: z.string().optional(),
+    scope: z.string().optional(),
+    id_token: z.string().optional(),
+  }),
+});
+
+// POST /v1/projects/:projectId/servers/:serverId/oauth/import-tokens
+// Store externally-obtained OAuth tokens for this server. Returns
+// { imported: true, expiresAt } on success.
+oauth.post(
+  "/projects/:projectId/servers/:serverId/oauth/import-tokens",
+  async (c) => {
+    const rawBody = await synthesizeServerBody(c);
+    const bearerToken = assertBearerToken(c);
+    const body = parseWithSchema(importTokensSchema, rawBody);
+
+    const convexUrl = process.env.CONVEX_HTTP_URL;
+    if (!convexUrl) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Server missing CONVEX_HTTP_URL configuration"
+      );
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(`${convexUrl}/web/oauth/import-tokens`, {
+        method: "POST",
+        headers: buildConvexAuthHeaders(c, bearerToken),
+        // `kind: "generic"` — the registry OAuth-proxy variant is a hosted
+        // client concern, not part of the public surface.
+        body: JSON.stringify({ ...body, kind: "generic" }),
+      });
+    } catch {
+      throw new WebRouteError(
+        502,
+        ErrorCode.SERVER_UNREACHABLE,
+        "Failed to reach the token import service"
+      );
+    }
+
+    type ImportTokensPayload = {
+      expiresAt?: number | null;
+      code?: string;
+      message?: string;
+    };
+    let payload: ImportTokensPayload | null = null;
+    try {
+      payload = (await response.json()) as ImportTokensPayload;
+    } catch {
+      // handled below
+    }
+
+    if (!response.ok) {
+      const status = response.status;
+      const code =
+        status === 401
+          ? ErrorCode.UNAUTHORIZED
+          : status === 403
+            ? ErrorCode.FORBIDDEN
+            : status === 404
+              ? ErrorCode.NOT_FOUND
+              : status === 400
+                ? ErrorCode.VALIDATION_ERROR
+                : ErrorCode.INTERNAL_ERROR;
+      throw new WebRouteError(
+        status >= 400 && status < 500 ? status : 502,
+        code,
+        payload?.message ?? `Token import failed (${status})`
+      );
+    }
+
+    return v1Resource(c, {
+      imported: true,
+      expiresAt: payload?.expiresAt ?? null,
+    });
+  }
+);
+
+export default oauth;

--- a/mcpjam-inspector/server/routes/v1/prompts.ts
+++ b/mcpjam-inspector/server/routes/v1/prompts.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
-import { promptsListSchema } from "../web/auth.js";
-import { listPrompts } from "../../utils/route-handlers.js";
+import { promptsGetSchema, promptsListSchema } from "../web/auth.js";
+import { getPrompt, listPrompts } from "../../utils/route-handlers.js";
 import { runV1ServerOp } from "./adapter.js";
-import { v1PageJson } from "./envelope.js";
+import { v1PageJson, v1Resource } from "./envelope.js";
 
 const prompts = new Hono();
 
@@ -16,6 +16,24 @@ prompts.post("/projects/:projectId/servers/:serverId/prompts", async (c) =>
     (manager, body) => listPrompts(manager, body),
     (ctx, result: { prompts?: unknown[]; nextCursor?: string }) =>
       v1PageJson(ctx, result.prompts ?? [], result.nextCursor)
+  )
+);
+
+// POST /v1/projects/:projectId/servers/:serverId/prompts/get
+// Render a prompt with arguments and return the MCP GetPromptResult directly
+// ({ description?, messages }). Wraps the same getPrompt core as
+// /api/web/prompts/get.
+prompts.post("/projects/:projectId/servers/:serverId/prompts/get", async (c) =>
+  runV1ServerOp(
+    c,
+    promptsGetSchema,
+    (manager, body) =>
+      getPrompt(manager, {
+        serverId: body.serverId,
+        name: body.promptName,
+        arguments: body.arguments,
+      }),
+    (ctx, result) => v1Resource(ctx, result)
   )
 );
 

--- a/mcpjam-inspector/server/routes/v1/tools.ts
+++ b/mcpjam-inspector/server/routes/v1/tools.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
-import { toolsListSchema } from "../web/auth.js";
+import { toolsExecuteSchema, toolsListSchema } from "../web/auth.js";
+import { ErrorCode, WebRouteError } from "../web/errors.js";
 import { listTools } from "../../utils/route-handlers.js";
 import { runV1ServerOp } from "./adapter.js";
-import { v1PageJson } from "./envelope.js";
+import { v1PageJson, v1Resource } from "./envelope.js";
 
 const tools = new Hono();
 
@@ -18,6 +19,33 @@ tools.post("/projects/:projectId/servers/:serverId/tools", async (c) =>
     (manager, body) => listTools(manager, body),
     (ctx, result: { tools?: unknown[]; nextCursor?: string }) =>
       v1PageJson(ctx, result.tools ?? [], result.nextCursor)
+  )
+);
+
+// POST /v1/projects/:projectId/servers/:serverId/tools/call
+// Execute a tool and return the MCP CallToolResult directly. Tool-level
+// failures (result.isError === true) are successful calls — the server
+// answered; only transport/auth errors flow through the v1 error envelope.
+// Mirrors /api/web/tools/execute, including the hosted task restriction.
+tools.post("/projects/:projectId/servers/:serverId/tools/call", async (c) =>
+  runV1ServerOp(
+    c,
+    toolsExecuteSchema,
+    async (manager, body) => {
+      if (body.taskOptions) {
+        throw new WebRouteError(
+          400,
+          ErrorCode.FEATURE_NOT_SUPPORTED,
+          "Task-augmented tool execution is not supported on /api/v1"
+        );
+      }
+      return await manager.executeTool(
+        body.serverId,
+        body.toolName,
+        body.parameters
+      );
+    },
+    (ctx, result) => v1Resource(ctx, result)
   )
 );
 

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -34,6 +34,7 @@ import {
 } from "./errors.js";
 import { buildHostedOAuthUnauthorizedHandler } from "../../utils/hosted-oauth-refresh.js";
 import { fetchRuntimeServerSecrets } from "../../utils/server-secrets.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 
 // ── Zod Schemas ──────────────────────────────────────────────────────
 
@@ -1103,7 +1104,15 @@ export async function runEphemeralConnection<S extends z.ZodTypeAny, T>(
     );
   }
 
-  const bearerToken = assertBearerToken(c);
+  // Under WorkOS API-key auth the raw `sk_` bearer is useless against
+  // Convex's JWT-only surfaces (`/web/oauth/force-refresh` inside the
+  // 401-refresh closure, reveal-secrets fallback). Swap in the short-lived
+  // delegated JWT so every bearer-forwarding path downstream of
+  // `createAuthorizedManager` works for API-key callers. JWT callers get
+  // their original bearer back unchanged. `authorizeBatch` is unaffected
+  // either way — `buildConvexAuthHeaders` branches on `authMethod`, not on
+  // this value.
+  const bearerToken = await getConvexBearerForRequest(c);
   const body = parseWithSchema(schema, rawBody);
   // Cast for internal plumbing — all web schemas include projectId + serverId(s).
   // The strongly-typed `body` is passed through to `fn` unchanged.

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -276,6 +276,7 @@ export const startSuiteRunWithRecorder = async ({
   matchOptionsOverride,
   namedHostId,
   runGroupId,
+  source,
 }: {
   convexClient: ConvexHttpClient;
   suiteId: string;
@@ -321,6 +322,12 @@ export const startSuiteRunWithRecorder = async ({
    * single-host launches.
    */
   runGroupId?: string;
+  /**
+   * Run origin persisted on `testSuiteRun.source` for audit attribution.
+   * Omitted means 'ui' (backend default); the public /api/v1 surface
+   * passes 'api'.
+   */
+  source?: "ui" | "api";
 }) => {
   const response = await convexClient.mutation(
     "testSuites:startTestSuiteRun" as any,
@@ -337,6 +344,7 @@ export const startSuiteRunWithRecorder = async ({
       matchOptionsOverride,
       ...(namedHostId ? { namedHostId } : {}),
       ...(runGroupId ? { runGroupId } : {}),
+      ...(source ? { source } : {}),
     },
   );
 

--- a/mcpjam-inspector/server/utils/v1-convex-token.ts
+++ b/mcpjam-inspector/server/utils/v1-convex-token.ts
@@ -1,0 +1,166 @@
+/**
+ * Convex bearer resolution for the public /api/v1 surface.
+ *
+ * Convex client auth (`ConvexHttpClient.setAuth`) and several Convex HTTP
+ * routes are JWT-only, but /api/v1 callers authenticate with WorkOS API keys
+ * (`sk_…`). For those requests the Inspector exchanges its service-token
+ * delegation (the same `x-mcpjam-acting-as` / `x-mcpjam-acting-in-org` trust
+ * model used by `authorizeBatch`) for a short-lived org-scoped JWT minted by
+ * the backend's `POST /web/delegated-token`. JWT callers pass through
+ * untouched.
+ *
+ * The minted token is an internal credential: it is held in this process
+ * (request flow + background eval task closures) and is never returned to
+ * the API caller.
+ */
+import type { Context } from "hono";
+import {
+  ErrorCode,
+  WebRouteError,
+  assertBearerToken,
+  parseErrorMessage,
+} from "../routes/web/errors.js";
+
+const MINT_TIMEOUT_MS = 10_000;
+// Re-mint when the cached token is within this window of expiry. Generous
+// because background eval runs capture the token at POST time and keep using
+// it for the duration of the run.
+const EXPIRY_SLACK_MS = 10 * 60 * 1000;
+
+type CachedToken = { token: string; expiresAt: number };
+
+// Keyed by `${workosUserId}:${organizationId}` — the only inputs to the mint.
+// Tokens live ~2h server-side, so steady-state v1 traffic pays the extra
+// Convex round-trip roughly once per user+org per token lifetime.
+const mintedTokenCache = new Map<string, CachedToken>();
+const inflightMints = new Map<string, Promise<CachedToken>>();
+
+function delegationContext(c: Context): {
+  workosUserId: string;
+  organizationId: string;
+} {
+  const workosUserId = c.get("workosUserId");
+  const organizationId = c.get("mcpjamOrganizationId");
+  if (!workosUserId || !organizationId) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Missing WorkOS delegation context for Convex token exchange"
+    );
+  }
+  return { workosUserId, organizationId };
+}
+
+async function mintDelegatedToken(
+  workosUserId: string,
+  organizationId: string
+): Promise<CachedToken> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_HTTP_URL configuration"
+    );
+  }
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!serviceToken) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing INSPECTOR_SERVICE_TOKEN for WorkOS API key auth"
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), MINT_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`${convexUrl}/web/delegated-token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${serviceToken}`,
+        "x-mcpjam-acting-as": workosUserId,
+        "x-mcpjam-acting-in-org": organizationId,
+      },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const isAbort =
+      error instanceof Error &&
+      (error.name === "AbortError" ||
+        (error as { code?: string }).code === "ABORT_ERR");
+    throw new WebRouteError(
+      isAbort ? 504 : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      isAbort
+        ? `Delegated token exchange timed out after ${MINT_TIMEOUT_MS}ms`
+        : `Failed to reach delegated token exchange: ${parseErrorMessage(error)}`
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  type MintResponse = { ok?: boolean; token?: string; expiresAt?: number };
+  let body: MintResponse | null = null;
+  try {
+    body = (await response.json()) as MintResponse;
+  } catch {
+    // handled below
+  }
+  if (!response.ok || !body?.ok || typeof body.token !== "string") {
+    throw new WebRouteError(
+      response.status === 403 ? 403 : 502,
+      response.status === 403
+        ? ErrorCode.FORBIDDEN
+        : ErrorCode.INTERNAL_ERROR,
+      `Delegated token exchange failed (${response.status})`
+    );
+  }
+  return {
+    token: body.token,
+    expiresAt:
+      typeof body.expiresAt === "number"
+        ? body.expiresAt
+        : Date.now() + EXPIRY_SLACK_MS,
+  };
+}
+
+/**
+ * Resolve the bearer to use against Convex for this request:
+ *   - JWT callers (WorkOS session, guest): the original bearer, verbatim.
+ *   - WorkOS API-key callers: a cached short-lived delegated JWT.
+ *
+ * Background tasks that outlive the request (async eval runs) should call
+ * this once during the request and capture the returned string — the token's
+ * TTL (hours) comfortably covers a capped eval run.
+ */
+export async function getConvexBearerForRequest(c: Context): Promise<string> {
+  if (c.get("authMethod") !== "workos_api_key") {
+    return assertBearerToken(c);
+  }
+  const { workosUserId, organizationId } = delegationContext(c);
+  const cacheKey = `${workosUserId}:${organizationId}`;
+
+  const cached = mintedTokenCache.get(cacheKey);
+  if (cached && cached.expiresAt - Date.now() > EXPIRY_SLACK_MS) {
+    return cached.token;
+  }
+
+  const inflight = inflightMints.get(cacheKey);
+  if (inflight) {
+    return (await inflight).token;
+  }
+
+  const mintPromise = mintDelegatedToken(workosUserId, organizationId)
+    .then((minted) => {
+      mintedTokenCache.set(cacheKey, minted);
+      return minted;
+    })
+    .finally(() => {
+      inflightMints.delete(cacheKey);
+    });
+  inflightMints.set(cacheKey, mintPromise);
+  return (await mintPromise).token;
+}

--- a/mcpjam-inspector/server/utils/v1-convex-token.ts
+++ b/mcpjam-inspector/server/utils/v1-convex-token.ts
@@ -26,6 +26,11 @@ const MINT_TIMEOUT_MS = 10_000;
 // because background eval runs capture the token at POST time and keep using
 // it for the duration of the run.
 const EXPIRY_SLACK_MS = 10 * 60 * 1000;
+// Assumed TTL when the mint response omits `expiresAt`. Must comfortably
+// exceed EXPIRY_SLACK_MS — a fallback of exactly the slack window would put
+// the token inside the re-mint window the moment it's cached, turning the
+// cache into a per-request mint. Tokens live ~2h server-side; 1h is safe.
+const FALLBACK_TTL_MS = 60 * 60 * 1000;
 
 type CachedToken = { token: string; expiresAt: number };
 
@@ -123,7 +128,7 @@ async function mintDelegatedToken(
     expiresAt:
       typeof body.expiresAt === "number"
         ? body.expiresAt
-        : Date.now() + EXPIRY_SLACK_MS,
+        : Date.now() + FALLBACK_TTL_MS,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds the write surface to the public `/api/v1` API so coding agents can operate their MCP server programmatically — call tools/prompts, and above all **run evals and poll for trace data, latency, and token usage** — while the run appears live in the hosted UI Runs/Cases tabs (same Convex tables the UI reads).

Pairs with MCPJam/mcpjam-backend#495 (delegated JWT mint + org scoping); the backend PR must deploy first.

### New endpoints (all under `/api/v1`, bearer auth, existing v1 envelope/contract — no new error codes, golden fixtures untouched)

**Live MCP writes**
- `POST /projects/:projectId/servers/:serverId/tools/call` — execute a tool, returns the MCP `CallToolResult` directly (tool-level `isError` results are successful calls; transport/auth errors map through the existing envelope, incl. `OAUTH_REQUIRED`).
- `POST .../prompts/get` — render a prompt (`GetPromptResult`).

**Async eval runs**
- `POST /projects/:projectId/eval-runs` — accepts an existing `suiteId` (rerun) and/or inline `tests` (≤100; same shapes as the web surface: models, runs ≤10, expectedToolCalls, matchOptions, predicates, passCriteria). Suite/case upsert, run creation, and quota checks run synchronously so errors surface on the POST; execution then detaches and the route responds **202** `{ runId, suiteId, status: "running", caseUpsert }`. Per-org in-process concurrency gate (`V1_MAX_CONCURRENT_EVAL_RUNS`, default 2) → `RATE_LIMITED` with `reason: CONCURRENT_RUN_LIMIT`. Runs are tagged `source: "api"`.
- `GET .../eval-runs/:runId` — status/result/summary; poll until terminal.
- `GET .../eval-runs/:runId/iterations?cursor=&limit=` — paginated per-iteration results: actual tool calls, structured token usage (input/output/cached/reasoning), `durationMs`.
- `GET .../iterations/:iterationId/trace` — full trace envelope (messages + spans); `TRACE_NOT_AVAILABLE` detail when absent.
- `GET .../eval-suites/:suiteId/runs` — recent runs for a suite.

**OAuth**
- `POST .../servers/:serverId/oauth/import-tokens` — agents that complete OAuth themselves (e.g. SDK `runOAuthLogin`: interactive loopback / headless / client-credentials) push tokens to the backend. Subsequent v1 connects inject the stored token via authorize-batch and 401s trigger server-side refresh — closes the `OAUTH_REQUIRED` loop for API callers.

### Implementation notes
- `runEvalsWithManager` is split at its natural seam into `prepareEvalRun` (validate → upsert → create run → resolve model config) returning an `execute()` closure; the web `/api/web/evals/run` path is byte-for-byte `prepare → await execute()`. The runner already owns terminal run status; the detached path adds a defensive `recorder.finalize({ status: "failed" })` catch and ties manager disconnect + slot release to task completion.
- `runEphemeralConnection` now resolves its Convex bearer via `getConvexBearerForRequest`: JWT callers pass through; WorkOS `sk_` callers get a short-lived org-scoped JWT minted by the backend's `/web/delegated-token` (cached in-process per user+org). This also fixes the hosted OAuth force-refresh closure under API-key auth, which previously captured the raw `sk_` bearer.
- Eval reads are thin proxies over the same Convex queries the UI uses, with `projectId` cross-checks so a valid id from another project reads as `NOT_FOUND` (belt-and-braces on top of the backend's delegated org-scope enforcement).

### Known limitations (follow-ups)
- An inspector restart orphans in-flight runs as `running`; a backend cron to fail stale runs is a follow-up.
- The concurrency gate is per-instance (single Railway instance today).
- Browser-completed OAuth session flow (`authorizationUrl` + progress polling) is deferred; `import-tokens` unblocks SDK/CLI agents now.
- Docs page + SDK wrappers (`client.evals.run/waitForRun`, `client.tools.call`, `client.oauth.importTokens`) are separate PRs.

## Testing
- 13 new route tests (`server/routes/v1/__tests__/write-routes.test.ts`): schema validation, 202 + detached execution, failure finalization, prepare-failure cleanup, DTO mapping, project cross-check 404s, trace fallback, import-tokens forwarding.
- Existing v1 contract/envelope/route tests and `routes/shared/evals` tests all pass (50 total in those suites); `server/routes/web` + `server/services` suites pass except two pre-existing browser-dependent smoke tests that also fail on `main`.
- `tsc --noEmit` clean for all touched files.

https://claude.ai/code/session_01CCMPcov16D89FPNUAqhxH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCMPcov16D89FPNUAqhxH3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches auth (delegated JWT mint), long-lived background eval execution with LLM/MCP side effects, and OAuth token storage—large new surface area with org-scoped but powerful mutating operations.
> 
> **Overview**
> This PR expands **`/api/v1`** from read-only diagnostics to a full agent-facing write surface: **tool and prompt execution**, **background eval suite runs with polling**, and **OAuth token import**, reusing the same web helpers and Convex data the hosted UI uses.
> 
> **Eval pipeline:** `runEvalsWithManager` is split into **`prepareEvalRun`** (sync validate, upsert, create run, return `execute()`) and a thin wrapper that still awaits execution for `/api/web`. Public **`POST …/eval-runs`** runs prepare synchronously, then **detaches** `execute()`, responds **202** with `runId`, and keeps the MCP manager alive until the background task finishes. Runs are tagged **`source: "api"`**. There is a per-caller/org **concurrency cap** (`V1_MAX_CONCURRENT_EVAL_RUNS`, default 2) with defensive env parsing and JWT callers keyed by bearer hash. Failure handling avoids double-finalizing when the runner already marked the run terminal.
> 
> **New v1 routes:** `tools/call`, `prompts/get`, eval **GET** proxies (run, iterations, trace, suite runs) with **projectId** cross-checks, and **`oauth/import-tokens`** proxied to Convex with delegation-aware headers.
> 
> **WorkOS API keys:** New **`getConvexBearerForRequest`** mints/caches a short-lived delegated JWT for Convex JWT-only paths; **`runEphemeralConnection`** and async evals use it so `sk_` keys work for OAuth refresh and secret reveal.
> 
> **Tests:** Large new **`write-routes.test.ts`** covering validation, 202/async behavior, finalize edge cases, concurrency, DTO mapping, and OAuth forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37adc05409d208dae5e52148bbb9a34d747d1d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->