### PR TITLE
fix(sdk): make stableStringifyJson key sort locale-independent

### DIFF
--- a/.changeset/fix-stable-stringify-determinism.md
+++ b/.changeset/fix-stable-stringify-determinism.md
@@ -1,0 +1,8 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Fix `stableStringifyJson` determinism: sort object keys by code-unit order
+instead of `localeCompare()`, which is host-locale-dependent and can reorder
+non-ASCII keys across environments — undermining the function's stable-output
+guarantee. ASCII keys (the overwhelming majority) are unaffected.

--- a/sdk/src/widget-runtime/json-utils.ts
+++ b/sdk/src/widget-runtime/json-utils.ts
@@ -13,7 +13,10 @@ function canonicalizeJsonValue(value: unknown): unknown {
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
+        // Code-unit (locale-independent) order so output is deterministic across
+        // environments — `localeCompare` without an explicit locale is
+        // host-dependent and can reorder non-ASCII keys per environment.
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
         .map(([key, nestedValue]) => [key, canonicalizeJsonValue(nestedValue)]),
     );
   }


### PR DESCRIPTION
## Context

Follow-up to a valid CodeRabbit finding on #2728 (value relocation) that merged before the fix landed.

`stableStringifyJson` (relocated to `@mcpjam/sdk/widget-runtime` in #2728) sorted object keys with `localeCompare()`. Without an explicit locale that's **host-dependent** — different ICU/locale data can reorder non-ASCII keys across environments, which undermines the function's whole point (deterministic output).

## Fix

Sort by **code-unit order** (`left < right ? -1 : left > right ? 1 : 0`) — locale-independent and deterministic everywhere.

- ASCII keys (the overwhelming majority of JSON keys) sort identically under both, so this is a no-op for virtually all real inputs.
- The output is only used for **in-session equality** (`getPersistentSurfaceId` hashing, `projectClientCapabilitiesNeedReconnect` diffing) — not persisted/compared across versions — so changing the non-ASCII ordering is safe.

## Verification

SDK build ✅ + typecheck ✅ (the identical change passed the full SDK suite — 1492 tests — during #2728's verification).

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line sort change in a pure JSON helper; ASCII keys unchanged and output is used only for in-session equality, not persisted cross-version comparisons.
> 
> **Overview**
> **`stableStringifyJson`** in `@mcpjam/sdk` now sorts object keys using **code-unit comparison** instead of **`localeCompare()`**, so canonical JSON output is the same across hosts regardless of ICU/locale settings.
> 
> Non-ASCII keys could previously order differently per environment, which broke the intended stable string guarantee. ASCII-only keys behave the same as before. A patch **changeset** documents the SDK fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49129c016e660edf673ff6e7881a833295c2768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->