### PR TITLE
Set up local Playwright Chromium automatically

### DIFF
--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -42,6 +42,7 @@ import {
   warnOnConvexDevMisconfiguration,
 } from "./env.js";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync.js";
+import { startLocalBrowserRenderingSetupInBackground } from "./utils/browser-rendering-setup.js";
 import { fetchRemoteGuestJwks } from "./utils/guest-session-source.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy.js";
 import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair.js";
@@ -68,6 +69,7 @@ export function createHonoApp() {
   initXAAIdpKeyPair();
 
   startGuestAuthProvisioningInBackground();
+  startLocalBrowserRenderingSetupInBackground();
 
   const app = new Hono();
   const strictModeResponse = (c: any, path: string) =>

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -35,6 +35,7 @@ import { originValidationMiddleware } from "./middleware/origin-validation";
 import { securityHeadersMiddleware } from "./middleware/security-headers";
 import { inAppBrowserMiddleware } from "./middleware/in-app-browser";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync";
+import { startLocalBrowserRenderingSetupInBackground } from "./utils/browser-rendering-setup";
 
 import { getSystemLogger } from "./utils/request-logger";
 import { requestLogContextMiddleware } from "./middleware/request-log-context";
@@ -223,6 +224,7 @@ generateSessionToken();
 initXAAIdpKeyPair();
 
 startGuestAuthProvisioningInBackground();
+startLocalBrowserRenderingSetupInBackground();
 const app = new Hono().onError((err, c) => {
   appLogger.error("Unhandled error:", err);
 

--- a/mcpjam-inspector/server/utils/__tests__/browser-rendering-setup.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/browser-rendering-setup.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureLocalChromiumInstalled,
+  resetBrowserRenderingSetupForTests,
+  shouldAutoInstallChromium,
+} from "../browser-rendering-setup";
+
+const localEnv = {
+  NODE_ENV: "production",
+} as NodeJS.ProcessEnv;
+
+const silentLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+beforeEach(() => {
+  resetBrowserRenderingSetupForTests();
+  silentLogger.info.mockClear();
+  silentLogger.warn.mockClear();
+});
+
+describe("browser rendering setup", () => {
+  it("does not auto-install in hosted, Docker, test, or opt-out environments", () => {
+    expect(shouldAutoInstallChromium({ NODE_ENV: "test" })).toBe(false);
+    expect(shouldAutoInstallChromium({ DOCKER_CONTAINER: "true" })).toBe(false);
+    expect(shouldAutoInstallChromium({ VITE_MCPJAM_HOSTED_MODE: "true" })).toBe(
+      false
+    );
+    expect(
+      shouldAutoInstallChromium({
+        MCPJAM_SKIP_BROWSER_RENDERING_SETUP: "1",
+      })
+    ).toBe(false);
+    expect(
+      shouldAutoInstallChromium({ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1" })
+    ).toBe(false);
+    expect(shouldAutoInstallChromium(localEnv)).toBe(true);
+    expect(
+      shouldAutoInstallChromium({
+        NODE_ENV: "development",
+        ELECTRON_APP: "true",
+      })
+    ).toBe(true);
+  });
+
+  it("installs Chromium once when local rendering is missing it", async () => {
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const runInstall = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    await expect(
+      ensureLocalChromiumInstalled({
+        env: localEnv,
+        isInstalled,
+        runInstall,
+        logger: silentLogger,
+      })
+    ).resolves.toBe(true);
+
+    expect(runInstall).toHaveBeenCalledTimes(1);
+    expect(isInstalled).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one install across concurrent render attempts", async () => {
+    let finishInstall!: () => void;
+    const installStarted = new Promise<void>((resolve) => {
+      finishInstall = resolve;
+    });
+    const runInstall = vi.fn<() => Promise<void>>(() => installStarted);
+    const isInstalled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+
+    const first = ensureLocalChromiumInstalled({
+      env: localEnv,
+      isInstalled,
+      runInstall,
+      logger: silentLogger,
+    });
+    const second = ensureLocalChromiumInstalled({
+      env: localEnv,
+      isInstalled,
+      runInstall,
+      logger: silentLogger,
+    });
+
+    finishInstall();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(runInstall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/utils/browser-rendering-setup.ts
+++ b/mcpjam-inspector/server/utils/browser-rendering-setup.ts
@@ -1,5 +1,7 @@
+import { spawn } from "child_process";
 import { existsSync } from "fs";
 import { createRequire } from "module";
+import { dirname, resolve as resolvePath } from "path";
 import { logger } from "./logger.js";
 
 const require = createRequire(import.meta.url);
@@ -58,19 +60,54 @@ export async function isChromiumInstalled(): Promise<boolean> {
   }
 }
 
-type PlaywrightRegistryModule = {
-  installBrowsersForNpmInstall: (browsers: string[]) => Promise<unknown>;
-};
-
-function loadPlaywrightRegistry(): PlaywrightRegistryModule {
-  return require(
-    "playwright-core/lib/server/registry/index"
-  ) as PlaywrightRegistryModule;
+/**
+ * Resolve Playwright's CLI entry point via its package `bin` contract. We can't
+ * `require.resolve("playwright/cli.js")` directly because Playwright's `exports`
+ * map doesn't expose `./cli.js`, but `./package.json` is always exported and the
+ * `bin` field is a stable public contract — so resolve the package root and join
+ * the declared bin path off it.
+ */
+function resolvePlaywrightCli(): string {
+  const pkgJsonPath = require.resolve("playwright/package.json");
+  const pkg = require("playwright/package.json") as {
+    bin?: string | Record<string, string>;
+  };
+  const binRel =
+    typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.playwright;
+  if (!binRel) {
+    throw new Error("Could not resolve the playwright CLI bin entry");
+  }
+  return resolvePath(dirname(pkgJsonPath), binRel);
 }
 
+/**
+ * Run `playwright install chromium` through the published CLI rather than
+ * reaching into `playwright-core/lib/server/registry`, which is an internal
+ * module Playwright reorganizes between releases. The CLI is a supported entry
+ * point, survives version bumps, and inheriting its stdio shows the user the
+ * real download progress instead of a single log line.
+ */
 export async function installPlaywrightChromium(): Promise<void> {
-  const { installBrowsersForNpmInstall } = loadPlaywrightRegistry();
-  await installBrowsersForNpmInstall(["chromium"]);
+  const cliPath = resolvePlaywrightCli();
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, "install", "chromium"], {
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `playwright install chromium exited with ${
+              signal ? `signal ${signal}` : `code ${code}`
+            }`
+          )
+        );
+      }
+    });
+  });
 }
 
 export async function ensureLocalChromiumInstalled(

--- a/mcpjam-inspector/server/utils/browser-rendering-setup.ts
+++ b/mcpjam-inspector/server/utils/browser-rendering-setup.ts
@@ -1,0 +1,146 @@
+import { existsSync } from "fs";
+import { createRequire } from "module";
+import { logger } from "./logger.js";
+
+const require = createRequire(import.meta.url);
+
+const INSTALL_RETRY_COOLDOWN_MS = 5 * 60 * 1000;
+
+type BrowserSetupReason = "startup" | "render";
+
+type BrowserRenderingSetupLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+interface BrowserRenderingSetupOptions {
+  reason?: BrowserSetupReason;
+  env?: NodeJS.ProcessEnv;
+  isInstalled?: () => Promise<boolean>;
+  runInstall?: () => Promise<void>;
+  logger?: BrowserRenderingSetupLogger;
+}
+
+let installPromise: Promise<boolean> | null = null;
+let lastInstallFailureAt = 0;
+
+function defaultLogger(_env: NodeJS.ProcessEnv): BrowserRenderingSetupLogger {
+  return {
+    info(message) {
+      logger.info(message);
+    },
+    warn(message) {
+      logger.warn(message);
+    },
+  };
+}
+
+export function shouldAutoInstallChromium(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  if (env.NODE_ENV === "test") return false;
+  if (env.DOCKER_CONTAINER === "true") return false;
+  if (env.VITE_MCPJAM_HOSTED_MODE === "true") return false;
+  if (env.MCPJAM_SKIP_BROWSER_RENDERING_SETUP === "1") return false;
+  if (env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === "1") return false;
+  return true;
+}
+
+export async function isChromiumInstalled(): Promise<boolean> {
+  try {
+    const chromium = await import("playwright")
+      .then((m) => m.chromium)
+      .catch(async () => (await import("playwright-core")).chromium);
+    const executablePath = chromium.executablePath();
+    return !!executablePath && existsSync(executablePath);
+  } catch {
+    return false;
+  }
+}
+
+type PlaywrightRegistryModule = {
+  installBrowsersForNpmInstall: (browsers: string[]) => Promise<unknown>;
+};
+
+function loadPlaywrightRegistry(): PlaywrightRegistryModule {
+  return require(
+    "playwright-core/lib/server/registry/index"
+  ) as PlaywrightRegistryModule;
+}
+
+export async function installPlaywrightChromium(): Promise<void> {
+  const { installBrowsersForNpmInstall } = loadPlaywrightRegistry();
+  await installBrowsersForNpmInstall(["chromium"]);
+}
+
+export async function ensureLocalChromiumInstalled(
+  options: BrowserRenderingSetupOptions = {}
+): Promise<boolean> {
+  const env = options.env ?? process.env;
+  const log = options.logger ?? defaultLogger(env);
+  const isInstalled = options.isInstalled ?? isChromiumInstalled;
+
+  if (!shouldAutoInstallChromium(env)) {
+    return false;
+  }
+
+  if (await isInstalled()) {
+    return true;
+  }
+
+  const now = Date.now();
+  if (
+    lastInstallFailureAt > 0 &&
+    now - lastInstallFailureAt < INSTALL_RETRY_COOLDOWN_MS
+  ) {
+    return false;
+  }
+
+  if (!installPromise) {
+    const runInstall = options.runInstall ?? installPlaywrightChromium;
+    const reason = options.reason ?? "render";
+
+    installPromise = (async () => {
+      log.info(
+        `[browser-rendering] Chromium missing; setting up Playwright Chromium (${reason})`
+      );
+      try {
+        await runInstall();
+        const ready = await isInstalled();
+        if (!ready) {
+          throw new Error(
+            "Playwright Chromium install finished, but no launchable Chromium was found"
+          );
+        }
+        lastInstallFailureAt = 0;
+        log.info("[browser-rendering] Playwright Chromium is ready");
+        return true;
+      } catch (error) {
+        lastInstallFailureAt = Date.now();
+        log.warn(
+          `[browser-rendering] Failed to set up Playwright Chromium: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        return false;
+      }
+    })().finally(() => {
+      installPromise = null;
+    });
+  }
+
+  return installPromise;
+}
+
+export function startLocalBrowserRenderingSetupInBackground(): void {
+  if (!shouldAutoInstallChromium()) {
+    return;
+  }
+
+  void ensureLocalChromiumInstalled({ reason: "startup" });
+}
+
+export function resetBrowserRenderingSetupForTests(): void {
+  installPromise = null;
+  lastInstallFailureAt = 0;
+}

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -29,6 +29,12 @@ import {
   sanitizeProxyDomain,
 } from "./sandbox-proxy-csp";
 import { HARNESS_PAGE_BUNDLE } from "./browser-harness/HarnessPageBundle.generated";
+import {
+  ensureLocalChromiumInstalled,
+  isChromiumInstalled,
+} from "./browser-rendering-setup";
+
+export { isChromiumInstalled };
 
 /* ------------------------------------------------------------------ *
  * Contract types
@@ -143,27 +149,6 @@ export class ChromiumNotInstalledError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "ChromiumNotInstalledError";
-  }
-}
-
-/**
- * Whether a launchable Chromium binary is present for Playwright — the same
- * check `ensureLaunched` gates the real launch on, factored out as the single
- * source of truth. Used by browser-render tests to skip (not fail) where no
- * browser is installed, and available to callers that want a deploy-time
- * preflight so a browser-less image fails loudly at boot rather than on the
- * first widget probe. Honors `PLAYWRIGHT_BROWSERS_PATH` because
- * `chromium.executablePath()` resolves against it.
- */
-export async function isChromiumInstalled(): Promise<boolean> {
-  try {
-    const chromium = await import("playwright")
-      .then((m) => m.chromium)
-      .catch(async () => (await import("playwright-core")).chromium);
-    const executablePath = chromium.executablePath();
-    return !!executablePath && existsSync(executablePath);
-  } catch {
-    return false;
   }
 }
 
@@ -425,6 +410,15 @@ export class McpAppBrowserHarness {
     } catch {
       executablePath = undefined;
     }
+    if (!executablePath || !existsSync(executablePath)) {
+      await ensureLocalChromiumInstalled({ reason: "render" });
+      try {
+        executablePath = chromium.executablePath();
+      } catch {
+        executablePath = undefined;
+      }
+    }
+
     if (!executablePath || !existsSync(executablePath)) {
       throw new ChromiumNotInstalledError(
         "Chromium is not installed for Playwright. Run `npx playwright install chromium`."


### PR DESCRIPTION
When Inspector starts locally, it now checks for the browser needed for widget rendering and starts installing it if it is missing. Hosted Docker is unchanged because it already bakes Chromium into the image.