### PR TITLE
Computers: delegate to a remote data plane so credential-less inspectors work

### DIFF
--- a/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
@@ -40,10 +40,17 @@ export function ComputerTerminal({
   mintToken,
   themeMode,
   className,
+  baseUrl,
 }: {
   mintToken: () => Promise<string>;
   themeMode: "light" | "dark";
   className?: string;
+  /**
+   * `ws(s)://host` of the data plane serving the terminal. Defaults to the
+   * page origin; set when this inspector delegates to a remote data plane
+   * (see useComputersDataPlaneConfig).
+   */
+  baseUrl?: string;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -102,6 +109,7 @@ export function ComputerTerminal({
       token,
       cols: term.cols,
       rows: term.rows,
+      ...(baseUrl ? { baseUrl } : {}),
       onOutput: (bytes) => {
         if (isStale()) return;
         term.write(bytes);
@@ -132,7 +140,7 @@ export function ComputerTerminal({
       if (isStale()) return;
       conn.ping();
     }, PING_INTERVAL_MS);
-  }, [mintToken, teardownConnection]);
+  }, [mintToken, teardownConnection, baseUrl]);
 
   // Create the xterm instance once; wire input + resize; auto-connect.
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -154,6 +154,20 @@ export function ComputerView({
         </PaneMessage>
       );
     }
+    // Don't mount the terminal until we know WHERE it lives: mounting while
+    // the config fetch is in flight would aim the first WebSocket at the page
+    // origin, and the mount-once effect never re-dials when the remote base
+    // URL arrives a moment later.
+    if (isReady && dataPlane === undefined) {
+      return (
+        <PaneMessage>
+          <span className="inline-flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Connecting to your computer…
+          </span>
+        </PaneMessage>
+      );
+    }
     if (isReady) {
       return (
         <ComputerTerminal

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -5,11 +5,13 @@ import { Button } from "@mcpjam/design-system/button";
 import { Loader2, RotateCcw, TerminalSquare, Trash2 } from "lucide-react";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import {
+  useComputersDataPlaneConfig,
   useComputerStatus,
   useDeleteComputer,
   useMintTerminalToken,
   useReserveComputer,
 } from "@/hooks/useProjectComputer";
+import { toTerminalWsBase } from "@/lib/computer-terminal-connection";
 import {
   getBillingErrorMessage,
   isComputerStartLimitError,
@@ -43,6 +45,18 @@ export function ComputerView({
   const [starting, setStarting] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  // Where the terminal lives: this server (local data plane), a deployed
+  // data plane (remote URL → cross-origin WS), or nowhere (honest empty
+  // state instead of a Ready badge next to a terminal that can't connect).
+  const dataPlane = useComputersDataPlaneConfig();
+  const remoteWsBase = dataPlane?.remoteDataPlaneUrl
+    ? toTerminalWsBase(dataPlane.remoteDataPlaneUrl)
+    : undefined;
+  const terminalBaseUrl =
+    dataPlane && !dataPlane.localConfigured ? remoteWsBase : undefined;
+  const dataPlaneUnavailable =
+    dataPlane !== undefined && !dataPlane.localConfigured && !remoteWsBase;
 
   const liveStatus = status === undefined ? undefined : status?.status ?? null;
   const isReady = liveStatus === "ready";
@@ -120,6 +134,19 @@ export function ComputerView({
   }
 
   const renderTerminalPane = () => {
+    if (dataPlaneUnavailable) {
+      return (
+        <PaneMessage dashed>
+          <span className="max-w-md text-center">
+            This inspector server isn't set up to run computers: it has no
+            data-plane credentials and no remote data plane to delegate to. Set{" "}
+            <code>COMPUTERS_REMOTE_DATA_PLANE_URL</code> (or the data-plane
+            secrets) in the server environment to enable the terminal and the
+            bash tool.
+          </span>
+        </PaneMessage>
+      );
+    }
     if (!terminalOpen) {
       return (
         <PaneMessage dashed>
@@ -133,6 +160,7 @@ export function ComputerView({
           mintToken={mintToken}
           themeMode={terminalTheme}
           className="h-full"
+          {...(terminalBaseUrl ? { baseUrl: terminalBaseUrl } : {})}
         />
       );
     }
@@ -203,7 +231,7 @@ export function ComputerView({
           <ComputerStatusChip status={liveStatus} />
         </div>
         <div className="flex items-center gap-2">
-          {!terminalOpen ? (
+          {!terminalOpen && !dataPlaneUnavailable ? (
             <Button
               size="sm"
               onClick={() => void openTerminal()}

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -161,6 +161,27 @@ describe("ComputerView", () => {
     );
   });
 
+  it("holds the terminal mount until the data-plane config resolves", () => {
+    mockDataPlane = undefined; // /config still in flight
+    mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
+    const { getByText, queryByTestId, getByTestId, rerender } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    fireEvent.click(getByText("Open terminal"));
+    // Mounting now would dial the page origin and never re-dial once the
+    // remote base URL arrives — show a spinner instead.
+    expect(queryByTestId("terminal-stub")).toBeNull();
+
+    mockDataPlane = {
+      localConfigured: false,
+      remoteDataPlaneUrl: "https://dp.example.test",
+    };
+    rerender(<ComputerView projectId="p1" isAuthenticated />);
+    expect(getByTestId("terminal-stub").getAttribute("data-base-url")).toBe(
+      "wss://dp.example.test"
+    );
+  });
+
   it("keeps the terminal on the page origin when locally configured", () => {
     mockDataPlane = {
       localConfigured: true,

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -6,12 +6,16 @@ const reserve = vi.fn(async () => ({} as never));
 const deleteComputer = vi.fn(async () => ({ deleted: true }));
 const mintToken = vi.fn(async () => ({ token: "t", expiresAt: 0 } as never));
 let mockStatus: ComputerViewModel | null | undefined;
+let mockDataPlane:
+  | { localConfigured: boolean; remoteDataPlaneUrl: string | null }
+  | undefined;
 
 vi.mock("@/hooks/useProjectComputer", () => ({
   useComputerStatus: () => mockStatus,
   useReserveComputer: () => reserve,
   useDeleteComputer: () => deleteComputer,
   useMintTerminalToken: () => mintToken,
+  useComputersDataPlaneConfig: () => mockDataPlane,
 }));
 
 vi.mock("@/stores/preferences/preferences-provider", () => ({
@@ -25,7 +29,9 @@ vi.mock("sonner", () => ({
 
 // Stub the xterm terminal so the orchestration test needs no real terminal.
 vi.mock("../ComputerTerminal", () => ({
-  ComputerTerminal: () => <div data-testid="terminal-stub" />,
+  ComputerTerminal: (props: { baseUrl?: string }) => (
+    <div data-testid="terminal-stub" data-base-url={props.baseUrl ?? ""} />
+  ),
 }));
 
 import { ComputerView } from "../ComputerView";
@@ -33,7 +39,12 @@ import { ComputerView } from "../ComputerView";
 afterEach(() => {
   vi.clearAllMocks();
   mockStatus = undefined;
+  mockDataPlane = { localConfigured: true, remoteDataPlaneUrl: null };
 });
+
+// Default for every test: this server IS a data plane (the pre-remote
+// behavior). Individual tests override to exercise the delegation states.
+mockDataPlane = { localConfigured: true, remoteDataPlaneUrl: null };
 
 describe("ComputerView", () => {
   it("prompts to sign in when unauthenticated", () => {
@@ -120,6 +131,48 @@ describe("ComputerView", () => {
     expect(queryByText(/Starting your computer/i)).toBeNull();
     expect(getByText("Try again")).toBeTruthy();
     expect(getByText("Close")).toBeTruthy();
+  });
+
+  it("shows an honest empty state when no data plane is available (no Open terminal)", () => {
+    mockDataPlane = { localConfigured: false, remoteDataPlaneUrl: null };
+    mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
+    const { getByText, queryByText } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    expect(getByText(/isn't set up to run computers/i)).toBeTruthy();
+    expect(queryByText("Open terminal")).toBeNull();
+    // The computer itself still exists (it lives in Convex/E2B, not on this
+    // server), so Delete must stay available.
+    expect(getByText("Delete")).toBeTruthy();
+  });
+
+  it("aims the terminal at the remote data plane when delegating", () => {
+    mockDataPlane = {
+      localConfigured: false,
+      remoteDataPlaneUrl: "https://dp.example.test",
+    };
+    mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
+    const { getByText, getByTestId } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    fireEvent.click(getByText("Open terminal"));
+    expect(getByTestId("terminal-stub").getAttribute("data-base-url")).toBe(
+      "wss://dp.example.test"
+    );
+  });
+
+  it("keeps the terminal on the page origin when locally configured", () => {
+    mockDataPlane = {
+      localConfigured: true,
+      // A remote URL alongside local credentials must be ignored.
+      remoteDataPlaneUrl: "https://dp.example.test",
+    };
+    mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
+    const { getByText, getByTestId } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    fireEvent.click(getByText("Open terminal"));
+    expect(getByTestId("terminal-stub").getAttribute("data-base-url")).toBe("");
   });
 
   it("shows a 'no longer available' pane when the computer disappears with the terminal open", () => {

--- a/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useAction, useMutation, useQuery } from "convex/react";
 
 /**
@@ -69,4 +70,68 @@ export function useMintTerminalToken(): (args: {
   projectId: string;
 }) => Promise<TerminalTokenResult> {
   return useAction("projectComputers:mintTerminalToken" as never) as never;
+}
+
+/**
+ * Which data plane serves this inspector (GET /api/web/computers/config):
+ * itself (`localConfigured` — it holds the vendor key + secrets) or a
+ * deployed one (`remoteDataPlaneUrl`). Neither ⇒ computers are unavailable
+ * here and the UI should say so instead of offering a terminal that can't
+ * connect.
+ */
+export interface ComputersDataPlaneConfig {
+  localConfigured: boolean;
+  remoteDataPlaneUrl: string | null;
+}
+
+// One fetch per page load — the answer is env-derived and can't change
+// without a server restart.
+let cachedDataPlaneConfig: ComputersDataPlaneConfig | null = null;
+
+function parseDataPlaneConfig(value: unknown): ComputersDataPlaneConfig | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.localConfigured !== "boolean") return null;
+  return {
+    localConfigured: record.localConfigured,
+    remoteDataPlaneUrl:
+      typeof record.remoteDataPlaneUrl === "string"
+        ? record.remoteDataPlaneUrl
+        : null,
+  };
+}
+
+/** `undefined` while loading. On fetch failure assumes a local data plane —
+ * the pre-config behavior, where the terminal WS surfaces the real error. */
+export function useComputersDataPlaneConfig():
+  | ComputersDataPlaneConfig
+  | undefined {
+  const [config, setConfig] = useState<ComputersDataPlaneConfig | undefined>(
+    cachedDataPlaneConfig ?? undefined
+  );
+
+  useEffect(() => {
+    if (cachedDataPlaneConfig) return;
+    let cancelled = false;
+    void fetch("/api/web/computers/config")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((json: unknown) => {
+        const parsed = parseDataPlaneConfig(json) ?? {
+          localConfigured: true,
+          remoteDataPlaneUrl: null,
+        };
+        cachedDataPlaneConfig = parsed;
+        if (!cancelled) setConfig(parsed);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setConfig({ localConfigured: true, remoteDataPlaneUrl: null });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return config;
 }

--- a/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
@@ -116,12 +116,16 @@ export function useComputersDataPlaneConfig():
     void fetch("/api/web/computers/config")
       .then((response) => (response.ok ? response.json() : null))
       .then((json: unknown) => {
-        const parsed = parseDataPlaneConfig(json) ?? {
-          localConfigured: true,
-          remoteDataPlaneUrl: null,
-        };
-        cachedDataPlaneConfig = parsed;
-        if (!cancelled) setConfig(parsed);
+        // Only cache real answers. The assume-local fallback below is
+        // per-mount, so a transient /config failure can't pin the wrong
+        // data plane for the rest of the SPA session.
+        const parsed = parseDataPlaneConfig(json);
+        if (parsed) cachedDataPlaneConfig = parsed;
+        if (!cancelled) {
+          setConfig(
+            parsed ?? { localConfigured: true, remoteDataPlaneUrl: null }
+          );
+        }
       })
       .catch(() => {
         if (!cancelled) {

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildTerminalWsUrl,
   openTerminalConnection,
+  toTerminalWsBase,
   type TerminalEvent,
 } from "../computer-terminal-connection";
 
@@ -139,5 +140,27 @@ describe("openTerminalConnection", () => {
       ws.onmessage?.({ data: "not json {{{" } as MessageEvent)
     ).not.toThrow();
     expect(events).toHaveLength(0);
+  });
+});
+
+describe("toTerminalWsBase", () => {
+  it("maps https to wss and http to ws, keeping host and port", () => {
+    expect(toTerminalWsBase("https://dp.example.test")).toBe(
+      "wss://dp.example.test"
+    );
+    expect(toTerminalWsBase("http://localhost:3500")).toBe(
+      "ws://localhost:3500"
+    );
+  });
+
+  it("drops any path — the WS route is fixed", () => {
+    expect(toTerminalWsBase("https://dp.example.test/some/path")).toBe(
+      "wss://dp.example.test"
+    );
+  });
+
+  it("returns undefined for invalid or non-http(s) inputs", () => {
+    expect(toTerminalWsBase("not a url")).toBeUndefined();
+    expect(toTerminalWsBase("ftp://dp.example.test")).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/lib/computer-terminal-connection.ts
+++ b/mcpjam-inspector/client/src/lib/computer-terminal-connection.ts
@@ -40,6 +40,24 @@ export interface OpenTerminalOptions {
   wsFactory?: (url: string) => WebSocket;
 }
 
+/**
+ * Convert a data-plane HTTP(S) origin into the `ws(s)://host` base expected
+ * by `buildTerminalWsUrl`. Used when this inspector delegates to a remote
+ * data plane (see GET /api/web/computers/config); the terminal token in the
+ * query string is the auth, so a cross-origin socket needs nothing else.
+ */
+export function toTerminalWsBase(httpOrigin: string): string | undefined {
+  try {
+    const url = new URL(httpOrigin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return undefined;
+    }
+    return `${url.protocol === "https:" ? "wss:" : "ws:"}//${url.host}`;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Build the `ws(s)://…/api/web/computers/terminal?…` URL from page origin. */
 export function buildTerminalWsUrl(args: {
   token: string;

--- a/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import { createComputersRoutes } from "../computers";
+import type { BashRunner } from "../../../utils/computers/run-command";
+
+// Route-level tests: GET /config (data-plane discovery) and POST /exec (the
+// endpoint a credential-less local inspector forwards bash calls to). The
+// Convex control plane is a fetch stub; E2B is an injected runner.
+
+const CONVEX_URL = "https://convex.example";
+
+type FetchCall = { path: string; headers: Record<string, string>; body: any };
+
+let fetchCalls: FetchCall[];
+let fetchHandler: (path: string, body: any) => { status: number; json: any };
+
+function installFetchStub() {
+  fetchCalls = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const path = new URL(String(url)).pathname;
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      fetchCalls.push({
+        path,
+        headers: (init?.headers ?? {}) as Record<string, string>,
+        body,
+      });
+      const { status, json } = fetchHandler(path, body);
+      return new Response(JSON.stringify(json), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    })
+  );
+}
+
+function happyControlPlane() {
+  fetchHandler = (path) => {
+    if (path === "/computers/reserve") {
+      return {
+        status: 200,
+        json: { computerId: "comp_1", status: "ready", provider: "e2b" },
+      };
+    }
+    if (path === "/computers/sandbox-info") {
+      return {
+        status: 200,
+        json: {
+          computerId: "comp_1",
+          providerComputerId: "sbx_42",
+          provider: "e2b",
+          status: "ready",
+          projectId: "proj_1",
+          ownerUserId: "user_1",
+        },
+      };
+    }
+    if (path === "/computers/commands") {
+      return { status: 200, json: { ok: "recorded" } };
+    }
+    throw new Error(`unexpected path ${path}`);
+  };
+}
+
+function createApp(runner?: BashRunner) {
+  const app = new Hono();
+  app.route("/api/web/computers", createComputersRoutes(runner));
+  return app;
+}
+
+function postExec(
+  app: Hono,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = { authorization: "Bearer user-token" }
+) {
+  return app.request("/api/web/computers/exec", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function stubLocalDataPlaneEnv() {
+  vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
+  vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "test-secret");
+  vi.stubEnv("E2B_API_KEY", "e2b_test");
+}
+
+beforeEach(() => {
+  installFetchStub();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/web/computers/config", () => {
+  it("reports an unconfigured server", async () => {
+    const response = await createApp().request("/api/web/computers/config");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      localConfigured: false,
+      remoteDataPlaneUrl: null,
+    });
+  });
+
+  it("reports a locally configured data plane", async () => {
+    stubLocalDataPlaneEnv();
+    const response = await createApp().request("/api/web/computers/config");
+    expect(await response.json()).toEqual({
+      localConfigured: true,
+      remoteDataPlaneUrl: null,
+    });
+  });
+
+  it("advertises the remote data plane origin", async () => {
+    vi.stubEnv(
+      "COMPUTERS_REMOTE_DATA_PLANE_URL",
+      "https://dp.example.test/ignored-path"
+    );
+    const response = await createApp().request("/api/web/computers/config");
+    expect(await response.json()).toEqual({
+      localConfigured: false,
+      remoteDataPlaneUrl: "https://dp.example.test",
+    });
+  });
+});
+
+describe("POST /api/web/computers/exec", () => {
+  it("runs the command with the caller's bearer and returns the output", async () => {
+    stubLocalDataPlaneEnv();
+    happyControlPlane();
+    const runner = vi.fn(async () => ({
+      stdout: "hello\n",
+      stderr: "",
+      exitCode: 0,
+    }));
+
+    const response = await postExec(createApp(runner), {
+      projectId: "proj_1",
+      command: "echo hello",
+      commandId: "call_7",
+      workdir: "/workspace",
+      timeoutSeconds: 30,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      stdout: "hello\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(runner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandboxId: "sbx_42",
+        command: "echo hello",
+        workdir: "/workspace",
+        timeoutMs: 30_000,
+      })
+    );
+    // The caller's bearer reaches Convex reserve (authz); the caller's
+    // commandId is the idempotency key on the durable log.
+    expect(fetchCalls[0].path).toBe("/computers/reserve");
+    expect(fetchCalls[0].headers.authorization).toBe("Bearer user-token");
+    expect(
+      fetchCalls.find((call) => call.path === "/computers/commands")?.body
+    ).toMatchObject({ commandId: "call_7", source: "chat" });
+  });
+
+  it("rejects requests without a bearer token", async () => {
+    stubLocalDataPlaneEnv();
+    const runner = vi.fn();
+    const response = await postExec(
+      createApp(runner),
+      { projectId: "proj_1", command: "ls", commandId: "c1" },
+      {}
+    );
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({ code: "UNAUTHORIZED" });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid bodies", async () => {
+    stubLocalDataPlaneEnv();
+    const response = await postExec(createApp(vi.fn()), {
+      projectId: "proj_1",
+      // command missing
+      commandId: "c1",
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("reports soft failure when this server is not a data plane — and never forwards", async () => {
+    // A remote URL is set, but /exec must not delegate: that would let a
+    // misconfigured pair of servers forward to each other in a loop.
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "https://dp.example.test");
+    const response = await postExec(createApp(vi.fn()), {
+      projectId: "proj_1",
+      command: "ls",
+      commandId: "c1",
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      error: "Computers are not configured on this server.",
+    });
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/computers.ts
+++ b/mcpjam-inspector/server/routes/web/computers.ts
@@ -1,0 +1,85 @@
+/**
+ * Project Computers — web routes for the data-plane split.
+ *
+ *   GET  /config  (open)    Which data plane serves this inspector: itself
+ *                           (`localConfigured`, it holds the vendor key +
+ *                           secrets) or a deployed one (`remoteDataPlaneUrl`,
+ *                           the NON-secret COMPUTERS_REMOTE_DATA_PLANE_URL).
+ *                           The client uses this to aim the terminal
+ *                           WebSocket and to render an honest empty state
+ *                           when neither is available. No secrets here — a
+ *                           boolean and a public URL.
+ *
+ *   POST /exec    (bearer)  Run one command on the CALLER'S computer. This is
+ *                           what a credential-less local inspector forwards
+ *                           its `bash` tool calls to (remote-data-plane.ts).
+ *                           Authorization is the user's bearer end to end:
+ *                           it's forwarded to Convex `/computers/reserve`,
+ *                           which only ever resolves the (project, user)
+ *                           computer of the bearer's owner — the shared
+ *                           secret stays on this server. Returns the bash
+ *                           tool's result shape; soft failures are
+ *                           `{ error }` with HTTP 200 so the delegating
+ *                           tool can relay them conversationally.
+ *                           This route never delegates further — an
+ *                           unconfigured server reports `{ error }`, so a
+ *                           misconfigured remote URL can't forward in a loop.
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import { isComputersDataPlaneConfigured } from "../../utils/computers/control-plane-client.js";
+import { getComputersRemoteDataPlaneUrl } from "../../utils/computers/remote-data-plane.js";
+import {
+  MAX_COMMAND_TIMEOUT_S,
+  e2bRunner,
+  runComputerCommand,
+  type BashRunner,
+} from "../../utils/computers/run-command.js";
+import { handleRoute, parseWithSchema, readJsonBody } from "./auth.js";
+import { assertBearerToken } from "./errors.js";
+
+const execSchema = z.object({
+  projectId: z.string().min(1),
+  command: z.string().min(1).max(10_000),
+  /** Idempotency key for the durable command log (the tool call id). */
+  commandId: z.string().min(1).max(200),
+  workdir: z.string().min(1).max(1_000).optional(),
+  timeoutSeconds: z.number().int().min(1).max(MAX_COMMAND_TIMEOUT_S).optional(),
+});
+
+export function createComputersRoutes(runner: BashRunner = e2bRunner): Hono {
+  const computers = new Hono();
+
+  computers.get("/config", (c) =>
+    c.json({
+      localConfigured: isComputersDataPlaneConfigured(),
+      remoteDataPlaneUrl: getComputersRemoteDataPlaneUrl(),
+    })
+  );
+
+  computers.post("/exec", async (c) =>
+    handleRoute(c, async () => {
+      const bearerToken = assertBearerToken(c);
+      const body = parseWithSchema(execSchema, await readJsonBody(c));
+      return runComputerCommand(
+        {
+          authHeader: `Bearer ${bearerToken}`,
+          projectId: body.projectId,
+          command: body.command,
+          commandId: body.commandId,
+          source: "chat",
+          ...(body.workdir ? { workdir: body.workdir } : {}),
+          ...(body.timeoutSeconds !== undefined
+            ? { timeoutSeconds: body.timeoutSeconds }
+            : {}),
+          signal: c.req.raw.signal,
+        },
+        runner
+      );
+    })
+  );
+
+  return computers;
+}
+
+export default createComputersRoutes();

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -21,6 +21,7 @@ import chatHistory from "./chat-history.js";
 import conformanceWeb from "./conformance.js";
 import checks from "./checks.js";
 import apiKeys from "./api-keys.js";
+import computers from "./computers.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -38,6 +39,10 @@ web.use("/chat-history/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/conformance/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/checks/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/server/*", bearerAuthMiddleware, guestRateLimitMiddleware);
+// `/computers/exec` runs commands — bearer required. `/computers/config` is
+// deliberately open: it returns only a boolean and a public URL, and the
+// client needs it before any authed flow to know where the terminal lives.
+web.use("/computers/exec", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use(
   "/apps/mcp-apps/widget-content",
   bearerAuthMiddleware,
@@ -62,6 +67,9 @@ web.route("/guest-session", guestSession);
 web.route("/chat-history", chatHistory);
 web.route("/conformance", conformanceWeb);
 web.route("/checks", checks);
+// `/computers/terminal` (the WS) is registered on the root app in
+// server/index.ts — only /config and /exec live on this sub-router.
+web.route("/computers", computers);
 // `/api-keys` carries its own bearer-auth `.use()` because
 // `sessionAuthMiddleware` bypasses `/api/web/*` entirely. Nothing on this
 // sub-router is reachable without a session JWT (WorkOS `sk_…` keys are

--- a/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-remote-data-plane.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getComputersRemoteDataPlaneUrl,
+  execViaRemoteDataPlane,
+} from "../computers/remote-data-plane";
+import { buildBashTool } from "../built-in-tools/bash";
+
+// The remote data plane is reached through global fetch; stub it and assert
+// both the standalone exec client and the bash tool's delegation branch.
+
+const REMOTE_URL = "https://dp.example.test";
+
+type FetchCall = { url: string; headers: Record<string, string>; body: any };
+
+let fetchCalls: FetchCall[];
+let fetchResponse: () => Response | Promise<Response>;
+
+function installFetchStub() {
+  fetchCalls = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL, init?: RequestInit) => {
+      fetchCalls.push({
+        url: String(url),
+        headers: (init?.headers ?? {}) as Record<string, string>,
+        body: init?.body ? JSON.parse(String(init.body)) : {},
+      });
+      return fetchResponse();
+    })
+  );
+}
+
+function jsonResponse(status: number, json: unknown): Response {
+  return new Response(JSON.stringify(json), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const execArgs = {
+  authHeader: "Bearer user-token",
+  projectId: "proj_1",
+  command: "echo hi",
+  commandId: "call_1",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("getComputersRemoteDataPlaneUrl", () => {
+  it("returns null when unset or blank", () => {
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "   ");
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+  });
+
+  it("normalizes to the origin (path and trailing slash dropped)", () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", `${REMOTE_URL}/some/path/`);
+    expect(getComputersRemoteDataPlaneUrl()).toBe(REMOTE_URL);
+  });
+
+  it("keeps explicit ports and allows plain http", () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "http://localhost:3500");
+    expect(getComputersRemoteDataPlaneUrl()).toBe("http://localhost:3500");
+  });
+
+  it("rejects invalid values and non-http(s) schemes", () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "not a url");
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "ftp://dp.example.test");
+    expect(getComputersRemoteDataPlaneUrl()).toBeNull();
+  });
+});
+
+describe("execViaRemoteDataPlane", () => {
+  beforeEach(() => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", REMOTE_URL);
+    installFetchStub();
+  });
+
+  it("POSTs the exec route with the user's bearer and returns the result", async () => {
+    fetchResponse = () =>
+      jsonResponse(200, { stdout: "hi\n", stderr: "", exitCode: 0 });
+
+    const result = await execViaRemoteDataPlane({
+      ...execArgs,
+      workdir: "/workspace",
+      timeoutSeconds: 30,
+    });
+    expect(result).toEqual({ stdout: "hi\n", stderr: "", exitCode: 0 });
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe(`${REMOTE_URL}/api/web/computers/exec`);
+    expect(fetchCalls[0].headers.authorization).toBe("Bearer user-token");
+    expect(fetchCalls[0].body).toEqual({
+      projectId: "proj_1",
+      command: "echo hi",
+      commandId: "call_1",
+      workdir: "/workspace",
+      timeoutSeconds: 30,
+    });
+  });
+
+  it("prefixes Bearer when the auth header is a bare token", async () => {
+    fetchResponse = () =>
+      jsonResponse(200, { stdout: "", stderr: "", exitCode: 0 });
+    await execViaRemoteDataPlane({ ...execArgs, authHeader: "raw-token" });
+    expect(fetchCalls[0].headers.authorization).toBe("Bearer raw-token");
+  });
+
+  it("passes through soft { error } results from the remote", async () => {
+    fetchResponse = () =>
+      jsonResponse(200, { error: "Computer unavailable: asleep" });
+    const result = await execViaRemoteDataPlane(execArgs);
+    expect(result).toEqual({ error: "Computer unavailable: asleep" });
+  });
+
+  it("maps webError envelopes (e.g. 401) to a tool-shaped error", async () => {
+    fetchResponse = () =>
+      jsonResponse(401, {
+        code: "UNAUTHORIZED",
+        message: "Missing or invalid bearer token",
+      });
+    const result = await execViaRemoteDataPlane(execArgs);
+    expect(result).toEqual({
+      error: "Computer unavailable: Missing or invalid bearer token",
+    });
+  });
+
+  it("reports unreachable remotes without throwing", async () => {
+    fetchResponse = () => {
+      throw new TypeError("fetch failed");
+    };
+    const result = await execViaRemoteDataPlane(execArgs);
+    expect(result).toEqual({
+      error: "Could not reach the computers data plane.",
+    });
+  });
+
+  it("rejects unexpected response shapes", async () => {
+    fetchResponse = () => jsonResponse(200, { unexpected: true });
+    const result = await execViaRemoteDataPlane(execArgs);
+    expect(result).toEqual({
+      error: "The computers data plane returned an unexpected response.",
+    });
+  });
+
+  it("errors cleanly when no remote is configured", async () => {
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", "");
+    const result = await execViaRemoteDataPlane(execArgs);
+    expect(result).toEqual({
+      error: "Computers are not configured on this server.",
+    });
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("bash tool delegation", () => {
+  beforeEach(() => {
+    // No local data-plane credentials — only the remote URL.
+    vi.stubEnv("COMPUTERS_REMOTE_DATA_PLANE_URL", REMOTE_URL);
+    installFetchStub();
+  });
+
+  function execTool(input: Record<string, unknown>) {
+    const runner = vi.fn();
+    const tool = buildBashTool(
+      {
+        authHeader: "Bearer user-token",
+        projectId: "proj_1",
+        workdir: "/workspace",
+      },
+      runner
+    );
+    return {
+      runner,
+      result: (tool as any).execute(input, {
+        toolCallId: "call_9",
+        abortSignal: undefined,
+        messages: [],
+      }) as Promise<unknown>,
+    };
+  }
+
+  it("forwards the exec to the remote data plane when local is unconfigured", async () => {
+    fetchResponse = () =>
+      jsonResponse(200, { stdout: "ok\n", stderr: "", exitCode: 0 });
+
+    const { runner, result } = execTool({ command: "ls", timeoutSeconds: 5 });
+    expect(await result).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+
+    // The local E2B runner must never be touched on the delegation path.
+    expect(runner).not.toHaveBeenCalled();
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe(`${REMOTE_URL}/api/web/computers/exec`);
+    expect(fetchCalls[0].body).toMatchObject({
+      projectId: "proj_1",
+      command: "ls",
+      commandId: "call_9",
+      workdir: "/workspace",
+      timeoutSeconds: 5,
+    });
+  });
+
+  it("prefers the local data plane when both are configured", async () => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "secret");
+    vi.stubEnv("E2B_API_KEY", "e2b_test");
+    fetchResponse = () =>
+      jsonResponse(200, {
+        computerId: "comp_1",
+        status: "ready",
+        provider: "e2b",
+        providerComputerId: "sbx_1",
+        projectId: "proj_1",
+        ownerUserId: "user_1",
+      });
+
+    const runner = vi.fn(async () => ({
+      stdout: "local\n",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const tool = buildBashTool(
+      { authHeader: "Bearer user-token", projectId: "proj_1" },
+      runner
+    );
+    const result = await (tool as any).execute(
+      { command: "true" },
+      { toolCallId: "call_1", abortSignal: undefined, messages: [] }
+    );
+    expect(result).toMatchObject({ stdout: "local\n", exitCode: 0 });
+    expect(runner).toHaveBeenCalled();
+    // Every fetch went to the Convex control plane, none to the remote.
+    expect(
+      fetchCalls.every((call) => call.url.startsWith("https://convex.example"))
+    ).toBe(true);
+  });
+});

--- a/mcpjam-inspector/server/utils/built-in-tools/bash.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/bash.ts
@@ -10,42 +10,32 @@
  * shape pattern as `exa-web-search.ts`: the inspector defines the tool;
  * authorization and durable state live in Convex.
  *
- * Execute flow (see mcpjam-backend docs/project-computers.md):
- *   1. `ensureComputerReady` — POST /computers/reserve with the user's bearer
- *      (member-gated, idempotent, wakes a hibernated machine) and poll to
- *      `ready`. Surfaces provisioning status to the model as a clean error
- *      when the budget runs out.
- *   2. `/computers/sandbox-info` (shared secret) — vendor sandbox id. The
- *      browser can never make this exchange.
- *   3. E2B exec: `Sandbox.connect(sandboxId)` (auto-resumes a paused box)
- *      then `commands.run` with the host-configured workdir.
- *   4. Record the command to the Convex log (best-effort, idempotent on
- *      `toolCallId`).
- *   5. Return `{ stdout, stderr, exitCode, authUrls? }` — auth-looking URLs
- *      are lifted out so device-flow logins (`gh auth login`) are clickable.
+ * The exec pipeline (reserve → sandbox-info → E2B exec → command log) lives
+ * in `computers/run-command.ts`, shared with the /api/web/computers/exec
+ * route. When THIS server isn't a configured data plane (an OSS
+ * contributor's localhost — no vendor key, no secrets), the tool delegates
+ * the exec to the deployed inspector named by
+ * `COMPUTERS_REMOTE_DATA_PLANE_URL`, forwarding the user's bearer; Convex
+ * authorizes it identically either way. See
+ * `computers/remote-data-plane.ts`.
  *
  * `execute` returns `{ error }` instead of throwing so the model can relay
  * problems conversationally instead of breaking the turn.
  */
 import { tool, type ToolSet } from "ai";
 import { z } from "zod";
-import { Sandbox, CommandExitError, TimeoutError } from "e2b";
+import { isComputersDataPlaneConfigured } from "../computers/control-plane-client.js";
+import { execViaRemoteDataPlane } from "../computers/remote-data-plane.js";
 import {
-  ensureComputerReady,
-  getComputerSandboxInfo,
-  isComputersDataPlaneConfigured,
-  recordComputerCommand,
-} from "../computers/control-plane-client.js";
-import { detectAuthUrls } from "../computers/auth-urls.js";
-import { logger } from "../logger.js";
+  DEFAULT_COMMAND_TIMEOUT_S,
+  MAX_COMMAND_TIMEOUT_S,
+  e2bRunner,
+  runComputerCommand,
+  type BashRunner,
+  type RunComputerCommandResult,
+} from "../computers/run-command.js";
 
 export const BASH_TOOL_NAME = "bash";
-
-// Caps on what the model sees; the Convex log stores its own (smaller)
-// preview and full-output archival is a backend follow-up.
-const MODEL_OUTPUT_CAP = 16_000;
-const DEFAULT_COMMAND_TIMEOUT_S = 120;
-const MAX_COMMAND_TIMEOUT_S = 600;
 
 export interface BashToolOptions {
   /** Bearer authorization forwarded to Convex (already in scope). */
@@ -56,61 +46,6 @@ export interface BashToolOptions {
   workdir?: string;
   /** Mirrors the host's requireToolApproval — a root shell must honor it. */
   requireToolApproval?: boolean;
-}
-
-interface BashExecOutput {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-  /** Device-flow/login URLs detected in the output, for clickable rendering. */
-  authUrls?: string[];
-}
-
-type BashRunner = (args: {
-  sandboxId: string;
-  command: string;
-  workdir?: string;
-  timeoutMs: number;
-  signal?: AbortSignal;
-}) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
-
-// Default runner — real E2B. Kept injectable so tests exercise the tool
-// without a vendor account.
-const e2bRunner: BashRunner = async ({
-  sandboxId,
-  command,
-  workdir,
-  timeoutMs,
-  signal,
-}) => {
-  const sandbox = await Sandbox.connect(sandboxId);
-  try {
-    const result = await sandbox.commands.run(command, {
-      ...(workdir ? { cwd: workdir } : {}),
-      timeoutMs,
-      ...(signal ? { signal } : {}),
-    });
-    return {
-      stdout: result.stdout,
-      stderr: result.stderr,
-      exitCode: result.exitCode,
-    };
-  } catch (error) {
-    // Non-zero exit is a normal shell outcome, not a tool failure.
-    if (error instanceof CommandExitError) {
-      return {
-        stdout: error.stdout,
-        stderr: error.stderr,
-        exitCode: error.exitCode ?? 1,
-      };
-    }
-    throw error;
-  }
-};
-
-function truncate(text: string, cap: number): string {
-  if (text.length <= cap) return text;
-  return `${text.slice(0, cap)}\n…[truncated ${text.length - cap} chars]`;
 }
 
 export function buildBashTool(
@@ -146,81 +81,22 @@ export function buildBashTool(
     execute: async (
       { command, timeoutSeconds },
       { toolCallId, abortSignal }
-    ): Promise<BashExecOutput | { error: string }> => {
-      if (!isComputersDataPlaneConfigured()) {
-        return { error: "Computers are not configured on this server." };
-      }
-
-      const ready = await ensureComputerReady({
-        bearer: opts.authHeader,
+    ): Promise<RunComputerCommandResult> => {
+      const execArgs = {
+        authHeader: opts.authHeader,
         projectId: opts.projectId,
-        signal: abortSignal,
-      });
-      if (!ready.ok) {
-        return { error: `Computer unavailable: ${ready.error}` };
-      }
-      const computerId = ready.value.computerId;
-
-      const info = await getComputerSandboxInfo({
-        computerId,
-        signal: abortSignal,
-      });
-      if (!info.ok) {
-        return { error: `Computer unavailable: ${info.error}` };
-      }
-      if (!info.value.providerComputerId) {
-        return {
-          error: "Computer is still provisioning — try again in a moment.",
-        };
-      }
-
-      const timeoutMs =
-        Math.min(
-          Math.max(timeoutSeconds ?? DEFAULT_COMMAND_TIMEOUT_S, 1),
-          MAX_COMMAND_TIMEOUT_S
-        ) * 1000;
-
-      let result: { stdout: string; stderr: string; exitCode: number };
-      try {
-        result = await runner({
-          sandboxId: info.value.providerComputerId,
-          command,
-          workdir: opts.workdir,
-          timeoutMs,
-          signal: abortSignal,
-        });
-      } catch (error) {
-        if (abortSignal?.aborted) {
-          return { error: "Command was cancelled." };
-        }
-        if (error instanceof TimeoutError) {
-          return {
-            error: `Command timed out after ${Math.round(timeoutMs / 1000)}s.`,
-          };
-        }
-        logger.error("[bash-tool] exec failed", error);
-        return { error: "Command failed to run on the computer." };
-      }
-
-      // Best-effort durable log; never fails the tool call. toolCallId is the
-      // idempotency key, so an AI-SDK retry can't double-log.
-      await recordComputerCommand({
-        computerId,
-        commandId: toolCallId,
-        source: "chat",
         command,
-        status: result.exitCode === 0 ? "completed" : "failed",
-        exitCode: result.exitCode,
-        outputPreview: `${result.stdout}\n${result.stderr}`.trim(),
-      }).catch(() => {});
-
-      const authUrls = detectAuthUrls(`${result.stdout}\n${result.stderr}`);
-      return {
-        stdout: truncate(result.stdout, MODEL_OUTPUT_CAP),
-        stderr: truncate(result.stderr, MODEL_OUTPUT_CAP),
-        exitCode: result.exitCode,
-        ...(authUrls.length > 0 ? { authUrls } : {}),
+        commandId: toolCallId,
+        workdir: opts.workdir,
+        timeoutSeconds,
+        signal: abortSignal,
       };
+      if (isComputersDataPlaneConfigured()) {
+        return runComputerCommand({ ...execArgs, source: "chat" }, runner);
+      }
+      // No vendor credentials here — delegate to the deployed data plane
+      // (or report unconfigured when no remote is named either).
+      return execViaRemoteDataPlane(execArgs);
     },
   });
 }

--- a/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
+++ b/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
@@ -1,0 +1,116 @@
+/**
+ * Remote data plane for Project Computers.
+ *
+ * Being the data plane requires `E2B_API_KEY` + the shared secrets —
+ * credentials a locally-run OSS inspector must never hold (the vendor key is
+ * billable; the secret resolves ANY user's sandbox id). Instead, a local
+ * server can name a deployed inspector via the NON-secret
+ * `COMPUTERS_REMOTE_DATA_PLANE_URL` and forward both data-plane operations
+ * there, keeping authorization per-user end to end:
+ *
+ *   - terminal: the browser opens its WebSocket against the remote origin
+ *     (advertised via GET /api/web/computers/config); auth is unchanged —
+ *     the Convex-minted per-user terminal token works on any data plane
+ *     holding the verify secret.
+ *   - bash exec: `execViaRemoteDataPlane` POSTs /api/web/computers/exec with
+ *     the user's bearer; the remote forwards it to Convex `/computers/reserve`
+ *     which authorizes exactly as if that server had received the chat turn.
+ *
+ * Local configuration (real secrets) always wins over the remote URL — a
+ * deployed data plane never delegates, so there is no forwarding loop.
+ */
+import { logger } from "../logger.js";
+import {
+  COMPUTERS_NOT_CONFIGURED_ERROR,
+  type RunComputerCommandResult,
+} from "./run-command.js";
+
+/** Origin of the deployed data plane, or null when unset/invalid. */
+export function getComputersRemoteDataPlaneUrl(): string | null {
+  const raw = process.env.COMPUTERS_REMOTE_DATA_PLANE_URL?.trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function isExecResult(payload: unknown): payload is RunComputerCommandResult {
+  if (!payload || typeof payload !== "object") return false;
+  const p = payload as Record<string, unknown>;
+  if (typeof p.error === "string") return true;
+  return (
+    typeof p.stdout === "string" &&
+    typeof p.stderr === "string" &&
+    typeof p.exitCode === "number"
+  );
+}
+
+export async function execViaRemoteDataPlane(args: {
+  /** Bearer authorization forwarded verbatim (the remote re-validates it). */
+  authHeader: string;
+  projectId: string;
+  command: string;
+  commandId: string;
+  workdir?: string;
+  timeoutSeconds?: number;
+  signal?: AbortSignal;
+}): Promise<RunComputerCommandResult> {
+  const base = getComputersRemoteDataPlaneUrl();
+  if (!base) {
+    return { error: COMPUTERS_NOT_CONFIGURED_ERROR };
+  }
+
+  const trimmed = args.authHeader.trim();
+  const authorization = /^bearer\s/i.test(trimmed)
+    ? trimmed
+    : `Bearer ${trimmed}`;
+
+  let response: Response;
+  try {
+    response = await fetch(`${base}/api/web/computers/exec`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization },
+      body: JSON.stringify({
+        projectId: args.projectId,
+        command: args.command,
+        commandId: args.commandId,
+        ...(args.workdir ? { workdir: args.workdir } : {}),
+        ...(args.timeoutSeconds !== undefined
+          ? { timeoutSeconds: args.timeoutSeconds }
+          : {}),
+      }),
+      ...(args.signal ? { signal: args.signal } : {}),
+    });
+  } catch (error) {
+    if (args.signal?.aborted) {
+      return { error: "Command was cancelled." };
+    }
+    logger.error("[computers] remote data plane exec network error", error);
+    return { error: "Could not reach the computers data plane." };
+  }
+
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch {
+    // fall through with null payload
+  }
+
+  if (!response.ok) {
+    // webError envelope: { code, message, … }.
+    const message =
+      payload &&
+      typeof payload === "object" &&
+      typeof (payload as { message?: unknown }).message === "string"
+        ? (payload as { message: string }).message
+        : `remote exec failed (${response.status})`;
+    return { error: `Computer unavailable: ${message}` };
+  }
+
+  if (isExecResult(payload)) return payload;
+  return { error: "The computers data plane returned an unexpected response." };
+}

--- a/mcpjam-inspector/server/utils/computers/run-command.ts
+++ b/mcpjam-inspector/server/utils/computers/run-command.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared exec core for Project Computers — one command, end to end:
+ * reserve/wake (user bearer) → sandbox-info (shared secret) → vendor exec →
+ * durable command log. Extracted from the `bash` built-in tool so the same
+ * pipeline serves two callers with the same trust shape:
+ *
+ *   - the `bash` tool (chat surface) when THIS server is the data plane;
+ *   - POST /api/web/computers/exec when this server is the data plane for a
+ *     remote inspector that holds no vendor credentials (an OSS contributor's
+ *     localhost — see remote-data-plane.ts).
+ *
+ * Soft failures return `{ error }` instead of throwing so the chat model can
+ * relay them conversationally; the exec route returns the same shape.
+ */
+import { Sandbox, CommandExitError, TimeoutError } from "e2b";
+import {
+  ensureComputerReady,
+  getComputerSandboxInfo,
+  isComputersDataPlaneConfigured,
+  recordComputerCommand,
+} from "./control-plane-client.js";
+import { detectAuthUrls } from "./auth-urls.js";
+import { logger } from "../logger.js";
+
+// Caps on what the model sees; the Convex log stores its own (smaller)
+// preview and full-output archival is a backend follow-up.
+const MODEL_OUTPUT_CAP = 16_000;
+export const DEFAULT_COMMAND_TIMEOUT_S = 120;
+export const MAX_COMMAND_TIMEOUT_S = 600;
+
+export const COMPUTERS_NOT_CONFIGURED_ERROR =
+  "Computers are not configured on this server.";
+
+export interface ComputerExecOutput {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  /** Device-flow/login URLs detected in the output, for clickable rendering. */
+  authUrls?: string[];
+}
+
+export type RunComputerCommandResult = ComputerExecOutput | { error: string };
+
+export type BashRunner = (args: {
+  sandboxId: string;
+  command: string;
+  workdir?: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+// Default runner — real E2B. Kept injectable so tests exercise the pipeline
+// without a vendor account.
+export const e2bRunner: BashRunner = async ({
+  sandboxId,
+  command,
+  workdir,
+  timeoutMs,
+  signal,
+}) => {
+  const sandbox = await Sandbox.connect(sandboxId);
+  try {
+    const result = await sandbox.commands.run(command, {
+      ...(workdir ? { cwd: workdir } : {}),
+      timeoutMs,
+      ...(signal ? { signal } : {}),
+    });
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    };
+  } catch (error) {
+    // Non-zero exit is a normal shell outcome, not a tool failure.
+    if (error instanceof CommandExitError) {
+      return {
+        stdout: error.stdout,
+        stderr: error.stderr,
+        exitCode: error.exitCode ?? 1,
+      };
+    }
+    throw error;
+  }
+};
+
+function truncate(text: string, cap: number): string {
+  if (text.length <= cap) return text;
+  return `${text.slice(0, cap)}\n…[truncated ${text.length - cap} chars]`;
+}
+
+export interface RunComputerCommandArgs {
+  /** Bearer authorization forwarded to Convex (authz + wake). */
+  authHeader: string;
+  /** Project whose (project, user) computer this command runs on. */
+  projectId: string;
+  command: string;
+  /** Idempotency key for the durable command log (tool call id). */
+  commandId: string;
+  source: "chat" | "terminal-api";
+  workdir?: string;
+  timeoutSeconds?: number;
+  signal?: AbortSignal;
+}
+
+export async function runComputerCommand(
+  args: RunComputerCommandArgs,
+  runner: BashRunner = e2bRunner
+): Promise<RunComputerCommandResult> {
+  if (!isComputersDataPlaneConfigured()) {
+    return { error: COMPUTERS_NOT_CONFIGURED_ERROR };
+  }
+
+  const ready = await ensureComputerReady({
+    bearer: args.authHeader,
+    projectId: args.projectId,
+    signal: args.signal,
+  });
+  if (!ready.ok) {
+    return { error: `Computer unavailable: ${ready.error}` };
+  }
+  const computerId = ready.value.computerId;
+
+  const info = await getComputerSandboxInfo({
+    computerId,
+    signal: args.signal,
+  });
+  if (!info.ok) {
+    return { error: `Computer unavailable: ${info.error}` };
+  }
+  if (!info.value.providerComputerId) {
+    return {
+      error: "Computer is still provisioning — try again in a moment.",
+    };
+  }
+
+  const timeoutMs =
+    Math.min(
+      Math.max(args.timeoutSeconds ?? DEFAULT_COMMAND_TIMEOUT_S, 1),
+      MAX_COMMAND_TIMEOUT_S
+    ) * 1000;
+
+  let result: { stdout: string; stderr: string; exitCode: number };
+  try {
+    result = await runner({
+      sandboxId: info.value.providerComputerId,
+      command: args.command,
+      workdir: args.workdir,
+      timeoutMs,
+      signal: args.signal,
+    });
+  } catch (error) {
+    if (args.signal?.aborted) {
+      return { error: "Command was cancelled." };
+    }
+    if (error instanceof TimeoutError) {
+      return {
+        error: `Command timed out after ${Math.round(timeoutMs / 1000)}s.`,
+      };
+    }
+    logger.error("[bash-tool] exec failed", error);
+    return { error: "Command failed to run on the computer." };
+  }
+
+  // Best-effort durable log; never fails the call. commandId is the
+  // idempotency key, so an AI-SDK retry can't double-log.
+  await recordComputerCommand({
+    computerId,
+    commandId: args.commandId,
+    source: args.source,
+    command: args.command,
+    status: result.exitCode === 0 ? "completed" : "failed",
+    exitCode: result.exitCode,
+    outputPreview: `${result.stdout}\n${result.stderr}`.trim(),
+  }).catch(() => {});
+
+  const authUrls = detectAuthUrls(`${result.stdout}\n${result.stderr}`);
+  return {
+    stdout: truncate(result.stdout, MODEL_OUTPUT_CAP),
+    stderr: truncate(result.stderr, MODEL_OUTPUT_CAP),
+    exitCode: result.exitCode,
+    ...(authUrls.length > 0 ? { authUrls } : {}),
+  };
+}


### PR DESCRIPTION
## Problem

A locally-run OSS inspector has no `E2B_API_KEY` or data-plane secrets — and must never hold them (the vendor key is billable; the shared secret resolves any user's sandbox id). But that left Project Computers dead on every contributor's localhost: the Convex control plane reports the computer **Ready** while the terminal rejects with *"Computers are not configured on this server."* — a contradictory, unfixable-from-the-UI state.

## Approach

A local inspector can now name a **deployed** inspector via the non-secret `COMPUTERS_REMOTE_DATA_PLANE_URL` and delegate the two data-plane operations there. Authorization stays per-user end to end; no credentials ever reach the local machine.

- **`GET /api/web/computers/config`** (open) — data-plane discovery: `{ localConfigured, remoteDataPlaneUrl }`. Returns only a boolean and a public URL.
- **Terminal** — the browser opens its WebSocket against the remote origin (`toTerminalWsBase`, https→wss). Auth unchanged: the Convex-minted ~60s per-user terminal token works on any data plane holding the verify secret.
- **Bash tool** — the exec pipeline (reserve → sandbox-info → E2B exec → command log) is extracted from `bash.ts` into `computers/run-command.ts`, shared by the tool and the new bearer-authed **`POST /api/web/computers/exec`**. A credential-less inspector forwards exec there with the user's bearer; Convex authorizes it on `/computers/reserve` exactly as if the remote had received the chat turn — the remote can only ever run commands on the caller's own computer.
- **UI** — when neither a local nor remote data plane exists, the Computer tab shows an honest empty state (and hides "Open terminal") instead of a Ready badge next to a terminal that can't connect. Delete stays available — the computer lives in Convex/E2B, not on the unconfigured server.

## Safety properties

- `/exec` never delegates further — a misconfigured pair of servers can't forward in a loop.
- Local configuration (real secrets) always wins over the remote URL.
- `/exec` sits behind `bearerAuthMiddleware` + guest rate limiting like the other MCP operation routes; the forwarded `commandId` (tool call id) keeps the durable command log idempotent across the hop.
- Soft failures stay `{ error }`-shaped end to end so the chat model relays them conversationally.

## Testing

- 54 tests pass across 7 files: new suites for URL resolution + remote exec client, the config/exec routes (including the no-loop guard and 401 path), bash-tool delegation (and local-wins precedence), `toTerminalWsBase`, plus all pre-existing computer tests unchanged in behavior.
- Client typecheck clean; server tsconfig errors and the one prettier warning in `web/index.ts` are pre-existing on main (verified against a clean checkout).

## Not included (ops follow-ups)

Standing up a dev data plane paired with the shared OSS-dev Convex deployment, and adding its URL to the committed `.env.local` so contributors get working computers on clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces cross-origin terminal WebSockets and bearer-forwarded remote command execution; mitigations include local-wins precedence, no exec chaining, and extensive tests, but auth and sandbox isolation still depend on Convex reserve and remote deployment correctness.
> 
> **Overview**
> **Local OSS inspectors without E2B/data-plane secrets** can point at a deployed inspector with **`COMPUTERS_REMOTE_DATA_PLANE_URL`** and still use Project Computers: user bearer auth stays end-to-end; no vendor keys on localhost.
> 
> **Server:** Adds **`GET /api/web/computers/config`** (open discovery: `localConfigured`, `remoteDataPlaneUrl`) and bearer **`POST /api/web/computers/exec`**, which runs the shared **`runComputerCommand`** pipeline extracted from the bash tool. **`execViaRemoteDataPlane`** forwards bash from unconfigured locals to the remote `/exec`; **`/exec` never re-delegates** (loop guard). Local secrets **win** over the remote URL when both are set.
> 
> **Client:** **`useComputersDataPlaneConfig`** fetches config once; **`ComputerTerminal`** accepts optional **`baseUrl`** for cross-origin WS; **`ComputerView`** shows an empty state when no plane exists, waits for config before mounting the terminal (avoids wrong-origin first connect), and hides **Open terminal** when unavailable.
> 
> **Tests** cover config/exec routes, remote URL normalization, delegation vs local-wins, and UI data-plane states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddbb9ca21ced37dc2dc09ed3c296c751339ca7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->