### PR TITLE
mark evals as failed when setup fails

### DIFF
--- a/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
@@ -193,6 +193,58 @@ describe("startSuiteRunWithRecorder", () => {
 
     expect(result.config.environment).toEqual(snapshotEnvironment);
   });
+
+  it("marks the suite run failed when iteration precreate fails", async () => {
+    const mutationMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        runId: "run-1",
+        testCases: [
+          {
+            _id: "tc-1",
+            title: "Broken setup",
+            query: "Try setup",
+            model: "gpt-5",
+            provider: "openai",
+            runs: 1,
+            expectedToolCalls: [],
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error("validation exploded"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      startSuiteRunWithRecorder({
+        convexClient: { mutation: mutationMock } as any,
+        suiteId: "suite-1",
+        serverIds: ["alpha"],
+      }),
+    ).rejects.toThrow(
+      "Could not start eval because MCPJam failed to prepare the test attempts. Try again.",
+    );
+
+    expect(mutationMock).toHaveBeenNthCalledWith(
+      2,
+      "testSuites:precreateIterationsForRun",
+      { runId: "run-1" },
+    );
+    expect(mutationMock).toHaveBeenNthCalledWith(
+      3,
+      "testSuites:markSetupPendingIterationsFailed",
+      { runId: "run-1", error: "validation exploded" },
+    );
+    expect(mutationMock).toHaveBeenNthCalledWith(
+      4,
+      "testSuites:updateTestSuiteRun",
+      {
+        runId: "run-1",
+        status: "failed",
+        summary: undefined,
+        notes: "Failed to prepare eval test attempts.",
+      },
+    );
+  });
 });
 
 describe("createSuiteRunRecorder", () => {

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -14,6 +14,7 @@ import type { ServerToolSnapshot } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
 import { finalizeEvalIteration } from "./finalize-iteration.js";
 import { resolveCaseSuccessPredicates } from "@/shared/eval-matching";
+import { ErrorCode, WebRouteError } from "../../routes/web/errors.js";
 
 type IterationStatus = "completed" | "failed" | "cancelled";
 
@@ -363,16 +364,49 @@ export const startSuiteRunWithRecorder = async ({
     throw new Error("Failed to start suite run");
   }
 
-  // Pre-create all iterations
-  await convexClient.mutation("testSuites:precreateIterationsForRun" as any, {
-    runId,
-  });
-
   const recorder = createSuiteRunRecorder({
     convexClient,
     suiteId,
     runId,
   });
+
+  // Pre-create all iterations
+  try {
+    await convexClient.mutation("testSuites:precreateIterationsForRun" as any, {
+      runId,
+    });
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    logger.error("[evals] Failed to pre-create suite run iterations", error, {
+      suiteId,
+      runId,
+    });
+    try {
+      await convexClient.mutation(
+        "testSuites:markSetupPendingIterationsFailed" as any,
+        { runId, error: cause },
+      );
+    } catch (cleanupError) {
+      logger.warn("[evals] Failed to mark setup iterations failed", {
+        suiteId,
+        runId,
+        error:
+          cleanupError instanceof Error
+            ? cleanupError.message
+            : String(cleanupError),
+      });
+    }
+    await recorder.finalize({
+      status: "failed",
+      notes: "Failed to prepare eval test attempts.",
+    });
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Could not start eval because MCPJam failed to prepare the test attempts. Try again.",
+      { runId, cause },
+    );
+  }
 
   // Use the full environment Convex snapshotted into the run (derived
   // from suite.hostConfigId.serverIds when available, else the legacy


### PR DESCRIPTION
Makes eval runs fail cleanly when they can’t start.
If MCPJam creates a run but fails while preparing the test attempts, the run is now marked as failed instead of staying stuck. Adds tests for that case.