### PR TITLE
feat(chatboxes): allow Generate with AI without required servers

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -246,33 +246,16 @@ export function ChatboxUsagePanel({
                 >
                   Hide synthetic
                 </Button>
-                {(() => {
-                  // Optional servers default off for a no-opt-in visitor, so a
-                  // chatbox with only optional attachments would open the dialog
-                  // and then no-op on "Generate personas". Gate the entry point on
-                  // the same predicate the server route enforces.
-                  const hasRequiredServers = chatbox.servers.some(
-                    (s) => s.optional !== true,
-                  );
-                  return (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      className="rounded-full"
-                      onClick={() => setGenerateOpen(true)}
-                      disabled={!hasRequiredServers}
-                      title={
-                        hasRequiredServers
-                          ? undefined
-                          : "Attach at least one required (non-optional) server to generate sessions"
-                      }
-                    >
-                      <Sparkles className="mr-1 size-3" />
-                      Generate with AI
-                    </Button>
-                  );
-                })()}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="rounded-full"
+                  onClick={() => setGenerateOpen(true)}
+                >
+                  <Sparkles className="mr-1 size-3" />
+                  Generate with AI
+                </Button>
               </div>
               <div className="min-h-0 flex-1 overflow-hidden">
                 <ShareUsageThreadList

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -97,6 +97,8 @@ export function GenerateSessionsDialog({
   // Server selection lives on the backend: the dialog forwards the full
   // chatbox server list and the start route filters optionals out so the
   // synthetic run matches what a real visitor with no opt-ins would see.
+  // With no required servers the run still proceeds: personas are grounded
+  // in the chatbox name only and sessions run toolless.
   const serversPayload = chatbox.servers.map((s) => ({
     serverId: s.serverId,
     serverName: s.serverName,
@@ -137,7 +139,6 @@ export function GenerateSessionsDialog({
   }
 
   async function handleGenerate() {
-    if (!hasRequiredServers) return;
     setGenerating(true);
     posthog.capture("chatbox_generate_personas_started", {
       ...standardEventProps("chatbox_usage_panel"),
@@ -421,6 +422,13 @@ export function GenerateSessionsDialog({
               </div>
             ) : null}
 
+            {!hasRequiredServers ? (
+              <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+                No required servers attached — personas are generated from the
+                chatbox name only, and sessions run without tools.
+              </div>
+            ) : null}
+
             <div className="flex justify-end gap-2">
               <Button variant="outline" size="sm" onClick={onClose}>
                 Cancel
@@ -428,7 +436,7 @@ export function GenerateSessionsDialog({
               <Button
                 size="sm"
                 onClick={handleGenerate}
-                disabled={!hasRequiredServers || generating}
+                disabled={generating}
               >
                 {generating ? (
                   <>

--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebTestApp, postJson, expectJson } from "./helpers/test-app.js";
+
+const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
+
+const fetchChatboxRuntimeConfigMock = vi.fn();
+const createRunMock = vi.fn();
+const generatePersonasMock = vi.fn();
+const startSimulationMock = vi.fn();
+
+vi.mock("../../../utils/chatbox-runtime-config.js", () => ({
+  fetchChatboxRuntimeConfig: (...args: unknown[]) =>
+    fetchChatboxRuntimeConfigMock(...args),
+}));
+
+vi.mock("../../../services/session-agent.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/session-agent.js")
+  >("../../../services/session-agent.js");
+  return {
+    ...actual,
+    createRun: (...args: unknown[]) => createRunMock(...args),
+    generatePersonas: (...args: unknown[]) => generatePersonasMock(...args),
+  };
+});
+
+vi.mock("../../../services/sessionSimulation/runner.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../services/sessionSimulation/runner.js")
+  >("../../../services/sessionSimulation/runner.js");
+  return {
+    ...actual,
+    startSimulation: (...args: unknown[]) => startSimulationMock(...args),
+  };
+});
+
+// A chatbox whose attachments are all optional (or absent) used to 400 with
+// "Chatbox has no required servers". Persona generation now degrades to
+// surface-name grounding and the simulation runs toolless instead.
+describe("web routes — chatbox-sessions with no required servers", () => {
+  const { app, token } = createWebTestApp();
+
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "https://test-deployment.convex.site";
+    fetchChatboxRuntimeConfigMock.mockReset();
+    createRunMock.mockReset();
+    generatePersonasMock.mockReset();
+    startSimulationMock.mockReset();
+    createRunMock.mockResolvedValue({ runId: "run-1" });
+    startSimulationMock.mockResolvedValue(undefined);
+    generatePersonasMock.mockResolvedValue([
+      { id: "p-1", name: "Curious First-Time User", role: "user", notes: "" },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (ORIGINAL_CONVEX_HTTP_URL === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = ORIGINAL_CONVEX_HTTP_URL;
+    }
+  });
+
+  const allOptionalServers = [
+    { serverId: "srv-1", serverName: "srv-1", optional: true },
+  ];
+
+  it("generate-personas accepts an all-optional server list", async () => {
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-1/generate-personas",
+      {
+        projectId: "proj-1",
+        servers: allOptionalServers,
+        personaCount: 3,
+        chatboxName: "Drawing Assistant",
+      },
+      token,
+    );
+    const { status, data } = await expectJson<{
+      personas?: Array<{ id: string }>;
+    }>(response);
+
+    expect(status).toBe(200);
+    expect(data.personas).toHaveLength(1);
+    expect(generatePersonasMock).toHaveBeenCalledTimes(1);
+    // The captured snapshot has zero servers; the attachment still carries
+    // the chatbox name for surface grounding with an empty scope.
+    const [toolSnapshot, , , , , , serverAttachment] =
+      generatePersonasMock.mock.calls[0];
+    expect(toolSnapshot.servers).toEqual([]);
+    expect(serverAttachment).toMatchObject({
+      name: "Drawing Assistant",
+      resolvedServerNames: [],
+    });
+  });
+
+  it("generate-personas accepts an empty server list", async () => {
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-1/generate-personas",
+      { projectId: "proj-1", servers: [], personaCount: 2 },
+      token,
+    );
+    const { status } = await expectJson(response);
+    expect(status).toBe(200);
+    expect(generatePersonasMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("simulate-sessions/start accepts an all-optional server list", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-1",
+        accessVersion: 0,
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: false,
+        hostStyle: "default",
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-1/simulate-sessions/start",
+      {
+        projectId: "proj-1",
+        servers: allOptionalServers,
+        personas: [
+          { id: "p-1", name: "Alice", role: "user", notes: "tries it" },
+        ],
+        sessionsPerPersona: 1,
+        maxTurns: 3,
+      },
+      token,
+    );
+    const { status, data } = await expectJson<{ runId?: string }>(response);
+
+    expect(status).toBe(200);
+    expect(data.runId).toBe("run-1");
+    expect(createRunMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -39,6 +39,9 @@ function requireConvexHttpUrl(): string {
 // optionals out, matching what a real visitor with no opt-ins would see.
 // Optional-default-off is enforced server-side so a tampered body can't
 // quietly widen the synthetic tool set beyond the no-opt-in baseline.
+// An empty result (all-optional or no servers attached) is allowed: persona
+// generation degrades to surface-name grounding and sessions run toolless,
+// the same as a real no-opt-in visitor's chat.
 const chatboxServerSchema = z.object({
   serverId: z.string().min(1),
   serverName: z.string().min(1).optional(),
@@ -47,7 +50,7 @@ const chatboxServerSchema = z.object({
 
 const generatePersonasSchema = z.object({
   projectId: z.string().min(1),
-  servers: z.array(chatboxServerSchema).min(1),
+  servers: z.array(chatboxServerSchema),
   personaCount: z.number().int().min(1).max(10),
   accessVersion: z.number().int().nonnegative().optional(),
   // Optional human label for the chatbox surface. Forwarded to the backend
@@ -65,7 +68,7 @@ const personaSlateSchema = z.object({
 
 const startSimulationSchema = z.object({
   projectId: z.string().min(1),
-  servers: z.array(chatboxServerSchema).min(1),
+  servers: z.array(chatboxServerSchema),
   accessVersion: z.number().int().nonnegative().optional(),
   personas: z.array(personaSlateSchema).min(1).max(10),
   sessionsPerPersona: z.number().int().min(1).max(5),
@@ -100,16 +103,12 @@ chatboxSessions.post("/:chatboxId/generate-personas", async (c) =>
       await readJsonBody<unknown>(c),
     );
     const convexHttpUrl = requireConvexHttpUrl();
+    // selectedServerIds may be empty (no required servers): the manager
+    // comes back connection-less, the snapshot captures zero servers, and
+    // the backend grounds personas in the chatbox name instead of tools.
     const { selectedServerIds, selectedServerNames } = resolveRequiredServers(
       body.servers,
     );
-    if (selectedServerIds.length === 0) {
-      throw new WebRouteError(
-        400,
-        ErrorCode.VALIDATION_ERROR,
-        "Chatbox has no required servers",
-      );
-    }
 
     const result = await withManager(
       createAuthorizedManager(
@@ -196,16 +195,12 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       );
     }
 
+    // selectedServerIds may be empty (no required servers): the manager
+    // factory returns a connection-less manager and the sessions run
+    // toolless, exactly like a real no-opt-in visitor's chat.
     const { selectedServerIds, selectedServerNames } = resolveRequiredServers(
       body.servers,
     );
-    if (selectedServerIds.length === 0) {
-      throw new WebRouteError(
-        400,
-        ErrorCode.VALIDATION_ERROR,
-        "Chatbox has no required servers",
-      );
-    }
 
     // BYOK is now supported on synthetic runs: the runner's
     // `drainAssistantTurn` dispatches MCPJam-provided models through


### PR DESCRIPTION
## Why

A chatbox whose attachments are all optional (or has none) showed a disabled "Generate with AI" button, and both synthetic-session routes 400ed with "Chatbox has no required servers". If the tool schemas are missing — e.g. someone just forgot to attach a required server — ICP/persona generation should still work with whatever context exists (the chatbox name), not hard-block.

## What

- **`ChatboxUsagePanel.tsx`** — removed the disabled gate (and its dead tooltip — native `title` doesn't even render on disabled buttons in some browsers).
- **`GenerateSessionsDialog.tsx`** — removed the `hasRequiredServers` guards on the Generate action; a muted notice explains the degraded mode instead: personas are generated from the chatbox name only, sessions run without tools.
- **`server/routes/web/chatbox-sessions.ts`** — dropped both required-servers 400s and the `.min(1)` on the servers schemas. No new plumbing needed: `createAuthorizedManager` already returns a connection-less manager for zero ids, the snapshot exporter returns an empty snapshot, `prepareChatV2` tolerates an empty server list, and the simulation runner already guards zero connected servers — so simulated sessions run toolless, exactly like a real no-opt-in visitor's chat.

The optional-filtering itself is unchanged: synthetic runs still model the no-opt-in baseline, and the server-side filter still prevents a tampered body from widening the toolset.

## Tests

- New `server/routes/web/__tests__/chatbox-sessions.no-required-servers.test.ts` (3 tests: all-optional + empty lists on both routes, asserting the empty snapshot and label-only attachment reach `generatePersonas`)
- Full `server/routes/web` suite: 170 passed; dialog + runner tests pass; client typecheck clean

## Rollout

⚠️ **Depends on MCPJam/mcpjam-backend#511 deploying first.** This PR makes the inspector send `serverAttachment.resolvedServerNames: []`, which the current backend rejects; until the backend ships, the no-required-servers path surfaces a toast error instead of a disabled button (no worse than today, but not yet functional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes synthetic session and persona API validation and behavior; full end-to-end success depends on a coordinated backend deploy (mcpjam-backend#511) for empty `resolvedServerNames`.
> 
> **Overview**
> **Generate with AI** is no longer blocked when a chatbox has only optional servers or none attached. The usage panel always opens the flow; the dialog explains degraded mode and still lets users generate personas.
> 
> On the server, **`generate-personas`** and **`simulate-sessions/start`** accept empty or all-optional server lists instead of returning **400** (`Chatbox has no required servers`). Zod no longer requires at least one server. With zero required servers, personas are grounded on the chatbox name and synthetic sessions run **toolless**, matching a no-opt-in visitor. Optional-server filtering for synthetic runs is unchanged.
> 
> New route tests cover all-optional and empty server payloads for both endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e39771afe83b935c3325ac511452d08bb9b16e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->