### PR TITLE
Tier B: publish-enable @mcpjam/widget-react

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,6 @@
   "ignore": [
     "@mcpjam/soundcheck",
     "@mcpjam/mcp",
-    "@mcpjam/design-system",
-    "@mcpjam/widget-react"
+    "@mcpjam/design-system"
   ]
 }

--- a/.changeset/widget-react-initial-release.md
+++ b/.changeset/widget-react-initial-release.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/widget-react": minor
+---
+
+Initial public release of `@mcpjam/widget-react` — the framework-free interactive MCP-Apps / OpenAI-Apps widget runtime (the renderer that satisfies `@mcpjam/chat-ui`'s `renderWidget` seam). It exposes the `WidgetHost` dependency-inversion contract (`WidgetHostProvider` / `useWidgetHost`), the `MCPAppsRenderer` / `WidgetSurfaceHost` renderer surfaces, the `SandboxedIframe` double-iframe sandbox, and UI-type detection helpers. The published type surface depends only on stable subpaths (`@mcpjam/sdk/browser`, `@mcpjam/sdk/widget-runtime`, `@modelcontextprotocol/*`); no inspector internals leak.

--- a/soundcheck/src/lib/changesets.ts
+++ b/soundcheck/src/lib/changesets.ts
@@ -158,12 +158,16 @@ export async function fetchPendingChangesets(
 }
 
 /**
- * Ignored packages (from .changeset/config.json). We hardcode the single
- * ignore rather than reading config.json so there's no second round-trip —
- * CLAUDE.md guarantees `@mcpjam/soundcheck` is the only ignored package.
- * If that contract ever changes, bump this list.
+ * Ignored packages — mirrors `.changeset/config.json`'s `ignore` list. We
+ * hardcode it rather than reading config.json so there's no second GitHub
+ * contents round-trip. Keep this in sync with `.changeset/config.json`: when a
+ * package is added to / removed from the ignore list there, update it here too.
  */
-const IGNORED_PACKAGES = new Set<string>(["@mcpjam/soundcheck"]);
+const IGNORED_PACKAGES = new Set<string>([
+  "@mcpjam/soundcheck",
+  "@mcpjam/mcp",
+  "@mcpjam/design-system"
+]);
 
 export interface BuildPlanInput {
   changesets: ChangesetFile[];

--- a/widget-react/package.json
+++ b/widget-react/package.json
@@ -3,8 +3,6 @@
   "version": "0.0.0",
   "description": "Interactive MCP-Apps / OpenAI-Apps widget runtime (React) for MCPJam. Tier B: the renderer that satisfies @mcpjam/chat-ui's renderWidget seam.",
   "license": "MIT",
-  "//private": "Phase 3c scaffolds the package boundary (WidgetHost context/hook). It is consumed inside the monorepo via a source alias and is NOT published until the renderer relocates here (3d) and the publish-ready surface pass lands. Flip `private` off then.",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## What

Makes `@mcpjam/widget-react` eligible for npm publishing, now that the renderer cutover (3d-ii-c, #2734) and public-surface hardening (3d-iii, #2736) have landed.

- Remove `@mcpjam/widget-react` from the Changesets **`ignore`** list (`.changeset/config.json`).
- Drop `private: true` from `widget-react/package.json` (mirrors `@mcpjam/sdk`; the repo's Changesets `access: "public"` config handles the scoped public publish).
- Add an initial **`minor`** changeset (`0.0.0` → `0.1.0`).

## Safety — no auto-publish on merge

Merging this does **not** publish anything. `changeset publish` runs **only** in `release.yml`, which is `workflow_dispatch`-only. The actual npm publish remains a deliberate manual release dispatch (scope `packages-only` or `full`) — your call to trigger.

The inspector keeps consuming the package via its **source alias** (it's a `*` devDependency), so nothing about the inspector build changes. This matches the already-published `@mcpjam/chat-ui` pattern.

## Verified
- `npx changeset status` → lists `@mcpjam/widget-react` (minor) in the release plan.
- `npm run build` (package) → ok.
- `npm pack --dry-run` → dist-only contents (`index.js` / `index.d.ts` / `index.js.map` / `styles.css` + `package.json`); 5 files.
- Lockfile unaffected by the `private` removal.

## Note
Once merged, the package publishes on the next manual `release.yml` dispatch. After that, a follow-up could switch the inspector from the source alias to the published package — but that's optional and separate. Next up in this series: the internal `resolveEnvironment` consolidation cleanup.

https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiK26ynDyggm1qvSqzp3c4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and packaging metadata only; no runtime or auth changes, and npm publish remains manual workflow dispatch.
> 
> **Overview**
> **Enables npm release planning for `@mcpjam/widget-react`** by taking it out of Changesets’ ignore list, removing `private: true` from its `package.json`, and adding a **minor** changeset for the initial public release (`0.0.0` → `0.1.0`).
> 
> **Soundcheck** now documents that its hardcoded `IGNORED_PACKAGES` must stay aligned with `.changeset/config.json`, and expands that set to include `@mcpjam/mcp` and `@mcpjam/design-system` (still excluding `@mcpjam/widget-react` so pending bumps show up in release dry-runs). Merging does not publish; publish still happens only via manual `release.yml` dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4cf3398d957a37ab98ccc23d588e2bc508876b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->