### PR TITLE
fix(test): scope run-detail KPI query, unblock Run Tests

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
@@ -197,7 +197,9 @@ describe("RunDetailView", () => {
     expect(kpi.getByText("Failed")).toBeInTheDocument();
     expect(kpi.getByText("Total")).toBeInTheDocument();
     expect(kpi.getByText("Duration")).toBeInTheDocument();
-    expect(screen.getByText(/^100$/)).toBeInTheDocument();
+    // Scope to the KPI strip: the run hero also renders "100" (accuracy 100%),
+    // so a global query is ambiguous.
+    expect(kpi.getByText(/^100$/)).toBeInTheDocument();
 
     const runHeading = screen.getByRole("heading", { name: /Run run-1/i });
     const panelGroup = screen.getByTestId("run-detail-resizable-group");


### PR DESCRIPTION
## TL;DR

`Run Tests` fails on **every open PR** because a pre-existing test in `run-detail-view.test.tsx` uses a global `getByText(/^100$/)` that now matches two elements: the run hero's accuracy **100%** and the body KPI strip's token count **100**. Scope the query to the KPI strip (like its sibling assertions).

## Change

```diff
-    expect(screen.getByText(/^100$/)).toBeInTheDocument();
+    expect(kpi.getByText(/^100$/)).toBeInTheDocument();
```

Pre-existing on main (the hero "100%" + KPI "100" collision came from the model-picker/KPI changes); not introduced by any feature branch. Merging this unblocks `Run Tests` across the open PR stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)