### PR TITLE
Refresh WidgetHost boundary comments after Phase 1b

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.ts
@@ -1,18 +1,19 @@
-// Tier B widget-runtime extraction — Phase 1 (services + surface + debug).
+// Tier B — `useWidgetHost`, the inspector-side adapter for the `WidgetHost`
+// dependency-inversion contract (see ./widget-host.ts). It reads the ambient
+// stores/contexts the widget renderer used to reach into directly and exposes
+// them as `environment` (raw ENV inputs), `resolvers` (bound config/style fns),
+// `services`, `surface`, and `debug`.
 //
-// `useWidgetHost` is the inspector-side adapter that implements the `WidgetHost`
-// dependency-inversion contract (see ./widget-host.ts) by reading the ambient
-// stores/contexts the widget renderer used to reach into directly. It is a
-// COMPOSITE HOOK, not a context provider: the renderer is always already
+// It is a COMPOSITE HOOK, not a context provider: the renderer is always already
 // mounted inside whatever provider hierarchy its surface needs (chat /
 // playground / chatbox / trace), so calling the same hooks the renderer calls
 // works on every surface with zero new mount points.
 //
 // This module — the boundary adapter — is allowed to import @/stores, @/contexts
-// and the api/config layer; the renderer will not. This PR covers the
-// `services`, `surface`, and `debug` slices; `resolveEnvironment` (the
-// security-sensitive profile/sandbox resolution) lands in the follow-up, at
-// which point the return type widens to the full `WidgetHost`.
+// and the api/config layer; `mcp-apps-renderer.tsx` is not (enforced by
+// check-renderer-tier-b-imports.mjs). Phase 1b routes the renderer's ambient
+// reads through `environment`/`resolvers` while keeping its derivation in place;
+// pre-resolving them into `WidgetHost.resolveEnvironment` is the Phase-3 target.
 
 import { useMemo, useRef } from "react";
 import { HOSTED_MODE, SANDBOX_ORIGIN } from "@/lib/config";

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
@@ -1,19 +1,23 @@
-// Tier B widget-runtime extraction — Phase 0 boundary (design only).
+// Tier B — the `WidgetHost` dependency-inversion contract.
 //
 // See ./widget-host.design.md for the rationale and the phased plan.
 //
-// `WidgetHost` is the dependency-inversion seam the interactive MCP-Apps widget
-// renderer (mcp-apps-renderer / widget-replay) will read from, instead of
-// reaching into ~14 inspector stores/contexts/resolvers directly. Today those
-// reads are scattered across mcp-apps-renderer.tsx (lines 22-103, 570-942,
-// 1364-2101). The inversion: the renderer reads ONE `WidgetHost`; the inspector
-// populates it from those sources at a single provider site.
+// `WidgetHost` is the seam the interactive MCP-Apps widget renderer
+// (mcp-apps-renderer) reads from instead of reaching into inspector
+// stores/contexts/resolvers directly. The inspector-side adapter `useWidgetHost`
+// (./use-widget-host.ts) implements it; `mcp-apps-renderer.tsx` consumes it and,
+// as of Phase 1b, imports zero `@/stores`/`@/contexts`/`@/lib/client-*` modules
+// (enforced by check-renderer-tier-b-imports.mjs).
 //
-// This file is the CONTRACT ONLY — nothing imports it yet, and no behavior
-// changes. The in-place refactor that routes the renderer through it lands in
-// Phase 1. The contract is anchored to the real inspector signatures via
+// Scope note: this boundary makes the RENDERER app-state-import-clean. It does
+// NOT yet make the whole widget runtime package-clean — e.g. the
+// `MCPAppsRenderer` wrapper still reads `usePersistentWidgetSurfaceHost`
+// directly, and sibling files (modal/chrome) still touch inspector state. Those
+// relocate in Phases 2-3.
+//
+// The contract is anchored to the real inspector signatures via
 // `typeof import(...)` / named result types, so it fails typecheck loudly if an
-// underlying shape drifts before the migration catches up.
+// underlying shape drifts.
 
 import type { ComponentType, ReactNode } from "react";
 import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps/app-bridge";


### PR DESCRIPTION
## What

Comment-only cleanup addressing the TL's review notes on #2702 (Phase 1b) — the `WidgetHost` boundary headers carried stale Phase-0/1a wording now that the renderer and adapter actually use the contract.

- **`widget-host.ts`** — removed "CONTRACT ONLY — nothing imports it yet" (the renderer + `useWidgetHost` now import it). Added a **scope note**: this boundary makes the **renderer** app-state-import-clean, **not** the whole widget runtime — the `MCPAppsRenderer` wrapper still reads `usePersistentWidgetSurfaceHost` directly, and modal/chrome siblings still touch inspector state (both relocate in Phases 2-3).
- **`use-widget-host.ts`** — header said it only covered services/surface/debug with `resolveEnvironment` "later"; it now also exposes `environment` + `resolvers`. Reworded; `resolveEnvironment` noted as the Phase-3 target.

No code change. `typecheck:client` (+ the renderer guard via the pre-hook) passes.

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to module comments; no runtime or type behavior changes.
> 
> **Overview**
> Updates **comment-only** headers on the Tier B `WidgetHost` boundary so they match Phase 1b reality instead of Phase 0/1a wording.
> 
> In **`widget-host.ts`**, the file no longer describes itself as contract-only with no importers; it now states that **`mcp-apps-renderer`** and **`useWidgetHost`** use the seam, that Phase 1b keeps the renderer free of `@/stores` / `@/contexts` / `@/lib/client-*` (via **`check-renderer-tier-b-imports.mjs`**), and adds a **scope note**: only the renderer is import-clean—**`MCPAppsRenderer`** still reads **`usePersistentWidgetSurfaceHost`**, and modal/chrome siblings still touch inspector state until Phases 2–3.
> 
> In **`use-widget-host.ts`**, the header now documents the full adapter surface (**`environment`**, **`resolvers`**, **`services`**, **`surface`**, **`debug`**) and Phase 1b routing of ambient reads through **`environment`** / **`resolvers`**, with **`WidgetHost.resolveEnvironment`** called out as the Phase 3 target instead of a vague “later” follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe7fffd314807a123c90b4eff5e837177b8b6ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->