### PR TITLE
feat(agent): mcpjam_* built-in tools — scaffold + handoff

### DIFF
--- a/HANDOFF-mcpjam-built-in-tools.md
+++ b/HANDOFF-mcpjam-built-in-tools.md
@@ -83,20 +83,30 @@ import type { Context } from "hono";
 
 export function buildMcpjamLiveOps(c: Context, projectId: string): McpjamLiveOps {
   return {
-    doctor: (serverId) =>
+    doctor: (serverId, _abortSignal) =>
       runHostedDoctor(c, { projectId, serverId }, WEB_CONNECT_TIMEOUT_MS),
-    listTools: (serverId, cursor) =>
+    listTools: (serverId, cursor, _abortSignal) =>
       runEphemeralConnection(c, { projectId, serverId, cursor }, toolsListSchema,
         (manager, body) => listTools(manager, body)),
-    callTool: (serverId, toolName, parameters) =>
+    callTool: (serverId, toolName, parameters, _abortSignal) =>
       runEphemeralConnection(c, { projectId, serverId, toolName, parameters },
         toolsExecuteSchema,
         (manager, body) => manager.executeTool(body.serverId, body.toolName, body.parameters)),
-    // listPrompts / getPrompt / listResources / readResource: same shape with
-    // promptsListSchema/promptsGetSchema/resourcesListSchema/resourcesReadSchema.
+    getPrompt: (serverId, name, args, _abortSignal) =>
+      runEphemeralConnection(c, { projectId, serverId, promptName: name, arguments: args },
+        promptsGetSchema,                       // NB: schema field is `promptName`, not `name`
+        (manager, body) => getPrompt(manager, body)),
+    // listPrompts / listResources / readResource: same shape with
+    // promptsListSchema/resourcesListSchema/resourcesReadSchema.
   };
 }
 ```
+
+Abort semantics (Bugbot round 1): every `McpjamLiveOps` method takes a trailing
+`abortSignal?: AbortSignal`, and the tool layer pre-checks `aborted` before
+dispatching. `runEphemeralConnection` has no signal parameter today, so the
+factory can ignore the signal initially (`_abortSignal`) — threading it into the
+manager/timeout layer is optional hardening, not required for slice 1.
 
 Reference implementations: `server/routes/v1/{tools,prompts,resources,servers}.ts`
 call the identical cores via `runV1ServerOp` (`server/routes/v1/adapter.ts`). Notes:

--- a/HANDOFF-mcpjam-built-in-tools.md
+++ b/HANDOFF-mcpjam-built-in-tools.md
@@ -1,0 +1,192 @@
+# Handoff: MCPJam built-in tools for the in-app agent
+
+> Status: **slice 1 in progress** — the tool module is written; wiring, tests, and the
+> backend catalog rows remain. Delete this file before merging.
+
+## Goal
+
+Give the chat agent (web chat-v2 / playground / future copilot) first-class tools to act
+on the MCPJam workspace itself — list project servers, diagnose connections, and run
+live MCP ops (tools/prompts/resources) against **any saved server**, not just the ones
+selected into the chat. Navigation/frontend tools are explicitly **phase 2**.
+
+Design follows the PostHog Max / Arize Alyx pattern survey (read-heavy toolset, writes
+gated by approval, ids = tool names) and reuses the same cores as the public `/api/v1`
+surface — no forked handler logic.
+
+## Decisions already made (and why)
+
+| Decision | Rationale |
+|---|---|
+| Per-tool catalog ids `mcpjam_*` (9 ids), not one bundle id | Backend invariant: "a catalog id doubles as the AI SDK tool name" (`convex/lib/builtInTools.ts`). Also gives hosts read-only granularity (enable diagnostics without `mcpjam_call_tool`). |
+| Extend `resolveHostTools()` registry, nothing else | It's THE single host-config → ToolSet path for every engine (chat routes, eval runners, sessionSimulation, docs agent). |
+| Live ops injected as a `McpjamLiveOps` runner from the chat route | The authorize→connect→run pipeline (`runEphemeralConnection`) is route-layer and context-bound. Engines that don't pass the runner simply never advertise those tools — same philosophy as `computer`/bash ("callers pass what their surface resolved"). |
+| Catalog reads hit Convex `/v1/*` directly with the caller's bearer | Same pattern as `exa-web-search.ts`; works on every engine, no Hono context needed. |
+| `mcpjam_call_tool` sets `needsApproval: requireToolApproval === true` | Mirrors bash exactly; it's the only side-effectful tool in the set. |
+| Guests: skip ALL `mcpjam_*` ids at advertise time | Matches the `/api/v1` boundary decision ("Guests cannot access /api/v1", `server/routes/v1/index.ts`). |
+| Tool `execute` returns `{ error: string }`, never throws | House style (exa/bash) — keeps the model turn alive. |
+
+## Done
+
+- `server/utils/built-in-tools/mcpjam.ts` — all 9 tool builders, `McpjamLiveOps`
+  interface, `MCPJAM_TOOL_IDS`, `isMcpjamToolId()`, `buildMcpjamTool(id, opts)`
+  dispatcher (returns `null` when an id needs the runner and none was provided).
+  **Not yet typechecked** — run the workspace typecheck before anything else.
+
+## Remaining work (in order)
+
+### 1. Registry wiring — `server/utils/built-in-tools/registry.ts`
+
+- Add to `BuiltInToolContext`: `mcpjamLiveOps?: McpjamLiveOps` (import type from
+  `./mcpjam.js`).
+- In the `for (const id of ids)` loop (after the bash branch, before the unknown-id
+  warn):
+
+```ts
+if (isMcpjamToolId(id)) {
+  if (ctx.isGuest) {
+    logger.debug("[built-in-tools] mcpjam tools not advertised to guest actor; skipping", { id });
+    continue;
+  }
+  const built = buildMcpjamTool(id, {
+    authHeader,
+    projectId: ctx.projectId,
+    liveOps: ctx.mcpjamLiveOps,
+    requireToolApproval: ctx.requireToolApproval,
+  });
+  if (!built) {
+    logger.debug("[built-in-tools] mcpjam live-op id without a runner; skipping", { id });
+    continue;
+  }
+  out[id] = built;
+  continue;
+}
+```
+
+- Update the module-header comment (it documents every gate by design — add the
+  mcpjam ids, the `mcpjamLiveOps` gate, and the guest gate).
+
+### 2. Live-ops factory — new file `server/routes/web/mcpjam-live-ops.ts`
+
+Route layer on purpose (it imports from `./auth.js` / `./servers.js`). Shape:
+
+```ts
+import { runEphemeralConnection, toolsListSchema, toolsExecuteSchema,
+  promptsListSchema, promptsGetSchema, resourcesListSchema, resourcesReadSchema,
+} from "./auth.js";
+import { runHostedDoctor } from "./servers.js";
+import { listTools, listPrompts, getPrompt, listResources, readResource,
+} from "../../utils/route-handlers.js";
+import { WEB_CONNECT_TIMEOUT_MS } from "../../config.js";
+import type { McpjamLiveOps } from "../../utils/built-in-tools/mcpjam.js";
+import type { Context } from "hono";
+
+export function buildMcpjamLiveOps(c: Context, projectId: string): McpjamLiveOps {
+  return {
+    doctor: (serverId) =>
+      runHostedDoctor(c, { projectId, serverId }, WEB_CONNECT_TIMEOUT_MS),
+    listTools: (serverId, cursor) =>
+      runEphemeralConnection(c, { projectId, serverId, cursor }, toolsListSchema,
+        (manager, body) => listTools(manager, body)),
+    callTool: (serverId, toolName, parameters) =>
+      runEphemeralConnection(c, { projectId, serverId, toolName, parameters },
+        toolsExecuteSchema,
+        (manager, body) => manager.executeTool(body.serverId, body.toolName, body.parameters)),
+    // listPrompts / getPrompt / listResources / readResource: same shape with
+    // promptsListSchema/promptsGetSchema/resourcesListSchema/resourcesReadSchema.
+  };
+}
+```
+
+Reference implementations: `server/routes/v1/{tools,prompts,resources,servers}.ts`
+call the identical cores via `runV1ServerOp` (`server/routes/v1/adapter.ts`). Notes:
+
+- `runEphemeralConnection` is at `server/routes/web/auth.ts:1080`; it resolves the
+  bearer itself (`getConvexBearerForRequest`) and handles manager lifecycle.
+- v1 rejects `taskOptions` on tools/call — programmatic bodies here never set it.
+- v1 drops the inspector-only `toolsMetadata`/`tokenCount` enrichments from
+  `listTools` at the public boundary; consider projecting to `result.tools` here
+  too to keep model context lean.
+
+### 3. Chat route wiring — `server/routes/web/chat-v2.ts` (~line 219)
+
+In the existing `resolveHostTools(...)` call, add to the ctx object:
+
+```ts
+mcpjamLiveOps: buildMcpjamLiveOps(c, hostedBody.projectId),
+```
+
+Cheap closures; gating stays in the registry. Leave `/api/mcp/chat-v2` (local mode)
+alone for now — no Convex there.
+
+### 4. Tests
+
+- Extend `server/utils/__tests__/built-in-tools-registry.test.ts` (style is in-file):
+  - catalog id (`mcpjam_list_servers`) resolves with ctx and **without** liveOps;
+  - live id (`mcpjam_call_tool`) is skipped without liveOps, resolves with a stub;
+  - guest ctx ⇒ no `mcpjam_*` ids advertised;
+  - `requireToolApproval: true` ⇒ `mcpjam_call_tool` has `needsApproval === true`,
+    and read tools don't.
+- New `server/utils/__tests__/mcpjam-built-in-tools.test.ts` for execute paths,
+  mirroring `computers-bash-tool.test.ts` conventions (`vi.stubEnv("CONVEX_HTTP_URL", …)`,
+  `vi.stubGlobal("fetch", …)`):
+  - list_servers: 200 passthrough; non-OK uses upstream `message`; missing
+    CONVEX_HTTP_URL ⇒ `{ error }`;
+  - call_tool: forwards (serverId, toolName, parameters) to the stub runner;
+    runner throwing `WebRouteError` ⇒ `{ error: message }`.
+
+### 5. Backend catalog rows — `mcpjam-backend/convex/builtInTools/catalog.ts`
+
+Append 9 rows to `SEED_ROWS` (ids must match `MCPJAM_TOOL_IDS` exactly; grammar
+`^[a-z][a-z0-9_]{0,63}$` already satisfied). All: `category: 'mcpjam'`,
+`billable: false`, no `requiresComputer`. Suggest `enabled: true` for the read
+tools and decide deliberately for `mcpjam_call_tool` (the bash precedent seeded
+disabled until launch-ready). Then run, per deployment:
+
+```sh
+npx convex run builtInTools/catalog:seedBuiltInTools
+```
+
+`validateBuiltInToolScope` needs no changes. The AttachmentEditor renders new rows
+automatically (live `listBuiltInTools` subscription) — **zero client code needed**.
+If catalog rows go enabled before the inspector deploy, the registry warns + skips
+unknown ids by design (documented drift path).
+
+### 6. Verify
+
+```sh
+# inspector workspace
+npm run typecheck -w @mcpjam/inspector   # check exact script name in its package.json
+npm run test -w @mcpjam/inspector
+```
+
+Manual: enable the ids on a host config (AttachmentEditor) → in chat ask
+"diagnose <server name>" → expect `mcpjam_list_servers` then `mcpjam_diagnose_server`
+calls; with approval ON, `mcpjam_call_tool` must show the Approve/Deny pill
+(`client/src/components/chat-v2/thread/parts/tool-part.tsx`).
+
+## Key file map (from exploration)
+
+| What | Where |
+|---|---|
+| Host-tool resolver (THE seam) | `server/utils/built-in-tools/registry.ts:112` |
+| Tool patterns to mirror | `built-in-tools/exa-web-search.ts`, `built-in-tools/bash.ts` |
+| Chat tool assembly + collision guard | `server/utils/chat-v2-orchestration.ts:528-632` |
+| resolveHostTools call site (web chat) | `server/routes/web/chat-v2.ts:219-234` |
+| Ephemeral authorize→connect→run | `server/routes/web/auth.ts:1080` (`runEphemeralConnection`) |
+| Doctor | `server/routes/web/servers.ts:147` (`runHostedDoctor`) |
+| MCP op cores | `server/utils/route-handlers.ts` |
+| v1 equivalents (reference) | `server/routes/v1/*` |
+| builtInToolIds flow (chatbox vs body) | `server/utils/host-execution-context.ts`, `server/utils/chatbox-runtime-config.ts` |
+| Backend catalog + id rules | `mcpjam-backend/convex/builtInTools/catalog.ts`, `convex/lib/builtInTools.ts` |
+
+## Phase 2 (deliberately deferred)
+
+- `mcpjam_run_eval` / `mcpjam_get_eval_run` (async POST + poll, v1 evals surface).
+- Navigation/frontend tools (`navigate`, prefilled connect card) — the AG-UI-style
+  client-executed tools discussed for the "connect to this server" flow.
+- `/api/mcp/chat-v2` (local/OSS mode) support.
+- Trimming large `listTools` results before they hit model context.
+- System-prompt guidance telling the model when to reach for `mcpjam_*` tools
+  (per the tool-triggering lessons — prescriptive "call this when…" descriptions
+  are already in the tool definitions).

--- a/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
@@ -63,21 +63,39 @@ export function isMcpjamToolId(id: string): id is McpjamToolId {
  * authorization/transport failures, which the tools translate to `{ error }`.
  */
 export interface McpjamLiveOps {
-  doctor(serverId: string): Promise<unknown>;
-  listTools(serverId: string, cursor?: string): Promise<unknown>;
+  doctor(serverId: string, abortSignal?: AbortSignal): Promise<unknown>;
+  listTools(
+    serverId: string,
+    cursor?: string,
+    abortSignal?: AbortSignal
+  ): Promise<unknown>;
   callTool(
     serverId: string,
     toolName: string,
-    parameters: Record<string, unknown>
+    parameters: Record<string, unknown>,
+    abortSignal?: AbortSignal
   ): Promise<unknown>;
-  listPrompts(serverId: string, cursor?: string): Promise<unknown>;
+  listPrompts(
+    serverId: string,
+    cursor?: string,
+    abortSignal?: AbortSignal
+  ): Promise<unknown>;
   getPrompt(
     serverId: string,
     name: string,
-    args?: Record<string, string>
+    args?: Record<string, string | number | boolean>,
+    abortSignal?: AbortSignal
   ): Promise<unknown>;
-  listResources(serverId: string, cursor?: string): Promise<unknown>;
-  readResource(serverId: string, uri: string): Promise<unknown>;
+  listResources(
+    serverId: string,
+    cursor?: string,
+    abortSignal?: AbortSignal
+  ): Promise<unknown>;
+  readResource(
+    serverId: string,
+    uri: string,
+    abortSignal?: AbortSignal
+  ): Promise<unknown>;
 }
 
 export interface McpjamToolOptions {
@@ -114,6 +132,10 @@ async function runLiveOp<T>(
   abortSignal: AbortSignal | undefined,
   what: string
 ): Promise<T | { error: string }> {
+  // The signal is also threaded into the op itself (McpjamLiveOps methods
+  // accept it) — this pre-check just avoids starting work the chat runtime
+  // already cancelled.
+  if (abortSignal?.aborted) return { error: `${what} was cancelled.` };
   try {
     return await op();
   } catch (error) {
@@ -211,7 +233,7 @@ function buildDiagnoseServerTool(liveOps: McpjamLiveOps): ToolSet[string] {
       "which step failed and why.",
     inputSchema: z.object({ serverId: serverIdField }),
     execute: async ({ serverId }, { abortSignal }) =>
-      runLiveOp(() => liveOps.doctor(serverId), abortSignal, "Diagnosis"),
+      runLiveOp(() => liveOps.doctor(serverId, abortSignal), abortSignal, "Diagnosis"),
   });
 }
 
@@ -225,7 +247,7 @@ function buildListToolsTool(liveOps: McpjamLiveOps): ToolSet[string] {
     inputSchema: z.object({ serverId: serverIdField, cursor: cursorField }),
     execute: async ({ serverId, cursor }, { abortSignal }) =>
       runLiveOp(
-        () => liveOps.listTools(serverId, cursor),
+        () => liveOps.listTools(serverId, cursor, abortSignal),
         abortSignal,
         "Listing tools"
       ),
@@ -257,7 +279,7 @@ function buildCallToolTool(
     needsApproval: opts.requireToolApproval === true,
     execute: async ({ serverId, toolName, parameters }, { abortSignal }) =>
       runLiveOp(
-        () => liveOps.callTool(serverId, toolName, parameters ?? {}),
+        () => liveOps.callTool(serverId, toolName, parameters ?? {}, abortSignal),
         abortSignal,
         "Tool execution"
       ),
@@ -272,7 +294,7 @@ function buildListPromptsTool(liveOps: McpjamLiveOps): ToolSet[string] {
     inputSchema: z.object({ serverId: serverIdField, cursor: cursorField }),
     execute: async ({ serverId, cursor }, { abortSignal }) =>
       runLiveOp(
-        () => liveOps.listPrompts(serverId, cursor),
+        () => liveOps.listPrompts(serverId, cursor, abortSignal),
         abortSignal,
         "Listing prompts"
       ),
@@ -288,13 +310,13 @@ function buildGetPromptTool(liveOps: McpjamLiveOps): ToolSet[string] {
       serverId: serverIdField,
       name: z.string().min(1).describe("Exact prompt name on the server"),
       arguments: z
-        .record(z.string())
+        .record(z.union([z.string(), z.number(), z.boolean()]))
         .optional()
-        .describe("Prompt arguments (string values)"),
+        .describe("Prompt arguments (string, number, or boolean values)"),
     }),
     execute: async ({ serverId, name, arguments: args }, { abortSignal }) =>
       runLiveOp(
-        () => liveOps.getPrompt(serverId, name, args),
+        () => liveOps.getPrompt(serverId, name, args, abortSignal),
         abortSignal,
         "Rendering the prompt"
       ),
@@ -309,7 +331,7 @@ function buildListResourcesTool(liveOps: McpjamLiveOps): ToolSet[string] {
     inputSchema: z.object({ serverId: serverIdField, cursor: cursorField }),
     execute: async ({ serverId, cursor }, { abortSignal }) =>
       runLiveOp(
-        () => liveOps.listResources(serverId, cursor),
+        () => liveOps.listResources(serverId, cursor, abortSignal),
         abortSignal,
         "Listing resources"
       ),
@@ -327,7 +349,7 @@ function buildReadResourceTool(liveOps: McpjamLiveOps): ToolSet[string] {
     }),
     execute: async ({ serverId, uri }, { abortSignal }) =>
       runLiveOp(
-        () => liveOps.readResource(serverId, uri),
+        () => liveOps.readResource(serverId, uri, abortSignal),
         abortSignal,
         "Reading the resource"
       ),

--- a/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
@@ -1,0 +1,366 @@
+/**
+ * MCPJam product tools (`mcpjam_*`): built-in tools that let the chat agent
+ * act on the user's MCPJam workspace itself — list the project's servers,
+ * diagnose a connection, and run live MCP operations (tools/prompts/resources)
+ * against any saved server, not just the ones selected into the chat.
+ *
+ * Two execution shapes, mirroring the public `/api/v1` split:
+ *
+ *   - Catalog reads (`mcpjam_list_servers`, `mcpjam_list_eval_suites`) proxy
+ *     the Convex `/v1/*` read surface with the caller's bearer — the same
+ *     backing the Inspector's `/api/v1/catalog/*` routes use. They need only
+ *     the auth context, so they work on every engine the registry serves.
+ *
+ *   - Live server ops (`mcpjam_diagnose_server`, `mcpjam_list_tools`,
+ *     `mcpjam_call_tool`, prompts/resources) need the authorize → connect →
+ *     run pipeline, which lives in the web route layer. The chat route
+ *     provides it as a `McpjamLiveOps` runner bound to its request context;
+ *     surfaces that don't pass one (eval runners, sessionSimulation) simply
+ *     never advertise these tools — same pattern as `computer` and bash.
+ *
+ * Every `execute` returns a structured `{ error }` instead of throwing so the
+ * model can relay the problem to the user instead of breaking the turn.
+ * `mcpjam_call_tool` is the only side-effectful tool here and honors the
+ * host's `requireToolApproval` policy exactly like bash does.
+ */
+import { tool, type ToolSet } from "ai";
+import { z } from "zod";
+
+export const MCPJAM_LIST_SERVERS_TOOL_NAME = "mcpjam_list_servers";
+export const MCPJAM_LIST_EVAL_SUITES_TOOL_NAME = "mcpjam_list_eval_suites";
+export const MCPJAM_DIAGNOSE_SERVER_TOOL_NAME = "mcpjam_diagnose_server";
+export const MCPJAM_LIST_TOOLS_TOOL_NAME = "mcpjam_list_tools";
+export const MCPJAM_CALL_TOOL_TOOL_NAME = "mcpjam_call_tool";
+export const MCPJAM_LIST_PROMPTS_TOOL_NAME = "mcpjam_list_prompts";
+export const MCPJAM_GET_PROMPT_TOOL_NAME = "mcpjam_get_prompt";
+export const MCPJAM_LIST_RESOURCES_TOOL_NAME = "mcpjam_list_resources";
+export const MCPJAM_READ_RESOURCE_TOOL_NAME = "mcpjam_read_resource";
+
+/** Catalog ids (== AI SDK tool names) this module implements. */
+export const MCPJAM_TOOL_IDS = [
+  MCPJAM_LIST_SERVERS_TOOL_NAME,
+  MCPJAM_LIST_EVAL_SUITES_TOOL_NAME,
+  MCPJAM_DIAGNOSE_SERVER_TOOL_NAME,
+  MCPJAM_LIST_TOOLS_TOOL_NAME,
+  MCPJAM_CALL_TOOL_TOOL_NAME,
+  MCPJAM_LIST_PROMPTS_TOOL_NAME,
+  MCPJAM_GET_PROMPT_TOOL_NAME,
+  MCPJAM_LIST_RESOURCES_TOOL_NAME,
+  MCPJAM_READ_RESOURCE_TOOL_NAME,
+] as const;
+
+export type McpjamToolId = (typeof MCPJAM_TOOL_IDS)[number];
+
+export function isMcpjamToolId(id: string): id is McpjamToolId {
+  return (MCPJAM_TOOL_IDS as readonly string[]).includes(id);
+}
+
+/**
+ * Live MCP operations against a saved server in the current project,
+ * authorized as the acting user. Implemented by the chat route over the same
+ * authorize → connect → run pipeline as `/api/web/*` and `/api/v1/*`
+ * (`server/routes/web/mcpjam-live-ops.ts`); ops throw `WebRouteError` on
+ * authorization/transport failures, which the tools translate to `{ error }`.
+ */
+export interface McpjamLiveOps {
+  doctor(serverId: string): Promise<unknown>;
+  listTools(serverId: string, cursor?: string): Promise<unknown>;
+  callTool(
+    serverId: string,
+    toolName: string,
+    parameters: Record<string, unknown>
+  ): Promise<unknown>;
+  listPrompts(serverId: string, cursor?: string): Promise<unknown>;
+  getPrompt(
+    serverId: string,
+    name: string,
+    args?: Record<string, string>
+  ): Promise<unknown>;
+  listResources(serverId: string, cursor?: string): Promise<unknown>;
+  readResource(serverId: string, uri: string): Promise<unknown>;
+}
+
+export interface McpjamToolOptions {
+  /** Bearer authorization header forwarded to Convex (already normalized). */
+  authHeader: string;
+  /** Project whose catalog and servers the tools operate on. */
+  projectId: string;
+  /** Live-op runner; absent on engines that can't run live MCP ops. */
+  liveOps?: McpjamLiveOps;
+  /** Host's approval policy — applied to the side-effectful call tool. */
+  requireToolApproval?: boolean;
+}
+
+const serverIdField = z
+  .string()
+  .min(1)
+  .describe(
+    "MCPJam server id from mcpjam_list_servers (not the server's display name)"
+  );
+
+const cursorField = z
+  .string()
+  .optional()
+  .describe("Opaque pagination cursor from a previous call");
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return "The operation failed. Please try again.";
+}
+
+/** Run a live op, translating thrown route errors into `{ error }`. */
+async function runLiveOp<T>(
+  op: () => Promise<T>,
+  abortSignal: AbortSignal | undefined,
+  what: string
+): Promise<T | { error: string }> {
+  try {
+    return await op();
+  } catch (error) {
+    if (abortSignal?.aborted) return { error: `${what} was cancelled.` };
+    return { error: errorMessage(error) };
+  }
+}
+
+/**
+ * GET a Convex `/v1/*` catalog read with the caller's bearer — the same
+ * backing surface as the Inspector's `/api/v1/catalog/*` proxies. Returns the
+ * upstream body verbatim on success (it already carries the public
+ * `{ items, nextCursor? }` envelope) and `{ error }` on any failure.
+ */
+async function convexCatalogRead(
+  opts: McpjamToolOptions,
+  path: string,
+  params: Record<string, string>,
+  abortSignal: AbortSignal | undefined,
+  what: string
+): Promise<unknown> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    return { error: `${what} is not configured on this server.` };
+  }
+  try {
+    const target = new URL(path, convexUrl);
+    for (const [name, value] of Object.entries(params)) {
+      target.searchParams.set(name, value);
+    }
+    const res = await fetch(target, {
+      method: "GET",
+      headers: { Authorization: opts.authHeader },
+      signal: abortSignal,
+    });
+    const body = (await res.json().catch(() => null)) as {
+      message?: unknown;
+    } | null;
+    if (!res.ok) {
+      const message =
+        body && typeof body.message === "string" && body.message.trim()
+          ? body.message
+          : `${what} failed (${res.status}).`;
+      return { error: message };
+    }
+    return body ?? { error: `${what} returned an empty response.` };
+  } catch (error) {
+    if (abortSignal?.aborted) return { error: `${what} was cancelled.` };
+    return { error: `${what} failed. Please try again.` };
+  }
+}
+
+function buildListServersTool(opts: McpjamToolOptions): ToolSet[string] {
+  return tool({
+    description:
+      "List the MCP servers saved in this MCPJam project — including ones " +
+      "not connected to this chat. Returns each server's id (used by the " +
+      "other mcpjam_* tools), name, and connection metadata.",
+    inputSchema: z.object({}),
+    execute: async (_input, { abortSignal }) =>
+      convexCatalogRead(
+        opts,
+        "/v1/project-servers",
+        { projectId: opts.projectId },
+        abortSignal,
+        "Listing servers"
+      ),
+  });
+}
+
+function buildListEvalSuitesTool(opts: McpjamToolOptions): ToolSet[string] {
+  return tool({
+    description:
+      "List the eval suites in this MCPJam project, with latest-run " +
+      "summaries. Use this to answer questions about the project's evals " +
+      "and their most recent results.",
+    inputSchema: z.object({}),
+    execute: async (_input, { abortSignal }) =>
+      convexCatalogRead(
+        opts,
+        "/v1/eval-suites",
+        { projectId: opts.projectId },
+        abortSignal,
+        "Listing eval suites"
+      ),
+  });
+}
+
+function buildDiagnoseServerTool(liveOps: McpjamLiveOps): ToolSet[string] {
+  return tool({
+    description:
+      "Diagnose an MCP server saved in this project: probe the endpoint, " +
+      "connect, initialize, and report capabilities. Use this when a server " +
+      "is failing to connect or behaving unexpectedly — the report explains " +
+      "which step failed and why.",
+    inputSchema: z.object({ serverId: serverIdField }),
+    execute: async ({ serverId }, { abortSignal }) =>
+      runLiveOp(() => liveOps.doctor(serverId), abortSignal, "Diagnosis"),
+  });
+}
+
+function buildListToolsTool(liveOps: McpjamLiveOps): ToolSet[string] {
+  return tool({
+    description:
+      "List the tools an MCP server in this project exposes (name, " +
+      "description, input schema). Works for any saved server, including " +
+      "ones not connected to this chat. Check schemas here before calling " +
+      "mcpjam_call_tool.",
+    inputSchema: z.object({ serverId: serverIdField, cursor: cursorField }),
+    execute: async ({ serverId, cursor }, { abortSignal }) =>
+      runLiveOp(
+        () => liveOps.listTools(serverId, cursor),
+        abortSignal,
+        "Listing tools"
+      ),
+  });
+}
+
+function buildCallToolTool(
+  opts: McpjamToolOptions,
+  liveOps: McpjamLiveOps
+): ToolSet[string] {
+  return tool({
+    description:
+      "Execute a tool on an MCP server saved in this project and return the " +
+      "result. The tool runs with the user's credentials and may have side " +
+      "effects — only call it when the user asked for the action. Use " +
+      "mcpjam_list_tools first to get exact tool names and input schemas. A " +
+      "result with isError=true means the server answered with a tool-level " +
+      "failure; relay it to the user.",
+    inputSchema: z.object({
+      serverId: serverIdField,
+      toolName: z.string().min(1).describe("Exact tool name on the server"),
+      parameters: z
+        .record(z.unknown())
+        .optional()
+        .describe("Tool arguments matching the tool's input schema"),
+    }),
+    // Executing arbitrary tools on the user's servers must honor the host's
+    // approval policy exactly like MCP/skill tools do.
+    needsApproval: opts.requireToolApproval === true,
+    execute: async ({ serverId, toolName, parameters }, { abortSignal }) =>
+      runLiveOp(
+        () => liveOps.callTool(serverId, toolName, parameters ?? {}),
+        abortSignal,
+        "Tool execution"
+      ),
+  });
+}
+
+function buildListPromptsTool(liveOps: McpjamLiveOps): ToolSet[string] {
+  return tool({
+    description:
+      "List the prompts an MCP server in this project exposes (name, " +
+      "description, arguments).",
+    inputSchema: z.object({ serverId: serverIdField, cursor: cursorField }),
+    execute: async ({ serverId, cursor }, { abortSignal }) =>
+      runLiveOp(
+        () => liveOps.listPrompts(serverId, cursor),
+        abortSignal,
+        "Listing prompts"
+      ),
+  });
+}
+
+function buildGetPromptTool(liveOps: McpjamLiveOps): ToolSet[string] {
+  return tool({
+    description:
+      "Render a prompt from an MCP server in this project with the given " +
+      "arguments and return its messages.",
+    inputSchema: z.object({
+      serverId: serverIdField,
+      name: z.string().min(1).describe("Exact prompt name on the server"),
+      arguments: z
+        .record(z.string())
+        .optional()
+        .describe("Prompt arguments (string values)"),
+    }),
+    execute: async ({ serverId, name, arguments: args }, { abortSignal }) =>
+      runLiveOp(
+        () => liveOps.getPrompt(serverId, name, args),
+        abortSignal,
+        "Rendering the prompt"
+      ),
+  });
+}
+
+function buildListResourcesTool(liveOps: McpjamLiveOps): ToolSet[string] {
+  return tool({
+    description:
+      "List the resources an MCP server in this project exposes (uri, name, " +
+      "mimeType).",
+    inputSchema: z.object({ serverId: serverIdField, cursor: cursorField }),
+    execute: async ({ serverId, cursor }, { abortSignal }) =>
+      runLiveOp(
+        () => liveOps.listResources(serverId, cursor),
+        abortSignal,
+        "Listing resources"
+      ),
+  });
+}
+
+function buildReadResourceTool(liveOps: McpjamLiveOps): ToolSet[string] {
+  return tool({
+    description:
+      "Read a resource from an MCP server in this project by uri and return " +
+      "its contents.",
+    inputSchema: z.object({
+      serverId: serverIdField,
+      uri: z.string().min(1).describe("Resource uri from mcpjam_list_resources"),
+    }),
+    execute: async ({ serverId, uri }, { abortSignal }) =>
+      runLiveOp(
+        () => liveOps.readResource(serverId, uri),
+        abortSignal,
+        "Reading the resource"
+      ),
+  });
+}
+
+/**
+ * Build one MCPJam tool by catalog id. Returns `null` when the id needs the
+ * live-op runner and the surface didn't provide one — the registry logs and
+ * skips, exactly like bash without a computer.
+ */
+export function buildMcpjamTool(
+  id: McpjamToolId,
+  opts: McpjamToolOptions
+): ToolSet[string] | null {
+  switch (id) {
+    case MCPJAM_LIST_SERVERS_TOOL_NAME:
+      return buildListServersTool(opts);
+    case MCPJAM_LIST_EVAL_SUITES_TOOL_NAME:
+      return buildListEvalSuitesTool(opts);
+    case MCPJAM_DIAGNOSE_SERVER_TOOL_NAME:
+      return opts.liveOps ? buildDiagnoseServerTool(opts.liveOps) : null;
+    case MCPJAM_LIST_TOOLS_TOOL_NAME:
+      return opts.liveOps ? buildListToolsTool(opts.liveOps) : null;
+    case MCPJAM_CALL_TOOL_TOOL_NAME:
+      return opts.liveOps ? buildCallToolTool(opts, opts.liveOps) : null;
+    case MCPJAM_LIST_PROMPTS_TOOL_NAME:
+      return opts.liveOps ? buildListPromptsTool(opts.liveOps) : null;
+    case MCPJAM_GET_PROMPT_TOOL_NAME:
+      return opts.liveOps ? buildGetPromptTool(opts.liveOps) : null;
+    case MCPJAM_LIST_RESOURCES_TOOL_NAME:
+      return opts.liveOps ? buildListResourcesTool(opts.liveOps) : null;
+    case MCPJAM_READ_RESOURCE_TOOL_NAME:
+      return opts.liveOps ? buildReadResourceTool(opts.liveOps) : null;
+  }
+}


### PR DESCRIPTION
## Handoff: `mcpjam_*` built-in tools for the in-app agent

Scaffold for giving the chat agent first-class MCPJam product tools (slice 1 — backend tools only; navigation/frontend tools are phase 2). **Marcelo is taking over implementation** — full instructions live in `HANDOFF-mcpjam-built-in-tools.md` on this branch (delete it before merge).

### Included
- `server/utils/built-in-tools/mcpjam.ts` — 9 tool builders following the exa/bash patterns: `mcpjam_list_servers`, `mcpjam_list_eval_suites` (Convex `/v1/*` catalog reads), `mcpjam_diagnose_server`, `mcpjam_list_tools`, `mcpjam_call_tool` (approval-aware), `mcpjam_list_prompts`, `mcpjam_get_prompt`, `mcpjam_list_resources`, `mcpjam_read_resource` (live ops via an injected `McpjamLiveOps` runner). Per-tool catalog ids preserve the id == AI SDK tool name invariant.
- `HANDOFF-mcpjam-built-in-tools.md` — decisions + rationale, remaining steps with file:line anchors and code sketches, test plan, backend seed rows, verification.

### Remaining (documented in the handoff)
1. Registry wiring in `resolveHostTools()` (+ `mcpjamLiveOps` on `BuiltInToolContext`, guest gate)
2. `server/routes/web/mcpjam-live-ops.ts` factory over `runEphemeralConnection`/`runHostedDoctor`
3. One-line ctx wiring in `routes/web/chat-v2.ts`
4. Registry + execute-path tests
5. `mcpjam-backend` catalog `SEED_ROWS` (9 rows, category `mcpjam`) + seed run
6. Typecheck/tests (the new module has **not** been typechecked yet)

https://claude.ai/code/session_013oxsDMEFvLyKqhRjUv6yCw

---
_Generated by [Claude Code](https://claude.ai/code/session_013oxsDMEFvLyKqhRjUv6yCw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New, unwired module and documentation only—no runtime behavior change until registry and chat route integration ship.
> 
> **Overview**
> Adds **slice 1 scaffolding** so the chat agent can eventually operate on the MCPJam workspace (list servers/evals, diagnose connections, live MCP tools/prompts/resources) via nine `mcpjam_*` catalog ids aligned with `/api/v1` behavior.
> 
> **New** `server/utils/built-in-tools/mcpjam.ts` implements all nine AI SDK tools: two **catalog reads** proxy Convex `/v1/*` with the caller’s bearer; seven **live ops** go through an injectable `McpjamLiveOps` runner (same pattern as `computer`/bash). Executions return `{ error }` instead of throwing; **`mcpjam_call_tool`** sets `needsApproval` from `requireToolApproval`.
> 
> **New** `HANDOFF-mcpjam-built-in-tools.md` documents decisions and **remaining work**: `resolveHostTools()` registry wiring + guest gate, `buildMcpjamLiveOps` in the web chat route, tests, Convex catalog seed rows, and typecheck. **Nothing is wired yet** — tools are not advertised until those steps land. Handoff file is marked delete-before-merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bcd51e7c9514d90667d28a6c5ec6c61c11e6766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->