### PR TITLE
Tier B Phase 3d-ii (values): relocate extractMethod + stableStringifyJson to @mcpjam/sdk/widget-runtime

### DIFF
--- a/.changeset/widget-relocate-json-utils-3d-ii-c1.md
+++ b/.changeset/widget-relocate-json-utils-3d-ii-c1.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": patch
+---
+
+Tier B Phase 3d-ii (value relocation): move the pure `extractMethod` +
+`stableStringifyJson` helpers into `@mcpjam/sdk/widget-runtime` so the
+(relocating) widget renderer and the inspector share one framework-free impl
+instead of duplicating it across the package boundary.
+
+The inspector's `@/stores/traffic-log-store` and `@/lib/client-config` now import
+the helpers from the SDK and re-export them for back-compat, so every existing
+import site is unchanged. No behavior change.

--- a/mcpjam-inspector/client/src/lib/client-config.ts
+++ b/mcpjam-inspector/client/src/lib/client-config.ts
@@ -4,6 +4,9 @@ import {
   mergeClientCapabilities,
   normalizeClientCapabilities,
 } from "@mcpjam/sdk/browser";
+// `stableStringifyJson` relocated to the SDK widget-runtime (Phase 3d-ii);
+// imported for internal use and re-exported below so existing import sites stay.
+import { stableStringifyJson } from "@mcpjam/sdk/widget-runtime";
 
 export type ProjectClientConfig = {
   version: 1;
@@ -353,25 +356,10 @@ export function normalizeProjectClientCapabilities(
   );
 }
 
-function canonicalizeJsonValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(canonicalizeJsonValue);
-  }
-
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, nestedValue]) => [key, canonicalizeJsonValue(nestedValue)]),
-    );
-  }
-
-  return value;
-}
-
-export function stableStringifyJson(value: unknown): string {
-  return JSON.stringify(canonicalizeJsonValue(value));
-}
+// `stableStringifyJson` (+ its private canonicalizer) relocated to
+// @mcpjam/sdk/widget-runtime (Phase 3d-ii); re-exported for back-compat with
+// `@/lib/client-config` consumers.
+export { stableStringifyJson };
 
 export function projectClientCapabilitiesNeedReconnect(args: {
   desiredCapabilities?: Record<string, unknown>;

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -18,6 +18,9 @@ import type {
   OAuthTraceSource,
   OAuthTraceStepStatus,
 } from "@/lib/oauth/oauth-trace";
+// `extractMethod` relocated to the SDK widget-runtime (Phase 3d-ii); imported
+// for internal use and re-exported below so existing import sites are unchanged.
+import { extractMethod } from "@mcpjam/sdk/widget-runtime";
 
 export type UiProtocol = "mcp-apps" | "openai-apps";
 export type McpServerLogKind = "rpc" | "oauth";
@@ -249,27 +252,6 @@ export function subscribeToRpcStream(): () => void {
   };
 }
 
-/**
- * Helper to extract method name from message based on protocol
- */
-export function extractMethod(message: unknown, protocol?: UiProtocol): string {
-  // OpenAI Apps: extract from "type" field (e.g., "openai:callTool" → "callTool")
-  if (protocol === "openai-apps") {
-    const msg = message as { type?: string };
-    if (typeof msg?.type === "string") {
-      return msg.type.replace("openai:", "");
-    }
-    return "unknown";
-  }
-
-  // MCP Apps (JSON-RPC): extract from method/result/error
-  const msg = message as {
-    method?: string;
-    result?: unknown;
-    error?: unknown;
-  };
-  if (typeof msg?.method === "string") return msg.method;
-  if (msg?.result !== undefined) return "result";
-  if (msg?.error !== undefined) return "error";
-  return "unknown";
-}
+// `extractMethod` is imported from @mcpjam/sdk/widget-runtime (Phase 3d-ii) and
+// re-exported here for back-compat with `@/stores/traffic-log-store` consumers.
+export { extractMethod };

--- a/sdk/src/widget-runtime/index.ts
+++ b/sdk/src/widget-runtime/index.ts
@@ -17,6 +17,9 @@ export {
 
 export { LoggingTransport } from "./logging-transport.js";
 
+// Pure JSON helpers shared with the inspector + widget renderer (Phase 3d-ii).
+export { extractMethod, stableStringifyJson } from "./json-utils.js";
+
 export {
   DEFAULT_IFRAME_SANDBOX,
   buildOuterAllowAttribute,

--- a/sdk/src/widget-runtime/json-utils.ts
+++ b/sdk/src/widget-runtime/json-utils.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure JSON helpers shared by the widget runtime and the inspector. Framework-
+ * free, browser- and Node-safe. Relocated here from the inspector in Phase
+ * 3d-ii so the (soon-to-relocate) widget renderer and the inspector share one
+ * implementation instead of duplicating it across the package boundary.
+ */
+
+function canonicalizeJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeJsonValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, canonicalizeJsonValue(nestedValue)]),
+    );
+  }
+
+  return value;
+}
+
+/** Deterministic JSON: deep object-key sort, then `JSON.stringify`. */
+export function stableStringifyJson(value: unknown): string {
+  return JSON.stringify(canonicalizeJsonValue(value));
+}
+
+/**
+ * Extract a method/label from a widget transport message. MCP Apps messages are
+ * JSON-RPC (`method`/`result`/`error`); OpenAI-shim messages carry an
+ * `openai:`-prefixed `type`. `protocol` defaults to the JSON-RPC reading.
+ */
+export function extractMethod(
+  message: unknown,
+  protocol?: "mcp-apps" | "openai-apps",
+): string {
+  // OpenAI Apps: extract from "type" (e.g., "openai:callTool" → "callTool").
+  if (protocol === "openai-apps") {
+    const msg = message as { type?: string };
+    if (typeof msg?.type === "string") {
+      return msg.type.replace("openai:", "");
+    }
+    return "unknown";
+  }
+
+  // MCP Apps (JSON-RPC): extract from method/result/error.
+  const msg = message as {
+    method?: string;
+    result?: unknown;
+    error?: unknown;
+  };
+  if (typeof msg?.method === "string") return msg.method;
+  if (msg?.result !== undefined) return "result";
+  if (msg?.error !== undefined) return "error";
+  return "unknown";
+}


### PR DESCRIPTION
## Context

First step of the **3d-ii cutover**. The widget renderer uses `extractMethod` + `stableStringifyJson` at module scope (e.g. `getPersistentSurfaceId`), so they must be package-accessible before the renderer relocates. The architecturally-correct home is the shared SDK (both inspector and package depend *down* on it), not the package (which would invert the layering).

## What moves

`extractMethod` (JSON-RPC / OpenAI-shim method label) and `stableStringifyJson` (+ its private canonicalizer) → **`@mcpjam/sdk/widget-runtime`** (new `json-utils.ts`), exported from the widget-runtime barrel. Both are pure + framework-free, fitting the subpath's existing contract ("Browser- and Node-safe: no React, no inspector-internal imports").

The inspector's `@/stores/traffic-log-store` and `@/lib/client-config` now **import them from the SDK** (for their own internal use) and **re-export for back-compat** — so every existing import site (the store internals, `client-config`, the widget-host shim, the renderer/modal) is unchanged.

## Publish-surface note

This grows the SDK's public API by two **pure** functions — clean to publish (unlike the deferred `HostConfigMcpProfileV1` / `Tool` items on the publish-readiness checklist).

## Verification

- SDK: build ✅ · typecheck ✅ · test ✅ (1492 passed, incl. packaging which validates the subpath exports)
- Inspector: `typecheck:client` ✅ + traffic-log + renderer tests ✅
- Root `typecheck` ✅

No behavior change.

## Next

`sandboxed-iframe` + `widget-file-messages` + `widget-surface-store/context` (config/service resolution), then the renderer + modal + replay cutover (provider switch + `components.Modal` injection).

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical move with re-exports preserving call sites; pure helpers with no auth or data-path changes.
> 
> **Overview**
> **Tier B Phase 3d-ii** centralizes two pure helpers in `@mcpjam/sdk/widget-runtime` via new `json-utils.ts`: **`stableStringifyJson`** (canonical JSON for capability comparisons) and **`extractMethod`** (traffic-log labels for MCP JSON-RPC vs OpenAI-shim messages).
> 
> The inspector drops duplicate implementations in `client-config` and `traffic-log-store`, **imports from the SDK**, and **re-exports** so existing `@/lib/client-config` and `@/stores/traffic-log-store` import paths stay the same. The widget-runtime barrel now exports both functions, expanding the SDK’s public surface ahead of relocating the widget renderer.
> 
> No intended behavior change; changeset bumps `@mcpjam/sdk` minor and `@mcpjam/inspector` patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c20e1a3029d766390a23df599f5e768583a3bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->