### PR TITLE
fix(xaa): resolve test-IdP issuer from server discovery, not browser origin

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Copy } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
@@ -9,7 +10,7 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
-import { getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
+import { fetchXaaIdpUrls, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
 interface XAABootstrapDialogProps {
   open: boolean;
@@ -49,7 +50,24 @@ export function XAABootstrapDialog({
   open,
   onOpenChange,
 }: XAABootstrapDialogProps) {
-  const { issuerBaseUrl, jwksUrl } = getXaaIdpUrls();
+  // Browser-origin guess up front; swap in the server-advertised issuer once
+  // the dialog opens (the guess can be wrong — see fetchXaaIdpUrls).
+  const [urls, setUrls] = useState(() => getXaaIdpUrls());
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const controller = new AbortController();
+    void fetchXaaIdpUrls(controller.signal).then((serverUrls) => {
+      if (serverUrls && !controller.signal.aborted) {
+        setUrls(serverUrls);
+      }
+    });
+    return () => controller.abort();
+  }, [open]);
+
+  const { issuerBaseUrl, jwksUrl } = urls;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -33,6 +33,7 @@ import {
   type XAADebugProfile,
 } from "@/lib/xaa/profile";
 import { createInspectorXAAStateMachine } from "@/lib/xaa/debug-state-machine-adapter";
+import { fetchXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
 // Captured at module load: the XAA route returns null while the feature flag
 // bootstraps and other startup code rewrites location.search, so reading the
@@ -371,6 +372,22 @@ export function XAAFlowTab({
 
   const hasTarget = Boolean(flowInput.serverUrl.trim());
 
+  // Resolve the real IdP issuer from the server's OpenID config so the ID-JAG
+  // inspection step lints against the issuer actually stamped into `iss`, not
+  // the browser origin (which differs from the backend through the dev proxy).
+  const [resolvedIssuerBaseUrl, setResolvedIssuerBaseUrl] = useState<
+    string | undefined
+  >(undefined);
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchXaaIdpUrls(controller.signal).then((urls) => {
+      if (urls && !controller.signal.aborted) {
+        setResolvedIssuerBaseUrl(urls.issuerBaseUrl);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
   const xaaStateMachine = useMemo(() => {
     return createInspectorXAAStateMachine({
       getState: () => flowStateRef.current,
@@ -384,8 +401,9 @@ export function XAAFlowTab({
       scope: flowInput.scope,
       authzServerIssuer: flowInput.authzServerIssuer,
       registrationId: flowInput.registrationId,
+      issuerBaseUrl: resolvedIssuerBaseUrl,
     });
-  }, [flowInput, updateFlowState]);
+  }, [flowInput, updateFlowState, resolvedIssuerBaseUrl]);
 
   const handleAdvance = useCallback(async () => {
     if (!hasTarget) {

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -5,7 +5,11 @@ import { Button } from "@mcpjam/design-system/button";
 import { Card } from "@mcpjam/design-system/card";
 import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
-import { fetchActiveKeyId, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
+import {
+  fetchActiveKeyId,
+  fetchXaaIdpUrls,
+  getXaaIdpUrls,
+} from "@/lib/xaa/idp-endpoints";
 
 function CopyRow({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
@@ -71,29 +75,39 @@ function CopyRow({ label, value }: { label: string; value: string }) {
 export function XAAIdpCard() {
   const [expanded, setExpanded] = useState(false);
   const [keyId, setKeyId] = useState<string | null>(null);
-  const fetchedKeyId = useRef(false);
+  // Start from the browser-origin guess, then swap in the server-advertised
+  // issuer once resolved — see fetchXaaIdpUrls for why the guess can be wrong.
+  const [urls, setUrls] = useState(() => getXaaIdpUrls());
+  const resolved = useRef(false);
 
-  const { issuerBaseUrl, openidConfigUrl, jwksUrl } = getXaaIdpUrls();
+  const { issuerBaseUrl, openidConfigUrl, jwksUrl } = urls;
 
-  // Fetch the active key id once, the first time the card is expanded.
+  // Resolve the real issuer (and active key id) once, the first time the card
+  // is expanded.
   useEffect(() => {
-    if (!expanded || fetchedKeyId.current) {
+    if (!expanded || resolved.current) {
       return;
     }
     const controller = new AbortController();
-    void fetchActiveKeyId(jwksUrl, controller.signal).then((kid) => {
-      // Mark done only once the fetch completes — setting it up front would
-      // lock out future expansions if the first attempt is aborted.
+    void (async () => {
+      const serverUrls = await fetchXaaIdpUrls(controller.signal);
       if (controller.signal.aborted) {
         return;
       }
-      fetchedKeyId.current = true;
-      if (kid) {
+      // Mark done only after a non-aborted resolution — setting it up front
+      // would lock out future expansions if the first attempt is aborted.
+      resolved.current = true;
+      const active = serverUrls ?? getXaaIdpUrls();
+      if (serverUrls) {
+        setUrls(serverUrls);
+      }
+      const kid = await fetchActiveKeyId(active.jwksUrl, controller.signal);
+      if (kid && !controller.signal.aborted) {
         setKeyId(kid);
       }
-    });
+    })();
     return () => controller.abort();
-  }, [expanded, jwksUrl]);
+  }, [expanded]);
 
   return (
     <Card className="mx-3 mt-3 mb-1 gap-0 p-0">

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -67,12 +67,32 @@ describe("XAAIdpCard", () => {
     expect(await screen.findByText("Copied")).toBeInTheDocument();
   });
 
+  // URL-aware fetch mock: the card first reads the server's OpenID config, then
+  // the JWKS. Each call gets its own Response (bodies are single-read).
+  const mockIdpFetch = (overrides: { issuer?: string; kid?: string } = {}) => {
+    const serverIssuer = overrides.issuer ?? issuer;
+    const kid = overrides.kid ?? "key-2026";
+    return vi.fn((url: string | URL) => {
+      const href = String(url);
+      if (href.includes("openid-configuration")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              issuer: serverIssuer,
+              jwks_uri: `${serverIssuer}/.well-known/jwks.json`,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ keys: [{ kid }] }), { status: 200 }),
+      );
+    });
+  };
+
   it("shows the active signing key id fetched from JWKS once expanded", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ keys: [{ kid: "key-2026" }] }), {
-        status: 200,
-      }),
-    );
+    const fetchMock = mockIdpFetch();
     vi.stubGlobal("fetch", fetchMock);
 
     const user = userEvent.setup();
@@ -88,5 +108,26 @@ describe("XAAIdpCard", () => {
       `${issuer}/.well-known/jwks.json`,
       expect.objectContaining({ signal: expect.anything() }),
     );
+  });
+
+  it("prefers the issuer advertised by the server over the browser origin", async () => {
+    // The jsdom browser origin is not localhost:6274 — simulate the dev-proxy
+    // skew where the backend mints a different-origin `iss`.
+    const serverIssuer = "http://localhost:6274/api/web/xaa";
+    vi.stubGlobal("fetch", mockIdpFetch({ issuer: serverIssuer }));
+
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+    );
+
+    expect(await screen.findByText(serverIssuer)).toBeInTheDocument();
+    expect(
+      screen.getByText(`${serverIssuer}/.well-known/openid-configuration`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`${serverIssuer}/.well-known/jwks.json`),
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
@@ -84,11 +84,17 @@ export function createXAADebugRequestExecutor(): XAARequestExecutor {
 }
 
 export function createInspectorXAAStateMachine(
-  config: Omit<BaseXAAStateMachineConfig, "issuerBaseUrl" | "requestExecutor">,
+  config: Omit<BaseXAAStateMachineConfig, "issuerBaseUrl" | "requestExecutor"> & {
+    // Ground-truth issuer resolved from the server's OpenID config. Falls back
+    // to the browser-origin guess, which is wrong when the browser reaches the
+    // API through the Vite dev proxy (browser :5173, backend :6274).
+    issuerBaseUrl?: string;
+  },
 ): XAAStateMachine {
+  const { issuerBaseUrl, ...rest } = config;
   return createXAAStateMachine({
-    ...config,
-    issuerBaseUrl: `${window.location.origin}${XAA_API_BASE}`,
+    ...rest,
+    issuerBaseUrl: issuerBaseUrl ?? `${window.location.origin}${XAA_API_BASE}`,
     requestExecutor: createXAADebugRequestExecutor(),
   });
 }

--- a/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/idp-endpoints.ts
@@ -12,8 +12,11 @@ function getIssuerBasePath(): string {
 
 /**
  * Resolve the MCPJam-as-IdP endpoints the user pastes into their own
- * authorization server. Same base path the bootstrap dialog and the flow
- * runner use, so the issuer/JWKS values stay consistent across surfaces.
+ * authorization server, derived from the browser origin. This is a synchronous
+ * best-effort guess used for the initial render and as a fallback — in local
+ * dev the browser origin (the Vite dev server) differs from the backend origin
+ * that actually mints the ID-JAG `iss`, so prefer `fetchXaaIdpUrls` when an
+ * accurate value matters (registration, issuer-trust comparisons).
  */
 export function getXaaIdpUrls(): XaaIdpUrls {
   const origin = typeof window === "undefined" ? "" : window.location.origin;
@@ -23,6 +26,45 @@ export function getXaaIdpUrls(): XaaIdpUrls {
     openidConfigUrl: `${issuerBaseUrl}/.well-known/openid-configuration`,
     jwksUrl: `${issuerBaseUrl}/.well-known/jwks.json`,
   };
+}
+
+/**
+ * Resolve the IdP endpoints from the server's own OpenID configuration. The
+ * server computes its `issuer` from the request it receives, so this reflects
+ * the exact value stamped into the ID-JAG `iss` — including the right port and
+ * scheme even when the browser reaches the API through the Vite dev proxy
+ * (browser on :5173, backend on :6274). Falls back to null on any failure;
+ * callers should default to `getXaaIdpUrls()` then.
+ */
+export async function fetchXaaIdpUrls(
+  signal?: AbortSignal,
+): Promise<XaaIdpUrls | null> {
+  const { openidConfigUrl } = getXaaIdpUrls();
+  try {
+    const response = await fetch(openidConfigUrl, { signal });
+    if (!response.ok) {
+      return null;
+    }
+    const config = (await response.json()) as {
+      issuer?: unknown;
+      jwks_uri?: unknown;
+    };
+    const issuer = typeof config.issuer === "string" ? config.issuer : null;
+    if (!issuer) {
+      return null;
+    }
+    const jwksUrl =
+      typeof config.jwks_uri === "string"
+        ? config.jwks_uri
+        : `${issuer}/.well-known/jwks.json`;
+    return {
+      issuerBaseUrl: issuer,
+      openidConfigUrl: `${issuer}/.well-known/openid-configuration`,
+      jwksUrl,
+    };
+  } catch {
+    return null;
+  }
 }
 
 interface JwksResponse {


### PR DESCRIPTION
## TL;DR

The **"Use MCPJam as your test IdP"** card (and the ID-JAG inspection step) built every URL from `window.location.origin` — the browser/Vite dev origin. But the backend that actually mints the ID-JAG `iss` runs on a **different origin behind the dev proxy**, so the card told users to register an issuer that never matched the minted token. Now we read the issuer from the **server's own OpenID configuration** (ground truth), so the displayed/registered issuer always matches `iss`.

## The bug

| | Value shown / used | What it was |
|---|---|---|
| Card "Issuer URL" | browser origin (Vite dev server) | `window.location.origin` |
| Actual minted `iss` | backend origin (proxied) | server-computed |

In local dev the browser and backend are different origins bridged by the Vite `/api` proxy, so the two diverged (wrong port + scheme). Result: registering the card's value produced an issuer-mismatch rejection downstream.

## Fix

Read the issuer from `/.well-known/openid-configuration`. The server computes its own `issuer` from the request it receives, so the value is correct regardless of proxy/port/scheme.

- `idp-endpoints.ts` — new `fetchXaaIdpUrls()`: resolves issuer + JWKS from the server's discovery doc; `getXaaIdpUrls()` stays as the synchronous fallback.
- `XAAIdpCard.tsx` — resolves from the server on expand; reads the active `kid` from the resolved JWKS URL.
- `XAABootstrapDialog.tsx` — resolves from the server when opened.
- `debug-state-machine-adapter.ts` — accepts an optional resolved `issuerBaseUrl`.
- `XAAFlowTab.tsx` — resolves the issuer once and feeds it to the state machine, so the ID-JAG inspect step lints against the real `iss`.
- Tests — URL-aware fetch mock + regression test asserting the server-advertised issuer wins over the browser origin.

## Risk register

| Concern | Answer |
|---|---|
| Breaks hosted/prod (same-origin)? | No — there the discovery `issuer` equals the app origin; displayed value unchanged. |
| Server fetch fails (offline/CORS)? | Falls back to the synchronous browser-origin guess — prior behavior, never blank. |
| setState after unmount? | Guarded with `AbortController` + `signal.aborted` checks before every `setState`. |
| Hooks-before-early-return / effect gate? | New hooks sit in the unconditional block; card effect keeps the `expanded` gate + dep. |
| Machine rebuild on resolve loses flow state? | No — flow state lives outside the machine (`flowStateRef`); the machine reads it via `getState`. |

Pairs with a change in the test resource-server to accept a loopback (`http://localhost`) issuer for local runs.
