### PR TITLE
[XAA Server Bar] PR-I4: server-side confidential secret + token-endpoint resolution

### DIFF
--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -383,6 +383,8 @@ export function createXAAStateMachine(
     scope,
     authzServerIssuer,
     registrationId,
+    serverId,
+    projectId,
   } = config;
 
   const state: Partial<XAAFlowState> = initialState ?? {};
@@ -921,14 +923,22 @@ export function createXAAStateMachine(
       return;
     }
 
-    // Registration-backed runs send only the registration id: the server
-    // resolves the stored secret and forces the outbound URL to the
-    // registration's stored token endpoint, so neither ever rides in from
-    // the browser. Manual runs may carry a profile-configured secret —
-    // confidential-client servers reject the jwt-bearer grant without one.
+    // Registration- and server-target runs send only an opaque id: the server
+    // resolves the stored secret and forces the outbound URL server-side, so
+    // neither the secret nor the destination ever rides in from the browser.
+    // Manual runs may carry a profile-configured secret — confidential-client
+    // servers reject the jwt-bearer grant without one.
     const tokenRequestBody = registrationId
       ? {
           registrationId,
+          assertion: state.idJag,
+          scope: state.scope,
+          resource: state.resourceUrl || state.serverUrl,
+        }
+      : serverId
+      ? {
+          serverId,
+          ...(projectId ? { projectId } : {}),
           assertion: state.idJag,
           scope: state.scope,
           resource: state.resourceUrl || state.serverUrl,

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -164,6 +164,12 @@ export interface BaseXAAStateMachineConfig {
    * inline client secret; the server resolves the stored secret and forces
    * the outbound URL to the registration's stored token endpoint. */
   registrationId?: string;
+  /** Server-target confidential runs: sent to the token proxy instead of an
+   * inline client secret or token endpoint. The server resolves the stored
+   * secret AND discovers the token endpoint from the server's own config, so
+   * neither the secret nor the destination rides in from the browser. */
+  serverId?: string;
+  projectId?: string;
 }
 
 export interface XAAStateMachine {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import {
+  initXAAIdpKeyPair,
+  resetXAAIdpKeyPairForTests,
+} from "../../../services/xaa-idp-keypair.js";
+import { createXaaRouter } from "../xaa.js";
+
+const DISCOVERED_TOKEN_ENDPOINT = "https://discovered-as.example.com/oauth/token";
+
+interface ServerSecretResolverResult {
+  clientSecret: string | null;
+  clientId: string | null;
+  serverUrl: string | null;
+  xaaAuthzIssuer: string | null;
+}
+
+function buildApp(resolver?: (args: {
+  serverId: string;
+  projectId: string;
+  bearerToken: string;
+}) => Promise<ServerSecretResolverResult>) {
+  const app = new Hono();
+  app.route(
+    "/api/web/xaa",
+    createXaaRouter({
+      issuerBasePath: "/api/web",
+      httpsOnlyProxy: false,
+      resolveServerSecret: resolver,
+    })
+  );
+  return app;
+}
+
+// Discovery GETs return metadata advertising the token endpoint; token POSTs
+// return an issued token. Distinguishing on method lets one mock serve both
+// legs of the server-side resolution.
+function stubDiscoveryAndToken(options?: {
+  tokenEndpoint?: string;
+  onTokenPost?: (url: string, init: RequestInit) => void;
+}) {
+  const fetchMock = vi.fn(async (url: any, init?: RequestInit) => {
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (method === "GET") {
+      return new Response(
+        JSON.stringify({
+          issuer: "https://stored-server.example.com",
+          token_endpoint: options?.tokenEndpoint ?? DISCOVERED_TOKEN_ENDPOINT,
+          grant_types_supported: [
+            "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    options?.onTokenPost?.(String(url), init as RequestInit);
+    return new Response(
+      JSON.stringify({ access_token: "issued-token", token_type: "Bearer" }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("server-target /proxy/token", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects serverId on an instance without a server secret resolver", async () => {
+    const app = buildApp();
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { message?: string };
+    expect(body.message).toContain("not available");
+  });
+
+  it("requires a bearer token before resolving the secret", async () => {
+    const resolver = vi.fn();
+    const app = buildApp(resolver);
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+    expect(response.status).toBe(401);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it("discovers the token endpoint server-side and pins the stored secret/client id, discarding client-supplied values", async () => {
+    const resolver = vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      clientId: "stored-client-id",
+      serverUrl: "https://stored-server.example.com",
+      xaaAuthzIssuer: null,
+    }));
+    const app = buildApp(resolver);
+
+    let tokenUrl = "";
+    let tokenInit: RequestInit | undefined;
+    const fetchMock = stubDiscoveryAndToken({
+      onTokenPost: (url, init) => {
+        tokenUrl = url;
+        tokenInit = init;
+      },
+    });
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+        // Attacker-controlled values that must all be discarded.
+        tokenEndpoint: "https://attacker.example.com/exfil",
+        clientId: "attacker-client",
+        clientSecret: "attacker-secret",
+        headers: { "X-Evil": "1" },
+        scope: "read:tools",
+        resource: "https://mcp.example.com",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolver).toHaveBeenCalledWith({
+      serverId: "srv_1",
+      projectId: "proj_1",
+      bearerToken: "user-token",
+    });
+
+    // The token POST went to the server-discovered endpoint, never the
+    // client-supplied one.
+    expect(tokenUrl).toContain("discovered-as.example.com");
+    expect(tokenUrl).not.toContain("attacker.example.com");
+
+    const headers = (tokenInit?.headers ?? {}) as Record<string, string>;
+    expect(headers["X-Evil"]).toBeUndefined();
+
+    const form = new URLSearchParams(String(tokenInit?.body));
+    expect(form.get("client_secret")).toBe("stored-secret");
+    expect(form.get("client_id")).toBe("stored-client-id");
+    expect(form.get("assertion")).toBe("aaa.bbb.ccc");
+
+    // The confidential secret is never echoed back to the browser.
+    const responseText = JSON.stringify(await response.json());
+    expect(responseText).not.toContain("stored-secret");
+
+    // Discovery used the GET leg; the mock served both.
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("prefers the stored xaaAuthzIssuer over the server URL for discovery", async () => {
+    const resolver = vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      clientId: "stored-client-id",
+      serverUrl: "https://stored-server.example.com",
+      xaaAuthzIssuer: "https://issuer.example.com",
+    }));
+    const app = buildApp(resolver);
+
+    let discoveryUrl = "";
+    const fetchMock = vi.fn(async (url: any, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET") {
+        discoveryUrl = String(url);
+        return new Response(
+          JSON.stringify({
+            issuer: "https://issuer.example.com",
+            token_endpoint: DISCOVERED_TOKEN_ENDPOINT,
+            grant_types_supported: [
+              "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+      return new Response(
+        JSON.stringify({ access_token: "tok", token_type: "Bearer" }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(discoveryUrl).toContain("issuer.example.com");
+    expect(discoveryUrl).not.toContain("stored-server.example.com");
+  });
+
+  it("returns 404 when no authorization server can be discovered", async () => {
+    const resolver = vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      clientId: "stored-client-id",
+      serverUrl: "https://stored-server.example.com",
+      xaaAuthzIssuer: null,
+    }));
+    const app = buildApp(resolver);
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "not_found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("server-target /negative-tests", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-srv-negtest-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  it("fires the broken assertions at the server-discovered endpoint with the stored secret", async () => {
+    const resolver = vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      clientId: "stored-client-id",
+      serverUrl: "https://stored-server.example.com",
+      xaaAuthzIssuer: null,
+    }));
+    const app = buildApp(resolver);
+
+    const tokenPosts: Array<{ url: string; body: string }> = [];
+    stubDiscoveryAndToken({
+      onTokenPost: (url, init) => {
+        tokenPosts.push({ url, body: String(init.body) });
+      },
+    });
+
+    const response = await app.request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        audience: "https://issuer.example.com",
+        resource: "https://mcp.example.com",
+        // Attacker values that must be ignored.
+        tokenEndpoint: "https://attacker.example.com/exfil",
+        clientSecret: "attacker-secret",
+        clientId: "attacker-client",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolver).toHaveBeenCalledWith({
+      serverId: "srv_1",
+      projectId: "proj_1",
+      bearerToken: "user-token",
+    });
+
+    expect(tokenPosts.length).toBeGreaterThan(0);
+    for (const post of tokenPosts) {
+      expect(post.url).toContain("discovered-as.example.com");
+      expect(post.url).not.toContain("attacker.example.com");
+      const form = new URLSearchParams(post.body);
+      expect(form.get("client_secret")).toBe("stored-secret");
+    }
+  });
+
+  it("requires a bearer token for server-target negative tests", async () => {
+    const resolver = vi.fn();
+    const app = buildApp(resolver);
+
+    const response = await app.request("/api/web/xaa/negative-tests", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        audience: "https://issuer.example.com",
+        resource: "https://mcp.example.com",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -30,8 +30,11 @@ import {
   buildDiscoveryCandidates,
   evaluateDiscovery,
 } from "../../services/xaa-discovery.js";
-import { WebRouteError } from "../web/errors.js";
-import type { XaaResourceAppSecretResult } from "../../utils/server-secrets.js";
+import { ErrorCode, WebRouteError } from "../web/errors.js";
+import type {
+  ServerClientSecretResult,
+  XaaResourceAppSecretResult,
+} from "../../utils/server-secrets.js";
 import { logger } from "../../utils/logger.js";
 
 const HEALTH_CHECK_TIMEOUT_MS = 10_000;
@@ -100,10 +103,15 @@ const negativeTestsSchema = z
     clientSecret: z.string().trim().min(1).optional(),
     headers: z.record(z.string(), z.string()).optional(),
     registrationId: z.string().trim().min(1).optional(),
+    serverId: z.string().trim().min(1).optional(),
+    projectId: z.string().trim().min(1).optional(),
   })
-  .refine((data) => data.registrationId || data.tokenEndpoint, {
-    message: "tokenEndpoint or registrationId is required",
-  });
+  .refine(
+    (data) => data.registrationId || data.serverId || data.tokenEndpoint,
+    {
+      message: "tokenEndpoint, registrationId, or serverId is required",
+    }
+  );
 
 type NegativeCaseOutcome = {
   mode: NegativeTestMode;
@@ -228,10 +236,18 @@ const proxyTokenSchema = z
     // Registration-backed runs: the server resolves the stored secret and
     // forces the outbound URL to the registration's stored token endpoint.
     registrationId: z.string().trim().min(1).optional(),
+    // Server-target runs: the server resolves the stored secret AND discovers
+    // the token endpoint from the server's own config (clientId/url/issuer
+    // are all pinned server-side).
+    serverId: z.string().trim().min(1).optional(),
+    projectId: z.string().trim().min(1).optional(),
   })
-  .refine((data) => data.registrationId || data.tokenEndpoint, {
-    message: "tokenEndpoint or registrationId is required",
-  });
+  .refine(
+    (data) => data.registrationId || data.serverId || data.tokenEndpoint,
+    {
+      message: "tokenEndpoint, registrationId, or serverId is required",
+    }
+  );
 
 interface CreateXaaRouterOptions {
   issuerBasePath: "/api/mcp" | "/api/web";
@@ -250,6 +266,14 @@ interface CreateXaaRouterOptions {
     registrationId: string;
     bearerToken: string;
   }) => Promise<XaaResourceAppSecretResult>;
+  // Resolves a server target's confidential client secret + non-secret config
+  // (clientId/url/issuer) server-side (hosted instance only). When absent — the
+  // unauthenticated local instance — server-target proxy requests are rejected.
+  resolveServerSecret?: (args: {
+    serverId: string;
+    projectId: string;
+    bearerToken: string;
+  }) => Promise<ServerClientSecretResult>;
 }
 
 type ParsedJwtPayload = {
@@ -287,6 +311,107 @@ function parseRequest<T>(schema: z.ZodSchema<T>, data: unknown): T {
     );
   }
   return parsed.data;
+}
+
+// Resolved authorization-server target for a server-target run. Every field
+// is pinned server-side from the stored server config; nothing is taken from
+// the request body.
+interface ResolvedServerTarget {
+  tokenEndpoint: string;
+  clientId?: string;
+  clientSecret?: string;
+}
+
+// Discover the token endpoint for a server target's issuer, reusing the same
+// well-known sweep as /discover-as. The issuer is the stored xaaAuthzIssuer
+// (or the server URL); the client never supplies it.
+async function discoverServerTargetTokenEndpoint(
+  issuer: string,
+  httpsOnly: boolean
+): Promise<string> {
+  let candidates: string[];
+  try {
+    candidates = buildDiscoveryCandidates(issuer);
+  } catch {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "The server's authorization issuer is not a valid URL"
+    );
+  }
+
+  for (const candidate of candidates) {
+    const result = await fetchOAuthMetadata(candidate, httpsOnly);
+    if ("metadata" in result) {
+      const verdict = evaluateDiscovery(result.metadata, {
+        requestedIssuer: issuer,
+        metadataUrl: candidate,
+      });
+      if (verdict.tokenEndpoint) {
+        return verdict.tokenEndpoint;
+      }
+    }
+  }
+
+  throw new WebRouteError(
+    404,
+    ErrorCode.NOT_FOUND,
+    "Couldn't discover an authorization server. Set the issuer in Configure Server to Test."
+  );
+}
+
+// Resolve a server target's secret AND token endpoint entirely server-side.
+// The browser sends only serverId + projectId; the stored config dictates the
+// secret, client id, and the endpoint the secret may be posted to — so a
+// caller can never redirect the confidential secret elsewhere.
+async function resolveServerTarget(
+  options: CreateXaaRouterOptions,
+  args: {
+    serverId: string;
+    projectId?: string;
+    bearerToken: string;
+  }
+): Promise<ResolvedServerTarget> {
+  if (!options.resolveServerSecret) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Server-target runs are not available on this instance"
+    );
+  }
+  if (!args.projectId) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "projectId is required for server-target runs"
+    );
+  }
+
+  const resolved = await options.resolveServerSecret({
+    serverId: args.serverId,
+    projectId: args.projectId,
+    bearerToken: args.bearerToken,
+  });
+
+  const issuer = resolved.xaaAuthzIssuer || resolved.serverUrl;
+  if (!issuer) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "The server has no URL or issuer to discover an authorization server from"
+    );
+  }
+
+  const tokenEndpoint = await discoverServerTargetTokenEndpoint(
+    issuer,
+    options.httpsOnlyProxy
+  );
+
+  return {
+    tokenEndpoint,
+    clientId: resolved.clientId ?? undefined,
+    clientSecret: resolved.clientSecret ?? undefined,
+  };
 }
 
 function getIssuerForRequest(
@@ -508,7 +633,29 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       let clientSecret = parsed.clientSecret;
       let extraHeaders = parsed.headers;
 
-      if (parsed.registrationId) {
+      if (parsed.serverId) {
+        const authHeader = c.req.header("authorization");
+        if (!authHeader?.startsWith("Bearer ")) {
+          return toJsonError("Missing or invalid bearer token", {
+            status: 401,
+            code: "UNAUTHORIZED",
+          });
+        }
+
+        // The secret AND the token endpoint are resolved/discovered from the
+        // stored server config. Everything is pinned by ASSIGNMENT — the
+        // client-supplied tokenEndpoint/clientId/clientSecret/headers are
+        // discarded so the confidential secret can't be redirected.
+        const resolved = await resolveServerTarget(options, {
+          serverId: parsed.serverId,
+          projectId: parsed.projectId,
+          bearerToken: authHeader.slice("Bearer ".length),
+        });
+        url = resolved.tokenEndpoint;
+        clientId = resolved.clientId;
+        clientSecret = resolved.clientSecret;
+        extraHeaders = undefined;
+      } else if (parsed.registrationId) {
         if (!options.resolveRegistrationSecret) {
           return toJsonError(
             "Registration-backed runs are not available on this instance",
@@ -747,7 +894,28 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
     let extraHeaders = parsed.headers;
 
     try {
-      if (parsed.registrationId) {
+      if (parsed.serverId) {
+        const authHeader = c.req.header("authorization");
+        if (!authHeader?.startsWith("Bearer ")) {
+          return toJsonError("Missing or invalid bearer token", {
+            status: 401,
+            code: "UNAUTHORIZED",
+          });
+        }
+        // Same server-side hardening as /proxy/token: secret + endpoint are
+        // resolved/discovered from the stored server config and pinned by
+        // assignment; client-supplied endpoint/clientId/secret/headers are
+        // discarded.
+        const resolved = await resolveServerTarget(options, {
+          serverId: parsed.serverId,
+          projectId: parsed.projectId,
+          bearerToken: authHeader.slice("Bearer ".length),
+        });
+        tokenEndpoint = resolved.tokenEndpoint;
+        clientId = resolved.clientId;
+        clientSecret = resolved.clientSecret;
+        extraHeaders = undefined;
+      } else if (parsed.registrationId) {
         if (!options.resolveRegistrationSecret) {
           return toJsonError(
             "Registration-backed runs are not available on this instance",

--- a/mcpjam-inspector/server/routes/web/xaa.ts
+++ b/mcpjam-inspector/server/routes/web/xaa.ts
@@ -1,6 +1,9 @@
 import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
 import { guestRateLimitMiddleware } from "../../middleware/guest-rate-limit.js";
-import { fetchXaaResourceAppSecret } from "../../utils/server-secrets.js";
+import {
+  fetchServerClientSecret,
+  fetchXaaResourceAppSecret,
+} from "../../utils/server-secrets.js";
 import { createXaaRouter } from "../mcp/xaa.js";
 
 const xaaWeb = createXaaRouter({
@@ -9,6 +12,7 @@ const xaaWeb = createXaaRouter({
   trustForwardedHeaders: true,
   protectedMiddlewares: [bearerAuthMiddleware, guestRateLimitMiddleware],
   resolveRegistrationSecret: (args) => fetchXaaResourceAppSecret(args),
+  resolveServerSecret: (args) => fetchServerClientSecret(args),
 });
 
 export default xaaWeb;

--- a/mcpjam-inspector/server/utils/server-secrets.ts
+++ b/mcpjam-inspector/server/utils/server-secrets.ts
@@ -257,3 +257,98 @@ export async function fetchXaaResourceAppSecret(args: {
       : null,
   };
 }
+
+export interface ServerClientSecretResult {
+  /** null for a public client (server with no stored secret). */
+  clientSecret: string | null;
+  /** The server's stored OAuth client id — pinned server-side. */
+  clientId: string | null;
+  /** The server's stored URL, used to discover the auth server when no
+   * explicit issuer is set. */
+  serverUrl: string | null;
+  /** Optional issuer override; takes precedence over serverUrl for discovery. */
+  xaaAuthzIssuer: string | null;
+}
+
+/**
+ * Resolve a server target's confidential client secret plus the non-secret
+ * config (client id, url, issuer) server-side, mirroring
+ * fetchXaaResourceAppSecret: the caller's bearer is forwarded as-is, so the
+ * backend enforces per-server ownership. The secret never reaches the browser
+ * and the inspector server — not the client — decides where it is posted.
+ */
+export async function fetchServerClientSecret(args: {
+  bearerToken: string;
+  serverId: string;
+  projectId: string;
+}): Promise<ServerClientSecretResult> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_HTTP_URL configuration"
+    );
+  }
+  const REVEAL_TIMEOUT_MS = 10_000;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REVEAL_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`${convexUrl}/web/xaa/server/reveal-secret`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${args.bearerToken}`,
+      },
+      body: JSON.stringify({
+        serverId: args.serverId,
+        projectId: args.projectId,
+      }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const isAbort =
+      error instanceof Error &&
+      (error.name === "AbortError" ||
+        (error as { code?: string }).code === "ABORT_ERR");
+    throw new WebRouteError(
+      isAbort ? 504 : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      isAbort
+        ? `Secret reveal service timed out after ${REVEAL_TIMEOUT_MS}ms`
+        : `Failed to reach secret reveal service: ${parseErrorMessage(error)}`
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch {
+    // ignored
+  }
+
+  if (!response.ok || !body?.success) {
+    const message =
+      typeof body?.error === "string"
+        ? body.error
+        : `Secret reveal failed (${response.status})`;
+    throw new WebRouteError(
+      response.ok ? 500 : response.status,
+      statusToErrorCode(response.ok ? 500 : response.status),
+      message
+    );
+  }
+
+  return {
+    clientSecret:
+      typeof body.clientSecret === "string" ? body.clientSecret : null,
+    clientId: typeof body.clientId === "string" ? body.clientId : null,
+    serverUrl: typeof body.serverUrl === "string" ? body.serverUrl : null,
+    xaaAuthzIssuer:
+      typeof body.xaaAuthzIssuer === "string" ? body.xaaAuthzIssuer : null,
+  };
+}


### PR DESCRIPTION
Add a server-target run path where the browser sends only an opaque
serverId + projectId. The inspector server resolves the confidential test
credential server-side AND discovers the token endpoint from the server's
own stored config (issuer override, else server URL), then pins the URL,
client id, and secret by assignment — every client-supplied tokenEndpoint /
clientId / clientSecret / header is discarded. Applied to BOTH /proxy/token
and /negative-tests; the secret never enters the browser and can't be
redirected to a foreign endpoint.

fetchServerClientSecret resolves the credential via the server-side reveal
endpoint (caller's bearer forwarded). The state-machine token body grows a
serverId branch. Additive and dormant until the tab supplies serverId.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>