### PR TITLE
Tier B Phase 3a: invert MCP Apps modal off inspector app-state

### DIFF
--- a/.changeset/widget-modal-di-inversion.md
+++ b/.changeset/widget-modal-di-inversion.md
@@ -1,0 +1,12 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Tier B Phase 3a (in-place DI): invert the MCP Apps widget modal's remaining
+inspector app-state reads. `mcp-apps-modal.tsx` no longer calls
+`useActiveMcpProfile` / `useWebManagedServers` / `resolveHostInfo` or reaches
+into `@/stores` — the resolved `hostInfo` and `webManagedServers` flow down as
+props from the renderer (which already computes them via `useWidgetHost()`), and
+the pure `extractMethod` parser + `CspMode` type come from the `WidgetHost`
+contract module. This removes the last app-state island in the widget renderer
+cluster ahead of the React relocation. No behavior change.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
@@ -9,7 +9,6 @@ import {
   SandboxedIframe,
   SandboxedIframeHandle,
 } from "@/components/ui/sandboxed-iframe";
-import { extractMethod } from "@/stores/traffic-log-store";
 import {
   AppBridge,
   PostMessageTransport,
@@ -19,16 +18,13 @@ import {
   type McpUiResourcePermissions,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { CallToolResult } from "@modelcontextprotocol/client";
-import type { CspMode } from "@/stores/ui-playground-store";
 import { LoggingTransport } from "./mcp-apps-logging-transport";
 import { fetchMcpAppsWidgetContent } from "./fetch-widget-content";
-import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
-import { useWebManagedServers } from "@/contexts/web-managed-servers-context";
-import { resolveHostInfo } from "@/lib/client-config-v2";
+// `extractMethod` (pure JSON-RPC parser) and the `CspMode` type come from the
+// `WidgetHost` contract module, not the inspector stores directly — keeping the
+// modal free of `@/stores`/`@/contexts` app-state coupling (Tier-B).
+import { extractMethod, type CspMode } from "./widget-host";
 import { useAppToolsRegistry } from "./app-tools-registry";
-
-// Injected by Vite at build time from package.json
-declare const __APP_VERSION__: string;
 
 export interface McpAppsModalProps {
   open: boolean;
@@ -93,6 +89,21 @@ export interface McpAppsModalProps {
    * permissions props.
    */
   effectiveHostCapabilities: Omit<McpUiHostCapabilities, "sandbox">;
+  /**
+   * Resolved AppBridge `hostInfo` the inline renderer already computed
+   * (`resolvers.resolveHostInfo(activeMcpProfile)` with the inspector
+   * fallback). Passed down rather than re-resolved here so the modal and
+   * inline bridges hand the widget an identical `hostInfo`, and so the modal
+   * holds no inspector-app-state coupling (`useActiveMcpProfile` /
+   * `resolveHostInfo` now live only in the renderer's `useWidgetHost()`).
+   */
+  hostInfo: { name: string; version: string };
+  /**
+   * Whether the active surface routes through web-managed (hosted) servers.
+   * Sourced from the renderer's `host.surface.webManagedServers` so the modal's
+   * widget-content fetch hits the same endpoint as the inline view.
+   */
+  webManagedServers: boolean;
   toolInputRef: React.RefObject<Record<string, unknown> | undefined>;
   toolOutputRef: React.RefObject<unknown>;
   themeModeRef: React.RefObject<string>;
@@ -129,6 +140,8 @@ export function McpAppsModal({
   cspMode,
   injectOpenAiCompat,
   effectiveHostCapabilities,
+  hostInfo,
+  webManagedServers,
   toolInputRef,
   toolOutputRef,
   themeModeRef,
@@ -144,12 +157,6 @@ export function McpAppsModal({
   // tools separate. Cleared on teardown so `isLive` short-circuits any
   // in-flight `listTools` after the modal closes.
   const modalAppToolsBridgeIdRef = useRef<string | null>(null);
-  // Same scope as the inline renderer — `ActiveMcpProfileProvider` wraps
-  // both. Used to resolve `hostInfo` for the modal's AppBridge handshake.
-  const activeMcpProfile = useActiveMcpProfile();
-  // Same scope as the inline renderer — chatbox runtime sessions route
-  // widget-content fetches through the hosted API on every platform.
-  const webManagedServers = useWebManagedServers();
   const modalColorScheme =
     hostContextRef.current?.theme === "light" ||
     hostContextRef.current?.theme === "dark"
@@ -223,21 +230,17 @@ export function McpAppsModal({
     const iframe = modalSandboxRef.current?.getIframeElement();
     if (!iframe?.contentWindow) return;
 
-    // Match the inline renderer: ChatGPT-like templates override this
-    // via mcpProfile.apps.uiInitialize.hostInfo. Backend soft-validates
-    // name+version when set, so the cast below is safe.
-    const resolvedHostInfo = (resolveHostInfo(activeMcpProfile) ?? {
-      name: "mcpjam-inspector",
-      version: __APP_VERSION__,
-    }) as { name: string; version: string };
     // Vendor-trait HostCapabilities come from the inline renderer's
     // resolver (matrix-derived + user override). Sandbox is composed
     // here from the widget-level resource CSP / permissions per
     // SEP-1865 (sandbox is per-resource, not a vendor trait — see
-    // HostMcpProfile.mcpAppsCapabilities doc).
+    // HostMcpProfile.mcpAppsCapabilities doc). `hostInfo` is the same
+    // resolved blob the inline renderer hands its bridge (ChatGPT-like
+    // templates may override it via mcpProfile.apps.uiInitialize.hostInfo);
+    // passing it down keeps inline + modal in lockstep.
     const bridge = new AppBridge(
       null,
-      resolvedHostInfo,
+      hostInfo,
       {
         ...effectiveHostCapabilities,
         sandbox: {
@@ -407,7 +410,7 @@ export function McpAppsModal({
     hostContextRef,
     toolInputRef,
     toolOutputRef,
-    activeMcpProfile,
+    hostInfo,
     effectiveHostCapabilities,
   ]);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -3810,6 +3810,12 @@ export function MCPAppsRendererSurface({
         // app.getHostCapabilities() returns the same record regardless
         // of which iframe the widget is mounted in.
         effectiveHostCapabilities={effectiveHostCapabilities}
+        // Resolved hostInfo + web-managed flag passed down (the modal no longer
+        // reads useActiveMcpProfile/useWebManagedServers/resolveHostInfo
+        // directly) so inline + modal stay in lockstep and the modal holds no
+        // inspector-app-state coupling.
+        hostInfo={resolvedBridgeHostInfo}
+        webManagedServers={webManagedServers}
         toolInputRef={toolInputRef}
         toolOutputRef={toolOutputRef}
         themeModeRef={themeModeRef}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.design.md
@@ -1,7 +1,11 @@
 # Tier B — interactive widget runtime extraction (`WidgetHost`)
 
-Status: **Phase 0 (design)** — `widget-host.ts` lands the contract only; nothing
-consumes it yet and there is no behavior change.
+Status: **Phases 0–2 merged** (for inspector-internal consumption); **Phase 3 in
+progress**. The `WidgetHost` contract + `useWidgetHost()` hook (Phases 0–1) and
+the framework-free core in `@mcpjam/sdk/widget-runtime` (Phase 2) are landed; the
+React renderer relocation into `@mcpjam/widget-react` is underway. npm-publishing
+the SDK `widget-runtime` surface still needs a public-surface pass (see
+"Pre-publish").
 
 This is the follow-on to the Tier A extraction (`@mcpjam/chat-ui`, the read-only
 transcript renderer). Tier A renders a **placeholder** for widget-bearing tool
@@ -141,20 +145,58 @@ reads for a single `useWidgetHost()`.
 
 ## Phased plan
 
-| Phase | What | Risk |
+| Phase | What | Status |
 | --- | --- | --- |
-| **0** (this) | `WidgetHost` contract + this doc. No behavior change. | low |
-| **1** | In-place DI refactor: land `WidgetHostProvider` + `useWidgetHost`; migrate services → environment → surface → debug reads; renderer imports zero `@/stores`/`@/contexts`. Run the Tier-B guard against it *before* moving. | med |
-| **2** | Extract the framework-free core (`host-app-bridge`, transports, `iframe-sandbox-policy`, reconciled `mcp-apps-utils`). | low–med |
-| **3** | Relocate the React renderer into the package; inspector becomes a thin `WidgetHost` adapter; add a Tier-B import guard. | med |
-| **4** | Wire the package's `renderWidget` seam; optionally collapse the inspector's parallel `PartSwitch`. Unblocks the eval trace viewer (Option B). | med |
+| **0** | `WidgetHost` contract + this doc. | ✅ merged |
+| **1** | In-place DI refactor. **Shipped as a composite `useWidgetHost()` hook (not a provider)** with an `environment`/`resolvers` split; `resolveEnvironment` deferred. Renderer imports zero `@/stores`/`@/contexts` (Tier-B guard enforced). | ✅ merged |
+| **2** | Framework-free core relocated to **`@mcpjam/sdk/widget-runtime`** (not the React package): tool-visibility, LoggingTransport, iframe-sandbox-policy, host-app-bridge, app-tool-invocation types. Inspector consumes via shims. | ✅ merged (internal); needs a pre-publish public-surface pass |
+| **3** | Relocate the React renderer into a new **`@mcpjam/widget-react`** package; inspector becomes a thin adapter; add the package's Tier-B guard. Sliced 3a–3d below. | 🚧 in progress |
+| **4** | Wire the package's `renderWidget` seam; optionally collapse the inspector's parallel `PartSwitch`. Unblocks the eval trace viewer. | later |
 
-## Package shape (open decision)
+### Phase 3 slices
 
-Recommended: a new **`@mcpjam/widget-react`** package (heavy
-`@modelcontextprotocol/ext-apps` + `@mcp-ui/client` deps), depending on
-`@mcpjam/sdk` for the policy/compat core, consumed by the inspector via the
-`renderWidget` seam. `@mcpjam/chat-ui` stays the lean Tier-A renderer and never
-imports it. Alternative considered: a `@mcpjam/chat-ui/widget` subpath — rejected
-because it would force Tier A consumers to risk pulling the heavy widget peer
-deps and would require a carve-out in the Tier-A import guard.
+| Slice | What | Risk |
+| --- | --- | --- |
+| **3a** | Finish the in-place DI: invert the **modal** — the last app-state island (it builds its own AppBridge and read `useActiveMcpProfile`/`useWebManagedServers`/`resolveHostInfo`). Resolved `hostInfo`/`webManagedServers` now flow down as props. | med |
+| **3b** | Invert the remaining cluster modules: `widget-replay` (host-support gate), `app-tools-registry` (split pure registry/sanitizer from `useTrafficLogStore`; inject traffic logging as a host callback), `widget-file-messages` (`authFetch`→`services`), config consts (`SANDBOX_ORIGIN`→`surface.sandboxOrigin`, `HOSTED_MODE`→env). Extend the Tier-B guard to the whole cluster. | low–med |
+| **3c** | Scaffold `@mcpjam/widget-react` and prove the **full** integration contract: source alias, build order, package guard, CSS/runtime imports, and a tiny inspector consumer through the same provider/adapter path the bulk move will use. | low |
+| **3d** | Relocate the renderer + cluster into the package; the package owns the `WidgetHost` React context + `useWidgetHost()` *contract* while the inspector supplies the concrete host via a **provider/adapter**; inject the modal chrome + `checkout-dialog` via `components.Modal`; fold `environment`+`resolvers` into a real `resolveEnvironment`; inspector files become shims. | med |
+
+## Package shape (decided)
+
+A new **`@mcpjam/widget-react`** package (heavy `@modelcontextprotocol/ext-apps`
++ `@mcp-ui/client` deps), depending on `@mcpjam/sdk` (widget-runtime + browser)
+for the policy/compat core, consumed by the inspector via the `renderWidget`
+seam. `@mcpjam/chat-ui` stays the lean Tier-A renderer and never imports it — its
+Tier-A guard forbids `ext-apps`/`@mcp-ui/client`/`sandboxed-iframe`/
+`design-system`, so the renderer cannot live there. Build mirrors chat-ui:
+ESM/tsup, `moduleResolution: bundler`, source-aliased into the inspector; build
+order `sdk → chat-ui → widget-react → inspector`. (Alternative considered: a
+`@mcpjam/chat-ui/widget` subpath — rejected: it would force Tier-A consumers to
+risk the heavy peer deps and need a carve-out in the Tier-A guard.)
+
+Decisions locked for Phase 3:
+- **`useWidgetHost()` ownership:** the package owns the `WidgetHost` React
+  context + `useWidgetHost()` *contract*; the inspector supplies the concrete
+  host via a provider/adapter (keeping the `@/stores`/`@/contexts` reads). This
+  is where the Phase-1 "hook, not provider" choice flips — with a package
+  boundary, the relocated renderer reads from the package's context.
+- **Peer deps:** `react`/`react-dom` are peers. Do **not** copy chat-ui's
+  `ai`/`@ai-sdk/react` peers blindly — audit for a real runtime import and
+  prefer package-local/structural types otherwise.
+- **Modal seam:** the package owns widget lifecycle + bridge; `components.Modal`
+  receives children/state/callbacks only — the inspector keeps the portal/chrome
+  (`design-system` dialog), billing, and `checkout-dialog`.
+- **detectUIType:** verify the inspector's `MCP_UI` inline-resource branch
+  matches chat-ui's pure detector, then share chat-ui's `UIType` vocabulary;
+  defer collapsing the inspector's parallel `PartSwitch` to Phase 4.
+
+## Pre-publish (separate from Phase 3 implementation)
+
+Phases 0–2 are merged for **inspector-internal** consumption. Publishing
+`@mcpjam/sdk/widget-runtime` to npm still needs a public-surface pass: the barrel
+imports `AppBridge` from `@modelcontextprotocol/ext-apps`, so the whole subpath
+requires `skipLibCheck:true` for NodeNext consumers. Fix by splitting the bridge
+into a narrower subpath (e.g. `@mcpjam/sdk/widget-runtime/host-bridge`) or hiding
+`AppBridge` behind a structural interface — settled **before** `@mcpjam/widget-react`
+bakes in its final SDK import paths for publish.


### PR DESCRIPTION
## Context

First slice of **Phase 3** (relocate the React widget renderer into a new `@mcpjam/widget-react` package). Phases 0–2 are merged **for inspector-internal consumption** — the `WidgetHost` contract + `useWidgetHost()` hook, and the framework-free core in `@mcpjam/sdk/widget-runtime`. (npm-publishing that SDK surface still needs a separate public-surface pass; tracked in the design doc's new "Pre-publish" section.)

Mapping the renderer cluster showed Phase 1 only inverted the **main renderer** — 4 sibling modules still read inspector app-state. The **modal is the riskiest of them** (it builds its own AppBridge), so it goes first to avoid leaving the hard part hidden behind an "almost done" extraction.

## What this does

`mcp-apps-modal.tsx` no longer reaches into inspector app-state:
- `useActiveMcpProfile` + `resolveHostInfo` → the renderer passes the already-resolved **`hostInfo`** prop (it computes `resolvers.resolveHostInfo(activeMcpProfile)` for its own inline bridge — now shared, keeping inline + modal in lockstep, which is the modal's existing pass-down convention for `injectOpenAiCompat`/`effectiveHostCapabilities`).
- `useWebManagedServers` → **`webManagedServers`** prop (from `host.surface.webManagedServers`).
- `extractMethod` (pure JSON-RPC parser) + `CspMode` type → imported from the `WidgetHost` contract module instead of `@/stores/*`.

The modal now holds **zero `@/stores`/`@/contexts`/`@/lib/client-config*` coupling**. No behavior change.

Also folds a concise Phase 3 plan into `widget-host.design.md` and refreshes the stale Phase 0–2 status (Phase 1 shipped as a hook not a provider; Phase 2 core landed in the SDK), per TL request to avoid a doc-only CI cycle.

## What's deferred (later slices, per plan)

The modal still imports `@mcpjam/design-system/dialog` and `@/components/ui/sandboxed-iframe` — those are **extraction** concerns: 3d injects the modal chrome via the `components.Modal` seam (package owns lifecycle/bridge, inspector owns chrome/billing/checkout). The Tier-B guard is extended to the whole cluster in 3b. This PR is scoped to the app-state island only.

## Verification

- `typecheck:client` + renderer Tier-B guard ✅
- root `typecheck` ✅
- targeted vitest: all 8 mcp-apps suites — **197 passed** (incl. 86 renderer tests that drive the modal path, 26 host-app-bridge, 6 use-widget-host) ✅
- modal hook-dependency change reviewed by hand (`hostInfo` used in the bridge-init effect; `webManagedServers` in the fetch effect)

Files were already prettier-dirty on `main` (prettier isn't gated here), so I left the pre-existing drift untouched and matched the surrounding style in my edits rather than injecting a whole-file reformat.

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> In-place dependency inversion with values already computed by the parent renderer; scoped to prop wiring and imports with tests noted as passing and no behavior change intended.
> 
> **Overview**
> **Tier B Phase 3a** removes the last inspector app-state coupling from the MCP Apps widget **modal** ahead of relocating the renderer into `@mcpjam/widget-react`.
> 
> `mcp-apps-modal.tsx` no longer calls `useActiveMcpProfile`, `useWebManagedServers`, or `resolveHostInfo`, and no longer imports `extractMethod` / `CspMode` from `@/stores`. The inline renderer passes **`hostInfo`** (same `resolvedBridgeHostInfo` its own `AppBridge` uses) and **`webManagedServers`** (from `host.surface.webManagedServers`) so modal fetches and bridge handshakes stay aligned with the inline iframe. Pure helpers **`extractMethod`** and **`CspMode`** now come from the **`widget-host`** contract module.
> 
> `widget-host.design.md` is refreshed with Phases 0–2 status, Phase 3 slices (3a–3d), and locked package decisions; the changeset records a patch with **no intended behavior change**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6bb12a5616a9dae0433ea4bb1869cc0494d6dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->