### PR TITLE
chore: add inspector changesets for unreleased work since v2.11.0

### DIFF
--- a/.changeset/agent-platform-catalog.md
+++ b/.changeset/agent-platform-catalog.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": minor
+---
+
+The mcpjam-agent MCP server now exposes the full platform catalog — eval, chatbox, and project tools plus live MCP server operations — advertises the `io.modelcontextprotocol/ui` capability, and connects the platform MCP server for native widget rendering.

--- a/.changeset/computer-use-expansion.md
+++ b/.changeset/computer-use-expansion.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Computer Use grows up: evals accept any vision + tool-calling model (not just a hardcoded allowlist), computers delegate to a remote data plane so credential-less inspectors can still drive sessions, synthetic sessions run through the same eval browser pipeline (render observations + Computer Use), and the computer terminal gets a themed UI with a toolbar and clipboard support.

--- a/.changeset/home-landing-default.md
+++ b/.changeset/home-landing-default.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": minor
+---
+
+The app now lands on Home instead of Connect. Home resolves the org from the active project and shows a skeleton while context loads, and the Host tab's focus panel starts expanded.

--- a/.changeset/org-models-availability.md
+++ b/.changeset/org-models-availability.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Clients can use models configured at the org level, and model pickers share one availability pipeline so chat, host, and evals agree on which models are offered.

--- a/.changeset/oss-community-backend.md
+++ b/.changeset/oss-community-backend.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Local OSS development points at the open community backend by default.

--- a/.changeset/relay-tunnels.md
+++ b/.changeset/relay-tunnels.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": minor
+---
+
+MCPJam relay tunneling replaces ngrok for exposing local MCP servers. Tunnel URLs are edge-secured bearer URLs with a transparent bridge and per-server isolation.


### PR DESCRIPTION
## Why

The last Release run failed at preflight (`Select release scope`) with:

> promote_production=true requires an inspector release in the selected scope.

23 inspector commits have landed since v2.11.0 but none added an `@mcpjam/inspector` changeset, so the changeset release plan had no inspector release to promote.

## What

Adds six changesets covering the unreleased inspector work, grouped by feature area:

- **computer-use-expansion** (minor) — any vision + tool-calling model for evals (#2625), remote data plane for credential-less inspectors (#2627), synthetic sessions on the eval browser pipeline (#2610), terminal polish with clipboard (#2645)
- **relay-tunnels** (minor) — MCPJam relay replaces ngrok (#2623), edge-secured bearer URLs with per-server isolation (#2608)
- **agent-platform-catalog** (minor) — full platform catalog (#2633), live server operations (#2624), `io.modelcontextprotocol/ui` capability (#2637), native widget rendering (#2644)
- **home-landing-default** (minor) — Home as default landing (#2631), org resolution + skeleton (#2618), Host focus panel expanded (#2628)
- **org-models-availability** (minor) — org models for clients (#2614), shared availability pipeline (#2619)
- **oss-community-backend** (patch) — local OSS dev points at the community backend (#2621)

Net effect: `@mcpjam/inspector` 2.11.0 → 2.12.0. `changeset status` validated locally; inspector, sdk, and cli all bump minor.

After this merges, re-dispatch Release with `scope=full` and `promote_production=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Changesets with no runtime, auth, or deployment logic changes.
> 
> **Overview**
> Adds **six new Changesets** for `@mcpjam/inspector` so the release workflow can plan a bump from **2.11.0 → 2.12.0** (five **minor**, one **patch**). There is **no product code** in this PR—only changelog entries that document unreleased work already on `main`.
> 
> The entries group prior inspector features: **Computer Use** (broader eval models, remote data plane, synthetic eval pipeline, terminal UI), **relay tunnels** (ngrok replacement), **agent platform catalog** (tools, UI capability, widgets), **Home as default landing**, **org-level models / shared picker availability**, and **OSS dev defaulting to the community backend**.
> 
> This unblocks `promote_production=true` releases that were failing when the changeset plan had no inspector release in scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3765d6cce12e5d905d0e4efddbe2fe2f349fd78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->