### PR TITLE
spike: Phase 0 — Claude Code harness on E2B (reference, not for merge)

### DIFF
--- a/experiments/harness-e2b-spike/.gitignore
+++ b/experiments/harness-e2b-spike/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/experiments/harness-e2b-spike/README.md
+++ b/experiments/harness-e2b-spike/README.md
@@ -1,0 +1,65 @@
+# Phase 0 spike — Claude Code harness on E2B
+
+Goal: prove the AI SDK v7 **Claude Code harness** runs on **our E2B setup** (not
+Vercel's sandbox), and that an attached MCP server's tool calls are observable
+with enough fidelity to grade. This is the go/no-go gate before building the
+runtime (E2B provider → `.mcp.json` → `runHarnessTurn` → UI).
+
+## Files
+
+- `e2b-sandbox-provider.ts` — an E2B-backed `HarnessV1SandboxProvider`. The crux
+  of "reuse our E2B": it implements the same contract the reference
+  `@ai-sdk/sandbox-vercel` satisfies. **This is essentially Phase 2's starting
+  point.** Pass `connectToSandboxId` to attach to MCPJam's per-(project,user)
+  computer (reserve → `getComputerSandboxInfo` → sandboxId) instead of creating
+  a fresh sandbox.
+- `spike.ts` — runner: `createClaudeCode` + `HarnessAgent` + the E2B provider +
+  a self-contained stdio MCP server written into the sandbox via
+  `onSandboxSession`, then the two tests.
+
+## What it already proves (no creds needed)
+
+`npm install && npx tsc --noEmit` passes against the real
+`@ai-sdk/harness@1.0.0-canary.13`, `@ai-sdk/harness-claude-code@1.0.0-canary.9`,
+and `e2b@^2`. That validates the biggest unknowns at compile time:
+
+- **The harness sandbox contract is generic, not Vercel-coupled** — an E2B
+  provider satisfies `HarnessV1SandboxProvider` / `HarnessV1NetworkSandboxSession`.
+- **E2B maps cleanly onto it:**
+  | Contract | E2B |
+  |---|---|
+  | `getPortUrl({ port })` (bridge WebSocket) | `sandbox.getHost(port)` |
+  | `readTextFile` / `writeTextFile` / binary / stream | `sandbox.files.read` / `.write` |
+  | `run` / `spawn` | `sandbox.commands.run` (+ `background`) |
+  | `id` / `stop` / `destroy` | `sandbox.sandboxId` / `.kill()` |
+- The adapter wiring compiles: `createClaudeCode({ auth: { anthropic | gateway }, model, thinking })`, `new HarnessAgent({ harness, sandbox, instructions, permissionMode, onSandboxSession })`, `agent.createSession()`, `agent.stream({ session, prompt })`.
+
+## What still needs a real run (creds required)
+
+1. **Port exposure** — confirm the CC bridge's WebSocket actually works over
+   E2B's `getHost` URL (`createSession()` resolving = bridge connected). TEST 1.
+2. **MCP tool-call fidelity** — confirm Claude Code calls the attached MCP tool
+   and the call (name + args) + result reach `fullStream` (sentinel check). TEST 2.
+
+## Run it
+
+```bash
+npm install
+E2B_API_KEY=…  ANTHROPIC_API_KEY=…  npm run spike
+# also honored: ANTHROPIC_AUTH_TOKEN, AI_GATEWAY_API_KEY/_BASE_URL, ANTHROPIC_BASE_URL
+# SPIKE_MODEL (default claude-sonnet-4-5), SPIKE_E2B_TEMPLATE
+```
+
+This environment has only `ANTHROPIC_BASE_URL` set — no E2B or Anthropic key — so
+it has not been run here.
+
+## Open runtime requirements / risks
+
+- **E2B template needs Node** (for the harness bridge + the stdio MCP server).
+  Use a template with Node 20+ (ideally the `claude` CLI / agent SDK pre-baked so
+  cold starts aren't an `npm install`). Set `SPIKE_E2B_TEMPLATE`.
+- **Model id** — `SPIKE_MODEL` default is a guess; set the real current CC model.
+- **Fallback** if the harness proves Vercel-coupled at runtime: drive
+  `@anthropic-ai/claude-agent-sdk` directly inside the E2B sandbox (just needs the
+  provider's command/file/`getHost` primitives) — no dependence on the harness
+  sandbox abstraction.

--- a/experiments/harness-e2b-spike/README.md
+++ b/experiments/harness-e2b-spike/README.md
@@ -34,12 +34,32 @@ and `e2b@^2`. That validates the biggest unknowns at compile time:
   | `id` / `stop` / `destroy` | `sandbox.sandboxId` / `.kill()` |
 - The adapter wiring compiles: `createClaudeCode({ auth: { anthropic | gateway }, model, thinking })`, `new HarnessAgent({ harness, sandbox, instructions, permissionMode, onSandboxSession })`, `agent.createSession()`, `agent.stream({ session, prompt })`.
 
-## What still needs a real run (creds required)
+## Runtime validation — ✅ both gates pass (ran on MCPJam's real E2B)
 
-1. **Port exposure** — confirm the CC bridge's WebSocket actually works over
-   E2B's `getHost` URL (`createSession()` resolving = bridge connected). TEST 1.
-2. **MCP tool-call fidelity** — confirm Claude Code calls the attached MCP tool
-   and the call (name + args) + result reach `fullStream` (sentinel check). TEST 2.
+Executed end-to-end against MCPJam's dev E2B (template `ciq83q75k6orlaznpxo7`,
+`SPIKE_MODEL=claude-sonnet-4-6`, a live Anthropic credential):
+
+- **TEST 1 — port exposure: PASS.** `createSession()` succeeded → the Claude Code
+  bridge WebSocket connected over E2B `getHost`/`getPortUrl`. The harness is not
+  Vercel-coupled; E2B port bridging works.
+- **TEST 2 — MCP tool-call fidelity: PASS.** Claude Code called
+  `mcp__weather__get_weather {"city":"Paris"}` and the result (`…19C and sunny.
+  [SPIKE_SENTINEL]`) reached `fullStream` as a structured tool-result part — not
+  just paraphrased prose. (Bonus: the harness resolves MCP tools via a
+  ToolSearch/deferred-tool step first, which round-trips correctly.)
+
+**Required template fix (found by the run):** the harness bootstrap shells
+`pnpm install` *before* `onSandboxSession`, and the computer template ships
+Node+npm but **no pnpm** (createSession died at `applyBootstrapRecipe`, exit 127).
+Fixed two ways: (1) the provider now provisions pnpm in `createSession`
+(idempotent), and (2) `mcpjam-backend templates/computer/e2b.Dockerfile` now
+bakes it in (needs a template rebuild to take effect).
+
+**Still unverified (Phase 2 runtime checks):**
+- the **reuse path** (`connectToSandboxId` / `Sandbox.connect`) against a
+  `secure: true` box — the create path works, the connect path is untested;
+- **wake-before-connect** + keepalive vs the ~30-min idle-hibernate cron (this
+  run created a fresh box rather than reusing a paused one).
 
 ## Run it
 

--- a/experiments/harness-e2b-spike/README.md
+++ b/experiments/harness-e2b-spike/README.md
@@ -45,21 +45,49 @@ and `e2b@^2`. That validates the biggest unknowns at compile time:
 
 ```bash
 npm install
-E2B_API_KEY=…  ANTHROPIC_API_KEY=…  npm run spike
+E2B_API_KEY=…  ANTHROPIC_API_KEY=…  \
+  SPIKE_E2B_TEMPLATE=ciq83q75k6orlaznpxo7  \
+  npm run spike
 # also honored: ANTHROPIC_AUTH_TOKEN, AI_GATEWAY_API_KEY/_BASE_URL, ANTHROPIC_BASE_URL
-# SPIKE_MODEL (default claude-sonnet-4-5), SPIKE_E2B_TEMPLATE
+# SPIKE_MODEL  (default claude-sonnet-4-6; current Claude ids: claude-sonnet-4-6 / claude-opus-4-8)
+# SPIKE_E2B_TEMPLATE  (MCPJam's computer template ciq83q75k6orlaznpxo7 ships Node 20)
+# SPIKE_E2B_SECURE=false  (provision a non-secure box to isolate harness vs secure-URL issues)
 ```
 
 This environment has only `ANTHROPIC_BASE_URL` set — no E2B or Anthropic key — so
 it has not been run here.
 
-## Open runtime requirements / risks
+## Confirmed by backend investigation
 
-- **E2B template needs Node** (for the harness bridge + the stdio MCP server).
-  Use a template with Node 20+ (ideally the `claude` CLI / agent SDK pre-baked so
-  cold starts aren't an `npm install`). Set `SPIKE_E2B_TEMPLATE`.
-- **Model id** — `SPIKE_MODEL` default is a guess; set the real current CC model.
-- **Fallback** if the harness proves Vercel-coupled at runtime: drive
-  `@anthropic-ai/claude-agent-sdk` directly inside the E2B sandbox (just needs the
-  provider's command/file/`getHost` primitives) — no dependence on the harness
-  sandbox abstraction.
+- **Reuse flow is exactly as guessed:** control plane `getOrReserveComputer`
+  (Convex, idempotent per project+owner, wakes a hibernated box) → data plane
+  `POST /computers/sandbox-info` (inspector server, gated by the
+  `x-computers-data-plane-secret` / `COMPUTERS_DATA_PLANE_SECRET` header) returns
+  `providerComputerId` = the E2B sandboxID = `connectToSandboxId`.
+- **Where this belongs (Phase 2):** the provider + harness driver are *data-plane*
+  code → live in the **inspector server**, authenticate with
+  `COMPUTERS_DATA_PLANE_SECRET`, and call `/computers/sandbox-info` for the
+  sandboxId. Convex stays control-plane only (no E2B SDK). `ownsSandbox=false` for
+  reused boxes already matches the control plane owning teardown.
+- **Template** `ciq83q75k6orlaznpxo7` ships Node 20 + a writable `/opt/npm-global`
+  prefix; it does **not** pre-bake the `claude` CLI / `@anthropic-ai/claude-agent-sdk`
+  (add to `templates/computer/e2b.Dockerfile` for cold-start, or `npm i -g` at session start).
+
+## Gotchas to verify at runtime
+
+1. **`secure: true` boxes.** Prod provisions every computer secure. The provider
+   relies on the SDK resolving the per-sandbox envd token from the org `apiKey` on
+   connect — TEST 1 (the getHost WebSocket) is exactly where a missing token would
+   surface. If it fails, retry with `SPIKE_E2B_SECURE=false` to confirm it's the
+   secure-URL path, then thread the envd token (and have `/computers/sandbox-info`
+   return it for the reuse path).
+2. **Hibernation racing the run.** Boxes auto-pause (~1h E2B timeout; idle cron
+   ~30m). Reuse must wake via `getOrReserveComputer` first (Sandbox.connect won't
+   resume), and keep `lastActiveAt` warm during a long run.
+3. **Egress denylist (SSRF guard).** RFC1918 outbound is blocked. getHost bridge +
+   remote MCP (public URLs) are fine; **local MCP servers must come in over the
+   tunnel relay**, never a private address.
+
+- **Fallback** if the harness proves Vercel-coupled or secure-URL handling is
+  awkward: drive `@anthropic-ai/claude-agent-sdk` directly inside the E2B sandbox
+  (only needs the provider's command/file/`getHost` primitives).

--- a/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
+++ b/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
@@ -87,11 +87,16 @@ export function createE2BSandboxProvider(
 
     createSession: async (createOpts) => {
       const abortSignal = createOpts?.abortSignal;
+      // Only sandboxes WE create are ours to tear down. A reused MCPJam
+      // computer (connectToSandboxId) is shared and lifecycle-managed by the
+      // control plane, so a harness session ending must never kill it.
+      const ownsSandbox = !opts.connectToSandboxId;
       const sandbox = opts.connectToSandboxId
         ? await Sandbox.connect(opts.connectToSandboxId, { apiKey: opts.apiKey })
         : await Sandbox.create(opts.template ?? "base", { apiKey: opts.apiKey });
 
-      let ports: number[] = [bridgePort];
+      // Mutated in place by setPorts so `session.ports` (same ref) stays live.
+      const ports: number[] = [bridgePort];
 
       const session: HarnessV1NetworkSandboxSession = {
         id: sandbox.sandboxId,
@@ -147,6 +152,13 @@ export function createE2BSandboxProvider(
         spawn: async ({ command, workingDirectory, env }) => {
           let outCtl!: ReadableStreamDefaultController<Uint8Array>;
           let errCtl!: ReadableStreamDefaultController<Uint8Array>;
+          let streamsClosed = false;
+          const closeStreams = () => {
+            if (streamsClosed) return;
+            streamsClosed = true;
+            try { outCtl.close(); } catch { /* already closed */ }
+            try { errCtl.close(); } catch { /* already closed */ }
+          };
           const stdout = new ReadableStream<Uint8Array>({
             start: (c) => (outCtl = c),
           });
@@ -157,8 +169,13 @@ export function createE2BSandboxProvider(
             background: true,
             cwd: workingDirectory ?? cwd,
             envs: env,
-            onStdout: (d: string) => outCtl.enqueue(enc.encode(d)),
-            onStderr: (d: string) => errCtl.enqueue(enc.encode(d)),
+            // Guard against enqueue-after-close once the process ends or is killed.
+            onStdout: (d: string) => {
+              if (!streamsClosed) outCtl.enqueue(enc.encode(d));
+            },
+            onStderr: (d: string) => {
+              if (!streamsClosed) errCtl.enqueue(enc.encode(d));
+            },
           });
           return {
             pid: handle.pid,
@@ -166,12 +183,12 @@ export function createE2BSandboxProvider(
             stderr,
             wait: async () => {
               const res = await handle.wait();
-              outCtl.close();
-              errCtl.close();
+              closeStreams();
               return { exitCode: res.exitCode };
             },
             kill: async () => {
               await handle.kill();
+              closeStreams(); // close so consumers don't hang (parity with wait)
             },
           };
         },
@@ -184,13 +201,17 @@ export function createE2BSandboxProvider(
           return `${scheme}://${host}`;
         },
         stop: async () => {
-          await sandbox.kill();
+          // Never tear down a reused (shared) computer; only one we created.
+          if (ownsSandbox) await sandbox.kill();
         },
-        destroy: async () => {
-          await sandbox.kill();
-        },
+        destroy: ownsSandbox
+          ? async () => {
+              await sandbox.kill();
+            }
+          : undefined,
         setPorts: async (next) => {
-          ports = [...next];
+          // Mutate in place so `session.ports` (same reference) reflects it.
+          ports.splice(0, ports.length, ...next);
         },
         // setNetworkPolicy omitted — E2B sets egress at create time; the
         // optional-call contract treats a missing impl as a no-op.

--- a/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
+++ b/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
@@ -24,10 +24,17 @@ import type {
 } from "@ai-sdk/harness";
 
 export interface E2BSandboxProviderOptions {
-  /** E2B template with Node + the claude-agent-sdk available (see README). */
+  /** E2B template with Node + the claude-agent-sdk available (see README).
+   *  MCPJam's computer template is `ciq83q75k6orlaznpxo7` (ships Node 20). */
   template?: string;
-  /** Reuse an existing E2B sandbox (MCPJam computer) instead of creating one. */
+  /** Reuse an existing E2B sandbox (MCPJam computer) instead of creating one.
+   *  The box must already be AWAKE — wake a hibernated computer via the control
+   *  plane (getOrReserveComputer) first; Sandbox.connect won't resume it. */
   connectToSandboxId?: string;
+  /** Mirror prod, which provisions every computer with `secure: true`. */
+  secure?: boolean;
+  /** Keep the box alive long enough for the harness run. */
+  timeoutMs?: number;
   /** Port the in-sandbox bridge binds to; declared via session.ports so the
    *  claude-code adapter picks it up. */
   bridgePort?: number;
@@ -100,8 +107,21 @@ export function createE2BSandboxProvider(
       // control plane, so a harness session ending must never kill it.
       const ownsSandbox = !opts.connectToSandboxId;
       const sandbox = opts.connectToSandboxId
-        ? await Sandbox.connect(opts.connectToSandboxId, { apiKey: opts.apiKey })
-        : await Sandbox.create(opts.template ?? "base", { apiKey: opts.apiKey });
+        ? // Reuse path: box must already be awake (control plane wakes it). For
+          // `secure: true` boxes the SDK resolves the per-sandbox envd token
+          // from the org apiKey on connect — TEST 1 confirms that holds.
+          await Sandbox.connect(opts.connectToSandboxId, {
+            apiKey: opts.apiKey,
+            timeoutMs: opts.timeoutMs,
+          })
+        : // Spike-owned box: mirror prod's `secure: true`. create() returns an
+          // already-tokened, connected instance, so getHost works without extra
+          // wiring. Flip SPIKE_E2B_SECURE=false to isolate harness vs secure-URL.
+          await Sandbox.create(opts.template ?? "base", {
+            apiKey: opts.apiKey,
+            secure: opts.secure ?? true,
+            timeoutMs: opts.timeoutMs,
+          });
 
       // Mutated in place by setPorts so `session.ports` (same ref) stays live.
       const ports: number[] = [bridgePort];

--- a/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
+++ b/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
@@ -1,0 +1,205 @@
+/**
+ * Phase 0 spike — an E2B-backed `HarnessV1SandboxProvider` for the AI SDK
+ * harness. This is the crux of "reuse our E2B setup": it proves (at the type
+ * level, and — with creds — at runtime) that E2B can satisfy the same contract
+ * the reference `@ai-sdk/sandbox-vercel` provider satisfies.
+ *
+ * Contract → E2B mapping (the whole reason this is feasible):
+ *   file I/O (readTextFile/writeTextFile/…) → sandbox.files.read / .write
+ *   exec (run) / spawn                      → sandbox.commands.run (+ background)
+ *   getPortUrl({ port })                    → sandbox.getHost(port)   ← the key one
+ *   id / defaultWorkingDirectory / ports / stop / destroy → native E2B
+ *
+ * Reuse path: pass `connectToSandboxId` to attach to an existing E2B sandbox
+ * (e.g. MCPJam's per-(project,user) computer resolved via reserve →
+ * getComputerSandboxInfo). Omit it and the provider creates a fresh sandbox.
+ *
+ * NOT run in this environment (no E2B_API_KEY) — written against the real
+ * canary `@ai-sdk/harness` types and validated with `tsc`.
+ */
+import { Sandbox } from "e2b";
+import type {
+  HarnessV1NetworkSandboxSession,
+  HarnessV1SandboxProvider,
+} from "@ai-sdk/harness";
+
+export interface E2BSandboxProviderOptions {
+  /** E2B template with Node + the claude-agent-sdk available (see README). */
+  template?: string;
+  /** Reuse an existing E2B sandbox (MCPJam computer) instead of creating one. */
+  connectToSandboxId?: string;
+  /** Port the in-sandbox bridge binds to; declared via session.ports so the
+   *  claude-code adapter picks it up. */
+  bridgePort?: number;
+  /** E2B default home for a standard template. */
+  defaultWorkingDirectory?: string;
+  apiKey?: string;
+}
+
+const enc = new TextEncoder();
+
+/** E2B's files.write `data` accepts string | ArrayBuffer | Blob | ReadableStream
+ *  (not a Uint8Array view), so hand it a clean, exactly-sized ArrayBuffer. */
+function u8ToArrayBuffer(u8: Uint8Array): ArrayBuffer {
+  return u8.slice().buffer as ArrayBuffer;
+}
+
+/** One-chunk ReadableStream from already-materialized bytes. */
+function bytesToStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+async function streamToBytes(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.byteLength;
+  }
+  return out;
+}
+
+export function createE2BSandboxProvider(
+  opts: E2BSandboxProviderOptions = {},
+): HarnessV1SandboxProvider {
+  const bridgePort = opts.bridgePort ?? 39271;
+  const cwd = opts.defaultWorkingDirectory ?? "/home/user";
+
+  return {
+    specificationVersion: "harness-sandbox-v1",
+    providerId: "mcpjam-e2b",
+    // Single-port pool — the bridge leases this one port. (E2B's getHost works
+    // for any listening port regardless, but the adapter reads `ports`.)
+    bridgePorts: [bridgePort],
+
+    createSession: async (createOpts) => {
+      const abortSignal = createOpts?.abortSignal;
+      const sandbox = opts.connectToSandboxId
+        ? await Sandbox.connect(opts.connectToSandboxId, { apiKey: opts.apiKey })
+        : await Sandbox.create(opts.template ?? "base", { apiKey: opts.apiKey });
+
+      let ports: number[] = [bridgePort];
+
+      const session: HarnessV1NetworkSandboxSession = {
+        id: sandbox.sandboxId,
+        defaultWorkingDirectory: cwd,
+        description:
+          `E2B sandbox ${sandbox.sandboxId}. Working dir ${cwd}. ` +
+          `Bridge port ${bridgePort} reachable at ${sandbox.getHost(bridgePort)}.`,
+
+        // ── file I/O ──────────────────────────────────────────────────────
+        readTextFile: async ({ path }) => {
+          try {
+            return await sandbox.files.read(path);
+          } catch {
+            return null; // contract: null when the file is absent
+          }
+        },
+        readBinaryFile: async ({ path }) => {
+          try {
+            return await sandbox.files.read(path, { format: "bytes" });
+          } catch {
+            return null;
+          }
+        },
+        readFile: async ({ path }) => {
+          try {
+            const bytes = await sandbox.files.read(path, { format: "bytes" });
+            return bytesToStream(bytes);
+          } catch {
+            return null;
+          }
+        },
+        writeTextFile: async ({ path, content }) => {
+          await sandbox.files.write([{ path, data: content }]);
+        },
+        writeBinaryFile: async ({ path, content }) => {
+          await sandbox.files.write([{ path, data: u8ToArrayBuffer(content) }]);
+        },
+        writeFile: async ({ path, content }) => {
+          const bytes = await streamToBytes(content);
+          await sandbox.files.write([{ path, data: u8ToArrayBuffer(bytes) }]);
+        },
+
+        // ── exec ──────────────────────────────────────────────────────────
+        run: async ({ command, workingDirectory, env }) => {
+          const res = await sandbox.commands.run(command, {
+            cwd: workingDirectory ?? cwd,
+            envs: env,
+          });
+          return { exitCode: res.exitCode, stdout: res.stdout, stderr: res.stderr };
+        },
+
+        // ── spawn (long-lived; adapt E2B callbacks → ReadableStreams) ──────
+        spawn: async ({ command, workingDirectory, env }) => {
+          let outCtl!: ReadableStreamDefaultController<Uint8Array>;
+          let errCtl!: ReadableStreamDefaultController<Uint8Array>;
+          const stdout = new ReadableStream<Uint8Array>({
+            start: (c) => (outCtl = c),
+          });
+          const stderr = new ReadableStream<Uint8Array>({
+            start: (c) => (errCtl = c),
+          });
+          const handle = await sandbox.commands.run(command, {
+            background: true,
+            cwd: workingDirectory ?? cwd,
+            envs: env,
+            onStdout: (d: string) => outCtl.enqueue(enc.encode(d)),
+            onStderr: (d: string) => errCtl.enqueue(enc.encode(d)),
+          });
+          return {
+            pid: handle.pid,
+            stdout,
+            stderr,
+            wait: async () => {
+              const res = await handle.wait();
+              outCtl.close();
+              errCtl.close();
+              return { exitCode: res.exitCode };
+            },
+            kill: async () => {
+              await handle.kill();
+            },
+          };
+        },
+
+        // ── infra surface ─────────────────────────────────────────────────
+        ports,
+        getPortUrl: async ({ port, protocol }) => {
+          const host = sandbox.getHost(port);
+          const scheme = protocol === "ws" ? "wss" : protocol ?? "https";
+          return `${scheme}://${host}`;
+        },
+        stop: async () => {
+          await sandbox.kill();
+        },
+        destroy: async () => {
+          await sandbox.kill();
+        },
+        setPorts: async (next) => {
+          ports = [...next];
+        },
+        // setNetworkPolicy omitted — E2B sets egress at create time; the
+        // optional-call contract treats a missing impl as a no-op.
+
+        restricted: () => session, // same resource, narrower static type
+      };
+
+      void abortSignal; // create() doesn't take a signal in this spike
+      return session;
+    },
+  };
+}

--- a/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
+++ b/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
@@ -126,6 +126,13 @@ export function createE2BSandboxProvider(
       // Mutated in place by setPorts so `session.ports` (same ref) stays live.
       const ports: number[] = [bridgePort];
 
+      // The @ai-sdk/harness-claude-code bootstrap shells `pnpm install` BEFORE
+      // onSandboxSession runs, and MCPJam's computer template ships Node + npm
+      // but not pnpm — provision it now (idempotent; the writable
+      // /opt/npm-global prefix means `-g` needs no sudo). Real fix: bake pnpm
+      // into templates/computer/e2b.Dockerfile so this no-ops.
+      await sandbox.commands.run("command -v pnpm || npm install -g pnpm");
+
       const session: HarnessV1NetworkSandboxSession = {
         id: sandbox.sandboxId,
         defaultWorkingDirectory: cwd,

--- a/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
+++ b/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
@@ -35,6 +35,10 @@ export interface E2BSandboxProviderOptions {
   secure?: boolean;
   /** Keep the box alive long enough for the harness run. */
   timeoutMs?: number;
+  /** Per-command exec timeout for `run`. E2B foreground commands default to
+   *  ~60s — too short for the harness bootstrap (`pnpm install`). Defaults to
+   *  the sandbox lifetime (`timeoutMs`) or 10 min. */
+  commandTimeoutMs?: number;
   /** Port the in-sandbox bridge binds to; declared via session.ports so the
    *  claude-code adapter picks it up. */
   bridgePort?: number;
@@ -92,6 +96,12 @@ export function createE2BSandboxProvider(
 ): HarnessV1SandboxProvider {
   const bridgePort = opts.bridgePort ?? 39271;
   const cwd = opts.defaultWorkingDirectory ?? "/home/user";
+  // E2B foreground `commands.run` defaults to a ~60s command timeout, separate
+  // from the sandbox's own lifetime — too short for the harness bootstrap
+  // (`pnpm install` of the claude-agent-sdk). Cap commands at the sandbox
+  // lifetime (or 10 min) instead, so a long install isn't killed while the box
+  // is still alive. (spawn/background commands aren't subject to this.)
+  const commandTimeoutMs = opts.commandTimeoutMs ?? opts.timeoutMs ?? 10 * 60_000;
 
   return {
     specificationVersion: "harness-sandbox-v1",
@@ -137,7 +147,9 @@ export function createE2BSandboxProvider(
       // before rethrowing. A reused (shared) box is the control plane's to
       // manage, so never kill it here.
       try {
-        await sandbox.commands.run("command -v pnpm || npm install -g pnpm");
+        await sandbox.commands.run("command -v pnpm || npm install -g pnpm", {
+          timeoutMs: commandTimeoutMs,
+        });
       } catch (err) {
         if (ownsSandbox) {
           try {
@@ -196,6 +208,7 @@ export function createE2BSandboxProvider(
             const res = await sandbox.commands.run(command, {
               cwd: workingDirectory ?? cwd,
               envs: env,
+              timeoutMs: commandTimeoutMs,
             });
             return { exitCode: res.exitCode, stdout: res.stdout, stderr: res.stderr };
           } catch (err) {

--- a/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
+++ b/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
@@ -17,7 +17,7 @@
  * NOT run in this environment (no E2B_API_KEY) — written against the real
  * canary `@ai-sdk/harness` types and validated with `tsc`.
  */
-import { Sandbox } from "e2b";
+import { Sandbox, FileNotFoundError, CommandExitError } from "e2b";
 import type {
   HarnessV1NetworkSandboxSession,
   HarnessV1SandboxProvider,
@@ -37,6 +37,14 @@ export interface E2BSandboxProviderOptions {
 }
 
 const enc = new TextEncoder();
+
+/** E2B throws FileNotFoundError for a missing path; the SandboxSession contract
+ *  wants `null` there, but real failures (transport / permission / sandbox-gone)
+ *  must propagate rather than masquerade as "file absent". */
+function nullIfMissing(err: unknown): null {
+  if (err instanceof FileNotFoundError) return null;
+  throw err;
+}
 
 /** E2B's files.write `data` accepts string | ArrayBuffer | Blob | ReadableStream
  *  (not a Uint8Array view), so hand it a clean, exactly-sized ArrayBuffer. */
@@ -109,23 +117,23 @@ export function createE2BSandboxProvider(
         readTextFile: async ({ path }) => {
           try {
             return await sandbox.files.read(path);
-          } catch {
-            return null; // contract: null when the file is absent
+          } catch (err) {
+            return nullIfMissing(err); // null only for a genuinely missing file
           }
         },
         readBinaryFile: async ({ path }) => {
           try {
             return await sandbox.files.read(path, { format: "bytes" });
-          } catch {
-            return null;
+          } catch (err) {
+            return nullIfMissing(err);
           }
         },
         readFile: async ({ path }) => {
           try {
             const bytes = await sandbox.files.read(path, { format: "bytes" });
             return bytesToStream(bytes);
-          } catch {
-            return null;
+          } catch (err) {
+            return nullIfMissing(err);
           }
         },
         writeTextFile: async ({ path, content }) => {
@@ -141,11 +149,20 @@ export function createE2BSandboxProvider(
 
         // ── exec ──────────────────────────────────────────────────────────
         run: async ({ command, workingDirectory, env }) => {
-          const res = await sandbox.commands.run(command, {
-            cwd: workingDirectory ?? cwd,
-            envs: env,
-          });
-          return { exitCode: res.exitCode, stdout: res.stdout, stderr: res.stderr };
+          try {
+            const res = await sandbox.commands.run(command, {
+              cwd: workingDirectory ?? cwd,
+              envs: env,
+            });
+            return { exitCode: res.exitCode, stdout: res.stdout, stderr: res.stderr };
+          } catch (err) {
+            // E2B throws on non-zero exit; the contract wants the result
+            // (exitCode + streams) surfaced, not a rejection.
+            if (err instanceof CommandExitError) {
+              return { exitCode: err.exitCode, stdout: err.stdout, stderr: err.stderr };
+            }
+            throw err;
+          }
         },
 
         // ── spawn (long-lived; adapt E2B callbacks → ReadableStreams) ──────
@@ -177,18 +194,35 @@ export function createE2BSandboxProvider(
               if (!streamsClosed) errCtl.enqueue(enc.encode(d));
             },
           });
+          // Observe exit exactly once; normalize E2B's throw-on-nonzero into an
+          // exit code so wait() resolves (contract) instead of rejecting.
+          const exitPromise: Promise<{ exitCode: number }> = handle
+            .wait()
+            .then((r) => ({ exitCode: r.exitCode }))
+            .catch((err) => {
+              if (err instanceof CommandExitError) return { exitCode: err.exitCode };
+              throw err;
+            });
+          // Close streams when the process ends on its OWN — not only via
+          // wait()/kill() — so a consumer reading to EOF never hangs.
+          void exitPromise.then(closeStreams, closeStreams);
           return {
             pid: handle.pid,
             stdout,
             stderr,
             wait: async () => {
-              const res = await handle.wait();
-              closeStreams();
-              return { exitCode: res.exitCode };
+              try {
+                return await exitPromise;
+              } finally {
+                closeStreams();
+              }
             },
             kill: async () => {
-              await handle.kill();
-              closeStreams(); // close so consumers don't hang (parity with wait)
+              try {
+                await handle.kill();
+              } finally {
+                closeStreams(); // parity with wait; never leave readers hanging
+              }
             },
           };
         },

--- a/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
+++ b/experiments/harness-e2b-spike/e2b-sandbox-provider.ts
@@ -131,7 +131,23 @@ export function createE2BSandboxProvider(
       // but not pnpm — provision it now (idempotent; the writable
       // /opt/npm-global prefix means `-g` needs no sudo). Real fix: bake pnpm
       // into templates/computer/e2b.Dockerfile so this no-ops.
-      await sandbox.commands.run("command -v pnpm || npm install -g pnpm");
+      //
+      // If this throws, the caller never receives a session to tear down, so a
+      // box WE created would leak until its E2B timeout — kill an owned box
+      // before rethrowing. A reused (shared) box is the control plane's to
+      // manage, so never kill it here.
+      try {
+        await sandbox.commands.run("command -v pnpm || npm install -g pnpm");
+      } catch (err) {
+        if (ownsSandbox) {
+          try {
+            await sandbox.kill();
+          } catch {
+            /* best effort — surface the original setup error, not a kill error */
+          }
+        }
+        throw err;
+      }
 
       const session: HarnessV1NetworkSandboxSession = {
         id: sandbox.sandboxId,

--- a/experiments/harness-e2b-spike/package-lock.json
+++ b/experiments/harness-e2b-spike/package-lock.json
@@ -1,0 +1,2420 @@
+{
+  "name": "harness-e2b-spike",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "harness-e2b-spike",
+      "dependencies": {
+        "@ai-sdk/harness": "^1.0.0-canary.13",
+        "@ai-sdk/harness-claude-code": "^1.0.0-canary.9",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.178",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ai": "^7.0.0-canary.176",
+        "e2b": "^2.30.0",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@types/node": "^25.9.3",
+        "tsx": "^4.22.4",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.0-canary.107",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.0-canary.107.tgz",
+      "integrity": "sha512-BPmARy2rc0ChkmoMhrmHa+L5lg7HWO8BZ1bMEWx3m3wH6lSy7a2CFu4T28PC2qaCPuWgpu5+PnSWC9eMpZh9rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.0-canary.18",
+        "@ai-sdk/provider-utils": "5.0.0-canary.48",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/harness": {
+      "version": "1.0.0-canary.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/harness/-/harness-1.0.0-canary.13.tgz",
+      "integrity": "sha512-SCifKEH8VmOOLTWVZSsvxPbOHWd7a2puJMP1jS0LAmqxQwVm+DtPoPdW9iWAe8fORkhhRK2TzbBFi+JtbsDbrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.0-canary.18",
+        "@ai-sdk/provider-utils": "5.0.0-canary.48",
+        "ai": "7.0.0-canary.176"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "ws": "^8.20.1"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/harness-claude-code": {
+      "version": "1.0.0-canary.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/harness-claude-code/-/harness-claude-code-1.0.0-canary.9.tgz",
+      "integrity": "sha512-sfewPgZF3HxXoxcCECeCEGNkGlh9b/mJE3yClIEImG27nAvBPQV+CUc8obP5WK19i1fWq68F+FtGuXVCkPvkUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/harness": "1.0.0-canary.13",
+        "@ai-sdk/provider-utils": "5.0.0-canary.48",
+        "ws": "^8.20.1",
+        "zod": "3.25.76"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/harness-claude-code/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.0-canary.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.0-canary.18.tgz",
+      "integrity": "sha512-+XBwXEPkN+l/90bb7TaSK15jAq9ScsGrauJ/NLSGip0KX5Mf1pfEfqBWDuJMIYVRYHNdV1dDBy7JCoKUCQe/tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.0-canary.48",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.0-canary.48.tgz",
+      "integrity": "sha512-340rMqAnqHDZOKS9ayrRbNr0/Om+orcopAnqJ7ftfEskxDUCTcudmhAhctFMSQeMzDnKaBPgz+4iff/hn7PkqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.0-canary.18",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.178.tgz",
+      "integrity": "sha512-PNsz20jWuahDWq7OU+pjrgYzr2TnpC1oj5yCZDxGWJ8OvucXIdD2AYlf/vUo7oE2JJwGbMTBFqXErNrfPi6Ffw==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.178",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.178",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.178",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.178",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.178",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.178",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.178",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.178"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.178.tgz",
+      "integrity": "sha512-RmIJRoZfjwcrd7cHR3fJOL1d4L8SN7oB0REcQPbIuPM1vav2Ft3g5hBX7I86u52A4LLFKBc3SMom3+E6lR1YtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.178.tgz",
+      "integrity": "sha512-wfNl7JoaUk9IzKWQPr+hyEOX8qnkM+e4GBZnKISh60xVhW9wOOp5RdfnYj5MoJzaLYivMSCbo5rb4ThWguhOMw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.178.tgz",
+      "integrity": "sha512-ktBU6EdJoZivf67AxRXe2uSwj0g5tCe20So9QvWVKuEEtRA4sXW5EpgxSWT6LXkgfwUoeNsJK7VAOuVjZumKmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.178.tgz",
+      "integrity": "sha512-Z3U0fNatVK3vkki3e5sjlLJMjros+cT6uq//tdohB2kjNK1CugUuPQFQxd6GU1Lq1DokmdSEPL4OGdKiHckNdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.178.tgz",
+      "integrity": "sha512-CPTivDz27LMn5m9iQnJSoWkztLo41e8QTbuYKlAC+CTr98gaYy3Mao0M2tirEK/nGno0xRJw/EpZ1G61yEM3yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.178.tgz",
+      "integrity": "sha512-K84Ybyr0Olsslg2I1Tzd7KIcSkZgFqqDHn7q1Dfqi7bXVxjMjJ4SaV+LnEAeHSM2es7H8A7ejoTEl89xMZde4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.178.tgz",
+      "integrity": "sha512-uKH3vgv7cQV3d9BPU4lrUKrFgoU/flmy/1QI62j9JzgE6uWVQKWC+BI4V7iceJ36tYVneRhjjuux+l+Q8egTHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.178",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.178.tgz",
+      "integrity": "sha512-wSC5qG6UA1laWGylOU7axuC4NQxZJtibGQ79sYeOQCc05G7CfkUKSzszLOzsPP3eK63cKi/bX5PA6dd4nA5Wow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.104.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
+      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
+      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.3.tgz",
+      "integrity": "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "2.0.0-rc.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.0-canary.176",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.0-canary.176.tgz",
+      "integrity": "sha512-0a+PeTou1uLouzrlLaEZNyBj21oFyYCI1BeOrP9uLJ2YGW6tsUAGME6zetfDdbl/bouIc4neUA36sH7mNjNp1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.0-canary.107",
+        "@ai-sdk/provider": "4.0.0-canary.18",
+        "@ai-sdk/provider-utils": "5.0.0-canary.48"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dockerfile-ast": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
+      "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/e2b": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.30.0.tgz",
+      "integrity": "sha512-4kvfwh3QfPukrYmWEhrVLxL3WnQabzHabvhIRmvk6oU/YTWQtCrlZX+jaA9XBtVI/vQUbu5E5a6GlOhDXmcKzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.6.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-web": "2.0.0-rc.3",
+        "chalk": "^5.3.0",
+        "compare-versions": "^6.1.0",
+        "dockerfile-ast": "^0.7.1",
+        "glob": "^11.1.0",
+        "openapi-fetch": "^0.14.1",
+        "platform": "^1.3.6",
+        "tar": "^7.5.11",
+        "undici": "^7.25.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/experiments/harness-e2b-spike/package.json
+++ b/experiments/harness-e2b-spike/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "harness-e2b-spike",
+  "private": true,
+  "type": "module",
+  "description": "Phase 0 de-risking spike: run the AI SDK Claude Code harness on E2B (reuse MCPJam's E2B), prove port exposure + MCP tool-call fidelity.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "spike": "tsx spike.ts"
+  },
+  "dependencies": {
+    "@ai-sdk/harness": "^1.0.0-canary.13",
+    "@ai-sdk/harness-claude-code": "^1.0.0-canary.9",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.178",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ai": "^7.0.0-canary.176",
+    "e2b": "^2.30.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3"
+  }
+}

--- a/experiments/harness-e2b-spike/spike.ts
+++ b/experiments/harness-e2b-spike/spike.ts
@@ -123,48 +123,57 @@ const agent = new HarnessAgent({
 async function main() {
   console.log("[spike] creating session (proves bridge reachable via getHost)…");
   const session = await agent.createSession();
-  console.log(`[spike] ✅ TEST 1 PASS — session ${session.sessionId} started; ` +
-    `the Claude Code bridge connected over E2B getHost/getPortUrl.`);
+  try {
+    console.log(`[spike] ✅ TEST 1 PASS — session ${session.sessionId} started; ` +
+      `the Claude Code bridge connected over E2B getHost/getPortUrl.`);
 
-  const res = await agent.stream({
-    session,
-    prompt: "What's the weather in Paris right now? Use your tools.",
-  });
+    const res = await agent.stream({
+      session,
+      prompt: "What's the weather in Paris right now? Use your tools.",
+    });
 
-  const toolCalls: Array<{ name: string; input: unknown }> = [];
-  const toolResults: string[] = [];
-  // The harness fullStream part union is broad; read it loosely at this
-  // boundary (spike-only) and classify by `type`.
-  for await (const part of res.fullStream as AsyncIterable<any>) {
-    if (typeof part?.type !== "string") continue;
-    if (part.type === "tool-call" || part.type === "tool-input-available") {
-      toolCalls.push({ name: part.toolName, input: part.input ?? part.args });
-      console.log(`[spike] tool-call: ${part.toolName}`, JSON.stringify(part.input ?? part.args));
-    } else if (part.type === "tool-result" || part.type === "tool-output-available") {
-      const text = JSON.stringify(part.output ?? part.result ?? "");
-      toolResults.push(text);
-      console.log(`[spike] tool-result: ${part.toolName} → ${text}`);
+    const toolCalls: Array<{ name: string; input: unknown }> = [];
+    const toolResults: string[] = [];
+    // The harness fullStream part union is broad; read it loosely at this
+    // boundary (spike-only) and classify by `type`.
+    for await (const part of res.fullStream as AsyncIterable<any>) {
+      if (typeof part?.type !== "string") continue;
+      if (part.type === "tool-call" || part.type === "tool-input-available") {
+        toolCalls.push({ name: part.toolName, input: part.input ?? part.args });
+        console.log(`[spike] tool-call: ${part.toolName}`, JSON.stringify(part.input ?? part.args));
+      } else if (part.type === "tool-result" || part.type === "tool-output-available") {
+        const text = JSON.stringify(part.output ?? part.result ?? "");
+        toolResults.push(text);
+        console.log(`[spike] tool-result: ${part.toolName} → ${text}`);
+      }
     }
-  }
-  const finalText = await res.text;
-  console.log("[spike] final text:", finalText);
+    const finalText = await res.text;
+    console.log("[spike] final text:", finalText);
 
-  // TEST 2: the MCP tool was actually called, with args + result detail.
-  const calledWeather = toolCalls.some((c) => c.name === "get_weather");
-  const sawSentinel =
-    toolResults.some((r) => r.includes("SPIKE_SENTINEL")) ||
-    finalText.includes("19C") ||
-    finalText.toLowerCase().includes("sunny");
-  if (calledWeather && sawSentinel) {
+    // TEST 2: the MCP tool was actually called, with args + result detail.
+    // Claude Code namespaces MCP tools as `mcp__<server>__<tool>` (here
+    // `mcp__weather__get_weather`), so match by substring, not exact name.
+    const calledWeather = toolCalls.some(
+      (c) => typeof c.name === "string" && c.name.includes("get_weather"),
+    );
+    const sawSentinel =
+      toolResults.some((r) => r.includes("SPIKE_SENTINEL")) ||
+      finalText.includes("19C") ||
+      finalText.toLowerCase().includes("sunny");
+    if (!calledWeather || !sawSentinel) {
+      // Throw → non-zero exit (via main().catch) so CI/automation gates on it.
+      throw new Error(
+        `TEST 2 FAIL — calledWeather=${calledWeather} sawSentinel=${sawSentinel}. ` +
+          `Tool-call detail insufficient to grade; inspect the raw parts above ` +
+          `(fallback: drive @anthropic-ai/claude-agent-sdk directly).`,
+      );
+    }
     console.log("[spike] ✅ TEST 2 PASS — Claude Code called the MCP tool and its " +
       "result (name + args + output) was observable for grading.");
-  } else {
-    console.log(`[spike] ❌ TEST 2 FAIL — calledWeather=${calledWeather} ` +
-      `sawSentinel=${sawSentinel}. Tool-call detail insufficient to grade; ` +
-      `inspect the raw parts above (fallback: drive @anthropic-ai/claude-agent-sdk directly).`);
+  } finally {
+    // Guarantee teardown even if streaming or the assertion throws.
+    await session.destroy();
   }
-
-  await session.destroy();
   console.log("[spike] done.");
 }
 

--- a/experiments/harness-e2b-spike/spike.ts
+++ b/experiments/harness-e2b-spike/spike.ts
@@ -68,7 +68,7 @@ rl.on("line", (line) => {
 `;
 
 const harness = createClaudeCode({
-  model: process.env.SPIKE_MODEL ?? "claude-sonnet-4-5",
+  model: process.env.SPIKE_MODEL ?? "claude-sonnet-4-6",
   thinking: "off",
   // Auth shape is { anthropic } | { gateway }. Prefer the gateway when present.
   auth: process.env.AI_GATEWAY_API_KEY
@@ -89,8 +89,11 @@ const harness = createClaudeCode({
 
 const sandbox = createE2BSandboxProvider({
   apiKey: e2bKey,
-  // Reuse MCPJam's computer by passing connectToSandboxId here instead.
-  template: process.env.SPIKE_E2B_TEMPLATE, // must have node (+ ideally claude CLI)
+  // Reuse MCPJam's computer by passing connectToSandboxId here instead (wake it
+  // via getOrReserveComputer first; Sandbox.connect won't resume a paused box).
+  template: process.env.SPIKE_E2B_TEMPLATE, // e.g. ciq83q75k6orlaznpxo7 (has Node)
+  secure: process.env.SPIKE_E2B_SECURE !== "false", // mirror prod (secure: true)
+  timeoutMs: 15 * 60 * 1000, // keep the box alive for the run
   bridgePort: 39271,
 });
 

--- a/experiments/harness-e2b-spike/spike.ts
+++ b/experiments/harness-e2b-spike/spike.ts
@@ -1,0 +1,174 @@
+/**
+ * Phase 0 de-risking spike — run the real Claude Code harness on E2B and prove:
+ *   1. PORT EXPOSURE: the harness bridge is reachable over E2B `getHost` (the
+ *      session starting at all = the bridge WebSocket connected over getPortUrl).
+ *   2. MCP TOOL-CALL FIDELITY: an attached MCP server's tool is actually called
+ *      by Claude Code, and the call (name + args) + result reach our stream with
+ *      enough detail to grade.
+ *
+ * RUN: needs E2B_API_KEY + an Anthropic credential. From this dir:
+ *   E2B_API_KEY=… ANTHROPIC_API_KEY=… npm run spike
+ * (Or AI_GATEWAY_API_KEY / ANTHROPIC_AUTH_TOKEN; ANTHROPIC_BASE_URL is honored.)
+ *
+ * It is NOT run in this environment (no creds). It is written against the real
+ * canary `@ai-sdk/harness` + `@ai-sdk/harness-claude-code` APIs and validated
+ * with `tsc --noEmit`.
+ */
+import { HarnessAgent } from "@ai-sdk/harness/agent";
+import { createClaudeCode } from "@ai-sdk/harness-claude-code";
+import { createE2BSandboxProvider } from "./e2b-sandbox-provider.js";
+
+const e2bKey = process.env.E2B_API_KEY;
+const anthropicAuth =
+  process.env.ANTHROPIC_API_KEY ??
+  process.env.ANTHROPIC_AUTH_TOKEN ??
+  process.env.AI_GATEWAY_API_KEY;
+
+if (!e2bKey || !anthropicAuth) {
+  console.error(
+    "[spike] Missing creds. Set E2B_API_KEY and one of " +
+      "ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN / AI_GATEWAY_API_KEY.",
+  );
+  process.exit(1);
+}
+
+/** Self-contained stdio MCP server (newline-delimited JSON-RPC) — no deps to
+ *  install in the sandbox; just needs `node`. Exposes one tool whose result
+ *  carries a sentinel so we can confirm it flowed back through Claude Code. */
+const WEATHER_MCP_SERVER = String.raw`
+import readline from "node:readline";
+const rl = readline.createInterface({ input: process.stdin });
+const send = (m) => process.stdout.write(JSON.stringify(m) + "\n");
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  let req; try { req = JSON.parse(line); } catch { return; }
+  const { id, method, params } = req;
+  if (method === "initialize") {
+    send({ jsonrpc: "2.0", id, result: {
+      protocolVersion: "2025-06-18",
+      capabilities: { tools: {} },
+      serverInfo: { name: "weather-spike", version: "0.0.1" },
+    }});
+  } else if (method === "tools/list") {
+    send({ jsonrpc: "2.0", id, result: { tools: [{
+      name: "get_weather",
+      description: "Get the current weather for a city.",
+      inputSchema: { type: "object", properties: { city: { type: "string" } }, required: ["city"] },
+    }]}});
+  } else if (method === "tools/call") {
+    const city = params?.arguments?.city ?? "unknown";
+    send({ jsonrpc: "2.0", id, result: { content: [{
+      type: "text",
+      text: "The weather in " + city + " is 19C and sunny. [SPIKE_SENTINEL]",
+    }]}});
+  } else if (id !== undefined) {
+    send({ jsonrpc: "2.0", id, error: { code: -32601, message: "method not found" } });
+  }
+});
+`;
+
+const harness = createClaudeCode({
+  model: process.env.SPIKE_MODEL ?? "claude-sonnet-4-5",
+  thinking: "off",
+  // Auth shape is { anthropic } | { gateway }. Prefer the gateway when present.
+  auth: process.env.AI_GATEWAY_API_KEY
+    ? {
+        gateway: {
+          apiKey: process.env.AI_GATEWAY_API_KEY,
+          baseUrl: process.env.AI_GATEWAY_BASE_URL,
+        },
+      }
+    : {
+        anthropic: {
+          apiKey: process.env.ANTHROPIC_API_KEY,
+          authToken: process.env.ANTHROPIC_AUTH_TOKEN,
+          baseUrl: process.env.ANTHROPIC_BASE_URL,
+        },
+      },
+});
+
+const sandbox = createE2BSandboxProvider({
+  apiKey: e2bKey,
+  // Reuse MCPJam's computer by passing connectToSandboxId here instead.
+  template: process.env.SPIKE_E2B_TEMPLATE, // must have node (+ ideally claude CLI)
+  bridgePort: 39271,
+});
+
+const agent = new HarnessAgent({
+  harness,
+  sandbox,
+  instructions:
+    "You are validating MCP tool wiring. When asked about the weather you MUST " +
+    "call the `get_weather` MCP tool and report its result verbatim.",
+  permissionMode: "allow-all",
+  onSandboxSession: async ({ session, sessionWorkDir }) => {
+    // Write the MCP server + a .mcp.json pointing at it (stdio) into the
+    // session workdir, before Claude Code starts — same hook the product would
+    // use to attach the host's MCP servers (remote: url+headers; local: tunnel).
+    await session.writeTextFile({
+      path: `${sessionWorkDir}/weather-mcp.mjs`,
+      content: WEATHER_MCP_SERVER,
+    });
+    await session.writeTextFile({
+      path: `${sessionWorkDir}/.mcp.json`,
+      content: JSON.stringify({
+        mcpServers: {
+          weather: { command: "node", args: [`${sessionWorkDir}/weather-mcp.mjs`] },
+        },
+      }),
+    });
+  },
+});
+
+async function main() {
+  console.log("[spike] creating session (proves bridge reachable via getHost)…");
+  const session = await agent.createSession();
+  console.log(`[spike] ✅ TEST 1 PASS — session ${session.sessionId} started; ` +
+    `the Claude Code bridge connected over E2B getHost/getPortUrl.`);
+
+  const res = await agent.stream({
+    session,
+    prompt: "What's the weather in Paris right now? Use your tools.",
+  });
+
+  const toolCalls: Array<{ name: string; input: unknown }> = [];
+  const toolResults: string[] = [];
+  // The harness fullStream part union is broad; read it loosely at this
+  // boundary (spike-only) and classify by `type`.
+  for await (const part of res.fullStream as AsyncIterable<any>) {
+    if (typeof part?.type !== "string") continue;
+    if (part.type === "tool-call" || part.type === "tool-input-available") {
+      toolCalls.push({ name: part.toolName, input: part.input ?? part.args });
+      console.log(`[spike] tool-call: ${part.toolName}`, JSON.stringify(part.input ?? part.args));
+    } else if (part.type === "tool-result" || part.type === "tool-output-available") {
+      const text = JSON.stringify(part.output ?? part.result ?? "");
+      toolResults.push(text);
+      console.log(`[spike] tool-result: ${part.toolName} → ${text}`);
+    }
+  }
+  const finalText = await res.text;
+  console.log("[spike] final text:", finalText);
+
+  // TEST 2: the MCP tool was actually called, with args + result detail.
+  const calledWeather = toolCalls.some((c) => c.name === "get_weather");
+  const sawSentinel =
+    toolResults.some((r) => r.includes("SPIKE_SENTINEL")) ||
+    finalText.includes("19C") ||
+    finalText.toLowerCase().includes("sunny");
+  if (calledWeather && sawSentinel) {
+    console.log("[spike] ✅ TEST 2 PASS — Claude Code called the MCP tool and its " +
+      "result (name + args + output) was observable for grading.");
+  } else {
+    console.log(`[spike] ❌ TEST 2 FAIL — calledWeather=${calledWeather} ` +
+      `sawSentinel=${sawSentinel}. Tool-call detail insufficient to grade; ` +
+      `inspect the raw parts above (fallback: drive @anthropic-ai/claude-agent-sdk directly).`);
+  }
+
+  await session.destroy();
+  console.log("[spike] done.");
+}
+
+main().catch((err) => {
+  console.error("[spike] ERROR:", err);
+  process.exit(1);
+});

--- a/experiments/harness-e2b-spike/spike.ts
+++ b/experiments/harness-e2b-spike/spike.ts
@@ -126,6 +126,7 @@ const agent = new HarnessAgent({
 async function main() {
   console.log("[spike] creating session (proves bridge reachable via getHost)…");
   const session = await agent.createSession();
+  let primaryError: unknown;
   try {
     console.log(`[spike] ✅ TEST 1 PASS — session ${session.sessionId} started; ` +
       `the Claude Code bridge connected over E2B getHost/getPortUrl.`);
@@ -177,9 +178,18 @@ async function main() {
     }
     console.log("[spike] ✅ TEST 2 PASS — Claude Code called the MCP tool and its " +
       "result (name + args + output) was observable for grading.");
+  } catch (err) {
+    primaryError = err;
+    throw err;
   } finally {
-    // Guarantee teardown even if streaming or the assertion throws.
-    await session.destroy();
+    // Tear down even on failure — but never let a destroy error mask the real
+    // cause of a test failure.
+    try {
+      await session.destroy();
+    } catch (destroyErr) {
+      if (primaryError === undefined) throw destroyErr;
+      console.error("[spike] WARN: session.destroy failed:", destroyErr);
+    }
   }
   console.log("[spike] done.");
 }

--- a/experiments/harness-e2b-spike/spike.ts
+++ b/experiments/harness-e2b-spike/spike.ts
@@ -156,15 +156,19 @@ async function main() {
     const calledWeather = toolCalls.some(
       (c) => typeof c.name === "string" && c.name.includes("get_weather"),
     );
-    const sawSentinel =
-      toolResults.some((r) => r.includes("SPIKE_SENTINEL")) ||
-      finalText.includes("19C") ||
-      finalText.toLowerCase().includes("sunny");
-    if (!calledWeather || !sawSentinel) {
+    // Strict: the sentinel must appear in a fullStream tool-RESULT chunk. The
+    // point of TEST 2 is gradeable tool-result fidelity *in the stream* — the
+    // model merely paraphrasing "sunny/19C" in its prose does NOT count, since
+    // that wouldn't give us the structured result an eval grader needs.
+    const sawSentinelInStream = toolResults.some((r) =>
+      r.includes("SPIKE_SENTINEL"),
+    );
+    if (!calledWeather || !sawSentinelInStream) {
       // Throw → non-zero exit (via main().catch) so CI/automation gates on it.
       throw new Error(
-        `TEST 2 FAIL — calledWeather=${calledWeather} sawSentinel=${sawSentinel}. ` +
-          `Tool-call detail insufficient to grade; inspect the raw parts above ` +
+        `TEST 2 FAIL — calledWeather=${calledWeather} ` +
+          `sawSentinelInStream=${sawSentinelInStream}. Tool-result detail not ` +
+          `observable in fullStream for grading; inspect the raw parts above ` +
           `(fallback: drive @anthropic-ai/claude-agent-sdk directly).`,
       );
     }

--- a/experiments/harness-e2b-spike/tsconfig.json
+++ b/experiments/harness-e2b-spike/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Phase 0 spike — does the Claude Code harness run on our E2B? (reference, **not for merge**)

De-risking spike for the runtime behind a `harness: "claude-code"` host config. Lives in `experiments/harness-e2b-spike/` — an **isolated, non-workspace dir**, so the monorepo install/CI ignore it (canary deps stay out of the root).

### Result: ✅ compile-validated against the real canary APIs (no creds needed)

`tsc --noEmit` passes against `@ai-sdk/harness@1.0.0-canary.13`, `@ai-sdk/harness-claude-code@1.0.0-canary.9`, and `e2b@^2`. That settles the biggest unknown — **the harness sandbox contract is generic, not Vercel-coupled**, and E2B satisfies it:

| `HarnessV1NetworkSandboxSession` | E2B |
|---|---|
| `getPortUrl({ port })` — bridge WebSocket | `sandbox.getHost(port)` |
| `readTextFile`/`writeTextFile`/binary/stream | `sandbox.files.read` / `.write` |
| `run` / `spawn` | `sandbox.commands.run` (+ `background`) |
| `id` / `stop` / `destroy` | `sandbox.sandboxId` / `.kill()` |

`e2b-sandbox-provider.ts` is effectively **Phase 2's starting point** — it takes `connectToSandboxId` to reuse MCPJam's per-(project,user) computer (reserve → `getComputerSandboxInfo` → sandboxId).

### Still needs a real run (creds)

The two runtime go/no-go checks in `spike.ts` need `E2B_API_KEY` + an Anthropic credential — not present in this session (only `ANTHROPIC_BASE_URL` is set), so it hasn't been executed:

1. **Port exposure** — the CC bridge's WebSocket actually works over E2B's `getHost` URL.
2. **MCP tool-call fidelity** — Claude Code calls an attached MCP server's tool and the call (name+args) + result reach `fullStream` (sentinel check).

```bash
cd experiments/harness-e2b-spike && npm install
E2B_API_KEY=…  ANTHROPIC_API_KEY=…  npm run spike
```

### Open requirements / fallback
- E2B template needs **Node** (for the harness bridge + the stdio MCP server) — ideally with the `claude` CLI/agent SDK pre-baked. Set `SPIKE_E2B_TEMPLATE`.
- `SPIKE_MODEL` default is a guess — set the real current CC model.
- If the harness proves Vercel-coupled at runtime: drive `@anthropic-ai/claude-agent-sdk` directly inside the E2B sandbox (only needs the provider's command/file/`getHost` primitives).

Provide creds (or point me at how MCPJam's E2B is reached from a worker) and I'll run it and report the two results; then Phase 2 builds on `e2b-sandbox-provider.ts`.

https://claude.ai/code/session_014PZ5uDgrDvnwuScwUbr5jb

---
_Generated by [Claude Code](https://claude.ai/code/session_014PZ5uDgrDvnwuScwUbr5jb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to `experiments/` with their own lockfile; no production paths or auth flows are modified.
> 
> **Overview**
> Adds an isolated **`experiments/harness-e2b-spike/`** package (not wired into the monorepo workspace) to de-risk running the AI SDK v7 **Claude Code harness** on **MCPJam’s E2B** instead of Vercel’s sandbox.
> 
> **`createE2BSandboxProvider`** implements `HarnessV1SandboxProvider` / `HarnessV1NetworkSandboxSession` on top of E2B: file I/O, `run`/`spawn`, **`getPortUrl` via `getHost`**, lifecycle (`stop`/`destroy`), optional **`connectToSandboxId`** reuse without killing shared computers, **`secure: true`** by default, longer command timeouts for harness bootstrap, and **idempotent pnpm provisioning** before bootstrap (workaround for templates that only ship npm).
> 
> **`spike.ts`** wires `createClaudeCode` + `HarnessAgent`, drops a stdio MCP server and `.mcp.json` via `onSandboxSession`, and gates on two runtime checks: bridge/session over E2B ports, and **MCP tool calls + structured tool results** (sentinel in `fullStream`, not prose). README documents compile-time validation, successful runs on the dev template, Phase 2 placement (inspector data plane), and remaining unverified paths (reuse/connect, hibernation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640b850d0103f00ff89d54307c6b49f0ae0866b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->