### PR TITLE
Preserve structuredContent for MCP App widgets on the shared chat path

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -1168,6 +1168,103 @@ describe("mcpjam-stream-handler", () => {
     ]);
   });
 
+  it("emits structuredContent in the UI tool-output chunk for a widget tool (scrubbed model output, raw result)", async () => {
+    // Reproduces the agent's "Missing structured content" bug: the model copy
+    // is scrubbed, but the raw `result` carries structuredContent. The UI chunk
+    // MUST surface structuredContent at the top level for the widget to render.
+    let fetchCall = 0;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      fetchCall += 1;
+      if (fetchCall === 1) {
+        return createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-w1",
+            toolName: "show_servers",
+            input: {},
+          },
+          {
+            type: "finish",
+            finishReason: "stop",
+            totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ]);
+      }
+      return createSseResponse([
+        {
+          type: "finish",
+          finishReason: "stop",
+          totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ]);
+    });
+    vi.mocked(hasUnresolvedToolCalls).mockImplementation(
+      (messages) =>
+        messages.some(
+          (message: any) =>
+            message?.role === "assistant" &&
+            Array.isArray(message.content) &&
+            message.content.some((part: any) => part.type === "tool-call")
+        ) && !messages.some((message: any) => message?.role === "tool")
+    );
+    const structuredContent = {
+      project: { id: "p1", name: "Default" },
+      servers: [{ name: "notion" }],
+      widget: "servers",
+    };
+    const rawResult = {
+      content: [{ type: "text", text: "8 servers" }],
+      structuredContent,
+      _meta: { "mcpjam/widget": true },
+    };
+    vi.mocked(executeToolCallsFromMessages).mockImplementation(
+      async (messages: any[]) => {
+        const toolResultMessage = {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-w1",
+              toolName: "show_servers",
+              // model-facing copy is scrubbed (no structuredContent)…
+              output: {
+                type: "json",
+                value: { content: rawResult.content },
+              },
+              // …raw result preserved for UI hydration.
+              result: rawResult,
+              serverId: "widget-server",
+            },
+          ],
+        };
+        messages.splice(2, 0, toolResultMessage);
+        return [toolResultMessage] as any;
+      }
+    );
+
+    await handleMCPJamFreeChatModel({
+      messages: [{ role: "user", content: "show servers" }] as any,
+      modelId: "anthropic/claude-haiku-4.5",
+      systemPrompt: "You are helpful",
+      tools: { show_servers: { _serverId: "widget-server" } } as any,
+      mcpClientManager: {
+        getAllToolsMetadata: vi.fn().mockReturnValue({ show_servers: {} }),
+      } as any,
+    });
+
+    await lastExecution;
+
+    const toolOutputChunk = writtenChunks.find(
+      (chunk) =>
+        chunk?.type === "tool-output-available" &&
+        chunk?.toolCallId === "call-w1"
+    );
+    expect(toolOutputChunk).toBeDefined();
+    expect((toolOutputChunk!.output as any).structuredContent).toEqual(
+      structuredContent
+    );
+  });
+
   describe("progressive discovery approval semantics", () => {
     // Minimal "plan enabled" — only the `enabled` flag is read on the
     // post-stream unresolved-tool detection + drain paths exercised here.

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -1237,7 +1237,19 @@ async function emitToolResults(
             typeof (part as any).serverId === "string"
               ? ((part as any).serverId as string)
               : undefined;
-          const rawOutput = part.output ?? (part as any).result;
+          // MCP App tools scrub structuredContent from the model-facing
+          // `output`; their widgets need the raw result, which
+          // `executeToolCallsFromMessages` stamps on `result` when it carries
+          // structuredContent. Prefer it so the widget receives
+          // structuredContent. All other tools keep the existing
+          // `output`-first behavior.
+          const rawResult = (part as any).result;
+          const rawOutput =
+            rawResult &&
+            typeof rawResult === "object" &&
+            "structuredContent" in rawResult
+              ? rawResult
+              : part.output ?? rawResult;
 
           let outputForUi: unknown = rawOutput;
           if (rawOutput && typeof rawOutput === "object") {

--- a/mcpjam-inspector/shared/__tests__/http-tool-calls.test.ts
+++ b/mcpjam-inspector/shared/__tests__/http-tool-calls.test.ts
@@ -1069,6 +1069,44 @@ describe("executeToolCallsFromMessages — toModelOutput (browser-render PR 14)"
     expect("result" in part).toBe(false);
   });
 
+  it("preserves the raw result for a toModelOutput tool that returns structuredContent (widget UI hydration)", async () => {
+    // MCP App tools define toModelOutput to scrub structuredContent from the
+    // model copy, but their widgets read `toolResult.structuredContent`. The
+    // raw result must still be stamped on the part (`result:`) for the UI.
+    // This is the agent's path: tools are passed directly (no clientManager).
+    const implResult = {
+      content: [{ type: "text", text: "8 servers" }],
+      structuredContent: {
+        project: { id: "p1", name: "Default" },
+        servers: [{ name: "notion" }],
+        widget: "servers",
+      },
+      _meta: { source: "platform" },
+    };
+    const tools = {
+      show_servers: {
+        execute: vi.fn().mockResolvedValue(implResult),
+        // scrub structuredContent for the model-facing copy
+        toModelOutput: ({ output }: { output: unknown }) => ({
+          type: "json" as const,
+          value: { content: (output as { content: unknown }).content },
+        }),
+      },
+    };
+
+    const messages = callMessage("show_servers");
+    const newMessages = await executeToolCallsFromMessages(messages, { tools });
+
+    const part = (newMessages[0] as any).content[0];
+    // Model copy is scrubbed (no structuredContent)...
+    expect(part.output).toEqual({
+      type: "json",
+      value: { content: implResult.content },
+    });
+    // ...but the raw result (with structuredContent + _meta) survives for the UI.
+    expect(part.result).toEqual(implResult);
+  });
+
   it("awaits an async toModelOutput", async () => {
     const tools = {
       computer: {

--- a/mcpjam-inspector/shared/http-tool-calls.ts
+++ b/mcpjam-inspector/shared/http-tool-calls.ts
@@ -252,6 +252,17 @@ export async function executeToolCallsFromMessages(
           ).toModelOutput;
           if (typeof toModelOutput === "function") {
             const mappedOutput = await toModelOutput({ output: result });
+            // MCP App tools scrub structuredContent from the model-facing copy
+            // (`mappedOutput`), but their widgets read structuredContent from
+            // the raw result. Preserve the raw result for UI hydration whenever
+            // it carries structuredContent — the model copy no longer does.
+            // Other toModelOutput tools (e.g. the eval `computer` tool) return
+            // no structuredContent, so they keep omitting `result:` and don't
+            // bloat subsequent per-step request bodies with large content.
+            const rawHasStructuredContent =
+              !!result &&
+              typeof result === "object" &&
+              "structuredContent" in (result as Record<string, unknown>);
             const toolResultMessage: ModelMessage = {
               role: "tool" as const,
               content: [
@@ -260,6 +271,9 @@ export async function executeToolCallsFromMessages(
                   toolCallId: content.toolCallId,
                   toolName: toolName,
                   output: mappedOutput,
+                  // UI-only raw result for app-tool widgets (stripped from the
+                  // model copy via `output`/toModelOutput above).
+                  ...(rawHasStructuredContent ? { result } : {}),
                   serverId: extractServerId(toolName),
                 },
               ],


### PR DESCRIPTION
## Problem

MCP App widgets that read `toolResult.structuredContent` (e.g. the platform `show_servers` widget) rendered **"Missing structured content"** on the new agent surface.

Root cause: MCP App tools scrub `structuredContent` from their model-facing output via `toModelOutput` — correctly, since the large UI-only payload shouldn't enter the model context (SEP-1865: *"structuredContent: not added to model context"*). But the shared chat pipeline only carried that scrubbed copy, so the widget bridge received an envelope with no `structuredContent`.

The agent (`mcpjam-agent.ts`) and the Playground (`chat-v2.ts`) **already share this entire pipeline** (`streamWebChatTurn` → `handleMCPJamFreeChatModel` → `executeToolCallsFromMessages` + `emitToolResults` → the shared `mcp-apps-renderer`/bridge). So this is fixed once, in shared code — not per-surface.

## Fix

- **`executeToolCallsFromMessages`** stamps the raw, unscrubbed `result` on the tool-result part whenever it carries `structuredContent` (UI hydration only). The model copy stays scrubbed, so per-step request bodies don't bloat for tools that return no `structuredContent` (e.g. the eval `computer` tool keep omitting `result:`).
- **`emitToolResults`** prefers that raw `result` for the streamed UI output when it carries `structuredContent`, falling back to the existing `output`-first behavior otherwise.

The widget bridge now receives a spec-correct `CallToolResult` (SEP-1865: `ui/notifications/tool-result` carries the full `{ content, structuredContent, _meta }`; the View reads `structuredContent`) from the same shared renderer the Playground already drives — with **no surface-specific normalization at the bridge**.

### Why no client-side change

An earlier iteration re-enveloped the payload at the bridge (`toCallToolResult` in `useToolInputStreaming` / `mcp-apps-modal`). That regressed the battle-tested Playground — it reshaped tool output for **every** widget, blanking the external Excalidraw app. Feeding the correct `CallToolResult` upstream means the shared bridge needs no changes.

## Verification

- `show_servers` renders its structured content on the agent. ✅
- Excalidraw `create_view` (external app) draws again in the Playground. ✅
- `shared/__tests__/http-tool-calls.test.ts` (39) + `server/utils/__tests__/mcpjam-stream-handler.test.ts` (41) pass, including new structuredContent-preservation cases. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared tool-result and streaming behavior used by agent and Playground; gated to structuredContent-only paths but incorrect handling could affect widget rendering or message payload size.
> 
> **Overview**
> Fixes MCP App widgets (e.g. `show_servers`) showing **"Missing structured content"** on the agent when tools use `toModelOutput` to strip `structuredContent` from the model-facing payload.
> 
> **`executeToolCallsFromMessages`** now attaches a UI-only **`result`** on tool-result parts when the raw tool return includes **`structuredContent`**, while **`output`** stays the scrubbed `toModelOutput` copy so later model steps are not bloated. Tools without `structuredContent` (e.g. eval `computer`) still omit **`result`**.
> 
> **`emitToolResults`** in the stream handler prefers that raw **`result`** for **`tool-output-available`** when it carries **`structuredContent`**, so streamed UI chunks expose a spec-shaped **`CallToolResult`** for the shared widget bridge. Other tools keep output-first behavior.
> 
> New tests cover preservation in **`http-tool-calls`** and **`structuredContent`** on the UI tool-output chunk in **`mcpjam-stream-handler`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1464ae0c5821bb0a518c44461d6864ed0fd564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->