### PR TITLE
Clarify XAA subject, carry email into ID-JAG, detail negative-test failures

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAConfigModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAConfigModal.tsx
@@ -209,12 +209,12 @@ export function XAAConfigModal({
               </CollapsibleTrigger>
               <CollapsibleContent className="mt-3 space-y-3">
                 <p className="text-xs text-muted-foreground">
-                  The MCPJam issuer mints a mock ID token for this user.
-                  Defaults work for most flows.
+                  The MCPJam issuer mints a mock ID token for this user, then
+                  exchanges it for an ID-JAG. Defaults work for most flows.
                 </p>
                 <div className="grid gap-3 md:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="xaa-user-id">User ID</Label>
+                    <Label htmlFor="xaa-user-id">Subject (sub)</Label>
                     <Input
                       id="xaa-user-id"
                       value={draft.userId}
@@ -226,6 +226,10 @@ export function XAAConfigModal({
                       }
                       placeholder="user-12345"
                     />
+                    <p className="text-[11px] text-muted-foreground">
+                      Becomes the <code>sub</code> claim — the end-user identity
+                      carried through the ID-JAG into the access token.
+                    </p>
                   </div>
 
                   <div className="space-y-2">

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -151,6 +151,9 @@ describe("mcp xaa routes", () => {
     const tokenExchangeBody = await tokenExchangeResponse.json();
     const payload = decodeJwtPayload(tokenExchangeBody.id_jag);
     expect(payload.aud).toBe("https://wrong-audience.example.com");
+    // The ID token's email rides into the ID-JAG (spec RECOMMENDED) so the
+    // Resource AS can use it for subject resolution.
+    expect(payload.email).toBe("demo.user@example.com");
   });
 
   describe("POST /discover-as", () => {

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -336,12 +336,19 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       const issuer = getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
       const identityPayload = decodeJwtPayloadUnsafe(parsed.identityAssertion);
       const subject = identityPayload.sub || "user-12345";
+      // Carry the ID token's email into the ID-JAG (spec RECOMMENDED) so the
+      // Resource AS can use it for subject resolution / JIT provisioning.
+      const email =
+        typeof identityPayload.email === "string"
+          ? identityPayload.email
+          : undefined;
 
       const issued =
         negativeTestMode === "valid"
           ? issueIdJag({
               issuer,
               subject,
+              email,
               audience: parsed.audience,
               resource: parsed.resource,
               clientId: parsed.clientId,
@@ -351,6 +358,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
               {
                 issuer,
                 subject,
+                email,
                 audience: parsed.audience,
                 resource: parsed.resource,
                 clientId: parsed.clientId,
@@ -774,7 +782,10 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
           verdict: accepted ? "fail" : "pass",
           status: response.status,
           detail: accepted
-            ? "Authorization server issued an access token for a broken assertion."
+            ? `The auth server returned HTTP ${response.status} with an access token for this broken assertion. ` +
+              `This test ${details.description.charAt(0).toLowerCase()}${details.description.slice(1)} ` +
+              `${details.expectedFailure} Because a token was issued instead, a malformed or unauthorized ` +
+              `assertion would be accepted in production.`
             : undefined,
         };
       } catch (error) {

--- a/mcpjam-inspector/server/services/xaa-idjag-signer.ts
+++ b/mcpjam-inspector/server/services/xaa-idjag-signer.ts
@@ -27,6 +27,12 @@ export interface IssueIdJagParams {
   resource: string;
   clientId: string;
   scope?: string;
+  /**
+   * End-user email. The spec RECOMMENDS the ID-JAG carry an `email` (and/or
+   * `aud_sub`) claim so the Resource Authorization Server can resolve/provision
+   * the subject. Optional — omitted from the payload when absent.
+   */
+  email?: string;
 }
 
 export interface IssueMockIdTokenParams {
@@ -71,6 +77,7 @@ function createValidIdJagPayload(
     iat: now,
     exp: now + ID_JAG_TTL_S,
     ...(params.scope ? { scope: params.scope } : {}),
+    ...(params.email ? { email: params.email } : {}),
   };
 }
 


### PR DESCRIPTION
## TL;DR

Three developer-clarity fixes in the XAA debugger, found while debugging a reference auth server against the negative-test scorecard. No behavior change to valid flows; the XAA route tests pass (20/20).

## Changes

| # | Change | Why |
|---|---|---|
| 1 | **"User ID" → "Subject (sub)"** + helper text | The field is the end-user `sub` that travels through the ID-JAG into the access token. "User ID" read like an account name and hid that. |
| 2 | **Carry `email` into the ID-JAG** | Spec **RECOMMENDS** the ID-JAG contain `email` (and/or `aud_sub`) for subject resolution / JIT provisioning. We minted it into the ID token but dropped it at the exchange step. Now it rides through (optional — omitted when absent). |
| 3 | **Per-mode negative-test failure detail** | The old detail was the same generic line for every red row: _"Authorization server issued an access token for a broken assertion."_ Now it states the HTTP status, what the test mutated, what the AS should have done, and the production impact. |

### Before / after — scorecard failure text

**Before:** `Authorization server issued an access token for a broken assertion.`

**After (example, `unknown_sub`):** `The auth server returned HTTP 200 with an access token for this broken assertion. This test sets `sub` to an unmapped user identifier. Authorization server should reject the unknown subject. Because a token was issued instead, a malformed or unauthorized assertion would be accepted in production.`

## Spec basis (email)

> `email` — OPTIONAL … RECOMMENDED that the ID-JAG contain an `email` and/or `aud_sub` claim. The Resource Authorization Server MAY use these claims for subject resolution, including JIT provisioning.

— [draft-ietf-oauth-identity-assertion-authz-grant](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/)

## Risk register

| Concern | Answer |
|---|---|
| Does adding `email` break ASes that don't expect it? | No — extra JWT claims are ignored by standard validators. Omitted entirely when the ID token has no email. |
| Does the relabel change any IDs/values? | No — label/help text only; the field id and state key are unchanged. |
| Negative-test verdict logic changed? | No — only the human-readable `detail` string; pass/fail is still status-based. |

## Test

- `server/routes/mcp/__tests__/xaa.test.ts` — 20/20 pass, incl. a new assertion that the ID-JAG carries `email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)