### PR TITLE
feat: default landing to Home instead of Connect

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1189,8 +1189,6 @@ export function ServersRedirectRoute() {
 export function HomeRoute() {
   const { activeProjectId, homeOrganizationId, isHomeContextResolving } =
     useAppRouteContext();
-  const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
-  if (!homeEnabled) return <ServersRoute />;
   return (
     <HomeTab
       // Membership-validated org for `/home` (the route carries none, so it is
@@ -1300,12 +1298,9 @@ export default function App() {
       setEvaluateRunsFlagsLoaded(posthog.featureFlags?.hasLoadedFlags === true);
     });
   }, [posthog]);
-  const defaultHubRoute = useMemo((): "connect" | "servers" => {
-    if (!evaluateRunsFlagsLoaded) {
-      return "servers";
-    }
-    return hostsHubFlagEnabled && isAuthenticated ? "connect" : "servers";
-  }, [evaluateRunsFlagsLoaded, hostsHubFlagEnabled, isAuthenticated]);
+  const defaultHubRoute = useMemo((): "home" | "connect" | "servers" => {
+    return "home";
+  }, []);
   const isHostedChatRoute = isChatboxChatRoute;
   const locationContext = useContext(UNSAFE_LocationContext);
   const routeOrganizationId = currentOrgRoute?.orgId;


### PR DESCRIPTION
## Summary

- Removes the `home-page-enabled` PostHog feature flag guard from `HomeRoute`, so visiting `/` or `/home` always renders `HomeTab` instead of falling back to `ServersRoute`
- Changes `defaultHubRoute` to always return `"home"`, so blocked-tab redirect guards (billing-locked, disabled features, etc.) also land on Home rather than Connect/Servers

## NUX / Playground "Try Me" flow

Unaffected. `"home"` was already in `isFirstRunEligible`'s route allowlist (`onboarding-state.ts`), so first-run users visiting `/` will still get redirected to `/playground` as expected.

## Test plan

- [ ] Visit `/` as a returning user → lands on Home tab
- [ ] Visit `/home` → lands on Home tab
- [ ] First-run user (no servers, no prior onboarding) → redirected to Playground (NUX unchanged)
- [ ] Navigate to a billing-locked or feature-flagged-off tab → redirects to Home instead of Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Routing and default landing behavior change for all users; misconfiguration could strand users on Home or skip expected Connect flows, though NUX to Playground is documented as unchanged.
> 
> **Overview**
> **Home is now the default hub** instead of Connect or Servers. Visiting `/` or `/home` always renders `HomeTab`; the `home-page-enabled` PostHog guard that previously sent users to `ServersRoute` is removed from `HomeRoute`.
> 
> **Blocked-tab redirects** (billing-locked features, disabled registry/learning/conformance, hosts hub off, etc.) now call `navigateToTarget(defaultHubRoute)` with `defaultHubRoute` fixed to `"home"`. The old logic waited on evaluate-run flags and chose `"connect"` when the hosts hub flag and auth allowed, otherwise `"servers"`.
> 
> First-run Playground redirect is unchanged: `isFirstRunEligible` already treats the home route as an allowed landing tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 628245febadd2e6bbc3c183eca7af9aea637e723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->