### PR TITLE
Tier B Phase 3d-i-a: relocate data/chrome/debug WidgetHost contract slices to the package

### DIFF
--- a/.changeset/widget-contract-slice-3d-i-a.md
+++ b/.changeset/widget-contract-slice-3d-i-a.md
@@ -1,0 +1,23 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Tier B Phase 3d-i-a: relocate the data/chrome/instrumentation slices of the
+`WidgetHost` contract into `@mcpjam/widget-react`.
+
+The package now owns the `surface` (completed), `debug`, and `components` slices,
+the primitives (`CspMode`, `DisplayMode`, `UiProtocol`, `OpenAiAppsCapabilities`),
+and the debug data types (`WidgetDebugInfo`, `WidgetGlobals`, `WidgetSandboxInfo`,
+`WidgetSandboxApplied`, `WidgetLifecycleEvent`, `WidgetMount`, `CspViolation`,
+`UiLogEvent`) + `WidgetDebugSink` — defined structurally so the package stays
+free of inspector internals. The inspector's `widget-host.ts` re-exports them, so
+every existing `./widget-host` import site (the cluster + the `use-widget-host`
+adapter) is unchanged.
+
+Drift-safety is preserved: `use-widget-host.ts` builds the host from the real
+stores and returns it typed as the package contract, so any source-shape drift
+fails typecheck there (replacing the old `typeof import(...)` pins for these
+slices).
+
+The fn-heavy / profile-derived slices (`environment`, `resolvers`, `services`)
+and the final `WidgetHost` move follow in 3d-i-b. No behavior change.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/widget-react-boundary.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/widget-react-boundary.test.tsx
@@ -22,7 +22,13 @@ describe("@mcpjam/widget-react package boundary (inspector consumer)", () => {
     // provider in 3d. Its surface is a structural subset of the adapter's
     // WidgetSurfaceInfo, so the real adapter will satisfy this contract too.
     const host: WidgetHost = {
-      surface: { kind: "chat", sandboxOrigin: "", webManagedServers: false },
+      surface: {
+        kind: "chat",
+        persistentSurfaceHost: false,
+        webManagedServers: false,
+        sandboxOrigin: "",
+        playgroundCspMode: "widget-declared",
+      },
     };
     render(
       <WidgetHostProvider value={host}>

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
@@ -9,25 +9,24 @@
 // as of Phase 1b, imports zero `@/stores`/`@/contexts`/`@/lib/client-*` modules
 // (enforced by check-renderer-tier-b-imports.mjs).
 //
-// Scope note: this boundary makes the RENDERER app-state-import-clean. It does
-// NOT yet make the whole widget runtime package-clean — e.g. the
-// `MCPAppsRenderer` wrapper still reads `usePersistentWidgetSurfaceHost`
-// directly, and sibling files (modal/chrome) still touch inspector state. Those
-// relocate in Phases 2-3.
+// Ownership (Phase 3d-i): the `surface`, `debug`, and `components` slices — plus
+// the primitives (`CspMode`, `DisplayMode`, `UiProtocol`, `OpenAiAppsCapabilities`)
+// and the debug data types — now live in `@mcpjam/widget-react`. This module
+// re-exports them so existing `./widget-host` import sites are unchanged, and
+// keeps the still-local slices (`environment`, `resolvers`, `services`) that fold
+// into the package in 3d-i-b. Drift-safety for the relocated structural types is
+// enforced by `use-widget-host.ts` conforming to the package contract.
 //
-// The contract is anchored to the real inspector signatures via
-// `typeof import(...)` / named result types, so it fails typecheck loudly if an
+// The still-local slices stay anchored to the real inspector signatures via
+// `typeof import(...)` / named result types, so they fail typecheck loudly if an
 // underlying shape drifts.
 
-import type { ComponentType, ReactNode } from "react";
 import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type {
-  OpenAiAppsCapabilities,
   ResolvedMcpAppsCapabilities,
   ResolvedOpenAiAppsCapabilities,
 } from "@/lib/client-styles";
 import type {
-  CspMode,
   DeviceCapabilities,
   DeviceType,
   PlaygroundGlobals,
@@ -37,18 +36,20 @@ import type { PreferencesState } from "@/stores/preferences/preferences-store";
 import type { ProjectHostContextDraft } from "@/lib/client-config";
 import type { HostConfigMcpProfileV1 } from "@/lib/client-config-v2";
 import type {
-  CspViolation,
-  WidgetDebugInfo,
-  WidgetGlobals,
-  WidgetLifecycleEvent,
-  WidgetSandboxApplied,
-  WidgetSandboxInfo,
-} from "@/stores/widget-debug-store";
-import type { UiLogEvent } from "@/stores/traffic-log-store";
-import type {
   FetchMcpAppsWidgetContentRequest,
   FetchMcpAppsWidgetContentResponse,
 } from "./fetch-widget-content";
+// Data / chrome / instrumentation contract slices now live in
+// @mcpjam/widget-react (Phase 3d-i-a). Imported for the slices that still
+// assemble locally (`WidgetHost`, `WidgetHostEnvironmentInputs`); re-exported
+// below so existing `./widget-host` consumers (the cluster + adapter) keep their
+// import sites unchanged.
+import type {
+  DisplayMode,
+  WidgetSurfaceInfo,
+  WidgetDebugSink,
+  WidgetHostComponents,
+} from "@mcpjam/widget-react";
 
 // --- Result shapes pinned to their current resolvers (source of truth) -------
 
@@ -187,19 +188,38 @@ export interface WidgetHostResolvers {
   stableStringifyJson: typeof import("@/lib/client-config").stableStringifyJson;
 }
 
-// --- Type re-exports for the renderer ----------------------------------------
+// --- Type re-exports for consumers -------------------------------------------
 //
-// The Tier-B import guard forbids the renderer from importing `@/stores/*` and
-// `@/lib/client-styles` even for `import type`. Re-export the type-only symbols
-// the renderer still needs here so it can import them from the host boundary.
-
+// The Tier-B guard forbids the cluster from importing `@/stores/*` and
+// `@/lib/client-styles` even for `import type`. `ResolvedMcpAppsCapabilities`
+// stays inspector-local (profile system) and is re-exported here; the
+// data/chrome/instrumentation slices are owned by @mcpjam/widget-react
+// (Phase 3d-i-a) and re-exported so `./widget-host` consumers are unaffected.
+export type { ResolvedMcpAppsCapabilities } from "@/lib/client-styles";
+// `DisplayMode` / `WidgetSurfaceInfo` / `WidgetDebugSink` / `WidgetHostComponents`
+// are also imported above (used locally by `WidgetHost` / `…EnvironmentInputs`);
+// re-export the local bindings.
 export type {
+  DisplayMode,
+  WidgetSurfaceInfo,
+  WidgetDebugSink,
+  WidgetHostComponents,
+};
+export type {
+  CspMode,
+  UiProtocol,
   OpenAiAppsCapabilities,
-  ResolvedMcpAppsCapabilities,
-} from "@/lib/client-styles";
-export type { CspMode } from "@/stores/ui-playground-store";
-export type { WidgetLifecycleEvent } from "@/stores/widget-debug-store";
-export type { UiProtocol } from "@/stores/traffic-log-store";
+  WidgetSurfaceKind,
+  WidgetDebugInfo,
+  WidgetGlobals,
+  WidgetSandboxInfo,
+  WidgetSandboxApplied,
+  WidgetLifecycleEvent,
+  WidgetMount,
+  CspViolation,
+  UiLogEvent,
+  WidgetModalProps,
+} from "@mcpjam/widget-react";
 
 // `extractMethod` is a pure JSON-RPC message parser (no store state, no React)
 // the renderer uses for traffic-log wiring. Re-exported through the boundary —
@@ -217,14 +237,6 @@ export { extractMethod } from "@/stores/traffic-log-store";
 // boundary instead of `@/lib/client-config` (Tier-B guard). Same underlying fn
 // as `resolvers.stableStringifyJson`, so the two paths can't diverge.
 export { stableStringifyJson } from "@/lib/client-config";
-
-/**
- * Widget display-mode union. Mirrors the inspector playground store's
- * `DisplayMode` (and the SEP `HostDisplayMode`); re-declared here (rather than
- * re-exported from `@/stores`) so the renderer can import it from the host
- * boundary and satisfy the Tier-B guard.
- */
-export type DisplayMode = "inline" | "pip" | "fullscreen";
 
 // --- Services ----------------------------------------------------------------
 
@@ -267,118 +279,6 @@ export interface WidgetHostServices {
   >;
   // Phase 1: OpenAI Apps file bridges (uploadFile / getFileDownloadUrl) bind to
   // widget-file-messages here once their host-facing signatures are firmed up.
-}
-
-// --- Surface -----------------------------------------------------------------
-
-export type WidgetSurfaceKind =
-  | "chat"
-  | "playground"
-  | "chatbox"
-  | "standalone";
-
-export interface WidgetSurfaceInfo {
-  /**
-   * useWidgetSurface + useIsChatboxSurface collapsed to one descriptor.
-   * Phase 1 must confirm chatbox / playground / chat are mutually exclusive
-   * (today they are two separate context signals); if they can overlap, `kind`
-   * must keep both bits rather than collapse to one enum.
-   */
-  kind: WidgetSurfaceKind;
-  /** usePersistentWidgetSurfaceHost — persistent resource-scoped surfaces. */
-  persistentSurfaceHost: boolean;
-  /** useWebManagedServers — route widget-content through /api/web. */
-  webManagedServers: boolean;
-  /** SANDBOX_ORIGIN (VITE_MCPJAM_SANDBOX_ORIGIN); "" when unset. */
-  sandboxOrigin: string;
-  /**
-   * Playground CSP-mode selection (useUIPlaygroundStore.mcpAppsCspMode) — an
-   * INPUT, not the effective mode. The renderer derives the effective sandbox
-   * CSP mode from `kind` + this + the per-widget `minimalMode` prop, mirroring
-   * mcp-apps-renderer.tsx:741-746:
-   *
-   *   kind === "chatbox" || minimalMode ? "permissive"
-   *     : kind === "playground"         ? playgroundCspMode
-   *     :                                 "widget-declared"
-   *
-   * Kept as an input (not pre-resolved in `resolveEnvironment`) because
-   * `minimalMode` is per-instance. Source it from the WidgetSurfaceContext —
-   * NOT `isPlaygroundActive` — to preserve the first-render iframe-rebuild fix
-   * documented at mcp-apps-renderer.tsx:729-739.
-   */
-  playgroundCspMode: CspMode;
-}
-
-// --- Instrumentation (optional) ----------------------------------------------
-
-/**
- * Diagnostics sink. Intentionally 1:1 with `useWidgetDebugStore` +
- * `useTrafficLogStore.addLog` (source of truth) so the Phase 1 migration is a
- * pure refactor — no consolidation. The inspector forwards each call to its
- * zustand stores; a non-inspector host can omit `debug` entirely and lose only
- * the Sandbox/Network debug panels. (Folding these into a single event stream
- * is a deliberately separate, later change.)
- */
-export interface WidgetDebugSink {
-  recordMount: (toolCallId: string, reason: string) => void;
-  setWidgetDebugInfo: (
-    toolCallId: string,
-    info: Partial<Omit<WidgetDebugInfo, "toolCallId" | "updatedAt">>,
-  ) => void;
-  setWidgetState: (toolCallId: string, state: unknown) => void;
-  setWidgetGlobals: (
-    toolCallId: string,
-    globals: Partial<WidgetGlobals>,
-  ) => void;
-  setWidgetCsp: (
-    toolCallId: string,
-    csp: Omit<WidgetSandboxInfo, "violations">,
-  ) => void;
-  addCspViolation: (toolCallId: string, violation: CspViolation) => void;
-  clearCspViolations: (toolCallId: string) => void;
-  setWidgetModelContext: (
-    toolCallId: string,
-    context: {
-      content?: unknown[];
-      structuredContent?: Record<string, unknown>;
-    } | null,
-  ) => void;
-  setWidgetHtml: (
-    toolCallId: string,
-    html: string,
-    injectedOpenAiCompat?: boolean,
-    injectedOpenAiCompatCapabilities?: OpenAiAppsCapabilities,
-  ) => void;
-  setSandboxApplied: (
-    toolCallId: string,
-    applied: WidgetSandboxApplied,
-    hostProfileId?: string,
-    hostInfo?: { name: string; version: string } | null,
-  ) => void;
-  appendLifecycle: (
-    toolCallId: string,
-    event: WidgetLifecycleEvent,
-  ) => void;
-  /** useTrafficLogStore.addLog */
-  addTrafficLog: (event: Omit<UiLogEvent, "id" | "timestamp">) => void;
-}
-
-// --- Chrome injection (optional) ---------------------------------------------
-
-/**
- * Provisional — props firm up when mcp-apps-modal is extracted (Phase 3). The
- * design-system <Dialog> chrome becomes an injected component so the renderer
- * stays free of @mcpjam/design-system.
- */
-export interface WidgetModalProps {
-  open: boolean;
-  onClose: () => void;
-  title?: string;
-  children: ReactNode;
-}
-
-export interface WidgetHostComponents {
-  Modal?: ComponentType<WidgetModalProps>;
 }
 
 // --- The seam ----------------------------------------------------------------

--- a/widget-react/src/__tests__/widget-host-context.test.tsx
+++ b/widget-react/src/__tests__/widget-host-context.test.tsx
@@ -12,7 +12,13 @@ function SurfaceProbe() {
 }
 
 const host: WidgetHost = {
-  surface: { kind: "playground", sandboxOrigin: "", webManagedServers: false },
+  surface: {
+    kind: "playground",
+    persistentSurfaceHost: false,
+    webManagedServers: false,
+    sandboxOrigin: "",
+    playgroundCspMode: "widget-declared",
+  },
 };
 
 describe("WidgetHostProvider / useWidgetHost", () => {

--- a/widget-react/src/index.ts
+++ b/widget-react/src/index.ts
@@ -11,6 +11,25 @@ export {
 } from "./widget-host-context";
 export type {
   WidgetHost,
+  // primitives
+  CspMode,
+  DisplayMode,
+  UiProtocol,
+  OpenAiAppsCapabilities,
+  // surface
   WidgetSurfaceInfo,
   WidgetSurfaceKind,
+  // instrumentation
+  WidgetDebugSink,
+  WidgetDebugInfo,
+  WidgetGlobals,
+  WidgetSandboxInfo,
+  WidgetSandboxApplied,
+  WidgetLifecycleEvent,
+  WidgetMount,
+  CspViolation,
+  UiLogEvent,
+  // chrome injection
+  WidgetModalProps,
+  WidgetHostComponents,
 } from "./widget-host";

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -1,18 +1,54 @@
 // The `WidgetHost` dependency-inversion contract — OWNED by the package.
 //
-// Tier B Phase 3c lands the boundary, not the renderer: the package defines the
-// React context + hook seam (`./widget-host-context`) over this contract, and
-// the inspector supplies the concrete host through `<WidgetHostProvider>` using
-// its existing `use-widget-host.ts` adapter. The interactive renderer cluster
-// reads the host via `useWidgetHost()` once it relocates here in 3d.
+// The package defines the React context + hook seam (`./widget-host-context`)
+// over this contract; the inspector supplies the concrete host through
+// `<WidgetHostProvider>` using its `use-widget-host.ts` adapter. The interactive
+// renderer reads the host via `useWidgetHost()` once it relocates here (3d-ii).
 //
-// This shape is intentionally a SEED. 3d folds in the remaining slices from the
-// inspector's in-place contract — `environment` (raw ambient inputs),
-// `resolvers` (bound config/style fns), `services` (widget-content fetch + MCP
-// transport), `debug?` (the 1:1 instrumentation sink), and `components?`
-// (injected modal chrome) — as the code that needs them moves in. Keeping it
-// minimal here is deliberate: 3c proves the package boundary is mechanically
-// correct, not that it moves meaningful LOC.
+// These types are STRUCTURAL replicas of the inspector shapes (the profile/store
+// systems stay in the inspector by design, so the package can't import them).
+// Drift-safety is enforced by the inspector's `use-widget-host.ts` adapter:
+// it builds the host from the real stores/resolvers and returns it typed as this
+// contract, so any source-shape drift fails typecheck there.
+//
+// Fold-in status: 3c seeded `surface`. 3d-i-a adds `surface` (completed),
+// `debug`, and `components`. 3d-i-b folds in `environment`, `resolvers`, and
+// `services` (the fn-heavy + profile-derived slices).
+
+import type { ComponentType, ReactNode } from "react";
+
+// --- Primitives --------------------------------------------------------------
+
+/** Sandbox CSP-mode selection. Mirrors the inspector ui-playground-store. */
+export type CspMode = "permissive" | "widget-declared";
+
+/** Widget display-mode union (SEP HostDisplayMode). */
+export type DisplayMode = "inline" | "pip" | "fullscreen";
+
+/** JSON-RPC protocol tag for traffic logging. */
+export type UiProtocol = "mcp-apps" | "openai-apps";
+
+/**
+ * OpenAI Apps compat capability flags (the `window.openai.*` surface to inject).
+ * Structural mirror of the inspector's `InjectedOpenAiCompatCapabilities`.
+ */
+export interface OpenAiAppsCapabilities {
+  callTool?: boolean;
+  sendFollowUpMessage?: boolean;
+  setWidgetState?: boolean;
+  requestDisplayMode?: "all" | "fullscreen-only" | "none";
+  notifyIntrinsicHeight?: boolean;
+  openExternal?: boolean;
+  setOpenInAppUrl?: boolean;
+  requestModal?: boolean;
+  uploadFile?: boolean;
+  selectFiles?: boolean;
+  getFileDownloadUrl?: boolean;
+  requestCheckout?: boolean;
+  requestClose?: boolean;
+}
+
+// --- Surface -----------------------------------------------------------------
 
 /**
  * Which surface the widget is mounted on. Collapses the inspector's
@@ -24,23 +60,231 @@ export type WidgetSurfaceKind =
   | "chatbox"
   | "standalone";
 
-/**
- * Per-surface identity + routing the renderer reads ambiently today. A subset
- * of the inspector's `WidgetSurfaceInfo`; 3d folds in the remaining fields
- * (`persistentSurfaceHost`, `playgroundCspMode`).
- */
+/** Per-surface identity + routing the renderer reads ambiently. */
 export interface WidgetSurfaceInfo {
   kind: WidgetSurfaceKind;
-  /** SANDBOX_ORIGIN (VITE_MCPJAM_SANDBOX_ORIGIN); "" when unset. */
-  sandboxOrigin: string;
+  /** usePersistentWidgetSurfaceHost — persistent resource-scoped surfaces. */
+  persistentSurfaceHost: boolean;
   /** useWebManagedServers — route widget-content through /api/web. */
   webManagedServers: boolean;
+  /** SANDBOX_ORIGIN (VITE_MCPJAM_SANDBOX_ORIGIN); "" when unset. */
+  sandboxOrigin: string;
+  /**
+   * Playground CSP-mode selection (useUIPlaygroundStore.mcpAppsCspMode) — an
+   * INPUT, not the effective mode. The renderer derives the effective sandbox
+   * CSP mode from `kind` + this + the per-widget `minimalMode` prop (kept as an
+   * input because `minimalMode` is per-instance).
+   */
+  playgroundCspMode: CspMode;
 }
 
-/**
- * The host the inspector injects and the widget runtime consumes. 3d expands
- * this with `environment`, `resolvers`, `services`, `debug?`, `components?`.
- */
+// --- Instrumentation ---------------------------------------------------------
+//
+// The debug sink is intentionally 1:1 with the inspector's widget-debug-store +
+// traffic-log addLog. A non-inspector host can omit `debug` entirely and lose
+// only the Sandbox/Network debug panels.
+
+export interface WidgetMount {
+  index: number;
+  reason: string;
+  at: number;
+}
+
+export interface CspViolation {
+  directive: string;
+  effectiveDirective?: string;
+  blockedUri: string;
+  sourceFile?: string | null;
+  lineNumber?: number | null;
+  columnNumber?: number | null;
+  timestamp: number;
+}
+
+export interface WidgetLifecycleEvent {
+  kind:
+    | "sandbox-proxy-ready"
+    | "widget-content-requested"
+    | "widget-content-ready"
+    | "widget-content-error"
+    | "widget-content-invalid-mimetype"
+    | "bridge-connect-start"
+    | "bridge-connect-ready"
+    | "bridge-connect-error"
+    | "bridge-connect-skipped"
+    | "app-initialized";
+  status: "ok" | "error" | "pending";
+  message?: string;
+  timestamp: number;
+}
+
+export interface WidgetSandboxApplied {
+  sandboxAttrs?: string[];
+  allowFeatures?: Record<string, string>;
+  cspDirectives?: Record<string, string[]>;
+  permissive: boolean;
+  hostPolicyApplied: boolean;
+  restrictTo?: {
+    connectDomains?: string[];
+    resourceDomains?: string[];
+    frameDomains?: string[];
+    baseUriDomains?: string[];
+  };
+  cspMode?: "host-default" | "declared" | "relaxed";
+  permissions?: {
+    camera?: {};
+    microphone?: {};
+    geolocation?: {};
+    clipboardWrite?: {};
+  };
+}
+
+export interface WidgetSandboxInfo {
+  mode: CspMode;
+  connectDomains: string[];
+  resourceDomains: string[];
+  frameDomains?: string[];
+  baseUriDomains?: string[];
+  permissions?: {
+    camera?: {};
+    microphone?: {};
+    geolocation?: {};
+    clipboardWrite?: {};
+  };
+  headerString?: string;
+  violations: CspViolation[];
+  widgetDeclared?: {
+    connect_domains?: string[];
+    resource_domains?: string[];
+    connectDomains?: string[];
+    resourceDomains?: string[];
+    frameDomains?: string[];
+    baseUriDomains?: string[];
+  } | null;
+}
+
+export interface WidgetGlobals {
+  theme: "light" | "dark";
+  displayMode: "inline" | "pip" | "fullscreen";
+  maxHeight?: number;
+  maxWidth?: number;
+  locale?: string;
+  safeArea?: {
+    insets: { top: number; bottom: number; left: number; right: number };
+  };
+  timeZone?: string;
+  deviceCapabilities?: { hover: boolean; touch: boolean };
+  safeAreaInsets?: { top: number; bottom: number; left: number; right: number };
+  userAgent?: {
+    device: { type: string };
+    capabilities: { hover: boolean; touch: boolean };
+  };
+}
+
+export interface WidgetDebugInfo {
+  toolCallId: string;
+  toolName: string;
+  protocol: "openai-apps" | "mcp-apps";
+  widgetState: unknown;
+  globals: WidgetGlobals;
+  prefersBorder?: boolean;
+  updatedAt: number;
+  csp?: WidgetSandboxInfo;
+  applied?: WidgetSandboxApplied;
+  hostProfileId?: string;
+  hostInfo?: { name: string; version: string } | null;
+  lifecycle: WidgetLifecycleEvent[];
+  mounts: WidgetMount[];
+  modelContext?: {
+    content?: unknown[];
+    structuredContent?: Record<string, unknown>;
+    updatedAt: number;
+  } | null;
+  widgetHtml?: string;
+  injectedOpenAiCompat?: boolean;
+  injectedOpenAiCompatCapabilities?: OpenAiAppsCapabilities;
+}
+
+export interface UiLogEvent {
+  id: string;
+  /** toolCallId */
+  widgetId: string;
+  serverId: string;
+  serverName?: string;
+  direction: "host-to-ui" | "ui-to-host";
+  protocol: UiProtocol;
+  method: string;
+  timestamp: string;
+  message: unknown;
+}
+
+/** Diagnostics sink — 1:1 with widget-debug-store + traffic-log addLog. */
+export interface WidgetDebugSink {
+  recordMount: (toolCallId: string, reason: string) => void;
+  setWidgetDebugInfo: (
+    toolCallId: string,
+    info: Partial<Omit<WidgetDebugInfo, "toolCallId" | "updatedAt">>,
+  ) => void;
+  setWidgetState: (toolCallId: string, state: unknown) => void;
+  setWidgetGlobals: (
+    toolCallId: string,
+    globals: Partial<WidgetGlobals>,
+  ) => void;
+  setWidgetCsp: (
+    toolCallId: string,
+    csp: Omit<WidgetSandboxInfo, "violations">,
+  ) => void;
+  addCspViolation: (toolCallId: string, violation: CspViolation) => void;
+  clearCspViolations: (toolCallId: string) => void;
+  setWidgetModelContext: (
+    toolCallId: string,
+    context: {
+      content?: unknown[];
+      structuredContent?: Record<string, unknown>;
+    } | null,
+  ) => void;
+  setWidgetHtml: (
+    toolCallId: string,
+    html: string,
+    injectedOpenAiCompat?: boolean,
+    injectedOpenAiCompatCapabilities?: OpenAiAppsCapabilities,
+  ) => void;
+  setSandboxApplied: (
+    toolCallId: string,
+    applied: WidgetSandboxApplied,
+    hostProfileId?: string,
+    hostInfo?: { name: string; version: string } | null,
+  ) => void;
+  appendLifecycle: (
+    toolCallId: string,
+    event: WidgetLifecycleEvent,
+  ) => void;
+  /** useTrafficLogStore.addLog */
+  addTrafficLog: (event: Omit<UiLogEvent, "id" | "timestamp">) => void;
+}
+
+// --- Chrome injection (optional) ---------------------------------------------
+//
+// The package owns widget lifecycle + bridge; the inspector injects the modal
+// CHROME (its design-system <Dialog>) + billing/checkout via `components.Modal`,
+// which receives children/state/callbacks only.
+
+export interface WidgetModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+}
+
+export interface WidgetHostComponents {
+  Modal?: ComponentType<WidgetModalProps>;
+}
+
+// --- The seam ----------------------------------------------------------------
+
 export interface WidgetHost {
   surface: WidgetSurfaceInfo;
+  debug?: WidgetDebugSink;
+  components?: WidgetHostComponents;
+  // 3d-i-b: `environment`, `resolvers`, `services` fold in here as the
+  // fn-heavy / profile-derived slices relocate.
 }


### PR DESCRIPTION
## Context

First slice of **3d-i** (the `WidgetHost` contract fold-in). 3c stood up `@mcpjam/widget-react` with the context/hook seam; 3d-i moves the contract *types* into the package so the relocated renderer (3d-ii) can import them from there.

Reading the full contract showed it pins **~20 inspector types across ~11 modules**, including a few expensive profile-system types (`HostStyleDefinition` via the resolver returns). That's too large/risky for one reviewable PR, so I split 3d-i. **This PR (3d-i-a) relocates the self-contained slices**; the fn-heavy / profile-derived slices follow in 3d-i-b.

## What moves into the package

Defined **structurally** (the profile/store *systems* stay in the inspector by design, so the package can't import them):
- **primitives:** `CspMode`, `DisplayMode`, `UiProtocol`, `OpenAiAppsCapabilities`
- **surface:** `WidgetSurfaceKind`, `WidgetSurfaceInfo` (completed — adds `persistentSurfaceHost` + `playgroundCspMode` to the 3c seed)
- **instrumentation:** `WidgetDebugSink` + `WidgetDebugInfo`, `WidgetGlobals`, `WidgetSandboxInfo`, `WidgetSandboxApplied`, `WidgetLifecycleEvent`, `WidgetMount`, `CspViolation`, `UiLogEvent`
- **chrome:** `WidgetModalProps`, `WidgetHostComponents`

The inspector's `widget-host.ts` **re-exports all of them** from `@mcpjam/widget-react`, so every existing `./widget-host` import site (the cluster + the `use-widget-host` adapter) is unchanged. The still-local slices (`environment`, `resolvers`, `services`) + `WidgetHost` stay put for now.

## Drift-safety

The old `typeof import("@/…")` pins for these slices are replaced by **adapter conformance**: `use-widget-host.ts` builds the host from the real stores/resolvers and returns it typed as the package contract, so any source-shape drift fails `typecheck:client` there. (Verified — typecheck passes, meaning the structural replicas match the real inspector types.)

No new package deps (still **react-only peers** — the moved slices need nothing from ext-apps/sdk).

## Verification

- Package: Tier-B guard ✅ · typecheck ✅ · test (2) ✅ · build ✅ (dts now emits the relocated types, 8.2 KB)
- Inspector: `typecheck:client` ✅ (adapter conformance / drift check) · 232 tests ✅ (renderer, replay, PartSwitch, app-tools, use-widget-host, boundary, …)
- Root `typecheck` chain ✅

## Next (3d-i-b)

`environment` + `resolvers` + `services` (fn signatures + the expensive profile-derived types, adding ext-apps/sdk imports where shareable), then move `WidgetHost` itself + decide the `extractMethod`/`stableStringifyJson` value re-exports. Then 3d-ii relocates the renderer.

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor and re-exports with no runtime logic changes; remaining contract slices still live in the inspector until 3d-i-b.
> 
> **Overview**
> **Tier B Phase 3d-i-a** moves the self-contained **`WidgetHost` contract slices** from the inspector into **`@mcpjam/widget-react`**, ahead of relocating the renderer.
> 
> The package now **owns** structural types for **primitives** (`CspMode`, `DisplayMode`, `UiProtocol`, `OpenAiAppsCapabilities`), a **completed `surface`** slice (`WidgetSurfaceInfo` adds `persistentSurfaceHost` and `playgroundCspMode`), **instrumentation** (`WidgetDebugSink` plus debug/traffic types), and **chrome injection** (`WidgetModalProps`, `WidgetHostComponents`). Package **`WidgetHost`** grows optional `debug?` and `components?` while **`environment` / `resolvers` / `services`** stay on the inspector contract for **3d-i-b**.
> 
> Inspector **`widget-host.ts` drops the inlined definitions** and **re-exports** them from `@mcpjam/widget-react`, so **`./widget-host` import sites** (renderer cluster and adapter) stay the same. Drift checks for these slices shift from **`typeof import(...)` pins** to **`use-widget-host.ts` building real store values** against the package types.
> 
> Tests that construct mock hosts were updated to the full **`WidgetSurfaceInfo`** shape. **No runtime behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2653b5b8edafec41d2c1ec8460c54aa5a2800d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->