### PR TITLE
fix(computers): hide computer-backed catalog rows from flag-off users

### DIFF
--- a/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
@@ -63,6 +63,7 @@ import {
   catalogHasComputerBackedTool,
   detachComputerPatch,
   shouldShowComputerToggle,
+  visibleBuiltInToolCatalog,
 } from "@/lib/host-config-computer";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 
@@ -164,8 +165,15 @@ export function ClientConfigEditor({
   // (loading → undefined → hidden) so empty installs don't show a dead card.
   const builtInToolCatalog = useBuiltInToolCatalog();
   const computersEnabled = useComputersEnabled();
+  // Render only the rows this user may see: with `computers-enabled` off,
+  // computer-backed rows (e.g. an enabled `bash`) stay hidden — except an
+  // already-selected id, which must remain visible to stay removable.
+  const visibleBuiltInTools = visibleBuiltInToolCatalog(builtInToolCatalog, {
+    computersEnabled,
+    selectedIds: value.builtInToolIds,
+  });
   const showBuiltInToolsSection =
-    owner !== "connection-only" && (builtInToolCatalog?.length ?? 0) > 0;
+    owner !== "connection-only" && (visibleBuiltInTools?.length ?? 0) > 0;
   // Eval suites can never use a personal computer: the backend aborts eval
   // runs whose resolved host config carries one. So hide the toggle and mark
   // computer-backed tools disallowed (they render blocked, but a stale id
@@ -408,7 +416,7 @@ export function ClientConfigEditor({
               <BuiltInToolCheckboxList
                 label="Built-in tools"
                 selected={value.builtInToolIds}
-                available={builtInToolCatalog ?? []}
+                available={visibleBuiltInTools ?? []}
                 computerAttached={value.computer !== undefined}
                 computerToolsDisallowed={computerToolsDisallowed}
                 onChange={(builtInToolIds) => update({ builtInToolIds })}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
@@ -28,6 +28,7 @@ import {
   catalogHasComputerBackedTool,
   detachComputerPatch,
   shouldShowComputerToggle,
+  visibleBuiltInToolCatalog,
 } from "@/lib/host-config-computer";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 
@@ -97,12 +98,19 @@ export function BehaviorTab({
   // deployed; `[]` on populated deployments with no enabled rows. Hide the
   // FocusBlock entirely in both cases so empty installs don't render a dead card.
   const builtInToolCatalog = useBuiltInToolCatalog();
-  const showBuiltInTools = (builtInToolCatalog?.length ?? 0) > 0;
+  const computersEnabled = useComputersEnabled();
+  // Render only the rows this user may see: with `computers-enabled` off,
+  // computer-backed rows (e.g. an enabled `bash`) stay hidden — except an
+  // already-selected id, which must remain visible to stay removable.
+  const visibleBuiltInTools = visibleBuiltInToolCatalog(builtInToolCatalog, {
+    computersEnabled,
+    selectedIds: draft.builtInToolIds,
+  });
+  const showBuiltInTools = (visibleBuiltInTools?.length ?? 0) > 0;
   // The personal-computer toggle appears once the deployment exposes a
   // computer-backed tool (the `bash` row ships disabled until launch) OR when
   // the host already has a computer attached, so an existing attachment is
   // always detachable even if no computer-backed tool is in the catalog.
-  const computersEnabled = useComputersEnabled();
   const showComputerToggle =
     computersEnabled &&
     shouldShowComputerToggle({
@@ -299,7 +307,7 @@ export function BehaviorTab({
             <BuiltInToolCheckboxList
               label="Attached"
               selected={draft.builtInToolIds}
-              available={builtInToolCatalog ?? []}
+              available={visibleBuiltInTools ?? []}
               computerAttached={draft.computer !== undefined}
               readOnly={readOnly}
               onChange={(builtInToolIds) => update({ builtInToolIds })}

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-computer.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-computer.test.ts
@@ -6,6 +6,7 @@ import {
   detachComputerPatch,
   sanitizeHostConfigForEvalSuite,
   shouldShowComputerToggle,
+  visibleBuiltInToolCatalog,
 } from "../host-config-computer";
 import { emptyHostConfigInputV2 } from "../client-config-v2";
 import type { BuiltInToolCatalogEntry } from "@/hooks/useBuiltInToolCatalog";
@@ -118,6 +119,44 @@ describe("shouldShowComputerToggle", () => {
         disallowed: true,
       })
     ).toBe(false);
+  });
+});
+
+describe("visibleBuiltInToolCatalog", () => {
+  it("returns the catalog unchanged when the computers flag is on", () => {
+    expect(
+      visibleBuiltInToolCatalog(CATALOG, {
+        computersEnabled: true,
+        selectedIds: [],
+      })
+    ).toBe(CATALOG);
+  });
+
+  it("hides computer-backed rows when the flag is off (enabled bash row stays invisible pre-rollout)", () => {
+    expect(
+      visibleBuiltInToolCatalog(CATALOG, {
+        computersEnabled: false,
+        selectedIds: [],
+      })
+    ).toEqual([CATALOG[0]]);
+  });
+
+  it("keeps a computer-backed row that is already selected, so a stale id stays removable", () => {
+    expect(
+      visibleBuiltInToolCatalog(CATALOG, {
+        computersEnabled: false,
+        selectedIds: ["bash"],
+      })
+    ).toEqual(CATALOG);
+  });
+
+  it("passes `undefined` through (catalog still loading)", () => {
+    expect(
+      visibleBuiltInToolCatalog(undefined, {
+        computersEnabled: false,
+        selectedIds: [],
+      })
+    ).toBeUndefined();
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/host-config-computer.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-computer.ts
@@ -52,6 +52,28 @@ export function computerBackedToolIds(
   return ids;
 }
 
+/**
+ * The catalog rows an editor should actually RENDER, honoring the
+ * `computers-enabled` rollout flag: when the flag is off for this user,
+ * computer-backed rows are hidden — the backend `bash` row can be enabled
+ * deployment-wide without leaking a dead "requires a computer" checkbox to
+ * users who can't see the (flag-gated) computer toggle it points at. A row
+ * whose id is ALREADY selected stays visible regardless, preserving the
+ * checkbox list's invariant that a stale selected id is always removable.
+ * `undefined` passes through (callers treat it as "catalog still loading").
+ */
+export function visibleBuiltInToolCatalog(
+  catalog: ReadonlyArray<BuiltInToolCatalogEntry> | undefined,
+  opts: {
+    computersEnabled: boolean;
+    selectedIds: ReadonlyArray<string>;
+  }
+): ReadonlyArray<BuiltInToolCatalogEntry> | undefined {
+  if (catalog === undefined || opts.computersEnabled) return catalog;
+  const selected = new Set(opts.selectedIds);
+  return catalog.filter((t) => !t.requiresComputer || selected.has(t.id));
+}
+
 /** Patch that attaches a personal computer (the only MVP resource shape). */
 export function attachComputerPatch(): Partial<HostConfigInputV2> {
   return { computer: { kind: "personal" } };


### PR DESCRIPTION
Closes the last hole in the `computers-enabled` PostHog gating, found while prepping the launch runbook after #2573 merged.

## The hole

The backend `bash` catalog row ships **disabled**, and flipping it to `enabled` is the documented launch switch (`convex/builtInTools/catalog.ts`). But the built-in tools checkbox list (`ClientConfigEditor` + `BehaviorTab`) rendered the **raw catalog** — so the moment that row flips, every user **including flag-OFF users** would see a blocked "Bash" checkbox whose hint says *"Requires a personal computer (attach it above)"* … pointing at a computer toggle that is flag-hidden for them. A dead-end UI that also leaks the feature pre-rollout, and it would make the launch switch unsafe to flip at less than 100% flag rollout.

## The fix

New `visibleBuiltInToolCatalog` helper (in `host-config-computer.ts`, next to its siblings): with the flag **off**, `requiresComputer` rows are filtered out of what the editors render — driving both the section-visibility check and the rows themselves. A row whose id is **already selected** stays visible regardless, preserving the checkbox list's invariant that a stale selected id is always removable.

Net effect: the catalog row can be enabled deployment-wide at any flag rollout percentage; visibility remains purely a PostHog decision.

## Tests

4 new unit tests on the helper (flag on ⇒ unchanged reference; flag off ⇒ computer-backed rows hidden; selected id kept removable; `undefined` loading passthrough). Existing `ClientConfigEditor` / focus-tab / checkbox-list / eval-suite suites all green; client typecheck clean.

https://claude.ai/code/session_01Jf7p3Q1YQN8sKzi3hTzcuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jf7p3Q1YQN8sKzi3hTzcuh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only display filtering aligned with existing PostHog gating; no auth, persistence, or backend behavior changes.
> 
> **Overview**
> Closes a gap in **`computers-enabled`** PostHog gating: host config editors were rendering the **full** built-in tool catalog, so enabling the deployment-wide `bash` row could show flag-off users a blocked Bash checkbox that references a hidden personal-computer toggle.
> 
> Adds **`visibleBuiltInToolCatalog`** in `host-config-computer.ts`. When the flag is off, **`requiresComputer`** rows are omitted from what **`ClientConfigEditor`** and **`BehaviorTab`** render and from the built-in-tools section visibility check. **Already-selected** computer-backed ids stay in the list so stale attachments remain **removable**.
> 
> Four unit tests cover flag-on passthrough, flag-off filtering, selected-id exception, and loading (`undefined`) passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f685befc0b762683861d17f521f3c7ebd86805a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->