### PR TITLE
[XAA Server Bar] PR-I1: plumb xaaAuthzIssuer + wire XAA route

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1037,7 +1037,13 @@ export function OAuthFlowRoute() {
 }
 
 export function XAAFlowRoute() {
-  const { xaaEnabled, appState, activeOrganizationId } = useAppRouteContext();
+  const {
+    xaaEnabled,
+    appState,
+    activeOrganizationId,
+    setSelectedServer,
+    saveServerConfigWithoutConnecting,
+  } = useAppRouteContext();
   if (xaaEnabled !== true) return null;
 
   return (
@@ -1052,6 +1058,8 @@ export function XAAFlowRoute() {
         serverConfigs={appState.servers}
         selectedServerName={appState.selectedServer}
         organizationId={activeOrganizationId ?? null}
+        onSelectServer={setSelectedServer}
+        onSaveServerConfig={saveServerConfigWithoutConnecting}
       />
     </ErrorBoundary>
   );

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -8,6 +8,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import type { ServerWithName } from "@/hooks/use-app-state";
+import type { ServerFormData } from "@/shared/types.js";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { useXaaResourceApps } from "@/hooks/useXaaResourceApps";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
@@ -117,6 +118,10 @@ interface XAAFlowTabProps {
   serverConfigs: Record<string, ServerWithName>;
   selectedServerName: string;
   organizationId?: string | null;
+  // Shared server-bar callbacks (mirror the OAuth Debugger). Wired in PR-I1;
+  // consumed starting in PR-I2 (modal save) and PR-I5 (chip selection).
+  onSelectServer?: (serverName: string) => void;
+  onSaveServerConfig?: (formData: ServerFormData) => void | Promise<void>;
 }
 
 export function XAAFlowTab({

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1267,6 +1267,9 @@ export function useServerState({
         oauthResourceUrl:
           serverEntry.oauthFlowProfile?.resourceUrl ||
           storedOAuthConfig.resourceUrl,
+        ...(serverEntry.xaaAuthzIssuer !== undefined
+          ? { xaaAuthzIssuer: serverEntry.xaaAuthzIssuer }
+          : {}),
       } as const;
 
       try {
@@ -2322,6 +2325,8 @@ export function useServerState({
           formData.secretPatch?.headers !== undefined
             ? Object.keys(formData.secretPatch.headers).length > 0
             : existingServerForSave?.hasHeaders,
+        xaaAuthzIssuer:
+          formData.xaaAuthzIssuer ?? existingServerForSave?.xaaAuthzIssuer,
       };
       // Both modes: await Convex sync so the returned serverId is available
       // for OAuth binding (hosted) and for the new {projectId, serverId}
@@ -2685,6 +2690,8 @@ export function useServerState({
           formData.secretPatch?.headers !== undefined
             ? Object.keys(formData.secretPatch.headers).length > 0
             : existingServer?.hasHeaders,
+        xaaAuthzIssuer:
+          formData.xaaAuthzIssuer ?? existingServer?.xaaAuthzIssuer,
       } as ServerWithName;
 
       const hasPendingOAuthCallback = new URLSearchParams(
@@ -4106,6 +4113,8 @@ export function useServerState({
           oauthFlowProfile: originalServer?.oauthFlowProfile,
           initializationInfo: originalServer?.initializationInfo,
           useOAuth: formData.useOAuth ?? false,
+          xaaAuthzIssuer:
+            formData.xaaAuthzIssuer ?? originalServer?.xaaAuthzIssuer,
         } as ServerWithName;
 
         if (!formData.useOAuth) {

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -48,6 +48,7 @@ export interface RemoteServer {
   hasEnv?: boolean;
   hasHeaders?: boolean;
   oauthResourceUrl?: string;
+  xaaAuthzIssuer?: string;
   createdAt: number;
   updatedAt: number;
 }

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -59,6 +59,11 @@ export interface ServerWithName {
   hasClientSecret?: boolean;
   hasEnv?: boolean;
   hasHeaders?: boolean;
+  /**
+   * Optional issuer override for the cross-app authorization test target.
+   * XAA metadata only — intentionally NOT part of MCPServerConfig / toMCPConfig.
+   */
+  xaaAuthzIssuer?: string;
 }
 
 export interface Project {

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -810,6 +810,8 @@ export interface ServerFormData {
   clientSecret?: string;
   hasClientSecret?: boolean;
   clearClientSecret?: boolean;
+  /** Optional issuer override for the cross-app authorization test target. */
+  xaaAuthzIssuer?: string;
   /** Registry credential key for resolving OAuth client ID from env (e.g. "github") */
   oauthCredentialKey?: string;
   /** True for registry servers that use backend-managed preregistered OAuth credentials */


### PR DESCRIPTION
Thread the new auth-flow test target server field through the client types
and the save path so it round-trips browser -> server config -> read-back:
- ServerFormData, ServerWithName, RemoteServer gain xaaAuthzIssuer.
- saveServerConfigWithoutConnecting carries it onto the server entry and
  syncServerToConvex includes it in the create/update payload.
- XAAFlowRoute passes the shared onSelectServer + onSaveServerConfig
  callbacks (mirroring the OAuth Debugger); XAAFlowTab accepts them
  (unused until the next step). No behavior change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>