### PR TITLE
fix(api-keys): resolve WorkOS org server-side when session lacks org_id

### DIFF
--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -155,6 +155,16 @@ function mapWorkOSError(status: number, body: any, fallback: string): never {
       : typeof body?.error_description === "string"
         ? body.error_description
         : fallback;
+  // WorkOS 422s carry the actual cause in `errors` (e.g.
+  // `[{field: "organization_id", code: "organization_id should not be empty"}]`)
+  // while `message` is just "Validation failed" — keep the field errors or the
+  // failure is undiagnosable from our logs.
+  const fieldErrors = Array.isArray(body?.errors) ? body.errors : undefined;
+  logger.error("WorkOS API call failed", {
+    workos_status: status,
+    message: safeMessage,
+    ...(fieldErrors ? { workos_errors: fieldErrors } : {}),
+  });
   if (status === 401) {
     throw new WebRouteError(401, ErrorCode.UNAUTHORIZED, safeMessage);
   }
@@ -164,7 +174,46 @@ function mapWorkOSError(status: number, body: any, fallback: string): never {
   if (status === 429) {
     throw new WebRouteError(429, ErrorCode.RATE_LIMITED, safeMessage);
   }
-  throw new WebRouteError(500, ErrorCode.INTERNAL_ERROR, safeMessage);
+  throw new WebRouteError(
+    500,
+    ErrorCode.INTERNAL_ERROR,
+    safeMessage,
+    fieldErrors ? { workosErrors: fieldErrors } : undefined,
+  );
+}
+
+/**
+ * WorkOS REQUIRES `organization_id` when minting a user API key (422
+ * "Validation failed" without it). Org-scoped sessions carry the org in the
+ * JWT's `org_id` claim; sessions signed in outside an organization context
+ * don't, so fall back to the user's active WorkOS memberships. Which WorkOS
+ * org hosts the key doesn't affect authorization — that's enforced by the
+ * MCPJam org binding — so the first active membership is fine.
+ */
+async function resolveWorkosOrgId(session: SessionContext): Promise<string> {
+  if (session.organizationId) {
+    return session.organizationId;
+  }
+  const { status, body } = await callWorkOS(
+    "GET",
+    `/user_management/organization_memberships?user_id=${encodeURIComponent(
+      session.userId,
+    )}&statuses=active`,
+  );
+  if (status < 200 || status >= 300) {
+    mapWorkOSError(status, body, "Failed to resolve your organization");
+  }
+  const first = Array.isArray(body?.data) ? body.data[0] : undefined;
+  const orgId =
+    typeof first?.organization_id === "string" ? first.organization_id : null;
+  if (!orgId) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Your account does not belong to a WorkOS organization, which is required to create API keys",
+    );
+  }
+  return orgId;
 }
 
 const createSchema = z.object({
@@ -193,10 +242,10 @@ apiKeys.post("/", async (c) =>
       );
     }
 
-    const payload: Record<string, unknown> = { name };
-    if (session.organizationId) {
-      payload.organization_id = session.organizationId;
-    }
+    const payload: Record<string, unknown> = {
+      name,
+      organization_id: await resolveWorkosOrgId(session),
+    };
 
     const { status, body } = await callWorkOS(
       "POST",


### PR DESCRIPTION
## Problem

Creating an API key failed with an opaque 500 (toast: "Validation failed") whenever the AuthKit session JWT had no `org_id` claim. WorkOS **requires** `organization_id` when minting a user API key:

```
HTTP 422 — {"errors":[{"field":"organization_id","code":"organization_id should not be empty"}]}
```

but the route only sent it when the session happened to be org-scoped, and `mapWorkOSError` dropped the `errors` array — keeping only the useless "Validation failed" message — before mapping the 422 to a 500 `internal_error`.

Hit in dev after the AuthKit app swap (fresh WorkOS user, no org membership), but latent for any user whose session isn't org-scoped.

## Fix

- **`resolveWorkosOrgId()`** — use the JWT `org_id` when present; otherwise fall back to the user's first active WorkOS org membership. A user with no membership at all now gets a clear 400 ("Your account does not belong to a WorkOS organization…") instead of a 500. Which WorkOS org hosts the key doesn't affect authorization — that's enforced by the MCPJam org binding minted alongside the key — so the first active membership is fine.
- **`mapWorkOSError()`** — log WorkOS's field-level `errors` array and attach it as `details.workosErrors` on 500s, so the next failure like this is diagnosable from the log line instead of requiring a curl replay.

## Testing

- Reproduced the 422 against WorkOS directly, then verified the exact create call succeeds once a membership exists (created + deleted a throwaway key, 204).
- `server/tsconfig.json` typecheck clean for the touched file; `bearer-auth` + `web/errors` vitest suites pass (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes API key minting and WorkOS error handling on an auth-adjacent route; behavior is more correct but adds an extra WorkOS membership lookup for non-org-scoped sessions.
> 
> **Overview**
> Fixes API key creation failing with an opaque **500** ("Validation failed") when the AuthKit JWT has no `org_id`. WorkOS requires `organization_id` on mint; the create route now **always** sends it via new **`resolveWorkosOrgId()`** (JWT org when present, otherwise first active WorkOS org membership), with a clear **400** when the user has no WorkOS org.
> 
> **`mapWorkOSError()`** now logs WorkOS field-level `errors` and attaches them as `details.workosErrors` on internal errors so 422 validation failures are diagnosable without replaying the call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ba7dbba5d2699b5190266c55820748a000fea24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->