### PR TITLE
Tier B Phase 0: WidgetHost boundary contract for the widget runtime

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
@@ -42,7 +42,8 @@ feed that renderer the inspector state it currently reads ambiently.
 | Source | Examples | Becomes |
 | --- | --- | --- |
 | `usePreferencesStore` | `themeMode`, `hostStyle` | `env.theme` / `env.hostStyle` |
-| `useUIPlaygroundStore` | cspMode, locale, timeZone, displayMode, capabilities, safeArea, deviceType, isPlaygroundActive | `env.cspMode`, `env.baseHostContext` |
+| `useUIPlaygroundStore` | `mcpAppsCspMode` | `surface.playgroundCspMode` (an **input** — effective CSP mode is derived in the renderer from `surface.kind` + per-widget `minimalMode`; see L741-746) |
+| `useUIPlaygroundStore` | locale, timeZone, displayMode, capabilities, safeArea, deviceType, isPlaygroundActive | `env.baseHostContext` |
 | `useActiveMcpProfile` | active profile → capability/sandbox/compat resolution | `env.*` (resolved by inspector) |
 | `useHostContextStore` | `draftHostContext` | `env.baseHostContext` |
 | `useChatboxHost{Style,Theme}` + `…CapabilitiesOverride` | per-chatbox overrides | `env.*` |
@@ -120,6 +121,17 @@ reads for a single `useWidgetHost()`.
   server); the inspector memoizes per `serverId`.
 - **`sandboxOrigin`** is the one true env/build coupling in the sandbox path;
   it becomes `surface.sandboxOrigin` instead of a module-level import.
+- **CSP mode is derived, not passthrough.** The effective sandbox CSP mode is
+  `f(surface.kind, per-widget minimalMode, playground mcpAppsCspMode)`
+  (mcp-apps-renderer.tsx:741-746). The contract exposes the input
+  (`surface.playgroundCspMode`) and the renderer keeps the derivation, so
+  Phase 1 stays behavior-preserving — including sourcing the surface from
+  context (not `isPlaygroundActive`) to preserve the first-render
+  iframe-rebuild fix (L729-739). `minimalMode` being per-instance is why CSP
+  mode is not on the per-server `env`.
+- **Surface collapse:** `kind` merges two distinct context signals
+  (`useIsChatboxSurface`, `useWidgetSurface`); Phase 1 must confirm they are
+  mutually exclusive before collapsing them.
 
 ## Phased plan
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
@@ -1,0 +1,142 @@
+# Tier B — interactive widget runtime extraction (`WidgetHost`)
+
+Status: **Phase 0 (design)** — `widget-host.ts` lands the contract only; nothing
+consumes it yet and there is no behavior change.
+
+This is the follow-on to the Tier A extraction (`@mcpjam/chat-ui`, the read-only
+transcript renderer). Tier A renders a **placeholder** for widget-bearing tool
+calls via the `renderWidget` seam. Tier B is the renderer that *satisfies* that
+seam — the interactive MCP-Apps / OpenAI-Apps widget runtime.
+
+## Why a boundary first (not a file move)
+
+The same lesson as Tier A: **don't move files first — invert dependencies in
+place first.** The widget runtime is ~7,000+ LOC and `mcp-apps-renderer.tsx`
+alone is ~3,866 lines, reaching into **~14 ambient inspector sources** (6
+zustand stores, 6 React contexts, 2 resolver modules). A lift-and-shift is not
+viable; a dependency inversion is.
+
+> Phase 1 is not "move the renderer." Phase 1 is "turn the renderer's
+> store/context reads into an injected `WidgetHost`, in place,
+> behavior-preserving." Only once the renderer imports zero `@/stores` /
+> `@/contexts` do we relocate it behind the existing `renderWidget` seam.
+
+## The seam already exists
+
+`@mcpjam/chat-ui` already exposes the host seam the runtime plugs into:
+
+```ts
+renderWidget?(input: WidgetRenderInput): ReactNode   // absent → WidgetPlaceholder
+```
+
+Today only `ReadOnlyTranscript` (ShareUsageThreadDetail) goes through the
+package; the live chat still uses the **inspector's own** `PartSwitch`, which
+renders `ToolPart` + `WidgetReplay` as siblings. Tier B doesn't need a new
+contract — it needs a renderer that satisfies this one, plus a `WidgetHost` to
+feed that renderer the inspector state it currently reads ambiently.
+
+## What couples the runtime today
+
+`mcp-apps-renderer.tsx` reads, ambiently:
+
+| Source | Examples | Becomes |
+| --- | --- | --- |
+| `usePreferencesStore` | `themeMode`, `hostStyle` | `env.theme` / `env.hostStyle` |
+| `useUIPlaygroundStore` | cspMode, locale, timeZone, displayMode, capabilities, safeArea, deviceType, isPlaygroundActive | `env.cspMode`, `env.baseHostContext` |
+| `useActiveMcpProfile` | active profile → capability/sandbox/compat resolution | `env.*` (resolved by inspector) |
+| `useHostContextStore` | `draftHostContext` | `env.baseHostContext` |
+| `useChatboxHost{Style,Theme}` + `…CapabilitiesOverride` | per-chatbox overrides | `env.*` |
+| `useIsChatboxSurface` / `useWidgetSurface` | surface identity | `surface.kind` |
+| `useWebManagedServers` | hosted endpoint routing | `surface.webManagedServers` |
+| `usePersistentWidgetSurfaceHost` | persistent surface flag | `surface.persistentSurfaceHost` |
+| `useWidgetDebugStore` (11 setters) | lifecycle / CSP / globals instrumentation | `debug` (1:1 sink) |
+| `useTrafficLogStore.addLog` | JSON-RPC traffic | `debug.addTrafficLog` |
+| `resolveEffective{HostCapabilities,McpAppsCapabilities,CompatRuntime}`, `resolveHostInfo` (client-config-v2) | capability/compat resolution | `env.*` (inspector calls them) |
+| `fetchMcpAppsWidgetContent` (authFetch + endpoint + HOSTED_MODE) | widget HTML | `services.fetchWidgetContent` |
+| `readResource` / `listResources` / `listPrompts` | MCP transport | `services.*` |
+| `SANDBOX_ORIGIN` (@/lib/config) | sandbox proxy origin | `surface.sandboxOrigin` |
+
+Per-widget props (`MCPAppsRendererProps`, `WidgetReplayProps` — `toolCallId`,
+`toolOutput`, `onCallTool`, `onRequest{Pip,Fullscreen}`, `renderOverride`, …)
+are **already explicit** and untouched. The DI work is only the 14 ambient
+reads above.
+
+## Four buckets (scoping)
+
+1. **MOVES into the package** (runtime-owned, just needs de-`@/`-ing):
+   `mcp-apps-renderer`, `sandboxed-iframe` + `iframe-sandbox-policy`,
+   `host-app-bridge`, `mcp-apps-logging-transport`, `app-tools-registry`,
+   `widget-surface-store`/`-host` (zustand stays *internal* to the package),
+   `useToolInputStreaming`, `widget-file-messages`, `widget-replay` (→ the
+   package's `renderWidget` factory). Reconcile `mcp-apps-utils` against
+   chat-ui's existing `widget-detection`.
+2. **INJECTED via `WidgetHost`** (inspector-app state/services): the 14 ambient
+   reads → `resolveEnvironment` + `services` + `surface` + `debug`; plus the
+   modal chrome via `components.Modal`.
+3. **STAYS in the inspector** (out of scope): the zustand **store
+   definitions**; the **profile system** (`client-config-v2`, `client-styles`);
+   the **context providers** (active-mcp-profile, chatbox-\*,
+   web-managed-servers); and `checkout-dialog-v2` (billing / app-specific —
+   explicitly excluded).
+4. **REUSED from `@mcpjam/sdk`** (already shared — no work):
+   `resolveSandboxCsp` / `resolveSandboxPermissions`, `host-config`,
+   `widget-helpers`, the compat runtimes (`@mcpjam/sdk/browser`).
+
+## The contract
+
+See `widget-host.ts`. Summary:
+
+```ts
+interface WidgetHost {
+  resolveEnvironment(serverId: string | undefined): WidgetHostEnvironment; // per-server
+  services: WidgetHostServices;          // fetchWidgetContent + readResource/listResources/listPrompts
+  surface: WidgetSurfaceInfo;            // kind, persistentSurfaceHost, webManagedServers, sandboxOrigin
+  debug?: WidgetDebugSink;               // 1:1 with widget-debug-store + traffic-log addLog
+  components?: { Modal?: ComponentType<WidgetModalProps> };
+}
+```
+
+The contract is anchored to real inspector signatures via
+`typeof import(...)` / named result types, so it fails typecheck if a source
+shape drifts before the migration catches up.
+
+## How the inspector satisfies it
+
+One `<WidgetHostProvider>` at the thread/chat root, built from the stores and
+contexts it *already* reads — `resolveEnvironment` calls the existing
+`resolveEffective*` helpers; `services` binds the existing api modules; `debug`
+forwards to the existing zustand stores 1:1. The renderer swaps its ~14 hook
+reads for a single `useWidgetHost()`.
+
+## Risks / notes
+
+- **Behavior preservation:** `debug` is a 1:1 sink (12 callbacks) specifically
+  so Phase 1 is a pure refactor — consolidation is a separate, later change.
+- **Reactivity / perf:** today each playground field is a fine-grained zustand
+  selector; a single provider subscribing to all of them broadens the
+  re-render to the widget subtree. Acceptable, and memoizable — but worth a
+  perf check in Phase 1 since the renderer is hot.
+- **`resolveEnvironment` must stay cheap/pure** (runs during render, per
+  server); the inspector memoizes per `serverId`.
+- **`sandboxOrigin`** is the one true env/build coupling in the sandbox path;
+  it becomes `surface.sandboxOrigin` instead of a module-level import.
+
+## Phased plan
+
+| Phase | What | Risk |
+| --- | --- | --- |
+| **0** (this) | `WidgetHost` contract + this doc. No behavior change. | low |
+| **1** | In-place DI refactor: land `WidgetHostProvider` + `useWidgetHost`; migrate services → environment → surface → debug reads; renderer imports zero `@/stores`/`@/contexts`. Run the Tier-B guard against it *before* moving. | med |
+| **2** | Extract the framework-free core (`host-app-bridge`, transports, `iframe-sandbox-policy`, reconciled `mcp-apps-utils`). | low–med |
+| **3** | Relocate the React renderer into the package; inspector becomes a thin `WidgetHost` adapter; add a Tier-B import guard. | med |
+| **4** | Wire the package's `renderWidget` seam; optionally collapse the inspector's parallel `PartSwitch`. Unblocks the eval trace viewer (Option B). | med |
+
+## Package shape (open decision)
+
+Recommended: a new **`@mcpjam/widget-react`** package (heavy
+`@modelcontextprotocol/ext-apps` + `@mcp-ui/client` deps), depending on
+`@mcpjam/sdk` for the policy/compat core, consumed by the inspector via the
+`renderWidget` seam. `@mcpjam/chat-ui` stays the lean Tier-A renderer and never
+imports it. Alternative considered: a `@mcpjam/chat-ui/widget` subpath — rejected
+because it would force Tier A consumers to risk pulling the heavy widget peer
+deps and would require a carve-out in the Tier-A import guard.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
@@ -90,7 +90,7 @@ See `widget-host.ts`. Summary:
 ```ts
 interface WidgetHost {
   resolveEnvironment(serverId: string | undefined): WidgetHostEnvironment; // per-server
-  services: WidgetHostServices;          // fetchWidgetContent + readResource/listResources/listPrompts
+  services: WidgetHostServices;          // fetchWidgetContent + readResource/listResources/listPrompts/listResourceTemplates
   surface: WidgetSurfaceInfo;            // kind, persistentSurfaceHost, webManagedServers, sandboxOrigin
   debug?: WidgetDebugSink;               // 1:1 with widget-debug-store + traffic-log addLog
   components?: { Modal?: ComponentType<WidgetModalProps> };
@@ -132,6 +132,12 @@ reads for a single `useWidgetHost()`.
 - **Surface collapse:** `kind` merges two distinct context signals
   (`useIsChatboxSurface`, `useWidgetSurface`); Phase 1 must confirm they are
   mutually exclusive before collapsing them.
+- **`listResourceTemplates` is host-owned, not the raw api fn.** The renderer
+  guards `HOSTED_MODE || webManagedServers` (mcp-apps-renderer.tsx:2861-2868),
+  but `mcp-resource-templates-api.listResourceTemplates` only enforces
+  `HOSTED_MODE`. The provider MUST wrap it and throw when
+  `surface.webManagedServers` is true — Phase 1 must not bind the raw fn
+  directly, or web-managed surfaces would drift.
 
 ## Phased plan
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
@@ -54,7 +54,7 @@ feed that renderer the inspector state it currently reads ambiently.
 | `useTrafficLogStore.addLog` | JSON-RPC traffic | `debug.addTrafficLog` |
 | `resolveEffective{HostCapabilities,McpAppsCapabilities,CompatRuntime}`, `resolveHostInfo` (client-config-v2) | capability/compat resolution | `env.*` (inspector calls them) |
 | `fetchMcpAppsWidgetContent` (authFetch + endpoint + HOSTED_MODE) | widget HTML | `services.fetchWidgetContent` |
-| `readResource` / `listResources` / `listPrompts` | MCP transport | `services.*` |
+| `readResource` / `listResources` / `listPrompts` / `listResourceTemplates` | MCP transport (templates are local-only — throw in hosted/web-managed) | `services.*` |
 | `SANDBOX_ORIGIN` (@/lib/config) | sandbox proxy origin | `surface.sandboxOrigin` |
 
 Per-widget props (`MCPAppsRendererProps`, `WidgetReplayProps` — `toolCallId`,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
@@ -1,0 +1,212 @@
+// Tier B widget-runtime extraction — Phase 0 boundary (design only).
+//
+// See ./widget-host.design.md for the rationale and the phased plan.
+//
+// `WidgetHost` is the dependency-inversion seam the interactive MCP-Apps widget
+// renderer (mcp-apps-renderer / widget-replay) will read from, instead of
+// reaching into ~14 inspector stores/contexts/resolvers directly. Today those
+// reads are scattered across mcp-apps-renderer.tsx (lines 22-103, 570-942,
+// 1364-2101). The inversion: the renderer reads ONE `WidgetHost`; the inspector
+// populates it from those sources at a single provider site.
+//
+// This file is the CONTRACT ONLY — nothing imports it yet, and no behavior
+// changes. The in-place refactor that routes the renderer through it lands in
+// Phase 1. The contract is anchored to the real inspector signatures via
+// `typeof import(...)` / named result types, so it fails typecheck loudly if an
+// underlying shape drifts before the migration catches up.
+
+import type { ComponentType, ReactNode } from "react";
+import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type {
+  OpenAiAppsCapabilities,
+  ResolvedMcpAppsCapabilities,
+  ResolvedOpenAiAppsCapabilities,
+} from "@/lib/client-styles";
+import type { CspMode } from "@/stores/ui-playground-store";
+import type {
+  CspViolation,
+  WidgetDebugInfo,
+  WidgetGlobals,
+  WidgetLifecycleEvent,
+  WidgetSandboxApplied,
+  WidgetSandboxInfo,
+} from "@/stores/widget-debug-store";
+import type { UiLogEvent } from "@/stores/traffic-log-store";
+import type {
+  FetchMcpAppsWidgetContentRequest,
+  FetchMcpAppsWidgetContentResponse,
+} from "./fetch-widget-content";
+
+// --- Result shapes pinned to their current resolvers (source of truth) -------
+
+/** Return of `resolveEffectiveHostCapabilities` (client-config-v2). */
+export type ResolvedHostCapabilities = ReturnType<
+  typeof import("@/lib/client-config-v2").resolveEffectiveHostCapabilities
+>;
+
+/** Return of `resolveHostInfo` (client-config-v2). */
+export type ResolvedHostInfo = ReturnType<
+  typeof import("@/lib/client-config-v2").resolveHostInfo
+>;
+
+/** Return of `getHostStyleOrDefault` (client-styles). */
+export type ResolvedHostStyle = ReturnType<
+  typeof import("@/lib/client-styles").getHostStyleOrDefault
+>;
+
+// --- Environment -------------------------------------------------------------
+
+/**
+ * Per-`serverId` host environment the renderer needs. Today this is assembled
+ * inline from `resolveEffective*` (client-config-v2), preferences + chatbox
+ * theme/style, the playground CSP mode, and the draft host context. The
+ * inspector computes it in `WidgetHost.resolveEnvironment`; a package renderer
+ * never sees the profile system.
+ *
+ * Resolution is a function of `serverId` (capabilities / CSP vary by the
+ * per-server profile), so this is returned by a method, not a static field.
+ */
+export interface WidgetHostEnvironment {
+  hostInfo: ResolvedHostInfo;
+  hostCapabilities: ResolvedHostCapabilities;
+  mcpAppsCapabilities: ResolvedMcpAppsCapabilities;
+  /** Resolved compat-runtime flag (resolveEffectiveCompatRuntime). */
+  injectOpenAiCompat: boolean;
+  /** Per-method `window.openai.*` surface to inject; omit when shim is off. */
+  openAiCompatCapabilities?: ResolvedOpenAiAppsCapabilities;
+  /** hostSupportsWidgetRendering(resolveHostCaps(serverId)). */
+  supportsWidgetRendering: boolean;
+  theme: string;
+  hostStyle: ResolvedHostStyle;
+  cspMode: CspMode;
+  /**
+   * Base `McpUiHostContext`: draftHostContext + extract*() projections +
+   * playground globals (locale, timeZone, safeArea, deviceType, displayMode).
+   * The renderer layers per-call fields (controlled display mode, etc.) on top.
+   */
+  baseHostContext: McpUiHostContext;
+}
+
+// --- Services ----------------------------------------------------------------
+
+export type FetchWidgetContentRequest = FetchMcpAppsWidgetContentRequest;
+export type FetchWidgetContentResponse = FetchMcpAppsWidgetContentResponse;
+
+/**
+ * Widget content fetch + MCP transport. The inspector binds these to
+ * `fetchMcpAppsWidgetContent` (authFetch + endpoint resolution + HOSTED_MODE)
+ * and the MCP resource/prompt apis. The renderer sees only these calls — never
+ * `authFetch`, Convex, or the `/api/*` endpoint layout.
+ */
+export interface WidgetHostServices {
+  fetchWidgetContent: (
+    req: FetchWidgetContentRequest,
+  ) => Promise<FetchWidgetContentResponse>;
+  readResource: typeof import("@/lib/apis/mcp-resources-api").readResource;
+  listResources: typeof import("@/lib/apis/mcp-resources-api").listResources;
+  listPrompts: typeof import("@/lib/apis/mcp-prompts-api").listPrompts;
+  // Phase 1: OpenAI Apps file bridges (uploadFile / getFileDownloadUrl) bind to
+  // widget-file-messages here once their host-facing signatures are firmed up.
+}
+
+// --- Surface -----------------------------------------------------------------
+
+export type WidgetSurfaceKind =
+  | "chat"
+  | "playground"
+  | "chatbox"
+  | "standalone";
+
+export interface WidgetSurfaceInfo {
+  /** useWidgetSurface + useIsChatboxSurface collapsed to one descriptor. */
+  kind: WidgetSurfaceKind;
+  /** usePersistentWidgetSurfaceHost — persistent resource-scoped surfaces. */
+  persistentSurfaceHost: boolean;
+  /** useWebManagedServers — route widget-content through /api/web. */
+  webManagedServers: boolean;
+  /** SANDBOX_ORIGIN (VITE_MCPJAM_SANDBOX_ORIGIN); "" when unset. */
+  sandboxOrigin: string;
+}
+
+// --- Instrumentation (optional) ----------------------------------------------
+
+/**
+ * Diagnostics sink. Intentionally 1:1 with `useWidgetDebugStore` +
+ * `useTrafficLogStore.addLog` (source of truth) so the Phase 1 migration is a
+ * pure refactor — no consolidation. The inspector forwards each call to its
+ * zustand stores; a non-inspector host can omit `debug` entirely and lose only
+ * the Sandbox/Network debug panels. (Folding these into a single event stream
+ * is a deliberately separate, later change.)
+ */
+export interface WidgetDebugSink {
+  recordMount: (toolCallId: string, reason: string) => void;
+  setWidgetDebugInfo: (
+    toolCallId: string,
+    info: Partial<Omit<WidgetDebugInfo, "toolCallId" | "updatedAt">>,
+  ) => void;
+  setWidgetState: (toolCallId: string, state: unknown) => void;
+  setWidgetGlobals: (
+    toolCallId: string,
+    globals: Partial<WidgetGlobals>,
+  ) => void;
+  setWidgetCsp: (
+    toolCallId: string,
+    csp: Omit<WidgetSandboxInfo, "violations">,
+  ) => void;
+  addCspViolation: (toolCallId: string, violation: CspViolation) => void;
+  clearCspViolations: (toolCallId: string) => void;
+  setWidgetModelContext: (
+    toolCallId: string,
+    context: {
+      content?: unknown[];
+      structuredContent?: Record<string, unknown>;
+    } | null,
+  ) => void;
+  setWidgetHtml: (
+    toolCallId: string,
+    html: string,
+    injectedOpenAiCompat?: boolean,
+    injectedOpenAiCompatCapabilities?: OpenAiAppsCapabilities,
+  ) => void;
+  setSandboxApplied: (
+    toolCallId: string,
+    applied: WidgetSandboxApplied,
+    hostProfileId?: string,
+    hostInfo?: { name: string; version: string } | null,
+  ) => void;
+  appendLifecycle: (
+    toolCallId: string,
+    event: WidgetLifecycleEvent,
+  ) => void;
+  /** useTrafficLogStore.addLog */
+  addTrafficLog: (event: Omit<UiLogEvent, "id" | "timestamp">) => void;
+}
+
+// --- Chrome injection (optional) ---------------------------------------------
+
+/**
+ * Provisional — props firm up when mcp-apps-modal is extracted (Phase 3). The
+ * design-system <Dialog> chrome becomes an injected component so the renderer
+ * stays free of @mcpjam/design-system.
+ */
+export interface WidgetModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+}
+
+export interface WidgetHostComponents {
+  Modal?: ComponentType<WidgetModalProps>;
+}
+
+// --- The seam ----------------------------------------------------------------
+
+export interface WidgetHost {
+  /** Resolved per-server host environment (see WidgetHostEnvironment). */
+  resolveEnvironment: (serverId: string | undefined) => WidgetHostEnvironment;
+  services: WidgetHostServices;
+  surface: WidgetSurfaceInfo;
+  debug?: WidgetDebugSink;
+  components?: WidgetHostComponents;
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
@@ -111,14 +111,25 @@ export interface WidgetHostServices {
   listPrompts: typeof import("@/lib/apis/mcp-prompts-api").listPrompts;
   /**
    * `resources/templates/list` for the MCP-Apps bridge
-   * (host-app-bridge `onListResourceTemplates`). Local-only today — the
-   * renderer throws in hosted / web-managed mode
-   * (mcp-apps-renderer.tsx:2861-2868) and the api fn calls `ensureLocalMode`;
-   * the inspector binding preserves that. Without it in the contract, a Phase 1
-   * migration would leave this path on ambient `authFetch` / `HOSTED_MODE` or
-   * silently return empty templates.
+   * (host-app-bridge `onListResourceTemplates`). HOST-OWNED — NOT the raw api
+   * fn. The provider MUST apply the same guard the renderer does today: throw
+   * when `HOSTED_MODE || surface.webManagedServers` is true
+   * (mcp-apps-renderer.tsx:2861-2868). The underlying
+   * `mcp-resource-templates-api.listResourceTemplates` only enforces
+   * `HOSTED_MODE` (via `ensureLocalMode`), NOT web-managed, so binding it
+   * directly in Phase 1 would let web-managed chatbox/widget surfaces drift.
+   * Typed structurally (return shape still pinned to the api) to signal the
+   * provider owns the implementation rather than forwarding the raw fn.
    */
-  listResourceTemplates: typeof import("@/lib/apis/mcp-resource-templates-api").listResourceTemplates;
+  listResourceTemplates: (
+    serverId: string,
+  ) => Promise<
+    Awaited<
+      ReturnType<
+        typeof import("@/lib/apis/mcp-resource-templates-api").listResourceTemplates
+      >
+    >
+  >;
   // Phase 1: OpenAI Apps file bridges (uploadFile / getFileDownloadUrl) bind to
   // widget-file-messages here once their host-facing signatures are firmed up.
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
@@ -109,6 +109,16 @@ export interface WidgetHostServices {
   readResource: typeof import("@/lib/apis/mcp-resources-api").readResource;
   listResources: typeof import("@/lib/apis/mcp-resources-api").listResources;
   listPrompts: typeof import("@/lib/apis/mcp-prompts-api").listPrompts;
+  /**
+   * `resources/templates/list` for the MCP-Apps bridge
+   * (host-app-bridge `onListResourceTemplates`). Local-only today — the
+   * renderer throws in hosted / web-managed mode
+   * (mcp-apps-renderer.tsx:2861-2868) and the api fn calls `ensureLocalMode`;
+   * the inspector binding preserves that. Without it in the contract, a Phase 1
+   * migration would leave this path on ambient `authFetch` / `HOSTED_MODE` or
+   * silently return empty templates.
+   */
+  listResourceTemplates: typeof import("@/lib/apis/mcp-resource-templates-api").listResourceTemplates;
   // Phase 1: OpenAI Apps file bridges (uploadFile / getFileDownloadUrl) bind to
   // widget-file-messages here once their host-facing signatures are firmed up.
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
@@ -78,7 +78,11 @@ export interface WidgetHostEnvironment {
   supportsWidgetRendering: boolean;
   theme: string;
   hostStyle: ResolvedHostStyle;
-  cspMode: CspMode;
+  // NOTE: the effective sandbox CSP mode is intentionally NOT here. It depends
+  // on the per-widget `minimalMode` prop (per-instance, not per-server), so it
+  // cannot be resolved by `resolveEnvironment(serverId)`. The input lives on
+  // `WidgetSurfaceInfo.playgroundCspMode`; the renderer derives the effective
+  // mode (see that field's doc + mcp-apps-renderer.tsx:741-746).
   /**
    * Base `McpUiHostContext`: draftHostContext + extract*() projections +
    * playground globals (locale, timeZone, safeArea, deviceType, displayMode).
@@ -118,7 +122,12 @@ export type WidgetSurfaceKind =
   | "standalone";
 
 export interface WidgetSurfaceInfo {
-  /** useWidgetSurface + useIsChatboxSurface collapsed to one descriptor. */
+  /**
+   * useWidgetSurface + useIsChatboxSurface collapsed to one descriptor.
+   * Phase 1 must confirm chatbox / playground / chat are mutually exclusive
+   * (today they are two separate context signals); if they can overlap, `kind`
+   * must keep both bits rather than collapse to one enum.
+   */
   kind: WidgetSurfaceKind;
   /** usePersistentWidgetSurfaceHost — persistent resource-scoped surfaces. */
   persistentSurfaceHost: boolean;
@@ -126,6 +135,22 @@ export interface WidgetSurfaceInfo {
   webManagedServers: boolean;
   /** SANDBOX_ORIGIN (VITE_MCPJAM_SANDBOX_ORIGIN); "" when unset. */
   sandboxOrigin: string;
+  /**
+   * Playground CSP-mode selection (useUIPlaygroundStore.mcpAppsCspMode) — an
+   * INPUT, not the effective mode. The renderer derives the effective sandbox
+   * CSP mode from `kind` + this + the per-widget `minimalMode` prop, mirroring
+   * mcp-apps-renderer.tsx:741-746:
+   *
+   *   kind === "chatbox" || minimalMode ? "permissive"
+   *     : kind === "playground"         ? playgroundCspMode
+   *     :                                 "widget-declared"
+   *
+   * Kept as an input (not pre-resolved in `resolveEnvironment`) because
+   * `minimalMode` is per-instance. Source it from the WidgetSurfaceContext —
+   * NOT `isPlaygroundActive` — to preserve the first-render iframe-rebuild fix
+   * documented at mcp-apps-renderer.tsx:729-739.
+   */
+  playgroundCspMode: CspMode;
 }
 
 // --- Instrumentation (optional) ----------------------------------------------


### PR DESCRIPTION
## What

Design-only first step (**Phase 0**) of extracting the interactive MCP-Apps / OpenAI-Apps widget runtime behind `@mcpjam/chat-ui`'s existing `renderWidget` seam (Tier B). Adds:

- `mcp-apps/widget-host.ts` — the `WidgetHost` dependency-inversion **contract**.
- `mcp-apps/widget-host.design.md` — rationale, four-bucket scoping, risks, and the phased plan.

## Why

The widget renderer (`mcp-apps-renderer.tsx`, ~3.8k LOC) currently reaches into **~14 ambient inspector sources** (6 zustand stores, 6 React contexts, 2 capability-resolver modules). A lift-and-shift into a package is not viable; a dependency inversion is. This lands the seam the renderer will read from instead:

```ts
interface WidgetHost {
  resolveEnvironment(serverId: string | undefined): WidgetHostEnvironment; // per-server caps/CSP/compat/theme/hostContext
  services: WidgetHostServices;          // fetchWidgetContent + readResource/listResources/listPrompts
  surface: WidgetSurfaceInfo;            // kind, persistentSurfaceHost, webManagedServers, sandboxOrigin
  debug?: WidgetDebugSink;               // 1:1 with widget-debug-store + traffic-log addLog
  components?: { Modal?: ComponentType<WidgetModalProps> };
}
```

## Guarantees

- **No behavior change.** Nothing imports the contract yet.
- **No runtime footprint.** All imports are type-only / type-position `typeof import(...)`, so the file emits no JS.
- **Anchored to reality.** Result shapes are pinned to the real resolvers/apis via `typeof import(...)`, so the contract fails typecheck if a source shape drifts before the migration catches up.
- **Behavior-preserving by design.** The `debug` sink is intentionally 1:1 with `widget-debug-store` + `traffic-log` so the Phase 1 in-place refactor is a pure relocation of reads (consolidation deferred).

## Scoping (in the doc)

- **Moves** into the package: renderer, sandboxed-iframe + policy, host bridge, transports, app-tools/surface stores, tool-input-streaming, widget-replay.
- **Injected** via `WidgetHost`: the 14 ambient reads + modal chrome.
- **Stays** inspector-side: store defs, profile system (`client-config-v2`/`client-styles`), context providers, `checkout-dialog-v2` (billing — excluded).
- **Reused** from `@mcpjam/sdk`: `resolveSandboxCsp`/`resolveSandboxPermissions`, host-config, compat runtimes (already shared).

## Open decisions for review

1. **Contract shape** — `WidgetHost` via context (this) vs. a flat prop bundle threaded through `WidgetReplay`.
2. **Package shape** — recommended new `@mcpjam/widget-react` (heavy ext-apps/mcp-ui deps) vs. a `@mcpjam/chat-ui/widget` subpath.
3. **`debug` as a 1:1 sink** for now (vs. redesigning the debug/traffic surface in the same pass).

## Verification

- `typecheck:client` ✓ (contract compiles against live signatures)
- No changeset: inspector-internal, dormant, no published-surface or behavior change.

## Next

Phase 1 = in-place DI refactor (land `WidgetHostProvider` + `useWidgetHost`; migrate services → environment → surface → debug reads; prove the renderer imports zero `@/stores`/`@/contexts` via the Tier-B guard *before* relocating).

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and unused type definitions only; no wiring, runtime footprint, or user-facing changes.
> 
> **Overview**
> **Phase 0 (design only)** for Tier B: extracting the interactive MCP-Apps widget runtime behind `@mcpjam/chat-ui`'s existing `renderWidget` seam. This PR adds **`widget-host.ts`** defining the **`WidgetHost`** dependency-inversion contract (`resolveEnvironment`, `services`, `surface`, optional `debug` / modal `components`) and **`widget-host.design.md`** documenting why inversion precedes a file move, how ~14 ambient store/context reads map onto the contract, phased migration, and risks (CSP derivation, `listResourceTemplates` host guard, surface `kind` collapse).
> 
> **Nothing imports the contract yet** — type-only shapes pinned via `typeof import(...)` so drift breaks typecheck before Phase 1 wiring. No runtime or product behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b9b7569937401aa53274b5d7f188beca0f1abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->