### PR TITLE
fix(evals): wait for a real painted frame before classifying a widget render

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
@@ -56,15 +56,33 @@ const app = new App({ name: "fixture-blank", version: "1.0.0" });
 app.connect().catch(() => {});
 `;
 
+// A guest that handshakes immediately but only PAINTS after a delay — mimics a
+// data/CDN-driven widget (e.g. Excalidraw) that finishes loading well after the
+// bridge handshake completes. The blank-first-frame must not classify as blank.
+const DELAYED_PAINT_GUEST_SRC = `
+import { App } from "@modelcontextprotocol/ext-apps";
+const app = new App({ name: "fixture-delayed", version: "1.0.0" });
+(async () => {
+  await app.connect();
+  await new Promise((r) => setTimeout(r, 600));
+  const d = document.createElement("div");
+  d.textContent = "painted late";
+  d.style.cssText = "font-size:40px;padding:60px";
+  document.body.appendChild(d);
+})();
+`;
+
 // Plain HTML with no guest SDK: paints text but never handshakes -> bridge_timeout.
 const STATIC_NO_BRIDGE_HTML = `<!doctype html><html><head><meta charset="utf-8"></head><body><p style="font-size:24px;padding:20px">Static content, no bridge handshake</p></body></html>`;
 
 let buttonHtml = "";
 let blankHtml = "";
+let delayedHtml = "";
 
 beforeAll(async () => {
   buttonHtml = guestHtml(await bundleGuest(BUTTON_GUEST_SRC));
   blankHtml = guestHtml(await bundleGuest(BLANK_GUEST_SRC));
+  delayedHtml = guestHtml(await bundleGuest(DELAYED_PAINT_GUEST_SRC));
 }, 60_000);
 
 const harnesses: McpAppBrowserHarness[] = [];
@@ -80,7 +98,13 @@ function makeHarness(
   );
   const h = new McpAppBrowserHarness({
     callTool,
-    budgets: { renderTimeoutMs: 1200, settleTimeoutMs: 1200 },
+    // Small paintTimeoutMs keeps the genuinely-blank fixture fast (it waits the
+    // whole paint budget before concluding blank).
+    budgets: {
+      renderTimeoutMs: 1200,
+      settleTimeoutMs: 1200,
+      paintTimeoutMs: 800,
+    },
     ...overrides,
   }) as McpAppBrowserHarness & { calls: typeof calls };
   h.calls = calls;
@@ -163,6 +187,28 @@ describe("McpAppBrowserHarness — render classification", () => {
       html: blankHtml,
     });
     expect(obs.status).toBe("blank_screenshot");
+    expect(obs.bridgeInitialized).toBe(true);
+  }, 30_000);
+
+  it("waits for a late paint instead of snapshotting a blank first frame", async () => {
+    // The widget handshakes immediately but only paints ~600ms later. Sampling
+    // blankness the instant the bridge handshakes (the old behavior) would
+    // mislabel it blank_screenshot; the paint budget must let it settle so a
+    // data/CDN-driven widget isn't a false negative based on load timing.
+    const h = makeHarness({
+      budgets: {
+        renderTimeoutMs: 1500,
+        settleTimeoutMs: 1200,
+        paintTimeoutMs: 3000,
+      },
+    });
+    const obs = await h.renderWidget({
+      toolCallId: "tc-late",
+      toolName: "late",
+      serverId: "s1",
+      html: delayedHtml,
+    });
+    expect(obs.status).toBe("rendered");
     expect(obs.bridgeInitialized).toBe(true);
   }, 30_000);
 

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-browser-harness.test.ts
@@ -190,6 +190,28 @@ describe("McpAppBrowserHarness — render classification", () => {
     expect(obs.bridgeInitialized).toBe(true);
   }, 30_000);
 
+  it("still classifies blank when the settle wait can outlast the paint budget", async () => {
+    // paintTimeoutMs <= settleTimeoutMs: the upfront networkidle wait could
+    // consume the whole budget. The paint poll must still run at least once and
+    // decide on a real frame — otherwise a blank widget falls through to
+    // "rendered". (Pins the Bugbot "paint deadline before polling" fix.)
+    const h = makeHarness({
+      budgets: {
+        renderTimeoutMs: 1200,
+        settleTimeoutMs: 1200,
+        paintTimeoutMs: 1,
+      },
+    });
+    const obs = await h.renderWidget({
+      toolCallId: "tc-3b",
+      toolName: "blank",
+      serverId: "s1",
+      html: blankHtml,
+    });
+    expect(obs.status).toBe("blank_screenshot");
+    expect(obs.bridgeInitialized).toBe(true);
+  }, 30_000);
+
   it("waits for a late paint instead of snapshotting a blank first frame", async () => {
     // The widget handshakes immediately but only paints ~600ms later. Sampling
     // blankness the instant the bridge handshakes (the old behavior) would

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -23,7 +23,6 @@
  */
 
 import { existsSync } from "fs";
-import sharp from "sharp";
 import type { Browser, BrowserContext, Page } from "playwright";
 import {
   buildSandboxProxyWidgetCsp,
@@ -294,24 +293,13 @@ export function injectCspMeta(html: string, cspContent: string): string {
   return tag + html;
 }
 
-/**
- * Pixel-level blank check: true when a screenshot is (near-)uniform, i.e. the
- * widget has not painted any visible content. This is the ground truth the
- * DOM-based `isDocumentBlank` cannot give — a `<canvas>` widget (Excalidraw)
- * mounts its canvas element (a layout box, so "non-blank" to the DOM) well
- * before it draws anything INTO it, so DOM-presence alone snapshots an empty
- * canvas. A truly blank frame has per-channel stdev 0; any real content
- * (even a single small button) pushes it well past the threshold.
- */
-const PAINT_STDEV_THRESHOLD = 2;
-async function isScreenshotBlank(png: Buffer): Promise<boolean> {
-  try {
-    const { channels } = await sharp(png).stats();
-    return channels.every((c) => c.stdev < PAINT_STDEV_THRESHOLD);
-  } catch {
-    // If we can't analyze it, don't claim it's blank (fail toward "painted").
-    return false;
-  }
+// Paint detection (see `waitForWidgetPaint`) compares whole-frame PNG
+// screenshots byte-for-byte. Chromium encodes identical pixels to identical
+// bytes, so a plain Buffer compare is a reliable "did these two frames differ"
+// test — no image decoding, and therefore no native-image dependency dragged
+// into the server bundle.
+function framesEqual(a: Buffer | null, b: Buffer | null): boolean {
+  return !!a && !!b && a.length === b.length && a.equals(b);
 }
 
 // SEP-1865 host capabilities are declared as OBJECTS (an empty `{}` means
@@ -341,6 +329,14 @@ export class McpAppBrowserHarness {
   private browser: Browser | null = null;
   private context: BrowserContext | null = null;
   private page: Page | null = null;
+  /**
+   * Screenshot of the empty host page, captured once before the first widget
+   * mounts. The host background + viewport are invariant, so this is the
+   * "nothing painted" reference every render's paint check diffs against. A
+   * widget that paints anything diverges from it; one that paints nothing
+   * stays identical to it (→ blank_screenshot).
+   */
+  private blankReference: Buffer | null = null;
 
   private readonly mounted = new Map<string, MountedWidget>();
   /**
@@ -587,6 +583,16 @@ export class McpAppBrowserHarness {
       };
     }
 
+    // Capture the empty-host baseline once, before the first widget ever mounts
+    // — nothing is on the page yet, so this is a clean "nothing painted" frame
+    // for the paint check to diff against. Host background + viewport are
+    // invariant, so the single reference serves every subsequent render.
+    if (!this.blankReference) {
+      this.blankReference = await page
+        .screenshot({ type: "png" })
+        .catch(() => null);
+    }
+
     // Capture only this render's console errors + blocked requests (otherwise
     // an observation would attach unrelated diagnostics from earlier widgets in
     // the same iteration).
@@ -746,38 +752,53 @@ export class McpAppBrowserHarness {
   }
 
   /**
-   * Wait until the widget has actually PAINTED pixels (not just mounted DOM),
-   * up to the paint budget; returns the final blank state. Polls real
-   * screenshots because `isDocumentBlank` reports a `<canvas>` widget as
-   * non-blank the moment its canvas element mounts — before it has drawn — so
-   * DOM-presence alone races the first real paint and snapshots an empty canvas.
-   * Returns as soon as the frame is non-blank, so a fast widget adds little
-   * latency and only a genuinely-blank one waits the whole budget.
+   * Wait until the widget's frame has both PAINTED (diverged from the empty-host
+   * baseline) and SETTLED (stopped changing between samples), bounded by the
+   * paint budget; returns the final blank state.
+   *
+   * This is content-agnostic, which is the point: it works the same for a DOM
+   * widget, a `<canvas>`/WebGL app (e.g. Excalidraw, which mounts its canvas
+   * element — "non-blank" to the DOM — long before it draws), a progressively
+   * hydrated app, or a slow CDN load, with no per-widget delay tuning. Frame
+   * equality is a byte compare of PNG screenshots (Chromium encodes identical
+   * pixels identically), so there's no image decoding and no native-image dep.
+   *
+   * - A widget that paints quickly diverges + stabilizes in a couple of samples.
+   * - A genuinely-blank widget never diverges from the baseline and falls
+   *   through to the budget → reported blank.
+   * - A perpetually-animating widget never stabilizes → hits the budget, and we
+   *   snapshot the latest (painted) frame → reported rendered.
    */
   private async waitForWidgetPaint(): Promise<boolean> {
     const page = this.page;
     if (!page) return true;
+    const baseline = this.blankReference;
     const deadline = Date.now() + this.budgets.paintTimeoutMs;
-    let blank = true;
+    // Let code/CDN fetches finish first, so a network-driven widget is sampled
+    // after its load rather than during it (avoids fixating on a pre-paint
+    // intermediate state). Best-effort — falls through on timeout.
+    await page
+      .waitForLoadState("networkidle", {
+        timeout: this.budgets.settleTimeoutMs,
+      })
+      .catch(() => {});
+
+    let prev: Buffer | null = null;
+    let frame: Buffer | null = null;
     while (Date.now() < deadline) {
-      const png = await page.screenshot({ type: "png" }).catch(() => null);
-      blank = png ? await isScreenshotBlank(png) : true;
-      if (!blank) break;
+      frame = await page.screenshot({ type: "png" }).catch(() => prev);
+      if (!frame) break;
+      const painted = !baseline || !framesEqual(frame, baseline);
+      const settled = framesEqual(frame, prev);
+      if (painted && settled) break;
+      prev = frame;
       await page.waitForTimeout(150);
     }
-    if (!blank) {
-      // The frame went non-blank on its FIRST visible pixels, but a widget like
-      // Excalidraw is still mid-draw then (fills appear before borders/text/
-      // arrows). Let outstanding subresource fetches settle, plus a short grace,
-      // so the snapshot is the finished widget — not a half-painted one.
-      await page
-        .waitForLoadState("networkidle", {
-          timeout: this.budgets.settleTimeoutMs,
-        })
-        .catch(() => {});
-      await page.waitForTimeout(400);
-    }
-    return blank;
+    // Blank iff the settled frame is still indistinguishable from the empty
+    // baseline. With no baseline (capture failed), fail toward "rendered" rather
+    // than mislabel a real widget blank.
+    if (!frame || !baseline) return false;
+    return framesEqual(frame, baseline);
   }
 
   /* ---- interact ---- */
@@ -985,6 +1006,8 @@ export class McpAppBrowserHarness {
     this.context = null;
     this.browser = null;
     this.page = null;
+    // Re-captured against the next launch's fresh page.
+    this.blankReference = null;
     this.mounted.clear();
     this.widgetCspSources = [];
   }

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -23,6 +23,7 @@
  */
 
 import { existsSync } from "fs";
+import sharp from "sharp";
 import type { Browser, BrowserContext, Page } from "playwright";
 import {
   buildSandboxProxyWidgetCsp,
@@ -111,6 +112,16 @@ export interface HarnessBudgets {
   settleTimeoutMs: number;
   /** During render, wait this long for iframe load + bridge init. */
   renderTimeoutMs: number;
+  /**
+   * After the bridge handshakes, wait up to this long for the widget to
+   * actually PAINT before snapshotting. Handshaking is not painting:
+   * data-driven widgets (e.g. Excalidraw) only render after they receive tool
+   * data and fetch their code from a CDN, so without this the classifier races
+   * the first paint and renderability becomes a function of CDN cache warmth.
+   * Returns as soon as the widget paints, so only genuinely-blank widgets wait
+   * the full budget.
+   */
+  paintTimeoutMs: number;
   /** Circuit breaker: total screenshots per iteration. */
   totalScreenshotsPerIteration: number;
 }
@@ -120,6 +131,7 @@ export const DEFAULT_HARNESS_BUDGETS: HarnessBudgets = {
   screenshotMaxBytes: 256 * 1024,
   settleTimeoutMs: 2000,
   renderTimeoutMs: 3000,
+  paintTimeoutMs: 8000,
   totalScreenshotsPerIteration: 60,
 };
 
@@ -280,6 +292,26 @@ export function injectCspMeta(html: string, cspContent: string): string {
     return html.slice(0, at) + `<head>${tag}</head>` + html.slice(at);
   }
   return tag + html;
+}
+
+/**
+ * Pixel-level blank check: true when a screenshot is (near-)uniform, i.e. the
+ * widget has not painted any visible content. This is the ground truth the
+ * DOM-based `isDocumentBlank` cannot give — a `<canvas>` widget (Excalidraw)
+ * mounts its canvas element (a layout box, so "non-blank" to the DOM) well
+ * before it draws anything INTO it, so DOM-presence alone snapshots an empty
+ * canvas. A truly blank frame has per-channel stdev 0; any real content
+ * (even a single small button) pushes it well past the threshold.
+ */
+const PAINT_STDEV_THRESHOLD = 2;
+async function isScreenshotBlank(png: Buffer): Promise<boolean> {
+  try {
+    const { channels } = await sharp(png).stats();
+    return channels.every((c) => c.stdev < PAINT_STDEV_THRESHOLD);
+  } catch {
+    // If we can't analyze it, don't claim it's blank (fail toward "painted").
+    return false;
+  }
 }
 
 // SEP-1865 host capabilities are declared as OBJECTS (an empty `{}` means
@@ -651,6 +683,18 @@ export class McpAppBrowserHarness {
       };
     }
 
+    // `pageResult.blank` is a DOM check sampled the instant the bridge
+    // handshakes — but handshaking is not painting, and DOM-presence is not
+    // pixels. Data-driven / canvas widgets (Excalidraw) only draw after they
+    // receive tool data and fetch their code from a CDN, seconds later. Whenever
+    // the bridge is live, wait for an actual painted frame (up to the paint
+    // budget) BEFORE snapshotting, so the screenshot shows the rendered widget
+    // and classification doesn't hinge on CDN cache warmth or DOM timing.
+    let blank = pageResult.blank;
+    if (pageResult.bridgeInitialized) {
+      blank = await this.waitForWidgetPaint();
+    }
+
     let screenshotBase64: string | undefined;
     try {
       screenshotBase64 = await this.captureScreenshot();
@@ -675,7 +719,7 @@ export class McpAppBrowserHarness {
 
     let status: WidgetRenderStatus;
     if (!pageResult.bridgeInitialized) status = "bridge_timeout";
-    else if (pageResult.blank) status = "blank_screenshot";
+    else if (blank) status = "blank_screenshot";
     else status = "rendered";
 
     // Only a fully-rendered widget stays mounted for Computer Use. Any other
@@ -699,6 +743,41 @@ export class McpAppBrowserHarness {
         : undefined,
       elapsedMs: Date.now() - started,
     };
+  }
+
+  /**
+   * Wait until the widget has actually PAINTED pixels (not just mounted DOM),
+   * up to the paint budget; returns the final blank state. Polls real
+   * screenshots because `isDocumentBlank` reports a `<canvas>` widget as
+   * non-blank the moment its canvas element mounts — before it has drawn — so
+   * DOM-presence alone races the first real paint and snapshots an empty canvas.
+   * Returns as soon as the frame is non-blank, so a fast widget adds little
+   * latency and only a genuinely-blank one waits the whole budget.
+   */
+  private async waitForWidgetPaint(): Promise<boolean> {
+    const page = this.page;
+    if (!page) return true;
+    const deadline = Date.now() + this.budgets.paintTimeoutMs;
+    let blank = true;
+    while (Date.now() < deadline) {
+      const png = await page.screenshot({ type: "png" }).catch(() => null);
+      blank = png ? await isScreenshotBlank(png) : true;
+      if (!blank) break;
+      await page.waitForTimeout(150);
+    }
+    if (!blank) {
+      // The frame went non-blank on its FIRST visible pixels, but a widget like
+      // Excalidraw is still mid-draw then (fills appear before borders/text/
+      // arrows). Let outstanding subresource fetches settle, plus a short grace,
+      // so the snapshot is the finished widget — not a half-painted one.
+      await page
+        .waitForLoadState("networkidle", {
+          timeout: this.budgets.settleTimeoutMs,
+        })
+        .catch(() => {});
+      await page.waitForTimeout(400);
+    }
+    return blank;
   }
 
   /* ---- interact ---- */

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -697,13 +697,19 @@ export class McpAppBrowserHarness {
     // budget) BEFORE snapshotting, so the screenshot shows the rendered widget
     // and classification doesn't hinge on CDN cache warmth or DOM timing.
     let blank = pageResult.blank;
+    let paintedFrame: Buffer | null = null;
     if (pageResult.bridgeInitialized) {
-      blank = await this.waitForWidgetPaint();
+      ({ blank, frame: paintedFrame } = await this.waitForWidgetPaint());
     }
 
     let screenshotBase64: string | undefined;
     try {
-      screenshotBase64 = await this.captureScreenshot();
+      // Store the exact frame the blank verdict was made on (encoding it to fit
+      // the byte budget); only re-shoot when the paint wait produced no frame
+      // (no bridge, or its screenshots failed).
+      screenshotBase64 = paintedFrame
+        ? await this.encodeScreenshot(paintedFrame)
+        : await this.captureScreenshot();
     } catch {
       // A widget we can't screenshot is useless for screenshot-driven Computer
       // Use, so unmount it even when keepMounted was requested — keeping
@@ -768,24 +774,39 @@ export class McpAppBrowserHarness {
    *   through to the budget → reported blank.
    * - A perpetually-animating widget never stabilizes → hits the budget, and we
    *   snapshot the latest (painted) frame → reported rendered.
+   *
+   * Returns the final blank verdict AND the frame it was decided on, so the
+   * caller stores the SAME image it classified (status can't disagree with the
+   * screenshot).
    */
-  private async waitForWidgetPaint(): Promise<boolean> {
+  private async waitForWidgetPaint(): Promise<{
+    blank: boolean;
+    frame: Buffer | null;
+  }> {
     const page = this.page;
-    if (!page) return true;
+    if (!page) return { blank: true, frame: null };
     const baseline = this.blankReference;
     const deadline = Date.now() + this.budgets.paintTimeoutMs;
     // Let code/CDN fetches finish first, so a network-driven widget is sampled
     // after its load rather than during it (avoids fixating on a pre-paint
-    // intermediate state). Best-effort — falls through on timeout.
+    // intermediate state). Capped to the paint budget so this can't consume it
+    // whole and starve the poll below — the poll does the actual classification
+    // and MUST run at least once. Best-effort: falls through on timeout.
     await page
       .waitForLoadState("networkidle", {
-        timeout: this.budgets.settleTimeoutMs,
+        timeout: Math.min(
+          this.budgets.settleTimeoutMs,
+          this.budgets.paintTimeoutMs
+        ),
       })
       .catch(() => {});
 
     let prev: Buffer | null = null;
     let frame: Buffer | null = null;
-    while (Date.now() < deadline) {
+    // do/while: always sample at least once, even if the wait above already
+    // exhausted the budget — otherwise `frame` stays null and we'd fail toward
+    // "rendered", mislabeling a blank widget.
+    do {
       frame = await page.screenshot({ type: "png" }).catch(() => prev);
       if (!frame) break;
       const painted = !baseline || !framesEqual(frame, baseline);
@@ -793,12 +814,13 @@ export class McpAppBrowserHarness {
       if (painted && settled) break;
       prev = frame;
       await page.waitForTimeout(150);
-    }
+    } while (Date.now() < deadline);
+
     // Blank iff the settled frame is still indistinguishable from the empty
     // baseline. With no baseline (capture failed), fail toward "rendered" rather
     // than mislabel a real widget blank.
-    if (!frame || !baseline) return false;
-    return framesEqual(frame, baseline);
+    const blank = !frame || !baseline ? false : framesEqual(frame, baseline);
+    return { blank, frame };
   }
 
   /* ---- interact ---- */
@@ -935,8 +957,20 @@ export class McpAppBrowserHarness {
   }
 
   private async captureScreenshot(): Promise<string> {
-    const page = this.page!;
-    const png = await page.screenshot({ type: "png" });
+    const png = await this.page!.screenshot({ type: "png" });
+    return this.encodeScreenshot(png);
+  }
+
+  /**
+   * Encode an already-captured PNG frame to a base64 image within the byte
+   * budget, re-shooting as progressively lower-quality JPEG only if the PNG is
+   * over budget (there's no in-process re-encoder — sharp is intentionally not a
+   * dependency — and the page still shows the same settled frame). Throws if it
+   * can't fit even at the lowest quality, which callers treat as
+   * `screenshot_failed`. Reused by `renderWidget` to store the very frame it
+   * classified, and by `captureScreenshot` for action screenshots.
+   */
+  private async encodeScreenshot(png: Buffer): Promise<string> {
     // Count only successful captures so a transient screenshot failure (caller
     // catches -> screenshot_failed) doesn't burn the per-iteration budget.
     this.screenshotCount += 1;
@@ -945,7 +979,7 @@ export class McpAppBrowserHarness {
     }
     // Re-encode as progressively lower-quality JPEG to fit the byte budget.
     for (const quality of [70, 50, 35, 20]) {
-      const jpeg = await page.screenshot({ type: "jpeg", quality });
+      const jpeg = await this.page!.screenshot({ type: "jpeg", quality });
       if (jpeg.byteLength <= this.budgets.screenshotMaxBytes) {
         return jpeg.toString("base64");
       }
@@ -953,7 +987,7 @@ export class McpAppBrowserHarness {
     // Still over the byte budget even at the lowest quality: fail closed rather
     // than hand back an oversized image (callers treat a screenshot throw as
     // `screenshot_failed` on render, or leave the action screenshot unset).
-    const jpeg = await page.screenshot({ type: "jpeg", quality: 20 });
+    const jpeg = await this.page!.screenshot({ type: "jpeg", quality: 20 });
     throw new Error(
       `screenshot exceeds byte budget after re-encoding ` +
         `(${jpeg.byteLength} > ${this.budgets.screenshotMaxBytes} bytes)`


### PR DESCRIPTION
## Problem

In the eval **Render Observations**, a genuinely-rendered widget could be reported as **"Blank screenshot — rendered but painted blank."** The clearest repro is the Excalidraw quickstart: the observation snapshot was blank (captured at ~250ms), while the same `create_view` widget rendered the Start → End diagram perfectly in the live trace.

So the harness was misreporting a working render as a failure — a false negative — and the screenshot it stored was blank/half-drawn.

## Root cause

The harness snapshotted + classified blankness the instant the **bridge handshake** completed, using `isDocumentBlank` (a **DOM** check). Two compounding issues:

1. **Handshaking ≠ painting.** Data/CDN-driven widgets only draw after they receive their tool data and fetch their code (e.g. Excalidraw from esm.sh) — seconds later. So whether the snapshot caught content depended on **CDN cache warmth** (warm: "rendered"; cold: "blank").
2. **DOM-presence ≠ pixels.** A `<canvas>` widget mounts its canvas element (a layout box, so "non-blank" to the DOM) *before* it draws into it. Even the DOM check passed while the canvas was still empty, so the stored screenshot was blank.

## Fix

Add a **pixel-level paint wait** before snapshotting/classifying. Once the bridge is live, poll real screenshots and measure per-channel stdev with `sharp` until the frame is non-uniform (actual pixels drawn) or a new `paintTimeoutMs` budget elapses, then let it settle (`networkidle` + a short grace) and capture.

- A truly-blank frame has per-channel stdev `0`; any real content (even a small button) clears the threshold, so genuinely-blank widgets still classify as `blank_screenshot`.
- Fast widgets return on the first frame (no added latency); only a genuinely-blank widget waits the full budget.
- The stored screenshot is now the **finished** widget, so the eval UI shows the painted render instead of a blank/half-drawn one.

## Verification

- Live Excalidraw quickstart with **default** budgets: now `status: "rendered"` and the captured observation screenshot is the complete Start → End diagram (previously blank).
- New deterministic regression test: a widget that handshakes immediately but paints ~600ms later is classified `rendered`, not `blank_screenshot`.
- Full harness suite green (26/26), including the genuinely-blank fixture still resolving to `blank_screenshot`.

Follow-up to #2553.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes render observation timing and classification for all browser-backed widget evals; mis-tuned budgets could add latency or misclassify edge cases, but scope is limited to the harness with regression tests.
> 
> **Overview**
> Fixes **false `blank_screenshot`** on slow/CDN-driven MCP App widgets by deferring snapshot and status until the page has actually **painted**, not just finished the bridge handshake.
> 
> After `bridgeInitialized`, **`waitForWidgetPaint`** (bounded by new **`paintTimeoutMs`**, default 8s) optionally waits for **`networkidle`**, then polls PNG screenshots and compares them byte-for-byte to a one-time **empty-host baseline** and to the previous sample until the frame **diverges from baseline and stabilizes** (or the budget expires). **`blank_screenshot`** now follows that pixel verdict instead of the in-page DOM **`pageResult.blank`** at handshake time. The observation stores **`encodeScreenshot`** output from the **same frame** used for classification.
> 
> Tests add a delayed-paint guest fixture and cover the edge case where settle wait must not prevent at least one paint poll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0362ccdfda0f7f70214a0217999c0cbeaa9659d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->