### PR TITLE
Tier B Phase 1a follow-up: useWidgetHost guard test + persistentSurfaceHost note

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/use-widget-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/use-widget-host.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { WebManagedServersProvider } from "@/contexts/web-managed-servers-context";
+import { ChatboxSurfaceProvider } from "@/contexts/chatbox-surface-context";
+import {
+  WidgetSurfaceProvider,
+  type WidgetSurface,
+} from "@/contexts/widget-surface-context";
+import { useWidgetHost } from "../use-widget-host";
+
+// Pin HOSTED_MODE off so the listResourceTemplates guard is exercised purely via
+// the web-managed-servers context (the security-sensitive boundary concern).
+vi.mock("@/lib/config", () => ({ HOSTED_MODE: false, SANDBOX_ORIGIN: "" }));
+
+// Isolate the hook from the api/network layer.
+const listResourceTemplatesMock = vi.fn();
+vi.mock("@/lib/apis/mcp-resource-templates-api", () => ({
+  listResourceTemplates: (...args: unknown[]) =>
+    listResourceTemplatesMock(...args),
+}));
+vi.mock("@/lib/apis/mcp-resources-api", () => ({
+  readResource: vi.fn(),
+  listResources: vi.fn(),
+}));
+vi.mock("@/lib/apis/mcp-prompts-api", () => ({ listPrompts: vi.fn() }));
+vi.mock("../fetch-widget-content", () => ({ fetchMcpAppsWidgetContent: vi.fn() }));
+
+function makeWrapper(opts: {
+  webManaged?: boolean;
+  chatbox?: boolean;
+  surface?: WidgetSurface;
+}) {
+  return ({ children }: { children: React.ReactNode }) => {
+    let node = <>{children}</>;
+    if (opts.surface !== undefined) {
+      node = (
+        <WidgetSurfaceProvider value={opts.surface}>
+          {node}
+        </WidgetSurfaceProvider>
+      );
+    }
+    if (opts.chatbox !== undefined) {
+      node = (
+        <ChatboxSurfaceProvider value={opts.chatbox}>
+          {node}
+        </ChatboxSurfaceProvider>
+      );
+    }
+    if (opts.webManaged !== undefined) {
+      node = (
+        <WebManagedServersProvider value={opts.webManaged}>
+          {node}
+        </WebManagedServersProvider>
+      );
+    }
+    return node;
+  };
+}
+
+describe("useWidgetHost", () => {
+  beforeEach(() => {
+    listResourceTemplatesMock.mockReset();
+  });
+
+  describe("services.listResourceTemplates (host-owned guard)", () => {
+    it("delegates to the api when the surface is not web-managed", async () => {
+      const templates = [{ uriTemplate: "ui://widget/{id}", name: "tpl" }];
+      listResourceTemplatesMock.mockResolvedValue(templates);
+
+      const { result } = renderHook(() => useWidgetHost(), {
+        wrapper: makeWrapper({ webManaged: false }),
+      });
+
+      await expect(
+        result.current.services.listResourceTemplates("server-1"),
+      ).resolves.toEqual(templates);
+      expect(listResourceTemplatesMock).toHaveBeenCalledWith("server-1");
+    });
+
+    it("throws and never hits the api on web-managed surfaces", async () => {
+      const { result } = renderHook(() => useWidgetHost(), {
+        wrapper: makeWrapper({ webManaged: true }),
+      });
+
+      await expect(
+        result.current.services.listResourceTemplates("server-1"),
+      ).rejects.toThrow(/hosted mode/i);
+      expect(listResourceTemplatesMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("surface.kind", () => {
+    it("defaults to chat", () => {
+      const { result } = renderHook(() => useWidgetHost(), {
+        wrapper: makeWrapper({}),
+      });
+      expect(result.current.surface.kind).toBe("chat");
+    });
+
+    it("is playground when the widget surface is playground", () => {
+      const { result } = renderHook(() => useWidgetHost(), {
+        wrapper: makeWrapper({ surface: "playground" }),
+      });
+      expect(result.current.surface.kind).toBe("playground");
+    });
+
+    it("is chatbox on a chatbox surface", () => {
+      const { result } = renderHook(() => useWidgetHost(), {
+        wrapper: makeWrapper({ chatbox: true }),
+      });
+      expect(result.current.surface.kind).toBe("chatbox");
+    });
+
+    it("lets chatbox win over playground (preserves CSP precedence)", () => {
+      const { result } = renderHook(() => useWidgetHost(), {
+        wrapper: makeWrapper({ chatbox: true, surface: "playground" }),
+      });
+      expect(result.current.surface.kind).toBe("chatbox");
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -554,6 +554,12 @@ function PersistentMCPAppsRendererRegistration(props: MCPAppsRendererProps) {
 }
 
 export function MCPAppsRenderer(props: MCPAppsRendererProps) {
+  // Read directly (not via useWidgetHost) because this wrapper gates
+  // persistent-vs-ephemeral routing before MCPAppsRendererSurface mounts;
+  // routing it through the host hook here would widen this wrapper's
+  // subscription set. Centralizing is deferred to the relocation PR — this is a
+  // relative-import context, so it does not affect the Tier-B import guard. See
+  // use-widget-host.ts.
   const persistentHostEnabled = usePersistentWidgetSurfaceHost();
   const isCachedReplay =
     !!props.cachedWidgetHtmlUrl && !props.liveFetchPreferred;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.ts
@@ -45,6 +45,14 @@ export function useWidgetHost(): WidgetHostServicesSurfaceDebug {
   const isChatboxSurface = useIsChatboxSurface();
   const widgetSurface = useWidgetSurface();
   const webManagedServers = useWebManagedServers();
+  // Mirrored into the surface bundle for completeness, but the
+  // `MCPAppsRenderer` wrapper still reads `usePersistentWidgetSurfaceHost()`
+  // directly — it gates persistent-vs-ephemeral routing *before*
+  // `MCPAppsRendererSurface` (the `useWidgetHost()` caller) mounts. Fully
+  // centralizing this read is intentionally deferred to the renderer-relocation
+  // PR to avoid widening the wrapper's subscription set (it would then re-render
+  // on every host input). It's a relative-import context, so it does not block
+  // the Tier-B `@/stores`/`@/contexts` guard regardless.
   const persistentSurfaceHost = usePersistentWidgetSurfaceHost();
   const playgroundCspMode = useUIPlaygroundStore((s) => s.mcpAppsCspMode);
 


### PR DESCRIPTION
## What

Small follow-up to the merged **Phase 1a** (#2697), addressing the two review notes from that PR:

1. **Focused test for the resource-template boundary** — `use-widget-host.test.tsx`:
   - `services.listResourceTemplates()` **throws and never hits the api** on web-managed surfaces (the security-sensitive guard), and **delegates + returns the array** otherwise.
   - `surface.kind` derivation: default → `chat`, widget-surface → `playground`, chatbox → `chatbox`, and **chatbox wins over playground** (the CSP precedence the inversion must preserve).
2. **`persistentSurfaceHost` deferral note** — documents that `surface.persistentSurfaceHost` is mirrored for completeness while the `MCPAppsRenderer` wrapper still reads `usePersistentWidgetSurfaceHost()` directly (it gates persistent-vs-ephemeral routing *before* `MCPAppsRendererSurface` mounts). Fully centralizing it is deferred to the renderer-relocation PR to avoid widening the wrapper's subscription set. It's a relative-import context, so it does **not** affect the Tier-B import guard.

## On the bridge `{ resourceTemplates }` wrapping

The guard + array delegation are covered at the service level (above) and the wrapping is a typechecked one-liner. A full-mount test of the bridge handler proved brittle — handlers register only after a sandbox-ready/connect dance in that suite's harness — so I scoped the test to the service boundary rather than add a flaky mount-based assertion.

## Verification

- `typecheck:client` ✓
- 118 widget tests pass: mcp-apps-renderer (86), host-app-bridge (26), **useWidgetHost (6, new)**.
- No production behavior change (test + comments only).

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and comment-only follow-up; the security-sensitive listResourceTemplates guard is now explicitly covered by unit tests.
> 
> **Overview**
> Adds **`use-widget-host.test.tsx`** with six Vitest cases for the Tier B **`useWidgetHost`** adapter: **`services.listResourceTemplates`** delegates to the API on non–web-managed surfaces and **throws without calling the API** on web-managed surfaces (with **`HOSTED_MODE`** mocked off so the guard is exercised via context). **`surface.kind`** is covered for default **`chat`**, **`playground`**, **`chatbox`**, and **chatbox over playground** (CSP precedence).
> 
> **Comments only** in **`MCPAppsRenderer`** and **`use-widget-host.ts`** explain why the outer renderer still calls **`usePersistentWidgetSurfaceHost()`** directly instead of routing through the host hook—persistent vs ephemeral routing runs before **`MCPAppsRendererSurface`** mounts, and centralizing would widen re-renders; full centralization is deferred to a later relocation PR and does not affect the Tier-B import guard.
> 
> No production behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b234042f787123976e4af966047c5f4eb98328bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->