### PR TITLE
fix(oauth): honor PRM-advertised resource indicator instead of overwriting with server URL

### DIFF
--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -429,6 +429,19 @@ export const createDebugOAuthStateMachine = (
   // Helper to get current state (use getState if provided, otherwise use initial state)
   const getCurrentState = () => (getState ? getState() : initialState);
 
+  // Per RFC 8707 and the MCP Authorization spec, the OAuth `resource` indicator
+  // must use the identifier advertised in the server's Protected Resource
+  // Metadata when one was discovered. That identifier may be any URI (including
+  // a URN) and is not required to equal the MCP endpoint URL, so the client must
+  // not overwrite it with the server URL. Only fall back to the server URL when
+  // no PRM `resource` is available. Resolving through a single helper also keeps
+  // the authorization request and the token request resource values identical —
+  // some authorization servers reject a mismatch between the two.
+  const resolveResourceParameter = (): string | undefined => {
+    const current = getCurrentState();
+    return current.resourceMetadata?.resource ?? current.serverUrl;
+  };
+
   const executeRequest = (url: string, options: RequestInit = {}) =>
     requestExecutor({
       url,
@@ -1460,7 +1473,7 @@ export const createDebugOAuthStateMachine = (
               {
                 code_challenge: codeChallenge,
                 method: "S256",
-                resource: state.serverUrl || "Unknown",
+                resource: resolveResourceParameter() || "Unknown",
               },
             );
 
@@ -1496,8 +1509,9 @@ export const createDebugOAuthStateMachine = (
             );
             authUrl.searchParams.set("code_challenge_method", "S256");
             authUrl.searchParams.set("state", state.state || "");
-            if (state.serverUrl) {
-              authUrl.searchParams.set("resource", state.serverUrl);
+            const authResourceParam = resolveResourceParameter();
+            if (authResourceParam) {
+              authUrl.searchParams.set("resource", authResourceParam);
             }
 
             const requestedScopeValue = resolveRequestedScopeValue({
@@ -1583,8 +1597,9 @@ export const createDebugOAuthStateMachine = (
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
             }
 
-            if (state.serverUrl) {
-              tokenRequestBodyObj.resource = state.serverUrl;
+            const tokenBodyResourceParam = resolveResourceParameter();
+            if (tokenBodyResourceParam) {
+              tokenRequestBodyObj.resource = tokenBodyResourceParam;
             }
 
             const tokenRequest = {
@@ -1650,8 +1665,9 @@ export const createDebugOAuthStateMachine = (
               }
 
               // Add resource parameter if available
-              if (state.serverUrl) {
-                tokenRequestBody.set("resource", state.serverUrl);
+              const tokenResourceParam = resolveResourceParameter();
+              if (tokenResourceParam) {
+                tokenRequestBody.set("resource", tokenResourceParam);
               }
 
               // Make the token request via backend proxy

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -571,6 +571,18 @@ export const createDebugOAuthStateMachine = (
   // Helper to get current state (use getState if provided, otherwise use initial state)
   const getCurrentState = () => (getState ? getState() : initialState);
 
+  // Per RFC 8707 and the MCP Authorization spec, the OAuth `resource` indicator
+  // must use the identifier advertised in the server's Protected Resource
+  // Metadata when one was discovered. That identifier may be any URI (including
+  // a URN) and is not required to equal the MCP endpoint URL, so the client must
+  // not overwrite it with the canonicalized server URL. Only fall back to the
+  // canonical server URL when no PRM `resource` is available. Resolving through a
+  // single helper also guarantees the authorization request and the token
+  // request send an identical resource value — some authorization servers reject
+  // a mismatch between the two.
+  const resolveResourceParameter = (): string =>
+    getCurrentState().resourceMetadata?.resource ?? canonicalServerUrl;
+
   const executeRequest = (url: string, options: RequestInit = {}) =>
     requestExecutor({
       url,
@@ -1749,7 +1761,7 @@ export const createDebugOAuthStateMachine = (
               {
                 code_challenge: codeChallenge,
                 method: "S256",
-                resource: canonicalServerUrl,
+                resource: resolveResourceParameter(),
               }
             );
 
@@ -1785,7 +1797,7 @@ export const createDebugOAuthStateMachine = (
             );
             authUrl.searchParams.set("code_challenge_method", "S256");
             authUrl.searchParams.set("state", state.state || "");
-            authUrl.searchParams.set("resource", canonicalServerUrl);
+            authUrl.searchParams.set("resource", resolveResourceParameter());
 
             const requestedScopeValue = resolveRequestedScopeValue({
               customScopes,
@@ -1870,7 +1882,7 @@ export const createDebugOAuthStateMachine = (
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
             }
 
-            tokenRequestBodyObj.resource = canonicalServerUrl;
+            tokenRequestBodyObj.resource = resolveResourceParameter();
 
             const tokenRequest = {
               method: "POST",
@@ -1934,8 +1946,9 @@ export const createDebugOAuthStateMachine = (
                 tokenRequestBody.set("client_secret", state.clientSecret);
               }
 
-              // Add resource parameter (canonicalized per RFC 8707)
-              tokenRequestBody.set("resource", canonicalServerUrl);
+              // Add resource parameter (per RFC 8707; prefers the PRM-advertised
+              // resource identifier, falling back to the canonical server URL)
+              tokenRequestBody.set("resource", resolveResourceParameter());
 
               // Make the token request via backend proxy
               const response = await executeRequest(

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -403,4 +403,128 @@ describe("OAuth state machine regressions", () => {
     expect(state.tokenEndpointAuthMethod).toBe("none");
     expect(state.error).toBeUndefined();
   });
+
+  // Regression for #2119: the OAuth `resource` indicator must honour the
+  // identifier advertised in the server's Protected Resource Metadata (which may
+  // be a URN, not the MCP endpoint URL) instead of being overwritten with the
+  // server URL. The authorization request and token request must also agree.
+  const RESOURCE_URN = "urn:example:my-resource";
+
+  const seedAuthorizationStart = (
+    resourceMetadata?: { resource: string },
+  ) => ({
+    ...EMPTY_OAUTH_FLOW_STATE,
+    currentStep: "received_client_credentials" as const,
+    serverUrl: SERVER_URL,
+    clientId: "test-client",
+    authorizationServerMetadata: {
+      authorization_endpoint: "https://auth.example.com/authorize",
+      token_endpoint: "https://auth.example.com/token",
+    } as any,
+    ...(resourceMetadata ? { resourceMetadata } : {}),
+    infoLogs: [],
+  });
+
+  const seedTokenExchange = (resourceMetadata?: { resource: string }) => ({
+    ...EMPTY_OAUTH_FLOW_STATE,
+    currentStep: "received_authorization_code" as const,
+    serverUrl: SERVER_URL,
+    clientId: "test-client",
+    codeVerifier: "test-code-verifier",
+    authorizationCode: "test-auth-code",
+    authorizationServerMetadata: {
+      token_endpoint: "https://auth.example.com/token",
+    } as any,
+    ...(resourceMetadata ? { resourceMetadata } : {}),
+    infoLogs: [],
+  });
+
+  it.each<OAuthProtocolVersion>(["2025-06-18", "2025-11-25"])(
+    "uses the PRM-advertised resource for the authorization request in %s",
+    async (protocolVersion) => {
+      let state: any = seedAuthorizationStart({ resource: RESOURCE_URN });
+
+      const machine = createOAuthStateMachine({
+        protocolVersion,
+        registrationStrategy: "preregistered" as any,
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        requestExecutor: jest.fn(),
+      });
+
+      await machine.proceedToNextStep(); // generate PKCE parameters
+      await machine.proceedToNextStep(); // build authorization URL
+
+      const authUrl = new URL(state.authorizationUrl);
+      expect(authUrl.searchParams.get("resource")).toBe(RESOURCE_URN);
+    },
+  );
+
+  it.each<OAuthProtocolVersion>(["2025-06-18", "2025-11-25"])(
+    "uses the PRM-advertised resource for the token request in %s",
+    async (protocolVersion) => {
+      let state: any = seedTokenExchange({ resource: RESOURCE_URN });
+
+      const machine = createOAuthStateMachine({
+        protocolVersion,
+        registrationStrategy: "preregistered" as any,
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        requestExecutor: jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: { access_token: "token" },
+        }),
+      });
+
+      await machine.proceedToNextStep(); // prepare token request body
+
+      expect(state.lastRequest?.body?.resource).toBe(RESOURCE_URN);
+    },
+  );
+
+  it.each<OAuthProtocolVersion>(["2025-06-18", "2025-11-25"])(
+    "falls back to the server URL when no PRM resource is advertised in %s",
+    async (protocolVersion) => {
+      let state: any = seedTokenExchange();
+
+      const machine = createOAuthStateMachine({
+        protocolVersion,
+        registrationStrategy: "preregistered" as any,
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        serverUrl: SERVER_URL,
+        serverName: "Test Server",
+        redirectUrl: REDIRECT_URI,
+        requestExecutor: jest.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: { access_token: "token" },
+        }),
+      });
+
+      await machine.proceedToNextStep(); // prepare token request body
+
+      expect(state.lastRequest?.body?.resource).toBe(SERVER_URL);
+    },
+  );
 });


### PR DESCRIPTION
## Problem

Fixes #2119.

When stepping through the OAuth debugger, the `resource` indicator sent in both the authorization request and the token request is unconditionally set to the MCP server URL — even when the server's **Protected Resource Metadata** (`/.well-known/oauth-protected-resource`) advertises a *different* `resource` identifier.

Per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) and the [MCP Authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization), the resource identifier may be any URI (including a URN) and **is not required to equal the MCP endpoint URL**. The client must not rewrite it. Two concrete symptoms reported on the issue:

- A server advertising `"resource": "urn:valid:urn:identifier"` still gets `http://localhost:8000/mcp` sent as the resource (visible already at the *Generate PKCE Parameters* stage).
- Authorization servers reject the flow because the resource sent to `/authorize` and `/token` doesn't match the one they expect.

The PRM `resource` value *is* fetched and stored on the flow state (`state.resourceMetadata.resource`) but was only used for display — the request builders ignored it and used the server URL.

## Solution

Introduce a single `resolveResourceParameter()` helper in the `2025-06-18` and `2025-11-25` state machines that prefers `state.resourceMetadata?.resource` (the PRM-advertised identifier, used verbatim — important for URNs) and falls back to the server URL only when no PRM resource was discovered. All resource-indicator sites (PKCE display log, authorization URL, token request body, and the actual token POST) now resolve through it.

Using one resolver also guarantees the authorization request and the token request send an **identical** resource value, which several authorization servers require.

The `2025-03-26` flow does not fetch Protected Resource Metadata at all, so it is intentionally left unchanged.

## Testing

Added regression tests in `sdk/tests/oauth/state-machine-regressions.test.ts` (run with `npm test -w @mcpjam/sdk`) that drive both state machines and assert the resource parameter on the authorization URL and token request:

- uses the PRM-advertised `urn:` resource for the authorization request (2025-06-18, 2025-11-25)
- uses the PRM-advertised `urn:` resource for the token request (2025-06-18, 2025-11-25)
- falls back to the server URL when no PRM resource is advertised (2025-06-18, 2025-11-25)

All 100 existing OAuth tests continue to pass. Confirmed the new tests fail on `main` (resource resolves to the server URL) and pass with this change.