### PR TITLE
Tier B Phase 3d-i-b: complete WidgetHost contract fold-in (inspector becomes a shim)

### DIFF
--- a/.changeset/widget-contract-fold-3d-i-b.md
+++ b/.changeset/widget-contract-fold-3d-i-b.md
@@ -1,0 +1,34 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Tier B Phase 3d-i-b: complete the `WidgetHost` contract fold-in into
+`@mcpjam/widget-react`, closing the temporary two-`WidgetHost` gap.
+
+The remaining slices — `environment` (raw ambient inputs), `resolvers` (bound
+config/style fns), `services` (widget-content fetch + MCP transport), and the
+result/profile shapes — now live in the package, and **`WidgetHost` itself** is
+package-owned. The inspector's `widget-host.ts` becomes a **pure re-export shim**
+(no local contract), keeping only the two inspector-sourced value re-exports
+(`extractMethod`, `stableStringifyJson`) until they relocate with the renderer in
+3d-ii.
+
+Typing follows the audited renderer usage rather than deep-replicating the
+inspector profile graph:
+- `ResolvedHostStyle` is a minimal structural surface (only the fields the
+  renderer reads); the real `HostStyleDefinition` is assignable to it.
+- ext-apps types (`McpUiHostContext`/`McpUiHostCapabilities`/`McpUiResourceCsp`/
+  `McpUiResourcePermissions`/`McpUiStyles`) are imported from
+  `@modelcontextprotocol/ext-apps`; `MCPPrompt`/`MCPResourceTemplate` from
+  `@mcpjam/sdk/browser`.
+- `HostConfigMcpProfileV1` is imported from `@mcpjam/sdk/host-config/internal`
+  (resolver↔adapter contravariance requires the real profile type). This is the
+  one intentional SDK-internal ref in the surface; hiding it behind the
+  `resolveEnvironment` fold is deferred to the publish-ready pass (3d-iii) while
+  the package is still private.
+
+`@mcpjam/widget-react` gains `@mcpjam/sdk` + `@modelcontextprotocol/ext-apps` as
+deps (externalized in tsup; the emitted `.d.ts` references them as external imports
+only — nothing inlined). Drift-safety holds: `use-widget-host.ts` builds the host
+from the real stores/resolvers and returns it typed as the package contract, so
+any drift fails typecheck. No behavior change.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/widget-react-boundary.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/widget-react-boundary.test.tsx
@@ -21,7 +21,10 @@ describe("@mcpjam/widget-react package boundary (inspector consumer)", () => {
     // Stand-in for the value the inspector's use-widget-host adapter feeds the
     // provider in 3d. Its surface is a structural subset of the adapter's
     // WidgetSurfaceInfo, so the real adapter will satisfy this contract too.
-    const host: WidgetHost = {
+    // Minimal host for the cross-boundary plumbing smoke test (the probe reads
+    // only `surface.kind`). The full WidgetHost contract is type-checked by the
+    // use-widget-host adapter conforming to it (typecheck:client).
+    const host = {
       surface: {
         kind: "chat",
         persistentSurfaceHost: false,
@@ -29,7 +32,7 @@ describe("@mcpjam/widget-react package boundary (inspector consumer)", () => {
         sandboxOrigin: "",
         playgroundCspMode: "widget-declared",
       },
-    };
+    } as unknown as WidgetHost;
     render(
       <WidgetHostProvider value={host}>
         <SurfaceProbe />

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-host.ts
@@ -1,215 +1,54 @@
-// Tier B — the `WidgetHost` dependency-inversion contract.
+// Tier B — `WidgetHost` contract re-export shim.
 //
-// See ./widget-host.design.md for the rationale and the phased plan.
+// As of Phase 3d-i, the ENTIRE `WidgetHost` dependency-inversion contract lives
+// in `@mcpjam/widget-react`. This module is a pure compatibility shim: it
+// re-exports the contract types so existing `./widget-host` import sites (the
+// renderer cluster + the `use-widget-host.ts` adapter) are unchanged, and keeps
+// the two inspector-sourced VALUE re-exports the renderer still calls
+// (`extractMethod`, `stableStringifyJson`) until they relocate with the renderer
+// in 3d-ii.
 //
-// `WidgetHost` is the seam the interactive MCP-Apps widget renderer
-// (mcp-apps-renderer) reads from instead of reaching into inspector
-// stores/contexts/resolvers directly. The inspector-side adapter `useWidgetHost`
-// (./use-widget-host.ts) implements it; `mcp-apps-renderer.tsx` consumes it and,
-// as of Phase 1b, imports zero `@/stores`/`@/contexts`/`@/lib/client-*` modules
-// (enforced by check-renderer-tier-b-imports.mjs).
+// There is no local contract here anymore — `use-widget-host.ts` builds the host
+// from the inspector's stores/resolvers and returns it typed as the package
+// contract, so any source-shape drift fails typecheck there.
 //
-// Ownership (Phase 3d-i): the `surface`, `debug`, and `components` slices — plus
-// the primitives (`CspMode`, `DisplayMode`, `UiProtocol`, `OpenAiAppsCapabilities`)
-// and the debug data types — now live in `@mcpjam/widget-react`. This module
-// re-exports them so existing `./widget-host` import sites are unchanged, and
-// keeps the still-local slices (`environment`, `resolvers`, `services`) that fold
-// into the package in 3d-i-b. Drift-safety for the relocated structural types is
-// enforced by `use-widget-host.ts` conforming to the package contract.
-//
-// The still-local slices stay anchored to the real inspector signatures via
-// `typeof import(...)` / named result types, so they fail typecheck loudly if an
-// underlying shape drifts.
+// See ./widget-host.design.md for the phased plan.
 
-import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type {
+export type {
+  // the seam
+  WidgetHost,
+  // environment / resolvers / services
+  WidgetHostEnvironment,
+  WidgetHostEnvironmentInputs,
+  WidgetHostResolvers,
+  WidgetHostServices,
+  FetchWidgetContentRequest,
+  FetchWidgetContentResponse,
+  ListResourcesResult,
+  // resolved profile shapes
+  ResolvedHostCapabilities,
+  ResolvedHostInfo,
+  ResolvedHostStyle,
   ResolvedMcpAppsCapabilities,
   ResolvedOpenAiAppsCapabilities,
-} from "@/lib/client-styles";
-import type {
+  EffectiveCompatRuntime,
+  // environment data types
+  ThemeMode,
+  ChatboxHostStyle,
   DeviceCapabilities,
   DeviceType,
-  PlaygroundGlobals,
   SafeAreaInsets,
-} from "@/stores/ui-playground-store";
-import type { PreferencesState } from "@/stores/preferences/preferences-store";
-import type { ProjectHostContextDraft } from "@/lib/client-config";
-import type { HostConfigMcpProfileV1 } from "@/lib/client-config-v2";
-import type {
-  FetchMcpAppsWidgetContentRequest,
-  FetchMcpAppsWidgetContentResponse,
-} from "./fetch-widget-content";
-// Data / chrome / instrumentation contract slices now live in
-// @mcpjam/widget-react (Phase 3d-i-a). Imported for the slices that still
-// assemble locally (`WidgetHost`, `WidgetHostEnvironmentInputs`); re-exported
-// below so existing `./widget-host` consumers (the cluster + adapter) keep their
-// import sites unchanged.
-import type {
-  DisplayMode,
-  WidgetSurfaceInfo,
-  WidgetDebugSink,
-  WidgetHostComponents,
-} from "@mcpjam/widget-react";
-
-// --- Result shapes pinned to their current resolvers (source of truth) -------
-
-/** Return of `resolveEffectiveHostCapabilities` (client-config-v2). */
-export type ResolvedHostCapabilities = ReturnType<
-  typeof import("@/lib/client-config-v2").resolveEffectiveHostCapabilities
->;
-
-/** Return of `resolveHostInfo` (client-config-v2). */
-export type ResolvedHostInfo = ReturnType<
-  typeof import("@/lib/client-config-v2").resolveHostInfo
->;
-
-/** Return of `getHostStyleOrDefault` (client-styles). */
-export type ResolvedHostStyle = ReturnType<
-  typeof import("@/lib/client-styles").getHostStyleOrDefault
->;
-
-// --- Environment -------------------------------------------------------------
-
-/**
- * Per-`serverId` host environment the renderer needs. Today this is assembled
- * inline from `resolveEffective*` (client-config-v2), preferences + chatbox
- * theme/style, the playground CSP mode, and the draft host context. The
- * inspector computes it in `WidgetHost.resolveEnvironment`; a package renderer
- * never sees the profile system.
- *
- * Resolution is a function of `serverId` (capabilities / CSP vary by the
- * per-server profile), so this is returned by a method, not a static field.
- */
-export interface WidgetHostEnvironment {
-  hostInfo: ResolvedHostInfo;
-  hostCapabilities: ResolvedHostCapabilities;
-  mcpAppsCapabilities: ResolvedMcpAppsCapabilities;
-  /** Resolved compat-runtime flag (resolveEffectiveCompatRuntime). */
-  injectOpenAiCompat: boolean;
-  /** Per-method `window.openai.*` surface to inject; omit when shim is off. */
-  openAiCompatCapabilities?: ResolvedOpenAiAppsCapabilities;
-  /** hostSupportsWidgetRendering(resolveHostCaps(serverId)). */
-  supportsWidgetRendering: boolean;
-  theme: string;
-  hostStyle: ResolvedHostStyle;
-  // NOTE: the effective sandbox CSP mode is intentionally NOT here. It depends
-  // on the per-widget `minimalMode` prop (per-instance, not per-server), so it
-  // cannot be resolved by `resolveEnvironment(serverId)`. The input lives on
-  // `WidgetSurfaceInfo.playgroundCspMode`; the renderer derives the effective
-  // mode (see that field's doc + mcp-apps-renderer.tsx:741-746).
-  /**
-   * Base `McpUiHostContext`: draftHostContext + extract*() projections +
-   * playground globals (locale, timeZone, safeArea, deviceType, displayMode).
-   * The renderer layers per-call fields (controlled display mode, etc.) on top.
-   */
-  baseHostContext: McpUiHostContext;
-}
-
-// --- Environment (Phase 1b: raw ambient inputs) ------------------------------
-
-/**
- * Raw ambient ENV inputs the renderer reads directly today (preferences,
- * chatbox style/theme/capability overrides, the active mcpProfile, the draft
- * host context, and the playground globals). Phase 1b routes these through the
- * host so the renderer keeps ALL of its existing derivation in place
- * (memoization, ternaries, dependency arrays) but stops importing `@/stores`
- * and `@/contexts`. The adapter (`useWidgetHost`) subscribes to the same
- * fine-grained selectors/hooks the renderer used, so reactivity is unchanged.
- *
- * Every field is pinned to its real source type so a source-shape drift fails
- * typecheck loudly before this contract goes stale. Phase 3 replaces these raw
- * inputs with `WidgetHost.resolveEnvironment` (see below).
- */
-export interface WidgetHostEnvironmentInputs {
-  /** usePreferencesStore((s) => s.themeMode). */
-  themeMode: PreferencesState["themeMode"];
-  /** usePreferencesStore((s) => s.hostStyle) — the "shared" host style. */
-  sharedHostStyle: PreferencesState["hostStyle"];
-  /** useChatboxHostStyle(). */
-  chatboxHostStyle: ReturnType<
-    typeof import("@/contexts/chatbox-client-style-context").useChatboxHostStyle
-  >;
-  /** useChatboxHostTheme(). */
-  chatboxHostTheme: ReturnType<
-    typeof import("@/contexts/chatbox-client-style-context").useChatboxHostTheme
-  >;
-  /** useChatboxHostCapabilitiesOverride(). */
-  hostCapabilitiesOverride: ReturnType<
-    typeof import("@/contexts/chatbox-client-capabilities-override-context").useChatboxHostCapabilitiesOverride
-  >;
-  /**
-   * useActiveMcpProfile(). Drives the capability / compat / sandbox resolvers
-   * AND the renderer's `apps.sandbox.*` reads (csp, permissions, sandboxAttrs,
-   * allowFeatures, cspDirectives) + `apps.uiInitialize.hostInfo`.
-   */
-  activeMcpProfile: HostConfigMcpProfileV1 | undefined;
-  /** useHostContextStore((s) => s.draftHostContext). */
-  draftHostContext: ProjectHostContextDraft;
-  /** useUIPlaygroundStore((s) => s.isPlaygroundActive). */
-  isPlaygroundActive: boolean;
-  /** useUIPlaygroundStore((s) => s.globals.locale). */
-  playgroundLocale: PlaygroundGlobals["locale"];
-  /** useUIPlaygroundStore((s) => s.globals.timeZone). */
-  playgroundTimeZone: PlaygroundGlobals["timeZone"];
-  /** useUIPlaygroundStore((s) => s.displayMode). */
-  playgroundDisplayMode: DisplayMode;
-  /** useUIPlaygroundStore((s) => s.capabilities). */
-  playgroundCapabilities: DeviceCapabilities;
-  /** useUIPlaygroundStore((s) => s.safeAreaInsets). */
-  playgroundSafeAreaInsets: SafeAreaInsets;
-  /** useUIPlaygroundStore((s) => s.deviceType). */
-  playgroundDeviceType: DeviceType;
-}
-
-// --- Resolvers (Phase 1b: bound util/resolver fns) ---------------------------
-
-/**
- * Resolver / projection functions the renderer imports from the inspector
- * config layer today (`client-config-v2`, `client-styles`, `client-config`).
- * Phase 1b binds them here so the renderer keeps its call sites verbatim
- * (`host.resolvers.x(...)`) while dropping the `@/lib/client-*` imports.
- *
- * Each member is pinned to the live exported function via `typeof import(...)`
- * so the bound surface can't silently drift from the source signatures.
- * `DEFAULT_HOST_STYLE` is the one non-function member — the renderer reads it
- * once to pin the SEP style-variable allowlist.
- */
-export interface WidgetHostResolvers {
-  resolveEffectiveCompatRuntime: typeof import("@/lib/client-config-v2").resolveEffectiveCompatRuntime;
-  resolveEffectiveMcpAppsCapabilities: typeof import("@/lib/client-config-v2").resolveEffectiveMcpAppsCapabilities;
-  resolveEffectiveHostCapabilities: typeof import("@/lib/client-config-v2").resolveEffectiveHostCapabilities;
-  resolveHostInfo: typeof import("@/lib/client-config-v2").resolveHostInfo;
-  getHostStyleOrDefault: typeof import("@/lib/client-styles").getHostStyleOrDefault;
-  DEFAULT_HOST_STYLE: typeof import("@/lib/client-styles").DEFAULT_HOST_STYLE;
-  extractHostTheme: typeof import("@/lib/client-config").extractHostTheme;
-  extractHostDisplayMode: typeof import("@/lib/client-config").extractHostDisplayMode;
-  extractHostDisplayModes: typeof import("@/lib/client-config").extractHostDisplayModes;
-  clampDisplayModeToAvailableModes: typeof import("@/lib/client-config").clampDisplayModeToAvailableModes;
-  stableStringifyJson: typeof import("@/lib/client-config").stableStringifyJson;
-}
-
-// --- Type re-exports for consumers -------------------------------------------
-//
-// The Tier-B guard forbids the cluster from importing `@/stores/*` and
-// `@/lib/client-styles` even for `import type`. `ResolvedMcpAppsCapabilities`
-// stays inspector-local (profile system) and is re-exported here; the
-// data/chrome/instrumentation slices are owned by @mcpjam/widget-react
-// (Phase 3d-i-a) and re-exported so `./widget-host` consumers are unaffected.
-export type { ResolvedMcpAppsCapabilities } from "@/lib/client-styles";
-// `DisplayMode` / `WidgetSurfaceInfo` / `WidgetDebugSink` / `WidgetHostComponents`
-// are also imported above (used locally by `WidgetHost` / `…EnvironmentInputs`);
-// re-export the local bindings.
-export type {
-  DisplayMode,
-  WidgetSurfaceInfo,
-  WidgetDebugSink,
-  WidgetHostComponents,
-};
-export type {
+  ProjectHostContextDraft,
+  // primitives
   CspMode,
+  DisplayMode,
   UiProtocol,
   OpenAiAppsCapabilities,
+  // surface
+  WidgetSurfaceInfo,
   WidgetSurfaceKind,
+  // instrumentation
+  WidgetDebugSink,
   WidgetDebugInfo,
   WidgetGlobals,
   WidgetSandboxInfo,
@@ -218,101 +57,20 @@ export type {
   WidgetMount,
   CspViolation,
   UiLogEvent,
+  // chrome injection
   WidgetModalProps,
+  WidgetHostComponents,
 } from "@mcpjam/widget-react";
 
-// `extractMethod` is a pure JSON-RPC message parser (no store state, no React)
-// the renderer uses for traffic-log wiring. Re-exported through the boundary —
-// alongside the `UiProtocol` type and the `WidgetDebugSink.addTrafficLog`
-// sink — so the renderer's call sites stay verbatim while it stops importing
-// `@/stores/*` (Tier-B guard). The function relocates with the traffic-log
-// utilities in a later phase.
+// `extractMethod` is a pure JSON-RPC message parser the renderer uses for
+// traffic-log wiring; re-exported through the boundary so the renderer's call
+// sites stay verbatim while it imports zero `@/stores/*` (Tier-B guard). It
+// relocates with the traffic-log utilities in 3d-ii.
 export { extractMethod } from "@/stores/traffic-log-store";
 
-// `stableStringifyJson` is exposed for components via `WidgetHostResolvers`
-// (read off `host.resolvers`), but `mcp-apps-renderer.tsx` also calls it from
-// MODULE scope (`getPersistentSurfaceId`, used by the `MCPAppsRenderer`
-// wrapper's persistent path) where no host instance exists. Re-export the pure
-// canonicalizer here so that module-level call site can import it from the
-// boundary instead of `@/lib/client-config` (Tier-B guard). Same underlying fn
-// as `resolvers.stableStringifyJson`, so the two paths can't diverge.
+// `stableStringifyJson` is read off `host.resolvers`, but `mcp-apps-renderer.tsx`
+// also calls it from MODULE scope (`getPersistentSurfaceId`) where no host
+// instance exists. Re-export the pure canonicalizer so that call site imports it
+// from the boundary instead of `@/lib/client-config` (Tier-B guard). Same fn as
+// `resolvers.stableStringifyJson`. Relocates in 3d-ii.
 export { stableStringifyJson } from "@/lib/client-config";
-
-// --- Services ----------------------------------------------------------------
-
-export type FetchWidgetContentRequest = FetchMcpAppsWidgetContentRequest;
-export type FetchWidgetContentResponse = FetchMcpAppsWidgetContentResponse;
-
-/**
- * Widget content fetch + MCP transport. The inspector binds these to
- * `fetchMcpAppsWidgetContent` (authFetch + endpoint resolution + HOSTED_MODE)
- * and the MCP resource/prompt apis. The renderer sees only these calls — never
- * `authFetch`, Convex, or the `/api/*` endpoint layout.
- */
-export interface WidgetHostServices {
-  fetchWidgetContent: (
-    req: FetchWidgetContentRequest,
-  ) => Promise<FetchWidgetContentResponse>;
-  readResource: typeof import("@/lib/apis/mcp-resources-api").readResource;
-  listResources: typeof import("@/lib/apis/mcp-resources-api").listResources;
-  listPrompts: typeof import("@/lib/apis/mcp-prompts-api").listPrompts;
-  /**
-   * `resources/templates/list` for the MCP-Apps bridge
-   * (host-app-bridge `onListResourceTemplates`). HOST-OWNED — NOT the raw api
-   * fn. The provider MUST apply the same guard the renderer does today: throw
-   * when `HOSTED_MODE || surface.webManagedServers` is true
-   * (mcp-apps-renderer.tsx:2861-2868). The underlying
-   * `mcp-resource-templates-api.listResourceTemplates` only enforces
-   * `HOSTED_MODE` (via `ensureLocalMode`), NOT web-managed, so binding it
-   * directly in Phase 1 would let web-managed chatbox/widget surfaces drift.
-   * Typed structurally (return shape still pinned to the api) to signal the
-   * provider owns the implementation rather than forwarding the raw fn.
-   */
-  listResourceTemplates: (
-    serverId: string,
-  ) => Promise<
-    Awaited<
-      ReturnType<
-        typeof import("@/lib/apis/mcp-resource-templates-api").listResourceTemplates
-      >
-    >
-  >;
-  // Phase 1: OpenAI Apps file bridges (uploadFile / getFileDownloadUrl) bind to
-  // widget-file-messages here once their host-facing signatures are firmed up.
-}
-
-// --- The seam ----------------------------------------------------------------
-
-export interface WidgetHost {
-  /**
-   * Resolved per-server host environment (see WidgetHostEnvironment) — the
-   * documented Phase-3 target: the inspector resolves the full per-server
-   * environment once and the renderer drops its derivation logic.
-   *
-   * OPTIONAL in the contract because Phase 1b deliberately does NOT implement
-   * it. Phase 1b is a behavior-preserving IN-PLACE inversion: it keeps the
-   * renderer's derivation byte-for-byte and only routes the renderer's raw
-   * ambient reads (see `environment`) and imported resolver fns (see
-   * `resolvers`) through the host. Pre-resolving the environment is a separate,
-   * higher-risk change saved for Phase 3; leaving this required would force
-   * `useWidgetHost` to implement the security-sensitive sandbox/profile
-   * resolution before its tests exist.
-   */
-  resolveEnvironment?: (serverId: string | undefined) => WidgetHostEnvironment;
-  /**
-   * Raw ambient ENV inputs (Phase 1b). The renderer keeps its existing
-   * derivation; this just relocates the store/context read sites behind the
-   * host so the renderer imports zero `@/stores`/`@/contexts`. Folded into
-   * `resolveEnvironment` in Phase 3.
-   */
-  environment: WidgetHostEnvironmentInputs;
-  /**
-   * Bound resolver/projection fns (Phase 1b) the renderer used to import from
-   * `@/lib/client-*` directly. Call sites stay verbatim as `resolvers.x(...)`.
-   */
-  resolvers: WidgetHostResolvers;
-  services: WidgetHostServices;
-  surface: WidgetSurfaceInfo;
-  debug?: WidgetDebugSink;
-  components?: WidgetHostComponents;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36902,6 +36902,10 @@
       "name": "@mcpjam/widget-react",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@mcpjam/sdk": "^1.17.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.2"
+      },
       "devDependencies": {
         "@testing-library/react": "^16.3.1",
         "@types/react": "^19",

--- a/widget-react/package.json
+++ b/widget-react/package.json
@@ -34,6 +34,10 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
+  "dependencies": {
+    "@mcpjam/sdk": "^1.17.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.2"
+  },
   "devDependencies": {
     "@testing-library/react": "^16.3.1",
     "@types/react": "^19",

--- a/widget-react/src/__tests__/widget-host-context.test.tsx
+++ b/widget-react/src/__tests__/widget-host-context.test.tsx
@@ -11,7 +11,10 @@ function SurfaceProbe() {
   return <span data-testid="kind">{host.surface.kind}</span>;
 }
 
-const host: WidgetHost = {
+// Minimal host for the provider/hook plumbing test (the probe reads only
+// `surface.kind`). The FULL WidgetHost contract is type-checked where it matters
+// — the inspector's use-widget-host adapter conforming to it (typecheck:client).
+const host = {
   surface: {
     kind: "playground",
     persistentSurfaceHost: false,
@@ -19,7 +22,7 @@ const host: WidgetHost = {
     sandboxOrigin: "",
     playgroundCspMode: "widget-declared",
   },
-};
+} as unknown as WidgetHost;
 
 describe("WidgetHostProvider / useWidgetHost", () => {
   it("provides the injected host to consumers", () => {

--- a/widget-react/src/index.ts
+++ b/widget-react/src/index.ts
@@ -16,9 +16,31 @@ export type {
   DisplayMode,
   UiProtocol,
   OpenAiAppsCapabilities,
+  // environment data types
+  ThemeMode,
+  ChatboxHostStyle,
+  DeviceCapabilities,
+  DeviceType,
+  SafeAreaInsets,
+  ProjectHostContextDraft,
+  // resolved profile shapes
+  ResolvedHostCapabilities,
+  ResolvedHostInfo,
+  ResolvedOpenAiAppsCapabilities,
+  EffectiveCompatRuntime,
+  ResolvedMcpAppsCapabilities,
+  ResolvedHostStyle,
   // surface
   WidgetSurfaceInfo,
   WidgetSurfaceKind,
+  // environment / resolvers / services
+  WidgetHostEnvironment,
+  WidgetHostEnvironmentInputs,
+  WidgetHostResolvers,
+  WidgetHostServices,
+  FetchWidgetContentRequest,
+  FetchWidgetContentResponse,
+  ListResourcesResult,
   // instrumentation
   WidgetDebugSink,
   WidgetDebugInfo,

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -16,6 +16,15 @@
 // `services` (the fn-heavy + profile-derived slices).
 
 import type { ComponentType, ReactNode } from "react";
+import type {
+  McpUiHostCapabilities,
+  McpUiHostContext,
+  McpUiResourceCsp,
+  McpUiResourcePermissions,
+  McpUiStyles,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { HostConfigMcpProfileV1 } from "@mcpjam/sdk/host-config/internal";
+import type { MCPPrompt, MCPResourceTemplate } from "@mcpjam/sdk/browser";
 
 // --- Primitives --------------------------------------------------------------
 
@@ -46,6 +55,94 @@ export interface OpenAiAppsCapabilities {
   getFileDownloadUrl?: boolean;
   requestCheckout?: boolean;
   requestClose?: boolean;
+}
+
+// --- Environment data types --------------------------------------------------
+
+/** usePreferencesStore theme mode. */
+export type ThemeMode = "light" | "dark";
+
+/** Host-style id (the inspector's `ChatboxHostStyle`). */
+export type ChatboxHostStyle = string;
+
+export interface DeviceCapabilities {
+  hover: boolean;
+  touch: boolean;
+}
+
+export type DeviceType = "fill" | "mobile" | "tablet" | "desktop" | "custom";
+
+export interface SafeAreaInsets {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+/** useHostContextStore draftHostContext. */
+export type ProjectHostContextDraft = Record<string, unknown>;
+
+// --- Resolved profile shapes -------------------------------------------------
+//
+// The profile system (client-config-v2 / client-styles) stays in the inspector;
+// these are the structural shapes its resolvers PRODUCE, typed to what the
+// renderer reads. The adapter assigns the real resolver results, which are
+// assignable to these (drift caught there).
+
+/** resolveEffectiveHostCapabilities — vendor-trait host caps (sandbox composed separately). */
+export type ResolvedHostCapabilities = Omit<McpUiHostCapabilities, "sandbox">;
+
+/** resolveHostInfo. */
+export type ResolvedHostInfo = Record<string, unknown> | undefined;
+
+/** Required form of the OpenAI Apps compat surface. */
+export type ResolvedOpenAiAppsCapabilities = Required<OpenAiAppsCapabilities>;
+
+/** resolveEffectiveCompatRuntime result. */
+export type EffectiveCompatRuntime =
+  | { injected: false }
+  | { injected: true; capabilities: ResolvedOpenAiAppsCapabilities };
+
+/** resolveEffectiveMcpAppsCapabilities — the resolved MCP-Apps capability matrix. */
+export type ResolvedMcpAppsCapabilities = {
+  availableDisplayModes: ("inline" | "fullscreen" | "pip")[];
+  toolInputPartial: boolean;
+  toolCancelled: boolean;
+  hostContextChanged: boolean;
+  resourceTeardown: boolean;
+  toolInfo: boolean;
+  openLinks: boolean;
+  serverTools: boolean;
+  serverResources: boolean;
+  logging: boolean;
+  updateModelContext: boolean;
+  message: boolean;
+  sandboxPermissions: boolean;
+  cspFrameDomains: boolean;
+  cspBaseUriDomains: boolean;
+  resourcePrefersBorder: boolean;
+  downloadFile: boolean;
+  requestTeardown: boolean;
+  widgetDisplayModeRequests: "accept" | "user-initiated-only" | "decline";
+};
+
+/**
+ * getHostStyleOrDefault / DEFAULT_HOST_STYLE result — typed to the renderer's
+ * AUDITED reads only: `.mcp.{resolveStyleVariables,fontCss,platform}` and
+ * `.chatUi.resolveChatBackground` (+ `.id`). The real `HostStyleDefinition` has
+ * more (the full profile/chat-ui graph); the adapter assigns it (assignable to
+ * this minimal surface), so the package never replicates that graph.
+ */
+export interface ResolvedHostStyle {
+  id: string;
+  mcp: {
+    resolveStyleVariables: (theme: "light" | "dark") => McpUiStyles;
+    fontCss: string;
+    platform: "web" | "desktop" | "mobile";
+  };
+  chatUi: {
+    resolveChatBackground: (theme: "light" | "dark") => string;
+  };
 }
 
 // --- Surface -----------------------------------------------------------------
@@ -279,12 +376,182 @@ export interface WidgetHostComponents {
   Modal?: ComponentType<WidgetModalProps>;
 }
 
+// --- Environment -------------------------------------------------------------
+
+/**
+ * Per-`serverId` resolved host environment — the deferred `resolveEnvironment`
+ * target. Currently unused by the renderer (Phase 1b reads the raw `environment`
+ * inputs + `resolvers` instead); kept on the contract for the eventual fold-in.
+ */
+export interface WidgetHostEnvironment {
+  hostInfo: ResolvedHostInfo;
+  hostCapabilities: ResolvedHostCapabilities;
+  mcpAppsCapabilities: ResolvedMcpAppsCapabilities;
+  injectOpenAiCompat: boolean;
+  openAiCompatCapabilities?: ResolvedOpenAiAppsCapabilities;
+  supportsWidgetRendering: boolean;
+  theme: string;
+  hostStyle: ResolvedHostStyle;
+  baseHostContext: McpUiHostContext;
+}
+
+/**
+ * Raw ambient ENV inputs the renderer reads (Phase 1b). The inspector's
+ * use-widget-host adapter supplies these from its stores/contexts; these are
+ * structural mirrors of the inspector store/context shapes.
+ */
+export interface WidgetHostEnvironmentInputs {
+  themeMode: ThemeMode;
+  sharedHostStyle: ChatboxHostStyle;
+  chatboxHostStyle: ChatboxHostStyle | null;
+  chatboxHostTheme: "light" | "dark" | null;
+  hostCapabilitiesOverride: Record<string, unknown> | undefined;
+  activeMcpProfile: HostConfigMcpProfileV1 | undefined;
+  draftHostContext: ProjectHostContextDraft;
+  isPlaygroundActive: boolean;
+  playgroundLocale: string;
+  playgroundTimeZone: string;
+  playgroundDisplayMode: DisplayMode;
+  playgroundCapabilities: DeviceCapabilities;
+  playgroundSafeAreaInsets: SafeAreaInsets;
+  playgroundDeviceType: DeviceType;
+}
+
+// --- Resolvers ---------------------------------------------------------------
+
+/**
+ * Resolver / projection fns the renderer calls. The inspector's use-widget-host
+ * adapter binds them to the real client-config-v2 / client-styles /
+ * client-config implementations; typed structurally so the package owns no
+ * inspector code. Drift is caught where the adapter assigns the real fns.
+ */
+export interface WidgetHostResolvers {
+  resolveEffectiveCompatRuntime: (args: {
+    profile: HostConfigMcpProfileV1 | undefined;
+    hostStyle: ChatboxHostStyle | string | null | undefined;
+  }) => EffectiveCompatRuntime;
+  resolveEffectiveMcpAppsCapabilities: (args: {
+    profile: HostConfigMcpProfileV1 | undefined;
+    hostStyle: ChatboxHostStyle | string | null | undefined;
+  }) => ResolvedMcpAppsCapabilities;
+  resolveEffectiveHostCapabilities: (args: {
+    hostStyle: string | null | undefined;
+    profile?: HostConfigMcpProfileV1;
+    hostCapabilitiesOverride?: Record<string, unknown>;
+  }) => ResolvedHostCapabilities;
+  resolveHostInfo: (
+    profile: HostConfigMcpProfileV1 | undefined,
+  ) => ResolvedHostInfo;
+  getHostStyleOrDefault: (id: string | null | undefined) => ResolvedHostStyle;
+  DEFAULT_HOST_STYLE: ResolvedHostStyle;
+  extractHostTheme: (
+    hostContext?: Record<string, unknown>,
+  ) => "light" | "dark" | undefined;
+  extractHostDisplayMode: (
+    hostContext?: Record<string, unknown>,
+  ) => DisplayMode | undefined;
+  extractHostDisplayModes: (
+    hostContext?: Record<string, unknown>,
+  ) => DisplayMode[];
+  clampDisplayModeToAvailableModes: (
+    displayMode: DisplayMode | undefined,
+    availableDisplayModes: DisplayMode[],
+  ) => DisplayMode;
+  stableStringifyJson: (value: unknown) => string;
+}
+
+// --- Services ----------------------------------------------------------------
+
+export interface FetchWidgetContentRequest {
+  serverId: string;
+  resourceUri: string;
+  toolInput: Record<string, unknown> | undefined;
+  toolOutput: unknown;
+  toolResponseMetadata?: Record<string, unknown> | null;
+  initialWidgetState?: unknown;
+  toolId: string;
+  toolName: string;
+  theme: string;
+  cspMode: CspMode;
+  injectOpenAiCompat: boolean;
+  openAiCompatCapabilities?: ResolvedOpenAiAppsCapabilities;
+  template?: string;
+  viewMode?: string;
+  viewParams?: Record<string, unknown>;
+  forceWebEndpoint?: boolean;
+}
+
+export interface FetchWidgetContentResponse {
+  html: string;
+  csp?: McpUiResourceCsp;
+  permissions?: McpUiResourcePermissions;
+  permissive?: boolean;
+  mimeTypeWarning?: string;
+  mimeTypeValid?: boolean;
+  prefersBorder?: boolean;
+  injectedOpenAiCompat?: boolean;
+  injectedOpenAiCompatCapabilities?: ResolvedOpenAiAppsCapabilities;
+}
+
+// A `type` alias (not interface) on purpose: the inspector api's
+// `ListResourcesResult` is a type alias, so it carries an implicit index
+// signature and stays assignable to the MCP bridge handler's index-signature
+// target. An interface here would break that assignability.
+export type ListResourcesResult = {
+  resources: Array<{
+    uri: string;
+    name: string;
+    description?: string;
+    mimeType?: string;
+  }>;
+  nextCursor?: string;
+};
+
+/**
+ * Widget content fetch + MCP transport. The inspector binds these to
+ * `fetchMcpAppsWidgetContent` + the MCP resource/prompt apis.
+ * `listResourceTemplates` is HOST-OWNED — the inspector applies the
+ * HOSTED_MODE / web-managed guard before calling the raw api.
+ */
+export interface WidgetHostServices {
+  fetchWidgetContent: (
+    req: FetchWidgetContentRequest,
+  ) => Promise<FetchWidgetContentResponse>;
+  // Mirrors the inspector api fn (returns `Promise<any>`); the bridge handler
+  // treats the resource payload opaquely.
+  readResource: (
+    serverId: string,
+    uri: string,
+    opts?: { forceHosted?: boolean },
+  ) => Promise<any>;
+  listResources: (
+    serverId: string,
+    cursor?: string,
+    opts?: { forceHosted?: boolean },
+  ) => Promise<ListResourcesResult>;
+  listPrompts: (
+    serverId: string,
+    opts?: { forceHosted?: boolean },
+  ) => Promise<MCPPrompt[]>;
+  listResourceTemplates: (serverId: string) => Promise<MCPResourceTemplate[]>;
+}
+
 // --- The seam ----------------------------------------------------------------
 
 export interface WidgetHost {
+  /**
+   * Resolved per-server environment — the deferred `resolveEnvironment` target.
+   * OPTIONAL: Phase 1b reads the raw `environment` inputs + `resolvers` instead.
+   * Folding into this (and dropping the raw inputs + the `HostConfigMcpProfileV1`
+   * surface) is the publish-ready pass (3d-iii).
+   */
+  resolveEnvironment?: (serverId: string | undefined) => WidgetHostEnvironment;
+  /** Raw ambient ENV inputs (Phase 1b); supplied by the inspector adapter. */
+  environment: WidgetHostEnvironmentInputs;
+  /** Bound resolver/projection fns (Phase 1b); bound by the inspector adapter. */
+  resolvers: WidgetHostResolvers;
+  services: WidgetHostServices;
   surface: WidgetSurfaceInfo;
   debug?: WidgetDebugSink;
   components?: WidgetHostComponents;
-  // 3d-i-b: `environment`, `resolvers`, `services` fold in here as the
-  // fn-heavy / profile-derived slices relocate.
 }

--- a/widget-react/tsup.config.ts
+++ b/widget-react/tsup.config.ts
@@ -14,7 +14,14 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   minify: false,
-  // React is a peer dep — never bundle it. (No `ai`/`@ai-sdk/react`: the widget
-  // runtime does not import them — audited in Phase 3c.)
-  external: ["react", "react-dom", "react/jsx-runtime"],
+  // React is a peer dep — never bundle it. @mcpjam/sdk + @modelcontextprotocol/*
+  // are runtime/type deps resolved at the consumer; keep them external so tsup
+  // (JS + dts) references them rather than inlining/resolving at build time.
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    /^@mcpjam\/sdk/,
+    /^@modelcontextprotocol\//,
+  ],
 });


### PR DESCRIPTION
## Context

Completes **3d-i** (the `WidgetHost` contract fold-in). 3d-i-a moved the data/chrome/debug slices; this PR moves the rest — `environment`, `resolvers`, `services`, the result/profile shapes, and **`WidgetHost` itself** — into `@mcpjam/widget-react`, **closing the temporary two-`WidgetHost` gap** the reviewer flagged. The renderer relocation (3d-ii) can now depend on the package's full contract.

## Meets the acceptance criteria

- ✅ **`WidgetHost` lives in `@mcpjam/widget-react`.**
- ✅ **Inspector `widget-host.ts` is a pure re-export shim** (no parallel contract) — it re-exports the full contract from the package and keeps only the two inspector-sourced value re-exports (`extractMethod`, `stableStringifyJson`) until they relocate in 3d-ii.
- ✅ **Clean `.d.ts` with intentional external refs only** — emitted dts has exactly three external imports (`@modelcontextprotocol/ext-apps/app-bridge`, `@mcpjam/sdk/host-config/internal`, `@mcpjam/sdk/browser`); nothing from the profile graph is inlined.
- ✅ Package guard / typecheck / test / build pass.
- ✅ Inspector `typecheck:client` proves adapter conformance (the `use-widget-host` adapter builds the host from the real stores and returns it typed as the package contract).
- ✅ Existing renderer / use-widget-host / cluster tests pass (232).

## Minimal typing, not a profile-system copy

Per the guidance, typed to **audited renderer usage** rather than deep-replicating the inspector graph:
- `ResolvedHostStyle` is a minimal structural surface (only `.mcp.{resolveStyleVariables,fontCss,platform}` + `.chatUi.resolveChatBackground` + `.id`, audited as the renderer's actual reads); the real `HostStyleDefinition` is assignable to it.
- ext-apps types imported from `@modelcontextprotocol/ext-apps`; `MCPPrompt`/`MCPResourceTemplate` from `@mcpjam/sdk/browser`.

**One intentional SDK-internal ref:** `HostConfigMcpProfileV1` (from `@mcpjam/sdk/host-config/internal`). The renderer both reads `activeMcpProfile.apps.*` and passes the profile into resolvers, and resolver↔adapter contravariance requires the *real* profile type — so fully hiding it = the deferred `resolveEnvironment` fold (a renderer refactor, not a type move). Since the package is still **private**, I kept it for this slice and deferred hiding it to the publish-ready pass (3d-iii), documented in the contract.

## Notes

- New package deps: `@mcpjam/sdk` + `@modelcontextprotocol/ext-apps`, externalized in tsup (regex), so the dts references them rather than inlining. SDK subpaths resolve via node_modules → built dist (I dropped a tsconfig path-to-source approach that pulled SDK files under `rootDir` — TS6059).
- Size: ~+225 LOC in the package, ~−245 in the inspector shim (net-neutral app code); well under the split threshold, so kept as one slice.
- Repo has no prettier config/gate; edits match surrounding style by hand.

## Next (3d-ii)

Relocate the renderer + cluster into the package; wrap the live chat subtree in `<WidgetHostProvider value={useWidgetHostValue()}>` so the moved renderer reads the package context; move the `extractMethod`/`stableStringifyJson` values.

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large contract relocation with SDK-internal types and MCP service signatures; drift is mitigated by adapter typechecking but mistakes could surface at compile time or when the renderer moves to the package.
> 
> **Overview**
> **Tier B Phase 3d-i-b** finishes moving the **`WidgetHost` dependency-inversion contract** into `@mcpjam/widget-react`, so there is a single package-owned seam instead of a duplicate inspector definition.
> 
> The inspector **`widget-host.ts` module is reduced to a compatibility shim**: it re-exports contract types from the package and still forwards **`extractMethod`** and **`stableStringifyJson`** from inspector code until the renderer move (3d-ii). **`environment`**, **`resolvers`**, **`services`**, resolved profile shapes, and the full **`WidgetHost`** interface now live in **`widget-react/src/widget-host.ts`** and are exported from the package barrel.
> 
> Package typing is **structural and renderer-audited** (e.g. minimal **`ResolvedHostStyle`**, explicit resolver/service signatures) rather than **`typeof import(...)`** pins to inspector modules. External types come from **`@modelcontextprotocol/ext-apps`** and **`@mcpjam/sdk`** (including **`HostConfigMcpProfileV1`** from an SDK internal path). **`@mcpjam/widget-react`** adds those dependencies and **tsup externalizes** them so declarations reference consumers’ installs.
> 
> Widget host **provider tests** use minimal stub hosts cast to **`WidgetHost`**; full contract conformance stays on **`use-widget-host`** via **`typecheck:client`**. **No runtime behavior change** is intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f47f6f70cbd114e94d8cd80b27fe55edb08c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->