### PR TITLE
fix(cli-auth): authorize `mcpjam login` against a dedicated Connect OAuth application

### DIFF
--- a/mcpjam-inspector/server/routes/cli-auth/__tests__/cli-auth.test.ts
+++ b/mcpjam-inspector/server/routes/cli-auth/__tests__/cli-auth.test.ts
@@ -11,6 +11,8 @@ import {
 const SECRET = "test-secret";
 const PUBLIC_ORIGIN = "https://app.example.com";
 const CLIENT_ID = "client_01TESTTESTTESTTESTTESTTEST";
+// A distinct WorkOS Connect OAuth-application client id (CLI_AUTH_CLIENT_ID).
+const OAUTH_APP_CLIENT_ID = "client_01OAUTHAPPOAUTHAPPOAUTHAP";
 const LOOPBACK = "http://127.0.0.1:43217/callback";
 // 43 unreserved chars — the minimum valid S256 challenge length.
 const CHALLENGE = "a".repeat(43);
@@ -42,6 +44,7 @@ function startUrl(
 const MANAGED_ENV_KEYS = [
   "CLI_AUTH_STATE_SECRET",
   "CLI_AUTH_PUBLIC_ORIGIN",
+  "CLI_AUTH_CLIENT_ID",
   "WORKOS_CLIENT_ID",
   "VITE_WORKOS_CLIENT_ID",
   "AUTHKIT_DOMAIN",
@@ -166,6 +169,18 @@ describe("GET /api/cli/auth/config", () => {
       scope: "openid profile email offline_access",
     });
   });
+
+  it("advertises CLI_AUTH_CLIENT_ID while deriving the issuer from the AuthKit client", async () => {
+    process.env.CLI_AUTH_CLIENT_ID = OAUTH_APP_CLIENT_ID;
+    const response = await makeApp().request("/api/cli/auth/config");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      issuer: "https://login.example.com",
+      clientId: OAUTH_APP_CLIENT_ID,
+      tokenEndpoint: "https://login.example.com/oauth2/token",
+    });
+  });
 });
 
 describe("GET /api/cli/auth/start", () => {
@@ -190,6 +205,20 @@ describe("GET /api/cli/auth/start", () => {
       cliRedirectUri: LOOPBACK,
       cliState: "cli-state-123",
     });
+  });
+
+  it("authorizes with CLI_AUTH_CLIENT_ID against the AuthKit issuer", async () => {
+    process.env.CLI_AUTH_CLIENT_ID = OAUTH_APP_CLIENT_ID;
+    const response = await makeApp().request(startUrl());
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin).toBe("https://login.example.com");
+    expect(location.pathname).toBe("/oauth2/authorize");
+    expect(location.searchParams.get("client_id")).toBe(OAUTH_APP_CLIENT_ID);
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      `${PUBLIC_ORIGIN}/api/cli/auth/callback`
+    );
   });
 
   it.each([

--- a/mcpjam-inspector/server/routes/cli-auth/index.ts
+++ b/mcpjam-inspector/server/routes/cli-auth/index.ts
@@ -22,6 +22,13 @@
  * these routes always mount at `/api/cli/auth` on the app root. Without
  * either env, every route answers 501 so self-hosted Inspectors degrade
  * cleanly.
+ *
+ * The `/oauth2/authorize` request authenticates a WorkOS Connect OAuth
+ * *application* (a Public/PKCE app registered separately from the AuthKit
+ * environment, with its own client id). Hosted deployments select it via
+ * `CLI_AUTH_CLIENT_ID`; when unset (self-hosted/dev where the two coincide)
+ * the AuthKit environment client id is used. The issuer is always derived
+ * from the AuthKit environment client id, independent of this override.
  */
 import { Hono } from "hono";
 import type { Context } from "hono";
@@ -70,14 +77,20 @@ function resolveCliAuthConfig(
     return null;
   }
 
-  const clientId = resolveWorkosClientId(env);
-  if (!clientId) {
+  // The AuthKit environment client id resolves the issuer (authorize/token
+  // endpoints). The `/oauth2/authorize` client id, however, must identify a
+  // WorkOS Connect OAuth application (its own Public/PKCE client id): hosted
+  // deployments set `CLI_AUTH_CLIENT_ID`, while self-hosted/dev setups where
+  // the two coincide fall back to the AuthKit environment client id.
+  const authkitClientId = resolveWorkosClientId(env);
+  if (!authkitClientId) {
     return null;
   }
-  const issuer = resolveAuthkitIssuer(clientId, env);
+  const issuer = resolveAuthkitIssuer(authkitClientId, env);
   if (!issuer) {
     return null;
   }
+  const clientId = env.CLI_AUTH_CLIENT_ID || authkitClientId;
 
   return { secret, publicOrigin, issuer, clientId };
 }


### PR DESCRIPTION
## Problem

`mcpjam login` (hosted OAuth bridge, `/api/cli/auth/*`) sends the **AuthKit environment client id** (`resolveWorkosClientId` → `WORKOS_CLIENT_ID`) to WorkOS's `/oauth2/authorize`. But that endpoint is WorkOS's **Connect / OAuth-applications** surface, which authenticates a **separately-registered OAuth application** with its *own* client id — not the AuthKit environment client. So WorkOS answers `application_not_found` and login fails on any deployment where the feature is enabled.

Verified live: `GET https://login.mcpjam.com/oauth2/authorize?client_id=<authkit-env-client>…` → `302 …/oauth2/error?error=application_not_found`.

## Fix

Resolve the authorize client id from a new optional **`CLI_AUTH_CLIENT_ID`** env (the Connect OAuth-application's client id). The **issuer** is still derived from the AuthKit environment client id, so endpoint resolution is unchanged. When `CLI_AUTH_CLIENT_ID` is unset, it falls back to the AuthKit environment client id — so self-hosted/dev setups where the two coincide keep working with no config change.

```
const authkitClientId = resolveWorkosClientId(env);   // issuer derivation
const issuer = resolveAuthkitIssuer(authkitClientId, env);
const clientId = env.CLI_AUTH_CLIENT_ID || authkitClientId;  // /oauth2/authorize
```

## Validation

Proven end-to-end against a WorkOS **Connect OAuth application** (Public/PKCE) in the Development environment via a local harness mounting only this router:

- `GET /api/cli/auth/config` → 200 advertising the Connect client id + correct issuer
- `GET /api/cli/auth/start` → 302 to `…/oauth2/authorize` carrying the Connect client id
- Full `mcpjam login` → browser auth → PKCE token exchange → `{ "status": "logged_in" }`

Unit tests added for both `/config` and `/start` covering the `CLI_AUTH_CLIENT_ID` override (32/32 passing).

## Ops follow-up (required to enable in prod)

1. Create a **Connect OAuth application** (WorkOS dashboard → **Connect → Applications**), type OAuth, "Managed by you" (first-party), **Use PKCE** checked (Public), redirect URI `https://app.mcpjam.com/api/cli/auth/callback`. Use its **`client_…` id** (not the `app_…` id).
2. Set `CLI_AUTH_CLIENT_ID=<that client id>` on the `mcp-inspector` service (alongside the existing `CLI_AUTH_PUBLIC_ORIGIN` + `CLI_AUTH_STATE_SECRET`).

The Connect app must live in the same WorkOS environment as the AuthKit domain it authorizes against (prod = `login.mcpjam.com`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OAuth client id used in the CLI login authorize redirect and config metadata; misconfiguration could break login on hosted deployments, but behavior falls back when the env is unset.
> 
> **Overview**
> Fixes hosted **`mcpjam login`** by using the correct WorkOS **Connect OAuth application** client id on `/oauth2/authorize` and in `/api/cli/auth/config`, instead of the AuthKit environment client id that triggers `application_not_found`.
> 
> **`resolveCliAuthConfig`** now derives the **issuer** from the AuthKit client (`resolveWorkosClientId`) and sets the advertised/authorize **`clientId`** from optional **`CLI_AUTH_CLIENT_ID`**, falling back to the AuthKit client when unset so self-hosted/dev setups stay unchanged.
> 
> Tests cover the override for **`/config`** and **`/start`** (redirect `client_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f465072c6070bce01ee4087a8325169eb8ec2d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->