### PR TITLE
fix(api/v1): create-time eval model validation, cursor pagination, -32601 mapping, docs model id

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -473,7 +473,7 @@
                     "title": "echo works",
                     "query": "Use the echo tool to say hi",
                     "runs": 1,
-                    "model": "claude-sonnet-4-6",
+                    "model": "anthropic/claude-haiku-4.5",
                     "provider": "anthropic",
                     "expectedToolCalls": [
                       { "toolName": "echo", "arguments": { "text": "hi" } }
@@ -1329,7 +1329,7 @@
           },
           "model": {
             "type": "string",
-            "description": "Model ID, e.g. `claude-sonnet-4-6`."
+            "description": "Model ID. Hosted-catalog ids use `provider/name` form (e.g. `anthropic/claude-haiku-4.5`) and run on org credits; provider-native ids require a matching `modelApiKeys` entry (BYOK). Unknown models are rejected with VALIDATION_ERROR at create time."
           },
           "provider": {
             "type": "string",

--- a/docs/reference/public-api.mdx
+++ b/docs/reference/public-api.mdx
@@ -257,7 +257,7 @@ RUN_ID=$(curl -fsS -X POST \
       "title": "echo works",
       "query": "Use the echo tool to say hi",
       "runs": 1,
-      "model": "claude-sonnet-4-6",
+      "model": "anthropic/claude-haiku-4.5",
       "provider": "anthropic",
       "expectedToolCalls": [{ "toolName": "echo", "arguments": { "text": "hi" } }]
     }]
@@ -271,6 +271,13 @@ curl -s "https://app.mcpjam.com/api/v1/projects/$PROJECT_ID/eval-runs/$RUN_ID" \
 curl -s "https://app.mcpjam.com/api/v1/projects/$PROJECT_ID/eval-runs/$RUN_ID/iterations" \
   -H "Authorization: Bearer $MCPJAM_API_KEY"
 ```
+
+`model` takes an id from the hosted catalog — `provider/name` form, e.g.
+`anthropic/claude-haiku-4.5` — and runs on your organization's credits.
+Provider-native ids (e.g. `claude-sonnet-4-5`) are bring-your-own-key: pass
+the key in `modelApiKeys`. A model the API can't execute is rejected at
+create time with `VALIDATION_ERROR`; `details.hostedModels` lists the valid
+hosted ids for that provider.
 
 Reruns are even shorter: `{ "suiteId": "...", "serverIds": ["..."] }` reruns
 the suite exactly as configured. Per-organization concurrency is capped

--- a/mcpjam-inspector/server/routes/v1/__tests__/catalog.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/catalog.test.ts
@@ -94,6 +94,24 @@ describe("v1 catalog read proxies", () => {
     }
   );
 
+  it("maps the public `cursor` param onto the upstream `before`", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [] }));
+    await request(makeApp(), "/api/v1/chat-sessions?limit=2&cursor=999");
+    const [target] = fetchMock.mock.calls[0] as [URL];
+    expect(String(target)).toBe(
+      "https://convex-http.example.com/v1/chat-sessions?limit=2&before=999"
+    );
+  });
+
+  it("lets `cursor` win over an explicit `before`", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [] }));
+    await request(makeApp(), "/api/v1/chat-sessions?before=123&cursor=999");
+    const [target] = fetchMock.mock.calls[0] as [URL];
+    expect(String(target)).toBe(
+      "https://convex-http.example.com/v1/chat-sessions?before=999"
+    );
+  });
+
   it("passes the upstream page body through verbatim", async () => {
     const page = {
       items: [{ id: "s_1", name: "echo", transportType: "http" }],

--- a/mcpjam-inspector/server/routes/v1/__tests__/envelope.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/envelope.test.ts
@@ -78,6 +78,32 @@ describe("mapErrorToV1 — OAUTH_REQUIRED promotion", () => {
   });
 });
 
+describe("mapErrorToV1 — FEATURE_NOT_SUPPORTED promotion", () => {
+  it("maps MCP -32601 Method-not-found errors to FEATURE_NOT_SUPPORTED", () => {
+    // Shape of the SDK's McpError: an Error carrying the numeric JSON-RPC
+    // code. prompts/get against a server with no prompts capability throws
+    // exactly this; it must NOT surface as a 500.
+    const err = Object.assign(new Error("MCP error -32601: Method not found"), {
+      code: -32601,
+    });
+
+    const result = mapErrorToV1(err);
+
+    expect(result.code).toBe("FEATURE_NOT_SUPPORTED");
+    expect(result.message).toContain("Method not found");
+  });
+
+  it("does not promote other JSON-RPC error codes", () => {
+    const err = Object.assign(new Error("MCP error -32602: Invalid params"), {
+      code: -32602,
+    });
+
+    const result = mapErrorToV1(err);
+
+    expect(result.code).toBe("INTERNAL_ERROR");
+  });
+});
+
 describe("mapErrorToV1 — passthrough", () => {
   it("maps a generic non-WebRouteError into INTERNAL_ERROR", () => {
     const result = mapErrorToV1(new Error("boom"));

--- a/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
@@ -180,6 +180,100 @@ describe("v1 write routes", () => {
       expect(prepareEvalRunMock).not.toHaveBeenCalled();
     });
 
+    describe("inline test model validation", () => {
+      const inlineTest = (model: string, provider = "anthropic") => ({
+        title: "echo works",
+        query: "Use the echo tool to say hi",
+        runs: 1,
+        model,
+        provider,
+        expectedToolCalls: [],
+      });
+
+      function mockHappyCreate() {
+        createAuthorizedManagerMock.mockResolvedValue({
+          manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+          oauthServerUrls: {},
+          authenticatedUserId: null,
+        });
+        prepareEvalRunMock.mockResolvedValue({
+          suiteId: "suite_1",
+          runId: "run_1",
+          caseUpsert: { committed: [], failed: [] },
+          recorder: { finalize: vi.fn() },
+          execute: vi.fn().mockResolvedValue(undefined),
+        });
+      }
+
+      it("rejects a model the API cannot execute, naming the hosted ids", async () => {
+        // The exact failure mode that motivated this: a raw Anthropic API id
+        // is not hosted and has no BYOK key, so the run would 202 and then
+        // die with zero tokens and an opaque stream error.
+        const res = await request(
+          makeApp(),
+          "POST",
+          "/api/v1/projects/p1/eval-runs",
+          { suiteName: "smoke", serverIds: ["s1"], tests: [inlineTest("claude-sonnet-4-6")] }
+        );
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as {
+          code?: string;
+          details?: { hostedModels?: string[] };
+        };
+        expect(body.code).toBe("VALIDATION_ERROR");
+        expect(body.details?.hostedModels).toContain(
+          "anthropic/claude-haiku-4.5"
+        );
+        expect(prepareEvalRunMock).not.toHaveBeenCalled();
+      });
+
+      it("admits a hosted catalog id", async () => {
+        mockHappyCreate();
+        const res = await request(
+          makeApp(),
+          "POST",
+          "/api/v1/projects/p1/eval-runs",
+          {
+            suiteName: "smoke",
+            serverIds: ["s1"],
+            tests: [inlineTest("anthropic/claude-haiku-4.5")],
+          }
+        );
+        expect(res.status).toBe(202);
+      });
+
+      it("admits an unknown id when the caller brings a provider key", async () => {
+        mockHappyCreate();
+        const res = await request(
+          makeApp(),
+          "POST",
+          "/api/v1/projects/p1/eval-runs",
+          {
+            suiteName: "smoke",
+            serverIds: ["s1"],
+            tests: [inlineTest("claude-sonnet-4-6")],
+            modelApiKeys: { anthropic: "sk-ant-test" },
+          }
+        );
+        expect(res.status).toBe(202);
+      });
+
+      it("admits a cataloged BYOK id without a caller key (org keys may cover it)", async () => {
+        mockHappyCreate();
+        const res = await request(
+          makeApp(),
+          "POST",
+          "/api/v1/projects/p1/eval-runs",
+          {
+            suiteName: "smoke",
+            serverIds: ["s1"],
+            tests: [inlineTest("claude-sonnet-4-5")],
+          }
+        );
+        expect(res.status).toBe(202);
+      });
+    });
+
     it("responds 202 with runId and detaches execution", async () => {
       const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
       createAuthorizedManagerMock.mockResolvedValue({
@@ -435,7 +529,7 @@ describe("v1 write routes", () => {
               title: "case",
               query: "do it",
               runs: 1,
-              model: "m",
+              model: "anthropic/claude-haiku-4.5",
               provider: "anthropic",
               expectedToolCalls: [],
             },

--- a/mcpjam-inspector/server/routes/v1/catalog.ts
+++ b/mcpjam-inspector/server/routes/v1/catalog.ts
@@ -149,9 +149,17 @@ catalog.get("/projects/:projectId/eval-suites", (c) =>
 // because the upstream merges personal + project-shared sessions and
 // `projectId` is an optional filter, not an owning scope.
 catalog.get("/chat-sessions", (c) =>
-  proxyConvexV1Read(c, "/v1/chat-sessions", (target) =>
-    forwardQueryParams(c, target, ["projectId", "status", "limit", "before"])
-  )
+  proxyConvexV1Read(c, "/v1/chat-sessions", (target) => {
+    forwardQueryParams(c, target, ["projectId", "status", "limit", "before"]);
+    // The public pagination contract is "pass the previous nextCursor as
+    // `cursor`"; the Convex upstream's parameter is `before`. Map it here —
+    // `cursor` wins over an explicit `before` so the documented pagination
+    // loop pages correctly instead of silently re-serving page one.
+    const cursor = c.req.query("cursor");
+    if (typeof cursor === "string" && cursor.length > 0) {
+      target.searchParams.set("before", cursor);
+    }
+  })
 );
 
 // GET /v1/projects/:projectId/chatboxes

--- a/mcpjam-inspector/server/routes/v1/envelope.ts
+++ b/mcpjam-inspector/server/routes/v1/envelope.ts
@@ -64,6 +64,10 @@ export function mapErrorToV1(error: unknown): {
     const message = error instanceof Error ? error.message : String(error);
     return { code: "OAUTH_REQUIRED", message };
   }
+  if (isMcpMethodNotFound(error)) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { code: "FEATURE_NOT_SUPPORTED", message };
+  }
   const routeError = mapRuntimeError(error);
   if (
     routeError.code === ErrorCode.UNAUTHORIZED &&
@@ -88,6 +92,24 @@ function safeIsMcpAuthError(error: unknown): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * MCP JSON-RPC "Method not found" (-32601): the target server doesn't
+ * implement the requested primitive (e.g. `prompts/get` against a server
+ * that never declared the prompts capability). The public contract reserves
+ * FEATURE_NOT_SUPPORTED (422) for exactly this; without the branch it falls
+ * through the runtime classifier as a 500 INTERNAL_ERROR. Duck-typed on the
+ * numeric JSON-RPC code so it matches `McpError` across SDK copies.
+ */
+const JSONRPC_METHOD_NOT_FOUND = -32601;
+
+function isMcpMethodNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === JSONRPC_METHOD_NOT_FOUND
+  );
 }
 
 /** Hono onError handler for the v1 router. */

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -34,6 +34,12 @@ import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { logger } from "../../utils/logger.js";
 import { v1Error, v1PageJson, v1Resource } from "./envelope.js";
 import { synthesizeServerBody } from "./adapter.js";
+import {
+  getCanonicalModelId,
+  isMCPJamProvidedModel,
+  isModelSupported,
+  SUPPORTED_MODELS,
+} from "@/shared/types";
 
 const evals = new Hono();
 
@@ -58,6 +64,63 @@ const createEvalRunSchema = RunEvalsRequestSchema.omit({
   .refine((body) => body.suiteId || (body.tests?.length ?? 0) > 0, {
     message: "Provide suiteId (rerun) and/or inline tests",
   });
+
+// ── Model validation ─────────────────────────────────────────────────
+
+/**
+ * Providers whose model namespace we cannot enumerate (local/self-hosted
+ * runtimes). Tests targeting them skip catalog validation entirely.
+ */
+const OPEN_MODEL_PROVIDERS = new Set(["custom", "ollama"]);
+
+/**
+ * Reject inline tests whose model can never execute BEFORE creating the run.
+ * Without this, an unknown model id (e.g. a raw Anthropic API id like
+ * "claude-sonnet-4-6" instead of the catalog's hosted
+ * "anthropic/claude-haiku-4.5") is accepted with a 202, and the run
+ * "completes" as failed with zero tokens and an opaque stream error — the
+ * caller has no signal that the request itself was wrong.
+ *
+ * A test is admitted when any of these hold:
+ *  - it resolves to an MCPJam-provided (hosted) model — runs on org credits;
+ *  - the caller supplied a `modelApiKeys` entry for its provider — BYOK, the
+ *    provider validates the id itself;
+ *  - its provider's namespace is open (custom/ollama) — not enumerable;
+ *  - the id is in the shared catalog — org-level BYOK keys may cover it
+ *    (the runner resolves those; we can't see them at create time).
+ * Everything else is a VALIDATION_ERROR naming the test and suggesting the
+ * hosted ids for that provider.
+ */
+export function assertInlineTestModelsValid(
+  tests: ReadonlyArray<{ title: string; model: string; provider: string }>,
+  modelApiKeys: Record<string, string> | undefined
+): void {
+  for (const test of tests) {
+    const provider = test.provider.trim().toLowerCase();
+    if (OPEN_MODEL_PROVIDERS.has(provider)) continue;
+    const canonical = getCanonicalModelId(test.model, test.provider);
+    if (isMCPJamProvidedModel(canonical, test.provider)) continue;
+    if (modelApiKeys?.[test.provider] ?? modelApiKeys?.[provider]) continue;
+    if (isModelSupported(canonical)) continue;
+
+    const hostedIds = SUPPORTED_MODELS.filter(
+      (m) =>
+        m.provider.toLowerCase() === provider &&
+        isMCPJamProvidedModel(String(m.id), m.provider)
+    ).map((m) => String(m.id));
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      `Unknown model "${test.model}" (provider "${test.provider}") in test "${test.title}". ` +
+        `Use a hosted model id, or pass modelApiKeys["${test.provider}"] to bring your own key.`,
+      {
+        model: test.model,
+        provider: test.provider,
+        ...(hostedIds.length > 0 ? { hostedModels: hostedIds } : {}),
+      }
+    );
+  }
+}
 
 // ── Concurrency gate ─────────────────────────────────────────────────
 
@@ -244,6 +307,10 @@ evals.post("/projects/:projectId/eval-runs", async (c) => {
     Boolean(body.suiteId) && body.tests.length === 0
       ? true
       : (body.suiteRerun ?? false);
+
+  // Fail unknown models now, with a pointer to valid ids, rather than
+  // letting the detached run die later with an opaque stream error.
+  assertInlineTestModelsValid(body.tests, body.modelApiKeys);
 
   const slotKey = orgConcurrencyKey(c);
   if (!tryAcquireRunSlot(slotKey)) {


### PR DESCRIPTION
Four fixes from an end-to-end verification of every endpoint on [docs.mcpjam.com/reference/public-api](https://docs.mcpjam.com/reference/public-api) (run against local dev with a real API key).

## Fixes

### 1. `POST /eval-runs` silently accepted models that can never execute
The docs' own example (`"model": "claude-sonnet-4-6"`) returned a clean `202`, then the detached run "completed" as **failed** with 0 tokens and the opaque error `Backend step returned no content (stream error or empty response)`. The caller gets no signal the request itself was wrong.

Inline tests are now validated at create time. A test is admitted when any of these hold:
- it resolves to an MCPJam-hosted model (runs on org credits),
- the caller supplied a `modelApiKeys` entry for its provider (BYOK — the provider validates the id),
- its provider's namespace is open (`custom`/`ollama`),
- the id is in the shared catalog (org-level BYOK keys may cover it; the route can't see those).

Everything else is rejected with `400 VALIDATION_ERROR` naming the test and listing the hosted ids for that provider in `details.hostedModels`.

### 2. `GET /chat-sessions` ignored the documented `cursor` param
The contract says "pass the previous `nextCursor` as `cursor`", but the proxy only forwarded `before` — cursor-following clients silently got page one forever. `cursor` now maps onto the upstream `before` (and wins if both are sent).

### 3. MCP `-32601` surfaced as `500 INTERNAL_ERROR`
`prompts/get` against a server without the prompts capability returned `{"code":"INTERNAL_ERROR","message":"Method not found"}`. JSON-RPC `-32601` now maps to the documented `422 FEATURE_NOT_SUPPORTED`. Other JSON-RPC codes are unaffected.

### 4. Docs example model id was the broken one
`public-api.mdx` and `openapi.json` examples switch to the verified-working hosted id `anthropic/claude-haiku-4.5`, plus a short note documenting hosted (`provider/name`) vs BYOK (provider-native id + `modelApiKeys`) and the new create-time rejection.

## Tests
- `envelope.test.ts`: `-32601` → `FEATURE_NOT_SUPPORTED`; `-32602` does not promote
- `catalog.test.ts`: `cursor` → `before` mapping; `cursor` wins over explicit `before`
- `write-routes.test.ts`: unknown model rejected with `hostedModels` hint; hosted id, BYOK-with-key, and cataloged bare id all admitted; one pre-existing fixture (`model: "m"`) updated to a hosted id since it now correctly trips validation

All 68 v1 route tests pass; no tsc errors in touched files.

## Not in this PR (mcpjam-backend follow-ups)
- `GET /projects/:id/chatboxes` 502s until the backend's `/v1/chatboxes` routes are deployed (they're on backend main already)
- Raw Convex `ArgumentValidationError` text leaking through catalog 400s is generated backend-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public v1 behavior (stricter eval create validation and different error codes for unsupported MCP methods); impact is positive for callers but may break integrations that relied on accepting bad models or treating method-not-found as 500.
> 
> **Overview**
> Four v1 API contract fixes from end-to-end public API verification.
> 
> **Eval runs:** `POST .../eval-runs` now validates inline test `model`/`provider` before accepting a run via `assertInlineTestModelsValid`. Unexecutable ids (e.g. raw `claude-sonnet-4-6` without BYOK) return **400 `VALIDATION_ERROR`** with `details.hostedModels` instead of **202** followed by a failed run with opaque stream errors. Hosted catalog ids, `modelApiKeys`, open providers (`custom`/`ollama`), and cataloged BYOK ids still pass.
> 
> **Catalog:** `GET /chat-sessions` maps the documented `cursor` query param to Convex’s `before` ( **`cursor` wins** if both are sent), fixing pagination that previously stuck on page one.
> 
> **Errors:** MCP JSON-RPC **-32601** (method not found) is promoted to **`422 FEATURE_NOT_SUPPORTED`** in `mapErrorToV1` instead of **500 `INTERNAL_ERROR`**.
> 
> **Docs:** OpenAPI and `public-api.mdx` examples use hosted id `anthropic/claude-haiku-4.5` and document hosted vs BYOK model ids and create-time rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9f6a3b34cdf9b5d7f5110b29df339c2a2dbc95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->