### PR TITLE
fix(xaa): make resource/AS discovery a fallback, not a mandatory first step

### DIFF
--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -463,4 +463,231 @@ describe("createXAAStateMachine", () => {
       ).toBe(true);
     });
   });
+
+  describe("discovery is a fallback, not a mandatory step", () => {
+    const idToken = makeJwt(
+      { iss: "https://issuer.example/api/web/xaa", sub: "user-12345" },
+      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" },
+    );
+    const idJag = makeJwt({
+      iss: "https://issuer.example/api/web/xaa",
+      sub: "user-12345",
+      aud: "https://auth.example.com",
+      resource: "https://mcp.example.com/mcp",
+      client_id: "mcpjam-debugger",
+      exp: Math.floor(Date.now() / 1000) + 300,
+    });
+
+    function tokenAndMcpExecutor() {
+      const externalUrls: string[] = [];
+      const executor = {
+        externalRequest: vi.fn(async (url: string) => {
+          externalUrls.push(url);
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { result: { serverInfo: { name: "demo" } } },
+            ok: true,
+          };
+        }),
+        internalRequest: vi.fn(async (path: string) => {
+          if (path === "/authenticate") {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: { id_token: idToken },
+              ok: true,
+            };
+          }
+          if (path === "/token-exchange") {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: { id_jag: idJag },
+              ok: true,
+            };
+          }
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: {
+                access_token: "access-token",
+                token_type: "Bearer",
+                expires_in: 300,
+              },
+            },
+            ok: true,
+          };
+        }),
+      };
+      return { executor, externalUrls };
+    }
+
+    it("skips resource AND AS discovery for a registration-backed run", async () => {
+      let state: XAAFlowState = createInitialXAAFlowState({
+        serverUrl: "https://mcp.example.com/mcp",
+        authzServerIssuer: "https://auth.example.com",
+        clientId: "mcpjam-debugger",
+      });
+      const { executor, externalUrls } = tokenAndMcpExecutor();
+      const machine = createXAAStateMachine({
+        getState: () => state,
+        updateState: (u) => {
+          state = { ...state, ...u };
+        },
+        serverUrl: "https://mcp.example.com/mcp",
+        issuerBaseUrl: "https://issuer.example/api/web/xaa",
+        requestExecutor: executor,
+        clientId: "mcpjam-debugger",
+        authzServerIssuer: "https://auth.example.com",
+        registrationId: "app_1",
+      });
+
+      await machine.runAll();
+
+      expect(state.currentStep).toBe("complete");
+      // No protected-resource or auth-server metadata probe was ever fired.
+      expect(
+        externalUrls.some((u) => u.includes("oauth-protected-resource")),
+      ).toBe(false);
+      expect(
+        externalUrls.some((u) => u.includes("oauth-authorization-server")),
+      ).toBe(false);
+    });
+
+    it("skips resource discovery when the issuer is configured but still discovers the token endpoint", async () => {
+      let state: XAAFlowState = createInitialXAAFlowState({
+        serverUrl: "https://mcp.example.com/mcp",
+        authzServerIssuer: "https://auth.example.com",
+        clientId: "mcpjam-debugger",
+      });
+      const externalUrls: string[] = [];
+      const executor = {
+        externalRequest: vi.fn(async (url: string) => {
+          externalUrls.push(url);
+          if (url.includes("oauth-authorization-server")) {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: {
+                issuer: "https://auth.example.com",
+                token_endpoint: "https://auth.example.com/oauth/token",
+              },
+              ok: true,
+            };
+          }
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: {},
+            ok: true,
+          };
+        }),
+        internalRequest: vi.fn(async () => ({
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: { id_token: idToken },
+          ok: true,
+        })),
+      };
+      const machine = createXAAStateMachine({
+        getState: () => state,
+        updateState: (u) => {
+          state = { ...state, ...u };
+        },
+        serverUrl: "https://mcp.example.com/mcp",
+        issuerBaseUrl: "https://issuer.example/api/web/xaa",
+        requestExecutor: executor,
+        clientId: "mcpjam-debugger",
+        authzServerIssuer: "https://auth.example.com",
+      });
+
+      // idle -> (skip resource) -> received_resource_metadata
+      await machine.proceedToNextStep();
+      expect(state.currentStep).toBe("received_resource_metadata");
+      expect(
+        externalUrls.some((u) => u.includes("oauth-protected-resource")),
+      ).toBe(false);
+
+      // received_resource_metadata -> AS discovery (RFC 8414) actually runs
+      await machine.proceedToNextStep();
+      expect(state.currentStep).toBe("received_authz_metadata");
+      expect(state.tokenEndpoint).toBe("https://auth.example.com/oauth/token");
+      expect(
+        externalUrls.some((u) => u.includes("oauth-authorization-server")),
+      ).toBe(true);
+    });
+
+    it("falls back to the root protected-resource form when path-insertion 404s", async () => {
+      let state: XAAFlowState = createInitialXAAFlowState({
+        serverUrl: "https://mcp.example.com/mcp",
+      });
+      const externalUrls: string[] = [];
+      const executor = {
+        externalRequest: vi.fn(async (url: string) => {
+          externalUrls.push(url);
+          // Path-insertion form 404s; only the root form is served.
+          if (url.endsWith("/.well-known/oauth-protected-resource/mcp")) {
+            return {
+              status: 404,
+              statusText: "Not Found",
+              headers: {},
+              body: {},
+              ok: false,
+            };
+          }
+          if (url.endsWith("/.well-known/oauth-protected-resource")) {
+            return {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body: {
+                resource: "https://mcp.example.com/mcp",
+                authorization_servers: ["https://auth.example.com"],
+              },
+              ok: true,
+            };
+          }
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: {},
+            ok: true,
+          };
+        }),
+        internalRequest: vi.fn(),
+      };
+      const machine = createXAAStateMachine({
+        getState: () => state,
+        updateState: (u) => {
+          state = { ...state, ...u };
+        },
+        serverUrl: "https://mcp.example.com/mcp",
+        issuerBaseUrl: "https://issuer.example/api/web/xaa",
+        requestExecutor: executor,
+      });
+
+      await machine.proceedToNextStep();
+
+      expect(state.currentStep).toBe("received_resource_metadata");
+      expect(state.authzServerIssuer).toBe("https://auth.example.com");
+      // Both forms were attempted, path-insertion first.
+      expect(externalUrls).toEqual([
+        "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+        "https://mcp.example.com/.well-known/oauth-protected-resource",
+      ]);
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -103,23 +103,30 @@ function mergeHeadersForAuthServer(
   return merged;
 }
 
-function buildResourceMetadataUrl(serverUrl: string): string {
+// RFC 9728 protected-resource metadata locations to probe, in order. The
+// path-insertion form (well-known segment between host and resource path) is
+// the RFC 9728 §3.1 form; the path-less root is the fallback some servers
+// (incl. MCP servers that serve PRM at the origin) use. Deduped so a
+// path-less resource yields a single URL.
+function buildResourceMetadataUrls(serverUrl: string): string[] {
   const url = new URL(serverUrl);
+  const root = new URL(
+    "/.well-known/oauth-protected-resource",
+    url.origin,
+  ).toString();
 
   if (url.pathname !== "/" && url.pathname !== "") {
     const pathname = url.pathname.endsWith("/")
       ? url.pathname.slice(0, -1)
       : url.pathname;
-    return new URL(
+    const pathInserted = new URL(
       `/.well-known/oauth-protected-resource${pathname}`,
       url.origin,
     ).toString();
+    return [pathInserted, root];
   }
 
-  return new URL(
-    "/.well-known/oauth-protected-resource",
-    url.origin,
-  ).toString();
+  return [root];
 }
 
 function canonicalizeResourceUrl(url: string): string {
@@ -500,104 +507,138 @@ export function createXAAStateMachine(
   const discoverResourceMetadata = async () => {
     const state = currentState();
     const activeServerUrl = state.serverUrl || serverUrl;
-    const resourceMetadataUrl = buildResourceMetadataUrl(activeServerUrl);
 
-    const request = {
-      method: "GET",
-      url: resourceMetadataUrl,
-      headers: {
-        Accept: "application/json",
-      },
-    };
-
-    try {
-      const result = await runRequest(
-        "discover_resource_metadata",
-        request,
-        () => requestExecutor.externalRequest(resourceMetadataUrl, request),
-      );
-
-      if (!result.ok) {
-        throw new Error(
-          extractErrorMessage(
-            result.body,
-            `Resource metadata request failed with ${result.status}`,
-          ),
-        );
-      }
-
-      const resourceMetadata = asRecord(result.body, "Resource metadata");
-      const resolvedAuthzIssuer =
-        state.authzServerIssuer ||
-        (Array.isArray(resourceMetadata.authorization_servers)
-          ? resourceMetadata.authorization_servers[0]
-          : undefined);
-      const resolvedResource =
-        typeof resourceMetadata.resource === "string"
-          ? resourceMetadata.resource
-          : canonicalizeResourceUrl(activeServerUrl);
-
-      if (!resolvedAuthzIssuer) {
-        throw new Error(
-          "Resource metadata did not include `authorization_servers`, and no Authorization Server issuer was configured manually.",
-        );
-      }
-
+    // RFC 9728 protected-resource metadata discovery only exists to learn
+    // which authorization server protects the resource. In XAA the requesting
+    // app already knows its target AS — so when the issuer is configured (a
+    // registration, or entered manually) there is nothing to discover. Skip
+    // the request entirely rather than firing a spurious (often 404ing) probe.
+    if (state.authzServerIssuer) {
       machine.updateState({
         currentStep: "received_resource_metadata",
-        resourceMetadataUrl,
-        resourceMetadata: resourceMetadata as XAAFlowState["resourceMetadata"],
-        resourceUrl: resolvedResource,
-        authzServerIssuer: resolvedAuthzIssuer,
-      });
-
-      pushInfo(
-        "received_resource_metadata",
-        "xaa-resource-metadata",
-        "Resource metadata",
-        {
-          resource: resolvedResource,
-          authorization_servers: resourceMetadata.authorization_servers,
-        },
-      );
-    } catch (error) {
-      if (!state.authzServerIssuer) {
-        machine.updateState({
-          currentStep: "discover_resource_metadata",
-          error:
-            error instanceof Error
-              ? error.message
-              : "Failed to discover resource metadata",
-        });
-        return;
-      }
-
-      machine.updateState({
-        currentStep: "received_resource_metadata",
-        resourceMetadataUrl,
-        resourceUrl: canonicalizeResourceUrl(activeServerUrl),
+        resourceUrl:
+          state.resourceUrl || canonicalizeResourceUrl(activeServerUrl),
         error: undefined,
       });
-
       pushInfo(
         "received_resource_metadata",
-        "xaa-resource-fallback",
-        "Resource metadata fallback",
+        "xaa-resource-metadata-skipped",
+        "Resource metadata discovery skipped",
         {
-          message:
-            error instanceof Error ? error.message : "Resource metadata lookup failed",
-          using_authz_server_issuer: state.authzServerIssuer,
-        },
-        {
-          level: "warning",
+          reason:
+            "Authorization server issuer is already configured; RFC 9728 discovery is not part of the XAA grant and isn't needed.",
+          authz_server_issuer: state.authzServerIssuer,
         },
       );
+      return;
     }
+
+    const candidateUrls = buildResourceMetadataUrls(activeServerUrl);
+    let lastError = "Failed to discover resource metadata";
+
+    for (const resourceMetadataUrl of candidateUrls) {
+      const request = {
+        method: "GET",
+        url: resourceMetadataUrl,
+        headers: {
+          Accept: "application/json",
+        },
+      };
+
+      try {
+        const result = await runRequest(
+          "discover_resource_metadata",
+          request,
+          () => requestExecutor.externalRequest(resourceMetadataUrl, request),
+        );
+
+        if (!result.ok) {
+          lastError = extractErrorMessage(
+            result.body,
+            `Resource metadata request failed with ${result.status}`,
+          );
+          continue;
+        }
+
+        const resourceMetadata = asRecord(result.body, "Resource metadata");
+        const resolvedAuthzIssuer = Array.isArray(
+          resourceMetadata.authorization_servers,
+        )
+          ? resourceMetadata.authorization_servers[0]
+          : undefined;
+        const resolvedResource =
+          typeof resourceMetadata.resource === "string"
+            ? resourceMetadata.resource
+            : canonicalizeResourceUrl(activeServerUrl);
+
+        if (!resolvedAuthzIssuer) {
+          throw new Error(
+            "Resource metadata did not include `authorization_servers`, and no Authorization Server issuer was configured manually.",
+          );
+        }
+
+        machine.updateState({
+          currentStep: "received_resource_metadata",
+          resourceMetadataUrl,
+          resourceMetadata:
+            resourceMetadata as XAAFlowState["resourceMetadata"],
+          resourceUrl: resolvedResource,
+          authzServerIssuer: resolvedAuthzIssuer,
+          error: undefined,
+        });
+
+        pushInfo(
+          "received_resource_metadata",
+          "xaa-resource-metadata",
+          "Resource metadata",
+          {
+            resource: resolvedResource,
+            authorization_servers: resourceMetadata.authorization_servers,
+          },
+        );
+        return;
+      } catch (error) {
+        lastError =
+          error instanceof Error
+            ? error.message
+            : "Failed to discover resource metadata";
+      }
+    }
+
+    machine.updateState({
+      currentStep: "discover_resource_metadata",
+      error: lastError,
+    });
   };
 
   const discoverAuthzMetadata = async () => {
     const state = currentState();
     const issuer = state.authzServerIssuer;
+
+    // RFC 8414 authorization-server metadata discovery only exists to learn
+    // the token endpoint. A registration-backed run resolves the stored
+    // endpoint server-side, and a manually-set token endpoint is already
+    // known — in either case skip the probe and advance.
+    if (registrationId || state.tokenEndpoint) {
+      machine.updateState({
+        currentStep: "received_authz_metadata",
+        error: undefined,
+      });
+      pushInfo(
+        "received_authz_metadata",
+        "xaa-authz-metadata-skipped",
+        "Authorization metadata discovery skipped",
+        {
+          reason: registrationId
+            ? "The registered resource's token endpoint is resolved server-side; RFC 8414 discovery isn't needed."
+            : "The token endpoint is already configured; RFC 8414 discovery isn't needed.",
+          ...(state.tokenEndpoint
+            ? { token_endpoint: state.tokenEndpoint }
+            : {}),
+        },
+      );
+      return;
+    }
 
     if (!issuer) {
       machine.updateState({


### PR DESCRIPTION
RFC 9728 protected-resource discovery and RFC 8414 auth-server discovery
are MCP/OAuth bootstrap steps for learning a resource's authorization
server and token endpoint — they are not part of the XAA (ID-JAG) grant.
The XAA debugger inherited them from the OAuth debugger and ran resource
discovery unconditionally as step 1, firing a probe (often a 404) even
when the auth server was already known.

- Skip resource-metadata discovery when the AS issuer is already
  configured (a registration, or entered manually): nothing to discover.
- Skip AS-metadata discovery when the token endpoint is known or a
  registration-backed run will resolve it server-side.
  -> a registered resource now starts the flow at "authenticate" with no
     spurious discovery request.
- When resource discovery IS needed (a bare MCP URL with nothing
  configured), try both RFC 9728 well-known forms — path-insertion
  (/.well-known/oauth-protected-resource/<path>) then the path-less root
  — mirroring AS discovery and the OAuth debugger. This was previously
  path-insertion only, so it 404'd against servers that serve
  protected-resource metadata at the origin.

Tests: registration-backed run fires no discovery probe; issuer-known
run skips resource discovery but still discovers the token endpoint;
resource discovery falls back to the root form when path-insertion 404s.
