### PR TITLE
[XAA] Clarify test-IdP card setup instructions

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -129,25 +129,62 @@ export function XAAIdpCard() {
           <CopyRow label="Issuer URL" value={issuerBaseUrl} />
           <CopyRow label="JWKS URL" value={jwksUrl} />
 
-          <ol className="list-decimal space-y-1.5 pl-5 text-xs text-muted-foreground marker:text-muted-foreground">
-            <li>
-              In Okta, Auth0, Keycloak, or your own authorization server,
-              register MCPJam as a trusted identity issuer using the issuer (or
-              JWKS) URL above.
-            </li>
-            <li>
-              Set the ID-JAG <code className="font-mono">aud</code> to your
-              authorization server&apos;s issuer.
-            </li>
-            <li>
-              Set the ID-JAG <code className="font-mono">resource</code> to the
-              MCP server&apos;s resource identifier.
-            </li>
-            <li>
-              Register MCPJam with the authorization server using the client ID
-              from your config.
-            </li>
-          </ol>
+          <p className="text-xs text-muted-foreground">
+            Use this to test whether your authorization server correctly
+            validates ID-JAGs from an external issuer. MCPJam acts as the test
+            IdP and the requesting client; your authorization server plays the
+            resource app&apos;s authorization server.
+          </p>
+
+          <div className="space-y-1.5">
+            <div className="text-xs font-medium text-foreground">
+              In your authorization server
+            </div>
+            <ul className="list-disc space-y-1.5 pl-5 text-xs text-muted-foreground marker:text-muted-foreground">
+              <li>
+                Trust MCPJam as an ID-JAG issuer so it can verify assertion
+                signatures. Give it <em>either</em> the Issuer URL (if your
+                server auto-discovers keys from OAuth/OIDC metadata) <em>or</em>{" "}
+                the JWKS URL directly — both resolve to the same signing keys,
+                so you don&apos;t need both.
+              </li>
+              <li>
+                Register the client ID MCPJam will present, so the token
+                exchange is recognized.
+              </li>
+            </ul>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="text-xs font-medium text-foreground">
+              MCPJam stamps these into each ID-JAG
+            </div>
+            <p className="text-xs text-muted-foreground">
+              You set these in the debugger run config, not in your
+              authorization server — make sure your server expects them.
+            </p>
+            <ul className="list-disc space-y-1.5 pl-5 text-xs text-muted-foreground marker:text-muted-foreground">
+              <li>
+                <code className="font-mono">aud</code> → your authorization
+                server&apos;s issuer
+              </li>
+              <li>
+                <code className="font-mono">resource</code> → the MCP
+                server&apos;s resource identifier
+              </li>
+              <li>
+                <code className="font-mono">client_id</code> → the client ID
+                from your config
+              </li>
+            </ul>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Cross-app access is new — some authorization servers don&apos;t yet
+            expose a way to trust an external ID-JAG issuer and redeem it via
+            the <code className="font-mono">jwt-bearer</code> grant. Check that
+            yours supports it before wiring up the steps above.
+          </p>
 
           {!HOSTED_MODE && (
             <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## TL;DR

Copy-only restructure of the **"Use MCPJam as your test IdP"** card. The old flat 4-item list blended *things you configure in your auth server* with *facts about the token MCPJam mints* — so users went hunting for settings (like the ID-JAG `aud`) that don't exist on the auth-server side. No logic touched.

## What was confusing

The card listed four "steps," but they actually live on **two different surfaces**:

| What it really is | Where it's configured |
|---|---|
| Trust MCPJam's issuer/JWKS | In your authorization server |
| Register the client | In your authorization server |
| `aud` = your AS issuer | In MCPJam's debugger run config |
| `resource` = MCP server id | In MCPJam's debugger run config |

Steps 2 & 3 read like action items but are token-claim facts — there's no "set the aud" knob in Okta/Auth0/Keycloak.

## Before / after

**Before** — one flat list:
> 1. Register MCPJam as a trusted identity issuer using the issuer/JWKS URL.
> 2. Set the ID-JAG `aud` to your authorization server's issuer.
> 3. Set the ID-JAG `resource` to the MCP server's resource identifier.
> 4. Register MCPJam with the authorization server using the client ID from your config.

**After** — purpose line + two labeled buckets + caveats:
- **Purpose line**: states that the card tests whether your auth server validates external ID-JAGs, and that MCPJam plays *both* the test IdP and the requesting client.
- **In your authorization server**: trust the issuer (with an explicit either/or — Issuer URL *or* JWKS URL, since both resolve to the same signing keys), register the client.
- **MCPJam stamps these into each ID-JAG**: `aud` / `resource` / `client_id`, labeled as run-config values, not server settings.
- **Caveat**: cross-app access is new — some auth servers don't yet support trusting an external issuer and redeeming via the `jwt-bearer` grant.

## Risk register

| Concern | Answer |
|---|---|
| Does this change any auth/token logic? | No — JSX copy and layout only. The `CopyRow` fields and issuer-resolution effect are untouched. |
| Are the claim values still correct? | Yes — identical to before, and they already matched the IETF ID-JAG draft (`iss`/`aud`/`resource`/`client_id`). Only the framing changed. |
| New imports / hooks / flag gates? | None. |
| Hosted-mode behavior | Unchanged — the `!HOSTED_MODE` local-URL note is preserved as-is. |

## Follow-up (not in this PR)

The card serves the OIDC discovery path (`/.well-known/openid-configuration`) but not the RFC 8414 path (`/.well-known/oauth-authorization-server`). Auth servers that do RFC 8414-style discovery from the issuer would 404 and must use the JWKS URL directly. Worth confirming separately whether to also serve that well-known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)