### PR TITLE
Replace ngrok with MCPJam relay tunneling

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -288,6 +288,11 @@ export function ServerConnectionCard({
       }
     };
 
+    // Run once up front: the tunnel can already be dead when the effect
+    // starts (a permanent relay close can race creation, and the create
+    // route answers with the grant URL by design) — don't advertise it for
+    // a full interval before the first check.
+    void revalidate();
     const intervalId = setInterval(revalidate, 5000);
     return () => {
       isCancelled = true;

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -363,7 +363,7 @@ export function ServerConnectionCard({
       const errorMessage =
         error instanceof Error ? error.message : "Failed to create tunnel";
       if (errorMessage.includes("No access token available")) {
-        toast.error("Sign in to create ngrok tunnels");
+        toast.error("Sign in to create tunnels");
       } else {
         toast.error(`Tunnel creation failed: ${errorMessage}`);
       }
@@ -830,7 +830,7 @@ export function ServerConnectionCard({
                         ) : (
                           <>
                             <Cable className="h-3 w-3" />
-                            <span>Copy ngrok URL</span>
+                            <span>Copy tunnel URL</span>
                           </>
                         )}
                       </button>
@@ -889,7 +889,7 @@ export function ServerConnectionCard({
                       )}
                       <span>
                         {canManageTunnels
-                          ? "Create ngrok tunnel"
+                          ? "Create tunnel"
                           : "Sign in for tunnel"}
                       </span>
                     </button>

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -255,9 +255,18 @@ export function ServerConnectionCard({
   // a tunnel server-side (grant superseded by another inspector, secret
   // rotated elsewhere, expired token), after which the local server 404s for
   // it — stop advertising a URL that no longer works. Skipped when the
-  // parent owns the URL via the serverTunnelUrl prop.
+  // parent owns the URL via the serverTunnelUrl prop, and while a local
+  // create/rotate/close is in flight (mid-rotation the server briefly has
+  // no entry; polling then would clear a healthy tunnel).
   useEffect(() => {
-    if (!tunnelUrl || !showTunnelActions || serverTunnelUrl !== undefined) {
+    if (
+      !tunnelUrl ||
+      !showTunnelActions ||
+      serverTunnelUrl !== undefined ||
+      isCreatingTunnel ||
+      isClosingTunnel ||
+      isRotatingTunnel
+    ) {
       return;
     }
     let isCancelled = false;
@@ -286,6 +295,9 @@ export function ServerConnectionCard({
     };
   }, [
     getAccessToken,
+    isClosingTunnel,
+    isCreatingTunnel,
+    isRotatingTunnel,
     server.name,
     serverTunnelUrl,
     showTunnelActions,

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -251,6 +251,47 @@ export function ServerConnectionCard({
     };
   }, [getAccessToken, server.name, showTunnelRequests, tunnelUrl]);
 
+  // Revalidate the displayed URL while a tunnel is shown: the relay can end
+  // a tunnel server-side (grant superseded by another inspector, secret
+  // rotated elsewhere, expired token), after which the local server 404s for
+  // it — stop advertising a URL that no longer works. Skipped when the
+  // parent owns the URL via the serverTunnelUrl prop.
+  useEffect(() => {
+    if (!tunnelUrl || !showTunnelActions || serverTunnelUrl !== undefined) {
+      return;
+    }
+    let isCancelled = false;
+
+    const revalidate = async () => {
+      try {
+        const accessToken = await getAccessToken();
+        const existingTunnel = await getServerTunnel(server.name, accessToken);
+        if (!isCancelled && existingTunnel === null) {
+          setTunnelUrl(null);
+          setShowTunnelRequests(false);
+          toast.warning(
+            `Tunnel for ${server.name} ended — create it again if you still need it`
+          );
+        }
+      } catch {
+        // Transient (network/auth) — keep the last known state; only an
+        // explicit "no tunnel" answer clears the URL.
+      }
+    };
+
+    const intervalId = setInterval(revalidate, 5000);
+    return () => {
+      isCancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [
+    getAccessToken,
+    server.name,
+    serverTunnelUrl,
+    showTunnelActions,
+    tunnelUrl,
+  ]);
+
   const copyToClipboard = async (text: string, fieldName: string) => {
     try {
       await navigator.clipboard.writeText(text);

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -873,7 +873,11 @@ export function ServerConnectionCard({
                       <button
                         data-server-card-context-menu-exempt
                         onClick={() => copyToClipboard(tunnelUrl!, "tunnel")}
-                        className="inline-flex items-center gap-1.5 px-2 py-0.5 text-[11px] transition-colors hover:bg-accent/60 cursor-pointer"
+                        // Rotation revokes the displayed URL at the edge
+                        // before the new one arrives (close kills it too), so
+                        // mid-mutation the URL must not be copyable.
+                        disabled={isTunnelMutationInFlight}
+                        className="inline-flex items-center gap-1.5 px-2 py-0.5 text-[11px] transition-colors hover:bg-accent/60 disabled:cursor-not-allowed disabled:opacity-60 cursor-pointer"
                       >
                         {copiedField === "tunnel" ? (
                           <>

--- a/mcpjam-inspector/client/src/components/connection/TunnelExplanationModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/TunnelExplanationModal.tsx
@@ -41,7 +41,7 @@ export function TunnelExplanationModal({
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            Create ngrok tunnel
+            Create tunnel
           </DialogTitle>
           <DialogDescription className="pt-4">
             Tunneling allows you to expose your local MCP servers over HTTPS for
@@ -84,10 +84,10 @@ export function TunnelExplanationModal({
             <div className="flex-1">
               <h4 className="font-medium text-sm mb-1">Secured at the Edge</h4>
               <p className="text-sm text-muted-foreground">
-                Requests without the secret key are rejected before they reach
-                your machine, and the tunnel only exposes this one server. Use
-                Rotate to revoke the current URL, or close the tunnel when
-                you're done.
+                Requests without the secret key are rejected at MCPJam's relay
+                edge before they reach your machine, and the tunnel only exposes
+                this one server. Use Rotate to revoke the current URL, or close
+                the tunnel when you're done.
               </p>
             </div>
           </div>
@@ -120,7 +120,7 @@ export function TunnelExplanationModal({
               Cancel
             </Button>
             <Button onClick={handleConfirm} disabled={isCreating}>
-              {isCreating ? "Creating..." : "Create ngrok tunnel"}
+              {isCreating ? "Creating..." : "Create tunnel"}
             </Button>
           </div>
         </DialogFooter>

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -77,6 +77,7 @@ vi.mock("sonner", () => ({
 
 // Must import after mocks are set up
 import { ServerConnectionCard } from "../ServerConnectionCard";
+import { TUNNEL_EXPLANATION_DISMISSED_KEY } from "../TunnelExplanationModal";
 import { useExploreCasesPrefetchOnConnect } from "@/hooks/use-explore-cases-prefetch-on-connect";
 
 // Mock navigator.clipboard
@@ -821,6 +822,53 @@ describe("ServerConnectionCard", () => {
         });
         expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
       } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("detects a tunnel that died during creation without waiting a full poll interval", async () => {
+      vi.useFakeTimers();
+      try {
+        const { getServerTunnel, createServerTunnel } = await import(
+          "@/lib/apis/mcp-tunnels-api"
+        );
+        // The create endpoint answers with the grant URL even when a
+        // permanent relay close raced the handshake (by design — see the
+        // create route); the server then holds no live entry.
+        (getServerTunnel as Mock).mockResolvedValue(null);
+        (createServerTunnel as Mock).mockResolvedValue({
+          url: seedUrl,
+          serverId: "test-server",
+        });
+        localStorage.setItem(TUNNEL_EXPLANATION_DISMISSED_KEY, "true");
+
+        render(
+          <ServerConnectionCard
+            server={createServer({ connectionStatus: "connected" })}
+            {...defaultProps}
+          />
+        );
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+
+        await act(async () => {
+          fireEvent.click(
+            screen.getByRole("button", { name: "Create tunnel" })
+          );
+        });
+        // Far less than the 5s poll cadence: the effect's immediate
+        // revalidation must catch the dead tunnel, not the first tick.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50);
+        });
+
+        expect(screen.queryByText("Copy tunnel URL")).not.toBeInTheDocument();
+        expect(toast.warning as Mock).toHaveBeenCalledWith(
+          expect.stringContaining("Tunnel for test-server ended")
+        );
+      } finally {
+        localStorage.removeItem(TUNNEL_EXPLANATION_DISMISSED_KEY);
         vi.useRealTimers();
       }
     });

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -626,6 +626,55 @@ describe("ServerConnectionCard", () => {
       });
     });
 
+    it("disables copying the URL while a rotation is in flight (old URL is already revoked)", async () => {
+      const { rotateServerTunnel, getServerTunnel } = await import(
+        "@/lib/apis/mcp-tunnels-api"
+      );
+      (getServerTunnel as Mock).mockResolvedValue({
+        url: seedUrl,
+        serverId: "test-server",
+      });
+      const rotatedUrl =
+        "https://old000000001.tunnels.mcpjam.com/api/mcp/adapter-http/test-server?k=new";
+      let resolveRotate:
+        | ((value: { url: string; serverId: string }) => void)
+        | undefined;
+      (rotateServerTunnel as Mock).mockImplementationOnce(
+        () =>
+          new Promise<{ url: string; serverId: string }>(
+            (resolve) => (resolveRotate = resolve)
+          )
+      );
+
+      render(
+        <ServerConnectionCard
+          server={createServer({ connectionStatus: "connected" })}
+          {...defaultProps}
+          serverTunnelUrl={seedUrl}
+        />
+      );
+
+      const copyBtn = screen
+        .getByText("Copy tunnel URL")
+        .closest("button") as HTMLButtonElement;
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Rotate tunnel secret (revokes the current URL)",
+        })
+      );
+
+      // The backend revokes the old grant as soon as rotation starts, so the
+      // stale URL must not be copyable mid-rotate.
+      await waitFor(() => expect(copyBtn).toBeDisabled());
+      fireEvent.click(copyBtn);
+      expect(mockClipboard.writeText).not.toHaveBeenCalled();
+
+      resolveRotate?.({ url: rotatedUrl, serverId: "test-server" });
+      await waitFor(() => expect(copyBtn).not.toBeDisabled());
+      fireEvent.click(copyBtn);
+      expect(mockClipboard.writeText).toHaveBeenCalledWith(rotatedUrl);
+    });
+
     it("disables rotate while a close is in flight (mutually exclusive)", async () => {
       const { rotateServerTunnel, closeServerTunnel, getServerTunnel } =
         await import("@/lib/apis/mcp-tunnels-api");

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -33,7 +33,7 @@ vi.mock("@/lib/apis/mcp-tunnels-api", () => ({
   }),
   closeServerTunnel: vi.fn().mockResolvedValue(undefined),
   rotateServerTunnel: vi.fn().mockResolvedValue({
-    url: "https://rotated.ngrok.app/api/mcp/adapter-http/test-server?k=newsecret",
+    url: "https://rotated0001.tunnels.mcpjam.com/api/mcp/adapter-http/test-server?k=newsecret",
     serverId: "test-server",
   }),
   getTunnelRequests: vi.fn().mockResolvedValue([]),
@@ -521,7 +521,7 @@ describe("ServerConnectionCard", () => {
         />
       );
 
-      expect(screen.getByText("Copy ngrok URL")).toBeInTheDocument();
+      expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
     });
 
     it("does not show copy url tunnel pill when disconnected", () => {
@@ -534,13 +534,13 @@ describe("ServerConnectionCard", () => {
         />
       );
 
-      expect(screen.queryByText("Copy ngrok URL")).not.toBeInTheDocument();
+      expect(screen.queryByText("Copy tunnel URL")).not.toBeInTheDocument();
     });
   });
 
   describe("tunnel rotate", () => {
     const seedUrl =
-      "https://old.ngrok.app/api/mcp/adapter-http/test-server?k=old";
+      "https://old000000001.tunnels.mcpjam.com/api/mcp/adapter-http/test-server?k=old";
 
     it("calls rotate and surfaces success", async () => {
       const { rotateServerTunnel, getServerTunnel } = await import(
@@ -611,7 +611,7 @@ describe("ServerConnectionCard", () => {
       });
       // The stale, copyable URL is dropped — the create pill is shown instead.
       await waitFor(() => {
-        expect(screen.queryByText("Copy ngrok URL")).not.toBeInTheDocument();
+        expect(screen.queryByText("Copy tunnel URL")).not.toBeInTheDocument();
       });
     });
 
@@ -654,7 +654,8 @@ describe("ServerConnectionCard", () => {
   });
 
   describe("tunnel recent-requests panel", () => {
-    const seedUrl = "https://t.ngrok.app/api/mcp/adapter-http/test-server?k=s";
+    const seedUrl =
+      "https://t00000000001.tunnels.mcpjam.com/api/mcp/adapter-http/test-server?k=s";
 
     it("polls and renders recent requests when opened", async () => {
       const { getServerTunnel, getTunnelRequests } = await import(

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -703,6 +703,66 @@ describe("ServerConnectionCard", () => {
       }
     });
 
+    it("does not clear the URL while a rotate is in flight (server briefly has no entry)", async () => {
+      vi.useFakeTimers();
+      try {
+        const { getServerTunnel, rotateServerTunnel } = await import(
+          "@/lib/apis/mcp-tunnels-api"
+        );
+        // Server-side view during rotation: the entry disappears between
+        // close and re-create, so revalidation would read null.
+        let tunnelVisible = true;
+        (getServerTunnel as Mock).mockImplementation(async () =>
+          tunnelVisible ? { url: seedUrl, serverId: "test-server" } : null
+        );
+        let finishRotate: (() => void) | undefined;
+        (rotateServerTunnel as Mock).mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              finishRotate = () =>
+                resolve({
+                  url: seedUrl.replace("?k=s", "?k=s2"),
+                  serverId: "test-server",
+                });
+            })
+        );
+
+        render(
+          <ServerConnectionCard
+            server={createServer({ connectionStatus: "connected" })}
+            {...defaultProps}
+          />
+        );
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
+
+        // Start a rotate that hangs; the server-side entry vanishes.
+        fireEvent.click(
+          screen.getByRole("button", {
+            name: "Rotate tunnel secret (revokes the current URL)",
+          })
+        );
+        tunnelVisible = false;
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(15000);
+        });
+        // The poll is suspended during the mutation: no clearing, no toast.
+        expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
+        expect(toast.warning as Mock).not.toHaveBeenCalled();
+
+        tunnelVisible = true;
+        finishRotate?.();
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("keeps the URL on transient revalidation errors", async () => {
       vi.useFakeTimers();
       try {

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -45,9 +45,13 @@ vi.mock("@/lib/apis/mcp-tunnels-api", () => ({
   getTunnelRequests: vi.fn().mockResolvedValue([]),
 }));
 
+// Stable getAccessToken reference across renders — a fresh fn per render
+// would make the card's tunnel-URL effects (which depend on getAccessToken)
+// re-run on every re-render, masking the real polling cadence under test.
+const mockGetAccessToken = vi.fn().mockResolvedValue("test-token");
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
-    getAccessToken: vi.fn().mockResolvedValue("test-token"),
+    getAccessToken: mockGetAccessToken,
   }),
 }));
 
@@ -703,14 +707,14 @@ describe("ServerConnectionCard", () => {
       }
     });
 
-    it("does not clear the URL while a rotate is in flight (server briefly has no entry)", async () => {
+    it("suspends revalidation while a rotate is in flight (server briefly has no entry)", async () => {
       vi.useFakeTimers();
       try {
         const { getServerTunnel, rotateServerTunnel } = await import(
           "@/lib/apis/mcp-tunnels-api"
         );
         // Server-side view during rotation: the entry disappears between
-        // close and re-create, so revalidation would read null.
+        // close and re-create, so a poll then would read null.
         let tunnelVisible = true;
         (getServerTunnel as Mock).mockImplementation(async () =>
           tunnelVisible ? { url: seedUrl, serverId: "test-server" } : null
@@ -737,24 +741,33 @@ describe("ServerConnectionCard", () => {
           await vi.advanceTimersByTimeAsync(0);
         });
         expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
+        const callsAfterMount = (getServerTunnel as Mock).mock.calls.length;
 
-        // Start a rotate that hangs; the server-side entry vanishes.
-        fireEvent.click(
-          screen.getByRole("button", {
-            name: "Rotate tunnel secret (revokes the current URL)",
-          })
-        );
+        // Start a rotate that hangs; the server-side entry vanishes. The
+        // awaited act flushes setIsRotatingTunnel(true) so the revalidation
+        // effect re-runs and tears down the poll before timers advance.
+        await act(async () => {
+          fireEvent.click(
+            screen.getByRole("button", {
+              name: "Rotate tunnel secret (revokes the current URL)",
+            })
+          );
+        });
         tunnelVisible = false;
         await act(async () => {
           await vi.advanceTimersByTimeAsync(15000);
         });
-        // The poll is suspended during the mutation: no clearing, no toast.
+        // Poll suspended: no extra getServerTunnel calls, URL kept, no toast.
+        expect((getServerTunnel as Mock).mock.calls.length).toBe(
+          callsAfterMount
+        );
         expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
         expect(toast.warning as Mock).not.toHaveBeenCalled();
 
+        // Rotation completes; the URL is still shown.
         tunnelVisible = true;
-        finishRotate?.();
         await act(async () => {
+          finishRotate?.();
           await vi.advanceTimersByTimeAsync(0);
         });
         expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import { toast } from "sonner";
 import type { ServerWithName } from "@/hooks/use-app-state";
 
@@ -60,6 +66,7 @@ vi.mock("sonner", () => ({
   toast: {
     error: vi.fn(),
     success: vi.fn(),
+    warning: vi.fn(),
     loading: vi.fn().mockReturnValue("toast-id"),
   },
 }));
@@ -650,6 +657,81 @@ describe("ServerConnectionCard", () => {
       await waitFor(() => {
         expect(closeServerTunnel).toHaveBeenCalledTimes(1);
       });
+    });
+  });
+
+  describe("tunnel revalidation", () => {
+    const seedUrl =
+      "https://r00000000001.tunnels.mcpjam.com/api/mcp/adapter-http/test-server?k=s";
+
+    it("clears the displayed URL once the server reports the tunnel ended", async () => {
+      vi.useFakeTimers();
+      try {
+        const { getServerTunnel } = await import("@/lib/apis/mcp-tunnels-api");
+        // Mount sees a live tunnel; the relay then ends it server-side
+        // (e.g. taken over by another inspector), so revalidation gets null.
+        // Stateful (not call-ordered) so StrictMode's double-mount fetch
+        // can't consume the "alive" answer early.
+        let tunnelAlive = true;
+        (getServerTunnel as Mock).mockImplementation(async () =>
+          tunnelAlive ? { url: seedUrl, serverId: "test-server" } : null
+        );
+
+        render(
+          <ServerConnectionCard
+            server={createServer({ connectionStatus: "connected" })}
+            {...defaultProps}
+          />
+        );
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
+
+        tunnelAlive = false;
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(5000);
+        });
+        // Dead URL is no longer copyable; the user is told why it vanished.
+        expect(screen.queryByText("Copy tunnel URL")).not.toBeInTheDocument();
+        expect(toast.warning as Mock).toHaveBeenCalledWith(
+          expect.stringContaining("Tunnel for test-server ended")
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("keeps the URL on transient revalidation errors", async () => {
+      vi.useFakeTimers();
+      try {
+        const { getServerTunnel } = await import("@/lib/apis/mcp-tunnels-api");
+        let failing = false;
+        (getServerTunnel as Mock).mockImplementation(async () => {
+          if (failing) throw new Error("network blip");
+          return { url: seedUrl, serverId: "test-server" };
+        });
+
+        render(
+          <ServerConnectionCard
+            server={createServer({ connectionStatus: "connected" })}
+            {...defaultProps}
+          />
+        );
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        failing = true;
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(5000);
+        });
+        expect(screen.getByText("Copy tunnel URL")).toBeInTheDocument();
+        expect(toast.warning as Mock).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/mcpjam-inspector/client/src/lib/apis/mcp-tunnels-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-tunnels-api.ts
@@ -6,19 +6,14 @@ import { authFetch } from "@/lib/session-token";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:6274";
 
-export interface TunnelResponse {
-  url: string;
-  existed?: boolean;
-}
-
 export interface ServerTunnelResponse {
-  // Full bearer URL (contains the ?k= secret enforced at the ngrok edge).
+  // Full bearer URL (contains the ?k= secret enforced at the relay edge).
   // Only ever returned from the local inspector server's in-memory state
   // or a create/rotate response — never from persisted backend records.
   url: string;
   serverId: string;
   existed?: boolean;
-  domain?: string;
+  slug?: string;
   secretVersion?: number;
 }
 
@@ -30,34 +25,6 @@ export interface TunnelRequestLogEntry {
 
 export interface TunnelError {
   error: string;
-}
-
-/**
- * Create a shared tunnel for all MCP servers
- * @param accessToken - Optional WorkOS access token for authenticated requests
- */
-export async function createTunnel(
-  accessToken?: string
-): Promise<TunnelResponse> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-
-  const response = await authFetch(`${API_BASE}/api/mcp/tunnels/create`, {
-    method: "POST",
-    headers,
-  });
-
-  if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.error || "Failed to create tunnel");
-  }
-
-  return response.json();
 }
 
 /**
@@ -88,38 +55,6 @@ export async function createServerTunnel(
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.error || "Failed to create server tunnel");
-  }
-
-  return response.json();
-}
-
-/**
- * Get existing shared tunnel URL
- * @param accessToken - Optional WorkOS access token for authenticated requests
- */
-export async function getTunnel(
-  accessToken?: string
-): Promise<TunnelResponse | null> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-
-  const response = await authFetch(`${API_BASE}/api/mcp/tunnels`, {
-    method: "GET",
-    headers,
-  });
-
-  if (response.status === 404) {
-    return null;
-  }
-
-  if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.error || "Failed to get tunnel");
   }
 
   return response.json();
@@ -163,30 +98,6 @@ export async function getServerTunnel(
 }
 
 /**
- * Close the shared tunnel
- * @param accessToken - Optional WorkOS access token for authenticated requests
- */
-export async function closeTunnel(accessToken?: string): Promise<void> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-
-  const response = await authFetch(`${API_BASE}/api/mcp/tunnels`, {
-    method: "DELETE",
-    headers,
-  });
-
-  if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.error || "Failed to close tunnel");
-  }
-}
-
-/**
  * Close a tunnel for an individual MCP server
  * @param serverId - The MCP server ID
  * @param accessToken - Optional WorkOS access token for authenticated requests
@@ -222,7 +133,7 @@ export async function closeServerTunnel(
  * the returned URL carries the new secret and the old URL stops working.
  * @param serverId - The MCP server ID
  * @param accessToken - Optional WorkOS access token for authenticated requests
- * @param full - Also rotate the reserved domain (new base URL). Rare.
+ * @param full - Also rotate the tunnel slug (new base URL). Rare.
  */
 export async function rotateServerTunnel(
   serverId: string,

--- a/mcpjam-inspector/client/src/lib/config.ts
+++ b/mcpjam-inspector/client/src/lib/config.ts
@@ -10,7 +10,7 @@
  * When enabled:
  * - STDIO connections are disabled (security: prevents RCE)
  * - Only HTTPS connections are allowed
- * - ngrok tunneling is disabled (not applicable for web)
+ * - tunneling is disabled (not applicable for web)
  *
  * Set VITE_MCPJAM_HOSTED_MODE=true at build time to enable.
  */

--- a/mcpjam-inspector/forge.config.ts
+++ b/mcpjam-inspector/forge.config.ts
@@ -7,8 +7,7 @@ import { MakerDMG } from "@electron-forge/maker-dmg";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
-import { resolve, join, dirname } from "path";
-import { cpSync, existsSync, mkdirSync, readdirSync } from "fs";
+import { resolve } from "path";
 
 const enableMacSigning = process.platform === "darwin";
 const macSignIdentity = process.env.MAC_CODESIGN_IDENTITY?.trim();
@@ -78,59 +77,6 @@ const config: ForgeConfig = {
     ],
     osxSign: osxSignOptions,
     osxNotarize: osxNotarizeOptions,
-    // VitePlugin only packs .vite/build/ into the asar; copy native externals here so require() resolves them.
-    afterCopy: [
-      (buildPath, _electronVersion, _platform, _arch, callback) => {
-        let ngrokSrc: string;
-        try {
-          const ngrokPkg = require.resolve("@ngrok/ngrok/package.json", {
-            paths: [__dirname],
-          });
-          ngrokSrc = dirname(dirname(ngrokPkg)); // …/@ngrok/ngrok/package.json -> …/@ngrok
-        } catch {
-          ngrokSrc = resolve(__dirname, "node_modules", "@ngrok");
-        }
-        if (!existsSync(ngrokSrc)) {
-          console.warn("[forge] @ngrok not found, skipping copy");
-          callback();
-          return;
-        }
-        const dest = join(buildPath, ".vite", "build", "node_modules", "@ngrok");
-        try {
-          mkdirSync(dest, { recursive: true });
-
-          const nativePkgs = readdirSync(ngrokSrc, { withFileTypes: true })
-            .filter(
-              (entry) => entry.isDirectory() && entry.name.startsWith("ngrok-")
-            )
-            .map((entry) => entry.name)
-            .sort();
-          if (nativePkgs.length === 0) {
-            console.warn(
-              "[forge] No @ngrok/ngrok-* native packages found — ngrok tunnels will fail at runtime",
-            );
-          }
-
-          const pkgsToCopy = ["ngrok", ...nativePkgs];
-          for (const pkg of pkgsToCopy) {
-            const src = join(ngrokSrc, pkg);
-            if (existsSync(src)) {
-              console.log(`[forge] Copying @ngrok/${pkg} to ${dest}`);
-              cpSync(src, join(dest, pkg), { recursive: true });
-            } else {
-              console.warn(
-                `[forge] @ngrok/${pkg} not found at ${src} — ngrok tunnels will fail at runtime`,
-              );
-            }
-          }
-        } catch (err) {
-          console.error(`[forge] Failed to copy @ngrok to ${dest}:`, err);
-          callback(err as Error);
-          return;
-        }
-        callback();
-      },
-    ],
   },
   rebuildConfig: {},
   makers: [

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -123,7 +123,6 @@
     "@mcpjam/sdk": "^1.16.0",
     "@modelcontextprotocol/client": "^2.0.0-alpha.2",
     "@modelcontextprotocol/ext-apps": "^1.7.2",
-    "@ngrok/ngrok": "^1.6.0",
     "@openrouter/ai-sdk-provider": "^2.0.2",
     "@sentry/electron": "^5.10.0",
     "@sentry/node": "^8.47.0",
@@ -182,6 +181,7 @@
     "update-electron-app": "^3.1.1",
     "url-template": "^3.1.1",
     "use-stick-to-bottom": "^1.1.1",
+    "ws": "^8.18.0",
     "zod": "^4.1.12",
     "zustand": "^5.0.6"
   },
@@ -206,6 +206,7 @@
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24",
+    "@types/ws": "^8.5.13",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@typescript-eslint/parser": "^8.53.1",

--- a/mcpjam-inspector/server/routes/mcp/http-adapters.ts
+++ b/mcpjam-inspector/server/routes/mcp/http-adapters.ts
@@ -103,7 +103,7 @@ function forwardedTunnelHost(c: any): string | undefined {
 }
 
 /**
- * Per-server isolation guard (defense-in-depth behind the ngrok Traffic
+ * Per-server isolation guard (defense-in-depth behind the relay edge
  * Policy path rule): a request that arrived through a per-server tunnel may
  * only address the serverId that tunnel was provisioned for.
  */
@@ -210,7 +210,7 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
         endpointBase = `${origin}/api/mcp/${routePrefix}/${serverId}/messages`;
       }
       // Propagate the tunnel bearer secret into the advertised endpoint:
-      // SSE clients POST to this URL verbatim, and without ?k= the ngrok
+      // SSE clients POST to this URL verbatim, and without ?k= the relay
       // edge policy would 401 their messages.
       const incomingSecret = incomingUrl.searchParams.get("k");
       if (incomingSecret && !/[?&]k=/.test(endpointBase)) {

--- a/mcpjam-inspector/server/routes/mcp/index.ts
+++ b/mcpjam-inspector/server/routes/mcp/index.ts
@@ -87,7 +87,7 @@ mcp.route("/models", models);
 // Tokenizer endpoints - count tokens for MCP tools
 mcp.route("/tokenizer", tokenizer);
 
-// Tunnel management endpoints - create ngrok tunnels for servers
+// Tunnel management endpoints - create relay tunnels for servers
 mcp.route("/tunnels", tunnelsRoute);
 
 // Logging level endpoint - configure per-server logging verbosity

--- a/mcpjam-inspector/server/routes/mcp/tunnels.ts
+++ b/mcpjam-inspector/server/routes/mcp/tunnels.ts
@@ -197,10 +197,14 @@ tunnels.post("/create/:serverId", async (c) => {
         secretVersion: grant.secretVersion,
       });
 
-      const serverTunnelUrl = tunnelManager.getServerTunnelUrl(serverId);
-      if (!serverTunnelUrl) {
-        throw new Error("Failed to build server tunnel URL");
-      }
+      // The handshake succeeded, so the grant URL is the right answer. Don't
+      // re-derive it from live manager state: a permanent edge close
+      // (replaced/revoked) racing in right after createTunnel could drop the
+      // entry and turn a completed create into a misleading 500. If the
+      // tunnel did die, the card's revalidation poll detects it and clears
+      // the URL.
+      const serverTunnelUrl =
+        tunnelManager.getServerTunnelUrl(serverId) ?? grant.url;
 
       getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.created", {
         tunnelKind: "server",

--- a/mcpjam-inspector/server/routes/mcp/tunnels.ts
+++ b/mcpjam-inspector/server/routes/mcp/tunnels.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import type { Context } from "hono";
 import { tunnelManager } from "../../services/tunnel-manager";
 import { withTunnelLock } from "../../services/tunnel-locks";
 import {
@@ -14,19 +13,18 @@ import { classifyTunnelError } from "../../utils/error-classify";
 
 const tunnels = new Hono();
 
-interface NgrokTokenResponse {
-  token: string;
-  credentialId: string;
-  domain: string;
-  domainId: string;
-  // Edge-security fields (present when the backend provisioned a
-  // per-server tunnel): bearer URL with ?k= secret, the Traffic Policy to
-  // bind at listen time, and rotation bookkeeping.
+// Grant minted by the Convex backend: a stable slug, the bearer URL with a
+// fresh ?k= secret, and a connect token the relay edge verifies at the
+// WebSocket handshake. The secret/URL/token live in inspector memory only.
+interface RelayGrant {
+  slug: string;
+  url: string;
   secret?: string;
-  secretVersion?: number;
-  url?: string;
-  trafficPolicy?: string;
   secretHash?: string;
+  secretVersion?: number;
+  connectToken: string;
+  connectTokenExpiresAt?: number;
+  relayWsUrl: string;
 }
 
 function convexHeaders(authHeader?: string): Record<string, string> {
@@ -47,59 +45,65 @@ function requireConvexUrl(): string {
   return convexUrl;
 }
 
-// Fetch ngrok token from Convex backend. Passing a serverId makes the
-// backend reuse this user+server's persistent reserved domain and return
-// the edge-enforcement material (secret-bearing URL + Traffic Policy).
-async function fetchNgrokToken(
-  authHeader?: string,
-  serverId?: string
-): Promise<NgrokTokenResponse> {
+function validateGrant(
+  data: Partial<RelayGrant> & { ok?: boolean }
+): RelayGrant {
+  if (!data.ok || !data.slug || !data.url) {
+    throw new Error("Invalid response from tunnel service");
+  }
+  if (!data.connectToken || !data.relayWsUrl) {
+    // Local-dev skew: a backend without the relay routes answered.
+    throw new Error(
+      "Tunnel backend does not support relay tunnels yet — deploy the relay-enabled backend (or set TUNNEL_RELAY_* env on it)"
+    );
+  }
+  return data as RelayGrant;
+}
+
+// Fetch a relay tunnel grant from the Convex backend. `transport=relay`
+// marks this inspector as relay-capable; backends answer pre-relay
+// inspectors (no marker) with an actionable 410.
+async function fetchRelayGrant(
+  serverId: string,
+  authHeader?: string
+): Promise<RelayGrant> {
   const convexUrl = requireConvexUrl();
 
-  const tokenUrl = serverId
-    ? `${convexUrl}/tunnels/token?serverId=${encodeURIComponent(serverId)}`
-    : `${convexUrl}/tunnels/token`;
-
-  const response = await fetch(tokenUrl, {
-    method: "GET",
-    headers: convexHeaders(authHeader),
-  });
+  const response = await fetch(
+    `${convexUrl}/tunnels/token?serverId=${encodeURIComponent(
+      serverId
+    )}&transport=relay`,
+    {
+      method: "GET",
+      headers: convexHeaders(authHeader),
+    }
+  );
 
   if (!response.ok) {
     const error = (await response.json()) as { error?: string };
-    throw new Error(error.error || "Failed to fetch ngrok token");
+    throw new Error(error.error || "Failed to fetch tunnel grant");
   }
 
-  const data = (await response.json()) as Partial<NgrokTokenResponse> & {
-    ok?: boolean;
-  };
-  if (
-    !data.ok ||
-    !data.token ||
-    !data.credentialId ||
-    !data.domain ||
-    !data.domainId
-  ) {
-    throw new Error("Invalid response from tunnel service");
-  }
-
-  return data as NgrokTokenResponse;
+  return validateGrant(
+    (await response.json()) as Partial<RelayGrant> & { ok?: boolean }
+  );
 }
 
-// Stage a secret rotation with the Convex backend (phase A of the
-// two-phase rotation; the commit happens via recordTunnel after the local
-// listener is re-established with the new policy).
-async function stageRotation(
+// Rotate the bearer secret with the Convex backend. Single-phase: the
+// backend patches the row AND revokes the old grant at the edge before
+// responding, so the old URL is already dead; we just reconnect with the
+// fresh grant.
+async function fetchRotationGrant(
   serverId: string,
   full: boolean,
   authHeader?: string
-): Promise<NgrokTokenResponse> {
+): Promise<RelayGrant> {
   const convexUrl = requireConvexUrl();
 
   const response = await fetch(`${convexUrl}/tunnels/rotate`, {
     method: "POST",
     headers: convexHeaders(authHeader),
-    body: JSON.stringify({ serverId, full }),
+    body: JSON.stringify({ serverId, full, transport: "relay" }),
   });
 
   if (!response.ok) {
@@ -107,42 +111,9 @@ async function stageRotation(
     throw new Error(error.error || "Failed to rotate tunnel");
   }
 
-  const data = (await response.json()) as Partial<NgrokTokenResponse> & {
-    ok?: boolean;
-  };
-  if (
-    !data.ok ||
-    !data.token ||
-    !data.credentialId ||
-    !data.domain ||
-    !data.domainId
-  ) {
-    throw new Error("Invalid response from tunnel service");
-  }
-
-  return data as NgrokTokenResponse;
-}
-
-// Abort a staged rotation whose local re-listen failed so the backend can
-// revoke the pending credential and surface an explicit error state.
-async function reportRotationFailed(
-  serverId: string,
-  errorMessage: string,
-  authHeader?: string
-): Promise<void> {
-  const convexUrl = process.env.CONVEX_HTTP_URL;
-  if (!convexUrl) {
-    return;
-  }
-  try {
-    await fetch(`${convexUrl}/tunnels/rotate-failed`, {
-      method: "POST",
-      headers: convexHeaders(authHeader),
-      body: JSON.stringify({ serverId, errorMessage }),
-    });
-  } catch (error) {
-    logger.error("Failed to report rotation failure", error, { serverId });
-  }
+  return validateGrant(
+    (await response.json()) as Partial<RelayGrant> & { ok?: boolean }
+  );
 }
 
 function safeHostname(url: string): string {
@@ -153,61 +124,9 @@ function safeHostname(url: string): string {
   }
 }
 
-// The secret-less base URL is the only shape ever reported for
-// persistence; the bearer URL stays in tunnel-manager memory.
-function stripBearerSecret(url: string): string {
-  return url.split("?")[0];
-}
-
-// Report tunnel state to Convex backend (also the phase-B commit of a
-// rotation when secretHash/secretVersion are present).
-async function recordTunnel(
-  serverId: string,
-  url: string,
-  credentialId?: string,
-  domainId?: string,
-  domain?: string,
-  authHeader?: string,
-  c?: Context,
-  secretHash?: string,
-  secretVersion?: number
-): Promise<void> {
-  const convexUrl = process.env.CONVEX_HTTP_URL;
-  if (!convexUrl) {
-    logger.warn("CONVEX_HTTP_URL not configured, skipping tunnel recording");
-    return;
-  }
-
-  try {
-    await fetch(`${convexUrl}/tunnels/record`, {
-      method: "POST",
-      headers: convexHeaders(authHeader),
-      body: JSON.stringify({
-        serverId,
-        url: stripBearerSecret(url),
-        credentialId,
-        domainId,
-        domain,
-        secretHash,
-        secretVersion,
-      }),
-    });
-  } catch (error) {
-    const tunnelKind = serverId === "shared" ? "shared" : "server";
-    if (c) {
-      getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.record_failed", {
-        tunnelKind,
-        tunnelDomain: domain,
-        errorCode: classifyTunnelError(error, "convex_record_failed"),
-      });
-    }
-    logger.error("Failed to record tunnel", error, { serverId, url });
-    // Don't throw - tunnel is already created, just log the error
-  }
-}
-
-// Report tunnel closure to Convex backend (which also revokes the
-// tunnel's ngrok credentials; the reserved domain is kept for reuse).
+// Report tunnel closure to Convex backend (which also tells the relay edge
+// to drop the socket and deny the now-superseded grant; the slug is kept so
+// the URL stays stable on recreate).
 async function reportTunnelClosure(
   serverId: string,
   authHeader?: string
@@ -228,88 +147,18 @@ async function reportTunnelClosure(
   }
 }
 
-// Create a shared tunnel (legacy whole-app tunnel; no per-server scoping)
-tunnels.post("/create", async (c) => {
-  const authHeader = c.req.header("authorization");
-
-  // Serialized per tunnel id: the existence check below must observe any
-  // concurrent create's listener instead of double-provisioning.
-  return withTunnelLock("shared", async () => {
-    try {
-      // Check if tunnel already exists
-      const existingUrl = tunnelManager.getTunnelUrl();
-      if (existingUrl) {
-        getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.created", {
-          tunnelKind: "shared",
-          tunnelDomain: safeHostname(existingUrl),
-          existed: true,
-        });
-        return c.json({
-          url: existingUrl,
-          existed: true,
-        });
-      }
-
-      const { token, credentialId, domain, domainId } = await fetchNgrokToken(
-        authHeader
-      );
-      const url = await tunnelManager.createTunnel("shared", {
-        localAddr: LOCAL_SERVER_ADDR,
-        ngrokToken: token,
-        credentialId,
-        domainId,
-        domain,
-      });
-      await recordTunnel(
-        "shared",
-        url,
-        credentialId,
-        domainId,
-        domain,
-        authHeader,
-        c
-      );
-
-      getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.created", {
-        tunnelKind: "shared",
-        tunnelDomain: domain,
-        existed: false,
-        credentialIdPresent: !!credentialId,
-      });
-      return c.json({
-        url,
-        existed: false,
-      });
-    } catch (error: any) {
-      getRequestLogger(c, "routes.mcp.tunnels").event(
-        "tunnel.creation_failed",
-        {
-          tunnelKind: "shared",
-          errorCode: classifyTunnelError(error),
-        }
-      );
-      logger.error("Error creating tunnel", error);
-      return c.json(
-        {
-          error: error.message || "Failed to create tunnel",
-        },
-        500
-      );
-    }
-  });
-});
-
-// Create a server-specific tunnel, secured at the ngrok edge: the bearer
-// secret in the returned URL and the per-server path scope are enforced by
-// the Traffic Policy bound at listen time.
+// Create a server-specific tunnel over the MCPJam relay: the bearer secret
+// in the returned URL and the per-server path scope are enforced at the
+// relay edge, and the tunnel is live exactly while our outbound WebSocket
+// is connected.
 tunnels.post("/create/:serverId", async (c) => {
   const authHeader = c.req.header("authorization");
   const serverId = c.req.param("serverId");
 
-  // Serialized per server: token minting revokes the previous credential
-  // and listening binds a fresh secret, so overlapping creates would leave
-  // the listener and persistence on different secrets. Inside the lock the
-  // existence check observes any concurrent create's finished listener.
+  // Serialized per server: grant minting rotates the secret server-side,
+  // so overlapping creates would race the edge's view of the live grant.
+  // Inside the lock the existence check observes any concurrent create's
+  // finished connection.
   return withTunnelLock(serverId, async () => {
     try {
       const existingUrl = tunnelManager.getServerTunnelUrl(serverId);
@@ -325,28 +174,28 @@ tunnels.post("/create/:serverId", async (c) => {
         });
       }
 
-      const data = await fetchNgrokToken(authHeader, serverId);
-      const baseUrl = await tunnelManager.createTunnel(serverId, {
+      let grant: RelayGrant;
+      try {
+        grant = await fetchRelayGrant(serverId, authHeader);
+      } catch (error: any) {
+        getRequestLogger(c, "routes.mcp.tunnels").event(
+          "tunnel.creation_failed",
+          {
+            tunnelKind: "server",
+            errorCode: classifyTunnelError(error, "fetch_relay_grant_failed"),
+          }
+        );
+        throw error;
+      }
+
+      await tunnelManager.createTunnel(serverId, {
         localAddr: LOCAL_SERVER_ADDR,
-        ngrokToken: data.token,
-        credentialId: data.credentialId,
-        domainId: data.domainId,
-        domain: data.domain,
-        trafficPolicy: data.trafficPolicy,
-        publicUrl: data.url,
-        secretVersion: data.secretVersion,
+        slug: grant.slug,
+        relayWsUrl: grant.relayWsUrl,
+        connectToken: grant.connectToken,
+        publicUrl: grant.url,
+        secretVersion: grant.secretVersion,
       });
-      await recordTunnel(
-        serverId,
-        data.url ?? baseUrl,
-        data.credentialId,
-        data.domainId,
-        data.domain,
-        authHeader,
-        c,
-        data.secretHash,
-        data.secretVersion
-      );
 
       const serverTunnelUrl = tunnelManager.getServerTunnelUrl(serverId);
       if (!serverTunnelUrl) {
@@ -355,15 +204,14 @@ tunnels.post("/create/:serverId", async (c) => {
 
       getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.created", {
         tunnelKind: "server",
-        tunnelDomain: data.domain,
+        tunnelDomain: safeHostname(grant.url),
         existed: false,
-        credentialIdPresent: !!data.credentialId,
       });
       return c.json({
         url: serverTunnelUrl,
         serverId,
-        domain: data.domain,
-        secretVersion: data.secretVersion,
+        slug: grant.slug,
+        secretVersion: grant.secretVersion,
         existed: false,
       });
     } catch (error: any) {
@@ -371,7 +219,7 @@ tunnels.post("/create/:serverId", async (c) => {
         "tunnel.creation_failed",
         {
           tunnelKind: "server",
-          errorCode: classifyTunnelError(error),
+          errorCode: classifyTunnelError(error, "relay_connect_failed"),
         }
       );
       logger.error("Error creating server-specific tunnel", error, {
@@ -387,9 +235,10 @@ tunnels.post("/create/:serverId", async (c) => {
   });
 });
 
-// Rotate a server tunnel's bearer secret (two-phase). The base domain is
-// stable; only the ?k= secret (and agent credential) change. `full: true`
-// additionally swaps the reserved domain — a rare escape hatch.
+// Rotate a server tunnel's bearer secret (single-phase). The slug is
+// stable; only the ?k= secret changes, and the backend revokes the old
+// grant at the edge before we even see the response. `full: true`
+// additionally swaps the slug — a rare escape hatch.
 tunnels.post("/rotate/:serverId", async (c) => {
   const authHeader = c.req.header("authorization");
   const serverId = c.req.param("serverId");
@@ -401,97 +250,67 @@ tunnels.post("/rotate/:serverId", async (c) => {
   } catch {}
 
   // Serialized with create/close for this server so a rotation can never
-  // interleave with another lifecycle operation's mint/listen steps.
+  // interleave with another lifecycle operation's grant/connect steps.
   return withTunnelLock(serverId, async () => {
-    let data: NgrokTokenResponse;
+    let grant: RelayGrant;
     try {
-      // Phase A: backend mints the new secret/credential as PENDING state.
-      data = await stageRotation(serverId, full, authHeader);
+      grant = await fetchRotationGrant(serverId, full, authHeader);
     } catch (error: any) {
       getRequestLogger(c, "routes.mcp.tunnels").event(
         "tunnel.rotation_failed",
         {
           tunnelKind: "server",
-          errorCode: classifyTunnelError(error),
+          errorCode: classifyTunnelError(error, "fetch_relay_grant_failed"),
         }
       );
-      logger.error("Error staging tunnel rotation", error, { serverId });
+      logger.error("Error rotating tunnel secret", error, { serverId });
       return c.json({ error: error.message || "Failed to rotate tunnel" }, 500);
     }
 
     try {
-      // Re-listen with the new authtoken + traffic policy. The old secret
-      // dies here: the previous listener is closed before the new one binds.
+      // Reconnect with the fresh grant. The old secret is already dead at
+      // the edge (the backend disconnected + deny-listed it), so a failure
+      // here leaves the tunnel offline — never serving the old secret.
       await tunnelManager.rotateTunnel(serverId, {
         localAddr: LOCAL_SERVER_ADDR,
-        ngrokToken: data.token,
-        credentialId: data.credentialId,
-        domainId: data.domainId,
-        domain: data.domain,
-        trafficPolicy: data.trafficPolicy,
-        publicUrl: data.url,
-        secretVersion: data.secretVersion,
+        slug: grant.slug,
+        relayWsUrl: grant.relayWsUrl,
+        connectToken: grant.connectToken,
+        publicUrl: grant.url,
+        secretVersion: grant.secretVersion,
       });
     } catch (error: any) {
-      // Phase B (abort): land in an explicit error state; the backend
-      // revokes the pending credential.
-      await reportRotationFailed(
-        serverId,
-        error?.message || "Failed to re-establish tunnel listener",
-        authHeader
-      );
       getRequestLogger(c, "routes.mcp.tunnels").event(
         "tunnel.rotation_failed",
         {
           tunnelKind: "server",
-          errorCode: classifyTunnelError(error),
-          tunnelDomain: data.domain,
+          errorCode: classifyTunnelError(error, "relay_connect_failed"),
+          tunnelDomain: safeHostname(grant.url),
         }
       );
-      logger.error("Error re-establishing rotated tunnel", error, { serverId });
+      logger.error("Error reconnecting rotated tunnel", error, { serverId });
       return c.json(
-        { error: error.message || "Failed to re-establish rotated tunnel" },
+        {
+          error:
+            (error.message || "Failed to reconnect rotated tunnel") +
+            " — the old URL is already revoked; retry rotate or recreate the tunnel",
+        },
         500
       );
     }
 
-    // Phase B (commit): promote the pending secret/credential to active;
-    // the backend revokes the superseded credential.
-    await recordTunnel(
-      serverId,
-      data.url ?? `https://${data.domain}`,
-      data.credentialId,
-      data.domainId,
-      data.domain,
-      authHeader,
-      c,
-      data.secretHash,
-      data.secretVersion
-    );
-
     getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.rotated", {
       tunnelKind: "server",
-      tunnelDomain: data.domain,
+      tunnelDomain: safeHostname(grant.url),
       full,
     });
     return c.json({
-      url: tunnelManager.getServerTunnelUrl(serverId) ?? data.url,
+      url: tunnelManager.getServerTunnelUrl(serverId) ?? grant.url,
       serverId,
-      domain: data.domain,
-      secretVersion: data.secretVersion,
+      slug: grant.slug,
+      secretVersion: grant.secretVersion,
     });
   });
-});
-
-// Get existing tunnel URL
-tunnels.get("/", async (c) => {
-  const url = tunnelManager.getTunnelUrl();
-
-  if (!url) {
-    return c.json({ error: "No tunnel found" }, 404);
-  }
-
-  return c.json({ url });
 });
 
 // Get server-specific tunnel URL (in-memory bearer URL — this protected
@@ -515,29 +334,6 @@ tunnels.get("/requests/:serverId", async (c) => {
   return c.json({ serverId, requests: getTunnelRequests(serverId) });
 });
 
-// Close the tunnel
-tunnels.delete("/", async (c) => {
-  const authHeader = c.req.header("authorization");
-
-  return withTunnelLock("shared", async () => {
-    try {
-      await tunnelManager.closeTunnel("shared");
-      // Backend revokes the tunnel's credentials; the domain is kept.
-      await reportTunnelClosure("shared", authHeader);
-      tunnelManager.clearCredentials("shared");
-      return c.json({ success: true });
-    } catch (error: any) {
-      logger.error("Error closing tunnel", error);
-      return c.json(
-        {
-          error: error.message || "Failed to close tunnel",
-        },
-        500
-      );
-    }
-  });
-});
-
 // Close a server-specific tunnel
 tunnels.delete("/server/:serverId", async (c) => {
   const authHeader = c.req.header("authorization");
@@ -546,12 +342,11 @@ tunnels.delete("/server/:serverId", async (c) => {
   return withTunnelLock(serverId, async () => {
     try {
       await tunnelManager.closeTunnel(serverId);
-      // Backend revokes the tunnel's credentials; the domain is kept so the
-      // URL stays stable when the tunnel is recreated.
+      // Backend marks the row closed and has the edge deny the grant; the
+      // slug is kept so the URL stays stable when the tunnel is recreated.
       await reportTunnelClosure(serverId, authHeader);
-      tunnelManager.clearCredentials(serverId);
-      // The observability panel describes the closed listener — drop it so a
-      // future tunnel for this server starts with a clean history.
+      // The observability panel describes the closed connection — drop it
+      // so a future tunnel for this server starts with a clean history.
       clearTunnelRequests(serverId);
       return c.json({ success: true, serverId });
     } catch (error: any) {

--- a/mcpjam-inspector/server/services/__tests__/relay-client.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/relay-client.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { WebSocketServer, type WebSocket } from "ws";
+import {
+  RelayConnection,
+  CLOSE_BAD_TOKEN,
+  CLOSE_REPLACED,
+} from "../relay-client.js";
+
+// ── Fake relay edge ─────────────────────────────────────────────────────────
+// Speaks just enough mcpjam-tunnel.v1 to drive the client: sends hello on
+// connect, exposes received frames, and lets tests push req frames and
+// close codes.
+
+interface EdgeConn {
+  ws: WebSocket;
+  authHeader: string | undefined;
+  frames: any[];
+  binary: { kind: number; id: number; payload: Buffer }[];
+}
+
+function startFakeEdge(): Promise<{
+  port: number;
+  connections: EdgeConn[];
+  close: () => Promise<void>;
+}> {
+  const connections: EdgeConn[] = [];
+  const server = http.createServer();
+  const wss = new WebSocketServer({ server, path: "/agent" });
+  wss.on("connection", (ws, req) => {
+    const conn: EdgeConn = {
+      ws,
+      authHeader: req.headers.authorization,
+      frames: [],
+      binary: [],
+    };
+    connections.push(conn);
+    ws.on("message", (data, isBinary) => {
+      if (isBinary) {
+        const buf = data as Buffer;
+        conn.binary.push({
+          kind: buf.readUInt8(0),
+          id: buf.readUInt32BE(1),
+          payload: buf.subarray(5),
+        });
+      } else {
+        conn.frames.push(JSON.parse(String(data)));
+      }
+    });
+    ws.send(
+      JSON.stringify({
+        t: "hello",
+        proto: 1,
+        slug: "testslug0001",
+        limits: { maxReqBody: 10485760, chunk: 65536, maxInflight: 32 },
+      })
+    );
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        port: (server.address() as AddressInfo).port,
+        connections,
+        close: () =>
+          new Promise<void>((r) => {
+            for (const c of connections) c.ws.terminate();
+            wss.close();
+            server.closeAllConnections?.();
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+// ── Local inspector stand-in ────────────────────────────────────────────────
+
+let localServer: http.Server;
+let localPort: number;
+const localRequests: { method: string; url: string; body: string }[] = [];
+
+beforeAll(async () => {
+  localServer = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      localRequests.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        body: Buffer.concat(chunks).toString("utf8"),
+      });
+      if ((req.url ?? "").includes("/sse")) {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write("data: one\n\n");
+        setTimeout(() => res.write("data: two\n\n"), 30);
+        return; // stays open
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, sawUrl: req.url }));
+    });
+  });
+  await new Promise<void>((r) => localServer.listen(0, "127.0.0.1", () => r()));
+  localPort = (localServer.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  localServer.closeAllConnections?.();
+  await new Promise<void>((r) => localServer.close(() => r()));
+});
+
+function makeConnection(
+  edgePort: number,
+  overrides: Partial<{
+    onPermanentFailure: (reason: string, code: number) => void;
+  }> = {}
+): RelayConnection {
+  return new RelayConnection({
+    serverId: "test-server",
+    slug: "testslug0001",
+    relayWsUrl: `ws://127.0.0.1:${edgePort}/agent`,
+    connectToken: "test-connect-token",
+    localAddr: `http://localhost:${localPort}`,
+    publicHost: "testslug0001.tunnels.mcpjam.com",
+    onPermanentFailure: overrides.onPermanentFailure,
+  });
+}
+
+async function waitFor<T>(
+  probe: () => T | undefined | false,
+  timeoutMs = 2000
+): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const value = probe();
+    if (value) return value as T;
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+let activeConnections: RelayConnection[] = [];
+let activeEdges: Awaited<ReturnType<typeof startFakeEdge>>[] = [];
+
+afterEach(async () => {
+  for (const c of activeConnections) c.close();
+  activeConnections = [];
+  for (const e of activeEdges) await e.close();
+  activeEdges = [];
+  localRequests.length = 0;
+});
+
+describe("RelayConnection", () => {
+  it("connects with the bearer token and resolves on hello", async () => {
+    const edge = await startFakeEdge();
+    activeEdges.push(edge);
+    const conn = makeConnection(edge.port);
+    activeConnections.push(conn);
+
+    await conn.connect();
+    expect(conn.isConnected).toBe(true);
+    expect(edge.connections[0].authHeader).toBe("Bearer test-connect-token");
+  });
+
+  it("replays req frames against the local server and streams the response back — URL verbatim incl. ?k=", async () => {
+    const edge = await startFakeEdge();
+    activeEdges.push(edge);
+    const conn = makeConnection(edge.port);
+    activeConnections.push(conn);
+    await conn.connect();
+    const ec = edge.connections[0];
+
+    ec.ws.send(
+      JSON.stringify({
+        t: "req",
+        id: 7,
+        method: "POST",
+        url: "/api/mcp/adapter-http/test-server?k=sekret&sessionId=s1",
+        headers: [
+          ["content-type", "application/json"],
+          ["x-forwarded-host", "testslug0001.tunnels.mcpjam.com"],
+        ],
+        hasBody: true,
+      })
+    );
+    // body as one binary chunk, then req_end
+    const payload = Buffer.from(JSON.stringify({ hello: "world" }));
+    const frame = Buffer.allocUnsafe(5 + payload.length);
+    frame.writeUInt8(0x01, 0);
+    frame.writeUInt32BE(7, 1);
+    payload.copy(frame, 5);
+    ec.ws.send(frame);
+    ec.ws.send(JSON.stringify({ t: "req_end", id: 7 }));
+
+    const res = await waitFor(() =>
+      ec.frames.find((f) => f.t === "res" && f.id === 7)
+    );
+    expect(res.status).toBe(200);
+    await waitFor(() => ec.frames.find((f) => f.t === "res_end" && f.id === 7));
+
+    const chunks = ec.binary.filter((b) => b.kind === 0x02 && b.id === 7);
+    const body = JSON.parse(
+      Buffer.concat(chunks.map((c) => c.payload)).toString("utf8")
+    );
+    // The ?k= secret reached the local adapter untouched (its SSE endpoint
+    // event depends on it) and the body round-tripped.
+    expect(body.sawUrl).toBe(
+      "/api/mcp/adapter-http/test-server?k=sekret&sessionId=s1"
+    );
+    expect(localRequests[0].body).toBe(JSON.stringify({ hello: "world" }));
+  });
+
+  it("streams SSE chunk-by-chunk as separate frames", async () => {
+    const edge = await startFakeEdge();
+    activeEdges.push(edge);
+    const conn = makeConnection(edge.port);
+    activeConnections.push(conn);
+    await conn.connect();
+    const ec = edge.connections[0];
+
+    ec.ws.send(
+      JSON.stringify({
+        t: "req",
+        id: 9,
+        method: "GET",
+        url: "/api/mcp/adapter-http/test-server/sse?k=sekret",
+        headers: [["accept", "text/event-stream"]],
+        hasBody: false,
+      })
+    );
+
+    await waitFor(() => ec.frames.find((f) => f.t === "res" && f.id === 9));
+    await waitFor(() => {
+      const text = Buffer.concat(
+        ec.binary.filter((b) => b.id === 9).map((b) => b.payload)
+      ).toString("utf8");
+      return text.includes("data: one") && text.includes("data: two");
+    });
+    // Two events arrived in at least two separate frames (no buffering),
+    // and the stream is still open (no res_end).
+    expect(ec.binary.filter((b) => b.id === 9).length).toBeGreaterThanOrEqual(
+      2
+    );
+    expect(ec.frames.find((f) => f.t === "res_end" && f.id === 9)).toBe(
+      undefined
+    );
+
+    // An edge abort tears down the local request without killing the socket.
+    ec.ws.send(JSON.stringify({ t: "abort", id: 9, code: "client_gone" }));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(conn.isConnected).toBe(true);
+  });
+
+  it("treats 4001 (replaced) as PERMANENT — no reconnect, surfaced to the owner", async () => {
+    const edge = await startFakeEdge();
+    activeEdges.push(edge);
+    let permanent: { reason: string; code: number } | null = null;
+    const conn = makeConnection(edge.port, {
+      onPermanentFailure: (reason, code) => {
+        permanent = { reason, code };
+      },
+    });
+    activeConnections.push(conn);
+    await conn.connect();
+
+    edge.connections[0].ws.close(CLOSE_REPLACED, "replaced");
+    await waitFor(() => permanent !== null);
+    expect(permanent!.code).toBe(CLOSE_REPLACED);
+    expect(conn.permanentFailure).toMatch(/another inspector/i);
+
+    // No reconnect attempt: the connection count must stay at 1.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(edge.connections.length).toBe(1);
+  });
+
+  it("treats 4000 (bad token) as permanent", async () => {
+    const edge = await startFakeEdge();
+    activeEdges.push(edge);
+    let code = 0;
+    const conn = makeConnection(edge.port, {
+      onPermanentFailure: (_r, c) => {
+        code = c;
+      },
+    });
+    activeConnections.push(conn);
+    await conn.connect();
+
+    edge.connections[0].ws.close(CLOSE_BAD_TOKEN, "expired");
+    await waitFor(() => code !== 0);
+    expect(code).toBe(CLOSE_BAD_TOKEN);
+    await new Promise((r) => setTimeout(r, 300));
+    expect(edge.connections.length).toBe(1);
+  });
+
+  it("reconnects immediately on 1012 (edge restart)", async () => {
+    const edge = await startFakeEdge();
+    activeEdges.push(edge);
+    const conn = makeConnection(edge.port);
+    activeConnections.push(conn);
+    await conn.connect();
+
+    edge.connections[0].ws.close(1012, "edge restarting");
+    await waitFor(() => edge.connections.length === 2, 3000);
+    await waitFor(() => conn.isConnected);
+    expect(conn.permanentFailure).toBeNull();
+  });
+
+  it("does not reconnect after an intentional close()", async () => {
+    const edge = await startFakeEdge();
+    activeEdges.push(edge);
+    const conn = makeConnection(edge.port);
+    activeConnections.push(conn);
+    await conn.connect();
+
+    conn.close();
+    await new Promise((r) => setTimeout(r, 300));
+    expect(edge.connections.length).toBe(1);
+    expect(conn.isConnected).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/services/__tests__/relay-client.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/relay-client.test.ts
@@ -317,4 +317,37 @@ describe("RelayConnection", () => {
     expect(edge.connections.length).toBe(1);
     expect(conn.isConnected).toBe(false);
   });
+
+  it("rejects connect() with the permanent reason when a transient drop is followed by a permanent close before hello", async () => {
+    // Edge that never sends hello: connection #1 closes transiently (1012,
+    // immediate reconnect), connection #2 closes permanently (4001). The
+    // reconnect dial must still carry onPermanent so connect() rejects with
+    // the real reason instead of stalling to the 15s connect timeout.
+    const server = http.createServer();
+    const wss = new WebSocketServer({ server, path: "/agent" });
+    let n = 0;
+    wss.on("connection", (ws) => {
+      n += 1;
+      ws.close(n === 1 ? 1012 : 4001, n === 1 ? "restart" : "replaced");
+    });
+    const port: number = await new Promise((resolve) =>
+      server.listen(0, "127.0.0.1", () =>
+        resolve((server.address() as AddressInfo).port)
+      )
+    );
+
+    try {
+      const conn = makeConnection(port);
+      activeConnections.push(conn);
+      const started = Date.now();
+      await expect(conn.connect()).rejects.toThrow(/another inspector/i);
+      // Rejected from the permanent close, not the 15s connect timeout.
+      expect(Date.now() - started).toBeLessThan(5000);
+      expect(n).toBe(2);
+    } finally {
+      wss.close();
+      server.closeAllConnections?.();
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
 });

--- a/mcpjam-inspector/server/services/__tests__/tunnel-manager.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/tunnel-manager.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isActiveTunnelDomain } from "../tunnel-registry";
+
+const relayMock = vi.hoisted(() => {
+  type ConnectImpl = (conn: MockRelayConnection) => Promise<void> | void;
+
+  let connectImpl: ConnectImpl = async (conn) => {
+    conn.connected = true;
+  };
+  const instances: MockRelayConnection[] = [];
+
+  class MockRelayConnection {
+    connected = false;
+    closed = false;
+    permanentFailure: string | null = null;
+
+    constructor(readonly options: any) {
+      instances.push(this);
+    }
+
+    get isConnected(): boolean {
+      return this.connected;
+    }
+
+    async connect(): Promise<void> {
+      await connectImpl(this);
+    }
+
+    close(): void {
+      this.closed = true;
+      this.connected = false;
+    }
+  }
+
+  return {
+    RelayConnection: MockRelayConnection,
+    instances,
+    reset() {
+      instances.length = 0;
+      connectImpl = async (conn) => {
+        conn.connected = true;
+      };
+    },
+    setConnectImpl(fn: ConnectImpl) {
+      connectImpl = fn;
+    },
+  };
+});
+
+vi.mock("../relay-client", () => ({
+  RelayConnection: relayMock.RelayConnection,
+}));
+
+const { tunnelManager } = await import("../tunnel-manager");
+
+const options = {
+  localAddr: "http://localhost:6274",
+  slug: "testslug0001",
+  relayWsUrl: "wss://agent.tunnels.mcpjam.com/agent",
+  connectToken: "test-connect-token",
+  publicUrl:
+    "https://testslug0001.tunnels.mcpjam.com/api/mcp/adapter-http/test-server?k=secret",
+  secretVersion: 1,
+};
+
+describe("TunnelManager", () => {
+  afterEach(async () => {
+    await tunnelManager.closeAll();
+    relayMock.reset();
+  });
+
+  it("registers a connected relay tunnel", async () => {
+    await expect(
+      tunnelManager.createTunnel("test-server", options)
+    ).resolves.toBe("https://testslug0001.tunnels.mcpjam.com");
+
+    expect(tunnelManager.getServerTunnelUrl("test-server")).toBe(
+      options.publicUrl
+    );
+    expect(isActiveTunnelDomain("testslug0001.tunnels.mcpjam.com")).toBe(true);
+  });
+
+  it("does not store a tunnel when the relay closes permanently before registration", async () => {
+    relayMock.setConnectImpl(async (conn) => {
+      conn.connected = false;
+      conn.permanentFailure = "Tunnel taken over by another inspector instance";
+      conn.options.onPermanentFailure?.(conn.permanentFailure, 4001);
+    });
+
+    await expect(
+      tunnelManager.createTunnel("test-server", options)
+    ).rejects.toThrow(/another inspector/i);
+
+    expect(tunnelManager.getServerTunnelUrl("test-server")).toBeNull();
+    expect(isActiveTunnelDomain("testslug0001.tunnels.mcpjam.com")).toBe(false);
+    expect(relayMock.instances[0]?.closed).toBe(true);
+  });
+});

--- a/mcpjam-inspector/server/services/__tests__/tunnel-manager.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/tunnel-manager.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach, beforeAll, afterAll } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { WebSocketServer } from "ws";
+import { tunnelManager } from "../tunnel-manager.js";
+import { isActiveTunnelDomain } from "../tunnel-registry.js";
+
+const SLUG = "tmslug000001";
+const HOST = `${SLUG}.tunnels.mcpjam.com`;
+
+// Fake relay edge: every agent gets a hello (which resolves connect()). When
+// `closeCodeAfterHello` is set, the edge immediately closes with that code,
+// exercising the "permanent close racing registration" path.
+function startFakeEdge(opts: { closeCodeAfterHello?: number } = {}) {
+  const server = http.createServer();
+  const wss = new WebSocketServer({ server, path: "/agent" });
+  wss.on("connection", (ws) => {
+    ws.send(
+      JSON.stringify({
+        t: "hello",
+        proto: 1,
+        slug: SLUG,
+        limits: { maxReqBody: 10485760, chunk: 65536, maxInflight: 32 },
+      })
+    );
+    if (opts.closeCodeAfterHello) {
+      ws.close(opts.closeCodeAfterHello, "test close");
+    }
+  });
+  return new Promise<{ port: number; close: () => Promise<void> }>(
+    (resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        resolve({
+          port: (server.address() as AddressInfo).port,
+          close: () =>
+            new Promise<void>((r) => {
+              wss.close();
+              server.closeAllConnections?.();
+              server.close(() => r());
+            }),
+        });
+      });
+    }
+  );
+}
+
+let localServer: http.Server;
+let localPort: number;
+
+beforeAll(async () => {
+  localServer = http.createServer((_req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  });
+  await new Promise<void>((r) => localServer.listen(0, "127.0.0.1", () => r()));
+  localPort = (localServer.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  localServer.closeAllConnections?.();
+  await new Promise<void>((r) => localServer.close(() => r()));
+});
+
+// Close any live tunnel first: a healthy RelayConnection reconnects on an
+// abnormal socket close, so tearing down the edge before the tunnel would
+// leave the edge's server.close() waiting on a reconnecting client.
+afterEach(async () => {
+  await tunnelManager.closeAll();
+});
+
+function grantOptions(port: number) {
+  return {
+    localAddr: `http://localhost:${localPort}`,
+    slug: SLUG,
+    relayWsUrl: `ws://127.0.0.1:${port}/agent`,
+    connectToken: "tm-test-token",
+    publicUrl: `https://${HOST}/api/mcp/adapter-http/srv?k=secret123`,
+    secretVersion: 1,
+  };
+}
+
+describe("tunnelManager relay lifecycle", () => {
+  it("registers a live tunnel and exposes its bearer URL", async () => {
+    const edge = await startFakeEdge();
+    try {
+      const opts = grantOptions(edge.port);
+      await tunnelManager.createTunnel("srv", opts);
+      expect(tunnelManager.getServerTunnelUrl("srv")).toBe(opts.publicUrl);
+      expect(isActiveTunnelDomain(HOST)).toBe(true);
+      // Stop the tunnel before edge teardown so it doesn't reconnect into a
+      // closing server (which would hang server.close()).
+      await tunnelManager.closeTunnel("srv");
+    } finally {
+      await edge.close();
+    }
+  });
+
+  it("never persists a tunnel whose relay permanently closes during/after the handshake", async () => {
+    // 4001 = replaced (permanent). Closing right after hello races the
+    // post-connect registration; the invariant is that no live entry and no
+    // registered domain survive, whichever branch handles the close.
+    const edge = await startFakeEdge({ closeCodeAfterHello: 4001 });
+    try {
+      const opts = grantOptions(edge.port);
+      let threw = false;
+      try {
+        await tunnelManager.createTunnel("srv", opts);
+      } catch {
+        threw = true;
+      }
+
+      // Allow a close that landed just after registration to propagate.
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Either createTunnel threw (guard caught it pre-registration) or it
+      // registered and dropEntry removed it — both leave no dead tunnel.
+      expect(tunnelManager.getServerTunnelUrl("srv")).toBeNull();
+      expect(isActiveTunnelDomain(HOST)).toBe(false);
+      // A permanent close must never silently yield a live tunnel.
+      expect(threw || tunnelManager.getServerTunnelUrl("srv") === null).toBe(
+        true
+      );
+    } finally {
+      await edge.close();
+    }
+  });
+});

--- a/mcpjam-inspector/server/services/relay-client.ts
+++ b/mcpjam-inspector/server/services/relay-client.ts
@@ -235,6 +235,10 @@ export class RelayConnection {
       logger.warn(
         `Tunnel relay disconnected (${code}); reconnecting in ${delay}ms`
       );
+      // Never let reconnect timers stack: a stale pending timer would dial a
+      // second overlapping socket on the same grant (which the edge would
+      // then 4001 against the other). At most one reconnect is ever queued.
+      if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
       this.reconnectTimer = setTimeout(() => this.dial(onHello), delay);
     });
   }

--- a/mcpjam-inspector/server/services/relay-client.ts
+++ b/mcpjam-inspector/server/services/relay-client.ts
@@ -239,7 +239,16 @@ export class RelayConnection {
       // second overlapping socket on the same grant (which the edge would
       // then 4001 against the other). At most one reconnect is ever queued.
       if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = setTimeout(() => this.dial(onHello), delay);
+      // Forward BOTH callbacks: a transient close before the first `hello`
+      // schedules this reconnect, and if that next attempt closes
+      // permanently (4000/4001/4002) before `hello`, onPermanent must still
+      // reject connect() with the real reason instead of leaving the caller
+      // to hit the 15s connect timeout. After connect() settles both are
+      // no-ops, so post-connect reconnects are unaffected.
+      this.reconnectTimer = setTimeout(
+        () => this.dial(onHello, onPermanent),
+        delay
+      );
     });
   }
 

--- a/mcpjam-inspector/server/services/relay-client.ts
+++ b/mcpjam-inspector/server/services/relay-client.ts
@@ -1,0 +1,412 @@
+/**
+ * Relay client: one outbound WebSocket per tunneled server, speaking
+ * `mcpjam-tunnel.v1` to the MCPJam tunnel edge. The edge sends `req`
+ * control frames + binary body chunks; this client replays them against
+ * the local inspector server and streams the response back frame-by-frame
+ * (SSE chunks flow as they happen — nothing is buffered).
+ *
+ * HAND-MIRRORED CONTRACT: frame shapes, limits, and close codes mirror
+ * `tunnel-edge/src/protocol.ts` in the mcpjam-backend repo. Change them
+ * only together (and only by bumping the subprotocol).
+ *
+ * Reconnect policy:
+ *  - network drops → backoff 1s→30s with jitter;
+ *  - 1012 (edge restarting) → reconnect immediately;
+ *  - 4000 (bad/expired token), 4002 (revoked by control plane) → PERMANENT;
+ *  - 4001 (replaced) → PERMANENT by design: another inspector took the
+ *    slug; auto-reconnecting would steal it back and flap forever.
+ */
+
+import http from "node:http";
+import { WebSocket } from "ws";
+import { logger } from "../utils/logger";
+
+export const RELAY_SUBPROTOCOL = "mcpjam-tunnel.v1";
+
+const CHUNK_BYTES = 64 * 1024;
+const HEARTBEAT_INTERVAL_MS = 25_000;
+const HEARTBEAT_MISSED_LIMIT = 2;
+const WS_BACKPRESSURE_HIGH_WATER_BYTES = 1024 * 1024;
+const RECONNECT_MIN_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+const CONNECT_TIMEOUT_MS = 15_000;
+
+export const CLOSE_BAD_TOKEN = 4000;
+export const CLOSE_REPLACED = 4001;
+export const CLOSE_CONTROL_PLANE = 4002;
+const CLOSE_EDGE_RESTART = 1012;
+
+type ControlFrame =
+  | {
+      t: "hello";
+      proto: number;
+      slug: string;
+      limits: { maxReqBody: number; chunk: number; maxInflight: number };
+    }
+  | {
+      t: "req";
+      id: number;
+      method: string;
+      url: string;
+      headers: [string, string][];
+      hasBody: boolean;
+    }
+  | { t: "req_end"; id: number }
+  | { t: "res"; id: number; status: number; headers: [string, string][] }
+  | { t: "res_end"; id: number }
+  | {
+      t: "abort";
+      id: number;
+      code:
+        | "timeout"
+        | "too_large"
+        | "client_gone"
+        | "upstream_error"
+        | "overloaded";
+      msg?: string;
+    };
+
+const BIN_REQ_CHUNK = 0x01;
+const BIN_RES_CHUNK = 0x02;
+
+function encodeBinaryFrame(
+  kind: number,
+  id: number,
+  payload: Uint8Array
+): Buffer {
+  const buf = Buffer.allocUnsafe(5 + payload.byteLength);
+  buf.writeUInt8(kind, 0);
+  buf.writeUInt32BE(id >>> 0, 1);
+  Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength).copy(
+    buf,
+    5
+  );
+  return buf;
+}
+
+function decodeBinaryFrame(
+  data: Buffer
+): { kind: number; id: number; payload: Buffer } | null {
+  if (data.byteLength < 5) return null;
+  return {
+    kind: data.readUInt8(0),
+    id: data.readUInt32BE(1),
+    payload: data.subarray(5),
+  };
+}
+
+export interface RelayConnectionOptions {
+  serverId: string;
+  slug: string;
+  /** wss://agent.tunnels.mcpjam.com/agent (from the backend grant). */
+  relayWsUrl: string;
+  connectToken: string;
+  /** Local inspector server base, e.g. http://localhost:6274 */
+  localAddr: string;
+  /** Public host injected by the edge; used for logging only here. */
+  publicHost: string;
+  onPermanentFailure?: (reason: string, closeCode: number) => void;
+}
+
+interface LocalRequest {
+  req: http.ClientRequest;
+  resumePoll: NodeJS.Timeout | null;
+}
+
+export class RelayConnection {
+  private ws: WebSocket | null = null;
+  private readonly local = new Map<number, LocalRequest>();
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private missedPongs = 0;
+  private reconnectDelayMs = RECONNECT_MIN_MS;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private closedByUs = false;
+  private permanent: string | null = null;
+
+  constructor(private readonly options: RelayConnectionOptions) {}
+
+  /** Resolves on the first successful hello; rejects on permanent failure. */
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          this.close();
+          reject(new Error("Timed out connecting to the tunnel relay"));
+        }
+      }, CONNECT_TIMEOUT_MS);
+      this.dial(
+        () => {
+          if (!settled) {
+            settled = true;
+            clearTimeout(timeout);
+            resolve();
+          }
+        },
+        (reason) => {
+          if (!settled) {
+            settled = true;
+            clearTimeout(timeout);
+            reject(new Error(reason));
+          }
+        }
+      );
+    });
+  }
+
+  get isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  get permanentFailure(): string | null {
+    return this.permanent;
+  }
+
+  private dial(
+    onHello?: () => void,
+    onPermanent?: (reason: string) => void
+  ): void {
+    if (this.closedByUs || this.permanent) return;
+    const ws = new WebSocket(this.options.relayWsUrl, RELAY_SUBPROTOCOL, {
+      headers: { Authorization: `Bearer ${this.options.connectToken}` },
+    });
+    this.ws = ws;
+
+    ws.on("message", (data, isBinary) => {
+      if (isBinary) {
+        this.handleBinary(data as Buffer);
+        return;
+      }
+      let frame: ControlFrame | null = null;
+      try {
+        frame = JSON.parse(String(data)) as ControlFrame;
+      } catch {
+        return;
+      }
+      if (frame.t === "hello") {
+        this.reconnectDelayMs = RECONNECT_MIN_MS;
+        logger.info(
+          `✓ Tunnel relay connected (${this.options.serverId}): ${this.options.publicHost}`
+        );
+        onHello?.();
+        return;
+      }
+      this.handleControl(frame);
+    });
+
+    ws.on("pong", () => {
+      this.missedPongs = 0;
+    });
+    ws.on("error", () => {
+      // 'close' always follows.
+    });
+    ws.on("open", () => this.startHeartbeat());
+    ws.on("close", (code, reasonBuf) => {
+      this.stopHeartbeat();
+      this.abortAllLocal();
+      if (this.closedByUs) return;
+      const reason = reasonBuf.toString() || `relay closed (${code})`;
+      if (
+        code === CLOSE_BAD_TOKEN ||
+        code === CLOSE_REPLACED ||
+        code === CLOSE_CONTROL_PLANE
+      ) {
+        const why =
+          code === CLOSE_REPLACED
+            ? "Tunnel taken over by another inspector instance — recreate the tunnel here to take it back"
+            : code === CLOSE_CONTROL_PLANE
+            ? "Tunnel was closed or its secret rotated elsewhere — recreate the tunnel"
+            : "Tunnel session expired — recreate the tunnel";
+        this.permanent = why;
+        logger.warn(`Tunnel relay closed permanently (${code}): ${reason}`);
+        onPermanent?.(why);
+        this.options.onPermanentFailure?.(why, code);
+        return;
+      }
+      const delay =
+        code === CLOSE_EDGE_RESTART
+          ? 0
+          : Math.floor(this.reconnectDelayMs * (0.5 + Math.random() * 0.5));
+      this.reconnectDelayMs = Math.min(
+        this.reconnectDelayMs * 2,
+        RECONNECT_MAX_MS
+      );
+      logger.warn(
+        `Tunnel relay disconnected (${code}); reconnecting in ${delay}ms`
+      );
+      this.reconnectTimer = setTimeout(() => this.dial(onHello), delay);
+    });
+  }
+
+  close(): void {
+    this.closedByUs = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.stopHeartbeat();
+    this.abortAllLocal();
+    try {
+      this.ws?.close();
+    } catch {
+      this.ws?.terminate();
+    }
+    this.ws = null;
+  }
+
+  // ── Edge frames → local server ────────────────────────────────────────────
+
+  private handleControl(frame: ControlFrame): void {
+    if (frame.t === "req") {
+      this.startLocalRequest(frame);
+    } else if (frame.t === "req_end") {
+      this.local.get(frame.id)?.req.end();
+    } else if (frame.t === "abort") {
+      const entry = this.local.get(frame.id);
+      if (entry) {
+        entry.req.destroy();
+        this.cleanupLocal(frame.id);
+      }
+    }
+    // 'res'/'res_end'/'hello' never arrive edge→agent beyond the handshake.
+  }
+
+  private handleBinary(data: Buffer): void {
+    const frame = decodeBinaryFrame(data);
+    if (!frame || frame.kind !== BIN_REQ_CHUNK) return;
+    this.local.get(frame.id)?.req.write(frame.payload);
+  }
+
+  private startLocalRequest(frame: Extract<ControlFrame, { t: "req" }>): void {
+    const base = new URL(this.options.localAddr);
+    const headers: Record<string, string | string[]> = {};
+    for (const [name, value] of frame.headers) {
+      const existing = headers[name];
+      if (existing === undefined) headers[name] = value;
+      else if (Array.isArray(existing)) existing.push(value);
+      else headers[name] = [existing, value];
+    }
+
+    const req = http.request({
+      host: base.hostname,
+      port: base.port || 80,
+      method: frame.method,
+      // Forwarded verbatim by the edge (?k= included): the adapter reads
+      // the bearer secret off this URL for its SSE `endpoint` event.
+      path: frame.url,
+      headers,
+    });
+    this.local.set(frame.id, { req, resumePoll: null });
+
+    req.on("response", (res) => {
+      const responseHeaders: [string, string][] = [];
+      for (let i = 0; i + 1 < res.rawHeaders.length; i += 2) {
+        responseHeaders.push([
+          res.rawHeaders[i] as string,
+          res.rawHeaders[i + 1] as string,
+        ]);
+      }
+      this.sendControl({
+        t: "res",
+        id: frame.id,
+        status: res.statusCode ?? 502,
+        headers: responseHeaders,
+      });
+      res.on("data", (chunk: Buffer) => {
+        const ws = this.ws;
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          res.destroy();
+          return;
+        }
+        for (let off = 0; off < chunk.byteLength; off += CHUNK_BYTES) {
+          ws.send(
+            encodeBinaryFrame(
+              BIN_RES_CHUNK,
+              frame.id,
+              chunk.subarray(off, off + CHUNK_BYTES)
+            )
+          );
+        }
+        // Backpressure: stop reading the local response while the socket's
+        // send buffer is saturated (a slow public client far away).
+        if (ws.bufferedAmount > WS_BACKPRESSURE_HIGH_WATER_BYTES) {
+          res.pause();
+          const entry = this.local.get(frame.id);
+          if (entry && !entry.resumePoll) {
+            entry.resumePoll = setInterval(() => {
+              if (ws.bufferedAmount < WS_BACKPRESSURE_HIGH_WATER_BYTES / 2) {
+                if (entry.resumePoll) clearInterval(entry.resumePoll);
+                entry.resumePoll = null;
+                res.resume();
+              }
+            }, 25);
+          }
+        }
+      });
+      res.on("end", () => {
+        this.sendControl({ t: "res_end", id: frame.id });
+        this.cleanupLocal(frame.id);
+      });
+      res.on("error", () => {
+        this.sendControl({
+          t: "abort",
+          id: frame.id,
+          code: "upstream_error",
+        });
+        this.cleanupLocal(frame.id);
+      });
+    });
+    req.on("error", () => {
+      this.sendControl({ t: "abort", id: frame.id, code: "upstream_error" });
+      this.cleanupLocal(frame.id);
+    });
+    if (!frame.hasBody) req.end();
+  }
+
+  private cleanupLocal(id: number): void {
+    const entry = this.local.get(id);
+    if (entry?.resumePoll) clearInterval(entry.resumePoll);
+    this.local.delete(id);
+  }
+
+  private abortAllLocal(): void {
+    for (const [id, entry] of [...this.local]) {
+      entry.req.destroy();
+      this.cleanupLocal(id);
+    }
+  }
+
+  private sendControl(frame: ControlFrame): void {
+    try {
+      this.ws?.send(JSON.stringify(frame));
+    } catch {
+      // Socket closing; the close handler aborts local requests.
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.missedPongs = 0;
+    this.heartbeatTimer = setInterval(() => {
+      const ws = this.ws;
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      if (this.missedPongs >= HEARTBEAT_MISSED_LIMIT) {
+        // A slept laptop notices its dead socket here; terminate triggers
+        // the close handler, which reconnects with backoff.
+        ws.terminate();
+        return;
+      }
+      this.missedPongs++;
+      try {
+        ws.ping();
+      } catch {
+        // close path follows
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+}

--- a/mcpjam-inspector/server/services/tunnel-locks.ts
+++ b/mcpjam-inspector/server/services/tunnel-locks.ts
@@ -1,9 +1,9 @@
 /**
  * Per-server serialization for tunnel lifecycle operations (create, rotate,
- * close). Provisioning spans several non-atomic steps — backend token mint
- * (which revokes the previous credential), ngrok listen, state recording —
- * so two overlapping requests for the same server could otherwise leave the
- * live listener enforcing one secret while persistence holds another.
+ * close). Provisioning spans several non-atomic steps — backend grant mint
+ * (which rotates the secret server-side) and the relay connect — so two
+ * overlapping requests for the same server could otherwise leave the live
+ * connection bound to one grant while the edge enforces another.
  *
  * Callers must re-check current state (e.g. "does a listener already
  * exist?") inside the locked section: the second of two racing creates

--- a/mcpjam-inspector/server/services/tunnel-manager.ts
+++ b/mcpjam-inspector/server/services/tunnel-manager.ts
@@ -67,6 +67,20 @@ class TunnelManager {
       throw error;
     }
 
+    // A permanent close (4000/4001/4002) can land between the handshake
+    // resolving and the registration below; its onPermanentFailure→dropEntry
+    // would be a no-op (entry not in the map yet), and we'd register a dead
+    // connection. Bail if the relay already gave up — this synchronous check
+    // and the registration that follows can't be interleaved by a later
+    // 'close' event, so registering past it is safe (that drop finds the
+    // entry).
+    if (connection.permanentFailure) {
+      const reason = connection.permanentFailure;
+      connection.close();
+      logger.warn(`✗ Tunnel (${serverId}) died during handshake: ${reason}`);
+      throw new Error(reason);
+    }
+
     const baseUrl = `https://${host}`;
     this.tunnels.set(serverId, {
       connection,

--- a/mcpjam-inspector/server/services/tunnel-manager.ts
+++ b/mcpjam-inspector/server/services/tunnel-manager.ts
@@ -1,168 +1,122 @@
-import ngrok from "@ngrok/ngrok";
-import type { Listener } from "@ngrok/ngrok";
 import { logger } from "../utils/logger";
+import { RelayConnection, type RelayConnectionOptions } from "./relay-client";
 import {
   registerTunnelDomain,
   unregisterTunnelDomain,
 } from "./tunnel-registry";
 
 interface TunnelEntry {
-  listener: Listener;
+  connection: RelayConnection;
+  /** Public host ({slug}.tunnels.mcpjam.com) registered for isolation checks. */
+  host: string;
   baseUrl: string;
-  credentialId?: string;
-  domainId?: string;
-  domain?: string;
+  slug: string;
   // Full bearer URL (contains the ?k= secret). Held in memory ONLY — the
   // backend persists just the secret hash, so this entry is the single
-  // holder of the plaintext URL while the listener is live.
-  publicUrl?: string;
+  // holder of the plaintext URL while the connection lives.
+  publicUrl: string;
   secretVersion?: number;
 }
 
-interface CreateTunnelOptions {
-  localAddr?: string;
-  ngrokToken: string;
-  credentialId?: string;
-  domainId?: string;
-  domain?: string;
-  // Stringified ngrok Traffic Policy enforcing the bearer secret, the
-  // per-server path scope, and rate limiting at the edge.
-  trafficPolicy?: string;
-  publicUrl?: string;
+export interface CreateTunnelOptions {
+  localAddr: string;
+  slug: string;
+  relayWsUrl: string;
+  connectToken: string;
+  publicUrl: string;
   secretVersion?: number;
 }
 
 class TunnelManager {
   private tunnels: Map<string, TunnelEntry> = new Map();
-  private readonly sharedTunnelId = "shared";
 
+  /**
+   * Open the relay connection for a server and return the public base URL.
+   * Idempotent per server: an existing live tunnel is returned as-is.
+   */
   async createTunnel(
-    tunnelId: string,
+    serverId: string,
     options: CreateTunnelOptions
   ): Promise<string> {
-    const existingTunnel = this.tunnels.get(tunnelId);
+    const existingTunnel = this.tunnels.get(serverId);
     if (existingTunnel) {
       return existingTunnel.baseUrl;
     }
 
-    const addr = options.localAddr || "http://localhost:6274";
+    const host = new URL(options.publicUrl).hostname;
+    const connection = new RelayConnection({
+      serverId,
+      slug: options.slug,
+      relayWsUrl: options.relayWsUrl,
+      connectToken: options.connectToken,
+      localAddr: options.localAddr,
+      publicHost: host,
+      onPermanentFailure: (reason, code) => {
+        // The relay refused this grant for good (expired, replaced by
+        // another inspector, or revoked) — drop the entry so the UI offers
+        // a fresh create instead of advertising a dead URL.
+        this.dropEntry(serverId, reason, code);
+      },
+    } satisfies RelayConnectionOptions);
 
     try {
-      const config: any = {
-        addr,
-        authtoken: options.ngrokToken,
-      };
-
-      if (options.domain) {
-        config.domain = options.domain;
-        // Add X-Forwarded-Host and X-Forwarded-Proto headers to preserve the original
-        // ngrok domain and protocol. This allows downstream servers to know the public URL.
-        config.request_header_add = [
-          `X-Forwarded-Host:${options.domain}`,
-          `X-Forwarded-Proto:https`,
-        ];
-      }
-
-      if (options.trafficPolicy) {
-        config.traffic_policy = options.trafficPolicy;
-      }
-
-      const listener = await ngrok.forward(config);
-      const baseUrl = listener.url()!;
-      this.tunnels.set(tunnelId, {
-        listener,
-        baseUrl,
-        credentialId: options.credentialId,
-        domainId: options.domainId,
-        domain: options.domain,
-        publicUrl: options.publicUrl,
-        secretVersion: options.secretVersion,
-      });
-      if (options.domain) {
-        registerTunnelDomain(
-          options.domain,
-          tunnelId === this.sharedTunnelId ? null : tunnelId
-        );
-      }
-
-      logger.info(`✓ Created tunnel (${tunnelId}): ${baseUrl} -> ${addr}`);
-      return baseUrl;
+      await connection.connect();
     } catch (error: any) {
+      connection.close();
       logger.error(`✗ Failed to create tunnel:`, error);
       throw error;
     }
+
+    const baseUrl = `https://${host}`;
+    this.tunnels.set(serverId, {
+      connection,
+      host,
+      baseUrl,
+      slug: options.slug,
+      publicUrl: options.publicUrl,
+      secretVersion: options.secretVersion,
+    });
+    registerTunnelDomain(host, serverId);
+
+    logger.info(
+      `✓ Created tunnel (${serverId}): ${baseUrl} -> ${options.localAddr}`
+    );
+    return baseUrl;
   }
 
   /**
-   * Re-establish the listener with a fresh authtoken + traffic policy.
-   * ngrok bakes both in at listen time, so rotation is close-then-forward;
-   * the reserved domain is reused so the base URL never changes — only the
-   * bearer secret in the policy/URL does.
+   * Re-establish the connection with a fresh grant (rotation). The slug is
+   * normally stable so the base URL never changes — only the bearer secret
+   * in the URL does (a `full` rotation swaps the slug too). The backend has
+   * already revoked the old grant at the edge, so close-then-connect is
+   * pure reconnection, not revocation.
    */
   async rotateTunnel(
-    tunnelId: string,
+    serverId: string,
     options: CreateTunnelOptions
   ): Promise<string> {
-    await this.closeTunnel(tunnelId);
-    return this.createTunnel(tunnelId, options);
+    await this.closeTunnel(serverId);
+    return this.createTunnel(serverId, options);
   }
 
-  async closeTunnel(tunnelId: string): Promise<void> {
-    const entry = this.tunnels.get(tunnelId);
+  async closeTunnel(serverId: string): Promise<void> {
+    const entry = this.tunnels.get(serverId);
     if (!entry) {
       return;
     }
 
-    await entry.listener.close();
-    this.tunnels.delete(tunnelId);
-    if (entry.domain) {
-      unregisterTunnelDomain(entry.domain);
-    }
-    logger.info(`✓ Closed tunnel (${tunnelId})`);
-
-    try {
-      if (this.tunnels.size === 0) {
-        await ngrok.disconnect();
-      }
-    } catch (error) {
-      // Already disconnected or no active listeners
-    }
-  }
-
-  getCredentialId(tunnelId: string): string | null {
-    return this.tunnels.get(tunnelId)?.credentialId ?? null;
-  }
-
-  getDomainId(tunnelId: string): string | null {
-    return this.tunnels.get(tunnelId)?.domainId ?? null;
-  }
-
-  clearCredentials(tunnelId: string): void {
-    const entry = this.tunnels.get(tunnelId);
-    if (!entry) {
-      return;
-    }
-    entry.credentialId = undefined;
-    entry.domainId = undefined;
-    entry.domain = undefined;
-  }
-
-  getTunnelUrl(tunnelId: string = this.sharedTunnelId): string | null {
-    return this.tunnels.get(tunnelId)?.baseUrl ?? null;
+    entry.connection.close();
+    this.tunnels.delete(serverId);
+    unregisterTunnelDomain(entry.host);
+    logger.info(`✓ Closed tunnel (${serverId})`);
   }
 
   getServerTunnelUrl(serverId: string): string | null {
-    const entry = this.tunnels.get(serverId);
-    if (!entry) {
-      return null;
-    }
-    // Prefer the bearer URL (contains the edge-enforced secret); fall back
-    // to the bare adapter path for legacy listeners without a policy.
-    if (entry.publicUrl) {
-      return entry.publicUrl;
-    }
-    const encodedServerId = encodeURIComponent(serverId);
-    return `${entry.baseUrl}/api/mcp/adapter-http/${encodedServerId}`;
+    return this.tunnels.get(serverId)?.publicUrl ?? null;
+  }
+
+  getServerTunnelSlug(serverId: string): string | null {
+    return this.tunnels.get(serverId)?.slug ?? null;
   }
 
   hasTunnel(): boolean {
@@ -170,16 +124,18 @@ class TunnelManager {
   }
 
   async closeAll(): Promise<void> {
-    const tunnelIds = [...this.tunnels.keys()];
-    for (const tunnelId of tunnelIds) {
-      await this.closeTunnel(tunnelId);
+    const serverIds = [...this.tunnels.keys()];
+    for (const serverId of serverIds) {
+      await this.closeTunnel(serverId);
     }
+  }
 
-    try {
-      await ngrok.disconnect();
-    } catch (error) {
-      // Already disconnected
-    }
+  private dropEntry(serverId: string, reason: string, code: number): void {
+    const entry = this.tunnels.get(serverId);
+    if (!entry) return;
+    this.tunnels.delete(serverId);
+    unregisterTunnelDomain(entry.host);
+    logger.warn(`Tunnel (${serverId}) ended by relay [${code}]: ${reason}`);
   }
 }
 

--- a/mcpjam-inspector/server/services/tunnel-manager.ts
+++ b/mcpjam-inspector/server/services/tunnel-manager.ts
@@ -44,6 +44,8 @@ class TunnelManager {
     }
 
     const host = new URL(options.publicUrl).hostname;
+    let registered = false;
+    let earlyPermanentFailure: { reason: string; code: number } | null = null;
     const connection = new RelayConnection({
       serverId,
       slug: options.slug,
@@ -55,12 +57,26 @@ class TunnelManager {
         // The relay refused this grant for good (expired, replaced by
         // another inspector, or revoked) — drop the entry so the UI offers
         // a fresh create instead of advertising a dead URL.
+        if (!registered) {
+          earlyPermanentFailure = { reason, code };
+          return;
+        }
         this.dropEntry(serverId, reason, code);
       },
     } satisfies RelayConnectionOptions);
 
     try {
       await connection.connect();
+      if (earlyPermanentFailure || connection.permanentFailure) {
+        throw new Error(
+          earlyPermanentFailure?.reason ??
+            connection.permanentFailure ??
+            "Tunnel relay closed permanently before registration"
+        );
+      }
+      if (!connection.isConnected) {
+        throw new Error("Tunnel relay closed before registration");
+      }
     } catch (error: any) {
       connection.close();
       logger.error(`✗ Failed to create tunnel:`, error);
@@ -76,6 +92,7 @@ class TunnelManager {
       publicUrl: options.publicUrl,
       secretVersion: options.secretVersion,
     });
+    registered = true;
     registerTunnelDomain(host, serverId);
 
     logger.info(

--- a/mcpjam-inspector/server/services/tunnel-registry.ts
+++ b/mcpjam-inspector/server/services/tunnel-registry.ts
@@ -4,9 +4,8 @@
  * HTTP adapter (per-server isolation guard, request logging) and the
  * session-token paths (tunnel-host leak invariant).
  *
- * Lives apart from tunnel-manager so consumers don't transitively load
- * the native @ngrok/ngrok module just to ask "did this request arrive
- * through a tunnel?".
+ * Lives apart from tunnel-manager so consumers can ask "did this request
+ * arrive through a tunnel?" without loading the relay-client machinery.
  */
 
 // domain (lowercase hostname) → bound serverId, or null for the legacy

--- a/mcpjam-inspector/server/utils/__tests__/localhost-check.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/localhost-check.test.ts
@@ -240,11 +240,18 @@ describe("mayServeSessionToken", () => {
         hostedMode: false,
       })
     ).toBe(false);
+    expect(
+      mayServeSessionToken({
+        host: "abc123.tunnels.mcpjam.com",
+        allowedHosts: [],
+        hostedMode: false,
+      })
+    ).toBe(false);
   });
 
   it("denies tunnel hosts via X-Forwarded-Host even when Host is localhost", () => {
-    // This is the real tunnel shape: ngrok forwards to localhost with the
-    // public domain carried in X-Forwarded-Host.
+    // This is the real tunnel shape: the relay edge forwards to localhost
+    // with the public domain carried in X-Forwarded-Host.
     expect(
       mayServeSessionToken({
         host: "localhost:6274",
@@ -253,15 +260,30 @@ describe("mayServeSessionToken", () => {
         hostedMode: false,
       })
     ).toBe(false);
+    expect(
+      mayServeSessionToken({
+        host: "localhost:6274",
+        forwardedHost: "abc123.tunnels.mcpjam.com",
+        allowedHosts: [],
+        hostedMode: false,
+      })
+    ).toBe(false);
   });
 
   it("SECURITY INVARIANT: denies a tunnel host even when allowlisted", () => {
-    // A future config mistake that allowlists an ngrok domain must not
+    // A future config mistake that allowlists a tunnel domain must not
     // start leaking the session token through the tunnel.
     expect(
       mayServeSessionToken({
         host: "abc123.ngrok.app",
         allowedHosts: ["abc123.ngrok.app", "*.ngrok.app"],
+        hostedMode: true,
+      })
+    ).toBe(false);
+    expect(
+      mayServeSessionToken({
+        host: "abc123.tunnels.mcpjam.com",
+        allowedHosts: ["abc123.tunnels.mcpjam.com", "*.tunnels.mcpjam.com"],
         hostedMode: true,
       })
     ).toBe(false);

--- a/mcpjam-inspector/server/utils/__tests__/localhost-check.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/localhost-check.test.ts
@@ -183,7 +183,15 @@ describe("isLocalhostRequest", () => {
 });
 
 describe("isTunnelHost", () => {
-  it("matches ngrok-controlled suffixes regardless of subdomain", () => {
+  it("matches the relay suffix regardless of subdomain", () => {
+    expect(isTunnelHost("x7d9j2m1p9k3.tunnels.mcpjam.com")).toBe(true);
+    expect(isTunnelHost("x7d9j2m1p9k3.tunnels.mcpjam.com:443")).toBe(true);
+    // Suffix-anchored: lookalike hosts must not match.
+    expect(isTunnelHost("eviltunnels.mcpjam.com")).toBe(false);
+    expect(isTunnelHost("tunnels.mcpjam.com.evil.example")).toBe(false);
+  });
+
+  it("matches legacy ngrok suffixes regardless of subdomain (defense-in-depth)", () => {
     expect(isTunnelHost("x7d9j2m1p9k3.ngrok.app")).toBe(true);
     expect(isTunnelHost("foo.ngrok.dev")).toBe(true);
     expect(isTunnelHost("foo.ngrok-free.app")).toBe(true);

--- a/mcpjam-inspector/server/utils/error-classify.ts
+++ b/mcpjam-inspector/server/utils/error-classify.ts
@@ -20,9 +20,10 @@ export function classifyWidgetError(error: unknown, hint?: string): string {
   return "unknown";
 }
 
-export function classifyTunnelError(error: unknown, hint?: string): string {
-  if (hint === "fetch_ngrok_token_failed") return "fetch_ngrok_token_failed";
-  if (hint === "ngrok_create_failed") return "ngrok_create_failed";
-  if (hint === "convex_record_failed") return "convex_record_failed";
+// Relay-era codes (PostHog continuity break vs. the ngrok-era
+// fetch_ngrok_token_failed / ngrok_create_failed / convex_record_failed).
+export function classifyTunnelError(_error: unknown, hint?: string): string {
+  if (hint === "fetch_relay_grant_failed") return "fetch_relay_grant_failed";
+  if (hint === "relay_connect_failed") return "relay_connect_failed";
   return "unknown";
 }

--- a/mcpjam-inspector/server/utils/localhost-check.ts
+++ b/mcpjam-inspector/server/utils/localhost-check.ts
@@ -45,10 +45,13 @@ export function isLocalhostRequest(hostHeader: string | undefined): boolean {
 }
 
 /**
- * ngrok-controlled host suffixes. Matching is suffix-based so any reserved
- * subdomain (e.g. "x7d9j2m1p9k3.ngrok.app") is covered.
+ * Tunnel host suffixes. Matching is suffix-based so any tunnel subdomain
+ * (e.g. "x7d9j2m1p9k3.tunnels.mcpjam.com") is covered. The retired ngrok
+ * suffixes stay as defense-in-depth for stragglers with live ngrok
+ * listeners from older versions.
  */
 const TUNNEL_HOST_SUFFIXES = [
+  ".tunnels.mcpjam.com",
   ".ngrok.app",
   ".ngrok.dev",
   ".ngrok-free.app",
@@ -57,18 +60,18 @@ const TUNNEL_HOST_SUFFIXES = [
 ];
 
 /**
- * Check whether the Host header belongs to a tunnel (ngrok) domain.
+ * Check whether the Host header belongs to a tunnel (relay) domain.
  *
  * SECURITY INVARIANT: the session token must NEVER be served or injected
  * for a tunnel host — tunnels expose the MCP adapter surface to the public
  * internet, and the bearer secret in the tunnel URL is the only credential
  * remote clients are meant to hold. This check is enforced independently of
- * `isAllowedHost` so a future config that allowlists an ngrok domain cannot
+ * `isAllowedHost` so a future config that allowlists a tunnel domain cannot
  * silently start leaking the session token through the tunnel.
  *
  * @param hostHeader - The Host header value from the request (the original
- *   ngrok host survives forwarding via the X-Forwarded-Host header the
- *   tunnel listener injects; callers should check both).
+ *   tunnel host survives forwarding via the X-Forwarded-Host header the
+ *   relay edge injects; callers should check both).
  * @param extraTunnelHosts - Exact additional tunnel hostnames to treat as
  *   tunnels (e.g. the domains of currently active listeners).
  */
@@ -90,7 +93,7 @@ export function isTunnelHost(
  * Single decision point for serving/injecting the session token.
  *
  * Tunnel hosts are denied BEFORE the allowlist is consulted, so even a
- * misconfiguration that adds an ngrok domain to MCPJAM_ALLOWED_HOSTS can
+ * misconfiguration that adds a tunnel domain to MCPJAM_ALLOWED_HOSTS can
  * never leak the session token through a tunnel.
  */
 export function mayServeSessionToken(options: {

--- a/mcpjam-inspector/vite.main.config.ts
+++ b/mcpjam-inspector/vite.main.config.ts
@@ -42,7 +42,6 @@ export default defineConfig({
     rollupOptions: {
       external: [
         "electron",
-        "@ngrok/ngrok",
         ...builtinModules,
         ...builtinModules.map((m) => `node:${m}`),
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -321,7 +321,6 @@
         "@mcpjam/sdk": "^1.16.0",
         "@modelcontextprotocol/client": "^2.0.0-alpha.2",
         "@modelcontextprotocol/ext-apps": "^1.7.2",
-        "@ngrok/ngrok": "^1.6.0",
         "@openrouter/ai-sdk-provider": "^2.0.2",
         "@sentry/electron": "^5.10.0",
         "@sentry/node": "^8.47.0",
@@ -380,6 +379,7 @@
         "update-electron-app": "^3.1.1",
         "url-template": "^3.1.1",
         "use-stick-to-bottom": "^1.1.1",
+        "ws": "^8.18.0",
         "zod": "^4.1.12",
         "zustand": "^5.0.6"
       },
@@ -410,6 +410,7 @@
         "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/ws": "^8.5.13",
         "@typescript-eslint/parser": "^8.53.1",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^3.2.4",
@@ -670,7 +671,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -1209,7 +1210,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -1223,7 +1224,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1233,7 +1234,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1247,7 +1248,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1257,7 +1258,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2447,7 +2448,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2467,7 +2468,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2491,7 +2492,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2519,7 +2520,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2542,7 +2543,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2567,7 +2568,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4807,7 +4808,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -6331,7 +6332,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -6989,235 +6990,6 @@
       "version": "15.5.15",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
       "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.7.0.tgz",
-      "integrity": "sha512-P06o9TpxrJbiRbHQkiwy/rUrlXRupc+Z8KT4MiJfmcdWxvIdzjCaJOdnNkcOTs6DMyzIOefG5tvk/HLdtjqr0g==",
-      "license": "(MIT OR Apache-2.0)",
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@ngrok/ngrok-android-arm64": "1.7.0",
-        "@ngrok/ngrok-darwin-arm64": "1.7.0",
-        "@ngrok/ngrok-darwin-universal": "1.7.0",
-        "@ngrok/ngrok-darwin-x64": "1.7.0",
-        "@ngrok/ngrok-freebsd-x64": "1.7.0",
-        "@ngrok/ngrok-linux-arm-gnueabihf": "1.7.0",
-        "@ngrok/ngrok-linux-arm64-gnu": "1.7.0",
-        "@ngrok/ngrok-linux-arm64-musl": "1.7.0",
-        "@ngrok/ngrok-linux-x64-gnu": "1.7.0",
-        "@ngrok/ngrok-linux-x64-musl": "1.7.0",
-        "@ngrok/ngrok-win32-arm64-msvc": "1.7.0",
-        "@ngrok/ngrok-win32-ia32-msvc": "1.7.0",
-        "@ngrok/ngrok-win32-x64-msvc": "1.7.0"
-      }
-    },
-    "node_modules/@ngrok/ngrok-android-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.7.0.tgz",
-      "integrity": "sha512-8tco3ID6noSaNy+CMS7ewqPoIkIM6XO5COCzsUp3Wv3XEbMSyn65RN6cflX2JdqLfUCHcMyD0ahr9IEiHwqmbQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-darwin-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.7.0.tgz",
-      "integrity": "sha512-+dmJSOzSO+MNDVrPOca2yYDP1W3KfP4qOlAkarIeFRIfqonQwq3QCBmcR7HAlZocLsSqEwyG6KP4RRvAuT0WGQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-darwin-universal": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.7.0.tgz",
-      "integrity": "sha512-fDEfewyE2pWGFBhOSwQZObeHUkc65U1l+3HIgSOe094TMHsqmyJD0KTCgW9KSn0VP4OvDZbAISi1T3nvqgZYhQ==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-darwin-x64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.7.0.tgz",
-      "integrity": "sha512-+fwMi5uHd9G8BS42MMa9ye6exI5lwTcjUO6Ut497Vu0qgLONdVRenRqnEePV+Q3KtQR7NjqkMnomVfkr9MBjtw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-freebsd-x64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.7.0.tgz",
-      "integrity": "sha512-2OGgbrjy3yLRrqAz5N6hlUKIWIXSpR5RjQa2chtZMsSbszQ6c9dI+uVQfOKAeo05tHMUgrYAZ7FocC+ig0dzdQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-linux-arm-gnueabihf": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.7.0.tgz",
-      "integrity": "sha512-SN9YIfEQiR9xN90QVNvdgvAemqMLoFVSeTWZs779145hQMhvF9Qd9rnWi6J+2uNNK10OczdV1oc/nq1es7u/3g==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-linux-arm64-gnu": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.7.0.tgz",
-      "integrity": "sha512-KDMgzPKFU2kbpVSaA2RZBBia5IPdJEe063YlyVFnSMJmPYWCUnMwdybBsucXfV9u1Lw/ZjKTKotIlbTWGn3HGw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-linux-arm64-musl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.7.0.tgz",
-      "integrity": "sha512-e66vUdVrBlQ0lT9ZdamB4U604zt5Gualt8/WVcUGzbu8s5LajWd6g/mzZCUjK4UepjvMpfgmCp1/+rX7Rk8d5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-linux-x64-gnu": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.7.0.tgz",
-      "integrity": "sha512-M6gF0DyOEFqXLfWxObfL3bxYZ4+PnKBHuyLVaqNfFN9Y5utY2mdPOn5422Ppbk4XoIK5/YkuhRqPJl/9FivKEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-linux-x64-musl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.7.0.tgz",
-      "integrity": "sha512-4Ijm0dKeoyzZTMaYxR2EiNjtlK81ebflg/WYIO1XtleFrVy4UJEGnxtxEidYoT4BfCqi4uvXiK2Mx216xXKvog==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-win32-arm64-msvc": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-arm64-msvc/-/ngrok-win32-arm64-msvc-1.7.0.tgz",
-      "integrity": "sha512-u7qyWIJI2/YG1HTBnHwUR1+Z2tyGfAsUAItJK/+N1G0FeWJhIWQvSIFJHlaPy4oW1Dc8mSDBX9qvVsiQgLaRFg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-win32-ia32-msvc": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.7.0.tgz",
-      "integrity": "sha512-/UdYUsLNv/Q8j9YJsyIfq/jLCoD8WP+NidouucTUzSoDtmOsXBBT3itLrmPiZTEdEgKiFYLuC1Zon8XQQvbVLA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ngrok/ngrok-win32-x64-msvc": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.7.0.tgz",
-      "integrity": "sha512-UFJg/duEWzZlLkEs61Gz6/5nYhGaKI62I8dvUGdBR3NCtIMagehnFaFxmnXZldyHmCM8U0aCIFNpWRaKcrQkoA==",
       "cpu": [
         "x64"
       ],
@@ -8766,7 +8538,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -14089,7 +13861,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -14099,7 +13870,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -14186,6 +13957,16 @@
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -16596,7 +16377,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -16818,7 +16599,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -17931,7 +17712,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -17952,7 +17733,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -17968,7 +17749,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -18539,7 +18320,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -18553,7 +18334,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -18650,7 +18431,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -20027,7 +19808,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -20038,7 +19818,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -22820,7 +22599,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -22887,7 +22666,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -22901,7 +22680,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -23714,7 +23493,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -25117,7 +24896,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -25157,7 +24936,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -25167,7 +24946,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -25181,7 +24960,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -25576,7 +25355,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -25609,7 +25388,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25630,7 +25408,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25651,7 +25428,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25672,7 +25448,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25693,7 +25468,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25714,7 +25488,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25735,7 +25508,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25756,7 +25528,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25777,7 +25548,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25798,7 +25568,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25819,7 +25588,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26738,7 +26506,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -29489,7 +29257,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -30405,7 +30173,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -31819,7 +31587,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -31911,7 +31679,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -32585,7 +32353,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -32604,7 +32372,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -33301,7 +33069,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -33448,7 +33216,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -33532,7 +33300,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -33790,7 +33558,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
       "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -33803,7 +33571,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -33907,7 +33675,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -33920,7 +33688,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -34268,7 +34036,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -34451,7 +34219,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -35464,7 +35232,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -35540,7 +35308,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -35645,7 +35413,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -35655,7 +35423,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -36503,7 +36271,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -36523,7 +36291,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {


### PR DESCRIPTION
## Summary
This PR replaces the ngrok-based tunneling system with a new MCPJam relay-based tunneling implementation. The relay uses WebSocket connections to the MCPJam backend edge, providing per-server tunnel isolation with bearer secret enforcement at the edge rather than via ngrok's traffic policies.

## Key Changes

### New Relay Client (`relay-client.ts`)
- Implements `RelayConnection` class that manages a single outbound WebSocket per tunneled server
- Speaks the `mcpjam-tunnel.v1` protocol with the relay edge
- Handles bidirectional frame exchange: receives `req` frames from the edge, forwards them to the local inspector server, and streams responses back as binary chunks
- Implements automatic reconnection with exponential backoff (1s→30s) for transient failures
- Treats permanent failures (4000/4001/4002 close codes) as terminal, surfacing them to the caller
- Includes heartbeat/ping-pong mechanism to detect dead sockets
- Manages backpressure when the WebSocket send buffer saturates

### Updated Tunnel Manager (`tunnel-manager.ts`)
- Replaced ngrok `Listener` with `RelayConnection`
- Simplified tunnel entry structure: removed ngrok-specific fields (credentialId, domainId, traffic policy)
- Added `slug` and `host` fields for relay-based identification
- Removed two-phase rotation commit logic (backend now does single-phase rotation with immediate revocation)
- Removed `recordTunnel()` and `reportRotationFailed()` functions (no longer needed with relay model)
- Tunnel lifecycle is now tied to WebSocket connection lifetime

### Updated Tunnel Routes (`tunnels.ts`)
- Removed legacy shared tunnel endpoint (`POST /create`)
- Renamed `fetchNgrokToken()` → `fetchRelayGrant()` with updated response handling
- Renamed `stageRotation()` → `fetchRotationGrant()` with single-phase semantics
- Removed `recordTunnel()` and `reportRotationFailed()` calls
- Updated response payloads: return `slug` instead of `domain`, removed `credentialIdPresent` field
- Added `transport=relay` query parameter to backend requests to signal relay capability
- Improved error classification for relay-specific failures

### API Changes (Client)
- Removed `createTunnel()` and `getTunnel()` functions (shared tunnel deprecated)
- Updated `ServerTunnelResponse` interface: `domain` → `slug`
- Kept `createServerTunnel()`, `getServerTunnel()`, `rotateServerTunnel()`, `closeServerTunnel()`

### Dependencies
- Removed `@ngrok/ngrok` dependency
- Added `ws` (WebSocket) for relay client implementation

### Supporting Updates
- Updated localhost check to recognize `tunnels.mcpjam.com` suffix (replacing ngrok.app)
- Updated error classification for relay-specific error codes
- Updated comments and documentation to reflect relay terminology
- Updated test mocks to use relay URLs instead of ngrok URLs

## Implementation Details

**Grant Model**: The backend mints a `RelayGrant` containing:
- `slug`: stable identifier for the tunnel (reused across rotations unless `full=true`)
- `url`: public bearer URL with `?k=` secret (held in memory only)
- `relayWsUrl`: edge WebSocket endpoint
- `connectToken`: bearer token for WebSocket auth
- `secretVersion`: for tracking rotations

**Protocol**: The relay edge sends control frames (JSON) and binary chunks (5-byte header + payload):
- `req` frame: method, URL (with `?k=` secret), headers, body flag
- Binary chunks: request body or response body (kind 0x01 or 0x02)
- `res` frame: status code and response headers
- `abort` frame: error codes (timeout, too_large, client_gone, upstream_error, overloaded)

**Lifecycle**: Unlike ngrok (which persists the domain), the relay tunnel is live exactly while the WebSocket is connected. Permanent failures (expired token, replaced by another inspector, revoked by control plane) are surfaced immediately rather than retried.

https://claude.ai/code/session_01FtmvshWYkLvS1uyWE32BjK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large architectural swap in remote exposure (auth grants, WebSocket lifecycle, edge revocation) plus session-token/tunnel-host invariants; requires a relay-enabled Convex backend to work.
> 
> **Overview**
> **Replaces ngrok with MCPJam relay tunnels** for per-server exposure: the inspector opens an outbound WebSocket to the relay edge (`mcpjam-tunnel.v1`), forwards inbound HTTP to localhost, and drops `@ngrok/ngrok` plus Electron Forge native ngrok packaging. Server routes now fetch **relay grants** from Convex (`transport=relay`), use **single-phase** secret rotation (no `recordTunnel` / two-phase commit), and remove the legacy **shared** tunnel HTTP API and client helpers.
> 
> **UI and safety:** `ServerConnectionCard` **polls `getServerTunnel`** (immediate + every 5s) to clear dead URLs and warn when the relay ended the tunnel; copy is disabled during create/rotate/close. Copy and modals say **“tunnel”** instead of **“ngrok”**; `localhost-check` treats `*.tunnels.mcpjam.com` as tunnel hosts (ngrok suffixes kept for older clients).
> 
> **Tests:** New `relay-client` and tunnel-manager relay tests; expanded card tests for revalidation, mid-rotate copy lock, and stable auth mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a4cf97f8bc3d343097b0e94452080a308c4388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->