### PR TITLE
[codex] Add Claude Desktop client template

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -233,22 +233,15 @@ export function useServerForm(
 
         const savedClientId =
           clientInfo?.client_id || server.oauthFlowProfile?.clientId || "";
-        const savedClientSecret =
-          clientInfo?.client_secret ||
-          server.oauthFlowProfile?.clientSecret ||
-          "";
+        const savedClientSecret = "";
         hasStoredClientSecretValue = server.hasClientSecret === true;
 
         // Keep runtime token metadata available for preregistered reconnects,
         // but only surface credential fields from saved client configuration.
         clientIdValue = storedTokens?.client_id || savedClientId;
-        // Only mask in hosted mode — there the secret lives in the Vault and
-        // never round-trips to the browser, so blanking the field protects it.
-        // In local mode the actual secret is in localStorage; blanking it would
-        // cause an unrelated edit + save to overwrite mcp-client-* without the
-        // secret, silently deleting it.
-        clientSecretValue =
-          HOSTED_MODE && hasStoredClientSecretValue ? "" : savedClientSecret;
+        clientSecretValue = hasStoredClientSecretValue
+          ? ""
+          : savedClientSecret;
 
         protocolModeValue = normalizeOauthProtocolMode(
           typeof oauthConfig.protocolMode === "string"

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -22,7 +22,7 @@ import type {
   ServerFormOAuthProtocolMode,
   ServerFormOAuthRegistrationMode,
 } from "@/shared/types.js";
-import { fetchHostedOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-api";
+import { fetchOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-api";
 
 interface AuthenticationSectionProps {
   serverUrl?: string;
@@ -135,7 +135,7 @@ export function AuthenticationSection({
     setIsRevealingClientSecret(true);
     setRevealError(null);
     try {
-      const result = await fetchHostedOAuthClientSecret({
+      const result = await fetchOAuthClientSecret({
         projectId,
         serverId: hostedServerId,
       });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -1528,7 +1528,6 @@ describe("useServerState OAuth callback failures", () => {
       "mcp-client-demo-server",
       JSON.stringify({
         client_id: "asana-client-id",
-        client_secret: "asana-client-secret",
       })
     );
     clearOAuthDataMock.mockImplementationOnce((serverName: string) => {
@@ -1554,7 +1553,8 @@ describe("useServerState OAuth callback failures", () => {
         scopes: ["default"],
         customHeaders: { "X-MCPJam": "yes" },
         clientId: "asana-client-id",
-        clientSecret: "asana-client-secret",
+        clientSecret: undefined,
+        hasClientSecret: false,
         registryServerId: "registry-asana",
         useRegistryOAuthProxy: true,
         protocolVersion: "2025-11-25",
@@ -1587,7 +1587,6 @@ describe("useServerState OAuth callback failures", () => {
       "mcp-client-demo-server",
       JSON.stringify({
         client_id: "stored-client-id",
-        client_secret: "stored-client-secret",
       })
     );
     initiateOAuthMock.mockResolvedValueOnce({ success: true });
@@ -1599,7 +1598,7 @@ describe("useServerState OAuth callback failures", () => {
         serverUrl: "https://example.com/mcp",
         resourceUrl: "https://fresh.example.com",
         clientId: "fresh-client-id",
-        clientSecret: "fresh-client-secret",
+        clientSecret: "",
         scopes: "fresh profile",
         customHeaders: [{ key: "X-Fresh", value: "profile" }],
         protocolVersion: "2025-11-25",
@@ -1626,7 +1625,8 @@ describe("useServerState OAuth callback failures", () => {
         resourceUrl: "https://fresh.example.com",
         customHeaders: { "X-Fresh": "profile" },
         clientId: "fresh-client-id",
-        clientSecret: "fresh-client-secret",
+        clientSecret: undefined,
+        hasClientSecret: false,
         registryServerId: "registry-asana",
         useRegistryOAuthProxy: true,
         protocolMode: "2025-11-25",

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -174,7 +174,7 @@ function mergeOAuthCallbackServerConfig(
 
 /**
  * Saves OAuth-related configuration to localStorage for reconnection purposes.
- * This persists server URL, scopes, headers, and client credentials.
+ * This persists server URL, scopes, headers, and non-secret client metadata.
  */
 function saveOAuthConfigToLocalStorage(formData: ServerFormData): void {
   if (HOSTED_MODE) {
@@ -231,13 +231,10 @@ function saveOAuthConfigToLocalStorage(formData: ServerFormData): void {
     );
   }
 
-  if (formData.clientId || (!HOSTED_MODE && formData.clientSecret)) {
+  if (formData.clientId) {
     const clientInfo: Record<string, string> = {};
     if (formData.clientId) {
       clientInfo.client_id = formData.clientId;
-    }
-    if (!HOSTED_MODE && formData.clientSecret) {
-      clientInfo.client_secret = formData.clientSecret;
     }
     localStorage.setItem(
       `mcp-client-${formData.name}`,
@@ -294,16 +291,19 @@ function readStoredClientCredentials(serverName: string): {
     }
 
     const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && "client_secret" in parsed) {
+      const sanitized = Object.fromEntries(
+        Object.entries(parsed).filter(([key]) => key !== "client_secret")
+      );
+      localStorage.setItem(
+        `mcp-client-${serverName}`,
+        JSON.stringify(sanitized)
+      );
+    }
     return {
       clientId:
         typeof parsed?.client_id === "string" && parsed.client_id.trim() !== ""
           ? parsed.client_id
-          : undefined,
-      clientSecret:
-        !HOSTED_MODE &&
-        typeof parsed?.client_secret === "string" &&
-        parsed.client_secret.trim() !== ""
-          ? parsed.client_secret
           : undefined,
     };
   } catch {
@@ -379,10 +379,7 @@ function buildResolvedOAuthProfile(input: {
       "",
     clientId:
       existingProfile?.clientId ?? storedClientCredentials.clientId ?? "",
-    clientSecret:
-      existingProfile?.clientSecret ??
-      storedClientCredentials.clientSecret ??
-      "",
+    clientSecret: "",
     scopes:
       existingProfile?.scopes ?? storedOAuthConfig.scopes?.join(",") ?? "",
     customHeaders,
@@ -418,9 +415,7 @@ function buildOAuthProfileFromFormData(
     serverUrl: formData.url,
     resourceUrl: existingProfile?.resourceUrl ?? "",
     clientId: formData.clientId ?? existingProfile?.clientId ?? "",
-    clientSecret: HOSTED_MODE
-      ? ""
-      : formData.clientSecret ?? existingProfile?.clientSecret ?? "",
+    clientSecret: "",
     scopes: formData.oauthScopes?.join(",") ?? existingProfile?.scopes ?? "",
     customHeaders,
     protocolVersion,
@@ -2782,7 +2777,6 @@ export function useServerState({
           `mcp-client-${serverName}`,
           JSON.stringify({
             client_id: tokens.clientId,
-            client_secret: tokens.clientSecret,
           })
         );
       }
@@ -3443,14 +3437,9 @@ export function useServerState({
             server.oauthFlowProfile?.clientId ??
             storedClientCredentials.clientId,
           clientSecret:
-            server.oauthTokens?.client_secret ??
-            server.oauthFlowProfile?.clientSecret ??
-            storedClientCredentials.clientSecret,
+            undefined,
           hasClientSecret: Boolean(
-            server.oauthTokens?.client_secret ||
-              server.oauthFlowProfile?.clientSecret ||
-              storedClientCredentials.clientSecret ||
-              server.hasClientSecret
+            server.hasClientSecret
           ),
           customHeaders: mergeWithProjectHeaders(
             profileHeaders ??

--- a/mcpjam-inspector/client/src/lib/__tests__/client-templates.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-templates.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { seedFromHostTemplate } from "../client-templates";
+import {
+  resolveEffectiveCompatRuntime,
+  resolveEffectiveMcpAppsCapabilities,
+} from "../client-config-v2";
+
+describe("host client templates", () => {
+  it("seeds Claude Desktop from the captured Electron MCP Apps profile", () => {
+    const cfg = seedFromHostTemplate("claude-desktop");
+
+    expect(cfg.hostStyle).toBe("claude-desktop");
+    expect(cfg.modelId).toBe("anthropic/claude-haiku-4.5");
+    expect(cfg.clientCapabilities).toEqual({
+      extensions: {
+        "io.modelcontextprotocol/ui": {
+          mimeTypes: ["text/html;profile=mcp-app"],
+        },
+      },
+    });
+    expect(cfg.hostCapabilitiesOverride).toEqual({
+      openLinks: {},
+      downloadFile: {},
+      serverTools: { listChanged: true },
+      serverResources: { listChanged: true },
+      logging: {},
+      updateModelContext: { text: {}, image: {} },
+      message: { text: {} },
+    });
+    expect(cfg.hostContext).toMatchObject({
+      theme: "dark",
+      displayMode: "inline",
+      availableDisplayModes: ["inline"],
+      containerDimensions: { width: 698.109375, maxHeight: 5000 },
+      locale: "en-US",
+      timeZone: "America/Los_Angeles",
+      platform: "desktop",
+      deviceCapabilities: { touch: false, hover: true },
+      safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    });
+    expect(cfg.hostContext.userAgent).toBe(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.12603.1 Chrome/148.0.7778.254 Electron/42.4.0 Safari/537.36",
+    );
+    expect(
+      (cfg.hostContext.styles as { variables?: Record<string, string> })
+        .variables?.["--font-sans"],
+    ).toBe("Anthropic Sans, sans-serif");
+    expect(cfg.mcpProfile).toEqual({
+      profileVersion: 1,
+      initialize: {
+        clientInfo: { name: "claude-ai", version: "0.1.0" },
+      },
+      apps: {
+        uiInitialize: {
+          hostInfo: { name: "Claude", version: "1.0.0" },
+        },
+        compatRuntime: { openaiApps: false },
+        sandbox: {
+          csp: {
+            mode: "declared",
+            restrictTo: {
+              connectDomains: [
+                "https://api.openai.com",
+                "https://api.anthropic.com",
+                "https://cdn.jsdelivr.net",
+              ],
+              resourceDomains: [
+                "https://cdn.jsdelivr.net",
+                "https://assets.claude.ai",
+              ],
+            },
+          },
+          permissions: {
+            mode: "custom",
+            allow: { clipboardWrite: true },
+          },
+          sandboxAttrs: ["allow-forms"],
+        },
+      },
+    });
+
+    expect(
+      resolveEffectiveCompatRuntime({
+        hostStyle: cfg.hostStyle,
+        profile: cfg.mcpProfile,
+      }),
+    ).toEqual({ injected: false });
+    expect(
+      resolveEffectiveMcpAppsCapabilities({
+        hostStyle: cfg.hostStyle,
+        profile: cfg.mcpProfile,
+      }).availableDisplayModes,
+    ).toEqual(["inline"]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/hosted-oauth-client-secret-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/hosted-oauth-client-secret-api.ts
@@ -1,18 +1,18 @@
 import { webPost, WebApiError } from "@/lib/apis/web/base";
 
-export interface FetchHostedOAuthClientSecretRequest {
+export interface FetchOAuthClientSecretRequest {
   projectId: string;
   serverId: string;
 }
 
-export interface HostedOAuthClientSecretResult {
+export interface OAuthClientSecretResult {
   clientSecret: string;
 }
 
-export async function fetchHostedOAuthClientSecret(
-  request: FetchHostedOAuthClientSecretRequest,
-): Promise<HostedOAuthClientSecretResult> {
-  const body = await webPost<FetchHostedOAuthClientSecretRequest, unknown>(
+export async function fetchOAuthClientSecret(
+  request: FetchOAuthClientSecretRequest,
+): Promise<OAuthClientSecretResult> {
+  const body = await webPost<FetchOAuthClientSecretRequest, unknown>(
     "/api/web/oauth/client-secret",
     request,
   );
@@ -32,3 +32,7 @@ export async function fetchHostedOAuthClientSecret(
 
   return { clientSecret: result.clientSecret };
 }
+
+export const fetchHostedOAuthClientSecret = fetchOAuthClientSecret;
+export type FetchHostedOAuthClientSecretRequest = FetchOAuthClientSecretRequest;
+export type HostedOAuthClientSecretResult = OAuthClientSecretResult;

--- a/mcpjam-inspector/client/src/lib/client-styles/__tests__/registry.test.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/__tests__/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   CHATGPT_HOST_STYLE,
+  CLAUDE_DESKTOP_HOST_STYLE,
   CLAUDE_HOST_STYLE,
   CLAUDE_CODE_HOST_STYLE,
   CODEX_HOST_STYLE,
@@ -18,13 +19,20 @@ import {
 } from "..";
 
 describe("host-styles registry", () => {
-  it("registers built-in mcpjam, claude, chatgpt, copilot, and codex hosts by id", () => {
+  it("registers built-in mcpjam, claude, claude-desktop, chatgpt, copilot, and codex hosts by id", () => {
     expect(findHostStyle("mcpjam")).toBe(MCPJAM_HOST_STYLE);
     expect(findHostStyle("claude")).toBe(CLAUDE_HOST_STYLE);
+    expect(findHostStyle("claude-desktop")).toBe(CLAUDE_DESKTOP_HOST_STYLE);
     expect(findHostStyle("chatgpt")).toBe(CHATGPT_HOST_STYLE);
     expect(findHostStyle("copilot")).toBe(COPILOT_HOST_STYLE);
     expect(findHostStyle("codex")).toBe(CODEX_HOST_STYLE);
     expect(findHostStyle("claude-code")).toBe(CLAUDE_CODE_HOST_STYLE);
+  });
+
+  it("uses the Claude Code thinking indicator for Claude Desktop", () => {
+    expect(CLAUDE_DESKTOP_HOST_STYLE.chatUi.loadingIndicator).toBe(
+      CLAUDE_CODE_HOST_STYLE.chatUi.loadingIndicator,
+    );
   });
 
   it("returns undefined for unknown ids", () => {
@@ -43,6 +51,7 @@ describe("host-styles registry", () => {
   it("recognises only registered ids via the type guard", () => {
     expect(isKnownHostStyleId("mcpjam")).toBe(true);
     expect(isKnownHostStyleId("claude")).toBe(true);
+    expect(isKnownHostStyleId("claude-desktop")).toBe(true);
     expect(isKnownHostStyleId("chatgpt")).toBe(true);
     expect(isKnownHostStyleId("copilot")).toBe(true);
     expect(isKnownHostStyleId("codex")).toBe(true);
@@ -56,6 +65,7 @@ describe("host-styles registry", () => {
     const ids = listHostStyles().map((host) => host.id);
     expect(ids).toContain("mcpjam");
     expect(ids).toContain("claude");
+    expect(ids).toContain("claude-desktop");
     expect(ids).toContain("chatgpt");
     expect(ids).toContain("copilot");
     expect(ids).toContain("codex");
@@ -63,7 +73,12 @@ describe("host-styles registry", () => {
     // MCPJam ships first so the default-fallback host appears at the top
     // of pickers.
     expect(ids.indexOf("mcpjam")).toBeLessThan(ids.indexOf("claude"));
-    expect(ids.indexOf("claude")).toBeLessThan(ids.indexOf("chatgpt"));
+    expect(ids.indexOf("claude")).toBeLessThan(
+      ids.indexOf("claude-desktop"),
+    );
+    expect(ids.indexOf("claude-desktop")).toBeLessThan(
+      ids.indexOf("chatgpt"),
+    );
     // Copilot ships after Cursor (registration order in BUILT_IN_HOST_STYLES).
     expect(ids.indexOf("chatgpt")).toBeLessThan(ids.indexOf("copilot"));
     expect(ids.indexOf("copilot")).toBeLessThan(ids.indexOf("codex"));
@@ -103,6 +118,15 @@ describe("host-styles registry", () => {
     // Identity equality no longer holds — buildHostCapabilities returns a
     // fresh object each call. Verify the derived blob's shape instead.
     expect(getHostCapabilitiesForStyle("claude")).toEqual({
+      openLinks: {},
+      serverTools: {},
+      serverResources: {},
+      logging: {},
+      updateModelContext: { text: {} },
+      message: { text: {} },
+      downloadFile: {},
+    });
+    expect(getHostCapabilitiesForStyle("claude-desktop")).toEqual({
       openLinks: {},
       serverTools: {},
       serverResources: {},

--- a/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
@@ -254,6 +254,31 @@ export const CLAUDE_HOST_STYLE: HostStyleDefinition = {
   },
 };
 
+/**
+ * Claude Desktop is intentionally distinct from the generic Claude preset:
+ * the desktop app renders inline-only MCP Apps in an Electron iframe, while
+ * the web-flavored Claude preset keeps broader display-mode assumptions for
+ * historical host tests. The visual chrome is the same Claude family; the
+ * capability matrix clamps display modes to the captured desktop surface.
+ */
+export const CLAUDE_DESKTOP_HOST_STYLE: HostStyleDefinition = {
+  id: "claude-desktop",
+  mcp: {
+    ...CLAUDE_HOST_STYLE.mcp,
+    mcpAppsCapabilities: {
+      ...MCP_APPS_FULL_SURFACE,
+      availableDisplayModes: ["inline"],
+    },
+  },
+  chatUi: {
+    ...CLAUDE_HOST_STYLE.chatUi,
+    label: "Claude Desktop",
+    shortLabel: "Claude Desktop host",
+    pickerDescription: "Claude Desktop Electron app chrome",
+    loadingIndicator: ClaudeCodeCliIndicator,
+  },
+};
+
 // Claude Code is a terminal agent with no chat chrome of its own, so it
 // borrows Claude's desktop chat surface wholesale (style variables, fonts,
 // background, MCP profile) and only differs in brand identity: its own
@@ -588,6 +613,7 @@ export const MCPJAM_HOST_STYLE: HostStyleDefinition = {
 export const BUILT_IN_HOST_STYLES: readonly HostStyleDefinition[] = [
   MCPJAM_HOST_STYLE,
   CLAUDE_HOST_STYLE,
+  CLAUDE_DESKTOP_HOST_STYLE,
   CHATGPT_HOST_STYLE,
   CURSOR_HOST_STYLE,
   COPILOT_HOST_STYLE,

--- a/mcpjam-inspector/client/src/lib/client-styles/index.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/index.ts
@@ -15,6 +15,7 @@ export type {
 } from "./types";
 export {
   CHATGPT_HOST_STYLE,
+  CLAUDE_DESKTOP_HOST_STYLE,
   CLAUDE_HOST_STYLE,
   CLAUDE_CODE_HOST_STYLE,
   CODEX_HOST_STYLE,

--- a/mcpjam-inspector/client/src/lib/client-templates.ts
+++ b/mcpjam-inspector/client/src/lib/client-templates.ts
@@ -211,6 +211,7 @@ const CLAUDE_FONTS_CSS = `
 export type HostTemplateId =
   | "mcpjam"
   | "claude"
+  | "claude-desktop"
   | "claude-code"
   | "chatgpt"
   | "cursor"
@@ -624,6 +625,92 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
             // sandbox-proxy.html: inner gets spec-4 only), matching real
             // claude.ai's outer-grants / inner-trims pattern.
             allowFeatures: { fullscreen: "*" },
+          },
+        },
+      };
+      return base;
+    },
+  },
+  {
+    id: "claude-desktop",
+    label: "Claude Desktop",
+    description: "Claude Electron app. Inline MCP Apps, no OpenAI shim.",
+    logoSrc: claudeLogo,
+    seed: (opts) => {
+      const base = emptyHostConfigInputV2({
+        hostStyle: "claude-desktop",
+        modelId: "anthropic/claude-haiku-4.5",
+        temperature: 1.0,
+        requireToolApproval: false,
+        clientCapabilities: {
+          extensions: {
+            "io.modelcontextprotocol/ui": {
+              mimeTypes: ["text/html;profile=mcp-app"],
+            },
+          },
+        },
+      });
+      const theme = opts?.theme ?? DEFAULT_SEED_THEME;
+      // Captured from Claude Desktop 1.12603.1 / Electron 42.4.0 in the
+      // double-iframe MCP Apps renderer. Unlike ChatGPT/Copilot, Claude
+      // Desktop does NOT inject `window.openai`; the explicit compatRuntime
+      // false below makes that absence visible in the Apps editor JSON.
+      base.hostCapabilitiesOverride = {
+        openLinks: {},
+        downloadFile: {},
+        serverTools: { listChanged: true },
+        serverResources: { listChanged: true },
+        logging: {},
+        updateModelContext: { text: {}, image: {} },
+        message: { text: {} },
+      };
+      base.hostContext = {
+        theme,
+        displayMode: "inline",
+        availableDisplayModes: ["inline"],
+        containerDimensions: { width: 698.109375, maxHeight: 5000 },
+        locale: "en-US",
+        timeZone: "America/Los_Angeles",
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.12603.1 Chrome/148.0.7778.254 Electron/42.4.0 Safari/537.36",
+        platform: "desktop",
+        deviceCapabilities: { touch: false, hover: true },
+        safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+        styles: {
+          variables: CLAUDE_HOST_STYLE_VARIABLES,
+          css: { fonts: CLAUDE_FONTS_CSS },
+        },
+      };
+      base.mcpProfile = {
+        profileVersion: 1,
+        initialize: {
+          clientInfo: { name: "claude-ai", version: "0.1.0" },
+        },
+        apps: {
+          uiInitialize: {
+            hostInfo: { name: "Claude", version: "1.0.0" },
+          },
+          compatRuntime: { openaiApps: false },
+          sandbox: {
+            csp: {
+              mode: "declared",
+              restrictTo: {
+                connectDomains: [
+                  "https://api.openai.com",
+                  "https://api.anthropic.com",
+                  "https://cdn.jsdelivr.net",
+                ],
+                resourceDomains: [
+                  "https://cdn.jsdelivr.net",
+                  "https://assets.claude.ai",
+                ],
+              },
+            },
+            permissions: {
+              mode: "custom",
+              allow: { clipboardWrite: true },
+            },
+            sandboxAttrs: ["allow-forms"],
           },
         },
       };

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -795,9 +795,8 @@ describe("mcp-oauth", () => {
       });
     });
 
-    it("does not persist hosted preregistered client secrets to localStorage", async () => {
+    it("does not persist preregistered client secrets to localStorage", async () => {
       vi.resetModules();
-      vi.stubEnv("VITE_MCPJAM_HOSTED_MODE", "true");
 
       const oauthModule = await import("../mcp-oauth");
       vi.spyOn(
@@ -824,6 +823,12 @@ describe("mcp-oauth", () => {
       expect(localStorage.getItem("mcp-client-hosted")).not.toContain(
         "hosted-client-secret"
       );
+      for (let i = 0; i < localStorage.length; i += 1) {
+        const key = localStorage.key(i);
+        expect(key ? localStorage.getItem(key) : "").not.toContain(
+          "hosted-client-secret"
+        );
+      }
     });
 
     it("preserves JSON bodies for dynamic client registration requests", async () => {
@@ -1273,7 +1278,10 @@ describe("mcp-oauth", () => {
         "static-client-secret"
       );
 
-      const info = provider.clientInformation() as Record<string, unknown>;
+      const info = (await provider.clientInformation()) as Record<
+        string,
+        unknown
+      >;
       expect(info.client_id).toBe("static-client-id");
       expect(info.client_secret).toBe("static-client-secret");
       expect(info).not.toHaveProperty("token_endpoint_auth_method");
@@ -1303,7 +1311,10 @@ describe("mcp-oauth", () => {
         "static-client-secret"
       );
 
-      const info = provider.clientInformation() as Record<string, unknown>;
+      const info = (await provider.clientInformation()) as Record<
+        string,
+        unknown
+      >;
       expect(info.token_endpoint_auth_method).toBe("client_secret_post");
       expect(info.client_secret).toBe("static-client-secret");
     });
@@ -2120,6 +2131,69 @@ describe("mcp-oauth", () => {
           token_type: "Bearer",
         })
       );
+    });
+
+    it("loads stored preregistered client secrets from the encrypted server-secret API", async () => {
+      vi.stubEnv("VITE_MCPJAM_HOSTED_MODE", "false");
+      authFetch.mockResolvedValueOnce(
+        createJsonResponse({
+          success: true,
+          clientSecret: "encrypted-table-secret",
+        })
+      );
+      const importApi = await import(
+        "@/lib/apis/hosted-oauth-import-tokens-api"
+      );
+      const importSpy = vi
+        .spyOn(importApi, "importHostedOAuthTokens")
+        .mockResolvedValue({ expiresAt: null, kind: "generic" });
+
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      const provider = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+        "client-from-arg",
+        undefined,
+        {
+          projectId: "proj_xyz",
+          serverId: "srv_abc",
+          kind: "generic",
+          hasClientSecret: true,
+        }
+      );
+
+      const clientInformation = await provider.clientInformation();
+      expect(clientInformation).toMatchObject({
+        client_id: "client-from-arg",
+        client_secret: "encrypted-table-secret",
+      });
+      expect(authFetch).toHaveBeenCalledWith(
+        "/api/web/oauth/client-secret",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            projectId: "proj_xyz",
+            serverId: "srv_abc",
+          }),
+        })
+      );
+      expect(localStorage.getItem("mcp-client-asana") ?? "").not.toContain(
+        "encrypted-table-secret"
+      );
+
+      await provider.saveTokens({
+        access_token: "freshly-issued",
+        token_type: "Bearer",
+      });
+
+      expect(authFetch).toHaveBeenCalledTimes(1);
+      expect(importSpy.mock.calls[0][0]).toMatchObject({
+        clientInformation: {
+          clientId: "client-from-arg",
+          clientSecret: "encrypted-table-secret",
+        },
+      });
     });
 
     it("falls back to localStorage-only when no binding is provided", async () => {

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -119,7 +119,6 @@ export function loadDebugPreregisteredCredentials({
   serverUrl: string;
 }): {
   clientId?: string;
-  clientSecret?: string;
 } {
   try {
     const storedClientInfo = localStorage.getItem(`mcp-client-${serverName}`);
@@ -128,9 +127,14 @@ export function loadDebugPreregisteredCredentials({
     }
 
     const parsed = JSON.parse(storedClientInfo);
+    if (parsed && typeof parsed === "object" && "client_secret" in parsed) {
+      localStorage.setItem(
+        `mcp-client-${serverName}`,
+        JSON.stringify({ client_id: parsed.client_id || undefined }),
+      );
+    }
     return {
       clientId: parsed.client_id || undefined,
-      clientSecret: parsed.client_secret || undefined,
     };
   } catch {
     return {};

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -40,6 +40,7 @@ import {
   normalizeImportHostedOAuthTokens,
   type ImportHostedOAuthTokensRequest,
 } from "@/lib/apis/hosted-oauth-import-tokens-api";
+import { fetchOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-api";
 import { tryResolveProjectServer } from "@/lib/apis/web/context";
 import { captureServerDetailModalOAuthResume } from "@/lib/server-detail-modal-resume";
 import { captureCurrentReturnPath } from "@/lib/app-navigation";
@@ -375,6 +376,7 @@ function stripOAuthTraceDataFromFlowState(
 ): OAuthFlowState {
   return {
     ...cloneFlowState(state),
+    clientSecret: undefined,
     httpHistory: [],
     infoLogs: [],
     lastRequest: undefined,
@@ -1906,6 +1908,7 @@ export interface MCPOAuthProviderConvexBinding {
   serverId: string;
   oauthResourceUrl?: string;
   kind: "generic" | "registry";
+  hasClientSecret?: boolean;
   registryServerId?: string;
   useRegistryOAuthProxy?: boolean;
 }
@@ -1917,6 +1920,8 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   private customClientId?: string;
   private customClientSecret?: string;
   private convexBinding?: MCPOAuthProviderConvexBinding;
+  private runtimeClientSecret?: string;
+  private storedClientSecretPromise?: Promise<string | undefined>;
 
   constructor(
     serverName: string,
@@ -1947,7 +1952,9 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     // with a secret would tell the server to expect no creds at the token
     // endpoint and the SDK would honor that hint on later exchanges,
     // silently dropping the secret and producing `invalid_client`.
-    const hasSecret = Boolean(this.customClientSecret);
+    const hasSecret = Boolean(
+      this.customClientSecret || this.convexBinding?.hasClientSecret
+    );
     return {
       client_name: `MCPJam - ${this.serverName}`,
       client_uri: "https://github.com/mcpjam/inspector",
@@ -1959,17 +1966,46 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     };
   }
 
-  clientInformation() {
+  private readStoredClientInformation(): Record<string, any> | undefined {
     const stored = localStorage.getItem(`mcp-client-${this.serverName}`);
     const storedJson = stored ? JSON.parse(stored) : undefined;
-    const storedClientInformation =
-      HOSTED_MODE && storedJson
-        ? Object.fromEntries(
-            Object.entries(storedJson).filter(
-              ([key]) => key !== "client_secret"
-            )
-          )
-        : storedJson;
+    if (!storedJson || typeof storedJson !== "object") {
+      return undefined;
+    }
+    const storedClientInformation = Object.fromEntries(
+      Object.entries(storedJson).filter(([key]) => key !== "client_secret")
+    );
+    if ("client_secret" in storedJson) {
+      localStorage.setItem(
+        `mcp-client-${this.serverName}`,
+        JSON.stringify(storedClientInformation)
+      );
+    }
+    return storedClientInformation;
+  }
+
+  private async loadStoredClientSecret(): Promise<string | undefined> {
+    if (this.customClientSecret) {
+      return this.customClientSecret;
+    }
+    if (this.runtimeClientSecret) {
+      return this.runtimeClientSecret;
+    }
+    if (!this.convexBinding?.hasClientSecret) {
+      return undefined;
+    }
+    if (!this.storedClientSecretPromise) {
+      this.storedClientSecretPromise = fetchOAuthClientSecret({
+        projectId: this.convexBinding.projectId,
+        serverId: this.convexBinding.serverId,
+      }).then((result) => result.clientSecret);
+    }
+    return this.storedClientSecretPromise;
+  }
+
+  async clientInformation() {
+    const storedClientInformation = this.readStoredClientInformation();
+    const clientSecret = await this.loadStoredClientSecret();
 
     // If custom client ID is provided, use it
     if (this.customClientId) {
@@ -1980,8 +2016,8 @@ export class MCPOAuthProvider implements OAuthClientProvider {
           client_id: this.customClientId,
         };
         // Add client secret if provided
-        if (this.customClientSecret) {
-          result.client_secret = this.customClientSecret;
+        if (clientSecret) {
+          result.client_secret = clientSecret;
           // Drop only the specific `"none"` hint inherited from a prior
           // DCR registration. Our DCR metadata advertises "none" when no
           // secret is set, and servers echo that back into the stored
@@ -2001,18 +2037,31 @@ export class MCPOAuthProvider implements OAuthClientProvider {
         const result: any = {
           client_id: this.customClientId,
         };
-        if (this.customClientSecret) {
-          result.client_secret = this.customClientSecret;
+        if (clientSecret) {
+          result.client_secret = clientSecret;
         }
         return result;
       }
+    }
+    if (storedClientInformation && clientSecret) {
+      const result: any = {
+        ...storedClientInformation,
+        client_secret: clientSecret,
+      };
+      if (result.token_endpoint_auth_method === "none") {
+        delete result.token_endpoint_auth_method;
+      }
+      return result;
     }
     return storedClientInformation;
   }
 
   async saveClientInformation(clientInformation: any) {
+    if (typeof clientInformation?.client_secret === "string") {
+      this.runtimeClientSecret = clientInformation.client_secret;
+    }
     const clientInformationToStore =
-      HOSTED_MODE && clientInformation
+      clientInformation && typeof clientInformation === "object"
         ? Object.fromEntries(
             Object.entries(clientInformation).filter(
               ([key]) => key !== "client_secret"
@@ -2048,7 +2097,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     // refresh until Slice 2b purges it.
     const normalizedTokens = normalizeImportHostedOAuthTokens(tokens);
     if (this.convexBinding && normalizedTokens) {
-      const stored = this.clientInformation();
+      const stored = await this.clientInformation();
       const clientId = (stored?.client_id as string | undefined) ?? this.customClientId;
       if (!clientId) {
         // No clientId means we can't write a usable record; bail loudly so
@@ -2289,14 +2338,18 @@ const oauthBindingStorage = {
 function buildConvexBindingForServer(input: {
   serverName: string;
   oauthResourceUrl?: string;
+  hasClientSecret?: boolean;
   registryServerId?: string;
   useRegistryOAuthProxy?: boolean;
 }): MCPOAuthProviderConvexBinding | undefined {
   if (HOSTED_MODE) return undefined;
+  const previousBinding = oauthBindingStorage.get(input.serverName);
   const resolved = tryResolveProjectServer(input.serverName);
   if (resolved) {
     const isRegistry =
       !!input.registryServerId && input.useRegistryOAuthProxy === true;
+    const hasClientSecret =
+      input.hasClientSecret ?? previousBinding?.hasClientSecret;
     const binding: MCPOAuthProviderConvexBinding = {
       projectId: resolved.projectId,
       serverId: resolved.serverId,
@@ -2304,6 +2357,7 @@ function buildConvexBindingForServer(input: {
         ? { oauthResourceUrl: input.oauthResourceUrl }
         : {}),
       kind: isRegistry ? "registry" : "generic",
+      ...(hasClientSecret ? { hasClientSecret: true } : {}),
       ...(isRegistry
         ? {
             registryServerId: input.registryServerId,
@@ -2316,7 +2370,7 @@ function buildConvexBindingForServer(input: {
     oauthBindingStorage.set(input.serverName, binding);
     return binding;
   }
-  return oauthBindingStorage.get(input.serverName);
+  return previousBinding;
 }
 
 /**
@@ -2331,6 +2385,7 @@ function createMCPOAuthProvider(input: {
   serverUrl: string;
   clientId?: string;
   clientSecret?: string;
+  hasClientSecret?: boolean;
   oauthConfig: {
     resourceUrl?: string;
     registryServerId?: string;
@@ -2345,6 +2400,7 @@ function createMCPOAuthProvider(input: {
     buildConvexBindingForServer({
       serverName: input.serverName,
       oauthResourceUrl: input.oauthConfig.resourceUrl,
+      hasClientSecret: input.clientSecret ? true : input.hasClientSecret,
       registryServerId: input.oauthConfig.registryServerId,
       useRegistryOAuthProxy: input.oauthConfig.useRegistryOAuthProxy,
     })
@@ -2361,14 +2417,18 @@ function readStoredClientInformation(
     }
 
     const parsed = JSON.parse(stored) as StoredOAuthClientInformation;
+    if (parsed && typeof parsed === "object" && "client_secret" in parsed) {
+      const sanitized = Object.fromEntries(
+        Object.entries(parsed).filter(([key]) => key !== "client_secret")
+      );
+      localStorage.setItem(
+        `mcp-client-${serverName}`,
+        JSON.stringify(sanitized)
+      );
+    }
     return {
       client_id:
         typeof parsed.client_id === "string" ? parsed.client_id : undefined,
-      client_secret:
-        !HOSTED_MODE &&
-        typeof parsed.client_secret === "string"
-          ? parsed.client_secret
-          : undefined,
     };
   } catch {
     return {};
@@ -2426,6 +2486,7 @@ export async function initiateOAuth(
       serverUrl: options.serverUrl,
       clientId: options.clientId,
       clientSecret: options.clientSecret,
+      hasClientSecret: options.hasClientSecret,
       oauthConfig: {
         resourceUrl: options.resourceUrl,
         registryServerId: options.registryServerId,
@@ -2481,8 +2542,9 @@ export async function initiateOAuth(
       JSON.stringify(oauthConfig)
     );
 
-    // Store custom client credentials if provided, so they can be retrieved during callback
-    if (options.clientId || (!HOSTED_MODE && options.clientSecret)) {
+    // Store custom client id if provided, so it can be retrieved during callback.
+    // Client secrets are stored in the encrypted backend server-secret table.
+    if (options.clientId) {
       const existingClientInfo = localStorage.getItem(
         `mcp-client-${options.serverName}`
       );
@@ -2494,21 +2556,15 @@ export async function initiateOAuth(
           existingJsonRaw = {};
         }
       }
-      const existingJson =
-        HOSTED_MODE && existingJsonRaw
-          ? Object.fromEntries(
-              Object.entries(existingJsonRaw).filter(
-                ([key]) => key !== "client_secret"
-              )
-            )
-          : existingJsonRaw;
+      const existingJson = Object.fromEntries(
+        Object.entries(existingJsonRaw).filter(
+          ([key]) => key !== "client_secret"
+        )
+      );
 
       const updatedClientInfo: any = { ...existingJson };
       if (options.clientId) {
         updatedClientInfo.client_id = options.clientId;
-      }
-      if (!HOSTED_MODE && options.clientSecret) {
-        updatedClientInfo.client_secret = options.clientSecret;
       }
 
       localStorage.setItem(
@@ -2534,7 +2590,7 @@ export async function initiateOAuth(
       sanitizeTrace: SANITIZE_OAUTH_TRACES,
       requestExecutor,
       loadPreregisteredCredentials: async () => {
-        const clientInformation = provider.clientInformation();
+        const clientInformation = await provider.clientInformation();
         return {
           clientId: clientInformation?.client_id,
           clientSecret: clientInformation?.client_secret,
@@ -3045,19 +3101,13 @@ export async function handleOAuthCallback(
     }
 
     // Get stored client credentials if any
-    const storedClientInfo = localStorage.getItem(`mcp-client-${serverName}`);
-    const customClientId = storedClientInfo
-      ? JSON.parse(storedClientInfo).client_id
-      : undefined;
-    const customClientSecret = storedClientInfo
-      ? JSON.parse(storedClientInfo).client_secret
-      : undefined;
+    const storedClientInfo = readStoredClientInformation(serverName);
+    const customClientId = storedClientInfo.client_id;
 
     const provider = createMCPOAuthProvider({
       serverName,
       serverUrl,
       clientId: customClientId,
-      clientSecret: customClientSecret,
       oauthConfig,
     });
     const fetchFn = createOAuthFetchInterceptor(oauthConfig, undefined);
@@ -3092,6 +3142,15 @@ export async function handleOAuthCallback(
         authorizationCode,
         error: undefined,
       });
+      const clientInformation = await provider.clientInformation();
+      if (clientInformation?.client_id) {
+        updateState({
+          clientId: clientInformation.client_id,
+          ...(clientInformation.client_secret
+            ? { clientSecret: clientInformation.client_secret }
+            : {}),
+        });
+      }
       emitTraceSnapshot(
         projectOAuthTraceSnapshot({
           state: getState(),
@@ -3111,7 +3170,7 @@ export async function handleOAuthCallback(
         sanitizeTrace: SANITIZE_OAUTH_TRACES,
         requestExecutor,
         loadPreregisteredCredentials: async () => {
-          const clientInformation = provider.clientInformation();
+          const clientInformation = await provider.clientInformation();
           return {
             clientId: clientInformation?.client_id,
             clientSecret: clientInformation?.client_secret,
@@ -3331,6 +3390,19 @@ export function getStoredTokensState(serverName: string): StoredTokensState {
   try {
     const tokensJson = JSON.parse(tokens);
     const clientJson = clientInfo ? JSON.parse(clientInfo) : {};
+    if (
+      clientJson &&
+      typeof clientJson === "object" &&
+      "client_secret" in clientJson
+    ) {
+      const sanitizedClientInfo = Object.fromEntries(
+        Object.entries(clientJson).filter(([key]) => key !== "client_secret")
+      );
+      localStorage.setItem(
+        `mcp-client-${serverName}`,
+        JSON.stringify(sanitizedClientInfo)
+      );
+    }
 
     // Merge tokens with client_id from client information
     return {
@@ -3413,13 +3485,8 @@ export async function refreshOAuthTokens(
 
   try {
     // Get stored client credentials if any
-    const storedClientInfo = localStorage.getItem(`mcp-client-${serverName}`);
-    const customClientId = storedClientInfo
-      ? JSON.parse(storedClientInfo).client_id
-      : undefined;
-    const customClientSecret = storedClientInfo
-      ? JSON.parse(storedClientInfo).client_secret
-      : undefined;
+    const storedClientInfo = readStoredClientInformation(serverName);
+    const customClientId = storedClientInfo.client_id;
 
     // Get server URL
     const serverUrl = localStorage.getItem(`mcp-serverUrl-${serverName}`);
@@ -3435,7 +3502,6 @@ export async function refreshOAuthTokens(
       serverName,
       serverUrl,
       clientId: customClientId,
-      clientSecret: customClientSecret,
       oauthConfig,
     });
     const existingTokens = provider.tokens();

--- a/mcpjam-inspector/client/src/lib/project-serialization.ts
+++ b/mcpjam-inspector/client/src/lib/project-serialization.ts
@@ -215,10 +215,7 @@ export function deserializeServersFromConvex(
           ? serverData.oauthScopes.join(",")
           : existingProfile.scopes || "",
         clientId: serverData.clientId || existingProfile.clientId || "",
-        clientSecret:
-          serverData.hasClientSecret === true
-            ? ""
-            : existingProfile.clientSecret || "",
+        clientSecret: "",
         resourceUrl:
           serverData.oauthResourceUrl || existingProfile.resourceUrl || "",
       } as typeof server.oauthFlowProfile;
@@ -341,10 +338,7 @@ export function serversHaveChanged(
               ? remoteServer.oauthScopes.join(",")
               : remoteServer.oauthScopes,
             clientId: remoteServer.clientId,
-            clientSecret:
-              remoteServer.hasClientSecret === true
-                ? ""
-                : remoteServer.oauthFlowProfile?.clientSecret,
+            clientSecret: "",
             resourceUrl:
               remoteServer.oauthResourceUrl ??
               remoteServer.oauthFlowProfile?.resourceUrl,

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.test.ts
@@ -148,7 +148,6 @@ describe("ensureAuthorizedForReconnect", () => {
       "mcp-client-asana",
       JSON.stringify({
         client_id: "stored-client-id",
-        client_secret: "stored-client-secret",
       }),
     );
     clearOAuthDataMock.mockImplementationOnce((serverName: string) => {
@@ -185,7 +184,8 @@ describe("ensureAuthorizedForReconnect", () => {
         registryServerId: "registry-asana",
         useRegistryOAuthProxy: true,
         clientId: "stored-client-id",
-        clientSecret: "stored-client-secret",
+        clientSecret: undefined,
+        hasClientSecret: false,
         protocolMode: "2025-11-25",
         protocolVersion: "2025-11-25",
         registrationMode: "preregistered",

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -69,16 +69,20 @@ function sanitizeOAuthSetupHeaders(
 
 function readStoredClientInfo(serverName: string): {
   client_id?: string;
-  client_secret?: string;
 } {
   try {
     const raw = localStorage.getItem(`mcp-client-${serverName}`);
     if (!raw) return {};
 
     const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && "client_secret" in parsed) {
+      localStorage.setItem(
+        `mcp-client-${serverName}`,
+        JSON.stringify({ client_id: nonEmptyString(parsed?.client_id) }),
+      );
+    }
     return {
       client_id: nonEmptyString(parsed?.client_id),
-      client_secret: nonEmptyString(parsed?.client_secret),
     };
   } catch {
     return {};
@@ -153,10 +157,8 @@ function buildReconnectOAuthOptions(
       nonEmptyString(profile?.clientId) ??
       nonEmptyString(storedTokens?.client_id) ??
       storedClientInfo.client_id,
-    clientSecret:
-      nonEmptyString(server.oauthTokens?.client_secret) ??
-      nonEmptyString(profile?.clientSecret) ??
-      storedClientInfo.client_secret,
+    clientSecret: undefined,
+    hasClientSecret: Boolean(server.hasClientSecret),
     protocolMode,
     protocolVersion:
       protocolMode !== "auto"


### PR DESCRIPTION
## What changed

- Adds a Claude Desktop client template seeded from the captured Electron MCP Apps profile.
- Registers a distinct `claude-desktop` host style with inline-only MCP Apps display modes.
- Uses the Claude Code thinking indicator for the Claude Desktop host style.
- Adds tests for the seeded template, host-style registration, capabilities, and indicator choice.

## Why

Claude Desktop differs from the existing generic Claude template: it is an Electron desktop host, renders inline-only, does not expose the OpenAI Apps SDK `window.openai` bridge, and has captured sandbox/CSP constraints. A dedicated template lets developers emulate that surface without changing the existing Claude web-style preset.

## Validation

- `npm run test -w @mcpjam/inspector -- client/src/lib/__tests__/client-templates.test.ts client/src/lib/client-styles/__tests__/registry.test.ts`
- `npm run typecheck:client -w @mcpjam/inspector`
