### PR TITLE
[XAA Server Bar] PR-I2: XAAServerModal

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1037,7 +1037,13 @@ export function OAuthFlowRoute() {
 }
 
 export function XAAFlowRoute() {
-  const { xaaEnabled, appState, activeOrganizationId } = useAppRouteContext();
+  const {
+    xaaEnabled,
+    appState,
+    activeOrganizationId,
+    setSelectedServer,
+    saveServerConfigWithoutConnecting,
+  } = useAppRouteContext();
   if (xaaEnabled !== true) return null;
 
   return (
@@ -1052,6 +1058,8 @@ export function XAAFlowRoute() {
         serverConfigs={appState.servers}
         selectedServerName={appState.selectedServer}
         organizationId={activeOrganizationId ?? null}
+        onSelectServer={setSelectedServer}
+        onSaveServerConfig={saveServerConfigWithoutConnecting}
       />
     </ErrorBoundary>
   );

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -14,6 +14,7 @@ import { useXaaResourceApps } from "@/hooks/useXaaResourceApps";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
 import { XAAFlowLogger } from "./XAAFlowLogger";
 import { XAAConfigModal } from "./XAAConfigModal";
+import { XAAServerModal } from "./XAAServerModal";
 import { XAAIdpCard } from "./XAAIdpCard";
 import { XAAResourceAppsSection } from "./registration/XAAResourceAppsSection";
 import { XAARunChips } from "./XAARunChips";
@@ -128,8 +129,11 @@ export function XAAFlowTab({
   serverConfigs,
   selectedServerName,
   organizationId,
+  onSelectServer,
+  onSaveServerConfig,
 }: XAAFlowTabProps) {
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
+  const [isServerModalOpen, setIsServerModalOpen] = useState(false);
   const [focusedStep, setFocusedStep] = useState<XAAFlowStep | null>(null);
   const [isRunningAll, setIsRunningAll] = useState(false);
 
@@ -421,7 +425,7 @@ export function XAAFlowTab({
 
   const handleAdvance = useCallback(async () => {
     if (!hasTarget) {
-      setIsConfigModalOpen(true);
+      setIsServerModalOpen(true);
       return;
     }
 
@@ -433,7 +437,7 @@ export function XAAFlowTab({
 
   const handleRunAll = useCallback(async () => {
     if (!hasTarget) {
-      setIsConfigModalOpen(true);
+      setIsServerModalOpen(true);
       return;
     }
 
@@ -543,7 +547,7 @@ export function XAAFlowTab({
               flowState={flowState}
               focusedStep={focusedStep}
               hasProfile={hasTarget}
-              onConfigure={() => setIsConfigModalOpen(true)}
+              onConfigure={() => setIsServerModalOpen(true)}
             />
           </ResizablePanel>
 
@@ -556,7 +560,7 @@ export function XAAFlowTab({
               activeStep={focusedStep ?? flowState.currentStep}
               onFocusStep={setFocusedStep}
               actions={{
-                onConfigure: () => setIsConfigModalOpen(true),
+                onConfigure: () => setIsServerModalOpen(true),
                 onReset: hasTarget ? () => resetFlow() : undefined,
                 onContinue: continueDisabled ? undefined : handleAdvance,
                 onChangeNegativeTestMode: handleChangeNegativeTestMode,
@@ -604,6 +608,17 @@ export function XAAFlowTab({
           );
           setFocusedStep(null);
           setIsConfigModalOpen(false);
+        }}
+      />
+
+      <XAAServerModal
+        open={isServerModalOpen}
+        onOpenChange={setIsServerModalOpen}
+        server={activeServer}
+        existingServerNames={Object.keys(serverConfigs)}
+        onSave={({ formData }) => {
+          void onSaveServerConfig?.(formData);
+          onSelectServer?.(formData.name);
         }}
       />
     </div>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -8,6 +8,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import type { ServerWithName } from "@/hooks/use-app-state";
+import type { ServerFormData } from "@/shared/types.js";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { useXaaResourceApps } from "@/hooks/useXaaResourceApps";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
@@ -117,6 +118,10 @@ interface XAAFlowTabProps {
   serverConfigs: Record<string, ServerWithName>;
   selectedServerName: string;
   organizationId?: string | null;
+  // Shared server-bar callbacks (mirror the OAuth Debugger). Wired in PR-I1;
+  // consumed starting in PR-I2 (modal save) and PR-I5 (chip selection).
+  onSelectServer?: (serverName: string) => void;
+  onSaveServerConfig?: (formData: ServerFormData) => void | Promise<void>;
 }
 
 export function XAAFlowTab({

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Label } from "@mcpjam/design-system/label";
+import type { ServerFormData } from "@/shared/types.js";
+import type { ServerWithName } from "@/hooks/use-app-state";
+import { deriveOAuthProfileFromServer } from "../oauth/utils";
+
+interface XAAServerModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  server?: ServerWithName;
+  existingServerNames: string[];
+  onSave: (payload: { formData: ServerFormData }) => void;
+}
+
+// "keep" the saved secret untouched, "replace" it with a new value, or
+// "clear" it (turn the target back into a public client). Only meaningful
+// when editing a server that already has a stored secret.
+type SecretAction = "keep" | "replace" | "clear";
+
+export function XAAServerModal({
+  open,
+  onOpenChange,
+  server,
+  existingServerNames,
+  onSave,
+}: XAAServerModalProps) {
+  const derived = useMemo(
+    () => deriveOAuthProfileFromServer(server),
+    [server],
+  );
+  const hasSavedSecret = Boolean(server?.hasClientSecret);
+  const isEditing = Boolean(server);
+
+  const [serverName, setServerName] = useState("");
+  const [serverUrl, setServerUrl] = useState("");
+  const [clientId, setClientId] = useState("");
+  const [scopes, setScopes] = useState("");
+  const [authzIssuer, setAuthzIssuer] = useState("");
+  const [secretInput, setSecretInput] = useState("");
+  const [secretAction, setSecretAction] = useState<SecretAction>("keep");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setServerName(server?.name ?? "");
+    setServerUrl(derived.serverUrl ?? "");
+    setClientId(derived.clientId ?? "");
+    // Scopes can be stored comma- or space-separated upstream; normalize to
+    // the space-separated form this modal edits.
+    setScopes((derived.scopes ?? "").replace(/,/g, " ").trim());
+    setAuthzIssuer(server?.xaaAuthzIssuer ?? "");
+    setSecretInput("");
+    setSecretAction(hasSavedSecret ? "keep" : "replace");
+    setError(null);
+  }, [open, server, derived, hasSavedSecret]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedName = serverName.trim();
+    if (!trimmedName) {
+      setError("Server name is required.");
+      return;
+    }
+    if (
+      !isEditing &&
+      existingServerNames.some((name) => name === trimmedName)
+    ) {
+      setError(`A server named "${trimmedName}" already exists.`);
+      return;
+    }
+
+    const trimmedUrl = serverUrl.trim();
+    if (!trimmedUrl) {
+      setError("Server URL is required.");
+      return;
+    }
+    try {
+      // eslint-disable-next-line no-new
+      new URL(trimmedUrl);
+    } catch {
+      setError("Enter a valid server URL (e.g. https://staging.example.com).");
+      return;
+    }
+
+    const trimmedClientId = clientId.trim();
+    if (!trimmedClientId) {
+      setError("Client ID is required.");
+      return;
+    }
+
+    const trimmedIssuer = authzIssuer.trim();
+    if (trimmedIssuer) {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(trimmedIssuer);
+      } catch {
+        setError("Authorization Server Issuer must be a valid URL, or blank.");
+        return;
+      }
+    }
+
+    const scopesArray = scopes
+      .split(/\s+/)
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0);
+
+    // Resolve the secret operation. A new server (or one without a saved
+    // secret) takes whatever was typed; an edit only changes the secret when
+    // the user explicitly replaces or clears it.
+    const trimmedSecret = secretInput.trim();
+    let clientSecret: string | undefined;
+    let clearClientSecret: boolean | undefined;
+    if (hasSavedSecret) {
+      if (secretAction === "replace" && trimmedSecret) {
+        clientSecret = trimmedSecret;
+      } else if (secretAction === "clear") {
+        clearClientSecret = true;
+      }
+    } else if (trimmedSecret) {
+      clientSecret = trimmedSecret;
+    }
+
+    setError(null);
+
+    const formData: ServerFormData = {
+      name: trimmedName,
+      type: "http",
+      url: trimmedUrl,
+      useOAuth: true,
+      clientId: trimmedClientId,
+      ...(clientSecret ? { clientSecret } : {}),
+      ...(clearClientSecret ? { clearClientSecret: true } : {}),
+      hasClientSecret: server?.hasClientSecret,
+      oauthScopes: scopesArray,
+      // Always send the issuer (possibly empty) so clearing it persists.
+      xaaAuthzIssuer: trimmedIssuer,
+    };
+
+    onSave({ formData });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl flex max-h-[85vh] flex-col">
+        <DialogHeader>
+          <DialogTitle>Configure Server to Test</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+          <div className="flex-1 min-h-0 overflow-y-auto pr-1 space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="xaa-server-name">
+                Server Name <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="xaa-server-name"
+                value={serverName}
+                onChange={(event) => setServerName(event.target.value)}
+                placeholder="staging-mcp"
+                autoFocus={!isEditing}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="xaa-server-url">
+                Server URL <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="xaa-server-url"
+                value={serverUrl}
+                onChange={(event) => setServerUrl(event.target.value)}
+                placeholder="https://staging.mcp.example.com"
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="xaa-client-id">
+                Client ID <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="xaa-client-id"
+                value={clientId}
+                onChange={(event) => setClientId(event.target.value)}
+                placeholder="mcpjam-debugger"
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="xaa-client-secret">Client Secret</Label>
+              {hasSavedSecret && secretAction === "keep" ? (
+                <div className="flex items-center gap-2">
+                  <span className="flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+                    •••••••• saved
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setSecretAction("replace")}
+                  >
+                    Replace
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setSecretAction("clear")}
+                  >
+                    Clear
+                  </Button>
+                </div>
+              ) : hasSavedSecret && secretAction === "clear" ? (
+                <div className="flex items-center gap-2">
+                  <span className="flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+                    Secret will be cleared on save.
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setSecretAction("keep")}
+                  >
+                    Keep
+                  </Button>
+                </div>
+              ) : (
+                <Input
+                  id="xaa-client-secret"
+                  type="password"
+                  autoComplete="off"
+                  value={secretInput}
+                  onChange={(event) => setSecretInput(event.target.value)}
+                  placeholder={
+                    hasSavedSecret
+                      ? "Enter a new client secret"
+                      : "Required by confidential-client auth servers"
+                  }
+                />
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="xaa-scopes">Scopes</Label>
+              <Input
+                id="xaa-scopes"
+                value={scopes}
+                onChange={(event) => setScopes(event.target.value)}
+                placeholder="read:tools read:resources"
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="xaa-authz-issuer">
+                Authorization Server Issuer
+              </Label>
+              <Input
+                id="xaa-authz-issuer"
+                value={authzIssuer}
+                onChange={(event) => setAuthzIssuer(event.target.value)}
+                placeholder="Auto-discovered if blank"
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              Client ID, secret, and scopes are this server's OAuth credentials
+              (shared with the OAuth Debugger).
+            </p>
+          </div>
+
+          {error && (
+            <p className="mt-3 text-sm text-red-600 flex-shrink-0" role="alert">
+              {error}
+            </p>
+          )}
+
+          <DialogFooter className="mt-4 flex-shrink-0 border-t border-border pt-3">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit">Save configuration</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAServerModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAServerModal.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { XAAServerModal } from "../XAAServerModal";
+import type { ServerWithName } from "@/hooks/use-app-state";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderModal(
+  props?: Partial<React.ComponentProps<typeof XAAServerModal>>,
+) {
+  const onSave = vi.fn();
+  const onOpenChange = vi.fn();
+  render(
+    <XAAServerModal
+      open
+      onOpenChange={onOpenChange}
+      existingServerNames={[]}
+      onSave={onSave}
+      {...props}
+    />,
+  );
+  return { onSave, onOpenChange };
+}
+
+describe("XAAServerModal", () => {
+  it("emits ServerFormData with xaaAuthzIssuer and the OAuth credentials on save", async () => {
+    const user = userEvent.setup();
+    const { onSave, onOpenChange } = renderModal();
+
+    await user.type(screen.getByLabelText(/Server Name/), "staging-mcp");
+    await user.type(
+      screen.getByLabelText(/Server URL/),
+      "https://staging.mcp.example.com",
+    );
+    await user.type(screen.getByLabelText(/Client ID/), "staging-client");
+    await user.type(screen.getByLabelText("Client Secret"), "super-secret");
+    await user.type(screen.getByLabelText("Scopes"), "read:tools read:resources");
+    await user.type(
+      screen.getByLabelText("Authorization Server Issuer"),
+      "https://auth.staging.example.com",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const { formData } = onSave.mock.calls[0][0];
+    expect(formData).toMatchObject({
+      name: "staging-mcp",
+      type: "http",
+      url: "https://staging.mcp.example.com",
+      useOAuth: true,
+      clientId: "staging-client",
+      clientSecret: "super-secret",
+      oauthScopes: ["read:tools", "read:resources"],
+      xaaAuthzIssuer: "https://auth.staging.example.com",
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("allows a public client with no secret and a blank issuer", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderModal();
+
+    await user.type(screen.getByLabelText(/Server Name/), "beta-mcp");
+    await user.type(
+      screen.getByLabelText(/Server URL/),
+      "https://beta.mcp.example.com",
+    );
+    await user.type(screen.getByLabelText(/Client ID/), "beta-client");
+
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const { formData } = onSave.mock.calls[0][0];
+    expect(formData.clientSecret).toBeUndefined();
+    expect(formData.xaaAuthzIssuer).toBe("");
+    expect(formData.oauthScopes).toEqual([]);
+  });
+
+  it("prefills fields and masks the saved secret when editing", () => {
+    const server = {
+      name: "prod-mcp",
+      config: { url: "https://prod.mcp.example.com/mcp" },
+      oauthFlowProfile: {
+        serverUrl: "https://prod.mcp.example.com/mcp",
+        clientId: "prod-client",
+        clientSecret: "",
+        scopes: "read write",
+        customHeaders: [],
+      },
+      xaaAuthzIssuer: "https://auth.prod.example.com",
+      hasClientSecret: true,
+      useOAuth: true,
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+    } as unknown as ServerWithName;
+
+    renderModal({ server });
+
+    expect(screen.getByLabelText(/Server Name/)).toHaveValue("prod-mcp");
+    expect(screen.getByLabelText(/Server URL/)).toHaveValue(
+      "https://prod.mcp.example.com/mcp",
+    );
+    expect(screen.getByLabelText(/Client ID/)).toHaveValue("prod-client");
+    expect(screen.getByLabelText("Scopes")).toHaveValue("read write");
+    expect(screen.getByLabelText("Authorization Server Issuer")).toHaveValue(
+      "https://auth.prod.example.com",
+    );
+    // A saved secret is masked behind Replace / Clear controls, not a field.
+    expect(screen.getByText(/saved/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Replace" }),
+    ).toBeInTheDocument();
+  });
+
+  it("clears the saved secret when the creator chooses Clear", async () => {
+    const user = userEvent.setup();
+    const server = {
+      name: "prod-mcp",
+      config: { url: "https://prod.mcp.example.com/mcp" },
+      oauthFlowProfile: {
+        serverUrl: "https://prod.mcp.example.com/mcp",
+        clientId: "prod-client",
+        clientSecret: "",
+        scopes: "",
+        customHeaders: [],
+      },
+      hasClientSecret: true,
+      useOAuth: true,
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+    } as unknown as ServerWithName;
+
+    const { onSave } = renderModal({ server });
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    const { formData } = onSave.mock.calls[0][0];
+    expect(formData.clearClientSecret).toBe(true);
+    expect(formData.clientSecret).toBeUndefined();
+  });
+
+  it("rejects a duplicate name when creating a new server", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderModal({ existingServerNames: ["staging-mcp"] });
+
+    await user.type(screen.getByLabelText(/Server Name/), "staging-mcp");
+    await user.type(
+      screen.getByLabelText(/Server URL/),
+      "https://staging.mcp.example.com",
+    );
+    await user.type(screen.getByLabelText(/Client ID/), "staging-client");
+    await user.click(screen.getByRole("button", { name: "Save configuration" }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1267,6 +1267,9 @@ export function useServerState({
         oauthResourceUrl:
           serverEntry.oauthFlowProfile?.resourceUrl ||
           storedOAuthConfig.resourceUrl,
+        ...(serverEntry.xaaAuthzIssuer !== undefined
+          ? { xaaAuthzIssuer: serverEntry.xaaAuthzIssuer }
+          : {}),
       } as const;
 
       try {
@@ -2322,6 +2325,8 @@ export function useServerState({
           formData.secretPatch?.headers !== undefined
             ? Object.keys(formData.secretPatch.headers).length > 0
             : existingServerForSave?.hasHeaders,
+        xaaAuthzIssuer:
+          formData.xaaAuthzIssuer ?? existingServerForSave?.xaaAuthzIssuer,
       };
       // Both modes: await Convex sync so the returned serverId is available
       // for OAuth binding (hosted) and for the new {projectId, serverId}
@@ -2685,6 +2690,8 @@ export function useServerState({
           formData.secretPatch?.headers !== undefined
             ? Object.keys(formData.secretPatch.headers).length > 0
             : existingServer?.hasHeaders,
+        xaaAuthzIssuer:
+          formData.xaaAuthzIssuer ?? existingServer?.xaaAuthzIssuer,
       } as ServerWithName;
 
       const hasPendingOAuthCallback = new URLSearchParams(
@@ -4106,6 +4113,8 @@ export function useServerState({
           oauthFlowProfile: originalServer?.oauthFlowProfile,
           initializationInfo: originalServer?.initializationInfo,
           useOAuth: formData.useOAuth ?? false,
+          xaaAuthzIssuer:
+            formData.xaaAuthzIssuer ?? originalServer?.xaaAuthzIssuer,
         } as ServerWithName;
 
         if (!formData.useOAuth) {

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -48,6 +48,7 @@ export interface RemoteServer {
   hasEnv?: boolean;
   hasHeaders?: boolean;
   oauthResourceUrl?: string;
+  xaaAuthzIssuer?: string;
   createdAt: number;
   updatedAt: number;
 }

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -59,6 +59,11 @@ export interface ServerWithName {
   hasClientSecret?: boolean;
   hasEnv?: boolean;
   hasHeaders?: boolean;
+  /**
+   * Optional issuer override for the cross-app authorization test target.
+   * XAA metadata only — intentionally NOT part of MCPServerConfig / toMCPConfig.
+   */
+  xaaAuthzIssuer?: string;
 }
 
 export interface Project {

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -810,6 +810,8 @@ export interface ServerFormData {
   clientSecret?: string;
   hasClientSecret?: boolean;
   clearClientSecret?: boolean;
+  /** Optional issuer override for the cross-app authorization test target. */
+  xaaAuthzIssuer?: string;
   /** Registry credential key for resolving OAuth client ID from env (e.g. "github") */
   oauthCredentialKey?: string;
   /** True for registry servers that use backend-managed preregistered OAuth credentials */


### PR DESCRIPTION
Add the "Configure Server to Test" modal (mirrors the OAuth Debugger's
profile modal): name, server URL, client ID, client secret (masked
replace/clear when editing a saved secret), scopes, and the optional
authorization-server issuer. Saving emits ServerFormData (incl.
xaaAuthzIssuer) through onSaveServerConfig, so the target appears in the
shared server bar and persists; the saved server is then selected.

The XAAFlowTab "Configure" triggers now open this modal. The legacy
single-config modal stays mounted for now; it is retired in a later step.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>