### PR TITLE
docs(changelog): note the `mcpjam mcp` stdio server command

### DIFF
--- a/docs/changelog/overview.mdx
+++ b/docs/changelog/overview.mdx
@@ -28,6 +28,12 @@ This changelog tracks all notable changes to MCPJam Inspector. We follow [Semant
 
 #### Added
 
+- **MCPJam CLI as an MCP server (`mcpjam mcp`)**
+  - New `mcpjam mcp` command runs MCPJam itself as a stdio MCP server, so MCP clients without shell access (Claude Desktop, Claude Code, Cursor, custom agents) can use the testing engine as tools
+  - Connect to, exercise, and debug other MCP servers: connection management, tool/resource/prompt calls, and stateless `server doctor` / `probe` diagnostics
+  - Connections stay open across tool calls, so agents can observe notifications and session behavior that one-shot commands can't
+  - See [MCPJam as an MCP server](/cli/mcp-server)
+
 - **OAuth Protocol 2025-03-26 Support**
   - Added support for original MCP OAuth specification (2025-03-26)
   - Direct RFC8414 discovery from MCP server base URL with fallback endpoints


### PR DESCRIPTION
## What

Adds a changelog entry for the `mcpjam mcp` command that shipped in #2639.

## Why

#2639 already shipped the full docs for the feature — a dedicated guide (`docs/cli/mcp-server.mdx`), an entry in the CLI overview table + section, the `mcp` command reference, and the `docs.json` nav wiring. The one docs surface it didn't touch was the **changelog**, so this adds a single entry under *Recent Updates → Added* pointing at the existing guide.

## Change

One 6-line bullet in `docs/changelog/overview.mdx`:

> **MCPJam CLI as an MCP server (`mcpjam mcp`)** — runs MCPJam itself as a stdio MCP server so clients without shell access (Claude Desktop, Claude Code, Cursor, custom agents) can use the testing engine as tools; connect/exercise/debug other MCP servers; connections stay open across calls so agents can observe notifications. Links to [MCPJam as an MCP server](/cli/mcp-server).

Docs-only; no code changes.

https://claude.ai/code/session_0163CCNS3TbamHGa2SWkRJmf

---
_Generated by [Claude Code](https://claude.ai/code/session_0163CCNS3TbamHGa2SWkRJmf)_