### PR TITLE
PR-I5: Registration wizard step 3 + registered-resource list

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1011,7 +1011,7 @@ export function OAuthFlowRoute() {
 }
 
 export function XAAFlowRoute() {
-  const { xaaEnabled, appState } = useAppRouteContext();
+  const { xaaEnabled, appState, activeOrganizationId } = useAppRouteContext();
   if (xaaEnabled !== true) return null;
 
   return (
@@ -1025,6 +1025,7 @@ export function XAAFlowRoute() {
       <XAAFlowTab
         serverConfigs={appState.servers}
         selectedServerName={appState.selectedServer}
+        organizationId={activeOrganizationId ?? null}
       />
     </ErrorBoundary>
   );

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -50,6 +50,10 @@ vi.mock("../xaa/XAAConfigModal", () => ({
   XAAConfigModal: () => null,
 }));
 
+vi.mock("../xaa/registration/XAAResourceAppsSection", () => ({
+  XAAResourceAppsSection: () => <div data-testid="xaa-resource-apps-section" />,
+}));
+
 vi.mock("../xaa/XAABootstrapDialog", () => ({
   XAABootstrapDialog: () => null,
 }));

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -12,6 +12,7 @@ import { XAAFlowLogger } from "./XAAFlowLogger";
 import { XAAConfigModal } from "./XAAConfigModal";
 import { XAABootstrapDialog } from "./XAABootstrapDialog";
 import { XAAIdpCard } from "./XAAIdpCard";
+import { XAAResourceAppsSection } from "./registration/XAAResourceAppsSection";
 import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
@@ -44,11 +45,13 @@ function buildFlowStateFromProfile(profile: XAADebugProfile): XAAFlowState {
 interface XAAFlowTabProps {
   serverConfigs: Record<string, ServerWithName>;
   selectedServerName: string;
+  organizationId?: string | null;
 }
 
 export function XAAFlowTab({
   serverConfigs,
   selectedServerName,
+  organizationId,
 }: XAAFlowTabProps) {
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [isBootstrapDialogOpen, setIsBootstrapDialogOpen] = useState(false);
@@ -165,6 +168,7 @@ export function XAAFlowTab({
   return (
     <div className="h-full flex flex-col bg-background">
       <XAAIdpCard />
+      <XAAResourceAppsSection organizationId={organizationId ?? null} />
       <div className="flex-1 overflow-hidden">
         <ResizablePanelGroup direction="horizontal" className="h-full">
           <ResizablePanel defaultSize={52} minSize={30}>

--- a/mcpjam-inspector/client/src/components/xaa/registration/ScopesConfigStep.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/ScopesConfigStep.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  checkResourceHealth,
+  type HealthCheckResult,
+} from "@/lib/xaa/discovery-client";
+import type { RegistrationDraft } from "./wizard-draft";
+
+interface ScopesConfigStepProps {
+  draft: RegistrationDraft;
+  onChange: (updates: Partial<RegistrationDraft>) => void;
+}
+
+type CheckState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "done"; result: HealthCheckResult }
+  | { status: "error"; message: string };
+
+function describeResult(result: HealthCheckResult): string {
+  if (result.ok) {
+    return `Reachable — HTTP ${result.status} in ${result.durationMs}ms`;
+  }
+  if (result.reason === "timeout") {
+    return "Timed out — the server didn't respond.";
+  }
+  if (result.reason === "redirect_not_followed") {
+    return `Responded with a redirect (HTTP ${result.status}); redirects aren't followed.`;
+  }
+  if (typeof result.status === "number") {
+    return `Reachable but unhealthy — HTTP ${result.status} ${result.statusText ?? ""}`.trim();
+  }
+  return "Unreachable.";
+}
+
+export function ScopesConfigStep({ draft, onChange }: ScopesConfigStepProps) {
+  const [check, setCheck] = useState<CheckState>({ status: "idle" });
+
+  const healthUrl = draft.healthCheckUrl.trim();
+
+  const handleCheck = async () => {
+    if (!healthUrl) return;
+    setCheck({ status: "loading" });
+    try {
+      const result = await checkResourceHealth(healthUrl);
+      setCheck({ status: "done", result });
+    } catch (error) {
+      setCheck({
+        status: "error",
+        message: error instanceof Error ? error.message : "Health check failed",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="xaa-reg-scopes">Scopes</Label>
+        <Input
+          id="xaa-reg-scopes"
+          value={draft.scopes}
+          onChange={(event) => onChange({ scopes: event.target.value })}
+          placeholder="read write (space-separated, optional)"
+          autoComplete="off"
+        />
+        <p className="text-xs text-muted-foreground">
+          Requested on the access token during a run.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="xaa-reg-health-url">Health check URL</Label>
+        <div className="flex items-stretch gap-2">
+          <Input
+            id="xaa-reg-health-url"
+            value={draft.healthCheckUrl}
+            onChange={(event) =>
+              onChange({ healthCheckUrl: event.target.value })
+            }
+            placeholder="https://your-server.example.com/health (optional)"
+            autoComplete="off"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0 self-stretch"
+            onClick={handleCheck}
+            disabled={!healthUrl || check.status === "loading"}
+          >
+            {check.status === "loading" ? (
+              <>
+                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                Checking
+              </>
+            ) : (
+              "Check"
+            )}
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Used to verify the resource is reachable before a run.
+        </p>
+      </div>
+
+      {check.status === "done" && (
+        <div
+          data-testid="xaa-reg-health-result"
+          className={
+            check.result.ok
+              ? "flex items-start gap-1.5 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-xs text-green-700 dark:border-green-900 dark:bg-green-950/20 dark:text-green-300"
+              : "flex items-start gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-900 dark:bg-amber-950/20 dark:text-amber-300"
+          }
+        >
+          {check.result.ok ? (
+            <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          ) : (
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          )}
+          {describeResult(check.result)}
+        </div>
+      )}
+      {check.status === "error" && (
+        <div
+          data-testid="xaa-reg-health-error"
+          className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/20 dark:text-red-300"
+        >
+          {check.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/registration/XAARegistrationWizard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/XAARegistrationWizard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import posthog from "posthog-js";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -11,22 +12,26 @@ import {
   DialogTitle,
 } from "@mcpjam/design-system/dialog";
 import { cn } from "@/lib/utils";
+import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { useXaaResourceApps } from "@/hooks/useXaaResourceApps";
 import type { XaaResourceApp } from "@/lib/xaa/types";
 import { BasicInfoStep } from "./BasicInfoStep";
 import { AuthServerStep } from "./AuthServerStep";
+import { ScopesConfigStep } from "./ScopesConfigStep";
 import {
   draftFromResourceApp,
   draftToInput,
   EMPTY_DRAFT,
   validateAuthServer,
   validateBasicInfo,
+  validateScopesConfig,
   type RegistrationDraft,
 } from "./wizard-draft";
 
 const STEPS = [
   { id: 1, title: "Basic info" },
   { id: 2, title: "Auth server" },
+  { id: 3, title: "Scopes & health" },
 ] as const;
 
 type StepId = (typeof STEPS)[number]["id"];
@@ -88,16 +93,17 @@ export function XAARegistrationWizard({
   };
 
   const handleNext = () => {
-    const error = validateBasicInfo(draft);
+    const error =
+      step === 1 ? validateBasicInfo(draft) : validateAuthServer(draft);
     if (error) {
       setValidationError(error);
       return;
     }
-    setStep(2);
+    setStep((current) => (current === 1 ? 2 : 3));
   };
 
   const handleSave = async () => {
-    const error = validateAuthServer(draft);
+    const error = validateScopesConfig(draft);
     if (error) {
       setValidationError(error);
       return;
@@ -106,6 +112,12 @@ export function XAARegistrationWizard({
     setSaveError(null);
     try {
       const { id } = await upsert(draftToInput(draft, editing?.id));
+      posthog.capture("xaa_resource_app_saved", {
+        resource_type: draft.resourceType,
+        auth_server_mode: draft.authServerMode,
+        platform: detectPlatform(),
+        environment: detectEnvironment(),
+      });
       onSaved?.(id);
       onOpenChange(false);
     } catch (err) {
@@ -161,12 +173,14 @@ export function XAARegistrationWizard({
 
         {step === 1 ? (
           <BasicInfoStep draft={draft} onChange={updateDraft} />
-        ) : (
+        ) : step === 2 ? (
           <AuthServerStep
             draft={draft}
             onChange={updateDraft}
             hasStoredSecret={Boolean(editing?.hasSecret)}
           />
+        ) : (
+          <ScopesConfigStep draft={draft} onChange={updateDraft} />
         )}
 
         {(validationError || saveError) && (
@@ -176,17 +190,17 @@ export function XAARegistrationWizard({
         )}
 
         <DialogFooter>
-          {step === 2 && (
+          {step > 1 && (
             <Button
               type="button"
               variant="outline"
-              onClick={() => setStep(1)}
+              onClick={() => setStep((current) => (current === 3 ? 2 : 1))}
               disabled={isSaving}
             >
               Back
             </Button>
           )}
-          {step === 1 ? (
+          {step < 3 ? (
             <Button type="button" onClick={handleNext}>
               Next
             </Button>

--- a/mcpjam-inspector/client/src/components/xaa/registration/XAAResourceAppsSection.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/XAAResourceAppsSection.tsx
@@ -1,0 +1,265 @@
+import { useState } from "react";
+import { useConvexAuth } from "convex/react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { KeyRound, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@mcpjam/design-system/alert-dialog";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { Card } from "@mcpjam/design-system/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import { useOrganizationQueries } from "@/hooks/useOrganizations";
+import { useXaaResourceApps } from "@/hooks/useXaaResourceApps";
+import type { XaaResourceApp } from "@/lib/xaa/types";
+import { XAARegistrationWizard } from "./XAARegistrationWizard";
+
+const LOCKED_REASON = "Only organization admins can manage registrations.";
+
+interface XAAResourceAppsSectionProps {
+  organizationId: string | null;
+}
+
+/**
+ * Edit/delete affordance for non-admins: rendered (so the feature is
+ * discoverable) but inert, with a tooltip explaining why. A truly `disabled`
+ * button wouldn't fire the tooltip's hover/focus events, hence
+ * aria-disabled + no onClick.
+ */
+function LockedIconButton({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-disabled={true}
+          aria-label={label}
+          tabIndex={0}
+          onClick={undefined}
+          className="opacity-50"
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-[14rem] text-center">
+        {LOCKED_REASON}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function XAAResourceAppsSection({
+  organizationId,
+}: XAAResourceAppsSectionProps) {
+  // Hooks run unconditionally; the flag/auth gates return null below.
+  const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
+  const { isAuthenticated: isConvexAuthenticated } = useConvexAuth();
+  const { resourceApps, isLoading, isAuthenticated, remove } =
+    useXaaResourceApps(organizationId);
+  const { sortedOrganizations } = useOrganizationQueries({
+    isAuthenticated: isConvexAuthenticated,
+  });
+
+  const [wizardOpen, setWizardOpen] = useState(false);
+  const [editing, setEditing] = useState<XaaResourceApp | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<XaaResourceApp | null>(
+    null,
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  if (registrationEnabled !== true || !isAuthenticated) {
+    return null;
+  }
+
+  const activeOrg = sortedOrganizations.find((o) => o._id === organizationId);
+  const canManage =
+    activeOrg?.myRole === "owner" ||
+    activeOrg?.myRole === "admin" ||
+    activeOrg?.isCreator === true;
+
+  const openCreate = () => {
+    setEditing(null);
+    setWizardOpen(true);
+  };
+
+  const openEdit = (app: XaaResourceApp) => {
+    setEditing(app);
+    setWizardOpen(true);
+  };
+
+  const confirmDelete = async () => {
+    if (!pendingDelete) return;
+    setIsDeleting(true);
+    try {
+      await remove(pendingDelete.id);
+      setPendingDelete(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Card className="mx-3 mt-2 mb-1 gap-0 p-0">
+      <div className="flex items-center gap-2 px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold">Registered resource apps</h3>
+          <p className="truncate text-xs text-muted-foreground">
+            Saved targets the flow runner can drive end to end.
+          </p>
+        </div>
+        {canManage ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={openCreate}
+          >
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            Register
+          </Button>
+        ) : (
+          <LockedIconButton label="Register resource app">
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            Register
+          </LockedIconButton>
+        )}
+      </div>
+
+      <div className="px-4 pb-3">
+        {isLoading ? (
+          <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Loading registrations…
+          </div>
+        ) : resourceApps.length === 0 ? (
+          <div
+            data-testid="xaa-reg-empty"
+            className="rounded-md border border-dashed border-border px-3 py-4 text-center text-xs text-muted-foreground"
+          >
+            No resource apps registered yet. Register one to run the full flow
+            against it without re-entering config each session.
+          </div>
+        ) : (
+          <ul className="space-y-1.5">
+            {resourceApps.map((app) => (
+              <li
+                key={app.id}
+                data-testid={`xaa-reg-row-${app.id}`}
+                className="flex items-center gap-2 rounded-md border border-border px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-xs font-medium">
+                      {app.name}
+                    </span>
+                    <Badge variant="secondary" className="text-[10px]">
+                      {app.resourceType === "mcp" ? "MCP" : "REST"}
+                    </Badge>
+                    <Badge variant="outline" className="text-[10px]">
+                      {app.authServerMode === "mcpjam" ? "MCPJam AS" : "Own AS"}
+                    </Badge>
+                    {app.hasSecret && (
+                      <KeyRound
+                        aria-label="Client secret stored"
+                        className="h-3 w-3 text-muted-foreground"
+                      />
+                    )}
+                  </div>
+                  <div className="truncate font-mono text-[11px] text-muted-foreground">
+                    {app.resourceUrl}
+                  </div>
+                </div>
+                {canManage ? (
+                  <>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      aria-label={`Edit ${app.name}`}
+                      onClick={() => openEdit(app)}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      aria-label={`Delete ${app.name}`}
+                      onClick={() => setPendingDelete(app)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <LockedIconButton label={`Edit ${app.name}`}>
+                      <Pencil className="h-3.5 w-3.5" />
+                    </LockedIconButton>
+                    <LockedIconButton label={`Delete ${app.name}`}>
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </LockedIconButton>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <XAARegistrationWizard
+        open={wizardOpen}
+        onOpenChange={setWizardOpen}
+        organizationId={organizationId}
+        editing={editing}
+      />
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {pendingDelete?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The registration and its stored credentials are removed. Flow
+              history is unaffected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void confirmDelete();
+              }}
+              disabled={isDeleting}
+            >
+              {isDeleting ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAARegistrationWizard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAARegistrationWizard.test.tsx
@@ -9,6 +9,18 @@ vi.mock("posthog-js/react", () => ({
   useFeatureFlagEnabled: () => flagValue,
 }));
 
+const captureMock = vi.fn();
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: (...args: unknown[]) => captureMock(...args),
+  },
+}));
+
+vi.mock("@/lib/PosthogUtils", () => ({
+  detectEnvironment: vi.fn().mockReturnValue("test"),
+  detectPlatform: vi.fn().mockReturnValue("web"),
+}));
+
 const upsert = vi.fn(async () => ({ id: "app_new" }));
 vi.mock("@/hooks/useXaaResourceApps", () => ({
   useXaaResourceApps: () => ({
@@ -22,8 +34,10 @@ vi.mock("@/hooks/useXaaResourceApps", () => ({
 }));
 
 const discoverMock = vi.fn();
+const healthCheckMock = vi.fn();
 vi.mock("@/lib/xaa/discovery-client", () => ({
   discoverAuthorizationServer: (input: unknown) => discoverMock(input),
+  checkResourceHealth: (url: unknown) => healthCheckMock(url),
 }));
 
 const ORG_ID = "org_test";
@@ -57,6 +71,8 @@ describe("XAARegistrationWizard", () => {
     flagValue = true;
     upsert.mockClear();
     discoverMock.mockReset();
+    healthCheckMock.mockReset();
+    captureMock.mockClear();
   });
 
   describe("flag gating", () => {
@@ -101,14 +117,34 @@ describe("XAARegistrationWizard", () => {
       expect(steps[0]).not.toHaveAttribute("aria-current");
     });
 
-    it("requires a token endpoint in own-AS mode before saving", async () => {
+    it("requires a token endpoint in own-AS mode before advancing past step 2", async () => {
       const user = userEvent.setup();
       renderWizard();
       await fillBasicInfoAndAdvance(user);
 
-      await user.click(screen.getByRole("button", { name: "Save" }));
+      await user.click(screen.getByRole("button", { name: "Next" }));
       expect(screen.getByRole("alert")).toHaveTextContent(
         "Token endpoint is required",
+      );
+      const steps = screen.getAllByRole("listitem");
+      expect(steps[1]).toHaveAttribute("aria-current", "step");
+      expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid health check URL on step 3", async () => {
+      const user = userEvent.setup();
+      renderWizard();
+      await fillBasicInfoAndAdvance(user);
+      await user.type(
+        screen.getByLabelText("Token endpoint"),
+        "https://auth.example.com/oauth/token",
+      );
+      await user.click(screen.getByRole("button", { name: "Next" }));
+
+      await user.type(screen.getByLabelText("Health check URL"), "not a url");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Health check URL must be a valid http(s) URL.",
       );
       expect(upsert).not.toHaveBeenCalled();
     });
@@ -224,6 +260,7 @@ describe("XAARegistrationWizard", () => {
       renderWizard({ editing });
 
       await user.click(screen.getByRole("button", { name: "Next" }));
+      await user.click(screen.getByRole("button", { name: "Next" }));
       await user.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => expect(upsert).toHaveBeenCalledTimes(1));
@@ -233,7 +270,7 @@ describe("XAARegistrationWizard", () => {
     });
   });
 
-  it("saves a new registration with the entered values", async () => {
+  it("saves a new registration with the entered values and fires telemetry", async () => {
     const user = userEvent.setup();
     const onSaved = vi.fn();
     renderWizard({ onSaved });
@@ -245,6 +282,13 @@ describe("XAARegistrationWizard", () => {
     );
     await user.type(screen.getByLabelText("Client ID"), "client-abc");
     await user.type(screen.getByLabelText("Client secret"), "cs-secret");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await user.type(screen.getByLabelText("Scopes"), "read write");
+    await user.type(
+      screen.getByLabelText("Health check URL"),
+      "https://resource.example.com/health",
+    );
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(onSaved).toHaveBeenCalledWith("app_new"));
@@ -256,6 +300,79 @@ describe("XAARegistrationWizard", () => {
       tokenEndpoint: "https://auth.example.com/oauth/token",
       targetClientId: "client-abc",
       secret: "cs-secret",
+      scopes: ["read", "write"],
+      healthCheckUrl: "https://resource.example.com/health",
     });
+    expect(captureMock).toHaveBeenCalledWith(
+      "xaa_resource_app_saved",
+      expect.objectContaining({
+        resource_type: "mcp",
+        auth_server_mode: "own",
+      }),
+    );
+  });
+
+  it("runs the health check from step 3 and shows the result", async () => {
+    healthCheckMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      durationMs: 42,
+    });
+
+    const user = userEvent.setup();
+    renderWizard();
+    await fillBasicInfoAndAdvance(user);
+    await user.type(
+      screen.getByLabelText("Token endpoint"),
+      "https://auth.example.com/oauth/token",
+    );
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await user.type(
+      screen.getByLabelText("Health check URL"),
+      "https://resource.example.com/health",
+    );
+    await user.click(screen.getByRole("button", { name: "Check" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("xaa-reg-health-result")).toHaveTextContent(
+        "Reachable — HTTP 200 in 42ms",
+      ),
+    );
+    expect(healthCheckMock).toHaveBeenCalledWith(
+      "https://resource.example.com/health",
+    );
+  });
+
+  it("shows the unreachable state without blocking the wizard", async () => {
+    healthCheckMock.mockResolvedValue({
+      ok: false,
+      reason: "timeout",
+      durationMs: 10000,
+    });
+
+    const user = userEvent.setup();
+    renderWizard();
+    await fillBasicInfoAndAdvance(user);
+    await user.type(
+      screen.getByLabelText("Token endpoint"),
+      "https://auth.example.com/oauth/token",
+    );
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await user.type(
+      screen.getByLabelText("Health check URL"),
+      "https://resource.example.com/health",
+    );
+    await user.click(screen.getByRole("button", { name: "Check" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("xaa-reg-health-result")).toHaveTextContent(
+        "Timed out",
+      ),
+    );
+    // The failed check doesn't block saving.
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAAResourceAppsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/__tests__/XAAResourceAppsSection.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { XAAResourceAppsSection } from "../XAAResourceAppsSection";
+import type { XaaResourceApp } from "@/lib/xaa/types";
+
+let flagValue: boolean | undefined = true;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => flagValue,
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+let resourceApps: XaaResourceApp[] = [];
+let hookAuthenticated = true;
+const removeMock = vi.fn(async () => undefined);
+vi.mock("@/hooks/useXaaResourceApps", () => ({
+  useXaaResourceApps: () => ({
+    resourceApps,
+    isLoading: false,
+    isAuthenticated: hookAuthenticated,
+    error: null,
+    upsert: vi.fn(),
+    remove: removeMock,
+  }),
+}));
+
+let myRole: string | undefined = "admin";
+vi.mock("@/hooks/useOrganizations", () => ({
+  useOrganizationQueries: () => ({
+    sortedOrganizations: [
+      { _id: "org_test", name: "Test Org", myRole, isCreator: false },
+    ],
+    isLoading: false,
+    createdCount: 0,
+    canCreateOrganization: true,
+  }),
+}));
+
+vi.mock("../XAARegistrationWizard", () => ({
+  XAARegistrationWizard: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="xaa-reg-wizard-open" /> : null,
+}));
+
+const ORG_ID = "org_test";
+
+const APP: XaaResourceApp = {
+  id: "app_1",
+  name: "My Resource",
+  resourceType: "mcp",
+  resourceUrl: "https://resource.example.com/mcp",
+  authServerMode: "own",
+  tokenEndpoint: "https://auth.example.com/oauth/token",
+  hasSecret: true,
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+describe("XAAResourceAppsSection", () => {
+  beforeEach(() => {
+    flagValue = true;
+    resourceApps = [];
+    hookAuthenticated = true;
+    myRole = "admin";
+    removeMock.mockClear();
+  });
+
+  describe("gating", () => {
+    it("renders nothing when the flag is false", () => {
+      flagValue = false;
+      render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+      expect(screen.queryByText("Registered resource apps")).toBeNull();
+    });
+
+    it("renders nothing when the flag is undefined", () => {
+      flagValue = undefined;
+      render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+      expect(screen.queryByText("Registered resource apps")).toBeNull();
+    });
+
+    it("renders nothing when the hook gate is closed (local mode / logged out)", () => {
+      hookAuthenticated = false;
+      render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+      expect(screen.queryByText("Registered resource apps")).toBeNull();
+    });
+  });
+
+  it("shows the empty state with a Register CTA", async () => {
+    const user = userEvent.setup();
+    render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+
+    expect(screen.getByTestId("xaa-reg-empty")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /register/i }));
+    expect(screen.getByTestId("xaa-reg-wizard-open")).toBeInTheDocument();
+  });
+
+  it("lists registrations with type/AS badges and a stored-secret indicator", () => {
+    resourceApps = [APP];
+    render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+
+    const row = screen.getByTestId("xaa-reg-row-app_1");
+    expect(row).toHaveTextContent("My Resource");
+    expect(row).toHaveTextContent("MCP");
+    expect(row).toHaveTextContent("Own AS");
+    expect(row).toHaveTextContent("https://resource.example.com/mcp");
+    expect(screen.getByLabelText("Client secret stored")).toBeInTheDocument();
+  });
+
+  it("deletes only after confirmation", async () => {
+    resourceApps = [APP];
+    const user = userEvent.setup();
+    render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete My Resource" }),
+    );
+    expect(removeMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Delete My Resource?")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(removeMock).toHaveBeenCalledWith("app_1"));
+  });
+
+  it("cancelling the confirm dialog does not delete", async () => {
+    resourceApps = [APP];
+    const user = userEvent.setup();
+    render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete My Resource" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  describe("non-admin locked state", () => {
+    it("renders inert edit/delete with a reason tooltip instead of live buttons", async () => {
+      myRole = "member";
+      resourceApps = [APP];
+      const user = userEvent.setup();
+      render(<XAAResourceAppsSection organizationId={ORG_ID} />);
+
+      const editButton = screen.getByRole("button", {
+        name: "Edit My Resource",
+      });
+      expect(editButton).toHaveAttribute("aria-disabled", "true");
+
+      const deleteButton = screen.getByRole("button", {
+        name: "Delete My Resource",
+      });
+      expect(deleteButton).toHaveAttribute("aria-disabled", "true");
+
+      // Clicking does nothing — no confirm dialog, no wizard.
+      await user.click(deleteButton);
+      expect(removeMock).not.toHaveBeenCalled();
+      expect(screen.queryByText("Delete My Resource?")).toBeNull();
+
+      await user.click(editButton);
+      expect(screen.queryByTestId("xaa-reg-wizard-open")).toBeNull();
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/xaa/registration/wizard-draft.ts
+++ b/mcpjam-inspector/client/src/components/xaa/registration/wizard-draft.ts
@@ -15,6 +15,9 @@ export interface RegistrationDraft {
   targetClientId: string;
   /** Never pre-filled from the server; blank on edit means "keep stored". */
   secret: string;
+  /** Space-separated in the form; split into an array on save. */
+  scopes: string;
+  healthCheckUrl: string;
 }
 
 export const EMPTY_DRAFT: RegistrationDraft = {
@@ -26,6 +29,8 @@ export const EMPTY_DRAFT: RegistrationDraft = {
   issuer: "",
   targetClientId: "",
   secret: "",
+  scopes: "",
+  healthCheckUrl: "",
 };
 
 export function draftFromResourceApp(app: XaaResourceApp): RegistrationDraft {
@@ -38,6 +43,8 @@ export function draftFromResourceApp(app: XaaResourceApp): RegistrationDraft {
     issuer: app.issuer ?? "",
     targetClientId: app.targetClientId ?? "",
     secret: "",
+    scopes: (app.scopes ?? []).join(" "),
+    healthCheckUrl: app.healthCheckUrl ?? "",
   };
 }
 
@@ -76,6 +83,20 @@ export function validateAuthServer(draft: RegistrationDraft): string | null {
   return null;
 }
 
+export function validateScopesConfig(draft: RegistrationDraft): string | null {
+  if (draft.healthCheckUrl.trim() && !isHttpUrl(draft.healthCheckUrl.trim())) {
+    return "Health check URL must be a valid http(s) URL.";
+  }
+  return null;
+}
+
+export function parseScopes(value: string): string[] {
+  return value
+    .split(/[\s,]+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}
+
 /** Map the draft to the upsert input; own-AS fields and the secret are only
  * sent when meaningful. */
 export function draftToInput(
@@ -83,6 +104,7 @@ export function draftToInput(
   editingId?: string,
 ): XaaResourceAppInput {
   const own = draft.authServerMode === "own";
+  const scopes = parseScopes(draft.scopes);
   return {
     ...(editingId ? { id: editingId } : {}),
     name: draft.name.trim(),
@@ -97,5 +119,9 @@ export function draftToInput(
       ? { targetClientId: draft.targetClientId.trim() }
       : {}),
     ...(own && draft.secret ? { secret: draft.secret } : {}),
+    ...(scopes.length > 0 ? { scopes } : {}),
+    ...(draft.healthCheckUrl.trim()
+      ? { healthCheckUrl: draft.healthCheckUrl.trim() }
+      : {}),
   };
 }

--- a/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
@@ -43,3 +43,39 @@ export async function discoverAuthorizationServer(input: {
 
   return body;
 }
+
+export interface HealthCheckResult {
+  ok: boolean;
+  status?: number;
+  statusText?: string;
+  durationMs: number;
+  reason?: "timeout" | "unreachable" | "redirect_not_followed";
+}
+
+/**
+ * Probe a registered health-check URL via the inspector server (which
+ * validates the outbound URL). Throws with the server's message when the URL
+ * itself is rejected; an unreachable or timed-out target resolves with
+ * `ok: false` instead.
+ */
+export async function checkResourceHealth(
+  url: string,
+): Promise<HealthCheckResult> {
+  const response = await authFetch(`${XAA_API_BASE}/health-check`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+
+  const body = (await response.json().catch(() => null)) as
+    | (HealthCheckResult & { message?: string })
+    | null;
+
+  if (!response.ok || !body) {
+    throw new Error(
+      body?.message || `Health check failed (${response.status})`,
+    );
+  }
+
+  return body;
+}


### PR DESCRIPTION
## Summary

Completes the registration surface behind the `xaa-registration` flag: wizard step 3 (scopes + health check) and the registered-resource list, mounted at the top of the XAA Flow tab.

## Changes

- **Wizard step 3 — Scopes & health:** space-separated scopes; optional health-check URL with a **Check** button (loading / reachable with status + duration / timeout / unreachable / rejected-URL states). A failed check never blocks saving. Saving fires `xaa_resource_app_saved` (`resource_type`, `auth_server_mode`).
- **Registered-resource list:** rows with name, MCP/REST badge, auth-server badge, resource URL, stored-secret indicator, edit/delete. Delete requires an explicit confirmation dialog. Empty state carries a Register CTA.
- **Locked state:** non-admin org members see Register/edit/delete rendered but inert with a reason tooltip (same pattern as the billing section).
- `XAAFlowTab` accepts `organizationId` from the route context; the section renders only in hosted mode with the flag on.

Stacked on #2568 (wizard steps 1–2).

## Verification

- 21 component tests: wizard 3-step traversal, step-3 validation, health-check states, full save payload incl. scopes/health URL, telemetry; section flag false/undefined/gate-closed suppression, empty state, badges, delete confirm + cancel, non-admin locked state.
- `npm run typecheck:client` passes.
