### PR TITLE
Remove icons from docs navigation tabs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,7 +34,6 @@
     "tabs": [
       {
         "tab": "Get Started",
-        "icon": "rocket",
         "pages": [
           "index",
           "getting-started",
@@ -47,7 +46,6 @@
       },
       {
         "tab": "Inspector",
-        "icon": "binoculars",
         "groups": [
           {
             "group": "Connect",
@@ -96,7 +94,6 @@
       },
       {
         "tab": "CLI",
-        "icon": "terminal",
         "groups": [
           {
             "group": "Guides",
@@ -121,7 +118,6 @@
       },
       {
         "tab": "SDK",
-        "icon": "code",
         "tag": "v1",
         "groups": [
           {
@@ -161,7 +157,6 @@
       },
       {
         "tab": "API",
-        "icon": "webhook",
         "tag": "Preview",
         "groups": [
           {


### PR DESCRIPTION
## Summary

- Removes `icon` fields from all five top-level navigation tabs in `docs/docs.json`: Get Started, Inspector, CLI, SDK, and API

https://claude.ai/code/session_015cHUvJGHruuTmP9HmnfFnH

---
_Generated by [Claude Code](https://claude.ai/code/session_015cHUvJGHruuTmP9HmnfFnH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only Mintlify config tweak with no runtime, API, or auth impact.
> 
> **Overview**
> Removes the **`icon`** property from all five top-level Mintlify navigation tabs in **`docs/docs.json`**: Get Started, Inspector, CLI, SDK, and API. Tab labels, page lists, **`tag`** values (e.g. SDK v1, API Preview), and nested **group** icons are unchanged—only the tab bar loses Lucide icons (rocket, binoculars, terminal, code, webhook).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b10764c7acf1fd2c88702e84f9c02f77376b6a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->