### PR TITLE
fix(connection): auto-fetch hidden stored headers when saving auth changes

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -522,7 +522,12 @@ export function ServerDetailModal({
             projectId,
             serverId: hostedServerId,
           });
-          revealedHeaders = secrets.headers ?? {};
+          // A null headers payload means the stored set couldn't be read;
+          // merging against it would wipe the saved headers, so fail closed.
+          if (!secrets.headers) {
+            throw new Error("Stored headers missing from reveal response");
+          }
+          revealedHeaders = secrets.headers;
         } catch {
           toast.error(
             "Couldn't load this server's saved headers to apply this change. Reveal saved headers in Advanced settings and try again."

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -46,6 +46,7 @@ import type {
   ProjectServerOverrideEntry,
 } from "@/lib/project-server-config";
 import { EffectiveProtocolVersionChip } from "./shared/EffectiveProtocolVersionChip";
+import { fetchServerSecrets } from "@/lib/apis/server-secrets-api";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 
@@ -503,9 +504,36 @@ export function ServerDetailModal({
       environment: detectEnvironment(),
     });
 
-    const finalFormData = formState.buildFormData();
     setIsSaving(true);
     try {
+      // Saving an auth or header change replaces the whole stored header
+      // set. When that set is hidden, fetch it first so e.g. rotating a
+      // bearer token doesn't wipe the other saved headers.
+      let revealedHeaders: Record<string, string> | undefined;
+      if (formState.needsStoredHeaderReveal) {
+        if (!projectId || !hostedServerId) {
+          toast.error(
+            "Reveal saved headers before changing authentication so existing hidden headers aren't lost."
+          );
+          return;
+        }
+        try {
+          const secrets = await fetchServerSecrets({
+            projectId,
+            serverId: hostedServerId,
+          });
+          revealedHeaders = secrets.headers ?? {};
+        } catch {
+          toast.error(
+            "Couldn't load this server's saved headers to apply this change. Reveal saved headers in Advanced settings and try again."
+          );
+          return;
+        }
+      }
+
+      const finalFormData = formState.buildFormData(
+        revealedHeaders ? { revealedHeaders } : undefined
+      );
       await onSubmit(finalFormData, server.name);
     } finally {
       setIsSaving(false);

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -116,7 +116,7 @@ describe("useServerForm", () => {
     });
   });
 
-  it("does not replace hidden stored headers when editing auth without reveal", async () => {
+  it("asks for stored headers when editing auth with hidden headers and merges them into the patch", async () => {
     const server = {
       name: "Hidden header server",
       config: {
@@ -140,13 +140,117 @@ describe("useServerForm", () => {
       result.current.setBearerToken("new-token");
     });
 
-    expect(result.current.buildFormData()).toMatchObject({
-      headers: { Authorization: "Bearer new-token" },
-    });
+    // Without the stored headers the form can't build a safe replacement
+    // patch, so it withholds one and flags that a reveal is needed.
+    expect(result.current.needsStoredHeaderReveal).toBe(true);
     expect(result.current.buildFormData().secretPatch?.headers).toBeUndefined();
-    expect(result.current.validateForm()).toBe(
-      "Reveal saved headers before changing authentication so existing hidden headers aren't lost."
-    );
+    expect(result.current.validateForm()).toBeNull();
+
+    // With the stored headers supplied at save time, the patch swaps the
+    // Authorization header and keeps the rest.
+    expect(
+      result.current.buildFormData({
+        revealedHeaders: {
+          Authorization: "Bearer old-token",
+          "X-Api-Key": "secret",
+        },
+      })
+    ).toMatchObject({
+      headers: {
+        Authorization: "Bearer new-token",
+        "X-Api-Key": "secret",
+      },
+      secretPatch: {
+        headers: {
+          Authorization: "Bearer new-token",
+          "X-Api-Key": "secret",
+        },
+      },
+    });
+  });
+
+  it("keeps the hidden Authorization header when only header rows change", async () => {
+    const server = {
+      name: "Hidden header server",
+      config: {
+        url: "https://example.com/mcp",
+      },
+      hasHeaders: true,
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+      enabled: true,
+    } as any;
+
+    const { result } = renderHook(() => useServerForm(server));
+
+    await waitFor(() => {
+      expect(result.current.hasStoredHeaders).toBe(true);
+    });
+
+    act(() => {
+      result.current.addCustomHeader();
+    });
+    act(() => {
+      result.current.updateCustomHeader(0, "key", "X-New");
+    });
+    act(() => {
+      result.current.updateCustomHeader(0, "value", "fresh");
+    });
+
+    expect(result.current.needsStoredHeaderReveal).toBe(true);
+    expect(
+      result.current.buildFormData({
+        revealedHeaders: {
+          Authorization: "Bearer keep-me",
+          "X-Api-Key": "secret",
+        },
+      }).secretPatch
+    ).toEqual({
+      headers: {
+        Authorization: "Bearer keep-me",
+        "X-Api-Key": "secret",
+        "X-New": "fresh",
+      },
+    });
+  });
+
+  it("drops the hidden Authorization header when auth switches away from bearer", async () => {
+    const server = {
+      name: "Hidden header server",
+      config: {
+        url: "https://example.com/mcp",
+      },
+      hasHeaders: true,
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+      enabled: true,
+    } as any;
+
+    const { result } = renderHook(() => useServerForm(server));
+
+    await waitFor(() => {
+      expect(result.current.hasStoredHeaders).toBe(true);
+    });
+
+    act(() => {
+      result.current.setAuthType("oauth");
+    });
+
+    expect(result.current.needsStoredHeaderReveal).toBe(true);
+    expect(
+      result.current.buildFormData({
+        revealedHeaders: {
+          Authorization: "Bearer old-token",
+          "X-Api-Key": "secret",
+        },
+      }).secretPatch
+    ).toEqual({
+      headers: {
+        "X-Api-Key": "secret",
+      },
+    });
   });
 
   it("sends a replacement header patch after stored headers are revealed", async () => {

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -139,6 +139,10 @@ export function useServerForm(
   const [hasStoredHeaders, setHasStoredHeaders] = useState(false);
   const [envDirty, setEnvDirty] = useState(false);
   const [headersDirty, setHeadersDirty] = useState(false);
+  // Auth edits (auth type / bearer token) are tracked apart from header-row
+  // edits: when hidden stored headers are merged in at save time, the saved
+  // Authorization header must only be dropped if the user touched auth.
+  const [authDirty, setAuthDirty] = useState(false);
   const [envRevealed, setEnvRevealed] = useState(false);
   const [headersRevealed, setHeadersRevealed] = useState(false);
   const [requestTimeout, setRequestTimeout] = useState<string>("");
@@ -384,6 +388,7 @@ export function useServerForm(
       setHasStoredHeaders(hasStoredHeadersValue);
       setHeadersRevealed(headersArray.length > 0);
       setHeadersDirty(false);
+      setAuthDirty(false);
       setShowConfiguration(
         headersArray.length > 0 ||
           timeoutValue.trim() !== "" ||
@@ -467,10 +472,6 @@ export function useServerForm(
         urlObj.protocol !== "https:"
       ) {
         return "HTTPS is required";
-      }
-
-      if (hasStoredHeaders && !headersRevealed && headersDirty) {
-        return "Reveal saved headers before changing authentication so existing hidden headers aren't lost.";
       }
     }
 
@@ -600,7 +601,14 @@ export function useServerForm(
     }
   };
 
-  const buildFormData = (): ServerFormData => {
+  const buildFormData = (buildOptions?: {
+    /**
+     * Stored headers fetched from the secrets API at save time. Supplying
+     * them lets a server with hidden stored headers take an auth or header
+     * change without wiping the headers the form can't see.
+     */
+    revealedHeaders?: Record<string, string>;
+  }): ServerFormData => {
     const parsedTimeout = Number.parseInt(requestTimeout.trim(), 10);
     const reqTimeout = Number.isFinite(parsedTimeout)
       ? parsedTimeout
@@ -645,7 +653,20 @@ export function useServerForm(
     }
 
     // Handle http-specific data
+    const revealedStoredHeaders = buildOptions?.revealedHeaders;
     const headers: Record<string, string> = {};
+
+    // Seed with the stored headers so the replacement patch keeps them. The
+    // saved Authorization header only carries over while auth is untouched —
+    // once the user edits auth, the auth section below is authoritative.
+    if (revealedStoredHeaders) {
+      for (const [key, value] of Object.entries(revealedStoredHeaders)) {
+        if (authDirty && isAuthorizationHeader(key)) {
+          continue;
+        }
+        headers[key] = value;
+      }
+    }
 
     // Add custom headers
     customHeaders.forEach(({ key, value }) => {
@@ -682,9 +703,10 @@ export function useServerForm(
     }
     const explicitHeaders =
       Object.keys(headers).length > 0 ? headers : undefined;
-    const canPatchHeaders = !hasStoredHeaders || headersRevealed;
+    const canPatchHeaders =
+      !hasStoredHeaders || headersRevealed || revealedStoredHeaders != null;
     const secretPatch =
-      headersDirty && canPatchHeaders ? { headers } : undefined;
+      (headersDirty || authDirty) && canPatchHeaders ? { headers } : undefined;
 
     return {
       name: name.trim(),
@@ -736,6 +758,7 @@ export function useServerForm(
     setHasStoredHeaders(false);
     setEnvDirty(false);
     setHeadersDirty(false);
+    setAuthDirty(false);
     setEnvRevealed(false);
     setHeadersRevealed(false);
     setRequestTimeout("");
@@ -777,6 +800,15 @@ export function useServerForm(
         JSON.stringify(iv.customHeaders)
     );
   })();
+
+  // Saving a header-affecting change replaces the whole stored header set,
+  // so when that set is hidden the caller must fetch it (secrets API) and
+  // pass it to buildFormData as `revealedHeaders` before submitting.
+  const needsStoredHeaderReveal =
+    type === "http" &&
+    hasStoredHeaders &&
+    !headersRevealed &&
+    (headersDirty || authDirty);
 
   const preregisteredOauthBlocksSubmit =
     type === "http" &&
@@ -822,12 +854,12 @@ export function useServerForm(
     setClearClientSecret,
     bearerToken,
     setBearerToken: (value: string) => {
-      setHeadersDirty(true);
+      setAuthDirty(true);
       setBearerToken(value);
     },
     authType,
     setAuthType: (value: "oauth" | "bearer" | "none") => {
-      setHeadersDirty(true);
+      setAuthDirty(true);
       setAuthType(value);
     },
     useCustomClientId,
@@ -859,6 +891,7 @@ export function useServerForm(
     headersDirty,
     envRevealed,
     headersRevealed,
+    needsStoredHeaderReveal,
 
     // Toggle states
     showConfiguration,


### PR DESCRIPTION
## Problem

Changing the bearer token (or auth type, or adding a header row) on an existing hosted server hard-blocked the save with:

> Reveal saved headers before changing authentication so existing hidden headers aren't lost.

Saving a header-affecting change replaces the entire stored header set, and in hosted mode the saved headers (including `Authorization`) are redacted from the client, so the form refused to build a replacement patch it couldn't make safely. The only way out was finding the "Reveal" button buried in Advanced settings — a dead end when you just want to rotate a token.

## Fix

Instead of blocking, `ServerDetailModal.handleSave` now fetches the stored headers through the existing `/api/web/server/reveal-secrets` API when needed and passes them to `buildFormData`, which merges the edit into them:

- The saved `Authorization` header is replaced/dropped **only when the user actually edited auth** (new `authDirty` flag, tracked separately from header-row edits) — adding an unrelated header row no longer risks losing a hidden bearer token.
- All other hidden headers are preserved in the replacement patch.
- The old blocking toast remains only as a fallback when the secrets can't be fetched (no project/server id yet, or the reveal request fails — e.g. non-creator).

Also fixes a latent bug: a bearer-token edit made *before* manually revealing headers was silently dropped from the secret patch, because reveal reset the dirty flag the patch depended on. `authDirty` survives the reveal, so the edit is kept.

## Testing

- Updated `use-server-form` tests: the auth-change-with-hidden-headers case now expects a merged patch instead of a validation error; added coverage for preserving the hidden `Authorization` on row-only edits and dropping it when switching to OAuth.
- `vitest run client/src/components/connection` — 11 files, 113 tests pass.
- `npm run typecheck:client` — clean.

Fixes the error Eric reported when changing bearer tokens for an existing server.

https://claude.ai/code/session_01DENLb6ErstWpuZThrLDWR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01DENLb6ErstWpuZThrLDWR9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how stored server secrets are assembled on save and could mis-merge headers if reveal fails or IDs are missing, though the code fails closed on API errors.
> 
> **Overview**
> **Hosted server saves no longer hard-block** when you change bearer auth, auth type, or custom headers while stored HTTP headers are still hidden. Instead of requiring a manual “Reveal” in Advanced settings, **`ServerDetailModal`** loads saved headers via **`fetchServerSecrets`** when **`needsStoredHeaderReveal`** is set, then passes them into **`buildFormData`** so the replacement **`secretPatch`** keeps non-auth headers and applies your edit.
> 
> **`useServerForm`** now tracks **auth edits separately** (`authDirty` vs header-row `headersDirty`). Merged patches only drop or replace the stored **`Authorization`** header when auth was actually changed; header-only edits can preserve a hidden bearer token. Validation no longer blocks save for hidden headers; fetch failures still show toasts and abort save.
> 
> Tests cover merge behavior for auth changes, header-only edits, and switching away from bearer/OAuth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cce650af180f2e1954477059ecf9efa6a374691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->