### PR TITLE
Sidebar IA cleanup: projects-first switcher, denser nav, Settings hub

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -29,6 +29,7 @@ import { CiEvalsTab } from "./components/CiEvalsTab";
 import { ViewsTab } from "./components/ViewsTab";
 import { ChatboxesTab } from "./components/ChatboxesTab";
 import { SettingsTab } from "./components/SettingsTab";
+import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
 import { ProjectSettingsTab } from "./components/ProjectSettingsTab";
 import { ProjectClientConfigSync } from "./components/client-config/ProjectClientConfigSync";
 import { ActiveHostServerReconciler } from "./components/ActiveHostServerReconciler";
@@ -1140,6 +1141,11 @@ export function SettingsRoute() {
       onNavigate={handleNavigate}
     />
   );
+}
+
+export function ApiKeysSettingsRoute() {
+  const { activeOrganizationId } = useAppRouteContext();
+  return <ApiKeysRoute activeOrganizationId={activeOrganizationId} />;
 }
 
 export function SupportRoute() {

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/lib/billing-entitlements";
 import type { CheckoutIntentWithOrganization } from "@/lib/billing-deep-link";
 import type { OrganizationRouteSection } from "@/lib/app-navigation";
+import { SettingsNav } from "@/components/settings/SettingsNav";
 import { BILLING_GATES, resolveBillingGateState } from "@/lib/billing-gates";
 import {
   getBillingUpsellCtaLabel,
@@ -908,6 +909,10 @@ function OrganizationPage({
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-5">
+        <SettingsNav
+          active="organization"
+          activeOrganizationId={organization._id}
+        />
         <Card className="overflow-hidden border-border/60">
           <CardContent className="space-y-5 p-5">
             <div className="flex flex-col gap-4 md:flex-row md:items-center">
@@ -1068,14 +1073,17 @@ function OrganizationPage({
                             billingStatus={billingStatus}
                             planCatalog={planCatalog}
                             isLoadingPlanCatalog={isLoadingPlanCatalog}
-                            onChangeBillingInterval={handleChangeBillingInterval}
+                            onChangeBillingInterval={
+                              handleChangeBillingInterval
+                            }
                             onCancelScheduledBillingChange={
                               scheduledBillingChangeCancellation
                                 ? handleOpenScheduledBillingChangeCancelDialog
                                 : undefined
                             }
                             cancelScheduledBillingChangeLabel={
-                              scheduledBillingChangeCancellation?.ctaLabel ?? null
+                              scheduledBillingChangeCancellation?.ctaLabel ??
+                              null
                             }
                             onManageBilling={handleManageBilling}
                             isOpeningPortal={isOpeningPortal}
@@ -1438,8 +1446,8 @@ function OrganizationPage({
                     , after which the organization returns to Free.
                   </span>
                   <span className="block">
-                    Once cancellation is scheduled, you can't change your billing
-                    interval (monthly or annual) until you reactivate.
+                    Once cancellation is scheduled, you can't change your
+                    billing interval (monthly or annual) until you reactivate.
                   </span>
                 </>
               ) : (

--- a/mcpjam-inspector/client/src/components/SettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SettingsTab.tsx
@@ -11,6 +11,7 @@ import { updateThemeMode } from "@/lib/theme-utils";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { Info, KeyRound } from "lucide-react";
 import { HOSTED_MODE } from "@/lib/config";
+import { SettingsNav } from "./settings/SettingsNav";
 
 interface SettingsTabProps {
   activeOrganizationId?: string;
@@ -43,7 +44,13 @@ export function SettingsTab({
   return (
     <div className="h-full overflow-y-auto">
       <div className="p-10 space-y-8 max-w-3xl">
-        <h1 className="text-2xl font-semibold">Settings</h1>
+        <div className="space-y-4">
+          <h1 className="text-2xl font-semibold">Settings</h1>
+          <SettingsNav
+            active="general"
+            activeOrganizationId={activeOrganizationId}
+          />
+        </div>
 
         {/* About */}
         <SettingsSection title="About">
@@ -107,9 +114,7 @@ export function SettingsTab({
                   variant="link"
                   className="h-auto p-0 text-sm justify-start"
                   onClick={() =>
-                    onNavigate?.(
-                      `organizations/${activeOrganizationId}/models`,
-                    )
+                    onNavigate?.(`organizations/${activeOrganizationId}/models`)
                   }
                 >
                   Go to Organization Models
@@ -135,7 +140,7 @@ export function SettingsTab({
                     window.open(
                       "https://app.mcpjam.com/organizations",
                       "_blank",
-                      "noopener,noreferrer",
+                      "noopener,noreferrer"
                     )
                   }
                 >

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -20,7 +20,6 @@ import {
   UserPlus,
   ShieldCheck,
   Loader2,
-  Key,
 } from "lucide-react";
 import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { isPostHogBooleanFlagOn, standardEventProps } from "@/lib/PosthogUtils";
@@ -73,7 +72,6 @@ import {
 import { HOSTED_LOCAL_ONLY_TOOLTIP } from "@/lib/hosted-ui";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
-import { NotificationBell } from "@/components/notifications/NotificationBell";
 import {
   useOrganizationBillingStatus,
   type BillingFeatureName,
@@ -84,7 +82,7 @@ import type { OrganizationRouteSection } from "@/lib/app-navigation";
 interface NavItem {
   title: string;
   url: string;
-  icon: React.ComponentType;
+  icon: React.ComponentType<{ className?: string }>;
   disabled?: boolean;
   disabledTooltip?: string;
   /** Only show this item when the named feature flag is enabled */
@@ -329,25 +327,21 @@ const navigationSections: NavSection[] = [
       },
     ],
   },
+];
+
+// Footer utility icons for users without an account menu (signed-out): the
+// account dropdown normally hosts Settings/Support, so signed-in users only
+// see the notification bell here. Same list for local and hosted guests.
+const signedOutUtilityItems: NavItem[] = [
   {
-    id: "settings",
-    items: [
-      {
-        title: "Support",
-        url: "/support",
-        icon: MessageCircleQuestionIcon,
-      },
-      {
-        title: "API Keys",
-        url: "/settings/api-keys",
-        icon: Key,
-      },
-      {
-        title: "Settings",
-        url: "/settings",
-        icon: Settings,
-      },
-    ],
+    title: "Support",
+    url: "/support",
+    icon: MessageCircleQuestionIcon,
+  },
+  {
+    title: "Settings",
+    url: "/settings",
+    icon: Settings,
   },
 ];
 
@@ -682,6 +676,16 @@ export function MCPSidebar({
     featureFlags
   );
 
+  // Signed-in users reach Settings/Support via the account menu; only
+  // signed-out users (no account menu) get utility icons in the footer.
+  const utilityItems = user ? [] : signedOutUtilityItems;
+
+  const isNavItemActive = (item: NavItem) =>
+    normalizeHostedHashTab(
+      item.url.replace(/^[#/]+/, "").split("/")[0] || "servers"
+    ) === activeTab ||
+    (activeTab !== undefined && (item.matchTabs?.includes(activeTab) ?? false));
+
   return (
     <>
       <Sidebar collapsible="icon" {...props}>
@@ -787,16 +791,20 @@ export function MCPSidebar({
             </div>
           )}
         </SidebarHeader>
-        <SidebarContent>
+        <SidebarContent className="gap-0">
           {visibleNavigationSections.map((section, sectionIndex) => {
-            const rawEvalsEntry = section.items.find((item) => item.evalsSubnav);
+            const rawEvalsEntry = section.items.find(
+              (item) => item.evalsSubnav
+            );
             // Only render Evaluate through the SidebarEvalsNavGroup wrapper
             // (which adds its own SidebarGroup padding) when there's actually
             // a Runs sub-item to nest. Otherwise, fold Evaluate into flatItems
             // so it sits flush with Views and matches sibling spacing.
             const useEvalsSubnavWrapper =
               !!rawEvalsEntry && evaluateRunsEnabled === true;
-            const evalsEntry = useEvalsSubnavWrapper ? rawEvalsEntry : undefined;
+            const evalsEntry = useEvalsSubnavWrapper
+              ? rawEvalsEntry
+              : undefined;
             const flatItems = section.items
               .map((item) => {
                 if (!item.evalsSubnav) return item;
@@ -817,13 +825,7 @@ export function MCPSidebar({
                 <NavMain
                   items={flatItems.map((item) => ({
                     ...item,
-                    isActive:
-                      normalizeHostedHashTab(
-                        item.url.replace(/^[#/]+/, "").split("/")[0] ||
-                          "servers"
-                      ) === activeTab ||
-                      (activeTab !== undefined &&
-                        (item.matchTabs?.includes(activeTab) ?? false)),
+                    isActive: isNavItemActive(item),
                   }))}
                   onItemClick={handleNavClick}
                   learnMore={
@@ -832,14 +834,6 @@ export function MCPSidebar({
                           onExpand: learnMore.openExpandedModal,
                         }
                       : null
-                  }
-                  renderSlotAfter={
-                    section.id === "settings"
-                      ? (itemTitle) =>
-                          itemTitle === "Support" ? (
-                            <NotificationBell variant="sidebar" />
-                          ) : null
-                      : undefined
                   }
                 />
                 {evalsEntry ? (
@@ -855,13 +849,36 @@ export function MCPSidebar({
                 ) : null}
                 {/* Add subtle divider between sections (except after the last section) */}
                 {sectionIndex < visibleNavigationSections.length - 1 && (
-                  <div className="mx-4 my-2 border-t border-border/50" />
+                  <div className="mx-4 my-1 border-t border-border/50" />
                 )}
               </React.Fragment>
             );
           })}
         </SidebarContent>
         <SidebarFooter>
+          {utilityItems.length > 0 ? (
+            <div className="flex items-center gap-1 px-1 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:px-0">
+              {utilityItems.map((item) => (
+                <Tooltip key={item.title}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={item.title}
+                      onClick={() => handleNavClick(item.url)}
+                      className={cn(
+                        "flex size-7 items-center justify-center rounded-md text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                        isNavItemActive(item) &&
+                          "bg-sidebar-accent text-sidebar-accent-foreground"
+                      )}
+                    >
+                      {item.icon ? <item.icon className="size-4" /> : null}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">{item.title}</TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
+          ) : null}
           {shouldShowInviteCta ? (
             <SidebarMenu>
               <SidebarMenuItem>

--- a/mcpjam-inspector/client/src/components/notifications/NotificationsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/notifications/NotificationsPanel.tsx
@@ -1,16 +1,8 @@
-import { Bell, Building2, FolderKanban, Inbox } from "lucide-react";
+import { Building2, FolderKanban, Inbox } from "lucide-react";
 import { useConvexAuth } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@mcpjam/design-system/popover";
+import { PopoverContent } from "@mcpjam/design-system/popover";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
-import {
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from "@/components/ui/sidebar";
 import {
   useNotifications,
   useNotificationMutations,
@@ -76,7 +68,7 @@ function NotificationItem({
     <div
       className={cn(
         "flex items-start gap-3 p-3 border-b last:border-b-0 cursor-pointer transition-colors hover:bg-muted/50",
-        !notification.isRead && "bg-muted/30",
+        !notification.isRead && "bg-muted/30"
       )}
       onClick={handleClick}
     >
@@ -85,7 +77,7 @@ function NotificationItem({
           "flex items-center justify-center h-8 w-8 rounded-full shrink-0",
           notification.type.includes("added")
             ? "bg-success/10 text-success"
-            : "bg-destructive/10 text-destructive",
+            : "bg-destructive/10 text-destructive"
         )}
       >
         {getNotificationIcon(notification.type)}
@@ -105,17 +97,27 @@ function NotificationItem({
   );
 }
 
-type NotificationBellProps = {
-  variant?: "header" | "sidebar";
-};
+interface NotificationsPanelContentProps {
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+}
 
-export function NotificationBell({ variant = "header" }: NotificationBellProps) {
+/**
+ * The notifications inbox, rendered as a `PopoverContent`. The caller owns
+ * the `Popover` root and whatever trigger/anchor opens it (currently the
+ * account menu's Notifications item).
+ */
+export function NotificationsPanelContent({
+  side = "right",
+  align = "end",
+}: NotificationsPanelContentProps) {
   const { isAuthenticated } = useConvexAuth();
-  const { notifications, unreadCount, isLoading } = useNotifications({
+  const { notifications, isLoading } = useNotifications({
     isAuthenticated,
   });
   const { markAsRead, markAllAsRead, clearAllNotifications } =
     useNotificationMutations();
+  const unreadCount = notifications.filter((n) => !n.isRead).length;
 
   const handleMarkAsRead = async (notificationId: string) => {
     try {
@@ -141,54 +143,11 @@ export function NotificationBell({ variant = "header" }: NotificationBellProps) 
     }
   };
 
-  if (!isAuthenticated) {
-    return null;
-  }
-
-  const displayCount = unreadCount > 9 ? "9+" : unreadCount;
-  const ariaLabel = `Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`;
-  const unreadBadge =
-    unreadCount > 0 ? (
-      <span
-        className={cn(
-          "flex items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-medium text-white",
-          variant === "sidebar"
-            ? "ml-auto h-4 min-w-4 group-data-[collapsible=icon]:absolute group-data-[collapsible=icon]:-top-0.5 group-data-[collapsible=icon]:-right-0.5 group-data-[collapsible=icon]:ml-0"
-            : "absolute -top-0.5 -right-0.5 h-4 min-w-4",
-        )}
-      >
-        {displayCount}
-      </span>
-    ) : null;
-
-  const trigger =
-    variant === "sidebar" ? (
-      <SidebarMenuButton
-        tooltip="Notifications"
-        className="relative cursor-pointer"
-        aria-label={ariaLabel}
-      >
-        <Bell className="h-4 w-4" />
-        <span className="truncate">Notifications</span>
-        {unreadBadge}
-      </SidebarMenuButton>
-    ) : (
-      <Button
-        variant="ghost"
-        size="icon"
-        className="relative"
-        aria-label={ariaLabel}
-      >
-        <Bell className="h-5 w-5" />
-        {unreadBadge}
-      </Button>
-    );
-
-  const panel = (
+  return (
     <PopoverContent
       className="w-80 p-0"
-      align={variant === "sidebar" ? "start" : "end"}
-      side={variant === "sidebar" ? "right" : "bottom"}
+      align={align}
+      side={side}
       sideOffset={8}
     >
       <div className="flex items-center justify-between p-3 border-b">
@@ -239,23 +198,5 @@ export function NotificationBell({ variant = "header" }: NotificationBellProps) 
         )}
       </ScrollArea>
     </PopoverContent>
-  );
-
-  if (variant === "sidebar") {
-    return (
-      <SidebarMenuItem>
-        <Popover>
-          <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-          {panel}
-        </Popover>
-      </SidebarMenuItem>
-    );
-  }
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      {panel}
-    </Popover>
   );
 }

--- a/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
@@ -16,6 +16,7 @@ import {
   revokeApiKey,
 } from "@/lib/apis/web/api-keys";
 import { writeApiKeysSignInReturnPath } from "@/lib/api-keys-signin-return-path";
+import { SettingsNav } from "./SettingsNav";
 
 /**
  * `/settings/api-keys` — manage WorkOS-issued `sk_…` API keys for the
@@ -26,7 +27,11 @@ import { writeApiKeysSignInReturnPath } from "@/lib/api-keys-signin-return-path"
  * `sk_…` key. That means visiting this page over a session JWT is the
  * only way to mint/revoke — there is no privilege escalation path here.
  */
-export function ApiKeysRoute() {
+interface ApiKeysRouteProps {
+  activeOrganizationId?: string | null;
+}
+
+export function ApiKeysRoute({ activeOrganizationId }: ApiKeysRouteProps = {}) {
   const [keys, setKeys] = useState<ApiKey[]>([]);
   const [loading, setLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
@@ -137,18 +142,24 @@ export function ApiKeysRoute() {
   return (
     <div className="h-full overflow-y-auto">
       <div className="p-10 space-y-8 max-w-3xl">
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">API keys</h1>
-          <Button onClick={() => setCreateOpen(true)}>
+        <div className="space-y-4">
+          <h1 className="text-2xl font-semibold">Settings</h1>
+          <SettingsNav
+            active="api-keys"
+            activeOrganizationId={activeOrganizationId}
+          />
+        </div>
+
+        <div className="flex items-start justify-between gap-4">
+          <p className="text-sm text-muted-foreground">
+            Use these keys to call the MCPJam v1 public API from CI, scripts, or
+            other non-browser contexts. Keys carry your account's permissions
+            and can be revoked any time.
+          </p>
+          <Button onClick={() => setCreateOpen(true)} className="shrink-0">
             <Plus className="mr-2 size-4" aria-hidden /> Create API key
           </Button>
         </div>
-
-        <p className="text-sm text-muted-foreground">
-          Use these keys to call the MCPJam v1 public API from CI, scripts, or
-          other non-browser contexts. Keys carry your account's permissions
-          and can be revoked any time.
-        </p>
 
         <SettingsSection title="Your keys">
           {loading ? (

--- a/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
@@ -1,0 +1,69 @@
+import { cn } from "@/lib/utils";
+import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
+
+export type SettingsNavSection = "general" | "api-keys" | "organization";
+
+interface SettingsNavProps {
+  active: SettingsNavSection;
+  /**
+   * Enables the Organization tab. Without an active org there is nothing to
+   * manage, so the tab is omitted rather than disabled.
+   */
+  activeOrganizationId?: string | null;
+}
+
+/**
+ * Top-level Settings sections, shared across `/settings`,
+ * `/settings/api-keys`, and the organization page so they read as one
+ * Settings surface. Styling mirrors the org page's section tabs.
+ */
+export function SettingsNav({
+  active,
+  activeOrganizationId,
+}: SettingsNavProps) {
+  const appNavigate = useAppNavigate();
+
+  const tabs: Array<{
+    id: SettingsNavSection;
+    label: string;
+    path: string;
+  }> = [
+    { id: "general", label: "General", path: "/settings" },
+    { id: "api-keys", label: "API Keys", path: "/settings/api-keys" },
+    ...(activeOrganizationId
+      ? [
+          {
+            id: "organization" as const,
+            label: "Organization",
+            path: buildOrganizationPath(activeOrganizationId),
+          },
+        ]
+      : []),
+  ];
+
+  return (
+    <nav
+      aria-label="Settings sections"
+      className="flex items-end gap-1 border-b border-border/60"
+    >
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          onClick={() => {
+            if (tab.id !== active) appNavigate(tab.path);
+          }}
+          aria-current={active === tab.id ? "page" : undefined}
+          className={cn(
+            "-mb-px shrink-0 border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+            active === tab.id
+              ? "border-primary text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/nav-main.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/nav-main.test.tsx
@@ -62,17 +62,17 @@ describe("NavMain", () => {
         ]}
         onItemClick={onItemClick}
         learnMore={{ onExpand: vi.fn() }}
-      />,
+      />
     );
 
     // Should show learn-more hover card with disabled message
     expect(screen.getByTestId("learn-more-skills")).toBeInTheDocument();
     expect(screen.getByTestId("disabled-message")).toHaveTextContent(
-      HOSTED_LOCAL_ONLY_TOOLTIP,
+      HOSTED_LOCAL_ONLY_TOOLTIP
     );
     // No native title attribute (double tooltip fix)
     expect(
-      screen.queryByTitle(HOSTED_LOCAL_ONLY_TOOLTIP),
+      screen.queryByTitle(HOSTED_LOCAL_ONLY_TOOLTIP)
     ).not.toBeInTheDocument();
 
     const button = screen.getByRole("button", { name: "Skills" });
@@ -95,11 +95,11 @@ describe("NavMain", () => {
           },
         ]}
         learnMore={{ onExpand: vi.fn() }}
-      />,
+      />
     );
 
     expect(
-      screen.queryByTestId("learn-more-no-learn-more"),
+      screen.queryByTestId("learn-more-no-learn-more")
     ).not.toBeInTheDocument();
     expect(screen.getByText("Not available")).toBeInTheDocument();
     expect(screen.queryByTitle("Not available")).not.toBeInTheDocument();
@@ -117,7 +117,7 @@ describe("NavMain", () => {
             disabledTooltip: HOSTED_LOCAL_ONLY_TOOLTIP,
           },
         ]}
-      />,
+      />
     );
 
     expect(screen.queryByTestId("learn-more-skills")).not.toBeInTheDocument();
@@ -137,7 +137,7 @@ describe("NavMain", () => {
           },
         ]}
         onItemClick={onItemClick}
-      />,
+      />
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Servers" }));
@@ -154,11 +154,11 @@ describe("NavMain", () => {
             icon: FakeIcon,
           },
         ]}
-      />,
+      />
     );
 
     expect(
-      screen.getByRole("button", { name: "Chatboxes" }),
+      screen.getByRole("button", { name: "Chatboxes" })
     ).toBeInTheDocument();
     expect(screen.queryByText("Plan upgrade required")).not.toBeInTheDocument();
   });
@@ -179,11 +179,13 @@ describe("NavMain", () => {
           },
         ]}
         learnMore={{ onExpand: vi.fn() }}
-      />,
+      />
     );
 
     expect(screen.getByTestId("learn-more-servers")).toBeInTheDocument();
-    expect(screen.queryByTestId("learn-more-chatboxes")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("learn-more-chatboxes")
+    ).not.toBeInTheDocument();
   });
 
   it("suppresses the built-in collapsed tooltip when learn more is handling it", () => {
@@ -199,11 +201,11 @@ describe("NavMain", () => {
           },
         ]}
         learnMore={{ onExpand: vi.fn() }}
-      />,
+      />
     );
 
     expect(screen.getByRole("button", { name: "Servers" })).not.toHaveAttribute(
-      "data-tooltip",
+      "data-tooltip"
     );
     expect(screen.getByTestId("learn-more-servers")).toBeInTheDocument();
   });

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
@@ -88,7 +88,9 @@ vi.mock("@mcpjam/design-system/dropdown-menu", async () => {
         onOpenChange?.(next);
       };
       return (
-        <Ctx.Provider value={{ open: isOpen, setOpen }}>{children}</Ctx.Provider>
+        <Ctx.Provider value={{ open: isOpen, setOpen }}>
+          {children}
+        </Ctx.Provider>
       );
     },
     DropdownMenuTrigger: ({
@@ -103,7 +105,7 @@ vi.mock("@mcpjam/design-system/dropdown-menu", async () => {
       if (asChild && React.isValidElement(children)) {
         return React.cloneElement(
           children as React.ReactElement<{ onClick?: () => void }>,
-          { onClick: handleClick },
+          { onClick: handleClick }
         );
       }
       return (
@@ -197,11 +199,13 @@ const projects = {
 
 function openMainDropdown() {
   // Trigger button has aria-label "Switch context: …" or "Switch project: …".
-  fireEvent.click(screen.getByRole("button", { name: /^Switch (context|project):/ }));
+  fireEvent.click(
+    screen.getByRole("button", { name: /^Switch (context|project):/ })
+  );
 }
 
-function openChipPopover() {
-  fireEvent.click(screen.getByTestId("org-chip-button"));
+function openOrgSwitchList() {
+  fireEvent.click(screen.getByTestId("switch-org-button"));
 }
 
 describe("SidebarContextSwitcher", () => {
@@ -239,16 +243,15 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     // Closed: menu content is absent.
-    expect(screen.queryByText("Organization")).not.toBeInTheDocument();
     expect(screen.queryByText("Projects")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("org-chip-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("org-context-row")).not.toBeInTheDocument();
     // Open: clicking the trigger reveals the menu.
     openMainDropdown();
-    expect(screen.getByText("Organization")).toBeInTheDocument();
-    expect(screen.getByTestId("org-chip-button")).toBeInTheDocument();
+    expect(screen.getByText("Projects")).toBeInTheDocument();
+    expect(screen.getByTestId("org-context-row")).toBeInTheDocument();
     // Close: clicking the trigger again hides it.
     openMainDropdown();
-    expect(screen.queryByText("Organization")).not.toBeInTheDocument();
+    expect(screen.queryByText("Projects")).not.toBeInTheDocument();
   });
 
   it("renders trigger with project name and active org name", () => {
@@ -267,7 +270,7 @@ describe("SidebarContextSwitcher", () => {
     expect(screen.getAllByText("Acme").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("shows the active org in the chip header and projects in the body by default", () => {
+  it("shows projects in the body and the active org as a footer row", () => {
     render(
       <SidebarContextSwitcher
         activeProjectId="p1"
@@ -279,16 +282,18 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     openMainDropdown();
-    // Chip header label
-    expect(screen.getByText("Organization")).toBeInTheDocument();
     // Projects body label
     expect(screen.getByText("Projects")).toBeInTheDocument();
     // Active org's projects rendered in body
     expect(screen.getByText("Sandbox")).toBeInTheDocument();
     // Other orgs' projects not in body by default
     expect(screen.queryByText("Nimbus Project")).not.toBeInTheDocument();
-    // Org popover is closed by default
-    expect(screen.queryByTestId("org-popover")).not.toBeInTheDocument();
+    // Active org name appears in the footer context row
+    expect(
+      within(screen.getByTestId("org-context-row")).getByText("Acme")
+    ).toBeInTheDocument();
+    // The org switch list is collapsed by default
+    expect(screen.queryByTestId("org-switch-list")).not.toBeInTheDocument();
   });
 
   it("shows the active org's credit usage right below the org", () => {
@@ -308,7 +313,7 @@ describe("SidebarContextSwitcher", () => {
     expect(creditUsage).toHaveAttribute("data-variant", "full");
   });
 
-  it("opens the org popover when chip is clicked, listing all organizations", () => {
+  it("expands the org switch list when 'Switch organization' is clicked, listing all organizations", () => {
     render(
       <SidebarContextSwitcher
         activeProjectId="p1"
@@ -320,13 +325,16 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     openMainDropdown();
-    openChipPopover();
-    expect(screen.getByTestId("org-popover")).toBeInTheDocument();
+    openOrgSwitchList();
+    expect(screen.getByTestId("org-switch-list")).toBeInTheDocument();
     expect(screen.getByTestId("org-row-org_a")).toBeInTheDocument();
     expect(screen.getByTestId("org-row-org_b")).toBeInTheDocument();
+    // Clicking the toggle again collapses the list
+    openOrgSwitchList();
+    expect(screen.queryByTestId("org-switch-list")).not.toBeInTheDocument();
   });
 
-  it("clicking an org in the popover commits the switch via onSwitchActiveOrganization (no navigation)", () => {
+  it("clicking an org in the switch list commits the switch via onSwitchActiveOrganization (no navigation)", () => {
     const onSwitchOrganization = vi.fn();
     const onSwitchActiveOrganization = vi.fn();
     render(
@@ -342,16 +350,16 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     openMainDropdown();
-    openChipPopover();
+    openOrgSwitchList();
     fireEvent.click(screen.getByTestId("org-row-org_b"));
     expect(onSwitchActiveOrganization).toHaveBeenCalledWith("org_b");
     // The navigating handler must NOT fire — staying on the current page is the point.
     expect(onSwitchOrganization).not.toHaveBeenCalled();
-    // Popover auto-closes
-    expect(screen.queryByTestId("org-popover")).not.toBeInTheDocument();
+    // The whole menu closes after switching
+    expect(screen.queryByTestId("org-switch-list")).not.toBeInTheDocument();
   });
 
-  it("clicking the already-active org in the popover does not call onSwitchActiveOrganization", () => {
+  it("clicking the already-active org in the switch list does not call onSwitchActiveOrganization", () => {
     const onSwitchActiveOrganization = vi.fn();
     render(
       <SidebarContextSwitcher
@@ -365,12 +373,12 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     openMainDropdown();
-    openChipPopover();
+    openOrgSwitchList();
     fireEvent.click(screen.getByTestId("org-row-org_a"));
     expect(onSwitchActiveOrganization).not.toHaveBeenCalled();
   });
 
-  it("clicking the gear icon in an org popover row navigates via onSwitchOrganization", () => {
+  it("clicking the gear icon in an org switch row navigates via onSwitchOrganization", () => {
     const onSwitchOrganization = vi.fn();
     render(
       <SidebarContextSwitcher
@@ -384,15 +392,36 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     openMainDropdown();
-    openChipPopover();
-    const popover = screen.getByTestId("org-popover");
+    openOrgSwitchList();
+    const list = screen.getByTestId("org-switch-list");
     fireEvent.click(
-      within(popover).getByRole("button", { name: "Open Acme settings" })
+      within(list).getByRole("button", { name: "Open Acme settings" })
     );
     expect(onSwitchOrganization).toHaveBeenCalledWith("org_a", "overview");
   });
 
-  it("renders the gear icon for every org in the popover regardless of role", () => {
+  it("clicking the footer org row gear opens the active org's settings", () => {
+    const onSwitchOrganization = vi.fn();
+    render(
+      <SidebarContextSwitcher
+        activeProjectId="p1"
+        activeOrganizationId="org_a"
+        projects={projects}
+        onSwitchProject={vi.fn()}
+        onCreateProject={vi.fn(async () => "")}
+        onDeleteProject={vi.fn()}
+        onSwitchOrganization={onSwitchOrganization}
+      />
+    );
+    openMainDropdown();
+    const footerRow = screen.getByTestId("org-context-row");
+    fireEvent.click(
+      within(footerRow).getByRole("button", { name: "Open Acme settings" })
+    );
+    expect(onSwitchOrganization).toHaveBeenCalledWith("org_a", "overview");
+  });
+
+  it("renders the gear icon for every org in the switch list regardless of role", () => {
     render(
       <SidebarContextSwitcher
         activeProjectId="p1"
@@ -405,13 +434,13 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     openMainDropdown();
-    openChipPopover();
-    const popover = screen.getByTestId("org-popover");
+    openOrgSwitchList();
+    const list = screen.getByTestId("org-switch-list");
     expect(
-      within(popover).getByRole("button", { name: "Open Acme settings" })
+      within(list).getByRole("button", { name: "Open Acme settings" })
     ).toBeInTheDocument();
     expect(
-      within(popover).getByRole("button", { name: "Open Nimbus settings" })
+      within(list).getByRole("button", { name: "Open Nimbus settings" })
     ).toBeInTheDocument();
   });
 
@@ -626,7 +655,7 @@ describe("SidebarContextSwitcher", () => {
     expect(screen.getByTitle("2 more")).toBeInTheDocument();
   });
 
-  it("clicking the 'New organization' header button opens the create org dialog", () => {
+  it("offers 'New organization' at the bottom of the switch list and opens the create org dialog", () => {
     render(
       <SidebarContextSwitcher
         activeProjectId="p1"
@@ -638,6 +667,11 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     openMainDropdown();
+    // Not visible until the switch list is expanded — it's a rare action.
+    expect(
+      screen.queryByRole("button", { name: "New organization" })
+    ).not.toBeInTheDocument();
+    openOrgSwitchList();
     fireEvent.click(screen.getByRole("button", { name: "New organization" }));
     expect(mockCreateOrgDialog).toHaveBeenCalled();
     const lastCall = mockCreateOrgDialog.mock.calls.at(-1)?.[0] as {
@@ -646,7 +680,7 @@ describe("SidebarContextSwitcher", () => {
     expect(lastCall.open).toBe(true);
   });
 
-  it("disables the 'New organization' button when the user has reached the creation limit", () => {
+  it("omits the 'New organization' button entirely when the user has reached the creation limit", () => {
     mockUseOrganizationQueries.mockReturnValue({
       sortedOrganizations: orgs,
       isLoading: false,
@@ -664,13 +698,10 @@ describe("SidebarContextSwitcher", () => {
       />
     );
     openMainDropdown();
-    const button = screen.getByRole("button", { name: "New organization" });
-    expect(button).toBeDisabled();
-    fireEvent.click(button);
-    const lastCall = mockCreateOrgDialog.mock.calls.at(-1)?.[0] as
-      | { open: boolean }
-      | undefined;
-    expect(lastCall?.open ?? false).toBe(false);
+    openOrgSwitchList();
+    expect(
+      screen.queryByRole("button", { name: "New organization" })
+    ).not.toBeInTheDocument();
   });
 
   it("clicking the 'Add project' header button calls onCreateProject with a unique name", () => {
@@ -794,7 +825,7 @@ describe("SidebarContextSwitcher", () => {
     );
   });
 
-  it("edge case: single org and single project still renders chip and full menu affordances", () => {
+  it("single org: hides the switch affordance and shows org context plus direct create row", () => {
     mockUseOrganizationQueries.mockReturnValue({
       sortedOrganizations: [orgs[0]],
       isLoading: false,
@@ -813,17 +844,76 @@ describe("SidebarContextSwitcher", () => {
     );
     openMainDropdown();
     expect(screen.getAllByText("Inspector").length).toBeGreaterThanOrEqual(1);
-    // Chip is rendered
-    expect(screen.getByTestId("org-chip-button")).toBeInTheDocument();
-    // Open the chip popover; the single org row is visible
-    openChipPopover();
-    expect(screen.getByTestId("org-row-org_a")).toBeInTheDocument();
-    // Section-header affordances are always visible (no popover required)
+    // Nothing to switch to → no switch affordance at all
+    expect(screen.queryByTestId("switch-org-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("org-switch-list")).not.toBeInTheDocument();
+    // Org still shown as ambient context in the footer
+    expect(
+      within(screen.getByTestId("org-context-row")).getByText("Acme")
+    ).toBeInTheDocument();
+    // With no owned org, create is offered directly in the footer
     expect(
       screen.getByRole("button", { name: "New organization" })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Add project" })
     ).toBeInTheDocument();
+  });
+
+  it("single org owned by the user: footer has no switch or create affordances", () => {
+    mockUseOrganizationQueries.mockReturnValue({
+      sortedOrganizations: [orgs[0]],
+      isLoading: false,
+      createdCount: 1,
+      canCreateOrganization: false,
+    });
+    render(
+      <SidebarContextSwitcher
+        activeProjectId="p1"
+        activeOrganizationId="org_a"
+        projects={{ p1: projects.p1 }}
+        onSwitchProject={vi.fn()}
+        onCreateProject={vi.fn(async () => "")}
+        onDeleteProject={vi.fn()}
+      />
+    );
+    openMainDropdown();
+    expect(screen.queryByTestId("switch-org-button")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "New organization" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("guest: footer shows a sign-in row that triggers sign in", () => {
+    const signIn = vi.fn();
+    mockUseAuth.mockReturnValue({ user: null, signIn });
+    mockUseConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    mockUseOrganizationQueries.mockReturnValue({
+      sortedOrganizations: [],
+      isLoading: false,
+      createdCount: 0,
+      canCreateOrganization: true,
+    });
+    render(
+      <SidebarContextSwitcher
+        activeProjectId="p1"
+        projects={{ p1: { ...projects.p1, organizationId: undefined } }}
+        onSwitchProject={vi.fn()}
+        onCreateProject={vi.fn(async () => "")}
+        onDeleteProject={vi.fn()}
+      />
+    );
+    openMainDropdown();
+    // No org context, switch, or create affordances for guests
+    expect(screen.queryByTestId("org-context-row")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("switch-org-button")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "New organization" })
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("org-sign-in-button"));
+    expect(signIn).toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -90,7 +90,9 @@ vi.mock("@/components/ui/sidebar", () => ({
   SidebarFooter: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
-  SidebarGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SidebarGroup: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
   SidebarGroupContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
@@ -157,7 +159,9 @@ function makeProject(id: string, name: string) {
   };
 }
 
-function renderSidebar(overrides: Partial<React.ComponentProps<typeof MCPSidebar>> = {}) {
+function renderSidebar(
+  overrides: Partial<React.ComponentProps<typeof MCPSidebar>> = {}
+) {
   return render(
     <MCPSidebar
       projects={{
@@ -170,7 +174,7 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof MCPSidebar
       onDeleteProject={vi.fn()}
       onProjectShared={vi.fn()}
       {...overrides}
-    />,
+    />
   );
 }
 
@@ -197,7 +201,7 @@ describe("sidebar invite CTA", () => {
           <div data-testid="share-project-dialog">
             Share dialog for {projectName}
           </div>
-        ) : null,
+        ) : null
     );
   });
 
@@ -213,7 +217,7 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     expect(
-      screen.queryByRole("button", { name: "Invite team members" }),
+      screen.queryByRole("button", { name: "Invite team members" })
     ).not.toBeInTheDocument();
   });
 
@@ -221,10 +225,10 @@ describe("sidebar invite CTA", () => {
     renderSidebar();
 
     expect(
-      screen.getByRole("button", { name: "Invite team members" }),
+      screen.getByRole("button", { name: "Invite team members" })
     ).toBeInTheDocument();
     expect(screen.getByText("Invite team members")).toHaveClass(
-      "group-data-[collapsible=icon]:hidden",
+      "group-data-[collapsible=icon]:hidden"
     );
   });
 
@@ -236,10 +240,12 @@ describe("sidebar invite CTA", () => {
     });
     const sidebarUser = screen.getByTestId("sidebar-user");
 
-    expect(screen.queryByTestId("sidebar-credit-usage")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("sidebar-credit-usage")
+    ).not.toBeInTheDocument();
     expect(
       inviteButton.compareDocumentPosition(sidebarUser) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+        Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
   });
 
@@ -261,17 +267,56 @@ describe("sidebar invite CTA", () => {
     expect(creditUsage).toHaveClass("px-1");
     expect(
       creditUsage.compareDocumentPosition(sidebarUser) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+        Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+
+  it("signed-in footer has no utility strip (everything lives in the account menu)", () => {
+    renderSidebar();
+
+    expect(
+      screen.queryByRole("button", { name: "Support" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Settings" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "API Keys" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Notifications/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("signed-out footer strip offers Support and Settings icons (no account menu to host them)", () => {
+    mockUseConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    mockUseAuth.mockReturnValue({
+      user: null,
+    });
+
+    renderSidebar();
+
+    expect(screen.getByRole("button", { name: "Support" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Settings" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "API Keys" })
+    ).not.toBeInTheDocument();
   });
 
   it("opens the share dialog for the active project", () => {
     renderSidebar();
 
-    fireEvent.click(screen.getByRole("button", { name: "Invite team members" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Invite team members" })
+    );
 
     expect(screen.getByTestId("share-project-dialog")).toHaveTextContent(
-      "Share dialog for Acme",
+      "Share dialog for Acme"
     );
   });
 
@@ -289,12 +334,11 @@ describe("sidebar invite CTA", () => {
         onCreateProject={vi.fn(async () => "project-created")}
         onDeleteProject={vi.fn()}
         onProjectShared={vi.fn()}
-      />,
+      />
     );
 
     expect(
-      screen.getByRole("button", { name: "Invite team members" }),
+      screen.getByRole("button", { name: "Invite team members" })
     ).toBeInTheDocument();
   });
-
 });

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-trial-countdown.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-trial-countdown.test.tsx
@@ -16,7 +16,7 @@ describe("SidebarTrialCountdown", () => {
       <SidebarTrialCountdown
         trialStartedAt={start - 6 * 24 * 60 * 60 * 1000}
         trialEndsAt={start + 60 * 60 * 1000 + 1_000}
-      />,
+      />
     );
 
     expect(screen.getByText("1h 0m 1s")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -5,13 +5,11 @@ import type { ButtonHTMLAttributes, ReactNode } from "react";
 const authState = vi.hoisted(() => ({
   signInMock: vi.fn(),
   signOutMock: vi.fn(),
-  user: null as
-    | null
-    | {
-        email: string;
-        firstName?: string;
-        lastName?: string;
-      },
+  user: null as null | {
+    email: string;
+    firstName?: string;
+    lastName?: string;
+  },
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -25,6 +23,15 @@ vi.mock("@workos-inc/authkit-react", () => ({
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
   useQuery: () => null,
+}));
+
+vi.mock("@mcpjam/design-system/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverAnchor: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/notifications/NotificationsPanel", () => ({
+  NotificationsPanelContent: () => <div data-testid="notifications-panel" />,
 }));
 
 vi.mock("@/lib/config", () => ({
@@ -56,7 +63,9 @@ vi.mock("@/components/sidebar/sidebar-credit-usage", () => ({
 }));
 
 vi.mock("@mcpjam/design-system/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
     <>{children}</>
   ),
@@ -108,7 +117,7 @@ describe("SidebarUser", () => {
     const signInButton = screen.getByRole("button", { name: "Sign in" });
     expect(signInButton).toHaveAttribute("aria-label", "Sign in");
     expect(signInButton.className).toContain(
-      "data-[state=open]:bg-sidebar-accent",
+      "data-[state=open]:bg-sidebar-accent"
     );
   });
 
@@ -130,6 +139,21 @@ describe("SidebarUser", () => {
     expect(
       screen.queryByTestId("sidebar-credit-usage")
     ).not.toBeInTheDocument();
+  });
+
+  it("account menu offers Notifications and Support alongside Profile and Settings", () => {
+    authState.user = {
+      email: "owner@example.com",
+      firstName: "Owner",
+      lastName: "Example",
+    };
+
+    render(<SidebarUser />);
+
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+    expect(screen.getByText("Support")).toBeInTheDocument();
   });
 
   it("returns logout to the app origin instead of the callback route", () => {
@@ -167,7 +191,7 @@ describe("SidebarUser", () => {
       });
     });
     expect(onBeforeSignOut.mock.invocationCallOrder[0]).toBeLessThan(
-      authState.signOutMock.mock.invocationCallOrder[0],
+      authState.signOutMock.mock.invocationCallOrder[0]
     );
   });
 

--- a/mcpjam-inspector/client/src/components/sidebar/nav-main.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/nav-main.tsx
@@ -50,16 +50,9 @@ interface NavMainProps {
   onItemClick?: (url: string) => void;
   /** Learn more hover card integration */
   learnMore?: LearnMoreProps | null;
-  /** Optional slot rendered immediately after a nav row, keyed by item title. */
-  renderSlotAfter?: (itemTitle: string) => React.ReactNode;
 }
 
-export function NavMain({
-  items,
-  onItemClick,
-  learnMore,
-  renderSlotAfter,
-}: NavMainProps) {
+export function NavMain({ items, onItemClick, learnMore }: NavMainProps) {
   const { open: sidebarOpen } = useSidebar();
 
   const handleClick = (url: string) => {
@@ -75,8 +68,8 @@ export function NavMain({
       item.disabled
         ? "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground"
         : isItemActive(item)
-          ? "[&[data-active=true]]:bg-accent cursor-pointer"
-          : "cursor-pointer",
+        ? "[&[data-active=true]]:bg-accent cursor-pointer"
+        : "cursor-pointer"
     );
 
   const shouldShowHoverCard = (item: NavMainItem): boolean => {
@@ -104,7 +97,7 @@ export function NavMain({
 
   const renderButton = (
     item: NavMainItem,
-    options: { suppressTooltip?: boolean; badge?: React.ReactNode } = {},
+    options: { suppressTooltip?: boolean; badge?: React.ReactNode } = {}
   ) => (
     <SidebarMenuButton
       tooltip={
@@ -129,22 +122,18 @@ export function NavMain({
   );
 
   return (
-    <SidebarGroup>
+    <SidebarGroup className="py-1">
       <SidebarGroupContent>
-        <SidebarMenu>
+        <SidebarMenu className="gap-0.5">
           {items.map((item) => {
-            const slotAfter = renderSlotAfter?.(item.title) ?? null;
-
             if (item.announcement && !item.disabled) {
               return (
-                <React.Fragment key={item.title}>
-                  <AnnouncementNavRow
-                    item={{ ...item, announcement: item.announcement }}
-                    sidebarOpen={sidebarOpen}
-                    renderButton={renderButton}
-                  />
-                  {slotAfter}
-                </React.Fragment>
+                <AnnouncementNavRow
+                  key={item.title}
+                  item={{ ...item, announcement: item.announcement }}
+                  sidebarOpen={sidebarOpen}
+                  renderButton={renderButton}
+                />
               );
             }
 
@@ -153,44 +142,35 @@ export function NavMain({
             if (item.disabled) {
               if (shouldShowHoverCard(item)) {
                 return (
-                  <React.Fragment key={item.title}>
-                    <SidebarMenuItem>
-                      {wrapWithHoverCard(
-                        item,
-                        <div className="w-full cursor-not-allowed">{button}</div>,
-                      )}
-                    </SidebarMenuItem>
-                    {slotAfter}
-                  </React.Fragment>
+                  <SidebarMenuItem key={item.title}>
+                    {wrapWithHoverCard(
+                      item,
+                      <div className="w-full cursor-not-allowed">{button}</div>
+                    )}
+                  </SidebarMenuItem>
                 );
               }
 
               return (
-                <React.Fragment key={item.title}>
-                  <SidebarMenuItem>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div className="w-full cursor-not-allowed">{button}</div>
-                      </TooltipTrigger>
-                      {item.disabledTooltip && (
-                        <TooltipContent side="right" align="center">
-                          {item.disabledTooltip}
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                  </SidebarMenuItem>
-                  {slotAfter}
-                </React.Fragment>
+                <SidebarMenuItem key={item.title}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="w-full cursor-not-allowed">{button}</div>
+                    </TooltipTrigger>
+                    {item.disabledTooltip && (
+                      <TooltipContent side="right" align="center">
+                        {item.disabledTooltip}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                </SidebarMenuItem>
               );
             }
 
             return (
-              <React.Fragment key={item.title}>
-                <SidebarMenuItem>
-                  {wrapWithHoverCard(item, button)}
-                </SidebarMenuItem>
-                {slotAfter}
-              </React.Fragment>
+              <SidebarMenuItem key={item.title}>
+                {wrapWithHoverCard(item, button)}
+              </SidebarMenuItem>
             );
           })}
         </SidebarMenu>
@@ -204,7 +184,7 @@ interface AnnouncementNavRowProps {
   sidebarOpen: boolean;
   renderButton: (
     item: NavMainItem,
-    options?: { suppressTooltip?: boolean; badge?: React.ReactNode },
+    options?: { suppressTooltip?: boolean; badge?: React.ReactNode }
   ) => React.ReactNode;
 }
 

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
@@ -1,5 +1,6 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
+  ArrowLeftRight,
   Building2,
   ChevronDown,
   ChevronsUpDown,
@@ -56,7 +57,7 @@ interface SidebarContextSwitcherProps {
   activeOrganizationId?: string;
   /**
    * Navigates to an organization's overview/billing page.
-   * Used by the chip-level gear and the per-row gear in the org popover.
+   * Used by the footer org row's gear and the per-row gear in the switch list.
    */
   onSwitchOrganization?: (
     organizationId: string,
@@ -131,47 +132,19 @@ export function SidebarContextSwitcher({
   const { isMobile } = useSidebar();
   const { isAuthenticated } = useConvexAuth();
   const { user, signIn } = useAuth();
-  const { sortedOrganizations, canCreateOrganization } =
-    useOrganizationQueries({ isAuthenticated });
+  const { sortedOrganizations, canCreateOrganization } = useOrganizationQueries(
+    { isAuthenticated }
+  );
   const showSignInChip = !user;
 
   const [menuOpen, setMenuOpen] = useState(false);
-  const [chipPopoverOpen, setChipPopoverOpen] = useState(false);
+  const [orgListOpen, setOrgListOpen] = useState(false);
   const [showCreateOrgDialog, setShowCreateOrgDialog] = useState(false);
-  const closePopoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
 
+  // Switching orgs is rare; start every menu open on the common case (projects).
   useEffect(() => {
-    if (menuOpen) {
-      setChipPopoverOpen(false);
-    }
+    setOrgListOpen(false);
   }, [menuOpen]);
-
-  useEffect(() => {
-    return () => {
-      if (closePopoverTimerRef.current) {
-        clearTimeout(closePopoverTimerRef.current);
-      }
-    };
-  }, []);
-
-  const openOrgPopover = () => {
-    if (closePopoverTimerRef.current) {
-      clearTimeout(closePopoverTimerRef.current);
-      closePopoverTimerRef.current = null;
-    }
-    setChipPopoverOpen(true);
-  };
-
-  const scheduleCloseOrgPopover = () => {
-    if (closePopoverTimerRef.current) {
-      clearTimeout(closePopoverTimerRef.current);
-    }
-    closePopoverTimerRef.current = setTimeout(() => {
-      setChipPopoverOpen(false);
-    }, 120);
-  };
 
   const activeProject = projects[activeProjectId];
 
@@ -209,6 +182,10 @@ export function SidebarContextSwitcher({
       return a.name.localeCompare(b.name);
     });
 
+  // Membership in >1 org (e.g. invited to an external one) is what makes
+  // switching meaningful; with a single org we render context only.
+  const canSwitchOrganizations = sortedOrganizations.length > 1;
+
   const handleCreateProject = () => {
     if (isCreateDisabled) return;
     const baseName = "New project";
@@ -221,6 +198,27 @@ export function SidebarContextSwitcher({
     }
     onCreateProject(name, true);
   };
+
+  const openCreateOrgDialog = () => {
+    setShowCreateOrgDialog(true);
+    setMenuOpen(false);
+  };
+
+  const newOrganizationRow = canCreateOrganization ? (
+    <button
+      type="button"
+      aria-label="New organization"
+      onClick={openCreateOrgDialog}
+      className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-[13px] text-muted-foreground hover:bg-accent/60 hover:text-foreground transition-colors"
+    >
+      <div className="flex items-center justify-center size-5 rounded bg-muted shrink-0">
+        <Plus className="size-3" />
+      </div>
+      <span className="flex-1 truncate text-left font-medium">
+        New organization
+      </span>
+    </button>
+  ) : null;
 
   const triggerButton = (
     <SidebarMenuButton
@@ -265,239 +263,12 @@ export function SidebarContextSwitcher({
               <DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
             )}
             <DropdownMenuContent
-              className="w-[300px] rounded-xl p-0 shadow-md bg-sidebar !overflow-x-visible !overflow-y-visible"
+              className="w-[300px] rounded-xl p-0 shadow-md bg-sidebar"
               side={isMobile ? "bottom" : "right"}
               align="start"
               sideOffset={4}
             >
-              {/* Org section */}
-              <div className="relative px-1.5 pt-2 pb-1">
-                <div className="flex items-center justify-between px-2 pb-1.5">
-                  <span className={SECTION_LABEL_CLASS}>Organization</span>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="inline-flex">
-                        <button
-                          type="button"
-                          aria-label="New organization"
-                          disabled={!canCreateOrganization}
-                          onClick={() => {
-                            if (!canCreateOrganization) return;
-                            setShowCreateOrgDialog(true);
-                            setChipPopoverOpen(false);
-                            setMenuOpen(false);
-                          }}
-                          className="p-0.5 rounded text-muted-foreground/70 hover:text-foreground hover:bg-muted transition-colors disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/70 disabled:cursor-not-allowed"
-                        >
-                          <Plus className="size-3.5" />
-                        </button>
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" sideOffset={6}>
-                      {canCreateOrganization
-                        ? "New organization"
-                        : "You can only create one organization. Ask to be invited to others."}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-                <div
-                  className="group/orgchip flex items-center gap-1 rounded-lg hover:bg-accent transition-colors"
-                  // Hover-to-open is desktop-only. On touch devices iOS fires a
-                  // synthetic mouseleave right after tap, which would schedule the
-                  // popover to close ~120ms after it opens. Tap-to-toggle (the
-                  // chip-button onClick) is the mobile interaction.
-                  onMouseEnter={
-                    isMobile || showSignInChip ? undefined : openOrgPopover
-                  }
-                  onMouseLeave={
-                    isMobile || showSignInChip
-                      ? undefined
-                      : scheduleCloseOrgPopover
-                  }
-                >
-                  <button
-                    type="button"
-                    data-testid="org-chip-button"
-                    onClick={() => {
-                      if (showSignInChip) {
-                        signIn();
-                        setMenuOpen(false);
-                        return;
-                      }
-                      setChipPopoverOpen((o) => !o);
-                    }}
-                    onFocus={
-                      isMobile || showSignInChip ? undefined : openOrgPopover
-                    }
-                    className="flex-1 flex items-center gap-2.5 pl-2 py-1.5 text-left min-w-0 rounded-l-lg"
-                  >
-                    {showSignInChip ? (
-                      <div className="flex items-center justify-center size-6 rounded-md bg-primary/10 text-primary shrink-0">
-                        <LogIn className="size-3.5" />
-                      </div>
-                    ) : activeOrg ? (
-                      <div
-                        className={cn(
-                          "flex items-center justify-center size-6 rounded-md text-[11px] font-semibold shrink-0",
-                          activeOrgTint!.bg,
-                          activeOrgTint!.fg
-                        )}
-                      >
-                        {activeOrg.name.charAt(0).toUpperCase()}
-                      </div>
-                    ) : (
-                      <div className="flex items-center justify-center size-6 rounded-md bg-muted text-muted-foreground shrink-0">
-                        <Building2 className="size-3.5" />
-                      </div>
-                    )}
-                    <span className="flex-1 min-w-0 text-[13px] font-medium truncate">
-                      {showSignInChip
-                        ? "Sign in"
-                        : (activeOrg?.name ?? "No organization")}
-                    </span>
-                    {/* Tap affordance — mobile only. Desktop relies on hover. */}
-                    {isMobile && !showSignInChip ? (
-                      <ChevronDown
-                        aria-hidden="true"
-                        className={cn(
-                          "size-3.5 mr-1 text-muted-foreground/70 shrink-0 transition-transform",
-                          chipPopoverOpen && "rotate-180"
-                        )}
-                      />
-                    ) : null}
-                  </button>
-                  {/* Settings gear on hover — mirrors the per-project row's
-                      gear so the current org has the same affordance. */}
-                  {!showSignInChip && activeOrg && onSwitchOrganization ? (
-                    <button
-                      type="button"
-                      aria-label={`Open ${activeOrg.name} settings`}
-                      title={`Open ${activeOrg.name} settings`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSwitchOrganization(activeOrg._id, "overview");
-                        setChipPopoverOpen(false);
-                        setMenuOpen(false);
-                      }}
-                      className="mr-1 p-0.5 rounded text-muted-foreground/70 hover:text-foreground hover:bg-muted transition-colors opacity-0 group-hover/orgchip:opacity-100 group-focus-within/orgchip:opacity-100"
-                    >
-                      <Settings className="size-3.5" />
-                    </button>
-                  ) : null}
-                </div>
-                {chipPopoverOpen && !showSignInChip ? (
-                  <div
-                    data-testid="org-popover"
-                    onMouseEnter={isMobile ? undefined : openOrgPopover}
-                    onMouseLeave={
-                      isMobile ? undefined : scheduleCloseOrgPopover
-                    }
-                    className={cn(
-                      "absolute z-10 rounded-lg border border-border bg-sidebar shadow-lg p-1",
-                      // On mobile the dropdown lives at the screen edge, so expanding
-                      // to the side would be clipped. Drop the popover below the chip
-                      // instead — it overlays the projects list while open.
-                      isMobile
-                        ? "left-2 right-2 top-[calc(100%+4px)]"
-                        : "left-[calc(100%+6px)] top-2 w-[260px]"
-                    )}
-                  >
-                    {sortedOrganizations.length === 0 ? (
-                      <div className="px-2 py-3 text-xs text-muted-foreground">
-                        No organizations yet
-                      </div>
-                    ) : (
-                      sortedOrganizations.map((org) => {
-                        const tint = getOrgTint(org._id);
-                        return (
-                          <div
-                            key={org._id}
-                            role="menuitem"
-                            tabIndex={0}
-                            data-testid={`org-row-${org._id}`}
-                            onClick={() => {
-                              if (org._id !== activeOrganizationId) {
-                                onSwitchActiveOrganization?.(org._id);
-                              }
-                              setChipPopoverOpen(false);
-                              setMenuOpen(false);
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                e.preventDefault();
-                                if (org._id !== activeOrganizationId) {
-                                  onSwitchActiveOrganization?.(org._id);
-                                }
-                                setChipPopoverOpen(false);
-                                setMenuOpen(false);
-                              }
-                            }}
-                            className={cn(
-                              "group/org flex items-center gap-2.5 rounded-md px-2 py-1.5 text-[13px] cursor-pointer",
-                              org._id === activeOrganizationId
-                                ? "bg-accent"
-                                : "hover:bg-accent/60"
-                            )}
-                          >
-                            <div
-                              className={cn(
-                                "flex items-center justify-center size-5 rounded text-[10px] font-semibold shrink-0",
-                                tint.bg,
-                                tint.fg
-                              )}
-                            >
-                              {org.name.charAt(0).toUpperCase()}
-                            </div>
-                            <span className="flex-1 truncate font-medium">
-                              {org.name}
-                            </span>
-                            {onSwitchOrganization ? (
-                              <button
-                                type="button"
-                                aria-label={`Open ${org.name} settings`}
-                                title={`Open ${org.name} settings`}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  onSwitchOrganization(org._id, "overview");
-                                  setMenuOpen(false);
-                                }}
-                                className="p-0.5 rounded text-muted-foreground/70 hover:text-foreground hover:bg-muted transition-colors opacity-0 group-hover/org:opacity-100 group-focus-within/org:opacity-100"
-                              >
-                                <Settings className="size-3.5" />
-                              </button>
-                            ) : null}
-                          </div>
-                        );
-                      })
-                    )}
-                  </div>
-                ) : null}
-
-                {/* Active org's shared credit usage, shown right below the
-                    org so it's always visible (not hidden behind a hover). */}
-                {!showSignInChip && activeOrganizationId ? (
-                  <div className="px-0.5 pt-1">
-                    <SidebarCreditUsage
-                      variant="full"
-                      organizationId={activeOrganizationId}
-                      onClick={
-                        activeOrg && onSwitchOrganization
-                          ? () => {
-                              onSwitchOrganization(activeOrg._id, "billing");
-                              setChipPopoverOpen(false);
-                              setMenuOpen(false);
-                            }
-                          : undefined
-                      }
-                    />
-                  </div>
-                ) : null}
-              </div>
-
-              {/* Inset hairline divider */}
-              <div className="mx-3 my-0.5 h-px bg-border/70" />
-
-              {/* Projects section */}
+              {/* Projects section — the frequent operation owns the body */}
               <div className="px-1.5 pt-2 pb-1">
                 <div className="flex items-center justify-between px-2 pb-1.5">
                   <span className={SECTION_LABEL_CLASS}>Projects</span>
@@ -568,6 +339,186 @@ export function SidebarContextSwitcher({
                     ))
                   )}
                 </div>
+              </div>
+
+              {/* Inset hairline divider */}
+              <div className="mx-3 my-0.5 h-px bg-border/70" />
+
+              {/* Org footer — ambient context, not a destination */}
+              <div className="px-1.5 pt-1 pb-1.5">
+                {showSignInChip ? (
+                  <button
+                    type="button"
+                    data-testid="org-sign-in-button"
+                    onClick={() => {
+                      signIn();
+                      setMenuOpen(false);
+                    }}
+                    className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left hover:bg-accent transition-colors"
+                  >
+                    <div className="flex items-center justify-center size-6 rounded-md bg-primary/10 text-primary shrink-0">
+                      <LogIn className="size-3.5" />
+                    </div>
+                    <span className="flex-1 min-w-0 text-[13px] font-medium truncate">
+                      Sign in
+                    </span>
+                  </button>
+                ) : (
+                  <>
+                    <div
+                      data-testid="org-context-row"
+                      className="group/orgrow flex items-center gap-2.5 rounded-lg px-2 py-1.5"
+                    >
+                      {activeOrg ? (
+                        <div
+                          className={cn(
+                            "flex items-center justify-center size-6 rounded-md text-[11px] font-semibold shrink-0",
+                            activeOrgTint!.bg,
+                            activeOrgTint!.fg
+                          )}
+                        >
+                          {activeOrg.name.charAt(0).toUpperCase()}
+                        </div>
+                      ) : (
+                        <div className="flex items-center justify-center size-6 rounded-md bg-muted text-muted-foreground shrink-0">
+                          <Building2 className="size-3.5" />
+                        </div>
+                      )}
+                      <span className="flex-1 min-w-0 text-[13px] font-medium truncate">
+                        {activeOrg?.name ?? "No organization"}
+                      </span>
+                      {activeOrg && onSwitchOrganization ? (
+                        <button
+                          type="button"
+                          aria-label={`Open ${activeOrg.name} settings`}
+                          title={`Open ${activeOrg.name} settings`}
+                          onClick={() => {
+                            onSwitchOrganization(activeOrg._id, "overview");
+                            setMenuOpen(false);
+                          }}
+                          className="p-0.5 rounded text-muted-foreground/70 hover:text-foreground hover:bg-muted transition-colors opacity-0 group-hover/orgrow:opacity-100 group-focus-within/orgrow:opacity-100"
+                        >
+                          <Settings className="size-3.5" />
+                        </button>
+                      ) : null}
+                    </div>
+
+                    {/* Active org's shared credit usage, right below the org name */}
+                    {activeOrganizationId ? (
+                      <div className="px-0.5 pt-1">
+                        <SidebarCreditUsage
+                          variant="full"
+                          organizationId={activeOrganizationId}
+                          onClick={
+                            activeOrg && onSwitchOrganization
+                              ? () => {
+                                  onSwitchOrganization(
+                                    activeOrg._id,
+                                    "billing"
+                                  );
+                                  setMenuOpen(false);
+                                }
+                              : undefined
+                          }
+                        />
+                      </div>
+                    ) : null}
+
+                    {canSwitchOrganizations ? (
+                      <button
+                        type="button"
+                        data-testid="switch-org-button"
+                        aria-expanded={orgListOpen}
+                        onClick={() => setOrgListOpen((o) => !o)}
+                        className="mt-0.5 flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-[13px] text-muted-foreground hover:bg-accent/60 hover:text-foreground transition-colors"
+                      >
+                        <div className="flex items-center justify-center size-5 rounded bg-muted shrink-0">
+                          <ArrowLeftRight className="size-3" />
+                        </div>
+                        <span className="flex-1 truncate text-left font-medium">
+                          Switch organization
+                        </span>
+                        <ChevronDown
+                          aria-hidden="true"
+                          className={cn(
+                            "size-3.5 shrink-0 transition-transform",
+                            orgListOpen && "rotate-180"
+                          )}
+                        />
+                      </button>
+                    ) : null}
+
+                    {canSwitchOrganizations && orgListOpen ? (
+                      <div data-testid="org-switch-list" className="mt-0.5">
+                        {sortedOrganizations.map((org) => {
+                          const tint = getOrgTint(org._id);
+                          return (
+                            <div
+                              key={org._id}
+                              role="menuitem"
+                              tabIndex={0}
+                              data-testid={`org-row-${org._id}`}
+                              onClick={() => {
+                                if (org._id !== activeOrganizationId) {
+                                  onSwitchActiveOrganization?.(org._id);
+                                }
+                                setMenuOpen(false);
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  if (org._id !== activeOrganizationId) {
+                                    onSwitchActiveOrganization?.(org._id);
+                                  }
+                                  setMenuOpen(false);
+                                }
+                              }}
+                              className={cn(
+                                "group/org flex items-center gap-2.5 rounded-md px-2 py-1.5 text-[13px] cursor-pointer",
+                                org._id === activeOrganizationId
+                                  ? "bg-accent"
+                                  : "hover:bg-accent/60"
+                              )}
+                            >
+                              <div
+                                className={cn(
+                                  "flex items-center justify-center size-5 rounded text-[10px] font-semibold shrink-0",
+                                  tint.bg,
+                                  tint.fg
+                                )}
+                              >
+                                {org.name.charAt(0).toUpperCase()}
+                              </div>
+                              <span className="flex-1 truncate font-medium">
+                                {org.name}
+                              </span>
+                              {onSwitchOrganization ? (
+                                <button
+                                  type="button"
+                                  aria-label={`Open ${org.name} settings`}
+                                  title={`Open ${org.name} settings`}
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    onSwitchOrganization(org._id, "overview");
+                                    setMenuOpen(false);
+                                  }}
+                                  className="p-0.5 rounded text-muted-foreground/70 hover:text-foreground hover:bg-muted transition-colors opacity-0 group-hover/org:opacity-100 group-focus-within/org:opacity-100"
+                                >
+                                  <Settings className="size-3.5" />
+                                </button>
+                              ) : null}
+                            </div>
+                          );
+                        })}
+                        {newOrganizationRow}
+                      </div>
+                    ) : null}
+
+                    {/* No second org to switch to: surface create directly
+                        (only renders for users who don't already own one). */}
+                    {!canSwitchOrganizations ? newOrganizationRow : null}
+                  </>
+                )}
               </div>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -22,14 +22,19 @@ import {
 } from "@/components/ui/sidebar";
 import { getInitials } from "@/lib/utils";
 import {
+  Bell,
   LogIn,
   ChevronsUpDown,
   CircleUser,
   LogOut,
+  MessageCircleQuestion,
   RefreshCw,
   Settings,
   User,
 } from "lucide-react";
+import { Popover, PopoverAnchor } from "@mcpjam/design-system/popover";
+import { NotificationsPanelContent } from "@/components/notifications/NotificationsPanel";
+import { useNotifications } from "@/hooks/useNotifications";
 import { useProfilePicture } from "@/hooks/useProfilePicture";
 import { HOSTED_MODE } from "@/lib/config";
 import { useAppNavigate } from "@/lib/app-navigation";
@@ -39,12 +44,14 @@ interface SidebarUserProps {
 }
 
 export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
-  const { isLoading, isAuthenticated: _isAuthenticated } = useConvexAuth();
+  const { isLoading, isAuthenticated } = useConvexAuth();
   const { user, signIn, signOut } = useAuth();
   const { profilePictureUrl } = useProfilePicture();
   const convexUser = useQuery("users:getCurrentUser" as any);
   const { isMobile } = useSidebar();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const { unreadCount } = useNotifications({ isAuthenticated });
   const appNavigate = useAppNavigate();
 
   const workOsName = user
@@ -135,83 +142,114 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-          <DropdownMenuTrigger asChild>
-            <SidebarMenuButton
-              size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+        <Popover open={notificationsOpen} onOpenChange={setNotificationsOpen}>
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <PopoverAnchor asChild>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton
+                  size="lg"
+                  className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                >
+                  <Avatar className="size-8 rounded-lg">
+                    <AvatarImage src={avatarUrl} alt={displayName} />
+                    <AvatarFallback className="rounded-lg bg-muted text-muted-foreground text-sm font-medium">
+                      {initials !== "?" ? (
+                        initials
+                      ) : (
+                        <CircleUser className="size-4" />
+                      )}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
+                    <span className="truncate font-semibold">
+                      {displayName}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {email}
+                    </span>
+                  </div>
+                  <ChevronsUpDown className="ml-auto size-4 group-data-[collapsible=icon]:hidden" />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+            </PopoverAnchor>
+            <DropdownMenuContent
+              className="w-[--radix-dropdown-menu-trigger-width] min-w-72 rounded-lg"
+              side={isMobile ? "bottom" : "right"}
+              align="end"
+              sideOffset={4}
             >
-              <Avatar className="size-8 rounded-lg">
-                <AvatarImage src={avatarUrl} alt={displayName} />
-                <AvatarFallback className="rounded-lg bg-muted text-muted-foreground text-sm font-medium">
-                  {initials !== "?" ? (
-                    initials
-                  ) : (
-                    <CircleUser className="size-4" />
-                  )}
-                </AvatarFallback>
-              </Avatar>
-              <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
-                <span className="truncate font-semibold">{displayName}</span>
-                <span className="truncate text-xs text-muted-foreground">
-                  {email}
-                </span>
-              </div>
-              <ChevronsUpDown className="ml-auto size-4 group-data-[collapsible=icon]:hidden" />
-            </SidebarMenuButton>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="w-[--radix-dropdown-menu-trigger-width] min-w-72 rounded-lg"
+              <DropdownMenuLabel className="p-0 font-normal">
+                <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                  <Avatar className="size-8 rounded-lg">
+                    <AvatarImage src={avatarUrl} alt={displayName} />
+                    <AvatarFallback className="rounded-lg bg-muted text-muted-foreground text-sm font-medium">
+                      {initials !== "?" ? (
+                        initials
+                      ) : (
+                        <CircleUser className="size-4" />
+                      )}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-semibold">
+                      {displayName}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {email}
+                    </span>
+                  </div>
+                </div>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => appNavigate("/profile")}
+                className="cursor-pointer"
+              >
+                <User className="size-4" />
+                Profile
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => appNavigate("/settings")}
+                className="cursor-pointer"
+              >
+                <Settings className="size-4" />
+                Settings
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setNotificationsOpen(true)}
+                className="cursor-pointer"
+              >
+                <Bell className="size-4" />
+                Notifications
+                {unreadCount > 0 ? (
+                  <span className="ml-auto flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-medium text-white">
+                    {unreadCount > 9 ? "9+" : unreadCount}
+                  </span>
+                ) : null}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => appNavigate("/support")}
+                className="cursor-pointer"
+              >
+                <MessageCircleQuestion className="size-4" />
+                Support
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={handleSignOut}
+                className="cursor-pointer"
+              >
+                <LogOut className="size-4" />
+                Log out
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <NotificationsPanelContent
             side={isMobile ? "bottom" : "right"}
             align="end"
-            sideOffset={4}
-          >
-            <DropdownMenuLabel className="p-0 font-normal">
-              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                <Avatar className="size-8 rounded-lg">
-                  <AvatarImage src={avatarUrl} alt={displayName} />
-                  <AvatarFallback className="rounded-lg bg-muted text-muted-foreground text-sm font-medium">
-                    {initials !== "?" ? (
-                      initials
-                    ) : (
-                      <CircleUser className="size-4" />
-                    )}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">{displayName}</span>
-                  <span className="truncate text-xs text-muted-foreground">
-                    {email}
-                  </span>
-                </div>
-              </div>
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => appNavigate("/profile")}
-              className="cursor-pointer"
-            >
-              <User className="size-4" />
-              Profile
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => appNavigate("/settings")}
-              className="cursor-pointer"
-            >
-              <Settings className="size-4" />
-              Settings
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              variant="destructive"
-              onClick={handleSignOut}
-              className="cursor-pointer"
-            >
-              <LogOut className="size-4" />
-              Log out
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+          />
+        </Popover>
       </SidebarMenuItem>
     </SidebarMenu>
   );

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, RouterProvider, redirect } from "react-router";
 import App, {
+  ApiKeysSettingsRoute,
   AuthRoute,
   ChatAliasRoute,
   ChatboxesRoute,
@@ -30,7 +31,6 @@ import App, {
   ViewsRoute,
   XAAFlowRoute,
 } from "./App";
-import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
 import { getAppRouter, setAppRouter } from "./router-ref";
 import { buildHostsPath } from "./lib/app-navigation";
 
@@ -95,7 +95,7 @@ export function createAppRouter(): AppRouter {
         { path: "views", element: <ViewsRoute /> },
         { path: "support", element: <SupportRoute /> },
         { path: "settings", element: <SettingsRoute /> },
-        { path: "settings/api-keys", element: <ApiKeysRoute /> },
+        { path: "settings/api-keys", element: <ApiKeysSettingsRoute /> },
         { path: "profile", element: <ProfileRoute /> },
         { path: "project-settings", element: <ProjectSettingsRoute /> },
         { path: "client-config", element: <ServersRedirectRoute /> },


### PR DESCRIPTION
## What

Restructures the sidebar and settings IA around conventional patterns (Linear/PostHog-style) so the nav fits a laptop viewport without scrolling and rare actions stop occupying prime real estate.

### Context switcher
- Popover leads with **Projects** (the frequent operation); org is a quiet footer row with the credits meter.
- "Switch organization" renders only when you belong to 2+ orgs and expands inline on click — the hover flyout and its close-timer machinery are gone.
- "New organization" appears only when the account can actually create one (bottom of the switch list, or directly when you're invited-only).

### Nav density
- Rows stay h-8 but section boundaries drop from ~49px to ~17px and row gaps from 4px to 2px. Flags-on nav now fits ~300px less vertical space.

### Settings hub
- New shared `SettingsNav` tabs — **General · API Keys · Organization** — across `/settings`, `/settings/api-keys`, and the organization page.
- API Keys loses its sidebar slot (it's a Settings section now). Org page keeps its URLs and its General/Models/Billing sub-tabs, so billing checkout returns and deep links are untouched.

### Account menu & footer
- Account menu: Profile, Settings, **Notifications** (unread badge; opens the inbox popover anchored to the account row), **Support**, Log out.
- Footer is just invite CTA + account row for signed-in users. Signed-out users (hosted or local — one code path) get compact Support/Settings icons since they have no account menu.
- `NotificationBell` deleted; the panel lives in `NotificationsPanel` and is owned by the account menu.

## Testing
- `npm test`: 5,577 passed (full suite), including new coverage for the switcher popover states, footer strip signed-in/out, and account-menu items.
- `npm run typecheck:client` clean.

## Notes for review
- On the org page the SettingsNav sits in that page's wider centered container, so the tabs shift position slightly vs `/settings` — cosmetic; normalizing the org page chrome was deliberately out of scope.
- The signed-out `/settings/api-keys` direct-URL gate keeps its full-screen sign-in prompt (no tab strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly navigation and layout refactors with expanded tests; no auth, billing checkout URLs, or API key server gates changed.
> 
> **Overview**
> **Sidebar and settings IA** are reorganized so primary nav fits better on laptop viewports and settings feel like one surface.
> 
> A new **`SettingsNav`** tab strip (**General · API Keys · Organization**) is added on `/settings`, `/settings/api-keys`, and the organization page; API Keys is removed from the main sidebar. **`ApiKeysSettingsRoute`** wires org context into the API keys page.
> 
> The **context switcher** leads with **Projects**; org name, credits, and **Switch organization** (only when the user has 2+ orgs) sit in a footer with inline expand/collapse instead of the old hover flyout. **New organization** appears only when creation is allowed.
> 
> **Signed-in** users get **Notifications** and **Support** in the account dropdown (inbox via **`NotificationsPanelContent`**); the sidebar **Settings / API Keys / Support** section and **`NotificationBell`** are removed. **Signed-out** users see compact **Support** and **Settings** icons in the footer.
> 
> **Nav density** is tightened (section dividers, **`NavMain`** spacing, shared **`isNavItemActive`**), and sidebar tests are updated for the new switcher and footer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c6c65577754a78b3bc42b4813d78c3ecfd93fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->