### PR TITLE
[XAA Server Bar] PR-I8: never run a confidential server with an empty secret

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -126,6 +126,8 @@ function makeTarget(overrides: Partial<XaaTestTarget> = {}): XaaTestTarget {
     targetKey: "bar_server:staging",
     isTestable: true,
     usesServerSideSecret: false,
+    secretUnavailable: false,
+    serversLoading: false,
     runInput: {
       mode: "local-profile",
       serverUrl: "https://staging.mcp.example.com",
@@ -280,6 +282,36 @@ describe("XAAFlowTab", () => {
       "data-unlocked",
       "false",
     );
+  });
+
+  it("blocks Run (no empty-secret request) when a confidential secret can't be resolved", () => {
+    currentTarget = makeTarget({
+      usesServerSideSecret: true,
+      secretUnavailable: true,
+      serversLoading: false,
+      serverId: undefined,
+    });
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="staging" />);
+
+    expect(
+      screen.getByRole("button", { name: /run all/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/couldn't resolve this server's saved secret/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a transient resolving message while project servers load", () => {
+    currentTarget = makeTarget({
+      usesServerSideSecret: true,
+      secretUnavailable: true,
+      serversLoading: true,
+      serverId: undefined,
+    });
+    render(<XAAFlowTab serverConfigs={{}} selectedServerName="staging" />);
+    expect(
+      screen.getByText(/resolving this server's saved secret/i),
+    ).toBeInTheDocument();
   });
 
   it("passes serverId/projectId to the machine for a confidential server", () => {

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -465,14 +465,25 @@ export function XAAFlowTab({
     ? "Flow Complete"
     : "Continue";
 
+  // A confidential server whose secret can't be resolved yet must not run —
+  // sending an empty secret would make the auth server reject the client.
+  const secretBlocked = target.secretUnavailable;
+  const secretBlockedReason = secretBlocked
+    ? target.serversLoading
+      ? "Resolving this server's saved secret…"
+      : "Couldn't resolve this server's saved secret. Re-save it in Configure Server to Test so its secret syncs to this project."
+    : null;
+
   const continueDisabled =
     !isTestable ||
+    secretBlocked ||
     flowState.isBusy ||
     isRunningAll ||
     flowState.currentStep === "complete" ||
     Boolean(flowState.negativeProbe);
 
-  const runAllDisabled = !isTestable || flowState.isBusy || isRunningAll;
+  const runAllDisabled =
+    !isTestable || secretBlocked || flowState.isBusy || isRunningAll;
 
   const targetName = selectedRegistration
     ? selectedRegistration.name
@@ -565,6 +576,19 @@ export function XAAFlowTab({
           >
             Use bar server
           </Button>
+        </div>
+      ) : null}
+      {secretBlockedReason ? (
+        <div
+          className="flex items-center gap-2 border-b border-border bg-muted/30 px-4 py-1.5 text-xs text-muted-foreground"
+          role="status"
+        >
+          {target.serversLoading ? (
+            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
+          ) : (
+            <ShieldAlert className="h-3.5 w-3.5 shrink-0 text-destructive" />
+          )}
+          <span>{secretBlockedReason}</span>
         </div>
       ) : null}
       <div className="flex-1 overflow-hidden">

--- a/mcpjam-inspector/client/src/hooks/__tests__/useXaaTestTarget.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useXaaTestTarget.test.ts
@@ -90,7 +90,30 @@ describe("useXaaTestTarget", () => {
     expect(result.current.usesServerSideSecret).toBe(true);
     expect(result.current.serverId).toBe("srv_1");
     expect(result.current.projectId).toBe("proj_1");
+    expect(result.current.secretUnavailable).toBe(false);
     // The secret is never in the browser-facing run input.
+    expect(result.current.runInput.clientSecret).toBe("");
+  });
+
+  it("marks the secret unavailable for a confidential server whose id can't resolve", () => {
+    // The server has a stored secret, but it isn't in the project's Convex
+    // server list — so its id (and vault secret) can't be resolved.
+    remoteServers = [];
+    const { result } = renderHook(() =>
+      useXaaTestTarget({
+        server: httpServer({ hasClientSecret: true }),
+        selectedServerName: "staging-mcp",
+        selectedRegistration: null,
+        runSettings,
+        projectId: "proj_1",
+      }),
+    );
+
+    // Still confidential — must NOT degrade to a public run with an empty
+    // secret — but the secret can't be sent, so the run is blocked.
+    expect(result.current.usesServerSideSecret).toBe(true);
+    expect(result.current.serverId).toBeUndefined();
+    expect(result.current.secretUnavailable).toBe(true);
     expect(result.current.runInput.clientSecret).toBe("");
   });
 

--- a/mcpjam-inspector/client/src/hooks/useXaaTestTarget.ts
+++ b/mcpjam-inspector/client/src/hooks/useXaaTestTarget.ts
@@ -36,8 +36,18 @@ export interface XaaTestTarget {
   serverId?: string;
   projectId?: string;
   /** bar_server with a stored secret → resolve it (and the token endpoint)
-   * server-side; the browser only sends serverId. */
+   * server-side; the browser only sends serverId. A server with a secret is
+   * ALWAYS confidential — it can never run as a public client with an empty
+   * secret, even before its serverId resolves. */
   usesServerSideSecret: boolean;
+  /** Confidential server whose secret can't be sent right now because its
+   * RemoteServer id hasn't resolved (not synced to this project, or still
+   * loading). Runs must be blocked in this state — sending an empty secret
+   * would make the auth server reject the client. */
+  secretUnavailable: boolean;
+  /** The project-servers query is still loading; distinguishes a transient
+   * "resolving" from a terminal "couldn't resolve". */
+  serversLoading: boolean;
   /** false for STDIO / non-OAuth / blank-URL servers. */
   isTestable: boolean;
   notTestableReason?: string;
@@ -93,10 +103,11 @@ export function useXaaTestTarget({
   projectId,
 }: UseXaaTestTargetParams): XaaTestTarget {
   const { isAuthenticated } = useConvexAuth();
-  const { servers: remoteServers } = useProjectServers({
-    projectId,
-    isAuthenticated,
-  });
+  const { servers: remoteServers, isLoading: serversLoading } =
+    useProjectServers({
+      projectId,
+      isAuthenticated,
+    });
 
   const httpConfig =
     server && "url" in server.config
@@ -143,6 +154,8 @@ export function useXaaTestTarget({
         },
         targetKey: `registration:${selectedRegistration.id}`,
         usesServerSideSecret: false,
+        secretUnavailable: false,
+        serversLoading,
         isTestable: true,
       };
     }
@@ -154,6 +167,8 @@ export function useXaaTestTarget({
         runInput: emptyInput(userId, email, negativeTestMode),
         targetKey: "none",
         usesServerSideSecret: false,
+        secretUnavailable: false,
+        serversLoading,
         isTestable: false,
       };
     }
@@ -165,12 +180,19 @@ export function useXaaTestTarget({
         runInput: emptyInput(userId, email, negativeTestMode),
         targetKey: `bar_server:${selectedServerName}`,
         usesServerSideSecret: false,
+        secretUnavailable: false,
+        serversLoading,
         isTestable: false,
         notTestableReason: NOT_TESTABLE_REASON,
       };
     }
 
-    const usesServerSideSecret = hasClientSecret && Boolean(remoteServerId);
+    // A server with a stored secret is ALWAYS confidential — never fall back
+    // to a public-client run with an empty secret (the auth server would
+    // reject it). The secret is sent only via the serverId path; until that
+    // id resolves, the run is blocked rather than silently sent without it.
+    const usesServerSideSecret = hasClientSecret;
+    const secretUnavailable = hasClientSecret && !remoteServerId;
 
     return {
       targetSource: "bar_server",
@@ -191,9 +213,12 @@ export function useXaaTestTarget({
       serverId: remoteServerId,
       projectId: remoteProjectId ?? projectId ?? undefined,
       usesServerSideSecret,
+      secretUnavailable,
+      serversLoading,
       isTestable: true,
     };
   }, [
+    serversLoading,
     selectedRegistration,
     server,
     selectedServerName,


### PR DESCRIPTION
A server with a stored secret is always a confidential client — it must send
its secret via the server-side resolution path. Previously the run only used
that path when the server's id had resolved; if it hadn't (not synced to the
project, or still loading), the run silently fell back to a public-client
request with an EMPTY secret, which the auth server rejects with a confusing
"client not recognized" error.

Now:
- usesServerSideSecret = hasClientSecret (confidential regardless of id state).
- When the secret can't be sent yet (id unresolved), the run is blocked with a
  clear message ("Resolving…" while loading, "Couldn't resolve this server's
  saved secret — re-save it" if it stays unresolved) instead of sending an
  empty secret.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>