### PR TITLE
refactor(home): use design-system Skeleton in HomeContextSkeleton

### DIFF
--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -12,6 +12,7 @@ import { usePostHog } from "posthog-js/react";
 import { ArrowLeft, Plus } from "lucide-react";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { Button } from "@mcpjam/design-system/button";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
 import { OrgStatsStrip } from "./home/OrgStatsStrip";
 import { RecommendedServers } from "./home/RecommendedServers";
 import { RecommendedHosts } from "./home/RecommendedHosts";
@@ -32,19 +33,20 @@ interface HomeTabProps {
   isContextLoading?: boolean;
 }
 
-// Mirrors the real home's header layout (greeting + stats strip) so the
-// loading state previews the page that's about to render rather than showing
-// a bare spinner or the misleading empty state.
+// Mirrors the real home's header layout (greeting line + stats strip) so the
+// loading state previews the page that's about to render rather than showing a
+// bare spinner or the misleading empty state. Sizes/spacing track the real
+// header (space-y-2, text-2xl greeting) to keep the preview faithful.
 function HomeContextSkeleton() {
   return (
     <div className="h-full overflow-y-auto bg-background">
       <div className="mx-auto flex max-w-3xl flex-col gap-4 px-6 py-8 sm:px-8">
-        <header className="space-y-3">
-          <div className="h-7 w-52 animate-pulse rounded-md bg-muted" />
-          <div className="h-3.5 w-72 animate-pulse rounded-sm bg-muted/70" />
+        <header className="space-y-2">
+          <Skeleton className="h-8 w-52" />
+          <Skeleton className="h-4 w-72" />
         </header>
-        <div className="h-32 w-full animate-pulse rounded-xl bg-muted/50" />
-        <div className="h-20 w-full animate-pulse rounded-xl bg-muted/30" />
+        <Skeleton className="h-32 w-full rounded-xl" />
+        <Skeleton className="h-20 w-full rounded-xl" />
       </div>
     </div>
   );


### PR DESCRIPTION
Follow-up polish to #2618 (now merged).

## What

The home loading skeleton (`HomeContextSkeleton`) was hand-rolled with raw `animate-pulse` divs and one-off Tailwind values, bypassing the shared `Skeleton` primitive used across the app (sidebar context switcher, servers, registry, etc.). This swaps it to `@mcpjam/design-system/skeleton`.

## Why

- **Consistency:** future changes to skeleton shimmer/color/radius tokens now apply here too, instead of silently skipping this one-off.
- **Less drift:** aligned the header spacing/sizes to the real home layout (`space-y-2`, `h-8` greeting matching the `text-2xl` heading) so the loading preview tracks the page it stands in for.

No behavior change — purely the visual primitive and a spacing tweak.

## Testing
- `tsc -p client/tsconfig.json --noEmit` clean on the edited file.
- Prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only refactor of the home loading skeleton with no auth, data, or routing changes.
> 
> **Overview**
> **Home context loading UI** now uses the shared `@mcpjam/design-system/skeleton` component instead of custom `animate-pulse` placeholder divs in `HomeContextSkeleton`.
> 
> Header spacing and placeholder sizes were nudged to match the loaded home layout (`space-y-2`, taller greeting line) so the skeleton preview aligns with the real greeting and stats strip. No change to when the skeleton shows or to home behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09b61c5d3c0b04bdc8bb1a451727db2377f333e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->