### PR TITLE
fix oauth debugger

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -29,6 +29,7 @@ const {
   testConnectionMock,
   reconnectServerMock,
   getInitializationInfoMock,
+  importHostedOAuthTokensMock,
   tryResolveProjectServerMock,
   mockConvexQuery,
   mockCreateServer,
@@ -49,6 +50,7 @@ const {
   testConnectionMock: vi.fn(),
   reconnectServerMock: vi.fn(),
   getInitializationInfoMock: vi.fn(),
+  importHostedOAuthTokensMock: vi.fn(),
   tryResolveProjectServerMock: vi.fn<
     (serverNameOrId: string) => { projectId: string; serverId: string } | null
   >(() => null),
@@ -108,6 +110,17 @@ vi.mock("@/lib/apis/web/context", () => ({
   tryGetHostedServerDisplayName: vi.fn(),
   tryResolveProjectServer: tryResolveProjectServerMock,
 }));
+
+vi.mock("@/lib/apis/hosted-oauth-import-tokens-api", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/lib/apis/hosted-oauth-import-tokens-api")
+    >();
+  return {
+    ...actual,
+    importHostedOAuthTokens: importHostedOAuthTokensMock,
+  };
+});
 
 vi.mock("@/lib/session-token", () => ({
   authFetch: vi.fn(async () => ({
@@ -278,6 +291,11 @@ beforeEach(() => {
     serverId: "srv_demo",
   });
   reconnectServerMock.mockReset();
+  importHostedOAuthTokensMock.mockReset();
+  importHostedOAuthTokensMock.mockResolvedValue({
+    expiresAt: null,
+    kind: "generic",
+  });
   getInitializationInfoMock.mockResolvedValue({
     success: true,
     initInfo: null,
@@ -696,6 +714,66 @@ describe("useServerState OAuth callback failures", () => {
       projectId: "project_default",
       serverId: "srv_demo",
     });
+  });
+
+  it("imports debugger-applied OAuth tokens before reconnecting a synced local server", async () => {
+    reconnectServerMock.mockResolvedValueOnce({
+      success: true,
+      initInfo: null,
+    });
+    readStoredOAuthConfigMock.mockReturnValueOnce({
+      registryServerId: "asana",
+      useRegistryOAuthProxy: true,
+      resourceUrl: "https://mcp.asana.com/sse",
+    });
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleConnectWithTokensFromOAuthFlow(
+        "demo-server",
+        {
+          accessToken: "access-token",
+          refreshToken: "refresh-token",
+          tokenType: "Bearer",
+          expiresIn: 3600,
+          clientId: "client-id",
+          clientSecret: "client-secret",
+        },
+        "https://mcp.asana.com/sse"
+      );
+    });
+
+    expect(importHostedOAuthTokensMock).toHaveBeenCalledWith({
+      projectId: "project_default",
+      serverId: "srv_demo",
+      serverUrl: "https://mcp.asana.com/sse",
+      oauthResourceUrl: "https://mcp.asana.com/sse",
+      kind: "registry",
+      registryServerId: "asana",
+      useRegistryOAuthProxy: true,
+      clientInformation: {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+      },
+      tokens: {
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      },
+    });
+    expect(reconnectServerMock).toHaveBeenCalledWith(
+      "srv_demo",
+      expect.objectContaining({
+        url: "https://mcp.asana.com/sse",
+      }),
+      expect.objectContaining({
+        projectId: "project_default",
+        serverName: "demo-server",
+      })
+    );
+    expect(toastSuccess).toHaveBeenCalledWith("Connected to demo-server!");
   });
 
   it("marks the pending server as failed when authorization is denied", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -35,6 +35,10 @@ import {
   isElectronMcpCallbackState,
   readStoredOAuthConfig,
 } from "@/lib/oauth/mcp-oauth";
+import {
+  importHostedOAuthTokens,
+  normalizeImportHostedOAuthTokens,
+} from "@/lib/apis/hosted-oauth-import-tokens-api";
 import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 import {
   clearHostedOAuthPendingState,
@@ -2785,6 +2789,46 @@ export function useServerState({
 
       if (!HOSTED_MODE) {
         localStorage.setItem(`mcp-serverUrl-${serverName}`, serverUrl);
+      }
+
+      if (!HOSTED_MODE) {
+        const resolved = tryResolveProjectServer(serverName);
+        const normalizedTokens = normalizeImportHostedOAuthTokens(tokenData);
+        if (resolved && normalizedTokens) {
+          if (!tokens.clientId) {
+            return {
+              success: false,
+              error:
+                "OAuth client information missing client_id; cannot import tokens to Convex",
+            };
+          }
+          const storedOAuthConfig = readStoredOAuthConfig(serverName);
+          const isRegistry =
+            !!storedOAuthConfig.registryServerId &&
+            storedOAuthConfig.useRegistryOAuthProxy === true;
+          await importHostedOAuthTokens({
+            projectId: resolved.projectId,
+            serverId: resolved.serverId,
+            serverUrl,
+            ...(storedOAuthConfig.resourceUrl
+              ? { oauthResourceUrl: storedOAuthConfig.resourceUrl }
+              : {}),
+            kind: isRegistry ? "registry" : "generic",
+            ...(isRegistry
+              ? {
+                  registryServerId: storedOAuthConfig.registryServerId,
+                  useRegistryOAuthProxy: true,
+                }
+              : {}),
+            clientInformation: {
+              clientId: tokens.clientId,
+              ...(tokens.clientSecret
+                ? { clientSecret: tokens.clientSecret }
+                : {}),
+            },
+            tokens: normalizedTokens,
+          });
+        }
       }
 
       const serverConfig = {


### PR DESCRIPTION
- The debugger was saving new OAuth tokens only in browser storage, but reconnect looked for them in Convex. This caused No hosted OAuth credential found.
- Now debugger-applied tokens are imported into Convex before reconnecting, with a regression test.