### PR TITLE
fix(xaa): render IdP header in a flat container, not a floating card

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { AlertTriangle, Check, Copy, Info, KeyRound } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
-import { Card } from "@mcpjam/design-system/card";
 import {
   HoverCard,
   HoverCardContent,
@@ -178,7 +177,7 @@ export function XAAIdpCard() {
   }, []);
 
   return (
-    <Card className="mx-3 mt-3 mb-1 gap-0 p-3">
+    <div className="border-b border-border bg-background px-4 py-3">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
         <div className="flex shrink-0 items-center gap-1.5">
           <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -204,6 +203,6 @@ export function XAAIdpCard() {
           </span>
         </div>
       )}
-    </Card>
+    </div>
   );
 }


### PR DESCRIPTION
The 'MCPJam is your identity provider' block used the design-system Card
(rounded-xl + shadow-sm + mx-3 margins), which read as a floating
modal-style card. Swap it for a flat full-width section (bottom border,
no shadow) so it sits inline with the rest of the debugger.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>