### PR TITLE
PR-I6: XAA flow runner — Run all, registration-backed runs, deep link

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { XAAFlowTab } from "../xaa/XAAFlowTab";
 import type { ServerWithName } from "@/hooks/use-app-state";
 
@@ -18,6 +19,18 @@ vi.mock("@/lib/PosthogUtils", () => ({
 
 vi.mock("../xaa/XAAIdpCard", () => ({
   XAAIdpCard: () => <div data-testid="xaa-idp-card" />,
+}));
+
+let resourceApps: unknown[] = [];
+vi.mock("@/hooks/useXaaResourceApps", () => ({
+  useXaaResourceApps: () => ({
+    resourceApps,
+    isLoading: false,
+    isAuthenticated: true,
+    error: null,
+    upsert: vi.fn(),
+    remove: vi.fn(),
+  }),
 }));
 
 vi.mock("../ui/resizable", () => ({
@@ -58,9 +71,11 @@ vi.mock("../xaa/XAABootstrapDialog", () => ({
   XAABootstrapDialog: () => null,
 }));
 
+const runAllMock = vi.fn(async () => undefined);
 vi.mock("@/lib/xaa/debug-state-machine-adapter", () => ({
   createInspectorXAAStateMachine: () => ({
     proceedToNextStep: vi.fn(),
+    runAll: runAllMock,
   }),
 }));
 
@@ -92,6 +107,12 @@ vi.mock("@/lib/xaa/profile", () => {
 });
 
 describe("XAAFlowTab", () => {
+  beforeEach(() => {
+    captureMock.mockClear();
+    runAllMock.mockClear();
+    resourceApps = [];
+  });
+
   const createServer = (
     overrides: Partial<ServerWithName> = {},
   ): ServerWithName =>
@@ -144,5 +165,42 @@ describe("XAAFlowTab", () => {
     );
     expect(viewedCalls).toHaveLength(1);
     expect(viewedCalls[0][1]).toMatchObject({ location: "xaa_flow_tab" });
+  });
+
+  it("disables Run all without a target", () => {
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="none" />);
+
+    expect(screen.getByRole("button", { name: /run all/i })).toBeDisabled();
+  });
+
+  it("Run all drives the machine and fires start + terminal telemetry", async () => {
+    const user = userEvent.setup();
+    const serverConfigs = {
+      "http-server": createServer({
+        name: "http-server",
+        config: { url: "https://mcp.example.com" },
+      }),
+    };
+
+    render(
+      <XAAFlowTab
+        serverConfigs={serverConfigs}
+        selectedServerName="http-server"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /run all/i }));
+
+    await waitFor(() => expect(runAllMock).toHaveBeenCalledTimes(1));
+    expect(captureMock).toHaveBeenCalledWith(
+      "xaa_flow_started",
+      expect.objectContaining({ mode: "local-profile" }),
+    );
+    // The mocked machine never reaches `complete`, so the terminal event
+    // reports the failure with the stalled step as its category.
+    expect(captureMock).toHaveBeenCalledWith(
+      "xaa_flow_completed",
+      expect.objectContaining({ success: false, error_category: "idle" }),
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import posthog from "posthog-js";
+import { Loader2, Play } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -7,17 +9,20 @@ import {
 } from "@/components/ui/resizable";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
+import { useXaaResourceApps } from "@/hooks/useXaaResourceApps";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
 import { XAAFlowLogger } from "./XAAFlowLogger";
 import { XAAConfigModal } from "./XAAConfigModal";
 import { XAABootstrapDialog } from "./XAABootstrapDialog";
 import { XAAIdpCard } from "./XAAIdpCard";
 import { XAAResourceAppsSection } from "./registration/XAAResourceAppsSection";
+import { XAARunChips } from "./XAARunChips";
 import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
   type XAAFlowState,
   type XAAFlowStep,
+  type XaaResourceApp,
 } from "@/lib/xaa/types";
 import {
   deriveXAADebugProfileFromServer,
@@ -27,19 +32,74 @@ import {
 } from "@/lib/xaa/profile";
 import { createInspectorXAAStateMachine } from "@/lib/xaa/debug-state-machine-adapter";
 
+// Captured at module load: the XAA route returns null while the feature flag
+// bootstraps and other startup code rewrites location.search, so reading the
+// deep link lazily would race. Consumed once the registration list resolves.
+const INITIAL_RESOURCE_PARAM =
+  typeof window === "undefined"
+    ? null
+    : new URLSearchParams(window.location.search).get("resource");
+
 const isHttpServer = (server?: ServerWithName) =>
   Boolean(server && "url" in server.config);
 
-function buildFlowStateFromProfile(profile: XAADebugProfile): XAAFlowState {
+/**
+ * The single mode-resolved input the runner consumes. Hosted runs against a
+ * selected registration; everything else uses the manual debug profile.
+ */
+interface XAAFlowInput {
+  mode: "hosted-registration" | "local-profile";
+  registrationId?: string;
+  serverUrl: string;
+  authzServerIssuer: string;
+  clientId: string;
+  scope: string;
+  userId: string;
+  email: string;
+  negativeTestMode: NegativeTestMode;
+}
+
+function buildFlowStateFromInput(input: XAAFlowInput): XAAFlowState {
   return createInitialXAAFlowState({
-    serverUrl: profile.serverUrl || undefined,
-    authzServerIssuer: profile.authzServerIssuer || undefined,
-    negativeTestMode: profile.negativeTestMode,
-    userId: profile.userId || undefined,
-    email: profile.email || undefined,
-    clientId: profile.clientId || undefined,
-    scope: profile.scope || undefined,
+    serverUrl: input.serverUrl || undefined,
+    authzServerIssuer: input.authzServerIssuer || undefined,
+    negativeTestMode: input.negativeTestMode,
+    userId: input.userId || undefined,
+    email: input.email || undefined,
+    clientId: input.clientId || undefined,
+    scope: input.scope || undefined,
   });
+}
+
+function inputFromProfile(profile: XAADebugProfile): XAAFlowInput {
+  return {
+    mode: "local-profile",
+    serverUrl: profile.serverUrl,
+    authzServerIssuer: profile.authzServerIssuer,
+    clientId: profile.clientId,
+    scope: profile.scope,
+    userId: profile.userId,
+    email: profile.email,
+    negativeTestMode: profile.negativeTestMode,
+  };
+}
+
+function inputFromRegistration(
+  registration: XaaResourceApp,
+  profile: XAADebugProfile,
+): XAAFlowInput {
+  return {
+    mode: "hosted-registration",
+    registrationId: registration.id,
+    serverUrl: registration.resourceUrl,
+    authzServerIssuer: registration.issuer ?? "",
+    clientId: registration.targetClientId ?? "",
+    scope: (registration.scopes ?? []).join(" "),
+    // Synthetic identity stays user-configurable regardless of source.
+    userId: profile.userId,
+    email: profile.email,
+    negativeTestMode: profile.negativeTestMode,
+  };
 }
 
 interface XAAFlowTabProps {
@@ -56,6 +116,7 @@ export function XAAFlowTab({
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [isBootstrapDialogOpen, setIsBootstrapDialogOpen] = useState(false);
   const [focusedStep, setFocusedStep] = useState<XAAFlowStep | null>(null);
+  const [isRunningAll, setIsRunningAll] = useState(false);
 
   const selectedServer =
     selectedServerName !== "none"
@@ -69,20 +130,98 @@ export function XAAFlowTab({
     deriveXAADebugProfileFromServer(activeServer, loadStoredXAADebugProfile()),
   );
   const [flowState, setFlowState] = useState<XAAFlowState>(() =>
-    buildFlowStateFromProfile(
-      deriveXAADebugProfileFromServer(activeServer, loadStoredXAADebugProfile()),
+    buildFlowStateFromInput(
+      inputFromProfile(
+        deriveXAADebugProfileFromServer(
+          activeServer,
+          loadStoredXAADebugProfile(),
+        ),
+      ),
     ),
   );
 
+  // The machine reads state through this ref (lazy getState). Keep it in
+  // sync *synchronously* with every write so a run that resets and then
+  // immediately advances never observes a stale snapshot.
+  const flowStateRef = useRef(flowState);
+
+  const applyFlowState = useCallback((next: XAAFlowState) => {
+    flowStateRef.current = next;
+    setFlowState(next);
+  }, []);
+
+  const updateFlowState = useCallback((updates: Partial<XAAFlowState>) => {
+    flowStateRef.current = { ...flowStateRef.current, ...updates };
+    setFlowState((current) => ({ ...current, ...updates }));
+  }, []);
+
+  // ── Registration selection (hosted) ────────────────────────────────
+  const { resourceApps } = useXaaResourceApps(organizationId ?? null);
+  const [selectedRegistrationId, setSelectedRegistrationId] = useState<
+    string | null
+  >(null);
+  const deepLinkConsumed = useRef(false);
+
   useEffect(() => {
-    if (profile.serverUrl.trim()) {
+    if (deepLinkConsumed.current || !INITIAL_RESOURCE_PARAM) return;
+    const match = resourceApps.find((app) => app.id === INITIAL_RESOURCE_PARAM);
+    if (match) {
+      deepLinkConsumed.current = true;
+      setSelectedRegistrationId(match.id);
+    }
+  }, [resourceApps]);
+
+  const selectedRegistration =
+    resourceApps.find((app) => app.id === selectedRegistrationId) ?? null;
+
+  const flowInput = useMemo(
+    () =>
+      selectedRegistration
+        ? inputFromRegistration(selectedRegistration, profile)
+        : inputFromProfile(profile),
+    [selectedRegistration, profile],
+  );
+
+  // ── Telemetry (started / terminal completed, once per run) ─────────
+  const completedFired = useRef(false);
+  const authServerModeForTelemetry =
+    selectedRegistration?.authServerMode ?? "own";
+
+  const fireFlowStarted = useCallback(() => {
+    completedFired.current = false;
+    posthog.capture("xaa_flow_started", {
+      mode: flowInput.mode,
+      auth_server_mode: authServerModeForTelemetry,
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+    });
+  }, [flowInput.mode, authServerModeForTelemetry]);
+
+  useEffect(() => {
+    if (flowState.currentStep === "complete" && !completedFired.current) {
+      completedFired.current = true;
+      posthog.capture("xaa_flow_completed", {
+        success: true,
+        auth_server_mode: authServerModeForTelemetry,
+        platform: detectPlatform(),
+        environment: detectEnvironment(),
+      });
+    }
+  }, [flowState.currentStep, authServerModeForTelemetry]);
+
+  // ── Flow-state lifecycle ────────────────────────────────────────────
+  useEffect(() => {
+    if (selectedRegistration || profile.serverUrl.trim()) {
       return;
     }
 
     const derived = deriveXAADebugProfileFromServer(activeServer, profile);
     setProfile(derived);
-    setFlowState(buildFlowStateFromProfile(derived));
-  }, [activeServer, profile.serverUrl]);
+    applyFlowState(buildFlowStateFromInput(inputFromProfile(derived)));
+    // Matches the original effect: keyed on serverUrl, not the profile
+    // object, so the derived profile (a fresh object) can't retrigger it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeServer, profile.serverUrl, selectedRegistration]);
 
   useEffect(() => {
     setFocusedStep(null);
@@ -96,61 +235,119 @@ export function XAAFlowTab({
     });
   }, []);
 
-  const flowStateRef = useRef(flowState);
+  // Switching the run target (registration picked/cleared) starts a fresh
+  // flow against it.
+  const lastAppliedRegistrationId = useRef<string | null>(null);
   useEffect(() => {
-    flowStateRef.current = flowState;
-  }, [flowState]);
-
-  const updateFlowState = useCallback((updates: Partial<XAAFlowState>) => {
-    setFlowState((current) => ({ ...current, ...updates }));
-  }, []);
-
-  const resetFlow = useCallback((nextProfile?: XAADebugProfile) => {
-    const profileToApply = nextProfile ?? profile;
-    setFlowState(buildFlowStateFromProfile(profileToApply));
+    if (lastAppliedRegistrationId.current === selectedRegistrationId) {
+      return;
+    }
+    lastAppliedRegistrationId.current = selectedRegistrationId;
+    applyFlowState(buildFlowStateFromInput(flowInput));
     setFocusedStep(null);
-  }, [profile]);
+  }, [selectedRegistrationId, flowInput, applyFlowState]);
 
-  const handleChangeNegativeTestMode = useCallback(
-    (mode: NegativeTestMode) => {
-      setProfile((current) => {
-        const next = { ...current, negativeTestMode: mode };
-        saveStoredXAADebugProfile(next);
-        setFlowState(buildFlowStateFromProfile(next));
-        setFocusedStep(null);
-        return next;
-      });
+  const resetFlow = useCallback(
+    (nextProfile?: XAADebugProfile) => {
+      const input = nextProfile
+        ? selectedRegistration
+          ? inputFromRegistration(selectedRegistration, nextProfile)
+          : inputFromProfile(nextProfile)
+        : flowInput;
+      applyFlowState(buildFlowStateFromInput(input));
+      setFocusedStep(null);
     },
-    [],
+    [flowInput, selectedRegistration, applyFlowState],
   );
 
-  const hasProfile = Boolean(profile.serverUrl.trim());
+  const handleChangeNegativeTestMode = useCallback((mode: NegativeTestMode) => {
+    setProfile((current) => {
+      const next = { ...current, negativeTestMode: mode };
+      saveStoredXAADebugProfile(next);
+      return next;
+    });
+    setFocusedStep(null);
+  }, []);
+
+  // Rebuild the flow when the negative-test mode changes (profile-sourced in
+  // both modes).
+  const lastNegativeTestMode = useRef(profile.negativeTestMode);
+  useEffect(() => {
+    if (lastNegativeTestMode.current === profile.negativeTestMode) {
+      return;
+    }
+    lastNegativeTestMode.current = profile.negativeTestMode;
+    applyFlowState(buildFlowStateFromInput(flowInput));
+  }, [profile.negativeTestMode, flowInput, applyFlowState]);
+
+  const hasTarget = Boolean(flowInput.serverUrl.trim());
 
   const xaaStateMachine = useMemo(() => {
     return createInspectorXAAStateMachine({
-      state: flowStateRef.current,
       getState: () => flowStateRef.current,
       updateState: updateFlowState,
-      serverUrl: profile.serverUrl || "http://localhost",
-      negativeTestMode: profile.negativeTestMode,
-      userId: profile.userId,
-      email: profile.email,
-      clientId: profile.clientId,
-      scope: profile.scope,
-      authzServerIssuer: profile.authzServerIssuer,
+      serverUrl: flowInput.serverUrl || "http://localhost",
+      negativeTestMode: flowInput.negativeTestMode,
+      userId: flowInput.userId,
+      email: flowInput.email,
+      clientId: flowInput.clientId,
+      scope: flowInput.scope,
+      authzServerIssuer: flowInput.authzServerIssuer,
+      registrationId: flowInput.registrationId,
     });
-  }, [profile, updateFlowState]);
+  }, [flowInput, updateFlowState]);
 
   const handleAdvance = useCallback(async () => {
-    if (!hasProfile) {
+    if (!hasTarget) {
       setIsConfigModalOpen(true);
       return;
     }
 
+    if (flowStateRef.current.currentStep === "idle") {
+      fireFlowStarted();
+    }
     await xaaStateMachine.proceedToNextStep();
-  }, [hasProfile, xaaStateMachine]);
+  }, [hasTarget, xaaStateMachine, fireFlowStarted]);
 
-  const continueLabel = !hasProfile
+  const handleRunAll = useCallback(async () => {
+    if (!hasTarget) {
+      setIsConfigModalOpen(true);
+      return;
+    }
+
+    // Every Run all begins from a clean slate so the chips reflect this run.
+    applyFlowState(buildFlowStateFromInput(flowInput));
+    setFocusedStep(null);
+    fireFlowStarted();
+    setIsRunningAll(true);
+    try {
+      await xaaStateMachine.runAll();
+    } finally {
+      setIsRunningAll(false);
+    }
+
+    const final = flowStateRef.current;
+    if (final.currentStep !== "complete" && !completedFired.current) {
+      completedFired.current = true;
+      posthog.capture("xaa_flow_completed", {
+        success: false,
+        // The step the run stopped on — an enum, never a raw error string.
+        error_category: final.currentStep,
+        auth_server_mode: authServerModeForTelemetry,
+        platform: detectPlatform(),
+        environment: detectEnvironment(),
+      });
+    }
+  }, [
+    hasTarget,
+    flowInput,
+    xaaStateMachine,
+    applyFlowState,
+    fireFlowStarted,
+    authServerModeForTelemetry,
+  ]);
+
+  const continueLabel = !hasTarget
     ? "Configure Target"
     : flowState.currentStep === "idle"
       ? "Start"
@@ -163,19 +360,60 @@ export function XAAFlowTab({
             : "Continue";
 
   const continueDisabled =
-    !hasProfile || flowState.isBusy || flowState.currentStep === "complete";
+    !hasTarget ||
+    flowState.isBusy ||
+    isRunningAll ||
+    flowState.currentStep === "complete";
+
+  const runAllDisabled = !hasTarget || flowState.isBusy || isRunningAll;
 
   return (
     <div className="h-full flex flex-col bg-background">
       <XAAIdpCard />
-      <XAAResourceAppsSection organizationId={organizationId ?? null} />
+      <XAAResourceAppsSection
+        organizationId={organizationId ?? null}
+        selectedId={selectedRegistrationId}
+        onSelect={(app) =>
+          setSelectedRegistrationId((current) =>
+            current === app.id ? null : app.id,
+          )
+        }
+      />
+      <div className="flex items-center gap-3 border-b border-border px-4 py-2">
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleRunAll}
+          disabled={runAllDisabled}
+        >
+          {isRunningAll ? (
+            <>
+              <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+              Running
+            </>
+          ) : (
+            <>
+              <Play className="mr-1 h-3.5 w-3.5" />
+              Run all
+            </>
+          )}
+        </Button>
+        <XAARunChips flowState={flowState} />
+        <span className="ml-auto min-w-0 truncate text-xs text-muted-foreground">
+          {selectedRegistration
+            ? `Target: ${selectedRegistration.name}`
+            : hasTarget
+              ? `Target: ${flowInput.serverUrl}`
+              : "No target configured"}
+        </span>
+      </div>
       <div className="flex-1 overflow-hidden">
         <ResizablePanelGroup direction="horizontal" className="h-full">
           <ResizablePanel defaultSize={52} minSize={30}>
             <XAASequenceDiagram
               flowState={flowState}
               focusedStep={focusedStep}
-              hasProfile={hasProfile}
+              hasProfile={hasTarget}
               onConfigure={() => setIsConfigModalOpen(true)}
             />
           </ResizablePanel>
@@ -185,25 +423,25 @@ export function XAAFlowTab({
           <ResizablePanel defaultSize={48} minSize={24} maxSize={52}>
             <XAAFlowLogger
               flowState={flowState}
-              hasProfile={hasProfile}
+              hasProfile={hasTarget}
               activeStep={focusedStep ?? flowState.currentStep}
               onFocusStep={setFocusedStep}
               actions={{
                 onConfigure: () => setIsConfigModalOpen(true),
-                onReset: hasProfile ? () => resetFlow() : undefined,
+                onReset: hasTarget ? () => resetFlow() : undefined,
                 onContinue: continueDisabled ? undefined : handleAdvance,
                 onChangeNegativeTestMode: handleChangeNegativeTestMode,
                 onShowBootstrap: () => setIsBootstrapDialogOpen(true),
                 continueLabel,
                 continueDisabled,
-                resetDisabled: !hasProfile || flowState.isBusy,
+                resetDisabled: !hasTarget || flowState.isBusy || isRunningAll,
               }}
               summary={{
-                serverUrl: profile.serverUrl,
-                authzServerIssuer: profile.authzServerIssuer || undefined,
-                clientId: profile.clientId || undefined,
-                scope: profile.scope || undefined,
-                negativeTestMode: profile.negativeTestMode,
+                serverUrl: flowInput.serverUrl,
+                authzServerIssuer: flowInput.authzServerIssuer || undefined,
+                clientId: flowInput.clientId || undefined,
+                scope: flowInput.scope || undefined,
+                negativeTestMode: flowInput.negativeTestMode,
               }}
             />
           </ResizablePanel>

--- a/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+import {
+  getXAAStepIndex,
+  getXAAStepInfo,
+  XAA_STEP_ORDER,
+} from "@/lib/xaa/step-metadata";
+import type { XAAFlowState, XAAFlowStep } from "@/lib/xaa/types";
+
+// "idle" and "complete" are machine states, not work the run performs.
+const CHIP_STEPS: XAAFlowStep[] = XAA_STEP_ORDER.filter(
+  (step) => step !== "idle" && step !== "complete",
+);
+
+type ChipStatus = "pass" | "fail" | "untouched";
+
+export function chipStatusFor(
+  step: XAAFlowStep,
+  flowState: Pick<XAAFlowState, "currentStep" | "error">,
+): ChipStatus {
+  const stepIndex = getXAAStepIndex(step);
+  const currentIndex = getXAAStepIndex(flowState.currentStep);
+
+  if (flowState.error && step === flowState.currentStep) {
+    return "fail";
+  }
+  if (stepIndex < currentIndex || flowState.currentStep === "complete") {
+    return "pass";
+  }
+  // The step the flow sits on without an error hasn't finished yet.
+  return "untouched";
+}
+
+/**
+ * Per-step pass/fail strip for the flow runner. A run stopped mid-flow shows
+ * green (done) / red (failed) / untouched chips rather than all-or-nothing.
+ */
+export function XAARunChips({
+  flowState,
+}: {
+  flowState: Pick<XAAFlowState, "currentStep" | "error">;
+}) {
+  return (
+    <ol aria-label="Run progress" className="flex flex-wrap items-center gap-1">
+      {CHIP_STEPS.map((step) => {
+        const status = chipStatusFor(step, flowState);
+        return (
+          <li
+            key={step}
+            data-testid={`xaa-run-chip-${step}`}
+            data-status={status}
+            title={getXAAStepInfo(step).title}
+            className={cn(
+              "h-2 w-5 rounded-full border",
+              status === "pass" &&
+                "border-green-600/40 bg-green-500/70 dark:bg-green-500/50",
+              status === "fail" &&
+                "border-red-600/40 bg-red-500/80 dark:bg-red-500/60",
+              status === "untouched" && "border-border bg-muted",
+            )}
+          />
+        );
+      })}
+    </ol>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAARunChips.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAARunChips.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { XAARunChips } from "../XAARunChips";
+
+describe("XAARunChips", () => {
+  it("renders every step untouched at idle", () => {
+    render(<XAARunChips flowState={{ currentStep: "idle" }} />);
+
+    const chips = screen.getAllByTestId(/xaa-run-chip-/);
+    expect(chips.length).toBeGreaterThan(0);
+    for (const chip of chips) {
+      expect(chip).toHaveAttribute("data-status", "untouched");
+    }
+  });
+
+  it("shows a partial run as green/red/untouched", () => {
+    render(
+      <XAARunChips
+        flowState={{ currentStep: "jwt_bearer_request", error: "boom" }}
+      />,
+    );
+
+    // Steps before the failure are green.
+    expect(
+      screen.getByTestId("xaa-run-chip-token_exchange_request"),
+    ).toHaveAttribute("data-status", "pass");
+    // The failing step is red.
+    expect(
+      screen.getByTestId("xaa-run-chip-jwt_bearer_request"),
+    ).toHaveAttribute("data-status", "fail");
+    // Steps after it stay untouched.
+    expect(
+      screen.getByTestId("xaa-run-chip-authenticated_mcp_request"),
+    ).toHaveAttribute("data-status", "untouched");
+  });
+
+  it("shows everything green on completion", () => {
+    render(<XAARunChips flowState={{ currentStep: "complete" }} />);
+
+    const chips = screen.getAllByTestId(/xaa-run-chip-/);
+    for (const chip of chips) {
+      expect(chip).toHaveAttribute("data-status", "pass");
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/components/xaa/registration/XAAResourceAppsSection.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/registration/XAAResourceAppsSection.tsx
@@ -20,6 +20,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@mcpjam/design-system/tooltip";
+import { cn } from "@/lib/utils";
 import { useOrganizationQueries } from "@/hooks/useOrganizations";
 import { useXaaResourceApps } from "@/hooks/useXaaResourceApps";
 import type { XaaResourceApp } from "@/lib/xaa/types";
@@ -29,6 +30,10 @@ const LOCKED_REASON = "Only organization admins can manage registrations.";
 
 interface XAAResourceAppsSectionProps {
   organizationId: string | null;
+  /** Registration currently selected as the flow runner's target. */
+  selectedId?: string | null;
+  /** Row click — toggles the runner target. */
+  onSelect?: (app: XaaResourceApp) => void;
 }
 
 /**
@@ -54,7 +59,8 @@ function LockedIconButton({
           aria-disabled={true}
           aria-label={label}
           tabIndex={0}
-          onClick={undefined}
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
           className="opacity-50"
         >
           {children}
@@ -69,6 +75,8 @@ function LockedIconButton({
 
 export function XAAResourceAppsSection({
   organizationId,
+  selectedId,
+  onSelect,
 }: XAAResourceAppsSectionProps) {
   // Hooks run unconditionally; the flag/auth gates return null below.
   const registrationEnabled = useFeatureFlagEnabled("xaa-registration");
@@ -160,67 +168,106 @@ export function XAAResourceAppsSection({
           </div>
         ) : (
           <ul className="space-y-1.5">
-            {resourceApps.map((app) => (
-              <li
-                key={app.id}
-                data-testid={`xaa-reg-row-${app.id}`}
-                className="flex items-center gap-2 rounded-md border border-border px-3 py-2"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-xs font-medium">
-                      {app.name}
-                    </span>
-                    <Badge variant="secondary" className="text-[10px]">
-                      {app.resourceType === "mcp" ? "MCP" : "REST"}
-                    </Badge>
-                    <Badge variant="outline" className="text-[10px]">
-                      {app.authServerMode === "mcpjam" ? "MCPJam AS" : "Own AS"}
-                    </Badge>
-                    {app.hasSecret && (
-                      <KeyRound
-                        aria-label="Client secret stored"
-                        className="h-3 w-3 text-muted-foreground"
-                      />
+            {resourceApps.map((app) => {
+              const isSelected = selectedId === app.id;
+              return (
+                <li key={app.id}>
+                  {/* Row-as-button (it contains real buttons, so the outer
+                      can't be a <button>). Click toggles the runner target. */}
+                  <div
+                    data-testid={`xaa-reg-row-${app.id}`}
+                    role={onSelect ? "button" : undefined}
+                    tabIndex={onSelect ? 0 : undefined}
+                    aria-pressed={onSelect ? isSelected : undefined}
+                    onClick={onSelect ? () => onSelect(app) : undefined}
+                    onKeyDown={
+                      onSelect
+                        ? (event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              onSelect(app);
+                            }
+                          }
+                        : undefined
+                    }
+                    className={cn(
+                      "flex items-center gap-2 rounded-md border px-3 py-2",
+                      isSelected
+                        ? "border-primary/60 bg-primary/5"
+                        : "border-border",
+                      onSelect && "cursor-pointer",
+                    )}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate text-xs font-medium">
+                          {app.name}
+                        </span>
+                        <Badge variant="secondary" className="text-[10px]">
+                          {app.resourceType === "mcp" ? "MCP" : "REST"}
+                        </Badge>
+                        <Badge variant="outline" className="text-[10px]">
+                          {app.authServerMode === "mcpjam"
+                            ? "MCPJam AS"
+                            : "Own AS"}
+                        </Badge>
+                        {app.hasSecret && (
+                          <KeyRound
+                            aria-label="Client secret stored"
+                            className="h-3 w-3 text-muted-foreground"
+                          />
+                        )}
+                        {isSelected && (
+                          <Badge className="text-[10px]">Run target</Badge>
+                        )}
+                      </div>
+                      <div className="truncate font-mono text-[11px] text-muted-foreground">
+                        {app.resourceUrl}
+                      </div>
+                    </div>
+                    {canManage ? (
+                      <>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Edit ${app.name}`}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            openEdit(app);
+                          }}
+                          onKeyDown={(event) => event.stopPropagation()}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Delete ${app.name}`}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setPendingDelete(app);
+                          }}
+                          onKeyDown={(event) => event.stopPropagation()}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </>
+                    ) : (
+                      <>
+                        <LockedIconButton label={`Edit ${app.name}`}>
+                          <Pencil className="h-3.5 w-3.5" />
+                        </LockedIconButton>
+                        <LockedIconButton label={`Delete ${app.name}`}>
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </LockedIconButton>
+                      </>
                     )}
                   </div>
-                  <div className="truncate font-mono text-[11px] text-muted-foreground">
-                    {app.resourceUrl}
-                  </div>
-                </div>
-                {canManage ? (
-                  <>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      aria-label={`Edit ${app.name}`}
-                      onClick={() => openEdit(app)}
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      aria-label={`Delete ${app.name}`}
-                      onClick={() => setPendingDelete(app)}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
-                  </>
-                ) : (
-                  <>
-                    <LockedIconButton label={`Edit ${app.name}`}>
-                      <Pencil className="h-3.5 w-3.5" />
-                    </LockedIconButton>
-                    <LockedIconButton label={`Delete ${app.name}`}>
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </LockedIconButton>
-                  </>
-                )}
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -262,4 +262,205 @@ describe("createXAAStateMachine", () => {
       ]),
     );
   });
+
+  describe("runner mode (runAll)", () => {
+    function buildRunnerHarness(options: {
+      registrationId?: string;
+      failTokenProxy?: boolean;
+    }) {
+      let state: XAAFlowState = createInitialXAAFlowState({
+        serverUrl: "https://mcp.example.com",
+        clientId: "mcpjam-debugger",
+        userId: "user-12345",
+        email: "demo.user@example.com",
+        scope: "read:tools",
+      });
+
+      const idToken = makeJwt(
+        {
+          iss: "https://issuer.example/api/web/xaa",
+          sub: "user-12345",
+          email: "demo.user@example.com",
+        },
+        { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" },
+      );
+      const idJag = makeJwt({
+        iss: "https://issuer.example/api/web/xaa",
+        sub: "user-12345",
+        aud: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        client_id: "mcpjam-debugger",
+        exp: Math.floor(Date.now() / 1000) + 300,
+        scope: "read:tools",
+      });
+
+      const tokenProxyBodies: any[] = [];
+
+      const executor = {
+        externalRequest: vi.fn(async (url: string) => {
+          if (url.includes(".well-known/oauth-protected-resource")) {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: {
+                resource: "https://mcp.example.com",
+                authorization_servers: ["https://auth.example.com"],
+              },
+              ok: true,
+            };
+          }
+
+          if (url.includes(".well-known/oauth-authorization-server")) {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: {
+                issuer: "https://auth.example.com",
+                token_endpoint: "https://auth.example.com/oauth/token",
+              },
+              ok: true,
+            };
+          }
+
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { result: { serverInfo: { name: "demo" } } },
+            ok: true,
+          };
+        }),
+        internalRequest: vi.fn(async (path: string, init?: RequestInit) => {
+          if (path === "/authenticate") {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: { id_token: idToken },
+              ok: true,
+            };
+          }
+
+          if (path === "/token-exchange") {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: { id_jag: idJag },
+              ok: true,
+            };
+          }
+
+          // /proxy/token
+          tokenProxyBodies.push(JSON.parse(String(init?.body)));
+          if (options.failTokenProxy) {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: {
+                status: 400,
+                statusText: "Bad Request",
+                headers: {},
+                body: { error: "invalid_grant" },
+              },
+              ok: true,
+            };
+          }
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: {
+                access_token: "access-token",
+                token_type: "Bearer",
+                expires_in: 300,
+              },
+            },
+            ok: true,
+          };
+        }),
+      };
+
+      const machine = createXAAStateMachine({
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: "https://mcp.example.com",
+        issuerBaseUrl: "https://issuer.example/api/web/xaa",
+        requestExecutor: executor,
+        clientId: "mcpjam-debugger",
+        userId: "user-12345",
+        email: "demo.user@example.com",
+        scope: "read:tools",
+        registrationId: options.registrationId,
+      });
+
+      return {
+        machine,
+        getStateSnapshot: () => state,
+        tokenProxyBodies,
+      };
+    }
+
+    it("drives a registration-backed run to completion sending only the registration id", async () => {
+      const { machine, getStateSnapshot, tokenProxyBodies } =
+        buildRunnerHarness({ registrationId: "app_1" });
+
+      await machine.runAll();
+
+      expect(getStateSnapshot().currentStep).toBe("complete");
+      expect(getStateSnapshot().accessToken).toBe("access-token");
+      expect(tokenProxyBodies).toHaveLength(1);
+      expect(tokenProxyBodies[0]).toMatchObject({ registrationId: "app_1" });
+      // The secret and endpoint live server-side; the browser never sends
+      // either on a registration-backed run.
+      expect(tokenProxyBodies[0]).not.toHaveProperty("clientSecret");
+      expect(tokenProxyBodies[0]).not.toHaveProperty("tokenEndpoint");
+      expect(tokenProxyBodies[0]).not.toHaveProperty("clientId");
+    });
+
+    it("drives an inline-profile run to completion sending the token endpoint", async () => {
+      const { machine, getStateSnapshot, tokenProxyBodies } =
+        buildRunnerHarness({});
+
+      await machine.runAll();
+
+      expect(getStateSnapshot().currentStep).toBe("complete");
+      expect(tokenProxyBodies[0]).toMatchObject({
+        tokenEndpoint: "https://auth.example.com/oauth/token",
+        clientId: "mcpjam-debugger",
+      });
+      expect(tokenProxyBodies[0]).not.toHaveProperty("registrationId");
+    });
+
+    it("stops at the failing step and preserves the partial run", async () => {
+      const { machine, getStateSnapshot } = buildRunnerHarness({
+        registrationId: "app_1",
+        failTokenProxy: true,
+      });
+
+      await machine.runAll();
+
+      const final = getStateSnapshot();
+      expect(final.currentStep).toBe("jwt_bearer_request");
+      expect(final.error).toBeTruthy();
+      expect(final.accessToken).toBeUndefined();
+      // Earlier steps completed and stay recorded — the run is partial,
+      // not all-or-nothing.
+      expect(final.idJag).toBeTruthy();
+      expect(
+        (final.httpHistory ?? []).some(
+          (entry) => entry.step === "token_exchange_request",
+        ),
+      ).toBe(true);
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -365,11 +365,15 @@ function buildIdJagInspection(
   };
 }
 
+// 14 distinct steps with a couple of paired sub-advances; 32 leaves headroom
+// without risking a hot loop if a step ever stops progressing silently.
+const XAA_RUN_ALL_MAX_ADVANCES = 32;
+
 export function createXAAStateMachine(
   config: BaseXAAStateMachineConfig,
 ): XAAStateMachine {
   const {
-    state,
+    state: initialState,
     getState,
     updateState,
     serverUrl,
@@ -381,7 +385,10 @@ export function createXAAStateMachine(
     clientId,
     scope,
     authzServerIssuer,
+    registrationId,
   } = config;
+
+  const state: Partial<XAAFlowState> = initialState ?? {};
 
   const machine: XAAStateMachine = {
     state: createInitialXAAFlowState({
@@ -400,6 +407,7 @@ export function createXAAStateMachine(
       updateState(updates);
     },
     proceedToNextStep: async () => {},
+    runAll: async () => {},
     resetFlow: () => {},
   };
 
@@ -875,7 +883,7 @@ export function createXAAStateMachine(
   const requestAccessToken = async () => {
     const state = currentState();
 
-    if (!state.idJag || !state.tokenEndpoint) {
+    if (!state.idJag || (!state.tokenEndpoint && !registrationId)) {
       machine.updateState({
         currentStep: "jwt_bearer_request",
         error:
@@ -884,19 +892,30 @@ export function createXAAStateMachine(
       return;
     }
 
+    // Registration-backed runs send only the registration id: the server
+    // resolves the stored secret and forces the outbound URL to the
+    // registration's stored token endpoint, so neither ever rides in from
+    // the browser.
     const request = {
       method: "POST",
       url: "/proxy/token",
       headers: {
         "Content-Type": "application/json",
       },
-      body: {
-        tokenEndpoint: state.tokenEndpoint,
-        assertion: state.idJag,
-        clientId: state.clientId,
-        scope: state.scope,
-        resource: state.resourceUrl || state.serverUrl,
-      },
+      body: registrationId
+        ? {
+            registrationId,
+            assertion: state.idJag,
+            scope: state.scope,
+            resource: state.resourceUrl || state.serverUrl,
+          }
+        : {
+            tokenEndpoint: state.tokenEndpoint,
+            assertion: state.idJag,
+            clientId: state.clientId,
+            scope: state.scope,
+            resource: state.resourceUrl || state.serverUrl,
+          },
     };
 
     try {
@@ -1108,6 +1127,30 @@ export function createXAAStateMachine(
       default: {
         const exhaustive: never = step;
         throw new Error(`Unhandled XAA flow step: ${exhaustive}`);
+      }
+    }
+  };
+
+  // Drive the flow to completion: keep advancing until the state machine
+  // reaches `complete`, records an error, or stops making progress (safety
+  // valve — every successful advance changes `currentStep`).
+  machine.runAll = async () => {
+    const MAX_ADVANCES = XAA_RUN_ALL_MAX_ADVANCES;
+    for (let i = 0; i < MAX_ADVANCES; i += 1) {
+      const before = currentState();
+      if (before.currentStep === "complete" || before.error) {
+        return;
+      }
+
+      await machine.proceedToNextStep();
+
+      const after = currentState();
+      if (after.error || after.currentStep === "complete") {
+        return;
+      }
+      if (after.currentStep === before.currentStep) {
+        // No progress and no error — bail rather than loop forever.
+        return;
       }
     }
   };

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -136,7 +136,9 @@ export interface XAARequestExecutor {
 }
 
 export interface BaseXAAStateMachineConfig {
-  state: XAAFlowState;
+  /** Initial state. Optional — prefer `getState` so the machine never holds a
+   * stale snapshot read during render. */
+  state?: XAAFlowState;
   getState?: () => XAAFlowState;
   updateState: (updates: Partial<XAAFlowState>) => void;
   serverUrl: string;
@@ -149,12 +151,18 @@ export interface BaseXAAStateMachineConfig {
   clientId?: string;
   scope?: string;
   authzServerIssuer?: string;
+  /** Hosted registration-backed runs: sent to the token proxy instead of an
+   * inline client secret; the server resolves the stored secret and forces
+   * the outbound URL to the registration's stored token endpoint. */
+  registrationId?: string;
 }
 
 export interface XAAStateMachine {
   state: XAAFlowState;
   updateState: (updates: Partial<XAAFlowState>) => void;
   proceedToNextStep: () => Promise<void>;
+  /** Drive every remaining step until the flow completes or a step fails. */
+  runAll: () => Promise<void>;
   resetFlow: () => void;
 }
 

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -368,3 +368,173 @@ describe("hosted xaa outbound guards", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("registration-backed /proxy/token", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-reg-proxy-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  function buildApp(options: {
+    resolver?: (args: {
+      registrationId: string;
+      bearerToken: string;
+    }) => Promise<{
+      clientSecret: string;
+      tokenEndpoint: string | null;
+      targetClientId: string | null;
+      scopes: string[] | null;
+    }>;
+  }) {
+    const app = new Hono();
+    app.route(
+      "/api/web/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/web",
+        httpsOnlyProxy: false,
+        resolveRegistrationSecret: options.resolver,
+      }),
+    );
+    return app;
+  }
+
+  it("rejects registrationId on an instance without a secret resolver", async () => {
+    const app = buildApp({});
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        registrationId: "app_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { message?: string };
+    expect(body.message).toContain("not available");
+  });
+
+  it("requires a bearer token before resolving the secret", async () => {
+    const resolver = vi.fn();
+    const app = buildApp({ resolver });
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        registrationId: "app_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it("forces the stored token endpoint and strips client-supplied endpoint/headers/secret", async () => {
+    const resolver = vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      tokenEndpoint: "https://stored-as.example.com/oauth/token",
+      targetClientId: "stored-client-id",
+      scopes: null,
+    }));
+    const app = buildApp({ resolver });
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ access_token: "tok", token_type: "Bearer" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        registrationId: "app_1",
+        assertion: "aaa.bbb.ccc",
+        // A caller must not be able to redirect the stored secret or smuggle
+        // headers/credentials alongside it.
+        tokenEndpoint: "https://attacker.example.com/exfil",
+        headers: { "X-Evil": "1" },
+        clientSecret: "attacker-secret",
+        clientId: "attacker-client-id",
+        scope: "read:tools",
+        resource: "https://mcp.example.com",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolver).toHaveBeenCalledWith({
+      registrationId: "app_1",
+      bearerToken: "user-token",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(calledUrl).toBe("https://stored-as.example.com/oauth/token");
+
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers["X-Evil"]).toBeUndefined();
+
+    const form = new URLSearchParams(String(calledInit.body));
+    expect(form.get("client_secret")).toBe("stored-secret");
+    expect(form.get("client_id")).toBe("stored-client-id");
+    expect(form.get("assertion")).toBe("aaa.bbb.ccc");
+    expect(form.get("scope")).toBe("read:tools");
+  });
+
+  it("rejects a registration without a stored token endpoint", async () => {
+    const resolver = vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      tokenEndpoint: null,
+      targetClientId: null,
+      scopes: null,
+    }));
+    const app = buildApp({ resolver });
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        registrationId: "app_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { message?: string };
+    expect(body.message).toContain("no stored token endpoint");
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -26,6 +26,8 @@ import {
   buildDiscoveryCandidates,
   evaluateDiscovery,
 } from "../../services/xaa-discovery.js";
+import { WebRouteError } from "../web/errors.js";
+import type { XaaResourceAppSecretResult } from "../../utils/server-secrets.js";
 import { logger } from "../../utils/logger.js";
 
 const HEALTH_CHECK_TIMEOUT_MS = 10_000;
@@ -58,15 +60,22 @@ const healthCheckSchema = z.object({
   url: z.string().trim().min(1),
 });
 
-const proxyTokenSchema = z.object({
-  tokenEndpoint: z.string().trim().min(1),
-  assertion: z.string().trim().min(1),
-  clientId: z.string().trim().min(1).optional(),
-  clientSecret: z.string().trim().min(1).optional(),
-  scope: z.string().trim().min(1).optional(),
-  resource: z.string().trim().min(1).optional(),
-  headers: z.record(z.string(), z.string()).optional(),
-});
+const proxyTokenSchema = z
+  .object({
+    tokenEndpoint: z.string().trim().min(1).optional(),
+    assertion: z.string().trim().min(1),
+    clientId: z.string().trim().min(1).optional(),
+    clientSecret: z.string().trim().min(1).optional(),
+    scope: z.string().trim().min(1).optional(),
+    resource: z.string().trim().min(1).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    // Registration-backed runs: the server resolves the stored secret and
+    // forces the outbound URL to the registration's stored token endpoint.
+    registrationId: z.string().trim().min(1).optional(),
+  })
+  .refine((data) => data.registrationId || data.tokenEndpoint, {
+    message: "tokenEndpoint or registrationId is required",
+  });
 
 interface CreateXaaRouterOptions {
   issuerBasePath: "/api/mcp" | "/api/web";
@@ -77,6 +86,14 @@ interface CreateXaaRouterOptions {
   // spoofed into advertising https for a plain-http localhost run.
   trustForwardedHeaders?: boolean;
   protectedMiddlewares?: MiddlewareHandler[];
+  // Resolves a registered resource app's client secret + stored token
+  // endpoint server-side (hosted instance only). When absent — the
+  // unauthenticated local instance — registration-backed proxy requests are
+  // rejected.
+  resolveRegistrationSecret?: (args: {
+    registrationId: string;
+    bearerToken: string;
+  }) => Promise<XaaResourceAppSecretResult>;
 }
 
 type ParsedJwtPayload = {
@@ -302,20 +319,65 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     try {
       const body = await c.req.json();
       const parsed = parseRequest(proxyTokenSchema, body);
+
+      let url: string;
+      let clientId = parsed.clientId;
+      let clientSecret = parsed.clientSecret;
+      let extraHeaders = parsed.headers;
+
+      if (parsed.registrationId) {
+        if (!options.resolveRegistrationSecret) {
+          return toJsonError(
+            "Registration-backed runs are not available on this instance",
+            { status: 400, code: "VALIDATION_ERROR" },
+          );
+        }
+
+        const authHeader = c.req.header("authorization");
+        if (!authHeader?.startsWith("Bearer ")) {
+          return toJsonError("Missing or invalid bearer token", {
+            status: 401,
+            code: "UNAUTHORIZED",
+          });
+        }
+
+        const resolved = await options.resolveRegistrationSecret({
+          registrationId: parsed.registrationId,
+          bearerToken: authHeader.slice("Bearer ".length),
+        });
+
+        if (!resolved.tokenEndpoint) {
+          return toJsonError("The registration has no stored token endpoint", {
+            status: 400,
+            code: "VALIDATION_ERROR",
+          });
+        }
+
+        // The stored secret is only ever posted to the registration's stored
+        // token endpoint. Client-supplied tokenEndpoint/headers/clientSecret
+        // are discarded so a caller can't redirect the secret elsewhere.
+        url = resolved.tokenEndpoint;
+        clientId = resolved.targetClientId ?? parsed.clientId;
+        clientSecret = resolved.clientSecret;
+        extraHeaders = undefined;
+      } else {
+        url = parsed.tokenEndpoint as string;
+      }
+
       const result = await executeOAuthProxy({
-        url: parsed.tokenEndpoint,
+        url,
         method: "POST",
         body: {
           grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
           assertion: parsed.assertion,
-          ...(parsed.clientId ? { client_id: parsed.clientId } : {}),
-          ...(parsed.clientSecret ? { client_secret: parsed.clientSecret } : {}),
+          ...(clientId ? { client_id: clientId } : {}),
+          ...(clientSecret ? { client_secret: clientSecret } : {}),
           ...(parsed.scope ? { scope: parsed.scope } : {}),
           ...(parsed.resource ? { resource: parsed.resource } : {}),
         },
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
-          ...(parsed.headers || {}),
+          ...(extraHeaders || {}),
         },
         httpsOnly: options.httpsOnlyProxy,
       });
@@ -327,6 +389,13 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
           status: error.status,
           code:
             error.status === 400 ? "VALIDATION_ERROR" : "SERVER_UNREACHABLE",
+        });
+      }
+
+      if (error instanceof WebRouteError) {
+        return toJsonError(error.message, {
+          status: error.status,
+          code: error.code,
         });
       }
 

--- a/mcpjam-inspector/server/routes/web/xaa.ts
+++ b/mcpjam-inspector/server/routes/web/xaa.ts
@@ -1,5 +1,6 @@
 import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
 import { guestRateLimitMiddleware } from "../../middleware/guest-rate-limit.js";
+import { fetchXaaResourceAppSecret } from "../../utils/server-secrets.js";
 import { createXaaRouter } from "../mcp/xaa.js";
 
 const xaaWeb = createXaaRouter({
@@ -7,6 +8,7 @@ const xaaWeb = createXaaRouter({
   httpsOnlyProxy: true,
   trustForwardedHeaders: true,
   protectedMiddlewares: [bearerAuthMiddleware, guestRateLimitMiddleware],
+  resolveRegistrationSecret: (args) => fetchXaaResourceAppSecret(args),
 });
 
 export default xaaWeb;

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -159,3 +159,101 @@ export async function fetchRuntimeServerSecrets(args: {
     headers: parseRecord(body.headers),
   };
 }
+
+export interface XaaResourceAppSecretResult {
+  clientSecret: string;
+  /** The registration's stored token endpoint — the only URL the proxy may
+   * post the secret to. */
+  tokenEndpoint: string | null;
+  targetClientId: string | null;
+  scopes: string[] | null;
+}
+
+/**
+ * Resolve a registered XAA resource app's client secret (plus the stored
+ * token endpoint it must be posted to) server-side, mirroring
+ * fetchRuntimeServerSecrets: the caller's bearer is forwarded as-is, so the
+ * backend enforces that the caller is a member of the registration's org.
+ * The secret never reaches the browser.
+ */
+export async function fetchXaaResourceAppSecret(args: {
+  bearerToken: string;
+  registrationId: string;
+}): Promise<XaaResourceAppSecretResult> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_HTTP_URL configuration"
+    );
+  }
+  const REVEAL_TIMEOUT_MS = 10_000;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REVEAL_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`${convexUrl}/web/xaa/resource-app/reveal-secret`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${args.bearerToken}`,
+      },
+      body: JSON.stringify({ id: args.registrationId }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const isAbort =
+      error instanceof Error &&
+      (error.name === "AbortError" ||
+        (error as { code?: string }).code === "ABORT_ERR");
+    throw new WebRouteError(
+      isAbort ? 504 : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      isAbort
+        ? `Secret reveal service timed out after ${REVEAL_TIMEOUT_MS}ms`
+        : `Failed to reach secret reveal service: ${parseErrorMessage(error)}`
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch {
+    // ignored
+  }
+
+  if (!response.ok || !body?.success) {
+    const message =
+      typeof body?.error === "string"
+        ? body.error
+        : `Secret reveal failed (${response.status})`;
+    throw new WebRouteError(
+      response.ok ? 500 : response.status,
+      statusToErrorCode(response.ok ? 500 : response.status),
+      message
+    );
+  }
+
+  if (typeof body.clientSecret !== "string") {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Secret reveal response was invalid"
+    );
+  }
+
+  return {
+    clientSecret: body.clientSecret,
+    tokenEndpoint:
+      typeof body.tokenEndpoint === "string" ? body.tokenEndpoint : null,
+    targetClientId:
+      typeof body.targetClientId === "string" ? body.targetClientId : null,
+    scopes: Array.isArray(body.scopes)
+      ? body.scopes.filter((s: unknown): s is string => typeof s === "string")
+      : null,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the XAA flow runner: a **Run all** button that drives the full flow end to end with per-step pass/fail chips, registration-backed runs whose client secret is resolved server-side, and a `?resource=<id>` deep link.

## Changes

**Server**
- `/proxy/token` accepts a `registrationId`. The hosted router resolves the registration's stored client secret server-side (forwarding the caller's bearer), **forces the outbound URL to the registration's stored token endpoint**, and discards any client-supplied `tokenEndpoint`/`headers`/`clientSecret` — a caller can't redirect a stored secret to a server they control. The local (unauthenticated) router has no resolver and rejects `registrationId`.

**Client**
- State machine gains `runAll()` (advance until complete, error, or no-progress) and a `registrationId` mode: registration-backed runs send only the registration id to the token proxy; local-profile runs send the inline endpoint as today. One mode-resolved flow input feeds the same machine.
- Refactor: the machine no longer takes an eager state snapshot read during render — state is read lazily, and the flow-state ref updates synchronously so reset-then-run never sees a stale snapshot.
- XAA tab: **Run all** + per-step chips (partial runs render green/red/untouched), registration rows are click-to-select as the run target, and `?resource=<id>` is captured at startup and consumed once the list resolves.
- Telemetry: `xaa_flow_started` and terminal `xaa_flow_completed { success, error_category }` — `error_category` is the step the run stopped on (an enum, never a raw error string).

Stacked on #2571. Registration-backed runs resolve secrets through the backend's server-side reveal channel; they can be unit-tested with a stubbed resolver (done here) and need a deployed backend only for end-to-end QA.

## Verification

- 40 tests across 6 files: runner-mode state-machine tests (registration body shape, inline-profile body shape, stop-at-failing-step partial run), server secret-injection tests (forces stored endpoint, strips client-supplied endpoint/headers/secret, 401 without bearer, 400 without resolver/stored endpoint), chip partial-run rendering, Run-all telemetry, updated wizard/section suites.
- `npm run typecheck:client` passes; server production files clean under `tsc`.
- Manual end-to-end QA against a deployed backend tracked separately.
