### PR TITLE
fix(cli): persist login API URL, hard-error on invalid --api-url (review follow-ups for #2591)

### DIFF
--- a/.changeset/cli-login-api-url-persistence.md
+++ b/.changeset/cli-login-api-url-persistence.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": patch
+---
+
+`mcpjam login` now stores the API base URL it was run against, and cloud commands using the stored login default to that deployment instead of prod. An invalid `--api-url` / `MCPJAM_API_URL` is a hard usage error rather than a silent fallback to prod, and rotated token expiries are computed from the injected clock.

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -7,6 +7,7 @@ import {
 } from "../lib/platform-auth.js";
 import {
   buildPlatformClient,
+  resolvePlatformBaseUrl,
   resolvePlatformOrigin,
   toCliError,
 } from "../lib/platform-client.js";
@@ -27,9 +28,10 @@ export function registerAuthCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const globalOptions = getGlobalOptions(command);
+      const apiUrl = resolvePlatformBaseUrl(options);
       const origin = resolvePlatformOrigin(options);
 
-      const result = await runPlatformLogin(origin, {
+      const result = await runPlatformLogin({ origin, apiUrl }, {
         ...(options.browser === false
           ? {
               openUrl: async (url: string) => {

--- a/cli/src/lib/auth-store.ts
+++ b/cli/src/lib/auth-store.ts
@@ -17,6 +17,14 @@ export interface StoredPlatformAuth {
   issuer: string;
   clientId: string;
   tokenEndpoint: string;
+  /**
+   * Platform API base URL the login was performed against (e.g.
+   * `https://staging.mcpjam.com/api/v1`). Cloud commands fall back to this
+   * when no `--api-url` / `MCPJAM_API_URL` is given, so a staging login
+   * never silently sends its token to prod. Optional for files written
+   * before this field existed.
+   */
+  apiUrl?: string;
   accessToken: string;
   refreshToken?: string;
   /** Access-token expiry, milliseconds since epoch. */
@@ -94,6 +102,11 @@ export function readStoredAuth(filePath: string): StoredPlatformAuth | null {
     clientId: record.clientId,
     tokenEndpoint: record.tokenEndpoint,
     accessToken: record.accessToken,
+    // Hand-edited files may hold a non-URL; dropping it here means readers
+    // fall back to the default base URL instead of producing broken requests.
+    ...(typeof record.apiUrl === "string" && URL.canParse(record.apiUrl)
+      ? { apiUrl: record.apiUrl }
+      : {}),
     ...(typeof record.refreshToken === "string"
       ? { refreshToken: record.refreshToken }
       : {}),

--- a/cli/src/lib/platform-auth.ts
+++ b/cli/src/lib/platform-auth.ts
@@ -130,6 +130,7 @@ async function refreshStoredAuth(
     },
     deps.fetchFn ?? fetch,
     "Token refresh failed. Run `mcpjam login` again.",
+    deps.now,
   );
 
   const refreshed: StoredPlatformAuth = {
@@ -160,6 +161,16 @@ export interface PlatformLoginResult {
   expiresAt?: number;
 }
 
+export interface PlatformLoginTarget {
+  /** Origin hosting the CLI auth bridge, e.g. `https://app.mcpjam.com`. */
+  origin: string;
+  /**
+   * Platform API base URL this login is for, persisted with the session so
+   * later cloud commands talk to the same deployment by default.
+   */
+  apiUrl: string;
+}
+
 interface CliAuthConfig {
   issuer: string;
   clientId: string;
@@ -169,11 +180,11 @@ interface CliAuthConfig {
 }
 
 export async function runPlatformLogin(
-  platformOrigin: string,
+  target: PlatformLoginTarget,
   deps: PlatformLoginDependencies = {},
 ): Promise<PlatformLoginResult> {
   const fetchFn = deps.fetchFn ?? fetch;
-  const config = await fetchCliAuthConfig(platformOrigin, fetchFn);
+  const config = await fetchCliAuthConfig(target.origin, fetchFn);
 
   const codeVerifier = generateRandomString(64);
   const state = generateRandomString(32);
@@ -228,6 +239,7 @@ export async function runPlatformLogin(
       issuer: config.issuer,
       clientId: config.clientId,
       tokenEndpoint: config.tokenEndpoint,
+      apiUrl: target.apiUrl,
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
       ...(tokens.expiresAt !== undefined

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -4,9 +4,9 @@ import {
   PlatformApiClient,
 } from "@mcpjam/sdk/platform";
 import packageJson from "../../package.json" with { type: "json" };
-import { CliError, cliError } from "./output.js";
+import { getAuthFilePath, readStoredAuth } from "./auth-store.js";
+import { CliError, cliError, usageError } from "./output.js";
 import {
-  DEFAULT_PLATFORM_ORIGIN,
   resolvePlatformCredential,
   type ResolveCredentialDependencies,
 } from "./platform-auth.js";
@@ -16,15 +16,49 @@ export interface PlatformClientOptions {
   apiUrl?: string;
 }
 
+/**
+ * An explicitly supplied API URL (flag or env) that does not parse must
+ * hard-error: silently falling back to prod would run a login or send a
+ * token somewhere the user did not ask for.
+ */
+function validateApiUrl(value: string, source: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw usageError(
+      `Invalid ${source} value "${value}". Expected a full URL like ${DEFAULT_PLATFORM_API_BASE_URL}.`,
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw usageError(
+      `Invalid ${source} value "${value}". Expected an http(s) URL like ${DEFAULT_PLATFORM_API_BASE_URL}.`,
+    );
+  }
+  return value;
+}
+
+/** The API URL the user explicitly asked for, if any (flag wins over env). */
+function resolveExplicitApiUrl(
+  options: Pick<PlatformClientOptions, "apiUrl">,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const flagUrl = options.apiUrl?.trim();
+  if (flagUrl) {
+    return validateApiUrl(flagUrl, "--api-url");
+  }
+  const envUrl = env.MCPJAM_API_URL?.trim();
+  if (envUrl) {
+    return validateApiUrl(envUrl, "MCPJAM_API_URL");
+  }
+  return undefined;
+}
+
 export function resolvePlatformBaseUrl(
   options: Pick<PlatformClientOptions, "apiUrl">,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  return (
-    options.apiUrl?.trim() ||
-    env.MCPJAM_API_URL?.trim() ||
-    DEFAULT_PLATFORM_API_BASE_URL
-  );
+  return resolveExplicitApiUrl(options, env) ?? DEFAULT_PLATFORM_API_BASE_URL;
 }
 
 /** Origin for the hosted CLI auth routes, derived from the API base URL. */
@@ -32,20 +66,27 @@ export function resolvePlatformOrigin(
   options: Pick<PlatformClientOptions, "apiUrl">,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  try {
-    return new URL(resolvePlatformBaseUrl(options, env)).origin;
-  } catch {
-    return DEFAULT_PLATFORM_ORIGIN;
-  }
+  return new URL(resolvePlatformBaseUrl(options, env)).origin;
 }
 
 export function buildPlatformClient(
   options: PlatformClientOptions,
   deps: ResolveCredentialDependencies = {},
 ): { client: PlatformApiClient; credentialKind: "api-key" | "oauth" } {
+  const env = deps.env ?? process.env;
   const credential = resolvePlatformCredential(options, deps);
+
+  // When the stored OAuth login is the credential, its tokens belong to the
+  // deployment it was created against — default to that deployment's API URL
+  // so a staging login never silently sends its token to prod.
+  let baseUrl = resolveExplicitApiUrl(options, env);
+  if (!baseUrl && credential.kind === "oauth") {
+    const stored = readStoredAuth(deps.authFilePath ?? getAuthFilePath({ env }));
+    baseUrl = stored?.apiUrl;
+  }
+
   const client = new PlatformApiClient({
-    baseUrl: resolvePlatformBaseUrl(options, deps.env ?? process.env),
+    baseUrl: baseUrl ?? DEFAULT_PLATFORM_API_BASE_URL,
     getAuth: credential.getAuth,
     ...(deps.fetchFn ? { fetch: deps.fetchFn } : {}),
     userAgent: `mcpjam-cli/${packageJson.version}`,

--- a/cli/tests/auth-commands.test.ts
+++ b/cli/tests/auth-commands.test.ts
@@ -160,6 +160,20 @@ test("whoami surfaces UNAUTHORIZED with login guidance", async () => {
   }
 });
 
+test("login hard-errors on an invalid --api-url before any network call", async () => {
+  const run = await captureProcessOutput(() =>
+    main(
+      ["node", "mcpjam", "login", "--api-url", "not-a-url"],
+      { telemetry: telemetryDisabled },
+    ),
+  );
+
+  assert.equal(run.result.exitCode, 2);
+  const payload = JSON.parse(run.stderr);
+  assert.equal(payload.error.code, "USAGE_ERROR");
+  assert.match(payload.error.message, /--api-url/);
+});
+
 test("whoami hard-errors on an explicit legacy key", async () => {
   const run = await captureProcessOutput(() =>
     main(

--- a/cli/tests/auth-store.test.ts
+++ b/cli/tests/auth-store.test.ts
@@ -108,3 +108,25 @@ test("readStoredAuth tolerates absent optional fields", async () => {
 
   assert.deepEqual(readStoredAuth(filePath), minimal);
 });
+
+test("readStoredAuth round-trips apiUrl and drops a non-URL value", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-auth-"));
+  const filePath = path.join(directory, "auth.json");
+  const withApiUrl = storedAuth({
+    apiUrl: "https://staging.mcpjam.com/api/v1",
+  });
+
+  await writeStoredAuth(withApiUrl, filePath);
+  assert.deepEqual(readStoredAuth(filePath), withApiUrl);
+
+  // A hand-edited, unparseable apiUrl is dropped rather than handed to the
+  // HTTP client, so readers fall back to the default deployment.
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(
+    filePath,
+    JSON.stringify({ ...storedAuth(), apiUrl: "not a url" }),
+    "utf8",
+  );
+  assert.equal(readStoredAuth(filePath)?.apiUrl, undefined);
+  assert.equal(readStoredAuth(filePath)?.accessToken, "access-token");
+});

--- a/cli/tests/platform-auth.test.ts
+++ b/cli/tests/platform-auth.test.ts
@@ -230,6 +230,9 @@ test("getOAuthAccessToken refreshes within 60s of expiry and persists rotation",
     const persisted = readStoredAuth(authFilePath);
     assert.equal(persisted?.accessToken, "rotated-access");
     assert.equal(persisted?.refreshToken, "rotated-refresh");
+    // The rotated expiry is computed from the injected clock, so it is
+    // exactly NOW + expires_in.
+    assert.equal(persisted?.expiresAt, NOW + 1800 * 1000);
 
     const tokenRequest = fixture.requests.find((r) => r.path === "/oauth2/token");
     assert.equal(tokenRequest?.body.get("grant_type"), "refresh_token");
@@ -260,12 +263,15 @@ test("runPlatformLogin completes the PKCE flow end to end and stores tokens", as
   try {
     const authFilePath = await tempAuthFile();
 
-    const result = await runPlatformLogin(fixture.origin, {
-      openUrl: browserSimulator(),
-      authFilePath,
-      timeoutMs: 10_000,
-      now: () => NOW,
-    });
+    const result = await runPlatformLogin(
+      { origin: fixture.origin, apiUrl: `${fixture.origin}/api/v1` },
+      {
+        openUrl: browserSimulator(),
+        authFilePath,
+        timeoutMs: 10_000,
+        now: () => NOW,
+      },
+    );
 
     assert.equal(result.authFilePath, authFilePath);
     const persisted = readStoredAuth(authFilePath);
@@ -273,6 +279,9 @@ test("runPlatformLogin completes the PKCE flow end to end and stores tokens", as
     assert.equal(persisted?.refreshToken, "new-refresh");
     assert.equal(persisted?.expiresAt, NOW + 3600 * 1000);
     assert.equal(persisted?.tokenEndpoint, `${fixture.origin}/oauth2/token`);
+    // The API base URL of the deployment is stored with the session so later
+    // cloud commands default to it instead of prod.
+    assert.equal(persisted?.apiUrl, `${fixture.origin}/api/v1`);
 
     const tokenRequest = fixture.requests.find((r) => r.path === "/oauth2/token");
     assert.equal(tokenRequest?.body.get("grant_type"), "authorization_code");
@@ -297,11 +306,14 @@ test("runPlatformLogin fails actionably when no refresh token is returned", asyn
     const authFilePath = await tempAuthFile();
 
     await assert.rejects(
-      runPlatformLogin(fixture.origin, {
-        openUrl: browserSimulator(),
-        authFilePath,
-        timeoutMs: 10_000,
-      }),
+      runPlatformLogin(
+        { origin: fixture.origin, apiUrl: `${fixture.origin}/api/v1` },
+        {
+          openUrl: browserSimulator(),
+          authFilePath,
+          timeoutMs: 10_000,
+        },
+      ),
       (error: unknown) =>
         error instanceof CliError && /refresh token/i.test(error.message),
     );
@@ -315,7 +327,10 @@ test("runPlatformLogin reports a disabled hosted bridge actionably", async () =>
   const fixture = await startAuthFixture({ configStatus: 501 });
   try {
     await assert.rejects(
-      runPlatformLogin(fixture.origin, { timeoutMs: 1000 }),
+      runPlatformLogin(
+        { origin: fixture.origin, apiUrl: `${fixture.origin}/api/v1` },
+        { timeoutMs: 1000 },
+      ),
       (error: unknown) =>
         error instanceof CliError &&
         /not enabled/i.test(error.message) &&

--- a/cli/tests/platform-client.test.ts
+++ b/cli/tests/platform-client.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  writeStoredAuth,
+  type StoredPlatformAuth,
+} from "../src/lib/auth-store.js";
+import { CliError } from "../src/lib/output.js";
+import {
+  buildPlatformClient,
+  resolvePlatformBaseUrl,
+  resolvePlatformOrigin,
+} from "../src/lib/platform-client.js";
+
+const NOW = 1_750_000_000_000;
+
+async function tempAuthFile(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-auth-"));
+  return path.join(directory, "auth.json");
+}
+
+function storedAuth(
+  overrides: Partial<StoredPlatformAuth> = {},
+): StoredPlatformAuth {
+  return {
+    version: 1,
+    issuer: "https://login.example.com",
+    clientId: "client_123",
+    tokenEndpoint: "https://login.example.com/oauth2/token",
+    accessToken: "stored-access",
+    refreshToken: "stored-refresh",
+    expiresAt: NOW + 60 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+/** Records request URLs and answers every call with a minimal /me payload. */
+function captureFetch(requested: string[]): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    requested.push(
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url,
+    );
+    return new Response(
+      JSON.stringify({ id: "user-1", email: "dev@example.com", name: "Dev" }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+}
+
+const isUsageError = (error: unknown) =>
+  error instanceof CliError && error.code === "USAGE_ERROR";
+
+test("resolvePlatformBaseUrl prefers the flag over env over the default", () => {
+  assert.equal(
+    resolvePlatformBaseUrl(
+      { apiUrl: "https://flag.example.com/api/v1" },
+      { MCPJAM_API_URL: "https://env.example.com/api/v1" },
+    ),
+    "https://flag.example.com/api/v1",
+  );
+  assert.equal(
+    resolvePlatformBaseUrl(
+      {},
+      { MCPJAM_API_URL: "https://env.example.com/api/v1" },
+    ),
+    "https://env.example.com/api/v1",
+  );
+  assert.equal(
+    resolvePlatformBaseUrl({}, {}),
+    "https://app.mcpjam.com/api/v1",
+  );
+});
+
+test("an invalid --api-url hard-errors instead of falling back to prod", () => {
+  assert.throws(
+    () => resolvePlatformBaseUrl({ apiUrl: "staging.mcpjam.com" }, {}),
+    isUsageError,
+  );
+  assert.throws(
+    () => resolvePlatformOrigin({ apiUrl: "not a url" }, {}),
+    isUsageError,
+  );
+  // Non-http(s) schemes are also explicit mistakes, not prod logins.
+  assert.throws(
+    () => resolvePlatformBaseUrl({ apiUrl: "ftp://example.com/api" }, {}),
+    isUsageError,
+  );
+});
+
+test("an invalid MCPJAM_API_URL hard-errors too", () => {
+  assert.throws(
+    () => resolvePlatformBaseUrl({}, { MCPJAM_API_URL: "nope" }),
+    isUsageError,
+  );
+});
+
+test("resolvePlatformOrigin strips the API path from the base URL", () => {
+  assert.equal(
+    resolvePlatformOrigin({ apiUrl: "https://staging.mcpjam.com/api/v1" }, {}),
+    "https://staging.mcpjam.com",
+  );
+});
+
+test("buildPlatformClient defaults to the API URL stored with the login", async () => {
+  const authFilePath = await tempAuthFile();
+  await writeStoredAuth(
+    storedAuth({ apiUrl: "https://staging.mcpjam.com/api/v1" }),
+    authFilePath,
+  );
+  const requested: string[] = [];
+
+  const { client, credentialKind } = buildPlatformClient(
+    {},
+    { env: {}, authFilePath, fetchFn: captureFetch(requested), now: () => NOW },
+  );
+  await client.getMe();
+
+  assert.equal(credentialKind, "oauth");
+  assert.equal(requested.length, 1);
+  assert.ok(
+    requested[0].startsWith("https://staging.mcpjam.com/api/v1/"),
+    `expected the stored deployment to be called, got ${requested[0]}`,
+  );
+});
+
+test("an explicit --api-url overrides the stored login URL", async () => {
+  const authFilePath = await tempAuthFile();
+  await writeStoredAuth(
+    storedAuth({ apiUrl: "https://staging.mcpjam.com/api/v1" }),
+    authFilePath,
+  );
+  const requested: string[] = [];
+
+  const { client } = buildPlatformClient(
+    { apiUrl: "https://other.example.com/api/v1" },
+    { env: {}, authFilePath, fetchFn: captureFetch(requested), now: () => NOW },
+  );
+  await client.getMe();
+
+  assert.ok(requested[0].startsWith("https://other.example.com/api/v1/"));
+});
+
+test("an sk_ API key does not inherit the stored login's URL", async () => {
+  const authFilePath = await tempAuthFile();
+  await writeStoredAuth(
+    storedAuth({ apiUrl: "https://staging.mcpjam.com/api/v1" }),
+    authFilePath,
+  );
+  const requested: string[] = [];
+
+  const { client, credentialKind } = buildPlatformClient(
+    { apiKey: "sk_test" },
+    { env: {}, authFilePath, fetchFn: captureFetch(requested), now: () => NOW },
+  );
+  await client.getMe();
+
+  // The stored URL belongs to the stored OAuth session; an explicit key
+  // without an explicit URL targets the default deployment.
+  assert.equal(credentialKind, "api-key");
+  assert.ok(requested[0].startsWith("https://app.mcpjam.com/api/v1/"));
+});
+
+test("a stored login without apiUrl still defaults to prod", async () => {
+  const authFilePath = await tempAuthFile();
+  await writeStoredAuth(storedAuth(), authFilePath);
+  const requested: string[] = [];
+
+  const { client } = buildPlatformClient(
+    {},
+    { env: {}, authFilePath, fetchFn: captureFetch(requested), now: () => NOW },
+  );
+  await client.getMe();
+
+  assert.ok(requested[0].startsWith("https://app.mcpjam.com/api/v1/"));
+});

--- a/mcpjam-inspector/server/routes/cli-auth/index.ts
+++ b/mcpjam-inspector/server/routes/cli-auth/index.ts
@@ -17,8 +17,11 @@
  *
  * Requires BOTH `CLI_AUTH_STATE_SECRET` (state HMAC key) and
  * `CLI_AUTH_PUBLIC_ORIGIN` (this deployment's public origin — explicit env
- * rather than forwarded-header reconstruction, which is spoofable). Without
- * either, every route answers 501 so self-hosted Inspectors degrade cleanly.
+ * rather than forwarded-header reconstruction, which is spoofable). The
+ * value is origin-only by design: any path component is stripped, because
+ * these routes always mount at `/api/cli/auth` on the app root. Without
+ * either env, every route answers 501 so self-hosted Inspectors degrade
+ * cleanly.
  */
 import { Hono } from "hono";
 import type { Context } from "hono";
@@ -59,6 +62,9 @@ function resolveCliAuthConfig(
 
   let publicOrigin: string;
   try {
+    // Origin-only by design: a path component in CLI_AUTH_PUBLIC_ORIGIN is
+    // intentionally stripped — the bridge routes always mount at
+    // /api/cli/auth on the app root.
     publicOrigin = new URL(rawOrigin).origin;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

Post-merge review follow-ups for #2591 (`mcpjam login` / hosted OAuth bridge). No changes to the OAuth security model.

### Medium: stored login now remembers which deployment it belongs to

`mcpjam login --api-url https://staging.../api/v1` used to succeed but leave later cloud commands pointing at prod unless `--api-url` was passed again — sending a staging token to `app.mcpjam.com`. Now:

- `runPlatformLogin` persists the resolved API base URL (`apiUrl`) in `auth.json`.
- `buildPlatformClient` resolution order: explicit `--api-url` > `MCPJAM_API_URL` > **the stored login's `apiUrl` (only when the stored OAuth session is the credential)** > prod default. `sk_` API keys never inherit the stored URL, since the stored URL belongs to the OAuth session, not the key.
- Old `auth.json` files without the field keep working (optional field, version unchanged); an unparseable hand-edited value is dropped at read time rather than handed to the HTTP client.

### Low/Medium: invalid API URL is a hard error

An invalid `--api-url` / `MCPJAM_API_URL` now throws `USAGE_ERROR` (exit 2) before any network call, instead of silently opening a login flow against prod. Non-http(s) schemes are rejected too.

### Nits

- `refreshStoredAuth` now threads the injected `now` into the token exchange, so rotated-expiry assertions are deterministic (`expiresAt === NOW + expires_in`).
- Documented (header + parse site) that `CLI_AUTH_PUBLIC_ORIGIN` is origin-only: path components are stripped intentionally because the bridge always mounts at `/api/cli/auth` on the app root. Comment-only change on the inspector side.

## Testing

- 10 new tests: `cli/tests/platform-client.test.ts` (precedence matrix, invalid-URL hard errors, stored-URL fallback / override / api-key isolation via captured fetch), `auth-store` apiUrl round-trip + corrupt-value drop, command-level `login --api-url not-a-url` → exit 2.
- `npm run test -w @mcpjam/cli`: 236 tests green; `tsc --noEmit` clean.
- Inspector `server/routes/cli-auth`: 30 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential routing so wrong-environment token use is less likely, but alters default API targets for logged-in users; invalid URL behavior is stricter (usage errors instead of silent prod).
> 
> **Overview**
> **`mcpjam login` now records the API base URL** (`apiUrl` in `auth.json`) for the deployment you logged into. Later cloud commands that use the stored OAuth session default to that URL (explicit `--api-url` / `MCPJAM_API_URL` still win; `sk_` keys do not inherit the stored URL). Older auth files without `apiUrl` keep using prod; corrupt `apiUrl` values are dropped on read.
> 
> **Invalid `--api-url` or `MCPJAM_API_URL`** now fail with **`USAGE_ERROR` (exit 2)** before any network I/O, including non-http(s) schemes, instead of silently targeting prod.
> 
> Token refresh passes the injected **`now`** into the exchange so rotated **`expiresAt`** is deterministic in tests. Inspector CLI auth bridge docs clarify **`CLI_AUTH_PUBLIC_ORIGIN`** is origin-only (paths stripped). New tests cover URL resolution, stored-login routing, and command-level login validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba246751fbc836963d016188fa1e66cd6487bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->