### PR TITLE
fix(xaa): drop blue focus ring on flow steps, add issuer auto-discovery hint

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -511,7 +511,6 @@ export function XAAFlowLogger({
   }, [groups]);
 
   const currentStepIndex = getXAAStepIndex(flowState.currentStep);
-  const focusedStep = activeStep ?? flowState.currentStep;
   const negativeModeSummary =
     NEGATIVE_TEST_MODE_DETAILS[summary.negativeTestMode];
 
@@ -840,12 +839,7 @@ export function XAAFlowLogger({
                     ref={(el) => {
                       stepRefs.current.set(group.step, el);
                     }}
-                    className={cn(
-                      "bg-background border rounded-lg shadow-sm",
-                      focusedStep === group.step
-                        ? "border-blue-400 ring-1 ring-blue-400/20"
-                        : "border-border"
-                    )}
+                    className="bg-background border border-border rounded-lg shadow-sm"
                   >
                     <button
                       onClick={() => toggleStep(group.step)}

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
+import { Info } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -312,9 +318,27 @@ export function XAAServerModal({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="xaa-authz-issuer">
-                Authorization Server Issuer
-              </Label>
+              <div className="flex items-center gap-1.5">
+                <Label htmlFor="xaa-authz-issuer">
+                  Authorization Server Issuer
+                </Label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      aria-label="How the authorization server issuer is auto-discovered"
+                    >
+                      <Info className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent variant="muted" side="top" className="max-w-xs">
+                    Leave blank to read it from the MCP server&apos;s OAuth
+                    metadata (its <code className="font-mono">.well-known</code>{" "}
+                    discovery endpoints).
+                  </TooltipContent>
+                </Tooltip>
+              </div>
               <Input
                 id="xaa-authz-issuer"
                 value={authzIssuer}


### PR DESCRIPTION
- Remove the blue border/ring highlight on the active flow-step card. It
  was left over from a progress bar that no longer exists; the Focus
  button still drives the diagram, so only the stray card highlight goes.
- Add an info icon next to the Authorization Server Issuer label in
  Configure Server to Test, with a one-line tooltip explaining that a
  blank field is read from the MCP server's OAuth discovery metadata.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>