### PR TITLE
feat(xaa): client secret for manual debugger runs (confidential-client jwt-bearer)

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAConfigModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAConfigModal.tsx
@@ -52,6 +52,7 @@ export function XAAConfigModal({
     const trimmedServerUrl = draft.serverUrl.trim();
     const trimmedIssuer = draft.authzServerIssuer.trim();
     const trimmedClientId = draft.clientId.trim();
+    const trimmedClientSecret = draft.clientSecret.trim();
     const trimmedScope = draft.scope.trim();
     const trimmedUserId = draft.userId.trim();
     const trimmedEmail = draft.email.trim();
@@ -81,6 +82,7 @@ export function XAAConfigModal({
       serverUrl: trimmedServerUrl,
       authzServerIssuer: trimmedIssuer,
       clientId: trimmedClientId,
+      clientSecret: trimmedClientSecret,
       scope: trimmedScope,
       userId: trimmedUserId || value.userId,
       email: trimmedEmail || value.email,
@@ -96,10 +98,7 @@ export function XAAConfigModal({
           <DialogTitle>Configure XAA Debugger</DialogTitle>
         </DialogHeader>
 
-        <form
-          onSubmit={handleSubmit}
-          className="flex min-h-0 flex-1 flex-col"
-        >
+        <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
           <div className="flex-1 min-h-0 overflow-y-auto pr-1 space-y-5">
             <div className="space-y-3">
               <div className="space-y-2">
@@ -155,6 +154,28 @@ export function XAAConfigModal({
               </div>
 
               <div className="space-y-2">
+                <Label htmlFor="xaa-client-secret">Client Secret</Label>
+                <Input
+                  id="xaa-client-secret"
+                  type="password"
+                  autoComplete="off"
+                  value={draft.clientSecret}
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      clientSecret: event.target.value,
+                    }))
+                  }
+                  placeholder="Required by confidential-client auth servers"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Needed when the auth server requires client authentication for
+                  the jwt-bearer grant. Test credentials only — masked in the
+                  request log.
+                </p>
+              </div>
+
+              <div className="space-y-2">
                 <Label htmlFor="xaa-scope">Scope</Label>
                 <Input
                   id="xaa-scope"
@@ -178,7 +199,7 @@ export function XAAConfigModal({
                   <ChevronDown
                     className={cn(
                       "h-4 w-4 transition-transform",
-                      identityOpen && "rotate-180",
+                      identityOpen && "rotate-180"
                     )}
                   />
                 </span>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -55,6 +55,9 @@ interface XAAFlowInput {
   serverUrl: string;
   authzServerIssuer: string;
   clientId: string;
+  /** Manual-profile runs only; registration-backed runs resolve the stored
+   * secret server-side and keep this empty. */
+  clientSecret: string;
   scope: string;
   userId: string;
   email: string;
@@ -69,6 +72,7 @@ function buildFlowStateFromInput(input: XAAFlowInput): XAAFlowState {
     userId: input.userId || undefined,
     email: input.email || undefined,
     clientId: input.clientId || undefined,
+    clientSecret: input.clientSecret || undefined,
     scope: input.scope || undefined,
   });
 }
@@ -79,6 +83,7 @@ function inputFromProfile(profile: XAADebugProfile): XAAFlowInput {
     serverUrl: profile.serverUrl,
     authzServerIssuer: profile.authzServerIssuer,
     clientId: profile.clientId,
+    clientSecret: profile.clientSecret,
     scope: profile.scope,
     userId: profile.userId,
     email: profile.email,
@@ -88,7 +93,7 @@ function inputFromProfile(profile: XAADebugProfile): XAAFlowInput {
 
 function inputFromRegistration(
   registration: XaaResourceApp,
-  profile: XAADebugProfile,
+  profile: XAADebugProfile
 ): XAAFlowInput {
   return {
     mode: "hosted-registration",
@@ -96,6 +101,8 @@ function inputFromRegistration(
     serverUrl: registration.resourceUrl,
     authzServerIssuer: registration.issuer ?? "",
     clientId: registration.targetClientId ?? "",
+    // The stored secret never enters the browser; /proxy/token resolves it.
+    clientSecret: "",
     scope: (registration.scopes ?? []).join(" "),
     // Synthetic identity stays user-configurable regardless of source.
     userId: profile.userId,
@@ -129,17 +136,17 @@ export function XAAFlowTab({
     : undefined;
 
   const [profile, setProfile] = useState(() =>
-    deriveXAADebugProfileFromServer(activeServer, loadStoredXAADebugProfile()),
+    deriveXAADebugProfileFromServer(activeServer, loadStoredXAADebugProfile())
   );
   const [flowState, setFlowState] = useState<XAAFlowState>(() =>
     buildFlowStateFromInput(
       inputFromProfile(
         deriveXAADebugProfileFromServer(
           activeServer,
-          loadStoredXAADebugProfile(),
-        ),
-      ),
-    ),
+          loadStoredXAADebugProfile()
+        )
+      )
+    )
   );
 
   // The machine reads state through this ref (lazy getState). Keep it in
@@ -181,7 +188,7 @@ export function XAAFlowTab({
       selectedRegistration
         ? inputFromRegistration(selectedRegistration, profile)
         : inputFromProfile(profile),
-    [selectedRegistration, profile],
+    [selectedRegistration, profile]
   );
 
   // Target identity for the positive-run gate; "local-profile" is its own
@@ -196,7 +203,7 @@ export function XAAFlowTab({
   // In-memory: targets that have completed a successful flow this session.
   // A page refresh clears it, re-locking the scorecard (§ negative-test gate).
   const [positiveRunTargets, setPositiveRunTargets] = useState<Set<string>>(
-    () => new Set(),
+    () => new Set()
   );
 
   const fireFlowStarted = useCallback(() => {
@@ -285,6 +292,7 @@ export function XAAFlowTab({
         audience,
         resource,
         clientId: flowInput.clientId || undefined,
+        clientSecret: flowInput.clientSecret || undefined,
         scope: flowInput.scope || undefined,
       },
     };
@@ -338,7 +346,7 @@ export function XAAFlowTab({
       applyFlowState(buildFlowStateFromInput(input));
       setFocusedStep(null);
     },
-    [flowInput, selectedRegistration, applyFlowState],
+    [flowInput, selectedRegistration, applyFlowState]
   );
 
   const handleChangeNegativeTestMode = useCallback((mode: NegativeTestMode) => {
@@ -372,6 +380,7 @@ export function XAAFlowTab({
       userId: flowInput.userId,
       email: flowInput.email,
       clientId: flowInput.clientId,
+      clientSecret: flowInput.clientSecret,
       scope: flowInput.scope,
       authzServerIssuer: flowInput.authzServerIssuer,
       registrationId: flowInput.registrationId,
@@ -431,14 +440,14 @@ export function XAAFlowTab({
   const continueLabel = !hasTarget
     ? "Configure Target"
     : flowState.currentStep === "idle"
-      ? "Start"
-      : flowState.currentStep === "inspect_id_jag"
-        ? "Request Access Token"
-        : flowState.currentStep === "received_access_token"
-          ? "Call MCP Server"
-          : flowState.currentStep === "complete"
-            ? "Flow Complete"
-            : "Continue";
+    ? "Start"
+    : flowState.currentStep === "inspect_id_jag"
+    ? "Request Access Token"
+    : flowState.currentStep === "received_access_token"
+    ? "Call MCP Server"
+    : flowState.currentStep === "complete"
+    ? "Flow Complete"
+    : "Continue";
 
   const continueDisabled =
     !hasTarget ||
@@ -456,7 +465,7 @@ export function XAAFlowTab({
         selectedId={selectedRegistrationId}
         onSelect={(app) =>
           setSelectedRegistrationId((current) =>
-            current === app.id ? null : app.id,
+            current === app.id ? null : app.id
           )
         }
       />
@@ -484,8 +493,8 @@ export function XAAFlowTab({
           {selectedRegistration
             ? `Target: ${selectedRegistration.name}`
             : hasTarget
-              ? `Target: ${flowInput.serverUrl}`
-              : "No target configured"}
+            ? `Target: ${flowInput.serverUrl}`
+            : "No target configured"}
         </span>
       </div>
       <div className="flex-1 overflow-hidden">

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createXAAStateMachine } from "../state-machine";
+import { CLIENT_SECRET_MASK, createXAAStateMachine } from "../state-machine";
 import { createInitialXAAFlowState, type XAAFlowState } from "../types";
 
 function encodePart(value: Record<string, any>): string {
@@ -12,7 +12,7 @@ function makeJwt(
     alg: "RS256",
     typ: "oauth-id-jag+jwt",
     kid: "xaa-idp-1",
-  },
+  }
 ): string {
   return `${encodePart(header)}.${encodePart(payload)}.signature`;
 }
@@ -33,7 +33,7 @@ describe("createXAAStateMachine", () => {
         sub: "user-12345",
         email: "demo.user@example.com",
       },
-      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" },
+      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" }
     );
     const idJag = makeJwt({
       iss: "https://issuer.example/api/web/xaa",
@@ -147,8 +147,77 @@ describe("createXAAStateMachine", () => {
       "/proxy/token",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
+  });
+
+  it("sends a configured client secret to /proxy/token but masks it in the logged request", async () => {
+    let state: XAAFlowState = createInitialXAAFlowState({
+      serverUrl: "https://mcp.example.com",
+      authzServerIssuer: "https://auth.example.com",
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      clientId: "mcpjam-debugger",
+      clientSecret: "test-secret-123",
+      userId: "user-12345",
+      email: "demo.user@example.com",
+      currentStep: "inspect_id_jag",
+      idJag: makeJwt({
+        iss: "https://issuer.example/api/web/xaa",
+        sub: "user-12345",
+        aud: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        client_id: "mcpjam-debugger",
+        exp: Math.floor(Date.now() / 1000) + 300,
+      }),
+    });
+
+    const executor = {
+      externalRequest: vi.fn(),
+      internalRequest: vi.fn(async () => ({
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {
+            access_token: "access-token",
+            token_type: "Bearer",
+            expires_in: 300,
+          },
+        },
+        ok: true,
+      })),
+    };
+
+    const machine = createXAAStateMachine({
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: "https://mcp.example.com",
+      issuerBaseUrl: "https://issuer.example/api/web/xaa",
+      requestExecutor: executor,
+    });
+
+    // Advance once: inspect_id_jag -> jwt_bearer_request.
+    await machine.proceedToNextStep();
+
+    // The wire request carries the real secret...
+    const [, init] = executor.internalRequest.mock.calls[0];
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody.clientSecret).toBe("test-secret-123");
+
+    // ...but no logged copy of the flow state contains it.
+    const jwtBearerEntry = (state.httpHistory || []).find(
+      (entry) => entry.step === "jwt_bearer_request"
+    );
+    expect(jwtBearerEntry?.request.body.clientSecret).toBe(CLIENT_SECRET_MASK);
+    expect(JSON.stringify(state.httpHistory)).not.toContain("test-secret-123");
+    expect(JSON.stringify(state.infoLogs)).not.toContain("test-secret-123");
+    expect(JSON.stringify(state.lastRequest)).not.toContain("test-secret-123");
   });
 
   it("passes the configured negative test mode to token exchange and flags the issue during inspection", async () => {
@@ -166,7 +235,7 @@ describe("createXAAStateMachine", () => {
         iss: "https://issuer.example/api/web/xaa",
         sub: "user-12345",
       },
-      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" },
+      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" }
     );
     const idJag = makeJwt(
       {
@@ -177,7 +246,7 @@ describe("createXAAStateMachine", () => {
         client_id: "mcpjam-debugger",
         exp: Math.floor(Date.now() / 1000) + 300,
       },
-      { alg: "RS256", typ: "oauth-id-jag+jwt", kid: "nonexistent-key-id" },
+      { alg: "RS256", typ: "oauth-id-jag+jwt", kid: "nonexistent-key-id" }
     );
 
     const executor = {
@@ -259,7 +328,7 @@ describe("createXAAStateMachine", () => {
         expect.objectContaining({
           field: "kid",
         }),
-      ]),
+      ])
     );
   });
 
@@ -282,7 +351,7 @@ describe("createXAAStateMachine", () => {
           sub: "user-12345",
           email: "demo.user@example.com",
         },
-        { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" },
+        { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" }
       );
       const idJag = makeJwt({
         iss: "https://issuer.example/api/web/xaa",
@@ -458,8 +527,8 @@ describe("createXAAStateMachine", () => {
       expect(final.idJag).toBeTruthy();
       expect(
         (final.httpHistory ?? []).some(
-          (entry) => entry.step === "token_exchange_request",
-        ),
+          (entry) => entry.step === "token_exchange_request"
+        )
       ).toBe(true);
     });
   });
@@ -467,7 +536,7 @@ describe("createXAAStateMachine", () => {
   describe("discovery is a fallback, not a mandatory step", () => {
     const idToken = makeJwt(
       { iss: "https://issuer.example/api/web/xaa", sub: "user-12345" },
-      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" },
+      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" }
     );
     const idJag = makeJwt({
       iss: "https://issuer.example/api/web/xaa",
@@ -556,10 +625,10 @@ describe("createXAAStateMachine", () => {
       expect(state.currentStep).toBe("complete");
       // No protected-resource or auth-server metadata probe was ever fired.
       expect(
-        externalUrls.some((u) => u.includes("oauth-protected-resource")),
+        externalUrls.some((u) => u.includes("oauth-protected-resource"))
       ).toBe(false);
       expect(
-        externalUrls.some((u) => u.includes("oauth-authorization-server")),
+        externalUrls.some((u) => u.includes("oauth-authorization-server"))
       ).toBe(false);
     });
 
@@ -617,7 +686,7 @@ describe("createXAAStateMachine", () => {
       await machine.proceedToNextStep();
       expect(state.currentStep).toBe("received_resource_metadata");
       expect(
-        externalUrls.some((u) => u.includes("oauth-protected-resource")),
+        externalUrls.some((u) => u.includes("oauth-protected-resource"))
       ).toBe(false);
 
       // received_resource_metadata -> AS discovery (RFC 8414) actually runs
@@ -625,7 +694,7 @@ describe("createXAAStateMachine", () => {
       expect(state.currentStep).toBe("received_authz_metadata");
       expect(state.tokenEndpoint).toBe("https://auth.example.com/oauth/token");
       expect(
-        externalUrls.some((u) => u.includes("oauth-authorization-server")),
+        externalUrls.some((u) => u.includes("oauth-authorization-server"))
       ).toBe(true);
     });
 

--- a/mcpjam-inspector/client/src/lib/xaa/profile.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/profile.ts
@@ -12,6 +12,14 @@ export interface XAADebugProfile {
   serverUrl: string;
   authzServerIssuer: string;
   clientId: string;
+  /**
+   * Test-credential client secret for the jwt-bearer grant at confidential-
+   * client auth servers. Persisted in localStorage alongside the rest of the
+   * manual profile — debugger test credentials only, never production
+   * secrets. Registration-backed runs resolve their secret server-side and
+   * leave this empty.
+   */
+  clientSecret: string;
   scope: string;
   userId: string;
   email: string;
@@ -22,6 +30,7 @@ export const EMPTY_XAA_DEBUG_PROFILE: XAADebugProfile = {
   serverUrl: "",
   authzServerIssuer: "",
   clientId: "",
+  clientSecret: "",
   scope: "",
   userId: "user-12345",
   email: "demo.user@example.com",
@@ -71,7 +80,7 @@ export function saveStoredXAADebugProfile(profile: XAADebugProfile): void {
 
 export function deriveXAADebugProfileFromServer(
   server?: ServerWithName,
-  existingProfile: XAADebugProfile = EMPTY_XAA_DEBUG_PROFILE,
+  existingProfile: XAADebugProfile = EMPTY_XAA_DEBUG_PROFILE
 ): XAADebugProfile {
   if (!server) {
     return existingProfile;
@@ -99,7 +108,7 @@ export function deriveXAADebugProfileFromServer(
     clientId: existingProfile.clientId || configuredClientId,
     scope: existingProfile.scope || configuredScopes,
     negativeTestMode: sanitizeNegativeTestMode(
-      existingProfile.negativeTestMode,
+      existingProfile.negativeTestMode
     ),
   };
 }

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -18,6 +18,10 @@ import type {
 import { createInitialXAAFlowState } from "./types";
 import { analyzeAsCompatibility } from "./capability-preflight";
 
+/** What the HTTP history shows in place of a client secret — the real value
+ * is sent on the wire but never enters the logged request. */
+export const CLIENT_SECRET_MASK = "••••••••";
+
 interface AddInfoLogOptions {
   level?: InfoLogLevel;
   error?: LogErrorDetails;
@@ -29,7 +33,7 @@ function addInfoLog(
   id: string,
   label: string,
   data: any,
-  options: AddInfoLogOptions = {},
+  options: AddInfoLogOptions = {}
 ): Array<XAAInfoLogEntry> {
   const { level = "info", error } = options;
 
@@ -70,7 +74,7 @@ function toLogErrorDetails(error: unknown): LogErrorDetails {
 
 function mergeHeadersForAuthServer(
   customHeaders: Record<string, string> | undefined,
-  requestHeaders: Record<string, string> = {},
+  requestHeaders: Record<string, string> = {}
 ): Record<string, string> {
   const merged: Record<string, string> = {};
   const keysByLowercase = new Map<string, string>();
@@ -112,7 +116,7 @@ function buildResourceMetadataUrls(serverUrl: string): string[] {
   const url = new URL(serverUrl);
   const root = new URL(
     "/.well-known/oauth-protected-resource",
-    url.origin,
+    url.origin
   ).toString();
 
   if (url.pathname !== "/" && url.pathname !== "") {
@@ -121,7 +125,7 @@ function buildResourceMetadataUrls(serverUrl: string): string[] {
       : url.pathname;
     const pathInserted = new URL(
       `/.well-known/oauth-protected-resource${pathname}`,
-      url.origin,
+      url.origin
     ).toString();
     return [pathInserted, root];
   }
@@ -152,10 +156,10 @@ function buildAuthServerMetadataUrls(authServerUrl: string): string[] {
 
   if (url.pathname === "/" || url.pathname === "") {
     urls.push(
-      new URL("/.well-known/oauth-authorization-server", url.origin).toString(),
+      new URL("/.well-known/oauth-authorization-server", url.origin).toString()
     );
     urls.push(
-      new URL("/.well-known/openid-configuration", url.origin).toString(),
+      new URL("/.well-known/openid-configuration", url.origin).toString()
     );
   } else {
     const pathname = url.pathname.endsWith("/")
@@ -165,20 +169,20 @@ function buildAuthServerMetadataUrls(authServerUrl: string): string[] {
     urls.push(
       new URL(
         `/.well-known/oauth-authorization-server${pathname}`,
-        url.origin,
-      ).toString(),
+        url.origin
+      ).toString()
     );
     urls.push(
       new URL(
         `/.well-known/openid-configuration${pathname}`,
-        url.origin,
-      ).toString(),
+        url.origin
+      ).toString()
     );
     urls.push(
       new URL(
         `${pathname}/.well-known/openid-configuration`,
-        url.origin,
-      ).toString(),
+        url.origin
+      ).toString()
     );
   }
 
@@ -203,10 +207,7 @@ function extractErrorMessage(body: any, fallback: string): string {
   );
 }
 
-function asRecord(
-  value: unknown,
-  label: string,
-): Record<string, any> {
+function asRecord(value: unknown, label: string): Record<string, any> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`${label} did not return a JSON object`);
   }
@@ -243,7 +244,7 @@ function buildIdJagInspection(
     clientId: string;
     scope?: string;
     negativeTestMode: NegativeTestMode;
-  },
+  }
 ): XAADecodedJwt {
   const decoded = decodeJWTParts(token);
   const issues: XAAJWTInspectionIssue[] = [];
@@ -273,7 +274,7 @@ function buildIdJagInspection(
     field: string,
     label: string,
     expectedValue: unknown,
-    actualValue: unknown,
+    actualValue: unknown
   ) => {
     issues.push({
       section,
@@ -285,13 +286,7 @@ function buildIdJagInspection(
   };
 
   if (header.typ !== "oauth-id-jag+jwt") {
-    addIssue(
-      "header",
-      "typ",
-      "JWT type",
-      "oauth-id-jag+jwt",
-      header.typ,
-    );
+    addIssue("header", "typ", "JWT type", "oauth-id-jag+jwt", header.typ);
   }
 
   if (header.kid !== XAA_IDP_KID) {
@@ -311,13 +306,7 @@ function buildIdJagInspection(
   }
 
   if (payload.aud !== expected.audience) {
-    addIssue(
-      "payload",
-      "aud",
-      "Audience",
-      expected.audience,
-      payload.aud,
-    );
+    addIssue("payload", "aud", "Audience", expected.audience, payload.aud);
   }
 
   if (payload.resource !== expected.resource) {
@@ -326,7 +315,7 @@ function buildIdJagInspection(
       "resource",
       "Resource",
       expected.resource,
-      payload.resource,
+      payload.resource
     );
   }
 
@@ -336,22 +325,22 @@ function buildIdJagInspection(
       "client_id",
       "Client ID",
       expected.clientId,
-      payload.client_id,
+      payload.client_id
     );
   }
 
   if (typeof payload.exp !== "number" || payload.exp <= Date.now() / 1000) {
-    addIssue(
-      "payload",
-      "exp",
-      "Expiration",
-      "A future timestamp",
-      payload.exp,
-    );
+    addIssue("payload", "exp", "Expiration", "A future timestamp", payload.exp);
   }
 
   if (expected.scope && payload.scope !== expected.scope) {
-    addIssue("payload", "scope", "Requested scopes", expected.scope, payload.scope);
+    addIssue(
+      "payload",
+      "scope",
+      "Requested scopes",
+      expected.scope,
+      payload.scope
+    );
   }
 
   if (expected.negativeTestMode === "bad_signature") {
@@ -360,7 +349,7 @@ function buildIdJagInspection(
       "signature",
       "Signature / JWKS",
       "Signed by the published XAA issuer key",
-      "Signed with a throwaway private key",
+      "Signed with a throwaway private key"
     );
   }
 
@@ -377,7 +366,7 @@ function buildIdJagInspection(
 const XAA_RUN_ALL_MAX_ADVANCES = 32;
 
 export function createXAAStateMachine(
-  config: BaseXAAStateMachineConfig,
+  config: BaseXAAStateMachineConfig
 ): XAAStateMachine {
   const {
     state: initialState,
@@ -390,6 +379,7 @@ export function createXAAStateMachine(
     userId,
     email,
     clientId,
+    clientSecret,
     scope,
     authzServerIssuer,
     registrationId,
@@ -406,6 +396,7 @@ export function createXAAStateMachine(
       userId: state.userId || userId,
       email: state.email || email,
       clientId: state.clientId || clientId,
+      clientSecret: state.clientSecret || clientSecret,
       scope: state.scope || scope,
       authzServerIssuer: state.authzServerIssuer || authzServerIssuer,
     }),
@@ -425,7 +416,7 @@ export function createXAAStateMachine(
     id: string,
     label: string,
     data: any,
-    options?: AddInfoLogOptions,
+    options?: AddInfoLogOptions
   ) => {
     machine.updateState({
       infoLogs: addInfoLog(currentState(), step, id, label, data, options),
@@ -440,7 +431,7 @@ export function createXAAStateMachine(
       headers: Record<string, string>;
       body?: any;
     },
-    executor: () => Promise<XAARequestResult>,
+    executor: () => Promise<XAARequestResult>
   ): Promise<XAARequestResult> => {
     machine.updateState({
       currentStep: step,
@@ -528,7 +519,7 @@ export function createXAAStateMachine(
           reason:
             "Authorization server issuer is already configured; RFC 9728 discovery is not part of the XAA grant and isn't needed.",
           authz_server_issuer: state.authzServerIssuer,
-        },
+        }
       );
       return;
     }
@@ -549,20 +540,20 @@ export function createXAAStateMachine(
         const result = await runRequest(
           "discover_resource_metadata",
           request,
-          () => requestExecutor.externalRequest(resourceMetadataUrl, request),
+          () => requestExecutor.externalRequest(resourceMetadataUrl, request)
         );
 
         if (!result.ok) {
           lastError = extractErrorMessage(
             result.body,
-            `Resource metadata request failed with ${result.status}`,
+            `Resource metadata request failed with ${result.status}`
           );
           continue;
         }
 
         const resourceMetadata = asRecord(result.body, "Resource metadata");
         const resolvedAuthzIssuer = Array.isArray(
-          resourceMetadata.authorization_servers,
+          resourceMetadata.authorization_servers
         )
           ? resourceMetadata.authorization_servers[0]
           : undefined;
@@ -573,7 +564,7 @@ export function createXAAStateMachine(
 
         if (!resolvedAuthzIssuer) {
           throw new Error(
-            "Resource metadata did not include `authorization_servers`, and no Authorization Server issuer was configured manually.",
+            "Resource metadata did not include `authorization_servers`, and no Authorization Server issuer was configured manually."
           );
         }
 
@@ -594,7 +585,7 @@ export function createXAAStateMachine(
           {
             resource: resolvedResource,
             authorization_servers: resourceMetadata.authorization_servers,
-          },
+          }
         );
         return;
       } catch (error) {
@@ -635,7 +626,7 @@ export function createXAAStateMachine(
           ...(state.tokenEndpoint
             ? { token_endpoint: state.tokenEndpoint }
             : {}),
-        },
+        }
       );
       return;
     }
@@ -665,13 +656,13 @@ export function createXAAStateMachine(
         const result = await runRequest(
           "discover_authz_metadata",
           request,
-          () => requestExecutor.externalRequest(url, request),
+          () => requestExecutor.externalRequest(url, request)
         );
 
         if (!result.ok) {
           lastError = extractErrorMessage(
             result.body,
-            `Auth server metadata request failed with ${result.status}`,
+            `Auth server metadata request failed with ${result.status}`
           );
           continue;
         }
@@ -679,7 +670,7 @@ export function createXAAStateMachine(
         const metadata = asRecord(result.body, "Authorization metadata");
         if (typeof metadata.token_endpoint !== "string") {
           throw new Error(
-            "Authorization metadata did not include a token_endpoint.",
+            "Authorization metadata did not include a token_endpoint."
           );
         }
 
@@ -717,7 +708,7 @@ export function createXAAStateMachine(
                   vendor: compatibilityReport.vendor,
                 }
               : undefined,
-          },
+          }
         );
 
         return;
@@ -754,21 +745,23 @@ export function createXAAStateMachine(
           method: "POST",
           headers: request.headers,
           body: JSON.stringify(request.body),
-        }),
+        })
       );
 
       if (!result.ok) {
         throw new Error(
           extractErrorMessage(
             result.body,
-            `Mock authentication failed with ${result.status}`,
-          ),
+            `Mock authentication failed with ${result.status}`
+          )
         );
       }
 
       const body = asRecord(result.body, "Authentication response");
       if (typeof body.id_token !== "string") {
-        throw new Error("Authentication response did not include an `id_token`.");
+        throw new Error(
+          "Authentication response did not include an `id_token`."
+        );
       }
 
       machine.updateState({
@@ -784,15 +777,13 @@ export function createXAAStateMachine(
         {
           userId: state.userId,
           email: state.email,
-        },
+        }
       );
     } catch (error) {
       machine.updateState({
         currentStep: "user_authentication",
         error:
-          error instanceof Error
-            ? error.message
-            : "Mock authentication failed",
+          error instanceof Error ? error.message : "Mock authentication failed",
       });
     }
   };
@@ -803,7 +794,8 @@ export function createXAAStateMachine(
     if (!state.identityAssertion) {
       machine.updateState({
         currentStep: "token_exchange_request",
-        error: "No identity assertion is available. Complete mock authentication first.",
+        error:
+          "No identity assertion is available. Complete mock authentication first.",
       });
       return;
     }
@@ -811,7 +803,8 @@ export function createXAAStateMachine(
     if (!state.authzServerIssuer) {
       machine.updateState({
         currentStep: "token_exchange_request",
-        error: "No authorization server issuer is available for the ID-JAG audience.",
+        error:
+          "No authorization server issuer is available for the ID-JAG audience.",
       });
       return;
     }
@@ -846,15 +839,15 @@ export function createXAAStateMachine(
           method: "POST",
           headers: request.headers,
           body: JSON.stringify(request.body),
-        }),
+        })
       );
 
       if (!result.ok) {
         throw new Error(
           extractErrorMessage(
             result.body,
-            `Token exchange failed with ${result.status}`,
-          ),
+            `Token exchange failed with ${result.status}`
+          )
         );
       }
 
@@ -870,21 +863,15 @@ export function createXAAStateMachine(
         error: undefined,
       });
 
-      pushInfo(
-        "received_id_jag",
-        "xaa-id-jag",
-        "ID-JAG issued",
-        {
-          negativeTestMode: state.negativeTestMode,
-          expectedFailure:
-            NEGATIVE_TEST_MODE_DETAILS[state.negativeTestMode].expectedFailure,
-        },
-      );
+      pushInfo("received_id_jag", "xaa-id-jag", "ID-JAG issued", {
+        negativeTestMode: state.negativeTestMode,
+        expectedFailure:
+          NEGATIVE_TEST_MODE_DETAILS[state.negativeTestMode].expectedFailure,
+      });
     } catch (error) {
       machine.updateState({
         currentStep: "token_exchange_request",
-        error:
-          error instanceof Error ? error.message : "Token exchange failed",
+        error: error instanceof Error ? error.message : "Token exchange failed",
       });
     }
   };
@@ -936,27 +923,37 @@ export function createXAAStateMachine(
     // Registration-backed runs send only the registration id: the server
     // resolves the stored secret and forces the outbound URL to the
     // registration's stored token endpoint, so neither ever rides in from
-    // the browser.
+    // the browser. Manual runs may carry a profile-configured secret —
+    // confidential-client servers reject the jwt-bearer grant without one.
+    const tokenRequestBody = registrationId
+      ? {
+          registrationId,
+          assertion: state.idJag,
+          scope: state.scope,
+          resource: state.resourceUrl || state.serverUrl,
+        }
+      : {
+          tokenEndpoint: state.tokenEndpoint,
+          assertion: state.idJag,
+          clientId: state.clientId,
+          ...(state.clientSecret ? { clientSecret: state.clientSecret } : {}),
+          scope: state.scope,
+          resource: state.resourceUrl || state.serverUrl,
+        };
+
+    // The request object lands verbatim in the HTTP history panel (and any
+    // export of it), so the logged copy masks the secret. Only
+    // `tokenRequestBody` is ever sent.
     const request = {
       method: "POST",
       url: "/proxy/token",
       headers: {
         "Content-Type": "application/json",
       },
-      body: registrationId
-        ? {
-            registrationId,
-            assertion: state.idJag,
-            scope: state.scope,
-            resource: state.resourceUrl || state.serverUrl,
-          }
-        : {
-            tokenEndpoint: state.tokenEndpoint,
-            assertion: state.idJag,
-            clientId: state.clientId,
-            scope: state.scope,
-            resource: state.resourceUrl || state.serverUrl,
-          },
+      body:
+        "clientSecret" in tokenRequestBody
+          ? { ...tokenRequestBody, clientSecret: CLIENT_SECRET_MASK }
+          : tokenRequestBody,
     };
 
     try {
@@ -964,16 +961,16 @@ export function createXAAStateMachine(
         requestExecutor.internalRequest("/proxy/token", {
           method: "POST",
           headers: request.headers,
-          body: JSON.stringify(request.body),
-        }),
+          body: JSON.stringify(tokenRequestBody),
+        })
       );
 
       if (!result.ok) {
         throw new Error(
           extractErrorMessage(
             result.body,
-            `JWT bearer proxy failed with ${result.status}`,
-          ),
+            `JWT bearer proxy failed with ${result.status}`
+          )
         );
       }
 
@@ -985,7 +982,9 @@ export function createXAAStateMachine(
       if (!upstreamStatus || upstreamStatus < 200 || upstreamStatus >= 300) {
         const detail = extractErrorMessage(
           upstreamPayload,
-          `Authorization server returned ${proxyBody.status ?? "an unknown status"}.`,
+          `Authorization server returned ${
+            proxyBody.status ?? "an unknown status"
+          }.`
         );
         machine.updateState({
           currentStep: "jwt_bearer_request",
@@ -999,15 +998,18 @@ export function createXAAStateMachine(
             status: proxyBody.status,
             body: upstreamPayload,
           },
-          { level: "error" },
+          { level: "error" }
         );
         return;
       }
 
-      const tokenResponse = asRecord(upstreamPayload, "JWT bearer token response");
+      const tokenResponse = asRecord(
+        upstreamPayload,
+        "JWT bearer token response"
+      );
       if (typeof tokenResponse.access_token !== "string") {
         throw new Error(
-          "Authorization server response did not include an `access_token`.",
+          "Authorization server response did not include an `access_token`."
         );
       }
 
@@ -1032,7 +1034,7 @@ export function createXAAStateMachine(
         {
           token_type: tokenResponse.token_type,
           expires_in: tokenResponse.expires_in,
-        },
+        }
       );
     } catch (error) {
       machine.updateState({
@@ -1089,7 +1091,7 @@ export function createXAAStateMachine(
             method: "POST",
             headers: request.headers,
             body: JSON.stringify(body),
-          }),
+          })
       );
 
       if (!result.ok) {
@@ -1097,7 +1099,7 @@ export function createXAAStateMachine(
           currentStep: "authenticated_mcp_request",
           error: extractErrorMessage(
             result.body,
-            `Authenticated MCP request failed with ${result.status}`,
+            `Authenticated MCP request failed with ${result.status}`
           ),
         });
         return;
@@ -1115,7 +1117,7 @@ export function createXAAStateMachine(
         {
           status: result.status,
           body: result.body,
-        },
+        }
       );
     } catch (error) {
       machine.updateState({
@@ -1200,16 +1202,17 @@ export function createXAAStateMachine(
     machine.updateState(
       createInitialXAAFlowState({
         serverUrl: currentState().serverUrl || serverUrl,
-        resourceUrl: canonicalizeResourceUrl(currentState().serverUrl || serverUrl),
-        negativeTestMode:
-          currentState().negativeTestMode || negativeTestMode,
+        resourceUrl: canonicalizeResourceUrl(
+          currentState().serverUrl || serverUrl
+        ),
+        negativeTestMode: currentState().negativeTestMode || negativeTestMode,
         userId: currentState().userId || userId,
         email: currentState().email || email,
         clientId: currentState().clientId || clientId,
         scope: currentState().scope || scope,
         authzServerIssuer:
           currentState().authzServerIssuer || authzServerIssuer,
-      }),
+      })
     );
   };
 

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -91,6 +91,9 @@ export interface XAAFlowState {
   userId?: string;
   email?: string;
   clientId?: string;
+  /** Test-credential secret for the jwt-bearer grant; never rendered — the
+   * logged copy of any request carrying it is masked. */
+  clientSecret?: string;
   scope?: string;
   identityAssertion?: string;
   idJag?: string;
@@ -127,11 +130,11 @@ export interface XAARequestResult {
 export interface XAARequestExecutor {
   internalRequest: (
     path: string,
-    init?: RequestInit,
+    init?: RequestInit
   ) => Promise<XAARequestResult>;
   externalRequest: (
     url: string,
-    init?: RequestInit,
+    init?: RequestInit
   ) => Promise<XAARequestResult>;
 }
 
@@ -149,6 +152,7 @@ export interface BaseXAAStateMachineConfig {
   userId?: string;
   email?: string;
   clientId?: string;
+  clientSecret?: string;
   scope?: string;
   authzServerIssuer?: string;
   /** Hosted registration-backed runs: sent to the token proxy instead of an
@@ -221,6 +225,7 @@ export const EMPTY_XAA_FLOW_STATE: XAAFlowState = {
   userId: undefined,
   email: undefined,
   clientId: undefined,
+  clientSecret: undefined,
   scope: undefined,
   identityAssertion: undefined,
   idJag: undefined,
@@ -237,13 +242,12 @@ export const EMPTY_XAA_FLOW_STATE: XAAFlowState = {
 };
 
 export function createInitialXAAFlowState(
-  overrides: Partial<XAAFlowState> = {},
+  overrides: Partial<XAAFlowState> = {}
 ): XAAFlowState {
   return {
     ...EMPTY_XAA_FLOW_STATE,
     ...overrides,
-    negativeTestMode:
-      overrides.negativeTestMode ?? DEFAULT_NEGATIVE_TEST_MODE,
+    negativeTestMode: overrides.negativeTestMode ?? DEFAULT_NEGATIVE_TEST_MODE,
     httpHistory: overrides.httpHistory ?? [],
     infoLogs: overrides.infoLogs ?? [],
   };


### PR DESCRIPTION
## TL;DR
Manual XAA debugger runs against confidential-client auth servers died at Phase 3 with `401 invalid_client: "No client_secret was provided. The jwt-bearer grant requires a confidential client"`. The server-side `/proxy/token` and `/negative-tests` routes **already accepted** `clientSecret` — only the Configure modal and state machine never carried it. This adds the field and plumbs it through, with the secret masked in every logged copy.

## Before / after

| | Before | After |
|---|---|---|
| Configure modal | No secret field | Password field + "test credentials only" helper |
| Manual jwt-bearer request | `{tokenEndpoint, assertion, clientId, scope, resource}` → 401 at confidential servers | `+ clientSecret` on the wire → token minted |
| HTTP history panel | n/a | Logged body shows `clientSecret: "••••••••"`; plaintext never enters `httpHistory`/`infoLogs`/`lastRequest` (test-asserted) |
| Negative-test scorecard | Broken assertions failed at client auth (wrong layer) | Secret attached → failures happen at assertion validation, as intended |
| Registration-backed runs | Secret resolved server-side | **Unchanged** — still never enters the browser |

## Risk register

| Concern | Answer |
|---|---|
| Secret leaks into the request log / export? | No — the wire body and logged body are separate objects; a test asserts `JSON.stringify` of httpHistory, infoLogs, and lastRequest contains no plaintext. |
| Secret in localStorage? | Yes, with the manual profile — same trust level as the rest of the debug profile; labeled "test credentials only." Registration-backed runs remain the no-browser-secret path. |
| Public-client servers (no secret needed)? | Field is optional; when empty the request body is byte-identical to before. |
| Stack position | PR 11, on `xaa-phase-grouped-debugger` (#2587). |

Tests: 116/116 XAA suites pass (new: secret-on-wire + masked-in-log), typecheck clean.
