### PR TITLE
[XAA] Apply edited simulated identity to the active run

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -47,6 +47,24 @@ vi.mock("@/hooks/useXaaTestTarget", () => ({
   useXaaTestTarget: () => currentTarget,
 }));
 
+// Controllable global run settings (simulated identity + mode). Tests mutate
+// runSettingsState then rerender to drive an identity edit.
+let runSettingsState: {
+  userId: string;
+  email: string;
+  negativeTestMode: "valid" | "expired" | "wrong_audience" | "bad_signature";
+} = { userId: "u", email: "e@example.com", negativeTestMode: "valid" };
+const setIdentityMock = vi.fn();
+const setNegativeTestModeMock = vi.fn();
+vi.mock("@/hooks/useXaaRunSettings", () => ({
+  useXaaRunSettings: () => ({
+    ...runSettingsState,
+    isDefaultIdentity: false,
+    setIdentity: setIdentityMock,
+    setNegativeTestMode: setNegativeTestModeMock,
+  }),
+}));
+
 vi.mock("../ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
     <div>{children}</div>
@@ -151,6 +169,13 @@ describe("XAAFlowTab", () => {
     machineShouldComplete = true;
     resourceApps = [];
     localStorage.clear();
+    runSettingsState = {
+      userId: "u",
+      email: "e@example.com",
+      negativeTestMode: "valid",
+    };
+    setIdentityMock.mockClear();
+    setNegativeTestModeMock.mockClear();
     currentTarget = makeTarget();
   });
 
@@ -227,6 +252,34 @@ describe("XAAFlowTab", () => {
         mode: "local-profile",
         target_source: "bar_server",
       }),
+    );
+  });
+
+  it("a debounced identity reset can't wipe a run started within its window", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <XAAFlowTab serverConfigs={{}} selectedServerName="staging" />,
+    );
+
+    // Edit the simulated identity — arms the 400ms debounced flow rebuild.
+    runSettingsState = { ...runSettingsState, userId: "john" };
+    currentTarget = makeTarget({
+      runInput: { ...makeTarget().runInput, userId: "john" },
+    });
+    rerender(<XAAFlowTab serverConfigs={{}} selectedServerName="staging" />);
+
+    // Start a run inside that window — Run all rebuilds + drives to complete.
+    await user.click(screen.getByRole("button", { name: /run all/i }));
+    await waitFor(() => expect(runAllMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("logger-continue-label")).toHaveTextContent(
+      "Flow Complete",
+    );
+
+    // Let the debounce elapse: the stale timer must skip (Run all already
+    // applied this identity) rather than rebuild and wipe the completed run.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(screen.getByTestId("logger-continue-label")).toHaveTextContent(
+      "Flow Complete",
     );
   });
 

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -299,6 +299,15 @@ export function XAAFlowTab({
   // refs; confirms via AlertDialog before discarding a busy or completed run.
   const lastAppliedTargetKey = useRef<string | null>(null);
   const lastNegativeTestMode = useRef(runSettings.negativeTestMode);
+  // The simulated identity the flow was last (re)built with. Tracked so an
+  // identity edit rebuilds the flow (clearing the already-minted ID token /
+  // ID-JAG that carry the old sub) — without that, advancing step-by-step
+  // keeps sending the stale subject. Seeded from the initial identity so no
+  // spurious reset fires on mount.
+  const lastAppliedIdentity = useRef({
+    userId: runSettings.userId,
+    email: runSettings.email,
+  });
   const [pendingReset, setPendingReset] = useState<{
     targetKey: string;
     negativeTestMode: NegativeTestMode;
@@ -308,6 +317,12 @@ export function XAAFlowTab({
     (nextTargetKey: string, nextMode: NegativeTestMode) => {
       lastAppliedTargetKey.current = nextTargetKey;
       lastNegativeTestMode.current = nextMode;
+      // A target rebuild already bakes in the current identity, so keep the
+      // identity tracker in sync to avoid a redundant follow-up reset.
+      lastAppliedIdentity.current = {
+        userId: runInput.userId,
+        email: runInput.email,
+      };
       applyFlowState(buildFlowStateFromInput(runInput));
       setFocusedStep(null);
     },
@@ -333,6 +348,29 @@ export function XAAFlowTab({
     }
     applyTargetReset(targetKey, nextMode);
   }, [targetKey, runSettings.negativeTestMode, applyTargetReset]);
+
+  // Identity edits rebuild the flow so the next run mints tokens for the new
+  // sub/email. Unlike target/mode (which change discretely), the identity
+  // inputs fire on every keystroke, so the rebuild is debounced — typing
+  // "john" resets once, not four times. No confirm dialog: editing the
+  // identity is a deliberate "test as someone else", and the chips clearing is
+  // the feedback. The live-read in the auth step covers the debounce window.
+  useEffect(() => {
+    const nextUserId = runSettings.userId;
+    const nextEmail = runSettings.email;
+    if (
+      lastAppliedIdentity.current.userId === nextUserId &&
+      lastAppliedIdentity.current.email === nextEmail
+    ) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      lastAppliedIdentity.current = { userId: nextUserId, email: nextEmail };
+      applyFlowState(buildFlowStateFromInput(runInput));
+      setFocusedStep(null);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [runSettings.userId, runSettings.email, runInput, applyFlowState]);
 
   useEffect(() => {
     setFocusedStep(null);

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -313,20 +313,27 @@ export function XAAFlowTab({
     negativeTestMode: NegativeTestMode;
   } | null>(null);
 
+  // Rebuild the flow from the current input and record the identity it was
+  // built with. Every rebuild path goes through here so the debounced identity
+  // reset can tell whether another path (Run all, Reset, target switch) already
+  // applied the current identity — and skip a stale timer that would otherwise
+  // wipe a freshly-started run.
+  const rebuildFlow = useCallback(() => {
+    lastAppliedIdentity.current = {
+      userId: runInput.userId,
+      email: runInput.email,
+    };
+    applyFlowState(buildFlowStateFromInput(runInput));
+    setFocusedStep(null);
+  }, [applyFlowState, runInput]);
+
   const applyTargetReset = useCallback(
     (nextTargetKey: string, nextMode: NegativeTestMode) => {
       lastAppliedTargetKey.current = nextTargetKey;
       lastNegativeTestMode.current = nextMode;
-      // A target rebuild already bakes in the current identity, so keep the
-      // identity tracker in sync to avoid a redundant follow-up reset.
-      lastAppliedIdentity.current = {
-        userId: runInput.userId,
-        email: runInput.email,
-      };
-      applyFlowState(buildFlowStateFromInput(runInput));
-      setFocusedStep(null);
+      rebuildFlow();
     },
-    [applyFlowState, runInput]
+    [rebuildFlow]
   );
 
   useEffect(() => {
@@ -365,12 +372,20 @@ export function XAAFlowTab({
       return;
     }
     const timer = setTimeout(() => {
-      lastAppliedIdentity.current = { userId: nextUserId, email: nextEmail };
-      applyFlowState(buildFlowStateFromInput(runInput));
-      setFocusedStep(null);
+      // Another path (Run all, Reset, target switch) may have rebuilt the flow
+      // with this identity while the timer was pending. If so the tracker
+      // already matches — bail rather than wipe that fresh (possibly running)
+      // state a second time.
+      if (
+        lastAppliedIdentity.current.userId === nextUserId &&
+        lastAppliedIdentity.current.email === nextEmail
+      ) {
+        return;
+      }
+      rebuildFlow();
     }, 400);
     return () => clearTimeout(timer);
-  }, [runSettings.userId, runSettings.email, runInput, applyFlowState]);
+  }, [runSettings.userId, runSettings.email, rebuildFlow]);
 
   useEffect(() => {
     setFocusedStep(null);
@@ -388,9 +403,8 @@ export function XAAFlowTab({
   }, []);
 
   const resetFlow = useCallback(() => {
-    applyFlowState(buildFlowStateFromInput(runInput));
-    setFocusedStep(null);
-  }, [runInput, applyFlowState]);
+    rebuildFlow();
+  }, [rebuildFlow]);
 
   const handleChangeNegativeTestMode = useCallback(
     (mode: NegativeTestMode) => {
@@ -457,8 +471,9 @@ export function XAAFlowTab({
     }
 
     // Every Run all begins from a clean slate so the chips reflect this run.
-    applyFlowState(buildFlowStateFromInput(runInput));
-    setFocusedStep(null);
+    // rebuildFlow also syncs the identity tracker, so a debounced identity
+    // reset armed just before this click can't fire mid-run and wipe it.
+    rebuildFlow();
     fireFlowStarted();
     setIsRunningAll(true);
     try {
@@ -482,9 +497,8 @@ export function XAAFlowTab({
     }
   }, [
     isTestable,
-    runInput,
+    rebuildFlow,
     xaaStateMachine,
-    applyFlowState,
     fireFlowStarted,
     authServerModeForTelemetry,
   ]);

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -151,6 +151,67 @@ describe("createXAAStateMachine", () => {
     );
   });
 
+  it("authenticates with the live config identity, not a stale flow snapshot", async () => {
+    // The flow was built with user-12345 but the simulated identity was later
+    // edited to john; the machine config carries the fresh value. The auth
+    // request must send john, otherwise the ID-JAG mints the wrong sub.
+    let state: XAAFlowState = createInitialXAAFlowState({
+      serverUrl: "https://mcp.example.com",
+      authzServerIssuer: "https://auth.example.com",
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      clientId: "mcpjam-debugger",
+      userId: "user-12345",
+      email: "stale@example.com",
+      currentStep: "received_authz_metadata",
+    });
+
+    const authBodies: any[] = [];
+    const executor = {
+      externalRequest: vi.fn(),
+      internalRequest: vi.fn(async (path: string, init?: any) => {
+        if (path === "/authenticate") {
+          authBodies.push(JSON.parse(init.body));
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { id_token: "id-token" },
+            ok: true,
+          };
+        }
+        return { status: 200, statusText: "OK", headers: {}, body: {}, ok: true };
+      }),
+    };
+
+    const machine = createXAAStateMachine({
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: "https://mcp.example.com",
+      issuerBaseUrl: "https://issuer.example/api/web/xaa",
+      requestExecutor: executor,
+      clientId: "mcpjam-debugger",
+      userId: "john",
+      email: "john@mcpjam.com",
+      scope: "read:tools",
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(authBodies).toHaveLength(1);
+    expect(authBodies[0].userId).toBe("john");
+    expect(authBodies[0].email).toBe("john@mcpjam.com");
+    const assertionLog = state.infoLogs?.find(
+      (log) => log.id === "xaa-identity-assertion"
+    );
+    expect(assertionLog?.data).toMatchObject({
+      userId: "john",
+      email: "john@mcpjam.com",
+    });
+  });
+
   it("sends a configured client secret to /proxy/token but masks it in the logged request", async () => {
     let state: XAAFlowState = createInitialXAAFlowState({
       serverUrl: "https://mcp.example.com",

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -729,6 +729,14 @@ export function createXAAStateMachine(
 
   const authenticateUser = async () => {
     const state = currentState();
+    // Read the simulated identity from the live machine config, not the flow
+    // snapshot. The machine is rebuilt whenever the identity changes, so the
+    // config always holds the latest sub/email — whereas state.userId is the
+    // value captured when the flow was last (re)built and can lag an edit made
+    // mid-run. `??` (not `||`) so a deliberately-cleared field stays empty
+    // rather than silently reviving the stale snapshot value.
+    const activeUserId = userId ?? state.userId;
+    const activeEmail = email ?? state.email;
     const request = {
       method: "POST",
       url: "/authenticate",
@@ -736,8 +744,8 @@ export function createXAAStateMachine(
         "Content-Type": "application/json",
       },
       body: {
-        userId: state.userId,
-        email: state.email,
+        userId: activeUserId,
+        email: activeEmail,
         audience: state.clientId || "mcpjam-xaa-debugger",
       },
     };
@@ -778,8 +786,8 @@ export function createXAAStateMachine(
         "xaa-identity-assertion",
         "Identity assertion issued",
         {
-          userId: state.userId,
-          email: state.email,
+          userId: activeUserId,
+          email: activeEmail,
         }
       );
     } catch (error) {


### PR DESCRIPTION
## TL;DR

Editing the **Simulated identity** (Subject / Email) in the XAA run bar didn't change what the run sent — it kept minting the ID token and ID-JAG (the signed "JWT authorization grant" presented to the target's auth server) with the **old** subject. So the auth server rejected an identity the user thought they'd already changed. This fixes it so the edited identity applies to the very next run.

## Repro (before)

1. Open the XAA flow, run it once (mints an ID-JAG for the default `sub`).
2. Open **Identity**, change Subject to `john`.
3. Advance step-by-step → the JWT bearer grant still carries the old `sub`, and the auth server returns:

```json
{ "status": 400,
  "body": { "error": "invalid_grant",
    "error_description": "The ID-JAG's subject (\"user-12345\") is not provisioned for this app." } }
```

## Root cause

Two copies of the identity. The popover edited one; the run read the other.

```
Identity popover ─▶ run input ─▶ state-machine config   (was unused at auth time)
run actually sent:  flow snapshot.userId                (only rebuilt on target/Mode change — never on identity edit)
```

The flow snapshot was rebuilt when the **target** or the negative-test **Mode** changed, but **not** when the identity changed — identity was the only run-level control that didn't reset the flow.

## Fix (before / after)

| | Change identity, then… | Before | After |
|---|---|---|---|
| | Run all | ✅ used new sub | ✅ |
| | Step-by-step | ❌ stale sub | ✅ |

- **Live-read at the auth step** — the authentication request now reads the identity from the live config (rebuilt on every edit) instead of the stale snapshot, so any run path uses the current `sub`/`email`.
- **Debounced flow rebuild on identity change** — clears the already-minted tokens that carry the old sub, mirroring how changing Mode already resets the flow. Debounced (~400ms) because the inputs fire per keystroke; no confirm dialog because editing the identity is a deliberate "test as someone else" and the run chips clearing is the feedback.

## Risk register

| Concern | Answer |
|---|---|
| Per-keystroke churn / dialogs? | Debounce collapses an edit burst to one rebuild; identity edits never trigger the "Switch target?" dialog. |
| Race where a run fires inside the debounce window with the old sub? | The live-read at the auth step closes it — correctness doesn't depend on the rebuild landing first. |
| Wipes a completed run the user wanted? | Intentional — they just changed *who* they're testing as; chips clearing signals it. Seeded tracker means no spurious reset on mount. |
| Empty subject silently revived? | `??` (not `||`), so a deliberately-cleared field stays empty rather than reusing the snapshot. |

## Tests

- New state-machine test: stale snapshot `user-12345` + live config `john` → `/authenticate` and the identity-assertion log both carry `john`.
- Client typecheck passes.
