### PR TITLE
host: expand focus panel by default on Host tab

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -79,7 +79,11 @@ export function HostBuilderViewRedesigned({
   const [isSaving, setIsSaving] = useState(false);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [showAddServer, setShowAddServer] = useState(false);
-  const [focusState, setFocusState] = useState<HostFocusState>(CLOSED_FOCUS);
+  const [focusState, setFocusState] = useState<HostFocusState>({
+    open: true,
+    tab: "behavior",
+    selectedServerId: null,
+  });
   // Diff snapshot — populated for ONE render after a host switch so the
   // canvas can mark changed leaves/fields. Cleared after the flash
   // duration so subsequent in-place edits don't keep re-firing the


### PR DESCRIPTION
## Summary
- Opens the Agent/behavior focus panel by default when navigating to the Host tab, instead of requiring a click on the host node first

## Test plan
- [ ] Navigate to the Host tab — the right panel should be open on the Agent tab immediately
- [ ] Closing the panel and re-opening still works
- [ ] Clicking canvas nodes still routes to the correct tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only default for local React state; no persistence, API, or auth changes.
> 
> **Overview**
> The redesigned host builder now **starts with the right focus rail open** on the **Agent** (`behavior`) tab instead of a closed panel that only appeared after clicking the host node.
> 
> This is a one-line initial-state change in `HostBuilderViewRedesigned`: `focusState` no longer seeds from `CLOSED_FOCUS`. **Close**, **re-open**, and **canvas node selection** still use the existing `closeFocus` / `openFocus` / `handleSelectNode` paths, so only the first-load default layout changes (split canvas + ~45% focus panel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13407361e191f06795851e4baaac139d201dfed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->