### PR TITLE
PR-I7: ID-JAG claim lint panel with spec citations

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,11 @@
           {
             "group": "Auth & Conformance",
             "icon": "shield-check",
-            "pages": ["inspector/guided-oauth", "inspector/xaa-debugger"]
+            "pages": [
+              "inspector/guided-oauth",
+              "inspector/xaa-debugger",
+              "inspector/xaa-test-idp"
+            ]
           },
           {
             "group": "Primitives",

--- a/docs/inspector/xaa-test-idp.mdx
+++ b/docs/inspector/xaa-test-idp.mdx
@@ -1,0 +1,46 @@
+---
+title: "Use MCPJam as a Test IdP"
+description: "Register MCPJam's built-in identity provider with your authorization server to test Cross-App Access flows end to end"
+icon: "key-round"
+---
+
+When you build an MCP resource server (or an authorization server) that accepts Cross-App Access (XAA) identity assertions, you need an identity provider (IdP) you can point it at. MCPJam ships one. The XAA Debugger plays the IdP for you — it mints ID tokens and signs the short-lived Identity Assertion Authorization Grant (ID-JAG) your authorization server redeems via the JWT-bearer grant (RFC 7523).
+
+To make that work, your authorization server has to **trust** MCPJam as an issuer. This page covers the three endpoints you register to establish that trust.
+
+## Where to find the endpoints
+
+Open the **XAA Flow** tab in MCPJam Inspector. At the top of the tab, expand the **Use MCPJam as your test IdP** card. It lists three copy-able URLs and the active signing key id (`kid`).
+
+## The three endpoints
+
+| Endpoint | What it is | Where it goes |
+| --- | --- | --- |
+| **Issuer URL** | The `iss` value MCPJam stamps on every assertion. | Register it as a trusted issuer at your authorization server. |
+| **OpenID configuration URL** | The `/.well-known/openid-configuration` document. Advertises the issuer, JWKS URI, and supported grant types. | Most authorization servers discover the JWKS automatically from here. |
+| **JWKS URL** | The public signing keys (`/.well-known/jwks.json`). | Register it directly if your authorization server doesn't auto-discover from the OpenID configuration. |
+
+## Registering trust
+
+1. Copy the **Issuer URL** (or **JWKS URL**) from the card.
+2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam as a **trusted identity issuer** using that URL.
+3. Set the ID-JAG `aud` claim to your authorization server's own issuer.
+4. Set the ID-JAG `resource` claim to your MCP server's resource identifier.
+5. Register MCPJam as a client at your authorization server using the client ID from your XAA target configuration.
+
+Once trust is established, run the flow from the XAA Flow tab. The sequence diagram shows each step — SSO, token exchange, JWT-bearer, and the authenticated MCP request — with every token decoded inline.
+
+## Vendor notes
+
+- **Okta** — Native JWT-bearer support. Register MCPJam as a trusted issuer using the JWKS URL.
+- **Auth0** — Supported with configuration. Set up a trusted issuer pointing at MCPJam's JWKS and map subjects to Auth0 users.
+- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's JWKS.
+
+## Local mode
+
+If you're running the inspector locally, the endpoint URLs point at your own machine. Your authorization server can only reach them if it can route to that machine — expose the inspector through a public tunnel first.
+
+## Next steps
+
+- [XAA Debugger](/inspector/xaa-debugger) — walk through and debug the full flow.
+- Review the [MCP authorization specification](https://modelcontextprotocol.io/specification/draft/basic/authorization) for XAA requirements.

--- a/docs/inspector/xaa-test-idp.mdx
+++ b/docs/inspector/xaa-test-idp.mdx
@@ -22,8 +22,8 @@ Open the **XAA Flow** tab in MCPJam Inspector. At the top of the tab, expand the
 
 ## Registering trust
 
-1. Copy the **Issuer URL** (or **JWKS URL**) from the card.
-2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam as a **trusted identity issuer** using that URL.
+1. Copy the **Issuer URL** from the card. Also copy the **JWKS URL** if your authorization server asks for the key-set endpoint directly.
+2. In your authorization server — Okta, Auth0, Keycloak, or your own — register MCPJam's **issuer URL** as the trusted identity issuer. The issuer is the trust anchor; use the JWKS URL only when the server explicitly asks for the key-set endpoint.
 3. Set the ID-JAG `aud` claim to your authorization server's own issuer.
 4. Set the ID-JAG `resource` claim to your MCP server's resource identifier.
 5. Register MCPJam as a client at your authorization server using the client ID from your XAA target configuration.
@@ -32,9 +32,9 @@ Once trust is established, run the flow from the XAA Flow tab. The sequence diag
 
 ## Vendor notes
 
-- **Okta** — Native JWT-bearer support. Register MCPJam as a trusted issuer using the JWKS URL.
-- **Auth0** — Supported with configuration. Set up a trusted issuer pointing at MCPJam's JWKS and map subjects to Auth0 users.
-- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's JWKS.
+- **Okta** — Native JWT-bearer support. Register MCPJam's issuer URL as a trusted issuer; Okta discovers the keys from the OpenID configuration.
+- **Auth0** — Supported with configuration. Register MCPJam's issuer as a trusted issuer and map subjects to Auth0 users; Auth0 fetches the JWKS from the issuer's discovery document.
+- **Keycloak** — Supports Token Exchange. Configure a brokered IdP that trusts MCPJam's issuer.
 
 ## Local mode
 

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -4,6 +4,22 @@ import { describe, expect, it, vi } from "vitest";
 import { XAAFlowTab } from "../xaa/XAAFlowTab";
 import type { ServerWithName } from "@/hooks/use-app-state";
 
+const captureMock = vi.fn();
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: (...args: unknown[]) => captureMock(...args),
+  },
+}));
+
+vi.mock("@/lib/PosthogUtils", () => ({
+  detectEnvironment: vi.fn().mockReturnValue("test"),
+  detectPlatform: vi.fn().mockReturnValue("web"),
+}));
+
+vi.mock("../xaa/XAAIdpCard", () => ({
+  XAAIdpCard: () => <div data-testid="xaa-idp-card" />,
+}));
+
 vi.mock("../ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
     <div>{children}</div>
@@ -112,5 +128,17 @@ describe("XAAFlowTab", () => {
     expect(screen.getByTestId("xaa-flow-logger")).toHaveTextContent(
       "No target configured",
     );
+  });
+
+  it("fires xaa_tab_viewed once per mount", () => {
+    captureMock.mockClear();
+
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="none" />);
+
+    const viewedCalls = captureMock.mock.calls.filter(
+      ([event]) => event === "xaa_tab_viewed",
+    );
+    expect(viewedCalls).toHaveLength(1);
+    expect(viewedCalls[0][1]).toMatchObject({ location: "xaa_flow_tab" });
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, Copy } from "lucide-react";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
@@ -7,19 +7,80 @@ import type { XAADecodedJwt } from "@/lib/xaa/types";
 import type { NegativeTestMode } from "@/shared/xaa.js";
 import { NEGATIVE_TEST_MODE_DETAILS } from "@/shared/xaa.js";
 import { copyToClipboard } from "@/lib/clipboard";
+import {
+  lintIdJag,
+  type IdJagLintContext,
+  type IdJagLintVerdict,
+} from "@/lib/xaa/idjag-lint";
 
 interface IdJagInspectorProps {
   rawJwt: string;
   decoded: XAADecodedJwt;
   negativeTestMode: NegativeTestMode;
+  lintContext?: IdJagLintContext;
+}
+
+const LINT_STATUS_STYLES: Record<
+  IdJagLintVerdict["status"],
+  { row: string; icon: string }
+> = {
+  pass: {
+    row: "border-green-200 dark:border-green-900 bg-green-50/50 dark:bg-green-950/10",
+    icon: "text-green-600 dark:text-green-400",
+  },
+  warn: {
+    row: "border-amber-200 dark:border-amber-900 bg-amber-50/50 dark:bg-amber-950/10",
+    icon: "text-amber-600 dark:text-amber-400",
+  },
+  fail: {
+    row: "border-red-300 dark:border-red-900 bg-red-50/50 dark:bg-red-950/10",
+    icon: "text-red-600 dark:text-red-400",
+  },
+};
+
+function LintVerdictRow({ verdict }: { verdict: IdJagLintVerdict }) {
+  const styles = LINT_STATUS_STYLES[verdict.status];
+  const Icon = verdict.status === "pass" ? CheckCircle2 : AlertTriangle;
+
+  return (
+    <div
+      data-testid={`idjag-lint-${verdict.id}`}
+      className={`border rounded-md px-3 py-2 ${styles.row}`}
+    >
+      <div className="flex items-center gap-2">
+        <Icon className={`h-3.5 w-3.5 shrink-0 ${styles.icon}`} />
+        <code className="text-xs font-mono font-medium">{verdict.claim}</code>
+        {verdict.actual !== undefined && (
+          <code className="min-w-0 truncate text-[11px] font-mono text-muted-foreground">
+            {verdict.actual}
+          </code>
+        )}
+        <Badge
+          variant="outline"
+          className="ml-auto shrink-0 text-[10px] font-normal"
+        >
+          {verdict.citation.spec} {verdict.citation.section}
+        </Badge>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">{verdict.detail}</p>
+    </div>
+  );
 }
 
 export function IdJagInspector({
   rawJwt,
   decoded,
   negativeTestMode,
+  lintContext,
 }: IdJagInspectorProps) {
   const [copied, setCopied] = useState(false);
+
+  const lintVerdicts = useMemo(
+    () => lintIdJag(decoded.header, decoded.payload, lintContext),
+    [decoded.header, decoded.payload, lintContext],
+  );
+  const failCount = lintVerdicts.filter((v) => v.status === "fail").length;
+  const warnCount = lintVerdicts.filter((v) => v.status === "warn").length;
 
   const handleCopy = async () => {
     const success = await copyToClipboard(rawJwt);
@@ -78,6 +139,27 @@ export function IdJagInspector({
             </div>
           ))
         )}
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <h4 className="text-xs font-semibold">Claim lint</h4>
+          <span className="text-[11px] text-muted-foreground">
+            {failCount === 0 && warnCount === 0
+              ? "All claims pass"
+              : [
+                  failCount > 0 ? `${failCount} failing` : null,
+                  warnCount > 0 ? `${warnCount} warning` : null,
+                ]
+                  .filter(Boolean)
+                  .join(", ")}
+          </span>
+        </div>
+        <div className="grid gap-1.5">
+          {lintVerdicts.map((verdict) => (
+            <LintVerdictRow key={verdict.id} verdict={verdict} />
+          ))}
+        </div>
       </div>
 
       <div className="grid gap-3 lg:grid-cols-2">

--- a/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
@@ -9,17 +9,11 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
+import { getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
 interface XAABootstrapDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}
-
-function getIssuerBaseUrl(): string {
-  if (typeof window === "undefined") {
-    return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
-  }
-  return `${window.location.origin}${HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa"}`;
 }
 
 function CopyRow({
@@ -55,8 +49,7 @@ export function XAABootstrapDialog({
   open,
   onOpenChange,
 }: XAABootstrapDialogProps) {
-  const issuerBaseUrl = getIssuerBaseUrl();
-  const jwksUrl = `${issuerBaseUrl}/.well-known/jwks.json`;
+  const { issuerBaseUrl, jwksUrl } = getXaaIdpUrls();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -489,6 +489,13 @@ export function XAAFlowLogger({
             rawJwt={flowState.idJag}
             decoded={flowState.idJagDecoded}
             negativeTestMode={flowState.negativeTestMode}
+            lintContext={{
+              expectedAudience:
+                flowState.authzMetadata?.issuer || flowState.authzServerIssuer,
+              expectedResource:
+                flowState.resourceMetadata?.resource || flowState.resourceUrl,
+              expectedClientId: flowState.clientId,
+            }}
           />
         )}
 

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import posthog from "posthog-js";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import type { ServerWithName } from "@/hooks/use-app-state";
+import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
 import { XAAFlowLogger } from "./XAAFlowLogger";
 import { XAAConfigModal } from "./XAAConfigModal";
 import { XAABootstrapDialog } from "./XAABootstrapDialog";
+import { XAAIdpCard } from "./XAAIdpCard";
 import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
@@ -82,6 +85,14 @@ export function XAAFlowTab({
     setFocusedStep(null);
   }, [flowState.currentStep]);
 
+  useEffect(() => {
+    posthog.capture("xaa_tab_viewed", {
+      location: "xaa_flow_tab",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+    });
+  }, []);
+
   const flowStateRef = useRef(flowState);
   useEffect(() => {
     flowStateRef.current = flowState;
@@ -153,6 +164,7 @@ export function XAAFlowTab({
 
   return (
     <div className="h-full flex flex-col bg-background">
+      <XAAIdpCard />
       <div className="flex-1 overflow-hidden">
         <ResizablePanelGroup direction="horizontal" className="h-full">
           <ResizablePanel defaultSize={52} minSize={30}>

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -80,9 +80,14 @@ export function XAAIdpCard() {
     if (!expanded || fetchedKeyId.current) {
       return;
     }
-    fetchedKeyId.current = true;
     const controller = new AbortController();
     void fetchActiveKeyId(jwksUrl, controller.signal).then((kid) => {
+      // Mark done only once the fetch completes — setting it up front would
+      // lock out future expansions if the first attempt is aborted.
+      if (controller.signal.aborted) {
+        return;
+      }
+      fetchedKeyId.current = true;
       if (kid) {
         setKeyId(kid);
       }

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, ChevronRight, Copy, KeyRound } from "lucide-react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { Card } from "@mcpjam/design-system/card";
+import { HOSTED_MODE } from "@/lib/config";
+import { copyToClipboard } from "@/lib/clipboard";
+import { fetchActiveKeyId, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
+
+function CopyRow({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const success = await copyToClipboard(value);
+    if (!success) {
+      return;
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="flex items-stretch gap-2">
+        <div className="min-w-0 flex-1 rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs break-all">
+          {value}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={handleCopy}
+          aria-label={`Copy ${label}`}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+          <span className="ml-1">{copied ? "Copied" : "Copy"}</span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Persistent "Use MCPJam as your test IdP" card. Surfaces the issuer,
+ * OpenID configuration, and JWKS URLs the user registers with their own
+ * authorization server so the JWT-bearer token exchange can succeed —
+ * previously only reachable through a transient bootstrap dialog.
+ */
+export function XAAIdpCard() {
+  const [expanded, setExpanded] = useState(false);
+  const [keyId, setKeyId] = useState<string | null>(null);
+  const fetchedKeyId = useRef(false);
+
+  const { issuerBaseUrl, openidConfigUrl, jwksUrl } = getXaaIdpUrls();
+
+  // Fetch the active key id once, the first time the card is expanded.
+  useEffect(() => {
+    if (!expanded || fetchedKeyId.current) {
+      return;
+    }
+    fetchedKeyId.current = true;
+    const controller = new AbortController();
+    void fetchActiveKeyId(jwksUrl, controller.signal).then((kid) => {
+      if (kid) {
+        setKeyId(kid);
+      }
+    });
+    return () => controller.abort();
+  }, [expanded, jwksUrl]);
+
+  return (
+    <Card className="mx-3 mt-3 mb-1 gap-0 p-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 px-4 py-3 text-left"
+      >
+        <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">
+              Use MCPJam as your test IdP
+            </span>
+            {keyId && (
+              <Badge variant="secondary" className="font-mono text-[10px]">
+                kid: {keyId}
+              </Badge>
+            )}
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            Register these endpoints with your authorization server to trust
+            MCPJam-issued assertions.
+          </p>
+        </div>
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="space-y-4 px-4 pb-4">
+          <CopyRow label="Issuer URL" value={issuerBaseUrl} />
+          <CopyRow label="OpenID configuration URL" value={openidConfigUrl} />
+          <CopyRow label="JWKS URL" value={jwksUrl} />
+
+          <p className="text-xs text-muted-foreground">
+            In Okta, Auth0, Keycloak, or your own authorization server, register
+            MCPJam as a trusted identity issuer using the issuer (or JWKS) URL
+            above. Then set the ID-JAG <code className="font-mono">aud</code> to
+            your authorization server&apos;s issuer and the{" "}
+            <code className="font-mono">resource</code> to the MCP server&apos;s
+            resource identifier.
+          </p>
+
+          {!HOSTED_MODE && (
+            <p className="text-xs text-muted-foreground">
+              Local URLs only work if your authorization server can reach this
+              machine (e.g. via a public tunnel).
+            </p>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -9,6 +9,7 @@ import { fetchActiveKeyId, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
 function CopyRow({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<number | null>(null);
 
   const handleCopy = async () => {
     const success = await copyToClipboard(value);
@@ -16,8 +17,23 @@ function CopyRow({ label, value }: { label: string; value: string }) {
       return;
     }
     setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      resetTimerRef.current = null;
+    }, 1500);
   };
+
+  // Clear the pending reset timer on unmount to avoid a stale state update.
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
     <div className="space-y-1.5">

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/IdJagInspector.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/IdJagInspector.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IdJagInspector } from "../IdJagInspector";
+import type { XAADecodedJwt } from "@/lib/xaa/types";
+
+vi.mock("@/components/ui/json-editor", () => ({
+  ScrollableJsonView: ({ value }: { value: unknown }) => (
+    <pre data-testid="json-view">{JSON.stringify(value)}</pre>
+  ),
+}));
+
+const NOW = Math.floor(Date.now() / 1000);
+
+function buildDecoded(
+  overrides: {
+    header?: Record<string, unknown>;
+    payload?: Record<string, unknown>;
+  } = {},
+): XAADecodedJwt {
+  return {
+    header: {
+      alg: "RS256",
+      typ: "oauth-id-jag+jwt",
+      kid: "xaa-idp-1",
+      ...overrides.header,
+    },
+    payload: {
+      iss: "https://idp.example.com",
+      sub: "user-12345",
+      aud: "https://as.example.com",
+      resource: "https://mcp.example.com",
+      client_id: "client-abc",
+      jti: "jti-1",
+      iat: NOW,
+      exp: NOW + 300,
+      ...overrides.payload,
+    },
+    signature: "signature-bytes",
+    issues: [],
+  };
+}
+
+describe("IdJagInspector claim lint", () => {
+  it("renders a passing verdict per claim with spec citations", () => {
+    render(
+      <IdJagInspector
+        rawJwt="aaa.bbb.ccc"
+        decoded={buildDecoded()}
+        negativeTestMode="valid"
+        lintContext={{
+          expectedAudience: "https://as.example.com",
+          expectedResource: "https://mcp.example.com",
+          expectedClientId: "client-abc",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Claim lint")).toBeInTheDocument();
+    expect(screen.getByText("All claims pass")).toBeInTheDocument();
+    const typRow = screen.getByTestId("idjag-lint-typ");
+    expect(typRow).toHaveTextContent("typ header");
+    expect(typRow).toHaveTextContent("ID-JAG draft");
+  });
+
+  it("flags an expired assertion and an audience mismatch", () => {
+    render(
+      <IdJagInspector
+        rawJwt="aaa.bbb.ccc"
+        decoded={buildDecoded({
+          payload: {
+            aud: "https://wrong-audience.example.com",
+            exp: NOW - 3600,
+          },
+        })}
+        negativeTestMode="valid"
+        lintContext={{ expectedAudience: "https://as.example.com" }}
+      />,
+    );
+
+    expect(screen.getByText(/2 failing/)).toBeInTheDocument();
+    expect(screen.getByTestId("idjag-lint-aud")).toHaveTextContent(
+      "exactly match",
+    );
+    expect(screen.getByTestId("idjag-lint-exp")).toHaveTextContent("expired");
+  });
+});

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { XAAIdpCard } from "../XAAIdpCard";
+
+const copyToClipboard = vi.fn(async () => true);
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: (value: string) => copyToClipboard(value),
+}));
+
+// HOSTED_MODE drives the issuer base path (/api/web/xaa vs /api/mcp/xaa).
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: true,
+}));
+
+describe("XAAIdpCard", () => {
+  // jsdom serves the suite from a fixed origin; derive the expected URLs from
+  // it rather than forcing a cross-origin replaceState (which jsdom rejects).
+  const issuer = `${window.location.origin}/api/web/xaa`;
+
+  beforeEach(() => {
+    copyToClipboard.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders collapsed with the hosted endpoints hidden until expanded", () => {
+    render(<XAAIdpCard />);
+
+    expect(screen.getByText("Use MCPJam as your test IdP")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByText("Issuer URL")).not.toBeInTheDocument();
+  });
+
+  it("reveals the hosted issuer/OpenID/JWKS URLs when expanded", async () => {
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+
+    expect(screen.getByText(issuer)).toBeInTheDocument();
+    expect(
+      screen.getByText(`${issuer}/.well-known/openid-configuration`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`${issuer}/.well-known/jwks.json`),
+    ).toBeInTheDocument();
+  });
+
+  it("copies a URL and shows inline confirmation", async () => {
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /copy issuer url/i }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(issuer);
+    expect(await screen.findByText("Copied")).toBeInTheDocument();
+  });
+
+  it("shows the active signing key id fetched from JWKS once expanded", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ keys: [{ kid: "key-2026" }] }), {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("kid: key-2026")).toBeInTheDocument(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${issuer}/.well-known/jwks.json`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/idjag-lint.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/idjag-lint.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import { lintIdJag, type IdJagLintContext } from "../idjag-lint";
+
+const NOW = 1_750_000_000;
+
+const VALID_HEADER = {
+  alg: "RS256",
+  typ: "oauth-id-jag+jwt",
+  kid: "xaa-idp-1",
+};
+
+const VALID_PAYLOAD = {
+  iss: "https://idp.example.com",
+  sub: "user-12345",
+  aud: "https://as.example.com",
+  resource: "https://mcp.example.com",
+  client_id: "client-abc",
+  jti: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+  iat: NOW,
+  exp: NOW + 5 * 60,
+};
+
+const CONTEXT: IdJagLintContext = {
+  expectedIssuer: "https://idp.example.com",
+  expectedAudience: "https://as.example.com",
+  expectedResource: "https://mcp.example.com",
+  expectedClientId: "client-abc",
+  nowSeconds: NOW,
+};
+
+function verdictFor(
+  header: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  id: string,
+  context: IdJagLintContext = CONTEXT,
+) {
+  const verdict = lintIdJag(header, payload, context).find((v) => v.id === id);
+  if (!verdict) throw new Error(`no verdict for ${id}`);
+  return verdict;
+}
+
+describe("lintIdJag", () => {
+  it("passes every claim on a valid ID-JAG", () => {
+    const verdicts = lintIdJag(VALID_HEADER, VALID_PAYLOAD, CONTEXT);
+    expect(verdicts).toHaveLength(8);
+    expect(verdicts.every((v) => v.status === "pass")).toBe(true);
+    expect(verdicts.every((v) => v.citation.spec.length > 0)).toBe(true);
+  });
+
+  describe("typ header", () => {
+    it("fails a generic JWT typ and cites the explicit-typing BCP", () => {
+      const verdict = verdictFor(
+        { ...VALID_HEADER, typ: "JWT" },
+        VALID_PAYLOAD,
+        "typ",
+      );
+      expect(verdict.status).toBe("fail");
+      expect(verdict.citation.spec).toBe("RFC 8725");
+      expect(verdict.actual).toBe("JWT");
+    });
+
+    it("fails a missing typ", () => {
+      const { typ: _typ, ...headerWithoutTyp } = VALID_HEADER;
+      const verdict = verdictFor(headerWithoutTyp, VALID_PAYLOAD, "typ");
+      expect(verdict.status).toBe("fail");
+      expect(verdict.actual).toBe("(absent)");
+    });
+  });
+
+  describe("iss", () => {
+    it("fails a wrong issuer against the configured flow", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, iss: "https://wrong-issuer.example.com" },
+        "iss",
+      );
+      expect(verdict.status).toBe("fail");
+      expect(verdict.detail).toContain("https://idp.example.com");
+    });
+
+    it("passes presence-only when no expected issuer is configured", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, iss: "https://anything.example.com" },
+        "iss",
+        { nowSeconds: NOW },
+      );
+      expect(verdict.status).toBe("pass");
+    });
+
+    it("fails a missing issuer", () => {
+      const { iss: _iss, ...payload } = VALID_PAYLOAD;
+      expect(verdictFor(VALID_HEADER, payload, "iss").status).toBe("fail");
+    });
+  });
+
+  describe("sub", () => {
+    it("fails a missing subject", () => {
+      const { sub: _sub, ...payload } = VALID_PAYLOAD;
+      expect(verdictFor(VALID_HEADER, payload, "sub").status).toBe("fail");
+    });
+
+    it("fails an empty subject", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, sub: "  " },
+        "sub",
+      );
+      expect(verdict.status).toBe("fail");
+    });
+  });
+
+  describe("aud", () => {
+    it("fails an audience mismatch (exact-match rule)", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, aud: "https://wrong-audience.example.com" },
+        "aud",
+      );
+      expect(verdict.status).toBe("fail");
+      expect(verdict.detail).toContain("exactly match");
+    });
+
+    it("fails an array audience", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, aud: ["https://as.example.com"] },
+        "aud",
+      );
+      expect(verdict.status).toBe("fail");
+      expect(verdict.detail).toContain("array");
+    });
+  });
+
+  describe("resource", () => {
+    it("fails a resource mismatch", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, resource: "https://wrong-resource.example.com" },
+        "resource",
+      );
+      expect(verdict.status).toBe("fail");
+    });
+
+    it("fails a missing resource", () => {
+      const { resource: _resource, ...payload } = VALID_PAYLOAD;
+      expect(verdictFor(VALID_HEADER, payload, "resource").status).toBe("fail");
+    });
+  });
+
+  describe("client_id", () => {
+    it("fails a client binding mismatch", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, client_id: "wrong-client-id" },
+        "client_id",
+      );
+      expect(verdict.status).toBe("fail");
+      expect(verdict.detail).toContain("client-abc");
+    });
+
+    it("fails a missing client_id", () => {
+      const { client_id: _clientId, ...payload } = VALID_PAYLOAD;
+      expect(verdictFor(VALID_HEADER, payload, "client_id").status).toBe(
+        "fail",
+      );
+    });
+  });
+
+  describe("jti", () => {
+    it("warns when jti is absent (replay detection)", () => {
+      const { jti: _jti, ...payload } = VALID_PAYLOAD;
+      const verdict = verdictFor(VALID_HEADER, payload, "jti");
+      expect(verdict.status).toBe("warn");
+      expect(verdict.detail).toContain("replay");
+    });
+  });
+
+  describe("exp", () => {
+    it("fails an expired assertion", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, exp: NOW - 60 },
+        "exp",
+      );
+      expect(verdict.status).toBe("fail");
+      expect(verdict.detail).toContain("expired");
+    });
+
+    it("fails a missing exp", () => {
+      const { exp: _exp, ...payload } = VALID_PAYLOAD;
+      expect(verdictFor(VALID_HEADER, payload, "exp").status).toBe("fail");
+    });
+
+    it("warns on an unusually long lifetime", () => {
+      const verdict = verdictFor(
+        VALID_HEADER,
+        { ...VALID_PAYLOAD, exp: NOW + 24 * 60 * 60 },
+        "exp",
+      );
+      expect(verdict.status).toBe("warn");
+    });
+  });
+
+  it("handles null header and payload without throwing", () => {
+    const verdicts = lintIdJag(null, null, { nowSeconds: NOW });
+    expect(verdicts).toHaveLength(8);
+    expect(verdicts.some((v) => v.status === "pass")).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/idjag-lint.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/idjag-lint.ts
@@ -1,0 +1,319 @@
+// Claim-by-claim lint for a decoded ID-JAG (Identity Assertion Authorization
+// Grant). Pure functions: each claim gets a pass/warn/fail verdict with a
+// spec citation, so the inspector can explain WHY a claim matters rather than
+// only flagging mismatches against the configured flow.
+
+export type IdJagLintStatus = "pass" | "warn" | "fail";
+
+export interface IdJagLintCitation {
+  spec: string;
+  section: string;
+}
+
+export interface IdJagLintVerdict {
+  id: "typ" | "iss" | "sub" | "aud" | "resource" | "client_id" | "jti" | "exp";
+  claim: string;
+  status: IdJagLintStatus;
+  detail: string;
+  citation: IdJagLintCitation;
+  actual?: string;
+}
+
+/**
+ * Expected values from the configured flow. All optional — when absent, the
+ * lint degrades to presence/format checks instead of exact-match checks.
+ */
+export interface IdJagLintContext {
+  expectedIssuer?: string;
+  expectedAudience?: string;
+  expectedResource?: string;
+  expectedClientId?: string;
+  /** Seconds-since-epoch "now"; injectable for tests. */
+  nowSeconds?: number;
+}
+
+const ID_JAG_TYP = "oauth-id-jag+jwt";
+
+// Lifetimes beyond this draw a warning: the ID-JAG is a single-use,
+// immediately-redeemed artifact, so a long exp only widens the replay window.
+const LONG_LIVED_THRESHOLD_S = 15 * 60;
+
+const CITATIONS = {
+  typ: { spec: "ID-JAG draft", section: "JWT typ header" },
+  typBcp: { spec: "RFC 8725", section: "§3.11 explicit typing" },
+  iss: { spec: "RFC 7523", section: "§3 (iss required)" },
+  sub: { spec: "RFC 7523", section: "§3 (sub identifies the principal)" },
+  aud: {
+    spec: "RFC 7523",
+    section: "§3 (aud must identify the authorization server)",
+  },
+  resource: { spec: "RFC 8707 / ID-JAG draft", section: "resource indicator" },
+  clientId: { spec: "ID-JAG draft", section: "client_id binding" },
+  jti: { spec: "RFC 7519", section: "§4.1.7 (jti replay prevention)" },
+  exp: { spec: "RFC 7523", section: "§3 (exp required; reject expired)" },
+} as const satisfies Record<string, IdJagLintCitation>;
+
+function show(value: unknown): string {
+  if (value === undefined) return "(absent)";
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function lintIdJag(
+  header: Record<string, unknown> | null,
+  payload: Record<string, unknown> | null,
+  context: IdJagLintContext = {},
+): IdJagLintVerdict[] {
+  const h = header ?? {};
+  const p = payload ?? {};
+  const now = context.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const verdicts: IdJagLintVerdict[] = [];
+
+  // typ header — explicit typing prevents this JWT from being replayed where
+  // a generic JWT (or an ID token) is accepted.
+  verdicts.push(
+    h.typ === ID_JAG_TYP
+      ? {
+          id: "typ",
+          claim: "typ header",
+          status: "pass",
+          detail: `Explicitly typed as ${ID_JAG_TYP}, so the assertion can't be confused with an ID token or generic JWT.`,
+          citation: CITATIONS.typ,
+          actual: show(h.typ),
+        }
+      : {
+          id: "typ",
+          claim: "typ header",
+          status: "fail",
+          detail: `Expected ${ID_JAG_TYP}. Without explicit typing, an authorization server may accept this token in contexts it was never meant for (token-confusion).`,
+          citation: h.typ === "JWT" ? CITATIONS.typBcp : CITATIONS.typ,
+          actual: show(h.typ),
+        },
+  );
+
+  // iss
+  if (!isNonEmptyString(p.iss)) {
+    verdicts.push({
+      id: "iss",
+      claim: "iss",
+      status: "fail",
+      detail:
+        "Missing issuer. The authorization server can't establish which identity provider signed the assertion.",
+      citation: CITATIONS.iss,
+      actual: show(p.iss),
+    });
+  } else if (context.expectedIssuer && p.iss !== context.expectedIssuer) {
+    verdicts.push({
+      id: "iss",
+      claim: "iss",
+      status: "fail",
+      detail: `Issuer does not match the identity provider configured for this flow (${context.expectedIssuer}). The authorization server will reject the assertion as untrusted.`,
+      citation: CITATIONS.iss,
+      actual: p.iss,
+    });
+  } else {
+    verdicts.push({
+      id: "iss",
+      claim: "iss",
+      status: "pass",
+      detail: "Issuer present and matches the identity provider.",
+      citation: CITATIONS.iss,
+      actual: p.iss,
+    });
+  }
+
+  // sub
+  verdicts.push(
+    isNonEmptyString(p.sub)
+      ? {
+          id: "sub",
+          claim: "sub",
+          status: "pass",
+          detail: "Subject identifies the user the grant was issued for.",
+          citation: CITATIONS.sub,
+          actual: p.sub,
+        }
+      : {
+          id: "sub",
+          claim: "sub",
+          status: "fail",
+          detail:
+            "Missing subject. The authorization server can't tell which user this grant represents.",
+          citation: CITATIONS.sub,
+          actual: show(p.sub),
+        },
+  );
+
+  // aud — exact match against the authorization server's issuer identifier.
+  if (!isNonEmptyString(p.aud)) {
+    verdicts.push({
+      id: "aud",
+      claim: "aud",
+      status: "fail",
+      detail: Array.isArray(p.aud)
+        ? "Audience is an array. The ID-JAG audience must be the single issuer identifier of the authorization server it will be redeemed at."
+        : "Missing audience. The assertion must name the authorization server it will be redeemed at.",
+      citation: CITATIONS.aud,
+      actual: show(p.aud),
+    });
+  } else if (context.expectedAudience && p.aud !== context.expectedAudience) {
+    verdicts.push({
+      id: "aud",
+      claim: "aud",
+      status: "fail",
+      detail: `Audience must exactly match the authorization server issuer (${context.expectedAudience}). A different audience means the assertion was minted for another server and must be rejected.`,
+      citation: CITATIONS.aud,
+      actual: p.aud,
+    });
+  } else {
+    verdicts.push({
+      id: "aud",
+      claim: "aud",
+      status: "pass",
+      detail:
+        "Audience names the authorization server the assertion is redeemed at.",
+      citation: CITATIONS.aud,
+      actual: p.aud,
+    });
+  }
+
+  // resource
+  if (!isNonEmptyString(p.resource)) {
+    verdicts.push({
+      id: "resource",
+      claim: "resource",
+      status: "fail",
+      detail:
+        "Missing resource indicator. The access token's audience can't be scoped to the protected resource.",
+      citation: CITATIONS.resource,
+      actual: show(p.resource),
+    });
+  } else if (
+    context.expectedResource &&
+    p.resource !== context.expectedResource
+  ) {
+    verdicts.push({
+      id: "resource",
+      claim: "resource",
+      status: "fail",
+      detail: `Resource does not match the protected resource configured for this flow (${context.expectedResource}).`,
+      citation: CITATIONS.resource,
+      actual: p.resource,
+    });
+  } else {
+    verdicts.push({
+      id: "resource",
+      claim: "resource",
+      status: "pass",
+      detail: "Resource identifies the protected resource being accessed.",
+      citation: CITATIONS.resource,
+      actual: p.resource,
+    });
+  }
+
+  // client_id
+  if (!isNonEmptyString(p.client_id)) {
+    verdicts.push({
+      id: "client_id",
+      claim: "client_id",
+      status: "fail",
+      detail:
+        "Missing client binding. The grant must name the client that will redeem it, so a different client can't replay it.",
+      citation: CITATIONS.clientId,
+      actual: show(p.client_id),
+    });
+  } else if (
+    context.expectedClientId &&
+    p.client_id !== context.expectedClientId
+  ) {
+    verdicts.push({
+      id: "client_id",
+      claim: "client_id",
+      status: "fail",
+      detail: `client_id does not match the client configured for this flow (${context.expectedClientId}). The authorization server must reject a grant bound to another client.`,
+      citation: CITATIONS.clientId,
+      actual: p.client_id,
+    });
+  } else {
+    verdicts.push({
+      id: "client_id",
+      claim: "client_id",
+      status: "pass",
+      detail: "Grant is bound to the redeeming client.",
+      citation: CITATIONS.clientId,
+      actual: p.client_id,
+    });
+  }
+
+  // jti
+  verdicts.push(
+    isNonEmptyString(p.jti)
+      ? {
+          id: "jti",
+          claim: "jti",
+          status: "pass",
+          detail:
+            "Unique token id present — the authorization server can detect replays of this assertion.",
+          citation: CITATIONS.jti,
+          actual: p.jti,
+        }
+      : {
+          id: "jti",
+          claim: "jti",
+          status: "warn",
+          detail:
+            "No jti. Without a unique token id the authorization server can't detect a replayed assertion.",
+          citation: CITATIONS.jti,
+          actual: show(p.jti),
+        },
+  );
+
+  // exp
+  if (typeof p.exp !== "number" || !Number.isFinite(p.exp)) {
+    verdicts.push({
+      id: "exp",
+      claim: "exp",
+      status: "fail",
+      detail:
+        "Missing or non-numeric expiration. JWT authorization grants must carry an exp and be rejected once past it.",
+      citation: CITATIONS.exp,
+      actual: show(p.exp),
+    });
+  } else if (p.exp <= now) {
+    verdicts.push({
+      id: "exp",
+      claim: "exp",
+      status: "fail",
+      detail:
+        "Assertion is expired. An authorization server that still issues an access token for it is not validating exp.",
+      citation: CITATIONS.exp,
+      actual: new Date(p.exp * 1000).toISOString(),
+    });
+  } else if (p.exp - now > LONG_LIVED_THRESHOLD_S) {
+    verdicts.push({
+      id: "exp",
+      claim: "exp",
+      status: "warn",
+      detail:
+        "Unusually long lifetime for a single-use assertion. The ID-JAG is redeemed immediately, so a short exp (minutes) keeps the replay window small.",
+      citation: CITATIONS.exp,
+      actual: new Date(p.exp * 1000).toISOString(),
+    });
+  } else {
+    verdicts.push({
+      id: "exp",
+      claim: "exp",
+      status: "pass",
+      detail: "Short-lived and not yet expired.",
+      citation: CITATIONS.exp,
+      actual: new Date(p.exp * 1000).toISOString(),
+    });
+  }
+
+  return verdicts;
+}

--- a/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
@@ -1,0 +1,52 @@
+import { HOSTED_MODE } from "@/lib/config";
+
+export interface XaaIdpUrls {
+  issuerBaseUrl: string;
+  openidConfigUrl: string;
+  jwksUrl: string;
+}
+
+function getIssuerBasePath(): string {
+  return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
+}
+
+/**
+ * Resolve the MCPJam-as-IdP endpoints the user pastes into their own
+ * authorization server. Same base path the bootstrap dialog and the flow
+ * runner use, so the issuer/JWKS values stay consistent across surfaces.
+ */
+export function getXaaIdpUrls(): XaaIdpUrls {
+  const origin = typeof window === "undefined" ? "" : window.location.origin;
+  const issuerBaseUrl = `${origin}${getIssuerBasePath()}`;
+  return {
+    issuerBaseUrl,
+    openidConfigUrl: `${issuerBaseUrl}/.well-known/openid-configuration`,
+    jwksUrl: `${issuerBaseUrl}/.well-known/jwks.json`,
+  };
+}
+
+interface JwksResponse {
+  keys?: Array<{ kid?: unknown }>;
+}
+
+/**
+ * Best-effort fetch of the active signing key id from the JWKS endpoint.
+ * Returns null on any failure — the kid is a convenience for the user
+ * configuring issuer trust, not required for the card to render.
+ */
+export async function fetchActiveKeyId(
+  jwksUrl: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  try {
+    const response = await fetch(jwksUrl, { signal });
+    if (!response.ok) {
+      return null;
+    }
+    const body = (await response.json()) as JwksResponse;
+    const kid = body.keys?.[0]?.kid;
+    return typeof kid === "string" && kid.length > 0 ? kid : null;
+  } catch {
+    return null;
+  }
+}

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { mkdtempSync, rmSync } from "fs";
 import os from "os";
@@ -14,7 +14,19 @@ import {
   initXAAIdpKeyPair,
   resetXAAIdpKeyPairForTests,
 } from "../../../services/xaa-idp-keypair.js";
-import xaa from "../xaa.js";
+import xaa, { createXaaRouter } from "../xaa.js";
+
+function jsonResponse(
+  body: unknown,
+  init?: { status?: number; contentType?: string },
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: {
+      "content-type": init?.contentType ?? "application/json",
+    },
+  });
+}
 
 function decodeJwtPayload(token: string): Record<string, any> {
   const [, payload] = token.split(".");
@@ -139,5 +151,220 @@ describe("mcp xaa routes", () => {
     const tokenExchangeBody = await tokenExchangeResponse.json();
     const payload = decodeJwtPayload(tokenExchangeBody.id_jag);
     expect(payload.aud).toBe("https://wrong-audience.example.com");
+  });
+
+  describe("POST /discover-as", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function authHeaders() {
+      return {
+        "Content-Type": "application/json",
+        "X-MCP-Session-Auth": `Bearer ${getSessionToken() || token}`,
+      };
+    }
+
+    it("resolves metadata via the root well-known form", async () => {
+      const fetchMock = vi.fn(async (input: string | URL) => {
+        const url = input.toString();
+        if (url === "https://as.example.com/.well-known/openid-configuration") {
+          return jsonResponse({
+            issuer: "https://as.example.com",
+            token_endpoint: "https://as.example.com/oauth/token",
+            grant_types_supported: [
+              "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ],
+          });
+        }
+        return new Response(null, { status: 404 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await app.request("/api/mcp/xaa/discover-as", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ issuer: "https://as.example.com" }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.issuer).toBe("https://as.example.com");
+      expect(body.jwtBearerSupport).toBe("pass");
+      expect(body.hasTokenEndpoint).toBe(true);
+      expect(body.issuerMismatch).toBeNull();
+    });
+
+    it("resolves metadata via the path-insertion well-known form", async () => {
+      const fetchMock = vi.fn(async (input: string | URL) => {
+        const url = input.toString();
+        if (
+          url ===
+          "https://login.example.com/.well-known/openid-configuration/realms/acme"
+        ) {
+          return jsonResponse({
+            issuer: "https://login.example.com/realms/acme",
+            token_endpoint:
+              "https://login.example.com/realms/acme/protocol/openid-connect/token",
+            grant_types_supported: [
+              "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ],
+          });
+        }
+        return new Response(null, { status: 404 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await app.request("/api/mcp/xaa/discover-as", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          issuer: "https://login.example.com/realms/acme",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.issuer).toBe("https://login.example.com/realms/acme");
+      expect(body.jwtBearerSupport).toBe("pass");
+    });
+
+    it("reports a scheme-only issuer mismatch", async () => {
+      const fetchMock = vi.fn(async () =>
+        jsonResponse({
+          issuer: "http://as.example.com",
+          token_endpoint: "http://as.example.com/oauth/token",
+          grant_types_supported: [
+            "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await app.request("/api/mcp/xaa/discover-as", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ issuer: "https://as.example.com" }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.issuerMismatch).toMatchObject({
+        requested: "https://as.example.com",
+        advertised: "http://as.example.com",
+        schemeOnly: true,
+      });
+    });
+
+    it("returns 404 when no well-known endpoint has metadata", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response(null, { status: 404 })),
+      );
+
+      const response = await app.request("/api/mcp/xaa/discover-as", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ issuer: "https://as.example.com" }),
+      });
+
+      expect(response.status).toBe(404);
+    });
+  });
+});
+
+describe("hosted xaa outbound guards", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+  let app: Hono;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-hosted-route-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+
+    // Hosted-mode router: httpsOnlyProxy rejects http + private/reserved hosts.
+    // No protected middlewares here so the test exercises the guard directly.
+    app = new Hono();
+    app.route(
+      "/api/web/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/web",
+        httpsOnlyProxy: true,
+        trustForwardedHeaders: true,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  it("rejects discovery against a reserved internal address", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/discover-as", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ issuer: "https://169.254.169.254" }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toBe("URL not allowed");
+    // The guard rejects before any outbound fetch is attempted.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an http health-check target in hosted mode", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/health-check", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "http://example.com/health" }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toBe("URL not allowed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not follow a health-check redirect to an internal address", async () => {
+    // redirect: manual means the 3xx is returned without being followed, so
+    // the internal Location is never fetched.
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "http://169.254.169.254/" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/health-check", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      // Public literal IP: passes validateUrl (IP literals skip DNS) without a
+      // real network lookup.
+      body: JSON.stringify({ url: "https://93.184.216.34/health" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(false);
+    expect(body.reason).toBe("redirect_not_followed");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -18,9 +18,17 @@ import {
 } from "../../services/xaa-idjag-signer.js";
 import {
   executeOAuthProxy,
+  fetchOAuthMetadata,
   OAuthProxyError,
+  validateUrl,
 } from "../../utils/oauth-proxy.js";
+import {
+  buildDiscoveryCandidates,
+  evaluateDiscovery,
+} from "../../services/xaa-discovery.js";
 import { logger } from "../../utils/logger.js";
+
+const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 
 const authenticateSchema = z.object({
   userId: z.string().trim().min(1).optional(),
@@ -35,6 +43,19 @@ const tokenExchangeSchema = z.object({
   clientId: z.string().trim().min(1),
   scope: z.string().trim().min(1).optional(),
   negativeTestMode: z.string().trim().optional(),
+});
+
+const discoverAsSchema = z
+  .object({
+    issuer: z.string().trim().min(1).optional(),
+    tokenEndpoint: z.string().trim().min(1).optional(),
+  })
+  .refine((data) => data.issuer || data.tokenEndpoint, {
+    message: "issuer or tokenEndpoint is required",
+  });
+
+const healthCheckSchema = z.object({
+  url: z.string().trim().min(1),
 });
 
 const proxyTokenSchema = z.object({
@@ -155,6 +176,8 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     router.use("/authenticate", ...protectedMiddlewares);
     router.use("/token-exchange", ...protectedMiddlewares);
     router.use("/proxy/token", ...protectedMiddlewares);
+    router.use("/discover-as", ...protectedMiddlewares);
+    router.use("/health-check", ...protectedMiddlewares);
   }
 
   router.get("/.well-known/jwks.json", (c) => {
@@ -312,6 +335,138 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         error instanceof Error ? error.message : "Unknown proxy error",
         { status: 500, code: "INTERNAL_ERROR" },
       );
+    }
+  });
+
+  router.post("/discover-as", async (c) => {
+    let parsed;
+    try {
+      parsed = parseRequest(discoverAsSchema, await c.req.json());
+    } catch (error) {
+      return toJsonError(
+        error instanceof Error ? error.message : "Invalid discovery request",
+        { status: 400, code: "VALIDATION_ERROR" },
+      );
+    }
+
+    const requestedIssuer = (parsed.issuer ?? parsed.tokenEndpoint) as string;
+
+    let candidates: string[];
+    try {
+      candidates = buildDiscoveryCandidates(requestedIssuer);
+    } catch {
+      return toJsonError("issuer or tokenEndpoint is not a valid URL", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    try {
+      const triedStatuses: Array<{ url: string; status: number }> = [];
+      for (const candidate of candidates) {
+        const result = await fetchOAuthMetadata(
+          candidate,
+          options.httpsOnlyProxy,
+        );
+        if ("metadata" in result) {
+          return c.json(
+            evaluateDiscovery(result.metadata, {
+              requestedIssuer,
+              metadataUrl: candidate,
+            }),
+          );
+        }
+        triedStatuses.push({ url: candidate, status: result.status });
+      }
+
+      return toJsonError(
+        "No authorization server metadata found at the well-known endpoints",
+        {
+          status: 404,
+          code: "DISCOVERY_NOT_FOUND",
+          details: { tried: triedStatuses },
+        },
+      );
+    } catch (error) {
+      // validateUrl inside fetchOAuthMetadata rejects disallowed outbound URLs
+      // (e.g. private/reserved hosts, or http in hosted mode). Every candidate
+      // shares the same host, so a guard rejection is terminal.
+      if (error instanceof OAuthProxyError) {
+        return toJsonError("URL not allowed", {
+          status: error.status,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      logger.error("[XAA Discover AS] Error", error);
+      return toJsonError(
+        error instanceof Error ? error.message : "Discovery failed",
+        { status: 502, code: "SERVER_UNREACHABLE" },
+      );
+    }
+  });
+
+  router.post("/health-check", async (c) => {
+    let parsed;
+    try {
+      parsed = parseRequest(healthCheckSchema, await c.req.json());
+    } catch (error) {
+      return toJsonError(
+        error instanceof Error ? error.message : "Invalid health check request",
+        { status: 400, code: "VALIDATION_ERROR" },
+      );
+    }
+
+    let validatedUrl: URL;
+    try {
+      ({ url: validatedUrl } = await validateUrl(
+        parsed.url,
+        options.httpsOnlyProxy,
+      ));
+    } catch (error) {
+      if (error instanceof OAuthProxyError) {
+        return toJsonError("URL not allowed", {
+          status: error.status,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      return toJsonError("URL not allowed", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const startedAt = Date.now();
+    try {
+      const response = await fetch(validatedUrl.toString(), {
+        method: "GET",
+        // In hosted mode redirects are not followed, so a redirect to an
+        // internal address can never be fetched.
+        redirect: options.httpsOnlyProxy ? "manual" : "follow",
+        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+        headers: { "User-Agent": "MCP-Inspector/1.0" },
+      });
+
+      const redirected =
+        options.httpsOnlyProxy &&
+        response.status >= 300 &&
+        response.status < 400;
+
+      return c.json({
+        ok: !redirected && response.status < 400,
+        status: response.status,
+        statusText: response.statusText,
+        durationMs: Date.now() - startedAt,
+        ...(redirected ? { reason: "redirect_not_followed" } : {}),
+      });
+    } catch (error) {
+      const isTimeout =
+        error instanceof Error &&
+        (error.name === "TimeoutError" || error.name === "AbortError");
+      return c.json({
+        ok: false,
+        reason: isTimeout ? "timeout" : "unreachable",
+        durationMs: Date.now() - startedAt,
+      });
     }
   });
 

--- a/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDiscoveryCandidates,
+  evaluateDiscovery,
+  JWT_BEARER_GRANT,
+} from "../xaa-discovery.js";
+
+describe("buildDiscoveryCandidates", () => {
+  it("covers path-insertion and root-append forms for a path-based issuer", () => {
+    const candidates = buildDiscoveryCandidates(
+      "https://login.example.com/realms/acme",
+    );
+
+    expect(candidates).toContain(
+      "https://login.example.com/.well-known/openid-configuration/realms/acme",
+    );
+    expect(candidates).toContain(
+      "https://login.example.com/.well-known/oauth-authorization-server/realms/acme",
+    );
+    expect(candidates).toContain(
+      "https://login.example.com/realms/acme/.well-known/openid-configuration",
+    );
+    expect(candidates).toContain(
+      "https://login.example.com/.well-known/openid-configuration",
+    );
+  });
+
+  it("uses the root well-known forms for a bare-origin issuer", () => {
+    const candidates = buildDiscoveryCandidates("https://issuer.example.com");
+
+    expect(candidates).toEqual([
+      "https://issuer.example.com/.well-known/openid-configuration",
+      "https://issuer.example.com/.well-known/oauth-authorization-server",
+    ]);
+  });
+
+  it("uses an explicit well-known URL verbatim", () => {
+    const url = "https://issuer.example.com/.well-known/openid-configuration";
+    expect(buildDiscoveryCandidates(url)).toEqual([url]);
+  });
+});
+
+describe("evaluateDiscovery", () => {
+  const metadataUrl = "https://as.example.com/.well-known/openid-configuration";
+
+  it("passes when jwt-bearer is advertised and a token endpoint exists", () => {
+    const verdict = evaluateDiscovery(
+      {
+        issuer: "https://as.example.com",
+        token_endpoint: "https://as.example.com/oauth/token",
+        grant_types_supported: [JWT_BEARER_GRANT, "authorization_code"],
+      },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+
+    expect(verdict.jwtBearerSupport).toBe("pass");
+    expect(verdict.hasTokenEndpoint).toBe(true);
+    expect(verdict.tokenEndpoint).toBe("https://as.example.com/oauth/token");
+    expect(verdict.issuerMismatch).toBeNull();
+  });
+
+  it("warns when grant_types_supported is absent", () => {
+    const verdict = evaluateDiscovery(
+      { issuer: "https://as.example.com" },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+    expect(verdict.jwtBearerSupport).toBe("warn");
+  });
+
+  it("fails when jwt-bearer is not in a non-empty grant list", () => {
+    const verdict = evaluateDiscovery(
+      {
+        issuer: "https://as.example.com",
+        grant_types_supported: ["authorization_code"],
+      },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+    expect(verdict.jwtBearerSupport).toBe("fail");
+  });
+
+  it("flags a scheme-only issuer mismatch (http advertised, https requested)", () => {
+    const verdict = evaluateDiscovery(
+      { issuer: "http://as.example.com" },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+
+    expect(verdict.issuerMismatch).toEqual({
+      requested: "https://as.example.com",
+      advertised: "http://as.example.com",
+      schemeOnly: true,
+    });
+  });
+
+  it("flags a host/path issuer mismatch as not scheme-only", () => {
+    const verdict = evaluateDiscovery(
+      { issuer: "https://other.example.com" },
+      { requestedIssuer: "https://as.example.com", metadataUrl },
+    );
+
+    expect(verdict.issuerMismatch?.schemeOnly).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/services/xaa-discovery.ts
+++ b/mcpjam-inspector/server/services/xaa-discovery.ts
@@ -1,0 +1,158 @@
+// Server-side authorization-server discovery helpers for the XAA test bench.
+// Pure functions (candidate URL construction + metadata verdicts) live here so
+// they can be unit-tested without a live authorization server; the route layer
+// in routes/mcp/xaa.ts wires them to the SSRF-guarded fetcher.
+
+export const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+const OIDC_SUFFIX = "/.well-known/openid-configuration";
+const OAUTH_AS_SUFFIX = "/.well-known/oauth-authorization-server";
+
+function stripTrailingSlash(path: string): string {
+  return path.endsWith("/") ? path.slice(0, -1) : path;
+}
+
+/**
+ * Build the ordered list of well-known metadata URLs to probe for an issuer
+ * (or token endpoint). Covers both forms so path-based issuers (Auth0 custom
+ * domains, Keycloak realms) and root issuers both resolve:
+ *   - RFC 8414 / OIDC path-insertion: origin + /.well-known/... + path
+ *   - root-append:                    issuer + /.well-known/openid-configuration
+ *   - pure root:                      origin + /.well-known/openid-configuration
+ *
+ * If the input already points at a well-known document, it's used verbatim.
+ */
+export function buildDiscoveryCandidates(input: string): string[] {
+  const url = new URL(input);
+
+  const path = stripTrailingSlash(url.pathname);
+  if (path.endsWith(OIDC_SUFFIX) || path.endsWith(OAUTH_AS_SUFFIX)) {
+    return [url.toString()];
+  }
+
+  const origin = url.origin;
+  const candidates: string[] = [];
+
+  if (path && path !== "") {
+    // Path-insertion forms (well-known segment inserted before the issuer path)
+    candidates.push(`${origin}${OIDC_SUFFIX}${path}`);
+    candidates.push(`${origin}${OAUTH_AS_SUFFIX}${path}`);
+    // Root-append form (well-known segment appended after the issuer path)
+    candidates.push(`${origin}${path}${OIDC_SUFFIX}`);
+  } else {
+    candidates.push(`${origin}${OIDC_SUFFIX}`);
+    candidates.push(`${origin}${OAUTH_AS_SUFFIX}`);
+  }
+
+  // Pure-root fallback regardless of path.
+  candidates.push(`${origin}${OIDC_SUFFIX}`);
+
+  return Array.from(new Set(candidates));
+}
+
+export type GrantSupportStatus = "pass" | "warn" | "fail";
+
+export interface IssuerMismatch {
+  requested: string;
+  advertised: string;
+  schemeOnly: boolean;
+}
+
+export interface DiscoveryVerdict {
+  issuer?: string;
+  tokenEndpoint?: string;
+  grantTypesSupported?: string[];
+  jwtBearerSupport: GrantSupportStatus;
+  jwtBearerDetail: string;
+  hasTokenEndpoint: boolean;
+  issuerMismatch: IssuerMismatch | null;
+  metadataUrl: string;
+}
+
+// Host + path, scheme excluded — used to detect a scheme-only mismatch
+// (the http-issuer-behind-https-proxy bug) separately from a real host/path
+// divergence.
+function hostAndPath(value: string): string {
+  try {
+    const url = new URL(value);
+    return `${url.host}${stripTrailingSlash(url.pathname)}`;
+  } catch {
+    return stripTrailingSlash(value);
+  }
+}
+
+// Full identity including scheme — two issuers are "the same" only when this
+// matches.
+function fullIdentity(value: string): string {
+  try {
+    const url = new URL(value);
+    return `${url.protocol}//${url.host}${stripTrailingSlash(url.pathname)}`;
+  } catch {
+    return stripTrailingSlash(value);
+  }
+}
+
+/**
+ * Turn fetched authorization-server metadata into the verdicts the runner
+ * renders: jwt-bearer grant support (pass/warn/fail), token-endpoint presence,
+ * and an issuer-mismatch flag (the classic http-issuer-behind-https-proxy bug).
+ */
+export function evaluateDiscovery(
+  metadata: Record<string, unknown>,
+  context: { requestedIssuer: string; metadataUrl: string },
+): DiscoveryVerdict {
+  const issuer =
+    typeof metadata.issuer === "string" ? metadata.issuer : undefined;
+  const tokenEndpoint =
+    typeof metadata.token_endpoint === "string"
+      ? metadata.token_endpoint
+      : undefined;
+  const grantTypesAdvertised = Array.isArray(metadata.grant_types_supported);
+  const grantTypes = grantTypesAdvertised
+    ? (metadata.grant_types_supported as unknown[]).filter(
+        (g): g is string => typeof g === "string",
+      )
+    : undefined;
+
+  let jwtBearerSupport: GrantSupportStatus;
+  let jwtBearerDetail: string;
+  if (grantTypes?.includes(JWT_BEARER_GRANT)) {
+    jwtBearerSupport = "pass";
+    jwtBearerDetail = "Advertised in grant_types_supported.";
+  } else if (!grantTypesAdvertised) {
+    jwtBearerSupport = "warn";
+    jwtBearerDetail =
+      "grant_types_supported is missing from discovery metadata. Support can't be verified without attempting the token exchange.";
+  } else {
+    jwtBearerSupport = "fail";
+    jwtBearerDetail =
+      grantTypes && grantTypes.length === 0
+        ? "grant_types_supported is an empty array; the authorization server declares no supported grant types."
+        : `grant_types_supported does not include ${JWT_BEARER_GRANT}.`;
+  }
+
+  let issuerMismatch: IssuerMismatch | null = null;
+  if (
+    issuer &&
+    fullIdentity(issuer) !== fullIdentity(context.requestedIssuer)
+  ) {
+    issuerMismatch = {
+      requested: context.requestedIssuer,
+      advertised: issuer,
+      // Same host/path, different scheme → almost always a proxy that
+      // terminates TLS but advertises an http:// issuer.
+      schemeOnly: hostAndPath(issuer) === hostAndPath(context.requestedIssuer),
+    };
+  }
+
+  return {
+    issuer,
+    tokenEndpoint,
+    grantTypesSupported: grantTypes,
+    jwtBearerSupport,
+    jwtBearerDetail,
+    hasTokenEndpoint: Boolean(tokenEndpoint),
+    issuerMismatch,
+    metadataUrl: context.metadataUrl,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a claim-by-claim lint panel to the ID-JAG inspector. Each claim gets a pass/warn/fail verdict with a spec citation explaining why the claim matters — instead of only flagging mismatches against the configured flow.

## Changes

- New `client/src/lib/xaa/idjag-lint.ts` (pure functions). Verdicts:
  - `typ` header — explicit `oauth-id-jag+jwt` typing (token-confusion prevention, RFC 8725 §3.11)
  - `iss` / `sub` — presence + issuer match (RFC 7523 §3)
  - `aud` — exact match against the authorization server issuer; arrays rejected (RFC 7523 §3)
  - `resource` — resource indicator presence/match (RFC 8707)
  - `client_id` — client binding match
  - `jti` — replay-prevention id; absence is a warning (RFC 7519 §4.1.7)
  - `exp` — expired = fail; unusually long lifetime = warn (RFC 7523 §3)
- `IdJagInspector` renders the verdicts with status icons, actual values, and citation badges. Expected values flow in from the flow state and degrade to presence-only checks when unset.

Independent of the other XAA test-bench PRs; no backend or server changes.

## Verification

- `client/src/lib/xaa/__tests__/idjag-lint.test.ts` — 19 unit tests, pass + fail fixtures per claim.
- `client/src/components/xaa/__tests__/IdJagInspector.test.tsx` — 2 component tests (all-pass render, expired + audience-mismatch render).
- `npm run typecheck:client` passes.
