### PR TITLE
fix(billing): scope dual-render billing tests to the Team upsell card

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -1039,7 +1039,11 @@ describe("OrganizationsTab billing", () => {
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
     expect(screen.queryByText("Coming soon")).not.toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Upgrade" })).toHaveLength(1);
+    // The Team upsell card mirrors the compare table's Team column, so an
+    // "Upgrade" CTA renders in both. Scope to the upsell card so the
+    // intentional dual render doesn't make the count ambiguous.
+    const upsell = within(screen.getByTestId("free-plan-team-upsell"));
+    expect(upsell.getByRole("button", { name: "Upgrade" })).toBeInTheDocument();
   });
 
   it("updates pricing when the billing interval toggle changes", () => {
@@ -1051,12 +1055,16 @@ describe("OrganizationsTab billing", () => {
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
+    // The upsell card and the compare table each render the Team price and an
+    // interval toggle. Scope to the upsell card, which owns its own interval
+    // state, so the toggle and price assertions are unambiguous.
+    const upsell = within(screen.getByTestId("free-plan-team-upsell"));
     // Default interval is annual — Team lists $30/seat/mo billed annually
-    expect(screen.getByText(/\$30/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /^Monthly$/ }));
-    expect(screen.getByText(/\$38/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Annual/ }));
-    expect(screen.getByText(/\$30/)).toBeInTheDocument();
+    expect(upsell.getByText(/\$30/)).toBeInTheDocument();
+    fireEvent.click(upsell.getByRole("button", { name: /^Monthly$/ }));
+    expect(upsell.getByText(/\$38/)).toBeInTheDocument();
+    fireEvent.click(upsell.getByRole("button", { name: /Annual/ }));
+    expect(upsell.getByText(/\$30/)).toBeInTheDocument();
   });
 
   it("shows deferred billing copy for active trials with enough time remaining", () => {


### PR DESCRIPTION
## TL;DR

`main` is red on two `OrganizationsTab.billing` tests. Cause: #2629 added the `FreePlanTeamUpsell` card, which mirrors the compare table's Team column — so on the Free plan the Team **price** and **Upgrade CTA** now render in two places. Two tests still assumed a single copy. **Test-only fix:** scope both to the upsell card. The dual render is intentional and unchanged.

> Not introduced by any open PR — these two tests fail on bare `main` (`abb373b3a`, run [27456096990](https://github.com/MCPJam/inspector/actions/runs/27456096990)). They were blocking unrelated XAA PRs whose own tests pass.

## What broke

| Test | Old assertion | Why it broke |
|---|---|---|
| shows Team as a purchasable upgrade | `getAllByRole("button", {name:"Upgrade"})` → length 1 | Upsell card **and** table each render an Upgrade button → 2 |
| updates pricing when the interval toggle changes | `getByText(/\$30/)`, `getByRole(button, /Monthly/)` | `$30` and the Monthly toggle now exist in both copies → "multiple elements" |

## Fix

Scope both to the upsell card via its existing `data-testid="free-plan-team-upsell"`, using the `within(screen.getByTestId(...))` pattern already used throughout this file. The upsell card owns its own interval state, so the toggle/price assertions are unambiguous.

```diff
- expect(screen.getAllByRole("button", { name: "Upgrade" })).toHaveLength(1);
+ const upsell = within(screen.getByTestId("free-plan-team-upsell"));
+ expect(upsell.getByRole("button", { name: "Upgrade" })).toBeInTheDocument();
```

## Risk register

| Concern | Answer |
|---|---|
| Is the duplicate render a UI bug to fix instead? | No — `FreePlanTeamUpsell`'s own doc-comment says it "mirrors the Team column of the comparison table." Both are intended to show. |
| Does the upsell card render in both tests' fixtures? | Yes — the original failure showed **two** `$30` spans, only possible if the upsell mounted. Both fixtures are on the Free plan. |
| Any production/component code changed? | No — test file only. |
| Could scoping hide a real regression? | No — it still asserts the Team CTA exists and the price reacts to the interval toggle; it just targets one of the two intentional copies. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)