### PR TITLE
fix(api-keys): verify revoke ownership via the user's key list

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebTestApp, expectJson } from "./helpers/test-app.js";
+
+// The session bearer is verified in-route (resolveSessionContext); stub it to
+// a fixed WorkOS user so tests exercise the WorkOS REST flow, not JWT crypto.
+vi.mock("../../../services/authkit-jwt.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    verifyAuthKitToken: vi.fn().mockResolvedValue({
+      sub: "user_session_1",
+      orgId: undefined,
+    }),
+  };
+});
+
+// Convex binding writes are out of scope here — keep the real
+// WorkosKeyBindingError class but neuter the network calls.
+vi.mock("../../../services/workos-key-bindings.js", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    createWorkosKeyBinding: vi.fn().mockResolvedValue(undefined),
+    removeWorkosKeyBinding: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const OWNED_KEY_ID = "api_key_owned_1";
+const USER_KEYS_PATH = "/user_management/users/user_session_1/api_keys";
+
+function workosJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function keyRecord(id: string) {
+  return {
+    object: "api_key",
+    id,
+    owner: { type: "user", id: "user_session_1" },
+    name: id,
+  };
+}
+
+/**
+ * Stub WorkOS: serve the user-scoped key list from `pages` (each entry is one
+ * page; `list_metadata.after` chains them) and accept the admin DELETE.
+ */
+function stubWorkOS(pages: Array<{ data: unknown[]; after?: string | null }>) {
+  const deleted: string[] = [];
+  const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    if (method === "GET" && url.pathname === USER_KEYS_PATH) {
+      const after = url.searchParams.get("after");
+      const index = after ? Number(after.replace("cursor_", "")) : 0;
+      const page = pages[index];
+      if (!page) {
+        return workosJson({ message: "bad cursor" }, 400);
+      }
+      return workosJson({
+        object: "list",
+        data: page.data,
+        list_metadata: { before: null, after: page.after ?? null },
+      });
+    }
+    if (method === "DELETE" && url.pathname.startsWith("/api_keys/")) {
+      deleted.push(decodeURIComponent(url.pathname.slice("/api_keys/".length)));
+      return new Response(null, { status: 204 });
+    }
+    return workosJson({ message: "unexpected WorkOS call" }, 500);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, deleted };
+}
+
+async function deleteKey(app: ReturnType<typeof createWebTestApp>["app"], id: string) {
+  return app.request(`/api/web/api-keys/${id}`, {
+    method: "DELETE",
+    headers: { Authorization: "Bearer session-jwt" },
+  });
+}
+
+describe("web routes — API key revoke ownership", () => {
+  const { app } = createWebTestApp();
+
+  beforeEach(() => {
+    vi.stubEnv("WORKOS_API_KEY", "sk_test_admin");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("revokes a key that appears in the session user's list", async () => {
+    const { deleted } = stubWorkOS([
+      { data: [keyRecord("api_key_other"), keyRecord(OWNED_KEY_ID)] },
+    ]);
+
+    const { status, data } = await expectJson(await deleteKey(app, OWNED_KEY_ID));
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ ok: true });
+    expect(deleted).toEqual([OWNED_KEY_ID]);
+  });
+
+  it("404s for a foreign or unknown key id without calling DELETE", async () => {
+    const { deleted, fetchMock } = stubWorkOS([
+      { data: [keyRecord("api_key_other")] },
+    ]);
+
+    const { status, data } = await expectJson(
+      await deleteKey(app, "api_key_someone_elses"),
+    );
+
+    expect(status).toBe(404);
+    expect(data).toMatchObject({ code: "NOT_FOUND" });
+    expect(deleted).toEqual([]);
+    // Only the ownership list walk ran.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("finds a key on a later page of the list", async () => {
+    const { deleted, fetchMock } = stubWorkOS([
+      { data: [keyRecord("api_key_other")], after: "cursor_1" },
+      { data: [keyRecord(OWNED_KEY_ID)] },
+    ]);
+
+    const { status, data } = await expectJson(await deleteKey(app, OWNED_KEY_ID));
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ ok: true });
+    expect(deleted).toEqual([OWNED_KEY_ID]);
+    // Two list pages + one DELETE.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const secondListUrl = new URL(String(fetchMock.mock.calls[1][0]));
+    expect(secondListUrl.searchParams.get("after")).toBe("cursor_1");
+  });
+
+  it("errors (not 404) when the page cap is exhausted with pages remaining", async () => {
+    // Every page points at itself, so the walk never terminates naturally.
+    const { deleted } = stubWorkOS([
+      { data: [keyRecord("api_key_other")], after: "cursor_0" },
+    ]);
+
+    const { status, data } = await expectJson(
+      await deleteKey(app, "api_key_beyond_cap"),
+    );
+
+    expect(status).toBe(500);
+    expect(data).toMatchObject({
+      code: "INTERNAL_ERROR",
+      message: "Could not verify API key ownership",
+    });
+    expect(deleted).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -35,9 +35,11 @@ import {
  * - A user can only mint a key as powerful as their own session: the
  *   create call routes through `/user_management/users/{userId}` and
  *   `userId` is taken from the session JWT.
- * - DELETE re-fetches the key and verifies `owner.id === sessionUserId`
+ * - DELETE verifies the key id appears in the session user's own key list
  *   before issuing the WorkOS delete, so passing another user's key id
- *   fails before WorkOS sees the request.
+ *   fails before WorkOS sees the request. (WorkOS exposes no single-key
+ *   GET for user keys — both `/api_keys/{id}` and the user-scoped variant
+ *   404 even for existing ids — so list membership is the ownership check.)
  * - `sk_…` keys cannot manage other `sk_…` keys (privilege isolation).
  */
 
@@ -216,6 +218,40 @@ async function resolveWorkosOrgId(session: SessionContext): Promise<string> {
   return orgId;
 }
 
+/**
+ * Whether `keyId` belongs to `userId`, checked by walking the user-scoped
+ * key list (see DELETE: WorkOS has no single-key GET for user keys).
+ */
+async function userOwnsApiKey(userId: string, keyId: string): Promise<boolean> {
+  let after: string | null = null;
+  // Page cap is a runaway guard only — real users have a handful of keys.
+  for (let page = 0; page < 10; page++) {
+    const params = new URLSearchParams({ limit: "100" });
+    if (after) {
+      params.set("after", after);
+    }
+    const { status, body } = await callWorkOS(
+      "GET",
+      `/user_management/users/${encodeURIComponent(userId)}/api_keys?${params.toString()}`,
+    );
+    if (status < 200 || status >= 300) {
+      mapWorkOSError(status, body, "Failed to load API keys");
+    }
+    const items: any[] = Array.isArray(body?.data) ? body.data : [];
+    if (items.some((key) => key?.id === keyId)) {
+      return true;
+    }
+    after =
+      typeof body?.list_metadata?.after === "string"
+        ? body.list_metadata.after
+        : null;
+    if (!after) {
+      return false;
+    }
+  }
+  return false;
+}
+
 const createSchema = z.object({
   name: z.string().min(1).max(120),
   // MCPJam organization id (Convex `Id<'organizations'>`) the key acts inside.
@@ -385,26 +421,13 @@ apiKeys.delete("/:id", async (c) =>
     }
     const session = await resolveSessionContext(c);
 
-    // Cross-user defense in depth: fetch the key first and confirm the
-    // owner matches the session user before deleting. WorkOS does not
-    // enforce per-user ownership for the org-level admin key.
-    const lookup = await callWorkOS(
-      "GET",
-      `/api_keys/${encodeURIComponent(id)}`,
-    );
-    if (lookup.status === 404) {
+    // Cross-user defense in depth: WorkOS does not enforce per-user
+    // ownership for the org-level admin key, and it exposes no single-key
+    // GET for user keys (404s even for existing ids). The key must appear
+    // in the session user's OWN key list — enumeration under the user is
+    // the ownership proof. An unknown or foreign id reads as not-found.
+    if (!(await userOwnsApiKey(session.userId, id))) {
       throw new WebRouteError(404, ErrorCode.NOT_FOUND, "API key not found");
-    }
-    if (lookup.status < 200 || lookup.status >= 300) {
-      mapWorkOSError(lookup.status, lookup.body, "Failed to load API key");
-    }
-    const ownerId = lookup.body?.owner?.id;
-    if (typeof ownerId !== "string" || ownerId !== session.userId) {
-      throw new WebRouteError(
-        404,
-        ErrorCode.NOT_FOUND,
-        "API key not found",
-      );
     }
 
     const { status, body } = await callWorkOS(

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -225,6 +225,9 @@ async function resolveWorkosOrgId(session: SessionContext): Promise<string> {
 async function userOwnsApiKey(userId: string, keyId: string): Promise<boolean> {
   let after: string | null = null;
   // Page cap is a runaway guard only — real users have a handful of keys.
+  // Exhausting it with pages still remaining means ownership is UNKNOWN,
+  // which must surface as an error: returning false here would read as a
+  // 404 and make keys beyond the cap silently unrevokeable.
   for (let page = 0; page < 10; page++) {
     const params = new URLSearchParams({ limit: "100" });
     if (after) {
@@ -249,7 +252,15 @@ async function userOwnsApiKey(userId: string, keyId: string): Promise<boolean> {
       return false;
     }
   }
-  return false;
+  logger.error("API key ownership check exhausted page cap", {
+    workos_user_id: userId,
+    workos_key_id: keyId,
+  });
+  throw new WebRouteError(
+    500,
+    ErrorCode.INTERNAL_ERROR,
+    "Could not verify API key ownership",
+  );
 }
 
 const createSchema = z.object({


### PR DESCRIPTION
## Problem

Revoking an API key always failed with 404 "API key not found", even for the user's own keys.

The DELETE route's defense-in-depth ownership check did `GET /api_keys/{id}` and compared `owner.id` to the session user — but WorkOS exposes **no single-key GET for user API keys**. Both `/api_keys/{id}` and the user-scoped `/user_management/users/{userId}/api_keys/{id}` return 404 even for ids that exist (verified directly against WorkOS). So the check 404'd before the delete ever ran. `DELETE /api_keys/{id}` itself works fine.

## Fix

Replace the single-key lookup with `userOwnsApiKey()`: walk the session user's own key list (the documented, working endpoint — same one GET / uses) and require the id to appear there. Enumeration under the user **is** the ownership proof, so the cross-user guarantee is unchanged: a foreign or unknown key id still reads as 404 before WorkOS sees the delete. List walk is paginated (limit 100, capped at 10 pages as a runaway guard).

Follow-up to #2588.

## Testing

- Verified against WorkOS directly: both single-key GET variants 404 for an existing key; the user-scoped list returns it; DELETE removes it (confirmed gone from the list).
- `server/tsconfig.json` typecheck clean for the touched file; `bearer-auth` + `web/errors` vitest suites pass (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization on API key revoke (security-sensitive), but behavior preserves cross-user 404 semantics and only fixes a broken WorkOS lookup path.
> 
> **Overview**
> Fixes **API key revoke** always returning 404 for valid keys by changing how DELETE proves ownership before calling WorkOS.
> 
> The route no longer uses **`GET /api_keys/{id}`** (WorkOS returns 404 for user keys even when they exist). It now walks the session user's **`/user_management/users/{userId}/api_keys`** list via new **`userOwnsApiKey`**, with pagination (limit 100, max 10 pages). Foreign or unknown ids still get **404** without DELETE; if the page cap is hit while more pages remain, the handler returns **500** so keys aren't silently treated as not owned.
> 
> Adds **`api-keys.test.ts`** covering successful revoke, foreign-key 404 without DELETE, multi-page lookup, and page-cap failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae7babf459a67cf12c8116eca97fa6ecf2e6f8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->