### PR TITLE
[XAA Debugger UX] PR-I1: clearer scorecard, setup copy, and flow orientation

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
@@ -265,7 +265,7 @@ export function NegativeTestScorecard({
                     {passedCount} of {run.result.results.length} broken
                     assertions correctly rejected.
                   </p>
-                  <div className="space-y-2">
+                  <div className="max-h-[420px] space-y-2 overflow-y-auto pr-1">
                     {run.result.results.map((row) => (
                       <VerdictRow key={row.mode} row={row} />
                     ))}

--- a/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
@@ -86,31 +86,35 @@ function VerdictRow({ row }: { row: NegativeTestCase }) {
     <div
       data-testid={`xaa-negtest-row-${row.mode}`}
       data-verdict={row.verdict}
-      className={`flex items-start gap-2 rounded-md px-2.5 py-2 text-xs ${
+      className={`rounded-lg border px-3 py-2.5 text-xs ${
         row.verdict === "fail"
-          ? "bg-red-50 dark:bg-red-950/20"
-          : "bg-background"
+          ? "border-red-300 bg-red-50 dark:border-red-900/60 dark:bg-red-950/20"
+          : "border-border bg-background"
       }`}
     >
-      <tone.Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${tone.className}`} />
-      <div className="min-w-0 flex-1 space-y-0.5">
-        <div className="flex items-center justify-between gap-2">
-          <span className="font-medium">{row.label}</span>
-          <StatusPill row={row} />
-        </div>
-        {body && <p className="text-muted-foreground">{body}</p>}
-        {row.diff && (
-          <div className="flex flex-wrap gap-x-4 gap-y-0.5 pt-0.5 font-mono text-[11px] text-muted-foreground">
-            <span>
-              {row.diff.field} sent{" "}
-              <span className="text-foreground">{row.diff.sent}</span>
-            </span>
-            <span>
-              expected{" "}
-              <span className="text-foreground">{row.diff.expected}</span>
-            </span>
+      <div className="flex items-start gap-2">
+        <tone.Icon
+          className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${tone.className}`}
+        />
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-medium">{row.label}</span>
+            <StatusPill row={row} />
           </div>
-        )}
+          {body && <p className="text-muted-foreground">{body}</p>}
+          {row.diff && (
+            <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 rounded-md bg-muted/50 px-2.5 py-1.5 font-mono text-[11px]">
+              <span className="text-muted-foreground">
+                {row.diff.field} sent
+              </span>
+              <span className="break-all text-foreground">{row.diff.sent}</span>
+              <span className="text-muted-foreground">expected</span>
+              <span className="break-all text-foreground">
+                {row.diff.expected}
+              </span>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -261,7 +265,7 @@ export function NegativeTestScorecard({
                     {passedCount} of {run.result.results.length} broken
                     assertions correctly rejected.
                   </p>
-                  <div className="space-y-1 rounded-md border border-border p-1">
+                  <div className="space-y-2">
                     {run.result.results.map((row) => (
                       <VerdictRow key={row.mode} row={row} />
                     ))}

--- a/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
@@ -12,15 +12,17 @@ import {
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { Card } from "@mcpjam/design-system/card";
-import { Input } from "@mcpjam/design-system/input";
+import { Checkbox } from "@mcpjam/design-system/checkbox";
+import {
+  NEGATIVE_TEST_MODE_DETAILS,
+  type NegativeTestMode,
+} from "@/shared/xaa.js";
 import {
   runNegativeTests,
   type NegativeTestCase,
   type NegativeTestsInput,
   type NegativeTestsResult,
 } from "@/lib/xaa/discovery-client";
-
-const OVERRIDE_PHRASE = "run anyway";
 
 interface NegativeTestScorecardProps {
   /** The AS target to fire broken assertions at, or null when there is no
@@ -39,42 +41,76 @@ type RunState =
   | { status: "done"; result: NegativeTestsResult }
   | { status: "error"; message: string };
 
+function StatusPill({ row }: { row: NegativeTestCase }) {
+  const httpSuffix = row.status ? ` · HTTP ${row.status}` : "";
+
+  if (row.verdict === "pass") {
+    return (
+      <span className="shrink-0 text-[11px] font-medium text-green-700 dark:text-green-400">
+        Rejected as expected{httpSuffix}
+      </span>
+    );
+  }
+
+  if (row.verdict === "fail") {
+    return (
+      <span className="shrink-0 text-[11px] font-medium text-red-600 dark:text-red-400">
+        Accepted — security risk{httpSuffix}
+      </span>
+    );
+  }
+
+  return (
+    <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
+      {row.outcome === "timeout" ? "Timed out" : "Inconclusive"}
+    </span>
+  );
+}
+
 function VerdictRow({ row }: { row: NegativeTestCase }) {
   const tone =
     row.verdict === "pass"
       ? { Icon: CheckCircle2, className: "text-green-600 dark:text-green-400" }
       : row.verdict === "fail"
-        ? { Icon: ShieldAlert, className: "text-red-500" }
-        : { Icon: HelpCircle, className: "text-muted-foreground" };
+      ? { Icon: ShieldAlert, className: "text-red-500" }
+      : { Icon: HelpCircle, className: "text-muted-foreground" };
+
+  // A correct server rejects every broken assertion, so the "what this checks"
+  // copy is the right explanation on a pass; a fail or timeout has its own
+  // server-supplied detail.
+  const description =
+    NEGATIVE_TEST_MODE_DETAILS[row.mode as NegativeTestMode]?.description;
+  const body = row.verdict === "pass" ? description : row.detail || description;
 
   return (
     <div
       data-testid={`xaa-negtest-row-${row.mode}`}
       data-verdict={row.verdict}
-      className="flex items-start gap-2 border-t border-border/60 px-1 py-1.5 text-xs first:border-t-0"
+      className={`flex items-start gap-2 rounded-md px-2.5 py-2 text-xs ${
+        row.verdict === "fail"
+          ? "bg-red-50 dark:bg-red-950/20"
+          : "bg-background"
+      }`}
     >
       <tone.Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${tone.className}`} />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="flex items-center justify-between gap-2">
           <span className="font-medium">{row.label}</span>
-          {row.verdict === "fail" && (
-            <Badge variant="destructive" className="text-[10px]">
-              security risk
-            </Badge>
-          )}
-          {row.verdict === "unknown" && (
-            <Badge variant="outline" className="text-[10px]">
-              {row.outcome === "timeout" ? "timed out" : "inconclusive"}
-            </Badge>
-          )}
+          <StatusPill row={row} />
         </div>
-        <p className="text-muted-foreground">
-          {row.verdict === "fail"
-            ? row.detail
-            : row.verdict === "pass"
-              ? `Rejected${row.status ? ` (HTTP ${row.status})` : ""} — ${row.expectedFailure}`
-              : row.detail}
-        </p>
+        {body && <p className="text-muted-foreground">{body}</p>}
+        {row.diff && (
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 pt-0.5 font-mono text-[11px] text-muted-foreground">
+            <span>
+              {row.diff.field} sent{" "}
+              <span className="text-foreground">{row.diff.sent}</span>
+            </span>
+            <span>
+              expected{" "}
+              <span className="text-foreground">{row.diff.expected}</span>
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -87,7 +123,6 @@ export function NegativeTestScorecard({
 }: NegativeTestScorecardProps) {
   const [expanded, setExpanded] = useState(false);
   const [run, setRun] = useState<RunState>({ status: "idle" });
-  const [overrideText, setOverrideText] = useState("");
   const [overrideAccepted, setOverrideAccepted] = useState(false);
 
   // Reset the last run whenever the target changes — including when config is
@@ -103,7 +138,6 @@ export function NegativeTestScorecard({
   useEffect(() => {
     setRun({ status: "idle" });
     setOverrideAccepted(false);
-    setOverrideText("");
   }, [targetKey]);
 
   const canRun = input !== null && (unlocked || overrideAccepted);
@@ -122,6 +156,11 @@ export function NegativeTestScorecard({
       });
     }
   };
+
+  const passedCount =
+    run.status === "done"
+      ? run.result.results.filter((r) => r.verdict === "pass").length
+      : 0;
 
   return (
     <Card className="mx-3 mt-1 mb-3 gap-0 p-0">
@@ -189,33 +228,21 @@ export function NegativeTestScorecard({
                 )}
               </div>
 
-              {!unlocked && !overrideAccepted && (
-                <div className="space-y-1.5 rounded-md border border-dashed border-border px-3 py-2">
-                  <p className="text-xs text-muted-foreground">
-                    Building the auth server (TDD)? If you own this server, type{" "}
-                    <code className="font-mono">{OVERRIDE_PHRASE}</code> to run
-                    anyway.
-                  </p>
-                  <div className="flex items-center gap-2">
-                    <Input
-                      aria-label="Override confirmation"
-                      value={overrideText}
-                      onChange={(event) => setOverrideText(event.target.value)}
-                      placeholder={OVERRIDE_PHRASE}
-                      className="h-8 text-xs"
-                    />
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      disabled={
-                        overrideText.trim().toLowerCase() !== OVERRIDE_PHRASE
-                      }
-                      onClick={() => setOverrideAccepted(true)}
-                    >
-                      Unlock
-                    </Button>
-                  </div>
+              {!unlocked && (
+                <div className="flex items-start gap-2 rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
+                  <Checkbox
+                    checked={overrideAccepted}
+                    onCheckedChange={(value) =>
+                      setOverrideAccepted(value === true)
+                    }
+                    className="mt-0.5"
+                    aria-label="I own this auth server and want to run before a passing flow"
+                  />
+                  <span>
+                    I&apos;m building this auth server — let me run the tests
+                    before a passing happy-path run. Use this only for a server
+                    you own and are developing.
+                  </span>
                 </div>
               )}
 
@@ -229,11 +256,17 @@ export function NegativeTestScorecard({
               )}
 
               {run.status === "done" && (
-                <div className="rounded-md border border-border">
-                  {run.result.results.map((row) => (
-                    <VerdictRow key={row.mode} row={row} />
-                  ))}
-                </div>
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    {passedCount} of {run.result.results.length} broken
+                    assertions correctly rejected.
+                  </p>
+                  <div className="space-y-1 rounded-md border border-border p-1">
+                    {run.result.results.map((row) => (
+                      <VerdictRow key={row.mode} row={row} />
+                    ))}
+                  </div>
+                </>
               )}
 
               {run.status === "done" && run.result.failures > 0 && (

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertCircle,
   AlertTriangle,
@@ -370,9 +370,26 @@ export function XAAFlowLogger({
     new Set()
   );
 
+  const stepRefs = useRef(new Map<XAAFlowStep, HTMLDivElement | null>());
+
   useEffect(() => {
     setExpandedSteps(new Set([flowState.currentStep]));
   }, [flowState.currentStep]);
+
+  // Bring the focused step (e.g. clicked in the run rail or the diagram) into
+  // view and open it, so focusing actually navigates to that step's card.
+  useEffect(() => {
+    if (!activeStep) return;
+    setExpandedSteps((previous) => {
+      if (previous.has(activeStep)) return previous;
+      const next = new Set(previous);
+      next.add(activeStep);
+      return next;
+    });
+    stepRefs.current
+      .get(activeStep)
+      ?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [activeStep]);
 
   const groups = useMemo(() => {
     const steps = new Map<
@@ -693,6 +710,9 @@ export function XAAFlowLogger({
                 return (
                   <div
                     key={group.step}
+                    ref={(el) => {
+                      stepRefs.current.set(group.step, el);
+                    }}
                     className={cn(
                       "bg-background border rounded-lg shadow-sm",
                       focusedStep === group.step

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import {
   AlertCircle,
   AlertTriangle,
@@ -31,6 +31,7 @@ import {
   getXAAPhaseNumber,
   getXAAStepInfo,
   getXAAStepIndex,
+  XAA_PHASE_ORDER,
   XAA_PHASES,
   XAA_STEP_ORDER,
   type XAAPhaseKey,
@@ -277,6 +278,68 @@ function PhaseHeader({
   );
 }
 
+/** Short, user-facing labels for the compact progress rail — the full phase
+ * titles are too long to sit five-across in the header. */
+const PHASE_RAIL_LABELS: Record<XAAPhaseKey, string> = {
+  bootstrap: "Discovery",
+  sso: "SSO",
+  token_exchange: "ID-JAG",
+  jwt_bearer: "Access token",
+  mcp_request: "MCP call",
+};
+
+/** At-a-glance "where am I" rail across the five phases, so the developer
+ * keeps their bearings without scrolling the step list. */
+function PhaseRail({ currentStep }: { currentStep: XAAFlowStep }) {
+  const currentPhase = getXAAStepInfo(currentStep).phase;
+  const currentPhaseNumber = currentPhase
+    ? getXAAPhaseNumber(currentPhase)
+    : -1;
+  const isComplete = currentStep === "complete";
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-1 gap-y-1"
+      aria-label="XAA flow progress"
+    >
+      {XAA_PHASE_ORDER.map((phase, index) => {
+        const number = getXAAPhaseNumber(phase);
+        const state =
+          isComplete || number < currentPhaseNumber
+            ? "done"
+            : number === currentPhaseNumber
+            ? "active"
+            : "pending";
+        return (
+          <Fragment key={phase}>
+            {index > 0 && (
+              <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/40" />
+            )}
+            <span
+              data-testid={`xaa-rail-${phase}`}
+              data-state={state}
+              className={cn(
+                "flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px]",
+                state === "active" &&
+                  "bg-blue-500/10 font-medium text-blue-600 dark:text-blue-400",
+                state === "done" && "text-green-600 dark:text-green-400",
+                state === "pending" && "text-muted-foreground"
+              )}
+            >
+              {state === "done" ? (
+                <CheckCircle2 className="h-3 w-3 shrink-0" />
+              ) : (
+                <span className="font-mono">{number}</span>
+              )}
+              {PHASE_RAIL_LABELS[phase]}
+            </span>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
 /** A "Tip" callout — visually distinct from diagnostics so static teaching
  * copy can't be mistaken for an error explanation. */
 function TeachableMoments({ moments }: { moments: string[] }) {
@@ -457,6 +520,8 @@ export function XAAFlowLogger({
 
         {hasProfile && (
           <>
+            <PhaseRail currentStep={flowState.currentStep} />
+
             <div className="flex flex-wrap items-center gap-2">
               <div className="flex items-center gap-1.5">
                 <span className="text-xs text-muted-foreground">Mode</span>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -520,7 +520,7 @@ export function XAAFlowTab({
           activeStep={focusedStep ?? flowState.currentStep}
           onFocusStep={setFocusedStep}
         />
-        <span className="ml-auto min-w-0 truncate pl-2 text-xs text-muted-foreground">
+        <span className="max-w-[40%] shrink-0 truncate pl-3 text-xs text-muted-foreground">
           {selectedRegistration
             ? `Target: ${selectedRegistration.name}`
             : hasTarget

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -520,7 +520,7 @@ export function XAAFlowTab({
           activeStep={focusedStep ?? flowState.currentStep}
           onFocusStep={setFocusedStep}
         />
-        <span className="min-w-0 shrink-0 truncate text-xs text-muted-foreground">
+        <span className="ml-auto min-w-0 truncate pl-2 text-xs text-muted-foreground">
           {selectedRegistration
             ? `Target: ${selectedRegistration.name}`
             : hasTarget

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -515,8 +515,12 @@ export function XAAFlowTab({
             </>
           )}
         </Button>
-        <XAARunChips flowState={flowState} />
-        <span className="ml-auto min-w-0 truncate text-xs text-muted-foreground">
+        <XAARunChips
+          flowState={flowState}
+          activeStep={focusedStep ?? flowState.currentStep}
+          onFocusStep={setFocusedStep}
+        />
+        <span className="min-w-0 shrink-0 truncate text-xs text-muted-foreground">
           {selectedRegistration
             ? `Target: ${selectedRegistration.name}`
             : hasTarget

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useRef, useState } from "react";
-import { Check, ChevronDown, ChevronRight, Copy, KeyRound } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  KeyRound,
+} from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { Card } from "@mcpjam/design-system/card";
 import { HOSTED_MODE } from "@/lib/config";
@@ -173,8 +180,8 @@ export function XAAIdpCard() {
                 server&apos;s resource identifier
               </li>
               <li>
-                <code className="font-mono">client_id</code> → the client ID
-                from your config
+                <code className="font-mono">client_id</code> → the Client ID you
+                set in Configure Target
               </li>
             </ul>
           </div>
@@ -187,10 +194,15 @@ export function XAAIdpCard() {
           </p>
 
           {!HOSTED_MODE && (
-            <p className="text-xs text-muted-foreground">
-              Local URLs only work if your authorization server can reach this
-              machine (e.g. via a public tunnel).
-            </p>
+            <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-muted-foreground">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+              <span>
+                These are local URLs. Your authorization server can only fetch
+                them if it can reach this machine — a cloud-hosted Okta or Auth0
+                tenant cannot reach <code className="font-mono">localhost</code>.
+                Expose the inspector with a public tunnel (e.g. ngrok) first.
+              </span>
+            </div>
           )}
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import {
+  getXAAPhaseNumber,
   getXAAStepIndex,
   getXAAStepInfo,
   XAA_STEP_ORDER,
@@ -8,14 +9,29 @@ import type { XAAFlowState, XAAFlowStep } from "@/lib/xaa/types";
 
 // "idle" and "complete" are machine states, not work the run performs.
 const CHIP_STEPS: XAAFlowStep[] = XAA_STEP_ORDER.filter(
-  (step) => step !== "idle" && step !== "complete",
+  (step) => step !== "idle" && step !== "complete"
 );
+
+// "phase.index" labels for each step (e.g. "2.1"), so a segment reads as a
+// place in the flow rather than an anonymous tick.
+const STEP_NUMBERS: Partial<Record<XAAFlowStep, string>> = (() => {
+  const labels: Partial<Record<XAAFlowStep, string>> = {};
+  const perPhase = new Map<number, number>();
+  for (const step of CHIP_STEPS) {
+    const phase = getXAAStepInfo(step).phase;
+    const phaseNumber = phase ? getXAAPhaseNumber(phase) : 0;
+    const next = (perPhase.get(phaseNumber) ?? 0) + 1;
+    perPhase.set(phaseNumber, next);
+    labels[step] = `${phaseNumber}.${next}`;
+  }
+  return labels;
+})();
 
 type ChipStatus = "pass" | "fail" | "untouched";
 
 export function chipStatusFor(
   step: XAAFlowStep,
-  flowState: Pick<XAAFlowState, "currentStep" | "error">,
+  flowState: Pick<XAAFlowState, "currentStep" | "error">
 ): ChipStatus {
   const stepIndex = getXAAStepIndex(step);
   const currentIndex = getXAAStepIndex(flowState.currentStep);
@@ -31,33 +47,57 @@ export function chipStatusFor(
 }
 
 /**
- * Per-step pass/fail strip for the flow runner. A run stopped mid-flow shows
- * green (done) / red (failed) / untouched chips rather than all-or-nothing.
+ * Full-width run-progress rail. Each step is a labelled segment coloured by
+ * outcome (pass / fail / pending) that the user can click to focus that step
+ * in the diagram and logger — replacing the old non-interactive tick strip.
  */
 export function XAARunChips({
   flowState,
+  activeStep,
+  onFocusStep,
 }: {
-  flowState: Pick<XAAFlowState, "currentStep" | "error">;
+  flowState: Pick<XAAFlowState, "currentStep" | "error" | "isBusy">;
+  activeStep?: XAAFlowStep | null;
+  onFocusStep?: (step: XAAFlowStep) => void;
 }) {
   return (
-    <ol aria-label="Run progress" className="flex flex-wrap items-center gap-1">
+    <ol aria-label="Run progress" className="flex flex-1 items-center gap-1">
       {CHIP_STEPS.map((step) => {
         const status = chipStatusFor(step, flowState);
+        const info = getXAAStepInfo(step);
+        const isCurrent =
+          step === flowState.currentStep &&
+          flowState.currentStep !== "complete";
+        const isFocused = activeStep === step;
+
         return (
-          <li
-            key={step}
-            data-testid={`xaa-run-chip-${step}`}
-            data-status={status}
-            title={getXAAStepInfo(step).title}
-            className={cn(
-              "h-2 w-5 rounded-full border",
-              status === "pass" &&
-                "border-green-600/40 bg-green-500/70 dark:bg-green-500/50",
-              status === "fail" &&
-                "border-red-600/40 bg-red-500/80 dark:bg-red-500/60",
-              status === "untouched" && "border-border bg-muted",
-            )}
-          />
+          <li key={step} className="min-w-0 flex-1">
+            <button
+              type="button"
+              data-testid={`xaa-run-chip-${step}`}
+              data-status={status}
+              title={info.title}
+              onClick={() => onFocusStep?.(step)}
+              disabled={!onFocusStep}
+              className={cn(
+                "flex h-6 w-full items-center justify-center rounded-md border px-1 text-[11px] transition-colors",
+                onFocusStep && "cursor-pointer hover:brightness-95",
+                status === "pass" &&
+                  "border-green-600/40 bg-green-500/15 text-green-700 dark:text-green-400",
+                status === "fail" &&
+                  "border-red-600/50 bg-red-500/15 text-red-600 dark:text-red-400",
+                status === "untouched" &&
+                  isCurrent &&
+                  "border-blue-500/50 bg-blue-500/15 text-blue-600 dark:text-blue-400",
+                status === "untouched" &&
+                  !isCurrent &&
+                  "border-border bg-muted text-muted-foreground",
+                isFocused && "ring-1 ring-blue-400"
+              )}
+            >
+              <span className="truncate">{STEP_NUMBERS[step] ?? ""}</span>
+            </button>
+          </li>
         );
       })}
     </ol>

--- a/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import {
   getXAAPhaseNumber,
@@ -47,9 +48,10 @@ export function chipStatusFor(
 }
 
 /**
- * Full-width run-progress rail. Each step is a labelled segment coloured by
- * outcome (pass / fail / pending) that the user can click to focus that step
- * in the diagram and logger — replacing the old non-interactive tick strip.
+ * Run-progress rail. Each step is a labelled segment coloured by outcome
+ * (pass / fail / pending). Steps that have run can be clicked to focus that
+ * step in the diagram and logger; hovering any segment shows its section name
+ * so the numbers aren't cryptic.
  */
 export function XAARunChips({
   flowState,
@@ -60,46 +62,75 @@ export function XAARunChips({
   activeStep?: XAAFlowStep | null;
   onFocusStep?: (step: XAAFlowStep) => void;
 }) {
-  return (
-    <ol aria-label="Run progress" className="flex flex-wrap items-center gap-1">
-      {CHIP_STEPS.map((step) => {
-        const status = chipStatusFor(step, flowState);
-        const info = getXAAStepInfo(step);
-        const isCurrent =
-          step === flowState.currentStep &&
-          flowState.currentStep !== "complete";
-        const isFocused = activeStep === step;
+  const [hoveredStep, setHoveredStep] = useState<XAAFlowStep | null>(null);
 
-        return (
-          <li key={step} className="shrink-0">
-            <button
-              type="button"
-              data-testid={`xaa-run-chip-${step}`}
-              data-status={status}
-              title={info.title}
-              onClick={() => onFocusStep?.(step)}
-              disabled={!onFocusStep}
-              className={cn(
-                "flex h-6 items-center justify-center rounded-md border px-2.5 text-[11px] transition-colors",
-                onFocusStep && "cursor-pointer hover:brightness-95",
-                status === "pass" &&
-                  "border-green-600/40 bg-green-500/15 text-green-700 dark:text-green-400",
-                status === "fail" &&
-                  "border-red-600/50 bg-red-500/15 text-red-600 dark:text-red-400",
-                status === "untouched" &&
-                  isCurrent &&
-                  "border-blue-500/50 bg-blue-500/15 text-blue-600 dark:text-blue-400",
-                status === "untouched" &&
-                  !isCurrent &&
-                  "border-border bg-muted text-muted-foreground",
-                isFocused && "ring-1 ring-blue-400"
-              )}
-            >
-              {STEP_NUMBERS[step] ?? ""}
-            </button>
-          </li>
-        );
-      })}
-    </ol>
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-3">
+      <ol
+        aria-label="Run progress"
+        className="flex flex-wrap items-center gap-1"
+      >
+        {CHIP_STEPS.map((step) => {
+          const status = chipStatusFor(step, flowState);
+          const info = getXAAStepInfo(step);
+          const isCurrent =
+            step === flowState.currentStep &&
+            flowState.currentStep !== "complete";
+          const isFocused = activeStep === step;
+          // Only steps the run has actually reached have something to navigate
+          // to, so untouched steps stay inert until the flow gets there.
+          const hasRun = status === "pass" || status === "fail" || isCurrent;
+          const interactive = Boolean(onFocusStep) && hasRun;
+
+          return (
+            <li key={step} className="shrink-0">
+              <button
+                type="button"
+                data-testid={`xaa-run-chip-${step}`}
+                data-status={status}
+                title={info.title}
+                onClick={() => interactive && onFocusStep?.(step)}
+                onMouseEnter={() => setHoveredStep(step)}
+                onMouseLeave={() =>
+                  setHoveredStep((current) =>
+                    current === step ? null : current
+                  )
+                }
+                onFocus={() => setHoveredStep(step)}
+                onBlur={() =>
+                  setHoveredStep((current) =>
+                    current === step ? null : current
+                  )
+                }
+                disabled={!onFocusStep}
+                aria-disabled={!interactive}
+                className={cn(
+                  "flex h-6 items-center justify-center rounded-md border px-2.5 text-[11px] transition-colors",
+                  interactive
+                    ? "cursor-pointer hover:brightness-95"
+                    : "cursor-default",
+                  status === "pass" &&
+                    "border-green-600/40 bg-green-500/15 text-green-700 dark:text-green-400",
+                  status === "fail" &&
+                    "border-red-600/50 bg-red-500/15 text-red-600 dark:text-red-400",
+                  status === "untouched" &&
+                    isCurrent &&
+                    "border-blue-500/50 bg-blue-500/15 text-blue-600 dark:text-blue-400",
+                  status === "untouched" &&
+                    !isCurrent &&
+                    "border-border bg-muted text-muted-foreground",
+                  isFocused && "ring-1 ring-blue-400"
+                )}
+              >
+                {STEP_NUMBERS[step] ?? ""}
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+      <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+        {hoveredStep ? getXAAStepInfo(hoveredStep).title : ""}
+      </span>
+    </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
@@ -61,7 +61,7 @@ export function XAARunChips({
   onFocusStep?: (step: XAAFlowStep) => void;
 }) {
   return (
-    <ol aria-label="Run progress" className="flex flex-1 items-center gap-1">
+    <ol aria-label="Run progress" className="flex flex-wrap items-center gap-1">
       {CHIP_STEPS.map((step) => {
         const status = chipStatusFor(step, flowState);
         const info = getXAAStepInfo(step);
@@ -71,7 +71,7 @@ export function XAARunChips({
         const isFocused = activeStep === step;
 
         return (
-          <li key={step} className="min-w-0 flex-1">
+          <li key={step} className="shrink-0">
             <button
               type="button"
               data-testid={`xaa-run-chip-${step}`}
@@ -80,7 +80,7 @@ export function XAARunChips({
               onClick={() => onFocusStep?.(step)}
               disabled={!onFocusStep}
               className={cn(
-                "flex h-6 w-full items-center justify-center rounded-md border px-1 text-[11px] transition-colors",
+                "flex h-6 items-center justify-center rounded-md border px-2.5 text-[11px] transition-colors",
                 onFocusStep && "cursor-pointer hover:brightness-95",
                 status === "pass" &&
                   "border-green-600/40 bg-green-500/15 text-green-700 dark:text-green-400",
@@ -95,7 +95,7 @@ export function XAARunChips({
                 isFocused && "ring-1 ring-blue-400"
               )}
             >
-              <span className="truncate">{STEP_NUMBERS[step] ?? ""}</span>
+              {STEP_NUMBERS[step] ?? ""}
             </button>
           </li>
         );

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/NegativeTestScorecard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/NegativeTestScorecard.test.tsx
@@ -17,7 +17,7 @@ const INPUT: NegativeTestsInput = {
 
 async function expand(user: ReturnType<typeof userEvent.setup>) {
   await user.click(
-    screen.getByRole("button", { name: /negative-test scorecard/i }),
+    screen.getByRole("button", { name: /negative-test scorecard/i })
   );
 }
 
@@ -33,15 +33,15 @@ describe("NegativeTestScorecard", () => {
         input={null}
         unlocked={false}
         unavailableReason="MCPJam test auth server has nothing to test."
-      />,
+      />
     );
     await expand(user);
 
     expect(
-      screen.getByText("MCPJam test auth server has nothing to test."),
+      screen.getByText("MCPJam test auth server has nothing to test.")
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /run negative tests/i }),
+      screen.queryByRole("button", { name: /run negative tests/i })
     ).toBeNull();
   });
 
@@ -51,10 +51,10 @@ describe("NegativeTestScorecard", () => {
     await expand(user);
 
     expect(
-      screen.getByRole("button", { name: /run negative tests/i }),
+      screen.getByRole("button", { name: /run negative tests/i })
     ).toBeDisabled();
     expect(
-      screen.getByText(/run a successful flow first/i),
+      screen.getByText(/run a successful flow first/i)
     ).toBeInTheDocument();
   });
 
@@ -78,6 +78,11 @@ describe("NegativeTestScorecard", () => {
           outcome: "rejected",
           verdict: "pass",
           status: 400,
+          diff: {
+            field: "aud",
+            sent: "https://wrong-audience.example.com",
+            expected: "https://auth.example.com",
+          },
         },
       ],
     });
@@ -87,37 +92,42 @@ describe("NegativeTestScorecard", () => {
     await expand(user);
 
     await user.click(
-      screen.getByRole("button", { name: /run negative tests/i }),
+      screen.getByRole("button", { name: /run negative tests/i })
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId("xaa-negtest-row-expired")).toBeInTheDocument(),
+      expect(screen.getByTestId("xaa-negtest-row-expired")).toBeInTheDocument()
     );
     expect(screen.getByTestId("xaa-negtest-row-expired")).toHaveAttribute(
       "data-verdict",
-      "fail",
+      "fail"
     );
     expect(
-      screen.getByTestId("xaa-negtest-row-wrong_audience"),
+      screen.getByTestId("xaa-negtest-row-wrong_audience")
     ).toHaveAttribute("data-verdict", "pass");
+    // Outcome-based copy: a pass reads as a result, not an instruction.
+    expect(screen.getByText(/rejected as expected/i)).toBeInTheDocument();
+    expect(screen.getByText(/accepted — security risk/i)).toBeInTheDocument();
+    // Expected-vs-actual diff for the tampered claim.
+    expect(
+      screen.getByText(/https:\/\/wrong-audience\.example\.com/)
+    ).toBeInTheDocument();
     expect(runMock).toHaveBeenCalledWith(INPUT);
   });
 
-  it("unlocks via the typed override for the half-built-AS case", async () => {
+  it("unlocks via the owner checkbox for the half-built-AS case", async () => {
     runMock.mockResolvedValue({ failures: 0, results: [] });
 
     const user = userEvent.setup();
     render(<NegativeTestScorecard input={INPUT} unlocked={false} />);
     await expand(user);
 
-    // The run button stays disabled until the exact phrase is typed.
-    expect(screen.getByRole("button", { name: /^unlock$/i })).toBeDisabled();
+    // The run button stays disabled until the owner toggle is checked.
+    expect(
+      screen.getByRole("button", { name: /run negative tests/i })
+    ).toBeDisabled();
 
-    await user.type(
-      screen.getByLabelText("Override confirmation"),
-      "run anyway",
-    );
-    await user.click(screen.getByRole("button", { name: /^unlock$/i }));
+    await user.click(screen.getByRole("checkbox"));
 
     const runButton = screen.getByRole("button", {
       name: /run negative tests/i,
@@ -179,13 +189,13 @@ describe("NegativeTestScorecard", () => {
     render(<NegativeTestScorecard input={INPUT} unlocked />);
     await expand(user);
     await user.click(
-      screen.getByRole("button", { name: /run negative tests/i }),
+      screen.getByRole("button", { name: /run negative tests/i })
     );
 
     await waitFor(() =>
       expect(screen.getByTestId("xaa-negtest-error")).toHaveTextContent(
-        "URL not allowed",
-      ),
+        "URL not allowed"
+      )
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -32,7 +32,7 @@ describe("XAAIdpCard", () => {
     expect(screen.getByText("Use MCPJam as your test IdP")).toBeInTheDocument();
     expect(screen.getByRole("button")).toHaveAttribute(
       "aria-expanded",
-      "false",
+      "false"
     );
     expect(screen.queryByText("Issuer URL")).not.toBeInTheDocument();
   });
@@ -42,17 +42,30 @@ describe("XAAIdpCard", () => {
     render(<XAAIdpCard />);
 
     await user.click(
-      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
     );
 
     expect(screen.getByText(issuer)).toBeInTheDocument();
     expect(
-      screen.getByText(`${issuer}/.well-known/jwks.json`),
+      screen.getByText(`${issuer}/.well-known/jwks.json`)
     ).toBeInTheDocument();
     // The OpenID configuration URL row was removed (derivable from the issuer).
     expect(
-      screen.queryByText(`${issuer}/.well-known/openid-configuration`),
+      screen.queryByText(`${issuer}/.well-known/openid-configuration`)
     ).not.toBeInTheDocument();
+  });
+
+  it("names the Configure Target Client ID in the registration steps", async () => {
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
+    );
+
+    expect(
+      screen.getByText(/the Client ID you set in Configure Target/i)
+    ).toBeInTheDocument();
   });
 
   it("copies a URL and shows inline confirmation", async () => {
@@ -60,7 +73,7 @@ describe("XAAIdpCard", () => {
     render(<XAAIdpCard />);
 
     await user.click(
-      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
     );
     await user.click(screen.getByRole("button", { name: /copy issuer url/i }));
 
@@ -78,9 +91,9 @@ describe("XAAIdpCard", () => {
             issuer: serverIssuer,
             jwks_uri: `${serverIssuer}/.well-known/jwks.json`,
           }),
-          { status: 200 },
-        ),
-      ),
+          { status: 200 }
+        )
+      )
     );
 
   it("prefers the issuer advertised by the server over the browser origin", async () => {
@@ -92,16 +105,43 @@ describe("XAAIdpCard", () => {
     const user = userEvent.setup();
     render(<XAAIdpCard />);
     await user.click(
-      screen.getByRole("button", { name: /use mcpjam as your test idp/i }),
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
     );
 
     expect(await screen.findByText(serverIssuer)).toBeInTheDocument();
     expect(
-      screen.getByText(`${serverIssuer}/.well-known/jwks.json`),
+      screen.getByText(`${serverIssuer}/.well-known/jwks.json`)
     ).toBeInTheDocument();
     // OpenID config URL is no longer shown as its own row.
     expect(
-      screen.queryByText(`${serverIssuer}/.well-known/openid-configuration`),
+      screen.queryByText(`${serverIssuer}/.well-known/openid-configuration`)
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("XAAIdpCard (non-hosted mode)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("warns that local URLs need a public tunnel when expanded", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/config", () => ({ HOSTED_MODE: false }));
+    vi.doMock("@/lib/clipboard", () => ({
+      copyToClipboard: async () => true,
+    }));
+    const { XAAIdpCard: LocalIdpCard } = await import("../XAAIdpCard");
+
+    const user = userEvent.setup();
+    render(<LocalIdpCard />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
+    );
+
+    expect(
+      screen.getByText(/Expose the\s+inspector with a public tunnel/i)
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAARunChips.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAARunChips.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import { XAARunChips } from "../XAARunChips";
 
 describe("XAARunChips", () => {
@@ -40,6 +41,29 @@ describe("XAARunChips", () => {
     const chips = screen.getAllByTestId(/xaa-run-chip-/);
     for (const chip of chips) {
       expect(chip).toHaveAttribute("data-status", "pass");
+    }
+  });
+
+  it("focuses a step when its segment is clicked after a full run", async () => {
+    const onFocusStep = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <XAARunChips
+        flowState={{ currentStep: "complete" }}
+        onFocusStep={onFocusStep}
+      />,
+    );
+
+    await user.click(screen.getByTestId("xaa-run-chip-token_exchange_request"));
+
+    expect(onFocusStep).toHaveBeenCalledWith("token_exchange_request");
+  });
+
+  it("renders inert segments when no focus handler is provided", () => {
+    render(<XAARunChips flowState={{ currentStep: "complete" }} />);
+
+    for (const chip of screen.getAllByTestId(/xaa-run-chip-/)) {
+      expect(chip).toBeDisabled();
     }
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAARunChips.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAARunChips.test.tsx
@@ -18,20 +18,20 @@ describe("XAARunChips", () => {
     render(
       <XAARunChips
         flowState={{ currentStep: "jwt_bearer_request", error: "boom" }}
-      />,
+      />
     );
 
     // Steps before the failure are green.
     expect(
-      screen.getByTestId("xaa-run-chip-token_exchange_request"),
+      screen.getByTestId("xaa-run-chip-token_exchange_request")
     ).toHaveAttribute("data-status", "pass");
     // The failing step is red.
     expect(
-      screen.getByTestId("xaa-run-chip-jwt_bearer_request"),
+      screen.getByTestId("xaa-run-chip-jwt_bearer_request")
     ).toHaveAttribute("data-status", "fail");
     // Steps after it stay untouched.
     expect(
-      screen.getByTestId("xaa-run-chip-authenticated_mcp_request"),
+      screen.getByTestId("xaa-run-chip-authenticated_mcp_request")
     ).toHaveAttribute("data-status", "untouched");
   });
 
@@ -51,7 +51,7 @@ describe("XAARunChips", () => {
       <XAARunChips
         flowState={{ currentStep: "complete" }}
         onFocusStep={onFocusStep}
-      />,
+      />
     );
 
     await user.click(screen.getByTestId("xaa-run-chip-token_exchange_request"));
@@ -65,5 +65,36 @@ describe("XAARunChips", () => {
     for (const chip of screen.getAllByTestId(/xaa-run-chip-/)) {
       expect(chip).toBeDisabled();
     }
+  });
+
+  it("does not focus a step that has not run yet", async () => {
+    const onFocusStep = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <XAARunChips
+        flowState={{ currentStep: "idle" }}
+        onFocusStep={onFocusStep}
+      />
+    );
+
+    const chip = screen.getByTestId("xaa-run-chip-token_exchange_request");
+    expect(chip).toHaveAttribute("aria-disabled", "true");
+    await user.click(chip);
+
+    expect(onFocusStep).not.toHaveBeenCalled();
+  });
+
+  it("shows the section name when a segment is hovered", async () => {
+    const user = userEvent.setup();
+    render(
+      <XAARunChips
+        flowState={{ currentStep: "complete" }}
+        onFocusStep={vi.fn()}
+      />
+    );
+
+    await user.hover(screen.getByTestId("xaa-run-chip-token_exchange_request"));
+
+    expect(screen.getByText("RFC 8693 Token Exchange")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/step-metadata.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/step-metadata.test.ts
@@ -50,4 +50,13 @@ describe("XAA phase metadata", () => {
       }
     }
   });
+
+  it("expands the ID-JAG acronym on the received_id_jag step", () => {
+    const moments = XAA_STEP_METADATA.received_id_jag.teachableMoments ?? [];
+    expect(
+      moments.some((m) =>
+        m.includes("Identity Assertion JWT Authorization Grant")
+      )
+    ).toBe(true);
+  });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/discovery-client.ts
@@ -1,5 +1,6 @@
 import { HOSTED_MODE } from "@/lib/config";
 import { authFetch } from "@/lib/session-token";
+import type { NegativeTestDiff } from "@/shared/xaa.js";
 
 const XAA_API_BASE = HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
 
@@ -59,7 +60,7 @@ export interface HealthCheckResult {
  * `ok: false` instead.
  */
 export async function checkResourceHealth(
-  url: string,
+  url: string
 ): Promise<HealthCheckResult> {
   const response = await authFetch(`${XAA_API_BASE}/health-check`, {
     method: "POST",
@@ -73,7 +74,7 @@ export async function checkResourceHealth(
 
   if (!response.ok || !body) {
     throw new Error(
-      body?.message || `Health check failed (${response.status})`,
+      body?.message || `Health check failed (${response.status})`
     );
   }
 
@@ -88,6 +89,7 @@ export interface NegativeTestCase {
   verdict: "pass" | "fail" | "unknown";
   status?: number;
   detail?: string;
+  diff?: NegativeTestDiff;
 }
 
 export interface NegativeTestsResult {
@@ -113,7 +115,7 @@ export interface NegativeTestsInput {
  * the stored secret and endpoint.
  */
 export async function runNegativeTests(
-  input: NegativeTestsInput,
+  input: NegativeTestsInput
 ): Promise<NegativeTestsResult> {
   const response = await authFetch(`${XAA_API_BASE}/negative-tests`, {
     method: "POST",
@@ -127,7 +129,7 @@ export async function runNegativeTests(
 
   if (!response.ok || !body) {
     throw new Error(
-      body?.message || `Negative tests failed (${response.status})`,
+      body?.message || `Negative tests failed (${response.status})`
     );
   }
 

--- a/mcpjam-inspector/client/src/lib/xaa/step-metadata.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/step-metadata.ts
@@ -153,6 +153,7 @@ export const XAA_STEP_METADATA: Record<XAAFlowStep, XAAStepInfo> = {
     phase: "sso",
     teachableMoments: [
       "The ID token is an input to token exchange; it is not sent directly to the target authorization server.",
+      'Naming note: here "identity assertion" means the OIDC ID token. Some IdPs (e.g. Okta) call the ID-JAG itself the "identity assertion" — in this debugger the ID-JAG is the grant minted in Phase 2.',
     ],
   },
   token_exchange_request: {
@@ -163,6 +164,7 @@ export const XAA_STEP_METADATA: Record<XAAFlowStep, XAAStepInfo> = {
     teachableMoments: [
       "Spec step 2: the `audience` parameter names the resource authorization server's issuer — the value discovered (or pre-configured) in Phase 0.",
       "This is where broken assertions get created for audience, issuer, header, and claim validation tests.",
+      "On the wire this exchange uses `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`.",
     ],
   },
   received_id_jag: {
@@ -171,6 +173,7 @@ export const XAA_STEP_METADATA: Record<XAAFlowStep, XAAStepInfo> = {
     phase: "token_exchange",
     teachableMoments: [
       "A valid ID-JAG includes `iss`, `sub`, `aud`, `resource`, `client_id`, `jti`, `iat`, and `exp`.",
+      "ID-JAG stands for Identity Assertion JWT Authorization Grant — the token type defined by the XAA spec.",
     ],
   },
   inspect_id_jag: {
@@ -191,6 +194,7 @@ export const XAA_STEP_METADATA: Record<XAAFlowStep, XAAStepInfo> = {
     teachableMoments: [
       "Spec step 3: the resource authorization server validates the ID-JAG's `iss`, `aud`, and `resource` before minting an access token.",
       "If this fails, check whether the server trusts the synthetic issuer JWKS and supports the JWT bearer grant.",
+      "On the wire this is `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` — match this against your authorization server's request logs.",
     ],
   },
   received_access_token: {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -18,7 +18,7 @@ import xaa, { createXaaRouter } from "../xaa.js";
 
 function jsonResponse(
   body: unknown,
-  init?: { status?: number; contentType?: string },
+  init?: { status?: number; contentType?: string }
 ): Response {
   return new Response(JSON.stringify(body), {
     status: init?.status ?? 200,
@@ -74,14 +74,14 @@ describe("mcp xaa routes", () => {
 
   it("serves the discovery document publicly without a session token", async () => {
     const response = await app.request(
-      "http://localhost/api/mcp/xaa/.well-known/openid-configuration",
+      "http://localhost/api/mcp/xaa/.well-known/openid-configuration"
     );
 
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.issuer).toBe("http://localhost/api/mcp/xaa");
     expect(body.jwks_uri).toBe(
-      "http://localhost/api/mcp/xaa/.well-known/jwks.json",
+      "http://localhost/api/mcp/xaa/.well-known/jwks.json"
     );
   });
 
@@ -95,14 +95,14 @@ describe("mcp xaa routes", () => {
           "x-forwarded-proto": "https",
           "x-forwarded-host": "evil.example.com",
         },
-      },
+      }
     );
 
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.issuer).toBe("http://localhost/api/mcp/xaa");
     expect(body.jwks_uri).toBe(
-      "http://localhost/api/mcp/xaa/.well-known/jwks.json",
+      "http://localhost/api/mcp/xaa/.well-known/jwks.json"
     );
   });
 
@@ -122,30 +122,36 @@ describe("mcp xaa routes", () => {
       "X-MCP-Session-Auth": `Bearer ${getSessionToken() || token}`,
     };
 
-    const authenticateResponse = await app.request("/api/mcp/xaa/authenticate", {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        userId: "user-12345",
-        email: "demo.user@example.com",
-      }),
-    });
+    const authenticateResponse = await app.request(
+      "/api/mcp/xaa/authenticate",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          userId: "user-12345",
+          email: "demo.user@example.com",
+        }),
+      }
+    );
 
     expect(authenticateResponse.status).toBe(200);
     const authenticateBody = await authenticateResponse.json();
     expect(authenticateBody.id_token).toEqual(expect.any(String));
 
-    const tokenExchangeResponse = await app.request("/api/mcp/xaa/token-exchange", {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        identityAssertion: authenticateBody.id_token,
-        audience: "https://auth.example.com",
-        resource: "https://mcp.example.com",
-        clientId: "mcpjam-debugger",
-        negativeTestMode: "wrong_audience",
-      }),
-    });
+    const tokenExchangeResponse = await app.request(
+      "/api/mcp/xaa/token-exchange",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          identityAssertion: authenticateBody.id_token,
+          audience: "https://auth.example.com",
+          resource: "https://mcp.example.com",
+          clientId: "mcpjam-debugger",
+          negativeTestMode: "wrong_audience",
+        }),
+      }
+    );
 
     expect(tokenExchangeResponse.status).toBe(200);
     const tokenExchangeBody = await tokenExchangeResponse.json();
@@ -240,7 +246,7 @@ describe("mcp xaa routes", () => {
           grant_types_supported: [
             "urn:ietf:params:oauth:grant-type:jwt-bearer",
           ],
-        }),
+        })
       );
       vi.stubGlobal("fetch", fetchMock);
 
@@ -262,7 +268,7 @@ describe("mcp xaa routes", () => {
     it("returns 404 when no well-known endpoint has metadata", async () => {
       vi.stubGlobal(
         "fetch",
-        vi.fn(async () => new Response(null, { status: 404 })),
+        vi.fn(async () => new Response(null, { status: 404 }))
       );
 
       const response = await app.request("/api/mcp/xaa/discover-as", {
@@ -296,7 +302,7 @@ describe("hosted xaa outbound guards", () => {
         issuerBasePath: "/api/web",
         httpsOnlyProxy: true,
         trustForwardedHeaders: true,
-      }),
+      })
     );
   });
 
@@ -352,7 +358,7 @@ describe("hosted xaa outbound guards", () => {
         new Response(null, {
           status: 302,
           headers: { location: "http://169.254.169.254/" },
-        }),
+        })
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -412,7 +418,7 @@ describe("registration-backed /proxy/token", () => {
         issuerBasePath: "/api/web",
         httpsOnlyProxy: false,
         resolveRegistrationSecret: options.resolver,
-      }),
+      })
     );
     return app;
   }
@@ -467,8 +473,8 @@ describe("registration-backed /proxy/token", () => {
       async () =>
         new Response(
           JSON.stringify({ access_token: "tok", token_type: "Bearer" }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        ),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -501,7 +507,7 @@ describe("registration-backed /proxy/token", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [calledUrl, calledInit] = fetchMock.mock.calls[0] as unknown as [
       string,
-      RequestInit,
+      RequestInit
     ];
     expect(calledUrl).toBe("https://stored-as.example.com/oauth/token");
 
@@ -573,7 +579,7 @@ describe("POST /negative-tests", () => {
       tokenEndpoint: string | null;
       targetClientId: string | null;
       scopes: string[] | null;
-    }>,
+    }>
   ) {
     const app = new Hono();
     app.route(
@@ -582,7 +588,7 @@ describe("POST /negative-tests", () => {
         issuerBasePath: "/api/web",
         httpsOnlyProxy: false,
         resolveRegistrationSecret: resolver,
-      }),
+      })
     );
     return app;
   }
@@ -599,8 +605,8 @@ describe("POST /negative-tests", () => {
       async () =>
         new Response(
           JSON.stringify({ access_token: "tok", token_type: "Bearer" }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        ),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
     );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -613,13 +619,25 @@ describe("POST /negative-tests", () => {
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
-      results: Array<{ mode: string; verdict: string }>;
+      results: Array<{
+        mode: string;
+        verdict: string;
+        diff?: { field: string; sent: string; expected: string };
+      }>;
       failures: number;
     };
     expect(body.results).toHaveLength(11);
     expect(body.failures).toBe(11);
     const expired = body.results.find((r) => r.mode === "expired");
     expect(expired?.verdict).toBe("fail");
+
+    // Each broken case carries a "sent vs expected" diff for the tampered field.
+    const wrongAud = body.results.find((r) => r.mode === "wrong_audience");
+    expect(wrongAud?.diff).toEqual({
+      field: "aud",
+      sent: "https://wrong-audience.example.com",
+      expected: "https://auth.example.com",
+    });
   });
 
   it("marks cases green when the auth server rejects broken assertions", async () => {
@@ -628,7 +646,7 @@ describe("POST /negative-tests", () => {
         new Response(JSON.stringify({ error: "invalid_grant" }), {
           status: 400,
           headers: { "content-type": "application/json" },
-        }),
+        })
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -6,6 +6,8 @@ import {
   isNegativeTestMode,
   NEGATIVE_TEST_MODES,
   NEGATIVE_TEST_MODE_DETAILS,
+  XAA_IDP_KID,
+  type NegativeTestDiff,
   type NegativeTestMode,
 } from "../../../shared/xaa.js";
 import {
@@ -114,12 +116,105 @@ type NegativeCaseOutcome = {
   verdict: "pass" | "fail" | "unknown";
   status?: number;
   detail?: string;
+  // What the broken assertion changed vs. a valid one, for the scorecard diff.
+  diff?: NegativeTestDiff;
 };
 
 // The 11 deliberately-broken modes (everything except the happy-path "valid").
 const NEGATIVE_CASE_MODES: NegativeTestMode[] = NEGATIVE_TEST_MODES.filter(
-  (mode): mode is NegativeTestMode => mode !== "valid",
+  (mode): mode is NegativeTestMode => mode !== "valid"
 );
+
+// Build the "sent X / expected Y" diff from the assertion the signer actually
+// emitted (header + payload), so the displayed values can't drift from the
+// real mutation. `expected` is the value a valid ID-JAG would carry.
+function buildNegativeDiff(
+  mode: NegativeTestMode,
+  header: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  expected: {
+    audience: string;
+    resource: string;
+    clientId: string;
+    subject: string;
+    scope?: string;
+    issuer: string;
+  }
+): NegativeTestDiff | undefined {
+  const show = (value: unknown): string =>
+    value === undefined || value === null ? "(omitted)" : String(value);
+
+  switch (mode) {
+    case "bad_signature":
+      return {
+        field: "signature",
+        sent: "signed with a throwaway key",
+        expected: "signed with the published JWKS key",
+      };
+    case "wrong_audience":
+      return {
+        field: "aud",
+        sent: show(payload.aud),
+        expected: expected.audience,
+      };
+    case "expired":
+      return {
+        field: "exp",
+        sent: `${new Date(Number(payload.exp) * 1000).toISOString()} (past)`,
+        expected: "a time in the future",
+      };
+    case "missing_claims":
+      return {
+        field: "sub, resource",
+        sent: "(omitted)",
+        expected: "both present",
+      };
+    case "invalid_type_header":
+      return {
+        field: "typ",
+        sent: show(header.typ),
+        expected: "oauth-id-jag+jwt",
+      };
+    case "wrong_issuer":
+      return {
+        field: "iss",
+        sent: show(payload.iss),
+        expected: expected.issuer,
+      };
+    case "resource_mismatch":
+      return {
+        field: "resource",
+        sent: show(payload.resource),
+        expected: expected.resource,
+      };
+    case "client_id_mismatch":
+      return {
+        field: "client_id",
+        sent: show(payload.client_id),
+        expected: expected.clientId,
+      };
+    case "unknown_kid":
+      return {
+        field: "kid",
+        sent: show(header.kid),
+        expected: XAA_IDP_KID,
+      };
+    case "unknown_sub":
+      return {
+        field: "sub",
+        sent: show(payload.sub),
+        expected: expected.subject,
+      };
+    case "scope_denial":
+      return {
+        field: "scope",
+        sent: show(payload.scope),
+        expected: expected.scope || "only the user's granted scopes",
+      };
+    default:
+      return undefined;
+  }
+}
 
 const proxyTokenSchema = z
   .object({
@@ -168,7 +263,7 @@ function toJsonError(
     status?: number;
     code?: string;
     details?: Record<string, unknown>;
-  },
+  }
 ) {
   const status = options?.status ?? 500;
   const code = options?.code ?? "INTERNAL_ERROR";
@@ -180,14 +275,16 @@ function toJsonError(
       error: message,
       ...(options?.details ? { details: options.details } : {}),
     },
-    { status },
+    { status }
   );
 }
 
 function parseRequest<T>(schema: z.ZodSchema<T>, data: unknown): T {
   const parsed = schema.safeParse(data);
   if (!parsed.success) {
-    throw new Error(parsed.error.issues[0]?.message || "Request validation failed");
+    throw new Error(
+      parsed.error.issues[0]?.message || "Request validation failed"
+    );
   }
   return parsed.data;
 }
@@ -195,7 +292,7 @@ function parseRequest<T>(schema: z.ZodSchema<T>, data: unknown): T {
 function getIssuerForRequest(
   c: Context,
   issuerBasePath: string,
-  trustForwardedHeaders: boolean,
+  trustForwardedHeaders: boolean
 ): string {
   const parsed = new URL(c.req.url);
 
@@ -223,12 +320,14 @@ function decodeJwtPayloadUnsafe(token: string): ParsedJwtPayload {
 
   try {
     const payload = JSON.parse(
-      Buffer.from(parts[1], "base64url").toString("utf-8"),
+      Buffer.from(parts[1], "base64url").toString("utf-8")
     ) as ParsedJwtPayload;
     return payload;
   } catch (error) {
     throw new Error(
-      `Identity assertion payload is not valid JSON (${error instanceof Error ? error.message : String(error)})`,
+      `Identity assertion payload is not valid JSON (${
+        error instanceof Error ? error.message : String(error)
+      })`
     );
   }
 }
@@ -268,7 +367,11 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
 
   router.get("/.well-known/openid-configuration", (c) => {
     initXAAIdpKeyPair();
-    const issuer = getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
+    const issuer = getIssuerForRequest(
+      c,
+      options.issuerBasePath,
+      trustForwardedHeaders
+    );
 
     return c.json(
       {
@@ -281,24 +384,28 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         grant_types_supported: [
           "urn:ietf:params:oauth:grant-type:token-exchange",
         ],
-        token_endpoint_auth_methods_supported: [
-          "none",
-          "client_secret_post",
-        ],
+        token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
         id_token_signing_alg_values_supported: ["RS256"],
       },
       200,
       {
         "Cache-Control": "public, max-age=300",
-      },
+      }
     );
   });
 
   router.post("/authenticate", async (c) => {
     try {
       const body = await c.req.json();
-      const { userId, email, audience } = parseRequest(authenticateSchema, body);
-      const issuer = getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
+      const { userId, email, audience } = parseRequest(
+        authenticateSchema,
+        body
+      );
+      const issuer = getIssuerForRequest(
+        c,
+        options.issuerBasePath,
+        trustForwardedHeaders
+      );
       const subject = userId || "user-12345";
       const resolvedEmail = email || "demo.user@example.com";
       const issued = issueMockIdToken({
@@ -313,7 +420,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         token_type: "Bearer",
         expires_in: Math.max(
           0,
-          Math.floor((issued.expiresAt - Date.now()) / 1000),
+          Math.floor((issued.expiresAt - Date.now()) / 1000)
         ),
         user: {
           sub: subject,
@@ -323,7 +430,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     } catch (error) {
       return toJsonError(
         error instanceof Error ? error.message : "Invalid authenticate request",
-        { status: 400, code: "VALIDATION_ERROR" },
+        { status: 400, code: "VALIDATION_ERROR" }
       );
     }
   });
@@ -333,7 +440,11 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       const body = await c.req.json();
       const parsed = parseRequest(tokenExchangeSchema, body);
       const negativeTestMode = resolveNegativeTestMode(parsed.negativeTestMode);
-      const issuer = getIssuerForRequest(c, options.issuerBasePath, trustForwardedHeaders);
+      const issuer = getIssuerForRequest(
+        c,
+        options.issuerBasePath,
+        trustForwardedHeaders
+      );
       const identityPayload = decodeJwtPayloadUnsafe(parsed.identityAssertion);
       const subject = identityPayload.sub || "user-12345";
       // Carry the ID token's email into the ID-JAG (spec RECOMMENDED) so the
@@ -364,7 +475,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
                 clientId: parsed.clientId,
                 scope: parsed.scope,
               },
-              negativeTestMode,
+              negativeTestMode
             );
 
       return c.json({
@@ -373,14 +484,16 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         issued_token_type: "urn:ietf:params:oauth:token-type:jwt",
         expires_in: Math.max(
           0,
-          Math.floor((issued.expiresAt - Date.now()) / 1000),
+          Math.floor((issued.expiresAt - Date.now()) / 1000)
         ),
         negative_test_mode: negativeTestMode,
       });
     } catch (error) {
       return toJsonError(
-        error instanceof Error ? error.message : "Invalid token exchange request",
-        { status: 400, code: "VALIDATION_ERROR" },
+        error instanceof Error
+          ? error.message
+          : "Invalid token exchange request",
+        { status: 400, code: "VALIDATION_ERROR" }
       );
     }
   });
@@ -399,7 +512,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         if (!options.resolveRegistrationSecret) {
           return toJsonError(
             "Registration-backed runs are not available on this instance",
-            { status: 400, code: "VALIDATION_ERROR" },
+            { status: 400, code: "VALIDATION_ERROR" }
           );
         }
 
@@ -472,7 +585,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       logger.error("[XAA Token Proxy] Error", error);
       return toJsonError(
         error instanceof Error ? error.message : "Unknown proxy error",
-        { status: 500, code: "INTERNAL_ERROR" },
+        { status: 500, code: "INTERNAL_ERROR" }
       );
     }
   });
@@ -484,7 +597,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     } catch (error) {
       return toJsonError(
         error instanceof Error ? error.message : "Invalid discovery request",
-        { status: 400, code: "VALIDATION_ERROR" },
+        { status: 400, code: "VALIDATION_ERROR" }
       );
     }
 
@@ -505,14 +618,14 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       for (const candidate of candidates) {
         const result = await fetchOAuthMetadata(
           candidate,
-          options.httpsOnlyProxy,
+          options.httpsOnlyProxy
         );
         if ("metadata" in result) {
           return c.json(
             evaluateDiscovery(result.metadata, {
               requestedIssuer,
               metadataUrl: candidate,
-            }),
+            })
           );
         }
         triedStatuses.push({ url: candidate, status: result.status });
@@ -524,7 +637,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
           status: 404,
           code: "DISCOVERY_NOT_FOUND",
           details: { tried: triedStatuses },
-        },
+        }
       );
     } catch (error) {
       // validateUrl inside fetchOAuthMetadata rejects disallowed outbound URLs
@@ -539,7 +652,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       logger.error("[XAA Discover AS] Error", error);
       return toJsonError(
         error instanceof Error ? error.message : "Discovery failed",
-        { status: 502, code: "SERVER_UNREACHABLE" },
+        { status: 502, code: "SERVER_UNREACHABLE" }
       );
     }
   });
@@ -551,7 +664,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     } catch (error) {
       return toJsonError(
         error instanceof Error ? error.message : "Invalid health check request",
-        { status: 400, code: "VALIDATION_ERROR" },
+        { status: 400, code: "VALIDATION_ERROR" }
       );
     }
 
@@ -559,7 +672,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     try {
       ({ url: validatedUrl } = await validateUrl(
         parsed.url,
-        options.httpsOnlyProxy,
+        options.httpsOnlyProxy
       ));
     } catch (error) {
       if (error instanceof OAuthProxyError) {
@@ -621,7 +734,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         error instanceof Error
           ? error.message
           : "Invalid negative-tests request",
-        { status: 400, code: "VALIDATION_ERROR" },
+        { status: 400, code: "VALIDATION_ERROR" }
       );
     }
 
@@ -638,7 +751,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         if (!options.resolveRegistrationSecret) {
           return toJsonError(
             "Registration-backed runs are not available on this instance",
-            { status: 400, code: "VALIDATION_ERROR" },
+            { status: 400, code: "VALIDATION_ERROR" }
           );
         }
         const authHeader = c.req.header("authorization");
@@ -657,7 +770,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
           // to fire broken assertions at.
           return toJsonError(
             "Negative tests require a registration with its own auth server",
-            { status: 400, code: "VALIDATION_ERROR" },
+            { status: 400, code: "VALIDATION_ERROR" }
           );
         }
         tokenEndpoint = resolved.tokenEndpoint;
@@ -683,7 +796,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     try {
       ({ url: validated } = await validateUrl(
         tokenEndpoint,
-        options.httpsOnlyProxy,
+        options.httpsOnlyProxy
       ));
     } catch (error) {
       if (error instanceof OAuthProxyError) {
@@ -701,34 +814,45 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     if (!checkNegativeTestHostCap(validated.host)) {
       return toJsonError(
         "Daily negative-test limit reached for this authorization server",
-        { status: 429, code: "RATE_LIMITED" },
+        { status: 429, code: "RATE_LIMITED" }
       );
     }
 
     const issuer = getIssuerForRequest(
       c,
       options.issuerBasePath,
-      trustForwardedHeaders,
+      trustForwardedHeaders
     );
     const subject = parsed.subject || "user-12345";
 
     const runCase = async (
-      mode: NegativeTestMode,
+      mode: NegativeTestMode
     ): Promise<NegativeCaseOutcome> => {
       const details = NEGATIVE_TEST_MODE_DETAILS[mode];
+      const resolvedClientId = clientId || "mcpjam-debugger";
       let token: string;
+      let diff: NegativeTestDiff | undefined;
       try {
-        token = issueNegativeIdJag(
+        const issued = issueNegativeIdJag(
           {
             issuer,
             subject,
             audience: parsed.audience,
             resource: parsed.resource,
-            clientId: clientId || "mcpjam-debugger",
+            clientId: resolvedClientId,
             scope: parsed.scope,
           },
-          mode,
-        ).token;
+          mode
+        );
+        token = issued.token;
+        diff = buildNegativeDiff(mode, issued.header, issued.payload, {
+          audience: parsed.audience,
+          resource: parsed.resource,
+          clientId: resolvedClientId,
+          subject,
+          scope: parsed.scope,
+          issuer,
+        });
       } catch (error) {
         return {
           mode,
@@ -787,6 +911,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
               `${details.expectedFailure} Because a token was issued instead, a malformed or unauthorized ` +
               `assertion would be accepted in production.`
             : undefined,
+          diff,
         };
       } catch (error) {
         const isTimeout =
@@ -799,11 +924,12 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
           outcome: isTimeout ? "timeout" : "error",
           // Couldn't reach a verdict — surfaced separately from a real finding.
           verdict: "unknown",
+          diff,
           detail: isTimeout
             ? `No response within ${NEGATIVE_TEST_CASE_TIMEOUT_MS}ms`
             : error instanceof Error
-              ? error.message
-              : "Request failed",
+            ? error.message
+            : "Request failed",
         };
       }
     };

--- a/mcpjam-inspector/shared/xaa.ts
+++ b/mcpjam-inspector/shared/xaa.ts
@@ -28,65 +28,93 @@ export const NEGATIVE_TEST_MODE_DETAILS: Record<
 > = {
   valid: {
     label: "Valid",
-    description: "Issue a well-formed ID-JAG for the happy path.",
+    description:
+      "Issues a correct ID-JAG. Your server should accept this one and mint an access token.",
     expectedFailure: "No failure expected.",
   },
   bad_signature: {
     label: "Bad Signature",
-    description: "Signs the JWT with a throwaway key instead of the published JWKS key.",
+    description:
+      "Signs the token with the wrong key. A correct server checks the signature against your published JWKS and rejects it.",
     expectedFailure: "Authorization server should reject the signature.",
   },
   wrong_audience: {
     label: "Wrong Audience",
-    description: "Sets `aud` to a different authorization server issuer.",
+    description:
+      "Addresses the token to a different server (the `aud` claim). A correct server only accepts tokens addressed to its own issuer.",
     expectedFailure: "Authorization server should reject the audience.",
   },
   expired: {
     label: "Expired",
-    description: "Backdates `exp` so the assertion is already expired.",
-    expectedFailure: "Authorization server should reject the expired assertion.",
+    description:
+      "Backdates the token so it is already expired. A correct server rejects tokens past their `exp` time.",
+    expectedFailure:
+      "Authorization server should reject the expired assertion.",
   },
   missing_claims: {
     label: "Missing Claims",
-    description: "Omits `sub` and `resource` from the ID-JAG payload.",
-    expectedFailure: "Authorization server should reject missing required claims.",
+    description:
+      "Drops required claims (`sub` and `resource`). A correct server rejects a token that is missing required fields.",
+    expectedFailure:
+      "Authorization server should reject missing required claims.",
   },
   invalid_type_header: {
     label: "Invalid `typ` Header",
-    description: "Uses `JWT` instead of `oauth-id-jag+jwt` in the JOSE header.",
+    description:
+      "Labels the token as a plain `JWT` instead of `oauth-id-jag+jwt`. A correct server checks the header type and rejects the wrong one.",
     expectedFailure: "Authorization server should reject the JWT type.",
   },
   wrong_issuer: {
     label: "Wrong Issuer",
-    description: "Sets `iss` to an untrusted issuer value.",
+    description:
+      "Claims the token came from an issuer you don't trust. A correct server only accepts issuers it is configured to trust.",
     expectedFailure: "Authorization server should reject the issuer.",
   },
   resource_mismatch: {
     label: "Resource Mismatch",
-    description: "Sets `resource` to a different MCP server resource identifier.",
+    description:
+      "Points the token at a different resource. A correct server checks the `resource` matches the MCP server it protects.",
     expectedFailure: "Authorization server should reject the resource claim.",
   },
   client_id_mismatch: {
     label: "Client ID Mismatch",
-    description: "Sets `client_id` to a different OAuth client.",
+    description:
+      "Names a different OAuth client than the one making the request. A correct server rejects the `client_id` mismatch.",
     expectedFailure: "Authorization server should reject the client identity.",
   },
   unknown_kid: {
     label: "Unknown `kid`",
-    description: "Uses a JOSE `kid` value that does not exist in JWKS.",
+    description:
+      "References a signing key (`kid`) that isn't in your published JWKS. A correct server can't find the key and rejects the token.",
     expectedFailure: "Authorization server should fail JWKS key lookup.",
   },
   unknown_sub: {
     label: "Unknown Subject",
-    description: "Sets `sub` to an unmapped user identifier.",
+    description:
+      "Names a user (`sub`) the server has never seen. A correct server rejects an unknown subject.",
     expectedFailure: "Authorization server should reject the unknown subject.",
   },
   scope_denial: {
     label: "Scope Denial",
-    description: "Requests privileged scopes the mock user should not receive.",
+    description:
+      "Requests high-privilege scopes the mock user shouldn't get. A correct server refuses to grant them.",
     expectedFailure: "Authorization server should reject the requested scopes.",
   },
 };
+
+/**
+ * The single field a negative test tampered with, paired with what a valid
+ * assertion would have carried. Lets the scorecard show "sent X, expected Y"
+ * so a developer can see exactly which claim their server caught (or missed).
+ */
+export interface NegativeTestDiff {
+  /** The claim or header field the broken assertion changed (e.g. `aud`). */
+  field: string;
+  /** What the broken assertion actually carried. */
+  sent: string;
+  /** What a valid assertion would carry. */
+  expected: string;
+}
 
 export function isNegativeTestMode(value: unknown): value is NegativeTestMode {
   return (


### PR DESCRIPTION
## TL;DR

UX and copy pass on the XAA (Cross-App Access) debugger, aimed at the auth-server developer who's new to XAA. The educational framing (sequence diagram, step-by-step walkthrough, teachable moments) stays as-is. The wins are in the negative-test scorecard, the test-IdP setup card, and orientation: results now read as outcomes with a sent-vs-expected diff, setup copy is unambiguous, and a phase rail shows where you are.

No behavioral changes to the auth flow itself — copy, presentation, and one new diagnostic field.

## What changed

| Area | Before | After |
|---|---|---|
| Scorecard result | "Rejected (HTTP 400) — Authorization server should reject the signature." (reads the same on pass and fail) | `Rejected as expected · HTTP 400` / `Accepted — security risk · HTTP 200` / `Timed out` |
| Scorecard diagnostics | verdict only | per-test "sent X / expected Y" diff for the one claim or header that was tampered with |
| Test descriptions | terse jargon ("Sets `aud` to a different authorization server issuer.") | plain language ("Addresses the token to a different server (the `aud` claim). A correct server only accepts tokens addressed to its own issuer.") |
| Owner override | type the phrase "run anyway" into a text box | a checkbox |
| Test-IdP card, step 4 | "…using the client ID from your config." | "…using the Client ID you set in Configure Target — the `client_id` the ID-JAG carries and your server must accept." |
| Local-URL caveat | muted footnote | amber warning callout (a cloud Okta/Auth0 tenant can't reach `localhost`) |
| Flow steps | "ID-JAG" unexpanded; grant type implicit | acronym expanded once; literal `grant_type` shown for the Phase 2 and Phase 3 requests |
| Orientation | scroll the step list to tell where you are | compact five-phase rail in the header (Discovery → SSO → ID-JAG → Access token → MCP call) |

## Sent-vs-expected diff — how it's built

The diff is derived from the assertion the signer **actually emitted** (its decoded header + payload), compared against the request inputs. It reads the real mutated value rather than a hardcoded copy, so the displayed "sent" can't drift from what was signed. Example for the wrong-audience case:

```
aud sent  https://wrong-audience.example.com
expected  https://auth.example.com
```

## Risk register

| Concern | Answer |
|---|---|
| Does this change the auth flow or what gets sent to a target server? | No. The only new server output is an additional `diff` field on each negative-test result; request bodies and validation are unchanged. |
| Does removing the typed-phrase override weaken the safety gate? | No — same gate (you still can't run rejection tests until a happy-path passes, unless you explicitly opt in as the server owner). A checkbox is the same intent with an honest affordance. |
| Could the checkbox wrapper mislead (text not clickable)? | The checkbox toggles on its own click; the wrapper is a `<div>` matching the existing codebase pattern, not a misleading clickable label. |
| Will the new copy break existing tests? | Tests updated and passing. Scorecard, test-IdP card, step-metadata, and server-route suites all assert the new strings/shape. |
| New telemetry or effects that could fire incorrectly? | None added. The phase rail is pure render; no new `useEffect`. |

## Testing

- 43 XAA tests pass (scorecard, test-IdP card, step-metadata, server route, flow tab, ID-JAG inspector).
- Client typecheck clean.
- New coverage: outcome copy on pass/fail, the sent-vs-expected diff (client render + server output), and the checkbox override path.

## Commits

Four small commits, one per area (step copy, test-IdP card, scorecard overhaul, phase rail). No changeset — relying on `npx changeset` at release time.