### PR TITLE
fix(agent): render structuredContent widgets in chat (show_servers)

### DIFF
--- a/mcpjam-inspector/client/src/lib/tool-result-utils.ts
+++ b/mcpjam-inspector/client/src/lib/tool-result-utils.ts
@@ -4,4 +4,5 @@ export {
   readToolResultObject,
   readToolResultMeta,
   readToolResultServerId,
+  toCallToolResult,
 } from "@mcpjam/widget-react";

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1168,6 +1168,103 @@ describe("mcpjam-stream-handler", () => {
     ]);
   });
 
+  it("emits structuredContent in the UI tool-output chunk for a widget tool (scrubbed model output, raw result)", async () => {
+    // Reproduces the agent's "Missing structured content" bug: the model copy
+    // is scrubbed, but the raw `result` carries structuredContent. The UI chunk
+    // MUST surface structuredContent at the top level for the widget to render.
+    let fetchCall = 0;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      fetchCall += 1;
+      if (fetchCall === 1) {
+        return createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-w1",
+            toolName: "show_servers",
+            input: {},
+          },
+          {
+            type: "finish",
+            finishReason: "stop",
+            totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ]);
+      }
+      return createSseResponse([
+        {
+          type: "finish",
+          finishReason: "stop",
+          totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ]);
+    });
+    vi.mocked(hasUnresolvedToolCalls).mockImplementation(
+      (messages) =>
+        messages.some(
+          (message: any) =>
+            message?.role === "assistant" &&
+            Array.isArray(message.content) &&
+            message.content.some((part: any) => part.type === "tool-call")
+        ) && !messages.some((message: any) => message?.role === "tool")
+    );
+    const structuredContent = {
+      project: { id: "p1", name: "Default" },
+      servers: [{ name: "notion" }],
+      widget: "servers",
+    };
+    const rawResult = {
+      content: [{ type: "text", text: "8 servers" }],
+      structuredContent,
+      _meta: { "mcpjam/widget": true },
+    };
+    vi.mocked(executeToolCallsFromMessages).mockImplementation(
+      async (messages: any[]) => {
+        const toolResultMessage = {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-w1",
+              toolName: "show_servers",
+              // model-facing copy is scrubbed (no structuredContent)…
+              output: {
+                type: "json",
+                value: { content: rawResult.content },
+              },
+              // …raw result preserved for UI hydration.
+              result: rawResult,
+              serverId: "widget-server",
+            },
+          ],
+        };
+        messages.splice(2, 0, toolResultMessage);
+        return [toolResultMessage] as any;
+      }
+    );
+
+    await handleMCPJamFreeChatModel({
+      messages: [{ role: "user", content: "show servers" }] as any,
+      modelId: "anthropic/claude-haiku-4.5",
+      systemPrompt: "You are helpful",
+      tools: { show_servers: { _serverId: "widget-server" } } as any,
+      mcpClientManager: {
+        getAllToolsMetadata: vi.fn().mockReturnValue({ show_servers: {} }),
+      } as any,
+    });
+
+    await lastExecution;
+
+    const toolOutputChunk = writtenChunks.find(
+      (chunk) =>
+        chunk?.type === "tool-output-available" &&
+        chunk?.toolCallId === "call-w1"
+    );
+    expect(toolOutputChunk).toBeDefined();
+    expect((toolOutputChunk!.output as any).structuredContent).toEqual(
+      structuredContent
+    );
+  });
+
   describe("progressive discovery approval semantics", () => {
     // Minimal "plan enabled" — only the `enabled` flag is read on the
     // post-stream unresolved-tool detection + drain paths exercised here.

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -1237,7 +1237,19 @@ async function emitToolResults(
             typeof (part as any).serverId === "string"
               ? ((part as any).serverId as string)
               : undefined;
-          const rawOutput = part.output ?? (part as any).result;
+          // MCP App tools scrub structuredContent from the model-facing
+          // `output`; their widgets need the raw result, which
+          // `executeToolCallsFromMessages` stamps on `result` when it carries
+          // structuredContent. Prefer it so the widget receives
+          // structuredContent. All other tools keep the existing
+          // `output`-first behavior.
+          const rawResult = (part as any).result;
+          const rawOutput =
+            rawResult &&
+            typeof rawResult === "object" &&
+            "structuredContent" in rawResult
+              ? rawResult
+              : part.output ?? rawResult;
 
           let outputForUi: unknown = rawOutput;
           if (rawOutput && typeof rawOutput === "object") {

--- a/mcpjam-inspector/shared/__tests__/http-tool-calls.test.ts
+++ b/mcpjam-inspector/shared/__tests__/http-tool-calls.test.ts
@@ -1069,6 +1069,44 @@ describe("executeToolCallsFromMessages — toModelOutput (browser-render PR 14)"
     expect("result" in part).toBe(false);
   });
 
+  it("preserves the raw result for a toModelOutput tool that returns structuredContent (widget UI hydration)", async () => {
+    // MCP App tools define toModelOutput to scrub structuredContent from the
+    // model copy, but their widgets read `toolResult.structuredContent`. The
+    // raw result must still be stamped on the part (`result:`) for the UI.
+    // This is the agent's path: tools are passed directly (no clientManager).
+    const implResult = {
+      content: [{ type: "text", text: "8 servers" }],
+      structuredContent: {
+        project: { id: "p1", name: "Default" },
+        servers: [{ name: "notion" }],
+        widget: "servers",
+      },
+      _meta: { source: "platform" },
+    };
+    const tools = {
+      show_servers: {
+        execute: vi.fn().mockResolvedValue(implResult),
+        // scrub structuredContent for the model-facing copy
+        toModelOutput: ({ output }: { output: unknown }) => ({
+          type: "json" as const,
+          value: { content: (output as { content: unknown }).content },
+        }),
+      },
+    };
+
+    const messages = callMessage("show_servers");
+    const newMessages = await executeToolCallsFromMessages(messages, { tools });
+
+    const part = (newMessages[0] as any).content[0];
+    // Model copy is scrubbed (no structuredContent)...
+    expect(part.output).toEqual({
+      type: "json",
+      value: { content: implResult.content },
+    });
+    // ...but the raw result (with structuredContent + _meta) survives for the UI.
+    expect(part.result).toEqual(implResult);
+  });
+
   it("awaits an async toModelOutput", async () => {
     const tools = {
       computer: {

--- a/mcpjam-inspector/shared/http-tool-calls.ts
+++ b/mcpjam-inspector/shared/http-tool-calls.ts
@@ -252,6 +252,17 @@ export async function executeToolCallsFromMessages(
           ).toModelOutput;
           if (typeof toModelOutput === "function") {
             const mappedOutput = await toModelOutput({ output: result });
+            // MCP App tools scrub structuredContent from the model-facing copy
+            // (`mappedOutput`), but their widgets read structuredContent from
+            // the raw result. Preserve the raw result for UI hydration whenever
+            // it carries structuredContent — the model copy no longer does.
+            // Other toModelOutput tools (e.g. the eval `computer` tool) return
+            // no structuredContent, so they keep omitting `result:` and don't
+            // bloat subsequent per-step request bodies with large content.
+            const rawHasStructuredContent =
+              !!result &&
+              typeof result === "object" &&
+              "structuredContent" in (result as Record<string, unknown>);
             const toolResultMessage: ModelMessage = {
               role: "tool" as const,
               content: [
@@ -260,6 +271,9 @@ export async function executeToolCallsFromMessages(
                   toolCallId: content.toolCallId,
                   toolName: toolName,
                   output: mappedOutput,
+                  // UI-only raw result for app-tool widgets (stripped from the
+                  // model copy via `output`/toModelOutput above).
+                  ...(rawHasStructuredContent ? { result } : {}),
                   serverId: extractServerId(toolName),
                 },
               ],

--- a/widget-react/src/__tests__/tool-result-utils.test.ts
+++ b/widget-react/src/__tests__/tool-result-utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { toCallToolResult } from "../tool-result-utils";
+
+describe("toCallToolResult", () => {
+  it("re-envelopes a bare structured payload so structuredContent resolves", () => {
+    // The platform `show_servers` payload as the chat pipeline collapses it:
+    // a bare object with no `content`/`structuredContent` wrapper.
+    const payload = {
+      project: { id: "p1", name: "Default" },
+      servers: [{ name: "notion" }],
+      widget: "servers",
+    };
+
+    const result = toCallToolResult(payload);
+
+    expect(result.structuredContent).toEqual(payload);
+    expect(result.content).toEqual([]);
+  });
+
+  it("passes through a real CallToolResult unchanged (no double-wrap)", () => {
+    const real = {
+      content: [{ type: "text", text: "ok" }],
+      structuredContent: { project: { id: "p1" }, servers: [] },
+      _meta: { _serverId: "mcpjam-platform" },
+    };
+
+    const result = toCallToolResult(real);
+
+    expect(result).toBe(real);
+    expect(result.structuredContent).toEqual(real.structuredContent);
+  });
+
+  it("passes through a content-only CallToolResult without inventing structuredContent", () => {
+    const real = { content: [{ type: "text", text: "hi" }] };
+
+    const result = toCallToolResult(real);
+
+    expect(result).toBe(real);
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("unwraps an AI-SDK { value, _meta } wrapper around a bare payload", () => {
+    const payload = { project: { id: "p1" }, servers: [] };
+    const wrapped = { value: payload, _meta: { _serverId: "s1" } };
+
+    const result = toCallToolResult(wrapped);
+
+    expect(result.structuredContent).toEqual(payload);
+    expect(result._meta).toEqual({ _serverId: "s1" });
+  });
+
+  it("unwraps a { value } wrapper around a real CallToolResult", () => {
+    const inner = {
+      content: [{ type: "text", text: "ok" }],
+      structuredContent: { project: { id: "p1" }, servers: [] },
+    };
+    const wrapped = { value: inner };
+
+    const result = toCallToolResult(wrapped);
+
+    expect(result).toBe(inner);
+  });
+
+  it("returns an empty result for non-object output", () => {
+    expect(toCallToolResult(undefined)).toEqual({ content: [] });
+    expect(toCallToolResult("oops")).toEqual({ content: [] });
+    expect(toCallToolResult(null)).toEqual({ content: [] });
+  });
+});

--- a/widget-react/src/index.ts
+++ b/widget-react/src/index.ts
@@ -24,6 +24,7 @@ export {
   readToolResultObject,
   readToolResultMeta,
   readToolResultServerId,
+  toCallToolResult,
 } from "./tool-result-utils";
 // App-provided tools registry (SEP-1865) + tool-input streaming (3d-ii-b).
 export * from "./app-tools-registry";

--- a/widget-react/src/mcp-apps-modal.tsx
+++ b/widget-react/src/mcp-apps-modal.tsx
@@ -8,10 +8,10 @@ import {
   type McpUiResourceCsp,
   type McpUiResourcePermissions,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type { CallToolResult } from "@modelcontextprotocol/client";
 // Pure JSON-RPC parser + logging transport are shared, framework-free runtime
 // helpers in the SDK.
 import { extractMethod, LoggingTransport } from "@mcpjam/sdk/widget-runtime";
+import { toCallToolResult } from "./tool-result-utils";
 // The `CspMode` type comes from the package's `WidgetHost` contract.
 import { type CspMode } from "./widget-host";
 // The package owns lifecycle + bridge; the inspector injects modal CHROME
@@ -286,7 +286,7 @@ export function McpAppsModal({
       const resolvedToolInput = toolInputRef.current ?? {};
       bridge.sendToolInput({ arguments: resolvedToolInput });
       if (toolOutputRef.current) {
-        bridge.sendToolResult(toolOutputRef.current as CallToolResult);
+        bridge.sendToolResult(toCallToolResult(toolOutputRef.current));
       }
 
       const appCaps = bridge.getAppCapabilities();

--- a/widget-react/src/tool-result-utils.ts
+++ b/widget-react/src/tool-result-utils.ts
@@ -6,6 +6,8 @@
  * shapes. Pure (no deps) — relocated from the inspector in Phase 3d-ii.
  */
 
+import type { CallToolResult } from "@modelcontextprotocol/client";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -46,4 +48,56 @@ export function readToolResultServerId(result: unknown): string | undefined {
 
   const meta = readToolResultMeta(result);
   return typeof meta?._serverId === "string" ? meta._serverId : undefined;
+}
+
+/**
+ * Normalise a tool output into a real `CallToolResult` before it is handed to
+ * an MCP App bridge via `bridge.sendToolResult`.
+ *
+ * Why this exists: native MCP Apps widgets read `toolResult.structuredContent`
+ * (e.g. the platform `show_servers` widget at `mcp/src/ui/app.tsx`). But the
+ * chat pipeline collapses an MCP tool result down to its bare payload before
+ * the renderer sees it (`getToolInfo` → `output.value ?? rawOutput`), so the
+ * value reaching the bridge is the structured payload itself, not a
+ * `{ content, structuredContent, _meta }` envelope. Sending that bare object
+ * straight through (the old `toolOutput as CallToolResult` cast) leaves the
+ * widget's `structuredContent` slot empty → "Missing structured content".
+ *
+ * This re-envelopes the payload so every surface hands the widget bundle the
+ * same shape the Playground already delivers directly. It is shape-agnostic and
+ * idempotent:
+ *   - a real `CallToolResult` (has `structuredContent` and/or a `content`
+ *     array) passes through unchanged — never double-wrapped;
+ *   - an AI-SDK `{ value, _meta }` wrapper is unwrapped, re-attaching the
+ *     wrapper's `_meta` when the inner value lacks its own;
+ *   - a bare structured payload is wrapped as
+ *     `{ content: [], structuredContent: payload }`;
+ *   - a non-object output yields an empty result.
+ */
+export function toCallToolResult(toolOutput: unknown): CallToolResult {
+  if (!isRecord(toolOutput)) {
+    return { content: [] };
+  }
+
+  // Already a result envelope: carries the fields widgets read. Pass through.
+  if ("structuredContent" in toolOutput || Array.isArray(toolOutput.content)) {
+    return toolOutput as unknown as CallToolResult;
+  }
+
+  // AI-SDK `{ value, _meta }` wrapper: the result/payload lives under `.value`.
+  if (isRecord(toolOutput.value)) {
+    const inner = toCallToolResult(toolOutput.value);
+    if (!inner._meta && isRecord(toolOutput._meta)) {
+      return { ...inner, _meta: toolOutput._meta };
+    }
+    return inner;
+  }
+
+  // Bare structured payload — re-envelope so `toolResult.structuredContent`
+  // resolves for MCP Apps widgets that read it.
+  return {
+    content: [],
+    structuredContent: toolOutput,
+    ...(isRecord(toolOutput._meta) ? { _meta: toolOutput._meta } : {}),
+  };
 }

--- a/widget-react/src/useToolInputStreaming.ts
+++ b/widget-react/src/useToolInputStreaming.ts
@@ -16,7 +16,7 @@ import {
   useLayoutEffect,
 } from "react";
 import type { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type { CallToolResult } from "@modelcontextprotocol/client";
+import { toCallToolResult } from "./tool-result-utils";
 // Re-exported from the WidgetHost contract module so this cluster file stays
 // free of `@/lib/client-styles` (Tier-B guard).
 import type { ResolvedMcpAppsCapabilities } from "./widget-host";
@@ -476,7 +476,7 @@ export function useToolInputStreaming({
     const outputKey = `${toolCallId}:${serialized}`;
     if (lastToolOutputRef.current === outputKey) return;
     lastToolOutputRef.current = outputKey;
-    bridge.sendToolResult(toolOutput as CallToolResult);
+    bridge.sendToolResult(toCallToolResult(toolOutput));
   }, [isReady, toolCallId, toolOutput, toolState, bridgeRef, reinitCount]);
 
   // 7. Tool error/cancellation delivery


### PR DESCRIPTION
## Problem

In the Home/MCPJam agent chat, widget-backed MCP App tools (e.g. the platform `show_servers` widget) rendered **"Missing structured content"**, while the Playground tool-runner rendered the same widget correctly.

## Root cause

MCP App tools define `toModelOutput`, which deliberately scrubs `structuredContent` from the **model-facing** tool output (per SEP-1865 — structuredContent is for the widget, `content` is for the model). The chat/agent streaming path (`executeToolCallsFromMessages` → `emitToolResults`) only forwarded that **scrubbed** copy to the UI:

- In the `toModelOutput` branch, the raw result was **not** preserved on the part (only the non-`toModelOutput` branch kept `result:` for UI hydration).
- `emitToolResults` then read the scrubbed `output`, so the widget's `toolResult.structuredContent` was empty.

The Playground tool-runner works because it hands the widget the raw `CallToolResult` directly, bypassing the model-scrubbing path.

## Fix

- **`shared/http-tool-calls.ts`** — in the `toModelOutput` branch, preserve the raw result on the tool-result part when it carries `structuredContent` (UI hydration). Tools without structuredContent (the eval `computer` tool) still omit it, so no per-step request-body bloat. Works on the agent's `{ tools }` execution path.
- **`server/utils/mcpjam-stream-handler.ts`** — the UI tool-output chunk prefers the raw result when it has `structuredContent`; all other tools keep the existing output-first behavior.
- **`widget-react`** — route the bridge `sendToolResult` through a new `toCallToolResult` normalizer (replaces an unsafe `as CallToolResult` cast) so the widget always receives a proper `CallToolResult`. Applied at both the inline and modal bridge sites.

## Tests

- `http-tool-calls.test.ts` — raw result is preserved on the agent's `{ tools }` path for a structuredContent-bearing `toModelOutput` tool.
- `mcpjam-stream-handler.test.ts` — the emitted `tool-output-available` UI chunk now carries top-level `structuredContent` (reproduces the bug; **fails under the old precedence**).
- `widget-react/.../tool-result-utils.test.ts` — `toCallToolResult` unit tests (passthrough / wrap / `{value}` unwrap / non-object).

Verified end-to-end: the agent's `show_servers` widget now renders the full server grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted chat/UI hydration changes with regression tests; model-facing scrubbing behavior is unchanged for tools without structuredContent.
> 
> **Overview**
> Fixes agent chat widgets (e.g. **`show_servers`**) showing **"Missing structured content"** when MCP App tools use **`toModelOutput`** to strip **`structuredContent`** from model-facing output.
> 
> **Server / agent path:** **`executeToolCallsFromMessages`** now attaches a UI-only **`result`** on tool-result parts when the raw execute payload includes **`structuredContent`**, while tools without it (e.g. eval **`computer`**) still omit **`result`** to avoid bloating follow-up requests. **`emitToolResults`** in **`mcpjam-stream-handler`** prefers that raw **`result`** for UI chunks so **`tool-output-available`** exposes top-level **`structuredContent`**.
> 
> **Widget bridge:** Adds **`toCallToolResult`** in **`widget-react`** to normalize bare payloads and AI-SDK **`{ value, _meta }`** wrappers into a proper **`CallToolResult`** before **`bridge.sendToolResult`** (inline + modal), replacing unsafe casts. Re-exported via the inspector shim.
> 
> Tests cover the **`toModelOutput`** preservation path, stream handler UI chunks, and **`toCallToolResult`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3fe938cc0792396453ad97ac7260e3b38a7b601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->