### PR TITLE
Host nav: collapse the stacked double navbar into a single row

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -49,6 +49,7 @@ import { SupportTab } from "./components/SupportTab";
 import { RegistryTab } from "./components/RegistryTab";
 import { HostsTab } from "./components/HostsTab";
 import { HostConfigCompareView } from "./components/hosts/comparison/HostConfigCompareView";
+import { HostSectionTabs } from "./components/hosts/HostSectionTabs";
 import { ConnectViewHeader } from "./components/hosts/ConnectViewHeader";
 import { ComputerView } from "./components/computer/ComputerView";
 import { useComputersEnabledState } from "./hooks/useComputersEnabled";
@@ -663,7 +664,7 @@ export function HostCompareRoute() {
       className="flex h-full min-h-0 flex-col"
     >
       <ConnectViewHeader
-        value="compare"
+        value="host"
         previewedHostId={previewedHostId}
         onChange={(next) => {
           if (next === "servers") {
@@ -674,6 +675,21 @@ export function HostCompareRoute() {
             navigate(routePaths.computer);
           }
         }}
+        rightSlot={
+          // Host/Compare sub-nav inline in the header row (single bar) rather
+          // than stacked beneath the primary nav.
+          <div className="flex min-w-0 items-center justify-center md:justify-end">
+            <HostSectionTabs
+              value="compare"
+              hostEnabled={Boolean(previewedHostId)}
+              onSelect={(next) => {
+                if (next === "host" && previewedHostId) {
+                  navigate(buildHostsPath(previewedHostId));
+                }
+              }}
+            />
+          </div>
+        }
       />
       <div className="min-h-0 flex-1">{compareView}</div>
     </motion.div>

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -127,12 +127,17 @@ export function HostsTab({
                 animate={{ opacity: 1, y: 0, scale: 1 }}
                 exit={{ opacity: 0, y: 18, scale: 0.97 }}
                 transition={SNAPPY_RAIL}
-                className="absolute inset-0 [transform-origin:50%_30%]"
+                className="absolute inset-0 flex flex-col [transform-origin:50%_30%]"
               >
-                <HostBuilderView
-                  hostId={selectedHostId}
-                  projectId={projectId}
-                />
+                {/* The Host/Compare segmented pill now lives inline in the
+                    host canvas header (HostBuilderViewRedesigned) so the
+                    section nav is a single row, not stacked above the canvas. */}
+                <div className="min-h-0 flex-1">
+                  <HostBuilderView
+                    hostId={selectedHostId}
+                    projectId={projectId}
+                  />
+                </div>
               </motion.div>
             ) : (
               <motion.div

--- a/mcpjam-inspector/client/src/components/__tests__/HostsTab.header-chrome.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/HostsTab.header-chrome.test.tsx
@@ -33,21 +33,26 @@ vi.mock("@/components/hosts/HostBuilderView", () => ({
 // jsdom doesn't fully expose; stub both to the bare DOM so the chrome assertion
 // can run without spinning up the animation runtime.
 vi.mock("framer-motion", () => {
-  const MotionDiv = React.forwardRef<
-    HTMLDivElement,
-    React.HTMLAttributes<HTMLDivElement> & Record<string, unknown>
-  >(function MotionDiv(props, ref) {
-    const {
-      initial: _initial,
-      animate: _animate,
-      exit: _exit,
-      transition: _transition,
-      ...rest
-    } = props;
-    return <div ref={ref} {...rest} />;
-  });
+  const makeMotion = (Tag: "div" | "span") =>
+    React.forwardRef<HTMLElement, Record<string, unknown>>(function Motion(
+      props,
+      ref,
+    ) {
+      const {
+        initial: _initial,
+        animate: _animate,
+        exit: _exit,
+        transition: _transition,
+        layoutId: _layoutId,
+        whileHover: _whileHover,
+        whileTap: _whileTap,
+        ...rest
+      } = props;
+      return React.createElement(Tag, { ref, ...rest });
+    });
   return {
-    motion: { div: MotionDiv },
+    motion: { div: makeMotion("div"), span: makeMotion("span") },
+    useReducedMotion: () => false,
     AnimatePresence: ({ children }: { children: React.ReactNode }) => (
       <>{children}</>
     ),

--- a/mcpjam-inspector/client/src/components/hosts/ConnectViewHeader.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/ConnectViewHeader.tsx
@@ -46,7 +46,8 @@ export function ConnectViewHeader({
                 label: "Host",
                 disabled: !previewedHostId,
               },
-              { value: "compare", label: "Compare" },
+              // "Compare" now lives as a sub-tab inside the Host section
+              // (see HostSectionTabs) rather than a peer primary tab.
               ...(computersEnabled
                 ? ([{ value: "computer", label: "Computer" }] as const)
                 : []),

--- a/mcpjam-inspector/client/src/components/hosts/HostSectionTabs.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostSectionTabs.tsx
@@ -1,0 +1,94 @@
+import { LayoutGroup, motion, useReducedMotion } from "framer-motion";
+import { Layers, SlidersHorizontal } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type HostSectionValue = "host" | "compare";
+
+const TABS: ReadonlyArray<{
+  value: HostSectionValue;
+  label: string;
+  Icon: typeof Layers;
+}> = [
+  { value: "host", label: "Host", Icon: SlidersHorizontal },
+  { value: "compare", label: "Compare", Icon: Layers },
+];
+
+/**
+ * Secondary nav for the Host section: switches between a single host's
+ * canvas ("Host") and the multi-host comparison ("Compare"). A refined
+ * segmented control — the active pill glides between tabs (shared layout),
+ * distinct from the primary underline nav.
+ *
+ * Renders as a bare inline-flex element so callers can drop it into a header
+ * row (e.g. beside the Save button) rather than stacking it as its own bar;
+ * pass `className` to control placement.
+ */
+export function HostSectionTabs({
+  value,
+  hostEnabled,
+  onSelect,
+  className,
+}: {
+  value: HostSectionValue;
+  /** "Host" needs a previewed host to land on; disabled otherwise. */
+  hostEnabled: boolean;
+  onSelect: (next: HostSectionValue) => void;
+  className?: string;
+}) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <div className={cn("inline-flex", className)}>
+      <LayoutGroup id="host-section-tabs">
+        <div
+          role="tablist"
+          aria-label="Host section"
+          className="inline-flex items-center gap-0.5 rounded-full border border-border/60 bg-muted/40 p-1 shadow-[inset_0_1px_2px_rgba(0,0,0,0.03)] backdrop-blur-sm"
+        >
+          {TABS.map(({ value: v, label, Icon }) => {
+            const active = v === value;
+            const disabled = v === "host" && !hostEnabled;
+            return (
+              <button
+                key={v}
+                role="tab"
+                type="button"
+                aria-selected={active}
+                disabled={disabled}
+                onClick={() => !active && !disabled && onSelect(v)}
+                className={cn(
+                  "relative inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-[12.5px] font-medium",
+                  "transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                  active
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                  disabled && "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+                )}
+              >
+                {active && (
+                  <motion.span
+                    layoutId="host-section-active-pill"
+                    aria-hidden="true"
+                    className="absolute inset-0 rounded-full bg-card shadow-sm ring-1 ring-border/70"
+                    transition={
+                      reduceMotion
+                        ? { duration: 0 }
+                        : { type: "spring", stiffness: 560, damping: 40, mass: 0.7 }
+                    }
+                  />
+                )}
+                <Icon
+                  className={cn(
+                    "relative z-10 size-3.5 transition-colors",
+                    active ? "text-primary" : "",
+                  )}
+                />
+                <span className="relative z-10">{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </LayoutGroup>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
@@ -28,6 +28,8 @@ interface HostCompareSelectorProps {
   onToggleHost: (hostId: string) => void;
   divergingOnly: boolean;
   onDivergingOnlyChange: (enabled: boolean) => void;
+  showDescriptions: boolean;
+  onShowDescriptionsChange: (enabled: boolean) => void;
   disabled?: boolean;
 }
 
@@ -38,6 +40,8 @@ export function HostCompareSelector({
   onToggleHost,
   divergingOnly,
   onDivergingOnlyChange,
+  showDescriptions,
+  onShowDescriptionsChange,
   disabled = false,
 }: HostCompareSelectorProps) {
   const selectedSet = new Set(selectedHostIds);
@@ -67,14 +71,24 @@ export function HostCompareSelector({
         />
       ) : null}
 
-      <label className="ml-auto flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground">
-        <Switch
-          checked={divergingOnly}
-          onCheckedChange={onDivergingOnlyChange}
-          aria-label="Show only diverging fields"
-        />
-        <span>Only diverging</span>
-      </label>
+      <div className="ml-auto flex items-center gap-4">
+        <label className="flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground">
+          <Switch
+            checked={showDescriptions}
+            onCheckedChange={onShowDescriptionsChange}
+            aria-label="Show field descriptions"
+          />
+          <span>Descriptions</span>
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground">
+          <Switch
+            checked={divergingOnly}
+            onCheckedChange={onDivergingOnlyChange}
+            aria-label="Show only diverging fields"
+          />
+          <span>Only diverging</span>
+        </label>
+      </div>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -38,6 +38,7 @@ export function HostConfigCompareView({
   >({});
   const [selectedHostIds, setSelectedHostIds] = useState<string[]>([]);
   const [divergingOnly, setDivergingOnly] = useState(false);
+  const [showDescriptions, setShowDescriptions] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   // Tracks whether the initial URL-driven selection has been applied.
   // After the first resolve, subsequent URL changes are ignored — Compare
@@ -199,6 +200,8 @@ export function HostConfigCompareView({
               onToggleHost={handleToggleHost}
               divergingOnly={divergingOnly}
               onDivergingOnlyChange={setDivergingOnly}
+              showDescriptions={showDescriptions}
+              onShowDescriptionsChange={setShowDescriptions}
               disabled={listLoading}
             />
 
@@ -220,6 +223,7 @@ export function HostConfigCompareView({
                 <HostConfigComparisonMatrix
                   subjects={orderedSubjects}
                   divergingOnly={divergingOnly}
+                  showDescriptions={showDescriptions}
                   onRemoveHost={
                     selectedHostIdSet.size > 1 ? handleToggleHost : undefined
                   }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
@@ -32,6 +32,8 @@ describe("HostCompareSelector", () => {
         onToggleHost={onToggleHost}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
+        showDescriptions={false}
+        onShowDescriptionsChange={vi.fn()}
       />,
     );
 
@@ -61,6 +63,8 @@ describe("HostCompareSelector", () => {
         onToggleHost={vi.fn()}
         divergingOnly={false}
         onDivergingOnlyChange={vi.fn()}
+        showDescriptions={false}
+        onShowDescriptionsChange={vi.fn()}
       />,
     );
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -1,11 +1,16 @@
 import { useMemo, useState } from "react";
-import { X } from "lucide-react";
+import { Info, X } from "lucide-react";
 import { motion, useReducedMotion } from "framer-motion";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@mcpjam/design-system/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { cn } from "@/lib/utils";
 import { getChatboxHostLogo } from "@/lib/chatbox-client-style";
 import {
@@ -20,6 +25,12 @@ interface HostConfigComparisonMatrixProps {
   subjects: ReadonlyArray<HostComparisonSubject>;
   /** When true, hide rows whose value is identical across every host. */
   divergingOnly?: boolean;
+  /**
+   * When true, render each field's description inline beneath its label.
+   * When false (default), the description moves into a hover `i` affordance
+   * so rows stay compact and scannable.
+   */
+  showDescriptions?: boolean;
   /** Remove a column; omitted when only one host remains. */
   onRemoveHost?: (hostId: string) => void;
 }
@@ -35,6 +46,7 @@ interface HostConfigComparisonMatrixProps {
 export function HostConfigComparisonMatrix({
   subjects,
   divergingOnly = false,
+  showDescriptions = false,
   onRemoveHost,
 }: HostConfigComparisonMatrixProps) {
   const groups = useMemo(() => groupHostConfigFields(HOST_CONFIG_FIELDS), []);
@@ -57,7 +69,12 @@ export function HostConfigComparisonMatrix({
   }
 
   return (
-    <div className="overflow-auto rounded-xl border border-border bg-card">
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+      className="overflow-auto rounded-xl border border-border bg-card shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_30px_-18px_rgba(0,0,0,0.18)]"
+    >
       <table className="w-full border-collapse text-[13px]">
         <colgroup>
           <col style={{ width: 300 }} />
@@ -84,7 +101,7 @@ export function HostConfigComparisonMatrix({
         </thead>
 
         <tbody>
-          {groups.map((group) => {
+          {groups.map((group, groupIndex) => {
             const visibleFieldsInGroup = group.subsections
               .flatMap((sub) => sub.fields)
               .filter((f) => !divergingOnly || divergingIds.has(f.id));
@@ -97,22 +114,25 @@ export function HostConfigComparisonMatrix({
             return (
               <SectionRows
                 key={group.section.id}
+                index={groupIndex}
                 sectionLabel={group.section.label}
                 divergeCount={groupDivergeCount}
                 subsections={group.subsections}
                 subjects={subjects}
                 divergingIds={divergingIds}
                 divergingOnly={divergingOnly}
+                showDescriptions={showDescriptions}
               />
             );
           })}
         </tbody>
       </table>
-    </div>
+    </motion.div>
   );
 }
 
 interface SectionRowsProps {
+  index: number;
   sectionLabel: string;
   divergeCount: number;
   subsections: ReadonlyArray<{
@@ -122,15 +142,18 @@ interface SectionRowsProps {
   subjects: ReadonlyArray<HostComparisonSubject>;
   divergingIds: ReadonlySet<string>;
   divergingOnly: boolean;
+  showDescriptions: boolean;
 }
 
 function SectionRows({
+  index,
   sectionLabel,
   divergeCount,
   subsections,
   subjects,
   divergingIds,
   divergingOnly,
+  showDescriptions,
 }: SectionRowsProps) {
   const colSpan = subjects.length + 1;
   return (
@@ -141,14 +164,32 @@ function SectionRows({
           scope="colgroup"
           className="sticky top-[64px] z-20 bg-secondary border-y border-border px-5 py-2 text-left"
         >
-          <div className="flex items-baseline gap-3">
+          <motion.div
+            className="flex items-baseline gap-3"
+            initial={{ opacity: 0, x: -8 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{
+              delay: 0.08 + index * 0.07,
+              duration: 0.4,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+          >
             <span className="text-[15px] font-medium tracking-tight">
               {sectionLabel}
             </span>
+            {divergeCount > 0 && (
+              <motion.span
+                aria-hidden
+                className="inline-block size-1.5 rounded-full bg-primary/70"
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                transition={{ delay: 0.2 + index * 0.07, type: "spring", stiffness: 600, damping: 18 }}
+              />
+            )}
             <span className="ml-auto text-[10.5px] text-muted-foreground tabular-nums">
               {divergeCount} diverging
             </span>
-          </div>
+          </motion.div>
         </th>
       </tr>
 
@@ -165,6 +206,7 @@ function SectionRows({
             subjects={subjects}
             divergingIds={divergingIds}
             colSpan={colSpan}
+            showDescriptions={showDescriptions}
           />
         );
       })}
@@ -178,12 +220,14 @@ function SubsectionRows({
   subjects,
   divergingIds,
   colSpan,
+  showDescriptions,
 }: {
   label: string;
   fields: ReadonlyArray<HostConfigFieldDef>;
   subjects: ReadonlyArray<HostComparisonSubject>;
   divergingIds: ReadonlySet<string>;
   colSpan: number;
+  showDescriptions: boolean;
 }) {
   return (
     <>
@@ -201,6 +245,7 @@ function SubsectionRows({
           field={field}
           subjects={subjects}
           diverges={divergingIds.has(field.id)}
+          showDescriptions={showDescriptions}
         />
       ))}
     </>
@@ -211,10 +256,12 @@ function FieldRow({
   field,
   subjects,
   diverges,
+  showDescriptions,
 }: {
   field: HostConfigFieldDef;
   subjects: ReadonlyArray<HostComparisonSubject>;
   diverges: boolean;
+  showDescriptions: boolean;
 }) {
   return (
     <tr className="border-b border-border last:border-b-0">
@@ -237,10 +284,32 @@ function FieldRow({
             }}
           />
         )}
-        <div className="text-[13px] font-medium text-foreground leading-tight">
-          {field.label}
+        <div className="flex items-center gap-1.5">
+          <span className="text-[13px] font-medium text-foreground leading-tight">
+            {field.label}
+          </span>
+          {field.description && !showDescriptions && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={`About ${field.label}`}
+                  className="inline-flex size-4 shrink-0 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                >
+                  <Info className="size-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                variant="muted"
+                className="max-w-[260px] text-left [text-wrap:normal]"
+              >
+                {field.description}
+              </TooltipContent>
+            </Tooltip>
+          )}
         </div>
-        {field.description && (
+        {field.description && showDescriptions && (
           <div className="text-[11px] text-muted-foreground mt-1 leading-snug">
             {field.description}
           </div>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -19,6 +19,7 @@ import { useAutoConnectProjectServers } from "@/hooks/useAutoConnectProjectServe
 import { useSharedAppState } from "@/state/app-state-context";
 import { AddServerModal } from "@/components/connection/AddServerModal";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
+import { HostSectionTabs } from "@/components/hosts/HostSectionTabs";
 import type { ServerFormData } from "@/shared/types";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import {
@@ -416,6 +417,15 @@ export function HostBuilderViewRedesigned({
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
       <div className="relative shrink-0 border-b border-border/40 px-8 py-2.5">
         <div className="flex min-w-0 items-center justify-end gap-2 sm:gap-3">
+          {/* Host/Compare sub-nav sits inline beside Save — a single header
+              row instead of a second segmented bar stacked over the canvas. */}
+          <HostSectionTabs
+            value="host"
+            hostEnabled
+            onSelect={(next) => {
+              if (next === "compare") navigate("/host-compare");
+            }}
+          />
           <Button
             size="sm"
             onClick={() => void handleSave()}
@@ -447,8 +457,6 @@ export function HostBuilderViewRedesigned({
                   // The URL→state sync in HostsRoute will clear the
                   // selected host when /servers takes over.
                   navigate("/servers");
-                } else if (next === "compare") {
-                  navigate("/host-compare");
                 } else if (next === "computer") {
                   navigate("/computer");
                 }
@@ -456,7 +464,8 @@ export function HostBuilderViewRedesigned({
               options={[
                 { value: "servers", label: "Servers" },
                 { value: "host", label: "Host" },
-                { value: "compare", label: "Compare" },
+                // "Compare" is reached from the inline Host|Compare pill, not
+                // this primary nav — keep it out so it isn't duplicated.
                 ...(computersEnabled
                   ? [{ value: "computer", label: "Computer" }]
                   : []),

--- a/mcpjam-inspector/client/src/components/shared/view-mode-selector.tsx
+++ b/mcpjam-inspector/client/src/components/shared/view-mode-selector.tsx
@@ -1,3 +1,4 @@
+import { motion, useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
 export type ViewModeSelectorOption<T extends string> = {
@@ -12,13 +13,23 @@ export function ViewModeSelector<T extends string>({
   onChange,
   ariaLabel,
   className,
+  /**
+   * Shared-layout id for the sliding active indicator. Each distinct
+   * selector instance on screen needs its own id so framer-motion doesn't
+   * try to animate one underline between two different navs. Defaults to the
+   * aria label.
+   */
+  indicatorId,
 }: {
   value: T;
   options: readonly ViewModeSelectorOption<T>[];
   onChange: (value: T) => void;
   ariaLabel: string;
   className?: string;
+  indicatorId?: string;
 }) {
+  const reduceMotion = useReducedMotion();
+  const layoutId = `view-mode-indicator-${indicatorId ?? ariaLabel}`;
   return (
     <nav
       className={cn(
@@ -37,16 +48,25 @@ export function ViewModeSelector<T extends string>({
             aria-current={active ? "page" : undefined}
             onClick={() => onChange(option.value)}
             className={cn(
-              "relative min-h-10 shrink-0 px-4 py-2 text-sm font-medium transition-colors sm:min-h-11 sm:px-5 sm:text-base md:min-h-10 md:px-4 lg:px-6",
+              "relative min-h-10 shrink-0 px-4 py-2 text-sm font-medium transition-colors duration-200 sm:min-h-11 sm:px-5 sm:text-base md:min-h-10 md:px-4 lg:px-6",
               active
                 ? "text-foreground"
                 : "text-muted-foreground hover:text-foreground",
               option.disabled ? "cursor-not-allowed opacity-40" : "",
             )}
           >
-            {option.label}
+            <span className="relative z-10">{option.label}</span>
             {active ? (
-              <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-primary sm:inset-x-4 md:inset-x-3 lg:inset-x-6" />
+              <motion.span
+                layoutId={layoutId}
+                aria-hidden="true"
+                className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-primary sm:inset-x-4 md:inset-x-3 lg:inset-x-6"
+                transition={
+                  reduceMotion
+                    ? { duration: 0 }
+                    : { type: "spring", stiffness: 520, damping: 38, mass: 0.7 }
+                }
+              />
             ) : null}
           </button>
         );


### PR DESCRIPTION
## What

When a host was selected, the Host section showed a **double navbar**: a `Host | Compare` segmented pill stacked above a second underline nav (`Servers · Host · Compare · Computer`). "Compare" appeared twice and "Host" was triplicated.

This was an incomplete refactor — the "Compare moves into a Host sub-pill" change had been applied to the browse header (`ConnectViewHeader`) but never to the host canvas header (`HostBuilderViewRedesigned`), which still rendered the old full nav. So the new pill and the stale nav stacked.

## Change

Collapse to a single header row:

- **`HostSectionTabs`** is now a bare `inline-flex` element so callers can drop it into a header row instead of it forcing its own centered bar.
- **`HostsTab`** — removed the stacked pill from the host-canvas branch.
- **`HostBuilderViewRedesigned`** — the `Host | Compare` pill now sits inline beside the Save button, and `Compare` was removed from the centered underline nav so it's no longer duplicated.
- **`HostCompareRoute`** (`App.tsx`) — the pill renders inline via `ConnectViewHeader`'s `rightSlot` instead of stacking under the primary nav.

Also bundles the related in-progress host comparison work already on `main` (`HostCompareSelector`, `HostConfigCompareView`, `host-config-comparison-matrix`, `view-mode-selector`, and their tests).

## Result

Host view is now one row: centered `Servers · Host · Computer` underline, with `( Host | Compare )` + `Save` on the right. The underline keeps "Host" lit while the pill toggles into Compare.

## Notes
- The unrelated MCPJam-agent tool-call work was deliberately **left out** of this PR.
- The centered underline + right-aligned pill share one row; on very narrow widths they could crowd. Easy follow-up is to switch that header to the `grid-cols-[1fr_auto_1fr]` layout `ConnectViewHeader` already uses.

## Test
- `HostsTab.header-chrome` test passes; touched files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side navigation and presentation only; routing targets are unchanged aside from where Compare is reached in the UI.
> 
> **Overview**
> Fixes the **double navbar** on host views by moving **Compare** out of the primary Connect underline nav and into a new inline **`Host | Compare`** segmented control (`HostSectionTabs`).
> 
> On the **host builder**, that pill sits on the right next to **Save** while **Servers · Host · Computer** stays centered; on **`/host-compare`**, the same pill lives in `ConnectViewHeader`'s **`rightSlot`** so Compare is one header row instead of a stacked bar. **`ConnectViewHeader`** and **`HostBuilderViewRedesigned`** no longer list Compare as a top-level tab, which removes the duplicate **Host/Compare** labels.
> 
> **Host compare** picks up a **Descriptions** toggle: compact rows use an info tooltip by default, or inline copy when the switch is on. The comparison matrix gets light motion/polish; **`ViewModeSelector`** uses a shared-layout sliding underline (with optional **`indicatorId`** so multiple navs don't cross-animate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ada6cead3f98b949f5d0cd71543ef43f2e7d927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->