### PR TITLE
fix(xaa): stop reconnect from wiping saved server OAuth config

### DIFF
--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1959,7 +1959,14 @@ export function useServerState({
 
         if (result.success && result.serverConfig && result.serverName) {
           const serverName = result.serverName;
-          const existingServer = latestEffectiveServersRef.current[serverName];
+          // Prefer the runtime entry over the project catalog: it holds the
+          // user's freshly-saved OAuth config (clientId/secret/scopes/issuer),
+          // which the catalog round-trip can lag or drop. Rebuilding from the
+          // catalog here — then syncing back — is what reset the config after a
+          // reconnect that needed re-auth.
+          const existingServer =
+            appStateServersRef.current[serverName] ??
+            latestEffectiveServersRef.current[serverName];
           const mergedServerConfig = mergeOAuthCallbackServerConfig(
             existingServer?.config,
             result.serverConfig
@@ -1988,6 +1995,7 @@ export function useServerState({
             oauthTokens: existingServer?.oauthTokens,
             oauthFlowProfile: resolvedOAuthProfile,
             hasClientSecret: existingServer?.hasClientSecret,
+            xaaAuthzIssuer: existingServer?.xaaAuthzIssuer,
             initializationInfo: existingServer?.initializationInfo,
             useOAuth: true,
             lastOAuthTrace: result.oauthTrace,

--- a/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
@@ -3,6 +3,7 @@ import {
   serversHaveChanged,
   serializeServersForPersistence,
   serializeServersForSharing,
+  deserializeServersFromConvex,
 } from "../project-serialization";
 import type { ServerWithName } from "@/state/app-types";
 
@@ -145,5 +146,53 @@ describe("serversHaveChanged redacted secrets", () => {
         },
       ])
     ).toBe(false);
+  });
+});
+
+describe("project-serialization xaaAuthzIssuer round-trip", () => {
+  // The XAA "Configure Server to Test" modal reads the Authorization Server
+  // Issuer from server.xaaAuthzIssuer. If serialize/deserialize drops it, the
+  // field resets every time the runtime entry is rebuilt from the catalog
+  // (e.g. on a reconnect that needs re-auth).
+  it("persists xaaAuthzIssuer through serialization", () => {
+    const out = serializeServersForPersistence(
+      makeOAuthHttpServer("read", {
+        xaaAuthzIssuer: "https://issuer.test",
+      })
+    );
+    expect((out.s1 as any).xaaAuthzIssuer).toBe("https://issuer.test");
+  });
+
+  it("restores xaaAuthzIssuer from the flat servers table", () => {
+    const out = deserializeServersFromConvex([
+      {
+        name: "s1",
+        enabled: true,
+        useOAuth: true,
+        url: "https://example.test/mcp",
+        clientId: "client-1",
+        xaaAuthzIssuer: "https://issuer.test",
+      },
+    ]);
+    expect(out.s1.xaaAuthzIssuer).toBe("https://issuer.test");
+  });
+
+  it("treats an xaaAuthzIssuer change as a difference to resync", () => {
+    const local = makeOAuthHttpServer("read", {
+      xaaAuthzIssuer: "https://issuer.test",
+    });
+    expect(
+      serversHaveChanged(local, [
+        {
+          name: "s1",
+          enabled: true,
+          useOAuth: true,
+          url: "https://example.test/mcp",
+          clientId: "client-1",
+          oauthScopes: ["read"],
+          xaaAuthzIssuer: "https://different.test",
+        },
+      ])
+    ).toBe(true);
   });
 });

--- a/mcpjam-inspector/client/src/lib/project-serialization.ts
+++ b/mcpjam-inspector/client/src/lib/project-serialization.ts
@@ -31,6 +31,10 @@ function serializeServersInternal(
       useOAuth: server.useOAuth,
     };
 
+    if (server.xaaAuthzIssuer !== undefined) {
+      serializedServer.xaaAuthzIssuer = server.xaaAuthzIssuer;
+    }
+
     if (server.config) {
       const config: Record<string, unknown> = {};
 
@@ -195,6 +199,12 @@ export function deserializeServersFromConvex(
       hasHeaders: serverData.hasHeaders === true,
     };
 
+    const xaaAuthzIssuer =
+      serverData.xaaAuthzIssuer ?? serverData.config?.xaaAuthzIssuer;
+    if (xaaAuthzIssuer !== undefined) {
+      server.xaaAuthzIssuer = xaaAuthzIssuer;
+    }
+
     // Handle oauthFlowProfile from legacy nested structure
     if (serverData.oauthFlowProfile) {
       server.oauthFlowProfile = serverData.oauthFlowProfile;
@@ -250,6 +260,11 @@ export function serversHaveChanged(
     if (localServer.name !== remoteServer.name) return true;
     if (localServer.enabled !== remoteServer.enabled) return true;
     if (localServer.useOAuth !== remoteServer.useOAuth) return true;
+
+    const remoteXaaAuthzIssuer =
+      remoteServer.xaaAuthzIssuer ?? remoteServer.config?.xaaAuthzIssuer;
+    if ((localServer.xaaAuthzIssuer ?? undefined) !== (remoteXaaAuthzIssuer ?? undefined))
+      return true;
 
     // Get local URL
     const localUrl =


### PR DESCRIPTION
Reconnecting an XAA test server from the top bar reset the saved
Configure-Server-to-Test fields (client id, client secret, scopes, and
Authorization Server Issuer) while leaving name + URL intact.

Two compounding causes:

1. xaaAuthzIssuer was never serialized or deserialized, so every
   project/catalog round-trip silently dropped it.
2. When a reconnect needs re-auth, the OAuth callback rebuilt the server
   entry from the project catalog (which can lag or drop fields) instead
   of the authoritative runtime entry the reducer preserves — then synced
   the emptied entry back, making the loss permanent.

Fixes:
- Serialize, deserialize, and diff xaaAuthzIssuer in project
  serialization so it survives the round-trip.
- Rebuild the post-OAuth entry from the runtime entry first, falling
  back to the catalog, and carry xaaAuthzIssuer through.

Adds round-trip tests for the issuer field.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>