### PR TITLE
[XAA Server Bar] PR-I3: global run settings + simulated identity

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -11,10 +11,12 @@ import type { ServerWithName } from "@/hooks/use-app-state";
 import type { ServerFormData } from "@/shared/types.js";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { useXaaResourceApps } from "@/hooks/useXaaResourceApps";
+import { useXaaRunSettings } from "@/hooks/useXaaRunSettings";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
 import { XAAFlowLogger } from "./XAAFlowLogger";
 import { XAAConfigModal } from "./XAAConfigModal";
 import { XAAServerModal } from "./XAAServerModal";
+import { XAASimulatedIdentity } from "./XAASimulatedIdentity";
 import { XAAIdpCard } from "./XAAIdpCard";
 import { XAAResourceAppsSection } from "./registration/XAAResourceAppsSection";
 import { XAARunChips } from "./XAARunChips";
@@ -198,13 +200,28 @@ export function XAAFlowTab({
   const selectedRegistration =
     resourceApps.find((app) => app.id === selectedRegistrationId) ?? null;
 
-  const flowInput = useMemo(
-    () =>
-      selectedRegistration
-        ? inputFromRegistration(selectedRegistration, profile)
-        : inputFromProfile(profile),
-    [selectedRegistration, profile]
-  );
+  // Global run settings: simulated identity (sub/email) + negative-test Mode
+  // are the same across every target, so they override the per-target base
+  // input rather than living on the singleton profile.
+  const runSettings = useXaaRunSettings();
+
+  const flowInput = useMemo(() => {
+    const base = selectedRegistration
+      ? inputFromRegistration(selectedRegistration, profile)
+      : inputFromProfile(profile);
+    return {
+      ...base,
+      userId: runSettings.userId,
+      email: runSettings.email,
+      negativeTestMode: runSettings.negativeTestMode,
+    };
+  }, [
+    selectedRegistration,
+    profile,
+    runSettings.userId,
+    runSettings.email,
+    runSettings.negativeTestMode,
+  ]);
 
   // Target identity for the positive-run gate; "local-profile" is its own
   // session-scoped key.
@@ -368,25 +385,23 @@ export function XAAFlowTab({
     [flowInput, selectedRegistration, applyFlowState]
   );
 
-  const handleChangeNegativeTestMode = useCallback((mode: NegativeTestMode) => {
-    setProfile((current) => {
-      const next = { ...current, negativeTestMode: mode };
-      saveStoredXAADebugProfile(next);
-      return next;
-    });
-    setFocusedStep(null);
-  }, []);
+  const handleChangeNegativeTestMode = useCallback(
+    (mode: NegativeTestMode) => {
+      runSettings.setNegativeTestMode(mode);
+      setFocusedStep(null);
+    },
+    [runSettings]
+  );
 
-  // Rebuild the flow when the negative-test mode changes (profile-sourced in
-  // both modes).
-  const lastNegativeTestMode = useRef(profile.negativeTestMode);
+  // Rebuild the flow when the global negative-test mode changes.
+  const lastNegativeTestMode = useRef(runSettings.negativeTestMode);
   useEffect(() => {
-    if (lastNegativeTestMode.current === profile.negativeTestMode) {
+    if (lastNegativeTestMode.current === runSettings.negativeTestMode) {
       return;
     }
-    lastNegativeTestMode.current = profile.negativeTestMode;
+    lastNegativeTestMode.current = runSettings.negativeTestMode;
     applyFlowState(buildFlowStateFromInput(flowInput));
-  }, [profile.negativeTestMode, flowInput, applyFlowState]);
+  }, [runSettings.negativeTestMode, flowInput, applyFlowState]);
 
   const hasTarget = Boolean(flowInput.serverUrl.trim());
 
@@ -539,6 +554,9 @@ export function XAAFlowTab({
             ? `Target: ${flowInput.serverUrl}`
             : "No target configured"}
         </span>
+        <div className="ml-auto shrink-0">
+          <XAASimulatedIdentity />
+        </div>
       </div>
       <div className="flex-1 overflow-hidden">
         <ResizablePanelGroup direction="horizontal" className="h-full">

--- a/mcpjam-inspector/client/src/components/xaa/XAASimulatedIdentity.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAASimulatedIdentity.tsx
@@ -1,0 +1,79 @@
+import { User } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import { useXaaRunSettings } from "@/hooks/useXaaRunSettings";
+
+interface XAASimulatedIdentityProps {
+  /** When true, the trigger collapses to an icon-only button (mobile). */
+  iconOnly?: boolean;
+}
+
+// Run-bar control for the global simulated identity (sub + email). The
+// MCPJam IdP mints a mock ID token for this user before exchanging it for an
+// ID-JAG. A dot on the trigger signals a non-default identity — preserving the
+// "you have a custom identity" cue the old auto-opening config modal gave.
+export function XAASimulatedIdentity({
+  iconOnly = false,
+}: XAASimulatedIdentityProps) {
+  const { userId, email, isDefaultIdentity, setIdentity } = useXaaRunSettings();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="relative shrink-0"
+          aria-label="Edit simulated identity"
+        >
+          <User className="h-3.5 w-3.5" />
+          {iconOnly ? null : <span className="ml-1.5">Identity</span>}
+          {!isDefaultIdentity ? (
+            <span
+              className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-primary"
+              aria-hidden="true"
+            />
+          ) : null}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 space-y-3">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Simulated identity</p>
+          <p className="text-xs text-muted-foreground">
+            The MCPJam issuer mints a mock ID token for this user, then
+            exchanges it for an ID-JAG. Applies to every target.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="xaa-identity-sub">Subject (sub)</Label>
+          <Input
+            id="xaa-identity-sub"
+            value={userId}
+            onChange={(event) => setIdentity({ userId: event.target.value })}
+            placeholder="user-12345"
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="xaa-identity-email">Email</Label>
+          <Input
+            id="xaa-identity-email"
+            value={email}
+            onChange={(event) => setIdentity({ email: event.target.value })}
+            placeholder="demo.user@example.com"
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAASimulatedIdentity.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAASimulatedIdentity.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { XAASimulatedIdentity } from "../XAASimulatedIdentity";
+
+const RUN_SETTINGS_KEY = "mcpjam-xaa-run-settings/v1";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("XAASimulatedIdentity", () => {
+  it("does not flag the trigger when the identity is default", () => {
+    render(<XAASimulatedIdentity />);
+    expect(
+      screen.getByRole("button", { name: /edit simulated identity/i }),
+    ).toBeInTheDocument();
+    // No non-default indicator dot in the DOM yet.
+    expect(
+      document.querySelector("span.rounded-full.bg-primary"),
+    ).toBeNull();
+  });
+
+  it("edits sub + email and persists them globally", async () => {
+    const user = userEvent.setup();
+    render(<XAASimulatedIdentity />);
+
+    await user.click(
+      screen.getByRole("button", { name: /edit simulated identity/i }),
+    );
+
+    const sub = screen.getByLabelText("Subject (sub)");
+    await user.clear(sub);
+    await user.type(sub, "person-99");
+    const email = screen.getByLabelText("Email");
+    await user.clear(email);
+    await user.type(email, "person@example.com");
+
+    const stored = JSON.parse(localStorage.getItem(RUN_SETTINGS_KEY) ?? "{}");
+    expect(stored.userId).toBe("person-99");
+    expect(stored.email).toBe("person@example.com");
+  });
+
+  it("shows the non-default indicator when a custom identity is stored", () => {
+    localStorage.setItem(
+      RUN_SETTINGS_KEY,
+      JSON.stringify({
+        userId: "custom",
+        email: "custom@example.com",
+        negativeTestMode: "valid",
+      }),
+    );
+
+    render(<XAASimulatedIdentity />);
+    expect(
+      document.querySelector("span.rounded-full.bg-primary"),
+    ).not.toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useXaaRunSettings.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useXaaRunSettings.test.ts
@@ -1,0 +1,121 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_XAA_RUN_SETTINGS,
+  useXaaRunSettings,
+} from "../useXaaRunSettings";
+
+const RUN_SETTINGS_KEY = "mcpjam-xaa-run-settings/v1";
+const LEGACY_PROFILE_KEY = "mcpjam-xaa-debugger-profile/v1";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("useXaaRunSettings", () => {
+  it("defaults to the built-in identity and mode with no stored keys", () => {
+    const { result } = renderHook(() => useXaaRunSettings());
+    expect(result.current.userId).toBe(DEFAULT_XAA_RUN_SETTINGS.userId);
+    expect(result.current.email).toBe(DEFAULT_XAA_RUN_SETTINGS.email);
+    expect(result.current.negativeTestMode).toBe(
+      DEFAULT_XAA_RUN_SETTINGS.negativeTestMode,
+    );
+    expect(result.current.isDefaultIdentity).toBe(true);
+  });
+
+  it("migrates identity + mode from the legacy debugger profile once", () => {
+    localStorage.setItem(
+      LEGACY_PROFILE_KEY,
+      JSON.stringify({
+        serverUrl: "https://legacy.example.com",
+        userId: "legacy-user",
+        email: "legacy@example.com",
+        negativeTestMode: "wrong_audience",
+      }),
+    );
+
+    const { result } = renderHook(() => useXaaRunSettings());
+
+    expect(result.current.userId).toBe("legacy-user");
+    expect(result.current.email).toBe("legacy@example.com");
+    expect(result.current.negativeTestMode).toBe("wrong_audience");
+    expect(result.current.isDefaultIdentity).toBe(false);
+
+    // The new key is now seeded from the legacy values.
+    const stored = JSON.parse(localStorage.getItem(RUN_SETTINGS_KEY) ?? "{}");
+    expect(stored).toMatchObject({
+      userId: "legacy-user",
+      email: "legacy@example.com",
+      negativeTestMode: "wrong_audience",
+    });
+  });
+
+  it("does not re-seed from the legacy profile once the new key exists", () => {
+    localStorage.setItem(
+      RUN_SETTINGS_KEY,
+      JSON.stringify({
+        userId: "kept-user",
+        email: "kept@example.com",
+        negativeTestMode: "expired",
+      }),
+    );
+    // A stale legacy profile with different values must be ignored.
+    localStorage.setItem(
+      LEGACY_PROFILE_KEY,
+      JSON.stringify({
+        userId: "legacy-user",
+        email: "legacy@example.com",
+        negativeTestMode: "wrong_audience",
+      }),
+    );
+
+    const { result } = renderHook(() => useXaaRunSettings());
+
+    expect(result.current.userId).toBe("kept-user");
+    expect(result.current.email).toBe("kept@example.com");
+    expect(result.current.negativeTestMode).toBe("expired");
+  });
+
+  it("sanitizes an invalid stored negativeTestMode to the default", () => {
+    localStorage.setItem(
+      RUN_SETTINGS_KEY,
+      JSON.stringify({
+        userId: "u",
+        email: "e@example.com",
+        negativeTestMode: "not-a-real-mode",
+      }),
+    );
+
+    const { result } = renderHook(() => useXaaRunSettings());
+    expect(result.current.negativeTestMode).toBe(
+      DEFAULT_XAA_RUN_SETTINGS.negativeTestMode,
+    );
+  });
+
+  it("persists identity + mode updates and sanitizes the mode setter", () => {
+    const { result } = renderHook(() => useXaaRunSettings());
+
+    act(() => {
+      result.current.setIdentity({ userId: "custom", email: "c@example.com" });
+    });
+    act(() => {
+      result.current.setNegativeTestMode("scope_denial");
+    });
+
+    expect(result.current.userId).toBe("custom");
+    expect(result.current.email).toBe("c@example.com");
+    expect(result.current.negativeTestMode).toBe("scope_denial");
+    expect(result.current.isDefaultIdentity).toBe(false);
+
+    const stored = JSON.parse(localStorage.getItem(RUN_SETTINGS_KEY) ?? "{}");
+    expect(stored).toMatchObject({
+      userId: "custom",
+      email: "c@example.com",
+      negativeTestMode: "scope_denial",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useXaaRunSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useXaaRunSettings.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  DEFAULT_NEGATIVE_TEST_MODE,
+  isNegativeTestMode,
+  type NegativeTestMode,
+} from "@/shared/xaa.js";
+
+// Run-level settings that are global across every XAA target: the simulated
+// identity (sub/email) and the negative-test Mode. Target-specific config
+// (server URL, client id, secret, scopes) lives on the server, not here.
+const RUN_SETTINGS_KEY = "mcpjam-xaa-run-settings/v1";
+// The legacy single-config debugger profile we migrate identity + mode from
+// once, on first load (mirrors profile.ts XAA_PROFILE_STORAGE_KEY).
+const LEGACY_PROFILE_KEY = "mcpjam-xaa-debugger-profile/v1";
+
+export interface XaaRunSettings {
+  userId: string;
+  email: string;
+  negativeTestMode: NegativeTestMode;
+}
+
+export const DEFAULT_XAA_RUN_SETTINGS: XaaRunSettings = {
+  userId: "user-12345",
+  email: "demo.user@example.com",
+  negativeTestMode: DEFAULT_NEGATIVE_TEST_MODE,
+};
+
+function sanitizeMode(value: unknown): NegativeTestMode {
+  return isNegativeTestMode(value) ? value : DEFAULT_NEGATIVE_TEST_MODE;
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : fallback;
+}
+
+// One-time read, consumed only inside the lazy useState initializer below —
+// never in the render body. When the new key is absent, identity + mode are
+// migrated from the legacy debugger profile once; once the new key exists the
+// legacy values are ignored, so the migration never re-seeds.
+function loadInitialRunSettings(): XaaRunSettings {
+  try {
+    const raw = localStorage.getItem(RUN_SETTINGS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<XaaRunSettings>;
+      return {
+        userId: readString(parsed.userId, DEFAULT_XAA_RUN_SETTINGS.userId),
+        email: readString(parsed.email, DEFAULT_XAA_RUN_SETTINGS.email),
+        negativeTestMode: sanitizeMode(parsed.negativeTestMode),
+      };
+    }
+
+    const legacyRaw = localStorage.getItem(LEGACY_PROFILE_KEY);
+    if (legacyRaw) {
+      const legacy = JSON.parse(legacyRaw) as Record<string, unknown>;
+      const migrated: XaaRunSettings = {
+        userId: readString(legacy.userId, DEFAULT_XAA_RUN_SETTINGS.userId),
+        email: readString(legacy.email, DEFAULT_XAA_RUN_SETTINGS.email),
+        negativeTestMode: sanitizeMode(legacy.negativeTestMode),
+      };
+      try {
+        localStorage.setItem(RUN_SETTINGS_KEY, JSON.stringify(migrated));
+      } catch {
+        // Ignore storage failures; the in-memory value still applies.
+      }
+      return migrated;
+    }
+  } catch {
+    // Ignore parse/storage failures and fall back to defaults.
+  }
+  return { ...DEFAULT_XAA_RUN_SETTINGS };
+}
+
+export function isDefaultIdentity(settings: {
+  userId: string;
+  email: string;
+}): boolean {
+  return (
+    settings.userId === DEFAULT_XAA_RUN_SETTINGS.userId &&
+    settings.email === DEFAULT_XAA_RUN_SETTINGS.email
+  );
+}
+
+export function useXaaRunSettings() {
+  const [settings, setSettings] =
+    useState<XaaRunSettings>(loadInitialRunSettings);
+
+  // Persist on change in an effect rather than inside the state updater, so a
+  // StrictMode double-invoked updater never double-writes.
+  useEffect(() => {
+    try {
+      localStorage.setItem(RUN_SETTINGS_KEY, JSON.stringify(settings));
+    } catch {
+      // Ignore storage failures.
+    }
+  }, [settings]);
+
+  const setNegativeTestMode = useCallback((mode: NegativeTestMode) => {
+    setSettings((current) => ({
+      ...current,
+      negativeTestMode: sanitizeMode(mode),
+    }));
+  }, []);
+
+  const setIdentity = useCallback(
+    (patch: { userId?: string; email?: string }) => {
+      setSettings((current) => ({
+        ...current,
+        ...(patch.userId !== undefined ? { userId: patch.userId } : {}),
+        ...(patch.email !== undefined ? { email: patch.email } : {}),
+      }));
+    },
+    [],
+  );
+
+  return useMemo(
+    () => ({
+      userId: settings.userId,
+      email: settings.email,
+      negativeTestMode: settings.negativeTestMode,
+      isDefaultIdentity: isDefaultIdentity(settings),
+      setNegativeTestMode,
+      setIdentity,
+    }),
+    [
+      settings,
+      setNegativeTestMode,
+      setIdentity,
+    ],
+  );
+}


### PR DESCRIPTION
Introduce useXaaRunSettings, which owns the run-level settings shared across
every target — simulated identity (sub/email) and the negative-test Mode —
in its own localStorage key, with a one-time idempotent migration from the
legacy single-config key. Add XAASimulatedIdentity, a run-bar popover that
edits sub/email and flags a non-default identity.

XAAFlowTab now sources identity + Mode from the hook: the existing Mode
dropdown is repointed to it (still the only Mode control) and the simulated
identity moves to the run bar. The legacy key is left intact so the
migration source survives until the singleton is retired.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>