### PR TITLE
feat(xaa): group debugger steps into spec phases (ID-JAG draft steps 1–4 + bootstrap)

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRight,
   Circle,
   KeyRound,
+  Lightbulb,
   Loader2,
   Pencil,
   RotateCcw,
@@ -28,9 +29,12 @@ import { HTTPHistoryEntry } from "@/components/oauth/HTTPHistoryEntry";
 import { InfoLogEntry } from "@/components/oauth/InfoLogEntry";
 import { IdJagInspector } from "./IdJagInspector";
 import {
+  getXAAPhaseNumber,
   getXAAStepInfo,
   getXAAStepIndex,
+  XAA_PHASES,
   XAA_STEP_ORDER,
+  type XAAPhaseKey,
 } from "@/lib/xaa/step-metadata";
 import type { XAAFlowState, XAAFlowStep } from "@/lib/xaa/types";
 import {
@@ -73,11 +77,7 @@ interface XAAFlowLoggerProps {
   };
 }
 
-function CompatibilityBanner({
-  report,
-}: {
-  report: XAACompatibilityReport;
-}) {
+function CompatibilityBanner({ report }: { report: XAACompatibilityReport }) {
   const [expanded, setExpanded] = useState(report.overall !== "pass");
   useEffect(() => {
     setExpanded(report.overall !== "pass");
@@ -93,27 +93,27 @@ function CompatibilityBanner({
           title: "Authorization server looks XAA-ready",
         }
       : report.overall === "warn"
-        ? {
-            Icon: AlertTriangle,
-            iconClass: "text-amber-500",
-            borderClass: "border-amber-500/40",
-            bgClass: "bg-amber-500/5",
-            title: "Authorization server capabilities are ambiguous",
-          }
-        : {
-            Icon: ShieldAlert,
-            iconClass: "text-red-500",
-            borderClass: "border-red-500/40",
-            bgClass: "bg-red-500/5",
-            title: "Authorization server isn't XAA-ready",
-          };
+      ? {
+          Icon: AlertTriangle,
+          iconClass: "text-amber-500",
+          borderClass: "border-amber-500/40",
+          bgClass: "bg-amber-500/5",
+          title: "Authorization server capabilities are ambiguous",
+        }
+      : {
+          Icon: ShieldAlert,
+          iconClass: "text-red-500",
+          borderClass: "border-red-500/40",
+          bgClass: "bg-red-500/5",
+          title: "Authorization server isn't XAA-ready",
+        };
 
   const checkStatusClass = (status: XAACheckStatus) =>
     status === "pass"
       ? "text-green-600 dark:text-green-400"
       : status === "fail"
-        ? "text-red-500"
-        : "text-amber-500";
+      ? "text-red-500"
+      : "text-amber-500";
 
   const checkStatusSymbol = (status: XAACheckStatus) =>
     status === "pass" ? "✓" : status === "fail" ? "✗" : "?";
@@ -123,7 +123,7 @@ function CompatibilityBanner({
       className={cn(
         "rounded-md border px-3 py-2.5 text-xs",
         tone.borderClass,
-        tone.bgClass,
+        tone.bgClass
       )}
     >
       <button
@@ -153,7 +153,7 @@ function CompatibilityBanner({
               <span
                 className={cn(
                   "font-mono shrink-0 w-3",
-                  checkStatusClass(check.status),
+                  checkStatusClass(check.status)
                 )}
                 aria-hidden
               >
@@ -242,6 +242,64 @@ function GuidanceCallout({
   );
 }
 
+/**
+ * Section header for one phase of the flow. Phases 1–4 are the numbered steps
+ * of draft-ietf-oauth-identity-assertion-authz-grant; Phase 0 is MCP
+ * discovery, which the spec doesn't define — labelling it as bootstrap keeps
+ * the grant itself from looking like it starts at the MCP server.
+ */
+function PhaseHeader({
+  phase,
+  skipped,
+}: {
+  phase: XAAPhaseKey;
+  skipped?: boolean;
+}) {
+  const info = XAA_PHASES[phase];
+  const number = getXAAPhaseNumber(phase);
+  return (
+    <div className="pt-2 first:pt-0" data-testid={`xaa-phase-${phase}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Phase {number} · {info.title}
+        </span>
+        {info.specStep === null ? (
+          <Badge variant="outline" className="text-[10px] h-4 px-1.5">
+            not part of the XAA grant
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="text-[10px] h-4 px-1.5">
+            spec step {info.specStep}
+          </Badge>
+        )}
+        {skipped && (
+          <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
+            skipped — auth server pre-configured
+          </Badge>
+        )}
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">{info.blurb}</p>
+    </div>
+  );
+}
+
+/** A "Tip" callout — visually distinct from diagnostics so static teaching
+ * copy can't be mistaken for an error explanation. */
+function TeachableMoments({ moments }: { moments: string[] }) {
+  return (
+    <div className="space-y-1.5 border-l-2 border-blue-400/40 pl-3">
+      {moments.map((moment) => (
+        <p
+          key={moment}
+          className="flex items-start gap-1.5 text-xs text-muted-foreground"
+        >
+          <Lightbulb className="h-3.5 w-3.5 mt-px shrink-0 text-blue-400" />
+          <span>{moment}</span>
+        </p>
+      ))}
+    </div>
+  );
+}
 
 export function XAAFlowLogger({
   flowState,
@@ -252,7 +310,7 @@ export function XAAFlowLogger({
   summary,
 }: XAAFlowLoggerProps) {
   const [expandedSteps, setExpandedSteps] = useState<Set<XAAFlowStep>>(
-    new Set(),
+    new Set()
   );
 
   useEffect(() => {
@@ -290,9 +348,27 @@ export function XAAFlowLogger({
     });
 
     return Array.from(steps.values()).sort(
-      (a, b) => getXAAStepIndex(a.step) - getXAAStepIndex(b.step),
+      (a, b) => getXAAStepIndex(a.step) - getXAAStepIndex(b.step)
     );
   }, [flowState.httpHistory, flowState.infoLogs]);
+
+  // Bucket consecutive step groups by phase so each phase renders one header.
+  const phasedGroups = useMemo(() => {
+    const sections: {
+      phase: XAAPhaseKey | undefined;
+      groups: typeof groups;
+    }[] = [];
+    for (const group of groups) {
+      const phase = getXAAStepInfo(group.step).phase;
+      const last = sections[sections.length - 1];
+      if (last && last.phase === phase) {
+        last.groups.push(group);
+      } else {
+        sections.push({ phase, groups: [group] });
+      }
+    }
+    return sections;
+  }, [groups]);
 
   const currentStepIndex = getXAAStepIndex(flowState.currentStep);
   const focusedStep = activeStep ?? flowState.currentStep;
@@ -321,7 +397,10 @@ export function XAAFlowLogger({
       };
     }
 
-    if (index < currentStepIndex || (!flowState.isBusy && index <= currentStepIndex)) {
+    if (
+      index < currentStepIndex ||
+      (!flowState.isBusy && index <= currentStepIndex)
+    ) {
       return {
         icon: CheckCircle2,
         className: "h-4 w-4 text-green-600 dark:text-green-400",
@@ -391,7 +470,7 @@ export function XAAFlowLogger({
                   value={summary.negativeTestMode}
                   onValueChange={(nextValue) =>
                     actions.onChangeNegativeTestMode?.(
-                      nextValue as NegativeTestMode,
+                      nextValue as NegativeTestMode
                     )
                   }
                   disabled={!actions.onChangeNegativeTestMode}
@@ -401,11 +480,7 @@ export function XAAFlowLogger({
                   </SelectTrigger>
                   <SelectContent>
                     {NEGATIVE_TEST_MODES.map((mode) => (
-                      <SelectItem
-                        key={mode}
-                        value={mode}
-                        className="text-xs"
-                      >
+                      <SelectItem key={mode} value={mode} className="text-xs">
                         {NEGATIVE_TEST_MODE_DETAILS[mode].label}
                       </SelectItem>
                     ))}
@@ -450,10 +525,10 @@ export function XAAFlowLogger({
 
         {(() => {
           const currentStepHttpEntries = (flowState.httpHistory || []).filter(
-            (entry) => entry.step === flowState.currentStep,
+            (entry) => entry.step === flowState.currentStep
           );
           const currentStepErroredEntry = latestErroredHttpEntry(
-            currentStepHttpEntries,
+            currentStepHttpEntries
           );
           if (!flowState.error && !currentStepErroredEntry) return null;
           const guidance = getXAAErrorGuidance({
@@ -501,10 +576,12 @@ export function XAAFlowLogger({
 
         {!hasProfile ? (
           <div className="bg-background border border-border rounded-lg p-6 space-y-3">
-            <h3 className="text-base font-semibold">Welcome to the XAA Debugger</h3>
+            <h3 className="text-base font-semibold">
+              Welcome to the XAA Debugger
+            </h3>
             <p className="text-sm text-muted-foreground">
-              Configure an MCP server, target authorization server, and client ID
-              to step through the full enterprise authorization flow.
+              Configure an MCP server, target authorization server, and client
+              ID to step through the full enterprise authorization flow.
             </p>
             <Button onClick={actions.onConfigure}>Configure Target</Button>
           </div>
@@ -513,156 +590,175 @@ export function XAAFlowLogger({
             No activity yet. Click &quot;{actions.continueLabel}&quot; to begin.
           </div>
         ) : (
-          groups.map((group, index) => {
-            const stepInfo = getXAAStepInfo(group.step);
-            const status = getStatus(group.step);
-            const StatusIcon = status.icon;
-            const entryCount =
-              group.infoEntries.length + group.httpEntries.length;
-            const hasError = group.httpEntries.some((entry) => entry.error);
+          phasedGroups.map((section) => (
+            <div key={section.phase ?? "no-phase"} className="space-y-3">
+              {section.phase && (
+                <PhaseHeader
+                  phase={section.phase}
+                  skipped={
+                    section.phase === "bootstrap" &&
+                    Boolean(summary.authzServerIssuer) &&
+                    section.groups.every(
+                      (group) => group.httpEntries.length === 0
+                    )
+                  }
+                />
+              )}
+              {section.groups.map((group, indexInPhase) => {
+                const stepInfo = getXAAStepInfo(group.step);
+                const status = getStatus(group.step);
+                const StatusIcon = status.icon;
+                const entryCount =
+                  group.infoEntries.length + group.httpEntries.length;
+                const hasError = group.httpEntries.some((entry) => entry.error);
+                const stepLabel = section.phase
+                  ? `${getXAAPhaseNumber(section.phase)}.${indexInPhase + 1} ${
+                      stepInfo.title
+                    }`
+                  : stepInfo.title;
 
-            return (
-              <div
-                key={group.step}
-                className={cn(
-                  "bg-background border rounded-lg shadow-sm",
-                  focusedStep === group.step
-                    ? "border-blue-400 ring-1 ring-blue-400/20"
-                    : "border-border",
-                )}
-              >
-                <button
-                  onClick={() => toggleStep(group.step)}
-                  className="w-full px-4 py-3 flex items-start gap-3 text-left hover:bg-muted/40 rounded-t-lg"
-                >
-                  <div className="flex-shrink-0 mt-0.5">
-                    {expandedSteps.has(group.step) ? (
-                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                return (
+                  <div
+                    key={group.step}
+                    className={cn(
+                      "bg-background border rounded-lg shadow-sm",
+                      focusedStep === group.step
+                        ? "border-blue-400 ring-1 ring-blue-400/20"
+                        : "border-border"
+                    )}
+                  >
+                    <button
+                      onClick={() => toggleStep(group.step)}
+                      className="w-full px-4 py-3 flex items-start gap-3 text-left hover:bg-muted/40 rounded-t-lg"
+                    >
+                      <div className="flex-shrink-0 mt-0.5">
+                        {expandedSteps.has(group.step) ? (
+                          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                        )}
+                      </div>
+                      <StatusIcon className={status.className} />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="text-sm font-semibold">
+                            {stepLabel}
+                          </span>
+                          <Badge
+                            variant="secondary"
+                            className="text-[10px] h-4 px-1.5"
+                          >
+                            {entryCount}
+                          </Badge>
+                          {hasError && (
+                            <Badge
+                              variant="destructive"
+                              className="text-[10px] h-4 px-1.5"
+                            >
+                              Error
+                            </Badge>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {stepInfo.summary}
+                        </p>
+                      </div>
+                      {onFocusStep && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-7"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onFocusStep(group.step);
+                          }}
+                        >
+                          Focus
+                        </Button>
+                      )}
+                    </button>
+
+                    {expandedSteps.has(group.step) && (
+                      <div className="border-t bg-muted/20 p-4 space-y-3">
+                        {(() => {
+                          if (group.step === flowState.currentStep) {
+                            // Top-level callout covers the current step.
+                            return null;
+                          }
+                          const erroredEntry = latestErroredHttpEntry(
+                            group.httpEntries
+                          );
+                          if (!erroredEntry) return null;
+                          const guidance = getXAAErrorGuidance({
+                            step: group.step,
+                            httpEntry: erroredEntry,
+                          });
+                          if (!guidance) return null;
+                          return (
+                            <GuidanceCallout
+                              guidance={guidance}
+                              onConfigure={actions.onConfigure}
+                              onShowBootstrap={actions.onShowBootstrap}
+                              onReset={actions.onReset}
+                            />
+                          );
+                        })()}
+
+                        {group.infoEntries.map((entry) => (
+                          <InfoLogEntry
+                            key={entry.id}
+                            label={entry.label}
+                            timestamp={entry.timestamp}
+                            data={entry.data}
+                            level={entry.level}
+                            error={entry.error}
+                          />
+                        ))}
+
+                        {group.httpEntries.map((entry) => (
+                          <HTTPHistoryEntry
+                            key={`${entry.timestamp}-${entry.request.url}`}
+                            method={entry.request.method}
+                            url={entry.request.url}
+                            status={entry.response?.status}
+                            statusText={entry.response?.statusText}
+                            duration={entry.duration}
+                            requestHeaders={entry.request.headers}
+                            requestBody={entry.request.body}
+                            responseHeaders={entry.response?.headers}
+                            responseBody={entry.response?.body}
+                            error={entry.error}
+                            step={entry.step}
+                          />
+                        ))}
+
+                        {stepInfo.teachableMoments?.length ? (
+                          <TeachableMoments
+                            moments={stepInfo.teachableMoments}
+                          />
+                        ) : null}
+                      </div>
                     )}
                   </div>
-                  <StatusIcon className={status.className} />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="text-sm font-semibold">
-                        {index + 1}. {stepInfo.title}
-                      </span>
-                      <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
-                        {entryCount}
-                      </Badge>
-                      {hasError && (
-                        <Badge
-                          variant="destructive"
-                          className="text-[10px] h-4 px-1.5"
-                        >
-                          Error
-                        </Badge>
-                      )}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {stepInfo.summary}
-                    </p>
-                  </div>
-                  {onFocusStep && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-7"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onFocusStep(group.step);
-                      }}
-                    >
-                      Focus
-                    </Button>
-                  )}
-                </button>
-
-                {expandedSteps.has(group.step) && (
-                  <div className="border-t bg-muted/20 p-4 space-y-3">
-                    {stepInfo.teachableMoments?.length ? (
-                      <div className="space-y-1">
-                        {stepInfo.teachableMoments.map((moment) => (
-                          <p
-                            key={moment}
-                            className="text-xs text-muted-foreground"
-                          >
-                            {moment}
-                          </p>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    {(() => {
-                      if (group.step === flowState.currentStep) {
-                        // Top-level callout covers the current step.
-                        return null;
-                      }
-                      const erroredEntry = latestErroredHttpEntry(
-                        group.httpEntries,
-                      );
-                      if (!erroredEntry) return null;
-                      const guidance = getXAAErrorGuidance({
-                        step: group.step,
-                        httpEntry: erroredEntry,
-                      });
-                      if (!guidance) return null;
-                      return (
-                        <GuidanceCallout
-                          guidance={guidance}
-                          onConfigure={actions.onConfigure}
-                          onShowBootstrap={actions.onShowBootstrap}
-                          onReset={actions.onReset}
-                        />
-                      );
-                    })()}
-
-                    {group.infoEntries.map((entry) => (
-                      <InfoLogEntry
-                        key={entry.id}
-                        label={entry.label}
-                        timestamp={entry.timestamp}
-                        data={entry.data}
-                        level={entry.level}
-                        error={entry.error}
-                      />
-                    ))}
-
-                    {group.httpEntries.map((entry) => (
-                      <HTTPHistoryEntry
-                        key={`${entry.timestamp}-${entry.request.url}`}
-                        method={entry.request.method}
-                        url={entry.request.url}
-                        status={entry.response?.status}
-                        statusText={entry.response?.statusText}
-                        duration={entry.duration}
-                        requestHeaders={entry.request.headers}
-                        requestBody={entry.request.body}
-                        responseHeaders={entry.response?.headers}
-                        responseBody={entry.response?.body}
-                        error={entry.error}
-                        step={entry.step}
-                      />
-                    ))}
-                  </div>
-                )}
-              </div>
-            );
-          })
+                );
+              })}
+            </div>
+          ))
         )}
 
-        {hasProfile && groups.length > 0 && flowState.currentStep !== "complete" && (
-          <div className="text-xs text-muted-foreground">
-            Remaining steps:{" "}
-            {
-              XAA_STEP_ORDER.filter(
-                (step) => getXAAStepIndex(step) > currentStepIndex,
-              ).length
-            }
-          </div>
-        )}
+        {hasProfile &&
+          groups.length > 0 &&
+          flowState.currentStep !== "complete" && (
+            <div className="text-xs text-muted-foreground">
+              Remaining steps:{" "}
+              {
+                XAA_STEP_ORDER.filter(
+                  (step) => getXAAStepIndex(step) > currentStepIndex
+                ).length
+              }
+            </div>
+          )}
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/step-metadata.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/step-metadata.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  getXAAPhaseNumber,
+  XAA_PHASE_ORDER,
+  XAA_PHASES,
+  XAA_STEP_METADATA,
+  XAA_STEP_ORDER,
+} from "../step-metadata";
+
+// The phase layer maps the debugger's machine steps onto the four numbered
+// steps of draft-ietf-oauth-identity-assertion-authz-grant plus a Phase 0
+// for MCP discovery. These invariants keep the teaching structure honest.
+
+describe("XAA phase metadata", () => {
+  it("assigns every step except idle to a phase", () => {
+    for (const step of XAA_STEP_ORDER) {
+      const { phase } = XAA_STEP_METADATA[step];
+      if (step === "idle") {
+        expect(phase).toBeUndefined();
+      } else {
+        expect(phase, `step ${step} must belong to a phase`).toBeDefined();
+        expect(XAA_PHASE_ORDER).toContain(phase);
+      }
+    }
+  });
+
+  it("orders steps so phases never interleave or run backwards", () => {
+    const phaseIndexes = XAA_STEP_ORDER.filter((s) => s !== "idle").map(
+      (step) => getXAAPhaseNumber(XAA_STEP_METADATA[step].phase!)
+    );
+    const sorted = [...phaseIndexes].sort((a, b) => a - b);
+    expect(phaseIndexes).toEqual(sorted);
+  });
+
+  it("numbers phases 0-4 with bootstrap as the only non-spec phase", () => {
+    expect(getXAAPhaseNumber("bootstrap")).toBe(0);
+    expect(XAA_PHASES.bootstrap.specStep).toBeNull();
+    // Phases 1-4 carry the draft's step numbers in order.
+    const specSteps = XAA_PHASE_ORDER.filter((p) => p !== "bootstrap").map(
+      (p) => XAA_PHASES[p].specStep
+    );
+    expect(specSteps).toEqual([1, 2, 3, 4]);
+  });
+
+  it("matches phase numbers to spec step numbers for the grant phases", () => {
+    for (const phase of XAA_PHASE_ORDER) {
+      const { specStep } = XAA_PHASES[phase];
+      if (specStep !== null) {
+        expect(getXAAPhaseNumber(phase)).toBe(specStep);
+      }
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/step-metadata.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/step-metadata.ts
@@ -1,8 +1,77 @@
 import type { XAAFlowStep } from "./types";
 
+/**
+ * Phases group the debugger's fine-grained machine steps onto the four
+ * numbered steps of draft-ietf-oauth-identity-assertion-authz-grant, plus a
+ * "Phase 0" for MCP discovery — which the spec does NOT define (it assumes a
+ * pre-configured client). Keeping that distinction visible is the point:
+ * developers should leave this screen knowing which parts are the XAA grant
+ * and which parts are MCP bootstrap.
+ */
+export type XAAPhaseKey =
+  | "bootstrap"
+  | "sso"
+  | "token_exchange"
+  | "jwt_bearer"
+  | "mcp_request";
+
+export interface XAAPhaseInfo {
+  title: string;
+  /** Step number in the ID-JAG draft (1–4); null = not part of the grant. */
+  specStep: number | null;
+  blurb: string;
+}
+
+export const XAA_PHASE_ORDER: XAAPhaseKey[] = [
+  "bootstrap",
+  "sso",
+  "token_exchange",
+  "jwt_bearer",
+  "mcp_request",
+];
+
+export const XAA_PHASES: Record<XAAPhaseKey, XAAPhaseInfo> = {
+  bootstrap: {
+    title: "Bootstrap — MCP discovery",
+    specStep: null,
+    blurb:
+      "RFC 9728/8414 discovery, not part of the XAA grant. The spec assumes the client already knows the resource's authorization server; an MCP client learns it here instead — and that issuer becomes the ID-JAG audience in Phase 2. Skipped entirely when the authorization server is pre-configured.",
+  },
+  sso: {
+    title: "User SSO with the IdP",
+    specStep: 1,
+    blurb:
+      "The user signs in at the enterprise IdP and the requesting app holds an OIDC ID token. This happens once per user session, independent of any particular MCP server. The debugger mocks the IdP.",
+  },
+  token_exchange: {
+    title: "Token exchange: ID token → ID-JAG",
+    specStep: 2,
+    blurb:
+      "RFC 8693 exchange at the IdP. The app presents the ID token with audience = the resource authorization server's issuer; the IdP mints an ID-JAG addressed to that server. The ID token itself never leaves the IdP relationship.",
+  },
+  jwt_bearer: {
+    title: "JWT bearer grant at the resource's auth server",
+    specStep: 3,
+    blurb:
+      "RFC 7523: the app presents the ID-JAG as an assertion to the resource authorization server's token endpoint. That server validates iss, aud, and resource, then mints an access token.",
+  },
+  mcp_request: {
+    title: "Authenticated resource request",
+    specStep: 4,
+    blurb:
+      "Call the MCP server with the access token — the only credential the resource server ever sees. Neither the ID token nor the ID-JAG is sent to it.",
+  },
+};
+
+export function getXAAPhaseNumber(phase: XAAPhaseKey): number {
+  return XAA_PHASE_ORDER.indexOf(phase);
+}
+
 export interface XAAStepInfo {
   title: string;
   summary: string;
+  /** Phase this step belongs to; undefined only for machine states like idle. */
+  phase?: XAAPhaseKey;
   teachableMoments?: string[];
 }
 
@@ -26,84 +95,108 @@ export const XAA_STEP_ORDER: XAAFlowStep[] = [
 export const XAA_STEP_METADATA: Record<XAAFlowStep, XAAStepInfo> = {
   idle: {
     title: "Idle",
-    summary: "The debugger is ready to walk through the XAA enterprise authorization flow.",
+    summary:
+      "The debugger is ready to walk through the XAA enterprise authorization flow.",
     teachableMoments: [
-      "You need three aligned values before stage 3 works: trusted issuer, audience, and resource.",
+      "You need three aligned values before the JWT bearer grant works: trusted issuer, audience, and resource.",
     ],
   },
   discover_resource_metadata: {
     title: "Discover Resource Metadata",
-    summary: "Fetch RFC 9728 protected resource metadata from the target MCP server.",
+    summary:
+      "Fetch RFC 9728 protected resource metadata from the target MCP server.",
+    phase: "bootstrap",
     teachableMoments: [
       "This tells the client which authorization server should mint access tokens for the MCP server.",
     ],
   },
   received_resource_metadata: {
     title: "Resource Metadata Received",
-    summary: "Capture the MCP server resource identifier and linked authorization server issuer.",
+    summary:
+      "Capture the MCP server resource identifier and linked authorization server issuer.",
+    phase: "bootstrap",
     teachableMoments: [
-      "The `resource` claim in the ID-JAG should line up with this metadata.",
+      "The `resource` claim in the ID-JAG minted in Phase 2 should line up with this metadata.",
     ],
   },
   discover_authz_metadata: {
     title: "Discover Authorization Metadata",
-    summary: "Fetch RFC 8414 or OIDC discovery metadata from the authorization server.",
+    summary:
+      "Fetch RFC 8414 or OIDC discovery metadata from the authorization server.",
+    phase: "bootstrap",
     teachableMoments: [
-      "The ID-JAG `aud` claim should match the authorization server issuer, not the token endpoint URL.",
+      "Note the `issuer` in this metadata: the ID-JAG minted in Phase 2 must carry it as `aud`. The spec requires the audience to be the authorization server's issuer identifier — not its `token_endpoint`.",
     ],
   },
   received_authz_metadata: {
     title: "Authorization Metadata Received",
-    summary: "Inspect the issuer and token endpoint that will receive the JWT bearer assertion.",
+    summary:
+      "Inspect the issuer and token endpoint that will receive the JWT bearer assertion.",
+    phase: "bootstrap",
     teachableMoments: [
       "If discovery fails, the authorization server issuer or well-known metadata is usually misconfigured.",
     ],
   },
   user_authentication: {
     title: "Mock User Authentication",
-    summary: "MCPJam issues a synthetic OIDC ID token for the simulated enterprise user.",
+    summary:
+      "MCPJam issues a synthetic OIDC ID token for the simulated enterprise user.",
+    phase: "sso",
     teachableMoments: [
-      "This is stage 1 of the XAA flow: a user identity assertion from the enterprise IdP.",
+      "Spec step 1: the user authenticates at the enterprise IdP and the app receives an identity assertion (an OIDC ID token).",
     ],
   },
   received_identity_assertion: {
     title: "Identity Assertion Ready",
-    summary: "The debugger stores the synthetic ID token that will be exchanged for an ID-JAG.",
+    summary:
+      "The debugger stores the synthetic ID token that will be exchanged for an ID-JAG.",
+    phase: "sso",
     teachableMoments: [
       "The ID token is an input to token exchange; it is not sent directly to the target authorization server.",
     ],
   },
   token_exchange_request: {
     title: "RFC 8693 Token Exchange",
-    summary: "Exchange the synthetic ID token for an ID-JAG, optionally injecting a negative test mode.",
+    summary:
+      "Exchange the synthetic ID token for an ID-JAG, optionally injecting a negative test mode.",
+    phase: "token_exchange",
     teachableMoments: [
+      "Spec step 2: the `audience` parameter names the resource authorization server's issuer — the value discovered (or pre-configured) in Phase 0.",
       "This is where broken assertions get created for audience, issuer, header, and claim validation tests.",
     ],
   },
   received_id_jag: {
     title: "ID-JAG Issued",
     summary: "The synthetic issuer returns a signed ID-JAG JWT.",
+    phase: "token_exchange",
     teachableMoments: [
       "A valid ID-JAG includes `iss`, `sub`, `aud`, `resource`, `client_id`, `jti`, `iat`, and `exp`.",
     ],
   },
   inspect_id_jag: {
     title: "Inspect ID-JAG",
-    summary: "Decode the header and payload locally before sending the assertion downstream.",
+    summary:
+      "Decode the header and payload locally before sending the assertion downstream.",
+    phase: "token_exchange",
     teachableMoments: [
+      "`aud` must exactly match the resource authorization server's issuer, and `resource` must match the MCP server's resource identifier.",
       "Use this step to confirm which field a negative test mode is intentionally breaking.",
     ],
   },
   jwt_bearer_request: {
     title: "RFC 7523 JWT Bearer Request",
-    summary: "Submit the ID-JAG to the target authorization server token endpoint through the debugger proxy.",
+    summary:
+      "Submit the ID-JAG to the target authorization server token endpoint through the debugger proxy.",
+    phase: "jwt_bearer",
     teachableMoments: [
+      "Spec step 3: the resource authorization server validates the ID-JAG's `iss`, `aud`, and `resource` before minting an access token.",
       "If this fails, check whether the server trusts the synthetic issuer JWKS and supports the JWT bearer grant.",
     ],
   },
   received_access_token: {
     title: "Access Token Received",
     summary: "Store the access token returned by the authorization server.",
+    phase: "jwt_bearer",
     teachableMoments: [
       "A successful response here proves the authorization server accepted the ID-JAG and policy checks passed.",
     ],
@@ -111,13 +204,15 @@ export const XAA_STEP_METADATA: Record<XAAFlowStep, XAAStepInfo> = {
   authenticated_mcp_request: {
     title: "Authenticated MCP Request",
     summary: "Retry an MCP initialize request with the issued access token.",
+    phase: "mcp_request",
     teachableMoments: [
-      "This closes the loop: the access token has to work on the real MCP server, not just the token endpoint.",
+      "Spec step 4: this closes the loop — the access token has to work on the real MCP server, not just the token endpoint.",
     ],
   },
   complete: {
     title: "Flow Complete",
     summary: "The debugger completed the synthetic XAA flow end-to-end.",
+    phase: "mcp_request",
     teachableMoments: [
       "Switch negative test modes to probe specific authorization server validation paths.",
     ],


### PR DESCRIPTION
## TL;DR
The XAA debugger showed 13 flat steps, so the grant looked like it *starts* at the MCP server and tutorial copy rendered like error diagnostics. This PR groups the steps into the [ID-JAG draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/)'s **four numbered steps** plus an explicitly-labelled **Phase 0: Bootstrap** for MCP discovery, and restyles teachable moments as Tips below the evidence.

## Before / after

| | Before | After |
|---|---|---|
| Structure | 13 flat numbered steps | 5 phase sections: `Phase 0 · Bootstrap — MCP discovery` (badge: *not part of the XAA grant*), `Phase 1 · User SSO with the IdP` (*spec step 1*) … `Phase 4 · Authenticated resource request` (*spec step 4*) |
| Step numbers | Global `1.`–`13.` | Per-phase `0.1`, `2.1`, `2.2` … (phase number == spec step number) |
| Discovery skipped | Invisible | `skipped — auth server pre-configured` badge on the bootstrap header |
| Teachable moments | Plain gray text at the **top** of an expanded step — directly above failures, reading as diagnostics (e.g. the "ID-JAG `aud`" hint above discovery 401s) | 💡 Tip styling (lightbulb, blue left border) **below** the request/response entries |
| Copy | "stage 1/stage 3" wording, aud-hint phrased as a finding | Cites "spec step N"; aud hint is forward-looking: *"the ID-JAG minted in Phase 2 must carry this issuer as `aud` — not the `token_endpoint`"* |

## Why this mapping (spec receipts)
- Draft defines exactly 4 steps: user SSO → RFC 8693 token exchange at the IdP → ID-JAG to the resource AS token endpoint (RFC 7523) → resource request.
- "The `aud` claim MUST contain the issuer identifier of the Resource Authorization Server as defined in RFC 8414" — which is why bootstrap matters to MCP clients (it's where the audience is learned) and why it's still not part of the grant.

## What changed
- `client/src/lib/xaa/step-metadata.ts` — new `XAA_PHASES` / `XAA_PHASE_ORDER` / `getXAAPhaseNumber`, `phase` on every step, copy rewording
- `client/src/components/xaa/XAAFlowLogger.tsx` — `PhaseHeader` + `TeachableMoments` components, phase-bucketed rendering, per-phase numbering
- `client/src/lib/xaa/__tests__/step-metadata.test.ts` — invariants: every step phased, phases never interleave, phase numbers 0–4 with phase N == spec step N

## Risk register

| Concern | Answer |
|---|---|
| State machine / flow behavior changed? | No — purely presentational; `XAA_STEP_ORDER`, step keys, and `getXAAStepIndex` are untouched, so `XAARunChips`, focus, and status logic behave identically. |
| "Skipped" badge wrong when AS discovery still runs? | No — it requires **zero** HTTP entries across all bootstrap steps; issuer-known runs that still fetch the token endpoint won't show it. |
| Existing tests? | 115/115 XAA tests pass; project typecheck gate clean; prettier applied. |
