### PR TITLE
fix(docker): copy widget-react workspace into inspector image build

### DIFF
--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -23,6 +23,7 @@ COPY sdk/package.json ./sdk/package.json
 COPY cli/package.json ./cli/package.json
 COPY design-system/package.json ./design-system/package.json
 COPY chat-ui/package.json ./chat-ui/package.json
+COPY widget-react/package.json ./widget-react/package.json
 COPY mcpjam-inspector/package.json ./mcpjam-inspector/package.json
 
 RUN npm ci --legacy-peer-deps
@@ -74,6 +75,12 @@ COPY design-system ./design-system
 # chat-ui workspace must be on disk before `build:client` runs. It is consumed
 # from source, not from a built dist, so no chat-ui build step is needed.
 COPY chat-ui ./chat-ui
+# The inspector client aliases `@mcpjam/widget-react` to
+# `../widget-react/src/index.ts` (see client/vite.config.ts), so — like chat-ui —
+# the widget-react workspace source must be on disk before `build:client` runs.
+# Consumed from source, not from a built dist, so no widget-react build step is
+# needed.
+COPY widget-react ./widget-react
 COPY mcpjam-inspector/client ./mcpjam-inspector/client
 COPY mcpjam-inspector/.env.production ./mcpjam-inspector/
 RUN npm run bundle:browser-harness -w @mcpjam/inspector && \


### PR DESCRIPTION
## Problem

PR previews (and the next staging/prod inspector deploy) are **broken at build time**, not at runtime. The Railway domain provisions, but nothing is served behind it — hence the "the train has not arrived at the station" 404.

The image build fails in the `build:client` step:

```
[vite:load-fallback] Could not load /usr/src/app/widget-react/src/index.ts
  (imported by client/src/lib/mcp-ui/mcp-apps-utils.ts): ENOENT
✗ Build failed in 4.63s
```

## Root cause

Tier B Phase 3d-ii (#2723) introduced the `@mcpjam/widget-react` workspace and made the inspector client import it. `client/vite.config.ts` resolves it **from source**:

```js
const widgetReactEntry = path.resolve(rootDir, "../widget-react/src/index.ts");
// "@mcpjam/widget-react": widgetReactEntry
```

…exactly like `@mcpjam/chat-ui`. But `mcpjam-inspector/Dockerfile` was never updated to copy the `widget-react` workspace into the build image, so `widget-react/src/index.ts` doesn't exist in the build context and vite can't resolve the alias.

## Impact

`main` and the same Dockerfile build previews **and** staging/prod, so this blocks every PR preview since #2723 merged and the next production deploy.

## Fix

Mirror the existing `chat-ui` handling:
- **deps stage** — copy `widget-react/package.json` so `npm ci` sees the workspace.
- **build stage** — copy the `widget-react` source before `build:client`.

Consumed from source (like chat-ui), so no widget-react build step is needed. widget-react's only `@mcpjam/*` dependency is `@mcpjam/sdk`, which is already built earlier in the Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-context-only change mirroring existing chat-ui handling; no runtime or application logic changes.
> 
> **Overview**
> **Unblocks inspector Docker builds** that started failing after the client began resolving `@mcpjam/widget-react` from source (same pattern as `@mcpjam/chat-ui`).
> 
> The **`deps` stage** now copies `widget-react/package.json` so workspace install sees the package. The **`build` stage** copies the full `widget-react` tree before `build:client`, so Vite can load `../widget-react/src/index.ts` instead of hitting ENOENT. No separate widget-react build step is added—source-only consumption matches the existing chat-ui setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b1d144b319035373307055b1ce1adc7e656e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->