### PR TITLE
feat(computers): guest access — bash for guests + sign-in CTA on daily cap

### DIFF
--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
+import { usePostHog } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Loader2, RotateCcw, TerminalSquare, Trash2 } from "lucide-react";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -9,7 +10,11 @@ import {
   useMintTerminalToken,
   useReserveComputer,
 } from "@/hooks/useProjectComputer";
-import { getBillingErrorMessage } from "@/lib/billing-entitlements";
+import {
+  getBillingErrorMessage,
+  isComputerStartLimitError,
+} from "@/lib/billing-entitlements";
+import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { ComputerStatusChip } from "./ComputerStatusChip";
 import { ComputerTerminal } from "./ComputerTerminal";
 
@@ -30,6 +35,7 @@ export function ComputerView({
   const reserve = useReserveComputer();
   const deleteComputer = useDeleteComputer();
   const mintTerminalToken = useMintTerminalToken();
+  const posthog = usePostHog();
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const terminalTheme = themeMode === "dark" ? "dark" : "light";
 
@@ -56,6 +62,9 @@ export function ComputerView({
 
   const openTerminal = useCallback(async () => {
     if (!effectiveProjectId) return;
+    posthog?.capture("computer_terminal_opened", {
+      computer_status: liveStatus ?? "none",
+    });
     setTerminalOpen(true);
     if (liveStatus !== "ready") {
       // Provision-on-first-use / wake; the live status query then drives the
@@ -65,14 +74,21 @@ export function ComputerView({
         await reserve({ projectId: effectiveProjectId });
       } catch (err) {
         setTerminalOpen(false);
-        toast.error(
-          getBillingErrorMessage(err, "Could not start the computer.")
-        );
+        if (isComputerStartLimitError(err)) {
+          // Daily start cap — the limit dialog carries the conversion CTA
+          // (sign-in for guests, top-up for signed-in users).
+          posthog?.capture("computer_start_limit_hit");
+          useMCPJamLimitDialogStore.getState().notifyLimitHit();
+        } else {
+          toast.error(
+            getBillingErrorMessage(err, "Could not start the computer.")
+          );
+        }
       } finally {
         setStarting(false);
       }
     }
-  }, [effectiveProjectId, liveStatus, reserve]);
+  }, [effectiveProjectId, liveStatus, posthog, reserve]);
 
   const onDelete = useCallback(async () => {
     if (!effectiveProjectId) return;

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -20,7 +20,8 @@ export type BillingLimitName =
   | "maxChatboxesPerProject"
   | "maxEvalRunsPerMonth"
   | "maxEvalIterationsPerMonth"
-  | "insightsPerDay";
+  | "insightsPerDay"
+  | "computerStartsPerDay";
 
 /** Mirrors backend premiumness gate keys exactly. */
 export type PremiumnessGateKey =

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -318,8 +318,33 @@ export function formatBillingLimitReachedMessage(
       ? `This organization has reached its project limit (${allowedValue}). Upgrade to create more projects.`
       : `This organization has reached its project limit (${allowedValue}). Ask an organization owner to upgrade.`;
   }
+  if (limitName === "computerStartsPerDay") {
+    if (typeof options?.resetsAt === "number") {
+      const resetTime = new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(new Date(options.resetsAt));
+      return `Daily computer limit reached (${allowedValue}). Resets ${resetTime}.`;
+    }
+    return `Daily computer limit reached (${allowedValue}).`;
+  }
 
   return null;
+}
+
+/**
+ * The guest daily computer-start cap (`computerStartsPerDay`). Detected
+ * separately so the computer surface can route it to the MCPJam limit dialog
+ * (sign-in CTA for guests) instead of a plain toast.
+ */
+export function isComputerStartLimitError(error: unknown): boolean {
+  const payload = extractBillingErrorPayload(error);
+  if (!payload || payload.code !== "billing_limit_reached") {
+    return false;
+  }
+  return (payload.limitName ?? payload.limit) === "computerStartsPerDay";
 }
 
 export function getBillingErrorMessage(

--- a/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/built-in-tools-registry.test.ts
@@ -95,12 +95,12 @@ describe("resolveHostTools — computer-backed bash", () => {
     expect(Object.keys(tools ?? {})).toEqual([WEB_SEARCH_TOOL_NAME]);
   });
 
-  it("skips bash for guest actors (advertise-time gate)", () => {
+  it("advertises bash to guest actors too (cost is contained backend-side)", () => {
     const tools = resolveHostTools(
       { builtInToolIds: [BASH_TOOL_NAME, WEB_SEARCH_TOOL_NAME], computer },
       { ...ctx, isGuest: true }
     );
-    expect(Object.keys(tools ?? {})).toEqual([WEB_SEARCH_TOOL_NAME]);
+    expect(Object.keys(tools ?? {})).toContain(BASH_TOOL_NAME);
   });
 
   it("does NOT advertise bash off the computer alone — the id must be granted", () => {

--- a/mcpjam-inspector/server/utils/built-in-tools/bash.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/bash.ts
@@ -3,10 +3,12 @@
  *
  * `bash` is a computer-backed CATALOG id: it's advertised for a turn only
  * when the host's `builtInToolIds` carries `"bash"` AND the host attaches a
- * `computer` resource AND the acting user is a signed-in member — all three
- * gates live in `registry.ts`'s `resolveHostTools`, the single construction
- * path for host tools. Same shape pattern as `exa-web-search.ts`: the
- * inspector defines the tool; authorization and durable state live in Convex.
+ * `computer` resource — both gates live in `registry.ts`'s
+ * `resolveHostTools`, the single construction path for host tools. Guests
+ * are included: Convex accepts guest bearers on `/computers/reserve` and
+ * contains cost via the guest daily start cap + idle-delete sweep. Same
+ * shape pattern as `exa-web-search.ts`: the inspector defines the tool;
+ * authorization and durable state live in Convex.
  *
  * Execute flow (see mcpjam-backend docs/project-computers.md):
  *   1. `ensureComputerReady` — POST /computers/reserve with the user's bearer

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -144,13 +144,9 @@ export function resolveHostTools(
         );
         continue;
       }
-      if (ctx.isGuest) {
-        logger.debug(
-          "[built-in-tools] bash not advertised to guest actor; skipping",
-          { projectId: ctx.projectId }
-        );
-        continue;
-      }
+      // Guests get bash too: the backend accepts guest bearers on
+      // /computers/reserve and contains cost via the guest daily start cap
+      // and the idle-delete sweep.
       out[BASH_TOOL_NAME] = buildBashTool({
         authHeader,
         projectId: ctx.projectId,


### PR DESCRIPTION
## Why

Companion to MCPJam/mcpjam-backend#512 (guests get Project Computers, contained by a 3-starts/day cap and an idle-delete sweep). Goal: let guests hit the computer aha moment, then convert at the limit.

Today a hosted guest navigating to `/computer` crashes the route with `Uncaught Error: Authenticated user required` — the view's Convex-auth gate passes for guests (guest bearers ARE Convex auth), the `getComputerStatus` query fires, and the backend's signed-in-only wrapper throws into the router error boundary. With the backend PR deployed, that same gate becomes the *correct* predicate: guests get the full tab, signed-out visitors keep the sign-in empty state, and the crash disappears with no client gating changes.

## What

- **Bash in chat for guests** — `registry.ts` no longer skips the bash tool for guest actors (the advertise-time filter stays the mechanism; only the policy changed). The tool already forwards the caller's bearer to `/computers/reserve`, which now accepts guests.
- **Conversion CTA** — `ComputerView` detects the `computerStartsPerDay` `billing_limit_reached` payload (new exported `isComputerStartLimitError`) and opens the global MCPJam limit dialog, which already renders the guest "Sign in" variant / signed-in top-up variant. Other reserve errors keep the existing toast.
- **Limit copy** — `formatBillingLimitReachedMessage` gains a `computerStartsPerDay` branch ("Daily computer limit reached (3). Resets …"), and `BillingLimitName` gains the union member (`PremiumnessGateKey` intentionally untouched — this limit isn't a premiumness gate).
- **Funnel instrumentation** — PostHog `computer_terminal_opened` and `computer_start_limit_hit` events from `ComputerView`.

## Sequencing

Backend PR should deploy first; until then guests still get the (pre-existing) crash on `/computer`. This PR is safe to merge in either order — it changes no gating, only adds the limit-error handling and the bash advertise policy, which is inert while the backend rejects guests.

## Tests

`built-in-tools-registry.test.ts`: the "skips bash for guest actors" case is replaced by "advertises bash to guest actors too". Full inspector suite green (5618 passed), client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Policy change exposes computer/bash to guests and routes billing limits through a conversion dialog; relies on backend caps being enforced on `/computers/reserve`.
> 
> **Overview**
> Enables **guest access to Project Computers** in chat and on the Computer tab by dropping the advertise-time **guest block on `bash`** in `resolveHostTools` (cost is expected to be bounded by the backend daily start cap and idle cleanup). Docs/comments in `bash.ts` are updated to match.
> 
> When **starting/reserving a computer** fails with **`computerStartsPerDay`** (`billing_limit_reached`), **`ComputerView`** now opens the **MCPJam limit dialog** (sign-in for guests, top-up for signed-in users) via new **`isComputerStartLimitError`**, instead of only showing a toast. Other reserve errors still use **`getBillingErrorMessage`**.
> 
> Adds **`computerStartsPerDay`** to billing limit typing and **user-facing limit messages** (including reset time when provided). **PostHog** events: **`computer_terminal_opened`** and **`computer_start_limit_hit`**.
> 
> Registry test updated: guests **do** receive **`bash`** when a computer is attached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 931c27ad44b116181a137c05efef675e7492d673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->