### PR TITLE
fix(test): repoint cross-matrix-isolation guard at the relocated useToolInputStreaming impl

### DIFF
--- a/.changeset/fix-cross-matrix-guard.md
+++ b/.changeset/fix-cross-matrix-guard.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Restore the cross-matrix-isolation guard's coverage after 3d-ii-b. The
+`useToolInputStreaming` source-text assertion was reading the inspector path,
+which became a re-export shim when the module relocated to `@mcpjam/widget-react`
+— so the guard no longer scanned the real implementation. Repointed it at
+`widget-react/src/useToolInputStreaming.ts` so the two-matrix architecture
+defense keeps inspecting the actual code. Test-only.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/cross-matrix-isolation.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/cross-matrix-isolation.test.ts
@@ -81,9 +81,16 @@ describe("cross-matrix isolation", () => {
     // (SEP-1865 spec bridge). PR B will gate it on the MCP Apps
     // matrix; today it gates on nothing matrix-related. Either way,
     // it must never read OpenAI shim refs.
-    const body = await readSource("../useToolInputStreaming.ts");
+    //
+    // The implementation relocated to @mcpjam/widget-react in Phase
+    // 3d-ii-b (the inspector `../useToolInputStreaming.ts` is now only a
+    // re-export shim). Scan the REAL source in the package so this guard
+    // keeps defending the actual code, not the shim.
+    const body = await readSource(
+      "../../../../../../../../widget-react/src/useToolInputStreaming.ts",
+    );
     assertNoRefs(body, OPENAI_SHIM_RUNTIME_REFS, {
-      module: "useToolInputStreaming.ts",
+      module: "widget-react/src/useToolInputStreaming.ts",
       surface: "MCP Apps spec bridge (app.*)",
     });
   });


### PR DESCRIPTION
## Context

Follow-up to a gap the reviewer caught in #2725 (3d-ii-b). When `useToolInputStreaming` relocated to `@mcpjam/widget-react`, the inspector path became a re-export shim — but `cross-matrix-isolation.test.ts` reads module **source text** to enforce the two-matrix architecture rule, and it was still reading `../useToolInputStreaming.ts` (now the shim). So that assertion passed trivially without scanning the real implementation, silently weakening the guard.

## Fix

Repoint only the `useToolInputStreaming` assertion at the relocated source (`widget-react/src/useToolInputStreaming.ts`) so the guard inspects the actual code again. The modal + `AppsExtensionTab` assertions are unchanged — those files are still in the inspector.

Test-only; no runtime change.

## Verification

`cross-matrix-isolation.test.ts` — 4 tests pass against the real source (`readFile` would throw on a bad path, so the read is confirmed).

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only path and assertion target change; no production code or architecture behavior is modified.
> 
> **Overview**
> After **3d-ii-b** moved `useToolInputStreaming` into `@mcpjam/widget-react`, the inspector file became a **re-export shim**. The **cross-matrix-isolation** test still read that shim’s source, so the OpenAI-shim ref check no longer covered the real implementation and the guard was effectively weakened.
> 
> This PR **repoints only that assertion** to `widget-react/src/useToolInputStreaming.ts` and updates the assertion’s module label/comments. Modal and `AppsExtensionTab` checks are unchanged. A **changeset** notes a test-only inspector patch.
> 
> **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d317897c18db34072256d30357203e80b601563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->