### PR TITLE
Tier B Phase 3d-iii: harden @mcpjam/widget-react public surface (drop internal SDK types)

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/use-widget-host.tsx
@@ -207,6 +207,12 @@ export function useWidgetHost(): WidgetHostImpl {
   const chatboxHostTheme = useChatboxHostTheme();
   const hostCapabilitiesOverride = useChatboxHostCapabilitiesOverride();
   const activeMcpProfile = useActiveMcpProfile();
+  // The profile is bound into the resolvers below (3d-iii) — it no longer leaves
+  // the inspector as a typed object. Read into a ref so the resolver fns keep a
+  // stable identity (never invalidating a renderer memo) while still resolving
+  // against the live profile; the renderer recomputes via `environment.profileKey`.
+  const activeMcpProfileRef = useRef(activeMcpProfile);
+  activeMcpProfileRef.current = activeMcpProfile;
   const draftHostContext = useHostContextStore((s) => s.draftHostContext);
   const isPlaygroundActive = useUIPlaygroundStore((s) => s.isPlaygroundActive);
   const playgroundLocale = useUIPlaygroundStore((s) => s.globals.locale);
@@ -225,7 +231,11 @@ export function useWidgetHost(): WidgetHostImpl {
       chatboxHostStyle,
       chatboxHostTheme,
       hostCapabilitiesOverride,
-      activeMcpProfile,
+      // Profile is bound in `resolvers`; expose only the reactivity hash + the
+      // minimal projections the renderer inspects (no `HostConfigMcpProfileV1`).
+      profileKey: stableStringifyJson(activeMcpProfile ?? null),
+      profileSandbox: activeMcpProfile?.apps?.sandbox,
+      profileHostInfo: activeMcpProfile?.apps?.uiInitialize?.hostInfo,
       draftHostContext,
       isPlaygroundActive,
       playgroundLocale,
@@ -254,14 +264,29 @@ export function useWidgetHost(): WidgetHostImpl {
   );
 
   // --- resolvers (Phase 1b bound util/resolver fns) --------------------------
-  // Module-level fns with stable identity; the object is frozen for the
-  // adapter's lifetime so it never invalidates a renderer memo/dep.
+  // Stable identity (frozen for the adapter's lifetime) so it never invalidates
+  // a renderer memo/dep. The profile-dependent resolvers BIND the active MCP
+  // profile here (read live via the ref) so `HostConfigMcpProfileV1` stays out
+  // of the public `WidgetHostResolvers` surface (3d-iii).
   const resolvers = useMemo<WidgetHostResolvers>(
     () => ({
-      resolveEffectiveCompatRuntime,
-      resolveEffectiveMcpAppsCapabilities,
-      resolveEffectiveHostCapabilities,
-      resolveHostInfo,
+      resolveEffectiveCompatRuntime: ({ hostStyle }) =>
+        resolveEffectiveCompatRuntime({
+          profile: activeMcpProfileRef.current,
+          hostStyle,
+        }),
+      resolveEffectiveMcpAppsCapabilities: ({ hostStyle }) =>
+        resolveEffectiveMcpAppsCapabilities({
+          profile: activeMcpProfileRef.current,
+          hostStyle,
+        }),
+      resolveEffectiveHostCapabilities: ({ hostStyle, hostCapabilitiesOverride }) =>
+        resolveEffectiveHostCapabilities({
+          hostStyle,
+          profile: activeMcpProfileRef.current,
+          hostCapabilitiesOverride,
+        }),
+      resolveHostInfo: () => resolveHostInfo(activeMcpProfileRef.current),
       getHostStyleOrDefault,
       DEFAULT_HOST_STYLE,
       extractHostTheme,

--- a/widget-react/src/index.ts
+++ b/widget-react/src/index.ts
@@ -18,6 +18,7 @@ export {
   getToolVisibility,
   isVisibleToModelOnly,
   isVisibleToAppOnly,
+  type ToolLike,
 } from "./mcp-apps-utils";
 export {
   readToolResultObject,

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -649,14 +649,13 @@ export function MCPAppsRendererSurface({
   const chatboxHostStyle = environment.chatboxHostStyle;
   const chatboxHostTheme = environment.chatboxHostTheme;
   const hostCapabilitiesOverride = environment.hostCapabilitiesOverride;
-  // Active hostConfig.mcpProfile from the surrounding scope (chatbox
-  // session, project default, eval suite). Drives the resolver below
-  // when set; undefined preserves widget-derived sandbox behavior.
-  const activeMcpProfile = environment.activeMcpProfile;
-  const activeMcpProfileKey = useMemo(
-    () => resolvers.stableStringifyJson(activeMcpProfile ?? null),
-    [activeMcpProfile]
-  );
+  // Active hostConfig.mcpProfile from the surrounding scope (chatbox session,
+  // project default, eval suite) is bound inside the adapter's resolvers (3d-iii);
+  // the renderer keys its capability memos on `profileKey` and reads only the
+  // minimal projections it inspects (sandbox overrides + hostInfo override).
+  const activeMcpProfileKey = environment.profileKey;
+  const profileSandbox = environment.profileSandbox;
+  const profileHostInfo = environment.profileHostInfo;
   const hostCapabilitiesOverrideKey = useMemo(
     () => resolvers.stableStringifyJson(hostCapabilitiesOverride ?? null),
     [hostCapabilitiesOverride]
@@ -670,7 +669,6 @@ export function MCPAppsRendererSurface({
   const liveEffectiveCompatRuntime = useMemo(
     () =>
       resolvers.resolveEffectiveCompatRuntime({
-        profile: activeMcpProfile,
         hostStyle: chatboxHostStyle ?? sharedHostStyle,
       }),
     [activeMcpProfileKey, chatboxHostStyle, sharedHostStyle]
@@ -798,7 +796,6 @@ export function MCPAppsRendererSurface({
   const earlyEffectiveMcpAppsCapabilities = useMemo(
     () =>
       resolvers.resolveEffectiveMcpAppsCapabilities({
-        profile: activeMcpProfile,
         hostStyle: earlyEffectiveHostStyle,
       }),
     [activeMcpProfileKey, earlyEffectiveHostStyle]
@@ -2098,7 +2095,6 @@ export function MCPAppsRendererSurface({
     () =>
       resolvers.resolveEffectiveHostCapabilities({
         hostStyle: effectiveHostStyle,
-        profile: activeMcpProfile,
         hostCapabilitiesOverride,
       }),
     [effectiveHostStyle, activeMcpProfileKey, hostCapabilitiesOverrideKey]
@@ -2283,11 +2279,11 @@ export function MCPAppsRendererSurface({
   // — SandboxedIframe treats `permissive: true` as "skip CSP injection
   // entirely", which would silently neuter the resolver output.
   const sandboxCspPolicy = useMemo(
-    () => activeMcpProfile?.apps?.sandbox?.csp,
+    () => profileSandbox?.csp,
     [activeMcpProfileKey]
   );
   const sandboxPermissionsPolicy = useMemo(
-    () => activeMcpProfile?.apps?.sandbox?.permissions,
+    () => profileSandbox?.permissions,
     [activeMcpProfileKey]
   );
   // Inspector-only emission knobs sourced directly from the profile. They
@@ -2295,15 +2291,15 @@ export function MCPAppsRendererSurface({
   // that has no spec slot (raw `sandbox=`/`allow=` tokens, CSP source
   // expressions). Passed through unchanged to <SandboxedIframe>.
   const sandboxAttrsPolicy = useMemo(
-    () => activeMcpProfile?.apps?.sandbox?.sandboxAttrs,
+    () => profileSandbox?.sandboxAttrs,
     [activeMcpProfileKey]
   );
   const allowFeaturesPolicy = useMemo(
-    () => activeMcpProfile?.apps?.sandbox?.allowFeatures,
+    () => profileSandbox?.allowFeatures,
     [activeMcpProfileKey]
   );
   const cspDirectivesPolicy = useMemo(
-    () => activeMcpProfile?.apps?.sandbox?.csp?.cspDirectives,
+    () => profileSandbox?.csp?.cspDirectives,
     [activeMcpProfileKey]
   );
   // Hosted-mode clamp for cspDirectives. The resolver's
@@ -2680,7 +2676,7 @@ export function MCPAppsRendererSurface({
     name: string;
     version: string;
   } | null>(() => {
-    const raw = activeMcpProfile?.apps?.uiInitialize?.hostInfo;
+    const raw = profileHostInfo;
     if (!raw || typeof raw !== "object") return null;
     const name = (raw as { name?: unknown }).name;
     const version = (raw as { version?: unknown }).version;
@@ -2690,7 +2686,7 @@ export function MCPAppsRendererSurface({
   }, [activeMcpProfileKey]);
   const resolvedBridgeHostInfo = useMemo(
     () =>
-      (resolvers.resolveHostInfo(activeMcpProfile) ?? {
+      (resolvers.resolveHostInfo() ?? {
         name: "mcpjam-inspector",
         version: __APP_VERSION__,
       }) as { name: string; version: string },

--- a/widget-react/src/mcp-apps-utils.ts
+++ b/widget-react/src/mcp-apps-utils.ts
@@ -5,7 +5,16 @@
 // need an inspector api type) and re-exports this core.
 import { isUIResource } from "@mcp-ui/client";
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type { Tool } from "@modelcontextprotocol/client";
+
+/**
+ * Minimal structural shape `detectUiTypeFromTool` needs — just the `_meta` bag.
+ * Kept structural (rather than importing `Tool` from
+ * `@modelcontextprotocol/client`) so the package's public detection surface
+ * doesn't pin a specific MCP SDK Tool type; any `{ _meta }`-bearing tool works.
+ */
+export interface ToolLike {
+  _meta?: Record<string, unknown>;
+}
 
 // SEP-1865 tool-visibility helpers live in the framework-free SDK leaf so the
 // host bridge and the renderer share one model-only visibility check. Re-exported
@@ -23,7 +32,7 @@ export enum UIType {
   MCP_UI = "mcp-ui",
 }
 
-export function detectUiTypeFromTool(tool: Tool): UIType | null {
+export function detectUiTypeFromTool(tool: ToolLike): UIType | null {
   const toolMeta = tool._meta;
   if (!toolMeta) return null;
   return detectUIType(toolMeta, undefined);

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -23,8 +23,12 @@ import type {
   McpUiResourcePermissions,
   McpUiStyles,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type { HostConfigMcpProfileV1 } from "@mcpjam/sdk/host-config/internal";
-import type { MCPPrompt, MCPResourceTemplate } from "@mcpjam/sdk/browser";
+import type {
+  MCPPrompt,
+  MCPResourceTemplate,
+  SandboxCspPolicy,
+  SandboxPermissionsPolicy,
+} from "@mcpjam/sdk/browser";
 
 // --- Primitives --------------------------------------------------------------
 
@@ -427,9 +431,28 @@ export interface WidgetHostEnvironment {
 }
 
 /**
+ * Minimal structural projection of `mcpProfile.apps.sandbox` (the host-policy
+ * sandbox overrides the renderer reads directly). The full `HostConfigMcpProfileV1`
+ * is bound inside the inspector adapter's resolvers and never enters the public
+ * surface; only these read-by-the-renderer fields are projected here. `csp` is
+ * the SDK `SandboxCspPolicy` plus the inspector-only `cspDirectives` escape hatch.
+ */
+export interface WidgetHostProfileSandbox {
+  csp?: SandboxCspPolicy & { cspDirectives?: Record<string, string[]> };
+  permissions?: SandboxPermissionsPolicy;
+  sandboxAttrs?: string[];
+  allowFeatures?: Record<string, string>;
+}
+
+/**
  * Raw ambient ENV inputs the renderer reads (Phase 1b). The inspector's
  * use-widget-host adapter supplies these from its stores/contexts; these are
  * structural mirrors of the inspector store/context shapes.
+ *
+ * The active MCP profile (`HostConfigMcpProfileV1`) is NOT exposed as a typed
+ * object — it is bound inside the adapter's resolvers (3d-iii). The renderer
+ * instead reads `profileKey` (a reactivity hash) plus the minimal structural
+ * projections it actually inspects (`profileSandbox`, `profileHostInfo`).
  */
 export interface WidgetHostEnvironmentInputs {
   themeMode: ThemeMode;
@@ -437,7 +460,16 @@ export interface WidgetHostEnvironmentInputs {
   chatboxHostStyle: ChatboxHostStyle | null;
   chatboxHostTheme: "light" | "dark" | null;
   hostCapabilitiesOverride: Record<string, unknown> | undefined;
-  activeMcpProfile: HostConfigMcpProfileV1 | undefined;
+  /**
+   * Stable hash of the active MCP profile. The profile object is bound in the
+   * adapter's resolvers; the renderer keys its capability memos on this so they
+   * recompute when the profile changes without the profile type leaking here.
+   */
+  profileKey: string;
+  /** `mcpProfile.apps.sandbox` projection (host-policy sandbox overrides). */
+  profileSandbox: WidgetHostProfileSandbox | undefined;
+  /** `mcpProfile.apps.uiInitialize.hostInfo` projection (AppBridge identity override). */
+  profileHostInfo: { name?: unknown; version?: unknown } | undefined;
   draftHostContext: ProjectHostContextDraft;
   isPlaygroundActive: boolean;
   playgroundLocale: string;
@@ -456,23 +488,22 @@ export interface WidgetHostEnvironmentInputs {
  * client-config implementations; typed structurally so the package owns no
  * inspector code. Drift is caught where the adapter assigns the real fns.
  */
+// The profile-dependent resolvers no longer take a `profile` argument — the
+// inspector adapter binds the active `HostConfigMcpProfileV1` into them, so the
+// profile type stays out of the public surface. `profileKey` drives the
+// renderer's recompute reactivity.
 export interface WidgetHostResolvers {
   resolveEffectiveCompatRuntime: (args: {
-    profile: HostConfigMcpProfileV1 | undefined;
     hostStyle: ChatboxHostStyle | string | null | undefined;
   }) => EffectiveCompatRuntime;
   resolveEffectiveMcpAppsCapabilities: (args: {
-    profile: HostConfigMcpProfileV1 | undefined;
     hostStyle: ChatboxHostStyle | string | null | undefined;
   }) => ResolvedMcpAppsCapabilities;
   resolveEffectiveHostCapabilities: (args: {
     hostStyle: string | null | undefined;
-    profile?: HostConfigMcpProfileV1;
     hostCapabilitiesOverride?: Record<string, unknown>;
   }) => ResolvedHostCapabilities;
-  resolveHostInfo: (
-    profile: HostConfigMcpProfileV1 | undefined,
-  ) => ResolvedHostInfo;
+  resolveHostInfo: () => ResolvedHostInfo;
   getHostStyleOrDefault: (id: string | null | undefined) => ResolvedHostStyle;
   DEFAULT_HOST_STYLE: ResolvedHostStyle;
   extractHostTheme: (
@@ -578,10 +609,11 @@ export interface WidgetHostServices {
 
 export interface WidgetHost {
   /**
-   * Resolved per-server environment — the deferred `resolveEnvironment` target.
-   * OPTIONAL: Phase 1b reads the raw `environment` inputs + `resolvers` instead.
-   * Folding into this (and dropping the raw inputs + the `HostConfigMcpProfileV1`
-   * surface) is the publish-ready pass (3d-iii).
+   * Resolved per-server environment — the deferred fully-pre-resolved target.
+   * OPTIONAL: the renderer reads the raw `environment` inputs + `resolvers`
+   * instead. 3d-iii already removed the `HostConfigMcpProfileV1` type from the
+   * public surface (the profile is bound inside the adapter's resolvers);
+   * collapsing `environment` + `resolvers` entirely into this is a later step.
    */
   resolveEnvironment?: (serverId: string | undefined) => WidgetHostEnvironment;
   /** Raw ambient ENV inputs (Phase 1b); supplied by the inspector adapter. */


### PR DESCRIPTION
## What

Removes inspector-internal / unstable types from `@mcpjam/widget-react`'s **published type surface** so it's publish-ready — **no runtime behavior change**.

### 1. `HostConfigMcpProfileV1` (from `@mcpjam/sdk/host-config/internal`) no longer leaks
The renderer treated the active MCP profile almost opaquely — it only (a) passed it to the profile-dependent resolvers and (b) read `apps.sandbox.*` + `apps.uiInitialize.hostInfo`. So:
- The profile-dependent resolvers (`resolveEffectiveCompatRuntime`, `resolveEffectiveMcpAppsCapabilities`, `resolveEffectiveHostCapabilities`, `resolveHostInfo`) **drop their `profile` parameter** — the inspector adapter now **binds** the live profile into them (read via a ref for stable identity).
- `WidgetHostEnvironmentInputs.activeMcpProfile` is replaced by:
  - `profileKey` — a reactivity hash so the renderer's capability memos still recompute when the profile changes,
  - `profileSandbox` (`WidgetHostProfileSandbox`, built on the **stable** `@mcpjam/sdk/browser` `SandboxCspPolicy` / `SandboxPermissionsPolicy`) and `profileHostInfo` — minimal structural projections of the only fields the renderer reads.

The full `HostConfigMcpProfileV1` stays inside the inspector adapter; the public `.d.ts` carries **no** `@mcpjam/sdk/host-config/internal` import (verified — the only remaining mentions are doc comments).

### 2. `detectUiTypeFromTool` takes a structural `ToolLike`
`{ _meta? }` instead of `Tool` from `@modelcontextprotocol/client`, so the detection API doesn't pin a specific MCP SDK `Tool` type (real `Tool`s still satisfy it).

## Why it's behavior-preserving
The same profile values flow through the same resolvers and the same renderer reads — they're just relocated so the type doesn't cross the package boundary. The reactivity is preserved via `profileKey` (same `stableStringifyJson` hash the renderer used to compute itself).

## Verification
- **package**: `typecheck` ✓ · tier guard ✓ · `build` ✓ (43 KB dts; public surface external deps are only `@mcpjam/sdk/{browser,widget-runtime}`, `@modelcontextprotocol/{client,ext-apps}`, `react`, `zustand` — no `/internal`) · `vitest` ✓
- **inspector**: `typecheck:client` ✓ · vitest — mcp-apps **206** (incl. the 86-test renderer suite) + chat-v2/ui/tools **653** all green
- **root** `typecheck` ✓

## Notes / follow-ups
- The package stays `private: true`. Flipping it off + adding a Changeset is the actual publish step (manual `release.yml` dispatch) — left as an explicit decision for you rather than enabling publish unilaterally.
- Remaining Tier B items: collapsing `environment` + `resolvers` fully into `resolveEnvironment` (further consolidation, optional); Phase 4 — wire the package `renderWidget` seam into `@mcpjam/chat-ui` + collapse the inspector's parallel `PartSwitch`; deferred review nits (MCP-UI `.value`-wrapped detection branch, chat-ui widget-detection dedup).

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-surface and adapter binding refactor with the same values flowing through the same resolvers; sandbox and capability behavior should be unchanged if profileKey reactivity matches the prior hash.
> 
> **Overview**
> **Hardens `@mcpjam/widget-react` for publish** by keeping inspector-internal types off the package’s public `.d.ts` — intended as **no runtime behavior change**.
> 
> The active MCP profile no longer crosses the boundary as `HostConfigMcpProfileV1`. The inspector **`use-widget-host` adapter** binds the live profile into profile-dependent resolvers via a **ref** (stable resolver identity), while **`WidgetHostEnvironmentInputs`** exposes **`profileKey`** (same `stableStringifyJson` hash for memo deps), **`profileSandbox`**, and **`profileHostInfo`** instead of the full profile object. **`WidgetHostResolvers`** drops `profile` from `resolveEffectiveCompatRuntime`, `resolveEffectiveMcpAppsCapabilities`, `resolveEffectiveHostCapabilities`, and `resolveHostInfo()`.
> 
> The renderer reads those projections and calls resolvers without passing a profile. **`detectUiTypeFromTool`** now accepts structural **`ToolLike`** (`{ _meta? }`) instead of MCP SDK **`Tool`**, and **`ToolLike`** is exported from the package barrel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdac3b31bfb5f87d86e2465195b82a2cd69ae195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->