### PR TITLE
[XAA Server Bar] PR-I7: XAA add-server saves without connecting + not-testable escape hatch + UI polish

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2955,7 +2955,19 @@ export default function App() {
           serverConfigs: projectServers,
           selectedServer: appState.selectedServer,
           onServerChange: setSelectedServer,
-          onConnect: handleConnect,
+          // XAA targets are saved server configs, never live connections.
+          // Adding one from the header picker must NOT launch a browser OAuth
+          // flow (handleConnect does a full-page redirect to the auth server,
+          // which strands the user on an error page when the client isn't
+          // registered). Save without connecting, then select it as the target.
+          onConnect:
+            activeTab === "xaa-flow" && xaaEnabled === true
+              ? async (formData) => {
+                  await saveServerConfigWithoutConnecting(formData);
+                  const name = formData.name?.trim();
+                  if (name) setSelectedServer(name);
+                }
+              : handleConnect,
           onReconnect: handleReconnect,
           isMultiSelectEnabled: activeTab === "chat",
           onMultiServerToggle: toggleServerSelection,

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -152,7 +152,7 @@ describe("XAAFlowTab", () => {
     currentTarget = makeTarget();
   });
 
-  it("shows the not-testable state for a selected STDIO/non-OAuth server", () => {
+  it("shows the not-testable state (named + badged) for a STDIO/non-OAuth server", () => {
     currentTarget = makeTarget({
       isTestable: false,
       notTestableReason:
@@ -163,12 +163,34 @@ describe("XAAFlowTab", () => {
       <XAAFlowTab serverConfigs={{}} selectedServerName="local-stdio" />,
     );
 
+    expect(screen.getByText(/Not XAA-compatible/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/can't be XAA-tested/i),
+      screen.getByText(/needs an HTTP URL and OAuth/i),
     ).toBeInTheDocument();
+    // The indicator names the selected server instead of lying "No server
+    // selected", and badges it as not testable.
+    expect(screen.getByText(/Target: local-stdio/)).toBeInTheDocument();
+    expect(screen.getByText(/not testable/)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /run all/i }),
     ).toBeDisabled();
+  });
+
+  it("'Back to start' clears the selection from the not-testable state", async () => {
+    const user = userEvent.setup();
+    const onSelectServer = vi.fn();
+    currentTarget = makeTarget({ isTestable: false });
+
+    render(
+      <XAAFlowTab
+        serverConfigs={{}}
+        selectedServerName="local-stdio"
+        onSelectServer={onSelectServer}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /back to start/i }));
+    expect(onSelectServer).toHaveBeenCalledWith("none");
   });
 
   it("fires xaa_tab_viewed once per mount with a target_count", () => {

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import posthog from "posthog-js";
-import { Loader2, Play } from "lucide-react";
+import { Loader2, Play, ShieldAlert } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   AlertDialog,
@@ -476,10 +476,14 @@ export function XAAFlowTab({
 
   const targetName = selectedRegistration
     ? selectedRegistration.name
-    : isTestable
+    : selectedServerName !== "none"
     ? selectedServerName
     : "";
-  const targetBadge = selectedRegistration ? "registered app" : "from server";
+  const targetBadge = selectedRegistration
+    ? "registered app"
+    : isTestable
+    ? "from server"
+    : "not testable";
 
   // Announce only the resolved target NAME (not badge flips), debounced so a
   // quick succession of switches doesn't spam the live region.
@@ -566,19 +570,32 @@ export function XAAFlowTab({
       <div className="flex-1 overflow-hidden">
         {showNotTestable ? (
           <div className="flex h-full items-center justify-center p-6">
-            <div className="max-w-md space-y-4 rounded-lg border border-dashed border-border p-8 text-center">
-              <p className="text-sm text-muted-foreground">
-                This server can't be XAA-tested — it needs an HTTP URL and
-                OAuth.
+            <div className="max-w-md rounded-lg border border-border bg-background p-8 text-center shadow-lg">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+                <ShieldAlert className="h-6 w-6 text-muted-foreground" />
+              </div>
+              <h3 className="mb-2 text-lg font-semibold">Not XAA-compatible</h3>
+              <p className="mb-6 text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">
+                  {selectedServerName}
+                </span>{" "}
+                needs an HTTP URL and OAuth to run the cross-app access flow.
               </p>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setIsServerModalOpen(true)}
-              >
-                Configure Server to Test
-              </Button>
+              <div className="flex items-center justify-center gap-2">
+                <Button
+                  type="button"
+                  onClick={() => setIsServerModalOpen(true)}
+                >
+                  Configure Server to Test
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => onSelectServer?.("none")}
+                >
+                  Back to start
+                </Button>
+              </div>
             </div>
           </div>
         ) : (

--- a/mcpjam-inspector/client/src/components/xaa/XAASimulatedIdentity.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAASimulatedIdentity.tsx
@@ -34,7 +34,7 @@ export function XAASimulatedIdentity({
           aria-label="Edit simulated identity"
         >
           <User className="h-3.5 w-3.5" />
-          {iconOnly ? null : <span className="ml-1.5">Identity</span>}
+          {iconOnly ? null : <span>Identity</span>}
           {!isDefaultIdentity ? (
             <span
               className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-primary"


### PR DESCRIPTION
- On the XAA route, the shared "Add Server +" now saves the server config
  without connecting (no full-page OAuth redirect that strands the user on
  the auth server's error page); the saved server is selected as the target.
- Not-testable state: name the selected server in both the indicator and the
  empty state, restyle the empty state to match the tab's icon-circle +
  primary-CTA pattern, and add a "Back to start" control that clears the
  selection back to the welcome screen.
- Fix the Identity button's doubled spacing (design-system Button already
  applies the gap).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>