### PR TITLE
PR-I3: XAA server endpoints — AS discovery + health check

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,11 @@
           {
             "group": "Auth & Conformance",
             "icon": "shield-check",
-            "pages": ["inspector/guided-oauth", "inspector/xaa-debugger"]
+            "pages": [
+              "inspector/guided-oauth",
+              "inspector/xaa-debugger",
+              "inspector/xaa-test-idp"
+            ]
           },
           {
             "group": "Primitives",

--- a/docs/inspector/xaa-test-idp.mdx
+++ b/docs/inspector/xaa-test-idp.mdx
@@ -1,0 +1,46 @@
+---
+title: "Use MCPJam as a Test IdP"
+description: "Register MCPJam's built-in identity provider with your authorization server to test Cross-App Access flows end to end"
+icon: "key-round"
+---
+
+When you build an MCP resource server (or an authorization server) that accepts Cross-App Access (XAA) identity assertions, you need an identity provider (IdP) you can point it at. MCPJam ships one. The XAA Debugger plays the IdP for you — it mints ID tokens and signs the short-lived Identity Assertion Authorization Grant (ID-JAG) your authorization server redeems via the JWT-bearer grant (RFC 7523).
+
+To make that work, your authorization server has to **trust** MCPJam as an issuer. This page covers the three endpoints you register to establish that trust.
+
+## Where to find the endpoints
+
+Open the **XAA Flow** tab in MCPJam Inspector. At the top of the tab, expand the **Use MCPJam as your test IdP** card. It lists three copy-able URLs and the active signing key id (`kid`).
+
+## The three endpoints
+
+| Endpoint | What it is | Where it goes |
+| --- | --- | --- |
+| **Issuer URL** | The `iss` value MCPJam stamps on every assertion. | Register it as a trusted issuer at your authorization server. |
+| **OpenID configuration URL** | The `/.well-known/openid-configuration` document. Advertises the issuer, JWKS URI, and supported grant types. | Most authorization servers discover the JWKS automatically from here. |
+| **JWKS URL** | The public signing keys (`/.well-known/jwks.json`). | Register it directly if your authorization server doesn't auto-discover from the OpenID configuration. |
+
+## Registering trust
+
+1. Copy the **Issuer URL** (or **JWKS URL**) from the card.
+2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam as a **trusted identity issuer** using that URL.
+3. Set the ID-JAG `aud` claim to your authorization server's own issuer.
+4. Set the ID-JAG `resource` claim to your MCP server's resource identifier.
+5. Register MCPJam as a client at your authorization server using the client ID from your XAA target configuration.
+
+Once trust is established, run the flow from the XAA Flow tab. The sequence diagram shows each step — SSO, token exchange, JWT-bearer, and the authenticated MCP request — with every token decoded inline.
+
+## Vendor notes
+
+- **Okta** — Native JWT-bearer support. Register MCPJam as a trusted issuer using the JWKS URL.
+- **Auth0** — Supported with configuration. Set up a trusted issuer pointing at MCPJam's JWKS and map subjects to Auth0 users.
+- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's JWKS.
+
+## Local mode
+
+If you're running the inspector locally, the endpoint URLs point at your own machine. Your authorization server can only reach them if it can route to that machine — expose the inspector through a public tunnel first.
+
+## Next steps
+
+- [XAA Debugger](/inspector/xaa-debugger) — walk through and debug the full flow.
+- Review the [MCP authorization specification](https://modelcontextprotocol.io/specification/draft/basic/authorization) for XAA requirements.

--- a/docs/inspector/xaa-test-idp.mdx
+++ b/docs/inspector/xaa-test-idp.mdx
@@ -22,8 +22,8 @@ Open the **XAA Flow** tab in MCPJam Inspector. At the top of the tab, expand the
 
 ## Registering trust
 
-1. Copy the **Issuer URL** (or **JWKS URL**) from the card.
-2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam as a **trusted identity issuer** using that URL.
+1. Copy the **Issuer URL** from the card. Also copy the **JWKS URL** if your authorization server asks for the key-set endpoint directly.
+2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam's **issuer URL** as the trusted identity issuer. The issuer is the trust anchor; use the JWKS URL only when the server explicitly asks for the key-set endpoint.
 3. Set the ID-JAG `aud` claim to your authorization server's own issuer.
 4. Set the ID-JAG `resource` claim to your MCP server's resource identifier.
 5. Register MCPJam as a client at your authorization server using the client ID from your XAA target configuration.
@@ -32,9 +32,9 @@ Once trust is established, run the flow from the XAA Flow tab. The sequence diag
 
 ## Vendor notes
 
-- **Okta** — Native JWT-bearer support. Register MCPJam as a trusted issuer using the JWKS URL.
-- **Auth0** — Supported with configuration. Set up a trusted issuer pointing at MCPJam's JWKS and map subjects to Auth0 users.
-- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's JWKS.
+- **Okta** — Native JWT-bearer support. Register MCPJam's issuer URL as a trusted issuer; Okta discovers the keys from the OpenID configuration.
+- **Auth0** — Supported with configuration. Register MCPJam's issuer as a trusted issuer and map subjects to Auth0 users; Auth0 fetches the JWKS from the issuer's discovery document.
+- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's issuer.
 
 ## Local mode
 

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -4,6 +4,22 @@ import { describe, expect, it, vi } from "vitest";
 import { XAAFlowTab } from "../xaa/XAAFlowTab";
 import type { ServerWithName } from "@/hooks/use-app-state";
 
+const captureMock = vi.fn();
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: (...args: unknown[]) => captureMock(...args),
+  },
+}));
+
+vi.mock("@/lib/PosthogUtils", () => ({
+  detectEnvironment: vi.fn().mockReturnValue("test"),
+  detectPlatform: vi.fn().mockReturnValue("web"),
+}));
+
+vi.mock("../xaa/XAAIdpCard", () => ({
+  XAAIdpCard: () => <div data-testid="xaa-idp-card" />,
+}));
+
 vi.mock("../ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
     <div>{children}</div>
@@ -112,5 +128,17 @@ describe("XAAFlowTab", () => {
     expect(screen.getByTestId("xaa-flow-logger")).toHaveTextContent(
       "No target configured",
     );
+  });
+
+  it("fires xaa_tab_viewed once per mount", () => {
+    captureMock.mockClear();
+
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="none" />);
+
+    const viewedCalls = captureMock.mock.calls.filter(
+      ([event]) => event === "xaa_tab_viewed",
+    );
+    expect(viewedCalls).toHaveLength(1);
+    expect(viewedCalls[0][1]).toMatchObject({ location: "xaa_flow_tab" });
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
@@ -9,17 +9,11 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
+import { getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
 interface XAABootstrapDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}
-
-function getIssuerBaseUrl(): string {
-  if (typeof window === "undefined") {
-    return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
-  }
-  return `${window.location.origin}${HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa"}`;
 }
 
 function CopyRow({
@@ -55,8 +49,7 @@ export function XAABootstrapDialog({
   open,
   onOpenChange,
 }: XAABootstrapDialogProps) {
-  const issuerBaseUrl = getIssuerBaseUrl();
-  const jwksUrl = `${issuerBaseUrl}/.well-known/jwks.json`;
+  const { issuerBaseUrl, jwksUrl } = getXaaIdpUrls();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import posthog from "posthog-js";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import type { ServerWithName } from "@/hooks/use-app-state";
+import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
 import { XAAFlowLogger } from "./XAAFlowLogger";
 import { XAAConfigModal } from "./XAAConfigModal";
 import { XAABootstrapDialog } from "./XAABootstrapDialog";
+import { XAAIdpCard } from "./XAAIdpCard";
 import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
@@ -82,6 +85,14 @@ export function XAAFlowTab({
     setFocusedStep(null);
   }, [flowState.currentStep]);
 
+  useEffect(() => {
+    posthog.capture("xaa_tab_viewed", {
+      location: "xaa_flow_tab",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+    });
+  }, []);
+
   const flowStateRef = useRef(flowState);
   useEffect(() => {
     flowStateRef.current = flowState;
@@ -153,6 +164,7 @@ export function XAAFlowTab({
 
   return (
     <div className="h-full flex flex-col bg-background">
+      <XAAIdpCard />
       <div className="flex-1 overflow-hidden">
         <ResizablePanelGroup direction="horizontal" className="h-full">
           <ResizablePanel defaultSize={52} minSize={30}>

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -80,9 +80,14 @@ export function XAAIdpCard() {
     if (!expanded || fetchedKeyId.current) {
       return;
     }
-    fetchedKeyId.current = true;
     const controller = new AbortController();
     void fetchActiveKeyId(jwksUrl, controller.signal).then((kid) => {
+      // Mark done only once the fetch completes — setting it up front would
+      // lock out future expansions if the first attempt is aborted.
+      if (controller.signal.aborted) {
+        return;
+      }
+      fetchedKeyId.current = true;
       if (kid) {
         setKeyId(kid);
       }

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, ChevronRight, Copy, KeyRound } from "lucide-react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { Card } from "@mcpjam/design-system/card";
+import { HOSTED_MODE } from "@/lib/config";
+import { copyToClipboard } from "@/lib/clipboard";
+import { fetchActiveKeyId, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
+
+function CopyRow({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const success = await copyToClipboard(value);
+    if (!success) {
+      return;
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="flex items-stretch gap-2">
+        <div className="min-w-0 flex-1 rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs break-all">
+          {value}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={handleCopy}
+          aria-label={`Copy ${label}`}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+          <span className="ml-1">{copied ? "Copied" : "Copy"}</span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Persistent "Use MCPJam as your test IdP" card. Surfaces the issuer,
+ * OpenID configuration, and JWKS URLs the user registers with their own
+ * authorization server so the JWT-bearer token exchange can succeed —
+ * previously only reachable through a transient bootstrap dialog.
+ */
+export function XAAIdpCard() {
+  const [expanded, setExpanded] = useState(false);
+  const [keyId, setKeyId] = useState<string | null>(null);
+  const fetchedKeyId = useRef(false);
+
+  const { issuerBaseUrl, openidConfigUrl, jwksUrl } = getXaaIdpUrls();
+
+  // Fetch the active key id once, the first time the card is expanded.
+  useEffect(() => {
+    if (!expanded || fetchedKeyId.current) {
+      return;
+    }
+    fetchedKeyId.current = true;
+    const controller = new AbortController();
+    void fetchActiveKeyId(jwksUrl, controller.signal).then((kid) => {
+      if (kid) {
+        setKeyId(kid);
+      }
+    });
+    return () => controller.abort();
+  }, [expanded, jwksUrl]);
+
+  return (
+    <Card className="mx-3 mt-3 mb-1 gap-0 p-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 px-4 py-3 text-left"
+      >
+        <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">
+              Use MCPJam as your test IdP
+            </span>
+            {keyId && (
+              <Badge variant="secondary" className="font-mono text-[10px]">
+                kid: {keyId}
+              </Badge>
+            )}
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            Register these endpoints with your authorization server to trust
+            MCPJam-issued assertions.
+          </p>
+        </div>
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="space-y-4 px-4 pb-4">
+          <CopyRow label="Issuer URL" value={issuerBaseUrl} />
+          <CopyRow label="OpenID configuration URL" value={openidConfigUrl} />
+          <CopyRow label="JWKS URL" value={jwksUrl} />
+
+          <p className="text-xs text-muted-foreground">
+            In Okta, Auth0, Keycloak, or your own authorization server, register
+            MCPJam as a trusted identity issuer using the issuer (or JWKS) URL
+            above. Then set the ID-JAG <code className="font-mono">aud</code> to
+            your authorization server&apos;s issuer and the{" "}
+            <code className="font-mono">resource</code> to the MCP server&apos;s
+            resource identifier.
+          </p>
+
+          {!HOSTED_MODE && (
+            <p className="text-xs text-muted-foreground">
+              Local URLs only work if your authorization server can reach this
+              machine (e.g. via a public tunnel).
+            </p>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -9,6 +9,7 @@ import { fetchActiveKeyId, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
 function CopyRow({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<number | null>(null);
 
   const handleCopy = async () => {
     const success = await copyToClipboard(value);
@@ -16,8 +17,23 @@ function CopyRow({ label, value }: { label: string; value: string }) {
       return;
     }
     setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      resetTimerRef.current = null;
+    }, 1500);
   };
+
+  // Clear the pending reset timer on unmount to avoid a stale state update.
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
     <div className="space-y-1.5">

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { XAAIdpCard } from "../XAAIdpCard";
+
+const copyToClipboard = vi.fn(async () => true);
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: (value: string) => copyToClipboard(value),
+}));
+
+// HOSTED_MODE drives the issuer base path (/api/web/xaa vs /api/mcp/xaa).
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: true,
+}));
+
+describe("XAAIdpCard", () => {
+  // jsdom serves the suite from a fixed origin; derive the expected URLs from
+  // it rather than forcing a cross-origin replaceState (which jsdom rejects).
+  const issuer = `${window.location.origin}/api/web/xaa`;
+
+  beforeEach(() => {
+    copyToClipboard.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders collapsed with the hosted endpoints hidden until expanded", () => {
+    render(<XAAIdpCard />);
+
+    expect(screen.getByText("Use MCPJam as your test IdP")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByText("Issuer URL")).not.toBeInTheDocument();
+  });
+
+  it("reveals the hosted issuer/OpenID/JWKS URLs when expanded", async () => {
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+
+    expect(screen.getByText(issuer)).toBeInTheDocument();
+    expect(
+      screen.getByText(`${issuer}/.well-known/openid-configuration`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`${issuer}/.well-known/jwks.json`),
+    ).toBeInTheDocument();
+  });
+
+  it("copies a URL and shows inline confirmation", async () => {
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /copy issuer url/i }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(issuer);
+    expect(await screen.findByText("Copied")).toBeInTheDocument();
+  });
+
+  it("shows the active signing key id fetched from JWKS once expanded", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ keys: [{ kid: "key-2026" }] }), {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("kid: key-2026")).toBeInTheDocument(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${issuer}/.well-known/jwks.json`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
@@ -1,0 +1,52 @@
+import { HOSTED_MODE } from "@/lib/config";
+
+export interface XaaIdpUrls {
+  issuerBaseUrl: string;
+  openidConfigUrl: string;
+  jwksUrl: string;
+}
+
+function getIssuerBasePath(): string {
+  return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
+}
+
+/**
+ * Resolve the MCPJam-as-IdP endpoints the user pastes into their own
+ * authorization server. Same base path the bootstrap dialog and the flow
+ * runner use, so the issuer/JWKS values stay consistent across surfaces.
+ */
+export function getXaaIdpUrls(): XaaIdpUrls {
+  const origin = typeof window === "undefined" ? "" : window.location.origin;
+  const issuerBaseUrl = `${origin}${getIssuerBasePath()}`;
+  return {
+    issuerBaseUrl,
+    openidConfigUrl: `${issuerBaseUrl}/.well-known/openid-configuration`,
+    jwksUrl: `${issuerBaseUrl}/.well-known/jwks.json`,
+  };
+}
+
+interface JwksResponse {
+  keys?: Array<{ kid?: unknown }>;
+}
+
+/**
+ * Best-effort fetch of the active signing key id from the JWKS endpoint.
+ * Returns null on any failure — the kid is a convenience for the user
+ * configuring issuer trust, not required for the card to render.
+ */
+export async function fetchActiveKeyId(
+  jwksUrl: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  try {
+    const response = await fetch(jwksUrl, { signal });
+    if (!response.ok) {
+      return null;
+    }
+    const body = (await response.json()) as JwksResponse;
+    const kid = body.keys?.[0]?.kid;
+    return typeof kid === "string" && kid.length > 0 ? kid : null;
+  } catch {
+    return null;
+  }
+}

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { mkdtempSync, rmSync } from "fs";
 import os from "os";
@@ -14,7 +14,19 @@ import {
   initXAAIdpKeyPair,
   resetXAAIdpKeyPairForTests,
 } from "../../../services/xaa-idp-keypair.js";
-import xaa from "../xaa.js";
+import xaa, { createXaaRouter } from "../xaa.js";
+
+function jsonResponse(
+  body: unknown,
+  init?: { status?: number; contentType?: string },
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: {
+      "content-type": init?.contentType ?? "application/json",
+    },
+  });
+}
 
 function decodeJwtPayload(token: string): Record<string, any> {
   const [, payload] = token.split(".");
@@ -139,5 +151,220 @@ describe("mcp xaa routes", () => {
     const tokenExchangeBody = await tokenExchangeResponse.json();
     const payload = decodeJwtPayload(tokenExchangeBody.id_jag);
     expect(payload.aud).toBe("https://wrong-audience.example.com");
+  });
+
+  describe("POST /discover-as", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function authHeaders() {
+      return {
+        "Content-Type": "application/json",
+        "X-MCP-Session-Auth": `Bearer ${getSessionToken() || token}`,
+      };
+    }
+
+    it("resolves metadata via the root well-known form", async () => {
+      const fetchMock = vi.fn(async (input: string | URL) => {
+        const url = input.toString();
+        if (url === "https://as.example.com/.well-known/openid-configuration") {
+          return jsonResponse({
+            issuer: "https://as.example.com",
+            token_endpoint: "https://as.example.com/oauth/token",
+            grant_types_supported: [
+              "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ],
+          });
+        }
+        return new Response(null, { status: 404 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await app.request("/api/mcp/xaa/discover-as", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ issuer: "https://as.example.com" }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.issuer).toBe("https://as.example.com");
+      expect(body.jwtBearerSupport).toBe("pass");
+      expect(body.hasTokenEndpoint).toBe(true);
+      expect(body.issuerMismatch).toBeNull();
+    });
+
+    it("resolves metadata via the path-insertion well-known form", async () => {
+      const fetchMock = vi.fn(async (input: string | URL) => {
+        const url = input.toString();
+        if (
+          url ===
+          "https://login.example.com/.well-known/openid-configuration/realms/acme"
+        ) {
+          return jsonResponse({
+            issuer: "https://login.example.com/realms/acme",
+            token_endpoint:
+              "https://login.example.com/realms/acme/protocol/openid-connect/token",
+            grant_types_supported: [
+              "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ],
+          });
+        }
+        return new Response(null, { status: 404 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await app.request("/api/mcp/xaa/discover-as", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          issuer: "https://login.example.com/realms/acme",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.issuer).toBe("https://login.example.com/realms/acme");
+      expect(body.jwtBearerSupport).toBe("pass");
+    });
+
+    it("reports a scheme-only issuer mismatch", async () => {
+      const fetchMock = vi.fn(async () =>
+        jsonResponse({
+          issuer: "http://as.example.com",
+          token_endpoint: "http://as.example.com/oauth/token",
+          grant_types_supported: [
+            "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await app.request("/api/mcp/xaa/discover-as", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ issuer: "https://as.example.com" }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.issuerMismatch).toMatchObject({
+        requested: "https://as.example.com",
+        advertised: "http://as.example.com",
+        schemeOnly: true,
+      });
+    });
+
+    it("returns 404 when no well-known endpoint has metadata", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response(null, { status: 404 })),
+      );
+
+      const response = await app.request("/api/mcp/xaa/discover-as", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ issuer: "https://as.example.com" }),
+      });
+
+      expect(response.status).toBe(404);
+    });
+  });
+});
+
+describe("hosted xaa outbound guards", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+  let app: Hono;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-hosted-route-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+
+    // Hosted-mode router: httpsOnlyProxy rejects http + private/reserved hosts.
+    // No protected middlewares here so the test exercises the guard directly.
+    app = new Hono();
+    app.route(
+      "/api/web/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/web",
+        httpsOnlyProxy: true,
+        trustForwardedHeaders: true,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  it("rejects discovery against a reserved internal address", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/discover-as", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ issuer: "https://169.254.169.254" }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toBe("URL not allowed");
+    // The guard rejects before any outbound fetch is attempted.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an http health-check target in hosted mode", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/health-check", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "http://example.com/health" }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toBe("URL not allowed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not follow a health-check redirect to an internal address", async () => {
+    // redirect: manual means the 3xx is returned without being followed, so
+    // the internal Location is never fetched.
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "http://169.254.169.254/" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/health-check", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      // Public literal IP: passes validateUrl (IP literals skip DNS) without a
+      // real network lookup.
+      body: JSON.stringify({ url: "https://93.184.216.34/health" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(false);
+    expect(body.reason).toBe("redirect_not_followed");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -18,9 +18,17 @@ import {
 } from "../../services/xaa-idjag-signer.js";
 import {
   executeOAuthProxy,
+  fetchOAuthMetadata,
   OAuthProxyError,
+  validateUrl,
 } from "../../utils/oauth-proxy.js";
+import {
+  buildDiscoveryCandidates,
+  evaluateDiscovery,
+} from "../../services/xaa-discovery.js";
 import { logger } from "../../utils/logger.js";
+
+const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 
 const authenticateSchema = z.object({
   userId: z.string().trim().min(1).optional(),
@@ -35,6 +43,19 @@ const tokenExchangeSchema = z.object({
   clientId: z.string().trim().min(1),
   scope: z.string().trim().min(1).optional(),
   negativeTestMode: z.string().trim().optional(),
+});
+
+const discoverAsSchema = z
+  .object({
+    issuer: z.string().trim().min(1).optional(),
+    tokenEndpoint: z.string().trim().min(1).optional(),
+  })
+  .refine((data) => data.issuer || data.tokenEndpoint, {
+    message: "issuer or tokenEndpoint is required",
+  });
+
+const healthCheckSchema = z.object({
+  url: z.string().trim().min(1),
 });
 
 const proxyTokenSchema = z.object({
@@ -155,6 +176,8 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     router.use("/authenticate", ...protectedMiddlewares);
     router.use("/token-exchange", ...protectedMiddlewares);
     router.use("/proxy/token", ...protectedMiddlewares);
+    router.use("/discover-as", ...protectedMiddlewares);
+    router.use("/health-check", ...protectedMiddlewares);
   }
 
   router.get("/.well-known/jwks.json", (c) => {
@@ -312,6 +335,138 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         error instanceof Error ? error.message : "Unknown proxy error",
         { status: 500, code: "INTERNAL_ERROR" },
       );
+    }
+  });
+
+  router.post("/discover-as", async (c) => {
+    let parsed;
+    try {
+      parsed = parseRequest(discoverAsSchema, await c.req.json());
+    } catch (error) {
+      return toJsonError(
+        error instanceof Error ? error.message : "Invalid discovery request",
+        { status: 400, code: "VALIDATION_ERROR" },
+      );
+    }
+
+    const requestedIssuer = (parsed.issuer ?? parsed.tokenEndpoint) as string;
+
+    let candidates: string[];
+    try {
+      candidates = buildDiscoveryCandidates(requestedIssuer);
+    } catch {
+      return toJsonError("issuer or tokenEndpoint is not a valid URL", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    try {
+      const triedStatuses: Array<{ url: string; status: number }> = [];
+      for (const candidate of candidates) {
+        const result = await fetchOAuthMetadata(
+          candidate,
+          options.httpsOnlyProxy,
+        );
+        if ("metadata" in result) {
+          return c.json(
+            evaluateDiscovery(result.metadata, {
+              requestedIssuer,
+              metadataUrl: candidate,
+            }),
+          );
+        }
+        triedStatuses.push({ url: candidate, status: result.status });
+      }
+
+      return toJsonError(
+        "No authorization server metadata found at the well-known endpoints",
+        {
+          status: 404,
+          code: "DISCOVERY_NOT_FOUND",
+          details: { tried: triedStatuses },
+        },
+      );
+    } catch (error) {
+      // validateUrl inside fetchOAuthMetadata rejects disallowed outbound URLs
+      // (e.g. private/reserved hosts, or http in hosted mode). Every candidate
+      // shares the same host, so a guard rejection is terminal.
+      if (error instanceof OAuthProxyError) {
+        return toJsonError("URL not allowed", {
+          status: error.status,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      logger.error("[XAA Discover AS] Error", error);
+      return toJsonError(
+        error instanceof Error ? error.message : "Discovery failed",
+        { status: 502, code: "SERVER_UNREACHABLE" },
+      );
+    }
+  });
+
+  router.post("/health-check", async (c) => {
+    let parsed;
+    try {
+      parsed = parseRequest(healthCheckSchema, await c.req.json());
+    } catch (error) {
+      return toJsonError(
+        error instanceof Error ? error.message : "Invalid health check request",
+        { status: 400, code: "VALIDATION_ERROR" },
+      );
+    }
+
+    let validatedUrl: URL;
+    try {
+      ({ url: validatedUrl } = await validateUrl(
+        parsed.url,
+        options.httpsOnlyProxy,
+      ));
+    } catch (error) {
+      if (error instanceof OAuthProxyError) {
+        return toJsonError("URL not allowed", {
+          status: error.status,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      return toJsonError("URL not allowed", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const startedAt = Date.now();
+    try {
+      const response = await fetch(validatedUrl.toString(), {
+        method: "GET",
+        // In hosted mode redirects are not followed, so a redirect to an
+        // internal address can never be fetched.
+        redirect: options.httpsOnlyProxy ? "manual" : "follow",
+        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+        headers: { "User-Agent": "MCP-Inspector/1.0" },
+      });
+
+      const redirected =
+        options.httpsOnlyProxy &&
+        response.status >= 300 &&
+        response.status < 400;
+
+      return c.json({
+        ok: !redirected && response.status < 400,
+        status: response.status,
+        statusText: response.statusText,
+        durationMs: Date.now() - startedAt,
+        ...(redirected ? { reason: "redirect_not_followed" } : {}),
+      });
+    } catch (error) {
+      const isTimeout =
+        error instanceof Error &&
+        (error.name === "TimeoutError" || error.name === "AbortError");
+      return c.json({
+        ok: false,
+        reason: isTimeout ? "timeout" : "unreachable",
+        durationMs: Date.now() - startedAt,
+      });
     }
   });
 

--- a/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDiscoveryCandidates,
+  evaluateDiscovery,
+  JWT_BEARER_GRANT,
+} from "../xaa-discovery.js";
+
+describe("buildDiscoveryCandidates", () => {
+  it("covers path-insertion and root-append forms for a path-based issuer", () => {
+    const candidates = buildDiscoveryCandidates(
+      "https://login.example.com/realms/acme",
+    );
+
+    expect(candidates).toContain(
+      "https://login.example.com/.well-known/openid-configuration/realms/acme",
+    );
+    expect(candidates).toContain(
+      "https://login.example.com/.well-known/oauth-authorization-server/realms/acme",
+    );
+    expect(candidates).toContain(
+      "https://login.example.com/realms/acme/.well-known/openid-configuration",
+    );
+    expect(candidates).toContain(
+      "https://login.example.com/.well-known/openid-configuration",
+    );
+  });
+
+  it("uses the root well-known forms for a bare-origin issuer", () => {
+    const candidates = buildDiscoveryCandidates("https://issuer.example.com");
+
+    expect(candidates).toEqual([
+      "https://issuer.example.com/.well-known/openid-configuration",
+      "https://issuer.example.com/.well-known/oauth-authorization-server",
+    ]);
+  });
+
+  it("uses an explicit well-known URL verbatim", () => {
+    const url = "https://issuer.example.com/.well-known/openid-configuration";
+    expect(buildDiscoveryCandidates(url)).toEqual([url]);
+  });
+});
+
+describe("evaluateDiscovery", () => {
+  const metadataUrl = "https://as.example.com/.well-known/openid-configuration";
+
+  it("passes when jwt-bearer is advertised and a token endpoint exists", () => {
+    const verdict = evaluateDiscovery(
+      {
+        issuer: "https://as.example.com",
+        token_endpoint: "https://as.example.com/oauth/token",
+        grant_types_supported: [JWT_BEARER_GRANT, "authorization_code"],
+      },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+
+    expect(verdict.jwtBearerSupport).toBe("pass");
+    expect(verdict.hasTokenEndpoint).toBe(true);
+    expect(verdict.tokenEndpoint).toBe("https://as.example.com/oauth/token");
+    expect(verdict.issuerMismatch).toBeNull();
+  });
+
+  it("warns when grant_types_supported is absent", () => {
+    const verdict = evaluateDiscovery(
+      { issuer: "https://as.example.com" },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+    expect(verdict.jwtBearerSupport).toBe("warn");
+  });
+
+  it("fails when jwt-bearer is not in a non-empty grant list", () => {
+    const verdict = evaluateDiscovery(
+      {
+        issuer: "https://as.example.com",
+        grant_types_supported: ["authorization_code"],
+      },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+    expect(verdict.jwtBearerSupport).toBe("fail");
+  });
+
+  it("flags a scheme-only issuer mismatch (http advertised, https requested)", () => {
+    const verdict = evaluateDiscovery(
+      { issuer: "http://as.example.com" },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+
+    expect(verdict.issuerMismatch).toEqual({
+      requested: "https://as.example.com",
+      advertised: "http://as.example.com",
+      schemeOnly: true,
+    });
+  });
+
+  it("flags a host/path issuer mismatch as not scheme-only", () => {
+    const verdict = evaluateDiscovery(
+      { issuer: "https://other.example.com" },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+
+    expect(verdict.issuerMismatch?.schemeOnly).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/services/xaa-discovery.ts
+++ b/mcpjam-inspector/server/services/xaa-discovery.ts
@@ -1,0 +1,158 @@
+// Server-side authorization-server discovery helpers for the XAA test bench.
+// Pure functions (candidate URL construction + metadata verdicts) live here so
+// they can be unit-tested without a live authorization server; the route layer
+// in routes/mcp/xaa.ts wires them to the SSRF-guarded fetcher.
+
+export const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+const OIDC_SUFFIX = "/.well-known/openid-configuration";
+const OAUTH_AS_SUFFIX = "/.well-known/oauth-authorization-server";
+
+function stripTrailingSlash(path: string): string {
+  return path.endsWith("/") ? path.slice(0, -1) : path;
+}
+
+/**
+ * Build the ordered list of well-known metadata URLs to probe for an issuer
+ * (or token endpoint). Covers both forms so path-based issuers (Auth0 custom
+ * domains, Keycloak realms) and root issuers both resolve:
+ *   - RFC 8414 / OIDC path-insertion: origin + /.well-known/... + path
+ *   - root-append:                    issuer + /.well-known/openid-configuration
+ *   - pure root:                      origin + /.well-known/openid-configuration
+ *
+ * If the input already points at a well-known document, it's used verbatim.
+ */
+export function buildDiscoveryCandidates(input: string): string[] {
+  const url = new URL(input);
+
+  const path = stripTrailingSlash(url.pathname);
+  if (path.endsWith(OIDC_SUFFIX) || path.endsWith(OAUTH_AS_SUFFIX)) {
+    return [url.toString()];
+  }
+
+  const origin = url.origin;
+  const candidates: string[] = [];
+
+  if (path && path !== "") {
+    // Path-insertion forms (well-known segment inserted before the issuer path)
+    candidates.push(`${origin}${OIDC_SUFFIX}${path}`);
+    candidates.push(`${origin}${OAUTH_AS_SUFFIX}${path}`);
+    // Root-append form (well-known segment appended after the issuer path)
+    candidates.push(`${origin}${path}${OIDC_SUFFIX}`);
+  } else {
+    candidates.push(`${origin}${OIDC_SUFFIX}`);
+    candidates.push(`${origin}${OAUTH_AS_SUFFIX}`);
+  }
+
+  // Pure-root fallback regardless of path.
+  candidates.push(`${origin}${OIDC_SUFFIX}`);
+
+  return Array.from(new Set(candidates));
+}
+
+export type GrantSupportStatus = "pass" | "warn" | "fail";
+
+export interface IssuerMismatch {
+  requested: string;
+  advertised: string;
+  schemeOnly: boolean;
+}
+
+export interface DiscoveryVerdict {
+  issuer?: string;
+  tokenEndpoint?: string;
+  grantTypesSupported?: string[];
+  jwtBearerSupport: GrantSupportStatus;
+  jwtBearerDetail: string;
+  hasTokenEndpoint: boolean;
+  issuerMismatch: IssuerMismatch | null;
+  metadataUrl: string;
+}
+
+// Host + path, scheme excluded — used to detect a scheme-only mismatch
+// (the http-issuer-behind-https-proxy bug) separately from a real host/path
+// divergence.
+function hostAndPath(value: string): string {
+  try {
+    const url = new URL(value);
+    return `${url.host}${stripTrailingSlash(url.pathname)}`;
+  } catch {
+    return stripTrailingSlash(value);
+  }
+}
+
+// Full identity including scheme — two issuers are "the same" only when this
+// matches.
+function fullIdentity(value: string): string {
+  try {
+    const url = new URL(value);
+    return `${url.protocol}//${url.host}${stripTrailingSlash(url.pathname)}`;
+  } catch {
+    return stripTrailingSlash(value);
+  }
+}
+
+/**
+ * Turn fetched authorization-server metadata into the verdicts the runner
+ * renders: jwt-bearer grant support (pass/warn/fail), token-endpoint presence,
+ * and an issuer-mismatch flag (the classic http-issuer-behind-https-proxy bug).
+ */
+export function evaluateDiscovery(
+  metadata: Record<string, unknown>,
+  context: { requestedIssuer: string; metadataUrl: string },
+): DiscoveryVerdict {
+  const issuer =
+    typeof metadata.issuer === "string" ? metadata.issuer : undefined;
+  const tokenEndpoint =
+    typeof metadata.token_endpoint === "string"
+      ? metadata.token_endpoint
+      : undefined;
+  const grantTypesAdvertised = Array.isArray(metadata.grant_types_supported);
+  const grantTypes = grantTypesAdvertised
+    ? (metadata.grant_types_supported as unknown[]).filter(
+        (g): g is string => typeof g === "string",
+      )
+    : undefined;
+
+  let jwtBearerSupport: GrantSupportStatus;
+  let jwtBearerDetail: string;
+  if (grantTypes?.includes(JWT_BEARER_GRANT)) {
+    jwtBearerSupport = "pass";
+    jwtBearerDetail = "Advertised in grant_types_supported.";
+  } else if (!grantTypesAdvertised) {
+    jwtBearerSupport = "warn";
+    jwtBearerDetail =
+      "grant_types_supported is missing from discovery metadata. Support can't be verified without attempting the token exchange.";
+  } else {
+    jwtBearerSupport = "fail";
+    jwtBearerDetail =
+      grantTypes && grantTypes.length === 0
+        ? "grant_types_supported is an empty array; the authorization server declares no supported grant types."
+        : `grant_types_supported does not include ${JWT_BEARER_GRANT}.`;
+  }
+
+  let issuerMismatch: IssuerMismatch | null = null;
+  if (
+    issuer &&
+    fullIdentity(issuer) !== fullIdentity(context.requestedIssuer)
+  ) {
+    issuerMismatch = {
+      requested: context.requestedIssuer,
+      advertised: issuer,
+      // Same host/path, different scheme → almost always a proxy that
+      // terminates TLS but advertises an http:// issuer.
+      schemeOnly: hostAndPath(issuer) === hostAndPath(context.requestedIssuer),
+    };
+  }
+
+  return {
+    issuer,
+    tokenEndpoint,
+    grantTypesSupported: grantTypes,
+    jwtBearerSupport,
+    jwtBearerDetail,
+    hasTokenEndpoint: Boolean(tokenEndpoint),
+    issuerMismatch,
+    metadataUrl: context.metadataUrl,
+  };
+}


### PR DESCRIPTION
## Summary

Adds two server endpoints to the XAA router that the test-bench runner needs: authorization-server **discovery** and a **health check**. Both reuse the existing outbound-URL guard that already protects `/proxy/token`.

## Changes

- **`POST /discover-as`** — probes an issuer (or token endpoint) for its authorization-server metadata, trying both RFC 8414 path-insertion and root `.well-known` forms so path-based issuers (Auth0 custom domains, Keycloak realms) and root issuers both resolve. Returns issuer, token endpoint, jwt-bearer grant support (pass/warn/fail), and an issuer-mismatch flag (catches an `http` issuer advertised behind an `https`-terminating proxy).
- **`POST /health-check`** — reports reachability (status / timeout / unreachable) for a URL.
- Both gated by the same protected middlewares as the other XAA endpoints (rate-limited in hosted mode). The server validates outbound URLs; `http` stays blocked in hosted mode and health-check redirects are not followed.
- Discovery candidate construction + metadata verdicts are pure functions in `server/services/xaa-discovery.ts`.

No backend dependency; independent of the other XAA test-bench PRs.

## Verification

- `server/services/__tests__/xaa-discovery.test.ts` (8) + `server/routes/mcp/__tests__/xaa.test.ts` — 20 tests pass (discovery via both well-known forms, scheme-only issuer mismatch, 404 when no metadata, hosted-mode outbound-guard rejection, redirect-to-internal not followed).
- `tsc -p server/tsconfig.json` clean for the changed files.
