### PR TITLE
feat: serve docs-server widget HTML via companion endpoint

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/fetch-widget-content.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/fetch-widget-content.ts
@@ -85,17 +85,32 @@ export interface FetchMcpAppsWidgetContentResponse {
   injectedOpenAiCompatCapabilities?: ResolvedOpenAiAppsCapabilities;
 }
 
+// The docs server is synthetic (not in the Convex project registry) so
+// it can't go through the standard hosted-mode `buildServerRequest` path.
+// The agent route exposes its own companion endpoint that creates an
+// ephemeral connection to docs.mcpjam.com/mcp directly.
+const MCPJAM_DOCS_SERVER_ID = "mcpjam-docs";
+
 export async function fetchMcpAppsWidgetContent(
   request: FetchMcpAppsWidgetContentRequest,
 ): Promise<FetchMcpAppsWidgetContentResponse> {
   const useWebEndpoint = HOSTED_MODE || request.forceWebEndpoint === true;
-  const endpoint = useWebEndpoint
-    ? "/api/web/apps/mcp-apps/widget-content"
-    : "/api/apps/mcp-apps/widget-content";
+  const isDocsServer = request.serverId === MCPJAM_DOCS_SERVER_ID;
 
-  const payload = useWebEndpoint
-    ? { ...buildServerRequest(request.serverId) }
-    : { serverId: request.serverId };
+  // Docs-server widgets use the agent's companion endpoint — the general
+  // `/api/web/apps/mcp-apps/widget-content` path would call
+  // `buildServerRequest("mcpjam-docs")` → `resolveHostedServerId` → throw.
+  const endpoint =
+    useWebEndpoint && isDocsServer
+      ? "/api/web/mcpjam-agent/widget-content"
+      : useWebEndpoint
+        ? "/api/web/apps/mcp-apps/widget-content"
+        : "/api/apps/mcp-apps/widget-content";
+
+  const payload =
+    useWebEndpoint && !isDocsServer
+      ? { ...buildServerRequest(request.serverId) }
+      : { serverId: request.serverId };
 
   const response = await authFetch(endpoint, {
     method: "POST",

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -27,6 +27,11 @@ import {
   MCP_UI_RESOURCE_MIME_TYPE,
 } from "@mcpjam/sdk";
 import { isMCPAuthError } from "@mcpjam/sdk";
+import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type {
+  McpUiResourceCsp,
+  McpUiResourcePermissions,
+} from "@modelcontextprotocol/ext-apps";
 import { WEB_STREAM_TIMEOUT_MS } from "../../config.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { streamWebChatTurn } from "../../utils/web-chat-turn.js";
@@ -34,11 +39,13 @@ import { WEB_SEARCH_TOOL_NAME } from "../../utils/built-in-tools/exa-web-search.
 import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
 import { MCPJAM_TOOL_IDS } from "../../utils/built-in-tools/mcpjam.js";
 import { buildMcpjamPlatformClient } from "./mcpjam-platform-client.js";
+import { injectOpenAICompat } from "../../utils/widget-helpers.js";
 import {
   assertBearerToken,
   readJsonBody,
   parseWithSchema,
   ErrorCode,
+  WebRouteError,
   webError,
   mapRuntimeError,
 } from "./auth.js";
@@ -201,6 +208,152 @@ mcpjamAgent.post("/", async (c) => {
       routeError.details,
       rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
     );
+  }
+});
+
+// ── Docs-server widget content ───────────────────────────────────────
+//
+// `POST /api/web/mcpjam-agent/widget-content` is the companion to
+// `/api/web/apps/mcp-apps/widget-content` for the docs server.
+// The general hosted endpoint resolves servers from the Convex project
+// registry; `mcpjam-docs` is a synthetic id that doesn't exist there.
+// This route creates its own ephemeral manager (same docsConfig as the
+// agent turn) so the renderer can fetch `ui://mcpjam/*.html` resources
+// without a separate server registration.
+
+const ACCEPTED_WIDGET_MIMETYPES = new Set<string>([
+  RESOURCE_MIME_TYPE,
+  "text/html+skybridge",
+  "text/html",
+]);
+
+const widgetContentSchema = z.object({
+  resourceUri: z.string().min(1),
+  toolInput: z.record(z.string(), z.unknown()).default({}),
+  toolOutput: z.unknown().optional(),
+  toolResponseMetadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  initialWidgetState: z.unknown().optional(),
+  toolId: z.string().min(1),
+  toolName: z.string().min(1),
+  theme: z.enum(["light", "dark"]).optional(),
+  cspMode: z.enum(["permissive", "widget-declared"]).optional(),
+  injectOpenAiCompat: z.boolean().optional().default(false),
+  openAiCompatCapabilities: z.record(z.string(), z.unknown()).optional(),
+  template: z.string().optional(),
+  viewMode: z.string().optional(),
+  viewParams: z.record(z.string(), z.unknown()).optional(),
+});
+
+mcpjamAgent.post("/widget-content", async (c) => {
+  let manager: InstanceType<typeof MCPClientManager> | undefined;
+  try {
+    assertBearerToken(c);
+    const rawBody = await readJsonBody<Record<string, unknown>>(c);
+    const body = parseWithSchema(widgetContentSchema, rawBody);
+
+    if (body.template && !body.template.startsWith("ui://")) {
+      return webError(c, 400, ErrorCode.VALIDATION_ERROR, "Template must use ui:// protocol");
+    }
+
+    const docsUrl = process.env.MCPJAM_DOCS_MCP_URL ?? DEFAULT_DOCS_URL;
+    const docsConfig: HttpServerConfig = {
+      url: docsUrl,
+      timeout: 30_000,
+      clientCapabilities: {
+        extensions: {
+          [MCP_UI_EXTENSION_ID]: {
+            mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE],
+          },
+        },
+      },
+    };
+
+    manager = new MCPClientManager(
+      { [DOCS_SERVER_ID]: docsConfig },
+      {
+        defaultTimeout: WEB_STREAM_TIMEOUT_MS,
+        retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
+      }
+    );
+
+    try {
+      const resolvedResourceUri = body.template ?? body.resourceUri;
+      const effectiveCspMode = body.cspMode ?? "permissive";
+
+      const resourceResult = await manager.readResource(DOCS_SERVER_ID, {
+        uri: resolvedResourceUri,
+      });
+
+      const contents = (resourceResult as any)?.contents ?? [];
+      const content = contents[0];
+      if (!content) {
+        return webError(c, 404, ErrorCode.NOT_FOUND, "No content in resource");
+      }
+
+      const contentMimeType = (content as { mimeType?: string }).mimeType;
+      const mimeTypeValid =
+        typeof contentMimeType === "string" &&
+        ACCEPTED_WIDGET_MIMETYPES.has(contentMimeType);
+      const mimeTypeWarning = !mimeTypeValid
+        ? contentMimeType
+          ? `Invalid mimetype "${contentMimeType}" - expected one of: ${[...ACCEPTED_WIDGET_MIMETYPES].join(", ")}`
+          : `Missing mimetype - expected one of: ${[...ACCEPTED_WIDGET_MIMETYPES].join(", ")}`
+        : null;
+
+      let html: string;
+      const record = content as Record<string, unknown>;
+      if (typeof record.text === "string") {
+        html = record.text;
+      } else if (typeof record.blob === "string") {
+        html = Buffer.from(record.blob, "base64").toString("utf-8");
+      } else {
+        return webError(c, 404, ErrorCode.NOT_FOUND, "No HTML content in resource");
+      }
+
+      const resourceMeta = content._meta as Record<string, unknown> | undefined;
+      const uiMeta = (resourceMeta as { ui?: any } | undefined)?.ui as
+        | { csp?: McpUiResourceCsp; permissions?: McpUiResourcePermissions; prefersBorder?: boolean }
+        | undefined;
+
+      if (body.injectOpenAiCompat === true) {
+        html = injectOpenAICompat(html, {
+          toolId: body.toolId,
+          toolName: body.toolName,
+          toolInput: body.toolInput ?? {},
+          toolOutput: body.toolOutput,
+          toolResponseMetadata: body.toolResponseMetadata ?? null,
+          initialWidgetState: body.initialWidgetState ?? null,
+          theme: body.theme,
+          viewMode: body.viewMode,
+          viewParams: body.viewParams,
+          capabilities: body.openAiCompatCapabilities as
+            | Parameters<typeof injectOpenAICompat>[1]["capabilities"]
+            | undefined,
+        });
+      }
+
+      return c.json({
+        html,
+        csp: effectiveCspMode === "permissive" ? undefined : uiMeta?.csp,
+        permissions: uiMeta?.permissions,
+        permissive: effectiveCspMode === "permissive",
+        cspMode: effectiveCspMode,
+        prefersBorder: uiMeta?.prefersBorder,
+        injectedOpenAiCompat: body.injectOpenAiCompat === true,
+        injectedOpenAiCompatCapabilities:
+          body.injectOpenAiCompat === true && body.openAiCompatCapabilities !== undefined
+            ? body.openAiCompatCapabilities
+            : undefined,
+        mimeType: contentMimeType,
+        mimeTypeValid,
+        mimeTypeWarning,
+      });
+    } finally {
+      await manager.disconnectAllServers();
+    }
+  } catch (error) {
+    const routeError = mapRuntimeError(error);
+    return webError(c, routeError.status, routeError.code, routeError.message, routeError.details);
   }
 });
 


### PR DESCRIPTION
## Summary

- `show_servers` on `docs.mcpjam.com/mcp` returns `ui://mcpjam/show-servers.html` as its widget resource URI
- In HOSTED_MODE, `fetchMcpAppsWidgetContent` routes through `buildServerRequest("mcpjam-docs")` → `resolveHostedServerId` → throws, because `mcpjam-docs` is synthetic (not in the Convex project registry)
- Adds `POST /api/web/mcpjam-agent/widget-content` companion endpoint that creates its own ephemeral `MCPClientManager` pointing to `docs.mcpjam.com/mcp`, reads the resource, and returns HTML in the same shape as the general widget endpoint
- Frontend: `serverId === "mcpjam-docs"` routes to the companion endpoint instead of calling `buildServerRequest`

## Test plan

- [ ] Start the Home page agent, ask it to show servers — confirm the `show_servers` tool renders a widget instead of raw JSON
- [ ] Verify other surfaces (regular chatbox widgets) are unaffected — `serverId !== "mcpjam-docs"` still hits `/api/web/apps/mcp-apps/widget-content`
- [ ] Verify `MCPJAM_DOCS_MCP_URL` env override works in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated web route that fetches and returns arbitrary widget HTML from an external MCP server; scope is limited to the synthetic docs server id and mirrors existing widget-content behavior.
> 
> **Overview**
> Fixes **hosted-mode widget rendering** for the synthetic **`mcpjam-docs`** server, which is not in the Convex project registry and previously failed when the client called **`buildServerRequest("mcpjam-docs")`** on the general **`/api/web/apps/mcp-apps/widget-content`** path.
> 
> **Client:** When **`serverId === "mcpjam-docs"`** and the web endpoint is used, **`fetchMcpAppsWidgetContent`** now posts to **`/api/web/mcpjam-agent/widget-content`** and sends **`{ serverId }`** only (no **`buildServerRequest`**). Other servers keep the existing web/local routing and payloads.
> 
> **Server:** Adds **`POST /api/web/mcpjam-agent/widget-content`**, which opens an ephemeral **`MCPClientManager`** to **`docs.mcpjam.com/mcp`** (same config as the agent turn), reads the **`ui://`** resource, optionally injects OpenAI compat via **`injectOpenAICompat`**, and returns the same JSON shape as the general widget-content route (HTML, CSP/permissions, mime validation, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd709e515cef790a42d8a0bc41d07671cef77d65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->