### PR TITLE
error msg when eval tools/list fails

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/evals.ts
+++ b/mcpjam-inspector/server/routes/mcp/evals.ts
@@ -24,6 +24,7 @@ function jsonRouteError(c: any, error: unknown) {
   if (error instanceof WebRouteError) {
     return c.json(
       {
+        code: error.code,
         error: error.message,
         ...(error.details ? { details: error.details } : {}),
       },

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -583,7 +583,8 @@ export function resolveServerIdsOrThrow(
       throw new WebRouteError(
         404,
         ErrorCode.NOT_FOUND,
-        `Server '${requestedId}' not found`,
+        `Could not start eval because "${requestedId}" is not connected. Reconnect the server and try again.`,
+        { serverId: requestedId },
       );
     }
 

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -2737,33 +2737,6 @@ export const runEvalSuiteWithAiSdk = async ({
           runId,
         });
 
-  // When a host policy is present we need the full tool set (including
-  // app-only) so `applyVisibilityPolicyAndCountSignals` can:
-  //   1. Count `toolsTotalBefore` honestly, and
-  //   2. Keep app-only tools when the host opted out of visibility filtering.
-  // Without this, getToolsForAiSdk pre-strips app-only tools and the policy
-  // sees a partial set — drops are reported as 0 even when tools were hidden.
-  const tools = await getEvalToolsForAiSdkOrThrow({
-    mcpClientManager,
-    serverIds,
-    includeAppOnly: Boolean(hostExecutionPolicy),
-    environment: config.environment,
-  });
-
-  // Apply visibility filtering when a host policy is present. The filter
-  // mutates `tools` in place (same as prepareChatV2) so downstream iteration
-  // runners see the post-filter set.
-  const resolvedToolSignals = hostExecutionPolicy
-    ? applyVisibilityPolicyAndCountSignals(
-        tools as Record<string, unknown>,
-        mcpClientManager,
-        hostExecutionPolicy
-      )
-    : undefined;
-
-  // Note: Iterations are now pre-created in startSuiteRunWithRecorder
-  // This code is no longer needed as precreateIterationsForRun is called there
-
   const summary = {
     total: 0,
     passed: 0,
@@ -2771,6 +2744,33 @@ export const runEvalSuiteWithAiSdk = async ({
   };
 
   try {
+    // When a host policy is present we need the full tool set (including
+    // app-only) so `applyVisibilityPolicyAndCountSignals` can:
+    //   1. Count `toolsTotalBefore` honestly, and
+    //   2. Keep app-only tools when the host opted out of visibility filtering.
+    // Without this, getToolsForAiSdk pre-strips app-only tools and the policy
+    // sees a partial set — drops are reported as 0 even when tools were hidden.
+    const tools = await getEvalToolsForAiSdkOrThrow({
+      mcpClientManager,
+      serverIds,
+      includeAppOnly: Boolean(hostExecutionPolicy),
+      environment: config.environment,
+    });
+
+    // Apply visibility filtering when a host policy is present. The filter
+    // mutates `tools` in place (same as prepareChatV2) so downstream iteration
+    // runners see the post-filter set.
+    const resolvedToolSignals = hostExecutionPolicy
+      ? applyVisibilityPolicyAndCountSignals(
+          tools as Record<string, unknown>,
+          mcpClientManager,
+          hostExecutionPolicy
+        )
+      : undefined;
+
+    // Note: Iterations are now pre-created in startSuiteRunWithRecorder
+    // This code is no longer needed as precreateIterationsForRun is called there
+
     // Check if run has been cancelled before starting (only for suite runs)
     if (runId !== null) {
       const currentRun = await convexClient.query(

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -56,6 +56,7 @@ import {
   type ToolErrorRecord,
 } from "@/shared/eval-matching";
 import type { ConvexHttpClient } from "convex/browser";
+import { ErrorCode, WebRouteError } from "../routes/web/errors";
 import {
   createSuiteRunRecorder,
   type SuiteRunRecorder,
@@ -294,6 +295,72 @@ const MAX_STEPS = 20;
 type ToolSet = Record<string, any>;
 type ToolCall = { toolName: string; arguments: Record<string, any> };
 type TraceSnapshotKind = "step_finish" | "turn_finish" | "failure";
+
+function getServerLabelForEvalError(
+  serverId: string,
+  environment: RunEvalSuiteOptions["config"]["environment"] | undefined,
+): string {
+  const binding = environment?.serverBindings?.find(
+    (entry) =>
+      entry.projectServerId === serverId ||
+      entry.projectServerId?.toLowerCase() === serverId.toLowerCase(),
+  );
+  return binding?.serverName || serverId;
+}
+
+function isMissingRuntimeServerError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /unknown mcp server/i.test(message) ||
+    /not connected/i.test(message) ||
+    /server .* is not connected/i.test(message)
+  );
+}
+
+async function getEvalToolsForAiSdkOrThrow(args: {
+  mcpClientManager: MCPClientManager;
+  serverIds: string[];
+  includeAppOnly: boolean;
+  environment: RunEvalSuiteOptions["config"]["environment"] | undefined;
+}): Promise<ToolSet> {
+  const perServerTools = await Promise.all(
+    args.serverIds.map(async (serverId) => {
+      try {
+        return args.includeAppOnly
+          ? await args.mcpClientManager.getToolsForAiSdk([serverId], {
+              includeAppOnly: true,
+            })
+          : await args.mcpClientManager.getToolsForAiSdk([serverId]);
+      } catch (error) {
+        const serverLabel = getServerLabelForEvalError(
+          serverId,
+          args.environment,
+        );
+        if (isMissingRuntimeServerError(error)) {
+          throw new WebRouteError(
+            409,
+            ErrorCode.SERVER_UNREACHABLE,
+            `Could not start eval because "${serverLabel}" is not connected. Reconnect the server and try again.`,
+            { serverId, serverName: serverLabel },
+          );
+        }
+        const cause = error instanceof Error ? error.message : String(error);
+        throw new WebRouteError(
+          502,
+          ErrorCode.SERVER_UNREACHABLE,
+          `Could not start eval because "${serverLabel}" failed to list tools. Reconnect the server and try again.`,
+          { serverId, serverName: serverLabel, cause },
+        );
+      }
+    }),
+  );
+
+  const flattened: ToolSet = {};
+  for (const toolset of perServerTools) {
+    Object.assign(flattened, toolset);
+  }
+  return flattened;
+}
 
 export function resolveConfiguredServerIds(args: {
   environment: RunEvalSuiteOptions["config"]["environment"] | undefined;
@@ -2676,13 +2743,12 @@ export const runEvalSuiteWithAiSdk = async ({
   //   2. Keep app-only tools when the host opted out of visibility filtering.
   // Without this, getToolsForAiSdk pre-strips app-only tools and the policy
   // sees a partial set — drops are reported as 0 even when tools were hidden.
-  const tools = (
-    hostExecutionPolicy
-      ? await mcpClientManager.getToolsForAiSdk(serverIds, {
-          includeAppOnly: true,
-        })
-      : await mcpClientManager.getToolsForAiSdk(serverIds)
-  ) as ToolSet;
+  const tools = await getEvalToolsForAiSdkOrThrow({
+    mcpClientManager,
+    serverIds,
+    includeAppOnly: Boolean(hostExecutionPolicy),
+    environment: config.environment,
+  });
 
   // Apply visibility filtering when a host policy is present. The filter
   // mutates `tools` in place (same as prepareChatV2) so downstream iteration

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -286,6 +286,34 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     );
   });
 
+  it("marks suite runs failed when tool loading fails", async () => {
+    mcpClientManager.getToolsForAiSdk.mockRejectedValueOnce(
+      new Error("tools/list exploded"),
+    );
+    const recorder = {
+      runId: "run-1",
+      suiteId: "suite-1",
+      startIteration: vi.fn(),
+      finishIteration: vi.fn(),
+      finalize: vi.fn(),
+    };
+
+    await expect(
+      runEvalSuiteWithAiSdk({
+        ...buildQuickRunConfig(),
+        runId: "run-1",
+        recorder,
+      } as any),
+    ).rejects.toThrow(
+      'Could not start eval because "Asana" failed to list tools. Reconnect the server and try again.',
+    );
+
+    expect(recorder.finalize).toHaveBeenCalledWith({
+      status: "failed",
+      summary: undefined,
+    });
+  });
+
   function createAsyncIterable<T>(items: T[]): AsyncIterable<T> {
     return {
       async *[Symbol.asyncIterator]() {

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -224,6 +224,68 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     };
   }
 
+  function buildQuickRunConfig(serverRef = "srv-1") {
+    return {
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Case",
+            query: "Hello",
+            runs: 1,
+            model: "gpt-4-turbo",
+            provider: "openai",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: {
+          servers: [serverRef],
+          serverBindings: [
+            {
+              serverName: "Asana",
+              projectServerId: "srv-1",
+            },
+          ],
+        },
+      },
+      modelApiKeys: { openai: "sk-test" },
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+    };
+  }
+
+  it("surfaces a clear error when the selected server is not connected at runtime", async () => {
+    mcpClientManager.getToolsForAiSdk.mockRejectedValueOnce(
+      new Error('Unknown MCP server "srv-1".'),
+    );
+
+    await expect(
+      runEvalSuiteWithAiSdk(buildQuickRunConfig() as any),
+    ).rejects.toThrow(
+      'Could not start eval because "Asana" is not connected. Reconnect the server and try again.',
+    );
+  });
+
+  it("surfaces a clear error when the selected server fails tools/list", async () => {
+    mcpClientManager.getToolsForAiSdk.mockRejectedValueOnce(
+      new Error("tools/list exploded"),
+    );
+
+    await expect(
+      runEvalSuiteWithAiSdk(buildQuickRunConfig() as any),
+    ).rejects.toThrow(
+      'Could not start eval because "Asana" failed to list tools. Reconnect the server and try again.',
+    );
+  });
+
   function createAsyncIterable<T>(items: T[]): AsyncIterable<T> {
     return {
       async *[Symbol.asyncIterator]() {


### PR DESCRIPTION
Improves eval rerun error messages when the selected MCP server can’t be used.
Now users see a clear message if the server is not connected or if tools/list fails, instead of the generic Server Error. Also adds tests for both cases.