### PR TITLE
fix(xaa): keep ID-JAG lint rows inside the flow panel on narrow widths

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
@@ -47,17 +47,19 @@ function LintVerdictRow({ verdict }: { verdict: IdJagLintVerdict }) {
       data-testid={`idjag-lint-${verdict.id}`}
       className={`border rounded-md px-3 py-2 ${styles.row}`}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
         <Icon className={`h-3.5 w-3.5 shrink-0 ${styles.icon}`} />
-        <code className="text-xs font-mono font-medium">{verdict.claim}</code>
+        <code className="shrink-0 text-xs font-mono font-medium">
+          {verdict.claim}
+        </code>
         {verdict.actual !== undefined && (
-          <code className="min-w-0 truncate text-[11px] font-mono text-muted-foreground">
+          <code className="min-w-0 flex-1 truncate text-[11px] font-mono text-muted-foreground">
             {verdict.actual}
           </code>
         )}
         <Badge
           variant="outline"
-          className="ml-auto shrink-0 text-[10px] font-normal"
+          className="ml-auto max-w-full whitespace-normal text-left text-[10px] font-normal"
         >
           {verdict.citation.spec} {verdict.citation.section}
         </Badge>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -582,7 +582,7 @@ export function XAAFlowLogger({
   };
 
   return (
-    <div className="h-full border-l border-border flex flex-col">
+    <div className="h-full min-w-0 border-l border-border flex flex-col">
       <div className="@container/xaa-run-bar bg-muted/30 border-b border-border px-4 py-3 space-y-3">
         <div className="flex flex-col gap-2 @min-[384px]/xaa-run-bar:flex-row @min-[384px]/xaa-run-bar:items-center">
           <button

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -611,7 +611,7 @@ export function XAAFlowTab({
           </div>
         ) : (
           <ResizablePanelGroup direction="horizontal" className="h-full">
-            <ResizablePanel defaultSize={52} minSize={30}>
+            <ResizablePanel defaultSize={52} minSize={30} className="min-w-0">
               <XAASequenceDiagram
                 flowState={flowState}
                 focusedStep={focusedStep}
@@ -622,7 +622,12 @@ export function XAAFlowTab({
 
             <ResizableHandle withHandle />
 
-            <ResizablePanel defaultSize={48} minSize={24} maxSize={52}>
+            <ResizablePanel
+              defaultSize={48}
+              minSize={24}
+              maxSize={52}
+              className="min-w-0"
+            >
               <XAAFlowLogger
                 flowState={flowState}
                 hasProfile={isTestable}


### PR DESCRIPTION
On a narrow window the ID-JAG claim-lint rows (and the citation badges)
pushed past the flow panel's edge, overlapping the sequence-diagram panel.

The resizable panels have overflow:hidden but no min-width:0, so the
default min-width:auto let the panel grow to its widest non-wrapping
child — the citation badge, which is whitespace-nowrap. Two fixes:

- Lint row reflows: wrap the citation badge, let the claim stay fixed,
  and let the actual value flex/truncate, so the row fits a narrow column
  instead of forcing it wider.
- Add min-w-0 to both flow panels and the logger root so each panel
  shrinks to its own column and clips, rather than bleeding over its
  sibling.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>