### PR TITLE
Host Compare: offer static host profiles as opt-in columns

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from "lucide-react";
 import { useSearchParams } from "react-router";
 import { useHost, useHostList } from "@/hooks/useClients";
 import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { HostCompareSelector } from "./HostCompareSelector";
 import {
   parseHostsParam,
@@ -10,6 +11,7 @@ import {
   toggleHostCompareSelection,
   writeHostCompareSelection,
 } from "./host-compare-selection";
+import { buildPresetCompareEntries } from "./host-compare-presets";
 import { HostConfigComparisonMatrix } from "./host-config-comparison-matrix";
 
 const HOSTS_QUERY_PARAM = "hosts";
@@ -28,10 +30,26 @@ export function HostConfigCompareView({
   projectId,
   isAuthenticated,
 }: HostConfigCompareViewProps) {
-  const { hosts, isLoading: listLoading } = useHostList({
+  const { hosts: liveHosts, isLoading: listLoading } = useHostList({
     isAuthenticated,
     projectId,
   });
+
+  // Static host profiles (Claude, ChatGPT, Cursor, …) offered as opt-in
+  // comparison columns even when the user hasn't created them — the same
+  // best-effort profiles the server detail modal's Hosts tab renders. Threaded
+  // with the current theme so preset configs match the rest of the app.
+  const themeMode = usePreferencesStore((s) => s.themeMode);
+  const presets = useMemo(
+    () => buildPresetCompareEntries(themeMode),
+    [themeMode],
+  );
+
+  // Real created hosts first, then presets — what the selector chips iterate.
+  const hosts = useMemo(
+    () => [...liveHosts, ...presets.hosts],
+    [liveHosts, presets.hosts],
+  );
 
   const [subjectsByHost, setSubjectsByHost] = useState<
     Record<string, HostComparisonSubject>
@@ -45,7 +63,15 @@ export function HostConfigCompareView({
   // becomes the source of truth and mirrors back into the URL.
   const urlConsumedRef = useRef(false);
 
+  // Real created hosts only — drives the default selection and the
+  // ?hosts=-is-default suppression. Presets are never part of the default.
   const liveHostIds = useMemo(
+    () => liveHosts.map((host) => host.hostId),
+    [liveHosts],
+  );
+  // Every selectable id (real + preset). URL / stored selections reconcile
+  // against this so a chosen preset column survives a reload.
+  const knownHostIds = useMemo(
     () => hosts.map((host) => host.hostId),
     [hosts],
   );
@@ -60,11 +86,12 @@ export function HostConfigCompareView({
       resolveInitialHostCompareSelection({
         projectId: projectId ?? "",
         liveHostIds,
+        knownHostIds,
         previousSelection: previous,
         urlSelection,
       }),
     );
-  }, [listLoading, liveHostIds, projectId, searchParams]);
+  }, [listLoading, liveHostIds, knownHostIds, projectId, searchParams]);
 
   useEffect(() => {
     if (!projectId || selectedHostIds.length === 0) return;
@@ -139,11 +166,18 @@ export function HostConfigCompareView({
     [selectedHostIds],
   );
 
+  // Preset subjects are static and available immediately; fetched real-host
+  // subjects (keyed by Convex id, no prefix collision) layer on top.
+  const allSubjects = useMemo(
+    () => ({ ...presets.subjects, ...subjectsByHost }),
+    [presets.subjects, subjectsByHost],
+  );
+
   const orderedSubjects = useMemo(() => {
     return selectedHostIds
-      .map((hostId) => subjectsByHost[hostId])
+      .map((hostId) => allSubjects[hostId])
       .filter((subject): subject is HostComparisonSubject => subject !== undefined);
-  }, [selectedHostIds, subjectsByHost]);
+  }, [selectedHostIds, allSubjects]);
 
   const loadedSelectedCount = orderedSubjects.length;
   const totalSelectedCount = selectedHostIds.length;
@@ -167,7 +201,10 @@ export function HostConfigCompareView({
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       {selectedHostIds.map((hostId) => {
-        const host = hosts.find((entry) => entry.hostId === hostId);
+        // Only real hosts hydrate over the wire — preset subjects are already
+        // in `presets.subjects`, so a preset id finds no `liveHosts` row and
+        // mounts no fetcher (and fires no Convex query against a synthetic id).
+        const host = liveHosts.find((entry) => entry.hostId === hostId);
         if (!host) return null;
         return (
           <HostConfigFetcher
@@ -196,7 +233,7 @@ export function HostConfigCompareView({
             <HostCompareSelector
               hosts={hosts}
               selectedHostIds={selectedHostIds}
-              subjectsByHost={subjectsByHost}
+              subjectsByHost={allSubjects}
               onToggleHost={handleToggleHost}
               divergingOnly={divergingOnly}
               onDivergingOnlyChange={setDivergingOnly}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { HOST_TEMPLATES } from "@/lib/client-templates";
+import {
+  PRESET_HOST_ID_PREFIX,
+  buildPresetCompareEntries,
+  isPresetHostId,
+} from "../host-compare-presets";
+
+describe("host-compare-presets", () => {
+  it("builds one preset host + subject per template, in catalog order", () => {
+    const { hosts, subjects } = buildPresetCompareEntries("dark");
+
+    expect(hosts).toHaveLength(HOST_TEMPLATES.length);
+    expect(hosts.map((h) => h.hostId)).toEqual(
+      HOST_TEMPLATES.map((t) => `${PRESET_HOST_ID_PREFIX}${t.id}`),
+    );
+    // Every preset host has a matching, immediately-available subject.
+    for (const host of hosts) {
+      const subject = subjects[host.hostId];
+      expect(subject).toBeDefined();
+      expect(subject.hostName).toBe(host.name);
+      expect(subject.config.modelId).toBe(host.modelId);
+      // Synthetic DTO fields the matrix never reads but must be present.
+      expect(subject.config.id).toBe(host.hostId);
+    }
+  });
+
+  it("marks every preset id and rejects a real Convex id", () => {
+    const { hosts } = buildPresetCompareEntries("light");
+    expect(hosts.every((h) => isPresetHostId(h.hostId))).toBe(true);
+    expect(isPresetHostId("k1234567890abcdef")).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
@@ -82,4 +82,41 @@ describe("host-compare-selection", () => {
       }),
     ).toEqual(["b"]);
   });
+
+  it("resolveInitialHostCompareSelection keeps a preset id from the URL via knownHostIds", () => {
+    // A preset is not a live host, so it must be reconciled against the
+    // known superset — otherwise a shared/reloaded preset column vanishes.
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: ["a"],
+        knownHostIds: ["a", "preset:claude"],
+        previousSelection: [],
+        urlSelection: ["a", "preset:claude"],
+      }),
+    ).toEqual(["a", "preset:claude"]);
+  });
+
+  it("resolveInitialHostCompareSelection resolves a preset selection with zero live hosts", () => {
+    writeHostCompareSelection("proj_1", ["preset:chatgpt"]);
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: [],
+        knownHostIds: ["preset:chatgpt", "preset:claude"],
+        previousSelection: [],
+      }),
+    ).toEqual(["preset:chatgpt"]);
+  });
+
+  it("resolveInitialHostCompareSelection default stays real-hosts-only (presets opt-in)", () => {
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: ["a", "b"],
+        knownHostIds: ["a", "b", "preset:claude", "preset:chatgpt"],
+        previousSelection: [],
+      }),
+    ).toEqual(["a", "b"]);
+  });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
@@ -1,0 +1,76 @@
+import type { HostThemeMode } from "@/lib/client-styles/types";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+import type { HostListItem } from "@/hooks/useClients";
+import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
+import { HOST_TEMPLATES } from "@/lib/client-templates";
+
+/**
+ * Static host profiles surfaced in Host Compare so a user can compare against
+ * Claude / ChatGPT / Cursor / Copilot / Codex … without having created (or
+ * connected) those hosts — the same "best-effort host profiles" the server
+ * detail modal's Hosts tab renders from `HOST_TEMPLATES`. Each preset is a
+ * synthetic, immediately-available comparison subject derived from a template
+ * `seed()`, never a real `hosts:listHosts` row.
+ */
+
+/** Prefix that marks a synthetic preset host id (`preset:claude`, …). Chosen so
+ * it can never collide with a Convex host id. */
+export const PRESET_HOST_ID_PREFIX = "preset:";
+
+export function isPresetHostId(hostId: string): boolean {
+  return hostId.startsWith(PRESET_HOST_ID_PREFIX);
+}
+
+export interface PresetCompareEntries {
+  /** Selector chips, in template order, appended after the real hosts. */
+  hosts: HostListItem[];
+  /** Ready-to-render subjects keyed by preset host id — no fetch required. */
+  subjects: Record<string, HostComparisonSubject>;
+}
+
+/**
+ * Build the preset selector chips + their comparison subjects from the host
+ * template catalog. A template `seed()` returns a `HostConfigInputV2`, which is
+ * structurally a `HostConfigDtoV2` minus the persisted `id` / `schemaVersion`
+ * — the matrix only reads the shared config fields, so we stamp synthetic
+ * values and use it directly instead of round-tripping through a real host.
+ *
+ * `theme` threads MCPJam's current theme into each seed so preset configs match
+ * the rest of the app, mirroring the Hosts-tab CTA's `seedFromHostTemplate`.
+ */
+export function buildPresetCompareEntries(
+  theme: HostThemeMode,
+): PresetCompareEntries {
+  const hosts: HostListItem[] = [];
+  const subjects: Record<string, HostComparisonSubject> = {};
+
+  for (const template of HOST_TEMPLATES) {
+    const hostId = `${PRESET_HOST_ID_PREFIX}${template.id}`;
+    const input = template.seed({ theme });
+    const config: HostConfigDtoV2 = {
+      ...input,
+      id: hostId,
+      schemaVersion: 2,
+    };
+
+    hosts.push({
+      hostId,
+      name: template.label,
+      hostConfigId: hostId,
+      modelId: config.modelId,
+      serverCount: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    subjects[hostId] = {
+      hostId,
+      hostName: template.label,
+      hostStyle: config.hostStyle,
+      configHashShort: template.id,
+      config,
+    };
+  }
+
+  return { hosts, subjects };
+}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
@@ -63,22 +63,32 @@ export function resolveInitialHostCompareSelection(args: {
   liveHostIds: ReadonlyArray<string>;
   previousSelection: ReadonlyArray<string>;
   urlSelection?: ReadonlyArray<string> | null;
+  /**
+   * Every id the user is allowed to select — real live hosts plus synthetic
+   * preset host ids. URL / stored / previous selections reconcile against this
+   * superset so a preset column survives a reload, while the default fallback
+   * stays real-hosts-only (presets are opt-in, never auto-selected). Defaults
+   * to `liveHostIds` when omitted (no presets in play).
+   */
+  knownHostIds?: ReadonlyArray<string>;
 }): string[] {
-  const live = new Set(args.liveHostIds);
-  if (live.size === 0) return [];
+  const known = new Set(args.knownHostIds ?? args.liveHostIds);
 
   if (args.urlSelection && args.urlSelection.length > 0) {
-    const fromUrl = reconcileHostCompareSelection(args.urlSelection, live);
+    const fromUrl = reconcileHostCompareSelection(args.urlSelection, known);
     if (fromUrl.length > 0) return fromUrl;
   }
 
   const stored = readHostCompareSelection(args.projectId);
   if (stored) {
-    const fromStorage = reconcileHostCompareSelection(stored, live);
+    const fromStorage = reconcileHostCompareSelection(stored, known);
     if (fromStorage.length > 0) return fromStorage;
   }
 
-  const fromPrevious = reconcileHostCompareSelection(args.previousSelection, live);
+  const fromPrevious = reconcileHostCompareSelection(
+    args.previousSelection,
+    known,
+  );
   if (fromPrevious.length > 0) return fromPrevious;
 
   return [...args.liveHostIds];


### PR DESCRIPTION
## What

Host Compare now offers the same **static host profiles** the server detail modal's Hosts tab shows (Claude, ChatGPT, Cursor, Copilot, Codex …) — as opt-in comparison columns you can add **without creating or connecting** those hosts.

Before, Compare only knew about hosts the user had actually created, so a fresh project had nothing to compare, and there was no way to line a real host up beside a reference profile.

## How

- New `host-compare-presets.ts` turns the `HOST_TEMPLATES` catalog into synthetic, immediately-available comparison subjects. A template `seed()` returns a `HostConfigInputV2`, which is structurally a `HostConfigDtoV2` minus `id`/`schemaVersion`, and the matrix only reads the shared config fields — so each preset becomes a column with **no Convex fetch**.
- Preset host ids are prefixed `preset:` so they never collide with a real host id and never mount a `HostConfigFetcher`.
- Selector lists real hosts first, then all presets (existing inline + overflow). Real hosts stay selected by default; **presets are opt-in**.
- Preset selections survive reload/share via a `knownHostIds` superset used for URL/storage reconciliation, while the "default = all live hosts" `?hosts=` suppression stays real-hosts-only.
- With zero real hosts, Compare is no longer blank.
- `resolveInitialHostCompareSelection` takes an optional `knownHostIds` (defaults to `liveHostIds`), so existing callers are unaffected.

Per product decision: presets are **always offered** and **look identical** to real host chips/columns (no preset marker).

## Tests

- New `host-compare-presets.test.ts`: builder produces one subject per template; preset ids are marked and a real Convex id is rejected.
- Extended `host-compare-selection.test.ts`: a preset id survives via `knownHostIds` (URL + zero-live-hosts cases) and the default stays real-hosts-only.
- Full comparison suite: 24 passing. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only compare UI using synthetic ids to avoid backend calls; selection logic extended with backward-compatible optional knownHostIds.
> 
> **Overview**
> **Host Compare** can now include **static reference profiles** (Claude, ChatGPT, Cursor, etc.) as opt-in columns, built from `HOST_TEMPLATES` with theme-aware `seed()` configs—no create/connect and **no Convex fetch** for those columns.
> 
> A new **`host-compare-presets`** module synthesizes list items and comparison subjects with `preset:` ids; the compare view appends them after live hosts, merges preset subjects with fetched ones, and only mounts **`HostConfigFetcher`** for real hosts. Default selection and clean `?hosts=` behavior stay **live-hosts-only**; optional **`knownHostIds`** lets URL/session selections keep preset columns on reload or share links, including when there are zero real hosts.
> 
> Tests cover preset building and selection reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d96a5fa14bba0977e7aecd07ce8671705bfbc5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->