### PR TITLE
test: update hosted-oauth tests for home default hub route

### DIFF
--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -1843,7 +1843,7 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText("Servers Tab")).toBeInTheDocument();
+      expect(screen.getByTestId("home-tab")).toBeInTheDocument();
     });
 
     expect(
@@ -2676,7 +2676,7 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
   });
 
-  it("redirects conformance to servers when the feature flag is disabled", async () => {
+  it("redirects conformance to home when the feature flag is disabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/conformance");
@@ -2689,11 +2689,11 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/servers");
+      expect(window.location.pathname).toBe("/home");
     });
   });
 
-  it("redirects xaa-flow to Servers when the xaa flag is disabled", async () => {
+  it("redirects xaa-flow to home when the xaa flag is disabled", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/xaa-flow");
@@ -2702,10 +2702,10 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText("Servers Tab")).toBeInTheDocument();
+      expect(screen.getByTestId("home-tab")).toBeInTheDocument();
     });
 
-    expect(window.location.pathname).toBe("/servers");
+    expect(window.location.pathname).toBe("/home");
     expect(screen.queryByTestId("xaa-flow-tab")).not.toBeInTheDocument();
   });
 
@@ -2936,10 +2936,10 @@ describe("App hosted OAuth callback handling", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Servers Tab")).toBeInTheDocument();
+      expect(screen.getByTestId("home-tab")).toBeInTheDocument();
     });
 
-    expect(window.location.pathname).toBe("/servers");
+    expect(window.location.pathname).toBe("/home");
     expect(screen.queryByTestId("evals-tab")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- PR #2631 changed `defaultHubRoute` to `"home"`, so all "redirect invalid/feature-flag-off tab to hub" paths now land on `/home` instead of `/servers`
- Four tests in `App.hosted-oauth.test.tsx` were still asserting `/servers` and `"Servers Tab"` for those redirect paths
- Updated to assert `/home` and `data-testid="home-tab"` to match the new default

**Tests fixed:**
- `clears billing handoff state when no organization is available`
- `redirects conformance to servers when the feature flag is disabled` → renamed to `…to home…`
- `redirects xaa-flow to Servers when the xaa flag is disabled` → renamed to `…to home…`
- `still applies the CI billing redirect when evaluate-ci is enabled`

## Test plan
- [ ] `npm run test -w @mcpjam/inspector` passes with 0 failures in `App.hosted-oauth.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production routing or behavior modified in this diff.
> 
> **Overview**
> Updates **`App.hosted-oauth.test.tsx`** so expectations match **`defaultHubRoute`** being **`"home"`** (instead of landing on **`/servers`** / the Servers tab mock).
> 
> Redirect and fallback cases now assert **`/home`** and **`data-testid="home-tab"`** for: billing handoff with no org, disabled **conformance** and **xaa-flow** flags, and the CI billing redirect when **evaluate-ci** is enabled. Two test titles were renamed to say **“to home”** instead of **servers**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7484a558385dd04828d4ad8f2d5890747a77458f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->