### PR TITLE
fix(evals): authenticate guest eval runs with the guest bearer

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -7,7 +7,6 @@ import {
   type KeyboardEvent,
 } from "react";
 import { useMutation, useQuery } from "convex/react";
-import { useAuth } from "@workos-inc/authkit-react";
 import posthog from "posthog-js";
 import {
   ArrowLeft,
@@ -105,7 +104,7 @@ import {
   hasUnavailableServers,
   normalizeSuiteServerRefs,
 } from "./use-eval-handlers";
-import { getGuestBearerToken } from "@/lib/guest-session";
+import { useConvexAccessToken } from "@/hooks/use-convex-access-token";
 import {
   reduceEvalStreamEvent,
   initialEvalStreamState,
@@ -400,7 +399,9 @@ export function TestTemplateEditor({
   ensureServersReady,
   projectServers,
 }: TestTemplateEditorProps) {
-  const { getAccessToken } = useAuth();
+  // Resolves the WorkOS token for signed-in users and the guest bearer for
+  // guests (project-owning guests included). See use-convex-access-token.
+  const getAccessToken = useConvexAccessToken();
   const [editForm, setEditForm] = useState<TestTemplate | null>(null);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editorMode, setEditorMode] = useState<EditorMode>(
@@ -1363,9 +1364,7 @@ export function TestTemplateEditor({
           },
           testCase: currentTestCase,
           selectedModel: modelValue,
-          getAccessToken: isDirectGuest
-            ? getGuestBearerToken
-            : getAccessToken,
+          getAccessToken,
           testCaseOverrides: {
             query: savePayload.query,
             expectedToolCalls: savePayload.expectedToolCalls,

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { useConvex } from "convex/react";
-import { useAuth } from "@workos-inc/authkit-react";
 import { toast } from "sonner";
 import posthog from "posthog-js";
 import { detectPlatform, detectEnvironment } from "@/lib/PosthogUtils";
@@ -34,7 +33,7 @@ import { isHostedMode } from "@/lib/apis/mode-client";
 import { normalizeHostedServerNames } from "@/lib/apis/web/context";
 import { generateAndPersistEvalTests } from "@/lib/evals/generate-and-persist-tests";
 import { collectUniqueModelsFromTestCases } from "@/lib/evals/collect-unique-suite-models";
-import { getGuestBearerToken } from "@/lib/guest-session";
+import { useConvexAccessToken } from "@/hooks/use-convex-access-token";
 import {
   getDefaultTestCaseModelValue,
   prepareSingleTestCaseRun,
@@ -210,7 +209,9 @@ export function useEvalHandlers({
   availableModels,
 }: UseEvalHandlersProps) {
   const convex = useConvex();
-  const { getAccessToken } = useAuth();
+  // Resolves the WorkOS token for signed-in users and the guest bearer for
+  // guests (project-owning guests included). See use-convex-access-token.
+  const getAccessToken = useConvexAccessToken();
 
   // Action states
   const [rerunningSuiteId, setRerunningSuiteId] = useState<string | null>(null);
@@ -445,11 +446,11 @@ export function useEvalHandlers({
       const replayToastId = toast.loading("Replaying run...");
 
       try {
-        // Hosted guests have no WorkOS access token; the request still
-        // authenticates via authFetch attaching a guest bearer. Treat the
-        // LoginRequired throw as an empty token — `buildEvalConvexAuthPayload`
-        // drops it in hosted mode anyway.
-        const accessToken = await getAccessToken().catch(() => "");
+        // Local guests authenticate via this body token (the guest bearer);
+        // hosted guests authenticate via authFetch's Authorization header and
+        // `buildEvalConvexAuthPayload` drops this field, so an empty string is
+        // harmless there.
+        const accessToken = (await getAccessToken()) ?? "";
         const endpoints = getEvalApiEndpoints();
         const response = await authFetch(endpoints.replayRun, {
           method: "POST",
@@ -654,10 +655,11 @@ export function useEvalHandlers({
 
       const suiteRunStartedAt = Date.now();
       try {
-        // Hosted guests have no WorkOS access token; authFetch attaches the
-        // guest bearer instead. `mergeHostedServerBatch` strips
-        // convexAuthToken in hosted mode so an empty string is harmless.
-        const accessToken = await getAccessToken().catch(() => "");
+        // Local guests authenticate via this body token (the guest bearer);
+        // hosted guests authenticate via authFetch's Authorization header and
+        // `mergeHostedServerBatch` strips convexAuthToken, so an empty string
+        // is harmless there.
+        const accessToken = (await getAccessToken()) ?? "";
 
         // Get pass criteria from suite's defaultPassCriteria, or fall back to latest run, or default to 100%
         const suiteDefault = suite.defaultPassCriteria?.minimumPassRate;
@@ -924,9 +926,7 @@ export function useEvalHandlers({
                 },
               },
               testCase,
-              getAccessToken: isDirectGuest
-                ? getGuestBearerToken
-                : getAccessToken,
+              getAccessToken,
               selectedModel,
               testCaseOverrides:
                 options?.iterationOverride !== undefined

--- a/mcpjam-inspector/client/src/hooks/use-convex-access-token.ts
+++ b/mcpjam-inspector/client/src/hooks/use-convex-access-token.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
+
+import { resolveConvexAccessToken } from "@/lib/auth/resolve-convex-access-token";
+
+/**
+ * Returns a stable getter that resolves the Convex bearer token for the
+ * current actor — the WorkOS access token for signed-in users, or the guest
+ * bearer for guests. Use this for any request that forwards a
+ * `convexAuthToken` (eval runs, test generation) so guests authenticate the
+ * same way the chat session does.
+ *
+ * See {@link resolveConvexAccessToken} for why the guest fallback keys on the
+ * presence of a WorkOS user rather than `isDirectGuest`.
+ */
+export function useConvexAccessToken(): () => Promise<string | null> {
+  const { user, getAccessToken } = useAuth();
+  return useCallback(
+    () =>
+      resolveConvexAccessToken({
+        getWorkosAccessToken: getAccessToken,
+        hasWorkosUser: Boolean(user),
+      }),
+    [user, getAccessToken],
+  );
+}

--- a/mcpjam-inspector/client/src/lib/auth/__tests__/resolve-convex-access-token.test.ts
+++ b/mcpjam-inspector/client/src/lib/auth/__tests__/resolve-convex-access-token.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/guest-session", () => ({
+  getGuestBearerToken: vi.fn(),
+}));
+
+import { resolveConvexAccessToken } from "../resolve-convex-access-token";
+import { getGuestBearerToken } from "@/lib/guest-session";
+
+describe("resolveConvexAccessToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getGuestBearerToken).mockResolvedValue("guest-token");
+  });
+
+  it("returns the WorkOS token for signed-in users without touching guest auth", async () => {
+    const token = await resolveConvexAccessToken({
+      getWorkosAccessToken: async () => "workos-token",
+      hasWorkosUser: true,
+    });
+
+    expect(token).toBe("workos-token");
+    expect(getGuestBearerToken).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the guest bearer when there is no WorkOS user", async () => {
+    const token = await resolveConvexAccessToken({
+      getWorkosAccessToken: async () => null,
+      hasWorkosUser: false,
+    });
+
+    expect(token).toBe("guest-token");
+  });
+
+  it("falls back to the guest bearer when the WorkOS getter throws for a guest", async () => {
+    const token = await resolveConvexAccessToken({
+      getWorkosAccessToken: async () => {
+        throw new Error("LoginRequiredError");
+      },
+      hasWorkosUser: false,
+    });
+
+    expect(token).toBe("guest-token");
+  });
+
+  it("never downgrades a signed-in user to a guest bearer if their token fails", async () => {
+    const token = await resolveConvexAccessToken({
+      getWorkosAccessToken: async () => {
+        throw new Error("transient");
+      },
+      hasWorkosUser: true,
+    });
+
+    expect(token).toBeNull();
+    expect(getGuestBearerToken).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a signed-in user whose token resolves empty", async () => {
+    const token = await resolveConvexAccessToken({
+      getWorkosAccessToken: async () => "",
+      hasWorkosUser: true,
+    });
+
+    expect(token).toBeNull();
+    expect(getGuestBearerToken).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/auth/resolve-convex-access-token.ts
+++ b/mcpjam-inspector/client/src/lib/auth/resolve-convex-access-token.ts
@@ -1,0 +1,35 @@
+import { getGuestBearerToken } from "@/lib/guest-session";
+
+/**
+ * Resolve the Convex bearer token for a request the same way the chat-session
+ * bootstrap does (see `use-chat-session.ts`): prefer the WorkOS access token
+ * for signed-in users, and fall back to the guest bearer when there is no
+ * WorkOS user.
+ *
+ * The fallback is keyed on guest-ness (`!hasWorkosUser`), NOT on
+ * `isDirectGuest`. `isDirectGuest` is false whenever a guest owns a project
+ * (e.g. the auto-created "Default" project) or in hosted mode, so the eval
+ * paths that selected `isDirectGuest ? getGuestBearerToken : getAccessToken`
+ * handed the WorkOS getter — which returns nothing for a guest — to the
+ * runner. The empty token reached Convex as `setAuth("")`, and `requireActor`
+ * threw "Authentication required". Falling back on guest-ness fixes
+ * project-owning guests while never downgrading a signed-in user to a guest
+ * bearer if their WorkOS token momentarily fails to resolve.
+ */
+export async function resolveConvexAccessToken(opts: {
+  getWorkosAccessToken: () => Promise<string | null | undefined>;
+  hasWorkosUser: boolean;
+}): Promise<string | null> {
+  try {
+    const token = await opts.getWorkosAccessToken();
+    if (token) return token;
+  } catch {
+    // WorkOS LoginRequiredError — not signed in; fall through to guest.
+  }
+
+  if (!opts.hasWorkosUser) {
+    return await getGuestBearerToken();
+  }
+
+  return null;
+}

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/generate-and-persist-tests.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/generate-and-persist-tests.test.ts
@@ -5,12 +5,7 @@ vi.mock("@/lib/apis/evals-api", () => ({
   generateEvalTests: vi.fn(),
 }));
 
-vi.mock("@/lib/guest-session", () => ({
-  getGuestBearerToken: vi.fn(),
-}));
-
 import { generateEvalTests } from "@/lib/apis/evals-api";
-import { getGuestBearerToken } from "@/lib/guest-session";
 
 describe("generateAndPersistEvalTests", () => {
   const mockQuery = vi.fn();
@@ -22,7 +17,6 @@ describe("generateAndPersistEvalTests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAccessToken.mockResolvedValue("token");
-    vi.mocked(getGuestBearerToken).mockResolvedValue("guest-token");
     vi.mocked(generateEvalTests).mockResolvedValue({
       success: true,
       tests: [],
@@ -132,8 +126,12 @@ describe("generateAndPersistEvalTests", () => {
     );
   });
 
-  it("uses the guest bearer token for direct guest generation", async () => {
+  // The guest bearer is now resolved by the caller's `getAccessToken`
+  // (see resolveConvexAccessToken / useConvexAccessToken); this function just
+  // forwards whatever token it returns. A direct guest still drops projectId.
+  it("forwards the resolved token and nulls projectId for direct guests", async () => {
     mockQuery.mockResolvedValue([]);
+    mockGetAccessToken.mockResolvedValue("guest-token");
     vi.mocked(generateEvalTests).mockResolvedValue({
       success: true,
       tests: [{ title: "T", query: "q", runs: 1, expectedToolCalls: [] }],
@@ -150,8 +148,7 @@ describe("generateAndPersistEvalTests", () => {
       isDirectGuest: true,
     });
 
-    expect(getGuestBearerToken).toHaveBeenCalledTimes(1);
-    expect(mockGetAccessToken).not.toHaveBeenCalled();
+    expect(mockGetAccessToken).toHaveBeenCalledTimes(1);
     expect(generateEvalTests).toHaveBeenCalledWith({
       projectId: null,
       serverIds: ["srv"],

--- a/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
+++ b/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
@@ -5,7 +5,6 @@ import {
   type ServerAttachmentInput,
 } from "@/lib/apis/evals-api";
 import { HOSTED_MODE } from "@/lib/config";
-import { getGuestBearerToken } from "@/lib/guest-session";
 import type { PromptTurn } from "@/shared/prompt-turns";
 
 export type CreateEvalTestCaseInput = {
@@ -190,11 +189,9 @@ export async function generateAndPersistEvalTests(
     modelsToUse = defaultEvalModels();
   }
 
-  const accessToken = HOSTED_MODE
-    ? null
-    : isDirectGuest
-      ? await getGuestBearerToken()
-      : await getAccessToken();
+  // `getAccessToken` already resolves the guest bearer for guests (see
+  // use-convex-access-token), so no `isDirectGuest` branch is needed here.
+  const accessToken = HOSTED_MODE ? null : await getAccessToken();
   if (!HOSTED_MODE && !accessToken) {
     throw new Error("Not authenticated");
   }


### PR DESCRIPTION
## Problem

Guests can't run evals. Clicking run surfaces a raw Convex error:

> Uncaught Error: Authentication required — at `requireIdentity` (convex/lib/actors.ts) → `requireActor`

`requireActor` saw a **null identity**, i.e. the eval request reached Convex with an empty `convexAuthToken` (`setAuth("")`).

## Root cause

The eval run / generate paths selected their Convex token with:

```ts
getAccessToken: isDirectGuest ? getGuestBearerToken : getAccessToken
```

But `useIsDirectGuest` returns **false** whenever a guest owns a project (the auto-created **"Default"** project) or in hosted mode. So a project-owning guest fell through to the WorkOS `getAccessToken`, which yields nothing for a guest — the empty token reached Convex and `requireActor` threw.

This was confirmed against deployment logs: a guest's **reactive** client (`useQuery`) carries a valid guest token, while the **server/getter-routed** eval calls (`updateTestSuite`, `startTestSuiteRun`) sent an empty token. The backend is correct — guest-owned suites (no `workspaceId`) are allowed and the run path never hits the signed-in-only `getSuiteConfig`; the only blocker was the empty client token.

## Fix — reuse the chat-session logic

`use-chat-session.ts` already resolves this correctly: try the WorkOS token, fall back to the guest bearer when there is **no WorkOS user**. Extracted into a shared helper and applied to the three eval token call sites:

- **`lib/auth/resolve-convex-access-token.ts`** — pure resolver (WorkOS → guest-bearer fallback, keyed on guest-ness; never downgrades a signed-in user whose token momentarily fails).
- **`hooks/use-convex-access-token.ts`** — hook wrapper over `useAuth`.
- Rewired token selection in `use-eval-handlers.ts` (run test case, replay, run-all), `test-template-editor.tsx` (run), and `generate-and-persist-tests.ts` (generate). The `isDirectGuest` token branch is gone.

Keying on guest-ness instead of `isDirectGuest` fixes project-owning guests while never downgrading a signed-in user to a guest bearer.

## Testing

- `npm run typecheck:client` — clean
- New `resolve-convex-access-token` unit suite + updated `generate-and-persist-tests`, plus `single-test-case-runner`, `test-template-editor-open-compare-route`, `EvalsTab` — **all pass (43 tests)**

## Out of scope (noticed, not addressed here)

- A guest hitting a `workspaceId`-scoped suite is rejected by `requireUserActor` in `getSuiteConfig` (orthogonal to the run-token path).
- `hosts:listHosts` passing a UUID where `v.id('projects')` is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication token selection for all eval API paths; incorrect fallback could block signed-in users or mis-authenticate guests, though behavior is guarded by new unit tests and explicit no-downgrade rules.
> 
> **Overview**
> Guest eval **run**, **replay**, **suite rerun**, **test generation**, and **compare run** paths now share **`resolveConvexAccessToken`** / **`useConvexAccessToken`**, matching chat-session behavior: use the WorkOS token when a user is signed in, otherwise use the **guest bearer**.
> 
> The old **`isDirectGuest ? getGuestBearerToken : getAccessToken`** branching is removed from **`use-eval-handlers`**, **`test-template-editor`**, and **`generate-and-persist-tests`**. That branch wrongly picked the WorkOS getter for guests who own a project (where **`isDirectGuest`** is false), which produced empty tokens and Convex **Authentication required** errors.
> 
> Signed-in users are **not** downgraded to guest tokens when WorkOS token fetch fails; replay/rerun now use **`(await getAccessToken()) ?? ""`** with updated comments for local vs hosted auth. Unit tests cover the resolver and updated generate-and-persist expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420e118b51dfe0e67ca4f097d151396908581f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->