### PR TITLE
feat(nux): route brand-new signups to Playground, keep returning users on Home

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -233,6 +233,11 @@ import type {
 } from "@/shared/inspector-command.js";
 
 const OCCUPATION_GATE_ROLLOUT_MS = Date.parse("2026-04-29T00:00:00.000Z");
+// Accounts created on/after this ship date are treated as "new" for the
+// first-run Playground redirect. Older accounts (created before the cutoff)
+// are never redirected, regardless of their onboarding flag, so returning
+// users always keep the Home landing.
+const FIRST_RUN_PLAYGROUND_ROLLOUT_MS = Date.parse("2026-06-16T00:00:00.000Z");
 const AUTH_EXIT_RUNTIME_CLEANUP_TIMEOUT_MS = 2_500;
 
 function getHostedOAuthCallbackErrorMessage(): string {
@@ -1753,6 +1758,15 @@ export default function App() {
       : currentUser.hasSeenOnboarding === true ||
         currentUser.hasCompletedOnboarding === true;
   const hasSeenFirstRunOnboarding = remoteFirstRunOnboardingShown === true;
+  // A signed-in user counts as "new" (and thus gets the first-run Playground
+  // redirect) only when their account was created on/after the rollout cutoff.
+  // This keeps every pre-existing account on Home even if its onboarding flag
+  // was never set, while still sending brand-new signups to Playground.
+  const isNewSignedInAccount =
+    !!workOsUser &&
+    currentUser?.isAnonymous !== true &&
+    typeof currentUser?.createdAt === "number" &&
+    currentUser.createdAt >= FIRST_RUN_PLAYGROUND_ROLLOUT_MS;
   const isHostedDefaultRoute =
     activeTab === "servers" || activeTab === "clients";
   const shouldHoldHostedDefaultRouteForAuth =
@@ -2356,7 +2370,8 @@ export default function App() {
         hasAnyFirstRunBlockingProjectServers,
         activeTab,
         !!workOsUser,
-        remoteFirstRunOnboardingShown
+        remoteFirstRunOnboardingShown,
+        isNewSignedInAccount
       )
     ) {
       navigateApp(routePaths.playground);
@@ -2371,6 +2386,7 @@ export default function App() {
     isAuthenticated,
     isHostedChatRoute,
     isLoadingRemoteProjects,
+    isNewSignedInAccount,
     isWorkOsLoading,
     remoteFirstRunOnboardingShown,
     workOsUser,

--- a/mcpjam-inspector/client/src/lib/__tests__/onboarding-state.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/onboarding-state.test.ts
@@ -26,7 +26,7 @@ describe("onboarding-state", () => {
     it("marks onboarding as started before the NUX is shown", () => {
       markOnboardingStarted();
       expect(readOnboardingState()).toEqual(
-        expect.objectContaining({ status: "started" }),
+        expect.objectContaining({ status: "started" })
       );
     });
 
@@ -34,7 +34,7 @@ describe("onboarding-state", () => {
       markOnboardingStarted();
       markOnboardingShown();
       expect(readOnboardingState()).toEqual(
-        expect.objectContaining({ status: "seen", shownAt: expect.any(Number) }),
+        expect.objectContaining({ status: "seen", shownAt: expect.any(Number) })
       );
     });
 
@@ -52,7 +52,7 @@ describe("onboarding-state", () => {
     it("returns null for invalid status", () => {
       localStorage.setItem(
         "mcp-onboarding-state",
-        JSON.stringify({ status: "invalid" }),
+        JSON.stringify({ status: "invalid" })
       );
       expect(readOnboardingState()).toBeNull();
     });
@@ -109,6 +109,22 @@ describe("onboarding-state", () => {
 
     it("returns false when the user is signed in with WorkOS", () => {
       expect(isFirstRunEligible(false, "", true)).toBe(false);
+    });
+
+    it("returns true for a brand-new signed-in account (not yet onboarded)", () => {
+      // isSignedInWithWorkOs=true but isNewSignedInAccount=true and the remote
+      // onboarding flag is false → genuinely-new signups get the first-run NUX.
+      expect(isFirstRunEligible(false, "", true, false, true)).toBe(true);
+    });
+
+    it("returns false for a new signed-in account that already saw onboarding", () => {
+      expect(isFirstRunEligible(false, "", true, true, true)).toBe(false);
+    });
+
+    it("returns false for a signed-in account that is not flagged new", () => {
+      // Older/returning accounts (isNewSignedInAccount=false) stay on Home even
+      // when their remote onboarding flag was never set.
+      expect(isFirstRunEligible(false, "", true, false, false)).toBe(false);
     });
 
     it("does not treat guest Convex auth as signed-in WorkOS state", () => {

--- a/mcpjam-inspector/client/src/lib/onboarding-state.ts
+++ b/mcpjam-inspector/client/src/lib/onboarding-state.ts
@@ -80,17 +80,21 @@ export function clearOnboardingState(): void {
  * - Onboarding has never been shown for the current identity. When a remote
  *   user row is available, that row is the source of truth; localStorage is
  *   only a fallback for runtimes without an identity.
- * - The user is not signed in with WorkOS. Hosted guests may be
- *   Convex-authenticated, but should still be eligible for first-run NUX.
+ * - The user is either a hosted guest (Convex-authenticated, no WorkOS) or a
+ *   freshly-created signed-in account. Signed-in users land on Home by default;
+ *   only brand-new accounts (`isNewSignedInAccount`) get the first-run NUX so
+ *   returning users — including older accounts whose onboarding flag was never
+ *   set — are never bounced off Home.
  */
 export function isFirstRunEligible(
   hasAnyBlockingServers: boolean,
   currentRouteTab: string,
   isSignedInWithWorkOs = false,
-  hasSeenRemoteOnboarding?: boolean
+  hasSeenRemoteOnboarding?: boolean,
+  isNewSignedInAccount = false
 ): boolean {
   if (hasAnyBlockingServers) return false;
-  if (isSignedInWithWorkOs) return false;
+  if (isSignedInWithWorkOs && !isNewSignedInAccount) return false;
 
   // Drop query strings and trailing slashes so `connect?foo=bar` and
   // `/connect/` still pass the allowlist — both land on the same hub route.


### PR DESCRIPTION
## Goal

**New users → Playground, existing users → Home.**

## Problem

The first-run redirect (`isFirstRunEligible` → `navigateApp(routePaths.playground)`) only fires for hosted **guests** — it hard-excludes anyone signed in with WorkOS (`onboarding-state.ts:93`, `if (isSignedInWithWorkOs) return false`). So a **brand-new user who signs up** before reaching the Playground NUX lands on **Home**, not Playground.

Simply relaxing that exclusion to "signed-in but `hasSeenOnboarding !== true`" would regress **returning** users: older accounts whose onboarding flag was never recorded (`undefined`/missing) would suddenly get bounced Home → Playground.

## Fix

Allow signed-in users through the first-run redirect, but **only when their account is provably new**:

- A signed-in user is "new" when their WorkOS-backed `users` row was created **on/after `FIRST_RUN_PLAYGROUND_ROLLOUT_MS`** (the ship date) — mirroring the existing `OCCUPATION_GATE_ROLLOUT_MS` pattern already used for `OccupationGate`.
- The creation-time cutoff is the safety net: **every pre-existing account (created before the cutoff) is never redirected**, regardless of its onboarding flag — so returning users always keep Home.

### Resulting behavior

| User | Result |
|------|--------|
| New guest (no WorkOS, not onboarded) | Playground (unchanged) |
| **New signup** (WorkOS, created ≥ cutoff, not onboarded) | **Playground** (new) |
| Returning user (created < cutoff) | Home — never redirected, even if onboarding flag unset |
| Account created ≥ cutoff but already onboarded | Home (flag gates it) |

Once a new user reaches Playground, `markOnboardingShown` sets the flag, so the redirect is one-time.

## Changes

- `lib/onboarding-state.ts`: `isFirstRunEligible` gains an `isNewSignedInAccount` arg; signed-in users are excluded unless it's true.
- `App.tsx`: add `FIRST_RUN_PLAYGROUND_ROLLOUT_MS`; derive `isNewSignedInAccount` from `currentUser.createdAt` + `isAnonymous`; pass it into the first-run effect (and deps).
- tests: new-signup-eligible, already-onboarded-excluded, not-flagged-new-excluded.

## Testing

- `client/src/lib/__tests__/onboarding-state.test.ts` — 31 passed
- `npm run typecheck:client` — pass
- prettier — clean

Not yet verified visually in a running app. Independent from the auth-flash PR (#2753).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default landing navigation for signed-in users at a fixed rollout date; incorrect cutoff or createdAt handling could mis-route existing accounts to Playground.
> 
> **Overview**
> Extends the first-run **Playground** redirect so **WorkOS signups** can qualify, not only hosted guests. **`isFirstRunEligible`** no longer blocks every signed-in user; it excludes signed-in users unless **`isNewSignedInAccount`** is true.
> 
> **`App.tsx`** adds **`FIRST_RUN_PLAYGROUND_ROLLOUT_MS`** (ship-date cutoff, same pattern as **`OCCUPATION_GATE_ROLLOUT_MS`**) and sets **`isNewSignedInAccount`** from **`currentUser.createdAt`**, non-anonymous identity, and a WorkOS session. That value is passed into the existing first-run **`useEffect`** that calls **`navigateApp(routePaths.playground)`**.
> 
> Accounts created **before** the cutoff never get the redirect, even when remote onboarding flags were never set, so returning users stay on **Home**. New signups on/after the cutoff who have not completed onboarding still redirect once; the remote onboarding flag continues to gate repeat visits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df558b96cc15395ad486ec23af2d48f671d284c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->