### PR TITLE
fix(test): scope billing upsell assertions after #2629 Team CTA

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -1039,7 +1039,12 @@ describe("OrganizationsTab billing", () => {
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
     expect(screen.queryByText("Coming soon")).not.toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Upgrade" })).toHaveLength(1);
+    // Since #2629 a free-plan org sees a dedicated Team upsell card (with its
+    // own Upgrade CTA) in addition to the comparison-table column, so an
+    // unscoped count is now 2. Scope to the upsell card and assert it offers
+    // the purchase affordance — that's what this test is about.
+    const upsell = within(screen.getByTestId("free-plan-team-upsell"));
+    expect(upsell.getByRole("button", { name: "Upgrade" })).toBeInTheDocument();
   });
 
   it("updates pricing when the billing interval toggle changes", () => {
@@ -1051,12 +1056,17 @@ describe("OrganizationsTab billing", () => {
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
+    // The free-plan Team upsell card (#2629) and the comparison table each
+    // render a price + interval toggle backed by the same `billingInterval`
+    // state, so global queries are now ambiguous. Drive and assert through the
+    // upsell card's own toggle.
+    const upsell = within(screen.getByTestId("free-plan-team-upsell"));
     // Default interval is annual — Team lists $30/seat/mo billed annually
-    expect(screen.getByText(/\$30/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /^Monthly$/ }));
-    expect(screen.getByText(/\$38/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Annual/ }));
-    expect(screen.getByText(/\$30/)).toBeInTheDocument();
+    expect(upsell.getByText(/\$30/)).toBeInTheDocument();
+    fireEvent.click(upsell.getByRole("button", { name: /^Monthly$/ }));
+    expect(upsell.getByText(/\$38/)).toBeInTheDocument();
+    fireEvent.click(upsell.getByRole("button", { name: /^Annual$/ }));
+    expect(upsell.getByText(/\$30/)).toBeInTheDocument();
   });
 
   it("shows deferred billing copy for active trials with enough time remaining", () => {


### PR DESCRIPTION
## Root cause

Not a flake — a **stale test after an intentional UI change**. [#2629](https://github.com/MCPJam/inspector/pull/2629) ("cta team plan") added a dedicated free-plan **Team upsell card** (`data-testid="free-plan-team-upsell"`) to `OrganizationBillingSection.tsx`, with its own price, billing-interval toggle, and Upgrade CTA, rendered above the existing plan-comparison table. The upsell and the table share the same `billingInterval` state.

So a free-plan org now legitimately renders **two** "Upgrade" buttons, **two** "$30/$38" prices, and **two** interval toggles — but #2629 didn't update `OrganizationsTab.billing.test.tsx`. Two cases that used unscoped strict queries broke:

- **"shows Team as a purchasable upgrade…"** — `getAllByRole("button", {name:"Upgrade"})` expected 1, got 2.
- **"updates pricing when the billing interval toggle changes"** — `getByText(/\$30/)` / `getByRole("button", {name:/Monthly/})` matched multiple elements.

### Why it looked like a flake

It's **deterministic on `main`** (reproduced 5/5 locally) but invisible on branches cut **before** #2629 landed. PR CI runs against the branch *merged with latest main*, so it picked up #2629 and failed; a developer's local branch (pre-#2629) passed. That mismatch is why it surfaced as an intermittent Required-check failure rather than an obvious main breakage.

## Fix

Scope both assertions to the upsell card via `within(screen.getByTestId("free-plan-team-upsell"))`, matching the `within(panel)` style the rest of this file already uses. The first test now asserts the upsell card offers an Upgrade CTA; the second drives and reads pricing through the upsell card's own toggle.

**Test-only change — no production code touched.** Billing suite 39/39 green across repeated local runs.

## Note

The duplicate price/toggle/CTA is *intended* product behavior from #2629 (the upsell mirrors the table by design). If the duplication is ever considered a UX concern, that's a separate product call — this PR only realigns the test with shipped behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or runtime behavior impact.
> 
> **Overview**
> Updates **`OrganizationsTab.billing.test.tsx`** so billing UI tests match the post-#2629 layout: free-plan orgs now show a **`free-plan-team-upsell`** card alongside the plan comparison table, each with its own Upgrade button, prices, and interval toggle.
> 
> The **Team purchasable upgrade** case no longer expects a single global Upgrade button; it asserts Upgrade inside the upsell card. The **billing interval toggle** case drives Monthly/Annual and checks **$30/$38** pricing only within that upsell, avoiding ambiguous `screen` queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb9cebdebff3cd2c2dfb307ae0cd12caf6a6f65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->