### PR TITLE
fix(sidebar): don't flash signed-out layout while auth resolves

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -53,6 +53,7 @@ import { SidebarTrialCountdown } from "@/components/sidebar/sidebar-trial-countd
 import { ShareProjectDialog } from "@/components/project/ShareProjectDialog";
 import { useUpdateNotification } from "@/hooks/useUpdateNotification";
 import { Button } from "@mcpjam/design-system/button";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
 import {
   Tooltip,
   TooltipContent,
@@ -308,6 +309,27 @@ const signedOutUtilityItems: NavItem[] = [
   },
 ];
 
+// Neutral placeholder shown while auth is resolving, so signed-in users don't
+// see the signed-out nav list flash before their authed items appear.
+function SidebarNavSkeleton() {
+  return (
+    <SidebarGroup>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <SidebarMenuItem key={i}>
+              <SidebarMenuButton disabled>
+                <Skeleton className="size-4 rounded" />
+                <Skeleton className="h-3.5 w-24 group-data-[collapsible=icon]:hidden" />
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
 export function getHostedNavigationSections(
   sections: NavSection[]
 ): NavSection[] {
@@ -534,8 +556,14 @@ export function MCPSidebar({
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
-  const { isAuthenticated } = useConvexAuth();
-  const { user } = useAuth();
+  const { isAuthenticated, isLoading: isConvexAuthLoading } = useConvexAuth();
+  const { user, isLoading: isWorkOsAuthLoading } = useAuth();
+  // Until WorkOS + Convex resolve the session we don't yet know guest-vs-authed
+  // (`user` is null and `isAuthenticated` is false even for signed-in users).
+  // Treat that window as "unknown" so the sidebar renders neutral skeletons
+  // instead of flashing the signed-out layout for users who are signed in.
+  const authResolving =
+    HOSTED_MODE && !user && (isWorkOsAuthLoading || isConvexAuthLoading);
   const learningEnabled = !!learningFlagEnabled && isAuthenticated;
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const { status: updateStatus, restartAndInstall } = useUpdateNotification();
@@ -619,7 +647,8 @@ export function MCPSidebar({
 
   // Signed-in users reach Settings/Support via the account menu; only
   // signed-out users (no account menu) get utility icons in the footer.
-  const utilityItems = user ? [] : signedOutUtilityItems;
+  // Suppress them while auth is resolving so they don't flash for signed-in users.
+  const utilityItems = user || authResolving ? [] : signedOutUtilityItems;
 
   const isNavItemActive = (item: NavItem) =>
     normalizeHostedHashTab(
@@ -702,7 +731,7 @@ export function MCPSidebar({
             onSwitchProject={onSwitchProject}
             onCreateProject={onCreateProject}
             onDeleteProject={onDeleteProject}
-            isLoading={isLoadingProjects}
+            isLoading={isLoadingProjects || authResolving}
             onNavigateToSettings={() => handleNavClick("#project-settings")}
             isCreateDisabled={isCreateProjectDisabled}
             createDisabledReason={createProjectDisabledReason}
@@ -733,56 +762,60 @@ export function MCPSidebar({
           )}
         </SidebarHeader>
         <SidebarContent className="gap-0">
-          {visibleNavigationSections.map((section, sectionIndex) => {
-            const rawEvalsEntry = section.items.find(
-              (item) => item.evalsSubnav
-            );
-            // Only render Evaluate through the SidebarEvalsNavGroup wrapper
-            // (which adds its own SidebarGroup padding) when there's actually
-            // a Runs sub-item to nest. Otherwise, fold Evaluate into flatItems
-            // so it sits flush with Views and matches sibling spacing.
-            const useEvalsSubnavWrapper =
-              !!rawEvalsEntry && evaluateRunsEnabled === true;
-            const evalsEntry = useEvalsSubnavWrapper
-              ? rawEvalsEntry
-              : undefined;
-            const flatItems = section.items.filter(
-              (item) => !item.evalsSubnav || !useEvalsSubnavWrapper
-            );
+          {authResolving ? (
+            <SidebarNavSkeleton />
+          ) : (
+            visibleNavigationSections.map((section, sectionIndex) => {
+              const rawEvalsEntry = section.items.find(
+                (item) => item.evalsSubnav
+              );
+              // Only render Evaluate through the SidebarEvalsNavGroup wrapper
+              // (which adds its own SidebarGroup padding) when there's actually
+              // a Runs sub-item to nest. Otherwise, fold Evaluate into flatItems
+              // so it sits flush with Views and matches sibling spacing.
+              const useEvalsSubnavWrapper =
+                !!rawEvalsEntry && evaluateRunsEnabled === true;
+              const evalsEntry = useEvalsSubnavWrapper
+                ? rawEvalsEntry
+                : undefined;
+              const flatItems = section.items.filter(
+                (item) => !item.evalsSubnav || !useEvalsSubnavWrapper
+              );
 
-            return (
-              <React.Fragment key={section.id}>
-                <NavMain
-                  items={flatItems.map((item) => ({
-                    ...item,
-                    isActive: isNavItemActive(item),
-                  }))}
-                  onItemClick={handleNavClick}
-                  learnMore={
-                    learnMoreEnabled
-                      ? {
-                          onExpand: learnMore.openExpandedModal,
-                        }
-                      : null
-                  }
-                />
-                {evalsEntry ? (
-                  <SidebarEvalsNavGroup
-                    title={evalsEntry.title}
-                    Icon={evalsEntry.icon}
-                    disabled={evalsEntry.disabled}
-                    disabledTooltip={evalsEntry.disabledTooltip}
-                    activeTab={activeTab}
-                    showRuns={evaluateRunsEnabled === true}
+              return (
+                <React.Fragment key={section.id}>
+                  <NavMain
+                    items={flatItems.map((item) => ({
+                      ...item,
+                      isActive: isNavItemActive(item),
+                    }))}
+                    onItemClick={handleNavClick}
+                    learnMore={
+                      learnMoreEnabled
+                        ? {
+                            onExpand: learnMore.openExpandedModal,
+                          }
+                        : null
+                    }
                   />
-                ) : null}
-                {/* Add subtle divider between sections (except after the last section) */}
-                {sectionIndex < visibleNavigationSections.length - 1 && (
-                  <div className="mx-4 my-1 border-t border-border/50" />
-                )}
-              </React.Fragment>
-            );
-          })}
+                  {evalsEntry ? (
+                    <SidebarEvalsNavGroup
+                      title={evalsEntry.title}
+                      Icon={evalsEntry.icon}
+                      disabled={evalsEntry.disabled}
+                      disabledTooltip={evalsEntry.disabledTooltip}
+                      activeTab={activeTab}
+                      showRuns={evaluateRunsEnabled === true}
+                    />
+                  ) : null}
+                  {/* Add subtle divider between sections (except after the last section) */}
+                  {sectionIndex < visibleNavigationSections.length - 1 && (
+                    <div className="mx-4 my-1 border-t border-border/50" />
+                  )}
+                </React.Fragment>
+              );
+            })
+          )}
         </SidebarContent>
         <SidebarFooter>
           {utilityItems.length > 0 ? (
@@ -831,7 +864,9 @@ export function MCPSidebar({
               className="mt-1"
             />
           ) : null}
-          {!user ? <SidebarCreditUsage className="px-1" includeGuests /> : null}
+          {!user && !authResolving ? (
+            <SidebarCreditUsage className="px-1" includeGuests />
+          ) : null}
           <SidebarUser onBeforeSignOut={onBeforeSignOut} />
         </SidebarFooter>
       </Sidebar>

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -45,7 +45,7 @@ interface SidebarUserProps {
 
 export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
   const { isLoading, isAuthenticated } = useConvexAuth();
-  const { user, signIn, signOut } = useAuth();
+  const { user, signIn, signOut, isLoading: isWorkOsAuthLoading } = useAuth();
   const { profilePictureUrl } = useProfilePicture();
   const convexUser = useQuery("users:getCurrentUser" as any);
   const { isMobile } = useSidebar();
@@ -101,6 +101,29 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
 
   const avatarUrl = profilePictureUrl;
 
+  const loadingState = (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton size="lg" disabled>
+          <RefreshCw className="size-4 animate-spin" />
+          <span className="truncate group-data-[collapsible=icon]:hidden">
+            Loading...
+          </span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+
+  // While WorkOS/Convex are still resolving the session, `user` is null even for
+  // signed-in users. Show the neutral loading state before the `!user` guest
+  // branch so authenticated users don't flash the "Sign in" footer on load.
+  const authResolving =
+    HOSTED_MODE && !user && (isWorkOsAuthLoading || isLoading);
+
+  if (authResolving) {
+    return loadingState;
+  }
+
   if (!user) {
     if (HOSTED_MODE) {
       return (
@@ -125,18 +148,7 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
   }
 
   if (isLoading) {
-    return (
-      <SidebarMenu>
-        <SidebarMenuItem>
-          <SidebarMenuButton size="lg" disabled>
-            <RefreshCw className="size-4 animate-spin" />
-            <span className="truncate group-data-[collapsible=icon]:hidden">
-              Loading...
-            </span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      </SidebarMenu>
-    );
+    return loadingState;
   }
 
   return (


### PR DESCRIPTION
## Problem

On initial load at app.mcpjam.com, signed-in users briefly (~1–2s) see the **logged-out / guest sidebar** before it flips to the authenticated view:

- "No Project" + "N" badge in the context switcher
- a "Sign in" button in the footer
- the signed-out nav (missing Chatboxes / Learning / Conformance / XAA Debugger)
- the guest "Free daily credits" widget

## Root cause

WorkOS AuthKit initializes with `{ user: null, isLoading: true }` and resolves the real session **asynchronously**. During that window the sidebar conflates **"auth not yet resolved"** with **"logged out"** — every guest-vs-authed decision keys off `!!user` / `isAuthenticated`, which are both falsy until WorkOS settles. Notably, `sidebar-user.tsx` checked `!user` *before* its `isLoading` branch, making the loading state dead code on first paint.

## Fix

Introduce a single auth-pending signal and gate the guest-vs-authed decision on it:

```ts
const authResolving = HOSTED_MODE && !user && (workOsLoading || convexLoading);
```

**`sidebar-user.tsx`**
- Pull `isLoading` from `useAuth()` (WorkOS); check the neutral loading state **before** the `!user` guest branch so "Sign in" no longer wins during resolution.
- Extract the shared `loadingState` JSX (reused by the new gate and the existing post-sign-in `isLoading` branch).

**`mcp-sidebar.tsx`**
- Context switcher: pass `isLoadingProjects || authResolving` → existing skeleton replaces "No Project".
- Nav list: render a new neutral `SidebarNavSkeleton` instead of the signed-out nav.
- Suppress the footer utility icons and the guest credit widget during resolution.

Scoped to `HOSTED_MODE`, so local/non-hosted mode is unchanged (no spurious spinner where there's never a WorkOS user).

## Result

Authenticated users see neutral skeletons for the resolution window, then the real authed sidebar — no flash of the guest layout. A genuinely signed-out user briefly sees the skeleton, then the guest UI (also flicker-free).

## Testing

- `npm run typecheck:client` — pass
- renderer tier-b import guard (`pretypecheck:client`) — pass
- prettier-formatted

No existing tests cover these components. Not yet verified visually in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading gates scoped to HOSTED_MODE; no auth, API, or data-path changes.
> 
> **Overview**
> In **hosted mode**, the sidebar now treats the WorkOS + Convex startup window as **auth unknown** instead of signed out, so authenticated users no longer briefly see guest nav, **Sign in**, and guest credits.
> 
> Both **`mcp-sidebar`** and **`sidebar-user`** use the same `authResolving` signal (`HOSTED_MODE && !user && (WorkOS or Convex loading)`). While it is true, the main nav shows a **`SidebarNavSkeleton`**, the project switcher stays in its loading state, footer Settings/Support and guest **`SidebarCreditUsage`** are hidden, and the user footer shows a neutral **Loading…** state instead of **Sign in**. Local/non-hosted behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a15d7a35fb3ba6a657bf902ae6da34667ab375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->