### PR TITLE
[XAA Debugger] Remove the redundant per-step Focus button

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -721,7 +721,16 @@ export function XAAFlowLogger({
                     )}
                   >
                     <button
-                      onClick={() => toggleStep(group.step)}
+                      onClick={() => {
+                        // Expanding a card also focuses it (highlighting it in
+                        // the sequence diagram); collapsing leaves focus put so
+                        // the auto-expand-on-focus effect can't re-open it.
+                        const willExpand = !expandedSteps.has(group.step);
+                        toggleStep(group.step);
+                        if (willExpand) {
+                          onFocusStep?.(group.step);
+                        }
+                      }}
                       className="w-full px-4 py-3 flex items-start gap-3 text-left hover:bg-muted/40 rounded-t-lg"
                     >
                       <div className="flex-shrink-0 mt-0.5">
@@ -756,20 +765,6 @@ export function XAAFlowLogger({
                           {stepInfo.summary}
                         </p>
                       </div>
-                      {onFocusStep && (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          className="h-7"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            onFocusStep(group.step);
-                          }}
-                        >
-                          Focus
-                        </Button>
-                      )}
                     </button>
 
                     {expandedSteps.has(group.step) && (


### PR DESCRIPTION
## TL;DR

The per-step "Focus" button was redundant — each step card already opens on click (it has a chevron), so the extra button was confusing. It was also a `<button>` nested inside the card-header `<button>` (invalid HTML). Removed it and folded its one unique job into the card click.

## What Focus actually did

| Affordance | Job |
|---|---|
| Card chevron / header click | expand / collapse that step's logs (right panel) |
| **Focus button** | set the focused step → cross-highlight it in the **sequence diagram** (left panel) |

So Focus wasn't *pure* duplication, but its label didn't convey "show in the diagram," and two click targets on one card read as noise.

## Change

- Removed the Focus button (also removes the nested-button HTML violation).
- The card-header click now does both jobs: **expanding** a card also focuses it (highlighting it in the sequence diagram); **collapsing** leaves focus untouched so the focus-driven auto-expand effect can't immediately re-open it.
- Run-rail segment clicks still focus steps as before — that path is unchanged.

## Risk register

| Concern | Answer |
|---|---|
| Can you still highlight a step in the diagram? | Yes — clicking the card (to open it) focuses it, same as Focus did. Run-rail clicks also still focus. |
| Does collapse still work, or does focus re-open it? | Works — collapsing deliberately does not re-focus, so the auto-expand-on-focus effect doesn't fire. |
| Lost any functionality? | No. Focus's only unique effect (diagram cross-highlight) is preserved via the card click. |

## Testing

- Client typecheck clean; the flow-tab render tests pass.
- No test referenced the removed button.
