### PR TITLE
[XAA Debugger] Consistent step status + reset for negative-test probe

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -517,6 +517,24 @@ export function XAAFlowLogger({
 
   const getStatus = (step: XAAFlowStep) => {
     const index = getXAAStepIndex(step);
+    // A negative-mode run ends at the step it reached: an accepted broken
+    // assertion is a failure (red), a rejection is the expected success
+    // (green). Without this the step icon would read "complete" next to the
+    // red security-risk banner.
+    if (flowState.negativeProbe && step === flowState.currentStep) {
+      if (flowState.negativeProbe.outcome === "accepted") {
+        return {
+          icon: AlertTriangle,
+          className: "h-4 w-4 text-red-500",
+          label: "Failed",
+        };
+      }
+      return {
+        icon: CheckCircle2,
+        className: "h-4 w-4 text-green-600 dark:text-green-400",
+        label: "Complete",
+      };
+    }
     if (flowState.isBusy && step === flowState.currentStep) {
       return {
         icon: Loader2,

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -575,6 +575,23 @@ describe("createXAAStateMachine", () => {
       // server.
       expect(final.currentStep).toBe("received_access_token");
     });
+
+    it("clears a prior probe outcome on reset", async () => {
+      const { machine, getStateSnapshot } = buildRunnerHarness({
+        registrationId: "app_1",
+        failTokenProxy: true,
+        negativeTestMode: "unknown_kid",
+      });
+
+      await machine.runAll();
+      expect(getStateSnapshot().negativeProbe).toBeDefined();
+
+      machine.resetFlow();
+
+      // Merge-based updates would otherwise retain the stale terminal outcome.
+      expect(getStateSnapshot().negativeProbe).toBeUndefined();
+      expect(getStateSnapshot().currentStep).toBe("idle");
+    });
   });
 
   describe("discovery is a fallback, not a mandatory step", () => {

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -243,6 +243,7 @@ export const EMPTY_XAA_FLOW_STATE: XAAFlowState = {
   httpHistory: [],
   infoLogs: [],
   error: undefined,
+  negativeProbe: undefined,
   compatibilityReport: undefined,
 };
 


### PR DESCRIPTION
Follow-up to #2690 (now merged) addressing two review comments on it.

## Fixes

1. **Step status icon ignored `negativeProbe`** ([#2690 review](https://github.com/MCPJam/inspector/pull/2690#discussion_r3410325699)) — `getStatus` now returns failed (red) for an accepted broken assertion and complete (green) for a rejection, so the per-step icon matches the security-risk banner instead of showing a green check next to it.
2. **`negativeProbe` missing from `EMPTY_XAA_FLOW_STATE`** ([#2690 review](https://github.com/MCPJam/inspector/pull/2690#discussion_r3410325700)) — added `negativeProbe: undefined` so merge-based resets clear a prior outcome rather than retaining a stale terminal state.

## Testing

- Added a regression test: a probe outcome is cleared on `resetFlow`.
- Full XAA suite + client typecheck pass.