### PR TITLE
Make VS Code, AgentCore, and Mistral thinking indicators faithful

### DIFF
--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -100,22 +100,20 @@
     color: var(--text-white-default, #ffffff);
   }
 
-  .mistral-mark-colors,
-  .mistral-spinner-indicator {
-    --mistral-spinner-badge: #faeee7;
-    --mistral-spinner-strong: #c4290a;
+  /* Mistral "M" mark colors — consumed by MistralStaticAvatar
+     (`mistral-avatar.tsx`) via `--mistral-spinner-{brand,white}`. The old
+     `.mistral-spinner-indicator` selector and `--mistral-spinner-{badge,strong}`
+     vars fed the retired avatar-ring spinner; the thinking indicator is now
+     Le Chat's SMIL five-square loader (`mistral-spinner.tsx`), which carries
+     its own brand hex, so those are dropped. */
+  .mistral-mark-colors {
     --mistral-spinner-brand: #fa500e;
     --mistral-spinner-white: #ffffff;
   }
 
-  .dark .mistral-spinner-indicator,
   .dark .mistral-mark-colors,
-  .app-theme-scope.dark .mistral-spinner-indicator,
   .app-theme-scope.dark .mistral-mark-colors,
-  [data-thread-theme="dark"] .mistral-mark-colors,
-  [data-thread-theme="dark"] .mistral-spinner-indicator {
-    --mistral-spinner-badge: #53330f;
-    --mistral-spinner-strong: #ff8a00;
+  [data-thread-theme="dark"] .mistral-mark-colors {
     --mistral-spinner-brand: #fa500f;
     --mistral-spinner-white: #ffffff;
   }
@@ -141,8 +139,7 @@
   .trace-waterfall-bar-tool,
   .trace-waterfall-bar-step,
   .trace-waterfall-bar-error {
-    box-shadow:
-      inset 0 0 0 1px rgb(255 255 255 / 0.28),
+    box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.28),
       0 1px 3px rgb(15 23 42 / 0.08);
   }
   .dark .trace-waterfall-bar-prompt,
@@ -155,8 +152,7 @@
   .app-theme-scope.dark .trace-waterfall-bar-tool,
   .app-theme-scope.dark .trace-waterfall-bar-step,
   .app-theme-scope.dark .trace-waterfall-bar-error {
-    box-shadow:
-      inset 0 0 0 1px rgb(255 255 255 / 0.12),
+    box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.12),
       0 1px 4px rgb(0 0 0 / 0.26);
   }
   .trace-waterfall-row-selected {
@@ -407,14 +403,12 @@
 }
 
 .claude-loading-indicator__strip--900 {
-  animation:
-    claude-strip-900-position 1.7s linear infinite,
+  animation: claude-strip-900-position 1.7s linear infinite,
     claude-strip-900-visibility 1.7s step-end infinite;
 }
 
 .claude-loading-indicator__strip--800 {
-  animation:
-    claude-strip-800-position 1.7s linear infinite,
+  animation: claude-strip-800-position 1.7s linear infinite,
     claude-strip-800-visibility 1.7s step-end infinite;
 }
 
@@ -666,7 +660,8 @@
    their Cursor-flavored names because they're stylesheet-internal;
    renaming them isn't worth churning Cursor's tests. */
 .cursor-shine-indicator,
-.codex-shine-indicator {
+.codex-shine-indicator,
+.agentcore-shine-indicator {
   /* `--cursor-shine-base` is what Cursor calls `--base` — a single
      foreground tone the gradient stops derive from. The 48% and 94%
      mixes are verbatim from Cursor's resolved `--text-tertiary` /
@@ -698,7 +693,8 @@
    light-mode foreground and gives the same 48%/94% contrast on white
    that #E4E4E4 gives on Cursor's #181818 editor background. */
 .cursor-shine-indicator[data-theme="light"],
-.codex-shine-indicator[data-theme="light"] {
+.codex-shine-indicator[data-theme="light"],
+.agentcore-shine-indicator[data-theme="light"] {
   --cursor-shine-base: #1a1a1a;
 }
 
@@ -713,7 +709,120 @@
 
 @media (prefers-reduced-motion: reduce) {
   .cursor-shine-indicator,
-  .codex-shine-indicator {
+  .codex-shine-indicator,
+  .agentcore-shine-indicator {
+    animation: none;
+    background: none;
+    -webkit-text-fill-color: currentColor;
+  }
+}
+
+/* VS Code (GitHub Copilot Chat) "shimmer" thinking indicator — verbatim
+   port of Copilot's own `p.chat-thinking-shimmer` rule (captured from VS
+   Code DevTools). Same shimmer family as Cursor above but distinct: the
+   highlight is pure white (not a dimmed foreground tone), the gradient
+   field is 400% wide with a tighter bright band, and the sweep travels
+   120% → -120% (Cursor runs a 200% field 100% → -100%). The keyframe is
+   namespaced `vscode-shimmer` to keep it independent of `cursor-shine`.
+
+   `--vscode-shimmer-{base,highlight}` derive the two gradient tones so
+   `data-theme` can swap them. Dark mode is the verbatim capture
+   (#8C8C8C base, #FFFFFF highlight); the light override sits in
+   `.vscode-shimmer-indicator[data-theme="light"]` below. */
+.vscode-shimmer-indicator {
+  --vscode-shimmer-base: #8c8c8c;
+  --vscode-shimmer-highlight: #ffffff;
+  background-image: linear-gradient(
+    90deg,
+    var(--vscode-shimmer-base) 0%,
+    var(--vscode-shimmer-base) 30%,
+    var(--vscode-shimmer-highlight) 50%,
+    var(--vscode-shimmer-base) 70%,
+    var(--vscode-shimmer-base) 100%
+  );
+  background-size: 400% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: vscode-shimmer 2s linear infinite;
+  will-change: background-position;
+}
+
+/* Light mode: VS Code has no captured light-theme dump yet, so this is a
+   best-effort mirror — a mid-grey base with a near-black highlight gives
+   the same "brighter stripe gliding through a dimmer base" read on a
+   light surface that the #8C8C8C/#FFF pair gives on Copilot's dark panel.
+   Replace with a verbatim capture if a light VS Code probe lands. */
+.vscode-shimmer-indicator[data-theme="light"] {
+  --vscode-shimmer-base: #8c8c8c;
+  --vscode-shimmer-highlight: #1a1a1a;
+}
+
+@keyframes vscode-shimmer {
+  0% {
+    background-position: 120% 0;
+  }
+  100% {
+    background-position: -120% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vscode-shimmer-indicator {
+    animation: none;
+    background: none;
+    -webkit-text-fill-color: currentColor;
+  }
+}
+
+/* Mistral Le Chat "Thinking" shimmer label — verbatim port of Le Chat's
+   `animate-shimmer-text` rule (captured from chat.mistral.ai DevTools). A
+   200%-wide gradient clips to the glyphs and a bright stripe sweeps
+   150% → -50% over 2s ease-in-out infinite. Pairs with the SMIL five-square
+   loader in `indicators/mistral-spinner.tsx`.
+
+   `--mistral-shimmer-{base,highlight}` derive the two tones so `data-theme`
+   can swap them. Dark mode is the verbatim capture (base
+   rgba(255,255,255,.498), highlight #fff); the light override inverts to a
+   dark base/highlight below. */
+.mistral-shimmer-text {
+  --mistral-shimmer-base: rgba(255, 255, 255, 0.498);
+  --mistral-shimmer-highlight: #ffffff;
+  background-image: linear-gradient(
+    90deg,
+    var(--mistral-shimmer-base) 0%,
+    var(--mistral-shimmer-base) 40%,
+    var(--mistral-shimmer-highlight) 50%,
+    var(--mistral-shimmer-base) 60%,
+    var(--mistral-shimmer-base) 100%
+  );
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: mistral-shimmer-text 2s ease-in-out infinite;
+  will-change: background-position;
+}
+
+/* Light mode: Le Chat's capture was dark-theme; mirror it on light with a
+   dark base + near-black highlight so the bright stripe still reads. */
+.mistral-shimmer-text[data-theme="light"] {
+  --mistral-shimmer-base: rgba(0, 0, 0, 0.498);
+  --mistral-shimmer-highlight: #000000;
+}
+
+@keyframes mistral-shimmer-text {
+  0%,
+  20% {
+    background-position: 150% 0;
+  }
+  100% {
+    background-position: -50% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mistral-shimmer-text {
     animation: none;
     background: none;
     -webkit-text-fill-color: currentColor;
@@ -1098,7 +1207,6 @@
  * utility. Falls back to the system mono stack offline.
  */
 @theme {
-  --font-metric:
-    "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  --font-metric: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
 }

--- a/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
@@ -47,6 +47,8 @@ import { CopilotPulseIndicator } from "./indicators/copilot-pulse";
 import { CodexShineIndicator } from "./indicators/codex-shine";
 import { MCPJamMarkIndicator } from "./indicators/mcpjam-mark";
 import { MistralSpinnerIndicator } from "./indicators/mistral-spinner";
+import { VSCodeShimmerIndicator } from "./indicators/vscode-shimmer";
+import { AgentCoreShineIndicator } from "./indicators/agentcore-shine";
 import type {
   HostStyleDefinition,
   ResolvedMcpAppsCapabilities,
@@ -507,8 +509,11 @@ export const CODEX_HOST_STYLE: HostStyleDefinition = {
  * literally "cursor-vscode" and its chat panel mirrors "VS Code / Cursor's
  * standard editor surface" (see cursor-client-context.ts). So VS Code
  * reuses Cursor's chrome base verbatim (platform, font, style variables,
- * chat background, shine indicator); only the label, picker description,
- * and logo are VS Code-specific.
+ * chat background); the label, picker description, and logo are
+ * VS Code-specific. The thinking indicator is VS Code's OWN shimmer
+ * (`indicators/vscode-shimmer.tsx`) — same shimmer family as Cursor but
+ * captured verbatim from Copilot Chat (pure-white highlight, 400% gradient
+ * field, 120% → -120% sweep), not Cursor's dimmer 200% variant.
  *
  * Capability surface mirrors Cursor's MCP Apps subset — VS Code renders
  * MCP UI resources (`text/html;profile=mcp-app`) inline in the chat panel
@@ -548,7 +553,7 @@ export const VSCODE_HOST_STYLE: HostStyleDefinition = {
     // Flat, dark, IDE-like surface — same visual family as Cursor/ChatGPT.
     family: "chatgpt",
     resolveChatBackground: (theme) => CURSOR_CHAT_BACKGROUND[theme],
-    loadingIndicator: CursorShineIndicator,
+    loadingIndicator: VSCodeShimmerIndicator,
   },
 };
 
@@ -562,9 +567,13 @@ export const VSCODE_HOST_STYLE: HostStyleDefinition = {
  *
  * Chrome reuses MCPJam's neutral house tokens — AgentCore has no published
  * chat UI of its own to copy, and the neutral surface is the honest choice
- * (don't invent AWS-branded chrome). The capability surface is the
- * spec-default "no claims" set because AgentCore renders nothing; the `mcp`
- * blob is unread in practice (no iframe is ever created).
+ * (don't invent AWS-branded chrome). The thinking indicator follows the
+ * same logic: it reuses the generic Cursor/Codex shimmer over "Thinking"
+ * (`indicators/agentcore-shine.tsx`) — a design-free busy state for a host
+ * that renders nothing, rather than borrowing MCPJam's branded mark. The
+ * capability surface is the spec-default "no claims" set because AgentCore
+ * renders nothing; the `mcp` blob is unread in practice (no iframe is ever
+ * created).
  */
 export const AGENTCORE_HOST_STYLE: HostStyleDefinition = {
   id: "agentcore",
@@ -586,7 +595,7 @@ export const AGENTCORE_HOST_STYLE: HostStyleDefinition = {
     // MCPJam, whose neutral tokens AgentCore borrows.
     family: "claude",
     resolveChatBackground: (theme) => MCPJAM_CHAT_BACKGROUND[theme],
-    loadingIndicator: MCPJamMarkIndicator,
+    loadingIndicator: AgentCoreShineIndicator,
   },
 };
 

--- a/mcpjam-inspector/client/src/lib/client-styles/indicators/__tests__/agentcore-shine.test.tsx
+++ b/mcpjam-inspector/client/src/lib/client-styles/indicators/__tests__/agentcore-shine.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentCoreShineIndicator } from "../agentcore-shine";
+import { ChatboxHostThemeProvider } from "@/contexts/chatbox-client-style-context";
+
+describe("AgentCoreShineIndicator", () => {
+  it("renders the shimmering 'Thinking' text node", () => {
+    const { getByTestId } = render(<AgentCoreShineIndicator />);
+    const node = getByTestId("loading-indicator-agentcore-shine");
+    expect(node).toBeTruthy();
+    expect(node.textContent).toBe("Thinking");
+  });
+
+  it("binds the agentcore-shine animation hook via class", () => {
+    // Animation values resolve from CSS in `index.css` — `.agentcore-shine-indicator`
+    // shares Cursor's `.cursor-shine-indicator` rule body via a multi-selector
+    // so the keyframe binding is the same. Assert the class wiring so a
+    // refactor can't silently drop it.
+    const { getByTestId } = render(<AgentCoreShineIndicator />);
+    expect(
+      getByTestId("loading-indicator-agentcore-shine").classList.contains(
+        "agentcore-shine-indicator"
+      )
+    ).toBe(true);
+  });
+
+  it("forwards className to the outer wrapper", () => {
+    const { container } = render(
+      <AgentCoreShineIndicator className="custom-test-class" />
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.classList.contains("custom-test-class")).toBe(true);
+  });
+
+  it("declares an aria-live region so the thinking state is announced", () => {
+    const { container } = render(<AgentCoreShineIndicator />);
+    const live = container.querySelector("[aria-live='polite']");
+    expect(live).not.toBeNull();
+    // The visible "Thinking" verb is also mirrored sr-only so the screen
+    // reader hears it even if the visible run-length glyph is masked to
+    // transparent by the shimmer gradient.
+    expect(container.textContent).toContain("Thinking");
+  });
+
+  it("defaults to data-theme='dark' when no chatbox host theme is mounted", () => {
+    // Matches the inspector's "no chatbox context" fallback (see
+    // CopilotMessageHeader / CursorShineIndicator). The dark base is the
+    // verbatim #E4E4E4 capture shared with Cursor; light mode overrides
+    // via the [data-theme="light"] rule.
+    const { getByTestId } = render(<AgentCoreShineIndicator />);
+    expect(getByTestId("loading-indicator-agentcore-shine").dataset.theme).toBe(
+      "dark"
+    );
+  });
+
+  it("switches to data-theme='light' under a light chatbox host theme", () => {
+    const { getByTestId } = render(
+      <ChatboxHostThemeProvider value="light">
+        <AgentCoreShineIndicator />
+      </ChatboxHostThemeProvider>
+    );
+    expect(getByTestId("loading-indicator-agentcore-shine").dataset.theme).toBe(
+      "light"
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/client-styles/indicators/__tests__/mistral-spinner.test.tsx
+++ b/mcpjam-inspector/client/src/lib/client-styles/indicators/__tests__/mistral-spinner.test.tsx
@@ -1,58 +1,77 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MistralSpinnerIndicator } from "../mistral-spinner";
+import { ChatboxHostThemeProvider } from "@/contexts/chatbox-client-style-context";
 
 describe("MistralSpinnerIndicator", () => {
-  it("renders Le Chat's spinner and centered mark", () => {
+  it("renders Le Chat's five-square loader and shimmering 'Thinking' label", () => {
+    render(<MistralSpinnerIndicator />);
+
+    const wrapper = screen.getByTestId("loading-indicator-mistral");
+    expect(wrapper).toHaveTextContent("Thinking");
+
+    // The morphing loader: a 200×200 SVG holding five animated squares.
+    const loader = screen.getByTestId("loading-indicator-mistral-loader");
+    expect(loader.tagName.toLowerCase()).toBe("svg");
+    expect(loader).toHaveAttribute("viewBox", "0 0 200 200");
+    expect(loader.querySelectorAll("rect")).toHaveLength(5);
+    expect(loader.querySelectorAll("animateTransform")).toHaveLength(5);
+    // Mistral's orange→amber ramp, verbatim from the capture.
+    const fills = Array.from(loader.querySelectorAll("rect")).map((r) =>
+      r.getAttribute("fill")
+    );
+    expect(fills).toEqual([
+      "#fa500f",
+      "#ff8205",
+      "#ffaf01",
+      "#ff8205",
+      "#fa500f",
+    ]);
+  });
+
+  it("binds the mistral-shimmer-text animation hook via class", () => {
+    // Animation resolves from CSS in `index.css` — assert the class wiring
+    // so a refactor can't silently drop the keyframe binding.
+    render(<MistralSpinnerIndicator />);
+    expect(
+      screen
+        .getByTestId("loading-indicator-mistral-label")
+        .classList.contains("mistral-shimmer-text")
+    ).toBe(true);
+  });
+
+  it("forwards className to the outer wrapper", () => {
+    const { container } = render(
+      <MistralSpinnerIndicator className="custom-test-class" />
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.classList.contains("custom-test-class")).toBe(true);
+  });
+
+  it("declares an aria-live region and mirrors the verb sr-only", () => {
     const { container } = render(<MistralSpinnerIndicator />);
+    const live = container.querySelector("[aria-live='polite']");
+    expect(live).not.toBeNull();
+    // The visible label is masked transparent by the shimmer, so the verb
+    // is also mirrored sr-only for screen readers.
+    expect(container.textContent).toContain("Thinking");
+  });
 
-    expect(screen.getByTestId("loading-indicator-mistral")).toHaveTextContent(
-      "Thinking"
-    );
-    expect(screen.getByTestId("loading-indicator-mistral")).toHaveClass(
-      "mistral-spinner-indicator"
-    );
+  it("defaults the label to data-theme='dark' when no chatbox host theme is mounted", () => {
+    render(<MistralSpinnerIndicator />);
     expect(
-      screen.getByRole("progressbar", { name: "Loading" })
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("loading-indicator-mistral-spinner")).toHaveClass(
-      "absolute",
-      "inset-0",
-      "size-12"
-    );
-    expect(
-      screen.getByTestId("loading-indicator-mistral-mark")
-    ).toBeInTheDocument();
-    const mark = screen.getByTestId("loading-indicator-mistral-mark");
-    expect(mark.tagName).toBe("DIV");
-    expect(mark).toHaveClass("relative", "size-12");
-    expect(mark).toHaveStyle({ borderRadius: "50%" });
-    expect(mark.querySelector('[data-slot="avatar"]')).toHaveClass(
-      "h-7",
-      "w-7",
-      "overflow-hidden",
-      "rounded-full"
-    );
-    expect(mark.querySelector(".bg-brand-500")).toBeInTheDocument();
-    expect(mark.querySelector(".bg-brand-500")).toHaveStyle({
-      backgroundColor: "var(--bg-brand-500, var(--mistral-spinner-brand))",
-    });
-    expect(
-      screen.getByTestId("loading-indicator-mistral-mark").querySelector("svg")
-    ).toHaveClass("text-white-default");
-    expect(
-      screen.getByTestId("loading-indicator-mistral-mark").querySelector("svg")
-    ).toHaveStyle({
-      color: "var(--text-white-default, var(--mistral-spinner-white))",
-    });
-    expect(mark.lastElementChild).toBe(
-      screen.getByTestId("loading-indicator-mistral-spinner")
-    );
+      screen.getByTestId("loading-indicator-mistral-label").dataset.theme
+    ).toBe("dark");
+  });
 
-    const spinningGroup = container.querySelector("g");
-    expect(spinningGroup).toHaveClass("animate-spin");
+  it("switches the label to data-theme='light' under a light chatbox host theme", () => {
+    render(
+      <ChatboxHostThemeProvider value="light">
+        <MistralSpinnerIndicator />
+      </ChatboxHostThemeProvider>
+    );
     expect(
-      container.querySelector("[stroke-dasharray='56.548667764616276']")
-    ).toBeInTheDocument();
+      screen.getByTestId("loading-indicator-mistral-label").dataset.theme
+    ).toBe("light");
   });
 });

--- a/mcpjam-inspector/client/src/lib/client-styles/indicators/__tests__/vscode-shimmer.test.tsx
+++ b/mcpjam-inspector/client/src/lib/client-styles/indicators/__tests__/vscode-shimmer.test.tsx
@@ -1,0 +1,64 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { VSCodeShimmerIndicator } from "../vscode-shimmer";
+import { ChatboxHostThemeProvider } from "@/contexts/chatbox-client-style-context";
+
+describe("VSCodeShimmerIndicator", () => {
+  it("renders the shimmering progress-step text node", () => {
+    const { getByTestId } = render(<VSCodeShimmerIndicator />);
+    const node = getByTestId("loading-indicator-vscode-shimmer");
+    expect(node).toBeTruthy();
+    expect(node.textContent).toBe("Working");
+  });
+
+  it("binds the vscode-shimmer animation hook via class", () => {
+    // Animation values resolve from CSS in `index.css` — assert the class
+    // wiring so a refactor can't silently drop the keyframe binding. The
+    // actual keyframe (`vscode-shimmer 2s linear infinite`) is verified in
+    // the preview, not here.
+    const { getByTestId } = render(<VSCodeShimmerIndicator />);
+    expect(
+      getByTestId("loading-indicator-vscode-shimmer").classList.contains(
+        "vscode-shimmer-indicator"
+      )
+    ).toBe(true);
+  });
+
+  it("forwards className to the outer wrapper", () => {
+    const { container } = render(
+      <VSCodeShimmerIndicator className="custom-test-class" />
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.classList.contains("custom-test-class")).toBe(true);
+  });
+
+  it("declares an aria-live region so the thinking state is announced", () => {
+    const { container } = render(<VSCodeShimmerIndicator />);
+    const live = container.querySelector("[aria-live='polite']");
+    expect(live).not.toBeNull();
+    // The visible verb is masked to transparent by the shimmer, so it's
+    // also mirrored sr-only for screen readers.
+    expect(container.textContent).toContain("Working");
+  });
+
+  it("defaults to data-theme='dark' when no chatbox host theme is mounted", () => {
+    // Matches the inspector's "no chatbox context" fallback (see
+    // CopilotMessageHeader). Dark is the verbatim #8C8C8C/#FFF capture;
+    // light mode overrides via the [data-theme="light"] rule.
+    const { getByTestId } = render(<VSCodeShimmerIndicator />);
+    expect(getByTestId("loading-indicator-vscode-shimmer").dataset.theme).toBe(
+      "dark"
+    );
+  });
+
+  it("switches to data-theme='light' under a light chatbox host theme", () => {
+    const { getByTestId } = render(
+      <ChatboxHostThemeProvider value="light">
+        <VSCodeShimmerIndicator />
+      </ChatboxHostThemeProvider>
+    );
+    expect(getByTestId("loading-indicator-vscode-shimmer").dataset.theme).toBe(
+      "light"
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/client-styles/indicators/agentcore-shine.tsx
+++ b/mcpjam-inspector/client/src/lib/client-styles/indicators/agentcore-shine.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/lib/utils";
+import { useChatboxHostTheme } from "@/contexts/chatbox-client-style-context";
+
+/**
+ * AWS Bedrock AgentCore thinking indicator — the same shimmer effect
+ * Cursor/Codex use on their status text (see `cursor-shine.tsx` for the
+ * verbatim Cursor 1.x DevTools capture). AgentCore is a server-side
+ * agent runtime with no chat UI of its own (text servers only — see the
+ * AgentCore entry in `built-ins.ts`), so there's no real surface to
+ * clone. We deliberately reuse the generic "subtle sweep over status
+ * text" shimmer rather than inventing AWS-branded chrome — the honest,
+ * design-free busy state for a host that renders nothing.
+ *
+ * Visual rules live alongside `.cursor-shine-indicator` in `index.css`
+ * via a multi-selector rule — the gradient, the `--cursor-shine-base`
+ * tone, the light-mode override, and the reduced-motion fallback all
+ * apply to `.agentcore-shine-indicator` too. The keyframe name
+ * (`cursor-shine`) and custom-property name stay Cursor-flavored; they're
+ * stylesheet-internal.
+ *
+ * Honors `prefers-reduced-motion` via the same `@media` rule in
+ * `index.css` (kills the animation and falls back to `currentColor`).
+ *
+ * Registry-shaped: accepts only `className`.
+ */
+export function AgentCoreShineIndicator({ className }: { className?: string }) {
+  // Chat-shell host theme. Falls back to "dark" to match the rest of
+  // the inspector's "no chatbox context" behavior (see CopilotMessageHeader).
+  const chatboxHostTheme = useChatboxHostTheme() ?? "dark";
+
+  return (
+    <span
+      className={cn("inline-flex min-h-6 items-center", className)}
+      aria-live="polite"
+    >
+      <span
+        aria-hidden="true"
+        data-testid="loading-indicator-agentcore-shine"
+        data-theme={chatboxHostTheme}
+        className="agentcore-shine-indicator text-sm"
+      >
+        Thinking
+      </span>
+      <span className="sr-only">Thinking</span>
+    </span>
+  );
+}

--- a/mcpjam-inspector/client/src/lib/client-styles/indicators/mistral-spinner.tsx
+++ b/mcpjam-inspector/client/src/lib/client-styles/indicators/mistral-spinner.tsx
@@ -1,64 +1,127 @@
 import { cn } from "@/lib/utils";
-import { MistralStaticAvatar } from "@/lib/client-styles/mistral-avatar";
+import { useChatboxHostTheme } from "@/contexts/chatbox-client-style-context";
 
+/**
+ * Mistral Le Chat thinking indicator — the brand's iconic morphing
+ * five-square loader followed by a shimmering "Thinking" label, captured
+ * verbatim from Le Chat's DevTools while the assistant was reasoning.
+ *
+ * The loader is a self-contained SMIL animation (no CSS): a 200×200
+ * viewBox holds five 40×40 squares that slide between grid cells over
+ * 1.033s on spline easing, recycling Mistral's orange→amber ramp
+ * (#fa500f / #ff8205 / #ffaf01). Values/keySplines/keyTimes are copied
+ * exactly off the live `<animateTransform>` nodes — this IS Le Chat's
+ * loader, not an approximation.
+ *
+ * The "Thinking" text uses Le Chat's `animate-shimmer-text` treatment: a
+ * 200%-wide gradient clipped to the glyphs with a bright stripe sweeping
+ * `150% → -50%` over 2s ease-in-out infinite (verbatim keyframe). The two
+ * gradient tones derive from `--mistral-shimmer-{base,highlight}` so
+ * `data-theme` can swap them; dark is the verbatim capture (base
+ * `rgba(255,255,255,.498)`, highlight `#fff`), light inverts to a dark
+ * base/highlight. Rule + keyframe live in `index.css`
+ * (`.mistral-shimmer-text` / `@keyframes mistral-shimmer-text`).
+ *
+ * Replaces the earlier avatar-ring spinner — real Le Chat shows this
+ * square loader + shimmer label during the thinking phase, not the "M"
+ * mark with an orbiting arc.
+ *
+ * Registry-shaped: accepts only `className`.
+ */
 export function MistralSpinnerIndicator({ className }: { className?: string }) {
+  // Chat-shell host theme. Falls back to "dark" to match the rest of the
+  // inspector's "no chatbox context" behavior (see CopilotMessageHeader).
+  const chatboxHostTheme = useChatboxHostTheme() ?? "dark";
+
   return (
-    <div
-      className={cn(
-        "mistral-spinner-indicator relative inline-flex size-12 items-center justify-center leading-none",
-        className
-      )}
+    <span
+      className={cn("inline-flex min-h-6 items-center gap-2", className)}
       aria-live="polite"
       data-testid="loading-indicator-mistral"
     >
-      <span className="sr-only">Thinking</span>
-      <MistralStaticAvatar
-        avatarClassName="rounded-full"
-        borderRadius="50%"
-        className="relative size-12"
-        testId="loading-indicator-mistral-mark"
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 200 200"
+        className="block size-4 shrink-0 overflow-hidden"
+        data-testid="loading-indicator-mistral-loader"
       >
-        <svg
-          viewBox="0 0 24 24"
-          className="absolute inset-0 size-12"
-          role="progressbar"
-          aria-label="Loading"
-          fill="none"
-          data-testid="loading-indicator-mistral-spinner"
-        >
-          <circle
-            cx="12"
-            cy="12"
-            r="9"
-            strokeWidth="2.5"
-            style={{
-              stroke: "var(--bg-badge-orange, var(--mistral-spinner-badge))",
-            }}
+        <g transform="translate(180 179.997)">
+          <animateTransform
+            attributeName="transform"
+            type="translate"
+            calcMode="spline"
+            dur="1.033s"
+            repeatCount="indefinite"
+            keyTimes="0;0.484;0.968;1"
+            keySplines="0.88 0.14 0.12 0.86;0.88 0.14 0.12 0.86;0 0 1 1"
+            values="180 179.997;20 180.003;180 179.997;180 179.997"
           />
-          <g
-            className="animate-spin"
-            style={{
-              transformOrigin: "center center",
-              transformBox: "view-box",
-            }}
-          >
-            <circle
-              cx="12"
-              cy="12"
-              r="9"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeDasharray="56.548667764616276"
-              strokeDashoffset="42.411500823462205"
-              transform="rotate(-90, 12, 12)"
-              style={{
-                stroke:
-                  "var(--bg-basic-orange-strong, var(--mistral-spinner-strong))",
-              }}
-            />
-          </g>
-        </svg>
-      </MistralStaticAvatar>
-    </div>
+          <rect fill="#fa500f" x="-20" y="-20.003" width="40" height="40.006" />
+        </g>
+        <g transform="translate(20 140.003)">
+          <animateTransform
+            attributeName="transform"
+            type="translate"
+            calcMode="spline"
+            dur="1.033s"
+            repeatCount="indefinite"
+            keyTimes="0;0.484;0.968;1"
+            keySplines="0.88 0.139 0.12 0.861;0.88 0.139 0.12 1;0 0 1 1"
+            values="20 140.003;140.613 140.003;20 140.003;20 140.003"
+          />
+          <rect fill="#ff8205" x="-20" y="-20.003" width="40" height="40.006" />
+        </g>
+        <g transform="translate(100 100.003)">
+          <animateTransform
+            attributeName="transform"
+            type="translate"
+            calcMode="spline"
+            dur="1.033s"
+            repeatCount="indefinite"
+            keyTimes="0;0.306;0.661;0.968;1"
+            keySplines="0.167 0.167 0.12 0.86;0.88 0.14 0.12 0.86;0.88 0.14 0.833 0.833;0 0 1 1"
+            values="100 100.003;20 100.003;180 100.003;100 100.003;100 100.003"
+          />
+          <rect fill="#ffaf01" x="-20" y="-20.003" width="40" height="40.006" />
+        </g>
+        <g transform="translate(180 60.003)">
+          <animateTransform
+            attributeName="transform"
+            type="translate"
+            calcMode="spline"
+            dur="1.033s"
+            repeatCount="indefinite"
+            keyTimes="0;0.484;0.968;1"
+            keySplines="0.42 0 0.58 1;0.42 0 0.58 1;0 0 1 1"
+            values="180 60.003;20 60.003;180 60.003;180 60.003"
+          />
+          <rect fill="#ff8205" x="-20" y="-20.003" width="40" height="40.006" />
+        </g>
+        <g transform="translate(20 20.003)">
+          <animateTransform
+            attributeName="transform"
+            type="translate"
+            calcMode="spline"
+            dur="1.033s"
+            repeatCount="indefinite"
+            keyTimes="0;0.484;0.968;1"
+            keySplines="0.88 0.14 0.12 0.86;0.88 0.14 0.12 0.86;0 0 1 1"
+            values="20 20.003;180 20.003;20 20.003;20 20.003"
+          />
+          <rect fill="#fa500f" x="-20" y="-20.003" width="40" height="40.006" />
+        </g>
+      </svg>
+
+      <span
+        aria-hidden="true"
+        data-theme={chatboxHostTheme}
+        data-testid="loading-indicator-mistral-label"
+        className="mistral-shimmer-text text-sm leading-5 font-medium"
+      >
+        Thinking
+      </span>
+      <span className="sr-only">Thinking</span>
+    </span>
   );
 }

--- a/mcpjam-inspector/client/src/lib/client-styles/indicators/vscode-shimmer.tsx
+++ b/mcpjam-inspector/client/src/lib/client-styles/indicators/vscode-shimmer.tsx
@@ -1,0 +1,64 @@
+import { cn } from "@/lib/utils";
+import { useChatboxHostTheme } from "@/contexts/chatbox-client-style-context";
+
+/**
+ * VS Code (GitHub Copilot Chat) thinking indicator — the shimmer that
+ * sweeps the progress-step text Copilot shows while the agent is working
+ * ("Optimizing tool selection", "Planning…", "Generating…", …). Like
+ * Cursor, the shimmer (not the wording) is the brand's busy-state
+ * identity; Copilot rotates the verb but the same `chat-thinking-shimmer`
+ * keyframe rides all of them. We render one stable representative verb.
+ *
+ * Captured verbatim from VS Code's Copilot Chat DevTools (the animated
+ * `p.chat-thinking-shimmer` node):
+ *
+ *   color: rgb(140, 140, 140);                       // #8C8C8C base
+ *   background-image: linear-gradient(
+ *     90deg,
+ *     #8C8C8C 0%, #8C8C8C 30%,
+ *     #FFFFFF 50%,                                    // pure-white highlight
+ *     #8C8C8C 70%, #8C8C8C 100%
+ *   );
+ *   background-size: 400% 100%;                       // wider than Cursor's 200%
+ *   background-clip: text; -webkit-text-fill-color: transparent;
+ *   animation: chat-thinking-shimmer 2s linear infinite;
+ *   @keyframes chat-thinking-shimmer {
+ *     0%   { background-position: 120% 0; }
+ *     100% { background-position: -120% 0; }
+ *   }
+ *
+ * Distinct from {@link CursorShineIndicator}: VS Code's highlight is pure
+ * white (vs Cursor's dimmer `--text-primary`), the gradient is 400% wide
+ * with a tighter bright band, and the sweep travels 120% → -120% (Cursor
+ * runs 100% → -100% over a 200% field). That's the difference the team
+ * flagged — VS Code reads brighter and the stripe is narrower. The rule
+ * lives under `.vscode-shimmer-indicator` in `index.css` (keyframe
+ * `vscode-shimmer`); `--vscode-shimmer-{base,highlight}` toggle dark vs
+ * light via `data-theme` (dark is the verbatim #8C8C8C/#FFF capture).
+ *
+ * Honors `prefers-reduced-motion` via a `@media` rule in `index.css`.
+ *
+ * Registry-shaped: accepts only `className`.
+ */
+export function VSCodeShimmerIndicator({ className }: { className?: string }) {
+  // Chat-shell host theme. Falls back to "dark" to match the rest of the
+  // inspector's "no chatbox context" behavior (see CopilotMessageHeader).
+  const chatboxHostTheme = useChatboxHostTheme() ?? "dark";
+
+  return (
+    <span
+      className={cn("inline-flex min-h-6 items-center", className)}
+      aria-live="polite"
+    >
+      <span
+        aria-hidden="true"
+        data-testid="loading-indicator-vscode-shimmer"
+        data-theme={chatboxHostTheme}
+        className="vscode-shimmer-indicator text-sm"
+      >
+        Working
+      </span>
+      <span className="sr-only">Working</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## What

Follow-up on the host "thinking mascot/pulse" nit for **VS Code** and **AgentCore**, plus a fix for **Mistral**. Each indicator was either borrowing another host's animation or didn't match the real product. Captured the real animations via DevTools and rebuilt them faithfully.

- **VS Code** — new shimmer captured verbatim from Copilot Chat (pure-white highlight, 400% gradient field, `120% → -120%` sweep), replacing the borrowed Cursor shine.
- **AgentCore** — reuses the generic Cursor/Codex shimmer over "Thinking" (a design-free busy state for a host that renders no UI), replacing MCPJam's branded mark.
- **Mistral** — the avatar-ring spinner didn't match. Replaced with Le Chat's real SMIL five-square loader + shimmering "Thinking" label (captured from chat.mistral.ai). Dropped the now-dead `.mistral-spinner-indicator` selectors and `--mistral-spinner-{badge,strong}` vars.

## How

Each host gets a component, an `index.css` rule/keyframes, `built-ins.ts` wiring, and a test — mirroring the existing Cursor/Codex/Copilot indicator pattern.

## Testing

- All 69 client-styles tests pass (12 new across the 3 indicators).
- `tsc` typecheck clean; prettier clean.

Validation tip: in the Playground, select each host and send a slow request (Network throttle) to watch the indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)