### PR TITLE
feat(hosts): Tools + Computer as dedicated host focus tabs

### DIFF
--- a/mcpjam-inspector/client/src/components/client-config/BuiltInToolCheckboxList.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/BuiltInToolCheckboxList.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { Label } from "@mcpjam/design-system/label";
+import { Switch } from "@mcpjam/design-system/switch";
+import { cn } from "@/lib/utils";
 import type { BuiltInToolCatalogEntry } from "@/hooks/useBuiltInToolCatalog";
 
 /**
@@ -21,8 +23,10 @@ export function BuiltInToolCheckboxList({
   computerAttached = false,
   computerToolsDisallowed = false,
   readOnly = false,
+  computerAttachHint = "attach it above",
+  variant = "default",
 }: {
-  label: string;
+  label?: string;
   selected: string[];
   available: ReadonlyArray<BuiltInToolCatalogEntry>;
   onChange: (ids: string[]) => void;
@@ -36,6 +40,20 @@ export function BuiltInToolCheckboxList({
   computerToolsDisallowed?: boolean;
   /** Disable every checkbox (no edits) — for read-only editor surfaces. */
   readOnly?: boolean;
+  /**
+   * Where the personal-computer toggle lives, woven into the "Requires a
+   * personal computer (…)" block reason. Defaults to "attach it above" for
+   * surfaces that render the toggle inline above this list (ClientConfigEditor);
+   * the host focus panel passes "attach it in the Computer tab" since the
+   * toggle moved to its own tab there.
+   */
+  computerAttachHint?: string;
+  /**
+   * `minimal` — compact switch rows for the host focus Tools tab (no
+   * descriptions, no section label). `default` — checkbox list with
+   * descriptions for ClientConfigEditor and eval surfaces.
+   */
+  variant?: "default" | "minimal";
 }) {
   const selectedSet = useMemo(() => new Set(selected), [selected]);
   const toggle = useCallback(
@@ -46,13 +64,22 @@ export function BuiltInToolCheckboxList({
       else next.add(id);
       onChange(Array.from(next));
     },
-    [selectedSet, onChange]
+    [selectedSet, onChange],
   );
+
+  const resolveBlockReason = (tool: BuiltInToolCatalogEntry): string | null => {
+    if (!tool.requiresComputer) return null;
+    if (computerToolsDisallowed) return "Not available for eval suites.";
+    if (!computerAttached) {
+      return `Requires a personal computer (${computerAttachHint}).`;
+    }
+    return null;
+  };
 
   if (available.length === 0) {
     return (
       <div>
-        <Label>{label}</Label>
+        {label ? <Label>{label}</Label> : null}
         <p className="text-xs text-muted-foreground mt-1">
           No built-in tools available.
         </p>
@@ -60,20 +87,53 @@ export function BuiltInToolCheckboxList({
     );
   }
 
+  if (variant === "minimal") {
+    return (
+      <div className="divide-y divide-border/50">
+        {available.map((tool) => {
+          const isSelected = selectedSet.has(tool.id);
+          const blockReason = resolveBlockReason(tool);
+          const blocked = blockReason !== null;
+          const disabled = readOnly || (blocked && !isSelected);
+          return (
+            <div
+              key={tool.id}
+              className={cn(
+                "flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0",
+                disabled && "opacity-60",
+              )}
+            >
+              <div className="min-w-0">
+                <span className="text-[12px] font-medium">
+                  {tool.displayLabel}
+                </span>
+                {blocked ? (
+                  <p className="mt-0.5 text-[11px] text-amber-600 dark:text-amber-500">
+                    {blockReason}
+                    {isSelected ? " Turn off to remove." : ""}
+                  </p>
+                ) : null}
+              </div>
+              <Switch
+                checked={isSelected}
+                disabled={disabled}
+                onCheckedChange={() => toggle(tool.id, disabled)}
+                aria-label={tool.displayLabel}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <div className="grid gap-2">
-      <Label>{label}</Label>
+      {label ? <Label>{label}</Label> : null}
       <div className="grid gap-1.5 max-h-40 overflow-y-auto rounded border px-2 py-2">
         {available.map((tool) => {
           const isSelected = selectedSet.has(tool.id);
-          let blockReason: string | null = null;
-          if (tool.requiresComputer) {
-            if (computerToolsDisallowed) {
-              blockReason = "Not available for eval suites.";
-            } else if (!computerAttached) {
-              blockReason = "Requires a personal computer (attach it above).";
-            }
-          }
+          const blockReason = resolveBlockReason(tool);
           const blocked = blockReason !== null;
           // Read-only disables everything. Otherwise: a blocked tool that is
           // already selected stays removable (so a stale invalid id like
@@ -88,7 +148,7 @@ export function BuiltInToolCheckboxList({
                   ? "flex items-start gap-2 text-sm cursor-not-allowed opacity-60"
                   : "flex items-start gap-2 text-sm cursor-pointer"
               }
-              title={disabled ? blockReason ?? undefined : undefined}
+              title={disabled ? (blockReason ?? undefined) : undefined}
             >
               <input
                 type="checkbox"

--- a/mcpjam-inspector/client/src/components/client-config/__tests__/BuiltInToolCheckboxList.test.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/__tests__/BuiltInToolCheckboxList.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { BuiltInToolCheckboxList } from "../BuiltInToolCheckboxList";
 import type { BuiltInToolCatalogEntry } from "@/hooks/useBuiltInToolCatalog";
@@ -37,7 +37,7 @@ describe("BuiltInToolCheckboxList — computer gating", () => {
         available={[WEB_SEARCH, BASH]}
         computerAttached={false}
         onChange={onChange}
-      />
+      />,
     );
 
     expect(checkboxFor(container, "Web Search").disabled).toBe(false);
@@ -59,7 +59,7 @@ describe("BuiltInToolCheckboxList — computer gating", () => {
         available={[BASH]}
         computerAttached
         onChange={onChange}
-      />
+      />,
     );
 
     const bash = checkboxFor(container, "Bash");
@@ -77,7 +77,7 @@ describe("BuiltInToolCheckboxList — computer gating", () => {
         available={[WEB_SEARCH]}
         computerAttached={false}
         onChange={onChange}
-      />
+      />,
     );
     fireEvent.click(checkboxFor(container, "Web Search"));
     expect(onChange).toHaveBeenCalledWith(["web_search"]);
@@ -94,7 +94,7 @@ describe("BuiltInToolCheckboxList — computer gating", () => {
         available={[BASH]}
         computerAttached={false}
         onChange={onChange}
-      />
+      />,
     );
     const bash = checkboxFor(container, "Bash");
     expect(bash.checked).toBe(true);
@@ -113,7 +113,7 @@ describe("BuiltInToolCheckboxList — computer gating", () => {
         computerAttached
         readOnly
         onChange={onChange}
-      />
+      />,
     );
     const webSearch = checkboxFor(container, "Web Search");
     const bash = checkboxFor(container, "Bash");
@@ -123,6 +123,24 @@ describe("BuiltInToolCheckboxList — computer gating", () => {
     fireEvent.click(webSearch);
     fireEvent.click(bash);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("minimal variant renders switch rows without descriptions", () => {
+    const onChange = vi.fn();
+    render(
+      <BuiltInToolCheckboxList
+        variant="minimal"
+        selected={[]}
+        available={[WEB_SEARCH, BASH]}
+        computerAttached={false}
+        onChange={onChange}
+      />,
+    );
+    expect(
+      screen.getByRole("switch", { name: "Web Search" }),
+    ).not.toBeDisabled();
+    expect(screen.getByRole("switch", { name: "Bash" })).toBeDisabled();
+    expect(screen.queryByText("Search the web")).toBeNull();
   });
 
   it("disallows computer-backed tools entirely on eval suites, but stale ones stay removable", () => {
@@ -135,7 +153,7 @@ describe("BuiltInToolCheckboxList — computer gating", () => {
         computerAttached
         computerToolsDisallowed
         onChange={onChange}
-      />
+      />,
     );
     // Even with a (hypothetical) computer attached, eval disallows it.
     expect(checkboxFor(container, "Bash").disabled).toBe(true);
@@ -150,7 +168,7 @@ describe("BuiltInToolCheckboxList — computer gating", () => {
         computerAttached={false}
         computerToolsDisallowed
         onChange={onChange}
-      />
+      />,
     );
     const bash = checkboxFor(container, "Bash");
     expect(bash.disabled).toBe(false);

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/__tests__/canvasBuilder.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/__tests__/canvasBuilder.test.ts
@@ -124,7 +124,9 @@ describe("buildRedesignedHostCanvas", () => {
     const data = matrixData(
       buildVm({ draft: next, prev: { hostName: "Prev", draft: prev } }),
     );
-    const updated = data.appsCaps.find((c) => c.capKey === "updateModelContext");
+    const updated = data.appsCaps.find(
+      (c) => c.capKey === "updateModelContext",
+    );
     expect(updated?.on).toBe(true);
     expect(updated?.isNewlyOn).toBe(true);
   });
@@ -642,9 +644,7 @@ describe("buildRedesignedHostCanvas — Project Computers islands", () => {
     const draft = emptyHostConfigInputV2();
     draft.builtInToolIds = ["mystery_tool"];
     // No catalog passed (mirrors the loading state).
-    const tools = builtinData(
-      buildVm({ computersEnabled: true, draft }),
-    ).tools;
+    const tools = builtinData(buildVm({ computersEnabled: true, draft })).tools;
     expect(tools).toEqual([
       { id: "mystery_tool", label: "mystery_tool", requiresComputer: false },
     ]);
@@ -686,8 +686,9 @@ describe("buildRedesignedHostCanvas — Project Computers islands", () => {
     // Explicit null (resolved, no machine reserved) is preserved distinct
     // from undefined (still loading) so the renderer can tell them apart.
     expect(
-      computerData(buildVm({ computersEnabled: true, draft, computerStatus: null }))
-        .status,
+      computerData(
+        buildVm({ computersEnabled: true, draft, computerStatus: null }),
+      ).status,
     ).toBeNull();
     expect(
       computerData(buildVm({ computersEnabled: true, draft })).status,
@@ -706,13 +707,13 @@ describe("buildRedesignedHostCanvas — Project Computers islands", () => {
 });
 
 describe("focusTabForNodeId — Project Computers islands", () => {
-  it("routes both island ids to the Agent (Behavior) tab", () => {
+  it("routes each island id to its own dedicated tab", () => {
     expect(focusTabForNodeId(BUILTIN_TOOLS_NODE_ID)).toEqual({
-      tab: "behavior",
+      tab: "tools",
       selectedServerId: null,
     });
     expect(focusTabForNodeId(COMPUTER_NODE_ID)).toEqual({
-      tab: "behavior",
+      tab: "computer",
       selectedServerId: null,
     });
   });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
@@ -23,16 +23,6 @@ import { useAvailableModels } from "@/hooks/use-available-models";
 import { FieldRow, FocusBlock } from "./primitives";
 import { fieldsWithIssues } from "./useHostDraftValidation";
 import type { HostAttentionIssue } from "../types";
-import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
-import { BuiltInToolCheckboxList } from "@/components/client-config/BuiltInToolCheckboxList";
-import {
-  attachComputerPatch,
-  catalogHasComputerBackedTool,
-  detachComputerPatch,
-  shouldShowComputerToggle,
-  visibleBuiltInToolCatalog,
-} from "@/lib/host-config-computer";
-import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 
 // Tri-state UI ↔ persisted value. The backend treats `undefined` as
 // "auto" (orchestrator may still enable progressive mode above the
@@ -43,14 +33,14 @@ import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 // stays distinct from an explicit on/off override.
 type ProgressiveTriState = "auto" | "on" | "off";
 function progressiveValueToTri(
-  value: boolean | undefined
+  value: boolean | undefined,
 ): ProgressiveTriState {
   if (value === true) return "on";
   if (value === false) return "off";
   return "auto";
 }
 function triToProgressiveValue(
-  value: ProgressiveTriState
+  value: ProgressiveTriState,
 ): boolean | undefined {
   if (value === "on") return true;
   if (value === "off") return false;
@@ -60,7 +50,7 @@ function triToProgressiveValue(
 interface BehaviorTabProps {
   draft: HostConfigInputV2;
   onDraftChange: (
-    updater: (prev: HostConfigInputV2) => HostConfigInputV2
+    updater: (prev: HostConfigInputV2) => HostConfigInputV2,
   ) => void;
   attention: ReadonlyArray<HostAttentionIssue>;
   /**
@@ -99,31 +89,6 @@ export function BehaviorTab({
 
   const update = (patch: Partial<HostConfigInputV2>) =>
     onDraftChange((prev) => ({ ...prev, ...patch }));
-
-  // Built-in tools catalog. `undefined` while loading or if the backend isn't
-  // deployed; `[]` on populated deployments with no enabled rows. Hide the
-  // FocusBlock entirely in both cases so empty installs don't render a dead card.
-  const builtInToolCatalog = useBuiltInToolCatalog();
-  const computersEnabled = useComputersEnabled();
-  // Render only the rows this user may see: with `computers-enabled` off,
-  // computer-backed rows (e.g. an enabled `bash`) stay hidden — except an
-  // already-selected id, which must remain visible to stay removable.
-  const visibleBuiltInTools = visibleBuiltInToolCatalog(builtInToolCatalog, {
-    computersEnabled,
-    selectedIds: draft.builtInToolIds,
-  });
-  const showBuiltInTools = (visibleBuiltInTools?.length ?? 0) > 0;
-  // The personal-computer toggle appears once the deployment exposes a
-  // computer-backed tool (the `bash` row ships disabled until launch) OR when
-  // the host already has a computer attached, so an existing attachment is
-  // always detachable even if no computer-backed tool is in the catalog.
-  const showComputerToggle =
-    computersEnabled &&
-    shouldShowComputerToggle({
-      catalogHasComputerBackedTool:
-        catalogHasComputerBackedTool(builtInToolCatalog),
-      computerAttached: draft.computer !== undefined,
-    });
 
   // Labels and descriptions are sourced from the shared field schema so
   // the focus tab and the cross-host comparison matrix stay in sync.
@@ -261,7 +226,7 @@ export function BehaviorTab({
                 if (!value) return;
                 update({
                   progressiveToolDiscovery: triToProgressiveValue(
-                    value as ProgressiveTriState
+                    value as ProgressiveTriState,
                   ),
                 });
               }}
@@ -281,41 +246,6 @@ export function BehaviorTab({
           }
         />
       </FocusBlock>
-
-      {showBuiltInTools || showComputerToggle ? (
-        <FocusBlock title="Built-in tools">
-          {showComputerToggle ? (
-            <FieldRow
-              label="Personal computer"
-              description="Attach a per-member cloud workstation (a persistent Linux sandbox). Required by computer-backed tools like Bash."
-              control={
-                <Switch
-                  checked={draft.computer !== undefined}
-                  onCheckedChange={(checked) =>
-                    update(
-                      checked
-                        ? attachComputerPatch()
-                        : detachComputerPatch(draft, builtInToolCatalog)
-                    )
-                  }
-                  aria-label="Personal computer"
-                  disabled={readOnly}
-                />
-              }
-            />
-          ) : null}
-          {showBuiltInTools ? (
-            <BuiltInToolCheckboxList
-              label="Attached"
-              selected={draft.builtInToolIds}
-              available={visibleBuiltInTools ?? []}
-              computerAttached={draft.computer !== undefined}
-              readOnly={readOnly}
-              onChange={(builtInToolIds) => update({ builtInToolIds })}
-            />
-          ) : null}
-        </FocusBlock>
-      ) : null}
 
       <FocusBlock title={fSystemPrompt.label}>
         <Textarea

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ComputerTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ComputerTab.tsx
@@ -1,0 +1,64 @@
+import { Switch } from "@mcpjam/design-system/switch";
+import type { HostConfigInputV2 } from "@/lib/client-config-v2";
+import { FieldRow, FocusBlock } from "./primitives";
+import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
+import {
+  attachComputerPatch,
+  detachComputerPatch,
+} from "@/lib/host-config-computer";
+
+interface ComputerTabProps {
+  draft: HostConfigInputV2;
+  onDraftChange: (
+    updater: (prev: HostConfigInputV2) => HostConfigInputV2,
+  ) => void;
+  /** Disable every control (read-only editor surfaces). */
+  readOnly?: boolean;
+}
+
+/**
+ * The host's personal-computer attachment as a dedicated focus tab — the
+ * attach/detach toggle the canvas "Computer" island deep-links to. Flag-gated
+ * (the tab itself is only surfaced when `computers-enabled` is on, or a
+ * computer is already attached so it stays detachable — see
+ * `visibleHostFocusTabs`).
+ *
+ * Attaching is the *resource*; computer-backed tools (e.g. Bash) are granted
+ * separately in the Tools tab and ride this attachment. Detaching strips any
+ * computer-backed tool ids so the backend's requiresComputer invariant holds
+ * (see `detachComputerPatch`).
+ */
+export function ComputerTab({
+  draft,
+  onDraftChange,
+  readOnly = false,
+}: ComputerTabProps) {
+  const builtInToolCatalog = useBuiltInToolCatalog();
+  const update = (patch: Partial<HostConfigInputV2>) =>
+    onDraftChange((prev) => ({ ...prev, ...patch }));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <FocusBlock title="Computer">
+        <FieldRow
+          label="Personal computer"
+          description="Attach a per-member cloud workstation (a persistent Linux sandbox). Required by computer-backed tools like Bash, which you enable in the Tools tab."
+          control={
+            <Switch
+              checked={draft.computer !== undefined}
+              onCheckedChange={(checked) =>
+                update(
+                  checked
+                    ? attachComputerPatch()
+                    : detachComputerPatch(draft, builtInToolCatalog),
+                )
+              }
+              aria-label="Personal computer"
+              disabled={readOnly}
+            />
+          }
+        />
+      </FocusBlock>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusDialog.tsx
@@ -23,7 +23,10 @@ import { ComputerTab } from "./ComputerTab";
 import { ProtocolTab } from "./ProtocolTab";
 import { AppsExtensionTab } from "./AppsExtensionTab";
 import { HostFocusTabBar } from "./HostFocusTabBar";
-import { useVisibleHostFocusTabs } from "./host-focus-tab-defs";
+import {
+  activeHostFocusTab,
+  useVisibleHostFocusTabs,
+} from "./host-focus-tab-defs";
 import {
   hostFocusShellDialogChromeClass,
   hostFocusShellHeaderRowClass,
@@ -94,6 +97,9 @@ export function HostFocusDialog({
 
   // Tools is GA; Computer is flag-gated (or shown when already attached).
   const visibleTabs = useVisibleHostFocusTabs(draft);
+  // Clamp to a visible tab so a hidden tab (e.g. detach + flag off on Computer)
+  // can't keep rendering or desync the tab bar.
+  const activeTab = activeHostFocusTab(tab, visibleTabs);
 
   // Click-out / Esc / X all route through this confirm path when the
   // draft is dirty. Without it, the user could lose unsaved work to a
@@ -243,27 +249,27 @@ export function HostFocusDialog({
             )}
           >
             <HostFocusTabBar
-              tab={tab}
+              tab={activeTab}
               onTabChange={onTabChange}
               tabs={visibleTabs}
             />
           </div>
 
           <div className={cn(hostFocusShellScrollClass, "px-6 py-5")}>
-            {tab === "behavior" ? (
+            {activeTab === "behavior" ? (
               <BehaviorTab
                 draft={draft}
                 onDraftChange={onDraftChange}
                 attention={attention}
               />
             ) : null}
-            {tab === "tools" ? (
+            {activeTab === "tools" ? (
               <ToolsTab draft={draft} onDraftChange={onDraftChange} />
             ) : null}
-            {tab === "computer" ? (
+            {activeTab === "computer" ? (
               <ComputerTab draft={draft} onDraftChange={onDraftChange} />
             ) : null}
-            {tab === "protocol" ? (
+            {activeTab === "protocol" ? (
               <ProtocolTab
                 key={hostId}
                 draft={draft}
@@ -271,7 +277,7 @@ export function HostFocusDialog({
                 attention={attention}
               />
             ) : null}
-            {tab === "apps" ? (
+            {activeTab === "apps" ? (
               <AppsExtensionTab
                 key={hostId}
                 draft={draft}
@@ -282,7 +288,7 @@ export function HostFocusDialog({
             {/* Servers tab moved to Project Settings → Servers. Legacy
                 state may still report `tab === "servers"`; we render
                 nothing and the tab bar no longer surfaces the entry. */}
-            {tab === "appearance" ? (
+            {activeTab === "appearance" ? (
               <AppearanceTab draft={draft} onDraftChange={onDraftChange} />
             ) : null}
           </div>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusDialog.tsx
@@ -18,9 +18,12 @@ import { fieldsWithIssues } from "./useHostDraftValidation";
 import { HostIdentityRow } from "./HostIdentityRow";
 import { AppearanceTab } from "./AppearanceTab";
 import { BehaviorTab } from "./BehaviorTab";
+import { ToolsTab } from "./ToolsTab";
+import { ComputerTab } from "./ComputerTab";
 import { ProtocolTab } from "./ProtocolTab";
 import { AppsExtensionTab } from "./AppsExtensionTab";
 import { HostFocusTabBar } from "./HostFocusTabBar";
+import { useVisibleHostFocusTabs } from "./host-focus-tab-defs";
 import {
   hostFocusShellDialogChromeClass,
   hostFocusShellHeaderRowClass,
@@ -89,6 +92,9 @@ export function HostFocusDialog({
   const behaviorIssues = fieldsWithIssues(attention, "behavior");
   const totalIssues = attention.length;
 
+  // Tools is GA; Computer is flag-gated (or shown when already attached).
+  const visibleTabs = useVisibleHostFocusTabs(draft);
+
   // Click-out / Esc / X all route through this confirm path when the
   // draft is dirty. Without it, the user could lose unsaved work to a
   // stray click on the scrim.
@@ -144,12 +150,7 @@ export function HostFocusDialog({
             Edit client configuration
           </DialogTitle>
 
-          <header
-            className={cn(
-              hostFocusShellHeaderRowClass,
-              "px-4 py-2.5",
-            )}
-          >
+          <header className={cn(hostFocusShellHeaderRowClass, "px-4 py-2.5")}>
             <Button
               size="icon"
               variant="ghost"
@@ -187,8 +188,7 @@ export function HostFocusDialog({
                   variant="outline"
                   className="border-amber-500/40 bg-amber-500/10 text-[10px] text-amber-800 dark:text-amber-200"
                 >
-                  {totalIssues}{" "}
-                  {totalIssues === 1 ? "issue" : "issues"}
+                  {totalIssues} {totalIssues === 1 ? "issue" : "issues"}
                 </Badge>
               ) : (
                 <Badge
@@ -230,10 +230,7 @@ export function HostFocusDialog({
           </header>
 
           <HostIdentityRow
-            className={cn(
-              hostFocusShellHeaderRowClass,
-              "border-t-0 px-4 py-2",
-            )}
+            className={cn(hostFocusShellHeaderRowClass, "border-t-0 px-4 py-2")}
             hostDisplayName={hostDisplayName}
             onHostDisplayNameChange={onHostDisplayNameChange}
             hasNameIssue={behaviorIssues.has("hostDisplayName")}
@@ -245,7 +242,11 @@ export function HostFocusDialog({
               "border-t-0 py-1 pl-3 pr-4",
             )}
           >
-            <HostFocusTabBar tab={tab} onTabChange={onTabChange} />
+            <HostFocusTabBar
+              tab={tab}
+              onTabChange={onTabChange}
+              tabs={visibleTabs}
+            />
           </div>
 
           <div className={cn(hostFocusShellScrollClass, "px-6 py-5")}>
@@ -255,6 +256,12 @@ export function HostFocusDialog({
                 onDraftChange={onDraftChange}
                 attention={attention}
               />
+            ) : null}
+            {tab === "tools" ? (
+              <ToolsTab draft={draft} onDraftChange={onDraftChange} />
+            ) : null}
+            {tab === "computer" ? (
+              <ComputerTab draft={draft} onDraftChange={onDraftChange} />
             ) : null}
             {tab === "protocol" ? (
               <ProtocolTab
@@ -293,8 +300,8 @@ export function HostFocusDialog({
           <div className="flex flex-col gap-2">
             <h2 className="text-base font-semibold">Discard changes?</h2>
             <p className="text-[12.5px] text-muted-foreground">
-              Your draft hasn't been saved as a snapshot yet. Closing now
-              will revert to the last saved configuration.
+              Your draft hasn't been saved as a snapshot yet. Closing now will
+              revert to the last saved configuration.
             </p>
             <div className="mt-2 flex items-center justify-end gap-2">
               <Button

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
@@ -10,9 +10,12 @@ import type {
 import { fieldsWithIssues } from "./useHostDraftValidation";
 import { AppearanceTab } from "./AppearanceTab";
 import { BehaviorTab } from "./BehaviorTab";
+import { ToolsTab } from "./ToolsTab";
+import { ComputerTab } from "./ComputerTab";
 import { ProtocolTab } from "./ProtocolTab";
 import { AppsExtensionTab } from "./AppsExtensionTab";
 import { HostFocusTabBar } from "./HostFocusTabBar";
+import { useVisibleHostFocusTabs } from "./host-focus-tab-defs";
 import { HostIdentityRow } from "./HostIdentityRow";
 import {
   hostFocusShellHeaderRowClass,
@@ -69,6 +72,9 @@ export function HostFocusPanel({
   // up red when empty.
   const behaviorIssues = fieldsWithIssues(attention, "behavior");
 
+  // Tools is GA; Computer is flag-gated (or shown when already attached).
+  const visibleTabs = useVisibleHostFocusTabs(draft);
+
   return (
     <div className={hostFocusShellRootClass}>
       <HostIdentityRow
@@ -83,7 +89,11 @@ export function HostFocusPanel({
           "items-stretch gap-2 py-1 sm:items-center",
         )}
       >
-        <HostFocusTabBar tab={tab} onTabChange={onTabChange} />
+        <HostFocusTabBar
+          tab={tab}
+          onTabChange={onTabChange}
+          tabs={visibleTabs}
+        />
         <Button
           size="icon"
           variant="ghost"
@@ -103,6 +113,12 @@ export function HostFocusPanel({
             onDraftChange={onDraftChange}
             attention={attention}
           />
+        ) : null}
+        {tab === "tools" ? (
+          <ToolsTab draft={draft} onDraftChange={onDraftChange} />
+        ) : null}
+        {tab === "computer" ? (
+          <ComputerTab draft={draft} onDraftChange={onDraftChange} />
         ) : null}
         {tab === "appearance" ? (
           <AppearanceTab draft={draft} onDraftChange={onDraftChange} />

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
@@ -15,7 +15,10 @@ import { ComputerTab } from "./ComputerTab";
 import { ProtocolTab } from "./ProtocolTab";
 import { AppsExtensionTab } from "./AppsExtensionTab";
 import { HostFocusTabBar } from "./HostFocusTabBar";
-import { useVisibleHostFocusTabs } from "./host-focus-tab-defs";
+import {
+  activeHostFocusTab,
+  useVisibleHostFocusTabs,
+} from "./host-focus-tab-defs";
 import { HostIdentityRow } from "./HostIdentityRow";
 import {
   hostFocusShellHeaderRowClass,
@@ -74,6 +77,9 @@ export function HostFocusPanel({
 
   // Tools is GA; Computer is flag-gated (or shown when already attached).
   const visibleTabs = useVisibleHostFocusTabs(draft);
+  // Guard against a tab being hidden out from under the user (e.g. detach +
+  // flag off while on Computer) — render the clamped tab everywhere.
+  const activeTab = activeHostFocusTab(tab, visibleTabs);
 
   return (
     <div className={hostFocusShellRootClass}>
@@ -90,7 +96,7 @@ export function HostFocusPanel({
         )}
       >
         <HostFocusTabBar
-          tab={tab}
+          tab={activeTab}
           onTabChange={onTabChange}
           tabs={visibleTabs}
         />
@@ -107,23 +113,23 @@ export function HostFocusPanel({
       </header>
 
       <div className={hostFocusShellScrollClass}>
-        {tab === "behavior" ? (
+        {activeTab === "behavior" ? (
           <BehaviorTab
             draft={draft}
             onDraftChange={onDraftChange}
             attention={attention}
           />
         ) : null}
-        {tab === "tools" ? (
+        {activeTab === "tools" ? (
           <ToolsTab draft={draft} onDraftChange={onDraftChange} />
         ) : null}
-        {tab === "computer" ? (
+        {activeTab === "computer" ? (
           <ComputerTab draft={draft} onDraftChange={onDraftChange} />
         ) : null}
-        {tab === "appearance" ? (
+        {activeTab === "appearance" ? (
           <AppearanceTab draft={draft} onDraftChange={onDraftChange} />
         ) : null}
-        {tab === "protocol" ? (
+        {activeTab === "protocol" ? (
           <ProtocolTab
             key={hostId}
             draft={draft}
@@ -131,7 +137,7 @@ export function HostFocusPanel({
             attention={attention}
           />
         ) : null}
-        {tab === "apps" ? (
+        {activeTab === "apps" ? (
           <AppsExtensionTab
             key={hostId}
             draft={draft}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusTabBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusTabBar.tsx
@@ -1,11 +1,20 @@
 import type { KeyboardEvent } from "react";
 import { cn } from "@/lib/utils";
 import type { HostFocusTabId } from "../types";
-import { HOST_FOCUS_TAB_DEFS } from "./host-focus-tab-defs";
+import {
+  HOST_FOCUS_TAB_DEFS,
+  type HostFocusTabDef,
+} from "./host-focus-tab-defs";
 
 interface HostFocusTabBarProps {
   tab: HostFocusTabId;
   onTabChange: (next: HostFocusTabId) => void;
+  /**
+   * Tabs to render. Defaults to the full static set; callers pass a filtered
+   * list (e.g. from `useVisibleHostFocusTabs`) to hide conditional tabs like
+   * the flag-gated Computer tab or the catalog-dependent Tools tab.
+   */
+  tabs?: ReadonlyArray<HostFocusTabDef>;
   className?: string;
 }
 
@@ -20,20 +29,18 @@ const tabBtnClass = cn(
 export function HostFocusTabBar({
   tab,
   onTabChange,
+  tabs = HOST_FOCUS_TAB_DEFS,
   className,
 }: HostFocusTabBarProps) {
   const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
     event.preventDefault();
-    const idx = HOST_FOCUS_TAB_DEFS.findIndex((t) => t.id === tab);
+    const idx = tabs.findIndex((t) => t.id === tab);
     if (idx === -1) return;
     const next =
       event.key === "ArrowRight"
-        ? HOST_FOCUS_TAB_DEFS[(idx + 1) % HOST_FOCUS_TAB_DEFS.length]
-        : HOST_FOCUS_TAB_DEFS[
-            (idx - 1 + HOST_FOCUS_TAB_DEFS.length) %
-              HOST_FOCUS_TAB_DEFS.length
-          ];
+        ? tabs[(idx + 1) % tabs.length]
+        : tabs[(idx - 1 + tabs.length) % tabs.length];
     onTabChange(next.id);
   };
 
@@ -47,7 +54,7 @@ export function HostFocusTabBar({
         className,
       )}
     >
-      {HOST_FOCUS_TAB_DEFS.map((t) => {
+      {tabs.map((t) => {
         const active = tab === t.id;
         return (
           <button

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ToolsTab.tsx
@@ -1,0 +1,64 @@
+import type { HostConfigInputV2 } from "@/lib/client-config-v2";
+import { FocusBlock } from "./primitives";
+import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
+import { BuiltInToolCheckboxList } from "@/components/client-config/BuiltInToolCheckboxList";
+import { visibleBuiltInToolCatalog } from "@/lib/host-config-computer";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+
+interface ToolsTabProps {
+  draft: HostConfigInputV2;
+  onDraftChange: (
+    updater: (prev: HostConfigInputV2) => HostConfigInputV2,
+  ) => void;
+  /** Disable every control (read-only editor surfaces). */
+  readOnly?: boolean;
+}
+
+/**
+ * Host-managed built-in tools (Web Search, Bash, …) as a dedicated focus
+ * tab. Previously lived inline in BehaviorTab; promoted to its own tab so
+ * the canvas "Built-in tools" island can deep-link straight to it.
+ *
+ * The personal-computer attach/detach toggle that gates computer-backed
+ * tools lives in the sibling ComputerTab — this tab only edits the tool
+ * selection. A computer-backed row (e.g. `bash`) renders blocked here until
+ * the computer is attached over there (BuiltInToolCheckboxList copy points
+ * to the Computer tab).
+ */
+export function ToolsTab({
+  draft,
+  onDraftChange,
+  readOnly = false,
+}: ToolsTabProps) {
+  const builtInToolCatalog = useBuiltInToolCatalog();
+  const computersEnabled = useComputersEnabled();
+  // Render only the rows this user may see: with `computers-enabled` off,
+  // computer-backed rows (e.g. an enabled `bash`) stay hidden — except an
+  // already-selected id, which must remain visible to stay removable.
+  const visibleBuiltInTools = visibleBuiltInToolCatalog(builtInToolCatalog, {
+    computersEnabled,
+    selectedIds: draft.builtInToolIds,
+  });
+
+  const update = (patch: Partial<HostConfigInputV2>) =>
+    onDraftChange((prev) => ({ ...prev, ...patch }));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <FocusBlock
+        title="System tools"
+        subtitle="First-party capabilities beyond MCP servers."
+      >
+        <BuiltInToolCheckboxList
+          variant="minimal"
+          selected={draft.builtInToolIds}
+          available={visibleBuiltInTools ?? []}
+          computerAttached={draft.computer !== undefined}
+          computerAttachHint="attach it in the Computer tab"
+          readOnly={readOnly}
+          onChange={(builtInToolIds) => update({ builtInToolIds })}
+        />
+      </FocusBlock>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostFocusTabBar.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/HostFocusTabBar.test.tsx
@@ -9,22 +9,24 @@ describe("HostFocusTabBar", () => {
     const user = userEvent.setup();
     const onTabChange = vi.fn();
 
-    render(
-      <HostFocusTabBar tab="behavior" onTabChange={onTabChange} />,
-    );
+    render(<HostFocusTabBar tab="behavior" onTabChange={onTabChange} />);
 
     const list = screen.getByRole("tablist");
     expect(list).toHaveAttribute("aria-orientation", "horizontal");
 
     screen.getByRole("tab", { name: /^Agent$/ }).focus();
     await user.keyboard("{ArrowRight}");
-    expect(onTabChange).toHaveBeenCalledWith("protocol");
+    // With no `tabs` prop the bar renders the full static set, so Agent's
+    // right neighbour is MCP Protocol (Agent → MCP Protocol → Apps → …).
+    expect(onTabChange).toHaveBeenCalledWith(
+      "protocol" satisfies HostFocusTabId,
+    );
 
     onTabChange.mockClear();
     await user.keyboard("{ArrowLeft}");
-    // Arrow-left from the first tab (Agent) wraps to the last tab.
-    // After the project-scoped server config rollout removed the
-    // per-host Servers tab, the last visible tab is Apps Extension.
-    expect(onTabChange).toHaveBeenCalledWith("apps" satisfies HostFocusTabId);
+    // Arrow-left from the first tab (Agent) wraps to the last tab (Computer).
+    expect(onTabChange).toHaveBeenCalledWith(
+      "computer" satisfies HostFocusTabId,
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ToolsComputerTabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ToolsComputerTabs.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+
+// Catalog with one GA tool (Web Search) plus a computer-backed tool (Bash),
+// so we can exercise both the plain row and the requiresComputer gating.
+vi.mock("@/hooks/useBuiltInToolCatalog", () => ({
+  useBuiltInToolCatalog: () => [
+    {
+      id: "web_search",
+      displayLabel: "Web Search",
+      description: "Search the web via Exa.",
+      category: "search",
+      billable: true,
+    },
+    {
+      id: "bash",
+      displayLabel: "Bash",
+      description: "Run shell commands on your personal computer.",
+      category: "code",
+      billable: false,
+      requiresComputer: true,
+    },
+  ],
+}));
+// Flag on so computer-backed rows (Bash) are visible in the Tools tab.
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+  useFeatureFlagEnabled: () => true,
+}));
+
+import { ToolsTab } from "../ToolsTab";
+import { ComputerTab } from "../ComputerTab";
+
+describe("ToolsTab", () => {
+  it("renders system tools as minimal switch rows", () => {
+    render(
+      <ToolsTab draft={emptyHostConfigInputV2()} onDraftChange={vi.fn()} />,
+    );
+    expect(screen.getByText("System tools")).toBeInTheDocument();
+    expect(
+      screen.getByText("First-party capabilities beyond MCP servers."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Web Search" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Bash" })).toBeInTheDocument();
+    expect(screen.queryByText(/Search the web via Exa/i)).toBeNull();
+    expect(screen.queryByText("Attached")).toBeNull();
+  });
+
+  it("points the Bash block reason at the Computer tab when no computer is attached", () => {
+    render(
+      <ToolsTab draft={emptyHostConfigInputV2()} onDraftChange={vi.fn()} />,
+    );
+    expect(
+      screen.getByText(/attach it in the Computer tab/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ComputerTab", () => {
+  it("renders the Personal computer attach toggle, off by default", () => {
+    render(
+      <ComputerTab draft={emptyHostConfigInputV2()} onDraftChange={vi.fn()} />,
+    );
+    const toggle = screen.getByRole("switch", { name: "Personal computer" });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("reflects an attached computer as checked", () => {
+    const draft = {
+      ...emptyHostConfigInputV2(),
+      computer: { kind: "personal" as const },
+    };
+    render(<ComputerTab draft={draft} onDraftChange={vi.fn()} />);
+    expect(
+      screen.getByRole("switch", { name: "Personal computer" }),
+    ).toBeChecked();
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/visibleHostFocusTabs.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/visibleHostFocusTabs.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { visibleHostFocusTabs } from "../host-focus-tab-defs";
+
+const ids = (opts: Parameters<typeof visibleHostFocusTabs>[0]) =>
+  visibleHostFocusTabs(opts).map((t) => t.id);
+
+describe("visibleHostFocusTabs", () => {
+  it("shows Tools only when the deployment exposes built-in tools", () => {
+    const base = { computersEnabled: false, computerAttached: false };
+    expect(ids({ ...base, hasBuiltInTools: false })).not.toContain("tools");
+    expect(ids({ ...base, hasBuiltInTools: true })).toContain("tools");
+  });
+
+  it("gates Computer behind the flag", () => {
+    const base = { hasBuiltInTools: true, computerAttached: false };
+    expect(ids({ ...base, computersEnabled: false })).not.toContain("computer");
+    expect(ids({ ...base, computersEnabled: true })).toContain("computer");
+  });
+
+  it("still shows Computer when one is attached even with the flag off (so it stays detachable)", () => {
+    expect(
+      ids({
+        hasBuiltInTools: true,
+        computersEnabled: false,
+        computerAttached: true,
+      }),
+    ).toContain("computer");
+  });
+
+  it("always keeps the static tabs (Agent, MCP Protocol, Apps)", () => {
+    const result = ids({
+      hasBuiltInTools: false,
+      computersEnabled: false,
+      computerAttached: false,
+    });
+    expect(result).toEqual(["behavior", "protocol", "apps"]);
+  });
+
+  it("orders the optional tabs at the right end when present", () => {
+    const result = ids({
+      hasBuiltInTools: true,
+      computersEnabled: true,
+      computerAttached: false,
+    });
+    expect(result).toEqual([
+      "behavior",
+      "protocol",
+      "apps",
+      "tools",
+      "computer",
+    ]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/visibleHostFocusTabs.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/visibleHostFocusTabs.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { visibleHostFocusTabs } from "../host-focus-tab-defs";
+import {
+  activeHostFocusTab,
+  visibleHostFocusTabs,
+} from "../host-focus-tab-defs";
 
 const ids = (opts: Parameters<typeof visibleHostFocusTabs>[0]) =>
   visibleHostFocusTabs(opts).map((t) => t.id);
@@ -49,5 +52,30 @@ describe("visibleHostFocusTabs", () => {
       "tools",
       "computer",
     ]);
+  });
+});
+
+describe("activeHostFocusTab", () => {
+  const allTabs = visibleHostFocusTabs({
+    hasBuiltInTools: true,
+    computersEnabled: true,
+    computerAttached: false,
+  });
+  const noComputer = visibleHostFocusTabs({
+    hasBuiltInTools: true,
+    computersEnabled: false,
+    computerAttached: false,
+  });
+
+  it("keeps the requested tab when it is visible", () => {
+    expect(activeHostFocusTab("computer", allTabs)).toBe("computer");
+    expect(activeHostFocusTab("tools", allTabs)).toBe("tools");
+  });
+
+  it("falls back to the first visible tab when the requested one is hidden", () => {
+    // Computer detached + flag off → the Computer tab is gone; don't keep
+    // rendering it.
+    expect(noComputer.some((t) => t.id === "computer")).toBe(false);
+    expect(activeHostFocusTab("computer", noComputer)).toBe("behavior");
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/host-focus-tab-defs.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/host-focus-tab-defs.tsx
@@ -49,6 +49,23 @@ export function visibleHostFocusTabs(opts: {
 }
 
 /**
+ * Clamp the requested tab to one that is actually visible. A tab can be hidden
+ * out from under the user — e.g. detaching the computer with the flag off while
+ * the Computer tab is open, or the catalog emptying while on Tools. Without
+ * clamping, the stored `tab` would keep rendering the now-hidden tab's content
+ * (letting the user re-attach from a tab the bar no longer shows) and desync
+ * the tab-bar highlight. Falls back to the first visible tab (always present;
+ * the static Agent/Protocol/Apps tabs are never filtered).
+ */
+export function activeHostFocusTab(
+  tab: HostFocusTabId,
+  visibleTabs: ReadonlyArray<HostFocusTabDef>,
+): HostFocusTabId {
+  if (visibleTabs.some((t) => t.id === tab)) return tab;
+  return visibleTabs[0]?.id ?? "behavior";
+}
+
+/**
  * Hook wrapper around `visibleHostFocusTabs` for the focus surfaces
  * (HostFocusPanel / HostFocusDialog) so the Tools/Computer gating lives in
  * one place. Subscribes to the same catalog + flag the Tools/Computer tab

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/host-focus-tab-defs.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/host-focus-tab-defs.tsx
@@ -1,3 +1,8 @@
+import { useMemo } from "react";
+import type { HostConfigInputV2 } from "@/lib/client-config-v2";
+import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { visibleBuiltInToolCatalog } from "@/lib/host-config-computer";
 import type { HostFocusTabId } from "../types";
 
 export interface HostFocusTabDef {
@@ -9,6 +14,10 @@ export const HOST_FOCUS_TAB_DEFS: ReadonlyArray<HostFocusTabDef> = [
   { id: "behavior", label: "Agent" },
   { id: "protocol", label: "MCP Protocol" },
   { id: "apps", label: "Apps" },
+  // Tools is GA (built-in tools like Web Search). Computer is flag-gated —
+  // see `visibleHostFocusTabs`. Both sit at the right end of the tab bar.
+  { id: "tools", label: "Tools" },
+  { id: "computer", label: "Computer" },
   // Servers moved to Project Settings → Servers (one server set across
   // every host in the project). Removed from the per-host tab list as
   // part of the project-scoped server config rollout. The "servers"
@@ -17,3 +26,52 @@ export const HOST_FOCUS_TAB_DEFS: ReadonlyArray<HostFocusTabDef> = [
   // legacy URLs / sessionStorage don't crash.
   // { id: "appearance", label: "Appearance" }, // hidden — to reintroduce soon
 ];
+
+/**
+ * Filter the static tab defs to those that should render for this host:
+ *   - **Tools** appears only when the deployment exposes at least one
+ *     built-in tool the user may see (no dead, empty tab on bare installs).
+ *   - **Computer** is gated behind `computers-enabled`, OR shown when a
+ *     computer is already attached so an existing attachment stays
+ *     detachable even with the flag off (mirrors `shouldShowComputerToggle`).
+ */
+export function visibleHostFocusTabs(opts: {
+  hasBuiltInTools: boolean;
+  computersEnabled: boolean;
+  computerAttached: boolean;
+}): HostFocusTabDef[] {
+  return HOST_FOCUS_TAB_DEFS.filter((t) => {
+    if (t.id === "tools") return opts.hasBuiltInTools;
+    if (t.id === "computer")
+      return opts.computersEnabled || opts.computerAttached;
+    return true;
+  });
+}
+
+/**
+ * Hook wrapper around `visibleHostFocusTabs` for the focus surfaces
+ * (HostFocusPanel / HostFocusDialog) so the Tools/Computer gating lives in
+ * one place. Subscribes to the same catalog + flag the Tools/Computer tab
+ * bodies use (cheap, shared Convex subscriptions).
+ */
+export function useVisibleHostFocusTabs(
+  draft: HostConfigInputV2,
+): HostFocusTabDef[] {
+  const catalog = useBuiltInToolCatalog();
+  const computersEnabled = useComputersEnabled();
+  const visible = visibleBuiltInToolCatalog(catalog, {
+    computersEnabled,
+    selectedIds: draft.builtInToolIds,
+  });
+  const hasBuiltInTools = (visible?.length ?? 0) > 0;
+  const computerAttached = draft.computer !== undefined;
+  return useMemo(
+    () =>
+      visibleHostFocusTabs({
+        hasBuiltInTools,
+        computersEnabled,
+        computerAttached,
+      }),
+    [hasBuiltInTools, computersEnabled, computerAttached],
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/types.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/types.ts
@@ -10,6 +10,8 @@ import type { BuiltInToolCatalogEntry } from "@/hooks/useBuiltInToolCatalog";
  */
 export type HostFocusTabId =
   | "behavior"
+  | "tools"
+  | "computer"
   | "protocol"
   | "apps"
   | "servers"
@@ -521,22 +523,24 @@ export function focusTabForNodeId(nodeId: string): {
   if (nodeId === AGENT_IDENTITY_NODE_ID) {
     return { tab: "behavior", selectedServerId: null };
   }
-  if (nodeId === BUILTIN_TOOLS_NODE_ID || nodeId === COMPUTER_NODE_ID) {
-    // Both Project Computers islands route to the Agent (Behavior) tab —
-    // that's where the personal-computer toggle and the built-in tool
-    // checkboxes live. The islands only visualize that state; the panel
-    // owns it.
-    return { tab: "behavior", selectedServerId: null };
+  if (nodeId === BUILTIN_TOOLS_NODE_ID) {
+    // The Built-in tools island opens its own dedicated Tools tab (the
+    // built-in tool checkbox list). The island only visualizes that
+    // state; the tab owns editing it.
+    return { tab: "tools", selectedServerId: null };
+  }
+  if (nodeId === COMPUTER_NODE_ID) {
+    // The Computer island opens the dedicated Computer tab (the
+    // personal-computer attach/detach toggle). Flag-gated, same as the
+    // island itself.
+    return { tab: "computer", selectedServerId: null };
   }
   // hostContext is a protocol-leaf-shaped node but lives under the
   // apps hub, so route it to the apps tab.
   if (nodeId === protocolLeafNodeId("hostContext")) {
     return { tab: "apps", selectedServerId: null };
   }
-  if (
-    nodeId === PROTOCOL_HUB_NODE_ID ||
-    nodeId.startsWith("protocol-leaf:")
-  ) {
+  if (nodeId === PROTOCOL_HUB_NODE_ID || nodeId.startsWith("protocol-leaf:")) {
     return { tab: "protocol", selectedServerId: null };
   }
   if (
@@ -559,10 +563,7 @@ export function focusTabForNodeId(nodeId: string): {
       ...(focusSubKey ? { focusSubKey } : {}),
     };
   }
-  if (
-    nodeId === SERVERS_HUB_NODE_ID ||
-    nodeId.startsWith("server-card:")
-  ) {
+  if (nodeId === SERVERS_HUB_NODE_ID || nodeId.startsWith("server-card:")) {
     // Server-related canvas clicks intentionally do NOT open the focus
     // panel anymore. The per-host Servers tab was removed when project-
     // scoped server config shipped; the project Servers tab header now


### PR DESCRIPTION
## What

Follow-up to #2698. The Project Computers canvas islands previously routed clicks to the **Agent** tab; this gives **Built-in tools** and the **personal-computer attachment** their own tabs, so each island deep-links straight to the surface it represents.

| Island | Routes to |
|---|---|
| Built-in tools (left) | **Tools** tab |
| Computer (right) | **Computer** tab |

## Changes

- **New tabs** — `ToolsTab` (built-in tool selection) and `ComputerTab` (attach/detach toggle), extracted out of `BehaviorTab` (which is now just Model & sampling + System prompt).
- **Routing** — `tools` / `computer` added to `HostFocusTabId`; `focusTabForNodeId` routes each island to its own tab.
- **Visibility** — `visibleHostFocusTabs` / `useVisibleHostFocusTabs`:
  - **Tools is GA** — shown whenever the catalog exposes built-in tools (Web Search).
  - **Computer is flag-gated** — behind `computers-enabled`, *or* shown when a computer is already attached so it stays detachable with the flag off.
  - Wired into both `HostFocusPanel` and `HostFocusDialog`; `HostFocusTabBar` now accepts a filtered `tabs` list.
- **Cross-surface copy** — `BuiltInToolCheckboxList` gains a `computerAttachHint` prop: the Tools tab points at the *Computer tab*, while `ClientConfigEditor` (toggle still inline) keeps the default *"attach it above"*. Also adds a compact `minimal` variant used by the Tools tab.

## Gating

| | Flag OFF (GA) | Flag ON |
|---|---|---|
| Tools tab | ✅ shown | ✅ shown |
| Computer tab | ❌ hidden* | ✅ shown |

\*unless a computer is already attached.

## Tests

156 passing across the `redesigned` + `client-config` suites. New/updated coverage: island routing → `tools`/`computer`, `visibleHostFocusTabs` gating (Tools-needs-catalog, Computer-flag-or-attached), `ToolsTab`/`ComputerTab` render, and tab-bar arrow-nav. Typecheck clean for all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor of host configuration editing; existing attach/detach and computer gating logic is reused, with new tests for routing and tab visibility.
> 
> **Overview**
> Adds **Tools** and **Computer** as separate host focus tabs so canvas **Built-in tools** and **Computer** islands deep-link to the right editor instead of the Agent tab.
> 
> Built-in tool selection and the personal-computer attach toggle move out of **BehaviorTab** into **ToolsTab** and **ComputerTab**. The tab bar gains conditional visibility (`visibleHostFocusTabs` / `useVisibleHostFocusTabs`): Tools when the catalog has visible built-in tools; Computer behind `computers-enabled` or when a computer is already attached. **HostFocusPanel** and **HostFocusDialog** clamp the active tab when a tab disappears (e.g. detach + flag off).
> 
> **BuiltInToolCheckboxList** adds optional `label`, a **`minimal`** switch-row variant for the Tools tab, and **`computerAttachHint`** (Tools tab → “attach it in the Computer tab”; ClientConfigEditor unchanged). **`focusTabForNodeId`** routes island clicks to `tools` / `computer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197aecfc00c8fa8b12b6c01aba276a43b85ba0f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->