### PR TITLE
fix(home): resolve org from active project + skeleton while context loads

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1187,12 +1187,20 @@ export function ServersRedirectRoute() {
 }
 
 export function HomeRoute() {
-  const { activeOrganizationId, activeProjectId } = useAppRouteContext();
+  const { activeOrganizationId, activeProjectId, activeProject } =
+    useAppRouteContext();
   const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
   if (!homeEnabled) return <ServersRoute />;
   return (
     <HomeTab
-      organizationId={activeOrganizationId ?? null}
+      // `/home` carries no org segment, so `activeOrganizationId` (set only
+      // from the route) is undefined here. Fall back to the active project's
+      // org — mirroring how billing resolves its org context above — so a
+      // signed-in user with an org-linked project sees their home, not the
+      // empty "Join or create an organization" state.
+      organizationId={
+        activeOrganizationId ?? activeProject?.organizationId ?? null
+      }
       projectId={activeProjectId ?? null}
     />
   );

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1187,8 +1187,12 @@ export function ServersRedirectRoute() {
 }
 
 export function HomeRoute() {
-  const { activeOrganizationId, activeProjectId, activeProject } =
-    useAppRouteContext();
+  const {
+    activeOrganizationId,
+    activeProjectId,
+    activeProject,
+    isHomeContextResolving,
+  } = useAppRouteContext();
   const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
   if (!homeEnabled) return <ServersRoute />;
   return (
@@ -1202,6 +1206,7 @@ export function HomeRoute() {
         activeOrganizationId ?? activeProject?.organizationId ?? null
       }
       projectId={activeProjectId ?? null}
+      isContextLoading={Boolean(isHomeContextResolving)}
     />
   );
 }
@@ -3004,11 +3009,25 @@ export default function App() {
         }
       : undefined;
 
+  // The home route has no org segment, so its org is resolved from the active
+  // project (see HomeRoute). Until auth, the db user, the org list, and the
+  // project list have all settled, that org is transiently null — which must
+  // read as "loading", not as the empty "no organization" state. Bounded:
+  // every signal here resolves once its query/bootstrap completes.
+  const isHomeContextResolving =
+    isAuthLoading ||
+    (isAuthenticated &&
+      (isEnsuringUser ||
+        !isUserReady ||
+        isLoadingOrganizations ||
+        isLoadingRemoteProjects));
+
   const routeContext: AppRouteContext = {
     activeMcpProfile,
     activeOrganizationId,
     activeOrganizationName,
     activeProject,
+    isHomeContextResolving,
     activeProjectBillingOrganizationId,
     activeProjectId,
     activeTabBillingFeature,

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1187,26 +1187,18 @@ export function ServersRedirectRoute() {
 }
 
 export function HomeRoute() {
-  const {
-    activeOrganizationId,
-    activeProjectId,
-    activeProject,
-    isHomeContextResolving,
-  } = useAppRouteContext();
+  const { activeProjectId, homeOrganizationId, isHomeContextResolving } =
+    useAppRouteContext();
   const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
   if (!homeEnabled) return <ServersRoute />;
   return (
     <HomeTab
-      // `/home` carries no org segment, so `activeOrganizationId` (set only
-      // from the route) is undefined here. Fall back to the active project's
-      // org — mirroring how billing resolves its org context above — so a
-      // signed-in user with an org-linked project sees their home, not the
-      // empty "Join or create an organization" state.
-      organizationId={
-        activeOrganizationId ?? activeProject?.organizationId ?? null
-      }
+      // Membership-validated org for `/home` (the route carries none, so it is
+      // derived from the active project and checked against the org list — see
+      // App). Null → the welcome "Get started" state.
+      organizationId={homeOrganizationId ?? null}
       projectId={activeProjectId ?? null}
-      isContextLoading={Boolean(isHomeContextResolving)}
+      isContextLoading={isHomeContextResolving}
     />
   );
 }
@@ -3022,12 +3014,27 @@ export default function App() {
         isLoadingOrganizations ||
         isLoadingRemoteProjects));
 
+  // Org shown on `/home`. Falls back to the active project's org (the route
+  // carries none) and then validates membership against the loaded org list —
+  // the same gate billing applies to `rawBillingOrganizationId` above — so a
+  // stale project pointing at an org the user no longer belongs to resolves to
+  // null (→ welcome CTA) instead of firing org-scoped queries that would throw.
+  const rawHomeOrganizationId =
+    activeOrganizationId ?? activeProject?.organizationId ?? null;
+  const homeOrganizationId =
+    !isLoadingOrganizations &&
+    rawHomeOrganizationId &&
+    effectiveOrganizations.some((org) => org._id === rawHomeOrganizationId)
+      ? rawHomeOrganizationId
+      : null;
+
   const routeContext: AppRouteContext = {
     activeMcpProfile,
     activeOrganizationId,
     activeOrganizationName,
     activeProject,
     isHomeContextResolving,
+    homeOrganizationId,
     activeProjectBillingOrganizationId,
     activeProjectId,
     activeTabBillingFeature,

--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { useQuery } from "convex/react";
 import { useSearchParams } from "react-router";
 import { useAuth } from "@workos-inc/authkit-react";
@@ -119,6 +125,14 @@ function clearPendingForSession(sessionId: string | null | undefined) {
   }
 }
 
+// Escape hatch: the loading signals feeding `isContextLoading` (notably the db
+// user bootstrap) can stick true indefinitely if a bootstrap mutation fails and
+// never retries. Without a cap, that strands the user on a permanent skeleton
+// instead of the actionable "Get started" CTA. After this long still resolving,
+// fall through to the empty state — a brief skeleton on a genuinely slow load is
+// the acceptable cost. Auth/orgs/projects normally settle in well under a second.
+const HOME_CONTEXT_LOADING_TIMEOUT_MS = 8000;
+
 export function HomeTab({
   organizationId,
   projectId,
@@ -129,6 +143,21 @@ export function HomeTab({
   const [searchParams, setSearchParams] = useSearchParams();
   const sessionParam = searchParams.get("session");
   const composeParam = searchParams.get("compose") === "1";
+
+  // Re-arms whenever loading restarts; only fires while still loading.
+  const [loadingTimedOut, setLoadingTimedOut] = useState(false);
+  useEffect(() => {
+    if (!isContextLoading) {
+      setLoadingTimedOut(false);
+      return;
+    }
+    const timer = window.setTimeout(
+      () => setLoadingTimedOut(true),
+      HOME_CONTEXT_LOADING_TIMEOUT_MS
+    );
+    return () => window.clearTimeout(timer);
+  }, [isContextLoading]);
+  const showContextSkeleton = isContextLoading && !loadingTimedOut;
 
   const handleSessionStart = useCallback(
     (id: string, firstMessage: string) => {
@@ -281,7 +310,7 @@ export function HomeTab({
   const greeting = useMemo(() => getGreeting(new Date()), []);
 
   if (!organizationId) {
-    if (isContextLoading) {
+    if (showContextSkeleton) {
       return <HomeContextSkeleton />;
     }
     return (

--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -16,6 +16,32 @@ import { McpjamAgentThread } from "./mcpjam-agent/McpjamAgentThread";
 interface HomeTabProps {
   organizationId: string | null;
   projectId: string | null;
+  /**
+   * True while auth / db user / org list / project list are still settling.
+   * On `/home` the org is derived from the active project, so it is
+   * transiently null during that window — render a skeleton, not the empty
+   * "no organization" state, so the welcome card doesn't flash for users who
+   * actually have an org.
+   */
+  isContextLoading?: boolean;
+}
+
+// Mirrors the real home's header layout (greeting + stats strip) so the
+// loading state previews the page that's about to render rather than showing
+// a bare spinner or the misleading empty state.
+function HomeContextSkeleton() {
+  return (
+    <div className="h-full overflow-y-auto bg-background">
+      <div className="mx-auto flex max-w-3xl flex-col gap-4 px-6 py-8 sm:px-8">
+        <header className="space-y-3">
+          <div className="h-7 w-52 animate-pulse rounded-md bg-muted" />
+          <div className="h-3.5 w-72 animate-pulse rounded-sm bg-muted/70" />
+        </header>
+        <div className="h-32 w-full animate-pulse rounded-xl bg-muted/50" />
+        <div className="h-20 w-full animate-pulse rounded-xl bg-muted/30" />
+      </div>
+    </div>
+  );
 }
 
 function getGreeting(d: Date): string {
@@ -31,7 +57,8 @@ function deriveFirstName(opts: {
   fullName: string;
   email: string | null | undefined;
 }): string {
-  if (opts.workosFirst && opts.workosFirst.trim()) return opts.workosFirst.trim();
+  if (opts.workosFirst && opts.workosFirst.trim())
+    return opts.workosFirst.trim();
   const fromFull = opts.fullName.split(" ")[0]?.trim();
   if (fromFull && fromFull.length > 1) return fromFull;
   const fromEmail = opts.email?.split("@")[0]?.trim();
@@ -92,7 +119,11 @@ function clearPendingForSession(sessionId: string | null | undefined) {
   }
 }
 
-export function HomeTab({ organizationId, projectId }: HomeTabProps) {
+export function HomeTab({
+  organizationId,
+  projectId,
+  isContextLoading = false,
+}: HomeTabProps) {
   const navigate = useAppNavigate();
   const posthog = usePostHog();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -211,7 +242,12 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
           description: string;
           category: string;
         }[];
-        members: { _id: string; name: string; imageUrl: string | null; email: string }[];
+        members: {
+          _id: string;
+          name: string;
+          imageUrl: string | null;
+          email: string;
+        }[];
       }
     | undefined;
 
@@ -245,12 +281,15 @@ export function HomeTab({ organizationId, projectId }: HomeTabProps) {
   const greeting = useMemo(() => getGreeting(new Date()), []);
 
   if (!organizationId) {
+    if (isContextLoading) {
+      return <HomeContextSkeleton />;
+    }
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4 bg-background p-8 text-center">
         <p className="text-lg font-medium">Welcome to MCPJam</p>
         <p className="max-w-sm text-sm text-muted-foreground">
-          Join or create an organization to see your team&apos;s activity, connected
-          servers, and projects in one place.
+          Join or create an organization to see your team&apos;s activity,
+          connected servers, and projects in one place.
         </p>
         <Button onClick={() => navigate("/organizations")}>Get started</Button>
       </div>


### PR DESCRIPTION
## Problem

A signed-in user who owns an org and has it as their active project still landed on the empty **"Welcome to MCPJam / Join or create an organization"** screen at `/home`. During loading, that same empty card also flashed before the real home rendered — a loading state showing as an empty state, which felt broken.

## Root cause

`activeOrganizationId` is set **only** from the `/organizations/:orgId/…` route segment. The Home nav points to bare `/home`, which carries no org segment, so `activeOrganizationId` is always `undefined` there. `HomeRoute` passed `activeOrganizationId ?? null` straight to `HomeTab`, dropping the org that was sitting on the active project the whole time → `null` → welcome card.

Billing three lines up already resolves its org via `activeOrganizationId ?? activeProject?.organizationId ?? null`; Home just wasn't using the same chain.

## Changes

1. **`HomeRoute` org fallback** — mirror the billing chain so a signed-in user with an org-linked project lands on their real home:
   `activeOrganizationId ?? activeProject?.organizationId ?? null`.

2. **Loading skeleton** — on `/home` the org is derived from the active project, so it's transiently `null` while auth, the db user, the org list, and the project list settle. Compute a single bounded `isHomeContextResolving` flag in `App` (every signal resolves once its query/bootstrap completes — no infinite-loader risk), thread it through the route context to `HomeRoute`, and render a layout-matching skeleton (greeting + stats placeholders) instead of the welcome card while it's true. The genuine no-org case still shows the "Get started" CTA once everything settles.

## Testing

- `tsc -p client/tsconfig.json --noEmit` is clean on the edited files (`App.tsx`, `HomeTab.tsx`). Pre-existing mock-typing errors in `App.hosted-oauth.test.tsx` are untouched.
- Prettier-formatted.
- Manually verified locally: signed-in user with an org-linked "Default" project now sees their home instead of the welcome card; the loading window shows the skeleton.

### Follow-up worth a manual check
Confirm the genuine empty state (brand-new account, no org, loading settled) still renders the "Get started" CTA and the skeleton doesn't stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and org-resolution logic on the home route only; mirrors existing billing membership gating with a bounded loading timeout.
> 
> **Overview**
> Fixes **`/home`** showing the **Welcome / Get started** screen for signed-in users whose org lives on the active project, and stops that card from flashing during bootstrap.
> 
> **Org resolution:** `HomeRoute` now uses **`homeOrganizationId`** instead of route-only `activeOrganizationId`. It follows the same chain as billing (`activeOrganizationId ?? activeProject?.organizationId`) and only accepts an id that appears in the loaded org list, so stale projects do not trigger org-scoped queries.
> 
> **Loading UX:** `App` exposes **`isHomeContextResolving`** (auth, db user, orgs, projects) into route context. **`HomeTab`** shows a layout-matching **`HomeContextSkeleton`** while org is still null during that window, with an **8s timeout** so a stuck bootstrap can still reach the Get started CTA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30ace8a8c432c0cb57bb6a4dfe4af5a5f7e9268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->