### PR TITLE
evals: open Computer Use to any vision + tool-calling model

### DIFF
--- a/mcpjam-inspector/server/services/__tests__/browser-session-context.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/browser-session-context.test.ts
@@ -20,6 +20,16 @@ vi.mock("../../utils/mcp-app-render-observation", () => ({
     isRenderableMcpAppTool(...args),
 }));
 
+// Capability lookup is network-backed (OpenRouter catalog) — stub it. Claude
+// ids never reach it (offline fast path); the default `false` preserves the
+// "no computer tools" behavior for unknown drivers.
+const modelSupportsComputerUse = vi.fn();
+
+vi.mock("../../utils/model-capabilities", () => ({
+  modelSupportsComputerUse: (...args: unknown[]) =>
+    modelSupportsComputerUse(...args),
+}));
+
 const harnessInstances: Array<{
   getMountedWidgetId: ReturnType<typeof vi.fn>;
   dismissWidget: ReturnType<typeof vi.fn>;
@@ -62,33 +72,38 @@ beforeEach(() => {
   vi.clearAllMocks();
   harnessInstances.length = 0;
   isRenderableMcpAppTool.mockReturnValue(false);
+  modelSupportsComputerUse.mockResolvedValue(false);
 });
 
 describe("createBrowserSessionContext — Computer Use surface", () => {
-  it("builds wire-format computer tools + gate for Claude drivers", () => {
-    const ctx = createBrowserSessionContext({
+  it("builds wire-format computer tools + gate for Claude drivers", async () => {
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
 
+    expect(ctx.computerUseSupported).toBe(true);
     expect(ctx.computerUseVersion).toBe("20250124");
+    // Claude ids resolve offline — the catalog lookup is never consulted.
+    expect(modelSupportsComputerUse).not.toHaveBeenCalled();
     expect(Object.keys(ctx.computerWidgetTools).sort()).toEqual([
       "computer",
       "finish_widget",
     ]);
     // Wire format: NOT the provider-defined factory output.
     expect(
-      (ctx.computerWidgetTools.computer as { id?: string }).id,
+      (ctx.computerWidgetTools.computer as { id?: string }).id
     ).toBeUndefined();
     expect(ctx.prepareAdvertisedTools).toBeDefined();
   });
 
-  it("builds no computer tools and no gate for non-Claude drivers", () => {
-    const ctx = createBrowserSessionContext({
+  it("builds no computer tools and no gate for capability-less drivers", async () => {
+    const ctx = await createBrowserSessionContext({
       model: NON_CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
 
+    expect(ctx.computerUseSupported).toBe(false);
     expect(ctx.computerUseVersion).toBeNull();
     expect(ctx.computerWidgetTools).toEqual({});
     expect(ctx.prepareAdvertisedTools).toBeUndefined();
@@ -96,8 +111,27 @@ describe("createBrowserSessionContext — Computer Use surface", () => {
     expect(harnessInstances).toHaveLength(0);
   });
 
-  it("gate hides computer tools until a widget is mounted, then reveals", () => {
-    const ctx = createBrowserSessionContext({
+  it("builds computer tools for non-Claude drivers with vision + tool calling", async () => {
+    modelSupportsComputerUse.mockResolvedValue(true);
+    const ctx = await createBrowserSessionContext({
+      model: NON_CLAUDE_MODEL,
+      mcpClientManager: stubManager(),
+    });
+
+    expect(modelSupportsComputerUse).toHaveBeenCalledWith(NON_CLAUDE_MODEL);
+    expect(ctx.computerUseSupported).toBe(true);
+    // No provider-native version — wire format doesn't need one.
+    expect(ctx.computerUseVersion).toBeNull();
+    expect(Object.keys(ctx.computerWidgetTools).sort()).toEqual([
+      "computer",
+      "finish_widget",
+    ]);
+    expect(ctx.prepareAdvertisedTools).toBeDefined();
+    expect(harnessInstances).toHaveLength(1);
+  });
+
+  it("gate hides computer tools until a widget is mounted, then reveals", async () => {
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -105,12 +139,12 @@ describe("createBrowserSessionContext — Computer Use surface", () => {
     const names = ["search", "computer", "finish_widget"];
 
     expect(
-      ctx.prepareAdvertisedTools!({ stepIndex: 0, defaultToolNames: names }),
+      ctx.prepareAdvertisedTools!({ stepIndex: 0, defaultToolNames: names })
     ).toEqual(["search"]);
 
     harness.getMountedWidgetId.mockReturnValue("tc-1");
     expect(
-      ctx.prepareAdvertisedTools!({ stepIndex: 1, defaultToolNames: names }),
+      ctx.prepareAdvertisedTools!({ stepIndex: 1, defaultToolNames: names })
     ).toEqual(names);
   });
 });
@@ -144,7 +178,7 @@ describe("createBrowserSessionContext — render hook", () => {
       ts: 123,
     });
 
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
       injectOpenAiCompat: true,
@@ -181,7 +215,7 @@ describe("createBrowserSessionContext — render hook", () => {
       executeTool: vi.fn(),
       getAllToolsMetadata: vi.fn().mockReturnValue({ show_widget: {} }),
     } as never;
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -205,12 +239,14 @@ describe("createBrowserSessionContext — render hook", () => {
     isRenderableMcpAppTool.mockReturnValue(true);
     renderMcpAppToolResult.mockRejectedValue(new Error("chromium exploded"));
 
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
 
-    await expect(ctx.handleEngineToolResult(baseEvent)).resolves.toBeUndefined();
+    await expect(
+      ctx.handleEngineToolResult(baseEvent)
+    ).resolves.toBeUndefined();
     expect(ctx.widgetRenderObservations).toEqual([]);
   });
 
@@ -231,7 +267,7 @@ describe("createBrowserSessionContext — render hook", () => {
       ts: 123,
     });
 
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -240,7 +276,7 @@ describe("createBrowserSessionContext — render hook", () => {
     await ctx.handleEngineToolResult(baseEvent);
     expect(
       (renderMcpAppToolResult.mock.calls[0]![0] as { toolInput?: unknown })
-        .toolInput,
+        .toolInput
     ).toEqual({ city: "lisbon" });
 
     // The entry was consumed; a second result for the same id no longer
@@ -248,7 +284,7 @@ describe("createBrowserSessionContext — render hook", () => {
     await ctx.handleEngineToolResult(baseEvent);
     expect(
       (renderMcpAppToolResult.mock.calls[1]![0] as { toolInput?: unknown })
-        .toolInput,
+        .toolInput
     ).toBeUndefined();
   });
 
@@ -269,7 +305,7 @@ describe("createBrowserSessionContext — render hook", () => {
       ts: 123,
     });
 
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: NON_CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -279,14 +315,14 @@ describe("createBrowserSessionContext — render hook", () => {
     // No Computer Use → don't keep the widget mounted.
     expect(
       (renderMcpAppToolResult.mock.calls[0]![0] as { keepMounted?: boolean })
-        .keepMounted,
+        .keepMounted
     ).toBe(false);
   });
 });
 
 describe("createBrowserSessionContext — interaction steps", () => {
   it("collects browserInteractionSteps from computer-tool actions with per-widget step ordinals", async () => {
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -321,7 +357,7 @@ describe("createBrowserSessionContext — interaction steps", () => {
   });
 
   it("narrows unknown harness notes instead of dropping the step", async () => {
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -346,7 +382,7 @@ describe("createBrowserSessionContext — interaction steps", () => {
 
 describe("createBrowserSessionContext — lifecycle", () => {
   it("dismissCarriedWidget dismisses only when a widget is mounted", async () => {
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -361,14 +397,14 @@ describe("createBrowserSessionContext — lifecycle", () => {
   });
 
   it("dispose tears down the harness; no-op when never constructed", async () => {
-    const claudeCtx = createBrowserSessionContext({
+    const claudeCtx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
     await claudeCtx.dispose();
     expect(harnessInstances[0]!.dispose).toHaveBeenCalledTimes(1);
 
-    const plainCtx = createBrowserSessionContext({
+    const plainCtx = await createBrowserSessionContext({
       model: NON_CLAUDE_MODEL,
       mcpClientManager: stubManager(),
     });
@@ -392,7 +428,7 @@ describe("createBrowserSessionContext — lifecycle", () => {
       ts: 1,
     });
 
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -411,7 +447,7 @@ describe("createBrowserSessionContext — lifecycle", () => {
 
     expect(
       (renderMcpAppToolResult.mock.calls[0]![0] as { toolInput?: unknown })
-        .toolInput,
+        .toolInput
     ).toBeUndefined();
   });
 });
@@ -442,7 +478,7 @@ describe("createBrowserSessionContext — direct (local AI-SDK) render hook", ()
       ts: 123,
     });
 
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
@@ -473,16 +509,19 @@ describe("createBrowserSessionContext — direct (local AI-SDK) render hook", ()
     isRenderableMcpAppTool.mockReturnValue(true);
     renderMcpAppToolResult.mockRejectedValue(new Error("chromium exploded"));
 
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });
 
-    await ctx.handleDirectToolResultChunk({ ...baseChunk, serverId: undefined });
+    await ctx.handleDirectToolResultChunk({
+      ...baseChunk,
+      serverId: undefined,
+    });
     expect(renderMcpAppToolResult).not.toHaveBeenCalled();
 
     await expect(
-      ctx.handleDirectToolResultChunk(baseChunk),
+      ctx.handleDirectToolResultChunk(baseChunk)
     ).resolves.toBeUndefined();
     expect(ctx.widgetRenderObservations).toEqual([]);
   });
@@ -505,10 +544,10 @@ describe("createBrowserSessionContext — drainNewArtifacts", () => {
         status: "rendered",
         elapsedMs: 5,
         ts: 123,
-      }),
+      })
     );
 
-    const ctx = createBrowserSessionContext({
+    const ctx = await createBrowserSessionContext({
       model: CLAUDE_MODEL,
       mcpClientManager: manager,
     });

--- a/mcpjam-inspector/server/services/browser-session-context.ts
+++ b/mcpjam-inspector/server/services/browser-session-context.ts
@@ -50,6 +50,7 @@ import {
   buildComputerUseTools,
   resolveComputerUseToolVersion,
 } from "../utils/computer-use-tool";
+import { modelSupportsComputerUse } from "../utils/model-capabilities";
 import {
   isRenderableMcpAppTool,
   renderMcpAppToolResult,
@@ -65,7 +66,9 @@ import {
 import { logger } from "../utils/logger";
 
 export interface CreateBrowserSessionContextParams {
-  /** Driver model id — decides Computer Use availability (Claude-only). */
+  /** Driver model id — decides Computer Use availability. Mapped Claude ids
+   *  resolve offline; other ids are checked against the OpenRouter catalog
+   *  for vision + tool calling (see model-capabilities.ts). */
   model: string;
   mcpClientManager: MCPClientManager;
   injectOpenAiCompat?: boolean;
@@ -74,9 +77,13 @@ export interface CreateBrowserSessionContextParams {
 }
 
 export interface BrowserSessionContext {
-  /** Non-null exactly when the driver model supports Computer Use. */
+  /** Whether the driver model gets the `computer` / `finish_widget` tools. */
+  readonly computerUseSupported: boolean;
+  /** Anthropic provider-native version for mapped Claude ids, else null.
+   *  Null does NOT mean Computer Use is off — see `computerUseSupported`. */
   readonly computerUseVersion: ReturnType<typeof resolveComputerUseToolVersion>;
-  /** Wire-format `computer` + `finish_widget`, or `{}` for non-Claude drivers. */
+  /** Wire-format `computer` + `finish_widget`, or `{}` when the driver model
+   *  lacks vision/tool-calling. */
   readonly computerWidgetTools: ToolSet;
   /** Collected render observations (promptIndex stamped at push time). */
   readonly widgetRenderObservations: RunnerWidgetRenderObservation[];
@@ -96,7 +103,7 @@ export interface BrowserSessionContext {
     chunk: Pick<
       DirectChatTurnToolResultChunk,
       "toolCallId" | "toolName" | "input" | "output" | "serverId"
-    >,
+    >
   ): Promise<void>;
   /**
    * Return artifacts appended since the previous drain (both arrays stay
@@ -114,12 +121,20 @@ export interface BrowserSessionContext {
   dispose(): Promise<void>;
 }
 
-export function createBrowserSessionContext(
-  params: CreateBrowserSessionContextParams,
-): BrowserSessionContext {
+export async function createBrowserSessionContext(
+  params: CreateBrowserSessionContextParams
+): Promise<BrowserSessionContext> {
   const { mcpClientManager, injectOpenAiCompat } = params;
   const scope = params.logScope ?? "evals";
   const computerUseVersion = resolveComputerUseToolVersion(params.model);
+  // Capability gate, resolved ONCE at construction so the tool surface is
+  // deterministic for the whole session/iteration: mapped Claude ids are
+  // eligible offline; anything else needs vision + tool calling per the
+  // OpenRouter catalog. Unknown/unreachable → no computer tools (the
+  // pre-feature behavior for non-Claude drivers).
+  const computerUseSupported =
+    computerUseVersion !== null ||
+    (await modelSupportsComputerUse(params.model));
 
   const widgetHarnessRef: { current: McpAppBrowserHarness | null } = {
     current: null,
@@ -145,11 +160,13 @@ export function createBrowserSessionContext(
   // Eager (cheap) construction when Computer Use is supported so the computer
   // tools can reference the harness; Chromium still launches lazily on the
   // first widget render.
-  if (computerUseVersion) ensureWidgetHarness();
+  if (computerUseSupported) ensureWidgetHarness();
 
-  const computerWidgetTools: ToolSet = computerUseVersion
+  const computerWidgetTools: ToolSet = computerUseSupported
     ? buildComputerUseTools({
-        version: computerUseVersion,
+        // Version only matters for the provider-native form; wire format is
+        // version-independent, so non-Claude drivers simply omit it.
+        ...(computerUseVersion ? { version: computerUseVersion } : {}),
         harness: ensureWidgetHarness(),
         // The harness keeps at most one widget mounted — it is the single
         // source of truth for the active widget across turns and dismissals.
@@ -204,12 +221,12 @@ export function createBrowserSessionContext(
   // `getActiveToolCallId` reads — so the model only sees `computer` /
   // `finish_widget` when an action can actually target a widget.
   const prepareAdvertisedTools: PrepareAdvertisedTools | undefined =
-    computerUseVersion
+    computerUseSupported
       ? ({ defaultToolNames }) =>
           widgetHarnessRef.current?.getMountedWidgetId()
             ? defaultToolNames
             : defaultToolNames.filter(
-                (n) => n !== "computer" && n !== "finish_widget",
+                (n) => n !== "computer" && n !== "finish_widget"
               )
       : undefined;
 
@@ -237,7 +254,7 @@ export function createBrowserSessionContext(
         mcpClientManager,
         injectOpenAiCompat,
         harness: ensureWidgetHarness(),
-        keepMounted: computerUseVersion !== null,
+        keepMounted: computerUseSupported,
       });
       // Stamp promptIndex at push-time — the harness type stays pure; the
       // runner loop is the single source of truth for promptIndex.
@@ -258,7 +275,7 @@ export function createBrowserSessionContext(
   };
 
   const handleEngineToolResult = async (
-    event: MCPJamToolResultEvent,
+    event: MCPJamToolResultEvent
   ): Promise<void> => {
     const { toolCallId, toolName, serverId } = event;
     // Feed the real tool-call args to the widget shim so the engine-path
@@ -286,7 +303,7 @@ export function createBrowserSessionContext(
     chunk: Pick<
       DirectChatTurnToolResultChunk,
       "toolCallId" | "toolName" | "input" | "output" | "serverId"
-    >,
+    >
   ): Promise<void> => {
     if (!chunk.serverId) return;
     await renderIfRenderable({
@@ -300,6 +317,7 @@ export function createBrowserSessionContext(
   };
 
   return {
+    computerUseSupported,
     computerUseVersion,
     computerWidgetTools,
     widgetRenderObservations,
@@ -316,7 +334,7 @@ export function createBrowserSessionContext(
       ) {
         inputByToolCallId.set(
           event.toolCallId,
-          event.input as Record<string, unknown>,
+          event.input as Record<string, unknown>
         );
       }
     },
@@ -324,7 +342,7 @@ export function createBrowserSessionContext(
     handleDirectToolResultChunk,
     drainNewArtifacts() {
       const observations = widgetRenderObservations.slice(
-        drainedObservationCount,
+        drainedObservationCount
       );
       const steps = browserInteractionSteps.slice(drainedStepCount);
       drainedObservationCount = widgetRenderObservations.length;

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1039,12 +1039,12 @@ const runIterationWithAiSdk = async ({
   let enhancedSystemPromptForPersist: string | undefined = undefined;
 
   // Browser-rendered MCP App eval (PR 5): render MCP App tool results in the
-  // headless-Chromium harness and (for Claude drivers) drive them with
-  // Computer Use. The shared context owns the harness, the Computer Use tools,
+  // headless-Chromium harness and (for models with vision + tool calling) drive
+  // them with Computer Use. The shared context owns the harness, the Computer Use tools,
   // the advertised-tool gate, and the artifact collectors; construction is
   // cheap and Chromium launches lazily on the first widget render, so
   // prompt-only / no-widget iterations pay nothing.
-  const browser = createBrowserSessionContext({
+  const browser = await createBrowserSessionContext({
     model: test.model,
     mcpClientManager,
     injectOpenAiCompat,
@@ -1105,7 +1105,7 @@ const runIterationWithAiSdk = async ({
       typeof toolChoice === "object" &&
       !Object.hasOwn(prepared.allTools, toolChoice.toolName) &&
       // `computer` / `finish_widget` are merged into the tool map below, so a
-      // forced tool choice naming one of them is valid on Claude drivers.
+      // forced tool choice naming one of them is valid on computer-capable drivers.
       !Object.hasOwn(browser.computerWidgetTools, toolChoice.toolName)
     ) {
       throw new Error(
@@ -1638,7 +1638,7 @@ const runIterationViaBackend = async (params: RunIterationBackendParams) => {
   // The wrapper owns disposal: try/finally guarantees a launched Chromium is
   // torn down on EVERY exit (cancellation early-returns, setup failures,
   // finalize throws), which per-exit dispose calls could miss.
-  const browser = createBrowserSessionContext({
+  const browser = await createBrowserSessionContext({
     model: params.test.model,
     mcpClientManager: params.mcpClientManager,
     injectOpenAiCompat: params.injectOpenAiCompat,
@@ -2790,9 +2790,10 @@ const streamIterationWithAiSdk = async ({
 
   // Browser-rendered MCP App eval (PR 9): mirror runIterationWithAiSdk on the
   // streamed path — render MCP App tool results in the headless-Chromium harness
-  // and (for Claude drivers) drive them with Computer Use. Declared BEFORE the
+  // and (for models with vision + tool calling) drive them with Computer
+  // Use. Declared BEFORE the
   // try so the finally can dispose even on a mid-stream abort.
-  const browser = createBrowserSessionContext({
+  const browser = await createBrowserSessionContext({
     model: test.model,
     mcpClientManager,
     injectOpenAiCompat,
@@ -2841,7 +2842,7 @@ const streamIterationWithAiSdk = async ({
       typeof toolChoice === "object" &&
       !Object.hasOwn(prepared.allTools, toolChoice.toolName) &&
       // `computer` / `finish_widget` are merged into the tool map below, so a
-      // forced tool choice naming one of them is valid on Claude drivers.
+      // forced tool choice naming one of them is valid on computer-capable drivers.
       !Object.hasOwn(browser.computerWidgetTools, toolChoice.toolName)
     ) {
       throw new Error(
@@ -3516,7 +3517,7 @@ const streamIterationViaBackend = async (
   // Browser-rendered MCP App eval (PR 14): hosted-path harness context for
   // the streaming runner — same wiring as `runIterationViaBackend`; the
   // wrapper's try/finally guarantees Chromium teardown on every exit.
-  const browser = createBrowserSessionContext({
+  const browser = await createBrowserSessionContext({
     model: params.test.model,
     mcpClientManager: params.mcpClientManager,
     injectOpenAiCompat: params.injectOpenAiCompat,

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
@@ -43,9 +43,9 @@ vi.mock("../../../utils/org-model-config.js", async () => {
 });
 
 vi.mock("../../session-agent.js", async () => {
-  const actual = await vi.importActual<
-    typeof import("../../session-agent.js")
-  >("../../session-agent.js");
+  const actual = await vi.importActual<typeof import("../../session-agent.js")>(
+    "../../session-agent.js"
+  );
   return {
     ...actual,
     personaNextTurn: (...args: unknown[]) => personaNextTurnMock(...args),
@@ -117,8 +117,9 @@ vi.mock("../../browser-artifact-serialization.js", async () => {
 });
 
 vi.mock("convex/browser", async () => {
-  const actual =
-    await vi.importActual<typeof import("convex/browser")>("convex/browser");
+  const actual = await vi.importActual<typeof import("convex/browser")>(
+    "convex/browser"
+  );
   return {
     ...actual,
     ConvexHttpClient: class {
@@ -149,6 +150,7 @@ function buildFakeBrowserContext(opts: { computerUse: boolean }) {
     steps: Array<Record<string, unknown>>;
   } = { observations: [], steps: [] };
   const ctx = {
+    computerUseSupported: opts.computerUse,
     computerUseVersion: opts.computerUse ? ("20250124" as const) : null,
     computerWidgetTools: opts.computerUse
       ? { computer: { fake: true }, finish_widget: { fake: true } }
@@ -180,7 +182,7 @@ function buildFakeBrowserContext(opts: { computerUse: boolean }) {
     /** Test handle: queue artifacts the next drain returns. */
     _queueArtifacts(
       observations: Array<Record<string, unknown>>,
-      steps: Array<Record<string, unknown>>,
+      steps: Array<Record<string, unknown>>
     ) {
       artifacts.observations = observations;
       artifacts.steps = steps;
@@ -287,7 +289,7 @@ describe("synthetic-session runner — browser pipeline wiring", () => {
           ts: 2,
           screenshotBase64: "img2",
         },
-      ],
+      ]
     );
     createBrowserSessionContextMock.mockReturnValue(fake);
 
@@ -329,7 +331,7 @@ describe("synthetic-session runner — browser pipeline wiring", () => {
     expect(persistChatSessionToConvexMock).toHaveBeenCalledTimes(1);
     expect(captureMcpAppWidgetSnapshotsMock).toHaveBeenCalledTimes(1);
     const artifactCall = convexMutationMock.mock.calls.find(
-      (c) => c[0] === "chatSessions:recordBrowserArtifacts",
+      (c) => c[0] === "chatSessions:recordBrowserArtifacts"
     );
     expect(artifactCall).toBeDefined();
     expect(artifactCall![1]).toMatchObject({
@@ -377,7 +379,7 @@ describe("synthetic-session runner — browser pipeline wiring", () => {
           promptIndex: 0,
         },
       ],
-      [],
+      []
     );
     createBrowserSessionContextMock.mockReturnValue(fake);
 
@@ -391,7 +393,7 @@ describe("synthetic-session runner — browser pipeline wiring", () => {
     expect(engineOpts.prepareAdvertisedTools).toBeUndefined();
 
     const artifactCall = convexMutationMock.mock.calls.find(
-      (c) => c[0] === "chatSessions:recordBrowserArtifacts",
+      (c) => c[0] === "chatSessions:recordBrowserArtifacts"
     );
     expect(artifactCall).toBeDefined();
     expect((artifactCall![1] as any).widgetRenderObservations).toHaveLength(1);
@@ -418,8 +420,8 @@ describe("synthetic-session runner — browser pipeline wiring", () => {
 
     expect(
       convexMutationMock.mock.calls.some(
-        (c) => c[0] === "chatSessions:recordBrowserArtifacts",
-      ),
+        (c) => c[0] === "chatSessions:recordBrowserArtifacts"
+      )
     ).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -532,12 +532,12 @@ async function runOneSession(args: {
     });
 
     // One browser context per session: renders MCP App tool results in the
-    // headless harness (render observations for every model) and, for Claude
-    // assistant models, adds the `computer` / `finish_widget` tools so the
+    // headless harness (render observations for every model) and, for assistant
+    // models with vision + tool calling, adds the `computer` / `finish_widget` tools so the
     // simulated assistant can interact with rendered widgets (interaction
     // steps). `injectOpenAiCompat` is omitted to match the snapshot capture
     // below — the chatbox runtime config doesn't carry the flag.
-    browser = createBrowserSessionContext({
+    browser = await createBrowserSessionContext({
       model: String(modelDefinition.id),
       mcpClientManager: manager,
       logScope: "sessionSimulation",
@@ -975,23 +975,20 @@ async function persistBrowserArtifactsForTurn(args: {
       await serializeBrowserStepsForBackend(steps, convexClient)
     ).map(toBrowserStepPayload);
 
-    await convexClient.mutation(
-      "chatSessions:recordBrowserArtifacts" as any,
-      {
-        chatboxId: args.chatboxId,
-        ...(args.accessVersion !== undefined
-          ? { accessVersion: args.accessVersion }
-          : {}),
-        chatSessionId: args.chatSessionId,
-        promptIndex: args.promptIndex,
-        ...(serializedObservations.length
-          ? { widgetRenderObservations: serializedObservations }
-          : {}),
-        ...(serializedSteps.length
-          ? { browserInteractionSteps: serializedSteps }
-          : {}),
-      }
-    );
+    await convexClient.mutation("chatSessions:recordBrowserArtifacts" as any, {
+      chatboxId: args.chatboxId,
+      ...(args.accessVersion !== undefined
+        ? { accessVersion: args.accessVersion }
+        : {}),
+      chatSessionId: args.chatSessionId,
+      promptIndex: args.promptIndex,
+      ...(serializedObservations.length
+        ? { widgetRenderObservations: serializedObservations }
+        : {}),
+      ...(serializedSteps.length
+        ? { browserInteractionSteps: serializedSteps }
+        : {}),
+    });
   } catch (err) {
     logger.warn("[sessionSimulation.runner] browser artifact persist failed", {
       chatSessionId: args.chatSessionId,

--- a/mcpjam-inspector/server/utils/__tests__/model-capabilities.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/model-capabilities.test.ts
@@ -1,0 +1,162 @@
+/**
+ * model-capabilities.test.ts — capability-based Computer Use eligibility.
+ *
+ * The OpenRouter catalog fetch is stubbed at the global-fetch level; the
+ * module-level cache is reset between tests via the exported test hook.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetModelCapabilitiesForTests,
+  modelSupportsComputerUse,
+} from "../model-capabilities";
+
+function catalogResponse(
+  data: Array<{
+    id: string;
+    input_modalities?: string[];
+    supported_parameters?: string[];
+  }>
+) {
+  return new Response(
+    JSON.stringify({
+      data: data.map((m) => ({
+        id: m.id,
+        architecture: { input_modalities: m.input_modalities ?? [] },
+        supported_parameters: m.supported_parameters ?? [],
+      })),
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  __resetModelCapabilitiesForTests();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("modelSupportsComputerUse", () => {
+  it("resolves mapped Claude ids offline — no catalog fetch", async () => {
+    await expect(
+      modelSupportsComputerUse("anthropic/claude-haiku-4.5")
+    ).resolves.toBe(true);
+    await expect(modelSupportsComputerUse("claude-opus-4-6")).resolves.toBe(
+      true
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a non-Claude model with image input + tools", async () => {
+    fetchMock.mockResolvedValue(
+      catalogResponse([
+        {
+          id: "openai/gpt-5",
+          input_modalities: ["text", "image"],
+          supported_parameters: ["tools", "temperature"],
+        },
+      ])
+    );
+
+    await expect(modelSupportsComputerUse("openai/gpt-5")).resolves.toBe(true);
+    // Catalog ids match case-insensitively (object-shaped ids too).
+    await expect(
+      modelSupportsComputerUse({ id: "OpenAI/GPT-5" })
+    ).resolves.toBe(true);
+  });
+
+  it("rejects models missing vision or tool calling", async () => {
+    fetchMock.mockResolvedValue(
+      catalogResponse([
+        {
+          id: "some/text-only-model",
+          input_modalities: ["text"],
+          supported_parameters: ["tools"],
+        },
+        {
+          id: "some/vision-no-tools-model",
+          input_modalities: ["text", "image"],
+          supported_parameters: ["temperature"],
+        },
+      ])
+    );
+
+    await expect(
+      modelSupportsComputerUse("some/text-only-model")
+    ).resolves.toBe(false);
+    await expect(
+      modelSupportsComputerUse("some/vision-no-tools-model")
+    ).resolves.toBe(false);
+  });
+
+  it("rejects ids missing from the catalog, and empty/absent ids", async () => {
+    fetchMock.mockResolvedValue(catalogResponse([]));
+
+    await expect(modelSupportsComputerUse("nobody/unknown")).resolves.toBe(
+      false
+    );
+    await expect(modelSupportsComputerUse("")).resolves.toBe(false);
+    await expect(modelSupportsComputerUse(null)).resolves.toBe(false);
+  });
+
+  it("caches the catalog across lookups (one fetch)", async () => {
+    fetchMock.mockResolvedValue(
+      catalogResponse([
+        {
+          id: "openai/gpt-5",
+          input_modalities: ["text", "image"],
+          supported_parameters: ["tools"],
+        },
+      ])
+    );
+
+    await modelSupportsComputerUse("openai/gpt-5");
+    await modelSupportsComputerUse("openai/gpt-5");
+    await modelSupportsComputerUse("nobody/unknown");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes concurrent lookups into a single in-flight fetch", async () => {
+    fetchMock.mockResolvedValue(
+      catalogResponse([
+        {
+          id: "openai/gpt-5",
+          input_modalities: ["text", "image"],
+          supported_parameters: ["tools"],
+        },
+      ])
+    );
+
+    const results = await Promise.all([
+      modelSupportsComputerUse("openai/gpt-5"),
+      modelSupportsComputerUse("openai/gpt-5"),
+      modelSupportsComputerUse("nobody/unknown"),
+    ]);
+    expect(results).toEqual([true, true, false]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed on catalog errors and backs off before refetching", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    await expect(modelSupportsComputerUse("openai/gpt-5")).resolves.toBe(false);
+    // Within the failure-backoff window: no second fetch attempt.
+    await expect(modelSupportsComputerUse("openai/gpt-5")).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Claude ids stay eligible regardless of catalog availability.
+    await expect(
+      modelSupportsComputerUse("anthropic/claude-sonnet-4.6")
+    ).resolves.toBe(true);
+  });
+
+  it("fails closed on a non-OK catalog response", async () => {
+    fetchMock.mockResolvedValue(new Response("nope", { status: 503 }));
+    await expect(modelSupportsComputerUse("openai/gpt-5")).resolves.toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/utils/computer-use-tool.ts
+++ b/mcpjam-inspector/server/utils/computer-use-tool.ts
@@ -13,8 +13,12 @@
  *   - `finish_widget` — a regular AI SDK tool the model calls to dismiss a
  *     rendered widget when it's done interacting.
  *
- * Computer Use is Claude-only; `resolveComputerUseToolVersion` returns `null`
- * for unsupported driver models so the caller drops both tools.
+ * Eligibility is capability-based, not Claude-only: the wire-format `computer`
+ * tool (the form every production path uses) is an ordinary function tool any
+ * vision + tool-calling model can drive — see
+ * `model-capabilities.ts#modelSupportsComputerUse`. `resolveComputerUseToolVersion`
+ * remains the offline fast path for mapped Claude ids and the version picker
+ * for the provider-native form.
  */
 
 import { tool, type ToolSet } from "ai";
@@ -37,36 +41,38 @@ export type ComputerUseToolVersion = "20250124" | "20251124";
  * like `claude-sonnet-4-5-20250929` resolve correctly). Updated whenever a new
  * Claude model with Computer Use ships.
  */
-export const COMPUTER_USE_TOOL_VERSIONS: Record<string, ComputerUseToolVersion> =
-  {
-    // computer_20251124 (Opus 4.5+ generation / newest)
-    "claude-opus-4-8": "20251124",
-    "claude-opus-4-7": "20251124",
-    "claude-opus-4-6": "20251124",
-    "claude-sonnet-4-7": "20251124",
-    "claude-sonnet-4-6": "20251124",
-    "claude-haiku-4-6": "20251124",
-    // computer_20250124 (4.x generation)
-    "claude-sonnet-4-5": "20250124",
-    "claude-haiku-4-5": "20250124",
-    "claude-opus-4-5": "20250124",
-    "claude-sonnet-4": "20250124",
-    "claude-opus-4": "20250124",
-    "claude-haiku-4": "20250124",
-  };
+export const COMPUTER_USE_TOOL_VERSIONS: Record<
+  string,
+  ComputerUseToolVersion
+> = {
+  // computer_20251124 (Opus 4.5+ generation / newest)
+  "claude-opus-4-8": "20251124",
+  "claude-opus-4-7": "20251124",
+  "claude-opus-4-6": "20251124",
+  "claude-sonnet-4-7": "20251124",
+  "claude-sonnet-4-6": "20251124",
+  "claude-haiku-4-6": "20251124",
+  // computer_20250124 (4.x generation)
+  "claude-sonnet-4-5": "20250124",
+  "claude-haiku-4-5": "20250124",
+  "claude-opus-4-5": "20250124",
+  "claude-sonnet-4": "20250124",
+  "claude-opus-4": "20250124",
+  "claude-haiku-4": "20250124",
+};
 
 // Longest-prefix order so e.g. `claude-opus-4-8` wins over `claude-opus-4`.
 const VERSION_KEYS_BY_LENGTH = Object.keys(COMPUTER_USE_TOOL_VERSIONS).sort(
-  (a, b) => b.length - a.length,
+  (a, b) => b.length - a.length
 );
 
 function normalizeModelId(
-  model: string | { id?: string; modelId?: string } | null | undefined,
+  model: string | { id?: string; modelId?: string } | null | undefined
 ): string | undefined {
   const raw =
     typeof model === "string"
       ? model
-      : (model?.id ?? model?.modelId ?? undefined);
+      : model?.id ?? model?.modelId ?? undefined;
   if (!raw) return undefined;
   // Strip a provider prefix (`anthropic/`, `anthropic.`), lowercase, and
   // convert version dots to hyphens so dotted MCPJam ids
@@ -85,7 +91,7 @@ function normalizeModelId(
  * tools.
  */
 export function resolveComputerUseToolVersion(
-  model: string | { id?: string; modelId?: string } | null | undefined,
+  model: string | { id?: string; modelId?: string } | null | undefined
 ): ComputerUseToolVersion | null {
   const id = normalizeModelId(model);
   if (!id) return null;
@@ -128,7 +134,9 @@ type ComputerModelOutput = {
 };
 
 /** Map the AI SDK computer action to the harness's supported action subset. */
-export function mapToBrowserAction(input: ComputerActionInput): BrowserActionSpec {
+export function mapToBrowserAction(
+  input: ComputerActionInput
+): BrowserActionSpec {
   switch (input.action) {
     case "left_click":
     case "double_click":
@@ -167,7 +175,9 @@ function detectImageMediaType(base64: string): string {
 }
 
 /** Human-readable summary of widget-initiated tools/call for the model. */
-export function summarizeWidgetToolCalls(calls: WidgetToolCall[]): string | null {
+export function summarizeWidgetToolCalls(
+  calls: WidgetToolCall[]
+): string | null {
   if (!calls.length) return null;
   const parts = calls.map((c) => {
     const argStr = Object.entries(c.args ?? {})
@@ -187,7 +197,7 @@ function formatArg(v: unknown): string {
 
 /** Translate the implementation output into model-visible content parts. */
 export function toComputerModelOutput(
-  output: ComputerImplOutput,
+  output: ComputerImplOutput
 ): ComputerModelOutput {
   const value: ComputerModelOutput["value"] = [];
   if (output.screenshotBase64) {
@@ -209,7 +219,11 @@ export function toComputerModelOutput(
 }
 
 export interface BuildComputerUseToolsOptions {
-  version: ComputerUseToolVersion;
+  /** Anthropic provider-native tool version. Required when `wireFormat` is
+   *  false (it picks the factory + beta header); wire-format callers may omit
+   *  it — the hand-rolled schema is version- and provider-independent, which
+   *  is what lets non-Claude drivers use the tool. */
+  version?: ComputerUseToolVersion;
   harness: McpAppBrowserHarness;
   /** The tool-call id of the widget that `computer` actions target (the active
    *  rendered widget). Returns null when no widget is mounted. */
@@ -227,7 +241,7 @@ export interface BuildComputerUseToolsOptions {
    */
   onAction?: (
     result: BrowserActionResult,
-    context: { toolCallId: string },
+    context: { toolCallId: string }
   ) => void;
   /**
    * PR 14 (hosted-path Computer Use): emit the `computer` tool as a REGULAR
@@ -273,7 +287,7 @@ function buildWireFormatComputerInputSchema(viewport: {
       .enum(WIRE_FORMAT_ACTIONS)
       .describe(
         "The action to perform on the rendered widget. Take a screenshot " +
-          "first to see the current state before clicking or typing.",
+          "first to see the current state before clicking or typing."
       ),
     coordinate: z
       .array(z.number().int().min(0))
@@ -282,14 +296,14 @@ function buildWireFormatComputerInputSchema(viewport: {
       .optional()
       .describe(
         `[x, y] pixel coordinate for click / mouse_move / scroll actions. ` +
-          `x is in [0, ${viewport.width}), y is in [0, ${viewport.height}).`,
+          `x is in [0, ${viewport.width}), y is in [0, ${viewport.height}).`
       ),
     text: z
       .string()
       .optional()
       .describe(
         "Text to type (for `type`), or the key / key-combination to press " +
-          "(for `key`, e.g. 'Return', 'Tab', 'ctrl+a').",
+          "(for `key`, e.g. 'Return', 'Tab', 'ctrl+a')."
       ),
     duration: z
       .number()
@@ -315,12 +329,12 @@ function buildWireFormatComputerInputSchema(viewport: {
  * the AI SDK Anthropic provider attach the matching beta header.
  */
 export function buildComputerUseTools(
-  opts: BuildComputerUseToolsOptions,
+  opts: BuildComputerUseToolsOptions
 ): ToolSet {
   const { harness, getActiveToolCallId, viewport } = opts;
 
   const execute = async (
-    input: ComputerActionInput,
+    input: ComputerActionInput
   ): Promise<ComputerImplOutput> => {
     const toolCallId = getActiveToolCallId();
     if (!toolCallId) {
@@ -372,26 +386,36 @@ export function buildComputerUseTools(
   // output type. The consumers are duck-typed (`serializeToolsForConvex`
   // reads `inputSchema`, `executeToolCallsFromMessages` reads `execute` /
   // `toModelOutput`), so the literal is a first-class tool.
-  const computer = opts.wireFormat
-    ? ({
-        description:
-          `A virtual ${viewport.width}x${viewport.height} browser viewport ` +
-          "showing the currently rendered MCP App widget. Use it to look at " +
-          "the widget (screenshot) and interact with it (click, type, " +
-          "scroll). Coordinates are pixels with (0, 0) at the top-left. " +
-          "Always take a screenshot first to see the widget before " +
-          "interacting, and after each action to verify its effect. When " +
-          "you are done interacting with the widget, call `finish_widget`.",
-        inputSchema: buildWireFormatComputerInputSchema(viewport),
-        // The wire schema types `coordinate` as number[] (tuple constraints
-        // ride as minItems/maxItems so the JSON round-trips through the
-        // backend's schema reconstruction); the impl type narrows it.
-        execute: (input: ComputerActionInput) => execute(input),
-        toModelOutput,
-      } as unknown as ToolSet[string])
-    : opts.version === "20251124"
-      ? anthropic.tools.computer_20251124(factoryArgs)
-      : anthropic.tools.computer_20250124(factoryArgs);
+  let computer: ToolSet[string];
+  if (opts.wireFormat) {
+    computer = {
+      description:
+        `A virtual ${viewport.width}x${viewport.height} browser viewport ` +
+        "showing the currently rendered MCP App widget. Use it to look at " +
+        "the widget (screenshot) and interact with it (click, type, " +
+        "scroll). Coordinates are pixels with (0, 0) at the top-left. " +
+        "Always take a screenshot first to see the widget before " +
+        "interacting, and after each action to verify its effect. When " +
+        "you are done interacting with the widget, call `finish_widget`.",
+      inputSchema: buildWireFormatComputerInputSchema(viewport),
+      // The wire schema types `coordinate` as number[] (tuple constraints
+      // ride as minItems/maxItems so the JSON round-trips through the
+      // backend's schema reconstruction); the impl type narrows it.
+      execute: (input: ComputerActionInput) => execute(input),
+      toModelOutput,
+    } as unknown as ToolSet[string];
+  } else {
+    if (!opts.version) {
+      throw new Error(
+        "buildComputerUseTools: `version` is required for the provider-native " +
+          "computer tool — only wire-format callers may omit it"
+      );
+    }
+    computer =
+      opts.version === "20251124"
+        ? anthropic.tools.computer_20251124(factoryArgs)
+        : anthropic.tools.computer_20250124(factoryArgs);
+  }
 
   const finish_widget = tool({
     description:

--- a/mcpjam-inspector/server/utils/model-capabilities.ts
+++ b/mcpjam-inspector/server/utils/model-capabilities.ts
@@ -1,0 +1,157 @@
+/**
+ * model-capabilities.ts — capability-based Computer Use eligibility for any
+ * driver model.
+ *
+ * The wire-format `computer` tool (see computer-use-tool.ts) is an ordinary
+ * function tool — nothing about it is provider-specific. What a model actually
+ * needs to drive it is (a) tool calling and (b) vision, since every action
+ * result returns a screenshot as image content. So eligibility is a capability
+ * check, not a provider check:
+ *
+ *   1. Mapped Claude ids resolve offline via COMPUTER_USE_TOOL_VERSIONS — no
+ *      network, deterministic, and covers direct-Anthropic (BYOK) ids that
+ *      don't exist in the OpenRouter catalog under that exact key.
+ *   2. Everything else is looked up in OpenRouter's PUBLIC model catalog
+ *      (`/api/v1/models`, no API key), keyed by the OpenRouter id the product
+ *      already uses as its model id (`openai/gpt-5`, `google/gemini-2.5-pro`,
+ *      …). Eligible iff `architecture.input_modalities` includes "image" AND
+ *      `supported_parameters` includes "tools". Because the endpoint is
+ *      unauthenticated this works identically for MCPJam-credit and BYOK runs.
+ *
+ * Failure semantics are deliberately conservative: if the catalog is
+ * unreachable or the id is unknown, a non-Claude model gets NO computer tools
+ * — exactly the pre-feature behavior. Claude models never depend on the
+ * network. The catalog is cached in-process (TTL + in-flight dedup + stale
+ * fallback) so one fetch serves many eval iterations.
+ */
+
+import { resolveComputerUseToolVersion } from "./computer-use-tool";
+import { logger } from "./logger";
+
+const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+const CATALOG_TTL_MS = 60 * 60 * 1000; // refresh hourly
+const FAILURE_RETRY_MS = 60 * 1000; // don't hammer OpenRouter after a failure
+const FETCH_TIMEOUT_MS = 10_000;
+
+interface CatalogCapabilities {
+  vision: boolean;
+  tools: boolean;
+}
+
+let catalog: Map<string, CatalogCapabilities> | null = null;
+let catalogFetchedAt = 0;
+let lastFetchFailureAt = 0;
+let inFlight: Promise<Map<string, CatalogCapabilities> | null> | null = null;
+
+/** Raw model id (no normalization beyond trim/lowercase — OpenRouter ids are
+ *  matched verbatim, dots and provider prefix included). */
+function rawModelId(
+  model: string | { id?: string; modelId?: string } | null | undefined
+): string | undefined {
+  const raw =
+    typeof model === "string"
+      ? model
+      : model?.id ?? model?.modelId ?? undefined;
+  const trimmed = raw?.trim().toLowerCase();
+  return trimmed ? trimmed : undefined;
+}
+
+async function fetchCatalog(): Promise<Map<
+  string,
+  CatalogCapabilities
+> | null> {
+  try {
+    const res = await fetch(OPENROUTER_MODELS_URL, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      logger.warn("[model-capabilities] OpenRouter catalog fetch failed", {
+        status: res.status,
+      });
+      return null;
+    }
+    const body = (await res.json()) as {
+      data?: Array<{
+        id?: string;
+        architecture?: { input_modalities?: string[] };
+        supported_parameters?: string[];
+      }>;
+    };
+    if (!Array.isArray(body.data)) {
+      logger.warn(
+        "[model-capabilities] OpenRouter catalog response missing data array"
+      );
+      return null;
+    }
+    const next = new Map<string, CatalogCapabilities>();
+    for (const entry of body.data) {
+      if (typeof entry?.id !== "string" || !entry.id) continue;
+      next.set(entry.id.toLowerCase(), {
+        vision:
+          entry.architecture?.input_modalities?.includes("image") ?? false,
+        tools: entry.supported_parameters?.includes("tools") ?? false,
+      });
+    }
+    logger.debug("[model-capabilities] OpenRouter catalog refreshed", {
+      models: next.size,
+    });
+    return next;
+  } catch (err) {
+    logger.warn("[model-capabilities] OpenRouter catalog fetch threw", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+async function getCatalog(): Promise<Map<string, CatalogCapabilities> | null> {
+  const now = Date.now();
+  if (catalog && now - catalogFetchedAt < CATALOG_TTL_MS) return catalog;
+  if (inFlight) return inFlight;
+  // Back off after a failure; serve the stale catalog (or null) meanwhile.
+  if (now - lastFetchFailureAt < FAILURE_RETRY_MS) return catalog;
+  inFlight = fetchCatalog().then((fresh) => {
+    inFlight = null;
+    if (fresh) {
+      catalog = fresh;
+      catalogFetchedAt = Date.now();
+    } else {
+      lastFetchFailureAt = Date.now();
+    }
+    return catalog;
+  });
+  return inFlight;
+}
+
+/**
+ * Whether the driver model can drive the wire-format Computer Use tools:
+ * mapped Claude id (offline), or OpenRouter catalog entry with image input +
+ * tool calling. Unknown/unreachable resolves to `false` — never advertise a
+ * tool the model can't call.
+ */
+export async function modelSupportsComputerUse(
+  model: string | { id?: string; modelId?: string } | null | undefined
+): Promise<boolean> {
+  if (resolveComputerUseToolVersion(model) !== null) return true;
+  const id = rawModelId(model);
+  if (!id) return false;
+  const entries = await getCatalog();
+  const capabilities = entries?.get(id);
+  if (!capabilities) {
+    logger.debug(
+      "[model-capabilities] model not in OpenRouter catalog; Computer Use off",
+      { model: id }
+    );
+    return false;
+  }
+  return capabilities.vision && capabilities.tools;
+}
+
+/** Test hook: clear the module-level catalog cache. */
+export function __resetModelCapabilitiesForTests(): void {
+  catalog = null;
+  catalogFetchedAt = 0;
+  lastFetchFailureAt = 0;
+  inFlight = null;
+}


### PR DESCRIPTION
## Why

Computer Use on rendered MCP Apps (screenshot/click/type during evals and synthetic sessions) was gated to a hand-curated map of Claude model ids. But every production path already emits the `computer` tool in **wire format** — an ordinary function tool with a hand-rolled JSON schema, with screenshots returned as plain image content. Nothing about it is provider-specific; the Claude-only gate was historical. Any model with **vision + tool calling** can drive it.

## What

Replace the provider gate with a capability gate:

- **`server/utils/model-capabilities.ts` (new)** — `modelSupportsComputerUse(model)`:
  1. Mapped Claude ids resolve **offline** via the existing `COMPUTER_USE_TOOL_VERSIONS` map (deterministic; also covers direct-Anthropic BYOK ids that don't exist in the OpenRouter catalog under that key).
  2. Everything else is looked up in OpenRouter's **public** `/api/v1/models` catalog — no API key, so MCPJam-credit and BYOK runs behave identically — keyed by the OpenRouter id the product already uses as its model id. Eligible iff `architecture.input_modalities` includes `"image"` **and** `supported_parameters` includes `"tools"`. Adding a new model to the UI needs no change here.
  - Catalog is cached in-process: 1h TTL, in-flight dedup, 60s failure backoff, stale-catalog fallback.
  - **Fails closed**: unknown id or unreachable catalog → no computer tools (the exact pre-feature behavior for non-Claude drivers). Claude ids never depend on the network.
- **`browser-session-context.ts`** — `createBrowserSessionContext` is now async; capability is resolved **once at construction** so the tool surface is deterministic for the whole iteration. Harness construction, tool build, `keepMounted`, and the advertised-tools gate all key off it. New `computerUseSupported` field alongside `computerUseVersion` (which now strictly means "provider-native version for mapped Claude ids").
- **`computer-use-tool.ts`** — `version` is optional; only the provider-native (non-wire) form requires it, and it throws with a clear message if omitted there. Wire format never used it.
- **Call sites** — the 4 eval-runner sites and the session-simulation runner `await` the context; stale "(for Claude drivers)" comments updated.

## Testing

- New `model-capabilities.test.ts`: capability combinations, case-insensitive id matching, cache/single-fetch, concurrent dedup, failure backoff, fail-closed on non-OK/network error, Claude offline path.
- `browser-session-context.test.ts`: capability module stubbed (no network in unit tests); new test that a capable non-Claude driver gets `computer` + `finish_widget`, with `computerUseVersion` null.
- All 60 tests across the four affected suites pass; real-Chromium integration tests (`computer-use-loop`, `mcp-app-browser-harness`, 28 tests) and the 65 `evals-runner` tests pass.
- Server tsc error count unchanged vs main (353 = 353). The TS2322 reported in `computer-use-tool.ts` is the pre-existing union-assignability error, moved from the return statement to the assignment by the restructure.

## Notes for reviewers

- Non-Claude models are not specifically trained on the computer-use action vocabulary — expect lower interaction quality than Claude drivers, especially within the 12-step-per-widget budget. This PR makes them *eligible*, it doesn't claim parity; a live smoke run with e.g. `openai/gpt-5` against an MCP App server is the recommended follow-up before announcing support.
- The provider-native Anthropic tool path (and its beta header) is kept intact for any future local-path use; it still requires a mapped version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a runtime dependency on OpenRouter catalog fetch for non-Claude models (mitigated by caching and fail-closed defaults) and makes browser context creation async across eval and simulation paths.
> 
> **Overview**
> Replaces the **Claude-only** Computer Use gate with a **capability gate** so evals and session simulation can expose `computer` / `finish_widget` to any driver that can use the existing wire-format tools (vision + tool calling).
> 
> Adds **`modelSupportsComputerUse`** in `model-capabilities.ts`: mapped Claude ids stay an **offline** fast path; other models are checked against OpenRouter’s public `/api/v1/models` catalog (image input + `tools` parameter), with in-process caching and **fail-closed** behavior when the catalog is missing or unreachable.
> 
> **`createBrowserSessionContext`** is now **async**, resolves eligibility once at construction, exposes **`computerUseSupported`**, and drives harness setup, wire tools, `keepMounted`, and the advertised-tools gate from that flag (not only `computerUseVersion`). **`buildComputerUseTools`** treats **`version`** as optional for wire format; provider-native builds still require it.
> 
> Eval runner and session simulation call sites **`await`** context creation; tests cover the new capability path and stub the catalog lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d76f1874b385719df119594abcac8db0676ffde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->