### PR TITLE
mcpjam-agent: add full platform catalog (eval, chatbox, project tools)

### DIFF
--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -27,6 +27,8 @@ import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { streamWebChatTurn } from "../../utils/web-chat-turn.js";
 import { WEB_SEARCH_TOOL_NAME } from "../../utils/built-in-tools/exa-web-search.js";
 import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
+import { MCPJAM_TOOL_IDS } from "../../utils/built-in-tools/mcpjam.js";
+import { buildMcpjamPlatformClient } from "./mcpjam-platform-client.js";
 import {
   assertBearerToken,
   readJsonBody,
@@ -106,11 +108,12 @@ mcpjamAgent.post("/", async (c) => {
       const authHeader = c.req.header("authorization");
       const builtInTools = authHeader
         ? resolveHostTools(
-            { builtInToolIds: [WEB_SEARCH_TOOL_NAME] },
+            { builtInToolIds: [WEB_SEARCH_TOOL_NAME, ...MCPJAM_TOOL_IDS] },
             {
               authHeader,
               projectId: body.projectId,
               chatSessionId: body.chatSessionId,
+              mcpjamPlatformClient: buildMcpjamPlatformClient(c),
             }
           )
         : undefined;

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-built-in-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-built-in-tools.test.ts
@@ -127,6 +127,7 @@ function execTool(
 describe("workspace tool catalog", () => {
   it("pins the operation names the backend catalog rows must mirror", () => {
     expect([...MCPJAM_TOOL_IDS]).toEqual([
+      "list_projects",
       "list_project_servers",
       "diagnose_server",
       "list_server_tools",
@@ -135,10 +136,19 @@ describe("workspace tool catalog", () => {
       "get_server_prompt",
       "list_server_resources",
       "read_server_resource",
+      "list_eval_suites",
+      "list_eval_suite_runs",
+      "run_eval_suite",
+      "get_eval_run",
+      "list_eval_run_iterations",
+      "get_eval_iteration_trace",
+      "list_chatboxes",
+      "get_chatbox",
+      "list_chat_sessions",
     ]);
     for (const id of MCPJAM_TOOL_IDS) expect(isMcpjamToolId(id)).toBe(true);
     expect(isMcpjamToolId("web_search")).toBe(false);
-    expect(isMcpjamToolId("list_projects")).toBe(false);
+    expect(isMcpjamToolId("show_servers")).toBe(false);
   });
 
   it("returns null for ids outside the workspace set", () => {

--- a/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
@@ -32,20 +32,31 @@ import { tool, type ToolSet } from "ai";
 import {
   callServerToolOperation,
   diagnoseServerOperation,
+  getChatboxOperation,
+  getEvalIterationTraceOperation,
+  getEvalRunOperation,
   getServerPromptOperation,
+  listChatboxesOperation,
+  listChatSessionsOperation,
+  listEvalRunIterationsOperation,
+  listEvalSuiteRunsOperation,
+  listEvalSuitesOperation,
+  listProjectsOperation,
   listProjectServersOperation,
   listServerPromptsOperation,
   listServerResourcesOperation,
   listServerToolsOperation,
   readServerResourceOperation,
+  runEvalSuiteOperation,
   type PlatformApiClient,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 
-// The workspace toolset, in advertise order. Backend catalog rows
-// (mcpjam-backend convex/builtInTools/catalog.ts SEED_ROWS) must carry these
-// exact operation names — a catalog id doubles as the AI SDK tool name.
+// The workspace toolset, in advertise order. Mirrors PLATFORM_CATALOG_OPERATIONS
+// in mcp/src/tools/platformTools.ts — both surfaces pull from the same SDK
+// operations. showServersOperation is intentionally omitted (MCP Apps widget only).
 const WORKSPACE_OPERATIONS: ReadonlyArray<PlatformOperation<any, unknown>> = [
+  listProjectsOperation,
   listProjectServersOperation,
   diagnoseServerOperation,
   listServerToolsOperation,
@@ -54,6 +65,15 @@ const WORKSPACE_OPERATIONS: ReadonlyArray<PlatformOperation<any, unknown>> = [
   getServerPromptOperation,
   listServerResourcesOperation,
   readServerResourceOperation,
+  listEvalSuitesOperation,
+  listEvalSuiteRunsOperation,
+  runEvalSuiteOperation,
+  getEvalRunOperation,
+  listEvalRunIterationsOperation,
+  getEvalIterationTraceOperation,
+  listChatboxesOperation,
+  getChatboxOperation,
+  listChatSessionsOperation,
 ];
 
 const OPERATIONS_BY_ID = new Map(
@@ -68,11 +88,18 @@ export function isMcpjamToolId(id: string): boolean {
   return OPERATIONS_BY_ID.has(id);
 }
 
-// Every operation except the pure platform read opens an ephemeral
-// connection to a saved MCP server, so it honors the host's approval policy.
-const CONNECTION_OPENING_IDS = new Set(
-  MCPJAM_TOOL_IDS.filter((id) => id !== listProjectServersOperation.name)
-);
+// Operations that open an ephemeral connection to a user's saved MCP server
+// inherit the host's requireToolApproval. Pure platform API reads (project,
+// eval, chatbox) never need approval.
+const CONNECTION_OPENING_IDS = new Set([
+  diagnoseServerOperation.name,
+  listServerToolsOperation.name,
+  callServerToolOperation.name,
+  listServerPromptsOperation.name,
+  getServerPromptOperation.name,
+  listServerResourcesOperation.name,
+  readServerResourceOperation.name,
+]);
 
 // Surface note appended to each operation's description: in-app, an omitted
 // `project` means the chat's project, not the catalog's "most recently


### PR DESCRIPTION
## Summary

- Expands `WORKSPACE_OPERATIONS` in `mcpjam.ts` from 8 server-operation tools to the full 18-tool platform catalog, matching what the MCP worker (`mcp/src/tools/platformTools.ts`) already advertises. Adds `list_projects`, 6 eval ops, 3 chatbox/session ops.
- Wires the workspace tools into `mcpjam-agent.ts` (already done in #2624 for the server ops; now picks up the new additions automatically via `MCPJAM_TOOL_IDS`).
- Replaces the "everything except list_project_servers" heuristic in `CONNECTION_OPENING_IDS` with an explicit set of the 7 ops that open ephemeral MCP connections, so eval/chatbox/project reads don't inherit `requireToolApproval`.
- These tools are hardcoded into the mcpjam-agent route only — not exposed through the host-config catalog. Companion backend PR #522 disables the catalog rows.

## Test plan

- [ ] Ask the Home page agent "list my eval suites" — should call `list_eval_suites` and return results
- [ ] Ask "list my chatboxes" — should call `list_chatboxes`
- [ ] Ask "list my projects" — should call `list_projects`
- [ ] Verify `call_server_tool` and other MCP-connection ops still prompt for approval when `requireToolApproval` is on
- [ ] Verify `list_eval_suites` and other pure reads do NOT prompt for approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds eval run and server-side tool execution paths to the Home agent; approval scoping changes affect UX for platform reads vs MCP ops but connection-opening tools still honor host approval.
> 
> **Overview**
> The Home **mcpjam-agent** route now advertises the full **18-tool** workspace catalog (via `MCPJAM_TOOL_IDS`), not just server MCP ops—adding **project**, **eval**, and **chatbox/session** platform reads and **`run_eval_suite`**, aligned with the MCP worker’s `PLATFORM_CATALOG_OPERATIONS`.
> 
> **`mcpjam.ts`** grows `WORKSPACE_OPERATIONS` with the new SDK operations and replaces the old “everything except `list_project_servers` needs approval” rule with an explicit **`CONNECTION_OPENING_IDS`** set (seven ops that open ephemeral MCP connections). Pure platform reads—including **`list_projects`**, eval listing/detail, and chatbox tools—no longer inherit **`requireToolApproval`**.
> 
> The agent route passes **`buildMcpjamPlatformClient(c)`** into **`resolveHostTools`** so those tools execute against the caller’s bearer on `/api/v1`. Tests pin the expanded operation name list and still assert approval only on connection-opening ops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 715add866572ed3663769e6c38b2d4d5c7b62a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->