### PR TITLE
[XAA Server Bar] PR-I9: stop password managers on XAA inputs + fix refresh-to-home bounce

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2604,7 +2604,11 @@ export default function App() {
       navigateToTarget(defaultHubRoute, { replace: true });
     } else if (activeTab === "conformance" && conformanceEnabled !== true) {
       navigateToTarget(defaultHubRoute, { replace: true });
-    } else if (activeTab === "xaa-flow" && xaaEnabled !== true) {
+    } else if (activeTab === "xaa-flow" && xaaEnabled === false) {
+      // Only bounce on an explicit `false`. While PostHog hydrates the flag is
+      // `undefined`; redirecting then would strand a flagged-in user who
+      // cold-loads /xaa-flow (the redirect fires before the flag resolves) —
+      // which is exactly the "refresh sends me home" bug. Mirrors ComputerRoute.
       navigateToTarget(defaultHubRoute, { replace: true });
     }
   }, [

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -197,6 +197,9 @@ export function XAAServerModal({
                 placeholder="mcpjam-debugger"
                 spellCheck={false}
                 autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                data-form-type="other"
               />
             </div>
 
@@ -243,6 +246,9 @@ export function XAAServerModal({
                   id="xaa-client-secret"
                   type="password"
                   autoComplete="off"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-form-type="other"
                   value={secretInput}
                   onChange={(event) => setSecretInput(event.target.value)}
                   placeholder={

--- a/mcpjam-inspector/client/src/components/xaa/XAASimulatedIdentity.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAASimulatedIdentity.tsx
@@ -60,6 +60,9 @@ export function XAASimulatedIdentity({
             placeholder="user-12345"
             spellCheck={false}
             autoComplete="off"
+            data-1p-ignore
+            data-lpignore="true"
+            data-form-type="other"
           />
         </div>
         <div className="space-y-2">
@@ -71,6 +74,9 @@ export function XAASimulatedIdentity({
             placeholder="demo.user@example.com"
             spellCheck={false}
             autoComplete="off"
+            data-1p-ignore
+            data-lpignore="true"
+            data-form-type="other"
           />
         </div>
       </PopoverContent>


### PR DESCRIPTION
- Add data-1p-ignore / data-lpignore / data-form-type="other" to the XAA
  client-id, client-secret, and simulated-identity (sub/email) inputs so
  1Password / LastPass stop attaching and prompting on nearby buttons.
- Fix the xaa-flow tab guard to redirect only on an explicit `xaaEnabled ===
  false`, not `!== true`. The PostHog flag is `undefined` while it hydrates on
  a cold reload, so the old check bounced a flagged-in user to the home route
  before the flag resolved — the "refresh sends me to the home page" bug.
  Mirrors the ComputerRoute pattern.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>