### PR TITLE
feat(evals): unify render checks into the prompt-test runner (per-turn pinned tool calls)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
@@ -28,6 +28,7 @@ import { detectPlatform, detectEnvironment } from "@/lib/PosthogUtils";
 import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
 import type { EvalCase, EvalSuite } from "./types";
 import { getEffectiveSuiteServers } from "./helpers";
+import { isPinnedOnly } from "@/shared/prompt-turns";
 import {
   formatCaseTitleForSidebar,
   getEvalCaseSidebarGroupKey,
@@ -118,7 +119,12 @@ export function TestCaseListSidebar({
   const missingServers = suiteServers.filter(
     (serverName) => !connectedServerNames?.has(serverName),
   );
-  const selectedCaseIsProbe = selectedTestCase?.caseType === "widget_probe";
+  const selectedCaseIsProbe = selectedTestCase
+    ? isPinnedOnly({
+        caseType: selectedTestCase.caseType,
+        promptTurns: selectedTestCase.promptTurns,
+      })
+    : false;
   const canRunSelectedCase =
     Boolean(selectedTestCase) &&
     !selectedCaseIsProbe &&

--- a/mcpjam-inspector/client/src/components/evals/pinned-tool-call-fields.tsx
+++ b/mcpjam-inspector/client/src/components/evals/pinned-tool-call-fields.tsx
@@ -134,7 +134,15 @@ export function PinnedToolCallFields({
         <div className="space-y-1">
           <Label className="text-[11px]">Server</Label>
           {suiteServers.length > 0 ? (
-            <Select value={serverName || undefined} onValueChange={setServerName}>
+            <Select
+              value={serverName || undefined}
+              onValueChange={(nextServer) => {
+                // Switching servers invalidates a tool picked from the old
+                // server — clear it so we never emit a server-B + tool-A pair.
+                if (nextServer !== serverName) setToolName("");
+                setServerName(nextServer);
+              }}
+            >
               <SelectTrigger className="h-8 text-xs">
                 <SelectValue placeholder="Pick a server…" />
               </SelectTrigger>

--- a/mcpjam-inspector/client/src/components/evals/suite-dashboard.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-dashboard.tsx
@@ -7,6 +7,7 @@ import { SuiteRunsList } from "./suite-runs-list";
 import { TestCasesOverview } from "./test-cases-overview";
 import { MonitoringTab } from "./monitoring-tab";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
+import { isPinnedOnly } from "@/shared/prompt-turns";
 
 interface RunTrendPoint {
   runId: string;
@@ -96,7 +97,12 @@ export function SuiteDashboard({
   const showMonitoringTab =
     syntheticMonitorsEnabled &&
     (Boolean(suite.schedule) ||
-      cases.some((testCase) => testCase.caseType === "widget_probe"));
+      cases.some((testCase) =>
+        isPinnedOnly({
+          caseType: testCase.caseType,
+          promptTurns: testCase.promptTurns,
+        }),
+      ));
   // A stale "monitoring" selection (flag toggled off, schedule/probes
   // removed) must not strand the tab strip with nothing highlighted —
   // resolve it to the default tab for both highlighting and content.

--- a/mcpjam-inspector/client/src/components/evals/test-case-prompt-flow.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-case-prompt-flow.tsx
@@ -57,6 +57,9 @@ type TestCasePromptFlowProps = {
   suiteServers: string[];
   /** Project servers, to resolve a display name to a stable id for pinning. */
   projectServers?: RemoteServer[];
+  /** Gates the per-turn "Render check" toggle (an already-pinned turn always
+   *  shows its controls so existing render checks stay editable). */
+  syntheticMonitorsEnabled: boolean;
 };
 
 export function TestCasePromptFlow({
@@ -74,6 +77,7 @@ export function TestCasePromptFlow({
   argumentMatching,
   suiteServers,
   projectServers,
+  syntheticMonitorsEnabled,
 }: TestCasePromptFlowProps) {
   const multi = promptTurns.length > 1;
 
@@ -275,45 +279,49 @@ export function TestCasePromptFlow({
                             >
                               {/* Per-turn input mode: a normal model prompt,
                                   or a model-free pinned tool call (render
-                                  check). */}
-                              <div className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-muted/30 p-0.5">
-                                <Button
-                                  type="button"
-                                  size="sm"
-                                  variant={pinned ? "ghost" : "secondary"}
-                                  className="h-6 px-2 text-[11px]"
-                                  onClick={() =>
-                                    updatePromptTurn(index, (currentTurn) => {
-                                      if (!isPinnedTurn(currentTurn))
-                                        return currentTurn;
-                                      const { pinnedToolCall, ...rest } =
-                                        currentTurn;
-                                      return rest;
-                                    })
-                                  }
-                                >
-                                  Prompt
-                                </Button>
-                                <Button
-                                  type="button"
-                                  size="sm"
-                                  variant={pinned ? "secondary" : "ghost"}
-                                  className="h-6 px-2 text-[11px]"
-                                  onClick={() =>
-                                    updatePromptTurn(index, (currentTurn) => ({
-                                      ...currentTurn,
-                                      pinnedToolCall:
-                                        currentTurn.pinnedToolCall ?? {
-                                          serverName: suiteServers[0] ?? "",
-                                          toolName: "",
-                                          arguments: {},
-                                        },
-                                    }))
-                                  }
-                                >
-                                  Render check
-                                </Button>
-                              </div>
+                                  check). Gated by the synthetic-monitors flag,
+                                  but an already-pinned turn always shows it so
+                                  existing render checks stay editable. */}
+                              {syntheticMonitorsEnabled || pinned ? (
+                                <div className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-muted/30 p-0.5">
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant={pinned ? "ghost" : "secondary"}
+                                    className="h-6 px-2 text-[11px]"
+                                    onClick={() =>
+                                      updatePromptTurn(index, (currentTurn) => {
+                                        if (!isPinnedTurn(currentTurn))
+                                          return currentTurn;
+                                        const { pinnedToolCall, ...rest } =
+                                          currentTurn;
+                                        return rest;
+                                      })
+                                    }
+                                  >
+                                    Prompt
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant={pinned ? "secondary" : "ghost"}
+                                    className="h-6 px-2 text-[11px]"
+                                    onClick={() =>
+                                      updatePromptTurn(index, (currentTurn) => ({
+                                        ...currentTurn,
+                                        pinnedToolCall:
+                                          currentTurn.pinnedToolCall ?? {
+                                            serverName: suiteServers[0] ?? "",
+                                            toolName: "",
+                                            arguments: {},
+                                          },
+                                      }))
+                                    }
+                                  >
+                                    Render check
+                                  </Button>
+                                </div>
+                              ) : null}
 
                               {pinned ? (
                                 <section className="space-y-2">

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -31,6 +31,7 @@ import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { computeIterationResult } from "./pass-criteria";
 import { formatRelativeTime, getEffectiveSuiteServers } from "./helpers";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
+import { isPinnedOnly } from "@/shared/prompt-turns";
 import type { SuiteOverviewView } from "@/lib/eval-route-types";
 import {
   caseListCardClassName,
@@ -508,9 +509,14 @@ export function TestCasesOverview({
                           (serverName) => !connectedServerNames.has(serverName)
                         );
                   const hasModels = Boolean(testCase.models?.length);
-                  // Probes have no quick-run path (suite/schedule only); keep
-                  // the gate explicit rather than riding on their empty models.
-                  const isProbeCase = testCase.caseType === "widget_probe";
+                  // Render checks have no quick-run path (suite/schedule only);
+                  // keep the gate explicit rather than riding on their empty
+                  // models. Detect both legacy widget_probe and new unified
+                  // pinned-only cases.
+                  const isProbeCase = isPinnedOnly({
+                    caseType: testCase.caseType,
+                    promptTurns: testCase.promptTurns,
+                  });
                   const isThisCaseRunning = runningTestCaseId === testCase._id;
                   const isAnotherCaseRunning =
                     runningTestCaseId != null &&

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -724,7 +724,10 @@ export function TestTemplateEditor({
   };
 
   const currentPromptTurns = useMemo(
-    () => (currentTestCase ? resolvePromptTurns(currentTestCase) : []),
+    // Match how editForm.promptTurns is seeded (legacy widget_probe → pinned
+    // turn) so a freshly-opened legacy render check doesn't read as dirty.
+    () =>
+      currentTestCase ? resolvePromptTurnsWithLegacyProbe(currentTestCase) : [],
     [currentTestCase]
   );
   const currentAdvancedConfig = useMemo(
@@ -835,7 +838,11 @@ export function TestTemplateEditor({
   ]);
 
   const runPrimaryDisabled =
-    (!casePinnedOnly && selectedModelValues.length === 0) ||
+    // A model-free render check has no editor quick-run path — it runs with the
+    // full suite (the compare path below would abort on "no model"). Disable
+    // Run for it with an explanatory tooltip instead of letting it fail.
+    casePinnedOnly ||
+    selectedModelValues.length === 0 ||
     isRunningCompare ||
     !canRun ||
     !arePromptTurnsValid;
@@ -844,7 +851,10 @@ export function TestTemplateEditor({
     if (!runPrimaryDisabled) {
       return null;
     }
-    if (!casePinnedOnly && selectedModelValues.length === 0) {
+    if (casePinnedOnly) {
+      return "Render checks run with the full suite, not on their own.";
+    }
+    if (selectedModelValues.length === 0) {
       return "Select at least one model to run.";
     }
     if (!canRun) {
@@ -870,6 +880,7 @@ export function TestTemplateEditor({
     return "Run is unavailable for this test right now.";
   }, [
     runPrimaryDisabled,
+    casePinnedOnly,
     selectedModelValues.length,
     canRun,
     missingServers,

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { useMutation, useQuery } from "convex/react";
 import posthog from "posthog-js";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import {
   ArrowLeft,
   Code2,
@@ -52,9 +53,9 @@ import {
   flattenAssertedExpectedToolCalls,
   isPinnedOnly,
   isPinnedTurn,
-  legacyProbeToPinnedTurn,
   resolveIterationDisplayExpectedToolCalls,
   resolvePromptTurns,
+  resolvePromptTurnsWithLegacyProbe,
   stripPromptTurnsFromAdvancedConfig,
   type PromptTurn,
 } from "@/shared/prompt-turns";
@@ -198,11 +199,21 @@ const validateExpectedToolCalls = (
   return true;
 };
 
-/** When every step has no asserted tool calls, the case expects no tool usage (stored as isNegativeTest). */
+/**
+ * A negative test = the MODEL is expected to call no tools. Pinned
+ * (render-check) turns are model-free and always carry empty
+ * `expectedToolCalls`, so exclude them — otherwise a case containing a pinned
+ * turn (or a pinned-only render check) would be mislabeled negative. A case
+ * with no model turns is not a negative test.
+ */
 function deriveIsNegativeTestFromPromptTurns(
   promptTurns: PromptTurn[]
 ): boolean {
-  return promptTurns.every((turn) => turn.expectedToolCalls.length === 0);
+  const modelTurns = promptTurns.filter((turn) => !isPinnedTurn(turn));
+  return (
+    modelTurns.length > 0 &&
+    modelTurns.every((turn) => turn.expectedToolCalls.length === 0)
+  );
 }
 
 /** A render-check (pinned) turn needs a server and a real (non-placeholder) tool. */
@@ -608,16 +619,11 @@ export function TestTemplateEditor({
     }
 
     // Legacy `widget_probe` rows store the pinned call as top-level
-    // `probeConfig` (not a turn). Surface it as a pinned turn so it edits in
-    // the unified editor like any render-check turn. (Post-migration rows
-    // already carry the pinned turn, so this is a no-op for them.)
-    const resolvedTurns = resolvePromptTurns(currentTestCase);
-    const promptTurns =
-      currentTestCase.caseType === "widget_probe" &&
-      currentTestCase.probeConfig &&
-      !resolvedTurns.some(isPinnedTurn)
-        ? [legacyProbeToPinnedTurn(currentTestCase.probeConfig)]
-        : resolvedTurns;
+    // `probeConfig` (not a turn); surface it as a pinned turn so it edits in
+    // the unified editor like any render-check turn. Shared with the runner's
+    // `normalizeTestForPinnedTurns` so the rule lives in one place. No-op for
+    // post-migration rows that already carry the pinned turn.
+    const promptTurns = resolvePromptTurnsWithLegacyProbe(currentTestCase);
     setEditForm({
       title: currentTestCase.title,
       runs: currentTestCase.runs,
@@ -786,6 +792,10 @@ export function TestTemplateEditor({
     () => (editForm ? isPinnedOnly({ promptTurns: editForm.promptTurns }) : false),
     [editForm],
   );
+  // Gates the per-turn "Render check" toggle, consistent with the widget-check
+  // gating in ChecksSection. An already-pinned turn always shows its controls
+  // so existing render checks remain editable when the flag is off.
+  const syntheticMonitorsEnabled = useFeatureFlagEnabled("synthetic-monitors");
 
   const arePredicatesValid = useMemo(() => {
     if (!editForm?.predicates) return true;
@@ -2183,6 +2193,7 @@ export function TestTemplateEditor({
                   }
                   suiteServers={effectiveSuiteServers}
                   projectServers={projectServers}
+                  syntheticMonitorsEnabled={syntheticMonitorsEnabled ?? false}
                 />
               ) : null}
             </div>

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -18,7 +18,7 @@ import type {
 } from "./types";
 import { getSuiteReplayEligibility } from "./replay-eligibility";
 import { getEffectiveSuiteServers } from "./helpers";
-import { isPinnedOnly } from "@/shared/prompt-turns";
+import { isPinnedOnly, isPinnedTurn } from "@/shared/prompt-turns";
 import type { useEvalMutations } from "./use-eval-mutations";
 import { authFetch } from "@/lib/session-token";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
@@ -310,13 +310,23 @@ export function useEvalHandlers({
 
       let probesSkippedMissingConfig = 0;
       for (const testCase of testCases) {
-        // Widget probes carry no models and no prompt — they must never fall
-        // into the LLM fan-out below (a probe with a suite default model
-        // would otherwise run as an empty-prompt LLM case). The sentinel
-        // model/provider strings satisfy the wire schema; the server forks
-        // probes off the LLM path before any model resolution.
-        if (testCase.caseType === "widget_probe") {
-          if (!testCase.probeConfig) {
+        // Model-free render checks (legacy widget_probe OR a unified case whose
+        // turns are all pinned) carry no models — they must never fall into the
+        // LLM fan-out below (a model-free case with a suite default model would
+        // otherwise run as an empty-prompt LLM case). The sentinel
+        // model/provider strings satisfy the wire schema; the server runs them
+        // model-free (routing on the pinned turns / legacy adapter).
+        if (
+          isPinnedOnly({
+            caseType: testCase.caseType,
+            promptTurns: testCase.promptTurns,
+          })
+        ) {
+          const pinnedTurns = Array.isArray(testCase.promptTurns)
+            ? testCase.promptTurns.filter(isPinnedTurn)
+            : [];
+          // Need either the new pinned turns or the legacy probeConfig to run.
+          if (pinnedTurns.length === 0 && !testCase.probeConfig) {
             probesSkippedMissingConfig++;
             continue;
           }
@@ -327,8 +337,15 @@ export function useEvalHandlers({
             model: "widget-probe",
             provider: "none",
             expectedToolCalls: [],
-            caseType: "widget_probe",
-            probeConfig: testCase.probeConfig,
+            ...(pinnedTurns.length > 0
+              ? { promptTurns: testCase.promptTurns }
+              : {}),
+            ...(testCase.caseType === "widget_probe"
+              ? { caseType: "widget_probe" as const }
+              : {}),
+            ...(testCase.probeConfig
+              ? { probeConfig: testCase.probeConfig }
+              : {}),
             testCaseId: testCase._id,
           });
           continue;

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -18,7 +18,6 @@ import type {
 } from "./types";
 import { getSuiteReplayEligibility } from "./replay-eligibility";
 import { getEffectiveSuiteServers } from "./helpers";
-import { PROBE_TOOL_NAME_PLACEHOLDER } from "@/shared/probe-config";
 import { isPinnedOnly } from "@/shared/prompt-turns";
 import type { useEvalMutations } from "./use-eval-mutations";
 import { authFetch } from "@/lib/session-token";
@@ -1331,81 +1330,6 @@ export function useEvalHandlers({
   // Created with placeholder probeConfig values the probe editor immediately
   // prompts the user to fix; seeded with a widgetRendered check so an
   // unedited probe still asserts something meaningful.
-  const handleCreateWidgetProbe = useCallback(
-    async (suiteId: string) => {
-      if (isCreatingTestCase) return;
-
-      setIsCreatingTestCase(true);
-
-      try {
-        const suite = await convex.query("testSuites:getTestSuite" as any, {
-          suiteId,
-        });
-        const firstServer: string =
-          (suite ? getEffectiveSuiteServers(suite)[0] : undefined) ?? "server";
-
-        // Unified shape: a render check is a single model-free pinned turn —
-        // no `caseType`/`probeConfig`. The runner detects it via `isPinnedOnly`
-        // (all turns pinned) and the editor dispatches on the same predicate.
-        const testCaseId = await mutations.createTestCaseMutation({
-          suiteId,
-          title: "Untitled render check",
-          query: "",
-          models: [],
-          promptTurns: [
-            {
-              id: "turn-1",
-              prompt: "",
-              expectedToolCalls: [],
-              pinnedToolCall: {
-                serverName: firstServer,
-                toolName: PROBE_TOOL_NAME_PLACEHOLDER,
-                arguments: {},
-              },
-            },
-          ],
-          predicates: {
-            mode: "replace",
-            list: [{ type: "widgetRendered" }],
-          },
-        });
-
-        toast.success("Render check created");
-
-        posthog.capture("eval_test_case_created", {
-          location: "evals_tab",
-          platform: detectPlatform(),
-          environment: detectEnvironment(),
-          suite_id: suiteId,
-          test_case_id: testCaseId,
-          case_type: "widget_probe",
-        });
-
-        navigateAfterTestCaseMutation({
-          type: "test-edit",
-          suiteId,
-          testId: testCaseId,
-        });
-
-        return testCaseId;
-      } catch (error) {
-        console.error("Failed to create render check:", error);
-        toast.error(
-          getBillingErrorMessage(error, "Failed to create render check")
-        );
-        return null;
-      } finally {
-        setIsCreatingTestCase(false);
-      }
-    },
-    [
-      isCreatingTestCase,
-      mutations.createTestCaseMutation,
-      convex,
-      navigateAfterTestCaseMutation,
-    ]
-  );
-
   // Handle delete test case - opens confirmation modal
   const handleDeleteTestCase = useCallback(
     (testCaseId: string, testCaseTitle: string) => {
@@ -1737,7 +1661,6 @@ export function useEvalHandlers({
     directDeleteRun,
     confirmDeleteRun,
     handleCreateTestCase,
-    handleCreateWidgetProbe,
     handleDeleteTestCase,
     directDeleteTestCase,
     confirmDeleteTestCase,

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -42,7 +42,11 @@ import {
   type ServerToolSnapshot,
 } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "../../services/evals/convex-sanitize.js";
-import { type PromptTurn, isPinnedOnly } from "@/shared/prompt-turns";
+import {
+  type PromptTurn,
+  countModelTurns,
+  isPinnedOnly,
+} from "@/shared/prompt-turns";
 import {
   matchOptionsSchema,
   resolveMatchOptions,
@@ -310,7 +314,10 @@ export function assertSuiteRunWithinCap(
     request.tests.reduce((sum, t) => {
       if (isPinnedOnly(t)) return sum;
       const iterations = override ?? t.runs ?? 0;
-      const turns = Math.max(t.promptTurns?.length ?? 0, 1);
+      // Count only model-driven turns — pinned (render-check) turns issue no
+      // LLM call, so a hybrid case shouldn't over-count its budget. Floor at 1
+      // for legacy single-turn cases that carry no promptTurns array.
+      const turns = Math.max(countModelTurns(t.promptTurns), 1);
       return sum + iterations * turns;
     }, 0) * Math.max(configCount, 1);
   if (totalCalls > MAX_TOTAL_LLM_CALLS) {

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -407,13 +407,17 @@ export function assertBareRerunCasesRunnable(
         model?: string;
         provider?: string;
         caseType?: string;
+        promptTurns?: unknown;
       }>
     | null,
 ): void {
   const unrunnable = (cases ?? [])
     .filter(
       (c) =>
-        c.caseType !== "widget_probe" &&
+        // Model-free pinned cases (legacy widget_probe OR a unified case whose
+        // turns are all pinned) need no model and ARE runnable — don't flag
+        // them as unrunnable prompt cases.
+        !isPinnedOnly({ caseType: c.caseType, promptTurns: c.promptTurns }) &&
         !(c.models && c.models.length > 0) &&
         !(c.model && c.provider),
     )

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1753,14 +1753,19 @@ const runIterationWithAiSdk = async ({
     // Check if request was aborted
     if (error instanceof Error && error.name === "AbortError") {
       logger.debug("[evals] iteration aborted due to cancellation");
-      // Don't record anything for aborted iterations
+      // Don't record anything for aborted iterations; force passed:false so an
+      // all-pinned case (which evaluateMultiTurnResults scores passed:true with
+      // no calls) can't inflate the suite's passed count on abort.
       return {
-        evaluation: evaluateMultiTurnResults(
-          promptTurns,
-          toolsCalledByPrompt,
-          test.isNegativeTest,
-          test.matchOptions
-        ),
+        evaluation: {
+          ...evaluateMultiTurnResults(
+            promptTurns,
+            toolsCalledByPrompt,
+            test.isNegativeTest,
+            test.matchOptions
+          ),
+          passed: false,
+        },
         iterationId: undefined,
       };
     }
@@ -2808,7 +2813,11 @@ export const runEvalSuiteWithAiSdk = async ({
         environment: config.environment,
       });
     const testPromises = tests.map((test) =>
-      test.caseType === "widget_probe"
+      // Cap concurrent headless browsers for every model-free render check
+      // (legacy widget_probe OR a unified case whose turns are all pinned),
+      // not just the legacy discriminator — otherwise a monitoring suite of
+      // new pinned-only cases launches one Chromium per case at once.
+      isPinnedOnly({ caseType: test.caseType, promptTurns: test.promptTurns })
         ? renderCheckLimit(() => runOne(test))
         : runOne(test)
     );
@@ -3782,13 +3791,18 @@ const streamIterationWithAiSdk = async ({
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
       logger.debug("[evals] streaming iteration aborted due to cancellation");
+      // Force passed:false (see the non-stream runner) so an all-pinned case
+      // can't score a pass on abort.
       return {
-        evaluation: evaluateMultiTurnResults(
-          promptTurns,
-          toolsCalledByPrompt,
-          test.isNegativeTest,
-          test.matchOptions
-        ),
+        evaluation: {
+          ...evaluateMultiTurnResults(
+            promptTurns,
+            toolsCalledByPrompt,
+            test.isNegativeTest,
+            test.matchOptions
+          ),
+          passed: false,
+        },
         iterationId: undefined,
       };
     }

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -4731,8 +4731,10 @@ export const streamTestCase = async (params: {
   // Streaming quick-run does not yet execute pinned (model-free) turns: the
   // SSE loop has no pinned branch and builds the model eagerly. Pinned-only
   // render checks run via the suite path (`runTestCase`); reject a pinned case
-  // here rather than send an empty prompt to the model.
-  if (resolveEvalTestCase(test).promptTurns.some(isPinnedTurn)) {
+  // here rather than send an empty prompt (or the sentinel model) to streamText.
+  // Use the legacy-probe-aware resolver so a PURE legacy widget_probe (whose
+  // probeConfig only becomes a pinned turn after the adapter) is caught too.
+  if (resolvePromptTurnsWithLegacyProbe(test).some(isPinnedTurn)) {
     throw new Error(
       "Pinned tool-call turns are not yet supported in streaming quick-run. Run the case as part of a suite."
     );

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -79,9 +79,9 @@ import {
   deriveLegacyPromptFields,
   isPinnedOnly,
   isPinnedTurn,
-  legacyProbeToPinnedTurn,
   needsModel,
   resolvePromptTurns,
+  resolvePromptTurnsWithLegacyProbe,
   stripPromptTurnsFromAdvancedConfig,
   type PinnedToolCall,
   type PromptTurn,
@@ -413,17 +413,13 @@ function resolveEvalTestCase(test: EvalTestCase): ResolvedEvalTestCase {
  * for them. Idempotent.
  */
 function normalizeTestForPinnedTurns(test: EvalTestCase): EvalTestCase {
-  if (
-    test.caseType === "widget_probe" &&
-    test.probeConfig &&
-    !resolvePromptTurns(test).some(isPinnedTurn)
-  ) {
-    return {
-      ...test,
-      promptTurns: [legacyProbeToPinnedTurn(test.probeConfig as PinnedToolCall)],
-    };
+  if (test.caseType !== "widget_probe" || !test.probeConfig) {
+    return test;
   }
-  return test;
+  // Shared with the editor's editForm seeding so the legacy-detection rule
+  // lives in one place.
+  const turns = resolvePromptTurnsWithLegacyProbe(test);
+  return turns.some(isPinnedTurn) ? { ...test, promptTurns: turns } : test;
 }
 
 /**
@@ -999,12 +995,18 @@ const runIterationWithAiSdk = async ({
       );
       if (currentRun?.status === "cancelled") {
         return {
-          evaluation: evaluateMultiTurnResults(
-            resolvedTest.promptTurns,
-            [],
-            test.isNegativeTest,
-            test.matchOptions
-          ),
+          // A cancelled / deleted-run iteration never executed — never score it
+          // as passed. evaluateMultiTurnResults returns passed:true for an
+          // all-pinned case with no calls, so override explicitly.
+          evaluation: {
+            ...evaluateMultiTurnResults(
+              resolvedTest.promptTurns,
+              [],
+              test.isNegativeTest,
+              test.matchOptions
+            ),
+            passed: false,
+          },
           iterationId: undefined,
         };
       }
@@ -1017,12 +1019,18 @@ const runIterationWithAiSdk = async ({
         errorMessage.includes("unauthorized")
       ) {
         return {
-          evaluation: evaluateMultiTurnResults(
-            resolvedTest.promptTurns,
-            [],
-            test.isNegativeTest,
-            test.matchOptions
-          ),
+          // A cancelled / deleted-run iteration never executed — never score it
+          // as passed. evaluateMultiTurnResults returns passed:true for an
+          // all-pinned case with no calls, so override explicitly.
+          evaluation: {
+            ...evaluateMultiTurnResults(
+              resolvedTest.promptTurns,
+              [],
+              test.isNegativeTest,
+              test.matchOptions
+            ),
+            passed: false,
+          },
           iterationId: undefined,
         };
       }
@@ -1108,20 +1116,29 @@ const runIterationWithAiSdk = async ({
   }
   const iterationParams = {
     testCaseId: test.testCaseId ?? testCaseId,
-    testCaseSnapshot: {
-      title: test.title,
-      query,
-      provider: test.provider,
-      model: test.model,
-      runs: test.runs,
-      expectedToolCalls,
-      isNegativeTest: test.isNegativeTest,
-      expectedOutput,
-      promptTurns,
-      advancedConfig,
-      matchOptions: test.matchOptions,
-      hostConfigOverride: test.hostConfigOverride,
-    },
+    // Model-free (pinned-only) iterations omit the testCaseSnapshot so the
+    // recorder pairs the pre-created row by testCaseId + iterationNumber. The
+    // snapshot's query is synthesized ("Pinned tool call: …") and would never
+    // match the pre-created row's stored query, leaving the row unpaired and
+    // perpetually pending. Mirrors the old probe path, which passed no snapshot.
+    ...(caseNeedsModel
+      ? {
+          testCaseSnapshot: {
+            title: test.title,
+            query,
+            provider: test.provider,
+            model: test.model,
+            runs: test.runs,
+            expectedToolCalls,
+            isNegativeTest: test.isNegativeTest,
+            expectedOutput,
+            promptTurns,
+            advancedConfig,
+            matchOptions: test.matchOptions,
+            hostConfigOverride: test.hostConfigOverride,
+          },
+        }
+      : {}),
     iterationNumber: runIndex + 1,
     startedAt: runStartedAt,
   };
@@ -1180,6 +1197,11 @@ const runIterationWithAiSdk = async ({
   // shape now matches pre-4d (system is the first message in
   // `messages`) while the wire shape stays chat-aligned.
   let enhancedSystemPromptForPersist: string | undefined = undefined;
+  // True when a pinned turn's server wasn't connected (a setup failure, not an
+  // assertion failure). Unlike the model path's failure detection — which
+  // deliberately records `status:"completed"` + `error` — this finalizes
+  // `status:"failed"`, matching the legacy probe's not-connected behavior.
+  let pinnedSetupFailure = false;
 
   // Browser-rendered MCP App eval (PR 5): render MCP App tool results in the
   // headless-Chromium harness and (for models with vision + tool calling) drive
@@ -1273,12 +1295,17 @@ const runIterationWithAiSdk = async ({
     // shape: drop the iteration entirely (no record).
     const localIsAborted = () => abortSignal?.aborted === true;
     const returnLocalCancelled = () => ({
-      evaluation: evaluateMultiTurnResults(
-        promptTurns,
-        toolsCalledByPrompt,
-        test.isNegativeTest,
-        test.matchOptions
-      ),
+      // Aborted mid-iteration — never score as passed (a pinned-only case would
+      // otherwise short-circuit to passed:true).
+      evaluation: {
+        ...evaluateMultiTurnResults(
+          promptTurns,
+          toolsCalledByPrompt,
+          test.isNegativeTest,
+          test.matchOptions
+        ),
+        passed: false,
+      },
       iterationId: undefined,
     });
 
@@ -1325,6 +1352,7 @@ const runIterationWithAiSdk = async ({
         }
         if (pinnedResult.iterationError && !iterationError) {
           iterationError = pinnedResult.iterationError;
+          pinnedSetupFailure = true;
         }
         continue;
       }
@@ -1624,7 +1652,7 @@ const runIterationWithAiSdk = async ({
           effectivePredicates
         )
       : [];
-    const passed = finalizePassedForEval({
+    let passed = finalizePassedForEval({
       matchPassed: evaluation.passed,
       trace: traceForGate,
       // PR 4b (mirrors PR 3 invariant): if the per-turn loop set
@@ -1636,6 +1664,14 @@ const runIterationWithAiSdk = async ({
       failOnToolError,
       predicateResults,
     });
+    // A pinned (model-free) tool call's error never enters the trace, so
+    // `finalizePassedForEval`'s `failOnToolError` gate (which inspects the
+    // trace) is blind to it. Apply the gate explicitly to pinned tool errors
+    // so a failing pinned call can't pass when tool-error gating is on and no
+    // widget/`noToolErrors` predicate happened to catch it.
+    if (passed && failOnToolError && pinnedToolErrors.length > 0) {
+      passed = false;
+    }
     // Reflect the gated verdict (match AND tool-error gate AND predicates) in
     // the returned evaluation so totals built from `evaluation.passed` agree
     // with the persisted iteration result.
@@ -1683,7 +1719,7 @@ const runIterationWithAiSdk = async ({
       ...(browser.browserInteractionSteps.length
         ? { browserInteractionSteps: browser.browserInteractionSteps }
         : {}),
-      status: "completed" as const,
+      status: pinnedSetupFailure ? ("failed" as const) : ("completed" as const),
       startedAt: runStartedAt,
       ...(iterationError ? { error: iterationError } : {}),
       ...(iterationErrorDetails ? { errorDetails: iterationErrorDetails } : {}),
@@ -1920,12 +1956,18 @@ const runIterationViaBackendWithBrowser = async (
       );
       if (currentRun?.status === "cancelled") {
         return {
-          evaluation: evaluateMultiTurnResults(
-            resolvedTest.promptTurns,
-            [],
-            test.isNegativeTest,
-            test.matchOptions
-          ),
+          // A cancelled / deleted-run iteration never executed — never score it
+          // as passed. evaluateMultiTurnResults returns passed:true for an
+          // all-pinned case with no calls, so override explicitly.
+          evaluation: {
+            ...evaluateMultiTurnResults(
+              resolvedTest.promptTurns,
+              [],
+              test.isNegativeTest,
+              test.matchOptions
+            ),
+            passed: false,
+          },
           iterationId: undefined,
         };
       }
@@ -1938,12 +1980,18 @@ const runIterationViaBackendWithBrowser = async (
         errorMessage.includes("unauthorized")
       ) {
         return {
-          evaluation: evaluateMultiTurnResults(
-            resolvedTest.promptTurns,
-            [],
-            test.isNegativeTest,
-            test.matchOptions
-          ),
+          // A cancelled / deleted-run iteration never executed — never score it
+          // as passed. evaluateMultiTurnResults returns passed:true for an
+          // all-pinned case with no calls, so override explicitly.
+          evaluation: {
+            ...evaluateMultiTurnResults(
+              resolvedTest.promptTurns,
+              [],
+              test.isNegativeTest,
+              test.matchOptions
+            ),
+            passed: false,
+          },
           iterationId: undefined,
         };
       }
@@ -2444,8 +2492,7 @@ const runTestCase = async (params: {
   // locally-executed pinned turn. Local BYOK hybrids work (the pinned branch
   // lives in runIterationWithAiSdk). Fail loudly rather than silently send a
   // pinned turn's empty prompt to the model.
-  const caseHasPinnedTurn = normalizedTest.promptTurns?.some(isPinnedTurn) ||
-    resolveEvalTestCase(normalizedTest).promptTurns.some(isPinnedTurn);
+  const caseHasPinnedTurn = resolvePromptTurns(normalizedTest).some(isPinnedTurn);
 
   const modelDefinition = buildModelDefinition(test);
   const resolvedModelId = getCanonicalModelId(
@@ -2942,12 +2989,18 @@ const streamIterationWithAiSdk = async ({
       );
       if (currentRun?.status === "cancelled") {
         return {
-          evaluation: evaluateMultiTurnResults(
-            resolvedTest.promptTurns,
-            [],
-            test.isNegativeTest,
-            test.matchOptions
-          ),
+          // A cancelled / deleted-run iteration never executed — never score it
+          // as passed. evaluateMultiTurnResults returns passed:true for an
+          // all-pinned case with no calls, so override explicitly.
+          evaluation: {
+            ...evaluateMultiTurnResults(
+              resolvedTest.promptTurns,
+              [],
+              test.isNegativeTest,
+              test.matchOptions
+            ),
+            passed: false,
+          },
           iterationId: undefined,
         };
       }
@@ -2959,12 +3012,18 @@ const streamIterationWithAiSdk = async ({
         errorMessage.includes("unauthorized")
       ) {
         return {
-          evaluation: evaluateMultiTurnResults(
-            resolvedTest.promptTurns,
-            [],
-            test.isNegativeTest,
-            test.matchOptions
-          ),
+          // A cancelled / deleted-run iteration never executed — never score it
+          // as passed. evaluateMultiTurnResults returns passed:true for an
+          // all-pinned case with no calls, so override explicitly.
+          evaluation: {
+            ...evaluateMultiTurnResults(
+              resolvedTest.promptTurns,
+              [],
+              test.isNegativeTest,
+              test.matchOptions
+            ),
+            passed: false,
+          },
           iterationId: undefined,
         };
       }
@@ -3050,20 +3109,29 @@ const streamIterationWithAiSdk = async ({
   }
   const iterationParams = {
     testCaseId: test.testCaseId ?? testCaseId,
-    testCaseSnapshot: {
-      title: test.title,
-      query,
-      provider: test.provider,
-      model: test.model,
-      runs: test.runs,
-      expectedToolCalls,
-      isNegativeTest: test.isNegativeTest,
-      expectedOutput,
-      promptTurns,
-      advancedConfig,
-      matchOptions: test.matchOptions,
-      hostConfigOverride: test.hostConfigOverride,
-    },
+    // Model-free (pinned-only) iterations omit the testCaseSnapshot so the
+    // recorder pairs the pre-created row by testCaseId + iterationNumber. The
+    // snapshot's query is synthesized ("Pinned tool call: …") and would never
+    // match the pre-created row's stored query, leaving the row unpaired and
+    // perpetually pending. Mirrors the old probe path, which passed no snapshot.
+    ...(caseNeedsModel
+      ? {
+          testCaseSnapshot: {
+            title: test.title,
+            query,
+            provider: test.provider,
+            model: test.model,
+            runs: test.runs,
+            expectedToolCalls,
+            isNegativeTest: test.isNegativeTest,
+            expectedOutput,
+            promptTurns,
+            advancedConfig,
+            matchOptions: test.matchOptions,
+            hostConfigOverride: test.hostConfigOverride,
+          },
+        }
+      : {}),
     iterationNumber: runIndex + 1,
     startedAt: runStartedAt,
   };
@@ -3203,12 +3271,17 @@ const streamIterationWithAiSdk = async ({
     // record without persisting cancelled state.
     const localIsAborted = () => abortSignal?.aborted === true;
     const returnLocalCancelled = () => ({
-      evaluation: evaluateMultiTurnResults(
-        promptTurns,
-        toolsCalledByPrompt,
-        test.isNegativeTest,
-        test.matchOptions
-      ),
+      // Aborted mid-iteration — never score as passed (a pinned-only case would
+      // otherwise short-circuit to passed:true).
+      evaluation: {
+        ...evaluateMultiTurnResults(
+          promptTurns,
+          toolsCalledByPrompt,
+          test.isNegativeTest,
+          test.matchOptions
+        ),
+        passed: false,
+      },
       iterationId: undefined,
     });
 
@@ -3938,12 +4011,18 @@ const streamIterationViaBackendWithBrowser = async (
       );
       if (currentRun?.status === "cancelled") {
         return {
-          evaluation: evaluateMultiTurnResults(
-            resolvedTest.promptTurns,
-            [],
-            test.isNegativeTest,
-            test.matchOptions
-          ),
+          // A cancelled / deleted-run iteration never executed — never score it
+          // as passed. evaluateMultiTurnResults returns passed:true for an
+          // all-pinned case with no calls, so override explicitly.
+          evaluation: {
+            ...evaluateMultiTurnResults(
+              resolvedTest.promptTurns,
+              [],
+              test.isNegativeTest,
+              test.matchOptions
+            ),
+            passed: false,
+          },
           iterationId: undefined,
         };
       }
@@ -3955,12 +4034,18 @@ const streamIterationViaBackendWithBrowser = async (
         errorMessage.includes("unauthorized")
       ) {
         return {
-          evaluation: evaluateMultiTurnResults(
-            resolvedTest.promptTurns,
-            [],
-            test.isNegativeTest,
-            test.matchOptions
-          ),
+          // A cancelled / deleted-run iteration never executed — never score it
+          // as passed. evaluateMultiTurnResults returns passed:true for an
+          // all-pinned case with no calls, so override explicitly.
+          evaluation: {
+            ...evaluateMultiTurnResults(
+              resolvedTest.promptTurns,
+              [],
+              test.isNegativeTest,
+              test.matchOptions
+            ),
+            passed: false,
+          },
           iterationId: undefined,
         };
       }

--- a/mcpjam-inspector/server/services/evals/pinned-turn.ts
+++ b/mcpjam-inspector/server/services/evals/pinned-turn.ts
@@ -87,6 +87,22 @@ export async function runPinnedTurn(
     };
   }
 
+  // Guard against an unfinished pinned turn reaching the runner (the editor's
+  // save gate normally blocks this): never call executeTool with an empty
+  // tool name — surface a clear content-error instead of a cryptic one.
+  if (!pinned.toolName || pinned.toolName.trim().length === 0) {
+    const toolError: ToolErrorRecord = {
+      toolName: pinned.toolName ?? "",
+      kind: "content-error",
+      message: "Pinned tool call has no tool selected",
+    };
+    return {
+      toolCall: null,
+      toolError,
+      summary: "Pinned tool call has no tool selected",
+    };
+  }
+
   let rawResult: unknown;
   let toolCallOk = false;
   let toolError: ToolErrorRecord | undefined;

--- a/mcpjam-inspector/shared/__tests__/prompt-turns.test.ts
+++ b/mcpjam-inspector/shared/__tests__/prompt-turns.test.ts
@@ -8,6 +8,7 @@ import {
   legacyProbeToPinnedTurn,
   needsModel,
   resolveIterationDisplayExpectedToolCalls,
+  resolvePromptTurnsWithLegacyProbe,
 } from "../prompt-turns";
 import type { ProbeConfig } from "../probe-config";
 
@@ -157,6 +158,51 @@ describe("pinned-turn selectors", () => {
     it("is model-driven for a hybrid (pinned + prompt) case", () => {
       expect(isPinnedOnly({ promptTurns: [pinnedTurn, promptTurn] })).toBe(false);
       expect(needsModel({ promptTurns: [pinnedTurn, promptTurn] })).toBe(true);
+    });
+
+    it("is model-driven for a widget_probe that carries model prompt turns", () => {
+      // Regression: a hybrid widget_probe must NOT route model-free (would throw
+      // when the loop hits a model turn with no LLM setup).
+      expect(
+        isPinnedOnly({ caseType: "widget_probe", promptTurns: [promptTurn] }),
+      ).toBe(false);
+      expect(
+        needsModel({ caseType: "widget_probe", promptTurns: [promptTurn] }),
+      ).toBe(true);
+    });
+  });
+
+  describe("resolvePromptTurnsWithLegacyProbe", () => {
+    it("surfaces a pure legacy probe's probeConfig as a single pinned turn", () => {
+      const turns = resolvePromptTurnsWithLegacyProbe({
+        caseType: "widget_probe",
+        probeConfig: probe,
+      });
+      expect(turns).toHaveLength(1);
+      expect(turns[0].pinnedToolCall).toEqual(probe);
+    });
+
+    it("does NOT clobber real prompt steps on a widget_probe row", () => {
+      // Regression: a widget_probe that also has authored prompt turns must keep
+      // them, not have the whole list replaced by the legacy pinned turn.
+      const real = {
+        id: "t1",
+        prompt: "do the thing",
+        expectedToolCalls: [{ toolName: "x", arguments: {} }],
+      };
+      const turns = resolvePromptTurnsWithLegacyProbe({
+        caseType: "widget_probe",
+        probeConfig: probe,
+        promptTurns: [real],
+      });
+      expect(turns).toEqual([real]);
+    });
+
+    it("leaves a normal prompt case untouched", () => {
+      const turns = resolvePromptTurnsWithLegacyProbe({
+        promptTurns: [promptTurn],
+      });
+      expect(turns).toEqual([promptTurn]);
     });
   });
 

--- a/mcpjam-inspector/shared/__tests__/prompt-turns.test.ts
+++ b/mcpjam-inspector/shared/__tests__/prompt-turns.test.ts
@@ -170,6 +170,18 @@ describe("pinned-turn selectors", () => {
         needsModel({ caseType: "widget_probe", promptTurns: [promptTurn] }),
       ).toBe(true);
     });
+
+    it("is pinned-only for a legacy widget_probe with only empty placeholder turns", () => {
+      // Regression (P3): a pre-migration widget_probe persisted with the
+      // resolvePromptTurns fallback shape [{prompt:"",expectedToolCalls:[]}] is
+      // still a pure probe — must stay model-free, not route to the model path.
+      const placeholder = { id: "turn-1", prompt: "", expectedToolCalls: [] };
+      expect(
+        isPinnedOnly({ caseType: "widget_probe", promptTurns: [placeholder] }),
+      ).toBe(true);
+      // But the same shape WITHOUT widget_probe is an unfilled prompt case.
+      expect(isPinnedOnly({ promptTurns: [placeholder] })).toBe(false);
+    });
   });
 
   describe("resolvePromptTurnsWithLegacyProbe", () => {

--- a/mcpjam-inspector/shared/prompt-turns.ts
+++ b/mcpjam-inspector/shared/prompt-turns.ts
@@ -335,3 +335,27 @@ export function legacyProbeToPinnedTurn(
     pinnedToolCall: { ...probeConfig },
   };
 }
+
+/**
+ * Resolve a case's turns, surfacing a legacy `widget_probe` row's top-level
+ * `probeConfig` as a single pinned turn so callers see ONE shape. No-op for
+ * already-pinned / prompt cases. Shared by the editor (editForm seeding) and
+ * the runner (`normalizeTestForPinnedTurns`) so the legacy-detection rule lives
+ * in one place.
+ */
+export function resolvePromptTurnsWithLegacyProbe(
+  input: {
+    caseType?: string | null;
+    probeConfig?: ProbeConfig;
+  } & Parameters<typeof resolvePromptTurns>[0],
+): PromptTurn[] {
+  const turns = resolvePromptTurns(input);
+  if (
+    input.caseType === "widget_probe" &&
+    input.probeConfig &&
+    !turns.some(isPinnedTurn)
+  ) {
+    return [legacyProbeToPinnedTurn(input.probeConfig)];
+  }
+  return turns;
+}

--- a/mcpjam-inspector/shared/prompt-turns.ts
+++ b/mcpjam-inspector/shared/prompt-turns.ts
@@ -300,14 +300,21 @@ export function hasPinnedTurn(promptTurns: unknown): boolean {
 }
 
 /**
- * True when the case requires no model: a legacy widget probe, or a case whose
- * (non-empty) turn list is entirely pinned. The empty-list guard prevents a
- * vacuous `[].every()` from classifying a fresh/model case as pinned-only.
+ * True when the case is entirely model-free (no model turns).
+ *
+ * - No authored turns: a legacy `widget_probe`'s `probeConfig` IS the single
+ *   model-free pinned call, so it's pinned-only; any other empty case is a
+ *   model case.
+ * - Authored turns: pinned-only iff EVERY turn is pinned. This intentionally
+ *   does NOT short-circuit on `caseType === "widget_probe"` — a widget_probe
+ *   that also carries model prompt turns (a hybrid) must be treated as
+ *   model-driven, or it would route model-free and then throw when the loop
+ *   reaches a model turn with no LLM setup.
  */
 export function isPinnedOnly(input: PinnedCaseInput): boolean {
-  if (input.caseType === "widget_probe") return true;
   const turns = rawTurns(input.promptTurns);
-  return turns.length > 0 && turns.every(isPinnedTurn);
+  if (turns.length === 0) return input.caseType === "widget_probe";
+  return turns.every(isPinnedTurn);
 }
 
 /** True when at least one turn needs the model (the inverse of pinned-only). */
@@ -350,11 +357,18 @@ export function resolvePromptTurnsWithLegacyProbe(
   } & Parameters<typeof resolvePromptTurns>[0],
 ): PromptTurn[] {
   const turns = resolvePromptTurns(input);
-  if (
-    input.caseType === "widget_probe" &&
-    input.probeConfig &&
-    !turns.some(isPinnedTurn)
-  ) {
+  // Only surface the legacy probeConfig as a pinned turn when the case carries
+  // NO real authored turn — i.e. a pure legacy probe (empty prompt, no expected
+  // calls, none already pinned). A widget_probe that also has real prompt steps
+  // must keep them; replacing the whole list would silently drop them in the
+  // editor and at run time.
+  const hasRealTurn = turns.some(
+    (t) =>
+      isPinnedTurn(t) ||
+      t.prompt.trim().length > 0 ||
+      t.expectedToolCalls.length > 0,
+  );
+  if (input.caseType === "widget_probe" && input.probeConfig && !hasRealTurn) {
     return [legacyProbeToPinnedTurn(input.probeConfig)];
   }
   return turns;

--- a/mcpjam-inspector/shared/prompt-turns.ts
+++ b/mcpjam-inspector/shared/prompt-turns.ts
@@ -299,6 +299,17 @@ export function hasPinnedTurn(promptTurns: unknown): boolean {
   return rawTurns(promptTurns).some(isPinnedTurn);
 }
 
+/** True when a turn actually drives the model: a non-empty prompt or asserted
+ *  tool calls. An empty placeholder turn (`{prompt:"",expectedToolCalls:[]}`)
+ *  does NOT. */
+function turnHasModelContent(turn: unknown): boolean {
+  const t = turn as { prompt?: unknown; expectedToolCalls?: unknown };
+  return (
+    (typeof t.prompt === "string" && t.prompt.trim().length > 0) ||
+    (Array.isArray(t.expectedToolCalls) && t.expectedToolCalls.length > 0)
+  );
+}
+
 /**
  * True when the case is entirely model-free (no model turns).
  *
@@ -310,11 +321,19 @@ export function hasPinnedTurn(promptTurns: unknown): boolean {
  *   that also carries model prompt turns (a hybrid) must be treated as
  *   model-driven, or it would route model-free and then throw when the loop
  *   reaches a model turn with no LLM setup.
+ * - Edge: a legacy `widget_probe` persisted with only EMPTY placeholder turns
+ *   (e.g. `[{prompt:"",expectedToolCalls:[]}]`, the `resolvePromptTurns`
+ *   fallback shape) is still a pure probe — classify it model-free so it isn't
+ *   mis-routed to the model path before migration converts it.
  */
 export function isPinnedOnly(input: PinnedCaseInput): boolean {
   const turns = rawTurns(input.promptTurns);
   if (turns.length === 0) return input.caseType === "widget_probe";
-  return turns.every(isPinnedTurn);
+  if (turns.every(isPinnedTurn)) return true;
+  if (input.caseType === "widget_probe") {
+    return !turns.some(turnHasModelContent);
+  }
+  return false;
 }
 
 /** True when at least one turn needs the model (the inverse of pinned-only). */


### PR DESCRIPTION
## What & why

A **render check** used to be its own case type (`caseType: "widget_probe"` + top-level `probeConfig`) with its own runner and editor. But a widget only ever renders as the result of a tool call — so a render check is just the *model-free* case of "call a tool, render its widget, assert." This collapses the two into **one engine and one editor**: a render check is now a **turn whose `pinnedToolCall` is set**.

This unlocks **hybrid** cases too (pin a tool to seed state, then let the model continue) and removes a whole parallel code path.

> Depends on **MCPJam/mcpjam-backend#577** — merge + deploy that first, or the editor will write `pinnedToolCall` to a database whose validator rejects it.

## Changes

**Engine**
- `shared/prompt-turns.ts`: `PromptTurn.pinnedToolCall` + selectors (`isPinnedTurn` / `hasPinnedTurn` / `isPinnedOnly` / `needsModel` / `countModelTurns` / `legacyProbeToPinnedTurn`); cap math, iteration UI, and the run guard route through them.
- `server/services/evals/pinned-turn.ts`: shared model-free turn executor (tool call → render via the shared browser harness → observation/error).
- `evals-runner.ts`: `runIterationWithAiSdk` gates **all** model setup behind `caseNeedsModel` and runs pinned turns inline; `runTestCase` routes pinned-only cases model-free; `evaluateMultiTurnResults` excludes pinned turns from tool-call matching but keeps them in the transcript for predicates. **Deletes `probe-iteration.ts`** (the parallel probe runner). Hybrid-on-hosted-model and streaming quick-run of pinned cases are guarded with clear errors (follow-ups).
- `@mcpjam/sdk` `buildIterationTranscript`: additive `toolErrors` input (merged with trace-derived) so a traceless pinned call's failures still gate `noToolErrors`.

**UI**
- Per-turn **Prompt | Render check** toggle (`test-case-prompt-flow.tsx`) backed by a shared `PinnedToolCallFields`. Removes the separate "Render check" New-case entry and the `WidgetProbeEditor`. Legacy `widget_probe` rows open as a pinned turn. Model picker + "select a model" run gate are suppressed for model-free cases.

## Compatibility

Existing `widget_probe` rows keep working through a runtime adapter (`normalizeTestForPinnedTurns`) and the editForm legacy-probe conversion. The legacy `caseType`/`probeConfig` fields are **retained** — removing them is a deploy-gated follow-up that requires the backfill migration (backend #577) to run in prod first.

## Test

- `npx vitest run server/services/evals shared/__tests__/prompt-turns.test.ts` → **208 passed** (incl. new `pinned-turn.test.ts`).
- Manual: create a case → toggle a turn to **Render check** → pick server/tool → add a `Widget rendered` check → run the suite → widget renders in the **Browser** tab and the check passes. Hybrid (prompt turn + render-check turn) runs both. Existing render checks still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval execution, pass/fail scoring, and suite-run payload shaping for render checks; regressions could affect monitoring suites and legacy `widget_probe` rows, though coverage is expanded in `prompt-turns` tests.
> 
> **Overview**
> This PR tightens **render check / pinned-only** behavior after unifying them into per-turn `pinnedToolCall`, with shared helpers and runner fixes so legacy rows, hybrids, and monitoring UX stay consistent.
> 
> **Shared routing (`prompt-turns.ts`)** — `isPinnedOnly` no longer treats every `widget_probe` as model-free: hybrid cases with real prompts stay on the LLM path, and legacy probes with only empty placeholder turns still count as pinned-only. New **`resolvePromptTurnsWithLegacyProbe`** centralizes surfacing `probeConfig` as a pinned turn (without clobbering real prompt steps); editor and runner both use it.
> 
> **UI** — Run/quick-run gates and monitoring tab detection use **`isPinnedOnly`** instead of `caseType === "widget_probe"`. The per-turn **Render check** toggle is gated by the **`synthetic-monitors`** flag (existing pinned turns stay editable). Pinned-only cases disable editor **Run** with a suite-only tooltip; **`deriveIsNegativeTestFromPromptTurns`** ignores pinned turns. **`handleCreateWidgetProbe`** is removed. Changing server in **`PinnedToolCallFields`** clears the selected tool.
> 
> **Runner & API** — Suite fan-out and browser concurrency use **`isPinnedOnly`**; wire payloads can send `promptTurns` for unified pinned cases. Model-free iterations **omit `testCaseSnapshot`** so pre-created rows pair correctly; pinned setup failures finalize as **`failed`**, and **`failOnToolError`** applies to pinned tool errors. Cancelled/aborted iterations force **`passed: false`** so all-pinned cases don’t false-pass. LLM call caps use **`countModelTurns`**. Empty pinned tool names fail with a clear error in **`pinned-turn.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3ba0aa6d0021a4700e2a1891e24fa4bec68e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->