### PR TITLE
fix(hosted): speed up guest cold load — drop project-loading gate + server-render guest bootstrap

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1712,21 +1712,8 @@ export default function App() {
     isWorkOsLoading,
     hasWorkOsUser: !!workOsUser,
     workOsUserEmail: workOsUser?.email ?? null,
-    isLoadingRemoteProjects,
   });
-  const hostedChatShellGateState = resolveHostedShellGateState({
-    hostedMode: HOSTED_MODE,
-    nonProdLockdown: NON_PROD_LOCKDOWN,
-    isConvexAuthLoading: isAuthLoading,
-    isConvexAuthenticated: isAuthenticated,
-    isWorkOsLoading,
-    hasWorkOsUser: !!workOsUser,
-    workOsUserEmail: workOsUser?.email ?? null,
-    isLoadingRemoteProjects: false,
-  });
-  const baseHostedShellGateState = isHostedChatRoute
-    ? hostedChatShellGateState
-    : hostedShellGateState;
+  const baseHostedShellGateState = hostedShellGateState;
   const pendingDashboardOAuthServer = pendingDashboardOAuth
     ? projectServers[pendingDashboardOAuth.serverName]
     : null;

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/hosted-shell-gate-state.test.ts
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/hosted-shell-gate-state.test.ts
@@ -12,7 +12,6 @@ describe("resolveHostedShellGateState", () => {
         isWorkOsLoading: false,
         hasWorkOsUser: false,
         workOsUserEmail: null,
-        isLoadingRemoteProjects: false,
       }),
     ).toBe("ready");
   });
@@ -27,7 +26,6 @@ describe("resolveHostedShellGateState", () => {
         isWorkOsLoading: true,
         hasWorkOsUser: false,
         workOsUserEmail: null,
-        isLoadingRemoteProjects: false,
       }),
     ).toBe("auth-loading");
   });
@@ -42,7 +40,6 @@ describe("resolveHostedShellGateState", () => {
         isWorkOsLoading: false,
         hasWorkOsUser: true,
         workOsUserEmail: "employee@mcpjam.com",
-        isLoadingRemoteProjects: false,
       }),
     ).toBe("auth-loading");
   });
@@ -57,12 +54,11 @@ describe("resolveHostedShellGateState", () => {
         isWorkOsLoading: false,
         hasWorkOsUser: false,
         workOsUserEmail: null,
-        isLoadingRemoteProjects: false,
       }),
     ).toBe("ready");
   });
 
-  it("returns project-loading when auth is ready but project data is pending", () => {
+  it("returns ready when auth is ready (no longer blocks on project data)", () => {
     expect(
       resolveHostedShellGateState({
         hostedMode: true,
@@ -72,9 +68,8 @@ describe("resolveHostedShellGateState", () => {
         isWorkOsLoading: false,
         hasWorkOsUser: true,
         workOsUserEmail: "employee@mcpjam.com",
-        isLoadingRemoteProjects: true,
       }),
-    ).toBe("project-loading");
+    ).toBe("ready");
   });
 
   it("returns ready when hosted auth and project are fully ready", () => {
@@ -87,7 +82,6 @@ describe("resolveHostedShellGateState", () => {
         isWorkOsLoading: false,
         hasWorkOsUser: true,
         workOsUserEmail: "employee@mcpjam.com",
-        isLoadingRemoteProjects: false,
       }),
     ).toBe("ready");
   });
@@ -102,7 +96,6 @@ describe("resolveHostedShellGateState", () => {
         isWorkOsLoading: false,
         hasWorkOsUser: false,
         workOsUserEmail: null,
-        isLoadingRemoteProjects: false,
       }),
     ).toBe("logged-out");
   });
@@ -117,7 +110,6 @@ describe("resolveHostedShellGateState", () => {
         isWorkOsLoading: false,
         hasWorkOsUser: true,
         workOsUserEmail: "contractor@example.com",
-        isLoadingRemoteProjects: false,
       }),
     ).toBe("restricted");
   });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/hosted-shell-gate-state.test.ts
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/hosted-shell-gate-state.test.ts
@@ -58,21 +58,7 @@ describe("resolveHostedShellGateState", () => {
     ).toBe("ready");
   });
 
-  it("returns ready when auth is ready (no longer blocks on project data)", () => {
-    expect(
-      resolveHostedShellGateState({
-        hostedMode: true,
-        nonProdLockdown: false,
-        isConvexAuthLoading: false,
-        isConvexAuthenticated: true,
-        isWorkOsLoading: false,
-        hasWorkOsUser: true,
-        workOsUserEmail: "employee@mcpjam.com",
-      }),
-    ).toBe("ready");
-  });
-
-  it("returns ready when hosted auth and project are fully ready", () => {
+  it("returns ready when hosted auth is settled (no longer blocks on project data)", () => {
     expect(
       resolveHostedShellGateState({
         hostedMode: true,

--- a/mcpjam-inspector/client/src/components/hosted/hosted-shell-gate-state.ts
+++ b/mcpjam-inspector/client/src/components/hosted/hosted-shell-gate-state.ts
@@ -9,7 +9,6 @@ interface ResolveHostedShellGateStateOptions {
   isWorkOsLoading: boolean;
   hasWorkOsUser: boolean;
   workOsUserEmail?: string | null;
-  isLoadingRemoteProjects: boolean;
 }
 
 export function resolveHostedShellGateState({
@@ -20,7 +19,6 @@ export function resolveHostedShellGateState({
   isWorkOsLoading,
   hasWorkOsUser,
   workOsUserEmail,
-  isLoadingRemoteProjects,
 }: ResolveHostedShellGateStateOptions): HostedShellGateState {
   if (!hostedMode) {
     return "ready";
@@ -46,10 +44,6 @@ export function resolveHostedShellGateState({
 
   if (!hasWorkOsUser && !isConvexAuthenticated) {
     return "ready";
-  }
-
-  if (isLoadingRemoteProjects) {
-    return "project-loading";
   }
 
   return "ready";

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
@@ -14,6 +14,8 @@ const mockState = vi.hoisted(() => ({
   ensureUser: vi.fn().mockResolvedValue(undefined),
   getGuestPromotionProof: vi.fn().mockResolvedValue(null),
   revokeGuestSessionAndCookie: vi.fn().mockResolvedValue(false),
+  getExistingGuestId: vi.fn().mockResolvedValue(null as string | null),
+  isGuestActivated: vi.fn().mockReturnValue(false),
   sentrySetUser: vi.fn(),
 }));
 
@@ -33,6 +35,8 @@ vi.mock("@/hooks/use-actor-key", () => ({
 vi.mock("@/lib/guest-session", () => ({
   getGuestPromotionProof: mockState.getGuestPromotionProof,
   revokeGuestSessionAndCookie: mockState.revokeGuestSessionAndCookie,
+  getExistingGuestId: mockState.getExistingGuestId,
+  isGuestActivated: mockState.isGuestActivated,
 }));
 
 vi.mock("@sentry/react", () => ({
@@ -45,6 +49,8 @@ describe("useEnsureDbUser", () => {
     mockState.ensureUser.mockResolvedValue(undefined);
     mockState.getGuestPromotionProof.mockResolvedValue(null);
     mockState.revokeGuestSessionAndCookie.mockResolvedValue(false);
+    mockState.getExistingGuestId.mockResolvedValue(null);
+    mockState.isGuestActivated.mockReturnValue(false);
     mockState.actorKey = "guest-1";
     mockState.auth.user = null;
     mockState.convexAuth.isAuthenticated = true;
@@ -226,6 +232,70 @@ describe("useEnsureDbUser", () => {
     });
 
     expect(mockState.ensureUser).toHaveBeenCalledTimes(2);
+  });
+
+  it("revokes an incidental (unactivated) guest cookie on WorkOS auth without promoting", async () => {
+    mockState.auth.user = { id: "workos-user-1" };
+    mockState.actorKey = "workos-user-1";
+    // A guest cookie exists (incidental document bootstrap) but was never
+    // activated as a guest.
+    mockState.getExistingGuestId.mockResolvedValue("guest-incidental");
+    mockState.isGuestActivated.mockReturnValue(false);
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledTimes(1);
+    });
+
+    // No promotion proof requested.
+    expect(mockState.getGuestPromotionProof).not.toHaveBeenCalled();
+    // ensureUser called WITHOUT guestProofJwt.
+    expect(mockState.ensureUser).toHaveBeenCalledWith({});
+    // Incidental cookie revoked.
+    await waitFor(() => {
+      expect(mockState.revokeGuestSessionAndCookie).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("promotes an activated guest on WorkOS auth", async () => {
+    mockState.auth.user = { id: "workos-user-1" };
+    mockState.actorKey = "workos-user-1";
+    mockState.getExistingGuestId.mockResolvedValue("guest-activated");
+    mockState.isGuestActivated.mockReturnValue(true);
+    mockState.getGuestPromotionProof.mockResolvedValue("proof-jwt");
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.getGuestPromotionProof).toHaveBeenCalledTimes(1);
+    });
+    // ensureUser called WITH the proof.
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledWith({
+        guestProofJwt: "proof-jwt",
+      });
+    });
+    // Activated guests still revoke their cookie after a successful promote.
+    await waitFor(() => {
+      expect(mockState.revokeGuestSessionAndCookie).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not request a promotion proof or revoke when no guest cookie exists", async () => {
+    mockState.auth.user = { id: "workos-user-1" };
+    mockState.actorKey = "workos-user-1";
+    mockState.getExistingGuestId.mockResolvedValue(null);
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockState.getGuestPromotionProof).not.toHaveBeenCalled();
+    expect(mockState.revokeGuestSessionAndCookie).not.toHaveBeenCalled();
+    expect(mockState.ensureUser).toHaveBeenCalledWith({});
   });
 
   it("does not retry unrelated ensureUser errors", async () => {

--- a/mcpjam-inspector/client/src/hooks/useClients.ts
+++ b/mcpjam-inspector/client/src/hooks/useClients.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from "convex/react";
 import type { HostConfigDtoV2, HostConfigInputV2 } from "@/lib/client-config-v2";
+import { shouldQueryProjectId } from "./useProjects";
 
 export interface HostListItem {
   hostId: string;
@@ -27,9 +28,14 @@ export function useHostList({
   hosts: HostListItem[];
   isLoading: boolean;
 } {
+  // Skip until `projectId` is a real Convex id. A transient LOCAL project id
+  // (UUID, or a `local_`/`project_` placeholder) flows in while the shared
+  // Convex id is still resolving — passing it to a `v.id("projects")` query
+  // throws an ArgumentValidationError. `shouldQueryProjectId` is the same guard
+  // every other project-scoped Convex query uses.
   const result = useQuery(
     "hosts:listHosts" as any,
-    isAuthenticated && projectId
+    isAuthenticated && shouldQueryProjectId(projectId)
       ? ({ projectId } as any)
       : "skip",
   ) as HostListItem[] | null | undefined;

--- a/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
+++ b/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
@@ -3,7 +3,9 @@ import { useMutation, useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import * as Sentry from "@sentry/react";
 import {
+  getExistingGuestId,
   getGuestPromotionProof,
+  isGuestActivated,
   revokeGuestSessionAndCookie,
 } from "@/lib/guest-session";
 import { useActorKey } from "@/hooks/use-actor-key";
@@ -198,12 +200,40 @@ export function useEnsureDbUser() {
       const isWorkOsAuth = !!workosUserId;
       let guestProofJwt: string | null = null;
       if (isWorkOsAuth) {
+        // Gate promotion on *activation*, not mere cookie presence. The
+        // server-rendered guest bootstrap (Pillar 1) can leave an incidental
+        // guest cookie on a browser whose user then signs in; that guest was
+        // never used as a guest and must not be absorbed into the account.
+        // Only mint a promotion proof when the cookie-backed guest carries an
+        // activation marker; otherwise revoke the incidental cookie and
+        // proceed without a proof.
+        let guestId: string | null = null;
         try {
-          guestProofJwt = await getGuestPromotionProof();
+          guestId = await getExistingGuestId();
         } catch {
-          // Network/transient failure minting the promotion proof is not
-          // fatal — the user can still create a fresh org-owned account.
-          guestProofJwt = null;
+          guestId = null;
+        }
+
+        if (guestId && isGuestActivated(guestId)) {
+          try {
+            guestProofJwt = await getGuestPromotionProof();
+          } catch {
+            // Network/transient failure minting the promotion proof is not
+            // fatal — the user can still create a fresh org-owned account.
+            guestProofJwt = null;
+          }
+        } else if (guestId) {
+          // Incidental, unactivated guest cookie: clean it up so it can't
+          // later be replayed, and do NOT promote it.
+          try {
+            await revokeGuestSessionAndCookie();
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error(
+              "[auth] incidental guest cookie revoke failed",
+              err
+            );
+          }
         }
       }
 

--- a/mcpjam-inspector/client/src/lib/__tests__/unified-convex-auth.test.tsx
+++ b/mcpjam-inspector/client/src/lib/__tests__/unified-convex-auth.test.tsx
@@ -11,6 +11,7 @@ const mockState = vi.hoisted(() => ({
   getCachedGuestSession: vi.fn(),
   getOrCreateGuestSession: vi.fn(),
   forceRefreshGuestSession: vi.fn(),
+  markGuestActivated: vi.fn(),
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -21,6 +22,7 @@ vi.mock("@/lib/guest-session", () => ({
   getCachedGuestSession: mockState.getCachedGuestSession,
   getOrCreateGuestSession: mockState.getOrCreateGuestSession,
   forceRefreshGuestSession: mockState.forceRefreshGuestSession,
+  markGuestActivated: mockState.markGuestActivated,
 }));
 
 describe("useUnifiedConvexAuth", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/unified-convex-auth.test.tsx
+++ b/mcpjam-inspector/client/src/lib/__tests__/unified-convex-auth.test.tsx
@@ -69,4 +69,29 @@ describe("useUnifiedConvexAuth", () => {
       id: "__guest__",
     });
   });
+
+  it("marks the guest activated only when Convex pulls the guest token, not on resolve", async () => {
+    const session = {
+      guestId: "guest-1",
+      token: "guest-token",
+      expiresAt: Date.now() + 60_000,
+    };
+    mockState.getOrCreateGuestSession.mockResolvedValue(session);
+    mockState.getCachedGuestSession.mockReturnValue(session);
+
+    const { result } = renderHook(() => useUnifiedConvexAuth());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Resolving the session must NOT activate — otherwise an authed user who
+    // merely opened the app would be promotable (the incidental-cookie guard).
+    expect(mockState.markGuestActivated).not.toHaveBeenCalled();
+
+    // Convex authenticating as the guest is the real activation signal.
+    await act(async () => {
+      await result.current.getAccessToken();
+    });
+    expect(mockState.markGuestActivated).toHaveBeenCalledWith("guest-1");
+  });
 });

--- a/mcpjam-inspector/client/src/lib/guest-session.ts
+++ b/mcpjam-inspector/client/src/lib/guest-session.ts
@@ -14,7 +14,25 @@
 
 import { NON_PROD_LOCKDOWN } from "@/lib/config";
 
+declare global {
+  interface Window {
+    // Server-injected guest bootstrap blob (Pillar 1). Read once at module
+    // eval before React renders, then deleted. NEVER written to localStorage —
+    // the bearer stays in module memory only, like a client-minted session.
+    __MCP_GUEST_BOOTSTRAP__?: {
+      token: string;
+      guestId?: string;
+      expiresAt: number;
+    };
+  }
+}
+
 const LEGACY_STORAGE_KEY = "mcpjam_guest_session_v1";
+// Persistent, non-secret marker recording that a guest was actually
+// *activated* (drove Convex auth as a guest), keyed by guestId. It is not the
+// bearer; it survives the guest→sign-in navigation so the promotion path can
+// tell a genuine guest from an incidental document bootstrap.
+const GUEST_ACTIVATED_STORAGE_KEY = "mcpjam_guest_activated";
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
 type GuestSessionMode = "lookup_or_create" | "lookup_only";
@@ -56,6 +74,79 @@ export function subscribeGuestSessionChanges(
     sessionListeners.delete(listener);
   };
 }
+
+/**
+ * Mark the guest identified by `guestId` as *activated* — i.e. it actually
+ * drove Convex auth as a guest (not just an incidental document bootstrap).
+ * Persisted (localStorage, non-secret) so the marker survives the guest →
+ * WorkOS sign-in navigation. The promotion path reads this to distinguish a
+ * genuine guest from an incidental cookie.
+ */
+export function markGuestActivated(guestId: string): void {
+  if (!guestId) return;
+  try {
+    if (localStorage.getItem(GUEST_ACTIVATED_STORAGE_KEY) !== guestId) {
+      localStorage.setItem(GUEST_ACTIVATED_STORAGE_KEY, guestId);
+    }
+  } catch {
+    // ignore (private mode / storage disabled)
+  }
+}
+
+/**
+ * Returns true when the guest identified by `guestId` was previously
+ * activated as a guest (`markGuestActivated`). Used by the promotion path to
+ * gate `getGuestPromotionProof()` on real activation, not mere cookie
+ * presence.
+ */
+export function isGuestActivated(guestId: string | null | undefined): boolean {
+  if (!guestId) return false;
+  try {
+    return localStorage.getItem(GUEST_ACTIVATED_STORAGE_KEY) === guestId;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the server-injected `window.__MCP_GUEST_BOOTSTRAP__` blob once at
+ * module load (before the first React render), validate it, and seed the
+ * in-memory cache so the lazy `useState` initializers in
+ * `unified-convex-auth.ts` / `use-actor-key.ts` see a non-null token on the
+ * very first render. One-shot: the global is deleted after reading; the bearer
+ * is never persisted to localStorage.
+ */
+function seedFromBootstrap(): void {
+  if (typeof window === "undefined") return;
+  const blob = window.__MCP_GUEST_BOOTSTRAP__;
+  try {
+    delete window.__MCP_GUEST_BOOTSTRAP__;
+  } catch {
+    window.__MCP_GUEST_BOOTSTRAP__ = undefined;
+  }
+  if (!blob) return;
+  if (
+    typeof blob.token !== "string" ||
+    blob.token.length === 0 ||
+    typeof blob.expiresAt !== "number"
+  ) {
+    return;
+  }
+  // Honor the same expiry buffer the rest of the cache uses so we never seed a
+  // token that's about to expire.
+  if (blob.expiresAt - EXPIRY_BUFFER_MS <= Date.now()) {
+    return;
+  }
+  cachedSession = {
+    guestId: typeof blob.guestId === "string" ? blob.guestId : "",
+    token: blob.token,
+    expiresAt: blob.expiresAt,
+  };
+}
+
+// Runs at import time (main.tsx imports this module transitively before
+// root.render), so the seed is in place before the first render.
+seedFromBootstrap();
 
 function consumeLegacyToken(): string | null {
   if (legacyMigrationConsumed) return null;
@@ -264,6 +355,29 @@ export async function getExistingGuestBearerToken(): Promise<string | null> {
 
   const session = await inFlightLookupOnly;
   return session?.token ?? null;
+}
+
+/**
+ * Resolve the `guestId` of the guest backed by the current cookie WITHOUT
+ * minting a new guest. Prefers the in-memory cache (the common same-tab
+ * guest→sign-in case) and otherwise issues a single `lookup_only`. Returns
+ * null when there is no existing guest cookie or on transient failure.
+ *
+ * Used by the promotion path to look up the activation marker for the cookie
+ * actually present, so an incidental document-bootstrap cookie (never
+ * activated) is not promoted.
+ */
+export async function getExistingGuestId(): Promise<string | null> {
+  const cached = getCachedGuestSession();
+  if (cached?.guestId) {
+    return cached.guestId;
+  }
+  try {
+    await getExistingGuestBearerToken();
+  } catch {
+    return null;
+  }
+  return getCachedGuestSession()?.guestId ?? null;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/guest-session.ts
+++ b/mcpjam-inspector/client/src/lib/guest-session.ts
@@ -125,10 +125,17 @@ function seedFromBootstrap(): void {
     window.__MCP_GUEST_BOOTSTRAP__ = undefined;
   }
   if (!blob) return;
+  // Require a non-empty guestId: a seeded session with an empty guestId would
+  // read as "resolved" (token present) yet leave the promotion path unable to
+  // identify the guest — activation and incidental-revoke would both no-op,
+  // stranding the document-minted cookie. If the server omitted guestId, skip
+  // the seed and fall back to the client lookup path (which fills guestId).
   if (
     typeof blob.token !== "string" ||
     blob.token.length === 0 ||
-    typeof blob.expiresAt !== "number"
+    typeof blob.expiresAt !== "number" ||
+    typeof blob.guestId !== "string" ||
+    blob.guestId.length === 0
   ) {
     return;
   }
@@ -138,7 +145,7 @@ function seedFromBootstrap(): void {
     return;
   }
   cachedSession = {
-    guestId: typeof blob.guestId === "string" ? blob.guestId : "",
+    guestId: blob.guestId,
     token: blob.token,
     expiresAt: blob.expiresAt,
   };

--- a/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
+++ b/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
@@ -35,6 +35,14 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Persist the "this browser used Convex as a guest" marker for the currently
+// cached guest. No-op when no guestId is resolved (e.g. a bootstrap seed that
+// carried no guestId — those are never seeded; see seedFromBootstrap).
+function markActiveGuest(): void {
+  const guestId = getCachedGuestSession()?.guestId;
+  if (guestId) markGuestActivated(guestId);
+}
+
 export function useUnifiedConvexAuth() {
   const workos = useWorkOSAuth();
   const [guestToken, setGuestToken] = useState<string | null>(
@@ -90,14 +98,6 @@ export function useUnifiedConvexAuth() {
           session ||
           attempt === GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS.length
         ) {
-          // This guest is now driving Convex auth as a guest (no WorkOS user),
-          // so it is genuinely *activated* — record a persistent marker keyed
-          // by guestId so the promotion path can distinguish it from an
-          // incidental document bootstrap. Skipped for the empty placeholder
-          // guestId a bootstrap-seeded session may carry.
-          if (session?.guestId) {
-            markGuestActivated(session.guestId);
-          }
           setGuestToken(session?.token ?? null);
           setGuestLoading(false);
           return;
@@ -133,11 +133,18 @@ export function useUnifiedConvexAuth() {
         if (opts?.forceRefreshToken) {
           const refreshed = await forceRefreshGuestSession();
           setGuestToken(refreshed);
+          markActiveGuest();
           return refreshed;
         }
         // Prefer the latest in-memory cache so a fresh token is used even
         // if React hasn't yet re-rendered with the new state.
         const cached = getCachedGuestSession()?.token ?? guestToken;
+        // Convex calls this to authenticate as the guest — the true "activated
+        // as a guest" signal. Marking HERE (rather than in the resolve effect)
+        // is immune to the effect-cancel race when a guest signs in mid-resolve,
+        // and never fires for an authed user (whose memo branch returns the
+        // WorkOS getAccessToken above). Keyed by guestId; idempotent.
+        if (cached) markActiveGuest();
         return cached ?? null;
       },
     };

--- a/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
+++ b/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
@@ -5,6 +5,7 @@ import {
   forceRefreshGuestSession,
   getCachedGuestSession,
   getOrCreateGuestSession,
+  markGuestActivated,
 } from "@/lib/guest-session";
 
 /**
@@ -89,6 +90,14 @@ export function useUnifiedConvexAuth() {
           session ||
           attempt === GUEST_SESSION_BOOTSTRAP_RETRY_DELAYS_MS.length
         ) {
+          // This guest is now driving Convex auth as a guest (no WorkOS user),
+          // so it is genuinely *activated* — record a persistent marker keyed
+          // by guestId so the promotion path can distinguish it from an
+          // incidental document bootstrap. Skipped for the empty placeholder
+          // guestId a bootstrap-seeded session may carry.
+          if (session?.guestId) {
+            markGuestActivated(session.guestId);
+          }
           setGuestToken(session?.token ?? null);
           setGuestLoading(false);
           return;

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -29,7 +29,16 @@ import {
   generateSessionToken,
   getSessionToken,
 } from "./services/session-token.js";
-import { isAllowedHost } from "./utils/localhost-check.js";
+import {
+  isAllowedHost,
+  mayServeGuestBootstrap,
+} from "./utils/localhost-check.js";
+import { getActiveTunnelDomains } from "./services/tunnel-registry.js";
+import {
+  appendGuestSessionSetCookie,
+  buildGuestBootstrapScript,
+  mintGuestSessionForDocument,
+} from "./routes/web/guest-session-shared.js";
 import {
   sessionAuthMiddleware,
   scrubTokenFromUrl,
@@ -344,7 +353,7 @@ export function createHonoApp() {
     app.use("/*", serveStatic({ root }));
 
     // For HTML pages, inject the session token (only for localhost requests)
-    app.get("/*", (c) => {
+    app.get("/*", async (c) => {
       const reqPath = c.req.path;
 
       // Don't intercept API routes
@@ -359,6 +368,7 @@ export function createHonoApp() {
         // SECURITY: Only inject token for localhost or allowed hosts (in hosted mode)
         // This prevents token leakage when bound to 0.0.0.0
         const host = c.req.header("Host");
+        const forwardedHost = c.req.header("X-Forwarded-Host");
 
         if (isAllowedHost(host, ALLOWED_HOSTS, HOSTED_MODE)) {
           const token = getSessionToken();
@@ -377,6 +387,46 @@ export function createHonoApp() {
         if (runtimeConfigScript) {
           html = html.replace("</head>", `${runtimeConfigScript}</head>`);
         }
+
+        // Guest bootstrap blob: mint a guest bearer server-side and inject it
+        // so a cold guest boots with a token already in hand. Gated on
+        // production + hosted + not locked-down + a host allowlist that
+        // includes the hosted app host(s) (mayServeGuestBootstrap), mirroring
+        // the session-token discipline. Wrapped in its own try/catch so a
+        // mint failure never 500s the document.
+        if (
+          process.env.NODE_ENV === "production" &&
+          HOSTED_MODE &&
+          process.env.MCPJAM_NONPROD_LOCKDOWN !== "true" &&
+          mayServeGuestBootstrap({
+            host,
+            forwardedHost,
+            allowedHosts: ALLOWED_HOSTS,
+            hostedMode: HOSTED_MODE,
+            activeTunnelDomains: getActiveTunnelDomains(),
+          })
+        ) {
+          try {
+            const { session, setCookies } =
+              await mintGuestSessionForDocument(c);
+            if (session && session.expiresAt > Date.now()) {
+              const bootstrapScript = buildGuestBootstrapScript(session);
+              html = html.replace("</head>", `${bootstrapScript}</head>`);
+              for (const cookie of setCookies) {
+                appendGuestSessionSetCookie(c, cookie);
+              }
+            }
+          } catch (error) {
+            appLogger.warn(
+              "[guest-bootstrap] document mint failed; serving without blob",
+              { error: error instanceof Error ? error.message : String(error) },
+            );
+          }
+        }
+
+        // The document may embed a per-guest bearer; never let a
+        // shared/browser cache replay one guest's blob to another.
+        c.header("Cache-Control", "no-store");
 
         return c.html(html);
       } catch (error) {

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -25,8 +25,16 @@ import {
   getSessionToken,
 } from "./services/session-token";
 import { inspectorCommandBus } from "./services/inspector-command-bus";
-import { mayServeSessionToken } from "./utils/localhost-check";
+import {
+  mayServeSessionToken,
+  mayServeGuestBootstrap,
+} from "./utils/localhost-check";
 import { getActiveTunnelDomains } from "./services/tunnel-registry";
+import {
+  appendGuestSessionSetCookie,
+  buildGuestBootstrapScript,
+  mintGuestSessionForDocument,
+} from "./routes/web/guest-session-shared";
 import {
   sessionAuthMiddleware,
   scrubTokenFromUrl,
@@ -549,6 +557,52 @@ if (process.env.NODE_ENV === "production") {
         )};</script>`;
         htmlContent = htmlContent.replace("</head>", `${configScript}</head>`);
       }
+
+      // Guest bootstrap blob: mint a guest bearer server-side and inject it so
+      // a cold guest boots with a token already in hand (no render-blocking
+      // POST /api/web/guest-session). Gated on production + hosted + not
+      // locked-down + a host allowlist that includes the hosted app host(s)
+      // (mayServeGuestBootstrap), mirroring the session-token discipline.
+      //
+      // Wrapped in its OWN try/catch so a mint failure never 500s the
+      // document — we just serve without the blob and let the client fall
+      // back to its POST path.
+      if (
+        process.env.NODE_ENV === "production" &&
+        HOSTED_MODE &&
+        process.env.MCPJAM_NONPROD_LOCKDOWN !== "true" &&
+        mayServeGuestBootstrap({
+          host,
+          forwardedHost,
+          allowedHosts: ALLOWED_HOSTS,
+          hostedMode: HOSTED_MODE,
+          activeTunnelDomains: getActiveTunnelDomains(),
+        })
+      ) {
+        try {
+          const { session, setCookies } =
+            await mintGuestSessionForDocument(c);
+          if (session && session.expiresAt > Date.now()) {
+            const bootstrapScript = buildGuestBootstrapScript(session);
+            htmlContent = htmlContent.replace(
+              "</head>",
+              `${bootstrapScript}</head>`
+            );
+            for (const cookie of setCookies) {
+              appendGuestSessionSetCookie(c, cookie);
+            }
+          }
+        } catch (error) {
+          appLogger.warn(
+            "[guest-bootstrap] document mint failed; serving without blob",
+            { error: error instanceof Error ? error.message : String(error) }
+          );
+        }
+      }
+
+      // The document may embed a per-guest bearer; never let a shared/browser
+      // cache replay one guest's blob to another.
+      c.header("Cache-Control", "no-store");
 
       return c.html(htmlContent);
     } catch (error) {

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session-document.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session-document.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono, type Context } from "hono";
+
+// Mock the upstream source module so we control mint outcomes deterministically.
+const mockFetchConvexGuestSession = vi.fn();
+const mockFetchRemoteGuestSession = vi.fn();
+
+vi.mock("../../../utils/guest-session-source.js", () => ({
+  fetchConvexGuestSession: (...args: unknown[]) =>
+    mockFetchConvexGuestSession(...args),
+  fetchRemoteGuestSession: (...args: unknown[]) =>
+    mockFetchRemoteGuestSession(...args),
+}));
+
+// Deterministic IP hash; the real impl degrades to null without a pepper but
+// mocking keeps the test independent of env.
+vi.mock("../../../utils/guest-spend-ip.js", () => ({
+  hashGuestSpendIp: vi.fn(async () => "hashed-ip"),
+}));
+
+// Avoid Sentry/Axiom side effects from the logger.
+vi.mock("../../../utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    event: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const ALLOWED_HOSTS = ["app.mcpjam.com"];
+const INDEX_HTML = "<html><head><title>app</title></head><body></body></html>";
+
+/**
+ * Mirror of the production SPA document handler's guest-bootstrap block,
+ * importing the REAL shared helpers + host gate. Kept in sync with
+ * server/index.ts / server/app.ts. Exercising the real helpers lets us assert
+ * escaping, no-store, cookie forwarding, host gating, lockdown, mint-failure,
+ * and the whole-helper timeout race without booting the full server.
+ */
+async function buildDocumentApp() {
+  const {
+    appendGuestSessionSetCookie,
+    buildGuestBootstrapScript,
+    mintGuestSessionForDocument,
+  } = await import("../guest-session-shared.js");
+  const { mayServeGuestBootstrap } = await import(
+    "../../../utils/localhost-check.js"
+  );
+
+  const app = new Hono();
+  app.get("/*", async (c: Context) => {
+    let html = INDEX_HTML;
+    const host = c.req.header("Host");
+    const forwardedHost = c.req.header("X-Forwarded-Host");
+
+    if (
+      process.env.NODE_ENV === "production" &&
+      process.env.MCPJAM_NONPROD_LOCKDOWN !== "true" &&
+      mayServeGuestBootstrap({
+        host,
+        forwardedHost,
+        allowedHosts: ALLOWED_HOSTS,
+        hostedMode: true,
+      })
+    ) {
+      try {
+        const { session, setCookies } = await mintGuestSessionForDocument(c);
+        if (session && session.expiresAt > Date.now()) {
+          html = html.replace(
+            "</head>",
+            `${buildGuestBootstrapScript(session)}</head>`
+          );
+          for (const cookie of setCookies) {
+            appendGuestSessionSetCookie(c, cookie);
+          }
+        }
+      } catch {
+        // serve without blob
+      }
+    }
+
+    c.header("Cache-Control", "no-store");
+    return c.html(html);
+  });
+  return app;
+}
+
+function get(
+  app: Awaited<ReturnType<typeof buildDocumentApp>>,
+  headers: Record<string, string> = {}
+) {
+  return app.request("http://app.mcpjam.com/", {
+    method: "GET",
+    headers: {
+      Host: "app.mcpjam.com",
+      "cf-connecting-ip": "203.0.113.7",
+      ...headers,
+    },
+  });
+}
+
+describe("guest-session document bootstrap", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalLockdown = process.env.MCPJAM_NONPROD_LOCKDOWN;
+  const originalHosted = process.env.VITE_MCPJAM_HOSTED_MODE;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.NODE_ENV = "production";
+    delete process.env.MCPJAM_NONPROD_LOCKDOWN;
+    // Force the Convex source branch (shouldFetchGuestSessionFromConvex()).
+    process.env.VITE_MCPJAM_HOSTED_MODE = "true";
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalLockdown === undefined) delete process.env.MCPJAM_NONPROD_LOCKDOWN;
+    else process.env.MCPJAM_NONPROD_LOCKDOWN = originalLockdown;
+    if (originalHosted === undefined) delete process.env.VITE_MCPJAM_HOSTED_MODE;
+    else process.env.VITE_MCPJAM_HOSTED_MODE = originalHosted;
+  });
+
+  it("injects an escaped blob and forwards cookies on a successful mint", async () => {
+    mockFetchConvexGuestSession.mockResolvedValue({
+      kind: "session",
+      session: {
+        // guestId carries breakout-attempt characters to verify escaping.
+        guestId: "g</script><script>alert(1)</script>",
+        token: "guest-bearer-token",
+        expiresAt: Date.now() + 60_000,
+      },
+      setCookies: ["__Host-mcpjam_guest_session=opaque; Path=/; HttpOnly"],
+    });
+
+    const app = await buildDocumentApp();
+    const res = await get(app);
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(body).toContain("window.__MCP_GUEST_BOOTSTRAP__=");
+    expect(body).toContain("guest-bearer-token");
+    // No raw </script> breakout — the literal closing tag from the guestId
+    // must be escaped inside the JSON payload.
+    expect(body).not.toContain("</script><script>alert(1)</script>");
+    expect(body).toContain("\\u003c");
+    // Cookie forwarded onto the document response.
+    expect(res.headers.get("set-cookie")).toContain(
+      "__Host-mcpjam_guest_session=opaque"
+    );
+    // no-store set unconditionally.
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("does not inject a blob for a non-allowed Host (host-allowlist gating)", async () => {
+    mockFetchConvexGuestSession.mockResolvedValue({
+      kind: "session",
+      session: {
+        guestId: "g",
+        token: "t",
+        expiresAt: Date.now() + 60_000,
+      },
+      setCookies: [],
+    });
+
+    const app = await buildDocumentApp();
+    const res = await get(app, { Host: "evil.example.com" });
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(body).not.toContain("__MCP_GUEST_BOOTSTRAP__");
+    expect(mockFetchConvexGuestSession).not.toHaveBeenCalled();
+    // no-store is unconditional regardless of gating.
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("does not inject a blob for a tunnel forwarded host", async () => {
+    mockFetchConvexGuestSession.mockResolvedValue({
+      kind: "session",
+      session: { guestId: "g", token: "t", expiresAt: Date.now() + 60_000 },
+      setCookies: [],
+    });
+
+    const app = await buildDocumentApp();
+    const res = await get(app, {
+      "X-Forwarded-Host": "abc123.tunnels.mcpjam.com",
+    });
+    const body = await res.text();
+
+    expect(body).not.toContain("__MCP_GUEST_BOOTSTRAP__");
+    expect(mockFetchConvexGuestSession).not.toHaveBeenCalled();
+  });
+
+  it("injects nothing under lockdown (no-op)", async () => {
+    process.env.MCPJAM_NONPROD_LOCKDOWN = "true";
+    mockFetchConvexGuestSession.mockResolvedValue({
+      kind: "session",
+      session: { guestId: "g", token: "t", expiresAt: Date.now() + 60_000 },
+      setCookies: [],
+    });
+
+    const app = await buildDocumentApp();
+    const res = await get(app);
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(body).not.toContain("__MCP_GUEST_BOOTSTRAP__");
+    expect(mockFetchConvexGuestSession).not.toHaveBeenCalled();
+  });
+
+  it("serves 200 without a blob when the mint fails (degrade, never 500)", async () => {
+    mockFetchConvexGuestSession.mockResolvedValue({
+      kind: "error",
+      status: 503,
+      setCookies: [],
+    });
+
+    const app = await buildDocumentApp();
+    const res = await get(app);
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(body).not.toContain("__MCP_GUEST_BOOTSTRAP__");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("serves 200 without a blob when the mint throws", async () => {
+    mockFetchConvexGuestSession.mockRejectedValue(new Error("boom"));
+
+    const app = await buildDocumentApp();
+    const res = await get(app);
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(body).not.toContain("__MCP_GUEST_BOOTSTRAP__");
+  });
+
+  it("bounds the whole mint against the 1500ms deadline (provisioning hang)", async () => {
+    // Simulate a hung mint that never resolves — the whole-helper race must
+    // abandon it and serve blob-less within the deadline.
+    mockFetchConvexGuestSession.mockImplementation(
+      () => new Promise(() => {})
+    );
+
+    vi.useFakeTimers();
+    try {
+      const app = await buildDocumentApp();
+      const resPromise = get(app);
+      // Advance past the 1500ms document deadline.
+      await vi.advanceTimersByTimeAsync(1600);
+      const res = await resPromise;
+      const body = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(body).not.toContain("__MCP_GUEST_BOOTSTRAP__");
+      expect(res.headers.get("cache-control")).toBe("no-store");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/mcpjam-inspector/server/routes/web/guest-session-shared.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session-shared.ts
@@ -1,0 +1,276 @@
+import { type Context } from "hono";
+import {
+  fetchConvexGuestSession,
+  fetchRemoteGuestSession,
+  type GuestSessionFetchContext,
+  type RemoteGuestSession,
+} from "../../utils/guest-session-source.js";
+import { getClientIp } from "../../utils/client-ip.js";
+import { hashGuestSpendIp } from "../../utils/guest-spend-ip.js";
+
+// IP-based rate limiting: 10 req/min per IP (sliding window).
+//
+// This state is a SINGLE shared singleton intentionally exported via
+// `allowMint(ip)` so the client `/api/web/guest-session` route AND the
+// document-bootstrap path draw from the SAME per-IP budget. Importing this
+// module from both keeps them on one limiter rather than two parallel ones.
+const ipWindows = new Map<string, { count: number; windowStart: number }>();
+const IP_RATE_LIMIT = 10;
+const IP_WINDOW_MS = 60_000;
+
+// Cleanup stale entries every 5 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of ipWindows) {
+    if (now - entry.windowStart > IP_WINDOW_MS * 2) {
+      ipWindows.delete(ip);
+    }
+  }
+}, 5 * 60_000).unref();
+
+/**
+ * Consume one unit of the per-IP rate-limit budget for `ip`. Returns `true`
+ * when the request is within budget (and records the consumption), `false`
+ * when the IP has exceeded `IP_RATE_LIMIT` within the current window.
+ *
+ * Shared singleton: both the client route and the document bootstrap call
+ * this so a guest cannot get 2x the budget by alternating paths.
+ */
+export function allowMint(ip: string): boolean {
+  const now = Date.now();
+  const entry = ipWindows.get(ip);
+  if (entry) {
+    if (now - entry.windowStart < IP_WINDOW_MS) {
+      if (entry.count >= IP_RATE_LIMIT) {
+        return false;
+      }
+      entry.count++;
+      return true;
+    }
+    // Reset window
+    entry.count = 1;
+    entry.windowStart = now;
+    return true;
+  }
+  ipWindows.set(ip, { count: 1, windowStart: now });
+  return true;
+}
+
+export const GUEST_SESSION_COOKIE_NAME = "__Host-mcpjam_guest_session";
+const LOCAL_GUEST_SESSION_COOKIE_NAME = "mcpjam_guest_session";
+const LOCAL_GUEST_SESSION_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
+
+// Forward only the guest-session cookie to the upstream guest service.
+// Passing the entire Cookie header would leak unrelated auth/CSRF cookies
+// from the Inspector origin to Convex / hosted MCPJam.
+function extractCookieValue(
+  cookieHeader: string | null | undefined,
+  cookieName: string
+): string | null {
+  if (!cookieHeader) return null;
+  const prefix = `${cookieName}=`;
+  for (const part of cookieHeader.split(/;\s*/)) {
+    if (part.startsWith(prefix)) {
+      return part.slice(prefix.length);
+    }
+  }
+  return null;
+}
+
+export function extractGuestSessionCookie(
+  cookieHeader: string | null | undefined
+): string | null {
+  const localCookie = extractCookieValue(
+    cookieHeader,
+    LOCAL_GUEST_SESSION_COOKIE_NAME
+  );
+  if (localCookie) {
+    return `${GUEST_SESSION_COOKIE_NAME}=${localCookie}`;
+  }
+
+  const upstreamCookie = extractCookieValue(
+    cookieHeader,
+    GUEST_SESSION_COOKIE_NAME
+  );
+  return upstreamCookie
+    ? `${GUEST_SESSION_COOKIE_NAME}=${upstreamCookie}`
+    : null;
+}
+
+function isLocalHttpRequest(requestUrl: string): boolean {
+  try {
+    const url = new URL(requestUrl);
+    return (
+      url.protocol === "http:" &&
+      LOCAL_GUEST_SESSION_HOSTNAMES.has(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function rewriteGuestSessionCookieForLocalHttp(cookie: string): string {
+  const parts = cookie
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const [nameValue, ...attributes] = parts;
+  if (!nameValue?.startsWith(`${GUEST_SESSION_COOKIE_NAME}=`)) {
+    return cookie;
+  }
+
+  return [
+    nameValue.replace(
+      `${GUEST_SESSION_COOKIE_NAME}=`,
+      `${LOCAL_GUEST_SESSION_COOKIE_NAME}=`
+    ),
+    ...attributes.filter((attribute) => !/^secure$/i.test(attribute)),
+  ].join("; ");
+}
+
+export function appendGuestSessionSetCookie(c: Context, cookie: string): void {
+  c.header("Set-Cookie", cookie, { append: true });
+  if (isLocalHttpRequest(c.req.url)) {
+    const localCookie = rewriteGuestSessionCookieForLocalHttp(cookie);
+    if (localCookie !== cookie) {
+      c.header("Set-Cookie", localCookie, { append: true });
+    }
+  }
+}
+
+export function shouldFetchGuestSessionFromConvex(): boolean {
+  if (process.env.VITE_MCPJAM_HOSTED_MODE === "true") {
+    return true;
+  }
+
+  return process.env.NODE_ENV !== "production";
+}
+
+// Hard deadline for the document-bootstrap mint. Bounds the ENTIRE mint path
+// (including `provisionGuestAuthConfigToConvex()` inside
+// `fetchConvexGuestSession`), not just the inner fetch — see the comment in
+// `mintGuestSessionForDocument`.
+const DOCUMENT_MINT_DEADLINE_MS = 1500;
+
+export type DocumentGuestMintResult = {
+  session: RemoteGuestSession | null;
+  setCookies: string[];
+};
+
+/**
+ * Mint (or look up) a guest session during a document (SPA HTML) request.
+ *
+ * Builds the same `GuestSessionFetchContext` the client route builds
+ * (request cookie, UA, hashed client IP, `mode: "lookup_or_create"`), selects
+ * the Convex vs remote source, and races the ENTIRE mint against a hard
+ * deadline.
+ *
+ * Why the whole-helper race (not just the fetch's AbortSignal):
+ * `fetchConvexGuestSession()` awaits `provisionGuestAuthConfigToConvex()`
+ * BEFORE the fetch's `AbortSignal.timeout` applies. A hung provisioning step
+ * would otherwise leave TTFB unbounded even with a capped fetch. Racing the
+ * whole `mint()` promise guarantees the document handler can never block past
+ * the deadline; losing the race abandons the mint and serves blob-less.
+ *
+ * Never throws and never rate-limit-fails the caller — on any failure,
+ * timeout, or rate-limit cap the caller simply serves the HTML without a blob
+ * and the client falls back to its own POST mint path.
+ */
+export async function mintGuestSessionForDocument(
+  c: Context
+): Promise<DocumentGuestMintResult> {
+  const empty: DocumentGuestMintResult = { session: null, setCookies: [] };
+
+  const ip = getClientIp(c);
+  // Match the client route's rate-limit key behavior: a missing IP keys to
+  // "local-dev" so non-prod runs aren't starved. The route hard-fails a
+  // missing IP in production, but the document path must NEVER fail the HTML,
+  // so we degrade to blob-less instead.
+  if (!ip && process.env.NODE_ENV === "production") {
+    return empty;
+  }
+  const rateLimitKey = ip ?? "local-dev";
+  if (!allowMint(rateLimitKey)) {
+    return empty;
+  }
+
+  const clientIp = getClientIp(c);
+  let ipHash: string | null = null;
+  try {
+    ipHash = clientIp ? await hashGuestSpendIp(clientIp) : null;
+  } catch {
+    ipHash = null;
+  }
+
+  const context: GuestSessionFetchContext = {
+    cookie: extractGuestSessionCookie(c.req.header("cookie")),
+    userAgent: c.req.header("user-agent") ?? null,
+    body: { mode: "lookup_or_create" },
+    ...(ipHash ? { ipHash } : {}),
+  };
+
+  const mint = async (): Promise<DocumentGuestMintResult> => {
+    const result = shouldFetchGuestSessionFromConvex()
+      ? await fetchConvexGuestSession(context, DOCUMENT_MINT_DEADLINE_MS)
+      : await fetchRemoteGuestSession(context, DOCUMENT_MINT_DEADLINE_MS);
+
+    if (result.kind === "session") {
+      return { session: result.session, setCookies: result.setCookies };
+    }
+    return { session: null, setCookies: result.setCookies };
+  };
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<DocumentGuestMintResult>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve(empty), DOCUMENT_MINT_DEADLINE_MS);
+  });
+
+  try {
+    return await Promise.race([mint(), deadline]);
+  } catch {
+    // Defense-in-depth: mint() is written to not throw, but never let a
+    // bootstrap mint failure escape into the document handler.
+    return empty;
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function escapeGuestBootstrapJson(json: string): string {
+  return json.replace(/[<>&\u2028\u2029]/g, (ch) => {
+    switch (ch) {
+      case "<":
+        return "\\u003c";
+      case ">":
+        return "\\u003e";
+      case "&":
+        return "\\u0026";
+      case "\u2028":
+        return "\\u2028";
+      case "\u2029":
+        return "\\u2029";
+      default:
+        return ch;
+    }
+  });
+}
+
+/**
+ * Build the `window.__MCP_GUEST_BOOTSTRAP__` injection script for a minted
+ * session, escaping `<`, `>`, `&`, U+2028 and U+2029 in the JSON so the
+ * embedded payload can never break out of the `<script>` element.
+ */
+export function buildGuestBootstrapScript(
+  session: RemoteGuestSession
+): string {
+  const json = escapeGuestBootstrapJson(
+    JSON.stringify({
+      token: session.token,
+      guestId: session.guestId,
+      expiresAt: session.expiresAt,
+    })
+  );
+  return `<script>window.__MCP_GUEST_BOOTSTRAP__=${json};</script>`;
+}

--- a/mcpjam-inspector/server/routes/web/guest-session-shared.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session-shared.ts
@@ -194,10 +194,9 @@ export async function mintGuestSessionForDocument(
     return empty;
   }
 
-  const clientIp = getClientIp(c);
   let ipHash: string | null = null;
   try {
-    ipHash = clientIp ? await hashGuestSpendIp(clientIp) : null;
+    ipHash = ip ? await hashGuestSpendIp(ip) : null;
   } catch {
     ipHash = null;
   }

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -1,4 +1,4 @@
-import { Hono, type Context } from "hono";
+import { Hono } from "hono";
 import {
   fetchConvexGuestPromotionProof,
   fetchConvexGuestSession,
@@ -11,114 +11,16 @@ import {
 } from "../../utils/guest-session-source.js";
 import { getClientIp } from "../../utils/client-ip.js";
 import { hashGuestSpendIp } from "../../utils/guest-spend-ip.js";
+import {
+  GUEST_SESSION_COOKIE_NAME,
+  allowMint,
+  appendGuestSessionSetCookie,
+  extractGuestSessionCookie,
+  shouldFetchGuestSessionFromConvex,
+} from "./guest-session-shared.js";
 import { ErrorCode } from "./errors.js";
 
 const guestSession = new Hono();
-
-// IP-based rate limiting: 10 req/min per IP (sliding window)
-const ipWindows = new Map<string, { count: number; windowStart: number }>();
-const IP_RATE_LIMIT = 10;
-const IP_WINDOW_MS = 60_000;
-
-// Cleanup stale entries every 5 minutes
-setInterval(() => {
-  const now = Date.now();
-  for (const [ip, entry] of ipWindows) {
-    if (now - entry.windowStart > IP_WINDOW_MS * 2) {
-      ipWindows.delete(ip);
-    }
-  }
-}, 5 * 60_000).unref();
-
-const GUEST_SESSION_COOKIE_NAME = "__Host-mcpjam_guest_session";
-const LOCAL_GUEST_SESSION_COOKIE_NAME = "mcpjam_guest_session";
-const LOCAL_GUEST_SESSION_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
-
-// Forward only the guest-session cookie to the upstream guest service.
-// Passing the entire Cookie header would leak unrelated auth/CSRF cookies
-// from the Inspector origin to Convex / hosted MCPJam.
-function extractCookieValue(
-  cookieHeader: string | null | undefined,
-  cookieName: string
-): string | null {
-  if (!cookieHeader) return null;
-  const prefix = `${cookieName}=`;
-  for (const part of cookieHeader.split(/;\s*/)) {
-    if (part.startsWith(prefix)) {
-      return part.slice(prefix.length);
-    }
-  }
-  return null;
-}
-
-function extractGuestSessionCookie(
-  cookieHeader: string | null | undefined
-): string | null {
-  const localCookie = extractCookieValue(
-    cookieHeader,
-    LOCAL_GUEST_SESSION_COOKIE_NAME
-  );
-  if (localCookie) {
-    return `${GUEST_SESSION_COOKIE_NAME}=${localCookie}`;
-  }
-
-  const upstreamCookie = extractCookieValue(
-    cookieHeader,
-    GUEST_SESSION_COOKIE_NAME
-  );
-  return upstreamCookie
-    ? `${GUEST_SESSION_COOKIE_NAME}=${upstreamCookie}`
-    : null;
-}
-
-function isLocalHttpRequest(requestUrl: string): boolean {
-  try {
-    const url = new URL(requestUrl);
-    return (
-      url.protocol === "http:" &&
-      LOCAL_GUEST_SESSION_HOSTNAMES.has(url.hostname)
-    );
-  } catch {
-    return false;
-  }
-}
-
-function rewriteGuestSessionCookieForLocalHttp(cookie: string): string {
-  const parts = cookie
-    .split(";")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  const [nameValue, ...attributes] = parts;
-  if (!nameValue?.startsWith(`${GUEST_SESSION_COOKIE_NAME}=`)) {
-    return cookie;
-  }
-
-  return [
-    nameValue.replace(
-      `${GUEST_SESSION_COOKIE_NAME}=`,
-      `${LOCAL_GUEST_SESSION_COOKIE_NAME}=`
-    ),
-    ...attributes.filter((attribute) => !/^secure$/i.test(attribute)),
-  ].join("; ");
-}
-
-function appendGuestSessionSetCookie(c: Context, cookie: string): void {
-  c.header("Set-Cookie", cookie, { append: true });
-  if (isLocalHttpRequest(c.req.url)) {
-    const localCookie = rewriteGuestSessionCookieForLocalHttp(cookie);
-    if (localCookie !== cookie) {
-      c.header("Set-Cookie", localCookie, { append: true });
-    }
-  }
-}
-
-function shouldFetchGuestSessionFromConvex(): boolean {
-  if (process.env.VITE_MCPJAM_HOSTED_MODE === "true") {
-    return true;
-  }
-
-  return process.env.NODE_ENV !== "production";
-}
 
 // Bound the size of the legacy migration token we will forward upstream.
 // Real guest JWTs are well under this limit; anything larger is either
@@ -181,29 +83,16 @@ guestSession.post("/", async (c) => {
     );
   }
   const rateLimitKey = ip ?? "local-dev";
-  const now = Date.now();
 
-  // Check rate limit
-  const entry = ipWindows.get(rateLimitKey);
-  if (entry) {
-    if (now - entry.windowStart < IP_WINDOW_MS) {
-      if (entry.count >= IP_RATE_LIMIT) {
-        return c.json(
-          {
-            code: ErrorCode.RATE_LIMITED,
-            message: "Too many guest session requests. Try again later.",
-          },
-          429
-        );
-      }
-      entry.count++;
-    } else {
-      // Reset window
-      entry.count = 1;
-      entry.windowStart = now;
-    }
-  } else {
-    ipWindows.set(rateLimitKey, { count: 1, windowStart: now });
+  // Check rate limit (shared singleton — see guest-session-shared.ts)
+  if (!allowMint(rateLimitKey)) {
+    return c.json(
+      {
+        code: ErrorCode.RATE_LIMITED,
+        message: "Too many guest session requests. Try again later.",
+      },
+      429
+    );
   }
 
   let body: GuestSessionRequestBody = {};
@@ -379,27 +268,15 @@ guestSession.post("/promotion-proof", async (c) => {
     );
   }
   const rateLimitKey = ip ?? "local-dev";
-  const now = Date.now();
 
-  const entry = ipWindows.get(rateLimitKey);
-  if (entry) {
-    if (now - entry.windowStart < IP_WINDOW_MS) {
-      if (entry.count >= IP_RATE_LIMIT) {
-        return c.json(
-          {
-            code: ErrorCode.RATE_LIMITED,
-            message: "Too many guest session requests. Try again later.",
-          },
-          429
-        );
-      }
-      entry.count++;
-    } else {
-      entry.count = 1;
-      entry.windowStart = now;
-    }
-  } else {
-    ipWindows.set(rateLimitKey, { count: 1, windowStart: now });
+  if (!allowMint(rateLimitKey)) {
+    return c.json(
+      {
+        code: ErrorCode.RATE_LIMITED,
+        message: "Too many guest session requests. Try again later.",
+      },
+      429
+    );
   }
 
   const context: GuestSessionFetchContext = {

--- a/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
@@ -273,6 +273,66 @@ describe("guest-session-source", () => {
     expect(headers["x-mcpjam-guest-ip-hash"]).toBeUndefined();
   });
 
+  it("uses the default 10_000ms fetch timeout when timeoutMs is omitted", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          guestId: "g",
+          token: "t",
+          expiresAt: Date.now() + 60_000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    await fetchConvexGuestSession();
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    timeoutSpy.mockRestore();
+  });
+
+  it("honors a shortened timeoutMs on the Convex fetch (defense-in-depth)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          guestId: "g",
+          token: "t",
+          expiresAt: Date.now() + 60_000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    await fetchConvexGuestSession(undefined, 1500);
+    expect(timeoutSpy).toHaveBeenCalledWith(1500);
+    timeoutSpy.mockRestore();
+  });
+
+  it("honors a shortened timeoutMs on the remote fetch", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          guestId: "g",
+          token: "t",
+          expiresAt: Date.now() + 60_000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    const { fetchRemoteGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    await fetchRemoteGuestSession(undefined, 1500);
+    expect(timeoutSpy).toHaveBeenCalledWith(1500);
+    timeoutSpy.mockRestore();
+  });
+
   it("waits for provisioning before fetching Convex JWKS", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response(JSON.stringify({ keys: [] }), {

--- a/mcpjam-inspector/server/utils/guest-session-source.ts
+++ b/mcpjam-inspector/server/utils/guest-session-source.ts
@@ -188,8 +188,14 @@ async function performGuestSessionFetch(
   }
 }
 
+// Default per-fetch timeout. Callers may shorten this (e.g. the document
+// bootstrap path) as defense-in-depth so the inner fetch can't outlive a
+// shorter whole-helper deadline. NOT a substitute for racing the whole mint.
+const DEFAULT_GUEST_FETCH_TIMEOUT_MS = 10_000;
+
 export async function fetchRemoteGuestSession(
-  context?: GuestSessionFetchContext
+  context?: GuestSessionFetchContext,
+  timeoutMs: number = DEFAULT_GUEST_FETCH_TIMEOUT_MS
 ): Promise<GuestSessionFetchResult> {
   return performGuestSessionFetch(
     getRemoteGuestSessionUrl(),
@@ -197,7 +203,7 @@ export async function fetchRemoteGuestSession(
       method: "POST",
       headers: buildForwardedHeaders(context, {}),
       body: buildRequestBody(context),
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(timeoutMs),
     },
     "MCPJam",
     context?.body?.mode
@@ -205,7 +211,8 @@ export async function fetchRemoteGuestSession(
 }
 
 export async function fetchConvexGuestSession(
-  context?: GuestSessionFetchContext
+  context?: GuestSessionFetchContext,
+  timeoutMs: number = DEFAULT_GUEST_FETCH_TIMEOUT_MS
 ): Promise<GuestSessionFetchResult> {
   try {
     await provisionGuestAuthConfigToConvex();
@@ -225,7 +232,7 @@ export async function fetchConvexGuestSession(
         [GUEST_SESSION_SECRET_HEADER]: getGuestSessionSharedSecret(),
       }),
       body: buildRequestBody(context),
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(timeoutMs),
     },
     "Convex",
     context?.body?.mode

--- a/mcpjam-inspector/server/utils/localhost-check.ts
+++ b/mcpjam-inspector/server/utils/localhost-check.ts
@@ -114,6 +114,38 @@ export function mayServeSessionToken(options: {
 }
 
 /**
+ * Decision point for injecting the guest bootstrap bearer into the SPA
+ * document.
+ *
+ * Like `mayServeSessionToken`, the guest bearer is a credential and must
+ * never be injected for a tunnel/relay `Host`/`X-Forwarded-Host` — tunnels
+ * are denied BEFORE the allowlist is consulted so a misconfiguration that
+ * adds a tunnel domain to MCPJAM_ALLOWED_HOSTS cannot leak the bearer.
+ *
+ * UNLIKE the session token (localhost-only), the guest bearer is meant to be
+ * served to the hosted app host(s) (e.g. `app.mcpjam.com`). It therefore
+ * shares the `isAllowedHost` allowlist — in hosted mode that includes the
+ * configured `MCPJAM_ALLOWED_HOSTS`, which the hosted deployment sets to its
+ * canonical app host(s).
+ */
+export function mayServeGuestBootstrap(options: {
+  host: string | undefined;
+  forwardedHost?: string | undefined;
+  allowedHosts: string[];
+  hostedMode: boolean;
+  activeTunnelDomains?: string[];
+}): boolean {
+  const tunnelDomains = options.activeTunnelDomains ?? [];
+  if (
+    isTunnelHost(options.host, tunnelDomains) ||
+    isTunnelHost(options.forwardedHost, tunnelDomains)
+  ) {
+    return false;
+  }
+  return isAllowedHost(options.host, options.allowedHosts, options.hostedMode);
+}
+
+/**
  * Check if the request is from an allowed host.
  *
  * In hosted mode (cloud deployments), this allows both localhost and


### PR DESCRIPTION
## Problem

A brand-new (incognito) guest landing on `app.mcpjam.com` now walks through three visible loading stages before the Playground is interactive — a sidebar/content skeleton, a full-screen **"Preparing project…"** overlay, then finally the Playground. It "used to just be" the final screen, and much faster.

**Root cause:** the guest bearer is now cookie/memory-only (no client cache on cold load), so the whole shell gates on a network mint *before* Convex auth can even start — a serial chain of round-trips behind a full-screen gate.

## What changed

### Pillar 2 — stop full-screen-blocking on data
`resolveHostedShellGateState` no longer returns `project-loading`. The shell renders immediately and panes own their own loading (sidebar skeleton, tools pane "Reconnecting…"). The `pendingDashboardOAuth` → `project-loading` override is preserved. This removes the "Preparing project…" overlay outright.

### Pillar 1 — server-render a guest bootstrap blob
- New `server/routes/web/guest-session-shared.ts`: shared cookie + **singleton** rate-limit helpers, plus `mintGuestSessionForDocument` which races the **whole** mint (incl. `provisionGuestAuthConfigToConvex`) against a hard **1500ms** deadline.
- Prod SPA handlers (`server/index.ts`, `server/app.ts`) host-gate via new `mayServeGuestBootstrap` (tunnels denied before the allowlist), inject an escaped `window.__MCP_GUEST_BOOTSTRAP__`, forward `Set-Cookie`, and set `Cache-Control: no-store` unconditionally. A mint failure never 500s the document.
- Client seeds `cachedSession` from the blob at module load (one-shot; bearer never persisted to `localStorage`) so the cold `POST /api/web/guest-session` is skipped.

### Promotion guard (security)
The always-on document mint can leave an **incidental** guest cookie on a browser whose user then signs in. A `guestId`-keyed activation marker is set **only** when a guest genuinely drives Convex auth; `useEnsureDbUser` gates the promotion proof on activation and **revokes** incidental cookies instead of absorbing them into the account.

## Scope / gating
- Pillar 1 is gated on **prod + hosted + host-allowlist**, so local `npm run dev` falls back to today's client-side mint (Vite serves the HTML, not the Node prod handler). Pillar 2 shows in any hosted-mode run.
- **Backend unchanged** — reuses the existing Convex `/guest/session` endpoint.
- Not included: a `GUEST_DOCUMENT_BOOTSTRAP` toggle and Pillar 3 (edge-sign / warm mint, data-gated on guest-mint p95).

## Testing
- **Pillar 2:** hosted-mode, incognito → Playground shell renders immediately, no "Preparing project…" overlay.
- **Pillar 1 (prod-style run):** cold incognito → HTML contains `window.__MCP_GUEST_BOOTSTRAP__`, `Cache-Control: no-store`, a guest `Set-Cookie`, and **no** `POST /api/web/guest-session` during boot.
- **Promotion guard:** sign in with no prior guest activity → incidental cookie revoked, not promoted; a genuinely-used guest → still promotes its projects.

## Verification
- `npm run typecheck:client` — clean.
- `npx vitest run` over the 7 changed test files — **93/93 pass** (gate-state, HostedShellGate, useEnsureDbUser, guest-session client, guest-session-source, guest-session route, new guest-session-document handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches guest session minting, HTML injection of bearer material, and guest→account promotion logic; mitigations include host/tunnel gating, JSON escaping, shared rate limits, and activation-gated promotion with new tests.
> 
> **Overview**
> **Hosted shell (Pillar 2)** no longer blocks on remote project loading: `resolveHostedShellGateState` drops `isLoadingRemoteProjects` and the `project-loading` outcome, and `App.tsx` uses one gate path instead of a chat-route variant that skipped project loading. The **"Preparing project…"** overlay from that gate goes away; pending dashboard OAuth can still force `project-loading` via the existing override.
> 
> **Guest cold boot (Pillar 1)** adds prod hosted SPA handlers that host-gate with `mayServeGuestBootstrap` (tunnels denied first), mint a guest session during the HTML response (`guest-session-shared.ts`, **1500ms** whole-mint deadline), inject escaped `window.__MCP_GUEST_BOOTSTRAP__`, forward `Set-Cookie`, and always set **`Cache-Control: no-store`**. Mint failures degrade to blob-less HTML instead of 500s. The client reads the blob once at module load into in-memory cache so the first render can skip the boot **`POST /api/web/guest-session`**. Guest-session rate limiting and cookie helpers are centralized so the API route and document mint share one per-IP budget.
> 
> **Promotion guard:** activation is recorded only when Convex actually calls guest `getAccessToken` (`markGuestActivated`), not when a session merely resolves. On WorkOS sign-in, `useEnsureDbUser` promotes only **activated** guests; **incidental** document-bootstrap cookies are revoked without a promotion proof.
> 
> **Other:** `useHostList` skips Convex queries until `shouldQueryProjectId` passes, avoiding validation errors on transient local project ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc62a75112a6b7db5dcac4fa083f524a6b4441d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->