### PR TITLE
[XAA Server Bar] PR-I11: keep "Configure Server to Test" input on a failed save

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -675,8 +675,11 @@ export function XAAFlowTab({
         onOpenChange={setIsServerModalOpen}
         server={selectedServer}
         existingServerNames={Object.keys(serverConfigs)}
-        onSave={({ formData }) => {
-          void onSaveServerConfig?.(formData);
+        onSave={async ({ formData }) => {
+          // Await so the modal can keep itself open (and preserve the entered
+          // values) if the save rejects. Selection only follows a save that
+          // didn't throw.
+          await onSaveServerConfig?.(formData);
           onSelectServer?.(formData.name);
           // A bar server overrides any selected registration.
           setSelectedRegistrationId(null);

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from "@mcpjam/design-system/dialog";
 import { Label } from "@mcpjam/design-system/label";
+import { validateServerFormData } from "@/lib/server-form-validation";
 import type { ServerFormData } from "@/shared/types.js";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import { deriveOAuthProfileFromServer } from "../oauth/utils";
@@ -18,7 +19,9 @@ interface XAAServerModalProps {
   onOpenChange: (open: boolean) => void;
   server?: ServerWithName;
   existingServerNames: string[];
-  onSave: (payload: { formData: ServerFormData }) => void;
+  // May be async. The modal stays open (preserving the entered values) if this
+  // rejects, so a downstream save failure never discards the form.
+  onSave: (payload: { formData: ServerFormData }) => void | Promise<void>;
 }
 
 // "keep" the saved secret untouched, "replace" it with a new value, or
@@ -48,6 +51,7 @@ export function XAAServerModal({
   const [secretInput, setSecretInput] = useState("");
   const [secretAction, setSecretAction] = useState<SecretAction>("keep");
   const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -61,9 +65,10 @@ export function XAAServerModal({
     setSecretInput("");
     setSecretAction(hasSavedSecret ? "keep" : "replace");
     setError(null);
+    setSaving(false);
   }, [open, server, derived, hasSavedSecret]);
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const trimmedName = serverName.trim();
@@ -146,8 +151,32 @@ export function XAAServerModal({
       xaaAuthzIssuer: trimmedIssuer,
     };
 
-    onSave({ formData });
-    onOpenChange(false);
+    // Final gate: the exact validator the save path runs. Any rule added there
+    // is enforced here too, so a new rule can never pass this form and then be
+    // rejected downstream — which would close the dialog and discard everything
+    // entered. The field-level messages above stay for nicer UX; this keeps the
+    // form and the save path in lockstep.
+    const validationError = validateServerFormData(formData);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    // Keep the modal open until the save resolves. If it throws, surface the
+    // reason inline and preserve every entered value instead of closing.
+    setSaving(true);
+    try {
+      await onSave({ formData });
+      onOpenChange(false);
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : "Couldn't save this server. Your changes were kept — try again.",
+      );
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -303,10 +332,13 @@ export function XAAServerModal({
               type="button"
               variant="ghost"
               onClick={() => onOpenChange(false)}
+              disabled={saving}
             >
               Cancel
             </Button>
-            <Button type="submit">Save configuration</Button>
+            <Button type="submit" disabled={saving}>
+              {saving ? "Saving…" : "Save configuration"}
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAServerModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAServerModal.test.tsx
@@ -161,4 +161,59 @@ describe("XAAServerModal", () => {
     expect(onSave).not.toHaveBeenCalled();
     expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
   });
+
+  it("stays open and preserves the entered values when the save rejects", async () => {
+    const user = userEvent.setup();
+    const onSave = vi
+      .fn()
+      .mockRejectedValue(new Error("Hosted mode requires HTTPS server URLs"));
+    const onOpenChange = vi.fn();
+    render(
+      <XAAServerModal
+        open
+        onOpenChange={onOpenChange}
+        existingServerNames={[]}
+        onSave={onSave}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/Server Name/), "staging-mcp");
+    await user.type(
+      screen.getByLabelText(/Server URL/),
+      "https://staging.mcp.example.com",
+    );
+    await user.type(screen.getByLabelText(/Client ID/), "staging-client");
+    await user.type(screen.getByLabelText("Client Secret"), "super-secret");
+    await user.type(
+      screen.getByLabelText("Scopes"),
+      "read:tools read:resources",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    // The modal surfaces the rejection inline and never closes.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Hosted mode requires HTTPS server URLs/i,
+    );
+
+    // Every entered value is still in the form, so there's nothing to re-type.
+    expect(screen.getByLabelText(/Server Name/)).toHaveValue("staging-mcp");
+    expect(screen.getByLabelText(/Server URL/)).toHaveValue(
+      "https://staging.mcp.example.com",
+    );
+    expect(screen.getByLabelText(/Client ID/)).toHaveValue("staging-client");
+    expect(screen.getByLabelText("Client Secret")).toHaveValue("super-secret");
+    expect(screen.getByLabelText("Scopes")).toHaveValue(
+      "read:tools read:resources",
+    );
+
+    // The submit button is interactive again for a retry.
+    expect(
+      screen.getByRole("button", { name: "Save configuration" }),
+    ).toBeEnabled();
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -46,6 +46,7 @@ import {
   writeHostedOAuthPendingMarker,
 } from "@/lib/hosted-oauth-callback";
 import { HOSTED_MODE } from "@/lib/config";
+import { validateServerFormData } from "@/lib/server-form-validation";
 import {
   injectHostedServerMapping,
   tryGetHostedServerDisplayName,
@@ -1120,27 +1121,10 @@ export function useServerState({
     ]
   );
 
-  const validateForm = (formData: ServerFormData): string | null => {
-    if (formData.type === "stdio") {
-      if (!formData.command || formData.command.trim() === "") {
-        return "Command is required for STDIO connections";
-      }
-      return null;
-    }
-    if (!formData.url || formData.url.trim() === "") {
-      return "URL is required for HTTP connections";
-    }
-    let parsedUrl: URL;
-    try {
-      parsedUrl = new URL(formData.url);
-    } catch (err) {
-      return `Invalid URL format: ${formData.url} ${err}`;
-    }
-    if (HOSTED_MODE && parsedUrl.protocol !== "https:") {
-      return "Hosted mode requires HTTPS server URLs";
-    }
-    return null;
-  };
+  // Shared with the forms that feed this save path (XAAServerModal, ...) so a
+  // form can never pass a config the save path would reject and lose the
+  // user's input. See lib/server-form-validation.
+  const validateForm = validateServerFormData;
 
   const setSelectedMultipleServersToAllServers = useCallback(() => {
     const connectedNames = Object.entries(appState.servers)

--- a/mcpjam-inspector/client/src/lib/__tests__/server-form-validation.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/server-form-validation.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ServerFormData } from "@/shared/types.js";
+
+const importValidator = async (hosted: boolean) => {
+  vi.resetModules();
+  vi.doMock("@/lib/config", () => ({ HOSTED_MODE: hosted }));
+  return (await import("../server-form-validation")).validateServerFormData;
+};
+
+afterEach(() => {
+  vi.doUnmock("@/lib/config");
+  vi.resetModules();
+});
+
+function httpForm(overrides?: Partial<ServerFormData>): ServerFormData {
+  return {
+    name: "staging",
+    type: "http",
+    url: "https://staging.mcp.example.com",
+    useOAuth: true,
+    ...overrides,
+  } as ServerFormData;
+}
+
+describe("validateServerFormData", () => {
+  it("accepts a valid HTTP(S) server", async () => {
+    const validate = await importValidator(false);
+    expect(validate(httpForm())).toBeNull();
+  });
+
+  it("requires a URL for HTTP connections", async () => {
+    const validate = await importValidator(false);
+    expect(validate(httpForm({ url: "" }))).toMatch(/URL is required/i);
+  });
+
+  it("rejects a malformed URL", async () => {
+    const validate = await importValidator(false);
+    expect(validate(httpForm({ url: "not a url" }))).toMatch(
+      /Invalid URL format/i,
+    );
+  });
+
+  it("requires a command for STDIO connections", async () => {
+    const validate = await importValidator(false);
+    expect(
+      validate({ name: "x", type: "stdio", command: "" } as ServerFormData),
+    ).toMatch(/Command is required/i);
+  });
+
+  it("allows plain http in local mode", async () => {
+    const validate = await importValidator(false);
+    expect(validate(httpForm({ url: "http://localhost:8787/mcp" }))).toBeNull();
+  });
+
+  it("rejects plain http in hosted mode", async () => {
+    const validate = await importValidator(true);
+    expect(validate(httpForm({ url: "http://localhost:8787/mcp" }))).toMatch(
+      /Hosted mode requires HTTPS/i,
+    );
+  });
+
+  it("allows https in hosted mode", async () => {
+    const validate = await importValidator(true);
+    expect(validate(httpForm())).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/server-form-validation.ts
+++ b/mcpjam-inspector/client/src/lib/server-form-validation.ts
@@ -1,0 +1,39 @@
+import { HOSTED_MODE } from "@/lib/config";
+import type { ServerFormData } from "@/shared/types.js";
+
+/**
+ * Single source of truth for server-config validation, shared by the save
+ * path (`use-server-state`) and every form that feeds it (XAAServerModal,
+ * the header Active Server selector, ...).
+ *
+ * Returns a human-readable error message, or null when the config is valid.
+ *
+ * Keeping ONE implementation is the point: a form must reject exactly what the
+ * save path rejects. If a form kept its own copy of these rules and the save
+ * path later gained a new one, the form would let the user submit, the dialog
+ * would close, and the save would fail downstream — silently discarding
+ * everything they typed. Both sides calling this means that can't happen.
+ */
+export function validateServerFormData(
+  formData: ServerFormData,
+): string | null {
+  if (formData.type === "stdio") {
+    if (!formData.command || formData.command.trim() === "") {
+      return "Command is required for STDIO connections";
+    }
+    return null;
+  }
+  if (!formData.url || formData.url.trim() === "") {
+    return "URL is required for HTTP connections";
+  }
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(formData.url);
+  } catch (err) {
+    return `Invalid URL format: ${formData.url} ${err}`;
+  }
+  if (HOSTED_MODE && parsedUrl.protocol !== "https:") {
+    return "Hosted mode requires HTTPS server URLs";
+  }
+  return null;
+}


### PR DESCRIPTION
The dialog closed the moment you pressed Save, before the save was
confirmed. If the save then bailed on a validation rule (e.g. the
HTTPS-only check), it showed a toast but the dialog had already closed and
discarded everything you typed, forcing a full re-entry.

- Hold the dialog open until the save resolves; on failure show the reason
  inline and preserve every field (Saving... + disabled buttons while in
  flight).
- Extract one shared server-config validator used by both the form and the
  save path, so a rule added in one place can't pass the form and then be
  rejected downstream (the exact way the data-loss bug came back).
- Tests: dialog stays open and values preserved on a rejected save; unit
  tests for the shared validator (local http vs hosted https, etc.).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>