### PR TITLE
fix: generate required artifacts before dev:server starts

### DIFF
--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -44,7 +44,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "predev": "npm run sdk:build",
+    "predev:server": "npm run sdk:build && npm run bundle:sandbox-proxies && npm run bundle:browser-harness",
     "dev": "run-script-os",
     "dev:default": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:win32": "concurrently --raw \"npm run dev:server\" \"npm run dev:client\"",


### PR DESCRIPTION
- On a fresh clone, the dev server crashes on startup with `ERR_MODULE_NOT_FOUND` and the browser shows an opaque 500 on `/api/session-token` (the Vite proxy has nothing to talk to).
- The cause: three gitignored build artifacts don't exist on a fresh clone — `sdk/dist`, `SandboxProxyHtml.bundled.ts`, and `HarnessPageBundle.generated.ts`. The existing `predev` hook only built the SDK, and only fired for `npm run dev` — not `npm run dev:server` on its own.
- This moves the hook to `predev:server` and adds the two bundle scripts (the same ones `pretest` already runs), so every way of starting the server works from a clean checkout. Still one build per start.
- Why not point the server tsconfig at SDK source like the client's Vite alias? Verified that breaks: tsx can't load the SDK's `.md` imports (tsup inlines them at build time), so building the SDK is the only working path.
- Verified locally: deleted all three artifacts, ran `npm run dev:server` — everything regenerates, the server boots, and `/api/session-token` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)