### PR TITLE
PR previews: deregister preview URLs from staging WorkOS on destroy

### DIFF
--- a/.github/scripts/workos-cleanup.sh
+++ b/.github/scripts/workos-cleanup.sh
@@ -54,15 +54,20 @@ WORKOS_API_BASE="${WORKOS_API_BASE:-https://api.workos.com}"
 #
 # Lists the resource (following pagination cursors), collects ids whose
 # <field> equals <value> exactly, then deletes each id. Collect-then-delete
-# so deletions can't shift pagination out from under the scan.
+# so deletions can't shift pagination out from under the scan. The scan
+# stops at the first match: WorkOS rejects exact duplicates (422 "already
+# exists"), so one entry per exact value is all that can exist. A scan that
+# ends without a match AND without seeing the end of the list (page cap,
+# list failure) must NOT report "already clean" — it warns instead.
 delete_matching() {
   local resource="$1" field="$2" value="$3"
-  local after="" page=0 ids=""
+  local after="" page=0 ids="" scan_complete=0
 
   while [ "$page" -lt 10 ]; do
     page=$((page + 1))
     local url="${WORKOS_API_BASE}/user_management/${resource}?limit=100"
     if [ -n "$after" ]; then
+      # Cursors are WorkOS object ids (URL-safe); no escaping needed.
       url="${url}&after=${after}"
     fi
 
@@ -75,27 +80,35 @@ delete_matching() {
       "$url" || true)
     http_code="${http_code:-000}"
     if [ "$http_code" != "200" ]; then
-      echo "::warning::WorkOS ${resource} list failed (HTTP ${http_code}) — remove '${value}' manually in the staging WorkOS dashboard" >&2
+      echo "::warning::WorkOS ${resource} list failed (HTTP ${http_code}) on page ${page} — scan incomplete" >&2
       rm -f "$resp_file"
-      return 0
+      break
     fi
 
     local page_ids
     page_ids=$(jq -r --arg f "$field" --arg v "$value" \
       '.data[]? | select(.[$f] == $v) | .id' "$resp_file" 2>/dev/null || true)
     if [ -n "$page_ids" ]; then
-      ids="${ids}${ids:+$'\n'}${page_ids}"
+      ids="$page_ids"
+      rm -f "$resp_file"
+      scan_complete=1
+      break
     fi
 
     after=$(jq -r '.list_metadata.after // empty' "$resp_file" 2>/dev/null || true)
     rm -f "$resp_file"
     if [ -z "$after" ]; then
+      scan_complete=1
       break
     fi
   done
 
   if [ -z "$ids" ]; then
-    echo "::notice::No WorkOS ${resource} entry matched '${value}' (already clean)"
+    if [ "$scan_complete" -eq 1 ]; then
+      echo "::notice::No WorkOS ${resource} entry matched '${value}' (already clean)"
+    else
+      echo "::warning::WorkOS ${resource} scan ended after ${page} page(s) without finding '${value}' — verify/remove it manually in the staging WorkOS dashboard" >&2
+    fi
     return 0
   fi
 

--- a/.github/scripts/workos-cleanup.sh
+++ b/.github/scripts/workos-cleanup.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Best-effort WorkOS deregistration for the PR preview pipeline.
+#
+# Usage:
+#   .github/scripts/workos-cleanup.sh <preview-url>
+#
+# Example:
+#   .github/scripts/workos-cleanup.sh https://mcp-inspector-pr-123.up.railway.app
+#
+# Requires:
+#   STAGING_WORKOS_API_KEY — API key for the staging WorkOS environment.
+#
+# Removes what the upsert jobs register per preview (pr-preview.yml,
+# "Register preview URL with WorkOS staging"):
+#   - redirect URI  <preview-url>/callback
+#   - CORS origin   <preview-url>
+#
+# Why raw curl instead of the workos CLI: as of workos@0.12.1 the CLI only
+# implements `config redirect add` / `config cors add` — there is no remove
+# subcommand, and WorkOS's public API spec documents only the create
+# endpoints. The resources are id-addressed (`ruri_*`), and list/delete are
+# served on the same paths (used by third-party integrations that manage
+# these resources), just undocumented:
+#   GET    /user_management/redirect_uris?limit=100  → { data: [{ id, uri, ... }] }
+#   DELETE /user_management/redirect_uris/<id>
+#   GET    /user_management/cors_origins?limit=100   → { data: [{ id, origin }] }
+#   DELETE /user_management/cors_origins/<id>
+# Because they are undocumented, every call here is treated as fallible and
+# the outcome is reported via workflow annotations either way.
+#
+# Exit codes:
+#   0 — always. This is hygiene on the PR-close path: a missing entry, an
+#       unavailable endpoint, or a bad key must never block PR close.
+#       Problems surface as ::warning:: annotations instead.
+
+set -uo pipefail
+
+PREVIEW_URL="${1:-}"
+if [ -z "$PREVIEW_URL" ]; then
+  echo "::warning::workos-cleanup.sh called without a preview URL — nothing to clean" >&2
+  exit 0
+fi
+if [ -z "${STAGING_WORKOS_API_KEY:-}" ]; then
+  echo "::warning::STAGING_WORKOS_API_KEY is not set — skipping WorkOS cleanup for ${PREVIEW_URL}" >&2
+  exit 0
+fi
+
+WORKOS_API_BASE="${WORKOS_API_BASE:-https://api.workos.com}"
+
+# delete_matching <resource> <field> <value>
+#   resource: redirect_uris | cors_origins
+#   field:    uri | origin
+#   value:    exact entry value to remove
+#
+# Lists the resource (following pagination cursors), collects ids whose
+# <field> equals <value> exactly, then deletes each id. Collect-then-delete
+# so deletions can't shift pagination out from under the scan.
+delete_matching() {
+  local resource="$1" field="$2" value="$3"
+  local after="" page=0 ids=""
+
+  while [ "$page" -lt 10 ]; do
+    page=$((page + 1))
+    local url="${WORKOS_API_BASE}/user_management/${resource}?limit=100"
+    if [ -n "$after" ]; then
+      url="${url}&after=${after}"
+    fi
+
+    local resp_file http_code
+    resp_file="$(mktemp)"
+    # On connection failure curl still emits "000" via -w, so don't append
+    # a fallback code — just tolerate the non-zero exit and default if empty.
+    http_code=$(curl -sS -o "$resp_file" -w "%{http_code}" --max-time 30 \
+      -H "Authorization: Bearer ${STAGING_WORKOS_API_KEY}" \
+      "$url" || true)
+    http_code="${http_code:-000}"
+    if [ "$http_code" != "200" ]; then
+      echo "::warning::WorkOS ${resource} list failed (HTTP ${http_code}) — remove '${value}' manually in the staging WorkOS dashboard" >&2
+      rm -f "$resp_file"
+      return 0
+    fi
+
+    local page_ids
+    page_ids=$(jq -r --arg f "$field" --arg v "$value" \
+      '.data[]? | select(.[$f] == $v) | .id' "$resp_file" 2>/dev/null || true)
+    if [ -n "$page_ids" ]; then
+      ids="${ids}${ids:+$'\n'}${page_ids}"
+    fi
+
+    after=$(jq -r '.list_metadata.after // empty' "$resp_file" 2>/dev/null || true)
+    rm -f "$resp_file"
+    if [ -z "$after" ]; then
+      break
+    fi
+  done
+
+  if [ -z "$ids" ]; then
+    echo "::notice::No WorkOS ${resource} entry matched '${value}' (already clean)"
+    return 0
+  fi
+
+  local id del_code
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    del_code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 30 -X DELETE \
+      -H "Authorization: Bearer ${STAGING_WORKOS_API_KEY}" \
+      "${WORKOS_API_BASE}/user_management/${resource}/${id}" || true)
+    del_code="${del_code:-000}"
+    case "$del_code" in
+      2*) echo "::notice::Removed WorkOS ${resource} entry ${id} ('${value}')" ;;
+      *) echo "::warning::Failed to delete WorkOS ${resource} ${id} (HTTP ${del_code}) — remove '${value}' manually in the staging WorkOS dashboard" >&2 ;;
+    esac
+  done <<< "$ids"
+}
+
+delete_matching redirect_uris uri "${PREVIEW_URL}/callback"
+delete_matching cors_origins origin "${PREVIEW_URL}"
+
+exit 0

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -545,13 +545,49 @@ jobs:
       BACKEND_REPO: ${{ vars.MCPJAM_BACKEND_REPO || 'MCPJam/mcpjam-backend' }}
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_INSPECTOR_SERVICE: ${{ vars.RAILWAY_INSPECTOR_SERVICE }}
       RAILWAY_STAGING_ENVIRONMENT: ${{ vars.RAILWAY_STAGING_ENVIRONMENT }}
     steps:
-      # Checkout is required so `.github/scripts/railway-retry.sh` is on disk.
+      # Checkout is required so the `.github/scripts/` helpers are on disk.
       - uses: actions/checkout@v4
 
       - name: Install Railway CLI
         run: npm install -g @railway/cli@4.57.1
+
+      # The preview's public domain only exists as RAILWAY_PUBLIC_DOMAIN
+      # inside the Railway environment, so it must be read BEFORE the
+      # environment is deleted — it's what the upsert job registered with
+      # WorkOS staging. Unlike the upsert jobs' version of this step, the
+      # environment may legitimately not exist here (manual deletion, an
+      # upsert that never ran), and railway-retry replays CLI error text on
+      # stdout — so only accept values shaped like a hostname.
+      - name: Read preview public domain
+        id: preview_domain
+        continue-on-error: true
+        run: |
+          DOMAIN=$(.github/scripts/railway-retry.sh railway run \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "${RAILWAY_ENV_PREFIX}${{ github.event.pull_request.number }}" \
+            --service "$RAILWAY_INSPECTOR_SERVICE" \
+            printenv RAILWAY_PUBLIC_DOMAIN | tail -n 1 | tr -d '\r')
+          if [[ "$DOMAIN" =~ ^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$ ]]; then
+            echo "url=https://${DOMAIN}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Inverse of "Register preview URL with WorkOS staging" in the upsert
+      # job. Without this, the staging WorkOS app accumulates redirect URIs
+      # and CORS origins pointing at deleted (reclaimable) *.up.railway.app
+      # domains — an auth-code-interception hygiene issue. Best-effort: must
+      # never block PR close. Runs before the env delete so a cancelled run
+      # leaves the env (re-registered on reopen) rather than dangling
+      # WorkOS entries. Uses curl, not the workos CLI — the CLI has no
+      # `config redirect/cors remove` subcommand (see workos-cleanup.sh).
+      - name: Deregister preview URL from WorkOS staging
+        if: steps.preview_domain.outputs.url != ''
+        env:
+          STAGING_WORKOS_API_KEY: ${{ secrets.STAGING_WORKOS_API_KEY }}
+        run: |
+          .github/scripts/workos-cleanup.sh "${{ steps.preview_domain.outputs.url }}" || true
 
       - name: Delete Railway preview environment
         run: |
@@ -583,15 +619,20 @@ jobs:
     env:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_INSPECTOR_SERVICE: ${{ vars.RAILWAY_INSPECTOR_SERVICE }}
       RAILWAY_STAGING_ENVIRONMENT: ${{ vars.RAILWAY_STAGING_ENVIRONMENT }}
     steps:
-      # Checkout is required so `.github/scripts/railway-retry.sh` is on disk.
+      # Checkout is required so the `.github/scripts/` helpers are on disk.
       - uses: actions/checkout@v4
 
       - name: Install Railway CLI
         run: npm install -g @railway/cli@4.57.1
 
-      - name: Delete Railway backend-PR preview environment
+      # The validated environment name is shared by the read/deregister/
+      # delete steps below; a bad payload fails the job here, before
+      # anything is read or deleted.
+      - name: Resolve preview environment metadata
+        id: meta
         env:
           BACKEND_PR_NUMBER: ${{ github.event.client_payload.backend_pr_number }}
         run: |
@@ -599,7 +640,33 @@ jobs:
             echo "::error::backend_pr_number is missing or non-numeric: '$BACKEND_PR_NUMBER'"
             exit 1
           fi
-          .github/scripts/railway-retry.sh .github/scripts/railway-env.sh delete "${RAILWAY_BACKEND_PR_ENV_PREFIX}${BACKEND_PR_NUMBER}" \
+          echo "environment=${RAILWAY_BACKEND_PR_ENV_PREFIX}${BACKEND_PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      # See destroy-preview above: the domain must be read before the
+      # environment is deleted, then its WorkOS registrations are removed.
+      - name: Read preview public domain
+        id: preview_domain
+        continue-on-error: true
+        run: |
+          DOMAIN=$(.github/scripts/railway-retry.sh railway run \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "${{ steps.meta.outputs.environment }}" \
+            --service "$RAILWAY_INSPECTOR_SERVICE" \
+            printenv RAILWAY_PUBLIC_DOMAIN | tail -n 1 | tr -d '\r')
+          if [[ "$DOMAIN" =~ ^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$ ]]; then
+            echo "url=https://${DOMAIN}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deregister preview URL from WorkOS staging
+        if: steps.preview_domain.outputs.url != ''
+        env:
+          STAGING_WORKOS_API_KEY: ${{ secrets.STAGING_WORKOS_API_KEY }}
+        run: |
+          .github/scripts/workos-cleanup.sh "${{ steps.preview_domain.outputs.url }}" || true
+
+      - name: Delete Railway backend-PR preview environment
+        run: |
+          .github/scripts/railway-retry.sh .github/scripts/railway-env.sh delete "${{ steps.meta.outputs.environment }}" \
             --yes || true
 
   sync-backend-preview:


### PR DESCRIPTION
## What this does

Every PR preview registers two entries with the **staging WorkOS app**: a redirect URI (`<preview-url>/callback`) and a CORS origin (`<preview-url>`). The destroy jobs deleted the Railway environment but never removed those entries, so the staging app has been accumulating redirect URIs and CORS origins pointing at deleted `*.up.railway.app` domains.

## Security framing

Dangling redirect URIs are an auth-code-interception risk: Railway subdomains are potentially reclaimable, and a reclaimed domain that is still an allowed redirect target can receive authorization codes for the staging app. Stale CORS origins similarly extend browser trust to domains we no longer control. Blast radius is **staging only** (employee-only, non-prod lockdown), which is why this is hygiene rather than an incident — but it's cheap to stop the bleeding at the source.

## How it works

Both `destroy-preview` and `destroy-backend-pr-preview` now:

1. **Read the preview's public domain before deleting the environment** (`railway run printenv RAILWAY_PUBLIC_DOMAIN`, the same pattern as the upsert jobs' "Read preview public domain" step). The domain only exists inside the Railway env, so this must happen first. A hostname-shape guard rejects CLI error text that `railway-retry.sh` replays on stdout when the env is already gone — a failure mode unique to the destroy path.
2. **Deregister from WorkOS** via the new `.github/scripts/workos-cleanup.sh`, which removes the exact redirect URI and CORS origin for that preview.
3. Delete the Railway environment as before. Deregistration runs *before* the delete so a cancelled run leaves a still-registered live env (re-registered idempotently on reopen) rather than dangling entries.

In `destroy-backend-pr-preview`, the existing `backend_pr_number` validation moved into a `meta` step so the read/deregister/delete steps share the validated environment name — same failure semantics as before (bad payload still fails the job before anything is touched).

## Why curl instead of `workos config redirect/cors remove`

That subcommand **does not exist**. Verified against `workos@0.12.1` (the CLI version the upsert jobs install): `workos config redirect` and `workos config cors` implement only `add`, and even the CLI's own `seed cleanup` cannot undo these resources. WorkOS's public API spec documents only the create endpoints — but the resources are id-addressed (`ruri_*`, `object: redirect_uri`) and list/delete are served on the same paths (`GET /user_management/redirect_uris?limit=100` → `{data:[{id,uri,…}]}`, `DELETE /user_management/redirect_uris/<id>`; same for `cors_origins`), as used by third-party integrations that manage these resources. Because the endpoints are undocumented, the script treats every call as fallible and reports the outcome either way.

## Best-effort guarantees

Cleanup can never block PR close:

- the script **always exits 0** — missing entry, withdrawn endpoint, bad key, or unreachable API all degrade to `::warning::`/`::notice::` annotations naming the entry to prune manually;
- the workflow step adds `|| true` on top, and the domain-read step is `continue-on-error` with the deregister step skipped when no domain was resolved;
- deletion only ever targets ids whose `uri`/`origin` **exactly equals** this preview's values, so staging's own entries can't be touched.

## ⚠️ One-time manual prune

This only stops new accumulation. Entries from previously closed PRs are still registered — someone should prune the stale `*.up.railway.app` redirect URIs and CORS origins from the **staging** WorkOS app's *Redirects* page in the dashboard once. (Don't touch `staging.mcpjam.com` or localhost entries.)

## Verification

- `workos-cleanup.sh` exercised against a local mock of the WorkOS API across 8 scenarios: happy path, idempotent rerun, target on page 2 of a paginated list, 401, 404 (endpoint withdrawn), unreachable API, missing arg, missing key — exits 0 in all, deletes only the target ids.
- Domain-read guard simulated under bash for success, success-after-retry, multi-word/single-word CLI error text, empty output, and CRLF.
- `actionlint` + `shellcheck` clean (the 3 pre-existing findings in this workflow are unchanged).
- Not verifiable from here: the undocumented GET/DELETE against the real WorkOS API (no removal exists in any official SDK/CLI to compare against). The first PR close after merge will show the result in the destroy job's annotations; if WorkOS doesn't serve them, the job stays green and warns with the exact entries to prune by hand.

**Ship/hold call:** low risk — touches only the PR-close path, fully guarded, staging-scoped. Worst case is identical to today's behavior plus a warning annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI destroy paths and staging WorkOS hygiene; cleanup is best-effort, exact-match scoped, and cannot block PR close.
> 
> **Overview**
> PR preview teardown now **removes the staging WorkOS redirect URI and CORS origin** that upsert jobs add, so closed previews do not leave allowed targets on deleted `*.up.railway.app` domains.
> 
> A new **`workos-cleanup.sh`** script lists and deletes entries by exact match (`<preview-url>/callback` and `<preview-url>`) via undocumented WorkOS list/delete APIs (the `workos` CLI has no remove). It always exits 0 and surfaces failures as workflow warnings.
> 
> **`destroy-preview`** and **`destroy-backend-pr-preview`** read `RAILWAY_PUBLIC_DOMAIN` **before** deleting the Railway env, run cleanup when a hostname-shaped URL is resolved (stricter than upsert to ignore CLI error text), then delete the env as before. Backend destroy refactors env name validation into a **`meta`** step shared by read/deregister/delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d621b00d6695ab5a3212ab0ca4feca3456637f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->