### PR TITLE
[XAA] Slim the IdP panel into a single top bar

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -1,19 +1,20 @@
 import { useEffect, useRef, useState } from "react";
-import {
-  AlertTriangle,
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Copy,
-  KeyRound,
-} from "lucide-react";
+import { AlertTriangle, Check, Copy, Info, KeyRound } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { Card } from "@mcpjam/design-system/card";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@mcpjam/design-system/hover-card";
 import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
 import { fetchXaaIdpUrls, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
-function CopyRow({ label, value }: { label: string; value: string }) {
+// Inline label + value + copy button, sized to share one horizontal bar with
+// the sibling field. The URL is truncated (the copy button carries the full
+// value); the native title surfaces it on hover for a quick read.
+function CopyField({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
   const resetTimerRef = useRef<number | null>(null);
 
@@ -42,168 +43,165 @@ function CopyRow({ label, value }: { label: string; value: string }) {
   }, []);
 
   return (
-    <div className="space-y-1.5">
-      <div className="text-xs font-medium text-muted-foreground">{label}</div>
-      <div className="flex items-stretch gap-2">
-        <div className="min-w-0 flex-1 rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs break-all">
-          {value}
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="shrink-0"
-          onClick={handleCopy}
-          aria-label={`Copy ${label}`}
-        >
-          {copied ? (
-            <Check className="h-3.5 w-3.5" />
-          ) : (
-            <Copy className="h-3.5 w-3.5" />
-          )}
-          <span className="ml-1">{copied ? "Copied" : "Copy"}</span>
-        </Button>
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <span className="shrink-0 text-xs font-medium text-muted-foreground">
+        {label}
+      </span>
+      <div
+        className="min-w-0 flex-1 truncate rounded-md border border-border bg-muted/30 px-2.5 py-1.5 font-mono text-xs"
+        title={value}
+      >
+        {value}
       </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="shrink-0"
+        onClick={handleCopy}
+        aria-label={`Copy ${label}`}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+        <span className="ml-1">{copied ? "Copied" : "Copy"}</span>
+      </Button>
     </div>
   );
 }
 
+// Long-form explanation, behind an info icon so the bar stays compact. Hover
+// (or focus) to read how MCPJam plays the IdP and what it stamps into each
+// ID-JAG.
+function IdpInfo() {
+  return (
+    <HoverCard openDelay={150} closeDelay={150}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="How MCPJam acts as your identity provider"
+        >
+          <Info className="h-3.5 w-3.5" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        align="start"
+        className="w-[26rem] space-y-3 text-xs text-muted-foreground"
+      >
+        <p>
+          Use this to test whether your authorization server correctly validates
+          ID-JAGs from an external issuer. MCPJam acts as the test IdP and the
+          requesting client; your authorization server plays the resource
+          app&apos;s authorization server.
+        </p>
+
+        <div className="space-y-1.5">
+          <div className="text-xs font-medium text-foreground">
+            In your authorization server
+          </div>
+          <ul className="list-disc space-y-1.5 pl-5 marker:text-muted-foreground">
+            <li>
+              Trust MCPJam as an ID-JAG issuer so it can verify assertion
+              signatures. Give it <em>either</em> the Issuer URL (if your server
+              auto-discovers keys from OAuth/OIDC metadata) <em>or</em> the JWKS
+              URL directly — both resolve to the same signing keys, so you
+              don&apos;t need both.
+            </li>
+            <li>
+              Register the client ID MCPJam will present, so the token exchange
+              is recognized.
+            </li>
+          </ul>
+        </div>
+
+        <div className="space-y-1.5">
+          <div className="text-xs font-medium text-foreground">
+            MCPJam stamps these into each ID-JAG
+          </div>
+          <p>
+            You set these in the debugger run config, not in your authorization
+            server — make sure your server expects them.
+          </p>
+          <ul className="list-disc space-y-1.5 pl-5 marker:text-muted-foreground">
+            <li>
+              <code className="font-mono">aud</code> → your authorization
+              server&apos;s issuer
+            </li>
+            <li>
+              <code className="font-mono">resource</code> → the MCP server&apos;s
+              resource identifier
+            </li>
+            <li>
+              <code className="font-mono">client_id</code> → the Client ID you
+              set in Configure Server to Test
+            </li>
+          </ul>
+        </div>
+
+        <p>
+          Cross-app access is new — some authorization servers don&apos;t yet
+          expose a way to trust an external ID-JAG issuer and redeem it via the{" "}
+          <code className="font-mono">jwt-bearer</code> grant. Check that yours
+          supports it before wiring up the steps above.
+        </p>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
 /**
- * Persistent "Use MCPJam as your test IdP" card. Surfaces the issuer,
- * OpenID configuration, and JWKS URLs the user registers with their own
- * authorization server so the JWT-bearer token exchange can succeed —
- * previously only reachable through a transient bootstrap dialog.
+ * Persistent "MCPJam is your identity provider" bar. The XAA debugger always
+ * mints assertions with MCPJam as the IdP, so this surfaces the issuer + JWKS
+ * URLs a developer registers with their own authorization server, inline with
+ * copy buttons. The how-and-why detail lives behind the info icon.
  */
 export function XAAIdpCard() {
-  const [expanded, setExpanded] = useState(false);
   // Start from the browser-origin guess, then swap in the server-advertised
   // issuer once resolved — see fetchXaaIdpUrls for why the guess can be wrong.
   const [urls, setUrls] = useState(() => getXaaIdpUrls());
-  const resolved = useRef(false);
-
   const { issuerBaseUrl, jwksUrl } = urls;
 
-  // Resolve the real issuer from the server's discovery doc once, the first
-  // time the card is expanded.
+  // Resolve the real issuer from the server's discovery doc once on mount —
+  // the URLs are always visible now, so there's no expand to defer it to.
   useEffect(() => {
-    if (!expanded || resolved.current) {
-      return;
-    }
     const controller = new AbortController();
     void fetchXaaIdpUrls(controller.signal).then((serverUrls) => {
-      if (controller.signal.aborted) {
+      if (controller.signal.aborted || !serverUrls) {
         return;
       }
-      // Mark done only after a non-aborted resolution — setting it up front
-      // would lock out future expansions if the first attempt is aborted.
-      resolved.current = true;
-      if (serverUrls) {
-        setUrls(serverUrls);
-      }
+      setUrls(serverUrls);
     });
     return () => controller.abort();
-  }, [expanded]);
+  }, []);
 
   return (
-    <Card className="mx-3 mt-3 mb-1 gap-0 p-0">
-      <button
-        type="button"
-        onClick={() => setExpanded((value) => !value)}
-        aria-expanded={expanded}
-        className="flex w-full items-center gap-2 px-4 py-3 text-left"
-      >
-        <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold">
-              Use MCPJam as your test IdP
-            </span>
-          </div>
-          <p className="truncate text-xs text-muted-foreground">
-            Only when you target your own authorization server — register these
-            endpoints so it trusts MCPJam-issued assertions.
-          </p>
+    <Card className="mx-3 mt-3 mb-1 gap-0 p-3">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        <div className="flex shrink-0 items-center gap-1.5">
+          <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="text-sm font-semibold">
+            MCPJam is your identity provider
+          </span>
+          <IdpInfo />
         </div>
-        {expanded ? (
-          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-        ) : (
-          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-        )}
-      </button>
+        <div className="flex min-w-[20rem] flex-[1_1_24rem] flex-wrap items-center gap-x-4 gap-y-2">
+          <CopyField label="Issuer URL" value={issuerBaseUrl} />
+          <CopyField label="JWKS URL" value={jwksUrl} />
+        </div>
+      </div>
 
-      {expanded && (
-        <div className="space-y-4 px-4 pb-4">
-          <CopyRow label="Issuer URL" value={issuerBaseUrl} />
-          <CopyRow label="JWKS URL" value={jwksUrl} />
-
-          <p className="text-xs text-muted-foreground">
-            Use this to test whether your authorization server correctly
-            validates ID-JAGs from an external issuer. MCPJam acts as the test
-            IdP and the requesting client; your authorization server plays the
-            resource app&apos;s authorization server.
-          </p>
-
-          <div className="space-y-1.5">
-            <div className="text-xs font-medium text-foreground">
-              In your authorization server
-            </div>
-            <ul className="list-disc space-y-1.5 pl-5 text-xs text-muted-foreground marker:text-muted-foreground">
-              <li>
-                Trust MCPJam as an ID-JAG issuer so it can verify assertion
-                signatures. Give it <em>either</em> the Issuer URL (if your
-                server auto-discovers keys from OAuth/OIDC metadata) <em>or</em>{" "}
-                the JWKS URL directly — both resolve to the same signing keys,
-                so you don&apos;t need both.
-              </li>
-              <li>
-                Register the client ID MCPJam will present, so the token
-                exchange is recognized.
-              </li>
-            </ul>
-          </div>
-
-          <div className="space-y-1.5">
-            <div className="text-xs font-medium text-foreground">
-              MCPJam stamps these into each ID-JAG
-            </div>
-            <p className="text-xs text-muted-foreground">
-              You set these in the debugger run config, not in your
-              authorization server — make sure your server expects them.
-            </p>
-            <ul className="list-disc space-y-1.5 pl-5 text-xs text-muted-foreground marker:text-muted-foreground">
-              <li>
-                <code className="font-mono">aud</code> → your authorization
-                server&apos;s issuer
-              </li>
-              <li>
-                <code className="font-mono">resource</code> → the MCP
-                server&apos;s resource identifier
-              </li>
-              <li>
-                <code className="font-mono">client_id</code> → the Client ID you
-                set in Configure Server to Test
-              </li>
-            </ul>
-          </div>
-
-          <p className="text-xs text-muted-foreground">
-            Cross-app access is new — some authorization servers don&apos;t yet
-            expose a way to trust an external ID-JAG issuer and redeem it via
-            the <code className="font-mono">jwt-bearer</code> grant. Check that
-            yours supports it before wiring up the steps above.
-          </p>
-
-          {!HOSTED_MODE && (
-            <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-muted-foreground">
-              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
-              <span>
-                These are local URLs. Your authorization server can only fetch
-                them if it can reach this machine — a cloud-hosted Okta or Auth0
-                tenant cannot reach <code className="font-mono">localhost</code>.
-                Expose the inspector with a public tunnel (e.g. ngrok) first.
-              </span>
-            </div>
-          )}
+      {!HOSTED_MODE && (
+        <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-muted-foreground">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+          <span>
+            These are local URLs. Your authorization server can only fetch them
+            if it can reach this machine — a cloud-hosted Okta or Auth0 tenant
+            cannot reach <code className="font-mono">localhost</code>. Expose the
+            inspector with a public tunnel (e.g. ngrok) first.
+          </span>
         </div>
       )}
     </Card>

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -22,49 +22,28 @@ describe("XAAIdpCard", () => {
     copyToClipboard.mockClear();
   });
 
+  // Only unstub globals (e.g. the fetch stub) — NOT restoreAllMocks, which
+  // would also reset the shared ResizeObserver mock from test setup that
+  // floating-ui (radix HoverCard) depends on, breaking the hover test.
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
-  it("renders collapsed with the hosted endpoints hidden until expanded", () => {
+  it("renders the new title and both URLs inline (no expand step)", () => {
     render(<XAAIdpCard />);
 
-    expect(screen.getByText("Use MCPJam as your test IdP")).toBeInTheDocument();
-    expect(screen.getByRole("button")).toHaveAttribute(
-      "aria-expanded",
-      "false"
-    );
-    expect(screen.queryByText("Issuer URL")).not.toBeInTheDocument();
-  });
-
-  it("reveals the hosted issuer/OpenID/JWKS URLs when expanded", async () => {
-    const user = userEvent.setup();
-    render(<XAAIdpCard />);
-
-    await user.click(
-      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
-    );
-
+    expect(
+      screen.getByText("MCPJam is your identity provider")
+    ).toBeInTheDocument();
     expect(screen.getByText(issuer)).toBeInTheDocument();
     expect(
       screen.getByText(`${issuer}/.well-known/jwks.json`)
     ).toBeInTheDocument();
-    // The OpenID configuration URL row was removed (derivable from the issuer).
     expect(
-      screen.queryByText(`${issuer}/.well-known/openid-configuration`)
-    ).not.toBeInTheDocument();
-  });
-
-  it("names the Configure Server to Test Client ID in the registration steps", async () => {
-    const user = userEvent.setup();
-    render(<XAAIdpCard />);
-
-    await user.click(
-      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
-    );
-
+      screen.getByRole("button", { name: /copy issuer url/i })
+    ).toBeInTheDocument();
     expect(
-      screen.getByText(/the Client ID you set in Configure Server to Test/i)
+      screen.getByRole("button", { name: /copy jwks url/i })
     ).toBeInTheDocument();
   });
 
@@ -72,16 +51,34 @@ describe("XAAIdpCard", () => {
     const user = userEvent.setup();
     render(<XAAIdpCard />);
 
-    await user.click(
-      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
-    );
     await user.click(screen.getByRole("button", { name: /copy issuer url/i }));
 
     expect(copyToClipboard).toHaveBeenCalledWith(issuer);
     expect(await screen.findByText("Copied")).toBeInTheDocument();
   });
 
-  // On expand the card reads the server's OpenID config to resolve the real
+  it("keeps the long-form detail behind the info icon until hovered", async () => {
+    const user = userEvent.setup();
+    render(<XAAIdpCard />);
+
+    expect(
+      screen.queryByText(/the Client ID you set in Configure Server to Test/i)
+    ).not.toBeInTheDocument();
+
+    await user.hover(
+      screen.getByRole("button", {
+        name: /how mcpjam acts as your identity provider/i,
+      })
+    );
+
+    expect(
+      await screen.findByText(
+        /the Client ID you set in Configure Server to Test/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  // On mount the card reads the server's OpenID config to resolve the real
   // issuer + jwks_uri (the displayed values).
   const mockIdpFetch = (serverIssuer: string) =>
     vi.fn(() =>
@@ -102,20 +99,12 @@ describe("XAAIdpCard", () => {
     const serverIssuer = "http://localhost:6274/api/web/xaa";
     vi.stubGlobal("fetch", mockIdpFetch(serverIssuer));
 
-    const user = userEvent.setup();
     render(<XAAIdpCard />);
-    await user.click(
-      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
-    );
 
     expect(await screen.findByText(serverIssuer)).toBeInTheDocument();
     expect(
       screen.getByText(`${serverIssuer}/.well-known/jwks.json`)
     ).toBeInTheDocument();
-    // OpenID config URL is no longer shown as its own row.
-    expect(
-      screen.queryByText(`${serverIssuer}/.well-known/openid-configuration`)
-    ).not.toBeInTheDocument();
   });
 });
 
@@ -125,7 +114,7 @@ describe("XAAIdpCard (non-hosted mode)", () => {
     vi.resetModules();
   });
 
-  it("warns that local URLs need a public tunnel when expanded", async () => {
+  it("warns that local URLs need a public tunnel", async () => {
     vi.resetModules();
     vi.doMock("@/lib/config", () => ({ HOSTED_MODE: false }));
     vi.doMock("@/lib/clipboard", () => ({
@@ -133,12 +122,7 @@ describe("XAAIdpCard (non-hosted mode)", () => {
     }));
     const { XAAIdpCard: LocalIdpCard } = await import("../XAAIdpCard");
 
-    const user = userEvent.setup();
     render(<LocalIdpCard />);
-
-    await user.click(
-      screen.getByRole("button", { name: /use mcpjam as your test idp/i })
-    );
 
     expect(
       screen.getByText(/Expose the\s+inspector with a public tunnel/i)


### PR DESCRIPTION
## TL;DR

The XAA debugger always runs with **MCPJam as the identity provider** — there's no way to swap in a different IdP (the sequence diagram hard-codes MCPJam as the IdP). So the "Use MCPJam as your test IdP" panel no longer needs to read like an optional, collapsible aside. This slims it into a single always-visible top bar, with the long explainer tucked behind an info icon.

## Before / after

| | Before | After |
|---|---|---|
| Shape | Collapsible card (chevron, expand to see anything) | One always-visible bar |
| Title | "Use MCPJam as your test IdP" | "MCPJam is your identity provider" |
| Subtitle | "Only when you target your own authorization server — register these endpoints…" | removed |
| Issuer + JWKS URLs | Stacked, hidden until expanded | Inline on the bar, each with its own copy button |
| How/why detail (registration steps, what's stamped into each ID-JAG, the jwt-bearer caveat) | Inline, expanded | Behind an info icon — hover to read |

## What stayed

- Same issuer + JWKS values, same copy-to-clipboard with inline "Copied" confirmation.
- Server-advertised issuer resolution (the dev-proxy origin skew fix) — now runs on mount instead of on expand, since the URLs are always shown.
- The local-URL / public-tunnel warning in non-hosted mode.

## Risk register

| Concern | Answer |
|---|---|
| Is the detail still discoverable? | Info icon with an `aria-label`; hover (radix HoverCard) reveals the full explainer. |
| Two long URLs on one row overflowing? | Fields flex-wrap and truncate (with a native `title` for the full value); the copy button always carries the complete URL. |
| Lost coverage from dropping the expand tests? | Rewritten suite asserts both URLs render inline, copy works, the detail stays hidden until the info icon is hovered, and the server-issuer resolution still wins. |
| Info icon nested in a clickable parent? | No — the card is no longer a button, so the trigger is a plain standalone button (no nested-interactive / propagation issue). |

## Tests

- `XAAIdpCard` suite rewritten for the bar layout (5 tests, all passing).
- One fix worth noting: the hover test needs floating-ui's `ResizeObserver`, so the suite now uses `unstubAllGlobals` in teardown instead of `restoreAllMocks` (which was resetting the shared `ResizeObserver` mock from test setup).
- Client typecheck passes.
