### PR TITLE
PR-I8: XAA negative-test scorecard

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -67,6 +67,12 @@ vi.mock("../xaa/registration/XAAResourceAppsSection", () => ({
   XAAResourceAppsSection: () => <div data-testid="xaa-resource-apps-section" />,
 }));
 
+vi.mock("../xaa/NegativeTestScorecard", () => ({
+  NegativeTestScorecard: () => (
+    <div data-testid="xaa-negative-test-scorecard" />
+  ),
+}));
+
 vi.mock("../xaa/XAABootstrapDialog", () => ({
   XAABootstrapDialog: () => null,
 }));

--- a/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
@@ -1,0 +1,236 @@
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  HelpCircle,
+  Loader2,
+  Lock,
+  ShieldAlert,
+} from "lucide-react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { Card } from "@mcpjam/design-system/card";
+import { Input } from "@mcpjam/design-system/input";
+import {
+  runNegativeTests,
+  type NegativeTestCase,
+  type NegativeTestsInput,
+  type NegativeTestsResult,
+} from "@/lib/xaa/discovery-client";
+
+const OVERRIDE_PHRASE = "run anyway";
+
+interface NegativeTestScorecardProps {
+  /** The AS target to fire broken assertions at, or null when there is no
+   * external auth server to test (MCPJam-issuer-only, or the token endpoint
+   * isn't known yet). */
+  input: NegativeTestsInput | null;
+  /** A successful positive run has completed for this target this session. */
+  unlocked: boolean;
+  /** Why `input` is null — shown when the scorecard can't run at all. */
+  unavailableReason?: string;
+}
+
+type RunState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "done"; result: NegativeTestsResult }
+  | { status: "error"; message: string };
+
+function VerdictRow({ row }: { row: NegativeTestCase }) {
+  const tone =
+    row.verdict === "pass"
+      ? { Icon: CheckCircle2, className: "text-green-600 dark:text-green-400" }
+      : row.verdict === "fail"
+        ? { Icon: ShieldAlert, className: "text-red-500" }
+        : { Icon: HelpCircle, className: "text-muted-foreground" };
+
+  return (
+    <div
+      data-testid={`xaa-negtest-row-${row.mode}`}
+      data-verdict={row.verdict}
+      className="flex items-start gap-2 border-t border-border/60 px-1 py-1.5 text-xs first:border-t-0"
+    >
+      <tone.Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${tone.className}`} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{row.label}</span>
+          {row.verdict === "fail" && (
+            <Badge variant="destructive" className="text-[10px]">
+              security risk
+            </Badge>
+          )}
+          {row.verdict === "unknown" && (
+            <Badge variant="outline" className="text-[10px]">
+              {row.outcome === "timeout" ? "timed out" : "inconclusive"}
+            </Badge>
+          )}
+        </div>
+        <p className="text-muted-foreground">
+          {row.verdict === "fail"
+            ? row.detail
+            : row.verdict === "pass"
+              ? `Rejected${row.status ? ` (HTTP ${row.status})` : ""} — ${row.expectedFailure}`
+              : row.detail}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function NegativeTestScorecard({
+  input,
+  unlocked,
+  unavailableReason,
+}: NegativeTestScorecardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [run, setRun] = useState<RunState>({ status: "idle" });
+  const [overrideText, setOverrideText] = useState("");
+  const [overrideAccepted, setOverrideAccepted] = useState(false);
+
+  const canRun = input !== null && (unlocked || overrideAccepted);
+
+  const handleRun = async () => {
+    if (!input) return;
+    setRun({ status: "loading" });
+    try {
+      const result = await runNegativeTests(input);
+      setRun({ status: "done", result });
+    } catch (error) {
+      setRun({
+        status: "error",
+        message:
+          error instanceof Error ? error.message : "Negative tests failed",
+      });
+    }
+  };
+
+  return (
+    <Card className="mx-3 mt-1 mb-3 gap-0 p-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 px-4 py-3 text-left"
+      >
+        <ShieldAlert className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <span className="text-sm font-semibold">Negative-test scorecard</span>
+          <p className="truncate text-xs text-muted-foreground">
+            Fire deliberately-broken assertions and verify your auth server
+            rejects them.
+          </p>
+        </div>
+        {run.status === "done" && (
+          <Badge
+            variant={run.result.failures > 0 ? "destructive" : "secondary"}
+            className="shrink-0 text-[10px]"
+          >
+            {run.result.failures > 0
+              ? `${run.result.failures} failing`
+              : "all rejected"}
+          </Badge>
+        )}
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="space-y-3 px-4 pb-4">
+          {input === null ? (
+            <div className="flex items-start gap-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+              <Lock className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              {unavailableReason ??
+                "Negative tests need a resource with its own auth server."}
+            </div>
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={handleRun}
+                  disabled={!canRun || run.status === "loading"}
+                >
+                  {run.status === "loading" ? (
+                    <>
+                      <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                      Running
+                    </>
+                  ) : (
+                    "Run negative tests"
+                  )}
+                </Button>
+                {!unlocked && !overrideAccepted && (
+                  <span className="text-xs text-muted-foreground">
+                    Run a successful flow first to unlock.
+                  </span>
+                )}
+              </div>
+
+              {!unlocked && !overrideAccepted && (
+                <div className="space-y-1.5 rounded-md border border-dashed border-border px-3 py-2">
+                  <p className="text-xs text-muted-foreground">
+                    Building the auth server (TDD)? If you own this server, type{" "}
+                    <code className="font-mono">{OVERRIDE_PHRASE}</code> to run
+                    anyway.
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      aria-label="Override confirmation"
+                      value={overrideText}
+                      onChange={(event) => setOverrideText(event.target.value)}
+                      placeholder={OVERRIDE_PHRASE}
+                      className="h-8 text-xs"
+                    />
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={
+                        overrideText.trim().toLowerCase() !== OVERRIDE_PHRASE
+                      }
+                      onClick={() => setOverrideAccepted(true)}
+                    >
+                      Unlock
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {run.status === "error" && (
+                <div
+                  data-testid="xaa-negtest-error"
+                  className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/20 dark:text-red-300"
+                >
+                  {run.message}
+                </div>
+              )}
+
+              {run.status === "done" && (
+                <div className="rounded-md border border-border">
+                  {run.result.results.map((row) => (
+                    <VerdictRow key={row.mode} row={row} />
+                  ))}
+                </div>
+              )}
+
+              {run.status === "done" && run.result.failures > 0 && (
+                <div className="flex items-start gap-2 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/20 dark:text-red-300">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  Your auth server issued a token for at least one broken
+                  assertion. Each red row is a token it should have rejected.
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -17,6 +17,8 @@ import { XAABootstrapDialog } from "./XAABootstrapDialog";
 import { XAAIdpCard } from "./XAAIdpCard";
 import { XAAResourceAppsSection } from "./registration/XAAResourceAppsSection";
 import { XAARunChips } from "./XAARunChips";
+import { NegativeTestScorecard } from "./NegativeTestScorecard";
+import type { NegativeTestsInput } from "@/lib/xaa/discovery-client";
 import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
@@ -182,10 +184,20 @@ export function XAAFlowTab({
     [selectedRegistration, profile],
   );
 
+  // Target identity for the positive-run gate; "local-profile" is its own
+  // session-scoped key.
+  const targetKey = selectedRegistration?.id ?? "local-profile";
+
   // ── Telemetry (started / terminal completed, once per run) ─────────
   const completedFired = useRef(false);
   const authServerModeForTelemetry =
     selectedRegistration?.authServerMode ?? "own";
+
+  // In-memory: targets that have completed a successful flow this session.
+  // A page refresh clears it, re-locking the scorecard (§ negative-test gate).
+  const [positiveRunTargets, setPositiveRunTargets] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const fireFlowStarted = useCallback(() => {
     completedFired.current = false;
@@ -206,8 +218,77 @@ export function XAAFlowTab({
         platform: detectPlatform(),
         environment: detectEnvironment(),
       });
+      // A green run proves the user holds valid client credentials the AS
+      // issued — that authorizes broken-token testing against it.
+      setPositiveRunTargets((current) => {
+        if (current.has(targetKey)) return current;
+        const next = new Set(current);
+        next.add(targetKey);
+        return next;
+      });
     }
-  }, [flowState.currentStep, authServerModeForTelemetry]);
+  }, [flowState.currentStep, authServerModeForTelemetry, targetKey]);
+
+  // ── Negative-test scorecard input ───────────────────────────────────
+  const scorecard = useMemo((): {
+    input: NegativeTestsInput | null;
+    unavailableReason?: string;
+  } => {
+    const audience =
+      flowState.authzMetadata?.issuer ||
+      flowInput.authzServerIssuer ||
+      selectedRegistration?.issuer ||
+      "";
+    const resource =
+      flowState.resourceMetadata?.resource || flowInput.serverUrl || "";
+
+    if (selectedRegistration) {
+      if (selectedRegistration.authServerMode === "mcpjam") {
+        return {
+          input: null,
+          unavailableReason:
+            "The MCPJam test auth server validates its own assertions — there's nothing to fire broken tokens at.",
+        };
+      }
+      if (!audience || !resource) {
+        return {
+          input: null,
+          unavailableReason:
+            "Run the flow once so the auth server issuer is known.",
+        };
+      }
+      return {
+        input: {
+          registrationId: selectedRegistration.id,
+          audience,
+          resource,
+          clientId: flowInput.clientId || undefined,
+          scope: flowInput.scope || undefined,
+        },
+      };
+    }
+
+    // Local profile: the token endpoint comes from discovery during a run.
+    if (!flowState.tokenEndpoint) {
+      return {
+        input: null,
+        unavailableReason:
+          "Run the flow first so the token endpoint is discovered.",
+      };
+    }
+    if (!audience || !resource) {
+      return { input: null };
+    }
+    return {
+      input: {
+        tokenEndpoint: flowState.tokenEndpoint,
+        audience,
+        resource,
+        clientId: flowInput.clientId || undefined,
+        scope: flowInput.scope || undefined,
+      },
+    };
+  }, [flowState, flowInput, selectedRegistration]);
 
   // ── Flow-state lifecycle ────────────────────────────────────────────
   useEffect(() => {
@@ -447,6 +528,12 @@ export function XAAFlowTab({
           </ResizablePanel>
         </ResizablePanelGroup>
       </div>
+
+      <NegativeTestScorecard
+        input={scorecard.input}
+        unlocked={positiveRunTargets.has(targetKey)}
+        unavailableReason={scorecard.unavailableReason}
+      />
 
       <XAAConfigModal
         open={isConfigModalOpen}

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/NegativeTestScorecard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/NegativeTestScorecard.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NegativeTestScorecard } from "../NegativeTestScorecard";
+import type { NegativeTestsInput } from "@/lib/xaa/discovery-client";
+
+const runMock = vi.fn();
+vi.mock("@/lib/xaa/discovery-client", () => ({
+  runNegativeTests: (input: unknown) => runMock(input),
+}));
+
+const INPUT: NegativeTestsInput = {
+  audience: "https://auth.example.com",
+  resource: "https://mcp.example.com",
+  registrationId: "app_1",
+};
+
+async function expand(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    screen.getByRole("button", { name: /negative-test scorecard/i }),
+  );
+}
+
+describe("NegativeTestScorecard", () => {
+  beforeEach(() => {
+    runMock.mockReset();
+  });
+
+  it("shows the unavailable reason when there is no auth-server target", async () => {
+    const user = userEvent.setup();
+    render(
+      <NegativeTestScorecard
+        input={null}
+        unlocked={false}
+        unavailableReason="MCPJam test auth server has nothing to test."
+      />,
+    );
+    await expand(user);
+
+    expect(
+      screen.getByText("MCPJam test auth server has nothing to test."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /run negative tests/i }),
+    ).toBeNull();
+  });
+
+  it("locks the run button until a positive run unlocks it", async () => {
+    const user = userEvent.setup();
+    render(<NegativeTestScorecard input={INPUT} unlocked={false} />);
+    await expand(user);
+
+    expect(
+      screen.getByRole("button", { name: /run negative tests/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/run a successful flow first/i),
+    ).toBeInTheDocument();
+  });
+
+  it("runs immediately when unlocked and renders per-case verdicts", async () => {
+    runMock.mockResolvedValue({
+      failures: 1,
+      results: [
+        {
+          mode: "expired",
+          label: "Expired",
+          expectedFailure: "AS should reject expired",
+          outcome: "accepted",
+          verdict: "fail",
+          status: 200,
+          detail: "Issued a token for an expired assertion.",
+        },
+        {
+          mode: "wrong_audience",
+          label: "Wrong Audience",
+          expectedFailure: "AS should reject the audience",
+          outcome: "rejected",
+          verdict: "pass",
+          status: 400,
+        },
+      ],
+    });
+
+    const user = userEvent.setup();
+    render(<NegativeTestScorecard input={INPUT} unlocked />);
+    await expand(user);
+
+    await user.click(
+      screen.getByRole("button", { name: /run negative tests/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("xaa-negtest-row-expired")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("xaa-negtest-row-expired")).toHaveAttribute(
+      "data-verdict",
+      "fail",
+    );
+    expect(
+      screen.getByTestId("xaa-negtest-row-wrong_audience"),
+    ).toHaveAttribute("data-verdict", "pass");
+    expect(runMock).toHaveBeenCalledWith(INPUT);
+  });
+
+  it("unlocks via the typed override for the half-built-AS case", async () => {
+    runMock.mockResolvedValue({ failures: 0, results: [] });
+
+    const user = userEvent.setup();
+    render(<NegativeTestScorecard input={INPUT} unlocked={false} />);
+    await expand(user);
+
+    // The run button stays disabled until the exact phrase is typed.
+    expect(screen.getByRole("button", { name: /^unlock$/i })).toBeDisabled();
+
+    await user.type(
+      screen.getByLabelText("Override confirmation"),
+      "run anyway",
+    );
+    await user.click(screen.getByRole("button", { name: /^unlock$/i }));
+
+    const runButton = screen.getByRole("button", {
+      name: /run negative tests/i,
+    });
+    expect(runButton).toBeEnabled();
+    await user.click(runButton);
+    await waitFor(() => expect(runMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("surfaces a run error", async () => {
+    runMock.mockRejectedValue(new Error("URL not allowed"));
+
+    const user = userEvent.setup();
+    render(<NegativeTestScorecard input={INPUT} unlocked />);
+    await expand(user);
+    await user.click(
+      screen.getByRole("button", { name: /run negative tests/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("xaa-negtest-error")).toHaveTextContent(
+        "URL not allowed",
+      ),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
@@ -79,3 +79,57 @@ export async function checkResourceHealth(
 
   return body;
 }
+
+export interface NegativeTestCase {
+  mode: string;
+  label: string;
+  expectedFailure: string;
+  outcome: "rejected" | "accepted" | "timeout" | "error";
+  verdict: "pass" | "fail" | "unknown";
+  status?: number;
+  detail?: string;
+}
+
+export interface NegativeTestsResult {
+  results: NegativeTestCase[];
+  failures: number;
+}
+
+export interface NegativeTestsInput {
+  audience: string;
+  resource: string;
+  subject?: string;
+  clientId?: string;
+  scope?: string;
+  tokenEndpoint?: string;
+  clientSecret?: string;
+  registrationId?: string;
+}
+
+/**
+ * Fire every deliberately-broken ID-JAG mode at the configured authorization
+ * server and report, per case, whether it correctly rejected the assertion.
+ * Registration-backed runs send only the registration id; the server resolves
+ * the stored secret and endpoint.
+ */
+export async function runNegativeTests(
+  input: NegativeTestsInput,
+): Promise<NegativeTestsResult> {
+  const response = await authFetch(`${XAA_API_BASE}/negative-tests`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+
+  const body = (await response.json().catch(() => null)) as
+    | (NegativeTestsResult & { message?: string })
+    | null;
+
+  if (!response.ok || !body) {
+    throw new Error(
+      body?.message || `Negative tests failed (${response.status})`,
+    );
+  }
+
+  return body;
+}

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -538,3 +538,171 @@ describe("registration-backed /proxy/token", () => {
     expect(body.message).toContain("no stored token endpoint");
   });
 });
+
+describe("POST /negative-tests", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-negtest-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  function buildApp(
+    resolver?: (args: {
+      registrationId: string;
+      bearerToken: string;
+    }) => Promise<{
+      clientSecret: string;
+      tokenEndpoint: string | null;
+      targetClientId: string | null;
+      scopes: string[] | null;
+    }>,
+  ) {
+    const app = new Hono();
+    app.route(
+      "/api/web/xaa",
+      createXaaRouter({
+        issuerBasePath: "/api/web",
+        httpsOnlyProxy: false,
+        resolveRegistrationSecret: resolver,
+      }),
+    );
+    return app;
+  }
+
+  const INLINE_BODY = {
+    audience: "https://auth.example.com",
+    resource: "https://mcp.example.com",
+    clientId: "mcpjam-debugger",
+    tokenEndpoint: "https://auth.example.com/oauth/token",
+  };
+
+  it("marks a case red when the auth server wrongly issues a token for a broken assertion", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ access_token: "tok", token_type: "Bearer" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = buildApp();
+    const response = await app.request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(INLINE_BODY),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      results: Array<{ mode: string; verdict: string }>;
+      failures: number;
+    };
+    expect(body.results).toHaveLength(11);
+    expect(body.failures).toBe(11);
+    const expired = body.results.find((r) => r.mode === "expired");
+    expect(expired?.verdict).toBe("fail");
+  });
+
+  it("marks cases green when the auth server rejects broken assertions", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = buildApp();
+    const response = await app.request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(INLINE_BODY),
+    });
+
+    const body = (await response.json()) as {
+      results: Array<{ verdict: string }>;
+      failures: number;
+    };
+    expect(body.failures).toBe(0);
+    expect(body.results.every((r) => r.verdict === "pass")).toBe(true);
+  });
+
+  it("yields partial results when a case times out (one slow case doesn't sink the run)", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return await new Promise<Response>((_resolve, reject) => {
+          setTimeout(() => {
+            const err = new Error("aborted");
+            err.name = "TimeoutError";
+            reject(err);
+          }, 5);
+        });
+      }
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = buildApp();
+    const response = await app.request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(INLINE_BODY),
+    });
+
+    const body = (await response.json()) as {
+      results: Array<{ outcome: string; verdict: string }>;
+    };
+    expect(body.results).toHaveLength(11);
+    expect(body.results.some((r) => r.outcome === "timeout")).toBe(true);
+    expect(body.results.some((r) => r.verdict === "pass")).toBe(true);
+  });
+
+  it("rejects an mcpjam-issuer-only registration (no own auth server)", async () => {
+    const resolver = vi.fn(async () => ({
+      clientSecret: "x",
+      tokenEndpoint: null,
+      targetClientId: null,
+      scopes: null,
+    }));
+    const app = buildApp(resolver);
+
+    const response = await app.request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        registrationId: "app_1",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { message?: string };
+    expect(body.message).toContain("its own auth server");
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 import {
   DEFAULT_NEGATIVE_TEST_MODE,
   isNegativeTestMode,
+  NEGATIVE_TEST_MODES,
+  NEGATIVE_TEST_MODE_DETAILS,
   type NegativeTestMode,
 } from "../../../shared/xaa.js";
 import {
@@ -31,6 +33,31 @@ import type { XaaResourceAppSecretResult } from "../../utils/server-secrets.js";
 import { logger } from "../../utils/logger.js";
 
 const HEALTH_CHECK_TIMEOUT_MS = 10_000;
+const NEGATIVE_TEST_CASE_TIMEOUT_MS = 8_000;
+
+// Hard per-host daily cap on negative-test runs. This is a server-side
+// backstop independent of the client-side "passed a positive run" gate: even
+// with the override, a single authorization-server host can't be hammered.
+const NEGATIVE_TEST_DAILY_CAP = 50;
+const NEGATIVE_TEST_DAY_MS = 24 * 60 * 60 * 1000;
+const negativeTestHostCounters = new Map<
+  string,
+  { count: number; windowStart: number }
+>();
+
+function checkNegativeTestHostCap(host: string): boolean {
+  const now = Date.now();
+  const existing = negativeTestHostCounters.get(host);
+  if (!existing || now - existing.windowStart >= NEGATIVE_TEST_DAY_MS) {
+    negativeTestHostCounters.set(host, { count: 1, windowStart: now });
+    return true;
+  }
+  if (existing.count >= NEGATIVE_TEST_DAILY_CAP) {
+    return false;
+  }
+  existing.count += 1;
+  return true;
+}
 
 const authenticateSchema = z.object({
   userId: z.string().trim().min(1).optional(),
@@ -59,6 +86,40 @@ const discoverAsSchema = z
 const healthCheckSchema = z.object({
   url: z.string().trim().min(1),
 });
+
+const negativeTestsSchema = z
+  .object({
+    audience: z.string().trim().min(1),
+    resource: z.string().trim().min(1),
+    subject: z.string().trim().min(1).optional(),
+    clientId: z.string().trim().min(1).optional(),
+    scope: z.string().trim().min(1).optional(),
+    tokenEndpoint: z.string().trim().min(1).optional(),
+    clientSecret: z.string().trim().min(1).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    registrationId: z.string().trim().min(1).optional(),
+  })
+  .refine((data) => data.registrationId || data.tokenEndpoint, {
+    message: "tokenEndpoint or registrationId is required",
+  });
+
+type NegativeCaseOutcome = {
+  mode: NegativeTestMode;
+  label: string;
+  expectedFailure: string;
+  // What the authorization server did with the deliberately-broken assertion.
+  outcome: "rejected" | "accepted" | "timeout" | "error";
+  // pass = the AS correctly rejected the broken assertion; fail = the AS
+  // issued a token for it (a real security finding); unknown = couldn't tell.
+  verdict: "pass" | "fail" | "unknown";
+  status?: number;
+  detail?: string;
+};
+
+// The 11 deliberately-broken modes (everything except the happy-path "valid").
+const NEGATIVE_CASE_MODES: NegativeTestMode[] = NEGATIVE_TEST_MODES.filter(
+  (mode): mode is NegativeTestMode => mode !== "valid",
+);
 
 const proxyTokenSchema = z
   .object({
@@ -195,6 +256,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     router.use("/proxy/token", ...protectedMiddlewares);
     router.use("/discover-as", ...protectedMiddlewares);
     router.use("/health-check", ...protectedMiddlewares);
+    router.use("/negative-tests", ...protectedMiddlewares);
   }
 
   router.get("/.well-known/jwks.json", (c) => {
@@ -537,6 +599,212 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         durationMs: Date.now() - startedAt,
       });
     }
+  });
+
+  // Negative-test scorecard: fire each deliberately-broken ID-JAG mode at the
+  // user's authorization server and report whether the server correctly
+  // rejected it (pass) or wrongly issued a token (fail — a real finding).
+  router.post("/negative-tests", async (c) => {
+    let parsed;
+    try {
+      parsed = parseRequest(negativeTestsSchema, await c.req.json());
+    } catch (error) {
+      return toJsonError(
+        error instanceof Error
+          ? error.message
+          : "Invalid negative-tests request",
+        { status: 400, code: "VALIDATION_ERROR" },
+      );
+    }
+
+    // Resolve the authorization-server target. Registration-backed runs
+    // resolve the stored secret + endpoint server-side (same hardening as
+    // /proxy/token); the client-supplied endpoint/headers/secret are ignored.
+    let tokenEndpoint: string;
+    let clientId = parsed.clientId;
+    let clientSecret = parsed.clientSecret;
+    let extraHeaders = parsed.headers;
+
+    try {
+      if (parsed.registrationId) {
+        if (!options.resolveRegistrationSecret) {
+          return toJsonError(
+            "Registration-backed runs are not available on this instance",
+            { status: 400, code: "VALIDATION_ERROR" },
+          );
+        }
+        const authHeader = c.req.header("authorization");
+        if (!authHeader?.startsWith("Bearer ")) {
+          return toJsonError("Missing or invalid bearer token", {
+            status: 401,
+            code: "UNAUTHORIZED",
+          });
+        }
+        const resolved = await options.resolveRegistrationSecret({
+          registrationId: parsed.registrationId,
+          bearerToken: authHeader.slice("Bearer ".length),
+        });
+        if (!resolved.tokenEndpoint) {
+          // mcpjam-issuer-only registration: there is no external auth server
+          // to fire broken assertions at.
+          return toJsonError(
+            "Negative tests require a registration with its own auth server",
+            { status: 400, code: "VALIDATION_ERROR" },
+          );
+        }
+        tokenEndpoint = resolved.tokenEndpoint;
+        clientId = resolved.targetClientId ?? parsed.clientId;
+        clientSecret = resolved.clientSecret;
+        extraHeaders = undefined;
+      } else {
+        tokenEndpoint = parsed.tokenEndpoint as string;
+      }
+    } catch (error) {
+      if (error instanceof WebRouteError) {
+        return toJsonError(error.message, {
+          status: error.status,
+          code: error.code,
+        });
+      }
+      throw error;
+    }
+
+    // Validate the outbound URL once (every case hits the same endpoint) and
+    // enforce the per-host daily cap.
+    let validated: URL;
+    try {
+      ({ url: validated } = await validateUrl(
+        tokenEndpoint,
+        options.httpsOnlyProxy,
+      ));
+    } catch (error) {
+      if (error instanceof OAuthProxyError) {
+        return toJsonError("URL not allowed", {
+          status: error.status,
+          code: "VALIDATION_ERROR",
+        });
+      }
+      return toJsonError("URL not allowed", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    if (!checkNegativeTestHostCap(validated.host)) {
+      return toJsonError(
+        "Daily negative-test limit reached for this authorization server",
+        { status: 429, code: "RATE_LIMITED" },
+      );
+    }
+
+    const issuer = getIssuerForRequest(
+      c,
+      options.issuerBasePath,
+      trustForwardedHeaders,
+    );
+    const subject = parsed.subject || "user-12345";
+
+    const runCase = async (
+      mode: NegativeTestMode,
+    ): Promise<NegativeCaseOutcome> => {
+      const details = NEGATIVE_TEST_MODE_DETAILS[mode];
+      let token: string;
+      try {
+        token = issueNegativeIdJag(
+          {
+            issuer,
+            subject,
+            audience: parsed.audience,
+            resource: parsed.resource,
+            clientId: clientId || "mcpjam-debugger",
+            scope: parsed.scope,
+          },
+          mode,
+        ).token;
+      } catch (error) {
+        return {
+          mode,
+          label: details.label,
+          expectedFailure: details.expectedFailure,
+          outcome: "error",
+          verdict: "unknown",
+          detail:
+            error instanceof Error ? error.message : "Failed to mint ID-JAG",
+        };
+      }
+
+      const form = new URLSearchParams();
+      form.set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer");
+      form.set("assertion", token);
+      if (clientId) form.set("client_id", clientId);
+      if (clientSecret) form.set("client_secret", clientSecret);
+      if (parsed.scope) form.set("scope", parsed.scope);
+      form.set("resource", parsed.resource);
+
+      try {
+        const response = await fetch(validated.toString(), {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "MCP-Inspector/1.0",
+            ...(extraHeaders || {}),
+          },
+          body: form.toString(),
+          redirect: options.httpsOnlyProxy ? "manual" : "follow",
+          signal: AbortSignal.timeout(NEGATIVE_TEST_CASE_TIMEOUT_MS),
+        });
+
+        let body: any = null;
+        try {
+          body = await response.json();
+        } catch {
+          // non-JSON response; body stays null
+        }
+
+        const accepted =
+          response.status >= 200 &&
+          response.status < 300 &&
+          typeof body?.access_token === "string";
+
+        return {
+          mode,
+          label: details.label,
+          expectedFailure: details.expectedFailure,
+          outcome: accepted ? "accepted" : "rejected",
+          verdict: accepted ? "fail" : "pass",
+          status: response.status,
+          detail: accepted
+            ? "Authorization server issued an access token for a broken assertion."
+            : undefined,
+        };
+      } catch (error) {
+        const isTimeout =
+          error instanceof Error &&
+          (error.name === "TimeoutError" || error.name === "AbortError");
+        return {
+          mode,
+          label: details.label,
+          expectedFailure: details.expectedFailure,
+          outcome: isTimeout ? "timeout" : "error",
+          // Couldn't reach a verdict — surfaced separately from a real finding.
+          verdict: "unknown",
+          detail: isTimeout
+            ? `No response within ${NEGATIVE_TEST_CASE_TIMEOUT_MS}ms`
+            : error instanceof Error
+              ? error.message
+              : "Request failed",
+        };
+      }
+    };
+
+    // Each case has its own timeout and resolves independently, so one slow
+    // or hanging authorization server can't sink the whole scorecard.
+    const results = await Promise.all(NEGATIVE_CASE_MODES.map(runCase));
+
+    return c.json({
+      results,
+      failures: results.filter((r) => r.verdict === "fail").length,
+    });
   });
 
   return router;


### PR DESCRIPTION
Fires every deliberately-broken ID-JAG mode at the user's authorization
server and reports, per case, whether it correctly rejected the
assertion (pass) or wrongly issued a token for it (fail — a real
finding).

Server:
- POST /negative-tests orchestrates the 11 broken modes (named
  /negative-tests, not /conformance — avoids the MCP-spec conformance
  route collision). Each case has its own timeout and resolves
  independently (Promise.all over per-case fetches), so one slow/hanging
  auth server can't sink the scorecard. Registration-backed runs resolve
  the stored secret + endpoint server-side (same hardening as
  /proxy/token) and an mcpjam-issuer-only registration is rejected (no
  external server to test). Always-on backstops regardless of the client
  gate: outbound-URL validation and a hard per-host/day cap.

Client:
- NegativeTestScorecard: collapsible card with a per-case results table
  (mode, expected rejection, verdict). Locked until a successful
  positive run completes for the selected target (proves the user holds
  valid client credentials the AS issued), tracked as in-memory session
  state in XAAFlowTab keyed by target id — a refresh re-locks. A typed
  "run anyway" override covers the half-built-AS / TDD case. Disabled
  with an explanation when there's no own auth server.
- runNegativeTests client helper.

Tests (29): server — buggy AS that accepts a broken assertion -> red
verdict, conforming AS -> all green, per-case timeout yields partial
results, mcpjam-only rejection; component — unavailable state, locked
state, unlocked auto-run with per-case verdicts, typed override unlock,
run error.
