### PR TITLE
fix(docker): copy chat-ui workspace into the staging build

### DIFF
--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -12,6 +12,7 @@ COPY package.json package-lock.json ./
 COPY sdk/package.json ./sdk/package.json
 COPY cli/package.json ./cli/package.json
 COPY design-system/package.json ./design-system/package.json
+COPY chat-ui/package.json ./chat-ui/package.json
 COPY mcpjam-inspector/package.json ./mcpjam-inspector/package.json
 
 RUN npm ci --legacy-peer-deps
@@ -58,6 +59,11 @@ RUN npm run bundle:chatgpt -w @mcpjam/inspector && \
 # disk; `build:server` consumes the generated harness bundle so it runs in the
 # same step.
 COPY design-system ./design-system
+# The inspector client aliases `@mcpjam/chat-ui` to `../chat-ui/src/index.ts`
+# (see client/vite.config.ts) and Tailwind scans the same source, so the
+# chat-ui workspace must be on disk before `build:client` runs. It is consumed
+# from source, not from a built dist, so no chat-ui build step is needed.
+COPY chat-ui ./chat-ui
 COPY mcpjam-inspector/client ./mcpjam-inspector/client
 COPY mcpjam-inspector/.env.production ./mcpjam-inspector/
 RUN npm run bundle:browser-harness -w @mcpjam/inspector && \


### PR DESCRIPTION
## Problem

Deploy Staging has failed on every run since #2680. The workflow itself is fine — the **Railway Docker build** fails during `BUILDING`, and the `Wait for Railway staging deploy to finish` step faithfully reports it:

```
Deploy e5a72539… status: INITIALIZING → BUILDING
##[error]Deploy e5a72539… ended in status FAILED
```

## Root cause

`mcpjam-inspector/Dockerfile` was never updated when the `@mcpjam/chat-ui` workspace was added in #2678:

- The `deps` stage copies each workspace's `package.json` (sdk, cli, design-system, inspector) but **not** `chat-ui/package.json`, even though the root lockfile now declares `chat-ui` as a workspace.
- The `build` stage **never copies `chat-ui/`** into the image. The inspector client aliases `@mcpjam/chat-ui` → `../chat-ui/src/index.ts` (`client/vite.config.ts:27,71`) and Tailwind scans the same source.

It stayed green through #2678 because nothing imported the package yet. #2680 added the first `import … from "@mcpjam/chat-ui"` (`ShareUsageThreadDetail.tsx:12`), so `build:client` began trying to resolve the alias to a path absent from the image → Rollup resolution failure → build `FAILED`. Every commit since fails identically.

CI / local builds were unaffected because a full checkout has `chat-ui/` on disk — only the hand-curated multi-stage Dockerfile omitted it.

## Fix

- `deps` stage: `COPY chat-ui/package.json` so `npm ci` sees the declared workspace.
- `build` stage: `COPY chat-ui` before `build:client`. chat-ui is consumed from source (aliased to `src`), so no chat-ui build step is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile change; no runtime behavior or application logic is modified.
> 
> **Overview**
> Repairs **Railway staging Docker builds** that broke once the inspector client started importing **`@mcpjam/chat-ui`**, which the multi-stage image never copied in.
> 
> The **`deps`** stage now copies **`chat-ui/package.json`** alongside the other workspace manifests so **`npm ci`** matches the root lockfile. The **`build`** stage **`COPY`s `chat-ui/`** before the client build, with a comment noting the Vite alias and Tailwind **`@source`** both read **`chat-ui/src`** directly—no separate chat-ui build step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca67ed9f7042a3f16c35a514b0d4ac5a871b6b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->