### PR TITLE
[XAA Debugger] Make the stepper agree with the scorecard on negative tests

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -340,6 +340,60 @@ function PhaseRail({ currentStep }: { currentStep: XAAFlowStep }) {
   );
 }
 
+/** Outcome banner for a negative-mode run: a rejection is the pass condition
+ * (green), an accepted broken assertion is the security risk (red). Without
+ * this, a (correct) rejection rendered as a generic red error and looked like
+ * a failure — the opposite of what the scorecard reports. */
+function NegativeProbeCallout({
+  probe,
+  mode,
+}: {
+  probe: NonNullable<XAAFlowState["negativeProbe"]>;
+  mode: NegativeTestMode;
+}) {
+  const label = NEGATIVE_TEST_MODE_DETAILS[mode]?.label ?? "negative test";
+
+  if (probe.outcome === "rejected") {
+    return (
+      <div className="rounded-md border border-green-500/40 bg-green-500/5 px-3 py-2.5 text-xs">
+        <div className="flex items-start gap-2">
+          <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
+          <div className="min-w-0 space-y-1">
+            <div className="font-medium text-foreground">
+              Correctly rejected — exactly what should happen
+            </div>
+            <div className="text-muted-foreground">
+              Your authorization server rejected the {label} assertion
+              {probe.status ? ` with HTTP ${probe.status}` : ""}. In a negative
+              test a rejection is the pass condition — the same result the
+              scorecard reports as a pass.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-red-500/40 bg-red-500/5 px-3 py-2.5 text-xs">
+      <div className="flex items-start gap-2">
+        <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+        <div className="min-w-0 space-y-1">
+          <div className="font-medium text-foreground">
+            Accepted a broken assertion — security risk
+          </div>
+          <div className="text-muted-foreground">
+            Your authorization server issued an access token for the {label}{" "}
+            assertion
+            {probe.status ? ` (HTTP ${probe.status})` : ""}. It should have
+            rejected it — this is the failure the negative test checks for.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /** A "Tip" callout — visually distinct from diagnostics so static teaching
  * copy can't be mistaken for an error explanation. */
 function TeachableMoments({ moments }: { moments: string[] }) {
@@ -585,6 +639,13 @@ export function XAAFlowLogger({
       <div className="flex-1 overflow-auto bg-muted/30 p-4 space-y-4">
         {hasProfile && flowState.compatibilityReport && (
           <CompatibilityBanner report={flowState.compatibilityReport} />
+        )}
+
+        {flowState.negativeProbe && (
+          <NegativeProbeCallout
+            probe={flowState.negativeProbe}
+            mode={flowState.negativeTestMode}
+          />
         )}
 
         {(() => {

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -466,6 +466,8 @@ export function XAAFlowTab({
 
   const continueLabel = !hasTarget
     ? "Configure Target"
+    : flowState.negativeProbe
+    ? "Negative test complete"
     : flowState.currentStep === "idle"
     ? "Start"
     : flowState.currentStep === "inspect_id_jag"
@@ -480,7 +482,8 @@ export function XAAFlowTab({
     !hasTarget ||
     flowState.isBusy ||
     isRunningAll ||
-    flowState.currentStep === "complete";
+    flowState.currentStep === "complete" ||
+    Boolean(flowState.negativeProbe);
 
   const runAllDisabled = !hasTarget || flowState.isBusy || isRunningAll;
 

--- a/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAARunChips.tsx
@@ -32,13 +32,18 @@ type ChipStatus = "pass" | "fail" | "untouched";
 
 export function chipStatusFor(
   step: XAAFlowStep,
-  flowState: Pick<XAAFlowState, "currentStep" | "error">
+  flowState: Pick<XAAFlowState, "currentStep" | "error" | "negativeProbe">
 ): ChipStatus {
   const stepIndex = getXAAStepIndex(step);
   const currentIndex = getXAAStepIndex(flowState.currentStep);
 
   if (flowState.error && step === flowState.currentStep) {
     return "fail";
+  }
+  // A negative-mode run ends at the step it reached: a rejection is the pass
+  // condition (green), an accepted broken assertion is the failure (red).
+  if (flowState.negativeProbe && step === flowState.currentStep) {
+    return flowState.negativeProbe.outcome === "rejected" ? "pass" : "fail";
   }
   if (stepIndex < currentIndex || flowState.currentStep === "complete") {
     return "pass";
@@ -58,7 +63,10 @@ export function XAARunChips({
   activeStep,
   onFocusStep,
 }: {
-  flowState: Pick<XAAFlowState, "currentStep" | "error" | "isBusy">;
+  flowState: Pick<
+    XAAFlowState,
+    "currentStep" | "error" | "isBusy" | "negativeProbe"
+  >;
   activeStep?: XAAFlowStep | null;
   onFocusStep?: (step: XAAFlowStep) => void;
 }) {

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAARunChips.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAARunChips.test.tsx
@@ -84,6 +84,41 @@ describe("XAARunChips", () => {
     expect(onFocusStep).not.toHaveBeenCalled();
   });
 
+  it("colours a negative-mode rejection green at the step it reached", () => {
+    render(
+      <XAARunChips
+        flowState={{
+          currentStep: "jwt_bearer_request",
+          negativeProbe: { outcome: "rejected", status: 400 },
+        }}
+      />
+    );
+
+    // A rejection is the pass condition for a negative test.
+    expect(
+      screen.getByTestId("xaa-run-chip-jwt_bearer_request")
+    ).toHaveAttribute("data-status", "pass");
+    // Downstream steps never ran.
+    expect(
+      screen.getByTestId("xaa-run-chip-authenticated_mcp_request")
+    ).toHaveAttribute("data-status", "untouched");
+  });
+
+  it("colours an accepted broken assertion red at the token step", () => {
+    render(
+      <XAARunChips
+        flowState={{
+          currentStep: "received_access_token",
+          negativeProbe: { outcome: "accepted", status: 200 },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId("xaa-run-chip-received_access_token")
+    ).toHaveAttribute("data-status", "fail");
+  });
+
   it("shows the section name when a segment is hovered", async () => {
     const user = userEvent.setup();
     render(

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -336,6 +336,7 @@ describe("createXAAStateMachine", () => {
     function buildRunnerHarness(options: {
       registrationId?: string;
       failTokenProxy?: boolean;
+      negativeTestMode?: XAAFlowState["negativeTestMode"];
     }) {
       let state: XAAFlowState = createInitialXAAFlowState({
         serverUrl: "https://mcp.example.com",
@@ -343,6 +344,7 @@ describe("createXAAStateMachine", () => {
         userId: "user-12345",
         email: "demo.user@example.com",
         scope: "read:tools",
+        negativeTestMode: options.negativeTestMode,
       });
 
       const idToken = makeJwt(
@@ -470,6 +472,7 @@ describe("createXAAStateMachine", () => {
         email: "demo.user@example.com",
         scope: "read:tools",
         registrationId: options.registrationId,
+        negativeTestMode: options.negativeTestMode,
       });
 
       return {
@@ -530,6 +533,47 @@ describe("createXAAStateMachine", () => {
           (entry) => entry.step === "token_exchange_request"
         )
       ).toBe(true);
+    });
+
+    it("treats a rejection in a negative-test mode as the expected outcome, not an error", async () => {
+      const { machine, getStateSnapshot, tokenProxyBodies } =
+        buildRunnerHarness({
+          registrationId: "app_1",
+          failTokenProxy: true,
+          negativeTestMode: "unknown_kid",
+        });
+
+      await machine.runAll();
+
+      const final = getStateSnapshot();
+      // A rejection is the pass condition here — no flow error.
+      expect(final.error).toBeUndefined();
+      expect(final.negativeProbe).toEqual({
+        outcome: "rejected",
+        status: 400,
+      });
+      expect(final.accessToken).toBeUndefined();
+      // The run stops on the outcome instead of re-firing the bearer request.
+      expect(tokenProxyBodies).toHaveLength(1);
+    });
+
+    it("flags an accepted broken assertion in a negative-test mode as a security risk", async () => {
+      const { machine, getStateSnapshot } = buildRunnerHarness({
+        registrationId: "app_1",
+        failTokenProxy: false,
+        negativeTestMode: "unknown_kid",
+      });
+
+      await machine.runAll();
+
+      const final = getStateSnapshot();
+      expect(final.negativeProbe).toEqual({
+        outcome: "accepted",
+        status: 200,
+      });
+      // It stops at the token step — the bad token is never used on the MCP
+      // server.
+      expect(final.currentStep).toBe("received_access_token");
     });
   });
 

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -437,6 +437,7 @@ export function createXAAStateMachine(
       currentStep: step,
       isBusy: true,
       error: undefined,
+      negativeProbe: undefined,
       lastRequest: request,
       lastResponse: undefined,
     });
@@ -980,6 +981,28 @@ export function createXAAStateMachine(
       const upstreamPayload = proxyBody.body;
 
       if (!upstreamStatus || upstreamStatus < 200 || upstreamStatus >= 300) {
+        // In a negative-test mode the broken assertion SHOULD be rejected — a
+        // clean rejection here is the expected, correct outcome, not a flow
+        // failure. (A missing/non-numeric status is a genuine proxy error and
+        // still falls through to the error path below.)
+        if (
+          state.negativeTestMode !== "valid" &&
+          typeof upstreamStatus === "number"
+        ) {
+          machine.updateState({
+            currentStep: "jwt_bearer_request",
+            error: undefined,
+            negativeProbe: { outcome: "rejected", status: upstreamStatus },
+          });
+          pushInfo(
+            "jwt_bearer_request",
+            "xaa-negative-rejected",
+            "Authorization server correctly rejected the broken assertion",
+            { status: upstreamStatus, mode: state.negativeTestMode }
+          );
+          return;
+        }
+
         const detail = extractErrorMessage(
           upstreamPayload,
           `Authorization server returned ${
@@ -1011,6 +1034,34 @@ export function createXAAStateMachine(
         throw new Error(
           "Authorization server response did not include an `access_token`."
         );
+      }
+
+      // In a negative-test mode the assertion was deliberately broken, so a
+      // token here means the server accepted something it should have rejected
+      // — the security risk the test probes for. Stop rather than using it.
+      if (state.negativeTestMode !== "valid") {
+        machine.updateState({
+          currentStep: "received_access_token",
+          accessToken: tokenResponse.access_token,
+          tokenType:
+            typeof tokenResponse.token_type === "string"
+              ? tokenResponse.token_type
+              : "Bearer",
+          expiresIn:
+            typeof tokenResponse.expires_in === "number"
+              ? tokenResponse.expires_in
+              : undefined,
+          error: undefined,
+          negativeProbe: { outcome: "accepted", status: upstreamStatus },
+        });
+        pushInfo(
+          "received_access_token",
+          "xaa-negative-accepted",
+          "Authorization server issued a token for a broken assertion",
+          { status: upstreamStatus, mode: state.negativeTestMode },
+          { level: "error" }
+        );
+        return;
       }
 
       machine.updateState({
@@ -1181,14 +1232,22 @@ export function createXAAStateMachine(
     const MAX_ADVANCES = XAA_RUN_ALL_MAX_ADVANCES;
     for (let i = 0; i < MAX_ADVANCES; i += 1) {
       const before = currentState();
-      if (before.currentStep === "complete" || before.error) {
+      if (
+        before.currentStep === "complete" ||
+        before.error ||
+        before.negativeProbe
+      ) {
         return;
       }
 
       await machine.proceedToNextStep();
 
       const after = currentState();
-      if (after.error || after.currentStep === "complete") {
+      if (
+        after.error ||
+        after.currentStep === "complete" ||
+        after.negativeProbe
+      ) {
         return;
       }
       if (after.currentStep === before.currentStep) {

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -116,6 +116,11 @@ export interface XAAFlowState {
   httpHistory?: Array<XAAHttpHistoryEntry>;
   infoLogs?: Array<XAAInfoLogEntry>;
   error?: string;
+  /** Outcome of a deliberately-broken (negative-mode) run once it reaches the
+   * authorization server. `rejected` is the success case — the server caught
+   * the broken assertion; `accepted` is the security risk — it issued a token
+   * anyway. Unset for the happy-path (valid) flow. */
+  negativeProbe?: { outcome: "rejected" | "accepted"; status?: number };
   compatibilityReport?: XAACompatibilityReport;
 }
 


### PR DESCRIPTION
## TL;DR

The XAA stepper and the negative-test scorecard disagreed on the same event. Select a negative mode (e.g. "Bad Signature"), run the flow, and a **correct rejection** by your auth server showed as a red failure in the stepper — while the scorecard (rightly) showed it as a pass. This makes the stepper negative-mode aware so both surfaces agree.

No change to the happy-path (valid) flow.

## The bug

Both surfaces fire the same broken assertion at your auth server and get the same HTTP 400. They framed it oppositely:

| Surface | A 400 (rejected) meant | Color |
|---|---|---|
| Stepper (Mode = negative) | "flow didn't get a token" → failure | 🔴 red error |
| Scorecard | "server correctly rejected it" → pass | 🟢 green |

Root cause: the bearer step treated any non-2xx as a flow error unconditionally, with no awareness that in a negative mode a rejection is the *goal*.

## The fix

The bearer step now records a structured outcome instead of a blanket error:

| In a negative mode, the server… | Outcome | Stepper now shows |
|---|---|---|
| rejects the broken assertion (non-2xx) | **expected pass** | green "correctly rejected" banner + green chip |
| issues a token anyway (2xx) | **security risk** | red "accepted — security risk" banner + red chip |

This mirrors the scorecard's logic exactly. `runAll` stops on either outcome, so it neither re-fires the request nor uses a wrongly-issued token on the MCP server. The happy-path (valid) flow is untouched — a rejection there is still a real error.

## Risk register

| Concern | Answer |
|---|---|
| Does this change the valid (happy-path) flow? | No. The new branch only applies when `negativeTestMode !== "valid"`; valid-mode rejection still surfaces as an error. |
| Could `runAll` loop or use a bad token now? | No. It terminates on the outcome before re-firing the bearer step or advancing to the MCP call. |
| Is a non-2xx with an unknown status mis-framed as success? | No. The expected-rejection path requires a concrete numeric status; a missing/garbled status still falls through to the error path. |
| Does the red error path for genuine misconfig still work? | Yes — untrusted issuer, wrong `aud`, etc. in valid mode are unchanged. |

## Testing

- State machine: a negative-mode rejection records `rejected` with no error and stops after one bearer call; an accepted broken assertion records `accepted` and stops at the token step (never calls the MCP server).
- Run-rail chips: rejection colors the reached step green, acceptance colors the token step red.
- Full XAA suite + client typecheck pass.
