### PR TITLE
fix(evals): keep polling after a transient poll-screenshot failure

### DIFF
--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -807,12 +807,18 @@ export class McpAppBrowserHarness {
     // exhausted the budget — otherwise `frame` stays null and we'd fail toward
     // "rendered", mislabeling a blank widget.
     do {
-      frame = await page.screenshot({ type: "png" }).catch(() => prev);
-      if (!frame) break;
-      const painted = !baseline || !framesEqual(frame, baseline);
-      const settled = framesEqual(frame, prev);
-      if (painted && settled) break;
-      prev = frame;
+      const shot = await page.screenshot({ type: "png" }).catch(() => null);
+      // A failed shot is transient: keep the last good frame and retry until the
+      // deadline rather than aborting (which would force a "rendered" verdict on
+      // an unseen frame). `frame` stays null only if EVERY shot failed — then the
+      // caller's screenshot also fails and the render is `screenshot_failed`.
+      if (shot) {
+        frame = shot;
+        const painted = !baseline || !framesEqual(shot, baseline);
+        const settled = framesEqual(shot, prev);
+        if (painted && settled) break;
+        prev = shot;
+      }
       await page.waitForTimeout(150);
     } while (Date.now() < deadline);
 


### PR DESCRIPTION
## Follow-up to #2563

This is the **third** Cursor Bugbot finding on #2563. The first two were fixed before that PR merged; this one landed a moment after the merge, so it missed the train. Opening it standalone.

## Problem

In `waitForWidgetPaint`'s paint-detection poll, a failed screenshot on the **first** sample (while `prev` is still `null`) made `frame` stay `null` and broke the loop immediately, forcing `blank = false`. So a one-off screenshot hiccup on the first poll could mark a **genuinely blank** widget as `rendered` — defeating the very purpose of the `do/while` (which exists to guarantee at least one real frame is classified).

> Reported by Cursor Bugbot ("Paint poll aborts screenshot retries", Medium severity) on commit `b0362cc`.

## Fix

A failed shot is treated as transient: keep the last good frame and **retry until the deadline** instead of aborting. `frame` stays `null` only if **every** shot fails — in which case the caller's own `captureScreenshot` also fails and the render is correctly reported as `screenshot_failed`, not a false `rendered`.

```
-      frame = await page.screenshot({ type: "png" }).catch(() => prev);
-      if (!frame) break;
-      const painted = !baseline || !framesEqual(frame, baseline);
-      const settled = framesEqual(frame, prev);
-      if (painted && settled) break;
-      prev = frame;
+      const shot = await page.screenshot({ type: "png" }).catch(() => null);
+      if (shot) {
+        frame = shot;
+        const painted = !baseline || !framesEqual(shot, baseline);
+        const settled = framesEqual(shot, prev);
+        if (painted && settled) break;
+        prev = shot;
+      }
       await page.waitForTimeout(150);
```

## Impact / risk

Low. Only changes behavior when a screenshot **throws** mid-poll (rare transient glitch); the happy path is unchanged. Scope is one method in the eval browser harness.

## Verification

- Full harness suite green (27/27) on top of current `main`, including the genuinely-blank fixture (`blank_screenshot`), the late-paint fixture (`rendered`), and the `paintTimeoutMs ≤ settleTimeoutMs` edge case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdpskaihKUgYPjMagqmWSb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method change in the eval browser harness; happy-path paint detection is unchanged and only screenshot-throw edge cases behave differently.
> 
> **Overview**
> **`waitForWidgetPaint`** paint polling no longer exits the loop when a Playwright screenshot throws. Failed captures are treated as transient: the loop keeps waiting and retrying until **`paintTimeoutMs`**, only updating paint/settle logic when a shot succeeds.
> 
> Previously, using **`prev`** as the fallback on failure and **`break`**ing when **`frame`** was still null (especially on the first sample) could leave **`frame`** unset and force **`blank = false`**, wrongly reporting **`rendered`** for a blank widget. **`frame`** stays null only if every poll attempt fails; then the caller still fails closed with **`screenshot_failed`** instead of a false **`rendered`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e363b48d0690b9f297d0f0be64e1b73329cfe33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->