### PR TITLE
fix(oauth): allow client secrets shorter than 8 characters

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -610,4 +610,13 @@ describe("useServerForm", () => {
     });
     expect(result.current.buildFormData().clientSecret).toBeUndefined();
   });
+
+  it("accepts client secrets of any length, including short ones from IdPs", () => {
+    const { result } = renderHook(() => useServerForm());
+
+    expect(result.current.validateClientSecret("")).toBeNull();
+    expect(result.current.validateClientSecret("banana")).toBeNull();
+    expect(result.current.validateClientSecret("s3cr3t")).toBeNull();
+    expect(result.current.validateClientSecret("a")).toBeNull();
+  });
 });

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -438,10 +438,11 @@ export function useServerForm(
     return null;
   };
 
-  const validateClientSecret = (value: string): string | null => {
-    if (value && value.length < 8) {
-      return "Client Secret must be at least 8 characters if provided";
-    }
+  const validateClientSecret = (_value: string): string | null => {
+    // OAuth 2.0 places no minimum length on client secrets — the value is
+    // issued by the authorization server, not chosen here, so enforcing an
+    // arbitrary length client-side rejects valid credentials from providers
+    // that issue short secrets.
     return null;
   };
 


### PR DESCRIPTION
## Problem

When adding an OAuth server with custom credentials, the form rejects any non-empty client secret shorter than 8 characters with `Client Secret must be at least 8 characters if provided`. This blocks users whose identity provider issues short client secrets — they cannot save the server at all (see #1723).

Reproduce:
1. Add Server → Authentication → OAuth → Advanced → "Use custom OAuth credentials"
2. Enter a short secret (e.g. `banana`)
3. Error: `Client Secret must be at least 8 characters if provided`

## Solution

Remove the arbitrary 8-character minimum in `validateClientSecret`. OAuth 2.0 (RFC 6749) defines no minimum length for client secrets — the value is issued by the authorization server, not chosen in the inspector — so enforcing a length client-side rejects otherwise valid credentials. Empty secrets continue to be allowed (no secret = public/PKCE client), as before.

## Testing

- Added a regression test in `use-server-form.test.ts` asserting `validateClientSecret` accepts secrets of any length (including `""`, `"banana"`, `"a"`).
- `vitest run` on `use-server-form.test.ts`: 22/22 passing.

Fixes #1723