### PR TITLE
Point local OSS development at the open community backend

### DIFF
--- a/mcpjam-inspector/.env.local
+++ b/mcpjam-inspector/.env.local
@@ -1,7 +1,7 @@
-VITE_CONVEX_URL=https://proper-clownfish-150.convex.cloud
-CONVEX_URL=https://proper-clownfish-150.convex.cloud
-VITE_WORKOS_CLIENT_ID=client_01K4C1TVA6CMQ3G32F1P301A9G
+VITE_CONVEX_URL=https://energized-ant-201.convex.cloud
+CONVEX_URL=https://energized-ant-201.convex.cloud
+VITE_WORKOS_CLIENT_ID=client_01KTN2EWHHJCKRB8RSR307X4SG
 VITE_WORKOS_REDIRECT_URI=mcpjam://oauth/callback
-CONVEX_HTTP_URL=https://proper-clownfish-150.convex.site
+CONVEX_HTTP_URL=https://energized-ant-201.convex.site
 ENVIRONMENT=local
 VITE_DISABLE_POSTHOG_LOCAL=true


### PR DESCRIPTION
## What

`mcpjam-inspector/.env.local` is tracked and is the file CONTRIBUTING.md tells contributors to copy — it is effectively the OSS local-dev backend config. Today it points at **staging** (`proper-clownfish-150`), whose employee-email lockdown rejects outside contributors and disables guest sessions, so anyone without backend-repo access is locked out of chat/auth/evals when developing the inspector from source.

This repoints local dev at the **community backend** (`energized-ant-201`): same backend code as staging (tracks `main`, deployed by MCPJam/mcpjam-backend#517), separate data, **no lockdown** — open sign-in and guest sessions, the same access posture as production. It also fixes the stale pre-migration WorkOS client id: the new value is the development AuthKit app (`deep-vanilla-68-test.authkit.app`) that `server/services/authkit-jwt.ts` already recognizes and that the community backend's auth config accepts.

Staging keeps its gates; OSS contributors simply stop sharing a backend with it.

## ⚠️ Merge gate

Do not merge until `energized-ant-201` is live and green:
1. MCPJam/mcpjam-backend#518 (unbreaks main's staging deploys)
2. MCPJam/mcpjam-backend#517 (deploys the community backend, lockdown off)
3. `CONVEX_PREVIEW_SHARED_DEPLOY_KEY` minted + the `deploy-shared-preview-backend` job green

Until then this file would point local dev at an empty deployment. After it merges, contributors just pull main — no other setup change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to local OSS defaults; no application logic, but merging before the community deployment is live would break contributor local dev until that backend exists.
> 
> **Overview**
> Repoints the tracked **`mcpjam-inspector/.env.local`** (the default OSS local-dev config) from the **staging** Convex deployment (`proper-clownfish-150`) to the **community** deployment (`energized-ant-201`), updating `VITE_CONVEX_URL`, `CONVEX_URL`, and `CONVEX_HTTP_URL` together so inspector chat/auth/evals hit an open backend instead of staging’s employee lockdown.
> 
> Also replaces **`VITE_WORKOS_CLIENT_ID`** with the development AuthKit app id (`client_01KTN2EWHHJCKRB8RSR307X4SG`), aligning local sign-in with what **`authkit-jwt.ts`** already treats as the development client and what the community backend expects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889b060b296b5ba017b862fd912568c0d9bbfaff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->