### PR TITLE
Playground: default chat to fill the panel, device presets opt-in

### DIFF
--- a/mcpjam-inspector/client/src/components/ViewsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ViewsTab.tsx
@@ -235,6 +235,11 @@ export function ViewsTab({
     const ctx = selectedView.defaultContext;
     if (ctx.deviceType) setDeviceType(ctx.deviceType);
     if (ctx.viewport) setCustomViewport(ctx.viewport);
+    // A context saved under the "fill" layout serializes with neither
+    // deviceType nor viewport (the persisted union only carries the
+    // fixed presets). Restore it explicitly so a preset left over from
+    // the previously selected view doesn't leak into this one.
+    if (!ctx.deviceType && !ctx.viewport) setDeviceType("fill");
     if (ctx.locale) updateGlobal("locale", ctx.locale);
     if (ctx.timeZone) updateGlobal("timeZone", ctx.timeZone);
     if (ctx.capabilities) setCapabilities(ctx.capabilities);

--- a/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
@@ -22,6 +22,7 @@ import {
   Cpu,
   Globe,
   Hand,
+  Maximize2,
   Moon,
   MousePointer2,
   Settings2,
@@ -74,6 +75,11 @@ export { PRESET_DEVICE_CONFIGS } from "@/components/shared/client-context-consta
 
 const CUSTOM_DEVICE_BASE = {
   label: "Custom",
+};
+
+const FILL_DEVICE_CONFIG = {
+  label: "Fill",
+  icon: Maximize2,
 };
 
 /** Muted toolbar hints (`design-system/tooltip`): popover chrome, avoids primary “CTA” orange. */
@@ -231,6 +237,9 @@ export function ClientContextHeader({
     Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 
   const deviceConfig = useMemo(() => {
+    if (deviceType === "fill") {
+      return FILL_DEVICE_CONFIG;
+    }
     if (deviceType === "custom") {
       return {
         ...CUSTOM_DEVICE_BASE,
@@ -301,9 +310,11 @@ export function ClientContextHeader({
                 >
                   {DeviceIcon ? <DeviceIcon className="h-3.5 w-3.5" /> : null}
                   <span className="whitespace-nowrap">{deviceConfig.label}</span>
-                  <span className="text-[10px] text-muted-foreground @max-[1020px]/playground-header:hidden">
-                    {deviceConfig.width}x{deviceConfig.height}
-                  </span>
+                  {"width" in deviceConfig ? (
+                    <span className="text-[10px] text-muted-foreground @max-[1020px]/playground-header:hidden">
+                      {deviceConfig.width}x{deviceConfig.height}
+                    </span>
+                  ) : null}
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>

--- a/mcpjam-inspector/client/src/components/shared/__tests__/ClientContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/ClientContextHeader.test.tsx
@@ -63,6 +63,7 @@ vi.mock("lucide-react", () => ({
   Settings2: () => <span data-testid="icon-settings" />,
   MousePointer2: () => <span data-testid="icon-mouse" />,
   Hand: () => <span data-testid="icon-hand" />,
+  Maximize2: () => <span data-testid="icon-maximize" />,
 }));
 
 vi.mock("@mcpjam/design-system/button", () => ({

--- a/mcpjam-inspector/client/src/components/shared/client-context-constants.ts
+++ b/mcpjam-inspector/client/src/components/shared/client-context-constants.ts
@@ -7,11 +7,11 @@ import { Smartphone, Tablet, Monitor } from "lucide-react";
 import {
   DEVICE_VIEWPORT_CONFIGS,
   type CspMode,
-  type DeviceType,
+  type PresetDeviceType,
 } from "@/stores/ui-playground-store";
 
 export const PRESET_DEVICE_CONFIGS: Record<
-  Exclude<DeviceType, "custom">,
+  PresetDeviceType,
   {
     width: number;
     height: number;

--- a/mcpjam-inspector/client/src/components/shared/client-context-picker-bodies.tsx
+++ b/mcpjam-inspector/client/src/components/shared/client-context-picker-bodies.tsx
@@ -2,7 +2,7 @@
  * Shared picker bodies for ClientContextHeader popovers.
  */
 
-import { Settings2 } from "lucide-react";
+import { Maximize2, Settings2 } from "lucide-react";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import {
@@ -17,11 +17,12 @@ import type {
   CustomViewport,
   CspMode,
   DeviceType,
+  PresetDeviceType,
 } from "@/stores/ui-playground-store";
 
 type PresetEntry = [
-  Exclude<DeviceType, "custom">,
-  (typeof PRESET_DEVICE_CONFIGS)[Exclude<DeviceType, "custom">],
+  PresetDeviceType,
+  (typeof PRESET_DEVICE_CONFIGS)[PresetDeviceType],
 ];
 
 export function DevicePickerBody({
@@ -43,6 +44,23 @@ export function DevicePickerBody({
 }) {
   return (
     <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => {
+          setDeviceType("fill");
+          onPickPreset?.();
+        }}
+        className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors hover:bg-accent ${
+          deviceType === "fill" ? "bg-accent text-accent-foreground" : ""
+        }`}
+      >
+        <Maximize2 className="h-3.5 w-3.5" />
+        <span>Fill</span>
+        <span className="ml-auto text-[10px] text-muted-foreground">
+          Full window
+        </span>
+      </button>
+
       {(Object.entries(PRESET_DEVICE_CONFIGS) as PresetEntry[]).map(
         ([type, config]) => {
           const Icon = config.icon;

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -2767,7 +2767,9 @@ export function PlaygroundMain({
   const showFullscreenChatOverlay =
     displayMode === "fullscreen" &&
     isWidgetFullscreen &&
-    storeDeviceType === "desktop" &&
+    // "fill" is the desktop-like default layout — it keeps the overlay
+    // composer/chat affordance fullscreen widgets had under "desktop".
+    (storeDeviceType === "fill" || storeDeviceType === "desktop") &&
     !isWidgetFullTakeover;
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -476,8 +476,16 @@ export function PlaygroundMain({
   const hostContext = useHostContextStore((s) => s.draftHostContext);
   const patchHostContext = useHostContextStore((s) => s.patchHostContext);
 
-  // Device config for frame sizing
-  const deviceConfig = useMemo(() => {
+  // Device config for frame sizing. "fill" (the default) takes the whole
+  // panel — no host renders chat inside a fixed-size frame, so emulation
+  // presets are opt-in.
+  const deviceConfig = useMemo<{
+    width: number | string;
+    height: number | string;
+  }>(() => {
+    if (storeDeviceType === "fill") {
+      return { width: "100%", height: "100%" };
+    }
     if (storeDeviceType === "custom") {
       return {
         ...CUSTOM_DEVICE_BASE,

--- a/mcpjam-inspector/client/src/lib/display-context-utils.ts
+++ b/mcpjam-inspector/client/src/lib/display-context-utils.ts
@@ -14,7 +14,13 @@ export function useCurrentDisplayContext(): DisplayContext {
   return {
     theme: globals.theme,
     displayMode: globals.displayMode,
-    deviceType: deviceType === "custom" ? undefined : deviceType,
+    // "fill" and "custom" are playground-only sizing modes; the persisted
+    // DisplayContext union (and its Convex validator) only accepts the
+    // mobile/tablet/desktop presets, so they serialize as undefined.
+    deviceType:
+      deviceType === "custom" || deviceType === "fill"
+        ? undefined
+        : deviceType,
     viewport:
       deviceType === "custom"
         ? { width: customViewport.width, height: customViewport.height }

--- a/mcpjam-inspector/client/src/lib/playground/__tests__/apply-client-defaults.test.ts
+++ b/mcpjam-inspector/client/src/lib/playground/__tests__/apply-client-defaults.test.ts
@@ -93,7 +93,7 @@ describe("applyHostDefaultsToPlayground", () => {
     // But the playground's device-frame viewport is NOT shrunk to the
     // View's container dimensions — chat stays full-width.
     expect(setCustomViewportSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
+    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
 
     expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
     expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
@@ -103,19 +103,19 @@ describe("applyHostDefaultsToPlayground", () => {
     expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
   });
 
-  it("snapshots ChatGPT template defaults: container metadata stays in host context, playground viewport stays desktop, model openai/gpt-5-nano (guest-allowed)", () => {
+  it("snapshots ChatGPT template defaults: container metadata stays in host context, playground viewport stays fill, model openai/gpt-5-nano (guest-allowed)", () => {
     applyHostDefaultsToPlayground("chatgpt", setters);
 
     expect(setHostStyle).toHaveBeenCalledWith("chatgpt");
     expect(replaceLeadModelIdSpy).toHaveBeenCalledWith("openai/gpt-5-nano");
     expect(setCustomViewportSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
+    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
     expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
     expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
     expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
   });
 
-  it("snapshots Cursor template defaults: container metadata stays in host context, playground viewport stays desktop, model anthropic/claude-sonnet-4.5 (guest-allowed)", () => {
+  it("snapshots Cursor template defaults: container metadata stays in host context, playground viewport stays fill, model anthropic/claude-sonnet-4.5 (guest-allowed)", () => {
     applyHostDefaultsToPlayground("cursor", setters);
 
     expect(setHostStyle).toHaveBeenCalledWith("cursor");
@@ -123,13 +123,13 @@ describe("applyHostDefaultsToPlayground", () => {
       "anthropic/claude-sonnet-4.5",
     );
     expect(setCustomViewportSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
+    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
     expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
     expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
     expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
   });
 
-  it("snapshots MCPJam fallback: setDeviceType('desktop'), widget-declared CSP, override set, model id NOT touched", () => {
+  it("snapshots MCPJam fallback: setDeviceType('fill'), widget-declared CSP, override set, model id NOT touched", () => {
     applyHostDefaultsToPlayground("mcpjam", setters);
 
     expect(setHostStyle).toHaveBeenCalledWith("mcpjam");
@@ -139,7 +139,7 @@ describe("applyHostDefaultsToPlayground", () => {
     expect(replaceLeadModelIdSpy).not.toHaveBeenCalled();
 
     expect(setCustomViewportSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
+    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
 
     // MCPJam template advertises apps.sandbox.csp.mode "declared" so the
     // Permissive chip resolves to widget-declared, same as Claude/ChatGPT.
@@ -163,7 +163,7 @@ describe("applyHostDefaultsToPlayground", () => {
     // MCPJam template's modelId is empty, the user's last picked model
     // is preserved.
     expect(replaceLeadModelIdSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
+    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
     // MCPJam fallback now stamps apps.sandbox.csp.mode "declared" and a
     // hostCapabilitiesOverride, so the BYO unknown id inherits both like
     // other branded templates.
@@ -208,7 +208,7 @@ describe("applyHostDefaultsToPlayground", () => {
       // containerDimensions belongs to the View iframe (delivered via
       // applyHostTemplate above), not the playground's device frame.
       expect(setCustomViewportSpy).not.toHaveBeenCalled();
-      expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
+      expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
       expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
       expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
       expect(setHostCapabilitiesOverride).toHaveBeenCalledWith({
@@ -299,7 +299,7 @@ describe("applyHostDefaultsToPlayground", () => {
       );
       expect(applyHostTemplateSpy).toHaveBeenCalledWith({});
       expect(setCustomViewportSpy).not.toHaveBeenCalled();
-      expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
+      expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
       expect(setCspModeSpy).toHaveBeenCalledWith("permissive");
       expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("permissive");
       expect(setHostCapabilitiesOverride).toHaveBeenCalledWith(undefined);

--- a/mcpjam-inspector/client/src/lib/playground/apply-client-defaults.ts
+++ b/mcpjam-inspector/client/src/lib/playground/apply-client-defaults.ts
@@ -140,9 +140,9 @@ export function applyHostConfigToPlayground(
   // delivered to Views via `ui/initialize.hostContext` (see
   // `applyHostTemplate` above). Don't project it onto the playground's
   // device-frame viewport — that shrunk the entire chat to e.g. 720px when
-  // picking Claude. Keep the playground full-width; the View iframe sizes
-  // itself from the hostContext.
-  useUIPlaygroundStore.getState().setDeviceType("desktop");
+  // picking Claude. Keep the playground filling the panel; the View iframe
+  // sizes itself from the hostContext.
+  useUIPlaygroundStore.getState().setDeviceType("fill");
 
   // Templates / configs encode their CSP intent under
   // `mcpProfile.apps.sandbox.csp.mode`; the only branded value today is

--- a/mcpjam-inspector/client/src/stores/ui-playground-store.ts
+++ b/mcpjam-inspector/client/src/stores/ui-playground-store.ts
@@ -229,6 +229,8 @@ const getDefaultCapabilities = (
   }
 };
 
+const initialDeviceType = getStoredDeviceType();
+
 const initialState = {
   isPlaygroundActive: false,
   selectedTool: null,
@@ -241,15 +243,15 @@ const initialState = {
   widgetUrl: null,
   widgetState: null,
   isWidgetTool: false,
-  deviceType: getStoredDeviceType(),
+  deviceType: initialDeviceType,
   displayMode: "inline" as DisplayMode,
-  globals: getInitialGlobals(),
+  globals: { ...getInitialGlobals(), deviceType: initialDeviceType },
   lastToolCallId: null,
   followUpMessages: [] as FollowUpMessage[],
   isSidebarVisible: getStoredVisibility(STORAGE_KEY_SIDEBAR, true),
   cspMode: "permissive" as CspMode,
   mcpAppsCspMode: "permissive" as CspMode,
-  capabilities: getDefaultCapabilities("fill"),
+  capabilities: getDefaultCapabilities(initialDeviceType),
   safeAreaPreset: "none" as SafeAreaPreset,
   safeAreaInsets: SAFE_AREA_PRESETS["none"],
   customViewport: getStoredCustomViewport(),
@@ -406,6 +408,7 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
         isPlaygroundActive: state.isPlaygroundActive,
         // Preserve device type and custom viewport from localStorage
         deviceType: storedDeviceType,
+        globals: { ...initialState.globals, deviceType: storedDeviceType },
         customViewport: getStoredCustomViewport(),
         capabilities: getDefaultCapabilities(storedDeviceType),
         // Preserve CSP modes (may be set via CLI config before reset fires)

--- a/mcpjam-inspector/client/src/stores/ui-playground-store.ts
+++ b/mcpjam-inspector/client/src/stores/ui-playground-store.ts
@@ -10,11 +10,14 @@ import { create } from "zustand";
 import type { Tool } from "@modelcontextprotocol/client";
 import type { FormField } from "@/lib/tool-form";
 
-export type DeviceType = "mobile" | "tablet" | "desktop" | "custom";
+export type DeviceType = "fill" | "mobile" | "tablet" | "desktop" | "custom";
+
+/** Fixed-size emulation presets; "fill" and "custom" size differently. */
+export type PresetDeviceType = Exclude<DeviceType, "fill" | "custom">;
 
 /** Device viewport configurations - shared across playground and MCP apps renderer */
 export const DEVICE_VIEWPORT_CONFIGS: Record<
-  Exclude<DeviceType, "custom">,
+  PresetDeviceType,
   { width: number; height: number }
 > = {
   mobile: { width: 430, height: 932 },
@@ -170,14 +173,18 @@ const getInitialGlobals = (): PlaygroundGlobals => ({
   theme: "dark",
   locale: navigator.language || "en-US",
   timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
-  deviceType: "desktop",
+  deviceType: "fill",
   displayMode: "inline",
   userLocation: null,
 });
 
 const STORAGE_KEY_SIDEBAR = "mcpjam-ui-playground-sidebar-visible";
 const STORAGE_KEY_CUSTOM_VIEWPORT = "mcpjam-ui-playground-custom-viewport";
-const STORAGE_KEY_DEVICE_TYPE = "mcpjam-ui-playground-device-type";
+// v2: "fill" became the default device. The v1 key is abandoned rather than
+// migrated — applyHostConfigToPlayground used to write "desktop" on every
+// host switch, so v1 values are machine-written and don't reflect a user's
+// deliberate preset choice.
+const STORAGE_KEY_DEVICE_TYPE = "mcpjam-ui-playground-device-type-v2";
 const getStoredVisibility = (key: string, defaultValue: boolean): boolean => {
   if (typeof window === "undefined") return defaultValue;
   const stored = localStorage.getItem(key);
@@ -194,23 +201,27 @@ const getStoredCustomViewport = (): CustomViewport => {
 };
 
 const getStoredDeviceType = (): DeviceType => {
-  if (typeof window === "undefined") return "desktop";
+  if (typeof window === "undefined") return "fill";
   const stored = localStorage.getItem(STORAGE_KEY_DEVICE_TYPE);
-  if (stored && ["mobile", "tablet", "desktop", "custom"].includes(stored)) {
+  if (
+    stored &&
+    ["fill", "mobile", "tablet", "desktop", "custom"].includes(stored)
+  ) {
     return stored as DeviceType;
   }
-  return "desktop";
+  return "fill";
 };
 
 /** Get default capabilities based on device type */
 const getDefaultCapabilities = (
-  deviceType: DeviceType = "desktop",
+  deviceType: DeviceType = "fill",
 ): DeviceCapabilities => {
   switch (deviceType) {
     case "mobile":
       return { hover: false, touch: true };
     case "tablet":
       return { hover: false, touch: true };
+    case "fill":
     case "custom":
     case "desktop":
     default:
@@ -238,7 +249,7 @@ const initialState = {
   isSidebarVisible: getStoredVisibility(STORAGE_KEY_SIDEBAR, true),
   cspMode: "permissive" as CspMode,
   mcpAppsCspMode: "permissive" as CspMode,
-  capabilities: getDefaultCapabilities("desktop"),
+  capabilities: getDefaultCapabilities("fill"),
   safeAreaPreset: "none" as SafeAreaPreset,
   safeAreaInsets: SAFE_AREA_PRESETS["none"],
   customViewport: getStoredCustomViewport(),


### PR DESCRIPTION
The chat thread rendered inside a device-emulation frame whose default "Desktop" preset is a fixed 1280x800 viewport, so on taller windows the chat stopped at 800px with dead space below (reported by Wes Bos — MCP apps were cramped). No real host renders chat inside a fixed frame, so emulation is now opt-in:

- New "fill" device type (the default): frame takes 100% of the panel.
- Phone/Tablet/Desktop/Custom presets unchanged, selectable as before; picker gains a "Fill" option at the top.
- Host-config apply resets to "fill" instead of "desktop".
- Device-type localStorage key bumped to v2: the old key was written "desktop" on every host switch, so v1 values are machine-written, not user intent.
- "fill" serializes to undefined in DisplayContext (like "custom"), so the persisted union and its Convex validator are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only playground layout and persistence-key changes with test updates; no auth, API, or schema validator changes.
> 
> **Overview**
> Playground chat now defaults to a new **`fill`** device mode so the preview uses the full panel instead of a fixed **1280×800** desktop frame; phone/tablet/desktop/custom presets stay available as opt-in emulation.
> 
> **`fill`** is wired through the store (new default, **`device-type-v2`** localStorage key abandons v1), host-config apply paths reset to **`fill`** instead of **`desktop`**, frame sizing uses **100%** width/height, and fullscreen widget overlay behavior treats **`fill`** like desktop. **`fill`** (like **`custom`**) omits **`deviceType`**/**`viewport`** when serializing **`DisplayContext`**; **ViewsTab** explicitly restores **`fill`** when a saved view has neither field so presets do not leak between views. Toolbar picker adds **Fill** and hides dimension text when there is no fixed size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00bb2a85f5dbc7ec5f9d617ca789d703ae8751fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->