### PR TITLE
Gate Claude Code host template behind PostHog flag

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
@@ -62,8 +62,17 @@ export function CreateHostDialog({
 
   useEffect(() => {
     if (!isOpen) return;
-    setSelectedTemplateId(initialTemplateId ?? DEFAULT_HOST_TEMPLATE_ID);
-  }, [isOpen, initialTemplateId]);
+    // Clamp the selection to a visible template. This enforces the
+    // flag at the selection source, not just in the grid render: a
+    // gated template (e.g. claude-code) can never become
+    // `selectedTemplateId`, so it can't flow into `seedFromHostTemplate`
+    // — even if a future caller passes it as `initialTemplateId` or the
+    // flag flips off after the dialog opened (claudeCodeEnabled is in
+    // the dep list so a flip-off re-clamps a stranded selection).
+    const requested = initialTemplateId ?? DEFAULT_HOST_TEMPLATE_ID;
+    const allowed = visibleTemplates.some((t) => t.id === requested);
+    setSelectedTemplateId(allowed ? requested : DEFAULT_HOST_TEMPLATE_ID);
+  }, [isOpen, initialTemplateId, claudeCodeEnabled]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
@@ -16,6 +16,7 @@ import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import { useHostMutations } from "@/hooks/useClients";
 import { useProjectServers } from "@/hooks/useViews";
+import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
 import {
   DEFAULT_HOST_TEMPLATE_ID,
   HOST_TEMPLATES,
@@ -45,6 +46,14 @@ export function CreateHostDialog({
   const { isAuthenticated } = useConvexAuth();
   const { servers } = useProjectServers({ isAuthenticated, projectId });
   const themeMode = usePreferencesStore((s) => s.themeMode);
+  // The Claude Code host template is gated behind a PostHog flag while the
+  // CLI host profile is iterated on. Off ⇒ drop it from the picker grid.
+  // claude-code is never a default or `initialTemplateId` (no caller seeds
+  // it), so hiding it here can't strand the selection on a missing tile.
+  const claudeCodeEnabled = useClaudeCodeHostEnabled();
+  const visibleTemplates = HOST_TEMPLATES.filter(
+    (t) => t.id !== "claude-code" || claudeCodeEnabled,
+  );
   const [name, setName] = useState("");
   const [selectedTemplateId, setSelectedTemplateId] = useState<HostTemplateId>(
     initialTemplateId ?? DEFAULT_HOST_TEMPLATE_ID,
@@ -131,7 +140,7 @@ export function CreateHostDialog({
           <div className="flex flex-col gap-2">
             <Label>Start from template</Label>
             <div className="grid grid-cols-3 gap-2">
-              {HOST_TEMPLATES.map((template) => {
+              {visibleTemplates.map((template) => {
                 const isSelected = template.id === selectedTemplateId;
                 return (
                   <button

--- a/mcpjam-inspector/client/src/hooks/useClaudeCodeHostEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useClaudeCodeHostEnabled.ts
@@ -1,0 +1,18 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+/**
+ * PostHog rollout gate for the "Claude Code" host template in the New Host
+ * template picker (CreateHostDialog). Flag off ⇒ the template is hidden from
+ * the grid, so we can iterate on the CLI host profile (roots + form
+ * elicitation, no widget rendering) before exposing it to everyone — no
+ * deploy needed to flip it on. Currently scoped to @mcpjam.com users.
+ *
+ * `useFeatureFlagEnabled` returns `undefined` while flags load — treated as
+ * off (`=== true`) so the template never flickers into the picker before
+ * PostHog resolves.
+ */
+export const CLAUDE_CODE_HOST_FEATURE_FLAG = "claude-code-host-enabled";
+
+export function useClaudeCodeHostEnabled(): boolean {
+  return useFeatureFlagEnabled(CLAUDE_CODE_HOST_FEATURE_FLAG) === true;
+}


### PR DESCRIPTION
## What

Hides the **Claude Code** host template in the New Host template picker (`CreateHostDialog`) unless the `claude-code-host-enabled` PostHog flag resolves `true`. The flag is currently scoped to **@mcpjam.com** users, so the CLI host profile (roots + form elicitation, no widget rendering) can be iterated on internally before a wider rollout — no deploy needed to flip it on.

## Changes

- **`useClaudeCodeHostEnabled` hook** — mirrors the existing `useComputersEnabled` pattern: the tri-state PostHog flag is treated as off (`=== true`) until it resolves, so the tile never flickers into the grid before PostHog hydrates.
- **`CreateHostDialog`** — filters `claude-code` out of the template grid when the flag is off via a `visibleTemplates` list.

## Why it's safe

`claude-code` is never the default template (`DEFAULT_HOST_TEMPLATE_ID === "mcpjam"`) and is never passed as `initialTemplateId` by any caller (the recommended-hosts and quick-add entry points use hardcoded id lists that don't include it). So hiding the tile can't strand the dialog's selection on a missing template. Other `HOST_TEMPLATES` consumers (logo-preset picker, compat label map) are display/utility-only and intentionally left untouched.

## PostHog

Flag created and live: [`claude-code-host-enabled`](https://us.posthog.com/project/212744/feature_flags/719039) — release condition `email icontains @mcpjam.com` at 100%, matching the existing `computers-enabled` / `home-page-enabled` internal-gating convention.

## Verification

- `npm run typecheck:client` (via `tsc -p client/tsconfig.typecheck.json`) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only feature flag gating in the host creation dialog; no auth, data, or API behavior changes.
> 
> **Overview**
> The **Claude Code** host template in **New Host** (`CreateHostDialog`) is now shown only when PostHog flag `claude-code-host-enabled` is explicitly `true`, so the CLI host profile can ship internally before a wider rollout.
> 
> A new **`useClaudeCodeHostEnabled`** hook follows the existing **`useComputersEnabled`** pattern: unresolved flag state is treated as off so the tile does not flash on while PostHog loads. The dialog builds **`visibleTemplates`** by dropping `claude-code` when the flag is off, and the open/selection **`useEffect`** clamps **`selectedTemplateId`** to a visible template (including if the flag turns off while the dialog is open or a caller passes a gated **`initialTemplateId`**), so **`seedFromHostTemplate`** cannot run for a hidden template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d305936a58d7bd540ba19456e6fd73075d060aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->