### PR TITLE
mcpjam-agent: explicitly advertise io.modelcontextprotocol/ui capability

### DIFF
--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -20,7 +20,12 @@
  */
 import { Hono } from "hono";
 import { z } from "zod";
-import { MCPClientManager, type HttpServerConfig } from "@mcpjam/sdk";
+import {
+  MCPClientManager,
+  type HttpServerConfig,
+  MCP_UI_EXTENSION_ID,
+  MCP_UI_RESOURCE_MIME_TYPE,
+} from "@mcpjam/sdk";
 import { isMCPAuthError } from "@mcpjam/sdk";
 import { WEB_STREAM_TIMEOUT_MS } from "../../config.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
@@ -86,6 +91,13 @@ mcpjamAgent.post("/", async (c) => {
     const docsConfig: HttpServerConfig = {
       url: docsUrl,
       timeout: 30_000,
+      clientCapabilities: {
+        extensions: {
+          [MCP_UI_EXTENSION_ID]: {
+            mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE],
+          },
+        },
+      },
     };
 
     manager = new MCPClientManager(


### PR DESCRIPTION
## Summary

- Adds `clientCapabilities` to `docsConfig` in `mcpjam-agent.ts` to explicitly declare the `io.modelcontextprotocol/ui` extension (`text/html;profile=mcp-app`) rather than relying on `getDefaultClientCapabilities()` fallback.
- Uses `MCP_UI_EXTENSION_ID` and `MCP_UI_RESOURCE_MIME_TYPE` constants exported from `@mcpjam/sdk`.

## Test plan

- [ ] Verify the docs MCP server receives `extensions["io.modelcontextprotocol/ui"]` in the `initialize` capabilities (visible in the MCPJam inspector's RPC log for the Home agent session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-route capability advertisement change with no auth, persistence, or tool-selection logic touched.
> 
> **Overview**
> The **MCPJam agent** route now sets **`clientCapabilities`** on the hardcoded docs MCP **`HttpServerConfig`** so **`initialize`** explicitly declares the **`io.modelcontextprotocol/ui`** extension with **`text/html;profile=mcp-app`**, using **`MCP_UI_EXTENSION_ID`** and **`MCP_UI_RESOURCE_MIME_TYPE`** from **`@mcpjam/sdk`** instead of implicit defaults.
> 
> This only affects the Home/docs agent’s dedicated **`MCPClientManager`** connection to the hosted docs server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e68440f62fa1e5487db83e8edde80c8c35166f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->