### PR TITLE
3DS Pop-up

### DIFF
--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -57,6 +57,7 @@ import {
   useOrganizationBilling,
   type BillingInterval,
   type OrganizationBillingStatus,
+  type OrganizationSeatPaymentIntent,
   type OrganizationPlan,
 } from "@/hooks/useOrganizationBilling";
 import {
@@ -191,6 +192,63 @@ function getScheduledBillingChangeCancellationState(
     dialogDescription: `This cancels the pending ${changeNoun} to ${scheduledDescriptor}${effectiveDateSuffix}. ${currentPlanName} ${currentIntervalLabel} remains active.`,
     successMessage: `Scheduled billing change canceled. ${currentPlanName} ${currentIntervalLabel} remains active.`,
   };
+}
+
+function PendingSeatPaymentNotice({
+  intent,
+  isFinishingSeatPayment,
+  isCancelingSeatPayment,
+  onFinish,
+  onCancel,
+}: {
+  intent: OrganizationSeatPaymentIntent;
+  isFinishingSeatPayment: boolean;
+  isCancelingSeatPayment: boolean;
+  onFinish: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <Alert
+      className="border-primary/20 bg-primary/[0.04]"
+      data-testid="pending-seat-payment-notice"
+    >
+      <CreditCard className="size-4 text-primary" />
+      <AlertTitle>Seat payment required</AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>
+          Finish payment to add {intent.email}. They will not get access or
+          credits until payment succeeds.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            size="sm"
+            onClick={onFinish}
+            disabled={isFinishingSeatPayment || isCancelingSeatPayment}
+          >
+            {isFinishingSeatPayment ? (
+              <Loader2 className="mr-2 size-4 animate-spin" />
+            ) : (
+              <CreditCard className="mr-2 size-4" />
+            )}
+            Finish payment
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isCancelingSeatPayment}
+          >
+            {isCancelingSeatPayment ? (
+              <Loader2 className="mr-2 size-4 animate-spin" />
+            ) : null}
+            Cancel
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
 }
 
 export function OrganizationsTab({
@@ -375,13 +433,22 @@ function OrganizationPage({
     pendingPlanChangeTarget,
     isOpeningPortal,
     isCancelingScheduledBillingChange,
+    activeSeatPaymentIntent,
+    isFinishingSeatPayment,
+    isCancelingSeatPayment,
+    isHandlingSeatPayment,
     error: billingError,
     startPlanChange,
     openPortal,
     openCancellationPortal,
     openIntervalChangePortal,
     cancelScheduledBillingChange,
-  } = useOrganizationBilling(organization._id, { enabled: isAuthenticated });
+    finishSeatPayment,
+    cancelSeatPayment,
+  } = useOrganizationBilling(organization._id, {
+    enabled: isAuthenticated,
+    includeSeatPaymentIntent: true,
+  });
   const billingEntitlementsUiEnabled = useFeatureFlagEnabled(
     "billing-entitlements-ui"
   );
@@ -545,18 +612,24 @@ function OrganizationPage({
       );
       return;
     }
+    const email = inviteEmail.trim();
     setIsInviting(true);
     try {
       const result = await addMember({
         organizationId: organization._id,
-        email: inviteEmail.trim(),
+        email,
       });
+      if (result.needsSeatPayment) {
+        setInviteEmail("");
+        await handleFinishSeatPayment(result.seatPaymentIntentId, email);
+        return;
+      }
       if (result.isPending) {
         toast.success(
-          `Invitation sent to ${inviteEmail}. They'll get access once they sign up.`
+          `Invitation sent to ${email}. They'll get access once they sign up.`
         );
       } else {
-        toast.success(`${inviteEmail} added to the organization.`);
+        toast.success(`${email} added to the organization.`);
       }
       setInviteEmail("");
     } catch (error) {
@@ -569,6 +642,39 @@ function OrganizationPage({
       );
     } finally {
       setIsInviting(false);
+    }
+  };
+
+  const handleFinishSeatPayment = async (
+    seatPaymentIntentId?: string,
+    email?: string
+  ) => {
+    try {
+      const result = await finishSeatPayment(seatPaymentIntentId);
+      if (result.status === "paid") {
+        toast.success(
+          `${email ?? activeSeatPaymentIntent?.email ?? "Member"} added to the organization.`
+        );
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Payment was not completed. The member was not added."
+      );
+    }
+  };
+
+  const handleCancelSeatPayment = async () => {
+    try {
+      await cancelSeatPayment();
+      toast.success("Pending seat payment canceled.");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to cancel pending seat payment"
+      );
     }
   };
 
@@ -905,6 +1011,17 @@ function OrganizationPage({
     ]
   );
 
+  const pendingSeatPaymentNotice =
+    activeSeatPaymentIntent && billingStatus?.canManageBilling ? (
+      <PendingSeatPaymentNotice
+        intent={activeSeatPaymentIntent}
+        isFinishingSeatPayment={isFinishingSeatPayment}
+        isCancelingSeatPayment={isCancelingSeatPayment}
+        onFinish={() => void handleFinishSeatPayment()}
+        onCancel={() => void handleCancelSeatPayment()}
+      />
+    ) : null;
+
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-5">
@@ -1023,6 +1140,7 @@ function OrganizationPage({
           />
         ) : activeSection === "billing" ? (
           <>
+            {pendingSeatPaymentNotice}
             <OrganizationBillingSection
               organizationId={organization._id}
               showPlanBilling={billingUiEnabled}
@@ -1116,6 +1234,7 @@ function OrganizationPage({
               <CardContent className="space-y-4 pt-0">
                 {canInvite ? (
                   <div className="space-y-3">
+                    {pendingSeatPaymentNotice}
                     <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
                       <Input
                         placeholder="Email address"
@@ -1133,12 +1252,15 @@ function OrganizationPage({
                         disabled={
                           !inviteEmail.trim() ||
                           isInviting ||
+                          isHandlingSeatPayment ||
                           memberInviteGate.isLoading ||
                           memberInviteGate.isDenied
                         }
                       >
                         <UserPlus className="mr-2 size-4" />
-                        {isInviting ? "Inviting..." : "Add member"}
+                        {isInviting || isHandlingSeatPayment
+                          ? "Working..."
+                          : "Add member"}
                       </Button>
                     </div>
 

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -197,12 +197,14 @@ function getScheduledBillingChangeCancellationState(
 function PendingSeatPaymentNotice({
   intent,
   isFinishingSeatPayment,
+  isCompletingSeatPayment,
   isCancelingSeatPayment,
   onFinish,
   onCancel,
 }: {
   intent: OrganizationSeatPaymentIntent;
   isFinishingSeatPayment: boolean;
+  isCompletingSeatPayment: boolean;
   isCancelingSeatPayment: boolean;
   onFinish: () => void;
   onCancel: () => void;
@@ -238,7 +240,7 @@ function PendingSeatPaymentNotice({
             size="sm"
             variant="outline"
             onClick={onCancel}
-            disabled={isCancelingSeatPayment}
+            disabled={isCompletingSeatPayment || isCancelingSeatPayment}
           >
             {isCancelingSeatPayment ? (
               <Loader2 className="mr-2 size-4 animate-spin" />
@@ -435,6 +437,7 @@ function OrganizationPage({
     isCancelingScheduledBillingChange,
     activeSeatPaymentIntent,
     isFinishingSeatPayment,
+    isCompletingSeatPayment,
     isCancelingSeatPayment,
     isHandlingSeatPayment,
     error: billingError,
@@ -1016,6 +1019,7 @@ function OrganizationPage({
       <PendingSeatPaymentNotice
         intent={activeSeatPaymentIntent}
         isFinishingSeatPayment={isFinishingSeatPayment}
+        isCompletingSeatPayment={isCompletingSeatPayment}
         isCancelingSeatPayment={isCancelingSeatPayment}
         onFinish={() => void handleFinishSeatPayment()}
         onCancel={() => void handleCancelSeatPayment()}

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
@@ -546,6 +546,75 @@ describe("OrganizationsTab member management", () => {
     await waitFor(() => expect(cancelSeatPayment).toHaveBeenCalledWith());
   });
 
+  it("disables pending seat cancel while payment completion is in progress", () => {
+    mockUseOrganizationBilling.mockReturnValue({
+      billingStatus: {
+        organizationId: "org-1",
+        organizationName: "Acme Org",
+        plan: "team",
+        effectivePlan: "team",
+        source: "subscription",
+        billingInterval: "monthly",
+        billingConfigured: true,
+        subscriptionStatus: "active",
+        canManageBilling: true,
+        isOwner: true,
+        hasCustomer: true,
+        stripeScheduledPlan: null,
+        stripeScheduledBillingInterval: null,
+        stripeScheduledPriceId: null,
+        stripeScheduledEffectiveAt: null,
+        stripeCancelAtPeriodEnd: false,
+        stripeCancelAt: null,
+        stripeCanceledAt: null,
+        stripeCurrentPeriodEnd: null,
+        stripePriceId: "price_team_monthly",
+        trialStatus: "none",
+        trialPlan: null,
+        trialStartedAt: null,
+        trialEndsAt: null,
+        trialDaysRemaining: null,
+        decisionRequired: false,
+        trialDecision: null,
+      },
+      organizationPremiumness: undefined,
+      activeSeatPaymentIntent: {
+        _id: "seat-payment-1",
+        organizationId: "org-1",
+        userId: "user-new",
+        email: "new@example.com",
+        role: "member",
+        source: "organization",
+        status: "requires_action",
+        targetSeatQuantity: 4,
+        stripeInvoiceId: "in_123",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      isLoadingBilling: false,
+      isStartingPlanChange: false,
+      pendingPlanChangeTarget: null,
+      isOpeningPortal: false,
+      isCancelingScheduledBillingChange: false,
+      isFinishingSeatPayment: true,
+      isCompletingSeatPayment: true,
+      isCancelingSeatPayment: false,
+      isHandlingSeatPayment: true,
+      error: null,
+      startPlanChange: vi.fn(),
+      openPortal: vi.fn(),
+      openIntervalChangePortal: vi.fn(),
+      cancelScheduledBillingChange: vi.fn(),
+      selectFreeAfterTrial: vi.fn(),
+      finishSeatPayment: vi.fn(),
+      cancelSeatPayment: vi.fn(),
+    });
+
+    render(<OrganizationsTab organizationId="org-1" />);
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+  });
+
   it("starts seat payment from the direct admin add-member action", async () => {
     const finishSeatPayment = vi
       .fn()

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
@@ -212,17 +212,23 @@ describe("OrganizationsTab member management", () => {
         trialDecision: null,
       },
       organizationPremiumness: undefined,
+      activeSeatPaymentIntent: null,
       isLoadingBilling: false,
       isStartingPlanChange: false,
       pendingPlanChangeTarget: null,
       isOpeningPortal: false,
       isCancelingScheduledBillingChange: false,
+      isFinishingSeatPayment: false,
+      isCancelingSeatPayment: false,
+      isHandlingSeatPayment: false,
       error: null,
       startPlanChange: vi.fn(),
       openPortal: vi.fn(),
       openIntervalChangePortal: vi.fn(),
       cancelScheduledBillingChange: vi.fn(),
       selectFreeAfterTrial: vi.fn(),
+      finishSeatPayment: vi.fn(),
+      cancelSeatPayment: vi.fn(),
     });
 
     mockUpdateOrganization.mockResolvedValue(undefined);
@@ -325,17 +331,23 @@ describe("OrganizationsTab member management", () => {
         trialDecision: null,
       },
       organizationPremiumness: undefined,
+      activeSeatPaymentIntent: null,
       isLoadingBilling: false,
       isStartingPlanChange: false,
       pendingPlanChangeTarget: null,
       isOpeningPortal: false,
       isCancelingScheduledBillingChange: false,
+      isFinishingSeatPayment: false,
+      isCancelingSeatPayment: false,
+      isHandlingSeatPayment: false,
       error: null,
       startPlanChange: vi.fn(),
       openPortal: vi.fn(),
       openIntervalChangePortal: vi.fn(),
       cancelScheduledBillingChange: vi.fn(),
       selectFreeAfterTrial: vi.fn(),
+      finishSeatPayment: vi.fn(),
+      cancelSeatPayment: vi.fn(),
     });
 
     render(<OrganizationsTab organizationId="org-1" />);
@@ -376,5 +388,235 @@ describe("OrganizationsTab member management", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
     expect(signIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows pending seat payment only inside the members admin area", async () => {
+    const finishSeatPayment = vi
+      .fn()
+      .mockResolvedValue({ status: "paid", seatQuantity: 4 });
+    const cancelSeatPayment = vi.fn().mockResolvedValue(undefined);
+
+    mockUseOrganizationBilling.mockReturnValue({
+      billingStatus: {
+        organizationId: "org-1",
+        organizationName: "Acme Org",
+        plan: "team",
+        effectivePlan: "team",
+        source: "subscription",
+        billingInterval: "monthly",
+        billingConfigured: true,
+        subscriptionStatus: "active",
+        canManageBilling: true,
+        isOwner: true,
+        hasCustomer: true,
+        stripeScheduledPlan: null,
+        stripeScheduledBillingInterval: null,
+        stripeScheduledPriceId: null,
+        stripeScheduledEffectiveAt: null,
+        stripeCancelAtPeriodEnd: false,
+        stripeCancelAt: null,
+        stripeCanceledAt: null,
+        stripeCurrentPeriodEnd: null,
+        stripePriceId: "price_team_monthly",
+        trialStatus: "none",
+        trialPlan: null,
+        trialStartedAt: null,
+        trialEndsAt: null,
+        trialDaysRemaining: null,
+        decisionRequired: false,
+        trialDecision: null,
+      },
+      organizationPremiumness: undefined,
+      activeSeatPaymentIntent: {
+        _id: "seat-payment-1",
+        organizationId: "org-1",
+        userId: "user-new",
+        email: "new@example.com",
+        role: "member",
+        source: "organization",
+        status: "requires_action",
+        targetSeatQuantity: 4,
+        stripeInvoiceId: "in_123",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      isLoadingBilling: false,
+      isStartingPlanChange: false,
+      pendingPlanChangeTarget: null,
+      isOpeningPortal: false,
+      isCancelingScheduledBillingChange: false,
+      isHandlingSeatPayment: false,
+      error: null,
+      startPlanChange: vi.fn(),
+      openPortal: vi.fn(),
+      openIntervalChangePortal: vi.fn(),
+      cancelScheduledBillingChange: vi.fn(),
+      selectFreeAfterTrial: vi.fn(),
+      finishSeatPayment,
+      cancelSeatPayment,
+    });
+
+    render(<OrganizationsTab organizationId="org-1" />);
+
+    expect(screen.getByTestId("pending-seat-payment-notice")).toHaveTextContent(
+      "Finish payment to add new@example.com",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish payment" }));
+    await waitFor(() =>
+      expect(finishSeatPayment).toHaveBeenCalledWith(undefined),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(cancelSeatPayment).toHaveBeenCalledWith());
+  });
+
+  it("keeps pending seat cancel available while finish payment is loading", async () => {
+    const cancelSeatPayment = vi.fn().mockResolvedValue(undefined);
+
+    mockUseOrganizationBilling.mockReturnValue({
+      billingStatus: {
+        organizationId: "org-1",
+        organizationName: "Acme Org",
+        plan: "team",
+        effectivePlan: "team",
+        source: "subscription",
+        billingInterval: "monthly",
+        billingConfigured: true,
+        subscriptionStatus: "active",
+        canManageBilling: true,
+        isOwner: true,
+        hasCustomer: true,
+        stripeScheduledPlan: null,
+        stripeScheduledBillingInterval: null,
+        stripeScheduledPriceId: null,
+        stripeScheduledEffectiveAt: null,
+        stripeCancelAtPeriodEnd: false,
+        stripeCancelAt: null,
+        stripeCanceledAt: null,
+        stripeCurrentPeriodEnd: null,
+        stripePriceId: "price_team_monthly",
+        trialStatus: "none",
+        trialPlan: null,
+        trialStartedAt: null,
+        trialEndsAt: null,
+        trialDaysRemaining: null,
+        decisionRequired: false,
+        trialDecision: null,
+      },
+      organizationPremiumness: undefined,
+      activeSeatPaymentIntent: {
+        _id: "seat-payment-1",
+        organizationId: "org-1",
+        userId: "user-new",
+        email: "new@example.com",
+        role: "member",
+        source: "organization",
+        status: "requires_action",
+        targetSeatQuantity: 4,
+        stripeInvoiceId: "in_123",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      isLoadingBilling: false,
+      isStartingPlanChange: false,
+      pendingPlanChangeTarget: null,
+      isOpeningPortal: false,
+      isCancelingScheduledBillingChange: false,
+      isFinishingSeatPayment: true,
+      isCancelingSeatPayment: false,
+      isHandlingSeatPayment: true,
+      error: null,
+      startPlanChange: vi.fn(),
+      openPortal: vi.fn(),
+      openIntervalChangePortal: vi.fn(),
+      cancelScheduledBillingChange: vi.fn(),
+      selectFreeAfterTrial: vi.fn(),
+      finishSeatPayment: vi.fn(),
+      cancelSeatPayment,
+    });
+
+    render(<OrganizationsTab organizationId="org-1" />);
+
+    expect(screen.getByRole("button", { name: "Finish payment" })).toBeDisabled();
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    expect(cancelButton).toBeEnabled();
+
+    fireEvent.click(cancelButton);
+    await waitFor(() => expect(cancelSeatPayment).toHaveBeenCalledWith());
+  });
+
+  it("starts seat payment from the direct admin add-member action", async () => {
+    const finishSeatPayment = vi
+      .fn()
+      .mockResolvedValue({ status: "paid", seatQuantity: 4 });
+    mockAddMember.mockResolvedValue({
+      needsSeatPayment: true,
+      seatPaymentIntentId: "seat-payment-2",
+    });
+    mockUseOrganizationBilling.mockReturnValue({
+      billingStatus: {
+        organizationId: "org-1",
+        organizationName: "Acme Org",
+        plan: "team",
+        effectivePlan: "team",
+        source: "subscription",
+        billingInterval: "monthly",
+        billingConfigured: true,
+        subscriptionStatus: "active",
+        canManageBilling: true,
+        isOwner: true,
+        hasCustomer: true,
+        stripeScheduledPlan: null,
+        stripeScheduledBillingInterval: null,
+        stripeScheduledPriceId: null,
+        stripeScheduledEffectiveAt: null,
+        stripeCancelAtPeriodEnd: false,
+        stripeCancelAt: null,
+        stripeCanceledAt: null,
+        stripeCurrentPeriodEnd: null,
+        stripePriceId: "price_team_monthly",
+        trialStatus: "none",
+        trialPlan: null,
+        trialStartedAt: null,
+        trialEndsAt: null,
+        trialDaysRemaining: null,
+        decisionRequired: false,
+        trialDecision: null,
+      },
+      organizationPremiumness: undefined,
+      activeSeatPaymentIntent: null,
+      isLoadingBilling: false,
+      isStartingPlanChange: false,
+      pendingPlanChangeTarget: null,
+      isOpeningPortal: false,
+      isCancelingScheduledBillingChange: false,
+      isHandlingSeatPayment: false,
+      error: null,
+      startPlanChange: vi.fn(),
+      openPortal: vi.fn(),
+      openIntervalChangePortal: vi.fn(),
+      cancelScheduledBillingChange: vi.fn(),
+      selectFreeAfterTrial: vi.fn(),
+      finishSeatPayment,
+      cancelSeatPayment: vi.fn(),
+    });
+
+    render(<OrganizationsTab organizationId="org-1" />);
+
+    fireEvent.change(screen.getByPlaceholderText("Email address"), {
+      target: { value: "new@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add member" }));
+
+    await waitFor(() => {
+      expect(mockAddMember).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        email: "new@example.com",
+      });
+    });
+    await waitFor(() => {
+      expect(finishSeatPayment).toHaveBeenCalledWith("seat-payment-2");
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -172,6 +172,7 @@ function createBillingHookState(overrides: Record<string, unknown>) {
     entitlements: undefined,
     organizationPremiumness: undefined,
     projectPremiumness: undefined,
+    activeSeatPaymentIntent: null,
     planCatalog: createPlanCatalog(),
     isLoadingBilling: false,
     isLoadingEntitlements: false,
@@ -183,6 +184,7 @@ function createBillingHookState(overrides: Record<string, unknown>) {
     isOpeningPortal: false,
     isCancelingScheduledBillingChange: false,
     isSelectingFreeAfterTrial: false,
+    isHandlingSeatPayment: false,
     error: null,
     startPlanChange: vi.fn(),
     openPortal: vi.fn(),
@@ -190,6 +192,8 @@ function createBillingHookState(overrides: Record<string, unknown>) {
     openIntervalChangePortal: vi.fn(),
     cancelScheduledBillingChange: vi.fn(),
     selectFreeAfterTrial: vi.fn(),
+    finishSeatPayment: vi.fn(),
+    cancelSeatPayment: vi.fn(),
     ...overrides,
   };
 }
@@ -366,6 +370,50 @@ describe("OrganizationsTab billing", () => {
     expect(panel.queryByText("Subscription status")).not.toBeInTheDocument();
     expect(screen.getByTestId("current-plan-renewal")).toHaveTextContent(
       "No active subscription",
+    );
+  });
+
+  it("shows pending seat payment notice in the billing view", async () => {
+    const finishSeatPayment = vi
+      .fn()
+      .mockResolvedValue({ status: "paid", seatQuantity: 4 });
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: {
+          _id: "seat-payment-1",
+          organizationId: "org-1",
+          userId: "user-new",
+          email: "new@example.com",
+          role: "member",
+          source: "workspace",
+          status: "pending",
+          targetSeatQuantity: null,
+          stripeInvoiceId: null,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        finishSeatPayment,
+      }),
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+
+    expect(screen.getByTestId("pending-seat-payment-notice")).toHaveTextContent(
+      "Finish payment to add new@example.com",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish payment" }));
+    await waitFor(() =>
+      expect(finishSeatPayment).toHaveBeenCalledWith(undefined),
     );
   });
 

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -293,8 +293,10 @@ export function useOrganizationBilling(
   const [isSelectingFreeAfterTrial, setIsSelectingFreeAfterTrial] =
     useState(false);
   const [isFinishingSeatPayment, setIsFinishingSeatPayment] = useState(false);
+  const [isCompletingSeatPayment, setIsCompletingSeatPayment] = useState(false);
   const [isCancelingSeatPayment, setIsCancelingSeatPayment] = useState(false);
   const seatPaymentCancelVersionRef = useRef(0);
+  const seatPaymentCompletionInFlightRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
 
   const startPlanChange = useCallback(
@@ -493,14 +495,24 @@ export function useOrganizationBilling(
             return { status: "noop", reason: "seat_payment_canceled" };
           }
 
-          const completeResult = await completeSeatPaymentAction({
-            seatPaymentIntentId: activeSeatPaymentIntentId,
-            stripeInvoiceId: startResult.stripeInvoiceId,
-          } as any);
-          if (completeResult.status !== "paid") {
-            throw new Error("Payment was not completed");
+          seatPaymentCompletionInFlightRef.current = true;
+          setIsCompletingSeatPayment(true);
+          try {
+            const completeResult = (await completeSeatPaymentAction({
+              seatPaymentIntentId: activeSeatPaymentIntentId,
+              stripeInvoiceId: startResult.stripeInvoiceId,
+            } as any)) as SeatPaymentResult;
+            if (seatPaymentCancelVersionRef.current !== cancelVersionAtStart) {
+              return { status: "noop", reason: "seat_payment_canceled" };
+            }
+            if (completeResult.status !== "paid") {
+              throw new Error("Payment was not completed");
+            }
+            return completeResult;
+          } finally {
+            seatPaymentCompletionInFlightRef.current = false;
+            setIsCompletingSeatPayment(false);
           }
-          return completeResult as SeatPaymentResult;
         }
 
         if (startResult.status === "failed") {
@@ -539,6 +551,9 @@ export function useOrganizationBilling(
       if (!activeSeatPaymentIntentId) {
         return;
       }
+      if (seatPaymentCompletionInFlightRef.current) {
+        return;
+      }
 
       setIsCancelingSeatPayment(true);
       seatPaymentCancelVersionRef.current += 1;
@@ -547,7 +562,8 @@ export function useOrganizationBilling(
         await cancelSeatPaymentAction({
           organizationId,
           seatPaymentIntentId: activeSeatPaymentIntentId,
-          stripeInvoiceId: activeSeatPaymentIntent?.stripeInvoiceId ?? undefined,
+          stripeInvoiceId:
+            activeSeatPaymentIntent?.stripeInvoiceId ?? undefined,
         } as any);
       } catch (err) {
         const message =
@@ -590,8 +606,12 @@ export function useOrganizationBilling(
     isCancelingScheduledBillingChange,
     isSelectingFreeAfterTrial,
     isFinishingSeatPayment,
+    isCompletingSeatPayment,
     isCancelingSeatPayment,
-    isHandlingSeatPayment: isFinishingSeatPayment || isCancelingSeatPayment,
+    isHandlingSeatPayment:
+      isFinishingSeatPayment ||
+      isCompletingSeatPayment ||
+      isCancelingSeatPayment,
     error,
     startPlanChange,
     openPortal,

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -1,5 +1,6 @@
 import { useAction, useMutation, useQuery } from "convex/react";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { confirmSeatPaymentWithStripe } from "@/lib/seat-payment-stripe";
 
 export type OrganizationPlan = "free" | "team" | "enterprise";
 export type BillingInterval = "monthly" | "annual";
@@ -106,6 +107,25 @@ export interface OrganizationBillingStatus {
   trialDecision: string | null;
 }
 
+export interface OrganizationSeatPaymentIntent {
+  _id: string;
+  organizationId: string;
+  userId: string;
+  email: string;
+  role: "guest" | "member";
+  source: string;
+  status: "pending" | "requires_action";
+  targetSeatQuantity: number | null;
+  stripeInvoiceId: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export type SeatPaymentResult =
+  | { status: "paid"; seatQuantity: number; stripeInvoiceId?: string }
+  | { status: "failed"; stripeInvoiceId?: string; reason?: string }
+  | { status: "noop"; reason: string };
+
 export interface PlanCatalogEntry {
   plan: OrganizationPlan;
   displayName: string;
@@ -174,6 +194,7 @@ export function isPaidPlan(plan: OrganizationPlan): boolean {
 export interface UseOrganizationBillingOptions {
   projectId?: string | null;
   enabled?: boolean;
+  includeSeatPaymentIntent?: boolean;
 }
 
 export interface UseOrganizationBillingStatusOptions {
@@ -204,6 +225,8 @@ export function useOrganizationBilling(
   const enabled = options?.enabled ?? true;
   const shouldQueryOrganization = enabled && !!organizationId;
   const shouldQueryProject = shouldQueryOrganization && !!projectId;
+  const shouldQuerySeatPaymentIntent =
+    shouldQueryOrganization && options?.includeSeatPaymentIntent === true;
 
   const billingStatus = useOrganizationBillingStatus(organizationId, {
     enabled,
@@ -229,6 +252,11 @@ export function useOrganizationBilling(
     shouldQueryOrganization ? ({ organizationId } as any) : "skip"
   ) as PlanCatalog | undefined;
 
+  const activeSeatPaymentIntent = useQuery(
+    "billing:getActiveOrganizationSeatPaymentIntent" as any,
+    shouldQuerySeatPaymentIntent ? ({ organizationId } as any) : "skip"
+  ) as OrganizationSeatPaymentIntent | null | undefined;
+
   const startPlanChangeAction = useAction(
     "billing:startOrganizationPlanChange" as any
   );
@@ -247,6 +275,11 @@ export function useOrganizationBilling(
   const selectFreeAfterTrialMutation = useMutation(
     "billing:selectOrganizationFreePlanAfterTrial" as any
   );
+  const startSeatPaymentAction = useAction("billing:startSeatPayment" as any);
+  const completeSeatPaymentAction = useAction(
+    "billing:completeSeatPayment" as any
+  );
+  const cancelSeatPaymentAction = useAction("billing:cancelSeatPayment" as any);
 
   const [isStartingPlanChange, setIsStartingPlanChange] = useState(false);
   const [pendingPlanChangeTarget, setPendingPlanChangeTarget] = useState<
@@ -259,6 +292,9 @@ export function useOrganizationBilling(
   ] = useState(false);
   const [isSelectingFreeAfterTrial, setIsSelectingFreeAfterTrial] =
     useState(false);
+  const [isFinishingSeatPayment, setIsFinishingSeatPayment] = useState(false);
+  const [isCancelingSeatPayment, setIsCancelingSeatPayment] = useState(false);
+  const seatPaymentCancelVersionRef = useRef(0);
   const [error, setError] = useState<string | null>(null);
 
   const startPlanChange = useCallback(
@@ -405,6 +441,131 @@ export function useOrganizationBilling(
     }
   }, [organizationId, selectFreeAfterTrialMutation]);
 
+  const finishSeatPayment = useCallback(
+    async (seatPaymentIntentId?: string): Promise<SeatPaymentResult> => {
+      if (!organizationId) throw new Error("Organization is required");
+      const activeSeatPaymentIntentId =
+        seatPaymentIntentId ?? activeSeatPaymentIntent?._id;
+      if (!activeSeatPaymentIntentId) {
+        return { status: "noop", reason: "no_pending_seat_payment" };
+      }
+
+      setIsFinishingSeatPayment(true);
+      setError(null);
+      const cancelVersionAtStart = seatPaymentCancelVersionRef.current;
+      try {
+        const startResult = await startSeatPaymentAction({
+          organizationId,
+          seatPaymentIntentId: activeSeatPaymentIntentId,
+        } as any);
+
+        if (seatPaymentCancelVersionRef.current !== cancelVersionAtStart) {
+          return { status: "noop", reason: "seat_payment_canceled" };
+        }
+
+        if (startResult.status === "requires_action") {
+          if (!startResult.clientSecret) {
+            throw new Error("Payment confirmation is unavailable");
+          }
+
+          try {
+            await confirmSeatPaymentWithStripe({
+              publishableKey: startResult.publishableKey,
+              clientSecret: startResult.clientSecret,
+            });
+          } catch (confirmError) {
+            try {
+              await cancelSeatPaymentAction({
+                organizationId,
+                seatPaymentIntentId: activeSeatPaymentIntentId,
+                stripeInvoiceId: startResult.stripeInvoiceId,
+              } as any);
+            } catch (cancelError) {
+              console.warn(
+                "[billing] Failed to cancel incomplete seat payment",
+                cancelError
+              );
+            }
+            throw confirmError;
+          }
+
+          if (seatPaymentCancelVersionRef.current !== cancelVersionAtStart) {
+            return { status: "noop", reason: "seat_payment_canceled" };
+          }
+
+          const completeResult = await completeSeatPaymentAction({
+            seatPaymentIntentId: activeSeatPaymentIntentId,
+            stripeInvoiceId: startResult.stripeInvoiceId,
+          } as any);
+          if (completeResult.status !== "paid") {
+            throw new Error("Payment was not completed");
+          }
+          return completeResult as SeatPaymentResult;
+        }
+
+        if (startResult.status === "failed") {
+          if (startResult.reason === "missing_payment_method") {
+            throw new Error(
+              "Stripe has no default payment method for this subscription. Add or select a card in Billing, then click Finish payment again."
+            );
+          }
+          throw new Error("Payment failed. The member was not added.");
+        }
+
+        return startResult as SeatPaymentResult;
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to finish seat payment";
+        setError(message);
+        throw err;
+      } finally {
+        setIsFinishingSeatPayment(false);
+      }
+    },
+    [
+      activeSeatPaymentIntent?._id,
+      cancelSeatPaymentAction,
+      completeSeatPaymentAction,
+      organizationId,
+      startSeatPaymentAction,
+    ]
+  );
+
+  const cancelSeatPayment = useCallback(
+    async (seatPaymentIntentId?: string): Promise<void> => {
+      if (!organizationId) throw new Error("Organization is required");
+      const activeSeatPaymentIntentId =
+        seatPaymentIntentId ?? activeSeatPaymentIntent?._id;
+      if (!activeSeatPaymentIntentId) {
+        return;
+      }
+
+      setIsCancelingSeatPayment(true);
+      seatPaymentCancelVersionRef.current += 1;
+      setError(null);
+      try {
+        await cancelSeatPaymentAction({
+          organizationId,
+          seatPaymentIntentId: activeSeatPaymentIntentId,
+          stripeInvoiceId: activeSeatPaymentIntent?.stripeInvoiceId ?? undefined,
+        } as any);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to cancel seat payment";
+        setError(message);
+        throw err;
+      } finally {
+        setIsCancelingSeatPayment(false);
+      }
+    },
+    [
+      activeSeatPaymentIntent?._id,
+      activeSeatPaymentIntent?.stripeInvoiceId,
+      cancelSeatPaymentAction,
+      organizationId,
+    ]
+  );
+
   const isLoadingOrganizationPremiumness =
     shouldQueryOrganization && organizationPremiumness === undefined;
   const isLoadingProjectPremiumness =
@@ -415,6 +576,7 @@ export function useOrganizationBilling(
     organizationPremiumness,
     projectPremiumness,
     entitlements,
+    activeSeatPaymentIntent,
     planCatalog,
     isLoadingBilling: shouldQueryOrganization && billingStatus === undefined,
     isLoadingEntitlements:
@@ -427,6 +589,9 @@ export function useOrganizationBilling(
     isOpeningPortal,
     isCancelingScheduledBillingChange,
     isSelectingFreeAfterTrial,
+    isFinishingSeatPayment,
+    isCancelingSeatPayment,
+    isHandlingSeatPayment: isFinishingSeatPayment || isCancelingSeatPayment,
     error,
     startPlanChange,
     openPortal,
@@ -434,5 +599,7 @@ export function useOrganizationBilling(
     openIntervalChangePortal,
     cancelScheduledBillingChange,
     selectFreeAfterTrial,
+    finishSeatPayment,
+    cancelSeatPayment,
   };
 }

--- a/mcpjam-inspector/client/src/lib/__tests__/seat-payment-stripe.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/seat-payment-stripe.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const STRIPE_SCRIPT_SELECTOR = 'script[src="https://js.stripe.com/v3/"]';
+
+async function importStripeHelpers() {
+  return await import("../seat-payment-stripe");
+}
+
+function getStripeScript(): HTMLScriptElement {
+  const script = document.querySelector<HTMLScriptElement>(
+    STRIPE_SCRIPT_SELECTOR
+  );
+  if (!script) {
+    throw new Error("Stripe script was not added");
+  }
+  return script;
+}
+
+function setLoadedStripe() {
+  const confirmCardPayment = vi.fn().mockResolvedValue({
+    paymentIntent: { status: "succeeded" },
+  });
+  window.Stripe = vi.fn(() => ({ confirmCardPayment }));
+  return confirmCardPayment;
+}
+
+describe("confirmSeatPaymentWithStripe", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete window.Stripe;
+    document.querySelectorAll(STRIPE_SCRIPT_SELECTOR).forEach((script) => {
+      script.remove();
+    });
+  });
+
+  afterEach(() => {
+    delete window.Stripe;
+    document.querySelectorAll(STRIPE_SCRIPT_SELECTOR).forEach((script) => {
+      script.remove();
+    });
+  });
+
+  it("retries loading Stripe.js after a newly-created script fails", async () => {
+    const { confirmSeatPaymentWithStripe } = await importStripeHelpers();
+
+    const firstAttempt = confirmSeatPaymentWithStripe({
+      publishableKey: "pk_test_fake",
+      clientSecret: "cs_test_fake",
+    });
+    getStripeScript().dispatchEvent(new Event("error"));
+
+    await expect(firstAttempt).rejects.toThrow("Failed to load Stripe");
+    expect(document.querySelector(STRIPE_SCRIPT_SELECTOR)).toBeNull();
+
+    const secondAttempt = confirmSeatPaymentWithStripe({
+      publishableKey: "pk_test_fake",
+      clientSecret: "cs_test_fake",
+    });
+    const confirmCardPayment = setLoadedStripe();
+    getStripeScript().dispatchEvent(new Event("load"));
+
+    await expect(secondAttempt).resolves.toBeUndefined();
+    expect(confirmCardPayment).toHaveBeenCalledWith("cs_test_fake");
+  });
+
+  it("retries loading Stripe.js after an existing script fails", async () => {
+    const existingScript = document.createElement("script");
+    existingScript.src = "https://js.stripe.com/v3/";
+    document.head.appendChild(existingScript);
+    const { confirmSeatPaymentWithStripe } = await importStripeHelpers();
+
+    const firstAttempt = confirmSeatPaymentWithStripe({
+      publishableKey: "pk_test_fake",
+      clientSecret: "cs_test_fake",
+    });
+    existingScript.dispatchEvent(new Event("error"));
+
+    await expect(firstAttempt).rejects.toThrow("Failed to load Stripe");
+    expect(document.querySelector(STRIPE_SCRIPT_SELECTOR)).toBeNull();
+
+    const secondAttempt = confirmSeatPaymentWithStripe({
+      publishableKey: "pk_test_fake",
+      clientSecret: "cs_test_fake",
+    });
+    const confirmCardPayment = setLoadedStripe();
+    getStripeScript().dispatchEvent(new Event("load"));
+
+    await expect(secondAttempt).resolves.toBeUndefined();
+    expect(confirmCardPayment).toHaveBeenCalledWith("cs_test_fake");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/seat-payment-stripe.ts
+++ b/mcpjam-inspector/client/src/lib/seat-payment-stripe.ts
@@ -33,6 +33,11 @@ function loadStripeJs(): Promise<void> {
   }
 
   stripeJsPromise = new Promise((resolve, reject) => {
+    const rejectAndReset = (failedScript: HTMLScriptElement) => {
+      failedScript.remove();
+      stripeJsPromise = null;
+      reject(new Error("Failed to load Stripe"));
+    };
     const existingScript = document.querySelector<HTMLScriptElement>(
       'script[src="https://js.stripe.com/v3/"]',
     );
@@ -41,8 +46,10 @@ function loadStripeJs(): Promise<void> {
       existingScript.addEventListener("load", () => resolve(), { once: true });
       existingScript.addEventListener(
         "error",
-        () => reject(new Error("Failed to load Stripe")),
-        { once: true },
+        () => rejectAndReset(existingScript),
+        {
+          once: true,
+        }
       );
       return;
     }
@@ -51,11 +58,9 @@ function loadStripeJs(): Promise<void> {
     script.src = "https://js.stripe.com/v3/";
     script.async = true;
     script.addEventListener("load", () => resolve(), { once: true });
-    script.addEventListener(
-      "error",
-      () => reject(new Error("Failed to load Stripe")),
-      { once: true },
-    );
+    script.addEventListener("error", () => rejectAndReset(script), {
+      once: true,
+    });
     document.head.appendChild(script);
   });
 

--- a/mcpjam-inspector/client/src/lib/seat-payment-stripe.ts
+++ b/mcpjam-inspector/client/src/lib/seat-payment-stripe.ts
@@ -1,0 +1,83 @@
+type StripeConfirmCardPaymentResult = {
+  error?: {
+    message?: string;
+  };
+  paymentIntent?: {
+    status?: string;
+  };
+};
+
+type StripeClient = {
+  confirmCardPayment: (
+    clientSecret: string,
+  ) => Promise<StripeConfirmCardPaymentResult>;
+};
+
+declare global {
+  interface Window {
+    Stripe?: (publishableKey: string) => StripeClient | null;
+  }
+}
+
+let stripeJsPromise: Promise<void> | null = null;
+
+function loadStripeJs(): Promise<void> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("Stripe is only available in the browser"));
+  }
+  if (window.Stripe) {
+    return Promise.resolve();
+  }
+  if (stripeJsPromise) {
+    return stripeJsPromise;
+  }
+
+  stripeJsPromise = new Promise((resolve, reject) => {
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      'script[src="https://js.stripe.com/v3/"]',
+    );
+
+    if (existingScript) {
+      existingScript.addEventListener("load", () => resolve(), { once: true });
+      existingScript.addEventListener(
+        "error",
+        () => reject(new Error("Failed to load Stripe")),
+        { once: true },
+      );
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://js.stripe.com/v3/";
+    script.async = true;
+    script.addEventListener("load", () => resolve(), { once: true });
+    script.addEventListener(
+      "error",
+      () => reject(new Error("Failed to load Stripe")),
+      { once: true },
+    );
+    document.head.appendChild(script);
+  });
+
+  return stripeJsPromise;
+}
+
+export async function confirmSeatPaymentWithStripe({
+  publishableKey,
+  clientSecret,
+}: {
+  publishableKey: string;
+  clientSecret: string;
+}): Promise<void> {
+  await loadStripeJs();
+
+  const stripe = window.Stripe?.(publishableKey);
+  if (!stripe) {
+    throw new Error("Failed to initialize Stripe");
+  }
+
+  const result = await stripe.confirmCardPayment(clientSecret);
+  if (result.error) {
+    throw new Error(result.error.message || "Payment was not completed");
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -573,7 +573,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -1063,7 +1063,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -1077,7 +1077,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1087,7 +1087,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1101,7 +1101,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1111,7 +1111,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@axiomhq/js": {
@@ -2250,7 +2250,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2270,7 +2270,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2294,7 +2294,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2322,7 +2322,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2345,7 +2345,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2370,7 +2370,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4610,7 +4610,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -6134,7 +6134,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -8569,7 +8569,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -13815,7 +13815,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -13825,7 +13824,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -16301,7 +16300,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -16523,7 +16522,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -17636,7 +17635,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -17657,7 +17656,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -17673,7 +17672,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -18244,7 +18243,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -18258,7 +18257,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -18355,7 +18354,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -19732,7 +19731,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -19743,7 +19741,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -22525,7 +22522,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -22592,7 +22589,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -22606,7 +22603,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -23419,7 +23416,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -24822,7 +24819,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -24862,7 +24859,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -24872,7 +24869,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -24886,7 +24883,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -25281,7 +25278,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -25314,7 +25311,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25335,7 +25331,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25356,7 +25351,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25377,7 +25371,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25398,7 +25391,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25419,7 +25411,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25440,7 +25431,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25461,7 +25451,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25482,7 +25471,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25503,7 +25491,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25524,7 +25511,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26443,7 +26429,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -29194,7 +29180,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -30110,7 +30096,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -31524,7 +31510,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -31616,7 +31602,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -32290,7 +32276,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -32309,7 +32295,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -33006,7 +32992,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -33153,7 +33139,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -33237,7 +33223,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -33495,7 +33481,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
       "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -33508,7 +33494,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -33612,7 +33598,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -33625,7 +33611,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -33973,7 +33959,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -34156,7 +34142,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -35169,7 +35155,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -35245,7 +35231,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -35350,7 +35336,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -35360,7 +35346,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -36208,7 +36194,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -36228,7 +36214,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {


### PR DESCRIPTION
<img width="2000" height="1365" alt="image" src="https://github.com/user-attachments/assets/3e71611d-76c5-49a1-824a-844293587f2b" />

## Summary

This PR fixes paid Team seat-add billing so members, credits, and eval iterations are only granted after Stripe confirms payment.

## Backend

- Added `orgPendingSeats` as a waiting room for paid Team seat adds.
- When an existing Team org adds a member mid-cycle, we now create a pending seat row instead of immediately adding the member.
- If Stripe payment succeeds:
  - mark the pending seat as `paid`
  - add the member
  - let normal Team billing grant credits / eval iterations
- If Stripe needs 3DS:
  - keep the pending seat in `requires_action`
  - wait for authentication
- If payment fails or is canceled:
  - member is not added
  - credits are not granted
  - eval iterations are not granted
- Added webhook recovery: If payment succeeds, the member is activated even if the browser flow does not finish cleanly.
- Fixed Stripe invoice reading: Stripe can put the subscription ID in a newer invoice field, so we now read both shapes and avoid fake “invoice does not belong” errors after successful 3DS.

## Frontend

- Added an admin-console-only “Seat payment required” notice.
- Added `Finish payment` and `Cancel` actions for pending paid seats.
- `Finish payment` opens Stripe 3DS when needed.
- No global banner or app-wide payment prompt was added.

## Testing

- Added coverage for paid seat success, 3DS, failure/cancel, webhook recovery, and invoice ownership checks.
- Verified focused backend billing/org/workspace/project/webhook tests pass.