### PR TITLE
feat(hosts): Computer + Built-in tools islands on the host graph canvas

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -34,6 +34,8 @@ import { RedesignedHostCanvas } from "./canvas/RedesignedHostCanvas";
 import { buildRedesignedHostCanvas } from "./canvas/canvasBuilder";
 import { HostFocusPanel } from "./focus/HostFocusPanel";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useComputerStatus } from "@/hooks/useProjectComputer";
+import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
 import {
   hasBlockingErrors,
   useHostDraftValidation,
@@ -69,6 +71,11 @@ export function HostBuilderViewRedesigned({
   });
   const { servers } = useProjectServers({ projectId, isAuthenticated });
   const computersEnabled = useComputersEnabled();
+  // Project Computers canvas inputs. Both queries resolve to `undefined`
+  // until their backend functions are deployed and stay cheap when the
+  // feature flag is off (the islands they feed aren't emitted then).
+  const computerStatus = useComputerStatus(projectId);
+  const builtInToolCatalog = useBuiltInToolCatalog();
   const { updateHost } = useHostMutations();
   const { createServer } = useServerMutations();
 
@@ -262,6 +269,9 @@ export function HostBuilderViewRedesigned({
         isDirty,
         projectServers: availableServersForCanvas,
         prev: prevHostSnapshot ?? undefined,
+        computersEnabled,
+        computerStatus,
+        builtInToolCatalog,
       },
       attention
     );
@@ -273,6 +283,9 @@ export function HostBuilderViewRedesigned({
     availableServersForCanvas,
     attention,
     prevHostSnapshot,
+    computersEnabled,
+    computerStatus,
+    builtInToolCatalog,
   ]);
 
   const openFocus = useCallback(
@@ -483,6 +496,7 @@ export function HostBuilderViewRedesigned({
                     onSelectNode={handleSelectNode}
                     onClearSelection={() => setSelectedNodeId(null)}
                     onAddServer={() => setShowAddServer(true)}
+                    onOpenComputer={() => navigate("/computer")}
                     shellStyle={canvasShellStyle}
                   />
                 </ReactFlowProvider>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/RedesignedHostCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/RedesignedHostCanvas.tsx
@@ -18,17 +18,22 @@ import {
   Handle,
   Position,
   ReactFlow,
+  type Edge,
   type EdgeProps,
   type Node,
   type NodeProps,
 } from "@xyflow/react";
-import { Plus, Server } from "lucide-react";
+import { ArrowRight, ArrowUpRight, Plus, Server, Settings, TerminalSquare } from "lucide-react";
 import "@xyflow/react/dist/style.css";
 import { cn } from "@/lib/utils";
+import { ComputerStatusChip } from "@/components/computer/ComputerStatusChip";
 import {
   ADD_SERVER_NODE_ID,
+  HOST_MATRIX_NODE_ID,
   SERVERS_HUB_NODE_ID,
   type AddServerPillNodeData,
+  type BuiltinToolsNodeData,
+  type ComputerNodeData,
   type HostMatrixNodeData,
   type HostRedesignViewModel,
   type ServerCardNodeData,
@@ -56,6 +61,8 @@ const HostMatrixContext = createContext<{
   selectedNodeId: string | null;
   onSelectNode: (id: string) => void;
   reportMatrixHeight: (height: number) => void;
+  /** Navigate to the Computer tab — threaded to the Computer island's "Open terminal" link. */
+  onOpenComputer?: () => void;
 } | null>(null);
 
 /* ============================================================
@@ -289,11 +296,196 @@ const AddServerPillRenderer = memo(
 );
 AddServerPillRenderer.displayName = "AddServerPillRenderer";
 
+/* ============================================================
+   Project Computers islands. Built-in tools sit to the left of
+   the matrix; the Computer island to the right. Both are gated
+   in the builder behind `computersEnabled`, so they only ever
+   mount when the feature flag is on. A click anywhere on either
+   island routes to the Agent (Behavior) tab via onNodeClick →
+   onSelectNode → focusTabForNodeId.
+   ============================================================ */
+const BuiltinToolsNodeRenderer = memo(
+  (props: NodeProps<Node<BuiltinToolsNodeData, "redesignBuiltinTools">>) => {
+    const { data, selected } = props;
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...SNAPPY_HOST_REVEAL, delay: 0.32 }}
+        className={cn(
+          "flex w-full flex-col gap-2 rounded-[10px] border border-border/70 bg-card/95 px-3 py-2.5 shadow-sm transition-shadow hover:shadow-md",
+          selected && "ring-2 ring-primary/40",
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <div className="flex size-7 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
+            <Settings className="size-3.5" strokeWidth={1.75} />
+          </div>
+          <div className="flex min-w-0 flex-col">
+            <span className="text-[13px] font-semibold text-foreground">
+              Built-in tools
+            </span>
+            <span className="text-[10.5px] text-muted-foreground">
+              {data.tools.length === 0
+                ? "None enabled"
+                : `${data.tools.length} enabled`}
+            </span>
+          </div>
+        </div>
+        {data.tools.length === 0 ? (
+          <span className="border-t border-dashed border-border/60 pt-2 text-[11px] text-muted-foreground">
+            No built-in tools
+          </span>
+        ) : (
+          <ul className="flex flex-col gap-1 border-t border-dashed border-border/60 pt-2">
+            {data.tools.map((tool) => (
+              <li
+                key={tool.id}
+                className="flex items-center justify-between gap-2 text-[11.5px]"
+              >
+                <span
+                  className="truncate font-medium text-foreground"
+                  title={tool.label}
+                >
+                  {tool.label}
+                </span>
+                {tool.requiresComputer ? (
+                  <span
+                    className="flex shrink-0 items-center gap-0.5 text-[10px] text-muted-foreground"
+                    title="Runs on the attached computer"
+                  >
+                    <ArrowRight className="size-2.5" />
+                    <TerminalSquare className="size-3" strokeWidth={1.75} />
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+        <Handle
+          type="target"
+          position={Position.Right}
+          id="right"
+          className={decorativeHandleClass}
+        />
+      </motion.div>
+    );
+  },
+);
+BuiltinToolsNodeRenderer.displayName = "BuiltinToolsNodeRenderer";
+
+const ComputerNodeRenderer = memo(
+  (props: NodeProps<Node<ComputerNodeData, "redesignComputer">>) => {
+    const { data, selected } = props;
+    const ctx = useContext(HostMatrixContext);
+    const onOpenComputer = ctx?.onOpenComputer;
+
+    if (!data.attached) {
+      // Ghost state — no attachment intent. A click routes to the Agent
+      // tab (via onNodeClick) where the "Personal computer" toggle lives.
+      return (
+        <motion.div
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ ...SNAPPY_HOST_REVEAL, delay: 0.32 }}
+          className={cn(
+            "flex w-full flex-col gap-1 rounded-[10px] border border-dashed border-border/70 bg-card/60 px-3 py-2.5 text-muted-foreground shadow-sm transition-shadow hover:shadow-md",
+            selected && "ring-2 ring-primary/40",
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <div className="flex size-7 items-center justify-center rounded-md bg-muted/40">
+              <TerminalSquare className="size-3.5" strokeWidth={1.75} />
+            </div>
+            <span className="text-[13px] font-semibold">+ Computer</span>
+          </div>
+          <span className="text-[10.5px]">Attach your personal computer</span>
+          <Handle
+            type="target"
+            position={Position.Left}
+            id="left"
+            className={decorativeHandleClass}
+          />
+        </motion.div>
+      );
+    }
+
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...SNAPPY_HOST_REVEAL, delay: 0.32 }}
+        className={cn(
+          "flex w-full flex-col gap-2 rounded-[10px] border border-border/70 bg-card/95 px-3 py-2.5 shadow-sm transition-shadow hover:shadow-md",
+          selected && "ring-2 ring-primary/40",
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <div className="flex size-7 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
+            <TerminalSquare className="size-3.5" strokeWidth={1.75} />
+          </div>
+          <div className="flex min-w-0 flex-col">
+            <span className="text-[13px] font-semibold text-foreground">
+              Computer
+            </span>
+            <span className="truncate text-[10.5px] text-muted-foreground">
+              personal · {data.workdir ?? "~/"}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 border-t border-dashed border-border/60 pt-2">
+          {data.status === null ? (
+            // Attached in config, but no machine reserved yet — distinct
+            // from the chip's "Loading…"/"No computer" states.
+            <span className="rounded-full border border-border/70 px-2 py-0.5 text-[10px] text-muted-foreground">
+              Not started
+            </span>
+          ) : (
+            <ComputerStatusChip status={data.status} />
+          )}
+        </div>
+        {data.backedToolLabels.length > 0 ? (
+          <span
+            className="truncate text-[11px] text-muted-foreground"
+            title={data.backedToolLabels.join(", ")}
+          >
+            ↳ {data.backedToolLabels.join(", ")}
+          </span>
+        ) : null}
+        {onOpenComputer ? (
+          <button
+            type="button"
+            onClick={(event) => {
+              // Don't also fire the node's onSelectNode (→ Agent tab); this
+              // link owns navigation to the Computer tab/terminal.
+              event.stopPropagation();
+              onOpenComputer();
+            }}
+            className="flex items-center gap-0.5 self-start text-[11px] font-medium text-primary hover:underline"
+          >
+            Open terminal
+            <ArrowUpRight className="size-3" />
+          </button>
+        ) : null}
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="left"
+          className={decorativeHandleClass}
+        />
+      </motion.div>
+    );
+  },
+);
+ComputerNodeRenderer.displayName = "ComputerNodeRenderer";
+
 const nodeTypes = {
   redesignHostMatrix: HostMatrixNodeRenderer,
   redesignServersHub: ServersHubNodeRenderer,
   redesignServerCard: ServerCardNodeRenderer,
   redesignAddServer: AddServerPillRenderer,
+  redesignBuiltinTools: BuiltinToolsNodeRenderer,
+  redesignComputer: ComputerNodeRenderer,
 };
 
 /**
@@ -317,6 +509,35 @@ interface FixedEdgeData {
   fixedSourceY: number;
   fixedTargetX: number;
   fixedTargetY: number;
+}
+
+/**
+ * Shift the reflowed `hostBranch` edges (host→hub→server cards) down by
+ * `dy` to track the matrix card's measured-vs-estimated height delta.
+ *
+ * Project Computers island edges are deliberately EXCLUDED: they source
+ * from the matrix node (`HOST_MATRIX_NODE_ID`), which never reflows — it
+ * sits at y=0 and grows downward — while their target island nodes are
+ * anchored near the top and aren't part of the servers-block shift. Shifting
+ * their baked endpoints by `dy` would slide the connector off the (static)
+ * island node, reintroducing the detached-edge artifact the fixed-edge
+ * coordinates exist to prevent. Exported for direct unit testing.
+ */
+export function shiftReflowedBranchEdges(edges: Edge[], dy: number): Edge[] {
+  if (dy === 0) return edges;
+  return edges.map((edge) => {
+    if (edge.type !== "hostBranch" || !edge.data) return edge;
+    if (edge.source === HOST_MATRIX_NODE_ID) return edge;
+    const d = edge.data as unknown as FixedEdgeData;
+    return {
+      ...edge,
+      data: {
+        ...d,
+        fixedSourceY: d.fixedSourceY + dy,
+        fixedTargetY: d.fixedTargetY + dy,
+      },
+    };
+  });
 }
 
 const TRUNK_CORNER = 14;
@@ -414,6 +635,8 @@ interface RedesignedHostCanvasProps {
   onSelectNode: (nodeId: string) => void;
   onClearSelection: () => void;
   onAddServer: () => void;
+  /** Navigate to the Computer tab — wired to the Computer island's "Open terminal" link. */
+  onOpenComputer?: () => void;
   shellStyle?: CSSProperties;
   /**
    * Read-only mode: rendered identically but inert.
@@ -441,6 +664,7 @@ export function RedesignedHostCanvas({
   onSelectNode,
   onClearSelection,
   onAddServer,
+  onOpenComputer,
   shellStyle,
   readOnly = false,
   onRequestEdit,
@@ -502,21 +726,10 @@ export function RedesignedHostCanvas({
     });
   }, [filteredNodes, dy]);
 
-  const shiftedEdges = useMemo(() => {
-    if (dy === 0) return filteredEdges;
-    return filteredEdges.map((edge) => {
-      if (edge.type !== "hostBranch" || !edge.data) return edge;
-      const d = edge.data as unknown as FixedEdgeData;
-      return {
-        ...edge,
-        data: {
-          ...d,
-          fixedSourceY: d.fixedSourceY + dy,
-          fixedTargetY: d.fixedTargetY + dy,
-        },
-      };
-    });
-  }, [filteredEdges, dy]);
+  const shiftedEdges = useMemo(
+    () => shiftReflowedBranchEdges(filteredEdges, dy),
+    [filteredEdges, dy],
+  );
 
   const nodes = useMemo(
     () =>
@@ -544,8 +757,15 @@ export function RedesignedHostCanvas({
             onSelectNode: () => onRequestEdit?.(),
             reportMatrixHeight,
           }
-        : { selectedNodeId, onSelectNode, reportMatrixHeight },
-    [selectedNodeId, onSelectNode, readOnly, onRequestEdit, reportMatrixHeight],
+        : { selectedNodeId, onSelectNode, reportMatrixHeight, onOpenComputer },
+    [
+      selectedNodeId,
+      onSelectNode,
+      readOnly,
+      onRequestEdit,
+      reportMatrixHeight,
+      onOpenComputer,
+    ],
   );
 
   // Hold the canvas edges invisible until the server pills have landed at

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/__tests__/RedesignedHostCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/__tests__/RedesignedHostCanvas.test.tsx
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { render, within } from "@testing-library/react";
-import { ReactFlowProvider } from "@xyflow/react";
+import { ReactFlowProvider, type Edge } from "@xyflow/react";
 import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
-import { HOST_MATRIX_NODE_ID, SERVERS_HUB_NODE_ID } from "../../types";
-import { RedesignedHostCanvas } from "../RedesignedHostCanvas";
+import {
+  BUILTIN_TOOLS_NODE_ID,
+  COMPUTER_NODE_ID,
+  HOST_MATRIX_NODE_ID,
+  SERVERS_HUB_NODE_ID,
+} from "../../types";
+import {
+  RedesignedHostCanvas,
+  shiftReflowedBranchEdges,
+} from "../RedesignedHostCanvas";
 import { buildRedesignedHostCanvas } from "../canvasBuilder";
 
 function renderCanvas(opts: {
@@ -187,5 +195,119 @@ describe("RedesignedHostCanvas", () => {
     );
     expect(openLinksBtn).toBeDefined();
     expect(openLinksBtn!.className).not.toMatch(/\bhp-cap--off\b/);
+  });
+
+  it("renders both Project Computers islands when the feature is enabled", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.builtInToolIds = ["web_search"];
+    const viewModel = buildRedesignedHostCanvas(
+      {
+        hostName: "Claude",
+        draft,
+        savedSnapshotId: "snap",
+        isDirty: false,
+        projectServers: [],
+        computersEnabled: true,
+        builtInToolCatalog: [
+          {
+            id: "web_search",
+            displayLabel: "Web Search",
+            description: "Search the web",
+            category: "search",
+            billable: true,
+          },
+        ],
+      },
+      [],
+    );
+    const { container } = render(
+      <ReactFlowProvider>
+        <div style={{ width: 1200, height: 700 }}>
+          <RedesignedHostCanvas
+            viewModel={viewModel}
+            selectedNodeId={null}
+            onSelectNode={() => {}}
+            onClearSelection={() => {}}
+            onAddServer={() => {}}
+          />
+        </div>
+      </ReactFlowProvider>,
+    );
+    const builtin = container.querySelector(
+      `.react-flow__node[data-id="${BUILTIN_TOOLS_NODE_ID}"]`,
+    );
+    const computer = container.querySelector(
+      `.react-flow__node[data-id="${COMPUTER_NODE_ID}"]`,
+    );
+    expect(builtin).not.toBeNull();
+    expect(computer).not.toBeNull();
+    expect(
+      within(builtin as HTMLElement).getByText("Web Search"),
+    ).toBeInTheDocument();
+    // No computer attached in the draft → ghost affordance.
+    expect(
+      within(computer as HTMLElement).getByText("+ Computer"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("shiftReflowedBranchEdges", () => {
+  const islandEdge: Edge = {
+    id: "host-to-computer",
+    source: HOST_MATRIX_NODE_ID,
+    target: COMPUTER_NODE_ID,
+    type: "hostBranch",
+    data: {
+      fixedSourceX: 580,
+      fixedSourceY: 54,
+      fixedTargetX: 640,
+      fixedTargetY: 54,
+    },
+  };
+  const serverEdge: Edge = {
+    id: "hub-to-server-x",
+    source: SERVERS_HUB_NODE_ID,
+    target: "server-card:x",
+    type: "hostBranch",
+    data: {
+      fixedSourceX: 100,
+      fixedSourceY: 200,
+      fixedTargetX: 120,
+      fixedTargetY: 300,
+    },
+  };
+  const trunkEdge: Edge = {
+    id: "host-matrix-to-hub",
+    source: HOST_MATRIX_NODE_ID,
+    target: SERVERS_HUB_NODE_ID,
+    type: "hostTrunk",
+  };
+
+  it("is a no-op when dy is 0 (returns the same array reference)", () => {
+    const edges = [islandEdge, serverEdge];
+    expect(shiftReflowedBranchEdges(edges, 0)).toBe(edges);
+  });
+
+  it("shifts the servers-block branch edges down by dy", () => {
+    const [shifted] = shiftReflowedBranchEdges([serverEdge], 40);
+    expect(shifted.data).toMatchObject({
+      fixedSourceY: 240,
+      fixedTargetY: 340,
+      // X is untouched.
+      fixedSourceX: 100,
+      fixedTargetX: 120,
+    });
+  });
+
+  it("leaves island edges (sourced from the matrix) pinned in place", () => {
+    const [shifted] = shiftReflowedBranchEdges([islandEdge], 40);
+    // Same reference back, endpoints unchanged — the regression guard.
+    expect(shifted).toBe(islandEdge);
+    expect(shifted.data).toMatchObject({ fixedSourceY: 54, fixedTargetY: 54 });
+  });
+
+  it("ignores non-hostBranch edges (the measured-position trunk)", () => {
+    const [shifted] = shiftReflowedBranchEdges([trunkEdge], 40);
+    expect(shifted).toBe(trunkEdge);
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/__tests__/canvasBuilder.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/__tests__/canvasBuilder.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import type { BuiltInToolCatalogEntry } from "@/hooks/useBuiltInToolCatalog";
 import {
   ADD_SERVER_NODE_ID,
+  BUILTIN_TOOLS_NODE_ID,
+  COMPUTER_NODE_ID,
   HOST_MATRIX_NODE_ID,
   SERVERS_HUB_NODE_ID,
+  focusTabForNodeId,
+  type BuiltinToolsNodeData,
+  type ComputerNodeData,
   type HostMatrixNodeData,
 } from "../../types";
 import { buildRedesignedHostCanvas } from "../canvasBuilder";
@@ -552,5 +558,162 @@ describe("buildRedesignedHostCanvas — mcpAppsBridge canvas chip", () => {
     const data = matrixData(buildVm({ draft }));
     expect(data.mcpAppsBridge.overrideCount).toBe(1);
     expect(data.compatRuntime.hasMethodOverrides).toBe(true);
+  });
+});
+
+const CATALOG: BuiltInToolCatalogEntry[] = [
+  {
+    id: "web_search",
+    displayLabel: "Web Search",
+    description: "Search the web",
+    category: "search",
+    billable: true,
+  },
+  {
+    id: "bash",
+    displayLabel: "Bash",
+    description: "Run shell commands",
+    category: "compute",
+    billable: false,
+    requiresComputer: true,
+  },
+];
+
+function builtinData(
+  vm: ReturnType<typeof buildRedesignedHostCanvas>,
+): BuiltinToolsNodeData {
+  const node = vm.nodes.find((n) => n.id === BUILTIN_TOOLS_NODE_ID);
+  if (!node || node.type !== "redesignBuiltinTools") {
+    throw new Error("Built-in tools node missing");
+  }
+  return node.data;
+}
+
+function computerData(
+  vm: ReturnType<typeof buildRedesignedHostCanvas>,
+): ComputerNodeData {
+  const node = vm.nodes.find((n) => n.id === COMPUTER_NODE_ID);
+  if (!node || node.type !== "redesignComputer") {
+    throw new Error("Computer node missing");
+  }
+  return node.data;
+}
+
+describe("buildRedesignedHostCanvas — Project Computers islands", () => {
+  it("emits no island nodes or edges when computersEnabled is omitted (GA path)", () => {
+    const vm = buildVm();
+    expect(vm.nodes.some((n) => n.id === BUILTIN_TOOLS_NODE_ID)).toBe(false);
+    expect(vm.nodes.some((n) => n.id === COMPUTER_NODE_ID)).toBe(false);
+    expect(vm.edges.some((e) => e.id === "host-to-builtin-tools")).toBe(false);
+    expect(vm.edges.some((e) => e.id === "host-to-computer")).toBe(false);
+  });
+
+  it("emits no island nodes when computersEnabled is explicitly false", () => {
+    const vm = buildVm({ computersEnabled: false });
+    expect(vm.nodes.some((n) => n.id === BUILTIN_TOOLS_NODE_ID)).toBe(false);
+    expect(vm.nodes.some((n) => n.id === COMPUTER_NODE_ID)).toBe(false);
+  });
+
+  it("emits both islands when computersEnabled is true, ghost computer by default", () => {
+    const vm = buildVm({ computersEnabled: true });
+    expect(builtinData(vm).tools).toEqual([]);
+    const computer = computerData(vm);
+    expect(computer.attached).toBe(false);
+    expect(computer.backedToolLabels).toEqual([]);
+  });
+
+  it("maps attached built-in tool ids through the catalog for labels", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.builtInToolIds = ["web_search", "bash"];
+    const tools = builtinData(
+      buildVm({
+        computersEnabled: true,
+        builtInToolCatalog: CATALOG,
+        draft,
+      }),
+    ).tools;
+    expect(tools).toEqual([
+      { id: "web_search", label: "Web Search", requiresComputer: false },
+      { id: "bash", label: "Bash", requiresComputer: true },
+    ]);
+  });
+
+  it("falls back to the raw id when the catalog has no matching row", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.builtInToolIds = ["mystery_tool"];
+    // No catalog passed (mirrors the loading state).
+    const tools = builtinData(
+      buildVm({ computersEnabled: true, draft }),
+    ).tools;
+    expect(tools).toEqual([
+      { id: "mystery_tool", label: "mystery_tool", requiresComputer: false },
+    ]);
+  });
+
+  it("reflects attachment intent and computer-backed tool labels on the computer node", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.builtInToolIds = ["web_search", "bash"];
+    draft.computer = { kind: "personal", workdir: "/home/dev" };
+    const computer = computerData(
+      buildVm({
+        computersEnabled: true,
+        builtInToolCatalog: CATALOG,
+        draft,
+      }),
+    );
+    expect(computer.attached).toBe(true);
+    expect(computer.workdir).toBe("/home/dev");
+    // Only the computer-backed tool (bash) bridges to the island.
+    expect(computer.backedToolLabels).toEqual(["Bash"]);
+  });
+
+  it("mirrors the caller's live computer status (value / null / loading)", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.computer = { kind: "personal" };
+    expect(
+      computerData(
+        buildVm({
+          computersEnabled: true,
+          draft,
+          computerStatus: {
+            computerId: "c1",
+            status: "ready",
+            provider: "e2b",
+          },
+        }),
+      ).status,
+    ).toBe("ready");
+    // Explicit null (resolved, no machine reserved) is preserved distinct
+    // from undefined (still loading) so the renderer can tell them apart.
+    expect(
+      computerData(buildVm({ computersEnabled: true, draft, computerStatus: null }))
+        .status,
+    ).toBeNull();
+    expect(
+      computerData(buildVm({ computersEnabled: true, draft })).status,
+    ).toBeUndefined();
+  });
+
+  it("anchors both island edges to the host matrix so the servers reflow can't move them", () => {
+    const vm = buildVm({ computersEnabled: true });
+    const builtinEdge = vm.edges.find((e) => e.id === "host-to-builtin-tools");
+    const computerEdge = vm.edges.find((e) => e.id === "host-to-computer");
+    expect(builtinEdge?.source).toBe(HOST_MATRIX_NODE_ID);
+    expect(builtinEdge?.type).toBe("hostBranch");
+    expect(computerEdge?.source).toBe(HOST_MATRIX_NODE_ID);
+    expect(computerEdge?.type).toBe("hostBranch");
+  });
+});
+
+describe("focusTabForNodeId — Project Computers islands", () => {
+  it("routes both island ids to the Agent (Behavior) tab", () => {
+    expect(focusTabForNodeId(BUILTIN_TOOLS_NODE_ID)).toEqual({
+      tab: "behavior",
+      selectedServerId: null,
+    });
+    expect(focusTabForNodeId(COMPUTER_NODE_ID)).toEqual({
+      tab: "behavior",
+      selectedServerId: null,
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/canvasBuilder.ts
@@ -10,6 +10,8 @@ import {
 } from "@/lib/client-config-v2";
 import {
   ADD_SERVER_NODE_ID,
+  BUILTIN_TOOLS_NODE_ID,
+  COMPUTER_NODE_ID,
   HOST_MATRIX_NODE_ID,
   SERVERS_HUB_NODE_ID,
   type AgentIdentityNodeData,
@@ -57,6 +59,20 @@ const SERVER_CARD_W = 220;
 const SERVER_CARD_H = 88;
 const SERVER_CARD_GAP_X = 16;
 const SERVERS_ROW_GAP = 40;
+
+/* ============================================================
+   Project Computers islands. Built-in tools fan to the LEFT of
+   the matrix and the Computer island to the RIGHT, both flanking
+   the matrix's header band. Emitted only when the builder context
+   has `computersEnabled === true`.
+   ============================================================ */
+const ISLAND_W = 240;
+const ISLAND_GAP = 60;
+const ISLAND_Y = 36;
+// Island edges anchor to the header band rather than the nodes'
+// content-driven vertical center, so the connector lands on the node no
+// matter how many tool rows the list grows to.
+const ISLAND_ANCHOR_Y = ISLAND_Y + 18;
 
 /* ============================================================
    Stable cap orders. Keeping order stable lets row diffs morph
@@ -821,6 +837,99 @@ export function buildRedesignedHostCanvas(
     draggable: false,
     selectable: false,
   });
+
+  // 1b) Project Computers islands — Built-in tools (left) + Computer
+  // (right), flanking the matrix header. Gated entirely behind
+  // `computersEnabled`; when off/omitted the canvas is the GA layout with
+  // no island nodes or edges. Both island edges source from the matrix
+  // (which never reflows — it sits at y=0 and grows downward), so the
+  // RedesignedHostCanvas measured-height shift leaves them pinned.
+  if (context.computersEnabled === true) {
+    const catalog = context.builtInToolCatalog ?? [];
+    const catalogById = new Map(catalog.map((entry) => [entry.id, entry]));
+    const tools = draft.builtInToolIds.map((id) => {
+      const entry = catalogById.get(id);
+      return {
+        id,
+        // Catalog rows carry `displayLabel`; fall back to the raw id while
+        // the catalog query is still loading or for an unknown id.
+        label: entry?.displayLabel ?? id,
+        requiresComputer: entry?.requiresComputer === true,
+      };
+    });
+
+    // Built-in tools node (left of the matrix).
+    nodes.push({
+      id: BUILTIN_TOOLS_NODE_ID,
+      type: "redesignBuiltinTools",
+      position: { x: -(ISLAND_W + ISLAND_GAP), y: ISLAND_Y },
+      style: { width: ISLAND_W },
+      data: { kind: "builtin-tools", tools },
+      draggable: false,
+    });
+    edges.push({
+      id: "host-to-builtin-tools",
+      source: HOST_MATRIX_NODE_ID,
+      target: BUILTIN_TOOLS_NODE_ID,
+      type: "hostBranch",
+      // Matrix left edge → built-in node right edge, level on the header band.
+      data: {
+        fixedSourceX: 0,
+        fixedSourceY: ISLAND_ANCHOR_Y,
+        fixedTargetX: -ISLAND_GAP,
+        fixedTargetY: ISLAND_ANCHOR_Y,
+      },
+      style: { stroke: "oklch(0.68 0.11 40 / 0.55)", strokeWidth: 1.5 },
+    });
+
+    // Computer node (right of the matrix). `attached` is the config intent
+    // (`draft.computer`); `status` is the orthogonal backend lifecycle.
+    const attached = draft.computer !== undefined;
+    const status =
+      context.computerStatus === undefined
+        ? undefined
+        : context.computerStatus === null
+          ? null
+          : context.computerStatus.status;
+    nodes.push({
+      id: COMPUTER_NODE_ID,
+      type: "redesignComputer",
+      position: { x: MATRIX_W + ISLAND_GAP, y: ISLAND_Y },
+      style: { width: ISLAND_W },
+      data: {
+        kind: "computer",
+        attached,
+        status,
+        ...(draft.computer?.workdir
+          ? { workdir: draft.computer.workdir }
+          : {}),
+        backedToolLabels: tools
+          .filter((tool) => tool.requiresComputer)
+          .map((tool) => tool.label),
+      },
+      draggable: false,
+    });
+    edges.push({
+      id: "host-to-computer",
+      source: HOST_MATRIX_NODE_ID,
+      target: COMPUTER_NODE_ID,
+      type: "hostBranch",
+      // Matrix right edge → computer node left edge, level on the header band.
+      data: {
+        fixedSourceX: MATRIX_W,
+        fixedSourceY: ISLAND_ANCHOR_Y,
+        fixedTargetX: MATRIX_W + ISLAND_GAP,
+        fixedTargetY: ISLAND_ANCHOR_Y,
+      },
+      style: {
+        stroke: "oklch(0.68 0.11 40 / 0.55)",
+        strokeWidth: 1.5,
+        // Dashed until the computer is actually attached, mirroring the
+        // ghost-vs-attached treatment of the node itself.
+        strokeDasharray: attached ? undefined : "4 4",
+      },
+    });
+  }
 
   // 2) Servers hub — sibling, below the matrix. Y tracks whether the
   // Apps section actually renders so there's no dead zone between the

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/types.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/types.ts
@@ -1,5 +1,7 @@
 import type { Edge, Node } from "@xyflow/react";
 import type { HostConfigInputV2, HostStyleId } from "@/lib/client-config-v2";
+import type { ComputerStatus, ComputerView } from "@/hooks/useProjectComputer";
+import type { BuiltInToolCatalogEntry } from "@/hooks/useBuiltInToolCatalog";
 
 /**
  * Identifiers for the focus-overlay tabs. Mirrors the header tab order in
@@ -357,23 +359,63 @@ export interface AddServerPillNodeData extends Record<string, unknown> {
   label: string;
 }
 
+/**
+ * Built-in tools island, fanned to the LEFT of the host matrix. Lists the
+ * host's attached `builtInToolIds` resolved through the catalog. Purely a
+ * visualization of state the Agent (Behavior) tab owns — clicking it opens
+ * that tab; the node itself isn't interactive beyond that. Only emitted
+ * when the builder context has `computersEnabled === true`.
+ */
+export interface BuiltinToolsNodeData extends Record<string, unknown> {
+  kind: "builtin-tools";
+  tools: Array<{ id: string; label: string; requiresComputer: boolean }>;
+}
+
+/**
+ * Computer island, fanned to the RIGHT of the host matrix. Reflects the
+ * host's personal-computer attachment intent plus the caller's live
+ * provisioning status. `attached` (config intent, from `draft.computer`)
+ * and `status` (backend lifecycle) are orthogonal — a host can be attached
+ * before any machine is reserved. Only emitted when the builder context
+ * has `computersEnabled === true`.
+ *
+ * `status`:
+ *   - `undefined` — caller status still loading
+ *   - `null` — attached in config, but no machine reserved yet
+ *   - `ComputerStatus` — live provider lifecycle (ready / waking / …)
+ */
+export interface ComputerNodeData extends Record<string, unknown> {
+  kind: "computer";
+  attached: boolean;
+  status: ComputerStatus | null | undefined;
+  workdir?: string;
+  /** Labels of attached built-in tools whose catalog row is computer-backed (e.g. "Bash"). */
+  backedToolLabels: string[];
+}
+
 export type HostRedesignNodeData =
   | HostMatrixNodeData
   | ServersHubNodeData
   | ServerCardNodeData
-  | AddServerPillNodeData;
+  | AddServerPillNodeData
+  | BuiltinToolsNodeData
+  | ComputerNodeData;
 
 export type HostRedesignNodeType =
   | "redesignHostMatrix"
   | "redesignServersHub"
   | "redesignServerCard"
-  | "redesignAddServer";
+  | "redesignAddServer"
+  | "redesignBuiltinTools"
+  | "redesignComputer";
 
 export type HostRedesignFlowNode =
   | Node<HostMatrixNodeData, "redesignHostMatrix">
   | Node<ServersHubNodeData, "redesignServersHub">
   | Node<ServerCardNodeData, "redesignServerCard">
-  | Node<AddServerPillNodeData, "redesignAddServer">;
+  | Node<AddServerPillNodeData, "redesignAddServer">
+  | Node<BuiltinToolsNodeData, "redesignBuiltinTools">
+  | Node<ComputerNodeData, "redesignComputer">;
 
 export interface HostRedesignViewModel {
   hostName: string;
@@ -411,6 +453,18 @@ export interface HostRedesignContext {
     hostName: string;
     draft: HostConfigInputV2;
   };
+  /**
+   * Project Computers visualization inputs. All optional so the builder
+   * stays pure and callers that don't surface the islands (e.g. the
+   * chatbox read-only canvas) can omit them. When `computersEnabled` is
+   * not exactly `true`, the builder emits NO island nodes/edges, so the
+   * GA canvas is byte-for-byte unchanged.
+   */
+  computersEnabled?: boolean;
+  /** Caller's live computer for the project (`null` none, `undefined` loading). */
+  computerStatus?: ComputerView | null;
+  /** Enabled built-in tool catalog (id → label / requiresComputer). */
+  builtInToolCatalog?: ReadonlyArray<BuiltInToolCatalogEntry>;
 }
 
 /** Stable ids for the canvas-level nodes. */
@@ -428,6 +482,9 @@ export const APPS_HUB_NODE_ID = "host-matrix:apps";
 export const SANDBOX_HUB_NODE_ID = "host-matrix:sandbox";
 export const SERVERS_HUB_NODE_ID = "servers-hub";
 export const ADD_SERVER_NODE_ID = "add-server";
+/** Project Computers islands (gated behind `computers-enabled`). */
+export const BUILTIN_TOOLS_NODE_ID = "builtin-tools";
+export const COMPUTER_NODE_ID = "computer";
 
 /** Leaf id constructors — stable across hosts so RF can morph in place. */
 export function protocolLeafNodeId(key: ProtocolLeafKey): string {
@@ -462,6 +519,13 @@ export function focusTabForNodeId(nodeId: string): {
     return { tab: "behavior", selectedServerId: null };
   }
   if (nodeId === AGENT_IDENTITY_NODE_ID) {
+    return { tab: "behavior", selectedServerId: null };
+  }
+  if (nodeId === BUILTIN_TOOLS_NODE_ID || nodeId === COMPUTER_NODE_ID) {
+    // Both Project Computers islands route to the Agent (Behavior) tab —
+    // that's where the personal-computer toggle and the built-in tool
+    // checkboxes live. The islands only visualize that state; the panel
+    // owns it.
     return { tab: "behavior", selectedServerId: null };
   }
   // hostContext is a protocol-leaf-shaped node but lives under the


### PR DESCRIPTION
## What

Visualizes Project Computers state on the redesigned host canvas. The host matrix now has its inputs fanned around it: **Built-in tools** to the left, the **Computer** island to the right, Servers below (unchanged). `bash` shows on the left node as a computer-backed tool (`→ 🖥`) and bridges to the Computer island as a `↳ Bash` chip, making the resource→capability dependency legible without opening the editor panel.

| State | Left node | Right island |
|---|---|---|
| No computer | lists `builtInToolIds` (e.g. Web Search) | ghost `+ Computer` ("Attach your personal computer") |
| Attached | `Bash` row shows `→ 🖥` | `TerminalSquare` + `personal · {workdir}` + status chip + `↳ Bash` + "Open terminal ↗" |

## Safety / gating

Purely **additive canvas decoration**, gated entirely behind the `computers-enabled` PostHog flag. The builder emits **no** island nodes or edges unless `computersEnabled === true`, so the **GA canvas is byte-for-byte unchanged**. The new `HostRedesignContext` fields are optional, so the read-only chatbox canvas (which omits them) renders no islands either.

No panel changes — the existing two-step attach flow (Personal computer toggle → Bash checkbox) is untouched. The islands only *visualize* state the Agent (Behavior) tab owns; clicking either island opens that tab, and the Computer island's "Open terminal" link routes to `/computer`.

## Notable design point

Island edges reuse the coordinate-baked `hostBranch` edge (no new ReactFlow handles). They are **excluded from the matrix measured-height reflow shift** — they anchor to the static matrix (which sits at `y=0` and grows downward), not the servers block that shifts by `dy`. Without this carve-out the island connectors would detach from their nodes as soon as the matrix's real height differs from the layout estimate (i.e. essentially always). The shift is extracted as the unit-tested `shiftReflowedBranchEdges()`.

## Changes

- **types.ts** — `BuiltinToolsNodeData` / `ComputerNodeData` + node ids, union/context extensions, focus routing for both island ids → Behavior tab.
- **canvasBuilder.ts** — emit the two islands behind the flag; map `builtInToolIds` through the catalog (`displayLabel`) for labels + `requiresComputer`; `attached` (config intent) and `status` (backend lifecycle) tracked as orthogonal.
- **RedesignedHostCanvas.tsx** — island renderers, "Open terminal" nav threading, and the reflow carve-out.
- **HostBuilderViewRedesigned.tsx** — feed `computersEnabled` / `computerStatus` / `builtInToolCatalog`; wire Open terminal → `/computer`.

## Tests

`npm run typecheck:client` clean; **188 tests pass** across the redesigned + chatbox suites. New coverage: flag-off/omitted emits no islands, attach + `backedToolLabels`, status tri-state (value/`null`/loading), focus routing for both ids, and a regression guard that island edges (sourced from the matrix) are **not** shifted while server-branch edges are.

## Backend prerequisite (separate, for end-to-end Bash)

The Computer island and the Web Search row work without it, but the `↳ Bash` chip / left-node Bash row only appear once the catalog row is enabled: flip `bash` to `enabled: true` in `mcpjam-backend convex/builtInTools/catalog.ts` and reseed (`builtInTools/catalog:seedBuiltInTools`). Out of scope for this UI PR.

https://claude.ai/code/session_01FK4uP3dcsY92a5xeGVVkQs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK4uP3dcsY92a5xeGVVkQs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, PostHog-gated canvas visualization with optional builder context; no host save or provisioning logic changes.
> 
> **Overview**
> When **`computers-enabled`** is on, the redesigned host canvas gains **Built-in tools** (left) and **Computer** (right) islands beside the host matrix, with connectors from the matrix header band. The builder maps `builtInToolIds` through the catalog (labels, `requiresComputer`), shows ghost vs attached computer state, workdir, live status, and computer-backed tool bridges; island clicks open the **Behavior** tab, and **Open terminal** navigates to `/computer`.
> 
> **HostBuilderViewRedesigned** now passes `computersEnabled`, `useComputerStatus`, and `useBuiltInToolCatalog` into the view model. With the flag off or context omitted, **no island nodes or edges** are emitted so the GA layout stays unchanged.
> 
> **Edge reflow:** matrix height measurement still shifts the servers block; **`shiftReflowedBranchEdges`** excludes edges sourced from the matrix so island connectors stay aligned (unit-tested).
> 
> New Vitest coverage covers gating, catalog mapping, status tri-state, focus routing, and the edge-shift regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19026879f654d56f35d26c8a9cd18494315ec9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->