### PR TITLE
Tier B Phase 3d-ii-a: relocate detection/parsing utils to @mcpjam/widget-react

### DIFF
--- a/.changeset/widget-relocate-utils-3d-ii-a.md
+++ b/.changeset/widget-relocate-utils-3d-ii-a.md
@@ -1,0 +1,19 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Tier B Phase 3d-ii-a: relocate the pure detection/parsing utilities into
+`@mcpjam/widget-react`.
+
+`tool-result-utils` (result `_meta`/`_serverId` readers) and the `mcp-apps-utils`
+UI-type detection core (`UIType`, `detectUIType`, `detectUiTypeFromTool`,
+`getUIResourceUri`, + the SEP-1865 tool-visibility re-exports) now live in the
+package. The inspector modules become re-export shims so every existing
+`@/lib/tool-result-utils` / `@/lib/mcp-ui/mcp-apps-utils` import site is
+unchanged; the `ListToolsResultWithMetadata`-typed `isMCPApp`/`isOpenAIApp`/
+`isOpenAIAppAndMCPApp` helpers stay in the inspector (they need an inspector api
+type).
+
+The package gains `@mcp-ui/client` + `@modelcontextprotocol/client` deps
+(externalized in tsup; dts references them as external imports only). First step
+of the renderer/cluster relocation (3d-ii). No behavior change.

--- a/mcpjam-inspector/client/src/lib/mcp-ui/mcp-apps-utils.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/mcp-apps-utils.ts
@@ -1,76 +1,20 @@
-import { isUIResource } from "@mcp-ui/client";
+// The UI-type detection core (UIType, detectUIType, getUIResourceUri,
+// detectUiTypeFromTool) + the SEP-1865 tool-visibility re-exports relocated to
+// @mcpjam/widget-react (Phase 3d-ii). Re-exported here so existing
+// `@/lib/mcp-ui/mcp-apps-utils` import sites are unchanged. The
+// `ListToolsResultWithMetadata`-typed convenience helpers stay local — they
+// depend on an inspector api type.
+import { detectUIType, UIType } from "@mcpjam/widget-react";
 import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
-import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type { Tool } from "@modelcontextprotocol/client";
 
-export enum UIType {
-  MCP_APPS = "mcp-apps",
-  OPENAI_SDK = "openai-sdk",
-  OPENAI_SDK_AND_MCP_APPS = "openai-sdk-and-mcp-apps",
-  MCP_UI = "mcp-ui",
-}
-
-export function detectUiTypeFromTool(tool: Tool): UIType | null {
-  const toolMeta = tool._meta;
-  if (!toolMeta) return null;
-  return detectUIType(toolMeta, undefined);
-}
-
-export function detectUIType(
-  toolMeta: Record<string, unknown> | undefined,
-  toolResult: unknown,
-): UIType | null {
-  // 1. OpenAI SDK and MCP Apps: Check for openai/outputTemplate and ui.resourceUri metadata
-  if (
-    toolMeta?.["openai/outputTemplate"] &&
-    getToolUiResourceUri({ _meta: toolMeta })
-  ) {
-    return UIType.OPENAI_SDK_AND_MCP_APPS;
-  }
-
-  // 2. OpenAI SDK: Check for openai/outputTemplate metadata
-  if (toolMeta?.["openai/outputTemplate"]) {
-    return UIType.OPENAI_SDK;
-  }
-
-  // 3. MCP Apps (SEP-1865): Check for ui.resourceUri metadata
-  if (getToolUiResourceUri({ _meta: toolMeta })) {
-    return UIType.MCP_APPS;
-  }
-
-  // 4. MCP-UI: Check for inline ui:// resource in result
-  const directResource = (toolResult as { resource?: { uri?: string } })
-    ?.resource;
-  if (directResource?.uri?.startsWith("ui://")) {
-    return UIType.MCP_UI;
-  }
-
-  const content = (toolResult as { content?: unknown[] })?.content;
-  if (Array.isArray(content)) {
-    for (const item of content) {
-      // isUIResource is a type guard, cast to any for runtime type check
-      if (isUIResource(item as any)) {
-        return UIType.MCP_UI;
-      }
-    }
-  }
-  return null;
-}
-
-export function getUIResourceUri(
-  uiType: UIType | null,
-  toolMeta: Record<string, unknown> | undefined,
-): string | null {
-  switch (uiType) {
-    case UIType.MCP_APPS:
-    case UIType.OPENAI_SDK_AND_MCP_APPS:
-      return getToolUiResourceUri({ _meta: toolMeta }) ?? null;
-    case UIType.OPENAI_SDK:
-      return (toolMeta?.["openai/outputTemplate"] as string) ?? null;
-    default:
-      return null;
-  }
-}
+export { detectUIType, UIType };
+export {
+  detectUiTypeFromTool,
+  getUIResourceUri,
+  getToolVisibility,
+  isVisibleToModelOnly,
+  isVisibleToAppOnly,
+} from "@mcpjam/widget-react";
 
 export function isMCPApp(
   toolsData?: ListToolsResultWithMetadata | null,
@@ -104,18 +48,3 @@ export function isOpenAIAppAndMCPApp(
     (meta) => detectUIType(meta, undefined) === UIType.OPENAI_SDK_AND_MCP_APPS,
   );
 }
-
-/**
- * SEP-1865 tool visibility helpers.
- *
- * The implementations live in the dependency-free leaf module
- * `@/lib/mcp-ui/tool-visibility` so the framework-free host bridge
- * (`host-app-bridge.ts`, consumed by the eval harness) can share the exact
- * model-only visibility check the production renderer enforces. Re-exported
- * here to preserve existing `@/lib/mcp-ui/mcp-apps-utils` import sites.
- */
-export {
-  getToolVisibility,
-  isVisibleToModelOnly,
-  isVisibleToAppOnly,
-} from "@/lib/mcp-ui/tool-visibility";

--- a/mcpjam-inspector/client/src/lib/tool-result-utils.ts
+++ b/mcpjam-inspector/client/src/lib/tool-result-utils.ts
@@ -1,49 +1,7 @@
-/**
- * Shared helpers for reading metadata and server IDs from tool results.
- *
- * Tool results may carry `_meta` and `_serverId` either at the top level
- * or nested under a `.value` wrapper. These utilities normalise access
- * across both shapes.
- */
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
-
-export function readToolResultObject(
-  result: unknown,
-): Record<string, unknown> | undefined {
-  if (!isRecord(result)) return undefined;
-  return result;
-}
-
-export function readToolResultMeta(
-  result: unknown,
-): Record<string, unknown> | undefined {
-  if (!isRecord(result)) return undefined;
-
-  if (isRecord(result._meta)) {
-    return result._meta;
-  }
-
-  if (isRecord(result.value) && isRecord(result.value._meta)) {
-    return result.value._meta;
-  }
-
-  return undefined;
-}
-
-export function readToolResultServerId(result: unknown): string | undefined {
-  if (!isRecord(result)) return undefined;
-
-  if (typeof result._serverId === "string") {
-    return result._serverId;
-  }
-
-  if (isRecord(result.value) && typeof result.value._serverId === "string") {
-    return result.value._serverId;
-  }
-
-  const meta = readToolResultMeta(result);
-  return typeof meta?._serverId === "string" ? meta._serverId : undefined;
-}
+// Relocated to @mcpjam/widget-react (Phase 3d-ii). This shim preserves existing
+// `@/lib/tool-result-utils` import sites.
+export {
+  readToolResultObject,
+  readToolResultMeta,
+  readToolResultServerId,
+} from "@mcpjam/widget-react";

--- a/package-lock.json
+++ b/package-lock.json
@@ -36903,7 +36903,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@mcp-ui/client": "^5.9.0",
         "@mcpjam/sdk": "^1.17.0",
+        "@modelcontextprotocol/client": "^2.0.0-alpha.2",
         "@modelcontextprotocol/ext-apps": "^1.7.2"
       },
       "devDependencies": {

--- a/widget-react/package.json
+++ b/widget-react/package.json
@@ -35,7 +35,9 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
+    "@mcp-ui/client": "^5.9.0",
     "@mcpjam/sdk": "^1.17.0",
+    "@modelcontextprotocol/client": "^2.0.0-alpha.2",
     "@modelcontextprotocol/ext-apps": "^1.7.2"
   },
   "devDependencies": {

--- a/widget-react/src/index.ts
+++ b/widget-react/src/index.ts
@@ -9,6 +9,21 @@ export {
   useWidgetHost,
   type WidgetHostProviderProps,
 } from "./widget-host-context";
+// UI-type detection + tool-visibility (relocated from the inspector, 3d-ii).
+export {
+  UIType,
+  detectUIType,
+  detectUiTypeFromTool,
+  getUIResourceUri,
+  getToolVisibility,
+  isVisibleToModelOnly,
+  isVisibleToAppOnly,
+} from "./mcp-apps-utils";
+export {
+  readToolResultObject,
+  readToolResultMeta,
+  readToolResultServerId,
+} from "./tool-result-utils";
 export type {
   WidgetHost,
   // primitives

--- a/widget-react/src/mcp-apps-utils.ts
+++ b/widget-react/src/mcp-apps-utils.ts
@@ -1,0 +1,86 @@
+// UI-type detection for widget-bearing tool calls. Relocated from the inspector
+// (`@/lib/mcp-ui/mcp-apps-utils`) in Phase 3d-ii; depends only on ext-apps +
+// @mcp-ui/client + the SDK tool-visibility leaf. The inspector keeps the
+// `ListToolsResultWithMetadata`-typed `isMCPApp`/`isOpenAIApp` helpers (they
+// need an inspector api type) and re-exports this core.
+import { isUIResource } from "@mcp-ui/client";
+import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { Tool } from "@modelcontextprotocol/client";
+
+// SEP-1865 tool-visibility helpers live in the framework-free SDK leaf so the
+// host bridge and the renderer share one model-only visibility check. Re-exported
+// here to preserve the existing `mcp-apps-utils` import surface.
+export {
+  getToolVisibility,
+  isVisibleToModelOnly,
+  isVisibleToAppOnly,
+} from "@mcpjam/sdk/widget-runtime";
+
+export enum UIType {
+  MCP_APPS = "mcp-apps",
+  OPENAI_SDK = "openai-sdk",
+  OPENAI_SDK_AND_MCP_APPS = "openai-sdk-and-mcp-apps",
+  MCP_UI = "mcp-ui",
+}
+
+export function detectUiTypeFromTool(tool: Tool): UIType | null {
+  const toolMeta = tool._meta;
+  if (!toolMeta) return null;
+  return detectUIType(toolMeta, undefined);
+}
+
+export function detectUIType(
+  toolMeta: Record<string, unknown> | undefined,
+  toolResult: unknown,
+): UIType | null {
+  // 1. OpenAI SDK and MCP Apps: openai/outputTemplate AND ui.resourceUri
+  if (
+    toolMeta?.["openai/outputTemplate"] &&
+    getToolUiResourceUri({ _meta: toolMeta })
+  ) {
+    return UIType.OPENAI_SDK_AND_MCP_APPS;
+  }
+
+  // 2. OpenAI SDK: openai/outputTemplate
+  if (toolMeta?.["openai/outputTemplate"]) {
+    return UIType.OPENAI_SDK;
+  }
+
+  // 3. MCP Apps (SEP-1865): ui.resourceUri
+  if (getToolUiResourceUri({ _meta: toolMeta })) {
+    return UIType.MCP_APPS;
+  }
+
+  // 4. MCP-UI: inline ui:// resource in result
+  const directResource = (toolResult as { resource?: { uri?: string } })
+    ?.resource;
+  if (directResource?.uri?.startsWith("ui://")) {
+    return UIType.MCP_UI;
+  }
+
+  const content = (toolResult as { content?: unknown[] })?.content;
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      // isUIResource is a type guard; cast to any for the runtime check.
+      if (isUIResource(item as any)) {
+        return UIType.MCP_UI;
+      }
+    }
+  }
+  return null;
+}
+
+export function getUIResourceUri(
+  uiType: UIType | null,
+  toolMeta: Record<string, unknown> | undefined,
+): string | null {
+  switch (uiType) {
+    case UIType.MCP_APPS:
+    case UIType.OPENAI_SDK_AND_MCP_APPS:
+      return getToolUiResourceUri({ _meta: toolMeta }) ?? null;
+    case UIType.OPENAI_SDK:
+      return (toolMeta?.["openai/outputTemplate"] as string) ?? null;
+    default:
+      return null;
+  }
+}

--- a/widget-react/src/tool-result-utils.ts
+++ b/widget-react/src/tool-result-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared helpers for reading metadata and server IDs from tool results.
+ *
+ * Tool results may carry `_meta` and `_serverId` either at the top level or
+ * nested under a `.value` wrapper. These utilities normalise access across both
+ * shapes. Pure (no deps) — relocated from the inspector in Phase 3d-ii.
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function readToolResultObject(
+  result: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(result)) return undefined;
+  return result;
+}
+
+export function readToolResultMeta(
+  result: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(result)) return undefined;
+
+  if (isRecord(result._meta)) {
+    return result._meta;
+  }
+
+  if (isRecord(result.value) && isRecord(result.value._meta)) {
+    return result.value._meta;
+  }
+
+  return undefined;
+}
+
+export function readToolResultServerId(result: unknown): string | undefined {
+  if (!isRecord(result)) return undefined;
+
+  if (typeof result._serverId === "string") {
+    return result._serverId;
+  }
+
+  if (isRecord(result.value) && typeof result.value._serverId === "string") {
+    return result.value._serverId;
+  }
+
+  const meta = readToolResultMeta(result);
+  return typeof meta?._serverId === "string" ? meta._serverId : undefined;
+}

--- a/widget-react/tsup.config.ts
+++ b/widget-react/tsup.config.ts
@@ -23,5 +23,6 @@ export default defineConfig({
     "react/jsx-runtime",
     /^@mcpjam\/sdk/,
     /^@modelcontextprotocol\//,
+    /^@mcp-ui\//,
   ],
 });


### PR DESCRIPTION
## Context

First step of **3d-ii** (relocating the renderer + cluster into `@mcpjam/widget-react`). This slice moves the **pure detection/parsing utilities** — the safest, most self-contained pieces — to establish the relocation pattern before the bigger mid-tier and renderer-cutover slices.

## What moves

- **`tool-result-utils`** (`readToolResultObject`/`readToolResultMeta`/`readToolResultServerId`) — pure, zero deps.
- **`mcp-apps-utils` core** — `UIType`, `detectUIType`, `detectUiTypeFromTool`, `getUIResourceUri`, plus the SEP-1865 tool-visibility re-exports (from `@mcpjam/sdk/widget-runtime`).

The inspector's `@/lib/tool-result-utils` and `@/lib/mcp-ui/mcp-apps-utils` become **re-export shims**, so every existing import site (renderer, widget-replay, part-switch, …) is unchanged. The `ListToolsResultWithMetadata`-typed convenience helpers (`isMCPApp`/`isOpenAIApp`/`isOpenAIAppAndMCPApp`) stay inspector-side — they need an inspector api type.

## Notes

- Package gains `@mcp-ui/client` + `@modelcontextprotocol/client` deps, externalized in tsup (the emitted dts references them as external imports only).
- The chat-ui detector dedup (the `widget-detection` reconcile) is intentionally *not* done here — both detectors coexist until Phase 4 wires the `renderWidget` seam; this slice is a straight relocation.

## Verification

- Package: guard / typecheck / test / build ✅ (dts 18.4 KB, external refs only)
- Inspector: `typecheck:client` ✅ + 232 tests ✅
- Root `typecheck` ✅

## Next (3d-ii-b, 3d-ii-c)

- **3d-ii-b:** mid-tier — `sandboxed-iframe`, `app-tools-registry`, surface store/host, `useToolInputStreaming`; resolve `HOSTED_MODE`/`SANDBOX_ORIGIN`; relocate the `extractMethod`/`stableStringifyJson` values.
- **3d-ii-c:** the renderer + modal + replay; the provider cutover (renderer reads the package `useWidgetHost()` context; inspector wraps the live chat in `<WidgetHostProvider>`); `components.Modal` injection for the design-system dialog + `checkout-dialog`.

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Straight code move with re-export shims; PR states no behavior change and leaves inspector-specific helpers in place.
> 
> **Overview**
> **Tier B Phase 3d-ii-a** moves pure widget detection and tool-result parsing from the inspector into `@mcpjam/widget-react`, ahead of relocating the renderer cluster.
> 
> **`tool-result-utils`** (`readToolResultObject`, `readToolResultMeta`, `readToolResultServerId`) and the **`mcp-apps-utils` core** (`UIType`, `detectUIType`, `detectUiTypeFromTool`, `getUIResourceUri`, plus SEP-1865 tool-visibility re-exports from `@mcpjam/sdk/widget-runtime`) now live under `widget-react/src` and are exported from the package barrel. Inspector paths `@/lib/tool-result-utils` and `@/lib/mcp-ui/mcp-apps-utils` are **re-export shims** only, so renderer/part-switch/widget-replay and other existing import sites stay unchanged.
> 
> **Inspector-only helpers** `isMCPApp`, `isOpenAIApp`, and `isOpenAIAppAndMCPApp` remain in the inspector because they depend on `ListToolsResultWithMetadata`.
> 
> **Package wiring:** `@mcpjam/widget-react` adds `@mcp-ui/client` and `@modelcontextprotocol/client`; tsup marks `@mcp-ui/*` external alongside existing MCP deps. Intended as a no-behavior-change structural step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d41fe4c9cc425c8a63004929f87fab90e6fb49f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->