### PR TITLE
Remove 11 fully rolled-out PostHog feature flags

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -11,7 +11,7 @@ import {
   type ComponentProps,
 } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
-import { AlertTriangle, Construction, Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { MCPJamLimitDialog } from "./components/mcpjam-limit-dialog";
 import { HomeTab } from "./components/HomeTab";
@@ -40,7 +40,6 @@ import { ConformanceTab } from "./components/conformance/ConformancePanel";
 import { XAAFlowTab } from "./components/xaa/XAAFlowTab";
 import { ErrorBoundary } from "./components/ui/error-boundary";
 import { PlaygroundTab } from "./components/playground/PlaygroundTab";
-import { EmptyState } from "./components/ui/empty-state";
 import { EXCALIDRAW_SERVER_NAME } from "./lib/excalidraw-quick-connect";
 import { isFirstRunEligible } from "./lib/onboarding-state";
 import { ProfileTab } from "./components/ProfileTab";
@@ -57,10 +56,7 @@ import { motion } from "framer-motion";
 import { SNAPPY_RAIL } from "./components/hosts/transition-tokens";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
-import {
-  MCPSidebar,
-  computeHostsHubFlagEnabled,
-} from "./components/mcp-sidebar";
+import { MCPSidebar } from "./components/mcp-sidebar";
 import {
   SidebarInset,
   SidebarProvider,
@@ -514,8 +510,7 @@ function ActiveBillingUpsellGate() {
 }
 
 export function ServersRoute() {
-  const { convexProjectId, hostsHubFlagEnabled, isAuthenticated } =
-    useAppRouteContext();
+  const { convexProjectId, isAuthenticated } = useAppRouteContext();
   const navigate = useAppNavigate();
 
   // From /servers, "select a host" means navigate to /hosts/:id. State sync
@@ -528,7 +523,7 @@ export function ServersRoute() {
     [navigate]
   );
 
-  if (!hostsHubFlagEnabled || !isAuthenticated) {
+  if (!isAuthenticated) {
     return <ServersTabBody />;
   }
 
@@ -595,7 +590,6 @@ function ServersTabBody() {
 export function HostsRoute() {
   const {
     convexProjectId,
-    hostsHubFlagEnabled,
     hostsTabSelectedHostId,
     isAuthenticated,
     setHostsTabSelectedHostId,
@@ -627,7 +621,7 @@ export function HostsRoute() {
     [navigate]
   );
 
-  if (!hostsHubFlagEnabled || !isAuthenticated) {
+  if (!isAuthenticated) {
     return <ServersTabBody />;
   }
 
@@ -643,8 +637,7 @@ export function HostsRoute() {
 }
 
 export function HostCompareRoute() {
-  const { convexProjectId, hostsHubFlagEnabled, isAuthenticated } =
-    useAppRouteContext();
+  const { convexProjectId, isAuthenticated } = useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
   const navigate = useAppNavigate();
 
@@ -655,9 +648,9 @@ export function HostCompareRoute() {
     />
   );
 
-  // Mirror the gating HostsRoute uses: when the hosts hub is off, Compare
-  // has no peer Servers/Client tabs to switch to, so render bare.
-  if (!hostsHubFlagEnabled || !isAuthenticated) {
+  // Mirror the gating HostsRoute uses: when signed out, Compare has no peer
+  // Servers/Client tabs to switch to, so render bare.
+  if (!isAuthenticated) {
     return compareView;
   }
 
@@ -688,8 +681,7 @@ export function HostCompareRoute() {
 }
 
 export function ComputerRoute() {
-  const { convexProjectId, hostsHubFlagEnabled, isAuthenticated } =
-    useAppRouteContext();
+  const { convexProjectId, isAuthenticated } = useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
   const navigate = useAppNavigate();
   const computersEnabled = useComputersEnabled();
@@ -707,7 +699,7 @@ export function ComputerRoute() {
     />
   );
 
-  if (!hostsHubFlagEnabled || !isAuthenticated) {
+  if (!isAuthenticated) {
     return computerView;
   }
 
@@ -784,7 +776,6 @@ export function ToolsRoute() {
 
 export function EvalsRoute() {
   const {
-    evaluateUiEnabled,
     billingUiEnabled,
     activeTabBillingLocked,
     activeTabBillingFeature,
@@ -793,16 +784,6 @@ export function EvalsRoute() {
     handleContinueEvalInChat,
     handleConnect,
   } = useAppRouteContext();
-
-  if (evaluateUiEnabled !== true) {
-    return (
-      <EmptyState
-        icon={Construction}
-        title="Evaluate Coming Soon"
-        description="The Evaluate suite is under construction. Stay tuned!"
-      />
-    );
-  }
 
   if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
     return <ActiveBillingUpsellGate />;
@@ -1189,8 +1170,6 @@ export function ServersRedirectRoute() {
 export function HomeRoute() {
   const { activeProjectId, homeOrganizationId, isHomeContextResolving } =
     useAppRouteContext();
-  const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
-  if (!homeEnabled) return <ServersRoute />;
   return (
     <HomeTab
       // Membership-validated org for `/home` (the route carries none, so it is
@@ -1238,17 +1217,7 @@ export default function App() {
   const learningEnabled = useFeatureFlagEnabled("mcpjam-learning");
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
-  const hostsEnabled = useFeatureFlagEnabled("hosts-enabled");
-  // Desktop builds default the Hosts/Connect rollout on (PostHog may be
-  // unreachable on the packaged Electron app), while hosted web keeps the
-  // PostHog gate. See `computeHostsHubFlagEnabled` for details.
-  const hostsHubFlagEnabled = computeHostsHubFlagEnabled({
-    hostsFlag: hostsEnabled,
-    hostedMode: HOSTED_MODE,
-  });
-  const playgroundEnabled = useFeatureFlagEnabled("playground-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
-  const evaluateUiEnabled = useFeatureFlagEnabled("evaluate-ui");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const {
     getAccessToken,
@@ -1300,12 +1269,10 @@ export default function App() {
       setEvaluateRunsFlagsLoaded(posthog.featureFlags?.hasLoadedFlags === true);
     });
   }, [posthog]);
-  const defaultHubRoute = useMemo((): "connect" | "servers" => {
-    if (!evaluateRunsFlagsLoaded) {
-      return "servers";
-    }
-    return hostsHubFlagEnabled && isAuthenticated ? "connect" : "servers";
-  }, [evaluateRunsFlagsLoaded, hostsHubFlagEnabled, isAuthenticated]);
+  const defaultHubRoute = useMemo(
+    (): "connect" | "servers" => (isAuthenticated ? "connect" : "servers"),
+    [isAuthenticated]
+  );
   const isHostedChatRoute = isChatboxChatRoute;
   const locationContext = useContext(UNSAFE_LocationContext);
   const routeOrganizationId = currentOrgRoute?.orgId;
@@ -1656,7 +1623,6 @@ export default function App() {
     isLoadingOrganizations,
     validOrganizations: effectiveOrganizations,
     routeOrganizationId: hasRouteOrganization ? routeOrganizationId : undefined,
-    hostsHubFlagEnabled,
     requestSignIn: () => {
       void signIn();
     },
@@ -1899,10 +1865,10 @@ export default function App() {
   // changes so it can't bleed across projects. `activeHostId` is owned by
   // useAppState (project-keyed in localStorage) and self-resets.
   useEffect(() => {
-    if (!hostsHubFlagEnabled || !isAuthenticated || !convexProjectId) {
+    if (!isAuthenticated || !convexProjectId) {
       setHostsTabSelectedHostId(null);
     }
-  }, [hostsHubFlagEnabled, isAuthenticated, convexProjectId]);
+  }, [isAuthenticated, convexProjectId]);
   useEffect(() => {
     setHostsTabSelectedHostId(null);
   }, [convexProjectId]);
@@ -2591,10 +2557,7 @@ export default function App() {
         )} plan. Upgrade the organization to continue.`
       );
       navigateToTarget(defaultHubRoute, { replace: true });
-    } else if (
-      activeTab === "clients" &&
-      (!hostsHubFlagEnabled || !isAuthenticated)
-    ) {
+    } else if (activeTab === "clients" && !isAuthenticated) {
       navigateToTarget(defaultHubRoute, { replace: true });
     } else if (activeTab === "registry" && registryEnabled !== true) {
       navigateToTarget(defaultHubRoute, { replace: true });
@@ -2613,7 +2576,6 @@ export default function App() {
   }, [
     conformanceEnabled,
     defaultHubRoute,
-    hostsHubFlagEnabled,
     registryEnabled,
     learningEnabled,
     evaluateRunsFlagsLoaded,
@@ -2978,7 +2940,7 @@ export default function App() {
 
   const isEvalsTab = activeTab === "evals" || activeTab === "ci-evals";
   const globalHostBarProps =
-    hostsHubFlagEnabled && isAuthenticated && convexProjectId && !isEvalsTab
+    isAuthenticated && convexProjectId && !isEvalsTab
       ? {
           projectId: convexProjectId,
           onEditHost: (hostId: string) => {
@@ -3072,8 +3034,6 @@ export default function App() {
     handleUpdate,
     handleUpdateHostContext,
     handleUpdateProject,
-    hostsEnabled,
-    hostsHubFlagEnabled,
     hostsTabSelectedHostId,
     isAuthLoading,
     isAuthenticated,
@@ -3084,8 +3044,6 @@ export default function App() {
     isWorkOsLoading,
     navigateToTarget,
     pendingDashboardOAuth,
-    playgroundEnabled,
-    evaluateUiEnabled,
     playgroundServerSelectorProps,
     posthog,
     projectServers,

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -765,6 +765,7 @@ describe("App hosted OAuth callback handling", () => {
     expect(
       screen.queryByTestId("hosted-oauth-loading")
     ).not.toBeInTheDocument();
+    expect(screen.getByTestId("hosts-tab")).toBeInTheDocument();
     expect(screen.getByText("Servers Tab")).toBeInTheDocument();
 
     await waitFor(() => {

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -2684,7 +2684,7 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/clients");
+      expect(window.location.pathname).toBe("/home");
     });
   });
 
@@ -2697,10 +2697,10 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText("Servers Tab")).toBeInTheDocument();
+      expect(screen.getByTestId("home-tab")).toBeInTheDocument();
     });
 
-    expect(window.location.pathname).toBe("/clients");
+    expect(window.location.pathname).toBe("/home");
     expect(screen.queryByTestId("xaa-flow-tab")).not.toBeInTheDocument();
   });
 
@@ -2931,10 +2931,10 @@ describe("App hosted OAuth callback handling", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Servers Tab")).toBeInTheDocument();
+      expect(screen.getByTestId("home-tab")).toBeInTheDocument();
     });
 
-    expect(window.location.pathname).toBe("/clients");
+    expect(window.location.pathname).toBe("/home");
     expect(screen.queryByTestId("evals-tab")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -304,6 +304,17 @@ vi.mock("../lib/guest-session", () => ({
 vi.mock("../components/ServersTab", () => ({
   ServersTab: () => <div>Servers Tab</div>,
 }));
+// Signed-in users get the Hosts hub at /servers (and /clients); the real
+// component embeds the legacy Servers tab as its `serversTabElement` view, so
+// the mock passes it through to keep "Servers Tab" queries meaningful.
+vi.mock("../components/HostsTab", () => ({
+  HostsTab: ({ serversTabElement }: { serversTabElement?: ReactNode }) => (
+    <div data-testid="hosts-tab">{serversTabElement}</div>
+  ),
+}));
+vi.mock("../components/HomeTab", () => ({
+  HomeTab: () => <div data-testid="home-tab">Home Tab</div>,
+}));
 vi.mock("../components/ToolsTab", () => ({
   ToolsTab: () => <div />,
 }));
@@ -405,17 +416,6 @@ vi.mock("../components/oauth/OAuthDebugCallback", () => ({
 }));
 vi.mock("../components/mcp-sidebar", () => ({
   MCPSidebar: (props: unknown) => mockMCPSidebar(props),
-  // App.tsx imports this helper to gate the Connect/Clients route on
-  // desktop. Tests run in jsdom (hosted-mode = true is the default but
-  // we still want the helper to behave correctly), so return the real
-  // semantic: hosted defers to PostHog, desktop default-on.
-  computeHostsHubFlagEnabled: ({
-    hostsFlag,
-    hostedMode,
-  }: {
-    hostsFlag: unknown;
-    hostedMode: boolean;
-  }) => (hostedMode ? hostsFlag === true : true),
 }));
 vi.mock("../components/ui/sidebar", () => ({
   SidebarInset: ({ children }: { children?: ReactNode }) => (
@@ -1840,7 +1840,7 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText("Servers Tab")).toBeInTheDocument();
+      expect(screen.getByTestId("home-tab")).toBeInTheDocument();
     });
 
     expect(
@@ -2673,24 +2673,22 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
   });
 
-  it("redirects conformance to servers when the feature flag is disabled", async () => {
+  it("redirects conformance to the hub when the feature flag is disabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/conformance");
     mockHandleOAuthCallback.mockReset();
 
-    mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "playground-enabled"
-    );
+    mockUseFeatureFlagEnabled.mockImplementation(() => false);
 
     render(<App />);
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/servers");
+      expect(window.location.pathname).toBe("/clients");
     });
   });
 
-  it("redirects xaa-flow to Servers when the xaa flag is disabled", async () => {
+  it("redirects xaa-flow to the hub when the xaa flag is disabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/xaa-flow");
@@ -2702,7 +2700,7 @@ describe("App hosted OAuth callback handling", () => {
       expect(screen.getByText("Servers Tab")).toBeInTheDocument();
     });
 
-    expect(window.location.pathname).toBe("/servers");
+    expect(window.location.pathname).toBe("/clients");
     expect(screen.queryByTestId("xaa-flow-tab")).not.toBeInTheDocument();
   });
 
@@ -2936,7 +2934,7 @@ describe("App hosted OAuth callback handling", () => {
       expect(screen.getByText("Servers Tab")).toBeInTheDocument();
     });
 
-    expect(window.location.pathname).toBe("/servers");
+    expect(window.location.pathname).toBe("/clients");
     expect(screen.queryByTestId("evals-tab")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -42,7 +42,7 @@ import { SaveAsTestCaseAction } from "@/components/chat-v2/shared/save-as-test-c
 import { type ReasoningDisplayMode } from "@/components/chat-v2/thread/parts/reasoning-part";
 import { ServerWithName } from "@/hooks/use-app-state";
 import { MCPJamFreeModelsPrompt } from "@/components/chat-v2/mcpjam-free-models-prompt";
-import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
+import { usePostHog } from "posthog-js/react";
 import {
   detectEnvironment,
   detectPlatform,
@@ -194,9 +194,6 @@ export function ChatTabV2({
   const { isVisible: isJsonRpcPanelVisible, toggle: toggleJsonRpcPanel } =
     useJsonRpcPanelVisibility();
   const posthog = usePostHog();
-  const chatHistoryRailEnabled = useFeatureFlagEnabled("chat-history-rail");
-  const sharedThreadsEnabled =
-    useFeatureFlagEnabled("shared-threads-enabled") === true;
 
   // Local state for ChatTabV2-specific features
   const [input, setInput] = useState("");
@@ -435,7 +432,7 @@ export function ChatTabV2({
 
   // Chat history handlers
   const showHistoryRail = Boolean(
-    HOSTED_MODE && !minimalMode && !hostedChatboxId && chatHistoryRailEnabled
+    HOSTED_MODE && !minimalMode && !hostedChatboxId
   );
   const {
     session: reactiveHistorySession,
@@ -2093,7 +2090,6 @@ export function ChatTabV2({
                 hostStyle={hostStyle}
                 isAuthenticated={isConvexAuthenticated}
                 isStreaming={historyRailStreaming}
-                sharedThreadsEnabled={sharedThreadsEnabled}
                 projectId={effectiveHostedProjectId}
                 enabled={isSessionBootstrapComplete}
                 refreshSignal={historyRefreshSignal}

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -50,7 +50,6 @@ import {
   type CreateSuitePayload,
 } from "./evals/create-suite-dialog";
 import { getEvalIterationQuotaDisabledReason } from "@/lib/eval-iteration-quota";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import posthog from "posthog-js";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
@@ -120,15 +119,11 @@ function EvalsTabContent({
 }: EvalsTabProps) {
   const { isAuthenticated, isLoading } = useConvexAuth();
   const { user } = useAuth();
-  // Note: intentionally NOT routed through computeHostsHubFlagEnabled.
   // create-suite-dialog uses `hostsEnabled` as both a feature gate AND a
   // "skeleton suite creation requires attachments" gate (attachmentsRequired
-  // = hostsEnabled && projectId). Defaulting it on for desktop blocks the
-  // empty-suite-then-attach-later flow that fresh/local projects rely on.
-  // We surface the new Connect/Clients UI via the sidebar + App routing
-  // changes; eval-dialog requirements stay on the PostHog rollout.
-  const hostsEnabled =
-    useFeatureFlagEnabled("hosts-enabled") === true && isAuthenticated;
+  // = hostsEnabled && projectId), so it stays auth-gated rather than
+  // unconditionally on.
+  const hostsEnabled = isAuthenticated;
   const route = useEvalsRouteFromUrl();
   const isDirectGuest = useIsDirectGuest({ projectId });
   const [previewedHostId] = usePreviewedHostId(projectId ?? null);

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -80,7 +80,6 @@ import { OrganizationCurrentPlanPanel } from "./organization/OrganizationCurrent
 import { OrganizationMemberRow } from "./organization/OrganizationMemberRow";
 import { OrganizationModelsSection } from "./organization/OrganizationModelsSection";
 import { useAppNavigate, buildOrganizationPath } from "@/lib/app-navigation";
-import { useCreditTopupsUiEnabled } from "@/lib/credit-topups-flag";
 
 interface OrganizationsTabProps {
   organizationId?: string;
@@ -457,12 +456,10 @@ function OrganizationPage({
     "billing-entitlements-ui"
   );
   const billingUiEnabled = billingEntitlementsUiEnabled === true;
-  const creditsUiEnabled = useCreditTopupsUiEnabled();
-  const billingSectionEnabled = billingUiEnabled || creditsUiEnabled;
   const activeSection: OrganizationRouteSection =
     section === "models"
       ? "models"
-      : billingSectionEnabled && section === "billing"
+      : section === "billing"
       ? "billing"
       : "overview";
   const memberInviteGate = resolveBillingGateState({
@@ -1124,21 +1121,19 @@ function OrganizationPage({
             >
               Models
             </button>
-            {billingSectionEnabled ? (
-              <button
-                type="button"
-                onClick={() => navigateToSection("billing")}
-                aria-current={activeSection === "billing" ? "page" : undefined}
-                className={cn(
-                  "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
-                  activeSection === "billing"
-                    ? "border-primary text-foreground"
-                    : "border-transparent text-muted-foreground hover:text-foreground"
-                )}
-              >
-                Billing
-              </button>
-            ) : null}
+            <button
+              type="button"
+              onClick={() => navigateToSection("billing")}
+              aria-current={activeSection === "billing" ? "page" : undefined}
+              className={cn(
+                "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
+                activeSection === "billing"
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              Billing
+            </button>
           </nav>
         </Card>
 
@@ -1153,7 +1148,7 @@ function OrganizationPage({
             <OrganizationBillingSection
               organizationId={organization._id}
               showPlanBilling={billingUiEnabled}
-              showCredits={creditsUiEnabled}
+              showCredits
               billingStatus={billingStatus}
               organizationName={organization.name}
               canManageCredits={canEdit || organization.isCreator === true}

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -258,13 +258,11 @@ vi.mock("@/components/chat-v2/thread", () => ({
 vi.mock("@/components/chat-v2/history/ChatHistoryRail", () => ({
   ChatHistoryRail: ({
     activeSessionId,
-    sharedThreadsEnabled = true,
     onNewChat,
     onSelectThread,
     onSessionAction,
   }: {
     activeSessionId?: string | null;
-    sharedThreadsEnabled?: boolean;
     onNewChat: (options?: { shared?: boolean }) => void;
     onSelectThread: (session: typeof mockHistorySession) => void;
     onSessionAction?: (event: {
@@ -275,17 +273,14 @@ vi.mock("@/components/chat-v2/history/ChatHistoryRail", () => ({
     <div
       data-testid="history-rail"
       data-active-session-id={activeSessionId ?? "none"}
-      data-shared-threads-enabled={sharedThreadsEnabled ? "true" : "false"}
     >
       <button onClick={() => onSelectThread({ ...mockHistorySession })}>
         Select thread
       </button>
       <button onClick={() => onNewChat()}>New personal thread</button>
-      {sharedThreadsEnabled ? (
-        <button onClick={() => onNewChat({ shared: true })}>
-          New shared thread
-        </button>
-      ) : null}
+      <button onClick={() => onNewChat({ shared: true })}>
+        New shared thread
+      </button>
       <button
         onClick={() =>
           void onSessionAction?.({
@@ -867,28 +862,6 @@ describe("ChatTabV2 history sync", () => {
 
     expect(lastUseChatSessionOptionsRef.current?.directVisibility).toBe(
       "project"
-    );
-  });
-
-  it("keeps the history rail visible while hiding shared-thread affordances when the flag is off", async () => {
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "shared-threads-enabled" ? false : true
-    );
-
-    render(<ChatTabV2 {...defaultProps} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Show sessions" }));
-
-    expect(screen.getByTestId("history-rail")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "New personal thread" })
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "New shared thread" })
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("history-rail")).toHaveAttribute(
-      "data-shared-threads-enabled",
-      "false"
     );
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -15,7 +15,6 @@ const sortedOrganizationsState: Array<{
   myRole?: string;
   isCreator?: boolean;
 }> = [];
-let creditsFlagState = true;
 
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
@@ -46,10 +45,6 @@ vi.mock("@/hooks/useOrganizations", () => ({
       org.isCreator === true),
 }));
 
-vi.mock("@/lib/credit-topups-flag", () => ({
-  useCreditTopupsUiEnabled: () => creditsFlagState,
-}));
-
 const originalHash = window.location.hash;
 
 beforeEach(() => {
@@ -57,7 +52,6 @@ beforeEach(() => {
   authState.isLoading = false;
   authState.user = null;
   sortedOrganizationsState.length = 0;
-  creditsFlagState = true;
   window.location.hash = "";
   localStorage.clear();
   useMCPJamLimitDialogStore.setState({
@@ -135,27 +129,6 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.getByRole("button", { name: /^top up$/i })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /bring your own key/i })
-    ).toBeInTheDocument();
-  });
-
-  it("hides the Top up button when the credits UI flag is off", () => {
-    creditsFlagState = false;
-    authState.user = { id: "user-1" };
-    sortedOrganizationsState.push({ _id: "org-1", myRole: "owner" });
-    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
-    render(<MCPJamLimitDialog />);
-
-    expect(
-      screen.queryByRole("button", { name: /^top up$/i })
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
-      "without waiting for your org's credits to reset"
-    );
-    expect(screen.getByTestId("limit-dialog-description")).not.toHaveTextContent(
-      /tomorrow/i
-    );
     expect(
       screen.getByRole("button", { name: /bring your own key/i })
     ).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
   applyBillingGateNavState,
-  computeHostsHubFlagEnabled,
   filterByFeatureFlags,
   getEvalsSubnavItems,
   getHostedNavigationSections,
@@ -409,56 +408,11 @@ describe("getHostedNavigationSections", () => {
   });
 });
 
-// The packaged Electron app ships a single binary with no staged rollout, so
-// gating Hosts/Connect on PostHog would just hide the new UI whenever the
-// feature flag hasn't resolved (or is blocked entirely). Desktop must default
-// the flag on for signed-in users while hosted web keeps the PostHog gate.
-//
-// Regression: Ray reported the desktop Clients tab showed empty/no affordances
-// because `useFeatureFlagEnabled("hosts-enabled")` returned `undefined` in the
-// packaged app, which collapsed both the sidebar nav filter and `HostsRoute`
-// gate to `false`. See `computeHostsHubFlagEnabled` in `mcp-sidebar.tsx`.
-describe("computeHostsHubFlagEnabled", () => {
-  it("defaults on for desktop when PostHog has not resolved the flag", () => {
-    expect(
-      computeHostsHubFlagEnabled({
-        hostsFlag: undefined,
-        hostedMode: false,
-      }),
-    ).toBe(true);
-  });
-
-  it("defaults on for desktop even when PostHog reports the flag off", () => {
-    expect(
-      computeHostsHubFlagEnabled({
-        hostsFlag: false,
-        hostedMode: false,
-      }),
-    ).toBe(true);
-  });
-
-  it("honors the PostHog flag in hosted web when the flag is on", () => {
-    expect(
-      computeHostsHubFlagEnabled({ hostsFlag: true, hostedMode: true }),
-    ).toBe(true);
-  });
-
-  it("keeps Hosts/Connect hidden in hosted web until PostHog enables it", () => {
-    expect(
-      computeHostsHubFlagEnabled({ hostsFlag: undefined, hostedMode: true }),
-    ).toBe(false);
-    expect(
-      computeHostsHubFlagEnabled({ hostsFlag: false, hostedMode: true }),
-    ).toBe(false);
-  });
-});
-
 // The sidebar uses `featureFlag` to keep "Connect" visible and `hiddenByFlag`
-// to swap "Servers" out once the rollout fires. Wire the helper through the
-// nav filter the same way the component does and verify the desktop default-on
-// path keeps "Connect" visible (and hides legacy "Servers") even when PostHog
-// has not resolved the flag.
-describe("filterByFeatureFlags + computeHostsHubFlagEnabled (Connect/Servers swap)", () => {
+// to swap "Servers" out. The "hosts-enabled" map entry is auth-driven (the
+// PostHog rollout finished and the flag was removed): signed-in users get
+// Connect, signed-out users keep the legacy Servers item.
+describe("filterByFeatureFlags (Connect/Servers swap)", () => {
   const connectAndServers = () => [
     {
       id: "connection",
@@ -479,45 +433,17 @@ describe("filterByFeatureFlags + computeHostsHubFlagEnabled (Connect/Servers swa
     },
   ];
 
-  const hostsEnabledForNav = (
-    hostsFlag: unknown,
-    hostedMode: boolean,
-    isAuthenticated: boolean,
-  ) =>
-    computeHostsHubFlagEnabled({ hostsFlag, hostedMode }) && isAuthenticated;
-
-  it("shows Connect on desktop when authenticated and PostHog is silent", () => {
+  it("shows Connect (and hides legacy Servers) when authenticated", () => {
     const result = filterByFeatureFlags(connectAndServers(), {
-      "hosts-enabled": hostsEnabledForNav(undefined, false, true),
+      "hosts-enabled": true,
     });
     expect(result[0].items.map((i) => i.title)).toEqual(["Connect"]);
   });
 
-  it("shows Connect on desktop when authenticated and PostHog reports off", () => {
+  it("falls back to legacy Servers until the user signs in", () => {
     const result = filterByFeatureFlags(connectAndServers(), {
-      "hosts-enabled": hostsEnabledForNav(false, false, true),
-    });
-    expect(result[0].items.map((i) => i.title)).toEqual(["Connect"]);
-  });
-
-  it("falls back to legacy Servers on desktop until the user signs in", () => {
-    const result = filterByFeatureFlags(connectAndServers(), {
-      "hosts-enabled": hostsEnabledForNav(undefined, false, false),
+      "hosts-enabled": false,
     });
     expect(result[0].items.map((i) => i.title)).toEqual(["Servers"]);
-  });
-
-  it("keeps legacy Servers on hosted web until PostHog enables the rollout", () => {
-    const result = filterByFeatureFlags(connectAndServers(), {
-      "hosts-enabled": hostsEnabledForNav(undefined, true, true),
-    });
-    expect(result[0].items.map((i) => i.title)).toEqual(["Servers"]);
-  });
-
-  it("swaps to Connect on hosted web once PostHog enables the rollout", () => {
-    const result = filterByFeatureFlags(connectAndServers(), {
-      "hosts-enabled": hostsEnabledForNav(true, true, true),
-    });
-    expect(result[0].items.map((i) => i.title)).toEqual(["Connect"]);
   });
 });

--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -23,8 +23,6 @@ import {
   formatCreditResetText,
   formatMonthlyResetText,
 } from "@/lib/credit-usage";
-import { useCreditTopupsUiEnabled } from "@/lib/credit-topups-flag";
-import { useTeamCreditsUiEnabled } from "@/lib/team-credits-flag";
 import type { CreditTopupSource } from "@/hooks/useCreditTopup";
 
 /** Pulls the limit-modal redirect flag out of the current URL and clears it
@@ -60,16 +58,12 @@ export function CreditBalanceCard({
   canManageCredits = false,
   chatSessionId,
 }: CreditBalanceCardProps = {}) {
-  const creditTopupsUiEnabled = useCreditTopupsUiEnabled();
-  const teamCreditsUiEnabled = useTeamCreditsUiEnabled();
   const { balance, isLoading } = useCreditBalance({
     organizationId,
-    enabled: creditTopupsUiEnabled,
   });
   const { quota: evalIterationQuota, isLoading: isEvalIterationQuotaLoading } =
     useEvalIterationQuota({
       organizationId,
-      enabled: creditTopupsUiEnabled && Boolean(organizationId),
     });
   const [isTopupOpen, setIsTopupOpen] = useState(false);
   const [topupSource, setTopupSource] =
@@ -84,24 +78,22 @@ export function CreditBalanceCard({
   // reopen the dialog. Source is recorded as `limit_modal` so the funnel can
   // attribute the top-up back to the limit-hit that triggered the redirect.
   useEffect(() => {
-    if (!creditTopupsUiEnabled) return;
     if (consumeTopupFlag()) {
       setArrivedFromLimitModal(true);
     }
-  }, [creditTopupsUiEnabled]);
+  }, []);
 
   // Open the dialog only once we know the user can manage credits. A member
   // who can't top up keeps `arrivedFromLimitModal` true and instead sees the
   // "ask an admin" hint below — not a silent dead-end where the flag was
   // consumed but nothing happened.
   useEffect(() => {
-    if (!creditTopupsUiEnabled) return;
     if (arrivedFromLimitModal && canManageCredits) {
       setTopupSource("limit_modal");
       setIsTopupOpen(true);
       setArrivedFromLimitModal(false);
     }
-  }, [arrivedFromLimitModal, canManageCredits, creditTopupsUiEnabled]);
+  }, [arrivedFromLimitModal, canManageCredits]);
 
   const handleManualTopup = () => {
     setTopupSource("billing_page");
@@ -113,8 +105,7 @@ export function CreditBalanceCard({
   // Team-plan orgs bill against a monthly per-seat allowance instead of the
   // daily free bucket. Paid top-ups are shown separately and spent only after
   // the allowance runs out.
-  const showMonthly =
-    teamCreditsUiEnabled && balance?.billingModel === "monthly_per_seat";
+  const showMonthly = balance?.billingModel === "monthly_per_seat";
   const monthlyTotal = balance?.monthlyAllowanceTotal ?? 0;
   const monthlyRemaining = balance?.monthlyAllowanceRemaining ?? 0;
   const paidRemaining = balance?.paidCreditsRemaining ?? 0;
@@ -126,8 +117,6 @@ export function CreditBalanceCard({
   const evalIterationLabel = getEvalIterationQuotaLabel(
     evalIterationQuota?.windowKind
   );
-
-  if (!creditTopupsUiEnabled) return null;
 
   return (
     <Card className="border-border/60 py-6 shadow-sm">

--- a/mcpjam-inspector/client/src/components/billing/TopupGatedErrorBox.tsx
+++ b/mcpjam-inspector/client/src/components/billing/TopupGatedErrorBox.tsx
@@ -3,7 +3,6 @@ import type { ComponentProps } from "react";
 import { ErrorBox } from "@/components/chat-v2/error";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useCreditTopupPresets } from "@/hooks/useCreditTopup";
-import { useCreditTopupsUiEnabled } from "@/lib/credit-topups-flag";
 
 type ErrorBoxProps = ComponentProps<typeof ErrorBox>;
 type TopupGatedErrorBoxProps = ErrorBoxProps & {
@@ -29,15 +28,11 @@ export function TopupGatedErrorBox({
   canManageCredits = false,
   ...props
 }: TopupGatedErrorBoxProps) {
-  const creditsUiEnabled = useCreditTopupsUiEnabled();
   const plainErrorBox = (
     <ErrorBox {...props} canTopUp={false} onTopUp={undefined} />
   );
   // Top-up isn't the relevant fix for this error — render plainly.
   if (props.canTopUp !== true) return plainErrorBox;
-  // Credits are behind a separate launch flag. When off, don't show any
-  // credit-specific CTA/copy.
-  if (!creditsUiEnabled) return plainErrorBox;
   // Top-up is relevant but the user can't buy credits: point them at an
   // admin instead of a button the backend would reject. No need to load
   // presets in this case.

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -20,8 +20,6 @@ let balanceState:
     }
   | undefined = undefined;
 let isLoadingState = false;
-let creditTopupsFlagState = true;
-let teamCreditsFlagState = true;
 let evalQuotaState:
   | {
       used: number;
@@ -49,14 +47,6 @@ vi.mock("@/hooks/use-eval-iteration-quota", () => ({
         evalQuotaState.used >= evalQuotaState.allowed
     ),
   }),
-}));
-
-vi.mock("@/lib/team-credits-flag", () => ({
-  useTeamCreditsUiEnabled: () => teamCreditsFlagState,
-}));
-
-vi.mock("@/lib/credit-topups-flag", () => ({
-  useCreditTopupsUiEnabled: () => creditTopupsFlagState,
 }));
 
 vi.mock("@/components/billing/CreditTopupDialog", () => ({
@@ -92,18 +82,9 @@ describe("CreditBalanceCard", () => {
       walletLocked: false,
     };
     isLoadingState = false;
-    creditTopupsFlagState = true;
-    teamCreditsFlagState = true;
     evalQuotaState = undefined;
     evalQuotaLoadingState = false;
     window.location.hash = "";
-  });
-
-  it("renders nothing when the top-ups UI flag is off", () => {
-    creditTopupsFlagState = false;
-    const { container } = render(<CreditBalanceCard organizationId="org-1" />);
-
-    expect(container).toBeEmptyDOMElement();
   });
 
   it("renders a skeleton state while balance is loading", () => {
@@ -361,24 +342,6 @@ describe("CreditBalanceCard", () => {
       expect(screen.getByTestId("usage-monthly-exhausted")).toHaveTextContent(
         /Monthly credits used/
       );
-    });
-
-    it("keeps the existing daily and top-up UI when only the team flag is off", async () => {
-      const user = userEvent.setup();
-      teamCreditsFlagState = false;
-
-      render(<CreditBalanceCard organizationId="org-1" canManageCredits />);
-
-      expect(screen.queryByTestId("usage-monthly")).not.toBeInTheDocument();
-      expect(screen.getByTestId("usage-daily")).toHaveTextContent(
-        /Free daily credits/
-      );
-      expect(screen.getByTestId("usage-paid")).toHaveTextContent(
-        /1,500 credits/
-      );
-
-      await user.click(screen.getByRole("button", { name: /Buy credits/i }));
-      expect(screen.getByTestId("topup-dialog")).toBeInTheDocument();
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/billing/__tests__/TopupGatedErrorBox.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/TopupGatedErrorBox.test.tsx
@@ -13,7 +13,6 @@ let presetsState:
   | undefined;
 let presetsLoadingState: boolean;
 let presetQueryShouldThrow = false;
-let creditsFlagState = true;
 
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
@@ -35,10 +34,6 @@ vi.mock("@/hooks/useCreditTopup", () => ({
     }
     return { presets: presetsState, isLoading: presetsLoadingState };
   },
-}));
-
-vi.mock("@/lib/credit-topups-flag", () => ({
-  useCreditTopupsUiEnabled: () => creditsFlagState,
 }));
 
 // Note: rate-limit errors (`user_rate_limit` / `mcpjam_rate_limit`) are now
@@ -77,7 +72,6 @@ describe("TopupGatedErrorBox", () => {
     ];
     presetsLoadingState = false;
     presetQueryShouldThrow = false;
-    creditsFlagState = true;
   });
 
   it("does not render the Buy credits CTA when canTopUp is false", () => {
@@ -105,25 +99,6 @@ describe("TopupGatedErrorBox", () => {
     expect(
       screen.getByRole("button", { name: /Buy credits to keep chatting/ })
     ).toBeInTheDocument();
-  });
-
-  it("hides credit-specific CTA/copy when the credits UI flag is off", () => {
-    creditsFlagState = false;
-    render(
-      <TopupGatedErrorBox
-        {...RATE_LIMIT_PROPS}
-        canTopUp
-        canManageCredits={false}
-        onTopUp={vi.fn()}
-      />
-    );
-
-    expect(
-      screen.queryByRole("button", { name: /Buy credits to keep chatting/ })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/Ask org admin to top up credits/)
-    ).not.toBeInTheDocument();
   });
 
   it("shows the ask-admin hint instead of the Buy credits CTA when the user cannot manage credits", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/history/ChatHistoryRail.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/ChatHistoryRail.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Archive, Folder, FolderOpen, Loader2, Plus } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
@@ -37,7 +36,6 @@ interface ChatHistoryRailProps {
   hostStyle?: ChatboxHostStyle;
   isAuthenticated: boolean;
   isStreaming: boolean;
-  sharedThreadsEnabled?: boolean;
   projectId?: string | null;
   requestHeaders?: HeadersInit;
   enabled?: boolean;
@@ -202,7 +200,6 @@ export function ChatHistoryRail({
   hostStyle = "claude",
   isAuthenticated,
   isStreaming,
-  sharedThreadsEnabled = true,
   projectId,
   requestHeaders,
   enabled = true,
@@ -218,8 +215,7 @@ export function ChatHistoryRail({
     useState<ArchiveSectionScope | null>(null);
   const [sessionToConvert, setSessionToConvert] =
     useState<ChatHistorySession | null>(null);
-  const canUseProjectSharing =
-    isAuthenticated && sharedThreadsEnabled && Boolean(projectId);
+  const canUseProjectSharing = isAuthenticated && Boolean(projectId);
   const { personal, project, loading, error, isReactive, refetch, actions } =
     useChatHistory({
       projectId,
@@ -277,9 +273,7 @@ export function ChatHistoryRail({
   }, [enabled, isReactive, refetch, refreshSignal]);
 
   const archiveBusy = archivingScope !== null;
-  const evaluateUiEnabled = useFeatureFlagEnabled("evaluate-ui");
-  const canConvertToTestCase =
-    Boolean(isAuthenticated) && evaluateUiEnabled === true;
+  const canConvertToTestCase = Boolean(isAuthenticated);
 
   const handleArchiveSection = async (
     scope: ArchiveSectionScope,

--- a/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/ChatHistoryRail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/ChatHistoryRail.test.tsx
@@ -208,7 +208,7 @@ describe("ChatHistoryRail", () => {
     }
   });
 
-  it("only exposes chat-to-test-case conversion when authenticated and playground flag is on", () => {
+  it("only exposes chat-to-test-case conversion when authenticated", () => {
     useChatHistoryMock.mockImplementation(() => ({
       personal: [sessionStub("personal-1")],
       project: [],
@@ -262,26 +262,6 @@ describe("ChatHistoryRail", () => {
     expect(chatHistoryRowPropsSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         canConvertToTestCase: true,
-      }),
-    );
-
-    chatHistoryRowPropsSpy.mockReset();
-    useFeatureFlagEnabledMock.mockReturnValue(false);
-
-    rerender(
-      <ChatHistoryRail
-        activeSessionId={null}
-        isAuthenticated
-        isStreaming={false}
-        projectId={null}
-        onSelectThread={vi.fn()}
-        onNewChat={vi.fn()}
-      />,
-    );
-
-    expect(chatHistoryRowPropsSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        canConvertToTestCase: false,
       }),
     );
   });
@@ -535,59 +515,6 @@ describe("ChatHistoryRail", () => {
 
     expect(onNewChat).toHaveBeenNthCalledWith(1);
     expect(onNewChat).toHaveBeenNthCalledWith(2, { shared: true });
-  });
-
-  it("hides the shared sessions section when shared threads are disabled", () => {
-    useChatHistoryMock.mockImplementation(() => ({
-      personal: [sessionStub("p1")],
-      project: [sessionStub("w1", { directVisibility: "project" })],
-      loading: false,
-      error: null,
-      isReactive: false,
-      refetch: refetchMock,
-      actions: {
-        rename: vi.fn(),
-        archive: vi.fn(),
-        unarchive: vi.fn(),
-        share: vi.fn(),
-        unshare: vi.fn(),
-        pin: vi.fn(),
-        unpin: vi.fn(),
-        archiveManySessionIds: archiveManySessionIdsMock,
-        archiveAllActive: vi.fn(),
-      },
-    }));
-
-    render(
-      <ChatHistoryRail
-        activeSessionId={null}
-        isAuthenticated
-        isStreaming={false}
-        sharedThreadsEnabled={false}
-        projectId="project-1"
-        onSelectThread={vi.fn()}
-        onNewChat={vi.fn()}
-      />,
-    );
-
-    expect(
-      screen.getByRole("button", { name: "New chat in Sessions" }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Sessions")).toBeInTheDocument();
-    expect(screen.queryByText("Shared Sessions")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", {
-        name: /archive all sessions in shared sessions/i,
-      }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "New chat in Shared Sessions" }),
-    ).not.toBeInTheDocument();
-    expect(
-      chatHistoryRowPropsSpy.mock.calls
-        .map((call) => call[0] as { session?: ChatHistorySession })
-        .some((props) => props.session?._id === "w1"),
-    ).toBe(false);
   });
 
   it("hides project sharing when there is no project scope", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
@@ -1,7 +1,6 @@
 import { useAction, useConvexAuth, useQuery } from "convex/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { toast } from "sonner";
 import {
   Dialog,
@@ -78,16 +77,10 @@ export function ConvertChatSessionDialog({
   const effectiveProjectId = session?.projectId ?? projectId ?? null;
   // Mirror Create suite's `hostsEnabled` gate: the server/host attachment
   // pickers (and the new-suite branch's serverAttachmentId/hostAttachments
-  // wiring) only apply in the unified-attachment world. Without the flag,
-  // we preserve the legacy path that #395 already covers.
-  // Intentionally tied to the raw PostHog flag, not the desktop-default-on
-  // helper: `attachmentPickersEnabled` also gates the new-suite branch's
-  // requires-attachments check, and flipping it on for desktop blocks the
-  // empty-skeleton-then-attach-later flow.
-  const hostsFlagEnabled = useFeatureFlagEnabled("hosts-enabled");
+  // wiring) only apply in the unified-attachment world. Signed-out or
+  // project-less sessions preserve the legacy path that #395 already covers.
   const { isAuthenticated: convexAuthed } = useConvexAuth();
-  const attachmentPickersEnabled =
-    hostsFlagEnabled === true && convexAuthed && Boolean(effectiveProjectId);
+  const attachmentPickersEnabled = convexAuthed && Boolean(effectiveProjectId);
   const { servers, serversById, isLoading: projectServersLoading } =
     useProjectServers({
       isAuthenticated,

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/save-as-test-case-action.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/save-as-test-case-action.tsx
@@ -1,7 +1,6 @@
 import { useAction, useConvexAuth, useQuery } from "convex/react";
 import { useEffect, useMemo, useState } from "react";
 import { FlaskConical, Loader2 } from "lucide-react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { toast } from "sonner";
 import {
   Dialog,
@@ -70,8 +69,6 @@ export function SaveAsTestCaseAction({
   promptPreview,
   projectId,
 }: SaveAsTestCaseActionProps) {
-  const evaluateUiEnabled = useFeatureFlagEnabled("evaluate-ui");
-  const hostsFlagEnabled = useFeatureFlagEnabled("hosts-enabled");
   const { isAuthenticated: convexAuthed } = useConvexAuth();
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -91,13 +88,10 @@ export function SaveAsTestCaseAction({
     [],
   );
 
-  // Intentionally tied to the raw PostHog flag, not the desktop-default-on
-  // helper: `attachmentPickersEnabled` also gates the "new suite requires
-  // both a server and a host attachment" requirement (see
-  // `newSuiteRequirementsMet` below). Flipping it on for desktop blocks the
-  // empty-skeleton-then-attach-later flow.
-  const attachmentPickersEnabled =
-    hostsFlagEnabled === true && convexAuthed && Boolean(projectId);
+  // `attachmentPickersEnabled` also gates the "new suite requires both a
+  // server and a host attachment" requirement (see `newSuiteRequirementsMet`
+  // below), so it stays scoped to authed sessions with a project.
+  const attachmentPickersEnabled = convexAuthed && Boolean(projectId);
 
   const { serverAttachments: projectServerAttachments } =
     useProjectServerAttachments({
@@ -224,11 +218,6 @@ export function SaveAsTestCaseAction({
 
   // No projectId => no destination suite => no point showing the action.
   if (!projectId) {
-    return null;
-  }
-
-  // Gated behind the same flag as the Evaluate sidebar entry.
-  if (evaluateUiEnabled !== true) {
     return null;
   }
 

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -7,7 +7,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { AdvancedConnectionSettingsSection } from "./shared/AdvancedConnectionSettingsSection";
 import { AuthenticationSection } from "./shared/AuthenticationSection";
 import { EnvVarsSection } from "./shared/EnvVarsSection";
@@ -44,7 +43,6 @@ export function EditServerFormContent({
   onMcpProtocolVersionOverrideChange,
 }: EditServerFormContentProps) {
   const hostedUrlPlaceholder = "https://example.com/mcp";
-  const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
   const [revealingEnv, setRevealingEnv] = useState(false);
   const [revealingHeaders, setRevealingHeaders] = useState(false);
   const [envRevealError, setEnvRevealError] = useState<string | null>(null);
@@ -298,11 +296,11 @@ export function EditServerFormContent({
         clientCapabilitiesOverrideError={
           formState.clientCapabilitiesOverrideError
         }
-        /* Render the row whenever the flag is on, regardless of whether
-           a setter is wired. When `onMcpProtocolVersionOverrideChange` is
-           absent (no project/server id, or project config still loading), the
-           select disables but remains visible for discoverability. */
-        showMcpProtocolVersionOverride={Boolean(statelessMcpEnabled)}
+        /* Render the row regardless of whether a setter is wired. When
+           `onMcpProtocolVersionOverrideChange` is absent (no project/server
+           id, or project config still loading), the select disables but
+           remains visible for discoverability. */
+        showMcpProtocolVersionOverride
         mcpProtocolVersionOverride={mcpProtocolVersionOverride}
         onMcpProtocolVersionOverrideChange={onMcpProtocolVersionOverrideChange}
         transportKind={formState.type}

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -47,7 +47,6 @@ import type {
 } from "@/lib/project-server-config";
 import { EffectiveProtocolVersionChip } from "./shared/EffectiveProtocolVersionChip";
 import { fetchServerSecrets } from "@/lib/apis/server-secrets-api";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 
 export type ServerDetailTab =
@@ -191,8 +190,6 @@ export function ServerDetailModal({
   // round-trip rather than a server-update. Read/write here so the
   // form control inside `EditServerFormContent` can stay a pure prop
   // consumer.
-  const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
-  const serverHistoryEnabled = useFeatureFlagEnabled("server-history-tab");
   const projectServerConfigDto = useQuery(
     "projectServerConfig:getConfig" as never,
     projectId ? ({ projectId } as never) : "skip"
@@ -211,10 +208,9 @@ export function ServerDetailModal({
   // `hostedServerId`.
   const serverId = hostedServerId ?? undefined;
   // The History tab + drift chip surface persisted snapshot revisions, which
-  // only exist for project-scoped (hosted) servers. Gated behind the
-  // `server-history-tab` PostHog flag (@mcpjam.com only) and hidden in local
-  // mode. Both surfaces key off `showHistory`, so this is the single gate.
-  const showHistory = Boolean(projectId && serverId && serverHistoryEnabled);
+  // only exist for project-scoped (hosted) servers — hidden in local mode.
+  // Both surfaces key off `showHistory`, so this is the single gate.
+  const showHistory = Boolean(projectId && serverId);
   const currentMcpProtocolVersionOverride = useMemo<
     McpProtocolVersion | undefined
   >(
@@ -660,7 +656,6 @@ export function ServerDetailModal({
               <EffectiveProtocolVersionChip
                 hostDefault={resolvedHostDefaultMcpProtocolVersion}
                 serverOverride={currentMcpProtocolVersionOverride}
-                flagEnabled={Boolean(statelessMcpEnabled)}
               />
               <span className="inline-flex items-center gap-1.5 px-1 text-[11px] text-muted-foreground">
                 {isReconnecting ? (

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -24,12 +24,10 @@ type DropdownValue = "inherit" | "latest" | "rc";
 const MCP_PROTOCOL_OPTIONS: Array<{
   value: DropdownValue;
   label: string;
-  /** When true, the option appears only with `stateless-mcp-enabled` flag. */
-  flagGated?: boolean;
 }> = [
   { value: "inherit", label: "Host default" },
   { value: "latest", label: "Latest (2025-11-25)" },
-  { value: "rc", label: "2026 RC (2026-07-28)", flagGated: true },
+  { value: "rc", label: "2026 RC (2026-07-28)" },
 ];
 
 interface HeaderEntry {
@@ -63,13 +61,11 @@ interface AdvancedConnectionSettingsSectionProps {
   clientCapabilitiesOverrideError?: string | null;
   headersWarning?: string;
   /**
-   * Visibility flag for the protocol-version override row. Wired from
-   * `useFeatureFlagEnabled("stateless-mcp-enabled")` at the caller. When
-   * false, the entire dropdown is hidden AND the `2026-07-28` RC option
-   * is omitted from the option list (the RC option is the flag-gated
-   * piece; stateful options are always available behind the same flag).
-   * Defaults to false. Host-default JSON keeps working regardless —
-   * just no per-server affordance.
+   * Visibility for the protocol-version override row. Edit-server contexts
+   * (where the per-server override can be persisted on the project layer)
+   * pass true; the Add Server modal leaves it off since no project server
+   * ref exists yet. Defaults to false. Host-default JSON keeps working
+   * regardless — just no per-server affordance.
    */
   showMcpProtocolVersionOverride?: boolean;
   /**
@@ -307,10 +303,9 @@ export function AdvancedConnectionSettingsSection({
           {/* Per-server MCP protocol-version pin. Tri-state picker:
               "Latest" → `"2025-11-25"` (legacy adapter + initialize
               handshake); "2026 RC" → `"2026-07-28"` (stateless RC
-              preview client). Gated by `stateless-mcp-enabled` at the
-              caller. The RC option is hidden on non-HTTP transports
-              because MCPJam's current stateless client requires
-              Streamable HTTP. */}
+              preview client). The RC option is hidden on non-HTTP
+              transports because MCPJam's current stateless client
+              requires Streamable HTTP. */}
           {showProtocolVersionControl && (
             <div className="space-y-1.5">
               <label

--- a/mcpjam-inspector/client/src/components/connection/shared/EffectiveProtocolVersionChip.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/EffectiveProtocolVersionChip.tsx
@@ -11,22 +11,13 @@ interface EffectiveProtocolVersionChipProps {
    * `undefined` = no override, inherit host default.
    */
   serverOverride?: McpProtocolVersion;
-  /**
-   * When the feature flag is off, the chip surfaces nothing — the
-   * config field may still carry a stored pin but it has no runtime
-   * effect until the dispatch wiring is enabled.
-   */
-  flagEnabled?: boolean;
 }
 
 /** Read-only label for the effective MCP protocol version on a server. */
 export function EffectiveProtocolVersionChip({
   hostDefault,
   serverOverride,
-  flagEnabled = false,
 }: EffectiveProtocolVersionChipProps) {
-  if (!flagEnabled) return null;
-
   const effective: McpProtocolVersion | undefined =
     serverOverride ?? hostDefault;
 

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -8,7 +8,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { isKnownProtocolVersion } from "@mcpjam/sdk/browser";
 import {
   type HostConfigInputV2,
@@ -272,7 +271,6 @@ export function ProtocolTab({
     applyParsedToDraft: applyJsonToDraft,
     onDraftChange,
   });
-  const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
   // Stored stateful literals (legacy carry-over) collapse to "Latest"
   // since they route to the same code path; saving normalizes back to
   // undefined.
@@ -310,36 +308,34 @@ export function ProtocolTab({
 
   return (
     <div className="flex h-full min-h-[480px] flex-col gap-3">
-      {statelessMcpEnabled ? (
-        <div className="rounded-[10px] border border-border bg-background px-3.5 py-2.5">
-          <div className="flex items-center gap-3">
-            <span
-              className="text-[12px] font-medium"
-              title="Latest: current stable MCP wire version (2025-11-25). 2026 RC: MCPJam's current 2026-07-28 stateless preview over Streamable HTTP POST."
-            >
-              {fProtocolVersion.label}
-            </span>
-            <Select
-              value={selectedDropdownValue}
-              onValueChange={(next) => {
-                setProtocolVersion(next === "rc" ? "2026-07-28" : undefined);
-              }}
-              disabled={readOnly}
-            >
-              <SelectTrigger className="h-9 text-xs">
-                <SelectValue placeholder="Latest" />
-              </SelectTrigger>
-              <SelectContent>
-                {HOST_PROTOCOL_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+      <div className="rounded-[10px] border border-border bg-background px-3.5 py-2.5">
+        <div className="flex items-center gap-3">
+          <span
+            className="text-[12px] font-medium"
+            title="Latest: current stable MCP wire version (2025-11-25). 2026 RC: MCPJam's current 2026-07-28 stateless preview over Streamable HTTP POST."
+          >
+            {fProtocolVersion.label}
+          </span>
+          <Select
+            value={selectedDropdownValue}
+            onValueChange={(next) => {
+              setProtocolVersion(next === "rc" ? "2026-07-28" : undefined);
+            }}
+            disabled={readOnly}
+          >
+            <SelectTrigger className="h-9 text-xs">
+              <SelectValue placeholder="Latest" />
+            </SelectTrigger>
+            <SelectContent>
+              {HOST_PROTOCOL_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-      ) : null}
+      </div>
       <div className="flex min-h-0 flex-1 flex-col">
         <JsonEditor
           rawContent={content}

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -22,7 +22,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
-import { isPostHogBooleanFlagOn, standardEventProps } from "@/lib/PosthogUtils";
+import { standardEventProps } from "@/lib/PosthogUtils";
 
 import { NavMain } from "@/components/sidebar/nav-main";
 import {
@@ -124,29 +124,6 @@ export function filterByFeatureFlags(
 }
 
 /**
- * Resolve the effective "hosts-enabled" rollout flag for the current build,
- * independent of authentication state.
- *
- * Hosted web rolls Hosts/Connect out via PostHog so the flag must be honored
- * server-side. Desktop ships a single binary with no staged rollout — and on
- * the packaged Electron app PostHog may be blocked, slow, or simply hasn't
- * resolved when the sidebar first renders. Treating the flag as off in that
- * window hides the new Connect tab and leaves the legacy Servers item in
- * place, which is what Ray reported.
- *
- * Callers still AND this with `isAuthenticated` at each site — only signed-in
- * users see the Hosts/Connect surface.
- */
-export function computeHostsHubFlagEnabled(opts: {
-  hostsFlag: unknown;
-  hostedMode: boolean;
-}): boolean {
-  const { hostsFlag, hostedMode } = opts;
-  if (!hostedMode) return true;
-  return isPostHogBooleanFlagOn(hostsFlag);
-}
-
-/**
  * Keeps billed nav items visible; marks them disabled when the gate denies access
  * and enforcement is enabled (not soft/disabled).
  *
@@ -242,7 +219,6 @@ const navigationSections: NavSection[] = [
         title: "Evaluate",
         url: "/evals",
         icon: FlaskConical,
-        featureFlag: "evaluate-ui",
         billingFeature: "evals",
         evalsSubnav: true,
       },
@@ -431,7 +407,6 @@ export function SidebarEvalsNavGroup({
   disabledTooltip,
   activeTab,
   showRuns = true,
-  playgroundEnabled = false,
 }: {
   title: string;
   Icon: React.ComponentType<{ className?: string }>;
@@ -439,10 +414,8 @@ export function SidebarEvalsNavGroup({
   disabledTooltip?: string;
   activeTab?: string;
   showRuns?: boolean;
-  playgroundEnabled?: boolean;
 }) {
   const isEvalsFamily = activeTab === "evals" || activeTab === "ci-evals";
-  const isPlaygroundLocked = !playgroundEnabled;
   const subnavItems = getEvalsSubnavItems({
     evaluateRunsEnabled: showRuns,
   });
@@ -451,15 +424,15 @@ export function SidebarEvalsNavGroup({
   const parentButton = (
     <SidebarMenuButton
       tooltip={title}
-      isActive={!disabled && !isPlaygroundLocked && isEvalsFamily}
+      isActive={!disabled && isEvalsFamily}
       onClick={() => {
-        if (disabled || isPlaygroundLocked) return;
+        if (disabled) return;
         navigateToEvalsExploreList();
       }}
-      aria-disabled={disabled || isPlaygroundLocked || undefined}
+      aria-disabled={disabled || undefined}
       tabIndex={disabled ? -1 : undefined}
       className={
-        disabled || isPlaygroundLocked
+        disabled
           ? "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground"
           : isEvalsFamily
           ? "[&[data-active=true]]:bg-accent cursor-pointer"
@@ -492,13 +465,6 @@ export function SidebarEvalsNavGroup({
                   </TooltipContent>
                 ) : null}
               </Tooltip>
-            ) : isPlaygroundLocked && !hasSubnav ? (
-              <Tooltip>
-                <TooltipTrigger asChild>{parentButton}</TooltipTrigger>
-                <TooltipContent side="right" sideOffset={6}>
-                  Coming soon. Playground is in beta.
-                </TooltipContent>
-              </Tooltip>
             ) : (
               parentButton
             )}
@@ -506,23 +472,21 @@ export function SidebarEvalsNavGroup({
               <SidebarMenuSub>
                 {subnavItems.map((item) => {
                   const ItemIcon = item.icon;
-                  const isItemDisabled = disabled || isPlaygroundLocked;
 
                   return (
                     <SidebarMenuSubItem key={item.title}>
                       <SidebarMenuSubButton
-                        isActive={!isItemDisabled && item.isActive(activeTab)}
+                        isActive={!disabled && item.isActive(activeTab)}
                         href={item.href}
                         onClick={(e) => {
                           e.preventDefault();
-                          if (isItemDisabled) return;
+                          if (disabled) return;
                           item.onClick();
                         }}
-                        aria-disabled={isItemDisabled || undefined}
+                        aria-disabled={disabled || undefined}
                         className={cn(
-                          isItemDisabled &&
-                            "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground",
-                          disabled && "pointer-events-none"
+                          disabled &&
+                            "pointer-events-none cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground"
                         )}
                       >
                         <ItemIcon className="h-4 w-4" />
@@ -567,13 +531,9 @@ export function MCPSidebar({
   const sandboxesEnabled = useFeatureFlagEnabled("sandboxes-enabled");
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
-  const evaluateUiEnabled = useFeatureFlagEnabled("evaluate-ui");
-  const playgroundEnabled = useFeatureFlagEnabled("playground-enabled");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
-  const hostsEnabled = useFeatureFlagEnabled("hosts-enabled");
-  const homePageEnabled = useFeatureFlagEnabled("home-page-enabled");
   const { isAuthenticated } = useConvexAuth();
   const { user } = useAuth();
   const learningEnabled = !!learningFlagEnabled && isAuthenticated;
@@ -636,13 +596,10 @@ export function MCPSidebar({
       "sandboxes-enabled": !!sandboxesEnabled && isAuthenticated,
       "registry-enabled": registryEnabled === true,
       "mcpjam-conformance": conformanceEnabled === true,
-      "hosts-enabled":
-        computeHostsHubFlagEnabled({
-          hostsFlag: hostsEnabled,
-          hostedMode: HOSTED_MODE,
-        }) && isAuthenticated,
-      "home-page-enabled": homePageEnabled === true && isAuthenticated,
-      "evaluate-ui": evaluateUiEnabled === true,
+      // Hosts/Connect and Home are fully rolled out; their nav visibility is
+      // purely auth-driven (signed-out users keep the legacy Servers item).
+      "hosts-enabled": isAuthenticated,
+      "home-page-enabled": isAuthenticated,
       xaa: xaaEnabled === true,
     }),
     [
@@ -650,9 +607,6 @@ export function MCPSidebar({
       sandboxesEnabled,
       registryEnabled,
       conformanceEnabled,
-      hostsEnabled,
-      homePageEnabled,
-      evaluateUiEnabled,
       xaaEnabled,
       isAuthenticated,
     ]
@@ -792,20 +746,9 @@ export function MCPSidebar({
             const evalsEntry = useEvalsSubnavWrapper
               ? rawEvalsEntry
               : undefined;
-            const flatItems = section.items
-              .map((item) => {
-                if (!item.evalsSubnav) return item;
-                if (useEvalsSubnavWrapper) return null;
-                const locked = playgroundEnabled !== true;
-                return {
-                  ...item,
-                  disabled: locked || item.disabled,
-                  disabledTooltip: locked
-                    ? "Coming soon. Playground is in beta."
-                    : item.disabledTooltip,
-                };
-              })
-              .filter((item): item is NavItem => item !== null);
+            const flatItems = section.items.filter(
+              (item) => !item.evalsSubnav || !useEvalsSubnavWrapper
+            );
 
             return (
               <React.Fragment key={section.id}>
@@ -831,7 +774,6 @@ export function MCPSidebar({
                     disabledTooltip={evalsEntry.disabledTooltip}
                     activeTab={activeTab}
                     showRuns={evaluateRunsEnabled === true}
-                    playgroundEnabled={playgroundEnabled === true}
                   />
                 ) : null}
                 {/* Add subtle divider between sections (except after the last section) */}

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelMount.tsx
@@ -1,6 +1,5 @@
 /**
  * Glue between the side-panel store and the rest of the app:
- * - gates the panel + shortcut behind the `home-page-enabled` PostHog flag;
  * - wires the global ⌘\ / Ctrl+\ shortcut to toggle the panel (skipping
  *   inputs/textareas/contentEditable to stay friendly to the composer);
  * - renders the panel itself.
@@ -10,7 +9,7 @@
  * instance.
  */
 import { useEffect } from "react";
-import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+import { usePostHog } from "posthog-js/react";
 import { AgentSidePanel } from "@/components/mcpjam-agent/AgentSidePanel";
 import { useAppReady } from "@/hooks/use-app-ready";
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
@@ -34,13 +33,10 @@ export function AgentSidePanelMount({
   organizationId,
   activeTab,
 }: AgentSidePanelMountProps) {
-  const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
-  const isOpen = useAgentPanelStore((s) => s.isOpen);
   const toggle = useAgentPanelStore((s) => s.toggle);
   const posthog = usePostHog();
 
   useEffect(() => {
-    if (!homeEnabled) return undefined;
     const handler = (event: KeyboardEvent) => {
       if (event.key !== "\\") return;
       if (!(event.metaKey || event.ctrlKey)) return;
@@ -58,18 +54,7 @@ export function AgentSidePanelMount({
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [activeTab, homeEnabled, posthog, toggle]);
-
-  // Even when the flag is off, an already-persisted `isOpen=true` should not
-  // be honored — the entry point is hidden, so a stale stored value must not
-  // leave the panel showing. Gate on the explicit `false` so the brief window
-  // where `useFeatureFlagEnabled` returns `undefined` during PostHog hydration
-  // doesn't silently close a panel the user reopened across reloads.
-  useEffect(() => {
-    if (homeEnabled === false && isOpen) {
-      useAgentPanelStore.getState().setOpen(false);
-    }
-  }, [homeEnabled, isOpen]);
+  }, [activeTab, posthog, toggle]);
 
   // Drop the persisted session pointer whenever the panel state and the
   // current active project disagree about which project the session belongs
@@ -90,12 +75,6 @@ export function AgentSidePanelMount({
     if (activeSessionProjectId === projectId) return;
     useAgentPanelStore.getState().setActiveSession(null, null);
   }, [activeSessionId, activeSessionProjectId, appReady.status, projectId]);
-
-  // Render the panel during the brief PostHog flag-hydration window so an
-  // in-flight `useChat` stream isn't unmounted by `useFeatureFlagEnabled`
-  // returning `undefined` before resolving. Only an explicit `false`
-  // disconnects the trigger and tears down the panel.
-  if (homeEnabled === false) return null;
 
   return (
     <AgentSidePanel

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelTrigger.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/AgentSidePanelTrigger.tsx
@@ -1,13 +1,9 @@
 /**
  * Header sparkle button that toggles the MCPJam Agent side panel.
- *
- * Gated behind the same `home-page-enabled` PostHog flag as the home-tab
- * takeover so the agent's entry points stay in sync. Renders nothing when
- * the flag is off (or still loading).
  */
 import { useCallback } from "react";
 import { MessageCircle } from "lucide-react";
-import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+import { usePostHog } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Tooltip,
@@ -23,7 +19,6 @@ const SHORTCUT_LABEL =
     : "Ctrl+\\";
 
 export function AgentSidePanelTrigger() {
-  const homeEnabled = useFeatureFlagEnabled("home-page-enabled");
   const isOpen = useAgentPanelStore((s) => s.isOpen);
   const toggle = useAgentPanelStore((s) => s.toggle);
   const posthog = usePostHog();
@@ -39,8 +34,6 @@ export function AgentSidePanelTrigger() {
     }
     toggle();
   }, [activeTab, isOpen, posthog, toggle]);
-
-  if (!homeEnabled) return null;
 
   return (
     <Tooltip>

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -17,7 +17,6 @@ import {
 import { readStoredActiveOrganizationId } from "@/lib/active-organization-storage";
 import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useAppNavigate } from "@/lib/app-navigation";
-import { useCreditTopupsUiEnabled } from "@/lib/credit-topups-flag";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -34,7 +33,6 @@ export function MCPJamLimitDialog() {
   // first by useOrganizationQueries.
   const { sortedOrganizations } = useOrganizationQueries({ isAuthenticated });
   const appNavigate = useAppNavigate();
-  const creditsUiEnabled = useCreditTopupsUiEnabled();
 
   useEffect(() => {
     setAuthStatus(isLoading ? "loading" : user ? "signedIn" : "guest");
@@ -69,7 +67,6 @@ export function MCPJamLimitDialog() {
   const isKnownNonManager = billingOrg
     ? !canManageOrgCredits(billingOrg)
     : false;
-  const canBuyCredits = creditsUiEnabled && !isKnownNonManager;
 
   const handleTopUp = () => {
     const orgId = resolveBillingOrgId();
@@ -131,26 +128,21 @@ export function MCPJamLimitDialog() {
             <DialogHeader>
               <DialogTitle>Your org is out of credits</DialogTitle>
               <DialogDescription data-testid="limit-dialog-description">
-                {creditsUiEnabled && isKnownNonManager
+                {isKnownNonManager
                   ? "Ask your org admin to top up credits."
-                  : canBuyCredits
-                  ? "Top up or bring your own key to allow your org to keep using MCPJam."
-                  : "Bring your own key to keep chatting on MCPJam's models without waiting for your org's credits to reset."}
+                  : "Top up or bring your own key to allow your org to keep using MCPJam."}
               </DialogDescription>
             </DialogHeader>
             {/* Non-managers get no CTAs — just the "ask your org admin" copy.
-                Managers (and the dev billing-off fallback) keep BYOK, plus a
-                Top up button when credit purchase is available. */}
+                Managers keep BYOK plus the Top up button. */}
             {!isKnownNonManager ? (
               <DialogFooter>
                 <Button type="button" variant="outline" onClick={handleBYOK}>
                   Bring your own key
                 </Button>
-                {canBuyCredits ? (
-                  <Button type="button" onClick={handleTopUp}>
-                    Top up
-                  </Button>
-                ) : null}
+                <Button type="button" onClick={handleTopUp}>
+                  Top up
+                </Button>
               </DialogFooter>
             ) : null}
           </DialogContent>

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Hammer, History } from "lucide-react";
-import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+import { usePostHog } from "posthog-js/react";
 import { standardEventProps } from "@/lib/PosthogUtils";
 import { ChatHistoryRail } from "@/components/chat-v2/history/ChatHistoryRail";
 import { usePlaygroundStateContext } from "@/components/ui-playground/hooks/use-playground-state";
@@ -18,15 +18,7 @@ type LeftRailTab = "sessions" | "tools";
  * `PlaygroundTab`.
  */
 export function PlaygroundLeftRail() {
-  const sessionsTabEnabled =
-    useFeatureFlagEnabled("playground-sessions-enabled") === true;
   const [activeTab, setActiveTab] = useState<LeftRailTab>("tools");
-
-  useEffect(() => {
-    if (!sessionsTabEnabled && activeTab === "sessions") {
-      setActiveTab("tools");
-    }
-  }, [sessionsTabEnabled, activeTab]);
 
   const posthog = usePostHog();
   const handleTabClick = useCallback(
@@ -51,21 +43,15 @@ export function PlaygroundLeftRail() {
           isActive={activeTab === "tools"}
           onClick={() => handleTabClick("tools")}
         />
-        {sessionsTabEnabled ? (
-          <TabButton
-            icon={History}
-            label="Sessions"
-            isActive={activeTab === "sessions"}
-            onClick={() => handleTabClick("sessions")}
-          />
-        ) : null}
+        <TabButton
+          icon={History}
+          label="Sessions"
+          isActive={activeTab === "sessions"}
+          onClick={() => handleTabClick("sessions")}
+        />
       </div>
       <div className="flex-1 min-h-0">
-        {activeTab === "sessions" && sessionsTabEnabled ? (
-          <SessionsBody />
-        ) : (
-          <ToolsBody />
-        )}
+        {activeTab === "sessions" ? <SessionsBody /> : <ToolsBody />}
       </div>
     </div>
   );
@@ -115,7 +101,6 @@ function SessionsBody() {
       hostStyle={bridge.hostStyle}
       isAuthenticated={bridge.isAuthenticated}
       isStreaming={bridge.isStreaming}
-      sharedThreadsEnabled={bridge.sharedThreadsEnabled}
       projectId={bridge.projectId}
       enabled={bridge.enabled}
       refreshSignal={bridge.refreshSignal}

--- a/mcpjam-inspector/client/src/components/playground/playground-chat-history-bridge.ts
+++ b/mcpjam-inspector/client/src/components/playground/playground-chat-history-bridge.ts
@@ -20,7 +20,6 @@ export interface PlaygroundChatHistoryBridge {
   hostStyle: ChatboxHostStyle | undefined;
   isAuthenticated: boolean;
   isStreaming: boolean;
-  sharedThreadsEnabled: boolean;
   projectId: string | null | undefined;
   enabled: boolean;
   refreshSignal: number;

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
@@ -19,8 +19,6 @@ let balanceState:
   | undefined;
 let isLoadingState = false;
 let hasWorkOsUserState = true;
-let creditTopupsFlagState = true;
-let teamCreditsFlagState = true;
 
 vi.mock("@/hooks/useCreditBalance", () => ({
   useCreditBalance: () => ({
@@ -28,14 +26,6 @@ vi.mock("@/hooks/useCreditBalance", () => ({
     isLoading: isLoadingState,
     hasWorkOsUser: hasWorkOsUserState,
   }),
-}));
-
-vi.mock("@/lib/team-credits-flag", () => ({
-  useTeamCreditsUiEnabled: () => teamCreditsFlagState,
-}));
-
-vi.mock("@/lib/credit-topups-flag", () => ({
-  useCreditTopupsUiEnabled: () => creditTopupsFlagState,
 }));
 
 describe("SidebarCreditUsage", () => {
@@ -53,8 +43,6 @@ describe("SidebarCreditUsage", () => {
     };
     isLoadingState = false;
     hasWorkOsUserState = true;
-    creditTopupsFlagState = true;
-    teamCreditsFlagState = true;
   });
 
   afterEach(() => {
@@ -70,14 +58,6 @@ describe("SidebarCreditUsage", () => {
     expect(dailyRow).toHaveTextContent("36 / 300");
     expect(dailyRow).toHaveTextContent("resets in 3h");
     expect(screen.queryByText(/10× the credits/i)).not.toBeInTheDocument();
-  });
-
-  it("renders nothing when the top-ups UI flag is off", () => {
-    creditTopupsFlagState = false;
-
-    const { container } = render(<SidebarCreditUsage />);
-
-    expect(container).toBeEmptyDOMElement();
   });
 
   it("keeps the sidebar strip focused on daily limits for paid users", () => {
@@ -145,36 +125,6 @@ describe("SidebarCreditUsage", () => {
     expect(monthlyRow).toHaveTextContent("resets in 16 days");
     expect(screen.queryByTestId("sidebar-usage-daily")).not.toBeInTheDocument();
 
-    const paidRow = screen.getByTestId("sidebar-usage-paid");
-    expect(paidRow).toHaveTextContent("Paid credits");
-    expect(paidRow).toHaveTextContent("988");
-    expect(paidRow).not.toHaveTextContent("24,500");
-  });
-
-  it("keeps the existing daily and paid rows when only the team flag is off", () => {
-    teamCreditsFlagState = false;
-    balanceState = {
-      paidCreditsRemaining: 988,
-      hasPurchaseHistory: true,
-      freeDailyPercentUsed: 0,
-      freeDailyResetAt: 0,
-      freeDailyCreditsRemaining: 0,
-      freeDailyCreditsTotal: 0,
-      walletLocked: false,
-      billingModel: "monthly_per_seat",
-      monthlyAllowanceTotal: 24_000,
-      monthlyAllowanceRemaining: 24_000,
-      monthlyResetAt: Date.now() + 16 * 24 * 60 * 60 * 1000,
-    };
-
-    render(<SidebarCreditUsage variant="full" />);
-
-    expect(
-      screen.queryByTestId("sidebar-usage-monthly")
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("sidebar-usage-daily")).toHaveTextContent(
-      "Free daily credits"
-    );
     const paidRow = screen.getByTestId("sidebar-usage-paid");
     expect(paidRow).toHaveTextContent("Paid credits");
     expect(paidRow).toHaveTextContent("988");

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -8,8 +8,6 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import { CoinStackIcon } from "@/components/ui/coin-stack-icon";
 import { useCreditBalance } from "@/hooks/useCreditBalance";
-import { useCreditTopupsUiEnabled } from "@/lib/credit-topups-flag";
-import { useTeamCreditsUiEnabled } from "@/lib/team-credits-flag";
 import {
   formatCreditResetText,
   formatMonthlyResetText,
@@ -31,24 +29,16 @@ export function SidebarCreditUsage({
   variant = "strip",
   onClick,
 }: SidebarCreditUsageProps = {}) {
-  const creditTopupsUiEnabled = useCreditTopupsUiEnabled();
-  const teamCreditsUiEnabled = useTeamCreditsUiEnabled();
   const { balance, isLoading, hasWorkOsUser } = useCreditBalance({
     organizationId,
     includeGuests,
-    enabled: creditTopupsUiEnabled,
   });
-
-  if (!creditTopupsUiEnabled) {
-    return null;
-  }
 
   if (!isLoading && !balance) {
     return null;
   }
 
-  const showMonthly =
-    teamCreditsUiEnabled && balance?.billingModel === "monthly_per_seat";
+  const showMonthly = balance?.billingModel === "monthly_per_seat";
   const monthlyTotal = balance?.monthlyAllowanceTotal ?? 0;
   const monthlyRemaining = balance?.monthlyAllowanceRemaining ?? 0;
   const paidRemaining = balance?.paidCreditsRemaining ?? 0;

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -159,7 +159,6 @@ import {
   prefetchChatHistorySession,
 } from "@/components/chat-v2/history/chat-history-prefetch";
 import { usePlaygroundChatHistoryBridgeStore } from "@/components/playground/playground-chat-history-bridge";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { WebApiError } from "@/lib/apis/web/base";
 import { useDirectChatSessionSubscription } from "@/hooks/use-direct-chat-session-subscription";
 import { WidgetSurfaceProvider } from "@/contexts/widget-surface-context";
@@ -357,8 +356,6 @@ export function PlaygroundMain({
   const { signUp } = useAuth();
   const posthog = usePostHog();
   const clearLogs = useTrafficLogStore((s) => s.clear);
-  const sharedThreadsEnabled =
-    useFeatureFlagEnabled("shared-threads-enabled") === true;
 
   // Chat-history coordination — Playground equivalent of ChatTabV2's history
   // machinery, scoped down to what the docked rail actually needs.
@@ -1941,7 +1938,6 @@ export function PlaygroundMain({
       // Use the multi-model-aware streaming flag so the rail disables New Chat
       // / row selection while any broadcast lane is still streaming.
       isStreaming: isStreamingActive,
-      sharedThreadsEnabled,
       projectId: convexProjectId,
       enabled: isSessionBootstrapComplete,
       refreshSignal: historyRefreshSignal,
@@ -1970,7 +1966,6 @@ export function PlaygroundMain({
     isSessionBootstrapComplete,
     isStreamingActive,
     setBridge,
-    sharedThreadsEnabled,
   ]);
 
   // Track streaming baseline + resumedVersion drift while a history session is

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -179,7 +179,6 @@ export function useAppState({
   hasOrganizations,
   isLoadingOrganizations,
   validOrganizations,
-  hostsHubFlagEnabled,
   requestSignIn,
 }: {
   currentUserId: string | null;
@@ -194,12 +193,6 @@ export function useAppState({
   hasOrganizations: boolean;
   isLoadingOrganizations: boolean;
   validOrganizations: Array<{ _id: string; myRole?: string }>;
-  /**
-   * Hosts-hub feature flag. When off, host queries are skipped and the
-   * connection path falls back to the project default (still authoritative
-   * via its shadow `projects.clientConfig`).
-   */
-  hostsHubFlagEnabled: boolean;
   requestSignIn?: () => void | Promise<void>;
 }) {
   const logger = useLogger("Connections");
@@ -507,7 +500,7 @@ export function useAppState({
     activeSharedProjectId ?? null,
   );
   const { host: selectedHost } = useHost({
-    isAuthenticated: isAuthenticated && hostsHubFlagEnabled,
+    isAuthenticated,
     hostId: activeHostId,
   });
   const activeHost = resolveEffectiveHost({

--- a/mcpjam-inspector/client/src/lib/credit-topups-flag.ts
+++ b/mcpjam-inspector/client/src/lib/credit-topups-flag.ts
@@ -1,7 +1,0 @@
-import { useFeatureFlagEnabled } from "posthog-js/react";
-
-export const CREDIT_TOPUPS_UI_FLAG = "credit-topups-ui";
-
-export function useCreditTopupsUiEnabled(): boolean {
-  return useFeatureFlagEnabled(CREDIT_TOPUPS_UI_FLAG) === true;
-}

--- a/mcpjam-inspector/client/src/lib/team-credits-flag.ts
+++ b/mcpjam-inspector/client/src/lib/team-credits-flag.ts
@@ -1,7 +1,0 @@
-import { useFeatureFlagEnabled } from "posthog-js/react";
-
-export const TEAM_CREDITS_UI_FLAG = "team-credits-ui";
-
-export function useTeamCreditsUiEnabled(): boolean {
-  return useFeatureFlagEnabled(TEAM_CREDITS_UI_FLAG) === true;
-}


### PR DESCRIPTION
## Summary

Removes the PostHog feature flags that are rolled out to **100% of all users** (confirmed against the PostHog dashboard by @marcelojimenez), making the gated code paths unconditional and deleting the flag plumbing.

**Flags removed (11):**

| Flag | What it gated |
|---|---|
| `playground-enabled` | Evaluate-entry lock ("Playground is in beta" tooltip) |
| `chat-history-rail` | Chat history rail in Chat |
| `shared-threads-enabled` | Shared/project thread sections + sharing actions |
| `hosts-enabled` | Hosts/Connect hub (routes, sidebar swap, attachment pickers) |
| `playground-sessions-enabled` | Sessions tab in the Playground left rail |
| `home-page-enabled` | Home tab + MCPJam Agent side panel/trigger |
| `evaluate-ui` | Evaluate tab UI, save-as-test-case, convert-to-test-case |
| `credit-topups-ui` | Credit top-up purchase UI (helper module deleted) |
| `team-credits-ui` | Team monthly-credits UI (helper module deleted) |
| `stateless-mcp-enabled` | Protocol-version pin controls + effective-version chip |
| `server-history-tab` | Server History tab + drift chip in ServerDetailModal |

**Flags intentionally kept** (still gated or partially rolled out per the dashboard): `sandboxes-enabled`, `billing-entitlements-ui`, `registry-enabled`, `learn-more-enabled`, `xaa`, `evaluate-ci`, `mcpjam-learning` + `mcpjam-conformance` (internal-only), `computers-enabled` (staged rollout).

## Notable code consequences

- **`computeHostsHubFlagEnabled` is deleted.** Its whole purpose was reconciling the PostHog gate with desktop builds (where PostHog may not resolve); with the flag gone, Hosts/Connect routes and the Connect/Servers sidebar swap collapse to plain `isAuthenticated` checks on every platform.
- **`defaultHubRoute` no longer waits for PostHog flags to load.** (`main` has since pointed it unconditionally at `"home"` via #2631 — this branch merged that, so redirects off disabled tabs land on `/home`.)
- The sidebar `featureFlags` map keeps the `"hosts-enabled"` / `"home-page-enabled"` keys, but they're now purely auth-driven nav-visibility conditions (commented as such).
- `ChatHistoryRail` loses its `sharedThreadsEnabled` prop; the playground chat-history bridge drops the field; `ChatHistoryRow`'s same-named prop stays (it receives the computed `canUseProjectSharing` permission, not the flag).
- `lib/credit-topups-flag.ts` and `lib/team-credits-flag.ts` are deleted; `CreditBalanceCard`, `SidebarCreditUsage`, `TopupGatedErrorBox`, `MCPJamLimitDialog`, and `OrganizationsTab` (Billing nav/section) simplified. The limit dialog's "billing-off" copy branch became dead and was removed.
- `EffectiveProtocolVersionChip` always renders (its `flagEnabled` prop is gone). The per-server protocol-override row shows unconditionally in the edit-server form; the Add Server modal keeps it hidden via the existing `showMcpProtocolVersionOverride` default (no project server ref exists at add time).
- `EvalsRoute`'s "Evaluate Coming Soon" empty state became unreachable and was removed.

## Things reviewers may want to double-check

- ⚠️ The `server-history-tab` gate carried an in-code comment saying "@mcpjam.com only". Per the dashboard it's now 100%, so the comment was stale — but worth a second look that the History tab is genuinely meant for everyone before merging.
- `home-page-enabled`'s route gate was independently removed on `main` by #2631 (default Home landing); this branch merged that, and additionally removes the flag from the sidebar Home item and the MCPJam Agent panel/trigger (those collapse to auth-only gating).
- After merging, the 11 flags can be deleted in PostHog itself.

## Verification

- `npm run typecheck:client` clean (re-run after merging `main`).
- Full vitest suite after merging `main`: **5766 passed / 17 failed** — the 17 failures are the pre-existing `mcp-app-browser-harness` / computer-use server tests that need headless Chromium, which isn't available in the sandbox this was developed in (`browser_unavailable`); they're untouched by this diff and fail identically without it.
- Flag-coupled tests updated: removed flag-off-only cases, added `HostsTab`/`HomeTab` mocks to the App routing tests (authed `/servers` now renders the Hosts hub with the Servers view embedded), and re-pointed hub-redirect assertions to `/home` (the post-#2631 default landing).

_Note: `mcpjam-backend` has no feature-flag usage (PostHog is telemetry-only there), so all changes are in this repo._

https://claude.ai/code/session_015kZ8erQdESwFcdeMejYD12

---
_Generated by [Claude Code](https://claude.ai/code/session_015kZ8erQdESwFcdeMejYD12)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, user-visible surface area (Hosts routing, billing/credits, Evaluate, and MCP protocol pins) becomes unconditional; regressions would affect most signed-in flows, though the intent is post-rollout cleanup rather than new behavior.
> 
> **Overview**
> This PR **removes eleven PostHog feature flags** that are already at 100% rollout and wires their behavior directly into the app, plus updates or drops tests that only asserted “flag off” behavior.
> 
> **Routing and navigation:** Hosts/Connect (`ServersRoute`, `HostsRoute`, compare/computer routes, global host bar, `useAppState` host queries) no longer use `computeHostsHubFlagEnabled` or `hosts-enabled`; signed-in users always get the hub, guests keep the legacy Servers tab. Sidebar nav treats `"hosts-enabled"` and `"home-page-enabled"` as **auth-only** visibility. Evaluate is always reachable—`EvalsRoute` loses the “Coming soon” empty state and sidebar Evaluate is no longer locked behind `playground-enabled` / `evaluate-ui`.
> 
> **Chat and Evaluate:** Hosted chat history rail and shared/project threads are always on when hosted (flags and `sharedThreadsEnabled` props removed). History rail convert-to-test-case and save-as-test-case actions no longer check `evaluate-ui` / raw `hosts-enabled`. Evals suite creation uses `hostsEnabled = isAuthenticated` for attachment requirements.
> 
> **Billing and org UI:** Credit top-ups, team monthly usage, org Billing tab, limit-dialog Top up, and sidebar credit usage no longer gate on `credit-topups-ui` / `team-credits-ui`; **`lib/credit-topups-flag.ts` and `lib/team-credits-flag.ts` are deleted**.
> 
> **Connection / protocol:** Per-server and host protocol-version controls, effective-version chip, and server History tab + drift chip show whenever context allows (project/server ids), without `stateless-mcp-enabled` or `server-history-tab`.
> 
> **Agent and playground:** MCPJam Agent panel, shortcut, and header trigger are always mounted (no `home-page-enabled`). Playground left rail always includes the Sessions tab.
> 
> Tests gain `HostsTab` mocks for authed `/servers` and shed flag-off-only cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86fc9c116541b3616e38e2fb8e249ced9b5511c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->