### PR TITLE
CLI: deliver update notice to any agent, not just TTYs

### DIFF
--- a/cli/src/lib/update-notifier.ts
+++ b/cli/src/lib/update-notifier.ts
@@ -13,7 +13,6 @@ export interface UpdateCheckCache {
 
 export interface SkipUpdateCheckOptions {
   env?: NodeJS.ProcessEnv;
-  isStderrTTY?: boolean;
 }
 
 export type StderrLike = {
@@ -180,13 +179,15 @@ export function shouldSkipUpdateCheck(
   options: SkipUpdateCheckOptions = {},
 ): boolean {
   const env = options.env ?? process.env;
-  const isStderrTTY = options.isStderrTTY ?? Boolean(process.stderr.isTTY);
 
+  // Intentionally not gated on stderr being a TTY. The notice is written to
+  // stderr only (never stdout/JSON), so it never corrupts machine-readable
+  // output. AI agents (Claude Code, Cursor, etc.) run the CLI non-interactively
+  // but still surface stderr to the model — a TTY gate would silence the update
+  // signal for every agent. CI and the explicit opt-out env vars cover the
+  // pipelines that genuinely should not be nudged.
   return Boolean(
-    env.CI ||
-      env.NO_UPDATE_NOTIFIER ||
-      env.MCPJAM_NO_UPDATE_CHECK ||
-      !isStderrTTY,
+    env.CI || env.NO_UPDATE_NOTIFIER || env.MCPJAM_NO_UPDATE_CHECK,
   );
 }
 
@@ -252,12 +253,7 @@ export function checkForUpdates(
   try {
     const env = options.env ?? process.env;
 
-    if (
-      shouldSkipUpdateCheck({
-        env,
-        isStderrTTY: options.isStderrTTY,
-      })
-    ) {
+    if (shouldSkipUpdateCheck({ env })) {
       return;
     }
 

--- a/cli/tests/update-notifier.test.ts
+++ b/cli/tests/update-notifier.test.ts
@@ -163,25 +163,17 @@ test("isUpdateCacheFresh uses the 24 hour freshness window", () => {
   );
 });
 
-test("shouldSkipUpdateCheck respects CI, opt-out env vars, and non-TTY stderr", () => {
-  assert.equal(shouldSkipUpdateCheck({ env: {}, isStderrTTY: true }), false);
-  assert.equal(shouldSkipUpdateCheck({ env: {}, isStderrTTY: false }), true);
+test("shouldSkipUpdateCheck respects CI and opt-out env vars, not TTY", () => {
+  // Interactive humans and non-interactive agents both get the check; only CI
+  // and explicit opt-outs suppress it. (No TTY gate — agents read stderr too.)
+  assert.equal(shouldSkipUpdateCheck({ env: {} }), false);
+  assert.equal(shouldSkipUpdateCheck({ env: { CI: "true" } }), true);
   assert.equal(
-    shouldSkipUpdateCheck({ env: { CI: "true" }, isStderrTTY: true }),
+    shouldSkipUpdateCheck({ env: { NO_UPDATE_NOTIFIER: "1" } }),
     true,
   );
   assert.equal(
-    shouldSkipUpdateCheck({
-      env: { NO_UPDATE_NOTIFIER: "1" },
-      isStderrTTY: true,
-    }),
-    true,
-  );
-  assert.equal(
-    shouldSkipUpdateCheck({
-      env: { MCPJAM_NO_UPDATE_CHECK: "1" },
-      isStderrTTY: true,
-    }),
+    shouldSkipUpdateCheck({ env: { MCPJAM_NO_UPDATE_CHECK: "1" } }),
     true,
   );
 });
@@ -199,7 +191,6 @@ test("checkForUpdates prints a fresh newer cached version to stderr", () => {
     checkForUpdates("3.0.0", {
       cachePath,
       env: {},
-      isStderrTTY: true,
       now: 1_000,
       stderr: {
         write(chunk) {
@@ -231,7 +222,6 @@ test("checkForUpdates stays quiet for fresh same or older cached versions", () =
     checkForUpdates("3.0.0", {
       cachePath,
       env: {},
-      isStderrTTY: true,
       now: 1_000,
       stderr: {
         write(chunk) {
@@ -266,7 +256,6 @@ test("checkForUpdates prints stale newer cache and refreshes in the background",
     checkForUpdates("3.0.0", {
       cachePath: staleCachePath,
       env: {},
-      isStderrTTY: true,
       now: 1_000 + UPDATE_CHECK_INTERVAL_MS,
       stderr: {
         write(chunk) {
@@ -300,7 +289,6 @@ test("checkForUpdates spawns a background fetch for stale same-version or missin
     checkForUpdates("3.0.0", {
       cachePath: staleCachePath,
       env: {},
-      isStderrTTY: true,
       now: 1_000 + UPDATE_CHECK_INTERVAL_MS,
       stderr: {
         write(chunk) {
@@ -313,7 +301,6 @@ test("checkForUpdates spawns a background fetch for stale same-version or missin
     checkForUpdates("3.0.0", {
       cachePath: missingCachePath,
       env: {},
-      isStderrTTY: true,
       now: 1_000,
       stderr: {
         write(chunk) {
@@ -344,7 +331,6 @@ test("checkForUpdates skips both notice and fetch when disabled", () => {
       env: {
         MCPJAM_NO_UPDATE_CHECK: "1",
       },
-      isStderrTTY: true,
       now: 1_000,
       stderr: {
         write(chunk) {


### PR DESCRIPTION
## Problem

When someone runs `mcpjam` through an AI agent (Claude Code, Cursor, an MCP harness, etc.), they get **no signal** that a newer `@mcpjam/cli` is available. The update notifier was gated on stderr being a TTY (`shouldSkipUpdateCheck` returned `true` when `!isStderrTTY`), and agents run the CLI non-interactively — so the check never even ran.

## Fix

Drop the `!isStderrTTY` term from `shouldSkipUpdateCheck`. It now suppresses **only** on `CI` / `NO_UPDATE_NOTIFIER` / `MCPJAM_NO_UPDATE_CHECK`.

This covers **any** agent generically rather than whitelisting known env vars — every agent run is the non-TTY-non-CI case. It's safe because:

- The notice is **stderr-only** and never touches the stdout/JSON an agent parses (the one rule the ecosystem — npm, `gh`, clig.dev — treats as inviolable).
- Agents capture stderr and surface it to the model, so the signal is actually seen.
- `CI` + the opt-out env vars still cover the pipelines that genuinely shouldn't be nudged.

Trade-off: plain non-CI shell pipelines now also see the stderr notice — harmless (doesn't corrupt redirected stdout) and silenceable via the opt-out vars. There's no way to "show to any agent" while "hiding from all non-TTY" — they're the same context.

Also removed the now-unused `isStderrTTY` option and updated the test.

## Verification

- `npm test` (update-notifier suite) → 11/11 pass; rewrote the skip test to assert the new behavior
- `npm run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to when stderr-only update text is shown; stdout/JSON and CI/opt-out suppression are unchanged.
> 
> **Overview**
> **Update checks no longer skip when stderr is not a TTY**, so AI agents and other non-interactive runs can see the “new version available” message on stderr without touching stdout/JSON.
> 
> `shouldSkipUpdateCheck` now only returns true for **`CI`**, **`NO_UPDATE_NOTIFIER`**, and **`MCPJAM_NO_UPDATE_CHECK`**. The **`isStderrTTY`** option was removed from **`SkipUpdateCheckOptions`**, **`checkForUpdates`**, and tests were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74c2346f5ff49f5688faa1d6b09ba3d45f4f95bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->