### PR TITLE
[XAA Server Bar] PR-I6: active-target indicator + precedence UX + telemetry

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -79,7 +79,19 @@ vi.mock("../xaa/XAAFlowLogger", () => ({
 }));
 
 vi.mock("../xaa/registration/XAAResourceAppsSection", () => ({
-  XAAResourceAppsSection: () => <div data-testid="xaa-resource-apps-section" />,
+  XAAResourceAppsSection: ({
+    onSelect,
+  }: {
+    onSelect: (app: { id: string }) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="select-registration"
+      onClick={() => onSelect({ id: "app_1" })}
+    >
+      select registration
+    </button>
+  ),
 }));
 
 vi.mock("../xaa/NegativeTestScorecard", () => ({
@@ -90,16 +102,19 @@ vi.mock("../xaa/NegativeTestScorecard", () => ({
 
 const runAllMock = vi.fn();
 let capturedMachineConfig: any = null;
+let machineShouldComplete = true;
 vi.mock("@/lib/xaa/debug-state-machine-adapter", () => ({
   createInspectorXAAStateMachine: (config: any) => {
     capturedMachineConfig = config;
     return {
       proceedToNextStep: vi.fn(),
-      // A "successful" run marks the flow complete, which fires the success
-      // telemetry + unlocks this target's scorecard.
+      // A "successful" run marks the flow complete (fires success telemetry +
+      // unlocks the scorecard); an unsuccessful one leaves it mid-flow.
       runAll: vi.fn(async () => {
         runAllMock();
-        config.updateState({ currentStep: "complete", isBusy: false });
+        if (machineShouldComplete) {
+          config.updateState({ currentStep: "complete", isBusy: false });
+        }
       }),
     };
   },
@@ -131,6 +146,7 @@ describe("XAAFlowTab", () => {
     captureMock.mockClear();
     runAllMock.mockClear();
     capturedMachineConfig = null;
+    machineShouldComplete = true;
     resourceApps = [];
     localStorage.clear();
     currentTarget = makeTarget();
@@ -266,5 +282,91 @@ describe("XAAFlowTab", () => {
     expect(
       screen.queryByText(/Configure XAA Debugger/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the source-badged indicator for a bar server", () => {
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="staging" />);
+    expect(screen.getByText(/Target: staging/)).toBeInTheDocument();
+    expect(screen.getByText(/from server/)).toBeInTheDocument();
+  });
+
+  it("surfaces the registration override with a clear control", async () => {
+    const user = userEvent.setup();
+    resourceApps = [
+      {
+        id: "app_1",
+        name: "AcmeApp",
+        resourceType: "mcp",
+        resourceUrl: "https://acme.example.com/mcp",
+        authServerMode: "own",
+        issuer: "https://acme-as.example.com",
+        scopes: [],
+        hasSecret: true,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    ];
+    currentTarget = makeTarget({
+      targetSource: "registration",
+      targetKey: "registration:app_1",
+      runInput: { ...makeTarget().runInput, mode: "hosted-registration" },
+    });
+
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="none" />);
+    await user.click(screen.getByTestId("select-registration"));
+
+    expect(
+      screen.getByText(/Using registered app — overrides the bar selection/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /use bar server/i }),
+    ).toBeInTheDocument();
+    // The indicator badge reads "· registered app".
+    expect(screen.getByText(/· registered app/)).toBeInTheDocument();
+  });
+
+  it("xaa_flow_started carries a salted target_id (no raw name/url)", async () => {
+    const user = userEvent.setup();
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="staging" />);
+    await user.click(screen.getByRole("button", { name: /run all/i }));
+
+    const started = captureMock.mock.calls.find(
+      ([event]) => event === "xaa_flow_started",
+    );
+    expect(started?.[1].target_id).toMatch(/^[0-9a-f]{8}$/);
+    expect(started?.[1].target_id).not.toContain("staging");
+  });
+
+  it("fires xaa_flow_completed with target_source at both the success and failure sites", async () => {
+    const user = userEvent.setup();
+
+    // Success site: the run reaches complete (effect-driven event).
+    machineShouldComplete = true;
+    const { unmount } = render(
+      <XAAFlowTab serverConfigs={{}} selectedServerName="staging" />,
+    );
+    await user.click(screen.getByRole("button", { name: /run all/i }));
+    await waitFor(() =>
+      expect(captureMock).toHaveBeenCalledWith(
+        "xaa_flow_completed",
+        expect.objectContaining({ success: true, target_source: "bar_server" }),
+      ),
+    );
+    unmount();
+
+    // Failure site: the run stops mid-flow (callback-driven event).
+    captureMock.mockClear();
+    machineShouldComplete = false;
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="staging" />);
+    await user.click(screen.getByRole("button", { name: /run all/i }));
+    await waitFor(() =>
+      expect(captureMock).toHaveBeenCalledWith(
+        "xaa_flow_completed",
+        expect.objectContaining({
+          success: false,
+          target_source: "bar_server",
+        }),
+      ),
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/lib/xaa/types";
 import { createInspectorXAAStateMachine } from "@/lib/xaa/debug-state-machine-adapter";
 import { fetchXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
+import { hashXaaTargetId } from "@/lib/xaa/target-telemetry";
 
 // Captured at module load: the XAA route returns null while the feature flag
 // bootstraps and other startup code rewrites location.search, so reading the
@@ -113,6 +114,18 @@ export function XAAFlowTab({
   const selectedRegistration =
     resourceApps.find((app) => app.id === selectedRegistrationId) ?? null;
 
+  // Selecting a bar chip clears an active registration so the bar server wins
+  // (one canonical active target). Guarded by a ref so the deep-link
+  // registration selection — which doesn't change the bar — isn't cleared.
+  const prevSelectedServerName = useRef(selectedServerName);
+  useEffect(() => {
+    if (prevSelectedServerName.current === selectedServerName) return;
+    prevSelectedServerName.current = selectedServerName;
+    if (selectedServerName !== "none") {
+      setSelectedRegistrationId(null);
+    }
+  }, [selectedServerName]);
+
   // ── Global run settings + resolved target ──────────────────────────
   const runSettings = useXaaRunSettings();
   const target = useXaaTestTarget({
@@ -149,9 +162,12 @@ export function XAAFlowTab({
   const authServerModeForTelemetry =
     selectedRegistration?.authServerMode ?? "own";
   // Captured in a ref so the success effect (which can fire on a re-render
-  // after the run) reports the source the run actually used.
+  // after the run) reports the source the run actually used. Written in an
+  // effect, never during render (React 18 concurrent rule).
   const targetSourceRef = useRef(target.targetSource);
-  targetSourceRef.current = target.targetSource;
+  useEffect(() => {
+    targetSourceRef.current = target.targetSource;
+  }, [target.targetSource]);
 
   // In-memory: targets that have completed a successful flow this session,
   // keyed per target so a green run on one server can't unlock another's
@@ -165,11 +181,13 @@ export function XAAFlowTab({
     posthog.capture("xaa_flow_started", {
       mode: runInput.mode,
       target_source: target.targetSource,
+      // Salted one-way bucket id — never a server name/URL/hostname.
+      target_id: hashXaaTargetId(targetKey),
       auth_server_mode: authServerModeForTelemetry,
       platform: detectPlatform(),
       environment: detectEnvironment(),
     });
-  }, [runInput.mode, target.targetSource, authServerModeForTelemetry]);
+  }, [runInput.mode, target.targetSource, targetKey, authServerModeForTelemetry]);
 
   useEffect(() => {
     if (flowState.currentStep === "complete" && !completedFired.current) {
@@ -456,11 +474,20 @@ export function XAAFlowTab({
 
   const runAllDisabled = !isTestable || flowState.isBusy || isRunningAll;
 
-  const targetLabel = selectedRegistration
-    ? `Target: ${selectedRegistration.name} · registered app`
+  const targetName = selectedRegistration
+    ? selectedRegistration.name
     : isTestable
-    ? `Target: ${runInput.serverUrl} · from server`
-    : "No server selected";
+    ? selectedServerName
+    : "";
+  const targetBadge = selectedRegistration ? "registered app" : "from server";
+
+  // Announce only the resolved target NAME (not badge flips), debounced so a
+  // quick succession of switches doesn't spam the live region.
+  const [announcedTarget, setAnnouncedTarget] = useState("");
+  useEffect(() => {
+    const id = setTimeout(() => setAnnouncedTarget(targetName), 250);
+    return () => clearTimeout(id);
+  }, [targetName]);
 
   // A server is selected but can't be XAA-tested (STDIO / non-OAuth).
   const showNotTestable =
@@ -504,9 +531,19 @@ export function XAAFlowTab({
         />
         <span
           className="max-w-[40%] shrink-0 truncate pl-3 text-xs text-muted-foreground"
-          aria-live="polite"
+          aria-hidden="true"
         >
-          {targetLabel}
+          {targetName ? (
+            <>
+              Target: {targetName}{" "}
+              <span className="text-muted-foreground/70">· {targetBadge}</span>
+            </>
+          ) : (
+            "No server selected"
+          )}
+        </span>
+        <span className="sr-only" aria-live="polite">
+          {announcedTarget ? `Target: ${announcedTarget}` : "No server selected"}
         </span>
         <div className="ml-auto shrink-0">
           <XAASimulatedIdentity />

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/target-telemetry.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/target-telemetry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { hashXaaTargetId } from "../target-telemetry";
+
+describe("hashXaaTargetId", () => {
+  it("is deterministic for the same target key", () => {
+    expect(hashXaaTargetId("bar_server:staging")).toBe(
+      hashXaaTargetId("bar_server:staging"),
+    );
+  });
+
+  it("produces distinct ids for distinct targets", () => {
+    expect(hashXaaTargetId("bar_server:staging")).not.toBe(
+      hashXaaTargetId("bar_server:prod"),
+    );
+    expect(hashXaaTargetId("bar_server:staging")).not.toBe(
+      hashXaaTargetId("registration:app_1"),
+    );
+  });
+
+  it("never embeds the raw target name and is a fixed-width hex bucket", () => {
+    const id = hashXaaTargetId("bar_server:staging-mcp.acme.com");
+    expect(id).toMatch(/^[0-9a-f]{8}$/);
+    expect(id).not.toContain("acme");
+    expect(id).not.toContain("staging");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/target-telemetry.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/target-telemetry.ts
@@ -1,0 +1,17 @@
+// Salted, non-reversible bucketing id for an XAA target, derived from the
+// target key (source + registration id or server name). Used as the
+// `target_id` analytics dimension so distinct targets can be counted without
+// ever sending a server name, URL, or hostname.
+const TARGET_ID_SALT = "mcpjam-xaa-target/v1";
+
+export function hashXaaTargetId(targetKey: string): string {
+  // FNV-1a 32-bit over salt + key → hex. Not cryptographic, but a stable
+  // one-way bucket id is all the distinct-count metric needs.
+  const input = `${TARGET_ID_SALT}:${targetKey}`;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}


### PR DESCRIPTION
- Source-badged target indicator ("Target: <name> · from server" /
  "· registered app") with an sr-only aria-live region that announces only
  the resolved target name (debounced; badge flips aren't announced).
- One canonical active target: selecting a bar chip clears an active
  registration, and the registration-overrides-bar state shows an explicit
  line plus a "Use bar server" clear control.
- Telemetry: xaa_flow_started and both xaa_flow_completed sites carry
  target_source; xaa_flow_started adds a salted, non-reversible target_id
  (never a server name/URL); xaa_tab_viewed carries target_count.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>