### PR TITLE
[XAA Server Bar] PR-I10: run a confidential server target locally

### DIFF
--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -264,6 +264,11 @@ const HOSTED_AUTH_PATH_PREFIXES = [
   // Local resolver path that calls Convex /web/authorize-batch-local.
   "/api/mcp/connect",
   "/api/mcp/servers/reconnect",
+  // Local XAA proxy paths whose server-target / registration runs resolve a
+  // Convex-stored secret on the user's behalf (the hosted `/api/web/xaa/*`
+  // equivalents are already covered by the `/api/web/` prefix above).
+  "/api/mcp/xaa/proxy/token",
+  "/api/mcp/xaa/negative-tests",
   // Convex HTTP actions called via absolute URL (OAuth completion, etc.).
   "/web/oauth/",
 ];

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -31,6 +31,10 @@ import {
   evaluateDiscovery,
 } from "../../services/xaa-discovery.js";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
+import {
+  fetchServerClientSecret,
+  fetchXaaResourceAppSecret,
+} from "../../utils/server-secrets.js";
 import type {
   ServerClientSecretResult,
   XaaResourceAppSecretResult,
@@ -259,16 +263,15 @@ interface CreateXaaRouterOptions {
   trustForwardedHeaders?: boolean;
   protectedMiddlewares?: MiddlewareHandler[];
   // Resolves a registered resource app's client secret + stored token
-  // endpoint server-side (hosted instance only). When absent — the
-  // unauthenticated local instance — registration-backed proxy requests are
-  // rejected.
+  // endpoint server-side, using the caller's bearer to read Convex. When
+  // absent, registration-backed proxy requests are rejected.
   resolveRegistrationSecret?: (args: {
     registrationId: string;
     bearerToken: string;
   }) => Promise<XaaResourceAppSecretResult>;
   // Resolves a server target's confidential client secret + non-secret config
-  // (clientId/url/issuer) server-side (hosted instance only). When absent — the
-  // unauthenticated local instance — server-target proxy requests are rejected.
+  // (clientId/url/issuer) server-side, using the caller's bearer to read
+  // Convex. When absent, server-target proxy requests are rejected.
   resolveServerSecret?: (args: {
     serverId: string;
     projectId: string;
@@ -1117,7 +1120,13 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
 
 const xaa = createXaaRouter({
   issuerBasePath: "/api/mcp",
+  // Local dev allows plain-http loopback targets (e.g. a localhost
+  // xaa-mcp-server). The hosted router keeps httpsOnlyProxy: true.
   httpsOnlyProxy: false,
+  // Server-target / registration runs resolve the confidential secret from
+  // Convex using the caller's bearer; works locally when the user is signed in.
+  resolveRegistrationSecret: (args) => fetchXaaResourceAppSecret(args),
+  resolveServerSecret: (args) => fetchServerClientSecret(args),
 });
 
 export default xaa;


### PR DESCRIPTION
The XAA debugger's server-target run resolves the stored confidential
client secret server-side, but only the hosted router was wired for it.
Running locally returned 401 "Missing or invalid bearer token" before the
secret was ever resolved.

- Wire the local XAA router with the same server-side secret + token-
  endpoint resolution the hosted router uses. Keeps httpsOnlyProxy:false so
  a localhost target stays reachable (hosted stays HTTPS-only).
- Attach the authenticated user's bearer to the local
  /api/mcp/xaa/proxy/token and /negative-tests paths so the resolver can
  authorize the run. The bearer is same-origin only and is never forwarded
  to the target server.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>