### PR TITLE
Synthetic sessions get the eval browser pipeline (render observations + Computer Use) and the shared machinery is unified

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -156,6 +156,15 @@ export function ShareUsageThreadDetail({
   const hasBrowserArtifacts =
     renderObservations.length > 0 || interactionSteps.length > 0;
 
+  // The "browser" mode is only valid while the LOADED session actually has
+  // artifacts. `viewMode` is component state that survives a `threadId`
+  // switch, so without this clamp a session without artifacts would render
+  // an orphaned empty Browser panel whose tab is hidden (Cursor Bugbot,
+  // PR 2610). Render-time fallback (not a reset effect) so flipping back to
+  // an artifact-carrying session restores the Browser view.
+  const effectiveViewMode: TraceViewMode | "browser" =
+    viewMode === "browser" && !hasBrowserArtifacts ? "chat" : viewMode;
+
   // Build a TraceEnvelope for the TraceViewer (timeline + raw). Browser
   // artifacts ride the envelope so the Raw view includes them.
   const traceEnvelope: TraceEnvelope | null = useMemo(() => {
@@ -333,24 +342,24 @@ export function ShareUsageThreadDetail({
           session carries browser-rendered MCP App artifacts (synthetic runs);
           its active mode lives outside the shared TraceViewMode union. */}
       <ChatTraceViewModeHeaderBar
-        mode={viewMode === "browser" ? "chat" : viewMode}
+        mode={effectiveViewMode === "browser" ? "chat" : effectiveViewMode}
         onModeChange={setViewMode}
         showBrowserTab={hasBrowserArtifacts}
-        browserActive={viewMode === "browser"}
+        browserActive={effectiveViewMode === "browser"}
         onSelectBrowser={() => setViewMode("browser")}
       />
 
       {/* Content area: must be a flex column so TraceViewer (fillContent) is a flex item; otherwise
           nested flex-1 / min-h-0 inside TraceTimeline collapses and the timeline paints empty. */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {viewMode === "browser" ? (
+        {effectiveViewMode === "browser" ? (
           <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
             <BrowserArtifactsView
               observations={renderObservations}
               steps={interactionSteps}
             />
           </div>
-        ) : viewMode === "chat" ? (
+        ) : effectiveViewMode === "chat" ? (
           <div className="min-h-0 flex-1 overflow-y-auto">
             <ChatboxSurfaceProvider value={isChatboxThread}>
               <TranscriptThread
@@ -378,7 +387,7 @@ export function ShareUsageThreadDetail({
           <TraceViewer
             trace={traceEnvelope}
             model={resolvedModel}
-            forcedViewMode={viewMode === "raw" ? "raw" : "timeline"}
+            forcedViewMode={effectiveViewMode === "raw" ? "raw" : "timeline"}
             hideToolbar
             fillContent
             traceStartedAtMs={traceStartedAtMs}

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -15,6 +15,7 @@ import {
   type TraceWidgetSnapshot,
 } from "@/components/evals/trace-viewer-adapter";
 import { TraceViewer } from "@/components/evals/trace-viewer";
+import { BrowserArtifactsView } from "@/components/evals/browser-artifacts-view";
 import {
   ChatTraceViewModeHeaderBar,
   type TraceViewMode,
@@ -23,6 +24,7 @@ import {
   useSharedChatThread,
   useSharedChatWidgetSnapshots,
   useSharedChatTurnTraces,
+  useSessionBrowserArtifacts,
   type SharedChatTurnTrace,
 } from "@/hooks/useSharedChatThreads";
 
@@ -68,10 +70,16 @@ export function ShareUsageThreadDetail({
   const { thread } = useSharedChatThread({ threadId });
   const { snapshots } = useSharedChatWidgetSnapshots({ threadId });
   const { traces: turnTraces } = useSharedChatTurnTraces({ threadId });
+  const { artifacts: browserArtifacts } = useSessionBrowserArtifacts({
+    threadId,
+  });
   const [messages, setMessages] = useState<unknown[] | null>(null);
   const [isLoadingMessages, setIsLoadingMessages] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<TraceViewMode>("chat");
+  // The eval-only "browser" mode lives outside the shared TraceViewMode union
+  // (see trace-view-mode-tabs.tsx) — widen locally, mirroring TraceViewer's
+  // own internal state.
+  const [viewMode, setViewMode] = useState<TraceViewMode | "browser">("chat");
   const [hydratedSpans, setHydratedSpans] = useState<EvalTraceSpan[]>([]);
 
   // Fetch messages from blob URL
@@ -141,15 +149,29 @@ export function ShareUsageThreadDetail({
     return snapshotsToTraceWidgetSnapshots(snapshots);
   }, [snapshots, thread]);
 
-  // Build a TraceEnvelope for the TraceViewer (timeline + raw)
+  // Browser-rendered MCP App artifacts (synthetic sessions). Tab visibility =
+  // artifact presence, the same heuristic the eval trace viewer uses.
+  const renderObservations = browserArtifacts?.widgetRenderObservations ?? [];
+  const interactionSteps = browserArtifacts?.browserInteractionSteps ?? [];
+  const hasBrowserArtifacts =
+    renderObservations.length > 0 || interactionSteps.length > 0;
+
+  // Build a TraceEnvelope for the TraceViewer (timeline + raw). Browser
+  // artifacts ride the envelope so the Raw view includes them.
   const traceEnvelope: TraceEnvelope | null = useMemo(() => {
     if (!messages) return null;
     return {
       messages: messages as any,
       widgetSnapshots,
       spans: hydratedSpans,
+      ...(renderObservations.length > 0
+        ? { widgetRenderObservations: renderObservations }
+        : {}),
+      ...(interactionSteps.length > 0
+        ? { browserInteractionSteps: interactionSteps }
+        : {}),
     };
-  }, [messages, widgetSnapshots, hydratedSpans]);
+  }, [messages, widgetSnapshots, hydratedSpans, renderObservations, interactionSteps]);
 
   // Adapt trace to UI messages for the chat view
   const adaptedTrace = useMemo(() => {
@@ -307,16 +329,28 @@ export function ShareUsageThreadDetail({
         </div>
       </div>
 
-      {/* Trace / Chat / Raw tabs */}
+      {/* Trace / Chat / [Browser] / Raw tabs. The Browser tab appears when the
+          session carries browser-rendered MCP App artifacts (synthetic runs);
+          its active mode lives outside the shared TraceViewMode union. */}
       <ChatTraceViewModeHeaderBar
-        mode={viewMode}
+        mode={viewMode === "browser" ? "chat" : viewMode}
         onModeChange={setViewMode}
+        showBrowserTab={hasBrowserArtifacts}
+        browserActive={viewMode === "browser"}
+        onSelectBrowser={() => setViewMode("browser")}
       />
 
       {/* Content area: must be a flex column so TraceViewer (fillContent) is a flex item; otherwise
           nested flex-1 / min-h-0 inside TraceTimeline collapses and the timeline paints empty. */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {viewMode === "chat" ? (
+        {viewMode === "browser" ? (
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+            <BrowserArtifactsView
+              observations={renderObservations}
+              steps={interactionSteps}
+            />
+          </div>
+        ) : viewMode === "chat" ? (
           <div className="min-h-0 flex-1 overflow-y-auto">
             <ChatboxSurfaceProvider value={isChatboxThread}>
               <TranscriptThread

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
@@ -184,4 +184,51 @@ describe("ShareUsageThreadDetail", () => {
     expect(screen.getByText("Computer Use timeline")).toBeInTheDocument();
     expect(screen.getByText("Left click (10, 20)")).toBeInTheDocument();
   });
+
+  it("falls back to Chat when the active browser view loses its artifacts (session switch)", async () => {
+    // Cursor Bugbot (PR 2610): viewMode is component state that survives a
+    // threadId switch; with the Browser tab hidden, a stale "browser" mode
+    // must not strand the user on an orphaned empty panel.
+    mockBrowserArtifactsState.artifacts = {
+      widgetRenderObservations: [
+        {
+          toolCallId: "tc-1",
+          toolName: "create_view",
+          serverId: "server-1",
+          promptIndex: 0,
+          status: "rendered",
+          screenshotUrl: null,
+          elapsedMs: 1200,
+          ts: 1,
+        },
+      ],
+      browserInteractionSteps: [],
+    };
+
+    const { rerender } = render(<ShareUsageThreadDetail threadId="thread-1" />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Browser" }),
+    );
+    expect(
+      await screen.findByTestId("browser-artifacts-view"),
+    ).toBeInTheDocument();
+
+    // The next session has no artifacts (same mounted component instance).
+    mockBrowserArtifactsState.artifacts = {
+      widgetRenderObservations: [],
+      browserInteractionSteps: [],
+    };
+    rerender(<ShareUsageThreadDetail threadId="thread-2" />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("browser-artifacts-view"),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Browser" }),
+    ).not.toBeInTheDocument();
+    // Chat content renders instead of a blank panel.
+    expect(screen.getByTestId("message-view")).toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
@@ -1,15 +1,23 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ShareUsageThreadDetail } from "../ShareUsageThreadDetail";
 
-const { mockMessageView, mockAdaptTraceToUiMessages, mockThreadState } =
-  vi.hoisted(() => ({
-    mockMessageView: vi.fn(),
-    mockAdaptTraceToUiMessages: vi.fn(),
-    mockThreadState: {
-      sourceType: "chatbox",
-    },
-  }));
+const {
+  mockMessageView,
+  mockAdaptTraceToUiMessages,
+  mockThreadState,
+  mockBrowserArtifactsState,
+} = vi.hoisted(() => ({
+  mockMessageView: vi.fn(),
+  mockAdaptTraceToUiMessages: vi.fn(),
+  mockThreadState: {
+    sourceType: "chatbox",
+  },
+  mockBrowserArtifactsState: {
+    artifacts: undefined as unknown,
+  },
+}));
 
 vi.mock("@/hooks/useSharedChatThreads", () => ({
   useSharedChatThread: () => ({
@@ -29,6 +37,13 @@ vi.mock("@/hooks/useSharedChatThreads", () => ({
   useSharedChatTurnTraces: () => ({
     traces: [],
   }),
+  useSessionBrowserArtifacts: () => ({
+    artifacts: mockBrowserArtifactsState.artifacts,
+  }),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
 }));
 
 vi.mock("@/components/evals/trace-viewer-adapter", () => ({
@@ -50,6 +65,7 @@ describe("ShareUsageThreadDetail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockThreadState.sourceType = "chatbox";
+    mockBrowserArtifactsState.artifacts = undefined;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => [{ role: "assistant", content: [] }],
@@ -114,4 +130,58 @@ describe("ShareUsageThreadDetail", () => {
     });
   });
 
+  it("hides the Browser tab when the session has no browser artifacts", async () => {
+    render(<ShareUsageThreadDetail threadId="thread-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Chat" })).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Browser" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Browser tab and renders the artifacts view when artifacts exist", async () => {
+    mockBrowserArtifactsState.artifacts = {
+      widgetRenderObservations: [
+        {
+          toolCallId: "tc-1",
+          toolName: "create_view",
+          serverId: "server-1",
+          promptIndex: 0,
+          status: "rendered",
+          screenshotUrl: null,
+          elapsedMs: 1200,
+          ts: 1,
+        },
+      ],
+      browserInteractionSteps: [
+        {
+          toolCallId: "tc-1",
+          stepIndex: 0,
+          promptIndex: 0,
+          action: "left_click",
+          coordinateX: 10,
+          coordinateY: 20,
+          screenshotUrl: null,
+          elapsedMs: 80,
+          ts: 2,
+        },
+      ],
+    };
+
+    render(<ShareUsageThreadDetail threadId="thread-1" />);
+
+    const browserTab = await screen.findByRole("button", { name: "Browser" });
+    await userEvent.click(browserTab);
+
+    // Render-observation card + the Computer Use timeline from
+    // BrowserArtifactsView (the same component the eval replay uses).
+    expect(
+      await screen.findByTestId("browser-artifacts-view"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("render-observation-card")).toBeInTheDocument();
+    expect(screen.getByText("Computer Use timeline")).toBeInTheDocument();
+    expect(screen.getByText("Left click (10, 20)")).toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
@@ -228,7 +228,9 @@ describe("ShareUsageThreadDetail", () => {
     expect(
       screen.queryByRole("button", { name: "Browser" }),
     ).not.toBeInTheDocument();
-    // Chat content renders instead of a blank panel.
-    expect(screen.getByTestId("message-view")).toBeInTheDocument();
+    // Chat content renders instead of a blank panel. findBy: the messages
+    // blob re-fetch on thread switch is async — don't depend on the previous
+    // thread's messages state being retained (CodeRabbit, PR 2610).
+    expect(await screen.findByTestId("message-view")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -133,15 +133,26 @@ export function TraceViewModeTabs({
 /**
  * Full-width Trace / Chat / Raw strip used in {@link ChatTabV2} and compare cards —
  * matches `bg-background/80 … border-b` + `px-4 py-2.5` + {@link TraceViewModeTabs} `layout="fullWidth"`.
+ *
+ * The optional Browser tab rides the same out-of-union props as
+ * {@link TraceViewModeTabs} (see the module doc): the Sessions viewer shows it
+ * when a session carries browser-rendered MCP App artifacts; chat / compare
+ * surfaces omit it.
  */
 export function ChatTraceViewModeHeaderBar({
   mode,
   onModeChange,
   className,
+  showBrowserTab = false,
+  browserActive = false,
+  onSelectBrowser,
 }: {
   mode: TraceViewMode;
   onModeChange: (mode: TraceViewMode) => void;
   className?: string;
+  showBrowserTab?: boolean;
+  browserActive?: boolean;
+  onSelectBrowser?: () => void;
 }) {
   return (
     <div
@@ -156,6 +167,9 @@ export function ChatTraceViewModeHeaderBar({
           mode={mode}
           onModeChange={onModeChange}
           showToolsTab={false}
+          showBrowserTab={showBrowserTab}
+          browserActive={browserActive}
+          onSelectBrowser={onSelectBrowser}
         />
       </div>
     </div>

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -1,4 +1,8 @@
 import { useQuery } from "convex/react";
+import type {
+  EvalTraceBrowserInteractionStepView,
+  EvalTraceWidgetRenderObservationView,
+} from "@/shared/eval-trace";
 
 export type SharedChatSourceType = "chatbox";
 
@@ -166,4 +170,28 @@ export function useSharedChatTurnTraces({
   ) as SharedChatTurnTrace[] | undefined;
 
   return { traces };
+}
+
+export interface SessionBrowserArtifacts {
+  widgetRenderObservations: EvalTraceWidgetRenderObservationView[];
+  browserInteractionSteps: EvalTraceBrowserInteractionStepView[];
+}
+
+/**
+ * Browser-rendered MCP App artifacts for a session (render observations +
+ * Computer Use steps), written by the synthetic-session runner. Sorted and
+ * screenshot-url-resolved server-side; empty arrays for sessions without
+ * browser artifacts (live visitor sessions, pre-feature synthetic runs).
+ */
+export function useSessionBrowserArtifacts({
+  threadId,
+}: {
+  threadId: string | null;
+}) {
+  const artifacts = useQuery(
+    "chatSessions:getBrowserArtifacts" as any,
+    threadId ? ({ sessionId: threadId } as any) : "skip",
+  ) as SessionBrowserArtifacts | undefined;
+
+  return { artifacts };
 }

--- a/mcpjam-inspector/server/services/__tests__/browser-session-context.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/browser-session-context.test.ts
@@ -1,18 +1,19 @@
 /**
- * browser-eval-context.test.ts — hosted-path browser eval context (PR 14).
+ * browser-session-context.test.ts — shared browser session context.
  *
- * Covers the engine-attachment surface the hosted runners
- * (`runIterationViaBackend` / `streamIterationViaBackend`) wire into
- * `runAssistantTurn`: Computer Use tool construction (wire format), the
- * advertised-tool gate, the render hook (engine `onToolResult`), input
- * caching, prompt-index stamping, and disposal.
+ * Covers the attachment surface every "mock a user session" runner (eval
+ * iterations, synthetic chatbox sessions) wires into its turn driver:
+ * Computer Use tool construction (wire format), the advertised-tool gate,
+ * both render hooks (engine `onToolResult` + local AI-SDK
+ * `onToolResultChunk`), input caching, prompt-index stamping, incremental
+ * artifact draining, and disposal.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const renderMcpAppToolResult = vi.fn();
 const isRenderableMcpAppTool = vi.fn();
 
-vi.mock("../../../utils/mcp-app-render-observation", () => ({
+vi.mock("../../utils/mcp-app-render-observation", () => ({
   renderMcpAppToolResult: (...args: unknown[]) =>
     renderMcpAppToolResult(...args),
   isRenderableMcpAppTool: (...args: unknown[]) =>
@@ -26,10 +27,10 @@ const harnessInstances: Array<{
   executeAction: ReturnType<typeof vi.fn>;
 }> = [];
 
-vi.mock("../../../utils/mcp-app-browser-harness", async () => {
+vi.mock("../../utils/mcp-app-browser-harness", async () => {
   const actual = await vi.importActual<
-    typeof import("../../../utils/mcp-app-browser-harness")
-  >("../../../utils/mcp-app-browser-harness");
+    typeof import("../../utils/mcp-app-browser-harness")
+  >("../../utils/mcp-app-browser-harness");
   return {
     ...actual,
     McpAppBrowserHarness: vi.fn().mockImplementation(() => {
@@ -45,7 +46,7 @@ vi.mock("../../../utils/mcp-app-browser-harness", async () => {
   };
 });
 
-import { createEvalBrowserContext } from "../browser-eval-context";
+import { createBrowserSessionContext } from "../browser-session-context";
 
 const CLAUDE_MODEL = "claude-haiku-4-5";
 const NON_CLAUDE_MODEL = "gpt-5-mini";
@@ -63,9 +64,9 @@ beforeEach(() => {
   isRenderableMcpAppTool.mockReturnValue(false);
 });
 
-describe("createEvalBrowserContext — Computer Use surface", () => {
+describe("createBrowserSessionContext — Computer Use surface", () => {
   it("builds wire-format computer tools + gate for Claude drivers", () => {
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -83,7 +84,7 @@ describe("createEvalBrowserContext — Computer Use surface", () => {
   });
 
   it("builds no computer tools and no gate for non-Claude drivers", () => {
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: NON_CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -96,7 +97,7 @@ describe("createEvalBrowserContext — Computer Use surface", () => {
   });
 
   it("gate hides computer tools until a widget is mounted, then reveals", () => {
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -114,7 +115,7 @@ describe("createEvalBrowserContext — Computer Use surface", () => {
   });
 });
 
-describe("createEvalBrowserContext — render hook", () => {
+describe("createBrowserSessionContext — render hook", () => {
   const baseEvent = {
     toolCallId: "tc-1",
     toolName: "show_widget",
@@ -143,7 +144,7 @@ describe("createEvalBrowserContext — render hook", () => {
       ts: 123,
     });
 
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
       injectOpenAiCompat: true,
@@ -180,7 +181,7 @@ describe("createEvalBrowserContext — render hook", () => {
       executeTool: vi.fn(),
       getAllToolsMetadata: vi.fn().mockReturnValue({ show_widget: {} }),
     } as never;
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -204,7 +205,7 @@ describe("createEvalBrowserContext — render hook", () => {
     isRenderableMcpAppTool.mockReturnValue(true);
     renderMcpAppToolResult.mockRejectedValue(new Error("chromium exploded"));
 
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -230,7 +231,7 @@ describe("createEvalBrowserContext — render hook", () => {
       ts: 123,
     });
 
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: NON_CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -245,9 +246,9 @@ describe("createEvalBrowserContext — render hook", () => {
   });
 });
 
-describe("createEvalBrowserContext — interaction steps", () => {
+describe("createBrowserSessionContext — interaction steps", () => {
   it("collects browserInteractionSteps from computer-tool actions with per-widget step ordinals", async () => {
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -282,7 +283,7 @@ describe("createEvalBrowserContext — interaction steps", () => {
   });
 
   it("narrows unknown harness notes instead of dropping the step", async () => {
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -305,9 +306,9 @@ describe("createEvalBrowserContext — interaction steps", () => {
   });
 });
 
-describe("createEvalBrowserContext — lifecycle", () => {
+describe("createBrowserSessionContext — lifecycle", () => {
   it("dismissCarriedWidget dismisses only when a widget is mounted", async () => {
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -322,14 +323,14 @@ describe("createEvalBrowserContext — lifecycle", () => {
   });
 
   it("dispose tears down the harness; no-op when never constructed", async () => {
-    const claudeCtx = createEvalBrowserContext({
+    const claudeCtx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
     await claudeCtx.dispose();
     expect(harnessInstances[0]!.dispose).toHaveBeenCalledTimes(1);
 
-    const plainCtx = createEvalBrowserContext({
+    const plainCtx = createBrowserSessionContext({
       model: NON_CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -353,7 +354,7 @@ describe("createEvalBrowserContext — lifecycle", () => {
       ts: 1,
     });
 
-    const ctx = createEvalBrowserContext({
+    const ctx = createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -374,5 +375,142 @@ describe("createEvalBrowserContext — lifecycle", () => {
       (renderMcpAppToolResult.mock.calls[0]![0] as { toolInput?: unknown })
         .toolInput,
     ).toBeUndefined();
+  });
+});
+
+describe("createBrowserSessionContext — direct (local AI-SDK) render hook", () => {
+  const baseChunk = {
+    toolCallId: "tc-1",
+    toolName: "show_widget",
+    input: { city: "porto" },
+    output: { content: [], structuredContent: { full: true } },
+    serverId: "srv-1",
+  };
+
+  it("renders renderable results with the chunk's inline input (no cache)", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi
+        .fn()
+        .mockReturnValue({ show_widget: { "mcpjam/widget": true } }),
+    } as never;
+    isRenderableMcpAppTool.mockReturnValue(true);
+    renderMcpAppToolResult.mockResolvedValue({
+      toolCallId: "tc-1",
+      toolName: "show_widget",
+      serverId: "srv-1",
+      status: "rendered",
+      elapsedMs: 5,
+      ts: 123,
+    });
+
+    const ctx = createBrowserSessionContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: manager,
+    });
+    ctx.setActivePromptIndex(3);
+
+    await ctx.handleDirectToolResultChunk(baseChunk);
+
+    expect(renderMcpAppToolResult).toHaveBeenCalledTimes(1);
+    const params = renderMcpAppToolResult.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(params.toolInput).toEqual({ city: "porto" });
+    expect(params.output).toBe(baseChunk.output);
+    expect(params.keepMounted).toBe(true);
+    expect(ctx.widgetRenderObservations).toEqual([
+      expect.objectContaining({ toolCallId: "tc-1", promptIndex: 3 }),
+    ]);
+  });
+
+  it("skips chunks without serverId and contains a throwing render", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi
+        .fn()
+        .mockReturnValue({ show_widget: { "mcpjam/widget": true } }),
+    } as never;
+    isRenderableMcpAppTool.mockReturnValue(true);
+    renderMcpAppToolResult.mockRejectedValue(new Error("chromium exploded"));
+
+    const ctx = createBrowserSessionContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: manager,
+    });
+
+    await ctx.handleDirectToolResultChunk({ ...baseChunk, serverId: undefined });
+    expect(renderMcpAppToolResult).not.toHaveBeenCalled();
+
+    await expect(
+      ctx.handleDirectToolResultChunk(baseChunk),
+    ).resolves.toBeUndefined();
+    expect(ctx.widgetRenderObservations).toEqual([]);
+  });
+});
+
+describe("createBrowserSessionContext — drainNewArtifacts", () => {
+  it("returns only rows appended since the previous drain; arrays stay intact", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi
+        .fn()
+        .mockReturnValue({ show_widget: { "mcpjam/widget": true } }),
+    } as never;
+    isRenderableMcpAppTool.mockReturnValue(true);
+    renderMcpAppToolResult.mockImplementation(
+      async (args: { toolCallId: string }) => ({
+        toolCallId: args.toolCallId,
+        toolName: "show_widget",
+        serverId: "srv-1",
+        status: "rendered",
+        elapsedMs: 5,
+        ts: 123,
+      }),
+    );
+
+    const ctx = createBrowserSessionContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: manager,
+    });
+    const harness = harnessInstances[0]!;
+    harness.getMountedWidgetId.mockReturnValue("tc-a");
+    harness.executeAction.mockResolvedValue({
+      action: { action: "screenshot" },
+      widgetToolCalls: [],
+      elapsedMs: 1,
+    });
+    const computer = ctx.computerWidgetTools.computer as {
+      execute: (input: unknown, opts: unknown) => Promise<unknown>;
+    };
+
+    // Nothing yet.
+    expect(ctx.drainNewArtifacts()).toEqual({ observations: [], steps: [] });
+
+    await ctx.handleDirectToolResultChunk({
+      toolCallId: "tc-a",
+      toolName: "show_widget",
+      input: {},
+      output: {},
+      serverId: "srv-1",
+    });
+    await computer.execute({ action: "screenshot" }, {});
+
+    const first = ctx.drainNewArtifacts();
+    expect(first.observations.map((o) => o.toolCallId)).toEqual(["tc-a"]);
+    expect(first.steps.map((s) => s.stepIndex)).toEqual([0]);
+
+    // A second drain with nothing new is empty.
+    expect(ctx.drainNewArtifacts()).toEqual({ observations: [], steps: [] });
+
+    await computer.execute({ action: "screenshot" }, {});
+    const second = ctx.drainNewArtifacts();
+    expect(second.observations).toEqual([]);
+    expect(second.steps.map((s) => s.stepIndex)).toEqual([1]);
+
+    // End-of-run consumers still see everything.
+    expect(ctx.widgetRenderObservations).toHaveLength(1);
+    expect(ctx.browserInteractionSteps).toHaveLength(2);
   });
 });

--- a/mcpjam-inspector/server/services/__tests__/browser-session-context.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/browser-session-context.test.ts
@@ -214,6 +214,44 @@ describe("createBrowserSessionContext — render hook", () => {
     expect(ctx.widgetRenderObservations).toEqual([]);
   });
 
+  it("releases the cached tool input once the call's result has been handled", async () => {
+    const manager = {
+      executeTool: vi.fn(),
+      getAllToolsMetadata: vi
+        .fn()
+        .mockReturnValue({ show_widget: { "mcpjam/widget": true } }),
+    } as never;
+    isRenderableMcpAppTool.mockReturnValue(true);
+    renderMcpAppToolResult.mockResolvedValue({
+      toolCallId: "tc-1",
+      toolName: "show_widget",
+      serverId: "srv-1",
+      status: "rendered",
+      elapsedMs: 5,
+      ts: 123,
+    });
+
+    const ctx = createBrowserSessionContext({
+      model: CLAUDE_MODEL,
+      mcpClientManager: manager,
+    });
+    ctx.noteToolCallInput({ toolCallId: "tc-1", input: { city: "lisbon" } });
+
+    await ctx.handleEngineToolResult(baseEvent);
+    expect(
+      (renderMcpAppToolResult.mock.calls[0]![0] as { toolInput?: unknown })
+        .toolInput,
+    ).toEqual({ city: "lisbon" });
+
+    // The entry was consumed; a second result for the same id no longer
+    // sees the input (cache stays bounded over long sessions).
+    await ctx.handleEngineToolResult(baseEvent);
+    expect(
+      (renderMcpAppToolResult.mock.calls[1]![0] as { toolInput?: unknown })
+        .toolInput,
+    ).toBeUndefined();
+  });
+
   it("renders for non-Claude drivers too (observations without Computer Use)", async () => {
     const manager = {
       executeTool: vi.fn(),

--- a/mcpjam-inspector/server/services/browser-artifact-serialization.ts
+++ b/mcpjam-inspector/server/services/browser-artifact-serialization.ts
@@ -1,0 +1,123 @@
+import type { ConvexHttpClient } from "convex/browser";
+import type {
+  BrowserInteractionStepPayload,
+  RunnerBrowserInteractionStep,
+  RunnerWidgetRenderObservation,
+  SerializedBrowserInteractionStep,
+  SerializedWidgetRenderObservation,
+  WidgetRenderObservationPayload,
+} from "@/shared/eval-trace";
+import { logger } from "../utils/logger.js";
+import { uploadScreenshotBlob } from "../utils/mcp-app-widget-capture.js";
+import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
+
+/**
+ * Serialize browser-rendered MCP App artifacts for the backend — shared by
+ * the eval finalizer (`finalizeEvalIteration`, once per iteration) and the
+ * synthetic-session runner (per turn, via `drainNewArtifacts`).
+ *
+ * Each helper:
+ *   - uploads the transient base64 screenshot (`screenshotBase64` →
+ *     `screenshotBlobId`) — best-effort: a failed upload drops the blob id but
+ *     KEEPS the row (status / timings / console errors stay useful for replay),
+ *   - runs the record through `sanitizeForConvexTransport` ($-key escaping is
+ *     required for the `widgetToolCalls[].args: v.any()` field on steps),
+ *   - retains `promptIndex` so per-turn consumers can bucket.
+ *
+ * Callers must invoke each helper exactly once per artifact batch so a
+ * screenshot blob is never uploaded twice (the eval finalizer serializes the
+ * whole iteration up front; the session runner drains incrementally).
+ *
+ * Uploads are sequential (not `Promise.all`): under the harness budgets
+ * (≤ 12 steps + a few observations per batch) the wall-clock cost is dwarfed
+ * by the rest of the persistence work, and the convex-test storage mock
+ * expects serial writes. Batch only if real runs show latency.
+ */
+export async function serializeRenderObservationsForBackend(
+  observations: RunnerWidgetRenderObservation[] | undefined,
+  convexClient: ConvexHttpClient,
+): Promise<SerializedWidgetRenderObservation[]> {
+  if (!observations?.length) return [];
+  const out: SerializedWidgetRenderObservation[] = [];
+  for (const obs of observations) {
+    let screenshotBlobId: string | undefined;
+    if (obs.screenshotBase64) {
+      try {
+        screenshotBlobId = await uploadScreenshotBlob(
+          convexClient,
+          obs.screenshotBase64,
+        );
+      } catch (err) {
+        logger.warn("[browser-artifacts] dropped render-obs screenshot upload", {
+          toolCallId: obs.toolCallId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    // Drop the transient base64; keep every other field (incl. promptIndex).
+    const { screenshotBase64: _screenshotBase64, ...rest } = obs;
+    const serialized: SerializedWidgetRenderObservation = {
+      ...rest,
+      ...(screenshotBlobId ? { screenshotBlobId } : {}),
+    };
+    // No $-key risk on observations (no v.any fields), but stay consistent with
+    // widgets and route through the sanitizer regardless.
+    out.push(sanitizeForConvexTransport(serialized));
+  }
+  return out;
+}
+
+export async function serializeBrowserStepsForBackend(
+  steps: RunnerBrowserInteractionStep[] | undefined,
+  convexClient: ConvexHttpClient,
+): Promise<SerializedBrowserInteractionStep[]> {
+  if (!steps?.length) return [];
+  const out: SerializedBrowserInteractionStep[] = [];
+  for (const step of steps) {
+    let screenshotBlobId: string | undefined;
+    if (step.screenshotBase64) {
+      try {
+        screenshotBlobId = await uploadScreenshotBlob(
+          convexClient,
+          step.screenshotBase64,
+        );
+      } catch (err) {
+        logger.warn("[browser-artifacts] dropped browser-step screenshot upload", {
+          toolCallId: step.toolCallId,
+          stepIndex: step.stepIndex,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    // Drop the transient base64; keep every other field (incl. promptIndex).
+    const { screenshotBase64: _screenshotBase64, ...rest } = step;
+    const serialized: SerializedBrowserInteractionStep = {
+      ...rest,
+      ...(screenshotBlobId ? { screenshotBlobId } : {}),
+    };
+    // $-keys can appear inside widgetToolCalls[].args (v.any() on the backend
+    // validator). sanitizeForConvexTransport handles the escape.
+    out.push(sanitizeForConvexTransport(serialized));
+  }
+  return out;
+}
+
+/**
+ * Strip `promptIndex` for the backend wire payloads — both writers stamp it
+ * server-side from a batch-level value (the eval turn wire from
+ * `turn.promptIndex`; the session wire from `recordBrowserArtifacts`'
+ * `promptIndex` arg), and the row validators reject unknown fields.
+ */
+export function toObservationPayload(
+  obs: SerializedWidgetRenderObservation,
+): WidgetRenderObservationPayload {
+  const { promptIndex: _promptIndex, ...payload } = obs;
+  return payload;
+}
+
+export function toBrowserStepPayload(
+  step: SerializedBrowserInteractionStep,
+): BrowserInteractionStepPayload {
+  const { promptIndex: _promptIndex, ...payload } = step;
+  return payload;
+}

--- a/mcpjam-inspector/server/services/browser-session-context.ts
+++ b/mcpjam-inspector/server/services/browser-session-context.ts
@@ -1,12 +1,13 @@
 /**
- * browser-eval-context.ts — per-iteration browser-rendered MCP App context for
- * the HOSTED eval runner paths (PR 14).
+ * browser-session-context.ts — per-session browser-rendered MCP App context for
+ * any runner that mocks a user session (eval iterations, synthetic chatbox
+ * sessions).
  *
- * `runIterationViaBackend` / `streamIterationViaBackend` drive their turns
- * through the shared engine (`runAssistantTurn` → `runChatEngineLoop`), so the
- * harness wiring that the local AI-SDK runners inline (PR 5/6b/9) attaches via
- * the engine's extension points instead:
+ * Grown out of the eval-only `browser-eval-context.ts` (PR 14): the harness
+ * wiring is surface-neutral, so the same context now serves every consumer
+ * through two attachment styles:
  *
+ *   Engine paths (`runAssistantTurn` → `runChatEngineLoop`):
  *   - `computerWidgetTools` — wire-format `computer` + `finish_widget` tools
  *     (regular function tools; the provider-native factory's lazy schema
  *     serializes to an empty object on the Convex `/stream` wire). Merged into
@@ -15,8 +16,8 @@
  *     image content via the tool's `toModelOutput` (honored by the shared
  *     executor since PR 14).
  *   - `prepareAdvertisedTools` — hides both tools until a widget is actually
- *     mounted in the harness (same gate the local runners use; the engine
- *     additionally enforces execution against the advertised subset).
+ *     mounted in the harness (the engine additionally enforces execution
+ *     against the advertised subset).
  *   - `handleEngineToolResult` — the engine's `onToolResult` hook (awaited by
  *     `emitToolResults` since PR 14, so a rendered widget is mounted before the
  *     next step's gate runs). Renders MCP App tool results in the harness and
@@ -25,8 +26,18 @@
  *     inputs so the render hook can feed the OpenAI-compat shim the same
  *     `toolInput` the live widget would have received.
  *
- * One context per iteration; `dispose()` MUST run (callers wrap the iteration
- * body in try/finally) so a launched Chromium never outlives its iteration.
+ *   Local AI-SDK paths (`runDirectChatTurn`):
+ *   - `handleDirectToolResultChunk` — the `traceEvents.onToolResultChunk`
+ *     hook (awaited by the helper). The chunk already carries the normalized
+ *     tool input, so no input cache is involved.
+ *   - The same `computerWidgetTools` / `prepareAdvertisedTools` attach to the
+ *     helper's tool map and prepareStep gate. Note the tools stay wire-format
+ *     here too: the local consumers (eval local-BYOK, simulation local org
+ *     BYOK) share finalize/persistence paths with hosted runs, and the
+ *     function-tool surface works on every provider.
+ *
+ * One context per session/iteration; `dispose()` MUST run (callers wrap the
+ * body in try/finally) so a launched Chromium never outlives its session.
  */
 
 import type { MCPClientManager } from "@mcpjam/sdk";
@@ -34,32 +45,35 @@ import type { ToolSet } from "ai";
 import {
   DEFAULT_VIEWPORT,
   McpAppBrowserHarness,
-} from "../../utils/mcp-app-browser-harness";
+} from "../utils/mcp-app-browser-harness";
 import {
   buildComputerUseTools,
   resolveComputerUseToolVersion,
-} from "../../utils/computer-use-tool";
+} from "../utils/computer-use-tool";
 import {
   isRenderableMcpAppTool,
   renderMcpAppToolResult,
-} from "../../utils/mcp-app-render-observation";
-import type { MCPJamToolResultEvent } from "../../utils/mcpjam-stream-handler.js";
-import type { PrepareAdvertisedTools } from "../../utils/advertised-tools";
+} from "../utils/mcp-app-render-observation";
+import type { MCPJamToolResultEvent } from "../utils/mcpjam-stream-handler.js";
+import type { DirectChatTurnToolResultChunk } from "../utils/direct-chat-turn.js";
+import type { PrepareAdvertisedTools } from "../utils/advertised-tools";
 import {
   isEvalTraceBrowserStepNote,
   type RunnerBrowserInteractionStep,
   type RunnerWidgetRenderObservation,
 } from "@/shared/eval-trace";
-import { logger } from "../../utils/logger";
+import { logger } from "../utils/logger";
 
-export interface CreateEvalBrowserContextParams {
-  /** Driver model id (`test.model`) — decides Computer Use availability. */
+export interface CreateBrowserSessionContextParams {
+  /** Driver model id — decides Computer Use availability (Claude-only). */
   model: string;
   mcpClientManager: MCPClientManager;
   injectOpenAiCompat?: boolean;
+  /** Log prefix so each surface stays greppable. Defaults to `"evals"`. */
+  logScope?: "evals" | "sessionSimulation";
 }
 
-export interface EvalBrowserContext {
+export interface BrowserSessionContext {
   /** Non-null exactly when the driver model supports Computer Use. */
   readonly computerUseVersion: ReturnType<typeof resolveComputerUseToolVersion>;
   /** Wire-format `computer` + `finish_widget`, or `{}` for non-Claude drivers. */
@@ -76,6 +90,23 @@ export interface EvalBrowserContext {
   noteToolCallInput(event: { toolCallId: string; input: unknown }): void;
   /** Engine `onToolResult` hook — renders MCP App results in the harness. */
   handleEngineToolResult(event: MCPJamToolResultEvent): Promise<void>;
+  /** Local AI-SDK `traceEvents.onToolResultChunk` hook — same render path,
+   *  with the tool input taken from the chunk instead of the call cache. */
+  handleDirectToolResultChunk(
+    chunk: Pick<
+      DirectChatTurnToolResultChunk,
+      "toolCallId" | "toolName" | "input" | "output" | "serverId"
+    >,
+  ): Promise<void>;
+  /**
+   * Return artifacts appended since the previous drain (both arrays stay
+   * intact for end-of-run consumers like `finalizeEvalIteration`). Lets
+   * per-turn persisters (the simulation runner) upload incrementally.
+   */
+  drainNewArtifacts(): {
+    observations: RunnerWidgetRenderObservation[];
+    steps: RunnerBrowserInteractionStep[];
+  };
   /** Start-of-turn hygiene: a widget kept mounted by a previous prompt turn
    *  must not bleed into this one. */
   dismissCarriedWidget(): Promise<void>;
@@ -83,10 +114,11 @@ export interface EvalBrowserContext {
   dispose(): Promise<void>;
 }
 
-export function createEvalBrowserContext(
-  params: CreateEvalBrowserContextParams,
-): EvalBrowserContext {
+export function createBrowserSessionContext(
+  params: CreateBrowserSessionContextParams,
+): BrowserSessionContext {
   const { mcpClientManager, injectOpenAiCompat } = params;
+  const scope = params.logScope ?? "evals";
   const computerUseVersion = resolveComputerUseToolVersion(params.model);
 
   const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
@@ -97,6 +129,8 @@ export function createEvalBrowserContext(
   const stepIndexByToolCallId = new Map<string, number>();
   const inputByToolCallId = new Map<string, Record<string, unknown>>();
   let activePromptIndex = 0;
+  let drainedObservationCount = 0;
+  let drainedStepCount = 0;
 
   const ensureWidgetHarness = (): McpAppBrowserHarness => {
     if (!widgetHarnessRef.current) {
@@ -126,8 +160,8 @@ export function createEvalBrowserContext(
         // `/stream` request; the provider-native factory can't ride that wire.
         wireFormat: true,
         // One browserInteractionStep per executeAction. The screenshot stays
-        // base64 here; finalizeEvalIteration uploads it once for both the W2
-        // and W1 persistence paths.
+        // base64 here; the persisters upload it (finalizeEvalIteration for
+        // evals, the per-turn artifact write for synthetic sessions).
         onAction: (result, { toolCallId }) => {
           const stepIndex = (stepIndexByToolCallId.get(toolCallId) ?? -1) + 1;
           stepIndexByToolCallId.set(toolCallId, stepIndex);
@@ -139,7 +173,7 @@ export function createEvalBrowserContext(
             if (isEvalTraceBrowserStepNote(result.note)) {
               note = result.note;
             } else {
-              logger.warn("[evals] dropping unknown browser-step note", {
+              logger.warn(`[${scope}] dropping unknown browser-step note`, {
                 note: result.note,
                 toolCallId,
               });
@@ -179,28 +213,27 @@ export function createEvalBrowserContext(
               )
       : undefined;
 
-  const handleEngineToolResult = async (
-    event: MCPJamToolResultEvent,
-  ): Promise<void> => {
-    const { toolCallId, toolName, serverId } = event;
-    if (!serverId || !toolName) return;
-    if (event.isError) return;
-    const meta = mcpClientManager.getAllToolsMetadata(serverId)?.[toolName];
+  /** Shared render path: read the widget resource, mount it in the harness,
+   *  record the observation. Containment contract: never throws. */
+  const renderIfRenderable = async (args: {
+    toolCallId: string;
+    toolName: string;
+    serverId: string;
+    toolInput: Record<string, unknown> | undefined;
+    output: unknown;
+  }): Promise<void> => {
+    const meta = mcpClientManager.getAllToolsMetadata(args.serverId)?.[
+      args.toolName
+    ];
     if (!isRenderableMcpAppTool(meta)) return;
     try {
       const obs = await renderMcpAppToolResult({
-        toolCallId,
-        toolName,
-        serverId,
+        toolCallId: args.toolCallId,
+        toolName: args.toolName,
+        serverId: args.serverId,
         toolMetadata: meta,
-        // Feed the real tool-call args to the widget shim so the hosted-path
-        // render matches what the local runners (and post-turn snapshot
-        // capture) inject.
-        toolInput: inputByToolCallId.get(toolCallId),
-        // `rawResult` is the unscrubbed implementation result; `output` on the
-        // event is the LLM-facing view with `_meta` / `structuredContent`
-        // scrubbed, which would starve the widget shim of its data.
-        output: event.rawResult ?? event.output,
+        toolInput: args.toolInput,
+        output: args.output,
         mcpClientManager,
         injectOpenAiCompat,
         harness: ensureWidgetHarness(),
@@ -212,16 +245,54 @@ export function createEvalBrowserContext(
         ...obs,
         promptIndex: activePromptIndex,
       });
-      logger.debug("[evals] widget render observation (hosted path)", {
-        toolName,
+      logger.debug(`[${scope}] widget render observation`, {
+        toolName: args.toolName,
         status: obs.status,
       });
     } catch (err) {
-      logger.warn("[evals] widget render failed (hosted path)", {
-        toolName,
+      logger.warn(`[${scope}] widget render failed`, {
+        toolName: args.toolName,
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  };
+
+  const handleEngineToolResult = async (
+    event: MCPJamToolResultEvent,
+  ): Promise<void> => {
+    const { toolCallId, toolName, serverId } = event;
+    if (!serverId || !toolName) return;
+    if (event.isError) return;
+    await renderIfRenderable({
+      toolCallId,
+      toolName,
+      serverId,
+      // Feed the real tool-call args to the widget shim so the engine-path
+      // render matches what the local runners (and post-turn snapshot
+      // capture) inject.
+      toolInput: inputByToolCallId.get(toolCallId),
+      // `rawResult` is the unscrubbed implementation result; `output` on the
+      // event is the LLM-facing view with `_meta` / `structuredContent`
+      // scrubbed, which would starve the widget shim of its data.
+      output: event.rawResult ?? event.output,
+    });
+  };
+
+  const handleDirectToolResultChunk = async (
+    chunk: Pick<
+      DirectChatTurnToolResultChunk,
+      "toolCallId" | "toolName" | "input" | "output" | "serverId"
+    >,
+  ): Promise<void> => {
+    if (!chunk.serverId) return;
+    await renderIfRenderable({
+      toolCallId: chunk.toolCallId,
+      toolName: chunk.toolName,
+      serverId: chunk.serverId,
+      // The chunk carries the already-normalized tool input inline.
+      toolInput: chunk.input,
+      output: chunk.output,
+    });
   };
 
   return {
@@ -246,6 +317,16 @@ export function createEvalBrowserContext(
       }
     },
     handleEngineToolResult,
+    handleDirectToolResultChunk,
+    drainNewArtifacts() {
+      const observations = widgetRenderObservations.slice(
+        drainedObservationCount,
+      );
+      const steps = browserInteractionSteps.slice(drainedStepCount);
+      drainedObservationCount = widgetRenderObservations.length;
+      drainedStepCount = browserInteractionSteps.length;
+      return { observations, steps };
+    },
     async dismissCarriedWidget(): Promise<void> {
       const carriedWidgetId =
         widgetHarnessRef.current?.getMountedWidgetId() ?? null;
@@ -256,7 +337,7 @@ export function createEvalBrowserContext(
     async dispose(): Promise<void> {
       await widgetHarnessRef.current?.dispose();
       if (widgetRenderObservations.length > 0) {
-        logger.debug("[evals] widget render observations (hosted path)", {
+        logger.debug(`[${scope}] widget render observations`, {
           count: widgetRenderObservations.length,
           statuses: widgetRenderObservations.map((o) => o.status),
         });

--- a/mcpjam-inspector/server/services/browser-session-context.ts
+++ b/mcpjam-inspector/server/services/browser-session-context.ts
@@ -261,16 +261,20 @@ export function createBrowserSessionContext(
     event: MCPJamToolResultEvent,
   ): Promise<void> => {
     const { toolCallId, toolName, serverId } = event;
+    // Feed the real tool-call args to the widget shim so the engine-path
+    // render matches what the local runners (and post-turn snapshot
+    // capture) inject. The entry is consumed here — once the call's result
+    // has arrived nothing reads it again, so release it on every exit path
+    // to keep the cache bounded over long sessions (CodeRabbit, PR 2610).
+    const toolInput = inputByToolCallId.get(toolCallId);
+    inputByToolCallId.delete(toolCallId);
     if (!serverId || !toolName) return;
     if (event.isError) return;
     await renderIfRenderable({
       toolCallId,
       toolName,
       serverId,
-      // Feed the real tool-call args to the widget shim so the engine-path
-      // render matches what the local runners (and post-turn snapshot
-      // capture) inject.
-      toolInput: inputByToolCallId.get(toolCallId),
+      toolInput,
       // `rawResult` is the unscrubbed implementation result; `output` on the
       // event is the LLM-facing view with `_meta` / `structuredContent`
       // scrubbed, which would starve the widget shim of its data.

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -64,7 +64,6 @@ import {
   finalizeAiSdkTraceOnFailure,
   patchAiSdkRecordedSpansMessageRangesFromSteps,
   registerAiSdkPrepareStep,
-  wrapToolSetForEvalTrace,
 } from "./evals/eval-trace-capture";
 import type {
   EvalTraceBlobV1,
@@ -85,13 +84,12 @@ import {
   prepareChatV2,
   type PrepareChatV2Result,
 } from "../utils/chat-v2-orchestration.js";
-import { runAssistantTurn } from "../utils/assistant-turn.js";
 import type {
-  MCPJamEngineErrorEvent,
   MCPJamStepFinishEvent,
   MCPJamToolCallEvent,
   MCPJamToolResultEvent,
 } from "../utils/mcpjam-stream-handler.js";
+import { driveHostedEvalTurn } from "./evals/drive-hosted-eval-turn.js";
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
 import { finalizeEvalIteration } from "./evals/finalize-iteration.js";
 import {
@@ -1953,267 +1951,39 @@ const runIterationViaBackendWithBrowser = async (
       return returnCancelled();
     }
 
-    const promptTurn = promptTurns[promptIndex]!;
-
-    // Browser-rendered MCP App eval (PR 14): stamp collected artifacts with
-    // this turn, and start the turn with a clean widget surface — a widget
-    // kept mounted by a previous prompt turn must not bleed into this one
-    // (otherwise Computer Use could be advertised against the prior turn's
-    // widget before this turn's own MCP App tool runs).
-    browser.setActivePromptIndex(promptIndex);
-    await browser.dismissCarriedWidget();
-
-    // Per-turn span-capture context. `wrapToolSetForEvalTrace` instruments
-    // each tool's `execute` to push to `traceCtx.recordedSpans`; we drain
-    // into `capturedSpans` after the engine finishes.
-    const traceCtx = createAiSdkEvalTraceContext(runStartedAt);
-    // PR 14: the Computer Use tools ride the same wrap so `computer` /
-    // `finish_widget` executions land as tool spans in the trace UI like
-    // every other locally-executed tool.
-    const tracedTools = wrapToolSetForEvalTrace(
-      { ...prepared.allTools, ...browser.computerWidgetTools },
-      traceCtx,
-      promptIndex
-    );
-
-    // Cursor review round-2 fix: push the user prompt into
-    // `messageHistory` BEFORE the engine call so a failed turn still
-    // persists the user side of the transcript. The legacy backend
-    // loop pushed the user message at the top of its per-step while
-    // loop; that meant `finishIteration` saw the user prompt even
-    // when the iteration failed mid-step. Recording the input keeps
-    // the transcript honest about WHICH turn errored.
-    messageHistory.push({
-      role: "user",
-      content: promptTurn.prompt,
+    // Shared hosted-turn body (engine call + browser pipeline + accumulator
+    // drains + three-shape failure detection) — see driveHostedEvalTurn.
+    // This batch runner layers no SSE sinks.
+    const outcome = await driveHostedEvalTurn({
+      promptIndex,
+      prompt: promptTurns[promptIndex]!.prompt,
+      browser,
+      prepared,
+      modelDefinition,
+      modelId,
+      selectedServers,
+      mcpClientManager,
+      evalAuthContext,
+      endpointPath,
+      extraBodyFields,
+      toolChoice,
+      abortSignal,
+      maxSteps: MAX_STEPS,
+      runStartedAt,
+      isAborted,
+      extractToolCalls: (messages) =>
+        extractToolCallsFromConversation({ messages }),
+      acc: {
+        messageHistory,
+        capturedSpans,
+        accumulatedUsage,
+        toolsCalledByPrompt,
+      },
     });
-    const messageCountBeforeTurn = messageHistory.length;
-    const inputMessages: ModelMessage[] = [...messageHistory];
-
-    // Cursor + Codex review fix: thread `toolChoice` AND
-    // `maxOutputTokens` through `extraBodyFields` since the engine's
-    // `RunAssistantTurnOptions` / `MCPJamHandlerOptions` don't expose
-    // them as first-class fields. The Convex `/stream` (and
-    // `/stream/org`) handlers already accept both in the request body
-    // — the engine spreads `extraBodyFields` into the body unchanged.
-    // `maxOutputTokens: 16384` matches the legacy per-step Convex body
-    // (Cursor round-2 finding "Dropped eval maxOutputTokens limit"):
-    // without it, hosted backend eval turns would inherit the
-    // `/stream` handler's default, which can truncate long multi-step
-    // tool loops differently than the historical eval cap.
-    const mergedExtraBodyFields: Record<string, unknown> = {
-      maxOutputTokens: 16384,
-      ...(extraBodyFields ?? {}),
-      ...(toolChoice ? { toolChoice } : {}),
-    };
-
-    let turnResult: Awaited<ReturnType<typeof runAssistantTurn>>;
-    try {
-      turnResult = await runAssistantTurn({
-        messages: inputMessages,
-        // Eval's `runTestCase` already resolved the canonical model id
-        // (`getCanonicalModelId(modelDefinition.id, provider)`) and threads
-        // it in as `modelId` — for the JAM-paid path that's e.g.
-        // `anthropic/claude-haiku-4.5`. The engine reads
-        // `modelDefinition.id` for the wire payload, so override here so
-        // backend wallet/quota lookup keys match what live chat sends.
-        modelDefinition: { ...modelDefinition, id: modelId },
-        systemPrompt: prepared.enhancedSystemPrompt,
-        ...(prepared.resolvedTemperature != null
-          ? { temperature: prepared.resolvedTemperature }
-          : {}),
-        tools: tracedTools,
-        ...(selectedServers.length
-          ? { selectedServerIds: selectedServers }
-          : {}),
-        mcpClientManager,
-        authContext: evalAuthContext,
-        sourceType: "eval",
-        origin: "eval",
-        streamSink: "none",
-        persistMode: "caller",
-        approvalMode: "auto-deny",
-        endpointPath,
-        extraBodyFields: mergedExtraBodyFields,
-        ...(abortSignal ? { abortSignal } : {}),
-        maxSteps: MAX_STEPS,
-        progressivePlan: prepared.progressivePlan,
-        discoveryState: prepared.discoveryState,
-        // Browser-rendered MCP App eval (PR 14): cache tool-call inputs for
-        // the widget shim, render MCP App tool results in the harness (the
-        // engine awaits the hook, so a mounted widget is visible to the next
-        // step's gate), and hide `computer` / `finish_widget` until a widget
-        // has actually rendered.
-        onToolCall: (event) => browser.noteToolCallInput(event),
-        onToolResult: (event) => browser.handleEngineToolResult(event),
-        ...(browser.prepareAdvertisedTools
-          ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
-          : {}),
-      });
-    } catch (error) {
-      // Cancellation: bail without recording. AbortError can surface
-      // either as a thrown exception (when fetch is aborted mid-flight)
-      // or as the engine's internal silent-cancellation path (handled
-      // by the `isAborted()` check after the success path below). Check
-      // `abortSignal.aborted` to catch BOTH paths consistently.
-      if (
-        isAborted() ||
-        (error instanceof Error && error.name === "AbortError")
-      ) {
-        logger.debug("[evals] backend iteration aborted due to cancellation");
-        return returnCancelled();
-      }
-
-      // Non-abort runtime error from the engine. Map to `iterationError`
-      // for the post-loop verdict gate; preserve a truncated message and,
-      // when available, a `responseBody` for `errorDetails`.
-      if (error instanceof Error) {
-        iterationError = error.message || error.toString();
-        const responseBody = (error as { responseBody?: unknown }).responseBody;
-        if (responseBody && typeof responseBody === "string") {
-          iterationErrorDetails = responseBody;
-        }
-      } else if (typeof error === "string") {
-        iterationError = error;
-      } else {
-        iterationError = String(error);
-      }
-      if (iterationError && iterationError.length > 500) {
-        iterationError = iterationError.substring(0, 497) + "...";
-      }
-      logger.error("[evals] runAssistantTurn failed", error);
-      break;
-    }
-
-    // Cursor review fix: cancellation that fired DURING
-    // `runAssistantTurn` without surfacing as a throw. The engine
-    // catches AbortError, sets its internal `aborted` flag, omits the
-    // `turnTrace`, and returns normally. Without this check we'd fall
-    // through to the silent-cycle-failure branch below and record an
-    // aborted run as a verdict failure.
-    if (isAborted()) {
-      logger.debug(
-        "[evals] backend iteration aborted mid-turn; skipping record"
-      );
-      return returnCancelled();
-    }
-
-    // Drain per-turn outputs into the iteration-level accumulators
-    // BEFORE the failure checks below. Doing it first preserves
-    // whatever partial good state the engine produced (tool spans,
-    // partial transcript, usage), so the persisted iteration shows
-    // what completed before the failure point.
-    //
-    // Codex round-3 (P2 "Preserve backend tool step indices"):
-    // `wrapToolSetForEvalTrace` records tool spans in
-    // `traceCtx.recordedSpans` but never gets `prepareStep` updates
-    // from the engine (eval is no longer calling `generateText`
-    // directly), so those spans land with `stepIndex: -1`. The engine
-    // emits its OWN correctly-indexed LLM-step spans into
-    // `turnTrace.spans` (already `EvalTraceSpan[]` shape — see
-    // `PersistedTurnTrace` in chat-ingestion.ts). Merge both: the
-    // engine's LLM spans give per-step granularity; the wrap's tool
-    // spans give per-tool-call detail. Tool spans still have
-    // `stepIndex: -1` for now — fixing that requires correlating
-    // each tool span back to its parent LLM step via the engine's
-    // step events, which is a separate workstream.
-    capturedSpans.push(...traceCtx.recordedSpans);
-    if (turnResult.turnTrace?.spans?.length) {
-      capturedSpans.push(...turnResult.turnTrace.spans);
-    }
-    if (turnResult.usage) {
-      accumulatedUsage.inputTokens =
-        (accumulatedUsage.inputTokens || 0) +
-        (turnResult.usage.inputTokens ?? 0);
-      accumulatedUsage.outputTokens =
-        (accumulatedUsage.outputTokens || 0) +
-        (turnResult.usage.outputTokens ?? 0);
-      accumulatedUsage.totalTokens =
-        (accumulatedUsage.totalTokens || 0) +
-        (turnResult.usage.totalTokens ?? 0);
-    }
-
-    // Extract per-turn tool calls from the new messages only (engine
-    // returns the FULL transcript; slice from `messageCountBeforeTurn`
-    // to get just this turn's appended assistant + tool messages so
-    // prior turns' calls aren't double-counted).
-    const newMessages = turnResult.messages.slice(messageCountBeforeTurn);
-    const promptToolsCalled = extractToolCallsFromConversation({
-      messages: newMessages,
-    });
-    toolsCalledByPrompt.push(promptToolsCalled);
-
-    // Roll the engine's transcript forward as the next turn's starting
-    // point. Includes prior conversation + this turn's user prompt + this
-    // turn's assistant/tool messages.
-    messageHistory.length = 0;
-    messageHistory.push(...turnResult.messages);
-
-    // Failure detection (ordered most-specific → least-specific).
-    // Three engine failure shapes the runner must catch:
-    //
-    //  (a) Cursor round-3 ("Partial turn hides engine failures"):
-    //      Engine catch fired AFTER partial messages were appended
-    //      (some text deltas / partial tool call landed before the
-    //      error). The engine's `executeEngine` `try { ... }
-    //      catch (error) { logger.error; emit error chunk; ... }` at
-    //      mcpjam-stream-handler.ts:2227 leaves `runSucceeded:
-    //      false` → `turnTrace` is NOT captured even though
-    //      `messages.length > messageCountBeforeTurn`. The
-    //      message-count check and the error-span check both miss
-    //      this. `!turnTrace` is the reliable signal.
-    //
-    //  (b) Codex P1 round-1 + the original silent-cycle-failure:
-    //      Engine succeeded (turnTrace captured) but produced no new
-    //      content (step-level non-OK at
-    //      mcpjam-stream-handler.ts:1384 returns
-    //      `shouldContinue:false`, synthetic finish, runSucceeded
-    //      true). Detect via `messages.length <=
-    //      messageCountBeforeTurn`.
-    //
-    //  (c) Codex P1 round-2 ("Fail turns when later backend steps
-    //      error"): step 1 succeeded, step 2 errored. `turnTrace`
-    //      captured, `messages.length` grew, but `turnTrace.spans`
-    //      includes an `EvalTraceSpan` with `status:"error"`.
-    if (!turnResult.turnTrace) {
-      iterationError =
-        "Backend stream failed during iteration (engine caught an error mid-turn)";
-      logger.error(
-        `[evals] runAssistantTurn returned no turnTrace (engine runSucceeded=false); treating as cycle failure (messagesGrew=${
-          newMessages.length > 0
-        })`
-      );
-      break;
-    }
-    if (newMessages.length === 0) {
-      iterationError =
-        "Backend step returned no content (stream error or empty response)";
-      logger.error(
-        "[evals] runAssistantTurn produced no new messages this turn; treating as cycle failure"
-      );
-      break;
-    }
-    // Codex P1 round-3 ("Don't treat tool-result error spans as
-    // backend failures"): `wrapBackendToolsForTrace` records ORDINARY
-    // local tool-result errors (MCP tool returned `isError: true`,
-    // tool execution threw, ...) as `status: "error"` with
-    // `category: "tool"`. The original match-any-error-span check
-    // would set `iterationError` and break before
-    // `finalizePassedForEval` could apply the configured
-    // `failOnToolError` policy — so otherwise-passing evals were
-    // force-failed when a tool returned a recoverable error and the
-    // model recovered. Filter to backend step / LLM failure spans
-    // only (categories `"step" | "llm" | "error"`); tool-category
-    // error spans flow through the existing tool-error gate (see
-    // `finalizePassedForEval` + `advancedConfig.failOnToolError`).
-    const stepErrorSpan = turnResult.turnTrace.spans.find(
-      (span) => span.status === "error" && span.category !== "tool"
-    );
-    if (stepErrorSpan) {
-      iterationError = `Backend step failed mid-turn: ${stepErrorSpan.name}`;
-      logger.error(
-        `[evals] runAssistantTurn turnTrace has non-tool error-status span; treating as cycle failure (span=${stepErrorSpan.name} category=${stepErrorSpan.category})`
-      );
+    if (outcome.kind === "cancelled") return returnCancelled();
+    if (outcome.kind === "failed") {
+      iterationError = outcome.iterationError;
+      iterationErrorDetails = outcome.iterationErrorDetails;
       break;
     }
   }
@@ -4065,623 +3835,265 @@ const streamIterationViaBackendWithBrowser = async (
     }
 
     const promptTurn = promptTurns[promptIndex]!;
-    const promptToolsCalled: ToolCall[] = [];
-    toolsCalledByPrompt.push(promptToolsCalled);
-    messageHistory.push({
-      role: "user",
-      content: promptTurn.prompt,
-    });
 
-    // Browser-rendered MCP App eval (PR 14): stamp collected artifacts with
-    // this turn, and start the turn with a clean widget surface (a widget
-    // kept mounted by a previous prompt turn must not bleed into this one).
-    browser.setActivePromptIndex(promptIndex);
-    await browser.dismissCarriedWidget();
-
-    emit({
-      type: "turn_start",
-      turnIndex: promptIndex,
+    // Shared hosted-turn body (engine call + browser pipeline + accumulator
+    // drains + three-shape failure detection) — see driveHostedEvalTurn.
+    // This SSE runner layers its emitters through `buildSinks`; the factory
+    // runs once per turn so the per-turn accumulators (partial-response
+    // builders, step counters, usage deltas) reset naturally.
+    const outcome = await driveHostedEvalTurn({
+      promptIndex,
       prompt: promptTurn.prompt,
-    });
+      browser,
+      prepared,
+      modelDefinition,
+      modelId,
+      selectedServers,
+      mcpClientManager,
+      evalAuthContext,
+      endpointPath,
+      extraBodyFields,
+      toolChoice,
+      abortSignal,
+      maxSteps: MAX_STEPS,
+      runStartedAt,
+      isAborted,
+      logSuffix: " (stream)",
+      extractToolCalls: (messages) =>
+        extractToolCallsFromConversation({ messages }),
+      acc: {
+        messageHistory,
+        capturedSpans,
+        accumulatedUsage,
+        toolsCalledByPrompt,
+      },
+      buildSinks: ({ baselineUsage, traceCtx, promptToolsCalled }) => {
+        // Track engine-emitted step events so the post-turn `turn_finish`
+        // trace_snapshot has a stable last-step index, and so failure
+        // branches can carry stepIndex when available.
+        let activeCompletedStepCount = 0;
+        let lastSettledStepIndex: number | undefined;
+        // Engine reports turn-cumulative usage on each `onStepFinish`. The
+        // legacy inline loop emitted PER-STEP token counts on `step_finish`
+        // SSE, so we track the previous step's cumulative and emit the delta.
+        // (Cursor PR 5b review fix: "Step finish reports cumulative usage".)
+        let prevStepCumulativeInput = 0;
+        let prevStepCumulativeOutput = 0;
 
-    // Per-turn span-capture context. `wrapToolSetForEvalTrace`
-    // instruments each tool's `execute` to push to
-    // `traceCtx.recordedSpans`; we drain into `capturedSpans` after the
-    // engine finishes (same shape as the non-stream backend runner).
-    const traceCtx = createAiSdkEvalTraceContext(runStartedAt);
-    // PR 14: Computer Use tools ride the same wrap (see the non-stream
-    // backend runner).
-    const tracedTools = wrapToolSetForEvalTrace(
-      { ...prepared.allTools, ...browser.computerWidgetTools },
-      traceCtx,
-      promptIndex
-    );
+        // In-flight partial-response accumulator. Mid-turn `step_finish`
+        // trace_snapshot needs to carry the assistant/tool content that
+        // already streamed within the turn — the engine doesn't roll its own
+        // `messageHistory` ref forward until the turn settles, so
+        // `messageHistory` here is stale (prior turns + this turn's user
+        // prompt). Mirror PR 5a's `activePartialResponseMessages` shape.
+        // (Cursor PR 5b review fix: "Step snapshots omit in-turn messages".)
+        let partialAssistantText = "";
+        const partialAssistantToolCalls: Array<{
+          type: "tool-call";
+          toolCallId: string;
+          toolName: string;
+          input: unknown;
+        }> = [];
+        const partialToolResultMessages: ModelMessage[] = [];
+        const buildPartialResponseMessages = (): ModelMessage[] => {
+          const content: unknown[] = [];
+          if (partialAssistantText) {
+            content.push({ type: "text", text: partialAssistantText });
+          }
+          content.push(...partialAssistantToolCalls);
+          const out: ModelMessage[] = [];
+          if (content.length > 0) {
+            out.push({ role: "assistant", content } as ModelMessage);
+          }
+          out.push(...partialToolResultMessages);
+          return out;
+        };
 
-    const messageCountBeforeTurn = messageHistory.length;
-    const inputMessages: ModelMessage[] = [...messageHistory];
-    const accumulatedUsageBeforeTurn = {
-      inputTokens: accumulatedUsage.inputTokens ?? 0,
-      outputTokens: accumulatedUsage.outputTokens ?? 0,
-      totalTokens: accumulatedUsage.totalTokens ?? 0,
-    };
-    // Track engine-emitted step events so the post-turn `turn_finish`
-    // trace_snapshot has a stable last-step index, and so failure
-    // branches can carry stepIndex when available.
-    let activeCompletedStepCount = 0;
-    let lastSettledStepIndex: number | undefined;
-    // Engine reports turn-cumulative usage on each `onStepFinish`. The
-    // legacy inline loop emitted PER-STEP token counts on
-    // `step_finish` SSE, so we track the previous step's cumulative
-    // and emit the delta. (Cursor PR 5b review fix: "Step finish
-    // reports cumulative usage" — multi-step hosted eval turns
-    // otherwise show inflated per-step counts vs the local-BYOK
-    // stream path / consumeFullStreamAsEvalEvents.)
-    let prevStepCumulativeInput = 0;
-    let prevStepCumulativeOutput = 0;
-
-    // In-flight partial-response accumulator. Mid-turn `step_finish`
-    // trace_snapshot needs to carry the assistant/tool content that
-    // already streamed within the turn — the engine doesn't roll its
-    // own `messageHistory` ref forward into `runAssistantTurn`'s
-    // return value until the turn settles, so `messageHistory` here
-    // is stale (only contains prior turns' history + this turn's user
-    // prompt). Mirror PR 5a's `activePartialResponseMessages` shape:
-    // synthesize one rolling assistant message from text deltas + tool
-    // calls, and append synthetic tool-result messages from tool
-    // results. (Cursor PR 5b review fix: "Step snapshots omit in-turn
-    // messages" — without this, live UI consumers watching SSE see
-    // empty assistant transcripts mid-turn even though tool_call /
-    // text_delta SSE already fired.)
-    let partialAssistantText = "";
-    const partialAssistantToolCalls: Array<{
-      type: "tool-call";
-      toolCallId: string;
-      toolName: string;
-      input: unknown;
-    }> = [];
-    const partialToolResultMessages: ModelMessage[] = [];
-    const buildPartialResponseMessages = (): ModelMessage[] => {
-      const content: unknown[] = [];
-      if (partialAssistantText) {
-        content.push({ type: "text", text: partialAssistantText });
-      }
-      content.push(...partialAssistantToolCalls);
-      const out: ModelMessage[] = [];
-      if (content.length > 0) {
-        out.push({ role: "assistant", content } as ModelMessage);
-      }
-      out.push(...partialToolResultMessages);
-      return out;
-    };
-
-    // PR 5b-followup-2: capture the engine's structured-error event
-    // when the Convex `/stream` response is non-OK (429 daily-cap,
-    // hosted-model errors, ...) or when an in-stream catch fires. The
-    // engine writes a generic `error` UI chunk to the no-op writer
-    // (because `streamSink: "none"`); the callback gives us the
-    // parsed `{ code?, message, details? }` shape so failure-detection
-    // branches below can surface the actual reason on the eval SSE
-    // error event instead of dropping the detail with the generic
-    // "Backend stream failed during iteration" fallback.
-    let lastEngineError: MCPJamEngineErrorEvent | undefined;
-
-    // Engine callbacks → SSE events. These mirror the events the old
-    // inline backend stream loop emitted from its chunk-processing
-    // switch:
-    //  - `onLiveTextDelta` → `text_delta` SSE + rolling assistant text
-    //  - `onToolCall`      → `tool_call` SSE + push to partial assistant
-    //  - `onToolResult`    → `tool_result` SSE + append synthetic tool msg
-    //  - `onStepFinish`    → `step_finish` SSE (with per-step usage
-    //                        DELTA, not cumulative) + step_finish trace
-    //                        snapshot. Gated on `settledWithError ===
-    //                        false` per Marcelo's PR 5b-pre review
-    //                        caveat. After firing, the partial-response
-    //                        accumulators reset so the next step starts
-    //                        fresh.
-    //  - `onEngineError`   → captures the structured guardrail error
-    //                        body for use in the failure-detection
-    //                        fallback (PR 5b-followup-2).
-    //
-    // `promptToolsCalled` mirrors the legacy local accumulator; the
-    // engine's `messageHistory` is the source of truth post-turn, so
-    // we also rebuild from there for the eval grader (see
-    // `extractToolCallsFromConversation` below). Pushing into
-    // `promptToolsCalled` here keeps the SSE consumer's running view
-    // aligned with the trace snapshot's `actualToolCalls`.
-    const onLiveTextDelta = (delta: string) => {
-      if (typeof delta !== "string" || delta.length === 0) return;
-      partialAssistantText += delta;
-      emit({ type: "text_delta", content: delta });
-    };
-    const onToolCall = (event: MCPJamToolCallEvent) => {
-      if (!event.toolName) return;
-      // PR 14: cache the input so the widget render hook can feed the
-      // OpenAI-compat shim the real tool-call args.
-      browser.noteToolCallInput(event);
-      const args = (event.input ?? {}) as Record<string, unknown>;
-      promptToolsCalled.push({
-        toolName: event.toolName,
-        arguments: args as Record<string, any>,
-      });
-      partialAssistantToolCalls.push({
-        type: "tool-call",
-        toolCallId: event.toolCallId,
-        toolName: event.toolName,
-        input: args,
-      });
-      emit({
-        type: "tool_call",
-        toolName: event.toolName,
-        toolCallId: event.toolCallId,
-        args,
-      });
-    };
-    const onToolResult = async (event: MCPJamToolResultEvent) => {
-      partialToolResultMessages.push({
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: event.toolCallId,
-            ...(event.toolName ? { toolName: event.toolName } : {}),
-            output: event.output,
-            ...(event.isError ? { isError: true } : {}),
+        // Engine callbacks → SSE events, mirroring the legacy inline loop:
+        //  - `onLiveTextDelta` → `text_delta` SSE + rolling assistant text
+        //  - `onToolCall`      → `tool_call` SSE + push to partial assistant
+        //                        (the input cache write happens in the shared
+        //                        helper before this sink fires)
+        //  - `onToolResult`    → `tool_result` SSE + synthetic tool msg (the
+        //                        harness render happens in the shared helper
+        //                        AFTER this sink — live consumers shouldn't
+        //                        wait on Chromium)
+        //  - `onStepFinish`    → `step_finish` SSE (per-step usage DELTA) +
+        //                        step_finish trace snapshot, gated on
+        //                        `settledWithError === false`
+        //  - `onTurnFailure`   → failure trace_snapshot + `error` SSE
+        //  - `onTurnSuccess`   → turn_finish trace_snapshot + `turn_finish`
+        return {
+          onTurnStart: () =>
+            emit({
+              type: "turn_start",
+              turnIndex: promptIndex,
+              prompt: promptTurn.prompt,
+            }),
+          onLiveTextDelta: (delta: string) => {
+            if (typeof delta !== "string" || delta.length === 0) return;
+            partialAssistantText += delta;
+            emit({ type: "text_delta", content: delta });
           },
-        ],
-      } as ModelMessage);
-      emit({
-        type: "tool_result",
-        toolCallId: event.toolCallId,
-        result: event.output,
-        isError: event.isError,
-      });
-      // PR 14: render MCP App tool results in the harness AFTER the SSE
-      // emit (live consumers shouldn't wait on Chromium). The engine awaits
-      // this callback, so the widget is mounted before the next step's
-      // advertised-tool gate runs.
-      await browser.handleEngineToolResult(event);
-    };
-    const onStepFinish = (event: MCPJamStepFinishEvent) => {
-      // Marcelo's PR 5b-pre review caveat: only emit `step_finish` for
-      // settled-OK steps; failed backend steps surface through the
-      // post-turn failure detection (no `turnTrace`, error span, etc).
-      if (event.settledWithError) return;
-      activeCompletedStepCount += 1;
-      lastSettledStepIndex = event.stepIndex;
-      // Per-step delta = cumulative-now − cumulative-at-prev-step.
-      // Engine reports turn-cumulative on `event.turnUsage`; emit just
-      // this step's contribution on the SSE `step_finish.usage` field
-      // so the wire shape matches the legacy inline loop (which
-      // forwarded each step's own `messageMetadata` totals).
-      const cumulativeInput = event.turnUsage?.inputTokens ?? 0;
-      const cumulativeOutput = event.turnUsage?.outputTokens ?? 0;
-      const cumulativeTotal = event.turnUsage?.totalTokens ?? 0;
-      const stepDeltaInput = Math.max(
-        0,
-        cumulativeInput - prevStepCumulativeInput
-      );
-      const stepDeltaOutput = Math.max(
-        0,
-        cumulativeOutput - prevStepCumulativeOutput
-      );
-      prevStepCumulativeInput = cumulativeInput;
-      prevStepCumulativeOutput = cumulativeOutput;
-      // Roll `accumulatedUsage` forward to the engine's reported
-      // turn-cumulative + the pre-turn baseline (multi-turn runs).
-      accumulatedUsage.inputTokens =
-        accumulatedUsageBeforeTurn.inputTokens + cumulativeInput;
-      accumulatedUsage.outputTokens =
-        accumulatedUsageBeforeTurn.outputTokens + cumulativeOutput;
-      accumulatedUsage.totalTokens =
-        accumulatedUsageBeforeTurn.totalTokens + cumulativeTotal;
-      emit({
-        type: "step_finish",
-        stepNumber: activeCompletedStepCount,
-        usage: {
-          inputTokens: stepDeltaInput,
-          outputTokens: stepDeltaOutput,
-        },
-      });
-      // Live trace snapshot for the step. Compose snapshot messages
-      // from the stale `messageHistory` (prior turns + this turn's
-      // user prompt) PLUS the in-flight partial response built from
-      // the chunk-event accumulators — without this, mid-turn step
-      // snapshots show only the user prompt even though `tool_call` /
-      // `text_delta` SSE already fired. Spans:
-      //  - `capturedSpans`        — prior turns' merged spans.
-      //  - `traceCtx.recordedSpans` — this turn's tool-instrumentation
-      //                              spans from `wrapToolSetForEvalTrace`.
-      //  - `event.turnSpans`      — PR 5b-followup-2: this turn's
-      //                              engine-recorded LLM-step + tool
-      //                              spans, snapshot at step settlement
-      //                              (closes Cursor PR 5b "Step
-      //                              snapshots omit LLM spans"). Without
-      //                              this the live trace UI lost
-      //                              per-step LLM timing for
-      //                              multi-step hosted streaming evals.
-      const snapshotMessages = [
-        ...messageHistory,
-        ...buildPartialResponseMessages(),
-      ];
-      emit(
-        buildTraceSnapshotEvent({
-          turnIndex: promptIndex,
-          stepIndex: event.stepIndex,
-          snapshotKind: "step_finish",
-          messages: withSystemPrefix(snapshotMessages),
-          spans: [
-            ...capturedSpans,
-            ...traceCtx.recordedSpans,
-            ...event.turnSpans,
-          ],
-          actualToolCalls: extractToolCallsFromConversation({
-            messages: snapshotMessages,
-          }),
-          usage: accumulatedUsage,
-        })
-      );
-      // NO per-step reset of partial-response accumulators. The
-      // earlier version of this PR cleared them here, which corrupted
-      // step N's snapshot by dropping step 1..N-1's assistant/tool
-      // content — `messageHistory` doesn't roll forward from
-      // `turnResult.messages` until AFTER `runAssistantTurn` returns,
-      // so during the turn the accumulators are the ONLY source of
-      // in-flight content for snapshot fidelity. The accumulators are
-      // per-turn `let`s scoped to this `for` body, so they reset
-      // naturally on the next prompt-turn iteration; no double-count
-      // risk because `messageHistory` is replaced with the engine's
-      // canonical post-turn transcript below before the next iteration.
-    };
-    // PR 5b-followup-2: capture the engine's structured-error event.
-    // The callback fires at the same site that emits the writer-side
-    // `error` UI chunk; capturing here lets the failure-detection
-    // branches below surface guardrail detail (429 daily-cap text,
-    // hosted-model setup errors, ...) on the eval SSE error event.
-    const onEngineError = (event: MCPJamEngineErrorEvent) => {
-      lastEngineError = event;
-    };
-
-    // `runAssistantTurn` call shape mirrors `runIterationViaBackend`
-    // (the non-stream backend runner) with SSE callback wires added.
-    // The contract bullets carried since PR 5a:
-    //  - Wire shape: `systemPrompt:` arg (engine sends `system:` field
-    //    to Convex `/stream`).
-    //  - Persistence prefix: `backendEnhancedSystemPromptForPersist`
-    //    prepended at finishParams (see post-loop section).
-    //  - SSE prefix: `withSystemPrefix` applied at every
-    //    `buildTraceSnapshotEvent` call site.
-    //  - Eval correctness invariants: progressive discovery, skill
-    //    tools, anthropic name validation flow from `prepareChatV2`.
-    //  - Resolver wire-up: `resolveExecutionContext` + suite
-    //    hostConfig already in place (PR 4d).
-    //  - UI event contract preserved: text_delta / tool_call /
-    //    tool_result / step_finish / turn_finish / trace_snapshot all
-    //    still emit in the same order as the legacy inline loop.
-    const mergedExtraBodyFields: Record<string, unknown> = {
-      maxOutputTokens: 16384,
-      ...(extraBodyFields ?? {}),
-      ...(toolChoice ? { toolChoice } : {}),
-    };
-
-    let turnResult: Awaited<ReturnType<typeof runAssistantTurn>>;
-    try {
-      turnResult = await runAssistantTurn({
-        messages: inputMessages,
-        modelDefinition: { ...modelDefinition, id: modelId },
-        systemPrompt: prepared.enhancedSystemPrompt,
-        ...(prepared.resolvedTemperature != null
-          ? { temperature: prepared.resolvedTemperature }
-          : {}),
-        tools: tracedTools,
-        ...(selectedServers.length
-          ? { selectedServerIds: selectedServers }
-          : {}),
-        mcpClientManager,
-        authContext: evalAuthContext,
-        sourceType: "eval",
-        origin: "eval",
-        streamSink: "none",
-        persistMode: "caller",
-        approvalMode: "auto-deny",
-        endpointPath,
-        extraBodyFields: mergedExtraBodyFields,
-        ...(abortSignal ? { abortSignal } : {}),
-        maxSteps: MAX_STEPS,
-        progressivePlan: prepared.progressivePlan,
-        discoveryState: prepared.discoveryState,
-        onLiveTextDelta,
-        onToolCall,
-        onToolResult,
-        onStepFinish,
-        onEngineError,
-        // Browser-rendered MCP App eval (PR 14): hide `computer` /
-        // `finish_widget` until a widget has actually rendered.
-        ...(browser.prepareAdvertisedTools
-          ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
-          : {}),
-      });
-    } catch (error) {
-      // Cancellation: bail without recording. AbortError can surface
-      // either as a thrown exception or as the engine's internal
-      // silent-cancellation path; check `isAborted()` to catch both.
-      if (
-        isAborted() ||
-        (error instanceof Error && error.name === "AbortError")
-      ) {
-        logger.debug(
-          "[evals] backend streaming iteration aborted due to cancellation"
-        );
-        return returnCancelled();
-      }
-
-      if (error instanceof Error) {
-        iterationError = error.message || error.toString();
-        const responseBody = (error as { responseBody?: unknown }).responseBody;
-        if (responseBody && typeof responseBody === "string") {
-          iterationErrorDetails = responseBody;
-        }
-      } else if (typeof error === "string") {
-        iterationError = error;
-      } else {
-        iterationError = String(error);
-      }
-      if (iterationError && iterationError.length > 500) {
-        iterationError = iterationError.substring(0, 497) + "...";
-      }
-      logger.error("[evals] runAssistantTurn (stream) failed", error);
-      // Mirror the in-stream failure signal the legacy inline loop
-      // emitted: failure trace_snapshot + error event before `break`
-      // so live SSE consumers don't see a silent end.
-      emit(
-        buildTraceSnapshotEvent({
-          turnIndex: promptIndex,
-          ...(lastSettledStepIndex != null
-            ? { stepIndex: lastSettledStepIndex }
-            : {}),
-          snapshotKind: "failure",
-          messages: withSystemPrefix(messageHistory),
-          spans: capturedSpans,
-          actualToolCalls: extractToolCallsFromConversation({
-            messages: messageHistory,
-          }),
-          usage: accumulatedUsage,
-        })
-      );
-      emit({
-        type: "error",
-        message: iterationError,
-        details: iterationErrorDetails,
-      });
-      break;
-    }
-
-    // Cancellation that fired DURING `runAssistantTurn` without
-    // surfacing as a throw (engine catches AbortError, sets internal
-    // `aborted` flag, omits `turnTrace`, returns normally).
-    if (isAborted()) {
-      logger.debug(
-        "[evals] backend streaming iteration aborted mid-turn; skipping record"
-      );
-      return returnCancelled();
-    }
-
-    // Drain per-turn outputs into iteration-level accumulators BEFORE
-    // failure checks. Same shape as `runIterationViaBackend` (PR 3/4d).
-    //
-    // Tool spans from `wrapToolSetForEvalTrace` land in
-    // `traceCtx.recordedSpans` with `stepIndex: -1` (no `prepareStep`
-    // bridge to the engine yet); the engine's own LLM-step spans land
-    // on `turnResult.turnTrace.spans` with correct per-step indices.
-    // Merge both for the persisted run.
-    capturedSpans.push(...traceCtx.recordedSpans);
-    if (turnResult.turnTrace?.spans?.length) {
-      capturedSpans.push(...turnResult.turnTrace.spans);
-    }
-    // Reconcile accumulated usage to the engine's canonical post-turn
-    // total. The per-step `onStepFinish` callback already updates
-    // `accumulatedUsage` for each completed step, but if the engine
-    // resolved with zero settled-OK steps (no-content failure path),
-    // the baseline is the only source of truth — fold in `turnTrace.usage`
-    // to match the non-stream runner's "totalUsage merged BEFORE
-    // failure branches" invariant from PR 4b.
-    if (turnResult.usage) {
-      accumulatedUsage.inputTokens =
-        accumulatedUsageBeforeTurn.inputTokens +
-        (turnResult.usage.inputTokens ?? 0);
-      accumulatedUsage.outputTokens =
-        accumulatedUsageBeforeTurn.outputTokens +
-        (turnResult.usage.outputTokens ?? 0);
-      accumulatedUsage.totalTokens =
-        accumulatedUsageBeforeTurn.totalTokens +
-        (turnResult.usage.totalTokens ?? 0);
-    }
-
-    // Per-turn tool calls — rebuild from the new messages only so
-    // prior turns' calls aren't double-counted. The engine returns
-    // the full transcript; slice from `messageCountBeforeTurn`.
-    const newMessages = turnResult.messages.slice(messageCountBeforeTurn);
-    // `promptToolsCalled` was already populated via the `onToolCall`
-    // callback during the run. Reconcile against the engine's
-    // transcript so the grader sees the canonical post-turn shape
-    // (handles cases where `onToolCall` arguments were `undefined`).
-    const canonicalPromptToolsCalled = extractToolCallsFromConversation({
-      messages: newMessages,
+          onToolCall: (event: MCPJamToolCallEvent) => {
+            if (!event.toolName) return;
+            const args = (event.input ?? {}) as Record<string, unknown>;
+            promptToolsCalled.push({
+              toolName: event.toolName,
+              arguments: args as Record<string, any>,
+            });
+            partialAssistantToolCalls.push({
+              type: "tool-call",
+              toolCallId: event.toolCallId,
+              toolName: event.toolName,
+              input: args,
+            });
+            emit({
+              type: "tool_call",
+              toolName: event.toolName,
+              toolCallId: event.toolCallId,
+              args,
+            });
+          },
+          onToolResult: (event: MCPJamToolResultEvent) => {
+            partialToolResultMessages.push({
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: event.toolCallId,
+                  ...(event.toolName ? { toolName: event.toolName } : {}),
+                  output: event.output,
+                  ...(event.isError ? { isError: true } : {}),
+                },
+              ],
+            } as ModelMessage);
+            emit({
+              type: "tool_result",
+              toolCallId: event.toolCallId,
+              result: event.output,
+              isError: event.isError,
+            });
+          },
+          onStepFinish: (event: MCPJamStepFinishEvent) => {
+            // Marcelo's PR 5b-pre review caveat: only emit `step_finish` for
+            // settled-OK steps; failed backend steps surface through the
+            // post-turn failure detection.
+            if (event.settledWithError) return;
+            activeCompletedStepCount += 1;
+            lastSettledStepIndex = event.stepIndex;
+            // Per-step delta = cumulative-now − cumulative-at-prev-step.
+            const cumulativeInput = event.turnUsage?.inputTokens ?? 0;
+            const cumulativeOutput = event.turnUsage?.outputTokens ?? 0;
+            const cumulativeTotal = event.turnUsage?.totalTokens ?? 0;
+            const stepDeltaInput = Math.max(
+              0,
+              cumulativeInput - prevStepCumulativeInput
+            );
+            const stepDeltaOutput = Math.max(
+              0,
+              cumulativeOutput - prevStepCumulativeOutput
+            );
+            prevStepCumulativeInput = cumulativeInput;
+            prevStepCumulativeOutput = cumulativeOutput;
+            // Roll `accumulatedUsage` forward to the engine's reported
+            // turn-cumulative + the pre-turn baseline (multi-turn runs).
+            accumulatedUsage.inputTokens =
+              baselineUsage.inputTokens + cumulativeInput;
+            accumulatedUsage.outputTokens =
+              baselineUsage.outputTokens + cumulativeOutput;
+            accumulatedUsage.totalTokens =
+              baselineUsage.totalTokens + cumulativeTotal;
+            emit({
+              type: "step_finish",
+              stepNumber: activeCompletedStepCount,
+              usage: {
+                inputTokens: stepDeltaInput,
+                outputTokens: stepDeltaOutput,
+              },
+            });
+            // Live trace snapshot for the step: stale `messageHistory`
+            // (prior turns + this turn's user prompt) PLUS the in-flight
+            // partial response; spans = prior turns' merged spans + this
+            // turn's tool-instrumentation spans + the engine's per-step
+            // LLM spans (PR 5b-followup-2).
+            const snapshotMessages = [
+              ...messageHistory,
+              ...buildPartialResponseMessages(),
+            ];
+            emit(
+              buildTraceSnapshotEvent({
+                turnIndex: promptIndex,
+                stepIndex: event.stepIndex,
+                snapshotKind: "step_finish",
+                messages: withSystemPrefix(snapshotMessages),
+                spans: [
+                  ...capturedSpans,
+                  ...traceCtx.recordedSpans,
+                  ...event.turnSpans,
+                ],
+                actualToolCalls: extractToolCallsFromConversation({
+                  messages: snapshotMessages,
+                }),
+                usage: accumulatedUsage,
+              })
+            );
+            // NO per-step reset of the partial-response accumulators: during
+            // the turn they are the ONLY source of in-flight content for
+            // snapshot fidelity; they reset naturally with the next turn's
+            // sink factory.
+          },
+          onTurnFailure: (failure) => {
+            // Mirror the in-stream failure signal the legacy inline loop
+            // emitted: failure trace_snapshot + error event before the break
+            // so live SSE consumers don't see a silent end.
+            emit(
+              buildTraceSnapshotEvent({
+                turnIndex: promptIndex,
+                ...(lastSettledStepIndex != null
+                  ? { stepIndex: lastSettledStepIndex }
+                  : {}),
+                snapshotKind: "failure",
+                messages: withSystemPrefix(messageHistory),
+                spans: capturedSpans,
+                actualToolCalls: extractToolCallsFromConversation({
+                  messages: messageHistory,
+                }),
+                usage: accumulatedUsage,
+              })
+            );
+            emit({
+              type: "error",
+              message: failure.iterationError,
+              ...(failure.iterationErrorDetails
+                ? { details: failure.iterationErrorDetails }
+                : {}),
+            });
+          },
+          onTurnSuccess: () => {
+            emit(
+              buildTraceSnapshotEvent({
+                turnIndex: promptIndex,
+                snapshotKind: "turn_finish",
+                messages: withSystemPrefix(messageHistory),
+                spans: capturedSpans,
+                actualToolCalls: extractToolCallsFromConversation({
+                  messages: messageHistory,
+                }),
+                usage: accumulatedUsage,
+              })
+            );
+            emit({ type: "turn_finish", turnIndex: promptIndex });
+          },
+        };
+      },
     });
-    promptToolsCalled.length = 0;
-    promptToolsCalled.push(...canonicalPromptToolsCalled);
-
-    // Roll the engine's transcript forward as the next turn's input.
-    messageHistory.length = 0;
-    messageHistory.push(...turnResult.messages);
-
-    // Failure detection — same three-signal shape as the non-stream
-    // backend runner (PR 3/4d):
-    //   (a) Engine catch fired mid-turn (`!turnTrace`) — engine
-    //       runSucceeded=false, partial messages may exist.
-    //   (b) Engine succeeded but produced no new content
-    //       (`newMessages.length === 0`).
-    //   (c) Engine succeeded and produced content, but a later step
-    //       errored (non-tool error span on `turnTrace.spans`).
-    if (!turnResult.turnTrace) {
-      // PR 5b-followup-2: prefer the engine's captured structured
-      // error when present. Closes Cursor PR 5b "Stream guardrail
-      // errors lose detail" — without this, 429 daily-cap users saw
-      // the generic fallback below instead of the actual reason
-      // ("Daily MCPJam model limit reached. Use BYOK or try again
-      // tomorrow."). When no engine error was captured (true engine
-      // catch shape vs. a missed `onEngineError` site), keep the
-      // generic fallback for diagnostic clarity.
-      if (lastEngineError) {
-        iterationError = lastEngineError.message;
-        iterationErrorDetails = lastEngineError.rawText;
-      } else {
-        iterationError =
-          "Backend stream failed during iteration (engine caught an error mid-turn)";
-      }
-      logger.error(
-        `[evals] runAssistantTurn (stream) returned no turnTrace (engine runSucceeded=false); treating as cycle failure (messagesGrew=${
-          newMessages.length > 0
-        }, engineError=${
-          lastEngineError ? lastEngineError.code ?? "uncoded" : "none"
-        })`
-      );
-      emit(
-        buildTraceSnapshotEvent({
-          turnIndex: promptIndex,
-          ...(lastSettledStepIndex != null
-            ? { stepIndex: lastSettledStepIndex }
-            : {}),
-          snapshotKind: "failure",
-          messages: withSystemPrefix(messageHistory),
-          spans: capturedSpans,
-          actualToolCalls: extractToolCallsFromConversation({
-            messages: messageHistory,
-          }),
-          usage: accumulatedUsage,
-        })
-      );
-      emit({
-        type: "error",
-        message: iterationError,
-        ...(iterationErrorDetails ? { details: iterationErrorDetails } : {}),
-      });
+    if (outcome.kind === "cancelled") return returnCancelled();
+    if (outcome.kind === "failed") {
+      iterationError = outcome.iterationError;
+      iterationErrorDetails = outcome.iterationErrorDetails;
       break;
     }
-    if (newMessages.length === 0) {
-      // PR 5b-followup-2 review fix (Cursor High "Guardrail errors
-      // ignore captured engine"): non-OK Convex `/stream` responses
-      // make `processOneStep` return `{shouldContinue: false}` — the
-      // engine breaks the loop, fires a synthetic finish chunk, sets
-      // `runSucceeded = true`, and surfaces a populated `turnTrace`.
-      // 429-shaped guardrail turns also add no assistant messages, so
-      // this branch fires (NOT the `!turnTrace` branch above). The
-      // captured `lastEngineError` is the actual reason ("Daily
-      // MCPJam model limit reached…"); the generic "Backend step
-      // returned no content" message loses it. Prefer the engine
-      // event here too.
-      if (lastEngineError) {
-        iterationError = lastEngineError.message;
-        iterationErrorDetails = lastEngineError.rawText;
-      } else {
-        iterationError =
-          "Backend step returned no content (stream error or empty response)";
-      }
-      logger.error(
-        `[evals] runAssistantTurn (stream) produced no new messages this turn; treating as cycle failure (engineError=${
-          lastEngineError ? lastEngineError.code ?? "uncoded" : "none"
-        })`
-      );
-      emit(
-        buildTraceSnapshotEvent({
-          turnIndex: promptIndex,
-          ...(lastSettledStepIndex != null
-            ? { stepIndex: lastSettledStepIndex }
-            : {}),
-          snapshotKind: "failure",
-          messages: withSystemPrefix(messageHistory),
-          spans: capturedSpans,
-          actualToolCalls: extractToolCallsFromConversation({
-            messages: messageHistory,
-          }),
-          usage: accumulatedUsage,
-        })
-      );
-      emit({
-        type: "error",
-        message: iterationError,
-        ...(iterationErrorDetails ? { details: iterationErrorDetails } : {}),
-      });
-      break;
-    }
-    // Cursor / Codex PR 5a review fix applied here too: filter to
-    // backend step / LLM failure spans only (exclude `category: "tool"`
-    // AND any span carrying a `toolCallId` — the child error span that
-    // `wrapToolSetForEvalTrace` emits alongside a failed tool span).
-    // Tool-category error spans flow through the `failOnToolError`
-    // gate below; treating them as cycle failures here would defeat
-    // that policy.
-    const stepErrorSpan = turnResult.turnTrace.spans.find(
-      (span) =>
-        span.status === "error" &&
-        span.category !== "tool" &&
-        !(span as { toolCallId?: string }).toolCallId
-    );
-    if (stepErrorSpan) {
-      // PR 5b-followup-2 review fix: same shape as the no-content
-      // branch above — a captured engine error is more informative
-      // than the span-name fallback. The error-span case fires for
-      // later-step failures after partial success (engine logged an
-      // `error`-category span via `pushAiSdkTrailingErrorSpan` or
-      // similar); if `onEngineError` also fired, prefer it.
-      if (lastEngineError) {
-        iterationError = lastEngineError.message;
-        iterationErrorDetails = lastEngineError.rawText;
-      } else {
-        iterationError = `Backend step failed mid-turn: ${stepErrorSpan.name}`;
-      }
-      logger.error(
-        `[evals] runAssistantTurn (stream) turnTrace has non-tool error-status span; treating as cycle failure (span=${
-          stepErrorSpan.name
-        } category=${stepErrorSpan.category} engineError=${
-          lastEngineError ? lastEngineError.code ?? "uncoded" : "none"
-        })`
-      );
-      emit(
-        buildTraceSnapshotEvent({
-          turnIndex: promptIndex,
-          ...(lastSettledStepIndex != null
-            ? { stepIndex: lastSettledStepIndex }
-            : {}),
-          snapshotKind: "failure",
-          messages: withSystemPrefix(messageHistory),
-          spans: capturedSpans,
-          actualToolCalls: extractToolCallsFromConversation({
-            messages: messageHistory,
-          }),
-          usage: accumulatedUsage,
-        })
-      );
-      emit({
-        type: "error",
-        message: iterationError,
-        ...(iterationErrorDetails ? { details: iterationErrorDetails } : {}),
-      });
-      break;
-    }
-
-    emit(
-      buildTraceSnapshotEvent({
-        turnIndex: promptIndex,
-        snapshotKind: "turn_finish",
-        messages: withSystemPrefix(messageHistory),
-        spans: capturedSpans,
-        actualToolCalls: extractToolCallsFromConversation({
-          messages: messageHistory,
-        }),
-        usage: accumulatedUsage,
-      })
-    );
-    emit({ type: "turn_finish", turnIndex: promptIndex });
   }
 
   const evaluation = evaluateMultiTurnResults(

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -35,18 +35,6 @@ import { resolveHostTools } from "../utils/built-in-tools/registry.js";
 import { logger } from "../utils/logger";
 import { captureMcpAppWidgetSnapshots } from "../utils/mcp-app-widget-capture";
 import {
-  McpAppBrowserHarness,
-  DEFAULT_VIEWPORT,
-} from "../utils/mcp-app-browser-harness";
-import {
-  buildComputerUseTools,
-  resolveComputerUseToolVersion,
-} from "../utils/computer-use-tool";
-import {
-  renderMcpAppToolResult,
-  isRenderableMcpAppTool,
-} from "../utils/mcp-app-render-observation";
-import {
   buildLlmRuntimeConfigFromOrgConfig,
   deriveOrgProviderKey,
   isLocalRuntimeEligible,
@@ -83,13 +71,8 @@ import type {
   EvalTraceSpan,
   PromptTraceSummary,
   EvalTraceWidgetSnapshot,
-  RunnerBrowserInteractionStep,
-  RunnerWidgetRenderObservation,
 } from "@/shared/eval-trace";
-import {
-  appendDedupedModelMessages,
-  isEvalTraceBrowserStepNote,
-} from "@/shared/eval-trace";
+import { appendDedupedModelMessages } from "@/shared/eval-trace";
 import {
   deriveLegacyPromptFields,
   resolvePromptTurns,
@@ -112,9 +95,9 @@ import type {
 import { sanitizeForConvexTransport } from "./evals/convex-sanitize.js";
 import { finalizeEvalIteration } from "./evals/finalize-iteration.js";
 import {
-  createEvalBrowserContext,
-  type EvalBrowserContext,
-} from "./evals/browser-eval-context.js";
+  createBrowserSessionContext,
+  type BrowserSessionContext,
+} from "./browser-session-context.js";
 import type {
   EvalStreamEvent,
   EvalStreamToolCall,
@@ -1059,36 +1042,15 @@ const runIterationWithAiSdk = async ({
 
   // Browser-rendered MCP App eval (PR 5): render MCP App tool results in the
   // headless-Chromium harness and (for Claude drivers) drive them with
-  // Computer Use. Harness construction is cheap; Chromium launches lazily on
-  // the first widget render, so prompt-only / no-widget iterations pay nothing.
-  const computerUseVersion = resolveComputerUseToolVersion(test.model);
-  // Ref-object (not a bare `let`): the only assignments happen inside the
-  // closures below, which TS control-flow analysis can't see — a bare `let`
-  // would stay narrowed to its `null` initializer in the outer `finally`.
-  const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
-    current: null,
-  };
-  const widgetRenderObservations: RunnerWidgetRenderObservation[] = [];
-  // PR 6b: Computer Use interaction steps, collected via the harness `onAction`
-  // callback wired into buildComputerUseTools below. This local AI-SDK path is
-  // the only place Computer Use runs, so it is the only place the array is
-  // non-empty (hosted + streaming paths land in PR 9/PR 10).
-  // `stepIndexByToolCallId` stamps a monotonic per-widget step ordinal.
-  const browserInteractionSteps: RunnerBrowserInteractionStep[] = [];
-  const stepIndexByToolCallId = new Map<string, number>();
-  const ensureWidgetHarness = (): McpAppBrowserHarness => {
-    if (!widgetHarnessRef.current) {
-      widgetHarnessRef.current = new McpAppBrowserHarness({
-        callTool: (sid, name, args) =>
-          mcpClientManager.executeTool(sid, name, args),
-        viewport: DEFAULT_VIEWPORT,
-      });
-    }
-    return widgetHarnessRef.current;
-  };
-  // Eager (cheap) construction when Computer Use is supported so the computer
-  // tools can reference the harness; Chromium still launches lazily.
-  if (computerUseVersion) ensureWidgetHarness();
+  // Computer Use. The shared context owns the harness, the Computer Use tools,
+  // the advertised-tool gate, and the artifact collectors; construction is
+  // cheap and Chromium launches lazily on the first widget render, so
+  // prompt-only / no-widget iterations pay nothing.
+  const browser = createBrowserSessionContext({
+    model: test.model,
+    mcpClientManager,
+    injectOpenAiCompat,
+  });
 
   try {
     // Adopt the chat-side tool/system/temperature pipeline. Eval used to skip
@@ -1133,61 +1095,6 @@ const runIterationWithAiSdk = async ({
     // (`appendEvalTurnTrace`) has no dedicated `systemPrompt` slot.
     enhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
 
-    // Computer Use tools (Claude drivers only). Included in the tool map so the
-    // AI SDK Anthropic provider auto-attaches the beta header; gated per step by
-    // `prepareAdvertisedTools` so they only appear once a widget has rendered.
-    const computerWidgetTools = computerUseVersion
-      ? buildComputerUseTools({
-          version: computerUseVersion,
-          harness: ensureWidgetHarness(),
-          // The harness keeps at most one widget mounted and drops it on
-          // dismiss / re-render / screenshot failure, so it is the single
-          // source of truth for the active widget — no separate id to track
-          // (and drift) across turns or after a finish_widget dismiss.
-          getActiveToolCallId: () =>
-            widgetHarnessRef.current?.getMountedWidgetId() ?? null,
-          viewport: DEFAULT_VIEWPORT,
-          // PR 6b: collect one browserInteractionStep per executeAction. The
-          // screenshot stays base64 here; finalizeEvalIteration uploads it once
-          // for both the W2 and W1 persistence paths.
-          onAction: (result, { toolCallId }) => {
-            const stepIndex = (stepIndexByToolCallId.get(toolCallId) ?? -1) + 1;
-            stepIndexByToolCallId.set(toolCallId, stepIndex);
-            // The harness types `note` as an open string; the backend union is
-            // closed and rejects the whole turn on an unknown literal. Narrow
-            // through the guard — keep the step, drop an unrecognized note.
-            let note: RunnerBrowserInteractionStep["note"];
-            if (result.note !== undefined) {
-              if (isEvalTraceBrowserStepNote(result.note)) {
-                note = result.note;
-              } else {
-                logger.warn("[evals] dropping unknown browser-step note", {
-                  note: result.note,
-                  toolCallId,
-                });
-              }
-            }
-            browserInteractionSteps.push({
-              toolCallId,
-              stepIndex,
-              promptIndex: activePromptIndex,
-              action: result.action.action,
-              coordinateX: result.action.coordinate?.[0],
-              coordinateY: result.action.coordinate?.[1],
-              text: result.action.text,
-              scrollDirection: result.action.scrollDirection,
-              scrollAmount: result.action.scrollAmount,
-              duration: result.action.duration,
-              screenshotBase64: result.screenshotBase64,
-              widgetToolCalls: result.widgetToolCalls,
-              elapsedMs: result.elapsedMs,
-              ...(note ? { note } : {}),
-              ts: Date.now(),
-            });
-          },
-        })
-      : {};
-
     const llmModel = createLlmModel(
       modelDefinition,
       modelRuntime.apiKey,
@@ -1201,7 +1108,7 @@ const runIterationWithAiSdk = async ({
       !Object.hasOwn(prepared.allTools, toolChoice.toolName) &&
       // `computer` / `finish_widget` are merged into the tool map below, so a
       // forced tool choice naming one of them is valid on Claude drivers.
-      !Object.hasOwn(computerWidgetTools, toolChoice.toolName)
+      !Object.hasOwn(browser.computerWidgetTools, toolChoice.toolName)
     ) {
       throw new Error(
         `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`
@@ -1227,16 +1134,13 @@ const runIterationWithAiSdk = async ({
       if (localIsAborted()) return returnLocalCancelled();
       const promptTurn = promptTurns[promptIndex]!;
       activePromptIndex = promptIndex;
+      browser.setActivePromptIndex(promptIndex);
       // Browser-rendered MCP App eval (PR 5): start each prompt turn with a
       // clean widget surface. A widget kept mounted by a previous turn must not
       // bleed into this one — otherwise Computer Use could be advertised (and
       // `computer` actions routed) against the prior turn's widget before this
       // turn's own MCP App tool runs.
-      const carriedWidgetId =
-        widgetHarnessRef.current?.getMountedWidgetId() ?? null;
-      if (carriedWidgetId) {
-        await widgetHarnessRef.current!.dismissWidget(carriedWidgetId);
-      }
+      await browser.dismissCarriedWidget();
       // PR 4b invariant (carried from closed #2458, originally PR 3 round 2):
       // push the user prompt to `conversationMessages` BEFORE the driver
       // call so a failed turn still records the prompt in the persisted
@@ -1287,30 +1191,14 @@ const runIterationWithAiSdk = async ({
         ...(prepared.resolvedTemperature == null
           ? {}
           : { temperature: prepared.resolvedTemperature }),
-        tools: { ...prepared.allTools, ...computerWidgetTools },
+        tools: { ...prepared.allTools, ...browser.computerWidgetTools },
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
         // Browser-rendered MCP App eval (PR 5): gate Computer Use tools so the
         // model only sees `computer` / `finish_widget` once a widget has
         // actually rendered in the harness (PR 2's prepareAdvertisedTools hook).
-        ...(computerUseVersion
-          ? {
-              prepareAdvertisedTools: ({
-                defaultToolNames,
-              }: {
-                stepIndex: number;
-                defaultToolNames: string[];
-              }) =>
-                // Gate on the harness's live widget — the SAME source
-                // `getActiveToolCallId` reads — so the tools are only advertised
-                // when a Computer Use action can actually target a mount (avoids
-                // advertising while the active id would resolve to null).
-                widgetHarnessRef.current?.getMountedWidgetId()
-                  ? defaultToolNames
-                  : defaultToolNames.filter(
-                      (n) => n !== "computer" && n !== "finish_widget"
-                    ),
-            }
+        ...(browser.prepareAdvertisedTools
+          ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
           : {}),
         ...(abortSignal ? { abortSignal } : {}),
         ...(toolChoice
@@ -1347,53 +1235,8 @@ const runIterationWithAiSdk = async ({
           // result in the harness and record a WidgetRenderObservation. Awaited
           // (direct-chat-turn awaits this callback) so a rendered widget is
           // mounted before the next step's Computer Use gate runs.
-          onToolResultChunk: async ({
-            toolCallId,
-            toolName,
-            input,
-            output,
-            serverId,
-          }) => {
-            if (!serverId) return;
-            const meta =
-              mcpClientManager.getAllToolsMetadata(serverId)?.[toolName];
-            if (!isRenderableMcpAppTool(meta)) return;
-            try {
-              const obs = await renderMcpAppToolResult({
-                toolCallId,
-                toolName,
-                serverId,
-                toolMetadata: meta,
-                // Feed the real tool-call args to the widget shim so the live
-                // render matches what post-turn snapshot capture injects.
-                toolInput: input,
-                output,
-                mcpClientManager,
-                injectOpenAiCompat,
-                harness: ensureWidgetHarness(),
-                keepMounted: computerUseVersion !== null,
-              });
-              // Stamp promptIndex at push-time — the harness type stays pure;
-              // the runner is the single source of truth for promptIndex.
-              widgetRenderObservations.push({
-                ...obs,
-                promptIndex: activePromptIndex,
-              });
-              // No separate active-widget bookkeeping: a `rendered` + kept widget
-              // stays in the harness mount (the single source of truth that the
-              // gate and getActiveToolCallId both read); every other outcome is
-              // already unmounted by renderWidget.
-              logger.debug("[evals] widget render observation", {
-                toolName,
-                status: obs.status,
-              });
-            } catch (err) {
-              logger.warn("[evals] widget render failed", {
-                toolName,
-                error: err instanceof Error ? err.message : String(err),
-              });
-            }
-          },
+          onToolResultChunk: (chunk) =>
+            browser.handleDirectToolResultChunk(chunk),
         },
       });
       // `runDirectChatTurn` exposes its internal traceContext so eval
@@ -1614,8 +1457,12 @@ const runIterationWithAiSdk = async ({
       // PR 6b: per-iteration browser artifacts, non-empty only on this local
       // AI-SDK Computer Use path. finalizeEvalIteration serializes them once
       // (screenshot upload + sanitize) for both the W2 and W1 persistence paths.
-      ...(widgetRenderObservations.length ? { widgetRenderObservations } : {}),
-      ...(browserInteractionSteps.length ? { browserInteractionSteps } : {}),
+      ...(browser.widgetRenderObservations.length
+        ? { widgetRenderObservations: browser.widgetRenderObservations }
+        : {}),
+      ...(browser.browserInteractionSteps.length
+        ? { browserInteractionSteps: browser.browserInteractionSteps }
+        : {}),
       status: "completed" as const,
       startedAt: runStartedAt,
       ...(iterationError ? { error: iterationError } : {}),
@@ -1744,8 +1591,12 @@ const runIterationWithAiSdk = async ({
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
       // PR 6b: browser artifacts collected before the failure still persist.
-      ...(widgetRenderObservations.length ? { widgetRenderObservations } : {}),
-      ...(browserInteractionSteps.length ? { browserInteractionSteps } : {}),
+      ...(browser.widgetRenderObservations.length
+        ? { widgetRenderObservations: browser.widgetRenderObservations }
+        : {}),
+      ...(browser.browserInteractionSteps.length
+        ? { browserInteractionSteps: browser.browserInteractionSteps }
+        : {}),
       status: "failed" as const,
       startedAt: runStartedAt,
       error: errorMessage,
@@ -1778,13 +1629,7 @@ const runIterationWithAiSdk = async ({
     // Browser-rendered MCP App eval (PR 5): tear down the harness (and its
     // headless Chromium, if launched) regardless of success/failure. No-op
     // when the harness was never constructed or never launched.
-    await widgetHarnessRef.current?.dispose();
-    if (widgetRenderObservations.length > 0) {
-      logger.debug("[evals] widget render observations", {
-        count: widgetRenderObservations.length,
-        statuses: widgetRenderObservations.map((o) => o.status),
-      });
-    }
+    await browser.dispose();
   }
 };
 
@@ -1795,7 +1640,7 @@ const runIterationViaBackend = async (params: RunIterationBackendParams) => {
   // The wrapper owns disposal: try/finally guarantees a launched Chromium is
   // torn down on EVERY exit (cancellation early-returns, setup failures,
   // finalize throws), which per-exit dispose calls could miss.
-  const browser = createEvalBrowserContext({
+  const browser = createBrowserSessionContext({
     model: params.test.model,
     mcpClientManager: params.mcpClientManager,
     injectOpenAiCompat: params.injectOpenAiCompat,
@@ -1842,7 +1687,7 @@ const runIterationViaBackendWithBrowser = async (
     suiteHostConfig,
     orgModelConfigTarget,
   }: RunIterationBackendParams,
-  browser: EvalBrowserContext
+  browser: BrowserSessionContext
 ) => {
   const resolvedTest = resolveEvalTestCase(test);
 
@@ -3177,24 +3022,11 @@ const streamIterationWithAiSdk = async ({
   // streamed path — render MCP App tool results in the headless-Chromium harness
   // and (for Claude drivers) drive them with Computer Use. Declared BEFORE the
   // try so the finally can dispose even on a mid-stream abort.
-  const computerUseVersion = resolveComputerUseToolVersion(test.model);
-  const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
-    current: null,
-  };
-  const widgetRenderObservations: RunnerWidgetRenderObservation[] = [];
-  const browserInteractionSteps: RunnerBrowserInteractionStep[] = [];
-  const stepIndexByToolCallId = new Map<string, number>();
-  const ensureWidgetHarness = (): McpAppBrowserHarness => {
-    if (!widgetHarnessRef.current) {
-      widgetHarnessRef.current = new McpAppBrowserHarness({
-        callTool: (sid, name, args) =>
-          mcpClientManager.executeTool(sid, name, args),
-        viewport: DEFAULT_VIEWPORT,
-      });
-    }
-    return widgetHarnessRef.current;
-  };
-  if (computerUseVersion) ensureWidgetHarness();
+  const browser = createBrowserSessionContext({
+    model: test.model,
+    mcpClientManager,
+    injectOpenAiCompat,
+  });
 
   try {
     // See `runIterationWithAiSdk`: adopt the chat-side pipeline inside the try
@@ -3227,54 +3059,6 @@ const streamIterationWithAiSdk = async ({
     // time (mirroring the non-stream runner's PR 4d Codex P2 fix).
     streamEnhancedSystemPromptForPersist = prepared.enhancedSystemPrompt;
 
-    // Computer Use tools (Claude drivers only). Gated per step by
-    // `prepareAdvertisedTools` below so they only appear once a widget renders.
-    const computerWidgetTools = computerUseVersion
-      ? buildComputerUseTools({
-          version: computerUseVersion,
-          harness: ensureWidgetHarness(),
-          getActiveToolCallId: () =>
-            widgetHarnessRef.current?.getMountedWidgetId() ?? null,
-          viewport: DEFAULT_VIEWPORT,
-          // PR 9: collect one browserInteractionStep per executeAction; the
-          // screenshot stays base64 here (finalizeEvalIteration uploads once).
-          onAction: (result, { toolCallId }) => {
-            const stepIndex = (stepIndexByToolCallId.get(toolCallId) ?? -1) + 1;
-            stepIndexByToolCallId.set(toolCallId, stepIndex);
-            // Narrow the harness's open-string note through the guard (the
-            // backend union is closed) — keep the step, drop an unknown note.
-            let note: RunnerBrowserInteractionStep["note"];
-            if (result.note !== undefined) {
-              if (isEvalTraceBrowserStepNote(result.note)) {
-                note = result.note;
-              } else {
-                logger.warn("[evals] dropping unknown browser-step note", {
-                  note: result.note,
-                  toolCallId,
-                });
-              }
-            }
-            browserInteractionSteps.push({
-              toolCallId,
-              stepIndex,
-              promptIndex: activePromptIndex,
-              action: result.action.action,
-              coordinateX: result.action.coordinate?.[0],
-              coordinateY: result.action.coordinate?.[1],
-              text: result.action.text,
-              scrollDirection: result.action.scrollDirection,
-              scrollAmount: result.action.scrollAmount,
-              duration: result.action.duration,
-              screenshotBase64: result.screenshotBase64,
-              widgetToolCalls: result.widgetToolCalls,
-              elapsedMs: result.elapsedMs,
-              ...(note ? { note } : {}),
-              ts: Date.now(),
-            });
-          },
-        })
-      : {};
-
     const llmModel = createLlmModel(
       modelDefinition,
       modelRuntime.apiKey,
@@ -3288,7 +3072,7 @@ const streamIterationWithAiSdk = async ({
       !Object.hasOwn(prepared.allTools, toolChoice.toolName) &&
       // `computer` / `finish_widget` are merged into the tool map below, so a
       // forced tool choice naming one of them is valid on Claude drivers.
-      !Object.hasOwn(computerWidgetTools, toolChoice.toolName)
+      !Object.hasOwn(browser.computerWidgetTools, toolChoice.toolName)
     ) {
       throw new Error(
         `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`
@@ -3313,14 +3097,11 @@ const streamIterationWithAiSdk = async ({
       if (localIsAborted()) return returnLocalCancelled();
       const promptTurn = promptTurns[promptIndex]!;
       activePromptIndex = promptIndex;
+      browser.setActivePromptIndex(promptIndex);
       // PR 9 (mirror PR 5): start each turn with a clean widget surface so a
       // widget kept mounted by a previous turn can't be advertised/targeted
       // before this turn's own MCP App tool runs.
-      const carriedWidgetId =
-        widgetHarnessRef.current?.getMountedWidgetId() ?? null;
-      if (carriedWidgetId) {
-        await widgetHarnessRef.current!.dismissWidget(carriedWidgetId);
-      }
+      await browser.dismissCarriedWidget();
       // PR 5a invariant (mirror PR 4b round 2): push the user prompt to
       // `conversationMessages` BEFORE the driver call so a failed turn
       // still records the prompt in the persisted transcript. Without
@@ -3372,26 +3153,14 @@ const streamIterationWithAiSdk = async ({
         ...(prepared.resolvedTemperature == null
           ? {}
           : { temperature: prepared.resolvedTemperature }),
-        tools: { ...prepared.allTools, ...computerWidgetTools },
+        tools: { ...prepared.allTools, ...browser.computerWidgetTools },
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
         // PR 9 (mirror PR 5): gate Computer Use tools so the model only sees
         // `computer` / `finish_widget` once a widget has actually rendered in
         // the harness (the same live-widget source `getActiveToolCallId` reads).
-        ...(computerUseVersion
-          ? {
-              prepareAdvertisedTools: ({
-                defaultToolNames,
-              }: {
-                stepIndex: number;
-                defaultToolNames: string[];
-              }) =>
-                widgetHarnessRef.current?.getMountedWidgetId()
-                  ? defaultToolNames
-                  : defaultToolNames.filter(
-                      (n) => n !== "computer" && n !== "finish_widget"
-                    ),
-            }
+        ...(browser.prepareAdvertisedTools
+          ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
           : {}),
         ...(abortSignal ? { abortSignal } : {}),
         ...(toolChoice
@@ -3463,46 +3232,8 @@ const streamIterationWithAiSdk = async ({
           // and record an observation. `onToolResultChunk` fires on the stream
           // path too; awaited so a rendered widget is mounted before the next
           // step's Computer Use gate runs.
-          onToolResultChunk: async ({
-            toolCallId,
-            toolName,
-            input,
-            output,
-            serverId,
-          }) => {
-            if (!serverId) return;
-            const meta =
-              mcpClientManager.getAllToolsMetadata(serverId)?.[toolName];
-            if (!isRenderableMcpAppTool(meta)) return;
-            try {
-              const obs = await renderMcpAppToolResult({
-                toolCallId,
-                toolName,
-                serverId,
-                toolMetadata: meta,
-                toolInput: input,
-                output,
-                mcpClientManager,
-                injectOpenAiCompat,
-                harness: ensureWidgetHarness(),
-                keepMounted: computerUseVersion !== null,
-              });
-              // Stamp promptIndex at push-time (runner is the source of truth).
-              widgetRenderObservations.push({
-                ...obs,
-                promptIndex: activePromptIndex,
-              });
-              logger.debug("[evals] widget render observation", {
-                toolName,
-                status: obs.status,
-              });
-            } catch (err) {
-              logger.warn("[evals] widget render failed", {
-                toolName,
-                error: err instanceof Error ? err.message : String(err),
-              });
-            }
-          },
+          onToolResultChunk: (chunk) =>
+            browser.handleDirectToolResultChunk(chunk),
         },
       });
       // `runDirectChatTurn` exposes its internal traceContext so eval
@@ -3805,8 +3536,12 @@ const streamIterationWithAiSdk = async ({
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
       // PR 9: browser artifacts from the streamed Computer Use path.
-      ...(widgetRenderObservations.length ? { widgetRenderObservations } : {}),
-      ...(browserInteractionSteps.length ? { browserInteractionSteps } : {}),
+      ...(browser.widgetRenderObservations.length
+        ? { widgetRenderObservations: browser.widgetRenderObservations }
+        : {}),
+      ...(browser.browserInteractionSteps.length
+        ? { browserInteractionSteps: browser.browserInteractionSteps }
+        : {}),
       status: "completed" as const,
       startedAt: runStartedAt,
       // PR 5a (mirror PR 4b): if the per-turn loop set `iterationError`
@@ -3962,8 +3697,12 @@ const streamIterationWithAiSdk = async ({
       ...(promptTraceSummaries.length ? { prompts: promptTraceSummaries } : {}),
       ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
       // PR 9: browser artifacts collected before the failure still persist.
-      ...(widgetRenderObservations.length ? { widgetRenderObservations } : {}),
-      ...(browserInteractionSteps.length ? { browserInteractionSteps } : {}),
+      ...(browser.widgetRenderObservations.length
+        ? { widgetRenderObservations: browser.widgetRenderObservations }
+        : {}),
+      ...(browser.browserInteractionSteps.length
+        ? { browserInteractionSteps: browser.browserInteractionSteps }
+        : {}),
       status: "failed" as const,
       startedAt: runStartedAt,
       error: errorMessage,
@@ -3995,13 +3734,7 @@ const streamIterationWithAiSdk = async ({
   } finally {
     // PR 9: tear down the harness (and its headless Chromium, if launched) on
     // success, failure, OR mid-stream abort. No-op when never constructed.
-    await widgetHarnessRef.current?.dispose();
-    if (widgetRenderObservations.length > 0) {
-      logger.debug("[evals] widget render observations (stream)", {
-        count: widgetRenderObservations.length,
-        statuses: widgetRenderObservations.map((o) => o.status),
-      });
-    }
+    await browser.dispose();
   }
 };
 
@@ -4013,7 +3746,7 @@ const streamIterationViaBackend = async (
   // Browser-rendered MCP App eval (PR 14): hosted-path harness context for
   // the streaming runner — same wiring as `runIterationViaBackend`; the
   // wrapper's try/finally guarantees Chromium teardown on every exit.
-  const browser = createEvalBrowserContext({
+  const browser = createBrowserSessionContext({
     model: params.test.model,
     mcpClientManager: params.mcpClientManager,
     injectOpenAiCompat: params.injectOpenAiCompat,
@@ -4062,7 +3795,7 @@ const streamIterationViaBackendWithBrowser = async (
   }: RunIterationBackendParams & {
     emit: StreamEmit;
   },
-  browser: EvalBrowserContext
+  browser: BrowserSessionContext
 ): Promise<EvalIterationOutcome> => {
   const resolvedTest = resolveEvalTestCase(test);
 

--- a/mcpjam-inspector/server/services/evals/__tests__/drive-hosted-eval-turn.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/drive-hosted-eval-turn.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// The engine must never be reached when pre-turn setup fails — the mock
+// throws a sentinel so an unexpected call fails the test loudly.
+const runAssistantTurnMock = vi.fn(async () => {
+  throw new Error("engine must not be reached in these tests");
+});
+vi.mock("../../../utils/assistant-turn.js", () => ({
+  runAssistantTurn: (...args: unknown[]) => runAssistantTurnMock(...args),
+}));
+
+import { driveHostedEvalTurn } from "../drive-hosted-eval-turn";
+import type { DriveHostedEvalTurnParams } from "../drive-hosted-eval-turn";
+
+function baseParams(
+  overrides: Partial<DriveHostedEvalTurnParams> = {},
+): DriveHostedEvalTurnParams {
+  const browser = {
+    setActivePromptIndex: vi.fn(),
+    dismissCarriedWidget: vi.fn(async () => {}),
+    computerWidgetTools: {},
+    noteToolCallInput: vi.fn(),
+    handleEngineToolResult: vi.fn(async () => {}),
+  };
+  return {
+    promptIndex: 0,
+    prompt: "hello",
+    browser: browser as unknown as DriveHostedEvalTurnParams["browser"],
+    prepared: {
+      allTools: {},
+      enhancedSystemPrompt: "sys",
+      resolvedTemperature: undefined,
+      progressivePlan: undefined,
+      discoveryState: undefined,
+    } as unknown as DriveHostedEvalTurnParams["prepared"],
+    modelDefinition: { id: "m", provider: "anthropic" } as never,
+    modelId: "m",
+    selectedServers: [],
+    mcpClientManager: {} as never,
+    evalAuthContext: { kind: "user_bearer", token: "t" },
+    endpointPath: "/x",
+    extraBodyFields: undefined,
+    toolChoice: undefined,
+    abortSignal: undefined,
+    maxSteps: 5,
+    runStartedAt: Date.now(),
+    isAborted: () => false,
+    extractToolCalls: () => [],
+    acc: {
+      messageHistory: [],
+      capturedSpans: [],
+      accumulatedUsage: {},
+      toolsCalledByPrompt: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("driveHostedEvalTurn pre-turn failure mapping (CodeRabbit, PR 2610)", () => {
+  beforeEach(() => {
+    runAssistantTurnMock.mockClear();
+  });
+
+  it("maps an onTurnStart throw to a failed outcome instead of escaping (engine never invoked)", async () => {
+    const onTurnFailure = vi.fn();
+    const params = baseParams({
+      buildSinks: () => ({
+        onTurnStart: () => {
+          throw new Error("sse write failed");
+        },
+        onTurnFailure,
+      }),
+    });
+
+    const outcome = await driveHostedEvalTurn(params);
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind === "failed") {
+      expect(outcome.iterationError).toBe("sse write failed");
+    }
+    // The sinks were built before the throw, so the failure sink fires.
+    expect(onTurnFailure).toHaveBeenCalledWith({
+      iterationError: "sse write failed",
+    });
+    expect(runAssistantTurnMock).not.toHaveBeenCalled();
+    // Transcript honesty: the user prompt was pushed before the failure.
+    expect(params.acc.messageHistory).toEqual([
+      { role: "user", content: "hello" },
+    ]);
+  });
+
+  it("maps a dismissCarriedWidget throw to a failed outcome (sinks not yet built)", async () => {
+    const params = baseParams();
+    (
+      params.browser as unknown as {
+        dismissCarriedWidget: ReturnType<typeof vi.fn>;
+      }
+    ).dismissCarriedWidget.mockRejectedValue(new Error("chromium crashed"));
+
+    const outcome = await driveHostedEvalTurn(params);
+
+    expect(outcome).toMatchObject({
+      kind: "failed",
+      iterationError: "chromium crashed",
+    });
+    expect(runAssistantTurnMock).not.toHaveBeenCalled();
+  });
+
+  it("maps a pre-turn throw under an active abort to cancelled, not failed", async () => {
+    const params = baseParams({ isAborted: () => true });
+    (
+      params.browser as unknown as {
+        dismissCarriedWidget: ReturnType<typeof vi.fn>;
+      }
+    ).dismissCarriedWidget.mockRejectedValue(new Error("torn down"));
+
+    const outcome = await driveHostedEvalTurn(params);
+
+    expect(outcome).toEqual({ kind: "cancelled" });
+    expect(runAssistantTurnMock).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -1,0 +1,443 @@
+/**
+ * drive-hosted-eval-turn.ts — the shared per-turn body of the two hosted eval
+ * runners (`runIterationViaBackendWithBrowser` — batch — and
+ * `streamIterationViaBackendWithBrowser` — SSE).
+ *
+ * Both runners drive turns through `runAssistantTurn` with identical engine
+ * options, browser-pipeline hooks, accumulator drains, and the three-shape
+ * failure detection; the stream runner additionally wires SSE emitters into
+ * the engine callbacks and emits failure/turn-finish events. This helper owns
+ * the shared skeleton; the stream runner layers its SSE concerns through
+ * {@link HostedEvalTurnSinks} (built per turn via a factory so the emit
+ * closures can see the turn context).
+ *
+ * Unification notes (deliberate convergences, both directions reviewed):
+ *  - `lastEngineError` preference in the failure branches (the PR
+ *    5b-followup-2 guardrail-detail fix) now applies to the batch runner too —
+ *    previously only the stream runner surfaced the structured 429/guardrail
+ *    reason instead of the generic fallback.
+ *  - The step-error-span filter excludes spans carrying a `toolCallId`
+ *    (the stream runner's Cursor/Codex review fix — child error spans that
+ *    `wrapToolSetForEvalTrace` emits alongside a failed tool span must flow
+ *    through the `failOnToolError` gate, not force a cycle failure). The
+ *    batch runner previously matched only on `category !== "tool"`.
+ *  - `toolsCalledByPrompt` gets its per-turn array pushed BEFORE the engine
+ *    call (the stream runner's shape, where `onToolCall` populates it live).
+ *    For the batch runner this means a turn whose engine call THROWS now
+ *    contributes an empty entry instead of no entry — verdict-neutral (the
+ *    accompanying `iterationError` already gates the iteration).
+ */
+import type { ModelMessage } from "@ai-sdk/provider-utils";
+import type { MCPClientManager } from "@mcpjam/sdk";
+import type { EvalTraceSpan } from "@/shared/eval-trace";
+import type { ModelDefinition } from "@/shared/types";
+import type { EvalToolChoice } from "@/shared/tool-choice";
+import { logger } from "../../utils/logger";
+import { runAssistantTurn } from "../../utils/assistant-turn.js";
+import type {
+  MCPJamEngineErrorEvent,
+  MCPJamStepFinishEvent,
+  MCPJamToolCallEvent,
+  MCPJamToolResultEvent,
+} from "../../utils/mcpjam-stream-handler.js";
+import type { PrepareChatV2Result } from "../../utils/chat-v2-orchestration.js";
+import type { BrowserSessionContext } from "../browser-session-context.js";
+import {
+  createAiSdkEvalTraceContext,
+  wrapToolSetForEvalTrace,
+} from "./eval-trace-capture";
+import type { UsageTotals } from "./types";
+
+type ToolCall = { toolName: string; arguments: Record<string, any> };
+
+export type HostedEvalTurnOutcome =
+  | { kind: "completed" }
+  /** Abort fired (between callbacks or mid-engine); record nothing. */
+  | { kind: "cancelled" }
+  /** Turn failed; the runner records the iteration with this error. */
+  | {
+      kind: "failed";
+      iterationError: string;
+      iterationErrorDetails?: string;
+    };
+
+/** Stream-runner SSE concerns, layered over the shared skeleton per turn. */
+export interface HostedEvalTurnSinks {
+  /** After the user prompt is appended, before the engine call (`turn_start`). */
+  onTurnStart?: () => void;
+  /** Engine callback wires (SSE emitters). The helper composes them with the
+   *  browser-pipeline hooks: `onToolCall` runs after the input cache write;
+   *  `onToolResult` runs BEFORE the harness render (live consumers shouldn't
+   *  wait on Chromium). */
+  onLiveTextDelta?: (delta: string) => void;
+  onToolCall?: (event: MCPJamToolCallEvent) => void;
+  onToolResult?: (event: MCPJamToolResultEvent) => void | Promise<void>;
+  onStepFinish?: (event: MCPJamStepFinishEvent) => void;
+  /** Before a failed turn returns (failure trace_snapshot + error SSE). */
+  onTurnFailure?: (failure: {
+    iterationError: string;
+    iterationErrorDetails?: string;
+  }) => void;
+  /** After a fully-successful turn (turn_finish snapshot + SSE). */
+  onTurnSuccess?: () => void;
+}
+
+/** Per-turn context handed to the sink factory so SSE closures can read the
+ *  turn's accumulators (the stream runner's snapshot/step-delta math). */
+export interface HostedEvalTurnSinkContext {
+  promptIndex: number;
+  /** Iteration-cumulative usage snapshot taken at turn start. */
+  baselineUsage: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
+  /** This turn's tool-instrumentation span context (`wrapToolSetForEvalTrace`). */
+  traceCtx: ReturnType<typeof createAiSdkEvalTraceContext>;
+  /** The per-turn tool-call accumulator (already pushed onto
+   *  `acc.toolsCalledByPrompt`); `onToolCall` sinks may populate it live. */
+  promptToolsCalled: ToolCall[];
+}
+
+export interface DriveHostedEvalTurnParams {
+  promptIndex: number;
+  prompt: string;
+  browser: BrowserSessionContext;
+  prepared: PrepareChatV2Result;
+  modelDefinition: ModelDefinition;
+  /** Canonical model id override for the wire payload (wallet/quota keys). */
+  modelId: string;
+  selectedServers: string[];
+  mcpClientManager: MCPClientManager;
+  evalAuthContext: { kind: "user_bearer"; token: string };
+  endpointPath: string;
+  extraBodyFields: Record<string, unknown> | undefined;
+  toolChoice: EvalToolChoice | undefined;
+  abortSignal: AbortSignal | undefined;
+  maxSteps: number;
+  runStartedAt: number;
+  isAborted: () => boolean;
+  /** `" (stream)"` on the SSE runner so log lines stay distinguishable. */
+  logSuffix?: string;
+  /** The runner's `extractToolCallsFromConversation`, passed in (rather than
+   *  imported) to avoid a module cycle with evals-runner.ts. */
+  extractToolCalls: (messages: ModelMessage[]) => ToolCall[];
+  /** Shared mutable iteration state. The helper appends/rolls in place. */
+  acc: {
+    messageHistory: ModelMessage[];
+    capturedSpans: EvalTraceSpan[];
+    accumulatedUsage: UsageTotals;
+    toolsCalledByPrompt: ToolCall[][];
+  };
+  buildSinks?: (ctx: HostedEvalTurnSinkContext) => HostedEvalTurnSinks;
+}
+
+const truncateError = (message: string): string =>
+  message.length > 500 ? message.substring(0, 497) + "..." : message;
+
+export async function driveHostedEvalTurn(
+  params: DriveHostedEvalTurnParams
+): Promise<HostedEvalTurnOutcome> {
+  const {
+    promptIndex,
+    browser,
+    prepared,
+    acc,
+    isAborted,
+    abortSignal,
+  } = params;
+  const logSuffix = params.logSuffix ?? "";
+
+  // Browser-rendered MCP App eval (PR 14): stamp collected artifacts with
+  // this turn, and start the turn with a clean widget surface — a widget
+  // kept mounted by a previous prompt turn must not bleed into this one
+  // (otherwise Computer Use could be advertised against the prior turn's
+  // widget before this turn's own MCP App tool runs).
+  browser.setActivePromptIndex(promptIndex);
+  await browser.dismissCarriedWidget();
+
+  // Per-turn span-capture context. `wrapToolSetForEvalTrace` instruments
+  // each tool's `execute` to push to `traceCtx.recordedSpans`; we drain
+  // into `acc.capturedSpans` after the engine finishes. The Computer Use
+  // tools ride the same wrap so `computer` / `finish_widget` executions
+  // land as tool spans in the trace UI like every other local tool.
+  const traceCtx = createAiSdkEvalTraceContext(params.runStartedAt);
+  const tracedTools = wrapToolSetForEvalTrace(
+    { ...prepared.allTools, ...browser.computerWidgetTools },
+    traceCtx,
+    promptIndex
+  );
+
+  // Push the user prompt into `messageHistory` BEFORE the engine call so a
+  // failed turn still persists the user side of the transcript (Cursor
+  // review round-2 — the transcript stays honest about WHICH turn errored).
+  acc.messageHistory.push({ role: "user", content: params.prompt });
+  const messageCountBeforeTurn = acc.messageHistory.length;
+  const inputMessages: ModelMessage[] = [...acc.messageHistory];
+
+  const baselineUsage = {
+    inputTokens: acc.accumulatedUsage.inputTokens ?? 0,
+    outputTokens: acc.accumulatedUsage.outputTokens ?? 0,
+    totalTokens: acc.accumulatedUsage.totalTokens ?? 0,
+  };
+
+  // Per-turn tool-call accumulator, pushed up front (the stream runner's
+  // `onToolCall` populates it live; the canonical post-turn reconcile below
+  // replaces the contents either way).
+  const promptToolsCalled: ToolCall[] = [];
+  acc.toolsCalledByPrompt.push(promptToolsCalled);
+
+  const sinks =
+    params.buildSinks?.({
+      promptIndex,
+      baselineUsage,
+      traceCtx,
+      promptToolsCalled,
+    }) ?? {};
+
+  sinks.onTurnStart?.();
+
+  // PR 5b-followup-2: capture the engine's structured-error event (429
+  // daily-cap, hosted-model setup errors, …). The engine writes a generic
+  // `error` UI chunk to the no-op writer (`streamSink: "none"`); the callback
+  // gives the parsed `{ code?, message, details? }` so failure branches can
+  // surface the actual reason instead of the generic fallback.
+  let lastEngineError: MCPJamEngineErrorEvent | undefined;
+
+  // Cursor + Codex review fix: thread `toolChoice` AND `maxOutputTokens`
+  // through `extraBodyFields` since the engine options don't expose them as
+  // first-class fields. `maxOutputTokens: 16384` matches the legacy per-step
+  // Convex body (Cursor round-2 "Dropped eval maxOutputTokens limit").
+  const mergedExtraBodyFields: Record<string, unknown> = {
+    maxOutputTokens: 16384,
+    ...(params.extraBodyFields ?? {}),
+    ...(params.toolChoice ? { toolChoice: params.toolChoice } : {}),
+  };
+
+  let turnResult: Awaited<ReturnType<typeof runAssistantTurn>>;
+  try {
+    turnResult = await runAssistantTurn({
+      messages: inputMessages,
+      // Eval's `runTestCase` already resolved the canonical model id
+      // (`getCanonicalModelId(modelDefinition.id, provider)`) and threads it
+      // in as `modelId`. The engine reads `modelDefinition.id` for the wire
+      // payload, so override here so backend wallet/quota lookup keys match
+      // what live chat sends.
+      modelDefinition: { ...params.modelDefinition, id: params.modelId },
+      systemPrompt: prepared.enhancedSystemPrompt,
+      ...(prepared.resolvedTemperature != null
+        ? { temperature: prepared.resolvedTemperature }
+        : {}),
+      tools: tracedTools,
+      ...(params.selectedServers.length
+        ? { selectedServerIds: params.selectedServers }
+        : {}),
+      mcpClientManager: params.mcpClientManager,
+      authContext: params.evalAuthContext,
+      sourceType: "eval",
+      origin: "eval",
+      streamSink: "none",
+      persistMode: "caller",
+      approvalMode: "auto-deny",
+      endpointPath: params.endpointPath,
+      extraBodyFields: mergedExtraBodyFields,
+      ...(abortSignal ? { abortSignal } : {}),
+      maxSteps: params.maxSteps,
+      progressivePlan: prepared.progressivePlan,
+      discoveryState: prepared.discoveryState,
+      ...(sinks.onLiveTextDelta
+        ? { onLiveTextDelta: sinks.onLiveTextDelta }
+        : {}),
+      // Browser-rendered MCP App eval (PR 14): cache tool-call inputs for the
+      // widget shim, render MCP App tool results in the harness (the engine
+      // awaits the hook, so a mounted widget is visible to the next step's
+      // gate), and hide `computer` / `finish_widget` until a widget has
+      // actually rendered. SSE sinks compose around the browser hooks:
+      // `onToolResult` SSE fires BEFORE the render so live consumers don't
+      // wait on Chromium.
+      onToolCall: (event) => {
+        browser.noteToolCallInput(event);
+        sinks.onToolCall?.(event);
+      },
+      onToolResult: async (event) => {
+        await sinks.onToolResult?.(event);
+        await browser.handleEngineToolResult(event);
+      },
+      ...(sinks.onStepFinish ? { onStepFinish: sinks.onStepFinish } : {}),
+      onEngineError: (event) => {
+        lastEngineError = event;
+      },
+      ...(browser.prepareAdvertisedTools
+        ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
+        : {}),
+    });
+  } catch (error) {
+    // Cancellation: bail without recording. AbortError can surface either as
+    // a thrown exception (fetch aborted mid-flight) or as the engine's
+    // internal silent-cancellation path (handled by the `isAborted()` check
+    // after the success path below). Check `abortSignal.aborted` to catch
+    // BOTH paths consistently.
+    if (
+      isAborted() ||
+      (error instanceof Error && error.name === "AbortError")
+    ) {
+      logger.debug(
+        `[evals] backend iteration${logSuffix} aborted due to cancellation`
+      );
+      return { kind: "cancelled" };
+    }
+
+    // Non-abort runtime error from the engine. Map to `iterationError` for
+    // the post-loop verdict gate; preserve a truncated message and, when
+    // available, a `responseBody` for `errorDetails`.
+    let iterationError: string;
+    let iterationErrorDetails: string | undefined;
+    if (error instanceof Error) {
+      iterationError = error.message || error.toString();
+      const responseBody = (error as { responseBody?: unknown }).responseBody;
+      if (responseBody && typeof responseBody === "string") {
+        iterationErrorDetails = responseBody;
+      }
+    } else if (typeof error === "string") {
+      iterationError = error;
+    } else {
+      iterationError = String(error);
+    }
+    iterationError = truncateError(iterationError);
+    logger.error(`[evals] runAssistantTurn${logSuffix} failed`, error);
+    const failure = {
+      iterationError,
+      ...(iterationErrorDetails ? { iterationErrorDetails } : {}),
+    };
+    sinks.onTurnFailure?.(failure);
+    return { kind: "failed", ...failure };
+  }
+
+  // Cancellation that fired DURING `runAssistantTurn` without surfacing as a
+  // throw: the engine catches AbortError, sets its internal `aborted` flag,
+  // omits the `turnTrace`, and returns normally. Without this check we'd
+  // fall through to the silent-cycle-failure branch below and record an
+  // aborted run as a verdict failure.
+  if (isAborted()) {
+    logger.debug(
+      `[evals] backend iteration${logSuffix} aborted mid-turn; skipping record`
+    );
+    return { kind: "cancelled" };
+  }
+
+  // Drain per-turn outputs into the iteration-level accumulators BEFORE the
+  // failure checks below — preserves whatever partial good state the engine
+  // produced (tool spans, partial transcript, usage), so the persisted
+  // iteration shows what completed before the failure point.
+  //
+  // Codex round-3 (P2 "Preserve backend tool step indices"): the wrap's tool
+  // spans land with `stepIndex: -1` (no `prepareStep` bridge to the engine);
+  // the engine's own LLM-step spans land on `turnTrace.spans` with correct
+  // per-step indices. Merge both.
+  acc.capturedSpans.push(...traceCtx.recordedSpans);
+  if (turnResult.turnTrace?.spans?.length) {
+    acc.capturedSpans.push(...turnResult.turnTrace.spans);
+  }
+  // Reconcile accumulated usage to the engine's canonical post-turn total
+  // against the pre-turn baseline. The stream runner's `onStepFinish` sink
+  // rolls `accumulatedUsage` per step for live snapshots; this final
+  // assignment lands on the same value (PR 4b "totalUsage merged BEFORE
+  // failure branches" invariant).
+  if (turnResult.usage) {
+    acc.accumulatedUsage.inputTokens =
+      baselineUsage.inputTokens + (turnResult.usage.inputTokens ?? 0);
+    acc.accumulatedUsage.outputTokens =
+      baselineUsage.outputTokens + (turnResult.usage.outputTokens ?? 0);
+    acc.accumulatedUsage.totalTokens =
+      baselineUsage.totalTokens + (turnResult.usage.totalTokens ?? 0);
+  }
+
+  // Per-turn tool calls — rebuild from the new messages only (the engine
+  // returns the FULL transcript; slice from `messageCountBeforeTurn` so
+  // prior turns' calls aren't double-counted). Replaces whatever the live
+  // `onToolCall` sink accumulated so the grader sees the canonical shape.
+  const newMessages = turnResult.messages.slice(messageCountBeforeTurn);
+  const canonicalPromptToolsCalled = params.extractToolCalls(newMessages);
+  promptToolsCalled.length = 0;
+  promptToolsCalled.push(...canonicalPromptToolsCalled);
+
+  // Roll the engine's transcript forward as the next turn's starting point.
+  acc.messageHistory.length = 0;
+  acc.messageHistory.push(...turnResult.messages);
+
+  // Failure detection (ordered most-specific → least-specific). Three engine
+  // failure shapes the runner must catch:
+  //
+  //  (a) Engine catch fired AFTER partial messages were appended — the
+  //      engine's `executeEngine` catch leaves `runSucceeded: false` →
+  //      `turnTrace` is NOT captured even though messages may have grown.
+  //      `!turnTrace` is the reliable signal.
+  //  (b) Engine succeeded (turnTrace captured) but produced no new content
+  //      (step-level non-OK → `shouldContinue: false`, synthetic finish).
+  //      Detect via `newMessages.length === 0`.
+  //  (c) Step 1 succeeded, a later step errored: `turnTrace` captured,
+  //      messages grew, but `turnTrace.spans` carries a non-tool
+  //      error-status span.
+  //
+  // PR 5b-followup-2: prefer the engine's captured structured error when
+  // present (429 daily-cap text, hosted-model setup errors, …) over the
+  // generic fallbacks.
+  const failTurn = (
+    fallbackError: string,
+    logLine: string
+  ): HostedEvalTurnOutcome => {
+    const failure = lastEngineError
+      ? {
+          iterationError: lastEngineError.message,
+          iterationErrorDetails: lastEngineError.rawText,
+        }
+      : { iterationError: fallbackError };
+    logger.error(logLine);
+    sinks.onTurnFailure?.(failure);
+    return { kind: "failed", ...failure };
+  };
+
+  if (!turnResult.turnTrace) {
+    return failTurn(
+      "Backend stream failed during iteration (engine caught an error mid-turn)",
+      `[evals] runAssistantTurn${logSuffix} returned no turnTrace (engine runSucceeded=false); treating as cycle failure (messagesGrew=${
+        newMessages.length > 0
+      }, engineError=${
+        lastEngineError ? (lastEngineError.code ?? "uncoded") : "none"
+      })`
+    );
+  }
+  if (newMessages.length === 0) {
+    return failTurn(
+      "Backend step returned no content (stream error or empty response)",
+      `[evals] runAssistantTurn${logSuffix} produced no new messages this turn; treating as cycle failure (engineError=${
+        lastEngineError ? (lastEngineError.code ?? "uncoded") : "none"
+      })`
+    );
+  }
+  // Cursor / Codex review fix: filter to backend step / LLM failure spans
+  // only — exclude `category: "tool"` AND any span carrying a `toolCallId`
+  // (the child error span `wrapToolSetForEvalTrace` emits alongside a failed
+  // tool span). Tool-category error spans flow through the configured
+  // `failOnToolError` gate; treating them as cycle failures here would
+  // defeat that policy.
+  const stepErrorSpan = turnResult.turnTrace.spans.find(
+    (span) =>
+      span.status === "error" &&
+      span.category !== "tool" &&
+      !(span as { toolCallId?: string }).toolCallId
+  );
+  if (stepErrorSpan) {
+    return failTurn(
+      `Backend step failed mid-turn: ${stepErrorSpan.name}`,
+      `[evals] runAssistantTurn${logSuffix} turnTrace has non-tool error-status span; treating as cycle failure (span=${
+        stepErrorSpan.name
+      } category=${stepErrorSpan.category} engineError=${
+        lastEngineError ? (lastEngineError.code ?? "uncoded") : "none"
+      })`
+    );
+  }
+
+  sinks.onTurnSuccess?.();
+  return { kind: "completed" };
+}

--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -149,12 +149,8 @@ export async function driveHostedEvalTurn(
   const logSuffix = params.logSuffix ?? "";
 
   // Browser-rendered MCP App eval (PR 14): stamp collected artifacts with
-  // this turn, and start the turn with a clean widget surface — a widget
-  // kept mounted by a previous prompt turn must not bleed into this one
-  // (otherwise Computer Use could be advertised against the prior turn's
-  // widget before this turn's own MCP App tool runs).
+  // this turn.
   browser.setActivePromptIndex(promptIndex);
-  await browser.dismissCarriedWidget();
 
   // Per-turn span-capture context. `wrapToolSetForEvalTrace` instruments
   // each tool's `execute` to push to `traceCtx.recordedSpans`; we drain
@@ -187,15 +183,82 @@ export async function driveHostedEvalTurn(
   const promptToolsCalled: ToolCall[] = [];
   acc.toolsCalledByPrompt.push(promptToolsCalled);
 
-  const sinks =
-    params.buildSinks?.({
-      promptIndex,
-      baselineUsage,
-      traceCtx,
-      promptToolsCalled,
-    }) ?? {};
+  // Built inside the pre-turn try below; `{}` until then so the failure
+  // mapper can always call `sinks.onTurnFailure?.()` safely.
+  let sinks: HostedEvalTurnSinks = {};
 
-  sinks.onTurnStart?.();
+  // Shared throw → outcome mapping for the pre-turn setup AND the engine
+  // call. Cancellation: AbortError can surface either as a thrown exception
+  // (fetch aborted mid-flight) or as the engine's internal
+  // silent-cancellation path (handled by the `isAborted()` check after the
+  // success path below) — check `abortSignal.aborted` to catch BOTH paths
+  // consistently. Non-abort errors map to `iterationError` for the post-loop
+  // verdict gate, preserving a truncated message and, when available, a
+  // `responseBody` for `errorDetails`. The turn's tool-instrumentation spans
+  // are drained first so the persisted iteration (and the stream sink's
+  // failure snapshot, which reads the same array) keeps whatever tool
+  // executions completed before the throw — aligning with the (a)/(b)/(c)
+  // failure branches below (CodeRabbit, PR 2610).
+  const mapThrownTurnError = (
+    error: unknown,
+    failedStage: string
+  ): HostedEvalTurnOutcome => {
+    if (
+      isAborted() ||
+      (error instanceof Error && error.name === "AbortError")
+    ) {
+      logger.debug(
+        `[evals] backend iteration${logSuffix} aborted due to cancellation`
+      );
+      return { kind: "cancelled" };
+    }
+
+    acc.capturedSpans.push(...traceCtx.recordedSpans);
+    let iterationError: string;
+    let iterationErrorDetails: string | undefined;
+    if (error instanceof Error) {
+      iterationError = error.message || error.toString();
+      const responseBody = (error as { responseBody?: unknown }).responseBody;
+      if (responseBody && typeof responseBody === "string") {
+        iterationErrorDetails = responseBody;
+      }
+    } else if (typeof error === "string") {
+      iterationError = error;
+    } else {
+      iterationError = String(error);
+    }
+    iterationError = truncateError(iterationError);
+    logger.error(`[evals] ${failedStage}${logSuffix} failed`, error);
+    const failure = {
+      iterationError,
+      ...(iterationErrorDetails ? { iterationErrorDetails } : {}),
+    };
+    sinks.onTurnFailure?.(failure);
+    return { kind: "failed", ...failure };
+  };
+
+  // Pre-turn setup that can genuinely throw: the Chromium widget dismissal
+  // (start the turn with a clean surface — a widget kept mounted by a
+  // previous prompt turn must not bleed into this one, otherwise Computer
+  // Use could be advertised against the prior turn's widget before this
+  // turn's own MCP App tool runs), the caller-built SSE sinks, and the
+  // turn-start emit. Route their failures through the same mapping as the
+  // engine call so hosted callers always receive an outcome and run normal
+  // iteration persistence, instead of the throw escaping to the coarse
+  // iteration-abort path (CodeRabbit, PR 2610).
+  try {
+    await browser.dismissCarriedWidget();
+    sinks =
+      params.buildSinks?.({
+        promptIndex,
+        baselineUsage,
+        traceCtx,
+        promptToolsCalled,
+      }) ?? {};
+    sinks.onTurnStart?.();
+  } catch (error) {
+    return mapThrownTurnError(error, "pre-turn setup");
+  }
 
   // PR 5b-followup-2: capture the engine's structured-error event (429
   // daily-cap, hosted-model setup errors, …). The engine writes a generic
@@ -272,52 +335,7 @@ export async function driveHostedEvalTurn(
         : {}),
     });
   } catch (error) {
-    // Cancellation: bail without recording. AbortError can surface either as
-    // a thrown exception (fetch aborted mid-flight) or as the engine's
-    // internal silent-cancellation path (handled by the `isAborted()` check
-    // after the success path below). Check `abortSignal.aborted` to catch
-    // BOTH paths consistently.
-    if (
-      isAborted() ||
-      (error instanceof Error && error.name === "AbortError")
-    ) {
-      logger.debug(
-        `[evals] backend iteration${logSuffix} aborted due to cancellation`
-      );
-      return { kind: "cancelled" };
-    }
-
-    // Non-abort runtime error from the engine. Map to `iterationError` for
-    // the post-loop verdict gate; preserve a truncated message and, when
-    // available, a `responseBody` for `errorDetails`.
-    //
-    // Drain this turn's tool-instrumentation spans first so the persisted
-    // iteration (and the stream sink's failure snapshot, which reads the
-    // same array) keeps whatever tool executions completed before the throw
-    // — aligning the catch with the (a)/(b)/(c) failure branches below,
-    // which drain before failing (CodeRabbit, PR 2610).
-    acc.capturedSpans.push(...traceCtx.recordedSpans);
-    let iterationError: string;
-    let iterationErrorDetails: string | undefined;
-    if (error instanceof Error) {
-      iterationError = error.message || error.toString();
-      const responseBody = (error as { responseBody?: unknown }).responseBody;
-      if (responseBody && typeof responseBody === "string") {
-        iterationErrorDetails = responseBody;
-      }
-    } else if (typeof error === "string") {
-      iterationError = error;
-    } else {
-      iterationError = String(error);
-    }
-    iterationError = truncateError(iterationError);
-    logger.error(`[evals] runAssistantTurn${logSuffix} failed`, error);
-    const failure = {
-      iterationError,
-      ...(iterationErrorDetails ? { iterationErrorDetails } : {}),
-    };
-    sinks.onTurnFailure?.(failure);
-    return { kind: "failed", ...failure };
+    return mapThrownTurnError(error, "runAssistantTurn");
   }
 
   // Cancellation that fired DURING `runAssistantTurn` without surfacing as a

--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -290,6 +290,13 @@ export async function driveHostedEvalTurn(
     // Non-abort runtime error from the engine. Map to `iterationError` for
     // the post-loop verdict gate; preserve a truncated message and, when
     // available, a `responseBody` for `errorDetails`.
+    //
+    // Drain this turn's tool-instrumentation spans first so the persisted
+    // iteration (and the stream sink's failure snapshot, which reads the
+    // same array) keeps whatever tool executions completed before the throw
+    // — aligning the catch with the (a)/(b)/(c) failure branches below,
+    // which drain before failing (CodeRabbit, PR 2610).
+    acc.capturedSpans.push(...traceCtx.recordedSpans);
     let iterationError: string;
     let iterationErrorDetails: string | undefined;
     if (error instanceof Error) {

--- a/mcpjam-inspector/server/services/evals/finalize-iteration-browser-artifacts.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration-browser-artifacts.ts
@@ -1,115 +1,17 @@
-import type { ConvexHttpClient } from "convex/browser";
-import type {
-  BrowserInteractionStepPayload,
-  RunnerBrowserInteractionStep,
-  RunnerWidgetRenderObservation,
-  SerializedBrowserInteractionStep,
-  SerializedWidgetRenderObservation,
-  WidgetRenderObservationPayload,
-} from "@/shared/eval-trace";
-import { logger } from "../../utils/logger.js";
-import { uploadScreenshotBlob } from "../../utils/mcp-app-widget-capture.js";
-import { sanitizeForConvexTransport } from "./convex-sanitize.js";
-
 /**
- * PR 6b: serialize browser-rendered MCP App eval artifacts for the backend.
+ * PR 6b: browser-rendered MCP App eval artifacts for the backend.
  *
- * These run inside `finalizeEvalIteration` exactly ONCE per iteration, BEFORE
- * the W2 per-turn fanout or the W1 single-call fallback consume the result, so
- * a screenshot blob is never uploaded twice. Each helper:
- *   - uploads the transient base64 screenshot (`screenshotBase64` →
- *     `screenshotBlobId`) — best-effort: a failed upload drops the blob id but
- *     KEEPS the row (status / timings / console errors stay useful for replay),
- *   - runs the record through `sanitizeForConvexTransport` ($-key escaping is
- *     required for the `widgetToolCalls[].args: v.any()` field on steps),
- *   - retains `promptIndex` so the fanout can bucket per turn.
- *
- * Uploads are sequential (not `Promise.all`): under the harness budgets
- * (≤ 12 steps + a few observations per iteration) the wall-clock cost is dwarfed
- * by the rest of the fanout, and the convex-test storage mock expects serial
- * writes. Batch only if real evals show latency (see PR plan risks).
+ * The implementation moved to the shared
+ * `services/browser-artifact-serialization.ts` (the synthetic-session runner
+ * uses the same serializers + payload mappers per turn); this module re-exports
+ * it so the eval persistence path keeps one import site. The serializers run
+ * inside `finalizeEvalIteration` exactly ONCE per iteration, BEFORE the W2
+ * per-turn fanout or the W1 single-call fallback consume the result, so a
+ * screenshot blob is never uploaded twice.
  */
-export async function serializeRenderObservationsForBackend(
-  observations: RunnerWidgetRenderObservation[] | undefined,
-  convexClient: ConvexHttpClient,
-): Promise<SerializedWidgetRenderObservation[]> {
-  if (!observations?.length) return [];
-  const out: SerializedWidgetRenderObservation[] = [];
-  for (const obs of observations) {
-    let screenshotBlobId: string | undefined;
-    if (obs.screenshotBase64) {
-      try {
-        screenshotBlobId = await uploadScreenshotBlob(
-          convexClient,
-          obs.screenshotBase64,
-        );
-      } catch (err) {
-        logger.warn("[eval-persist] dropped render-obs screenshot upload", {
-          toolCallId: obs.toolCallId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
-    // Drop the transient base64; keep every other field (incl. promptIndex).
-    const { screenshotBase64: _screenshotBase64, ...rest } = obs;
-    const serialized: SerializedWidgetRenderObservation = {
-      ...rest,
-      ...(screenshotBlobId ? { screenshotBlobId } : {}),
-    };
-    // No $-key risk on observations (no v.any fields), but stay consistent with
-    // widgets and route through the sanitizer regardless.
-    out.push(sanitizeForConvexTransport(serialized));
-  }
-  return out;
-}
-
-export async function serializeBrowserStepsForBackend(
-  steps: RunnerBrowserInteractionStep[] | undefined,
-  convexClient: ConvexHttpClient,
-): Promise<SerializedBrowserInteractionStep[]> {
-  if (!steps?.length) return [];
-  const out: SerializedBrowserInteractionStep[] = [];
-  for (const step of steps) {
-    let screenshotBlobId: string | undefined;
-    if (step.screenshotBase64) {
-      try {
-        screenshotBlobId = await uploadScreenshotBlob(
-          convexClient,
-          step.screenshotBase64,
-        );
-      } catch (err) {
-        logger.warn("[eval-persist] dropped browser-step screenshot upload", {
-          toolCallId: step.toolCallId,
-          stepIndex: step.stepIndex,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
-    // Drop the transient base64; keep every other field (incl. promptIndex).
-    const { screenshotBase64: _screenshotBase64, ...rest } = step;
-    const serialized: SerializedBrowserInteractionStep = {
-      ...rest,
-      ...(screenshotBlobId ? { screenshotBlobId } : {}),
-    };
-    // $-keys can appear inside widgetToolCalls[].args (v.any() on the backend
-    // validator). sanitizeForConvexTransport handles the escape.
-    out.push(sanitizeForConvexTransport(serialized));
-  }
-  return out;
-}
-
-/** Strip `promptIndex` for the backend turn payload — the backend stamps it
- *  from `turn.promptIndex` server-side. */
-export function toObservationPayload(
-  obs: SerializedWidgetRenderObservation,
-): WidgetRenderObservationPayload {
-  const { promptIndex: _promptIndex, ...payload } = obs;
-  return payload;
-}
-
-export function toBrowserStepPayload(
-  step: SerializedBrowserInteractionStep,
-): BrowserInteractionStepPayload {
-  const { promptIndex: _promptIndex, ...payload } = step;
-  return payload;
-}
+export {
+  serializeBrowserStepsForBackend,
+  serializeRenderObservationsForBackend,
+  toBrowserStepPayload,
+  toObservationPayload,
+} from "../browser-artifact-serialization.js";

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
@@ -1,0 +1,425 @@
+/**
+ * runner.browser.test.ts — browser-rendered MCP App pipeline wiring in the
+ * synthetic-session runner.
+ *
+ * Locks the per-session browser-context lifecycle (create → per-turn
+ * setActivePromptIndex + dismissCarriedWidget → dispose-on-every-exit), the
+ * Computer Use tool merge + hook threading into `drainAssistantTurn`, the
+ * per-turn artifact drain → `chatSessions:recordBrowserArtifacts` persist,
+ * and that the inert widget-snapshot capture (Data/Sandbox iframe) still
+ * runs alongside.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runAssistantTurnMock = vi.fn();
+const resolveSyntheticModelSourceMock = vi.fn();
+const personaNextTurnMock = vi.fn();
+const updateRunMock = vi.fn();
+const persistChatSessionToConvexMock = vi.fn();
+const captureMcpAppWidgetSnapshotsMock = vi.fn();
+const prepareChatV2Mock = vi.fn();
+const convexMutationMock = vi.fn();
+const createBrowserSessionContextMock = vi.fn();
+
+vi.mock("../../../utils/assistant-turn.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/assistant-turn.js")
+  >("../../../utils/assistant-turn.js");
+  return {
+    ...actual,
+    runAssistantTurn: (...args: unknown[]) => runAssistantTurnMock(...args),
+  };
+});
+
+vi.mock("../../../utils/org-model-config.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/org-model-config.js")
+  >("../../../utils/org-model-config.js");
+  return {
+    ...actual,
+    resolveSyntheticModelSource: (...args: unknown[]) =>
+      resolveSyntheticModelSourceMock(...args),
+  };
+});
+
+vi.mock("../../session-agent.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../session-agent.js")
+  >("../../session-agent.js");
+  return {
+    ...actual,
+    personaNextTurn: (...args: unknown[]) => personaNextTurnMock(...args),
+    updateRun: (...args: unknown[]) => updateRunMock(...args),
+  };
+});
+
+vi.mock("../../../utils/chat-ingestion.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chat-ingestion.js")
+  >("../../../utils/chat-ingestion.js");
+  return {
+    ...actual,
+    persistChatSessionToConvex: (...args: unknown[]) =>
+      persistChatSessionToConvexMock(...args),
+  };
+});
+
+vi.mock("../../../utils/mcp-app-widget-capture.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/mcp-app-widget-capture.js")
+  >("../../../utils/mcp-app-widget-capture.js");
+  return {
+    ...actual,
+    captureMcpAppWidgetSnapshots: (...args: unknown[]) =>
+      captureMcpAppWidgetSnapshotsMock(...args),
+  };
+});
+
+vi.mock("../../../utils/chat-v2-orchestration.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chat-v2-orchestration.js")
+  >("../../../utils/chat-v2-orchestration.js");
+  return {
+    ...actual,
+    prepareChatV2: (...args: unknown[]) => prepareChatV2Mock(...args),
+  };
+});
+
+vi.mock("../../browser-session-context.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../browser-session-context.js")
+  >("../../browser-session-context.js");
+  return {
+    ...actual,
+    createBrowserSessionContext: (...args: unknown[]) =>
+      createBrowserSessionContextMock(...args),
+  };
+});
+
+// Identity serializers: skip the screenshot blob upload, keep the rows.
+vi.mock("../../browser-artifact-serialization.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../browser-artifact-serialization.js")
+  >("../../browser-artifact-serialization.js");
+  return {
+    ...actual,
+    serializeRenderObservationsForBackend: async (obs: unknown[] | undefined) =>
+      (obs ?? []).map((o) => {
+        const { screenshotBase64: _s, ...rest } = o as Record<string, unknown>;
+        return rest;
+      }),
+    serializeBrowserStepsForBackend: async (steps: unknown[] | undefined) =>
+      (steps ?? []).map((s) => {
+        const { screenshotBase64: _s, ...rest } = s as Record<string, unknown>;
+        return rest;
+      }),
+  };
+});
+
+vi.mock("convex/browser", async () => {
+  const actual =
+    await vi.importActual<typeof import("convex/browser")>("convex/browser");
+  return {
+    ...actual,
+    ConvexHttpClient: class {
+      setAuth() {}
+      mutation(...args: unknown[]) {
+        return convexMutationMock(...args);
+      }
+    },
+  };
+});
+
+import { startSimulation } from "../runner.js";
+
+const TURN_TRACE = {
+  turnId: "turn-1",
+  promptIndex: 0,
+  startedAt: 0,
+  endedAt: 1,
+  spans: [],
+};
+
+/** Ordered call log shared by the fake browser context + engine mock. */
+let callOrder: string[] = [];
+
+function buildFakeBrowserContext(opts: { computerUse: boolean }) {
+  const artifacts: {
+    observations: Array<Record<string, unknown>>;
+    steps: Array<Record<string, unknown>>;
+  } = { observations: [], steps: [] };
+  const ctx = {
+    computerUseVersion: opts.computerUse ? ("20250124" as const) : null,
+    computerWidgetTools: opts.computerUse
+      ? { computer: { fake: true }, finish_widget: { fake: true } }
+      : {},
+    widgetRenderObservations: [],
+    browserInteractionSteps: [],
+    prepareAdvertisedTools: opts.computerUse ? vi.fn() : undefined,
+    setActivePromptIndex: vi.fn((i: number) => {
+      callOrder.push(`setActivePromptIndex:${i}`);
+    }),
+    noteToolCallInput: vi.fn(),
+    handleEngineToolResult: vi.fn(),
+    handleDirectToolResultChunk: vi.fn(),
+    drainNewArtifacts: vi.fn(() => {
+      const out = {
+        observations: artifacts.observations,
+        steps: artifacts.steps,
+      };
+      artifacts.observations = [];
+      artifacts.steps = [];
+      return out;
+    }),
+    dismissCarriedWidget: vi.fn(async () => {
+      callOrder.push("dismissCarriedWidget");
+    }),
+    dispose: vi.fn(async () => {
+      callOrder.push("dispose");
+    }),
+    /** Test handle: queue artifacts the next drain returns. */
+    _queueArtifacts(
+      observations: Array<Record<string, unknown>>,
+      steps: Array<Record<string, unknown>>,
+    ) {
+      artifacts.observations = observations;
+      artifacts.steps = steps;
+    },
+  };
+  return ctx;
+}
+
+function baseOptions() {
+  return {
+    runId: "run-1",
+    chatboxId: "chatbox-1",
+    projectId: "proj-1",
+    personas: [{ id: "p1", name: "Persona One", role: "tester" }],
+    sessionsPerPersona: 1,
+    maxTurns: 3,
+    modelId: "anthropic/claude-haiku-4.5",
+    systemPrompt: "system",
+    requireToolApproval: false,
+    convexHttpUrl: "https://convex.site",
+    convexAuthToken: "Bearer token",
+    authHeader: "Bearer token",
+    managerFactory: async () => ({
+      manager: {
+        hasServer: () => false,
+        executeTool: vi.fn(),
+        getAllToolsMetadata: vi.fn().mockReturnValue({}),
+      } as never,
+      connectedServerIds: ["server-1"],
+      connectedServerNames: ["Server One"],
+      dispose: async () => {},
+    }),
+  };
+}
+
+beforeEach(() => {
+  callOrder = [];
+  vi.stubEnv("CONVEX_URL", "https://convex.cloud");
+  runAssistantTurnMock.mockReset();
+  resolveSyntheticModelSourceMock.mockReset();
+  personaNextTurnMock.mockReset();
+  updateRunMock.mockReset().mockResolvedValue(undefined);
+  persistChatSessionToConvexMock.mockReset().mockResolvedValue(undefined);
+  captureMcpAppWidgetSnapshotsMock.mockReset().mockResolvedValue([]);
+  prepareChatV2Mock.mockReset().mockResolvedValue({
+    allTools: { search: { description: "noop" } },
+    enhancedSystemPrompt: "enhanced system",
+    resolvedTemperature: undefined,
+    progressivePlan: undefined,
+    discoveryState: undefined,
+  });
+  convexMutationMock.mockReset().mockResolvedValue(null);
+  createBrowserSessionContextMock.mockReset();
+  resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+  // One user turn, then the persona ends the session.
+  personaNextTurnMock
+    .mockResolvedValueOnce({ message: "draw me a box", endSession: false })
+    .mockResolvedValue({ message: "", endSession: true });
+  runAssistantTurnMock.mockImplementation(async (opts: any) => {
+    callOrder.push("runAssistantTurn");
+    return {
+      messages: [
+        ...opts.messages,
+        { role: "assistant", content: "drew a box" },
+      ],
+      assistantMessages: [],
+      toolCalls: [],
+      toolResults: [],
+      turnTrace: TURN_TRACE,
+    };
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("synthetic-session runner — browser pipeline wiring", () => {
+  it("creates one context per session, runs per-turn hygiene before the engine, merges computer tools, threads hooks, persists artifacts, and disposes", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: true });
+    fake._queueArtifacts(
+      [
+        {
+          toolCallId: "tc-1",
+          toolName: "create_view",
+          serverId: "server-1",
+          status: "rendered",
+          elapsedMs: 50,
+          ts: 1,
+          promptIndex: 0,
+          screenshotBase64: "img",
+        },
+      ],
+      [
+        {
+          toolCallId: "tc-1",
+          stepIndex: 0,
+          promptIndex: 0,
+          action: "left_click",
+          coordinateX: 1,
+          coordinateY: 2,
+          elapsedMs: 5,
+          ts: 2,
+          screenshotBase64: "img2",
+        },
+      ],
+    );
+    createBrowserSessionContextMock.mockReturnValue(fake);
+
+    await startSimulation(baseOptions());
+
+    // Context per session, surface-scoped logging, the session's manager.
+    expect(createBrowserSessionContextMock).toHaveBeenCalledTimes(1);
+    expect(createBrowserSessionContextMock.mock.calls[0]![0]).toMatchObject({
+      model: "anthropic/claude-haiku-4.5",
+      logScope: "sessionSimulation",
+    });
+
+    // Per-turn hygiene runs BEFORE the engine; dispose runs at session end.
+    expect(callOrder).toEqual([
+      "setActivePromptIndex:0",
+      "dismissCarriedWidget",
+      "runAssistantTurn",
+      "dispose",
+    ]);
+
+    // Computer tools merged into the advertised set + hooks threaded.
+    const engineOpts = runAssistantTurnMock.mock.calls[0]![0] as any;
+    expect(Object.keys(engineOpts.tools).sort()).toEqual([
+      "computer",
+      "finish_widget",
+      "search",
+    ]);
+    expect(engineOpts.prepareAdvertisedTools).toBe(fake.prepareAdvertisedTools);
+    expect(typeof engineOpts.onToolCall).toBe("function");
+    expect(typeof engineOpts.onToolResult).toBe("function");
+    engineOpts.onToolCall({ toolCallId: "tc-1", input: { a: 1 } });
+    expect(fake.noteToolCallInput).toHaveBeenCalledWith({
+      toolCallId: "tc-1",
+      input: { a: 1 },
+    });
+
+    // The turn persisted, the inert snapshot capture still ran, and the
+    // drained artifacts went to recordBrowserArtifacts with the turn index.
+    expect(persistChatSessionToConvexMock).toHaveBeenCalledTimes(1);
+    expect(captureMcpAppWidgetSnapshotsMock).toHaveBeenCalledTimes(1);
+    const artifactCall = convexMutationMock.mock.calls.find(
+      (c) => c[0] === "chatSessions:recordBrowserArtifacts",
+    );
+    expect(artifactCall).toBeDefined();
+    expect(artifactCall![1]).toMatchObject({
+      chatboxId: "chatbox-1",
+      chatSessionId: "synth_run-1_p1_0",
+      promptIndex: 0,
+    });
+    const payload = artifactCall![1] as any;
+    // promptIndex + transient base64 are stripped from rows (the mutation
+    // stamps the batch-level promptIndex; validators reject unknown keys).
+    expect(payload.widgetRenderObservations).toEqual([
+      {
+        toolCallId: "tc-1",
+        toolName: "create_view",
+        serverId: "server-1",
+        status: "rendered",
+        elapsedMs: 50,
+        ts: 1,
+      },
+    ]);
+    expect(payload.browserInteractionSteps).toEqual([
+      {
+        toolCallId: "tc-1",
+        stepIndex: 0,
+        action: "left_click",
+        coordinateX: 1,
+        coordinateY: 2,
+        elapsedMs: 5,
+        ts: 2,
+      },
+    ]);
+  });
+
+  it("non-Claude drivers get no computer tools but artifacts still persist", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: false });
+    fake._queueArtifacts(
+      [
+        {
+          toolCallId: "tc-9",
+          toolName: "create_view",
+          serverId: "server-1",
+          status: "bridge_timeout",
+          elapsedMs: 9,
+          ts: 3,
+          promptIndex: 0,
+        },
+      ],
+      [],
+    );
+    createBrowserSessionContextMock.mockReturnValue(fake);
+
+    await startSimulation({
+      ...baseOptions(),
+      modelId: "openai/gpt-5-mini",
+    });
+
+    const engineOpts = runAssistantTurnMock.mock.calls[0]![0] as any;
+    expect(Object.keys(engineOpts.tools)).toEqual(["search"]);
+    expect(engineOpts.prepareAdvertisedTools).toBeUndefined();
+
+    const artifactCall = convexMutationMock.mock.calls.find(
+      (c) => c[0] === "chatSessions:recordBrowserArtifacts",
+    );
+    expect(artifactCall).toBeDefined();
+    expect((artifactCall![1] as any).widgetRenderObservations).toHaveLength(1);
+    expect((artifactCall![1] as any).browserInteractionSteps).toBeUndefined();
+  });
+
+  it("disposes the context when the turn throws (session failure path)", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: true });
+    createBrowserSessionContextMock.mockReturnValue(fake);
+    runAssistantTurnMock.mockRejectedValue(new Error("provider exploded"));
+
+    await startSimulation(baseOptions());
+
+    expect(fake.dispose).toHaveBeenCalledTimes(1);
+    // The failed session is counted, not thrown out of the batch loop.
+    expect(updateRunMock).toHaveBeenCalled();
+  });
+
+  it("skips the artifact mutation when a turn drained nothing", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: true });
+    createBrowserSessionContextMock.mockReturnValue(fake);
+
+    await startSimulation(baseOptions());
+
+    expect(
+      convexMutationMock.mock.calls.some(
+        (c) => c[0] === "chatSessions:recordBrowserArtifacts",
+      ),
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -336,6 +336,48 @@ describe("drainAssistantTurn — engine error surfacing", () => {
     ).rejects.toThrow(/spend cap.*spend_cap_exceeded.*HTTP 429/i);
   });
 
+  it("throws when the engine returns no turnTrace even WITHOUT a captured engine error (no silent empty turns)", async () => {
+    // Cursor Bugbot (PR 2610): a missing turnTrace on a non-aborted turn
+    // always means runSucceeded=false — engine-internal aborts or error
+    // sites the onEngineError callback doesn't cover must still fail the
+    // session instead of silently recording an empty assistant reply.
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+    runAssistantTurnMock.mockImplementation(async (opts: any) => ({
+      messages: opts.messages,
+      assistantMessages: [],
+      toolCalls: [],
+      toolResults: [],
+      // no turnTrace, no onEngineError fired
+    }));
+
+    await expect(
+      drainAssistantTurn(
+        baseArgs() as Parameters<typeof drainAssistantTurn>[0],
+      ),
+    ).rejects.toThrow(/engine returned no turn trace/i);
+  });
+
+  it("does not throw on a missing turnTrace when the abort signal fired (cancellation, not failure)", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+    const controller = new AbortController();
+    runAssistantTurnMock.mockImplementation(async (opts: any) => {
+      controller.abort();
+      return {
+        messages: opts.messages,
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+      };
+    });
+
+    const result = await drainAssistantTurn(
+      baseArgs({
+        abortSignal: controller.signal,
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+    expect(result.turnTrace).toBeUndefined();
+  });
+
   it("does not throw when a turnTrace was produced despite a recovered per-step engine error", async () => {
     resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
     runAssistantTurnMock.mockImplementation(async (opts: any) => {

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.dispatch.test.ts
@@ -2,9 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ModelDefinition } from "@/shared/types";
 
-const handleMCPJamFreeChatModelMock = vi.fn();
-const handleHostedOrgChatModelMock = vi.fn();
-const handleLocalOrgChatModelMock = vi.fn();
+const runAssistantTurnMock = vi.fn();
+const runLocalOrgChatTurnHeadlessMock = vi.fn();
 // The runner calls the shared `resolveSyntheticModelSource` helper which
 // internally calls `resolveOrgProviderRuntime`. Mocking the latter via
 // module mocking doesn't intercept the call because both functions live
@@ -14,14 +13,13 @@ const handleLocalOrgChatModelMock = vi.fn();
 // exercises the same surface as production.
 const resolveSyntheticModelSourceMock = vi.fn();
 
-vi.mock("../../../utils/mcpjam-stream-handler.js", async () => {
+vi.mock("../../../utils/assistant-turn.js", async () => {
   const actual = await vi.importActual<
-    typeof import("../../../utils/mcpjam-stream-handler.js")
-  >("../../../utils/mcpjam-stream-handler.js");
+    typeof import("../../../utils/assistant-turn.js")
+  >("../../../utils/assistant-turn.js");
   return {
     ...actual,
-    handleMCPJamFreeChatModel: (...args: unknown[]) =>
-      handleMCPJamFreeChatModelMock(...args),
+    runAssistantTurn: (...args: unknown[]) => runAssistantTurnMock(...args),
   };
 });
 
@@ -31,10 +29,8 @@ vi.mock("../../../utils/org-model-stream-handler.js", async () => {
   >("../../../utils/org-model-stream-handler.js");
   return {
     ...actual,
-    handleHostedOrgChatModel: (...args: unknown[]) =>
-      handleHostedOrgChatModelMock(...args),
-    handleLocalOrgChatModel: (...args: unknown[]) =>
-      handleLocalOrgChatModelMock(...args),
+    runLocalOrgChatTurnHeadless: (...args: unknown[]) =>
+      runLocalOrgChatTurnHeadlessMock(...args),
   };
 });
 
@@ -51,27 +47,42 @@ vi.mock("../../../utils/org-model-config.js", async () => {
 
 import { drainAssistantTurn } from "../runner.js";
 
+const TURN_TRACE = {
+  turnId: "test-turn",
+  promptIndex: 0,
+  startedAt: 0,
+  endedAt: 0,
+  spans: [],
+};
+
 /**
- * The runner's drainAssistantTurn awaits handler responses and then reads
- * `response.body` to drain the SSE stream before returning. The handler
- * also fires `onConversationComplete` synchronously inside the handler
- * (in production via the AI SDK stream's onFinish). For dispatch tests we
- * return an empty Response and invoke onConversationComplete before
- * returning so the captured history flows through.
+ * `drainAssistantTurn` drives turns headlessly: the engine branches call
+ * `runAssistantTurn` (streamSink: "none") whose result carries the
+ * transcript synchronously; the local org-BYOK branch calls
+ * `runLocalOrgChatTurnHeadless`. The stubs return the input messages as
+ * the post-turn history plus a turnTrace, mirroring a successful turn.
  */
-function buildHandlerStub(captureCalls: unknown[]) {
+function buildEngineStub(captureCalls: unknown[]) {
   return vi.fn(async (opts: any) => {
     captureCalls.push(opts);
-    // Synchronously invoke onConversationComplete with a captured history
-    // so the runner has something to return.
-    opts.onConversationComplete?.(opts.messages, {
-      turnId: "test-turn",
-      promptIndex: 0,
-      startedAt: 0,
-      endedAt: 0,
-      spans: [],
-    });
-    return new Response(null, { status: 200 });
+    return {
+      messages: opts.messages,
+      assistantMessages: [],
+      toolCalls: [],
+      toolResults: [],
+      turnTrace: TURN_TRACE,
+    };
+  });
+}
+
+function buildLocalHeadlessStub(captureCalls: unknown[]) {
+  return vi.fn(async (opts: any) => {
+    captureCalls.push(opts);
+    return {
+      messages: opts.messages,
+      turnTrace: TURN_TRACE,
+      aborted: false,
+    };
   });
 }
 
@@ -96,9 +107,8 @@ const baseArgs = (overrides: Record<string, unknown> = {}) => ({
 
 describe("drainAssistantTurn — model-aware dispatch", () => {
   beforeEach(() => {
-    handleMCPJamFreeChatModelMock.mockReset();
-    handleHostedOrgChatModelMock.mockReset();
-    handleLocalOrgChatModelMock.mockReset();
+    runAssistantTurnMock.mockReset();
+    runLocalOrgChatTurnHeadlessMock.mockReset();
     resolveSyntheticModelSourceMock.mockReset();
   });
 
@@ -106,27 +116,40 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
     vi.clearAllMocks();
   });
 
-  it("dispatches MCPJam-provided models through handleMCPJamFreeChatModel and threads synthesisRunId via extraBodyFields", async () => {
+  it("dispatches MCPJam-provided models through runAssistantTurn headlessly with synthesisRunId as a typed option", async () => {
     const calls: unknown[] = [];
-    handleMCPJamFreeChatModelMock.mockImplementation(buildHandlerStub(calls));
+    runAssistantTurnMock.mockImplementation(buildEngineStub(calls));
     resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
 
     const result = await drainAssistantTurn(
       baseArgs() as Parameters<typeof drainAssistantTurn>[0],
     );
 
-    expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledTimes(1);
-    expect(handleHostedOrgChatModelMock).not.toHaveBeenCalled();
-    expect(handleLocalOrgChatModelMock).not.toHaveBeenCalled();
+    expect(runAssistantTurnMock).toHaveBeenCalledTimes(1);
+    expect(runLocalOrgChatTurnHeadlessMock).not.toHaveBeenCalled();
     expect(result.modelSource).toBe("mcpjam");
+    expect(result.turnTrace).toEqual(TURN_TRACE);
     const opts = calls[0] as any;
-    expect(opts.extraBodyFields).toMatchObject({ synthesisRunId: "run-xyz" });
+    // `runAssistantTurn` itself appends synthesisRunId to extraBodyFields,
+    // so the wire body matches the old handler-built shape.
+    expect(opts.synthesisRunId).toBe("run-xyz");
     expect(opts.approvalMode).toBe("auto-deny");
+    // Headless contract: no SSE Response, caller-owned persistence.
+    expect(opts.streamSink).toBe("none");
+    expect(opts.persistMode).toBe("caller");
+    expect(opts.sourceType).toBe("chatbox");
+    expect(opts.origin).toBe("chatbox");
+    expect(opts.authContext).toEqual({
+      kind: "user_bearer",
+      token: "Bearer abc",
+    });
+    // JAM-paid path stays on the default `/stream` endpoint.
+    expect(opts.endpointPath).toBeUndefined();
   });
 
-  it("dispatches non-MCPJam models with cloud runtime through handleHostedOrgChatModel and threads synthesisRunId via extraBodyFields", async () => {
+  it("dispatches non-MCPJam models with cloud runtime through runAssistantTurn at /stream/org with providerKey + serverIds", async () => {
     const calls: unknown[] = [];
-    handleHostedOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
+    runAssistantTurnMock.mockImplementation(buildEngineStub(calls));
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "byok",
       orgRuntime: { runtimeLocation: "cloud", providerKey: "anthropic" },
@@ -143,21 +166,30 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
       }) as Parameters<typeof drainAssistantTurn>[0],
     );
 
-    expect(handleHostedOrgChatModelMock).toHaveBeenCalledTimes(1);
-    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
-    expect(handleLocalOrgChatModelMock).not.toHaveBeenCalled();
+    expect(runAssistantTurnMock).toHaveBeenCalledTimes(1);
+    expect(runLocalOrgChatTurnHeadlessMock).not.toHaveBeenCalled();
     expect(result.modelSource).toBe("byok");
     const opts = calls[0] as any;
-    expect(opts.extraBodyFields).toMatchObject({ synthesisRunId: "run-xyz" });
-    expect(opts.providerKey).toBe("anthropic");
+    // Hosted org-BYOK contract — byte-matching what
+    // `handleHostedOrgChatModel` constructed before the headless refactor.
+    expect(opts.endpointPath).toBe("/stream/org");
+    expect(opts.extraBodyFields).toMatchObject({
+      providerKey: "anthropic",
+      serverIds: ["server-a"],
+    });
+    expect(opts.synthesisRunId).toBe("run-xyz");
     // Synthetic runs must auto-deny approval-required tool calls — there
     // is no human in the loop. Regression guard for #2486 PR review.
     expect(opts.approvalMode).toBe("auto-deny");
+    expect(opts.streamSink).toBe("none");
+    expect(opts.persistMode).toBe("caller");
   });
 
-  it("dispatches non-MCPJam models with local runtime through handleLocalOrgChatModel and threads synthesisRunId as a typed option", async () => {
+  it("dispatches non-MCPJam models with local runtime through runLocalOrgChatTurnHeadless and threads synthesisRunId as a typed option", async () => {
     const calls: unknown[] = [];
-    handleLocalOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
+    runLocalOrgChatTurnHeadlessMock.mockImplementation(
+      buildLocalHeadlessStub(calls),
+    );
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "local_byok",
       orgRuntime: {
@@ -178,10 +210,10 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
       }) as Parameters<typeof drainAssistantTurn>[0],
     );
 
-    expect(handleLocalOrgChatModelMock).toHaveBeenCalledTimes(1);
-    expect(handleHostedOrgChatModelMock).not.toHaveBeenCalled();
-    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+    expect(runLocalOrgChatTurnHeadlessMock).toHaveBeenCalledTimes(1);
+    expect(runAssistantTurnMock).not.toHaveBeenCalled();
     expect(result.modelSource).toBe("local_byok");
+    expect(result.turnTrace).toEqual(TURN_TRACE);
     const opts = calls[0] as any;
     expect(opts.synthesisRunId).toBe("run-xyz");
   });
@@ -212,13 +244,15 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
       /approval-required tool calls.*Disable tool approval/i,
     );
 
-    // Refusal happens before the handler is invoked.
-    expect(handleLocalOrgChatModelMock).not.toHaveBeenCalled();
+    // Refusal happens before the turn driver is invoked.
+    expect(runLocalOrgChatTurnHeadlessMock).not.toHaveBeenCalled();
   });
 
   it("still dispatches local-runtime org BYOK when requireToolApproval is false", async () => {
     const calls: unknown[] = [];
-    handleLocalOrgChatModelMock.mockImplementation(buildHandlerStub(calls));
+    runLocalOrgChatTurnHeadlessMock.mockImplementation(
+      buildLocalHeadlessStub(calls),
+    );
     resolveSyntheticModelSourceMock.mockResolvedValue({
       source: "local_byok",
       orgRuntime: {
@@ -240,7 +274,7 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
       }) as Parameters<typeof drainAssistantTurn>[0],
     );
 
-    expect(handleLocalOrgChatModelMock).toHaveBeenCalledTimes(1);
+    expect(runLocalOrgChatTurnHeadlessMock).toHaveBeenCalledTimes(1);
   });
 
   it("throws with a clear message when org-BYOK derivation fails (custom provider without a name)", async () => {
@@ -265,5 +299,117 @@ describe("drainAssistantTurn — model-aware dispatch", () => {
         }) as Parameters<typeof drainAssistantTurn>[0],
       ),
     ).rejects.toThrow(/derive org provider key/i);
+  });
+});
+
+describe("drainAssistantTurn — engine error surfacing", () => {
+  beforeEach(() => {
+    runAssistantTurnMock.mockReset();
+    runLocalOrgChatTurnHeadlessMock.mockReset();
+    resolveSyntheticModelSourceMock.mockReset();
+  });
+
+  it("throws when the engine reports an error and produces no turnTrace (spend-cap classification path)", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+    runAssistantTurnMock.mockImplementation(async (opts: any) => {
+      // streamSink: "none" contract — the engine never throws; it fires
+      // onEngineError and returns without a turnTrace.
+      opts.onEngineError?.({
+        message: "Daily spend cap reached for free models",
+        code: "spend_cap_exceeded",
+        httpStatus: 429,
+        rawText: "{}",
+        promptIndex: 0,
+      });
+      return {
+        messages: opts.messages,
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+      };
+    });
+
+    await expect(
+      drainAssistantTurn(
+        baseArgs() as Parameters<typeof drainAssistantTurn>[0],
+      ),
+    ).rejects.toThrow(/spend cap.*spend_cap_exceeded.*HTTP 429/i);
+  });
+
+  it("does not throw when a turnTrace was produced despite a recovered per-step engine error", async () => {
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+    runAssistantTurnMock.mockImplementation(async (opts: any) => {
+      opts.onEngineError?.({
+        message: "transient step error",
+        rawText: "{}",
+        promptIndex: 0,
+      });
+      return {
+        messages: opts.messages,
+        assistantMessages: [],
+        toolCalls: [],
+        toolResults: [],
+        turnTrace: TURN_TRACE,
+      };
+    });
+
+    const result = await drainAssistantTurn(
+      baseArgs() as Parameters<typeof drainAssistantTurn>[0],
+    );
+    expect(result.turnTrace).toEqual(TURN_TRACE);
+  });
+
+  it("threads turn hooks into the engine call (browser session context attachment)", async () => {
+    const calls: unknown[] = [];
+    runAssistantTurnMock.mockImplementation(buildEngineStub(calls));
+    resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
+
+    const onToolCall = vi.fn();
+    const onToolResult = vi.fn();
+    const prepareAdvertisedTools = vi.fn();
+
+    await drainAssistantTurn(
+      baseArgs({
+        hooks: { onToolCall, onToolResult, prepareAdvertisedTools },
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+
+    const opts = calls[0] as any;
+    expect(opts.onToolCall).toBe(onToolCall);
+    expect(opts.onToolResult).toBe(onToolResult);
+    expect(opts.prepareAdvertisedTools).toBe(prepareAdvertisedTools);
+  });
+
+  it("threads local-branch hooks into runLocalOrgChatTurnHeadless", async () => {
+    const calls: unknown[] = [];
+    runLocalOrgChatTurnHeadlessMock.mockImplementation(
+      buildLocalHeadlessStub(calls),
+    );
+    resolveSyntheticModelSourceMock.mockResolvedValue({
+      source: "local_byok",
+      orgRuntime: {
+        runtimeLocation: "local",
+        provider: { providerKey: "openai" } as any,
+      },
+    });
+
+    const prepareAdvertisedTools = vi.fn();
+    const onToolResultChunk = vi.fn();
+
+    await drainAssistantTurn(
+      baseArgs({
+        modelId: "llama3",
+        modelDefinition: {
+          id: "llama3",
+          name: "Llama3 local",
+          provider: "ollama",
+        } as ModelDefinition,
+        hooks: { prepareAdvertisedTools, onToolResultChunk },
+      }) as Parameters<typeof drainAssistantTurn>[0],
+    );
+
+    const opts = calls[0] as any;
+    expect(opts.prepareAdvertisedTools).toBe(prepareAdvertisedTools);
+    expect(opts.onToolResultChunk).toBe(onToolResultChunk);
   });
 });

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -8,13 +8,14 @@ import type { ModelDefinition } from "@/shared/types";
 // when the chatbox modelId isn't in SUPPORTED_MODELS, which is the common
 // case for org-BYOK chatboxes (Ollama, custom: providers, OpenRouter ids).
 import { logger } from "../../utils/logger.js";
-import {
-  handleMCPJamFreeChatModel,
-  type MCPJamHandlerOptions,
+import type {
+  MCPJamEngineErrorEvent,
+  MCPJamHandlerOptions,
 } from "../../utils/mcpjam-stream-handler.js";
+import { runAssistantTurn } from "../../utils/assistant-turn.js";
 import {
-  handleHostedOrgChatModel,
-  handleLocalOrgChatModel,
+  runLocalOrgChatTurnHeadless,
+  type RunLocalOrgChatTurnHeadlessOptions,
 } from "../../utils/org-model-stream-handler.js";
 import {
   buildSyntheticModelDefinition,
@@ -847,15 +848,33 @@ async function captureAndPersistWidgetSnapshotsForSession(args: {
 // runner and the shared resolver stay in lockstep.
 
 /**
- * Drive one assistant turn through the appropriate model handler:
- *   - MCPJam-provided modelId → `handleMCPJamFreeChatModel` (JAM-paid)
- *   - Org-BYOK cloud runtime → `handleHostedOrgChatModel`
- *   - Org-BYOK local runtime → `handleLocalOrgChatModel`
+ * Hooks a caller can attach to the assistant turn (the browser session
+ * context wires these so MCP App tool results render in the headless
+ * harness and Computer Use tools gate on a live widget mount).
+ */
+export interface DrainAssistantTurnHooks {
+  /** Engine branches (`/stream`, `/stream/org`): MCPJamHandlerOptions pass-throughs. */
+  onToolCall?: MCPJamHandlerOptions["onToolCall"];
+  onToolResult?: MCPJamHandlerOptions["onToolResult"];
+  /** All branches: per-step advertised-tool narrowing. */
+  prepareAdvertisedTools?: MCPJamHandlerOptions["prepareAdvertisedTools"];
+  /** Local AI-SDK branch: awaited per-tool-result render hook. */
+  onToolResultChunk?: RunLocalOrgChatTurnHeadlessOptions["onToolResultChunk"];
+}
+
+/**
+ * Drive one assistant turn through the appropriate headless turn driver:
+ *   - MCPJam-provided modelId → `runAssistantTurn` (JAM-paid `/stream`)
+ *   - Org-BYOK cloud runtime → `runAssistantTurn` with
+ *     `endpointPath: "/stream/org"` + `extraBodyFields: { providerKey,
+ *     serverIds }` (byte-matching what `handleHostedOrgChatModel` builds)
+ *   - Org-BYOK local runtime → `runLocalOrgChatTurnHeadless`
  *
- * Mirrors `web-chat-turn.ts`'s three-way dispatch but re-implements the
- * minimum branch logic here because the shared dispatcher's surface is
- * UIMessage-shaped and bakes in persist/SSE concerns that synthetic runs
- * own themselves (per-turn `persistChatSessionToConvex` from
+ * No SSE Response is built or drained: the engine branches run
+ * `streamSink: "none"` / `persistMode: "caller"` (the agent loop and the
+ * transcript capture complete before `runAssistantTurn` returns), and the
+ * local branch consumes `runDirectChatTurn` headlessly. Synthetic runs own
+ * persistence themselves (per-turn `persistChatSessionToConvex` from
  * `runOneSession` with `synthetic: true`, `personaId`, `synthesisRunId`).
  *
  * User-API-key direct chats are NOT supported on the synthetic path —
@@ -863,12 +882,18 @@ async function captureAndPersistWidgetSnapshotsForSession(args: {
  * the route boundary; this dispatcher's only fallthrough is for an
  * unexpected `resolveOrgProviderRuntime` shape, which throws.
  *
- * Returns the post-turn message history, the per-turn trace captured by
- * `onConversationComplete`, and the resolved `modelSource` so the caller
- * can stamp `persistChatSessionToConvex` correctly.
+ * Error contract: turn failures THROW. The engine doesn't throw in
+ * `streamSink: "none"` mode — it routes failures through `onEngineError`
+ * and returns with no turnTrace — so this dispatcher converts that signal
+ * into a throw. The old SSE-drain implementation discarded error chunks
+ * into the drained stream, silently recording an empty assistant turn;
+ * surfacing the failure lets `runOneSession`'s classifier see real spend-cap
+ * / rate-limit errors (→ `"rate_limited"`) and genuine provider failures
+ * (→ `"failed"`).
  *
- * Drains the SSE response body (`createUIMessageStreamResponse` requires
- * the consumer to read the stream before `onFinish` runs).
+ * Returns the post-turn message history, the per-turn trace, and the
+ * resolved `modelSource` so the caller can stamp
+ * `persistChatSessionToConvex` correctly.
  */
 export async function drainAssistantTurn(
   args: Omit<
@@ -880,33 +905,16 @@ export async function drainAssistantTurn(
     modelDefinition: ModelDefinition;
     /** Synthesis run id — stamped onto BYOK usage records for attribution. */
     synthesisRunId: string;
+    /** Optional turn hooks (browser session context attachment points). */
+    hooks?: DrainAssistantTurnHooks;
   }
 ): Promise<{
   history: ModelMessage[];
   turnTrace: PersistedTurnTrace | undefined;
   modelSource: SyntheticModelSource;
 }> {
-  let captured: ModelMessage[] = [];
-  let capturedTurnTrace: PersistedTurnTrace | undefined;
-  const {
-    chatSessionId: _omitSession,
-    modelDefinition,
-    synthesisRunId,
-    extraBodyFields,
-    ...rest
-  } = args;
-
+  const { modelDefinition, synthesisRunId, extraBodyFields, hooks } = args;
   const modelIdStr = String(modelDefinition.id);
-  const onConversationComplete = (
-    fullHistory: ModelMessage[],
-    turnTrace: PersistedTurnTrace
-  ) => {
-    captured = [...fullHistory];
-    capturedTurnTrace = turnTrace;
-  };
-
-  let response: Response;
-  let modelSource: SyntheticModelSource;
 
   // Classify once, dispatch off the result. The same resolver is used by
   // the empty-session fallback persist so the two attribution paths can't
@@ -921,37 +929,29 @@ export async function drainAssistantTurn(
     serverIds: args.selectedServers,
   });
 
-  if (resolution.source === "mcpjam") {
-    // MCPJam-paid path: synthesisRunId rides via extraBodyFields on /stream
-    // so the JAM-paid forwarder stamps it onto the llmUsageRecord.
-    modelSource = "mcpjam";
-    const options: MCPJamHandlerOptions = {
-      ...rest,
-      approvalMode: "auto-deny",
-      extraBodyFields: { ...(extraBodyFields ?? {}), synthesisRunId },
-      onConversationComplete,
-    };
-    response = await handleMCPJamFreeChatModel(options);
-  } else {
+  // Narrow MCPJamHandlerOptions' open `sourceType` string to the engine
+  // union; the simulation runner always passes "chatbox".
+  const sourceType =
+    args.sourceType === "direct" || args.sourceType === "eval"
+      ? args.sourceType
+      : ("chatbox" as const);
+
+  if (resolution.source !== "mcpjam") {
     // resolution.orgRuntime is guaranteed defined for non-"mcpjam" sources
-    // (the resolver only omits it when source === "mcpjam"). The type
-    // narrows after the explicit check below; cast comment + check keeps
-    // strict mode happy without weakening the contract.
+    // (the resolver only omits it when source === "mcpjam").
     const orgRuntime = resolution.orgRuntime!;
 
     if (orgRuntime.runtimeLocation === "local") {
-      modelSource = "local_byok";
       // Local-runtime org providers don't have an approval loop today —
-      // handleLocalOrgChatModel rejects synchronously with
-      // `tool_approval_unsupported` when requireToolApproval is true and
-      // any tools are exposed. Cloud BYOK paths handle this via
-      // `approvalMode: "auto-deny"` (the loop denies each call and
-      // continues); the local path has no equivalent yet, so a synthetic
-      // run on an approval-required chatbox would have every turn fail
-      // with the same error. Refuse upfront with a clear message rather
-      // than letting the per-turn errors stack up silently. Disable
-      // approval on the chatbox or switch the provider to cloud runtime
-      // to unblock.
+      // the local turn driver rejects with `tool_approval_unsupported`
+      // when requireToolApproval is true and any tools are exposed. Cloud
+      // BYOK paths handle this via `approvalMode: "auto-deny"` (the loop
+      // denies each call and continues); the local path has no equivalent
+      // yet, so a synthetic run on an approval-required chatbox would have
+      // every turn fail with the same error. Refuse upfront with a clear
+      // message rather than letting the per-turn errors stack up silently.
+      // Disable approval on the chatbox or switch the provider to cloud
+      // runtime to unblock.
       if (
         args.requireToolApproval === true &&
         args.tools &&
@@ -961,12 +961,12 @@ export async function drainAssistantTurn(
           "Synthetic runs on local-runtime org BYOK models don't yet support approval-required tool calls. Disable tool approval on this chatbox or switch the provider to cloud runtime."
         );
       }
-      response = handleLocalOrgChatModel({
+      const headless = await runLocalOrgChatTurnHeadless({
         provider: orgRuntime.provider,
         projectId: args.projectId ?? "",
         modelId: modelIdStr,
         chatSessionId: args.chatSessionId,
-        sourceType: args.sourceType,
+        sourceType,
         messages: args.messages,
         systemPrompt: args.systemPrompt,
         temperature: args.temperature,
@@ -979,56 +979,114 @@ export async function drainAssistantTurn(
         selectedServers: args.selectedServers,
         serverIds: args.selectedServers,
         requireToolApproval: args.requireToolApproval,
-        onConversationComplete,
         abortSignal: args.abortSignal,
+        // Forwarded to /stream/org/local-usage so the backend BYOK writer
+        // stamps synthesisRunId onto the resulting llmUsageRecord.
         synthesisRunId,
+        ...(hooks?.prepareAdvertisedTools
+          ? { prepareAdvertisedTools: hooks.prepareAdvertisedTools }
+          : {}),
+        ...(hooks?.onToolResultChunk
+          ? { onToolResultChunk: hooks.onToolResultChunk }
+          : {}),
       });
-    } else {
-      modelSource = "byok";
-      response = await handleHostedOrgChatModel({
-        projectId: args.projectId ?? "",
-        providerKey: orgRuntime.providerKey,
-        modelId: modelIdStr,
-        chatSessionId: args.chatSessionId,
-        sourceType: args.sourceType,
-        messages: args.messages,
-        systemPrompt: args.systemPrompt,
-        temperature: args.temperature,
-        tools: args.tools as ToolSet,
-        progressivePlan: args.progressivePlan,
-        discoveryState: args.discoveryState,
-        authHeader: args.authHeader,
-        chatboxId: args.chatboxId,
-        accessVersion: args.accessVersion,
-        mcpClientManager: args.mcpClientManager,
-        selectedServers: args.selectedServers,
-        serverIds: args.selectedServers,
-        requireToolApproval: args.requireToolApproval,
-        // Synthetic runs have no human-in-the-loop. Auto-deny any
-        // approval-required tool call inside the loop so the run can
-        // make forward progress instead of pausing forever waiting for
-        // an approval that will never arrive. Matches the MCPJam-paid
-        // branch above.
-        approvalMode: "auto-deny",
-        onConversationComplete,
-        abortSignal: args.abortSignal,
-        // Threaded through to /stream/org so the BYOK forwarder stamps
-        // synthesisRunId onto the resulting llmUsageRecord.
-        extraBodyFields: { ...(extraBodyFields ?? {}), synthesisRunId },
-      });
+      return {
+        history: headless.messages,
+        turnTrace: headless.turnTrace,
+        modelSource: "local_byok",
+      };
     }
   }
 
-  if (response.body) {
-    const reader = response.body.getReader();
-    while (true) {
-      const { done } = await reader.read();
-      if (done) break;
-    }
+  // Engine branches (JAM-paid `/stream` and hosted org-BYOK `/stream/org`)
+  // share the runAssistantTurn surface; only the endpoint + extra body
+  // fields differ.
+  const modelSource: SyntheticModelSource =
+    resolution.source === "mcpjam" ? "mcpjam" : "byok";
+  let lastEngineError: MCPJamEngineErrorEvent | undefined;
+
+  const result = await runAssistantTurn({
+    messages: args.messages,
+    modelDefinition,
+    systemPrompt: args.systemPrompt,
+    ...(args.temperature !== undefined
+      ? { temperature: args.temperature }
+      : {}),
+    tools: args.tools as ToolSet,
+    mcpClientManager: args.mcpClientManager,
+    authContext: { kind: "user_bearer", token: args.authHeader ?? "" },
+    sourceType,
+    origin: "chatbox",
+    streamSink: "none",
+    persistMode: "caller",
+    // Synthetic runs have no human-in-the-loop. Auto-deny any
+    // approval-required tool call inside the loop so the run can make
+    // forward progress instead of pausing forever waiting for an approval
+    // that will never arrive.
+    approvalMode: "auto-deny",
+    chatSessionId: args.chatSessionId,
+    ...(args.projectId ? { projectId: args.projectId } : {}),
+    ...(args.chatboxId ? { chatboxId: args.chatboxId } : {}),
+    ...(args.accessVersion !== undefined
+      ? { accessVersion: args.accessVersion }
+      : {}),
+    ...(args.selectedServers
+      ? { selectedServerIds: args.selectedServers }
+      : {}),
+    ...(args.requireToolApproval !== undefined
+      ? { requireToolApproval: args.requireToolApproval }
+      : {}),
+    ...(args.progressivePlan ? { progressivePlan: args.progressivePlan } : {}),
+    ...(args.discoveryState ? { discoveryState: args.discoveryState } : {}),
+    ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
+    // `runAssistantTurn` appends synthesisRunId to extraBodyFields last, so
+    // the merged `/stream` body matches the old handler-built shape.
+    synthesisRunId,
+    ...(resolution.source === "mcpjam"
+      ? { ...(extraBodyFields ? { extraBodyFields } : {}) }
+      : {
+          // Hosted org-BYOK contract — byte-matching what
+          // `handleHostedOrgChatModel` constructs: providerKey + serverIds
+          // ride extraBodyFields on /stream/org.
+          endpointPath: "/stream/org",
+          extraBodyFields: {
+            ...(extraBodyFields ?? {}),
+            providerKey: resolution.orgRuntime!.providerKey,
+            ...(args.selectedServers?.length
+              ? { serverIds: args.selectedServers }
+              : {}),
+          },
+        }),
+    ...(hooks?.onToolCall ? { onToolCall: hooks.onToolCall } : {}),
+    ...(hooks?.onToolResult ? { onToolResult: hooks.onToolResult } : {}),
+    ...(hooks?.prepareAdvertisedTools
+      ? { prepareAdvertisedTools: hooks.prepareAdvertisedTools }
+      : {}),
+    onEngineError: (event) => {
+      lastEngineError = event;
+    },
+  });
+
+  // Surface engine failures as throws (see the error contract above). A
+  // produced turnTrace means the turn semantically succeeded — per-step
+  // engine errors that the loop recovered from don't fail the turn.
+  if (lastEngineError && !result.turnTrace && !args.abortSignal?.aborted) {
+    const detail = [
+      lastEngineError.code,
+      lastEngineError.httpStatus !== undefined
+        ? `HTTP ${lastEngineError.httpStatus}`
+        : undefined,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    throw new Error(
+      detail ? `${lastEngineError.message} (${detail})` : lastEngineError.message
+    );
   }
+
   return {
-    history: captured.length > 0 ? captured : args.messages,
-    turnTrace: capturedTurnTrace,
+    history: result.messages,
+    turnTrace: result.turnTrace,
     modelSource,
   };
 }

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -1218,18 +1218,31 @@ export async function drainAssistantTurn(
 
   // Surface engine failures as throws (see the error contract above). A
   // produced turnTrace means the turn semantically succeeded — per-step
-  // engine errors that the loop recovered from don't fail the turn.
-  if (lastEngineError && !result.turnTrace && !args.abortSignal?.aborted) {
-    const detail = [
-      lastEngineError.code,
-      lastEngineError.httpStatus !== undefined
-        ? `HTTP ${lastEngineError.httpStatus}`
-        : undefined,
-    ]
-      .filter(Boolean)
-      .join(", ");
+  // engine errors that the loop recovered from don't fail the turn. A
+  // MISSING turnTrace on a non-aborted turn always means the engine failed
+  // (`runSucceeded === false`) — the same signal the eval runners' failure
+  // detection keys on — so throw even when no `onEngineError` event was
+  // captured (engine-internal aborts without our signal flipping, or error
+  // sites the callback doesn't cover). Without this, a failed turn would
+  // silently record an empty assistant reply and skip persistence.
+  if (!result.turnTrace && !args.abortSignal?.aborted) {
+    if (lastEngineError) {
+      const detail = [
+        lastEngineError.code,
+        lastEngineError.httpStatus !== undefined
+          ? `HTTP ${lastEngineError.httpStatus}`
+          : undefined,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      throw new Error(
+        detail
+          ? `${lastEngineError.message} (${detail})`
+          : lastEngineError.message
+      );
+    }
     throw new Error(
-      detail ? `${lastEngineError.message} (${detail})` : lastEngineError.message
+      "Assistant turn failed: the engine returned no turn trace (stream error or empty response)"
     );
   }
 

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -30,6 +30,16 @@ import {
 } from "../../utils/chat-ingestion.js";
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "../../utils/export-helpers.js";
 import { captureMcpAppWidgetSnapshots } from "../../utils/mcp-app-widget-capture.js";
+import {
+  createBrowserSessionContext,
+  type BrowserSessionContext,
+} from "../browser-session-context.js";
+import {
+  serializeBrowserStepsForBackend,
+  serializeRenderObservationsForBackend,
+  toBrowserStepPayload,
+  toObservationPayload,
+} from "../browser-artifact-serialization.js";
 import type { EvalTraceWidgetSnapshot } from "@/shared/eval-trace";
 import {
   evalTraceSnapshotToPayload,
@@ -462,6 +472,11 @@ async function runOneSession(args: {
   const chatSessionId = `synth_${runId}_${persona.id}_${sessionIdx}`;
   let manager: MCPClientManager | undefined;
   let dispose: (() => Promise<void>) | undefined;
+  // Browser-rendered MCP App pipeline (same machinery as eval iterations):
+  // declared before the try so the finally can dispose a launched Chromium
+  // on every exit. Construction is cheap; Chromium launches lazily on the
+  // first widget render, so sessions that never touch an MCP App pay nothing.
+  let browser: BrowserSessionContext | undefined;
 
   try {
     const built = await managerFactory();
@@ -516,6 +531,18 @@ async function runOneSession(args: {
       ...(builtInTools ? { builtInTools } : {}),
     });
 
+    // One browser context per session: renders MCP App tool results in the
+    // headless harness (render observations for every model) and, for Claude
+    // assistant models, adds the `computer` / `finish_widget` tools so the
+    // simulated assistant can interact with rendered widgets (interaction
+    // steps). `injectOpenAiCompat` is omitted to match the snapshot capture
+    // below — the chatbox runtime config doesn't carry the flag.
+    browser = createBrowserSessionContext({
+      model: String(modelDefinition.id),
+      mcpClientManager: manager,
+      logScope: "sessionSimulation",
+    });
+
     let messageHistory: ModelMessage[] = [];
     let lastTranscript: Array<{ role: "user" | "assistant"; content: string }> =
       [];
@@ -546,6 +573,13 @@ async function runOneSession(args: {
       } as ModelMessage);
       lastTranscript.push({ role: "user", content: next.message });
 
+      // Stamp artifacts with this persona turn and start it with a clean
+      // widget surface — a widget kept mounted by the previous turn must not
+      // be advertised/targeted before this turn's own MCP App tool runs
+      // (same per-turn hygiene as the eval runners).
+      browser.setActivePromptIndex(turn);
+      await browser.dismissCarriedWidget();
+
       const {
         history: updatedHistory,
         turnTrace,
@@ -558,7 +592,18 @@ async function runOneSession(args: {
         sourceType: "chatbox",
         systemPrompt: prepared.enhancedSystemPrompt,
         temperature: prepared.resolvedTemperature,
-        tools: prepared.allTools,
+        // `computer` / `finish_widget` merge into the advertised set; the
+        // prepareAdvertisedTools hook hides them until a widget is mounted.
+        tools: { ...prepared.allTools, ...browser.computerWidgetTools },
+        hooks: {
+          onToolCall: (event) => browser!.noteToolCallInput(event),
+          onToolResult: (event) => browser!.handleEngineToolResult(event),
+          ...(browser.prepareAdvertisedTools
+            ? { prepareAdvertisedTools: browser.prepareAdvertisedTools }
+            : {}),
+          onToolResultChunk: (chunk) =>
+            browser!.handleDirectToolResultChunk(chunk),
+        },
         progressivePlan: prepared.progressivePlan,
         discoveryState: prepared.discoveryState,
         mcpClientManager: manager,
@@ -657,6 +702,20 @@ async function runOneSession(args: {
         chatboxId,
         accessVersion,
       });
+
+      // Persist this turn's browser-rendered artifacts (render observations
+      // + Computer Use steps) — additive to the inert HTML snapshots above,
+      // which keep powering the viewer's interactive Data/Sandbox iframe.
+      // Best-effort like the snapshot capture; the session row exists (the
+      // turn persist above just ran), so there's no /ingest-chat race here.
+      await persistBrowserArtifactsForTurn({
+        browser,
+        convexAuthToken,
+        chatSessionId,
+        chatboxId,
+        accessVersion,
+        promptIndex: turn,
+      });
     }
 
     if (!anyTurnPersisted) {
@@ -719,6 +778,19 @@ async function runOneSession(args: {
     });
     return "failed";
   } finally {
+    // Tear down the browser harness (and its headless Chromium, if launched)
+    // before the manager: the harness's widget bridge dispatches tools/call
+    // through the manager, so it must die first.
+    if (browser) {
+      try {
+        await browser.dispose();
+      } catch (err) {
+        logger.warn("[sessionSimulation.runner] browser dispose failed", {
+          runId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
     if (dispose) {
       try {
         await dispose();
@@ -842,6 +914,83 @@ async function captureAndPersistWidgetSnapshotsForSession(args: {
       }
     })
   );
+}
+
+/**
+ * Drain the browser session context's artifacts collected during this turn
+ * (render observations + Computer Use interaction steps), upload screenshots,
+ * and persist via `chatSessions:recordBrowserArtifacts` — the synthetic
+ * sibling of the eval finalizer's artifact hand-off. Idempotent backend
+ * upserts (`(sessionId, toolCallId)` / `(sessionId, toolCallId, stepIndex)`)
+ * make a retried turn-write safe.
+ *
+ * Best-effort end-to-end, mirroring the widget-snapshot capture above: any
+ * failure is logged and swallowed — never aborts the synthetic run. (The
+ * drained rows are dropped on failure; the next turn's drain only carries
+ * new artifacts. Screenshots are the only loss — statuses for re-rendered
+ * widgets re-upsert on later renders.)
+ */
+async function persistBrowserArtifactsForTurn(args: {
+  browser: BrowserSessionContext;
+  convexAuthToken: string;
+  chatSessionId: string;
+  chatboxId: string;
+  accessVersion: number | undefined;
+  promptIndex: number;
+}): Promise<void> {
+  const { observations, steps } = args.browser.drainNewArtifacts();
+  if (observations.length === 0 && steps.length === 0) {
+    return;
+  }
+
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl) {
+    logger.warn(
+      "[sessionSimulation.runner] CONVEX_URL not set; skipping browser artifact persist",
+      { chatSessionId: args.chatSessionId, chatboxId: args.chatboxId }
+    );
+    return;
+  }
+
+  try {
+    const convexClient = new ConvexHttpClient(convexUrl);
+    convexClient.setAuth(args.convexAuthToken);
+
+    // Serialize uploads the transient base64 screenshots → blob ids; the
+    // payload mappers strip the per-row promptIndex (the mutation stamps the
+    // batch-level value server-side).
+    const serializedObservations = (
+      await serializeRenderObservationsForBackend(observations, convexClient)
+    ).map(toObservationPayload);
+    const serializedSteps = (
+      await serializeBrowserStepsForBackend(steps, convexClient)
+    ).map(toBrowserStepPayload);
+
+    await convexClient.mutation(
+      "chatSessions:recordBrowserArtifacts" as any,
+      {
+        chatboxId: args.chatboxId,
+        ...(args.accessVersion !== undefined
+          ? { accessVersion: args.accessVersion }
+          : {}),
+        chatSessionId: args.chatSessionId,
+        promptIndex: args.promptIndex,
+        ...(serializedObservations.length
+          ? { widgetRenderObservations: serializedObservations }
+          : {}),
+        ...(serializedSteps.length
+          ? { browserInteractionSteps: serializedSteps }
+          : {}),
+      }
+    );
+  } catch (err) {
+    logger.warn("[sessionSimulation.runner] browser artifact persist failed", {
+      chatSessionId: args.chatSessionId,
+      observations: observations.length,
+      steps: steps.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 // `SyntheticModelSource` is imported from `org-model-config.ts` so the

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -635,7 +635,16 @@ async function runOneSession(args: {
       const assistantText = extractAssistantText(updatedHistory);
       lastTranscript.push({ role: "assistant", content: assistantText });
 
-      if (!turnTrace) continue;
+      if (!turnTrace) {
+        // No-trace turns skip persistence (today only the aborted local-BYOK
+        // path reaches here — failed turns throw above). Discard whatever the
+        // browser context collected during this turn: a later turn's drain
+        // would otherwise sweep these rows up and persist them under ITS
+        // batch promptIndex, misattributing artifacts across turns
+        // (CodeRabbit, PR 2610).
+        browser.drainNewArtifacts();
+        continue;
+      }
 
       // Mirror chat-v2's per-turn persistence so the Trace tab and the
       // tool-snapshot/serverInspections fan-out work identically for

--- a/mcpjam-inspector/server/utils/__tests__/org-model-stream-handler-headless.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/org-model-stream-handler-headless.test.ts
@@ -1,0 +1,235 @@
+/**
+ * runLocalOrgChatTurnHeadless — the headless sibling of
+ * `handleLocalOrgChatModel` used by the synthetic-session runner. Locks the
+ * route-3 invariants the SSE handler enforces: model validation before the
+ * engine runs, the 30-step default, the unconditional `postLocalUsage`
+ * writeback, the `streamErrored` ingestion gate (throw instead of silently
+ * returning a partial transcript), and the deduped history rebuild.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelMessage } from "@ai-sdk/provider-utils";
+
+const runDirectChatTurnMock = vi.fn();
+const consumeDirectChatTurnHeadlessMock = vi.fn();
+const assertOrgModelAllowedMock = vi.fn();
+const buildOrgModelFromResolvedConfigMock = vi.fn();
+
+vi.mock("../direct-chat-turn.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../direct-chat-turn.js")
+  >("../direct-chat-turn.js");
+  return {
+    ...actual,
+    runDirectChatTurn: (...args: unknown[]) => runDirectChatTurnMock(...args),
+    consumeDirectChatTurnHeadless: (...args: unknown[]) =>
+      consumeDirectChatTurnHeadlessMock(...args),
+  };
+});
+
+vi.mock("@mcpjam/sdk/model-factory", async () => {
+  const actual = await vi.importActual<
+    typeof import("@mcpjam/sdk/model-factory")
+  >("@mcpjam/sdk/model-factory");
+  return {
+    ...actual,
+    assertOrgModelAllowed: (...args: unknown[]) =>
+      assertOrgModelAllowedMock(...args),
+    buildOrgModelFromResolvedConfig: (...args: unknown[]) =>
+      buildOrgModelFromResolvedConfigMock(...args),
+  };
+});
+
+import { runLocalOrgChatTurnHeadless } from "../org-model-stream-handler.js";
+
+const PROVIDER = { providerKey: "openai" } as never;
+const MESSAGES: ModelMessage[] = [{ role: "user", content: "hi" }];
+const TURN_TRACE = {
+  turnId: "turn-1",
+  promptIndex: 0,
+  startedAt: 0,
+  endedAt: 1,
+  spans: [],
+} as never;
+
+const baseOptions = (overrides: Record<string, unknown> = {}) =>
+  ({
+    provider: PROVIDER,
+    projectId: "proj-1",
+    modelId: "llama3",
+    chatSessionId: "sess_1",
+    sourceType: "chatbox",
+    messages: MESSAGES,
+    systemPrompt: "system",
+    tools: {},
+    authHeader: "Bearer abc",
+    synthesisRunId: "run-xyz",
+    ...overrides,
+  }) as Parameters<typeof runLocalOrgChatTurnHeadless>[0];
+
+/**
+ * Configure the engine mocks for one turn. `consume` simulates the engine
+ * lifecycle: optionally fire `onEngineError`, then `onPersist` (the real
+ * engine's onFinish fires onPersist on every non-aborted completion, even
+ * after a mid-stream error), then resolve the headless result.
+ */
+function stubEngineTurn(params: {
+  responseMessages?: ModelMessage[];
+  engineError?: { message: string };
+  aborted?: boolean;
+  skipPersist?: boolean;
+}) {
+  const captured: { options?: any } = {};
+  runDirectChatTurnMock.mockImplementation((options: any) => {
+    captured.options = options;
+    return { handleSentinel: true };
+  });
+  consumeDirectChatTurnHeadlessMock.mockImplementation(async () => {
+    const options = captured.options!;
+    if (params.engineError) {
+      options.onEngineError?.({
+        message: params.engineError.message,
+        rawText: params.engineError.message,
+        promptIndex: 0,
+      });
+    }
+    if (!params.aborted && !params.skipPersist) {
+      await options.onPersist?.({
+        responseMessages: params.responseMessages ?? [],
+        assistantText: "",
+        toolCalls: [],
+        toolResults: [],
+        turnTrace: TURN_TRACE,
+      });
+    }
+    return {
+      messages: params.responseMessages ?? [],
+      steps: [],
+      totalUsage: {},
+      finishReason: "stop",
+      spans: [],
+      aborted: params.aborted === true,
+    };
+  });
+  return captured;
+}
+
+describe("runLocalOrgChatTurnHeadless", () => {
+  const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+    globalThis.fetch = fetchMock as never;
+    runDirectChatTurnMock.mockReset();
+    consumeDirectChatTurnHeadlessMock.mockReset();
+    assertOrgModelAllowedMock.mockReset();
+    buildOrgModelFromResolvedConfigMock.mockReset();
+    buildOrgModelFromResolvedConfigMock.mockReturnValue({ model: true });
+    fetchMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("validates the model, applies the 30-step default, and returns the deduped history + trace", async () => {
+    const assistantReply: ModelMessage = {
+      role: "assistant",
+      content: "hello!",
+    };
+    const captured = stubEngineTurn({ responseMessages: [assistantReply] });
+
+    const result = await runLocalOrgChatTurnHeadless(baseOptions());
+
+    expect(assertOrgModelAllowedMock).toHaveBeenCalledWith(PROVIDER, "llama3");
+    expect(buildOrgModelFromResolvedConfigMock).toHaveBeenCalledWith(
+      PROVIDER,
+      "llama3",
+    );
+    // Route-3 default preserved (hosted MCPJam parity).
+    expect(captured.options.maxSteps).toBe(30);
+    expect(result.aborted).toBe(false);
+    expect(result.turnTrace).toEqual(TURN_TRACE);
+    expect(result.messages).toEqual([...MESSAGES, assistantReply]);
+  });
+
+  it("posts the usage writeback with synthesisRunId (fire-and-forget billing)", async () => {
+    stubEngineTurn({ responseMessages: [] });
+
+    await runLocalOrgChatTurnHeadless(baseOptions());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]! as unknown as [
+      string,
+      { body: string },
+    ];
+    expect(url).toBe("https://convex.test/stream/org/local-usage");
+    expect(JSON.parse(init.body)).toMatchObject({
+      projectId: "proj-1",
+      providerKey: "openai",
+      model: "llama3",
+      synthesisRunId: "run-xyz",
+    });
+  });
+
+  it("throws on a mid-stream engine error AFTER the usage writeback fired (ingestion gated, billing not)", async () => {
+    stubEngineTurn({
+      responseMessages: [],
+      engineError: { message: "provider exploded" },
+    });
+
+    await expect(
+      runLocalOrgChatTurnHeadless(baseOptions()),
+    ).rejects.toThrow(/provider exploded/);
+    // onPersist ran (engine fires it after error too): billing posted…
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws the tool_approval_unsupported guard before running the engine", async () => {
+    await expect(
+      runLocalOrgChatTurnHeadless(
+        baseOptions({
+          requireToolApproval: true,
+          tools: { search: { description: "noop" } },
+        }),
+      ),
+    ).rejects.toThrow(/Tool approval is not supported/i);
+    expect(runDirectChatTurnMock).not.toHaveBeenCalled();
+  });
+
+  it("throws config/allowlist failures instead of returning an error stream", async () => {
+    assertOrgModelAllowedMock.mockImplementation(() => {
+      throw new Error("model not allowed for this org");
+    });
+
+    await expect(
+      runLocalOrgChatTurnHeadless(baseOptions()),
+    ).rejects.toThrow(/not allowed/);
+    expect(runDirectChatTurnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns aborted without throwing when the signal fired mid-turn", async () => {
+    stubEngineTurn({ aborted: true });
+
+    const result = await runLocalOrgChatTurnHeadless(baseOptions());
+    expect(result).toEqual({ messages: MESSAGES, aborted: true });
+  });
+
+  it("forwards prepareAdvertisedTools and onToolResultChunk to the engine", async () => {
+    const captured = stubEngineTurn({ responseMessages: [] });
+    const prepareAdvertisedTools = vi.fn();
+    const onToolResultChunk = vi.fn();
+
+    await runLocalOrgChatTurnHeadless(
+      baseOptions({ prepareAdvertisedTools, onToolResultChunk }),
+    );
+
+    expect(captured.options.prepareAdvertisedTools).toBe(
+      prepareAdvertisedTools,
+    );
+    expect(captured.options.traceEvents?.onToolResultChunk).toBe(
+      onToolResultChunk,
+    );
+  });
+});

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -40,9 +40,13 @@ import type { PersistedTurnTrace } from "./chat-ingestion";
 import { handleMCPJamFreeChatModel } from "./mcpjam-stream-handler.js";
 import { logger } from "./logger.js";
 import {
+  consumeDirectChatTurnHeadless,
   runDirectChatTurn,
+  type DirectChatTurnPersistEvent,
+  type DirectChatTurnTraceEvents,
   type RunDirectChatTurnHandle,
 } from "./direct-chat-turn.js";
+import type { PrepareAdvertisedTools } from "./advertised-tools.js";
 import { buildDirectChatTraceCallbacks } from "./direct-chat-sse-callbacks.js";
 import { appendDedupedModelMessages } from "@/shared/eval-trace";
 import {
@@ -232,23 +236,16 @@ export function handleLocalOrgChatModel(
 ): Response {
   const {
     provider,
-    projectId,
     modelId,
-    chatSessionId,
-    sourceType,
     messages,
     systemPrompt,
     temperature,
     tools,
     requireToolApproval,
-    authHeader,
-    chatboxId,
-    accessVersion,
     onConversationComplete,
     onStreamComplete,
     onStreamWriterReady,
     onLiveTextDelta,
-    synthesisRunId,
   } = options;
 
   if (requireToolApproval && Object.keys(tools).length > 0) {
@@ -296,19 +293,7 @@ export function handleLocalOrgChatModel(
     return createUIMessageStreamResponse({ stream });
   }
 
-  // `maxSteps`: legacy route 3 defaulted to 30 + accepted caller
-  // override. CodeRabbit PR-review fix (Major "Do not silently drop
-  // maxSteps"): thread `options.maxSteps ?? 30` through
-  // `RunDirectChatTurnOptions.maxSteps` so the wrapper honors the
-  // caller-supplied ceiling AND preserves the legacy default. Route 4
-  // and eval headless still get the engine default (20) because they
-  // omit the option.
-  const resolvedMaxSteps =
-    typeof options.maxSteps === "number" &&
-    Number.isFinite(options.maxSteps) &&
-    options.maxSteps > 0
-      ? Math.floor(options.maxSteps)
-      : 30;
+  const resolvedMaxSteps = resolveLocalOrgMaxSteps(options.maxSteps);
 
   // Declared before `createUIMessageStream` so the top-level `onError`
   // (which can fire before `execute` runs) can read it; assigned inside
@@ -385,56 +370,11 @@ export function handleLocalOrgChatModel(
         // is enforced by `runDirectChatTurn` — `onPersist` only fires on
         // non-aborted completion, preserving the legacy `postLocalUsage`
         // semantics (success only, never on abort).
-        onPersist: async (event) => {
-          // Post usage to Convex (best-effort, non-blocking on failure).
-          // Preserves the legacy fire-and-forget behavior so an
-          // ingestion failure can't block the usage writeback or vice
-          // versa.
-          postLocalUsage({
-            projectId,
-            providerKey: provider.providerKey,
-            model: modelId,
-            usage: event.usage,
-            finishReason: event.finishReason,
-            chatSessionId,
-            sourceType,
-            turnId: event.turnTrace.turnId,
-            promptIndex: event.turnTrace.promptIndex,
-            authHeader,
-            chatboxId,
-            accessVersion,
-            selectedServers: options.selectedServers,
-            serverIds: options.serverIds,
-            synthesisRunId,
-          }).catch((err) => {
-            logger.warn("[org/local] Failed to post local usage", {
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
-
-          // Cursor PR-review fix (Medium "Failed turns persist sessions"):
-          // skip ingestion when the stream errored mid-flight; matches
-          // legacy `if (!streamErrored)` gate at the old
-          // `onConversationComplete` site. Billing already happened
-          // above so the only thing we're suppressing is persistence
-          // of a partial transcript.
-          if (streamErrored || !onConversationComplete) return;
-
-          // Cursor PR-review fix (Medium "History rebuild skips
-          // deduplication"): legacy code did
-          // `appendDedupedModelMessages(traceHistory, responseMessages)`
-          // against the FULL prefix (initial messages + accumulated
-          // responses). The engine dedupes `responseMessages` against
-          // itself across steps; the wrapper now dedupes again against
-          // the initial-messages prefix so messages that overlap by
-          // id / JSON identity don't double-write into the persisted
-          // transcript. Real-world impact is low (AI SDK rarely emits
-          // overlapping content with the prompt prefix), but restores
-          // the legacy defensive-dedup semantics.
-          const fullHistory: ModelMessage[] = [...messages];
-          appendDedupedModelMessages(fullHistory, event.responseMessages);
-          await onConversationComplete(fullHistory, event.turnTrace);
-        },
+        onPersist: buildLocalOrgOnPersist({
+          options,
+          isStreamErrored: () => streamErrored,
+          onConversationComplete,
+        }),
         onPersistError: (err) => {
           logger.warn("[org/local] onFinish ingestion error", {
             error: err instanceof Error ? err.message : String(err),
@@ -472,6 +412,211 @@ export function handleLocalOrgChatModel(
   });
 
   return createUIMessageStreamResponse({ stream });
+}
+
+// ---------------------------------------------------------------------------
+// Shared local-runtime turn pieces (SSE handler + headless variant)
+// ---------------------------------------------------------------------------
+
+/**
+ * `maxSteps`: legacy route 3 defaulted to 30 + accepted caller override.
+ * CodeRabbit PR-review fix (Major "Do not silently drop maxSteps"): honor the
+ * caller-supplied ceiling AND preserve the legacy default. Route 4 and eval
+ * headless still get the engine default (20) because they omit the option.
+ */
+function resolveLocalOrgMaxSteps(maxSteps: number | undefined): number {
+  return typeof maxSteps === "number" &&
+    Number.isFinite(maxSteps) &&
+    maxSteps > 0
+    ? Math.floor(maxSteps)
+    : 30;
+}
+
+/**
+ * Route-3 persistence wrapper shared by the SSE handler and the headless
+ * variant: post usage back to Convex AND fire `onConversationComplete`
+ * (chat ingestion / transcript capture). Silent-cancel is enforced by
+ * `runDirectChatTurn` — `onPersist` only fires on non-aborted completion,
+ * preserving the legacy `postLocalUsage` semantics (success only, never on
+ * abort).
+ */
+function buildLocalOrgOnPersist(params: {
+  options: OrgLocalModelHandlerOptions;
+  isStreamErrored: () => boolean;
+  onConversationComplete: OrgLocalModelHandlerOptions["onConversationComplete"];
+}): (event: DirectChatTurnPersistEvent) => Promise<void> {
+  const { options, isStreamErrored, onConversationComplete } = params;
+  return async (event) => {
+    // Post usage to Convex (best-effort, non-blocking on failure).
+    // Preserves the legacy fire-and-forget behavior so an ingestion
+    // failure can't block the usage writeback or vice versa.
+    postLocalUsage({
+      projectId: options.projectId,
+      providerKey: options.provider.providerKey,
+      model: options.modelId,
+      usage: event.usage,
+      finishReason: event.finishReason,
+      chatSessionId: options.chatSessionId,
+      sourceType: options.sourceType,
+      turnId: event.turnTrace.turnId,
+      promptIndex: event.turnTrace.promptIndex,
+      authHeader: options.authHeader,
+      chatboxId: options.chatboxId,
+      accessVersion: options.accessVersion,
+      selectedServers: options.selectedServers,
+      serverIds: options.serverIds,
+      synthesisRunId: options.synthesisRunId,
+    }).catch((err) => {
+      logger.warn("[org/local] Failed to post local usage", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+
+    // Cursor PR-review fix (Medium "Failed turns persist sessions"):
+    // skip ingestion when the stream errored mid-flight; matches
+    // legacy `if (!streamErrored)` gate at the old
+    // `onConversationComplete` site. Billing already happened
+    // above so the only thing we're suppressing is persistence
+    // of a partial transcript.
+    if (isStreamErrored() || !onConversationComplete) return;
+
+    // Cursor PR-review fix (Medium "History rebuild skips
+    // deduplication"): legacy code did
+    // `appendDedupedModelMessages(traceHistory, responseMessages)`
+    // against the FULL prefix (initial messages + accumulated
+    // responses). The engine dedupes `responseMessages` against
+    // itself across steps; the wrapper now dedupes again against
+    // the initial-messages prefix so messages that overlap by
+    // id / JSON identity don't double-write into the persisted
+    // transcript. Real-world impact is low (AI SDK rarely emits
+    // overlapping content with the prompt prefix), but restores
+    // the legacy defensive-dedup semantics.
+    const fullHistory: ModelMessage[] = [...options.messages];
+    appendDedupedModelMessages(fullHistory, event.responseMessages);
+    await onConversationComplete(fullHistory, event.turnTrace);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Headless local org BYOK turn (synthetic-session runner)
+// ---------------------------------------------------------------------------
+
+export interface RunLocalOrgChatTurnHeadlessOptions
+  extends Omit<
+    OrgLocalModelHandlerOptions,
+    "onConversationComplete" | "onStreamComplete" | "onStreamWriterReady" | "onLiveTextDelta"
+  > {
+  /** Per-step advertised-tool narrowing (browser session context gate). */
+  prepareAdvertisedTools?: PrepareAdvertisedTools;
+  /** Awaited per tool result (browser session context render hook). */
+  onToolResultChunk?: DirectChatTurnTraceEvents["onToolResultChunk"];
+}
+
+/**
+ * Headless sibling of {@link handleLocalOrgChatModel} for callers with no SSE
+ * consumer (the synthetic-session runner). Drives `runDirectChatTurn` via
+ * `consumeDirectChatTurnHeadless` — no `createUIMessageStream`, no Response
+ * to drain — and shares the SSE handler's route-3 invariants through the
+ * helpers above: model validation, the 30-step default, the unconditional
+ * `postLocalUsage` writeback, the `streamErrored` ingestion gate, and the
+ * deduped history rebuild.
+ *
+ * Error contract: where the SSE handler writes error chunks into the stream,
+ * this variant THROWS — config/allowlist failures, the
+ * `tool_approval_unsupported` guard, and mid-turn engine errors all surface
+ * to the caller (usage writeback for completed steps has already fired via
+ * `onPersist` where the engine ran far enough to produce one).
+ */
+export async function runLocalOrgChatTurnHeadless(
+  options: RunLocalOrgChatTurnHeadlessOptions
+): Promise<{
+  messages: ModelMessage[];
+  turnTrace?: PersistedTurnTrace;
+  aborted: boolean;
+}> {
+  const { provider, modelId, messages, systemPrompt, temperature, tools } =
+    options;
+
+  if (options.requireToolApproval && Object.keys(tools).length > 0) {
+    throw new Error(
+      "Tool approval is not supported for local-runtime org providers yet. Disable tool approval or switch this provider to cloud runtime."
+    );
+  }
+
+  // Same validation the SSE handler runs before opening its stream; headless
+  // callers get the typed error (OrgProviderConfigError) instead of a
+  // formatted error chunk.
+  assertOrgModelAllowed(provider, modelId);
+  const llmModel = buildOrgModelFromResolvedConfig(provider, modelId);
+
+  let streamErrored = false;
+  let engineErrorText: string | undefined;
+  let capturedHistory: ModelMessage[] | undefined;
+  let capturedTrace: PersistedTurnTrace | undefined;
+
+  const handle = runDirectChatTurn({
+    // Same typing bridge as the SSE handler: the org-resolved model is the
+    // AI SDK `LanguageModel` union; the engine option is the narrower
+    // `createLlmModel` return. Both reach the same `streamText` slot.
+    llmModel: llmModel as unknown as Parameters<
+      typeof runDirectChatTurn
+    >[0]["llmModel"],
+    modelId,
+    messageHistory: messages,
+    systemPrompt,
+    ...(temperature !== undefined ? { temperature } : {}),
+    tools,
+    progressivePlan: options.progressivePlan,
+    discoveryState: options.discoveryState,
+    ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+    maxSteps: resolveLocalOrgMaxSteps(options.maxSteps),
+    ...(options.prepareAdvertisedTools
+      ? { prepareAdvertisedTools: options.prepareAdvertisedTools }
+      : {}),
+    ...(options.onToolResultChunk
+      ? { traceEvents: { onToolResultChunk: options.onToolResultChunk } }
+      : {}),
+    onEngineError: (event) => {
+      streamErrored = true;
+      engineErrorText = event.message;
+    },
+    onPersist: buildLocalOrgOnPersist({
+      options,
+      isStreamErrored: () => streamErrored,
+      onConversationComplete: (fullHistory, turnTrace) => {
+        capturedHistory = fullHistory;
+        capturedTrace = turnTrace;
+      },
+    }),
+    onPersistError: (err) => {
+      logger.warn("[org/local] headless onPersist error", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    },
+  });
+
+  const headless = await consumeDirectChatTurnHeadless(handle);
+  if (headless.aborted) {
+    return { messages, aborted: true };
+  }
+  if (streamErrored) {
+    throw new Error(
+      engineErrorText ?? "Local org-BYOK turn failed mid-stream."
+    );
+  }
+
+  // `onPersist` fired on every non-aborted completion, so `capturedHistory`
+  // is normally set; the rebuild below is a defensive fallback with the same
+  // dedup semantics.
+  if (!capturedHistory) {
+    capturedHistory = [...messages];
+    appendDedupedModelMessages(capturedHistory, headless.messages);
+  }
+  return {
+    messages: capturedHistory,
+    ...(capturedTrace ? { turnTrace: capturedTrace } : {}),
+    aborted: false,
+  };
 }
 
 async function postLocalUsage(params: {


### PR DESCRIPTION
Synthetic chatbox sessions ("Generate with AI") now get the same browser-rendered MCP App treatment as eval iterations — headless-Chromium render observations for every model, and Anthropic Computer Use interaction with rendered widgets for Claude assistant models — always on (chatboxes are pre-release; no flag). Along the way, the duplicated "mock a user session" machinery between the eval runner and the session-simulation runner is consolidated.

Pairs with MCPJam/mcpjam-backend#515 (write/read endpoints; lands first, this PR's runner + viewer consume it).

## Commits (independently revertible stages)

1. **Shared browser session context** — `evals/browser-eval-context.ts` → `services/browser-session-context.ts` with surface-neutral names, a `handleDirectToolResultChunk` adapter for the local AI-SDK engine (one shared `renderIfRenderable` path with the engine hook), and `drainNewArtifacts()` for incremental per-turn persisters. Both local eval paths drop their inline duplicate pipelines (~200 lines deleted); hosted paths are a rename.
2. **Headless synthetic turns** — `drainAssistantTurn` stops building SSE `Response`s and draining them for side effects: the mcpjam-paid and hosted org-BYOK branches call `runAssistantTurn` (`streamSink: "none"`, `persistMode: "caller"`, `/stream/org` + `providerKey` byte-matching the old wrapper), and a new `runLocalOrgChatTurnHeadless` drives the local org-BYOK engine, sharing the SSE handler's route-3 invariants via extracted helpers (30-step default, unconditional `postLocalUsage`, `streamErrored` ingestion gate, deduped history rebuild). **Behavior change:** turn failures now throw instead of vanishing into a drained stream — `runOneSession`'s classifier finally sees real spend-cap / provider errors instead of silently recording empty turns.
3. **Browser pipeline in the simulation runner** — one context per session (Chromium launches lazily; disposed in the session `finally`), per-turn widget hygiene, `computer`/`finish_widget` merged into the advertised set (gated until a widget mounts), and per-turn `drainNewArtifacts → chatSessions:recordBrowserArtifacts` persistence. The inert HTML snapshots are untouched — they keep powering the viewer's interactive Data/Sandbox iframe; artifacts are additive. Serializers moved to a shared `browser-artifact-serialization.ts`.
4. **Sessions viewer Browser tab** — `ShareUsageThreadDetail` gains the eval replay's Browser tab (visible iff artifacts exist), reusing `BrowserArtifactsView` for the render-observation cards + Computer Use timeline; artifacts also ride the Raw envelope.
5. **Hosted eval runner dedup** — the batch and SSE hosted runners' duplicated per-turn bodies (~300 lines) extract into `driveHostedEvalTurn`; the SSE runner layers its emitters through a per-turn sink factory with event order preserved. Two deliberate convergences bring the stream runner's review fixes to the batch runner: structured engine-error detail in failure messages, and the stricter step-error-span filter. Net **−588 lines** in evals-runner.ts.

## Verification

- Full suites green: server 1559, client 3879, shared 170 (plus backend 2267 on the paired PR).
- Real-Chromium Computer Use smoke tests (`computer-use-loop*.test.ts`) pass against the migrated local eval paths.
- New suites: `browser-session-context.test.ts` (15), `runner.dispatch.test.ts` rewritten against the headless drivers (10), `org-model-stream-handler-headless.test.ts` (7), `runner.browser.test.ts` (4), Sessions-viewer Browser-tab tests.
- Suggested manual E2E once both PRs are on a dev deployment: chatbox wired to the Excalidraw MCP server with a Claude model, Generate with AI using a persona whose notes require manipulating the canvas — the session's Browser tab should show a `Rendered` observation card and a numbered click/type timeline with per-step screenshots, while the Data/Sandbox interactive widget still renders.

https://claude.ai/code/session_01AuvTbfGa1ybMzWNPCkP4k3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuvTbfGa1ybMzWNPCkP4k3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large refactor across eval runners, Chromium lifecycle, and synthetic session turns; turn failures now throw instead of silent empty drains, and hosted eval behavior converges via shared failure detection.
> 
> **Overview**
> Unifies eval and synthetic chatbox runners on a shared **browser session context** (headless MCP App rendering + optional Claude Computer Use), wires **Generate with AI** to persist artifacts per turn, and surfaces them in the shared sessions viewer.
> 
> **Server:** Renames/consolidates `browser-eval-context` into `createBrowserSessionContext` with engine and local AI-SDK hooks, incremental `drainNewArtifacts()`, and shared screenshot serialization in `browser-artifact-serialization.ts`. Eval runners drop duplicated inline harness code; hosted batch and SSE paths share `driveHostedEvalTurn` (with pre-turn failure mapping and aligned error-span handling). The simulation runner creates one context per session, merges computer tools, and calls `chatSessions:recordBrowserArtifacts` after each turn.
> 
> **Client:** `ShareUsageThreadDetail` loads browser artifacts via `useSessionBrowserArtifacts`, adds an optional **Browser** tab (same `BrowserArtifactsView` as eval replay), clamps stale `browser` view mode when switching to artifact-less sessions, and includes artifacts in the Raw trace envelope. `ChatTraceViewModeHeaderBar` gains optional browser tab props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ae63105542a39c2e4dcd1182cb7df3e016cc5f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->