### PR TITLE
inspector: adopt @mcpjam/chat-ui ReadOnlyTranscript in ShareUsageThreadDetail

### DIFF
--- a/.changeset/chat-ui-shareusage-adoption.md
+++ b/.changeset/chat-ui-shareusage-adoption.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Render the read-only share-usage thread transcript via the new
+`@mcpjam/chat-ui` `ReadOnlyTranscript` — the first inspector adopter of the
+Tier A package — replacing the interactive `TranscriptThread` on that
+read-only surface. `@mcpjam/chat-ui` is resolved from source via vite/vitest/
+tsconfig aliases (mirroring the SDK pattern) so no chat-ui build is required.

--- a/.changeset/chat-ui-wrap-without-stylesheet.md
+++ b/.changeset/chat-ui-wrap-without-stylesheet.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/chat-ui": patch
+---
+
+`JsonView` and the markdown wrapper now wrap long content via Tailwind
+utilities (`whitespace-pre-wrap` + `overflow-wrap`) instead of relying solely on
+the package stylesheet's `.mcpjam-chat-json` / `.mcpjam-chat-markdown` rules. Tool
+input/output and markdown no longer scroll horizontally when a consumer renders
+the transcript with Tailwind but hasn't imported `@mcpjam/chat-ui/styles.css`.

--- a/chat-ui/src/internal/markdown.tsx
+++ b/chat-ui/src/internal/markdown.tsx
@@ -16,7 +16,7 @@ export const Markdown = memo(function Markdown({
   className?: string;
 }) {
   return (
-    <div className={cn("mcpjam-chat-markdown", className)}>
+    <div className={cn("mcpjam-chat-markdown [overflow-wrap:anywhere]", className)}>
       <Streamdown>{content}</Streamdown>
     </div>
   );

--- a/chat-ui/src/parts/json-view.tsx
+++ b/chat-ui/src/parts/json-view.tsx
@@ -46,7 +46,7 @@ export function JsonView({
   return (
     <pre
       className={cn(
-        "mcpjam-chat-json overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed text-foreground",
+        "mcpjam-chat-json overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed text-foreground",
         className,
       )}
     >

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -32,6 +32,18 @@ import {
 
 const EMPTY_SPANS: EvalTraceSpan[] = [];
 
+/**
+ * Bridge inspector ToolRenderOverrides — whose widget/CSP fields use the MCP
+ * Apps SDK types — to chat-ui's placeholder types. The read-only transcript
+ * never reads those widget-specific fields, so the cast is safe. Kept as a
+ * named seam so future read-only consumers can reuse it.
+ */
+function bridgeToolRenderOverrides(
+  overrides: Record<string, unknown> | undefined,
+): Record<string, ChatUiToolRenderOverride> | undefined {
+  return overrides as Record<string, ChatUiToolRenderOverride> | undefined;
+}
+
 interface ShareUsageThreadDetailProps {
   threadId: string;
   /**
@@ -365,16 +377,9 @@ export function ShareUsageThreadDetail({
             <ReadOnlyTranscript
               messages={adaptedTrace.messages}
               model={resolvedModel}
-              // The trace adapter builds inspector ToolRenderOverrides whose
-              // widget/CSP fields use the MCP Apps SDK types; the package's
-              // placeholder types are structural stand-ins the read-only path
-              // never reads. Bridge the two at this seam.
-              toolRenderOverrides={
-                adaptedTrace.toolRenderOverrides as unknown as Record<
-                  string,
-                  ChatUiToolRenderOverride
-                >
-              }
+              toolRenderOverrides={bridgeToolRenderOverrides(
+                adaptedTrace.toolRenderOverrides,
+              )}
               reasoningDisplayMode={reasoningDisplayMode}
               widgetPolicy="placeholder"
               className="mx-auto max-w-4xl px-4 py-4"

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -6,8 +6,10 @@ import { Button } from "@mcpjam/design-system/button";
 import { copyToClipboard } from "@/lib/clipboard";
 import type { ModelDefinition, ModelProvider } from "@/shared/types";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
-import { TranscriptThread } from "@/components/chat-v2/thread/transcript-thread";
-import { ChatboxSurfaceProvider } from "@/contexts/chatbox-surface-context";
+import {
+  ReadOnlyTranscript,
+  type ToolRenderOverride as ChatUiToolRenderOverride,
+} from "@mcpjam/chat-ui";
 import {
   adaptTraceToUiMessages,
   snapshotsToTraceWidgetSnapshots,
@@ -28,7 +30,6 @@ import {
   type SharedChatTurnTrace,
 } from "@/hooks/useSharedChatThreads";
 
-const NOOP = (..._args: unknown[]) => {};
 const EMPTY_SPANS: EvalTraceSpan[] = [];
 
 interface ShareUsageThreadDetailProps {
@@ -361,27 +362,23 @@ export function ShareUsageThreadDetail({
           </div>
         ) : effectiveViewMode === "chat" ? (
           <div className="min-h-0 flex-1 overflow-y-auto">
-            <ChatboxSurfaceProvider value={isChatboxThread}>
-              <TranscriptThread
-                messages={adaptedTrace.messages}
-                model={resolvedModel}
-                sendFollowUpMessage={NOOP}
-                toolsMetadata={{}}
-                toolServerMap={{}}
-                pipWidgetId={null}
-                fullscreenWidgetId={null}
-                onRequestPip={NOOP}
-                onExitPip={NOOP}
-                onRequestFullscreen={NOOP}
-                onExitFullscreen={NOOP}
-                toolRenderOverrides={adaptedTrace.toolRenderOverrides}
-                showSaveViewButton={false}
-                minimalMode={!isChatboxThread}
-                interactive={false}
-                reasoningDisplayMode={reasoningDisplayMode}
-                contentClassName="max-w-4xl space-y-8 px-4 py-4"
-              />
-            </ChatboxSurfaceProvider>
+            <ReadOnlyTranscript
+              messages={adaptedTrace.messages}
+              model={resolvedModel}
+              // The trace adapter builds inspector ToolRenderOverrides whose
+              // widget/CSP fields use the MCP Apps SDK types; the package's
+              // placeholder types are structural stand-ins the read-only path
+              // never reads. Bridge the two at this seam.
+              toolRenderOverrides={
+                adaptedTrace.toolRenderOverrides as unknown as Record<
+                  string,
+                  ChatUiToolRenderOverride
+                >
+              }
+              reasoningDisplayMode={reasoningDisplayMode}
+              widgetPolicy="placeholder"
+              className="mx-auto max-w-4xl px-4 py-4"
+            />
           </div>
         ) : (
           <TraceViewer

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadDetail.test.tsx
@@ -5,11 +5,13 @@ import { ShareUsageThreadDetail } from "../ShareUsageThreadDetail";
 
 const {
   mockMessageView,
+  mockReadOnlyTranscript,
   mockAdaptTraceToUiMessages,
   mockThreadState,
   mockBrowserArtifactsState,
 } = vi.hoisted(() => ({
   mockMessageView: vi.fn(),
+  mockReadOnlyTranscript: vi.fn(),
   mockAdaptTraceToUiMessages: vi.fn(),
   mockThreadState: {
     sourceType: "chatbox",
@@ -56,6 +58,13 @@ vi.mock("@/components/chat-v2/thread/message-view", () => ({
   MessageView: (props: Record<string, unknown>) => {
     mockMessageView(props);
     return <div data-testid="message-view" />;
+  },
+}));
+
+vi.mock("@mcpjam/chat-ui", () => ({
+  ReadOnlyTranscript: (props: Record<string, unknown>) => {
+    mockReadOnlyTranscript(props);
+    return <div data-testid="read-only-transcript" />;
   },
 }));
 
@@ -107,11 +116,10 @@ describe("ShareUsageThreadDetail", () => {
           toolResultDisplay: "attached-to-tool",
         }),
       );
-      expect(mockMessageView).toHaveBeenCalledWith(
+      expect(mockReadOnlyTranscript).toHaveBeenCalledWith(
         expect.objectContaining({
           reasoningDisplayMode: "collapsible",
-          interactive: false,
-          minimalMode: false,
+          widgetPolicy: "placeholder",
         }),
       );
     });
@@ -121,9 +129,8 @@ describe("ShareUsageThreadDetail", () => {
     render(<ShareUsageThreadDetail threadId="thread-1" />);
 
     await waitFor(() => {
-      expect(mockMessageView).toHaveBeenCalledWith(
+      expect(mockReadOnlyTranscript).toHaveBeenCalledWith(
         expect.objectContaining({
-          minimalMode: false,
           reasoningDisplayMode: "collapsible",
         }),
       );
@@ -231,6 +238,6 @@ describe("ShareUsageThreadDetail", () => {
     // Chat content renders instead of a blank panel. findBy: the messages
     // blob re-fetch on thread switch is async — don't depend on the previous
     // thread's messages state being retained (CodeRabbit, PR 2610).
-    expect(await screen.findByTestId("message-view")).toBeInTheDocument();
+    expect(await screen.findByTestId("read-only-transcript")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -4,6 +4,12 @@
 
 @source "../../node_modules/streamdown/dist/*.js";
 @source "../../../design-system/src/**/*.tsx";
+/* @mcpjam/chat-ui is aliased to source (outside client/src), so Tailwind must
+   scan it to emit the transcript's utility classes. Includes .ts because
+   thread-helpers.ts carries className strings (tool-state icon styles). The
+   read-only transcript relies on the inspector's existing global shadcn tokens
+   for color values, so no package stylesheet import is needed here. */
+@source "../../../chat-ui/src/**/*.{ts,tsx}";
 
 @layer base {
   * {

--- a/mcpjam-inspector/client/tsconfig.json
+++ b/mcpjam-inspector/client/tsconfig.json
@@ -23,7 +23,8 @@
       "@repo/assets/*": ["./src/assets/*"],
       "@mcpjam/sdk": ["../../sdk/src/index.ts"],
       "@mcpjam/sdk/browser": ["../../sdk/src/browser.ts"],
-      "@mcpjam/sdk/*": ["../../sdk/src/*"]
+      "@mcpjam/sdk/*": ["../../sdk/src/*"],
+      "@mcpjam/chat-ui": ["../../chat-ui/src/index.ts"]
     }
   },
   "include": ["src", "../shared/**/*.ts"],

--- a/mcpjam-inspector/client/vite.config.ts
+++ b/mcpjam-inspector/client/vite.config.ts
@@ -21,6 +21,10 @@ const sdkHostConfigInternalEntry = path.resolve(
   rootDir,
   "../sdk/src/host-config/internal.ts",
 );
+// @mcpjam/chat-ui publishes from dist, but a clean checkout has no
+// chat-ui/dist until it is built. Resolve the package from source so the
+// inspector's dev/build/typecheck/test never depend on a chat-ui build.
+const chatUiEntry = path.resolve(rootDir, "../chat-ui/src/index.ts");
 // Bypass stale Vite optimized deps for MCP SDK auth helpers by resolving
 // directly to the installed ESM entrypoints.
 const mcpSdkClientAuthEntry = path.resolve(
@@ -64,6 +68,7 @@ export default defineConfig(({ mode }) => {
         "@repo/assets": path.resolve(clientDir, "src/assets"),
         "@/shared": path.resolve(clientDir, "../shared"),
         "@": path.resolve(clientDir, "./src"),
+        "@mcpjam/chat-ui": chatUiEntry,
         "@mcpjam/sdk/browser": sdkBrowserEntry,
         "@mcpjam/sdk/host-config/internal": sdkHostConfigInternalEntry,
         "@modelcontextprotocol/sdk/client/auth.js": mcpSdkClientAuthEntry,

--- a/mcpjam-inspector/client/vitest.config.ts
+++ b/mcpjam-inspector/client/vitest.config.ts
@@ -64,7 +64,13 @@ export default defineConfig({
       name: "stub-static-assets",
       enforce: "pre",
       resolveId(id) {
-        return /\.(png|jpe?g|gif|svg|webp|avif|ico)(\?.*)?$/.test(id)
+        // Only stub ABSOLUTE public-dir asset imports (e.g. "/claude_logo.png"
+        // in client-styles/built-ins.ts). Leave relative and query imports to
+        // vite — notably `*.svg?raw` (raw SVG markup, used by
+        // HandDrawnSendHint) and `?url`/`?worker`, whose loader semantics we
+        // must not clobber.
+        return id.startsWith("/") &&
+          /\.(png|jpe?g|gif|svg|webp|avif|ico)$/.test(id)
           ? `\0static-asset:${id}`
           : null;
       },

--- a/mcpjam-inspector/client/vitest.config.ts
+++ b/mcpjam-inspector/client/vitest.config.ts
@@ -20,6 +20,9 @@ const sdkHostConfigInternalEntry = path.resolve(
   rootDir,
   "../sdk/src/host-config/internal.ts",
 );
+// Resolve @mcpjam/chat-ui from source (its published exports point at dist,
+// which a clean checkout hasn't built). Mirrors the SDK source aliases above.
+const chatUiEntry = path.resolve(rootDir, "../chat-ui/src/index.ts");
 const mcpSdkClientAuthEntry = path.resolve(
   workspaceNodeModulesDir,
   "@modelcontextprotocol/sdk/dist/esm/client/auth.js",
@@ -52,6 +55,26 @@ export default defineConfig({
         };
       },
     },
+    {
+      // Vite serves static image imports (e.g. `import logo from
+      // "/claude_logo.png"` in client-styles/built-ins.ts) as URL strings from
+      // the public dir, but jsdom/vitest has no public-dir resolution and fails
+      // import-analysis. Stub them to a URL string so modules that pull in the
+      // chat-v2/client-styles graph (e.g. the eval TraceViewer) load in tests.
+      name: "stub-static-assets",
+      enforce: "pre",
+      resolveId(id) {
+        return /\.(png|jpe?g|gif|svg|webp|avif|ico)(\?.*)?$/.test(id)
+          ? `\0static-asset:${id}`
+          : null;
+      },
+      load(id) {
+        const prefix = "\0static-asset:";
+        return id.startsWith(prefix)
+          ? `export default ${JSON.stringify(id.slice(prefix.length))};`
+          : null;
+      },
+    },
   ],
   test: {
     globals: true,
@@ -70,6 +93,7 @@ export default defineConfig({
   },
   resolve: {
     alias: [
+      { find: "@mcpjam/chat-ui", replacement: chatUiEntry },
       {
         find: "@mcpjam/sdk/skill-reference",
         replacement: sdkSkillReferenceEntry,

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -200,6 +200,7 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^2.0.0",
     "@eslint/eslintrc": "^3",
+    "@mcpjam/chat-ui": "*",
     "@mcpjam/design-system": "*",
     "@playwright/test": "^1.54.2",
     "@tailwindcss/postcss": "^4.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -437,6 +437,7 @@
         "@electron-forge/publisher-github": "^7.11.1",
         "@electron/fuses": "^2.0.0",
         "@eslint/eslintrc": "^3",
+        "@mcpjam/chat-ui": "*",
         "@mcpjam/design-system": "*",
         "@playwright/test": "^1.54.2",
         "@tailwindcss/postcss": "^4.1.11",


### PR DESCRIPTION
## What

The first **inspector adopter** of the Tier A `@mcpjam/chat-ui` package (shipped in #2678). `ShareUsageThreadDetail`'s read-only **chat tab** now renders the `adaptTraceToUiMessages` output through the package's `ReadOnlyTranscript` instead of the interactive `TranscriptThread`. This pressure-tests the public API against real trace data — the adoption proof we agreed the package needed before it drifts.

## Why this PR (per the merge discussion)

> "This PR creates the package but does not prove adoption … the very next PR should migrate one read-only consumer, ideally `ShareUsageThreadDetail`, so the API gets pressure-tested against real inspector data."

## How

- **Renderer swap** — the chat-tab `TranscriptThread` (+ `ChatboxSurfaceProvider`) is replaced with `<ReadOnlyTranscript messages=… toolRenderOverrides=… reasoningDisplayMode=… widgetPolicy="placeholder" />`. The existing `adaptTraceToUiMessages` call is unchanged (the adapter stays in the inspector for now).
- **Resolution seam** — `@mcpjam/chat-ui` is resolved **from source** via `vite.config.ts` / `vitest.config.ts` / `client/tsconfig.json` aliases, mirroring the existing `@mcpjam/sdk` source-alias pattern. So inspector dev/build/typecheck/test never depend on a `chat-ui` dist build, while the package stays publishable from `dist`.
- **Type bridge** — the trace adapter builds inspector `ToolRenderOverride`s whose widget/CSP fields use the MCP Apps SDK types; the package's placeholder types are structural stand-ins the read-only path never reads. Bridged with a cast at the single call site (commented).
- **Test infra** — `vitest.config.ts` now stubs static image asset imports (e.g. `/claude_logo.png` in `client-styles/built-ins.ts`). Pulling the package in makes the test load the eval `TraceViewer`'s `chat-v2/client-styles` graph, and jsdom has no public-dir resolution; the stub mirrors vite's build-time asset-as-URL behavior and is robust for any asset-import path.
- Updated the `ShareUsageThreadDetail` test to assert against the `ReadOnlyTranscript` API; added a changeset.

## ⚠️ Reviewer decision — host-style fidelity

The package is intentionally **host-style-free** (Tier A). So `sourceType === "chatbox"` threads **lose the ChatGPT/Copilot avatar mimicry** on this read-only admin surface (they now render with the package's generic assistant avatar). Reasoning collapse behavior is preserved (`collapsible`/`collapsed`). If we want the mimicry back here, a host-style adapter on the package is a follow-up — flagging for your call.

## Verification

- `npm run typecheck:client -w @mcpjam/inspector` ✓ (resolves `@mcpjam/chat-ui` → source; type bridge compiles)
- `ShareUsageThreadDetail` test ✓ (5/5, now asserting the `ReadOnlyTranscript` API)
- `client-styles` + `chat-v2/thread` suites ✓ (69/69 — confirms the asset stub doesn't disturb existing tests)
- chat-ui package itself unchanged.

## Follow-ups (unchanged from the roadmap)

De-dup the pure logic (inspector imports `thread-helpers`/`persisted-execution-replay`/adapter from the package), split the interactive `ToolPart` to compose `ToolCallPart`, migrate the eval trace viewer / Views, and a compiled CSS bundle. Tier B (real widget replay via `renderWidget`) remains separate.

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Read-only admin UI behavior changes (generic avatars vs chatbox host mimicry) and relies on a typed cast for tool overrides; build/test wiring is broader but low-risk.
> 
> **Overview**
> **Share usage** read-only chat view swaps **`TranscriptThread`** (and **`ChatboxSurfaceProvider`**) for **`ReadOnlyTranscript`** from **`@mcpjam/chat-ui`**, wiring the same adapted trace messages, reasoning mode, and tool overrides via a small **`bridgeToolRenderOverrides`** cast at the call site with **`widgetPolicy="placeholder"`**.
> 
> **`@mcpjam/chat-ui`** is wired into the inspector like the SDK: **vite/vitest/tsconfig** resolve the package from **`chat-ui/src`**, **`package.json`** adds the workspace dep, and **`index.css`** adds a Tailwind **`@source`** scan so transcript utilities compile without importing **`styles.css`**. **`JsonView`** and internal **`Markdown`** gain **`whitespace-pre-wrap`** / **`overflow-wrap`** so long tool output and markdown wrap when consumers skip the package stylesheet.
> 
> Tests mock **`ReadOnlyTranscript`** instead of the old thread path; **vitest** stubs absolute public asset imports so modules that pull **`client-styles`** load under jsdom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c8693dde34a26186c61a088b87a620fb2307da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->