### PR TITLE
PR-I1: Persistent "Use MCPJam as your test IdP" card + docs page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,11 @@
           {
             "group": "Auth & Conformance",
             "icon": "shield-check",
-            "pages": ["inspector/guided-oauth", "inspector/xaa-debugger"]
+            "pages": [
+              "inspector/guided-oauth",
+              "inspector/xaa-debugger",
+              "inspector/xaa-test-idp"
+            ]
           },
           {
             "group": "Primitives",

--- a/docs/inspector/xaa-test-idp.mdx
+++ b/docs/inspector/xaa-test-idp.mdx
@@ -1,0 +1,46 @@
+---
+title: "Use MCPJam as a Test IdP"
+description: "Register MCPJam's built-in identity provider with your authorization server to test Cross-App Access flows end to end"
+icon: "key-round"
+---
+
+When you build an MCP resource server (or an authorization server) that accepts Cross-App Access (XAA) identity assertions, you need an identity provider (IdP) you can point it at. MCPJam ships one. The XAA Debugger plays the IdP for you — it mints ID tokens and signs the short-lived Identity Assertion Authorization Grant (ID-JAG) your authorization server redeems via the JWT-bearer grant (RFC 7523).
+
+To make that work, your authorization server has to **trust** MCPJam as an issuer. This page covers the three endpoints you register to establish that trust.
+
+## Where to find the endpoints
+
+Open the **XAA Flow** tab in MCPJam Inspector. At the top of the tab, expand the **Use MCPJam as your test IdP** card. It lists three copy-able URLs and the active signing key id (`kid`).
+
+## The three endpoints
+
+| Endpoint | What it is | Where it goes |
+| --- | --- | --- |
+| **Issuer URL** | The `iss` value MCPJam stamps on every assertion. | Register it as a trusted issuer at your authorization server. |
+| **OpenID configuration URL** | The `/.well-known/openid-configuration` document. Advertises the issuer, JWKS URI, and supported grant types. | Most authorization servers discover the JWKS automatically from here. |
+| **JWKS URL** | The public signing keys (`/.well-known/jwks.json`). | Register it directly if your authorization server doesn't auto-discover from the OpenID configuration. |
+
+## Registering trust
+
+1. Copy the **Issuer URL** (or **JWKS URL**) from the card.
+2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam as a **trusted identity issuer** using that URL.
+3. Set the ID-JAG `aud` claim to your authorization server's own issuer.
+4. Set the ID-JAG `resource` claim to your MCP server's resource identifier.
+5. Register MCPJam as a client at your authorization server using the client ID from your XAA target configuration.
+
+Once trust is established, run the flow from the XAA Flow tab. The sequence diagram shows each step — SSO, token exchange, JWT-bearer, and the authenticated MCP request — with every token decoded inline.
+
+## Vendor notes
+
+- **Okta** — Native JWT-bearer support. Register MCPJam as a trusted issuer using the JWKS URL.
+- **Auth0** — Supported with configuration. Set up a trusted issuer pointing at MCPJam's JWKS and map subjects to Auth0 users.
+- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's JWKS.
+
+## Local mode
+
+If you're running the inspector locally, the endpoint URLs point at your own machine. Your authorization server can only reach them if it can route to that machine — expose the inspector through a public tunnel first.
+
+## Next steps
+
+- [XAA Debugger](/inspector/xaa-debugger) — walk through and debug the full flow.
+- Review the [MCP authorization specification](https://modelcontextprotocol.io/specification/draft/basic/authorization) for XAA requirements.

--- a/docs/inspector/xaa-test-idp.mdx
+++ b/docs/inspector/xaa-test-idp.mdx
@@ -22,8 +22,8 @@ Open the **XAA Flow** tab in MCPJam Inspector. At the top of the tab, expand the
 
 ## Registering trust
 
-1. Copy the **Issuer URL** (or **JWKS URL**) from the card.
-2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam as a **trusted identity issuer** using that URL.
+1. Copy the **Issuer URL** from the card. Also copy the **JWKS URL** if your authorization server asks for the key-set endpoint directly.
+2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam's **issuer URL** as the trusted identity issuer. The issuer is the trust anchor; use the JWKS URL only when the server explicitly asks for the key-set endpoint.
 3. Set the ID-JAG `aud` claim to your authorization server's own issuer.
 4. Set the ID-JAG `resource` claim to your MCP server's resource identifier.
 5. Register MCPJam as a client at your authorization server using the client ID from your XAA target configuration.
@@ -32,9 +32,9 @@ Once trust is established, run the flow from the XAA Flow tab. The sequence diag
 
 ## Vendor notes
 
-- **Okta** — Native JWT-bearer support. Register MCPJam as a trusted issuer using the JWKS URL.
-- **Auth0** — Supported with configuration. Set up a trusted issuer pointing at MCPJam's JWKS and map subjects to Auth0 users.
-- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's JWKS.
+- **Okta** — Native JWT-bearer support. Register MCPJam's issuer URL as a trusted issuer; Okta discovers the keys from the OpenID configuration.
+- **Auth0** — Supported with configuration. Register MCPJam's issuer as a trusted issuer and map subjects to Auth0 users; Auth0 fetches the JWKS from the issuer's discovery document.
+- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's issuer.
 
 ## Local mode
 

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -4,6 +4,22 @@ import { describe, expect, it, vi } from "vitest";
 import { XAAFlowTab } from "../xaa/XAAFlowTab";
 import type { ServerWithName } from "@/hooks/use-app-state";
 
+const captureMock = vi.fn();
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: (...args: unknown[]) => captureMock(...args),
+  },
+}));
+
+vi.mock("@/lib/PosthogUtils", () => ({
+  detectEnvironment: vi.fn().mockReturnValue("test"),
+  detectPlatform: vi.fn().mockReturnValue("web"),
+}));
+
+vi.mock("../xaa/XAAIdpCard", () => ({
+  XAAIdpCard: () => <div data-testid="xaa-idp-card" />,
+}));
+
 vi.mock("../ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
     <div>{children}</div>
@@ -112,5 +128,17 @@ describe("XAAFlowTab", () => {
     expect(screen.getByTestId("xaa-flow-logger")).toHaveTextContent(
       "No target configured",
     );
+  });
+
+  it("fires xaa_tab_viewed once per mount", () => {
+    captureMock.mockClear();
+
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="none" />);
+
+    const viewedCalls = captureMock.mock.calls.filter(
+      ([event]) => event === "xaa_tab_viewed",
+    );
+    expect(viewedCalls).toHaveLength(1);
+    expect(viewedCalls[0][1]).toMatchObject({ location: "xaa_flow_tab" });
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
@@ -9,17 +9,11 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
+import { getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
 interface XAABootstrapDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}
-
-function getIssuerBaseUrl(): string {
-  if (typeof window === "undefined") {
-    return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
-  }
-  return `${window.location.origin}${HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa"}`;
 }
 
 function CopyRow({
@@ -55,8 +49,7 @@ export function XAABootstrapDialog({
   open,
   onOpenChange,
 }: XAABootstrapDialogProps) {
-  const issuerBaseUrl = getIssuerBaseUrl();
-  const jwksUrl = `${issuerBaseUrl}/.well-known/jwks.json`;
+  const { issuerBaseUrl, jwksUrl } = getXaaIdpUrls();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import posthog from "posthog-js";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import type { ServerWithName } from "@/hooks/use-app-state";
+import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
 import { XAAFlowLogger } from "./XAAFlowLogger";
 import { XAAConfigModal } from "./XAAConfigModal";
 import { XAABootstrapDialog } from "./XAABootstrapDialog";
+import { XAAIdpCard } from "./XAAIdpCard";
 import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
@@ -82,6 +85,14 @@ export function XAAFlowTab({
     setFocusedStep(null);
   }, [flowState.currentStep]);
 
+  useEffect(() => {
+    posthog.capture("xaa_tab_viewed", {
+      location: "xaa_flow_tab",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+    });
+  }, []);
+
   const flowStateRef = useRef(flowState);
   useEffect(() => {
     flowStateRef.current = flowState;
@@ -153,6 +164,7 @@ export function XAAFlowTab({
 
   return (
     <div className="h-full flex flex-col bg-background">
+      <XAAIdpCard />
       <div className="flex-1 overflow-hidden">
         <ResizablePanelGroup direction="horizontal" className="h-full">
           <ResizablePanel defaultSize={52} minSize={30}>

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -80,9 +80,14 @@ export function XAAIdpCard() {
     if (!expanded || fetchedKeyId.current) {
       return;
     }
-    fetchedKeyId.current = true;
     const controller = new AbortController();
     void fetchActiveKeyId(jwksUrl, controller.signal).then((kid) => {
+      // Mark done only once the fetch completes — setting it up front would
+      // lock out future expansions if the first attempt is aborted.
+      if (controller.signal.aborted) {
+        return;
+      }
+      fetchedKeyId.current = true;
       if (kid) {
         setKeyId(kid);
       }

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, ChevronRight, Copy, KeyRound } from "lucide-react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { Card } from "@mcpjam/design-system/card";
+import { HOSTED_MODE } from "@/lib/config";
+import { copyToClipboard } from "@/lib/clipboard";
+import { fetchActiveKeyId, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
+
+function CopyRow({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const success = await copyToClipboard(value);
+    if (!success) {
+      return;
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="flex items-stretch gap-2">
+        <div className="min-w-0 flex-1 rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs break-all">
+          {value}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={handleCopy}
+          aria-label={`Copy ${label}`}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+          <span className="ml-1">{copied ? "Copied" : "Copy"}</span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Persistent "Use MCPJam as your test IdP" card. Surfaces the issuer,
+ * OpenID configuration, and JWKS URLs the user registers with their own
+ * authorization server so the JWT-bearer token exchange can succeed —
+ * previously only reachable through a transient bootstrap dialog.
+ */
+export function XAAIdpCard() {
+  const [expanded, setExpanded] = useState(false);
+  const [keyId, setKeyId] = useState<string | null>(null);
+  const fetchedKeyId = useRef(false);
+
+  const { issuerBaseUrl, openidConfigUrl, jwksUrl } = getXaaIdpUrls();
+
+  // Fetch the active key id once, the first time the card is expanded.
+  useEffect(() => {
+    if (!expanded || fetchedKeyId.current) {
+      return;
+    }
+    fetchedKeyId.current = true;
+    const controller = new AbortController();
+    void fetchActiveKeyId(jwksUrl, controller.signal).then((kid) => {
+      if (kid) {
+        setKeyId(kid);
+      }
+    });
+    return () => controller.abort();
+  }, [expanded, jwksUrl]);
+
+  return (
+    <Card className="mx-3 mt-3 mb-1 gap-0 p-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 px-4 py-3 text-left"
+      >
+        <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">
+              Use MCPJam as your test IdP
+            </span>
+            {keyId && (
+              <Badge variant="secondary" className="font-mono text-[10px]">
+                kid: {keyId}
+              </Badge>
+            )}
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            Register these endpoints with your authorization server to trust
+            MCPJam-issued assertions.
+          </p>
+        </div>
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="space-y-4 px-4 pb-4">
+          <CopyRow label="Issuer URL" value={issuerBaseUrl} />
+          <CopyRow label="OpenID configuration URL" value={openidConfigUrl} />
+          <CopyRow label="JWKS URL" value={jwksUrl} />
+
+          <p className="text-xs text-muted-foreground">
+            In Okta, Auth0, Keycloak, or your own authorization server, register
+            MCPJam as a trusted identity issuer using the issuer (or JWKS) URL
+            above. Then set the ID-JAG <code className="font-mono">aud</code> to
+            your authorization server&apos;s issuer and the{" "}
+            <code className="font-mono">resource</code> to the MCP server&apos;s
+            resource identifier.
+          </p>
+
+          {!HOSTED_MODE && (
+            <p className="text-xs text-muted-foreground">
+              Local URLs only work if your authorization server can reach this
+              machine (e.g. via a public tunnel).
+            </p>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -9,6 +9,7 @@ import { fetchActiveKeyId, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
 function CopyRow({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<number | null>(null);
 
   const handleCopy = async () => {
     const success = await copyToClipboard(value);
@@ -16,8 +17,23 @@ function CopyRow({ label, value }: { label: string; value: string }) {
       return;
     }
     setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      resetTimerRef.current = null;
+    }, 1500);
   };
+
+  // Clear the pending reset timer on unmount to avoid a stale state update.
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
     <div className="space-y-1.5">

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { XAAIdpCard } from "../XAAIdpCard";
+
+const copyToClipboard = vi.fn(async () => true);
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: (value: string) => copyToClipboard(value),
+}));
+
+// HOSTED_MODE drives the issuer base path (/api/web/xaa vs /api/mcp/xaa).
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: true,
+}));
+
+describe("XAAIdpCard", () => {
+  // jsdom serves the suite from a fixed origin; derive the expected URLs from
+  // it rather than forcing a cross-origin replaceState (which jsdom rejects).
+  const issuer = `${window.location.origin}/api/web/xaa`;
+
+  beforeEach(() => {
+    copyToClipboard.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders collapsed with the hosted endpoints hidden until expanded", () => {
+    render(<XAAIdpCard />);
+
+    expect(screen.getByText("Use MCPJam as your test IdP")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByText("Issuer URL")).not.toBeInTheDocument();
+  });
+
+  it("reveals the hosted issuer/OpenID/JWKS URLs when expanded", async () => {
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+
+    expect(screen.getByText(issuer)).toBeInTheDocument();
+    expect(
+      screen.getByText(`${issuer}/.well-known/openid-configuration`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`${issuer}/.well-known/jwks.json`),
+    ).toBeInTheDocument();
+  });
+
+  it("copies a URL and shows inline confirmation", async () => {
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /copy issuer url/i }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(issuer);
+    expect(await screen.findByText("Copied")).toBeInTheDocument();
+  });
+
+  it("shows the active signing key id fetched from JWKS once expanded", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ keys: [{ kid: "key-2026" }] }), {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("kid: key-2026")).toBeInTheDocument(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${issuer}/.well-known/jwks.json`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
@@ -1,0 +1,52 @@
+import { HOSTED_MODE } from "@/lib/config";
+
+export interface XaaIdpUrls {
+  issuerBaseUrl: string;
+  openidConfigUrl: string;
+  jwksUrl: string;
+}
+
+function getIssuerBasePath(): string {
+  return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
+}
+
+/**
+ * Resolve the MCPJam-as-IdP endpoints the user pastes into their own
+ * authorization server. Same base path the bootstrap dialog and the flow
+ * runner use, so the issuer/JWKS values stay consistent across surfaces.
+ */
+export function getXaaIdpUrls(): XaaIdpUrls {
+  const origin = typeof window === "undefined" ? "" : window.location.origin;
+  const issuerBaseUrl = `${origin}${getIssuerBasePath()}`;
+  return {
+    issuerBaseUrl,
+    openidConfigUrl: `${issuerBaseUrl}/.well-known/openid-configuration`,
+    jwksUrl: `${issuerBaseUrl}/.well-known/jwks.json`,
+  };
+}
+
+interface JwksResponse {
+  keys?: Array<{ kid?: unknown }>;
+}
+
+/**
+ * Best-effort fetch of the active signing key id from the JWKS endpoint.
+ * Returns null on any failure — the kid is a convenience for the user
+ * configuring issuer trust, not required for the card to render.
+ */
+export async function fetchActiveKeyId(
+  jwksUrl: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  try {
+    const response = await fetch(jwksUrl, { signal });
+    if (!response.ok) {
+      return null;
+    }
+    const body = (await response.json()) as JwksResponse;
+    const kid = body.keys?.[0]?.kid;
+    return typeof kid === "string" && kid.length > 0 ? kid : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Surfaces the MCPJam test-IdP endpoints in a persistent card on the XAA Flow tab. They were previously only reachable through a transient bootstrap dialog, so users couldn't easily find the issuer / JWKS URLs to register with their authorization server.

## Changes

- New **"Use MCPJam as your test IdP"** card (collapsible) at the top of the XAA Flow tab: issuer, OpenID configuration, and JWKS URLs with copy buttons + inline copy confirmation, plus the active signing key id fetched from JWKS.
- Shared `getXaaIdpUrls()` helper; the existing bootstrap dialog now reuses it.
- New docs page **"Use MCPJam as a Test IdP"** under Auth & Conformance.
- Fires `xaa_tab_viewed` once per XAA Flow tab mount.

Gated by the existing `xaa` flag at the route (unchanged).

## Verification

- `client/src/components/xaa/__tests__/XAAIdpCard.test.tsx` + `XAAFlowTab.test.tsx` — 6 tests pass (collapsed/expanded render, hosted URLs, copy + confirmation, kid fetch, telemetry fires once).
- `npm run typecheck:client` passes.
