### PR TITLE
fix(hosted): allow the Computer tab in hosted mode

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -51,7 +51,7 @@ import { HostsTab } from "./components/HostsTab";
 import { HostConfigCompareView } from "./components/hosts/comparison/HostConfigCompareView";
 import { ConnectViewHeader } from "./components/hosts/ConnectViewHeader";
 import { ComputerView } from "./components/computer/ComputerView";
-import { useComputersEnabled } from "./hooks/useComputersEnabled";
+import { useComputersEnabledState } from "./hooks/useComputersEnabled";
 import { motion } from "framer-motion";
 import { SNAPPY_RAIL } from "./components/hosts/transition-tokens";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
@@ -684,12 +684,17 @@ export function ComputerRoute() {
   const { convexProjectId, isAuthenticated } = useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
   const navigate = useAppNavigate();
-  const computersEnabled = useComputersEnabled();
+  const computersEnabled = useComputersEnabledState();
 
-  // Flag off ⇒ the feature is hidden; bounce to Servers so a stale /computer
-  // URL doesn't strand the user on a blank route.
-  if (!computersEnabled) {
+  // Only redirect on an explicit `false`. While PostHog hydrates the flag is
+  // `undefined`; bouncing then would strand a flagged-in user who cold-loads
+  // /computer directly (the redirect fires before the flag resolves). Render
+  // nothing until it settles — disabled users get the bounce a beat later.
+  if (computersEnabled === false) {
     return <Navigate to={routePaths.servers} replace />;
+  }
+  if (computersEnabled === undefined) {
+    return null;
   }
 
   const computerView = (

--- a/mcpjam-inspector/client/src/__tests__/ComputerRoute.flag-hydration.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/ComputerRoute.flag-hydration.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { routePaths } from "../lib/app-navigation";
+
+// Controls the tri-state PostHog flag the route guard reads. `undefined`
+// models the pre-hydration window; the regression is that the guard must NOT
+// redirect during it (only on an explicit `false`).
+let flagState: boolean | undefined = undefined;
+
+const { mockRouteContext, mockNavigate } = vi.hoisted(() => ({
+  mockRouteContext: {
+    convexProjectId: "project-1" as string | null,
+    isAuthenticated: true,
+  },
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock("../hooks/useComputersEnabled", () => ({
+  COMPUTERS_FEATURE_FLAG: "computers-enabled",
+  useComputersEnabledState: () => flagState,
+  useComputersEnabled: () => flagState === true,
+}));
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useOutletContext: () => mockRouteContext,
+    // Sentinel so a redirect is observable without a real router.
+    Navigate: ({ to }: { to: string }) => (
+      <div data-testid="navigate" data-to={to} />
+    ),
+  };
+});
+
+vi.mock("../components/computer/ComputerView", () => ({
+  ComputerView: () => <div data-testid="computer-view" />,
+}));
+
+vi.mock("../components/hosts/ConnectViewHeader", () => ({
+  ConnectViewHeader: () => <div data-testid="connect-header" />,
+}));
+
+vi.mock("../hooks/use-previewed-client-id", () => ({
+  usePreviewedHostId: () => [null],
+}));
+
+vi.mock("../lib/app-navigation", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../lib/app-navigation")>();
+  return { ...actual, useAppNavigate: () => mockNavigate };
+});
+
+// App.tsx's import graph pulls in the CodeMirror JSON editor; stub it (and the
+// CodeMirror packages it imports) so the route module loads under jsdom. Mirror
+// of ChatboxesRoute.billing.test.tsx.
+vi.mock("../components/ui/json-editor/codemirror-json-editor", () => ({
+  CodemirrorJsonEditor: () => null,
+}));
+vi.mock("@codemirror/lang-json", () => ({ json: () => ({}) }));
+vi.mock("@codemirror/view", () => ({
+  EditorView: class {},
+  lineNumbers: () => ({}),
+  highlightActiveLine: () => ({}),
+  highlightSpecialChars: () => ({}),
+  keymap: () => ({}),
+}));
+vi.mock("@codemirror/state", () => ({ EditorState: { create: vi.fn() } }));
+vi.mock("@codemirror/commands", () => ({
+  defaultKeymap: [],
+  history: () => ({}),
+  historyKeymap: [],
+}));
+vi.mock("@codemirror/language", () => ({
+  bracketMatching: () => ({}),
+  foldGutter: () => ({}),
+  indentOnInput: () => ({}),
+  syntaxHighlighting: () => ({}),
+  defaultHighlightStyle: {},
+}));
+vi.mock("@codemirror/lint", () => ({
+  linter: () => ({}),
+  lintGutter: () => ({}),
+}));
+
+import { ComputerRoute } from "../App";
+
+afterEach(() => {
+  flagState = undefined;
+  vi.clearAllMocks();
+});
+
+describe("ComputerRoute — flag hydration", () => {
+  it("does not redirect while the flag is still loading (undefined)", () => {
+    flagState = undefined;
+    render(<ComputerRoute />);
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    // Nothing renders yet either — it waits for the flag to settle.
+    expect(screen.queryByTestId("computer-view")).not.toBeInTheDocument();
+  });
+
+  it("does not redirect across an undefined -> true transition", () => {
+    flagState = undefined;
+    const { rerender } = render(<ComputerRoute />);
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+
+    // PostHog resolves the flag to enabled.
+    flagState = true;
+    rerender(<ComputerRoute />);
+
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    expect(screen.getByTestId("computer-view")).toBeInTheDocument();
+  });
+
+  it("redirects to servers only on an explicit false", () => {
+    flagState = false;
+    render(<ComputerRoute />);
+    const nav = screen.getByTestId("navigate");
+    expect(nav).toBeInTheDocument();
+    expect(nav).toHaveAttribute("data-to", routePaths.servers);
+    expect(screen.queryByTestId("computer-view")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useComputersEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useComputersEnabled.ts
@@ -14,6 +14,17 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
  */
 export const COMPUTERS_FEATURE_FLAG = "computers-enabled";
 
+/**
+ * Tri-state flag: `true` enabled, `false` explicitly disabled, `undefined`
+ * while PostHog is still loading. Route guards must distinguish "disabled"
+ * from "not resolved yet" so a direct /computer cold load doesn't redirect a
+ * flagged-in user before the flag hydrates (see `ComputerRoute`). Visibility
+ * gates that only hide UI should use `useComputersEnabled` instead.
+ */
+export function useComputersEnabledState(): boolean | undefined {
+  return useFeatureFlagEnabled(COMPUTERS_FEATURE_FLAG);
+}
+
 export function useComputersEnabled(): boolean {
-  return useFeatureFlagEnabled(COMPUTERS_FEATURE_FLAG) === true;
+  return useComputersEnabledState() === true;
 }

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
@@ -88,4 +88,17 @@ describe("hosted-tab-policy", () => {
     expect(isHostedSidebarTabAllowed("learning")).toBe(true);
     expect(isHostedHashTabAllowed("learning")).toBe(true);
   });
+
+  it("allows the computer hash in hosted mode without adding a sidebar item", () => {
+    // Project Computers are reachable in hosted mode (E2B-backed), gated by
+    // project membership + entitlement + the `computers-enabled` flag — so the
+    // App hosted-mode effect must NOT bounce /computer back to /servers.
+    expect(HOSTED_HASH_ALLOWED_TABS).toContain("computer");
+    expect(isHostedHashTabAllowed("computer")).toBe(true);
+    expect(isHostedHashTabBlocked("computer")).toBe(false);
+    // Computer is reached via the Connect tab switcher, not its own sidebar
+    // entry, so it deliberately stays out of the sidebar allow-list.
+    expect(HOSTED_SIDEBAR_ALLOWED_TABS).not.toContain("computer");
+    expect(isHostedSidebarTabAllowed("computer")).toBe(false);
+  });
 });

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -34,6 +34,15 @@ export const HOSTED_HASH_ALLOWED_TABS = [
   "profile",
   "organizations",
   "project-settings",
+  // Project Computers (E2B-backed) are supported in hosted mode: the server
+  // leaves /api/web/computers/* outside the hosted block partition, and the
+  // control plane gates access by project membership + the `projectComputers`
+  // org entitlement + a per-user HMAC terminal token. The tab is reached via
+  // the Connect tab switcher (gated by the `computers-enabled` flag), not a
+  // standalone sidebar item, so it only needs the hash allow-list — not the
+  // sidebar one. ComputerView itself reports unavailability when no data plane
+  // (local E2B creds or COMPUTERS_REMOTE_DATA_PLANE_URL) is configured.
+  "computer",
 ] as const;
 
 export const HOSTED_HASH_BLOCKED_TABS = [

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -34,14 +34,9 @@ export const HOSTED_HASH_ALLOWED_TABS = [
   "profile",
   "organizations",
   "project-settings",
-  // Project Computers (E2B-backed) are supported in hosted mode: the server
-  // leaves /api/web/computers/* outside the hosted block partition, and the
-  // control plane gates access by project membership + the `projectComputers`
-  // org entitlement + a per-user HMAC terminal token. The tab is reached via
-  // the Connect tab switcher (gated by the `computers-enabled` flag), not a
-  // standalone sidebar item, so it only needs the hash allow-list — not the
-  // sidebar one. ComputerView itself reports unavailability when no data plane
-  // (local E2B creds or COMPUTERS_REMOTE_DATA_PLANE_URL) is configured.
+  // Project Computers are supported in hosted mode (access is enforced
+  // server-side, not by this list). Reached via the Connect tab switcher, not
+  // a standalone sidebar item, so it needs the hash allow-list only — see PR.
   "computer",
 ] as const;
 


### PR DESCRIPTION
## Why

The **Computer** tab (Project Computers, E2B-backed) is unreachable in hosted mode — navigating to `/computer` fires a `computer is not available in hosted mode.` toast and bounces to `/servers`.

That bounce comes from `App.tsx`'s hosted-mode effect, which redirects any tab not in `HOSTED_HASH_ALLOWED_TABS`. `"computer"` was **never** in that allow-list (`git log -S '"computer"'` finds no history) — the list predates the computers feature. It's a stale gate, not a real capability limit.

## Computers are supported in hosted mode

- The server leaves `/api/web/computers/*` **outside** the hosted block partition (`server/app.ts`) — `/config` and the terminal WS are reachable in hosted mode by design.
- Access is enforced **server-side**, independent of tab visibility: project membership (`resolveProjectAccess`) + the `projectComputers` org entitlement (`requireOrganizationFeature`) + a per-user, ~60s HMAC terminal token (`mintTerminalToken`).
- `ComputerView` resolves a local or remote (`COMPUTERS_REMOTE_DATA_PLANE_URL`) data plane and self-reports when neither is configured.

The UI allow-list is **not** a security boundary — an unauthorized caller could already hit the endpoints and be rejected by the control plane. Unhiding the tab grants no new access.

## Change

Add `"computer"` to `HOSTED_HASH_ALLOWED_TABS` only. Computer is reached via the **Connect** tab switcher (`matchTabs: ["clients","host-compare","computer"]`, gated by the `computers-enabled` flag), not a standalone sidebar item — so it deliberately stays out of `HOSTED_SIDEBAR_ALLOWED_TABS`. A new test asserts that asymmetry.

## Test plan

- [x] `hosted-tab-policy.test.ts` — 13 passed (incl. the new computer case)

## Deploy prerequisites (NOT code — verified against prod Convex)

- [x] E2B control plane provisioned: `E2B_API_KEY` + `E2B_TEMPLATE_ID` set in prod; all `projectComputers.*` functions deployed.
- [ ] **`COMPUTERS_TERMINAL_TOKEN_SECRET` is NOT set in prod Convex** → `mintTerminalToken` throws, so the interactive terminal would fail. Must be set (≥ min length) on Convex prod **and** matched on the inspector/data-plane side before enabling the flag.
- [ ] Inspector hosted deployment has `COMPUTERS_REMOTE_DATA_PLANE_URL` (or local E2B creds) — Railway env, not verified here.
- [ ] Rollout gated by the `computers-enabled` PostHog flag. Note: the `projectComputers` entitlement is `true` for **all** plans incl. free, and signed-in `computerStartsPerDay` is uncapped (cost bounded by the idle-hibernate sweep); the PostHog flag is the real throttle. No credit metering exists yet (backend `getComputerUsage` unmerged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only routing and feature-flag gating; no auth or API behavior changes, with regression tests for the hydration edge case.
> 
> **Overview**
> **Hosted navigation** now treats `/computer` as an allowed hash tab so the hosted-mode redirect no longer shows “not available in hosted mode” and sends users to `/servers`. `"computer"` is added only to `HOSTED_HASH_ALLOWED_TABS` (Connect tab switcher), not the hosted sidebar allow-list.
> 
> **`ComputerRoute`** uses a new tri-state `useComputersEnabledState()` instead of the boolean `useComputersEnabled()`. It redirects to `/servers` only when the PostHog `computers-enabled` flag is explicitly `false`, and renders nothing while the flag is still `undefined` so cold loads of `/computer` are not bounced before PostHog hydrates.
> 
> Tests cover the hydration guard and the hosted hash vs sidebar policy for `computer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b9cc5a423af65c3bde48846f4692b857f84f8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->