### PR TITLE
feat(chat-ui): recorded-trace waterfall (TraceTimeline)

### DIFF
--- a/.changeset/chat-ui-trace-timeline.md
+++ b/.changeset/chat-ui-trace-timeline.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/chat-ui": minor
+---
+
+Add the recorded-trace waterfall as a new `@mcpjam/chat-ui/trace-timeline` subpath.
+
+`TraceTimeline` renders the per-step trace waterfall (per-span latency + token
+counts, hover for wall-clock start/end) from a `TraceSpan[]`. Tier-A clean:
+provider-free, no posthog / design-system / convex / widget-runtime imports —
+it reuses the package's own `JsonView` / `Markdown` / `tool-result-text` / `cn`
+plus small local UI shims, and the `trace-waterfall-*` classes + their tokens
+ship in `styles.css` scoped under `.mcpjam-chat-ui`. New subpath only; existing
+exports are unchanged.

--- a/chat-ui/package.json
+++ b/chat-ui/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/trace.js",
       "default": "./dist/trace.js"
     },
+    "./trace-timeline": {
+      "types": "./dist/trace-timeline.d.ts",
+      "import": "./dist/trace-timeline.js",
+      "default": "./dist/trace-timeline.js"
+    },
     "./styles.css": "./dist/styles.css"
   },
   "sideEffects": [

--- a/chat-ui/src/__tests__/trace-timeline.test.tsx
+++ b/chat-ui/src/__tests__/trace-timeline.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+
+import { TraceTimeline } from "../internal/trace-timeline/trace-timeline";
+import type { TraceSpan } from "../internal/trace-timeline/eval-trace";
+
+const spans: TraceSpan[] = [
+  {
+    id: "p0-llm",
+    name: "Agent",
+    category: "llm",
+    startMs: 0,
+    endMs: 2420,
+    promptIndex: 0,
+    stepIndex: 0,
+    inputTokens: 100,
+    outputTokens: 50,
+    totalTokens: 150,
+  },
+  {
+    id: "p0-tool",
+    name: "read_me",
+    category: "tool",
+    startMs: 2420,
+    endMs: 2516,
+    promptIndex: 0,
+    toolCallId: "tc1",
+    toolName: "read_me",
+  },
+];
+
+describe("TraceTimeline (recorded waterfall)", () => {
+  it("renders waterfall rows with per-span latency for recorded spans", () => {
+    const { getAllByTestId, getByText, container } = render(
+      <TraceTimeline recordedSpans={spans} />,
+    );
+
+    // Self-applies the `.mcpjam-chat-ui` scope root (tokens + waterfall classes
+    // live under it), so the timeline styles without a consumer wrapper.
+    expect(container.querySelector(".mcpjam-chat-ui")).not.toBeNull();
+
+    // A prompt group row + the two span rows should all render.
+    expect(getAllByTestId("trace-row").length).toBeGreaterThanOrEqual(2);
+
+    // Tool span surfaces its name and its 96ms latency.
+    getByText("Tool · read_me");
+    getByText("96ms");
+    // LLM span latency (2420ms -> "2.42s").
+    getByText("2.42s");
+  });
+
+  it("renders the empty state when there are no recorded spans", () => {
+    const { getByText } = render(<TraceTimeline recordedSpans={[]} />);
+    getByText(/No timing data recorded/i);
+  });
+});

--- a/chat-ui/src/internal/trace-timeline/eval-trace.ts
+++ b/chat-ui/src/internal/trace-timeline/eval-trace.ts
@@ -1,0 +1,45 @@
+// Rendering-only trace span types for the Tier-A trace timeline.
+//
+// This is a structural SUBSET of the inspector's `shared/eval-trace.ts`
+// `EvalTraceSpan` (which the inspector server + persistence layer own and which
+// must NOT move into a UI package). TypeScript is structural, so the inspector's
+// richer `EvalTraceSpan[]` assigns directly to `TraceSpan[]` when it consumes
+// `<TraceTimeline recordedSpans={...} />` from this package.
+//
+// Keep these field names in lockstep with the inspector type; a drift here only
+// affects what the timeline can read, never what is persisted.
+
+export type TraceSpanCategory = "step" | "llm" | "tool" | "error";
+export type TraceSpanStatus = "ok" | "error";
+
+export type TraceSpan = {
+  id: string;
+  parentId?: string;
+  name: string;
+  category: TraceSpanCategory;
+  /** Milliseconds relative to the trace (or prompt-group) start. */
+  startMs: number;
+  /** Milliseconds relative to the trace (or prompt-group) start. */
+  endMs: number;
+  promptIndex?: number;
+  stepIndex?: number;
+  status?: TraceSpanStatus;
+  toolCallId?: string;
+  toolName?: string;
+  serverId?: string;
+  modelId?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  /** Inclusive index of the first related transcript message. */
+  messageStartIndex?: number;
+  /** Inclusive index of the last related transcript message. */
+  messageEndIndex?: number;
+};
+
+// Internal aliases so the ported timeline keeps its original identifiers
+// (`EvalTraceSpan`, `EvalTraceSpanCategory`) without churn. The public export
+// name is `TraceSpan` (see src/trace-timeline.ts).
+export type EvalTraceSpan = TraceSpan;
+export type EvalTraceSpanCategory = TraceSpanCategory;
+export type EvalTraceSpanStatus = TraceSpanStatus;

--- a/chat-ui/src/internal/trace-timeline/recorded-trace-toolbar.tsx
+++ b/chat-ui/src/internal/trace-timeline/recorded-trace-toolbar.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from "react";
+import { Expand, Shrink } from "lucide-react";
+import { Button } from "./ui";
+import { cn } from "../cn";
+
+export const TRACE_TIMELINE_FILTERS = ["all", "llm", "tool", "error"] as const;
+export type TimelineFilter = (typeof TRACE_TIMELINE_FILTERS)[number];
+
+export function timelineFilterLabel(entry: TimelineFilter): string {
+  switch (entry) {
+    case "all":
+      return "All";
+    case "llm":
+      return "LLM";
+    case "tool":
+      return "Tool";
+    case "error":
+      return "Error";
+    default:
+      return entry;
+  }
+}
+
+/**
+ * Tier-A toolbar for the recorded trace timeline. The inspector original used a
+ * `@mcpjam/design-system` DropdownMenu for the category filter; this package
+ * keeps it dependency-free as an inline segmented row of buttons.
+ */
+export function RecordedTraceToolbar({
+  filter,
+  onFilterChange,
+  isFullyExpanded,
+  expandDisabled,
+  onToggleExpandAll,
+  zoomControls,
+  showBottomBorder = true,
+}: {
+  filter: TimelineFilter;
+  onFilterChange: (next: TimelineFilter) => void;
+  isFullyExpanded: boolean;
+  expandDisabled: boolean;
+  onToggleExpandAll: () => void;
+  /** Optional zoom cluster (+ / −) rendered after the expand control. */
+  zoomControls?: ReactNode;
+  /** Timeline embed hides this; an outer row can supply the divider instead. */
+  showBottomBorder?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-7 min-w-0 flex-1 flex-row flex-nowrap items-center gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        showBottomBorder && "border-b border-border/30 pb-2",
+      )}
+    >
+      <div
+        role="group"
+        aria-label="Filter timeline rows"
+        className="flex shrink-0 items-center gap-0.5 rounded-md border border-border/50 p-0.5"
+      >
+        {TRACE_TIMELINE_FILTERS.map((entry) => (
+          <Button
+            key={entry}
+            type="button"
+            variant={filter === entry ? "secondary" : "outline"}
+            size="sm"
+            aria-pressed={filter === entry}
+            className={cn(
+              "h-6 border-transparent px-2 text-[10px] font-medium",
+              filter === entry
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            onClick={() => onFilterChange(entry)}
+          >
+            {timelineFilterLabel(entry)}
+          </Button>
+        ))}
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        disabled={expandDisabled}
+        className="h-7 w-7 shrink-0 border-border/50 text-muted-foreground hover:text-foreground disabled:opacity-40"
+        title={isFullyExpanded ? "Collapse all" : "Expand all"}
+        aria-label={isFullyExpanded ? "Collapse all" : "Expand all"}
+        aria-pressed={isFullyExpanded}
+        onClick={onToggleExpandAll}
+      >
+        {isFullyExpanded ? (
+          <Shrink className="size-3.5" strokeWidth={2} aria-hidden />
+        ) : (
+          <Expand className="size-3.5" strokeWidth={2} aria-hidden />
+        )}
+      </Button>
+      {zoomControls ? (
+        <>
+          <span
+            className="hidden h-3 w-px shrink-0 bg-border md:block"
+            aria-hidden
+          />
+          <div className="flex shrink-0 items-center gap-0.5">
+            {zoomControls}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
+++ b/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
@@ -1,0 +1,2755 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+  AlertCircle,
+  Bot,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Layers,
+  ListTree,
+  MessageSquareQuote,
+  Minus,
+  Plus,
+  User,
+  Wrench,
+} from "lucide-react";
+import type { EvalTraceSpan, EvalTraceSpanCategory } from "./eval-trace";
+import { Markdown } from "../markdown";
+import { JsonView } from "../../parts/json-view";
+import { extractTextFromToolResult } from "../tool-result-text";
+import { cn } from "../cn";
+import type { ThemeMode } from "../../types";
+import {
+  Badge,
+  Button,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  ScrollArea,
+} from "./ui";
+import {
+  RecordedTraceToolbar,
+  type TimelineFilter,
+} from "./recorded-trace-toolbar";
+
+/**
+ * Same scope contract as `ReadOnlyTranscript`: the package's tokens, waterfall
+ * classes, and glyph rules live under `.mcpjam-chat-ui` in styles.css, so the
+ * component must apply that class to its own root (and to anything it portals
+ * out of the tree) rather than relying on the consumer to wrap it.
+ */
+function themeClass(themeMode: ThemeMode): string | undefined {
+  if (themeMode === "dark") return "dark";
+  if (themeMode === "light") return "light";
+  return undefined;
+}
+
+const ALL_AXIS_TICK_PERCENTS = [0, 25, 50, 75, 100] as const;
+
+/**
+ * Approximate horizontal space needed per tick (10px tabular nums; labels like "9.99s" are wide).
+ */
+const AXIS_TICK_MIN_GAP_PX = 54;
+
+/** When only [0,100] ticks fit but the track is narrower than this, draw one range label (endpoints collide). */
+const AXIS_SINGLE_RANGE_LABEL_BELOW_PX = 120;
+
+/**
+ * Chooses tick positions for the time axis based on measured column width.
+ * Exported for unit tests.
+ */
+export function selectAxisTickPercents(widthPx: number): number[] {
+  if (!Number.isFinite(widthPx)) {
+    return [0, 100];
+  }
+  // Unmeasured (initial render) or zero-sized: avoid stacking many labels in one column.
+  if (widthPx <= 0) {
+    return [0, 100];
+  }
+  const maxTicks = Math.max(2, Math.floor(widthPx / AXIS_TICK_MIN_GAP_PX));
+  if (maxTicks >= ALL_AXIS_TICK_PERCENTS.length) {
+    return [...ALL_AXIS_TICK_PERCENTS];
+  }
+  if (maxTicks <= 2) {
+    return [0, 100];
+  }
+  if (maxTicks === 3) {
+    return [0, 50, 100];
+  }
+  return [0, 25, 75, 100];
+}
+
+function axisTickLabelAlignClass(tick: number): string {
+  if (tick <= 0) {
+    return "left-0 top-1/2 -translate-x-0 -translate-y-1/2 text-left";
+  }
+  if (tick >= 100) {
+    return "left-0 top-1/2 -translate-x-full -translate-y-1/2 text-right";
+  }
+  return "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center";
+}
+
+function formatAxisRangeLabel(axisMaxMs: number): string {
+  if (axisMaxMs <= 0) {
+    return formatAxisLabel(0);
+  }
+  return `${formatAxisLabel(0)}–${formatAxisLabel(axisMaxMs)}`;
+}
+
+export type { TimelineFilter };
+
+type TranscriptMessage = {
+  role: string;
+  content?: unknown;
+};
+
+type TraceNode = {
+  span: EvalTraceSpan;
+  children: TraceNode[];
+};
+
+type PromptGroup = {
+  key: string;
+  promptIndex: number;
+  label: string;
+  spans: EvalTraceSpan[];
+  roots: TraceNode[];
+  startMs: number;
+  endMs: number;
+  messageStartIndex?: number;
+  messageEndIndex?: number;
+  counts: Record<EvalTraceSpanCategory, number>;
+};
+
+type PromptRow = {
+  kind: "prompt";
+  key: string;
+  promptIndex: number;
+  label: string;
+  /** User message preview when available, e.g. `User: "Draw me a flowchart..."` */
+  conversationLabel?: string;
+  startMs: number;
+  endMs: number;
+  messageStartIndex?: number;
+  messageEndIndex?: number;
+  counts: Record<EvalTraceSpanCategory, number>;
+  /** Includes transcript-derived tool failures, not only category:error spans. */
+  hasAnyFailure: boolean;
+  isExpanded: boolean;
+  /** Sum of token fields across `category === "llm"` spans in this group, when recorded. */
+  aggregatedInputTokens?: number;
+  aggregatedOutputTokens?: number;
+  aggregatedTotalTokens?: number;
+};
+
+type SpanRow = {
+  kind: "span";
+  key: string;
+  promptIndex: number;
+  depth: number;
+  span: EvalTraceSpan;
+  hasChildren: boolean;
+  isExpanded: boolean;
+};
+
+type TimelineRow = PromptRow | SpanRow;
+
+function aggregateLlmTokenTotals(spans: EvalTraceSpan[]): {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+} {
+  const llm = spans.filter((s) => s.category === "llm");
+  let inputSum = 0;
+  let inputN = 0;
+  let outputSum = 0;
+  let outputN = 0;
+  let totalSum = 0;
+  let totalN = 0;
+  for (const s of llm) {
+    if (typeof s.inputTokens === "number") {
+      inputSum += s.inputTokens;
+      inputN++;
+    }
+    if (typeof s.outputTokens === "number") {
+      outputSum += s.outputTokens;
+      outputN++;
+    }
+    if (typeof s.totalTokens === "number") {
+      totalSum += s.totalTokens;
+      totalN++;
+    }
+  }
+  return {
+    ...(inputN ? { inputTokens: inputSum } : {}),
+    ...(outputN ? { outputTokens: outputSum } : {}),
+    ...(totalN ? { totalTokens: totalSum } : {}),
+  };
+}
+
+type TranscriptRange = {
+  startIndex: number;
+  endIndex: number;
+};
+
+export type TraceRevealSelection = {
+  focusSourceIndex: number;
+  highlightSourceIndices: number[];
+};
+
+function categoryRank(category: EvalTraceSpanCategory): number {
+  switch (category) {
+    case "step":
+      return 0;
+    case "llm":
+      return 1;
+    case "tool":
+      return 2;
+    case "error":
+      return 3;
+    default:
+      return 9;
+  }
+}
+
+function compareSpans(a: EvalTraceSpan, b: EvalTraceSpan): number {
+  if (a.startMs !== b.startMs) return a.startMs - b.startMs;
+  const categoryDiff = categoryRank(a.category) - categoryRank(b.category);
+  if (categoryDiff !== 0) return categoryDiff;
+  if (a.endMs !== b.endMs) return a.endMs - b.endMs;
+  return a.name.localeCompare(b.name);
+}
+
+function formatDuration(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(ms >= 10_000 ? 1 : 2)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function formatAxisLabel(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function partToolName(part: Record<string, unknown>): string | undefined {
+  const toolName = part.toolName ?? part.name;
+  return typeof toolName === "string" && toolName.trim() ? toolName : undefined;
+}
+
+function getMessageParts(
+  message: TranscriptMessage,
+): Record<string, unknown>[] {
+  if (!Array.isArray(message.content)) {
+    return typeof message.content === "string"
+      ? [{ type: "text", text: message.content }]
+      : [];
+  }
+
+  return message.content.filter(
+    (part): part is Record<string, unknown> =>
+      isRecord(part) && typeof part.type === "string",
+  );
+}
+
+function summarizeValue(value: unknown): string {
+  if (value == null) return "None";
+  if (typeof value === "string") {
+    return value.length > 180 ? `${value.slice(0, 177)}...` : value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `${value.length} item${value.length === 1 ? "" : "s"}`;
+  }
+  if (isRecord(value)) {
+    const keys = Object.keys(value);
+    return keys.length > 0
+      ? `{ ${keys.slice(0, 4).join(", ")}${keys.length > 4 ? ", ..." : ""} }`
+      : "{}";
+  }
+
+  return String(value);
+}
+
+function formatMessageSummary(message: TranscriptMessage): string {
+  const parts = getMessageParts(message);
+  if (parts.length === 0) {
+    return typeof message.content === "string" ? message.content : "No content";
+  }
+
+  const summary = parts
+    .slice(0, 3)
+    .map((part) => {
+      if (part.type === "text" && typeof part.text === "string") {
+        return part.text;
+      }
+      if (part.type === "tool-call") {
+        return `Tool call: ${partToolName(part) ?? "Tool"}`;
+      }
+      if (part.type === "tool-result") {
+        return `Tool result: ${partToolName(part) ?? "Tool"}`;
+      }
+      if (typeof part.type === "string") {
+        return part.type;
+      }
+      return "content";
+    })
+    .join(" | ");
+
+  return summary.length > 220 ? `${summary.slice(0, 217)}...` : summary;
+}
+
+/** Match AI SDK / trace envelope tool output wrapper `{ type, value }`. */
+function unwrapTraceToolOutput(output: unknown): unknown {
+  if (!isRecord(output)) return output;
+  if (!("type" in output) || !("value" in output)) return output;
+  return output.value;
+}
+
+function toolResultDisplayValue(part: Record<string, unknown>): unknown {
+  if (part.result !== undefined) return part.result;
+  return unwrapTraceToolOutput(part.output);
+}
+
+/** Mirrors trace-viewer-adapter `getToolErrorText` for raw transcript parts. */
+function toolResultPartErrorText(
+  part: Record<string, unknown>,
+): string | undefined {
+  const displayValue = toolResultDisplayValue(part);
+
+  if (typeof part.error === "string" && part.error.trim()) {
+    return part.error.trim();
+  }
+
+  if (isRecord(part.error) && typeof part.error.message === "string") {
+    return part.error.message;
+  }
+
+  if (isRecord(part.output) && part.output.type === "error-text") {
+    return typeof part.output.value === "string"
+      ? part.output.value
+      : "Tool error";
+  }
+
+  if (isRecord(part.result) && part.result.isError === true) {
+    return extractTextFromToolResult(displayValue) ?? "Tool error";
+  }
+
+  if (
+    isRecord(part.output) &&
+    isRecord(part.output.value) &&
+    part.output.value.isError === true
+  ) {
+    return extractTextFromToolResult(displayValue) ?? "Tool error";
+  }
+
+  if (part.isError === true) {
+    return extractTextFromToolResult(displayValue) ?? "Tool error";
+  }
+
+  return undefined;
+}
+
+function extractToolData(
+  messages: TranscriptMessage[],
+  toolCallId?: string,
+  toolName?: string,
+): {
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+} {
+  if (!toolCallId && !toolName) {
+    return {};
+  }
+
+  let input: unknown;
+  let output: unknown;
+  let errorText: string | undefined;
+
+  for (const message of messages) {
+    for (const part of getMessageParts(message)) {
+      const matchesToolCallId =
+        typeof toolCallId === "string" && part.toolCallId === toolCallId;
+      const matchesToolName =
+        !matchesToolCallId &&
+        typeof toolName === "string" &&
+        partToolName(part) === toolName;
+
+      if (!matchesToolCallId && !matchesToolName) {
+        continue;
+      }
+
+      if (part.type === "tool-call") {
+        input = part.input ?? part.parameters ?? part.args;
+      }
+
+      if (part.type === "tool-result") {
+        output =
+          part.result ??
+          (isRecord(part.output) && "value" in part.output
+            ? part.output.value
+            : part.output);
+        const fromPart = toolResultPartErrorText(part);
+        if (fromPart) {
+          errorText = fromPart;
+        }
+      }
+    }
+  }
+
+  return { input, output, errorText };
+}
+
+function spanIndicatesTranscriptFailure(
+  span: EvalTraceSpan,
+  messages: TranscriptMessage[],
+): boolean {
+  if (span.category === "error") return true;
+  if (span.status === "error") return true;
+  if (span.category === "tool") {
+    return Boolean(
+      extractToolData(messages, span.toolCallId, span.toolName ?? span.name)
+        .errorText,
+    );
+  }
+  return false;
+}
+
+function getTranscriptRange(
+  startIndex: number | undefined,
+  endIndex: number | undefined,
+): TranscriptRange | undefined {
+  if (typeof startIndex !== "number" && typeof endIndex !== "number") {
+    return undefined;
+  }
+
+  const start = startIndex ?? endIndex ?? 0;
+  const end = endIndex ?? startIndex ?? start;
+  return {
+    startIndex: Math.min(start, end),
+    endIndex: Math.max(start, end),
+  };
+}
+
+function getPromptRowTranscriptRange(
+  row: PromptRow,
+): TranscriptRange | undefined {
+  return getTranscriptRange(row.messageStartIndex, row.messageEndIndex);
+}
+
+function getSpanRowTranscriptRange(row: SpanRow): TranscriptRange | undefined {
+  return getTranscriptRange(
+    row.span.messageStartIndex,
+    row.span.messageEndIndex,
+  );
+}
+
+function getSourceIndicesForRange(
+  range: TranscriptRange | undefined,
+): number[] {
+  if (!range) return [];
+  const indices: number[] = [];
+  for (let index = range.startIndex; index <= range.endIndex; index += 1) {
+    indices.push(index);
+  }
+  return indices;
+}
+
+function findMessageIndexInRange(
+  messages: TranscriptMessage[],
+  range: TranscriptRange | undefined,
+  predicate: (message: TranscriptMessage) => boolean,
+): number | undefined {
+  if (!range) return undefined;
+  for (let index = range.startIndex; index <= range.endIndex; index += 1) {
+    const message = messages[index];
+    if (message && predicate(message)) {
+      return index;
+    }
+  }
+  return undefined;
+}
+
+function findUserMessageIndexForRange(
+  messages: TranscriptMessage[],
+  startIndex?: number,
+  endIndex?: number,
+): number | undefined {
+  if (!messages.length) return undefined;
+  const range = getTranscriptRange(startIndex, endIndex);
+  if (!range) {
+    const userMessageIndex = messages.findIndex(
+      (message) => message.role === "user",
+    );
+    return userMessageIndex >= 0 ? userMessageIndex : undefined;
+  }
+  const inRangeIndex = findMessageIndexInRange(
+    messages,
+    range,
+    (message) => message.role === "user",
+  );
+  if (typeof inRangeIndex === "number") {
+    return inRangeIndex;
+  }
+
+  if (range && range.startIndex > 0) {
+    for (let index = range.startIndex - 1; index >= 0; index -= 1) {
+      const message = messages[index]!;
+      if (message.role === "user") {
+        return index;
+      }
+      if (message.role === "assistant") {
+        break;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function getWaterfallBarClass(
+  row: TimelineRow,
+  spanShowsFailure: boolean,
+): string {
+  if (row.kind === "prompt") return "trace-waterfall-bar-prompt";
+  if (row.kind === "span" && spanShowsFailure) {
+    return "trace-waterfall-bar-error";
+  }
+  if (row.kind !== "span") return "trace-waterfall-bar-step";
+  switch (row.span.category) {
+    case "llm":
+      return "trace-waterfall-bar-llm";
+    case "tool":
+      return "trace-waterfall-bar-tool";
+    case "step":
+      return "trace-waterfall-bar-step";
+    case "error":
+      return "trace-waterfall-bar-error";
+    default:
+      return "trace-waterfall-bar-step";
+  }
+}
+
+function getCategoryIconClass(
+  category: EvalTraceSpanCategory | "prompt",
+): string {
+  switch (category) {
+    case "prompt":
+      return "trace-waterfall-glyph-prompt";
+    case "step":
+      return "trace-waterfall-glyph-step";
+    case "llm":
+      return "trace-waterfall-glyph-llm";
+    case "tool":
+      return "trace-waterfall-glyph-tool";
+    case "error":
+      return "trace-waterfall-glyph-error";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+function getRowBorderAccentClass(
+  row: TimelineRow,
+  spanShowsFailure: boolean,
+): string {
+  if (row.kind === "prompt") {
+    return "trace-waterfall-row-accent-prompt";
+  }
+  const cat = spanShowsFailure ? "error" : row.span.category;
+  switch (cat) {
+    case "llm":
+      return "trace-waterfall-row-accent-llm";
+    case "tool":
+      return "trace-waterfall-row-accent-tool";
+    case "error":
+      return "trace-waterfall-row-accent-error";
+    case "step":
+      return "trace-waterfall-row-accent-step";
+    default:
+      return "border-l-muted-foreground";
+  }
+}
+
+export function buildPromptGroups(spans: EvalTraceSpan[]): PromptGroup[] {
+  const spansByPrompt = new Map<number, EvalTraceSpan[]>();
+  for (const span of spans) {
+    const promptIndex =
+      typeof span.promptIndex === "number" ? span.promptIndex : 0;
+    const existing = spansByPrompt.get(promptIndex);
+    if (existing) {
+      existing.push(span);
+    } else {
+      spansByPrompt.set(promptIndex, [span]);
+    }
+  }
+
+  return [...spansByPrompt.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([promptIndex, promptSpans]) => {
+      const nodesById = new Map<string, TraceNode>();
+      promptSpans.forEach((span) => {
+        nodesById.set(span.id, {
+          span,
+          children: [],
+        });
+      });
+
+      const roots: TraceNode[] = [];
+      promptSpans.forEach((span) => {
+        const node = nodesById.get(span.id)!;
+        const parent =
+          typeof span.parentId === "string"
+            ? nodesById.get(span.parentId)
+            : undefined;
+        if (parent) {
+          parent.children.push(node);
+          return;
+        }
+        roots.push(node);
+      });
+
+      const sortNodes = (nodes: TraceNode[]) => {
+        nodes.sort((a, b) => compareSpans(a.span, b.span));
+        nodes.forEach((node) => sortNodes(node.children));
+      };
+      sortNodes(roots);
+
+      const messageIndices = promptSpans.flatMap((span) => {
+        const values: number[] = [];
+        if (typeof span.messageStartIndex === "number") {
+          values.push(span.messageStartIndex);
+        }
+        if (typeof span.messageEndIndex === "number") {
+          values.push(span.messageEndIndex);
+        }
+        return values;
+      });
+
+      const counts: Record<EvalTraceSpanCategory, number> = {
+        step: 0,
+        llm: 0,
+        tool: 0,
+        error: 0,
+      };
+      for (const span of promptSpans) {
+        if (span.category in counts) {
+          counts[span.category]++;
+        }
+      }
+
+      return {
+        key: `prompt-${promptIndex}`,
+        promptIndex,
+        label: `Prompt ${promptIndex + 1}`,
+        spans: promptSpans,
+        roots,
+        startMs: Math.min(...promptSpans.map((span) => span.startMs)),
+        endMs: Math.max(...promptSpans.map((span) => span.endMs)),
+        messageStartIndex:
+          messageIndices.length > 0 ? Math.min(...messageIndices) : undefined,
+        messageEndIndex:
+          messageIndices.length > 0 ? Math.max(...messageIndices) : undefined,
+        counts,
+      };
+    });
+}
+
+export function collectStepSpanIdsWithChildren(
+  groups: PromptGroup[],
+): Set<string> {
+  const ids = new Set<string>();
+  function walk(nodes: TraceNode[]) {
+    for (const node of nodes) {
+      if (node.span.category === "step" && node.children.length > 0) {
+        ids.add(node.span.id);
+      }
+      walk(node.children);
+    }
+  }
+  for (const group of groups) {
+    walk(group.roots);
+  }
+  return ids;
+}
+
+function toPlainTranscriptMessage(
+  message: TranscriptMessage,
+): Record<string, unknown> {
+  return {
+    role: message.role,
+    content: message.content,
+  };
+}
+
+/**
+ * Full conversation context sent to the model before the assistant reply for this span:
+ * all transcript messages from index 0 up to (but not including) the first assistant
+ * message within the span's message range. If there is no assistant in-range, returns
+ * messages through `endIndex` (inclusive).
+ */
+function getLlmInputMessages(
+  messages: TranscriptMessage[],
+  startIndex?: number,
+  endIndex?: number,
+): TranscriptMessage[] {
+  const range = getTranscriptRange(startIndex, endIndex);
+  if (!range) return [];
+  const slice = messages.slice(range.startIndex, range.endIndex + 1);
+  if (slice.length === 0) return [];
+
+  let firstAssistantInSlice = -1;
+  for (let i = 0; i < slice.length; i++) {
+    if (slice[i]!.role === "assistant") {
+      firstAssistantInSlice = i;
+      break;
+    }
+  }
+
+  if (firstAssistantInSlice < 0) {
+    return messages.slice(0, range.endIndex + 1);
+  }
+
+  const absoluteFirstAssistant = range.startIndex + firstAssistantInSlice;
+  if (absoluteFirstAssistant === 0) return [];
+  return messages.slice(0, absoluteFirstAssistant);
+}
+
+/** Split transcript slice into model input messages vs last assistant output (same range as LLM span). */
+function extractLlmTranscriptIo(
+  messages: TranscriptMessage[],
+  startIndex?: number,
+  endIndex?: number,
+): { input: unknown; output: unknown } {
+  const range = getTranscriptRange(startIndex, endIndex);
+  if (!range) {
+    return { input: null, output: null };
+  }
+  const slice = messages.slice(range.startIndex, range.endIndex + 1);
+  if (slice.length === 0) {
+    return { input: [], output: null };
+  }
+
+  let lastAssistant = -1;
+  for (let i = slice.length - 1; i >= 0; i -= 1) {
+    if (slice[i]!.role === "assistant") {
+      lastAssistant = i;
+      break;
+    }
+  }
+
+  if (lastAssistant < 0) {
+    return {
+      input: slice.map(toPlainTranscriptMessage),
+      output: null,
+    };
+  }
+
+  const inputSlice = getLlmInputMessages(messages, startIndex, endIndex);
+  const outMsg = slice[lastAssistant]!;
+  return {
+    input:
+      inputSlice.length > 0 ? inputSlice.map(toPlainTranscriptMessage) : null,
+    output: toPlainTranscriptMessage(outMsg),
+  };
+}
+
+const ROW_SUBTITLE_MAX = 96;
+
+function truncateRowSubtitle(text: string, max = ROW_SUBTITLE_MAX): string {
+  const t = text.replace(/\s+/g, " ").trim();
+  if (t.length <= max) return t;
+  return `${t.slice(0, max - 1)}…`;
+}
+
+function flattenTextFromMessage(message: TranscriptMessage): string {
+  if (typeof message.content === "string") {
+    return message.content.trim();
+  }
+  const parts = getMessageParts(message);
+  return parts
+    .map((p) => {
+      if (p.type === "text" && typeof p.text === "string") {
+        return (p.text as string).trim();
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join(" ");
+}
+
+function toolCallNamesFromAssistantMessage(
+  message: TranscriptMessage,
+): string[] {
+  const parts = getMessageParts(message);
+  const names: string[] = [];
+  for (const part of parts) {
+    if (part.type === "tool-call") {
+      names.push(partToolName(part) ?? "tool");
+    }
+  }
+  return names;
+}
+
+/** Best-effort one-line preview of the prompt / context for an LLM or step span. */
+function promptPreviewForLlmSpan(
+  messages: TranscriptMessage[],
+  span: EvalTraceSpan,
+): string | undefined {
+  if (!messages.length) return undefined;
+  const inputMsgs = getLlmInputMessages(
+    messages,
+    span.messageStartIndex,
+    span.messageEndIndex,
+  );
+  if (inputMsgs.length === 0) return undefined;
+
+  for (let i = inputMsgs.length - 1; i >= 0; i--) {
+    const m = inputMsgs[i]!;
+    if (m.role === "user") {
+      const t = flattenTextFromMessage(m);
+      if (t) return truncateRowSubtitle(t);
+    }
+  }
+  for (const m of inputMsgs) {
+    if (m.role === "system") {
+      const t = flattenTextFromMessage(m);
+      if (t) return truncateRowSubtitle(t);
+    }
+  }
+  for (let i = inputMsgs.length - 1; i >= 0; i--) {
+    const m = inputMsgs[i]!;
+    if (m.role === "tool") {
+      const s = formatMessageSummary(m);
+      if (s && s !== "No content") return truncateRowSubtitle(s);
+    }
+  }
+  return undefined;
+}
+
+type LlmAssistantRowPreview =
+  | { kind: "text"; preview: string }
+  | { kind: "tools"; preview: string };
+
+/** Preview from the last assistant message(s) in-range: user-visible text, else tool-call names. */
+function assistantPreviewForLlmSpan(
+  messages: TranscriptMessage[],
+  span: EvalTraceSpan,
+): LlmAssistantRowPreview | undefined {
+  if (!messages.length) return undefined;
+  const range = getTranscriptRange(
+    span.messageStartIndex,
+    span.messageEndIndex,
+  );
+  if (!range) return undefined;
+  const slice = messages.slice(range.startIndex, range.endIndex + 1);
+  for (let i = slice.length - 1; i >= 0; i--) {
+    const m = slice[i]!;
+    if (m.role !== "assistant") continue;
+    const t = flattenTextFromMessage(m);
+    if (t) {
+      return { kind: "text", preview: truncateRowSubtitle(t) };
+    }
+    const toolNames = toolCallNamesFromAssistantMessage(m);
+    if (toolNames.length > 0) {
+      return {
+        kind: "tools",
+        preview: truncateRowSubtitle(`Calling ${toolNames.join(", ")}`),
+      };
+    }
+  }
+  return undefined;
+}
+
+/** Best-effort one-line preview of the user prompt for a prompt group's message range. */
+function promptPreviewForRange(
+  messages: TranscriptMessage[],
+  startIndex?: number,
+  endIndex?: number,
+): string | undefined {
+  const userMessageIndex = findUserMessageIndexForRange(
+    messages,
+    startIndex,
+    endIndex,
+  );
+  if (typeof userMessageIndex !== "number") return undefined;
+  const text = flattenTextFromMessage(messages[userMessageIndex]!);
+  return text ? truncateRowSubtitle(text) : undefined;
+}
+
+/** Full (non-truncated) user prompt text for the detail pane. */
+function fullUserPromptForRange(
+  messages: TranscriptMessage[],
+  startIndex?: number,
+  endIndex?: number,
+): string | undefined {
+  const userMessageIndex = findUserMessageIndexForRange(
+    messages,
+    startIndex,
+    endIndex,
+  );
+  if (typeof userMessageIndex !== "number") return undefined;
+  const text = flattenTextFromMessage(messages[userMessageIndex]!);
+  return text || undefined;
+}
+
+function partMatchesToolSpan(
+  part: Record<string, unknown>,
+  span: EvalTraceSpan,
+): boolean {
+  if (
+    typeof span.toolCallId === "string" &&
+    part.toolCallId === span.toolCallId
+  ) {
+    return true;
+  }
+  const spanToolName = span.toolName?.trim() || span.name?.trim();
+  return Boolean(spanToolName && partToolName(part) === spanToolName);
+}
+
+function findToolFocusSourceIndex(
+  messages: TranscriptMessage[],
+  span: EvalTraceSpan,
+  range: TranscriptRange | undefined,
+): number | undefined {
+  if (!range) return undefined;
+
+  for (let index = range.startIndex; index <= range.endIndex; index += 1) {
+    const message = messages[index];
+    if (!message) continue;
+
+    const parts = getMessageParts(message);
+    const hasToolCall = parts.some(
+      (part) => part.type === "tool-call" && partMatchesToolSpan(part, span),
+    );
+    if (hasToolCall) {
+      return index;
+    }
+
+    const hasToolResult = parts.some(
+      (part) => part.type === "tool-result" && partMatchesToolSpan(part, span),
+    );
+    if (hasToolResult) {
+      return index;
+    }
+  }
+
+  return undefined;
+}
+
+function getPromptRevealSelection(
+  row: PromptRow,
+  transcriptMessages: TranscriptMessage[],
+): TraceRevealSelection | undefined {
+  const userMessageIndex = findUserMessageIndexForRange(
+    transcriptMessages,
+    row.messageStartIndex,
+    row.messageEndIndex,
+  );
+  if (typeof userMessageIndex === "number") {
+    return {
+      focusSourceIndex: userMessageIndex,
+      highlightSourceIndices: [userMessageIndex],
+    };
+  }
+
+  const transcriptRange = getPromptRowTranscriptRange(row);
+  const highlightSourceIndices = getSourceIndicesForRange(transcriptRange);
+  if (highlightSourceIndices.length === 0) {
+    return undefined;
+  }
+
+  return {
+    focusSourceIndex: highlightSourceIndices[0]!,
+    highlightSourceIndices,
+  };
+}
+
+function getSpanRevealSelection(
+  row: SpanRow,
+  transcriptMessages: TranscriptMessage[],
+): TraceRevealSelection | undefined {
+  const transcriptRange = getSpanRowTranscriptRange(row);
+  const highlightSourceIndices = getSourceIndicesForRange(transcriptRange);
+  if (highlightSourceIndices.length === 0) {
+    return undefined;
+  }
+
+  const assistantMessageIndex = findMessageIndexInRange(
+    transcriptMessages,
+    transcriptRange,
+    (message) => message.role === "assistant",
+  );
+  const toolFocusSourceIndex =
+    row.span.category === "tool"
+      ? findToolFocusSourceIndex(transcriptMessages, row.span, transcriptRange)
+      : undefined;
+  const focusSourceIndex =
+    toolFocusSourceIndex ?? assistantMessageIndex ?? highlightSourceIndices[0]!;
+
+  return {
+    focusSourceIndex,
+    highlightSourceIndices,
+  };
+}
+
+function toolSubtitleFromTranscript(
+  messages: TranscriptMessage[],
+  span: EvalTraceSpan,
+): string | undefined {
+  const data = extractToolData(
+    messages,
+    span.toolCallId,
+    span.toolName ?? span.name,
+  );
+  if (data.input == null) return undefined;
+  const s = summarizeValue(data.input);
+  if (!s || s === "None") return undefined;
+  return truncateRowSubtitle(s);
+}
+
+function CategoryGlyph({
+  category,
+  size = "sm",
+}: {
+  category: EvalTraceSpanCategory | "prompt";
+  size?: "sm" | "lg";
+}) {
+  const iconClass = cn(
+    size === "lg" ? "h-5 w-5 shrink-0" : "h-3.5 w-3.5 shrink-0",
+    getCategoryIconClass(category),
+  );
+  switch (category) {
+    case "prompt":
+      return <User className={iconClass} aria-hidden />;
+    case "llm":
+      return <Bot className={iconClass} aria-hidden />;
+    case "tool":
+      return <Wrench className={iconClass} aria-hidden />;
+    case "error":
+      return <AlertCircle className={iconClass} aria-hidden />;
+    case "step":
+    default:
+      return <ListTree className={iconClass} aria-hidden />;
+  }
+}
+
+function findStepLlmTokenStats(
+  recordedSpans: EvalTraceSpan[],
+  span: EvalTraceSpan,
+): {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+} {
+  const p = span.promptIndex;
+  const s = span.stepIndex;
+  if (typeof p !== "number" || typeof s !== "number") {
+    return {};
+  }
+  const llm = recordedSpans.find(
+    (sp) => sp.category === "llm" && sp.promptIndex === p && sp.stepIndex === s,
+  );
+  if (!llm) {
+    return {};
+  }
+  return {
+    ...(typeof llm.inputTokens === "number"
+      ? { inputTokens: llm.inputTokens }
+      : {}),
+    ...(typeof llm.outputTokens === "number"
+      ? { outputTokens: llm.outputTokens }
+      : {}),
+    ...(typeof llm.totalTokens === "number"
+      ? { totalTokens: llm.totalTokens }
+      : {}),
+  };
+}
+
+function getRowTokenStats(
+  row: TimelineRow,
+  recordedSpans?: EvalTraceSpan[] | null,
+): {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+} {
+  if (row.kind === "prompt") {
+    return {
+      inputTokens: row.aggregatedInputTokens,
+      outputTokens: row.aggregatedOutputTokens,
+      totalTokens: row.aggregatedTotalTokens,
+    };
+  }
+  const base = {
+    inputTokens: row.span.inputTokens,
+    outputTokens: row.span.outputTokens,
+    totalTokens: row.span.totalTokens,
+  };
+  const hasAny =
+    typeof base.inputTokens === "number" ||
+    typeof base.outputTokens === "number" ||
+    typeof base.totalTokens === "number";
+  if (
+    hasAny ||
+    !recordedSpans?.length ||
+    (row.span.category !== "llm" && row.span.category !== "step")
+  ) {
+    return base;
+  }
+  const inherited = findStepLlmTokenStats(recordedSpans, row.span);
+  if (
+    typeof inherited.inputTokens === "number" ||
+    typeof inherited.outputTokens === "number" ||
+    typeof inherited.totalTokens === "number"
+  ) {
+    return inherited;
+  }
+  return base;
+}
+
+function formatTokenCount(value?: number): string {
+  return typeof value === "number" ? value.toLocaleString() : "—";
+}
+
+function formatWallClockTimestamp(timestampMs?: number | null): string {
+  return typeof timestampMs === "number" && Number.isFinite(timestampMs)
+    ? new Date(timestampMs).toLocaleString()
+    : "—";
+}
+
+function getTraceStartAnchorMs({
+  traceStartedAtMs,
+  traceEndedAtMs,
+  traceDurationMs,
+}: {
+  traceStartedAtMs?: number | null;
+  traceEndedAtMs?: number | null;
+  traceDurationMs: number;
+}): number | null {
+  if (
+    typeof traceStartedAtMs === "number" &&
+    Number.isFinite(traceStartedAtMs)
+  ) {
+    return traceStartedAtMs;
+  }
+  if (typeof traceEndedAtMs === "number" && Number.isFinite(traceEndedAtMs)) {
+    return traceEndedAtMs - traceDurationMs;
+  }
+  return null;
+}
+
+function deriveSpanLabel(
+  row: SpanRow,
+  transcriptMessages: TranscriptMessage[],
+): {
+  title: string;
+  subtitle?: string;
+} {
+  const { span, promptIndex } = row;
+  const modelHint = span.modelId?.trim()
+    ? truncateRowSubtitle(span.modelId.trim(), 56)
+    : undefined;
+  const rawName = span.name?.trim() ?? "";
+
+  if (span.category === "step") {
+    const stepNumber =
+      typeof span.stepIndex === "number" ? span.stepIndex + 1 : undefined;
+    const defaultTitle =
+      typeof stepNumber === "number" ? `Step ${stepNumber}` : rawName || "Step";
+    const genericName =
+      typeof stepNumber === "number" &&
+      (rawName === `Step ${stepNumber}` ||
+        rawName.toLowerCase() === `step ${stepNumber}`);
+    const title =
+      rawName && !genericName ? truncateRowSubtitle(rawName, 64) : defaultTitle;
+    const preview = promptPreviewForLlmSpan(transcriptMessages, span);
+    if (preview) {
+      return { title, subtitle: preview };
+    }
+    if (modelHint) {
+      return { title, subtitle: modelHint };
+    }
+    return { title, subtitle: `Prompt ${promptIndex + 1}` };
+  }
+
+  if (span.category === "llm") {
+    const assistantPreview = assistantPreviewForLlmSpan(
+      transcriptMessages,
+      span,
+    );
+    const genericLlmName =
+      !rawName ||
+      /^assistant$/i.test(rawName) ||
+      /^llm$/i.test(rawName) ||
+      /^model$/i.test(rawName) ||
+      rawName === "Model response" ||
+      /·\s*response$/i.test(rawName);
+    const baseName = genericLlmName
+      ? "Agent"
+      : truncateRowSubtitle(rawName, 64);
+    if (assistantPreview?.kind === "text") {
+      return {
+        title: `${baseName}: "${assistantPreview.preview}"`,
+        subtitle: modelHint,
+      };
+    }
+    if (assistantPreview?.kind === "tools") {
+      return {
+        title: `${baseName} · ${assistantPreview.preview}`,
+        subtitle: modelHint,
+      };
+    }
+    return { title: baseName, subtitle: modelHint };
+  }
+
+  if (span.category === "tool") {
+    const name = (span.toolName ?? span.name).trim() || "tool";
+    const title = `Tool · ${name}`;
+    const toolSub = toolSubtitleFromTranscript(transcriptMessages, span);
+    // Skip trivial subtitles like "{}" for empty tool inputs
+    const isTrivialSub = !toolSub || toolSub === "{}" || toolSub === "None";
+    if (toolSub && !isTrivialSub) {
+      return { title, subtitle: toolSub };
+    }
+    // When input is empty/trivial, try to show output summary instead
+    if (isTrivialSub) {
+      const data = extractToolData(
+        transcriptMessages,
+        span.toolCallId,
+        span.toolName ?? span.name,
+      );
+      if (data.output != null) {
+        const outputPreview = summarizeValue(data.output);
+        if (
+          outputPreview &&
+          outputPreview !== "None" &&
+          outputPreview !== "{}"
+        ) {
+          return { title, subtitle: truncateRowSubtitle(outputPreview) };
+        }
+      }
+    }
+    if (typeof span.stepIndex === "number") {
+      return {
+        title,
+        subtitle: modelHint
+          ? `${modelHint} · step ${span.stepIndex + 1}`
+          : `step ${span.stepIndex + 1}`,
+      };
+    }
+    return {
+      title,
+      subtitle: modelHint,
+    };
+  }
+
+  return {
+    title: span.name,
+    subtitle:
+      typeof span.stepIndex === "number"
+        ? modelHint
+          ? `${modelHint} · step ${span.stepIndex + 1}`
+          : `step ${span.stepIndex + 1}`
+        : modelHint,
+  };
+}
+
+function getRowTiming(row: TimelineRow): {
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+} {
+  const startMs = row.kind === "prompt" ? row.startMs : row.span.startMs;
+  const endMs = row.kind === "prompt" ? row.endMs : row.span.endMs;
+  return {
+    startMs,
+    endMs,
+    durationMs: endMs - startMs,
+  };
+}
+
+type PayloadVisualFormat = "plain" | "markdown";
+
+function StringPayloadFormatToggles({
+  format,
+  onFormatChange,
+}: {
+  format: PayloadVisualFormat;
+  onFormatChange: (next: PayloadVisualFormat) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {(["plain", "markdown"] as const).map((key) => (
+        <Button
+          key={key}
+          type="button"
+          size="sm"
+          variant={format === key ? "secondary" : "outline"}
+          className="h-7 text-[10px] capitalize"
+          onClick={() => onFormatChange(key)}
+        >
+          {key === "plain" ? "Plain" : "Markdown"}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+function PayloadPreview({
+  value,
+}: {
+  value: unknown;
+}) {
+  const [format, setFormat] = useState<PayloadVisualFormat>("plain");
+
+  useEffect(() => {
+    if (typeof value === "string") {
+      setFormat("plain");
+    }
+  }, [value]);
+
+  if (value == null) {
+    return (
+      <div className="rounded-md border border-dashed border-border/60 px-3 py-2 text-xs text-muted-foreground">
+        None
+      </div>
+    );
+  }
+
+  if (typeof value === "string") {
+    const body =
+      format === "markdown" ? (
+        <div className="max-h-44 overflow-auto rounded-md border border-border/60 bg-muted/10 p-3 text-xs leading-relaxed text-foreground">
+          <Markdown content={value} />
+        </div>
+      ) : (
+        <pre className="max-h-44 overflow-auto rounded-md border border-border/60 bg-muted/20 p-3 text-xs whitespace-pre-wrap break-words">
+          {value}
+        </pre>
+      );
+
+    return (
+      <div className="space-y-2">
+        <StringPayloadFormatToggles
+          format={format}
+          onFormatChange={setFormat}
+        />
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <JsonView
+      value={value}
+      className="max-h-56 rounded-md border border-border/60"
+    />
+  );
+}
+
+function TimelineDetailPane({
+  row,
+  transcriptMessages,
+  onRevealInTranscript,
+}: {
+  row: TimelineRow | undefined;
+  transcriptMessages: TranscriptMessage[];
+  onRevealInTranscript?: (selection: TraceRevealSelection) => void;
+}) {
+  if (!row) {
+    return (
+      <div
+        data-testid="trace-detail-pane"
+        className="flex min-h-[280px] flex-col items-center justify-center gap-3 rounded-lg bg-muted/5 px-6 py-12 text-center"
+      >
+        <div className="flex h-14 w-14 items-center justify-center rounded-full border border-border/50 bg-background shadow-sm">
+          <Layers className="h-7 w-7 text-muted-foreground" aria-hidden />
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">
+            No span selected
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Click a row or use arrow keys
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const revealSelection =
+    row.kind === "prompt"
+      ? getPromptRevealSelection(row, transcriptMessages)
+      : getSpanRevealSelection(row, transcriptMessages);
+  const toolData =
+    row.kind === "span"
+      ? extractToolData(
+          transcriptMessages,
+          row.span.toolCallId,
+          row.span.toolName ?? row.span.name,
+        )
+      : {};
+  const { durationMs } = getRowTiming(row);
+  const spanLabel =
+    row.kind === "span" ? deriveSpanLabel(row, transcriptMessages) : null;
+  const title = row.kind === "prompt" ? row.label : spanLabel!.title;
+  const status =
+    row.kind === "prompt"
+      ? row.hasAnyFailure
+        ? "error"
+        : "ok"
+      : spanIndicatesTranscriptFailure(row.span, transcriptMessages)
+        ? "error"
+        : "ok";
+  const detailGlyphCategory: EvalTraceSpanCategory | "prompt" =
+    row.kind === "prompt"
+      ? "prompt"
+      : row.span.category === "tool" &&
+          spanIndicatesTranscriptFailure(row.span, transcriptMessages)
+        ? "error"
+        : row.span.category;
+
+  const llmIo =
+    row.kind === "span" &&
+    (row.span.category === "llm" || row.span.category === "step")
+      ? extractLlmTranscriptIo(
+          transcriptMessages,
+          row.span.messageStartIndex,
+          row.span.messageEndIndex,
+        )
+      : { input: null as unknown, output: null as unknown };
+
+  const isToolIoSpan =
+    row.kind === "span" &&
+    row.span.category === "tool" &&
+    (Boolean(row.span.toolCallId) ||
+      Boolean(row.span.toolName?.trim() || row.span.name?.trim()));
+
+  const tabInputValue =
+    row.kind === "prompt"
+      ? null
+      : isToolIoSpan
+        ? toolData.input
+        : row.kind === "span" &&
+            (row.span.category === "llm" || row.span.category === "step")
+          ? llmIo.input
+          : row.kind === "span" && row.span.category === "error"
+            ? null
+            : null;
+
+  const tabOutputValue =
+    row.kind === "prompt"
+      ? null
+      : isToolIoSpan
+        ? toolData.output
+        : row.kind === "span" &&
+            (row.span.category === "llm" || row.span.category === "step")
+          ? llmIo.output
+          : row.kind === "span" && row.span.category === "error"
+            ? row.span.name
+            : null;
+
+  // Extract the full user prompt text for the detail pane (not truncated)
+  const promptUserMessage =
+    row.kind === "prompt"
+      ? fullUserPromptForRange(
+          transcriptMessages,
+          row.messageStartIndex,
+          row.messageEndIndex,
+        )
+      : undefined;
+
+  const hasSpanTokenStats =
+    row.kind === "span" &&
+    (typeof row.span.inputTokens === "number" ||
+      typeof row.span.outputTokens === "number" ||
+      typeof row.span.totalTokens === "number");
+
+  const hasPromptTokenStats =
+    row.kind === "prompt" &&
+    (typeof row.aggregatedInputTokens === "number" ||
+      typeof row.aggregatedOutputTokens === "number" ||
+      typeof row.aggregatedTotalTokens === "number");
+
+  const toolErrorExcerpt =
+    row.kind === "span" && toolData.errorText ? toolData.errorText : null;
+
+  const showRevealInChat = Boolean(revealSelection && onRevealInTranscript);
+
+  return (
+    <div
+      data-testid="trace-detail-pane"
+      className="space-y-4 bg-background p-4"
+    >
+      <div
+        className={cn(
+          "border-b border-border/40 pb-3",
+          showRevealInChat
+            ? "flex flex-col gap-3 min-[400px]:flex-row min-[400px]:items-start"
+            : "",
+        )}
+      >
+        <div
+          className={cn(
+            "flex gap-3",
+            showRevealInChat ? "min-w-0 min-[400px]:flex-1" : "",
+          )}
+        >
+          <div className="shrink-0 pt-0.5">
+            {row.kind === "prompt" ? (
+              <CategoryGlyph category="prompt" size="lg" />
+            ) : (
+              <CategoryGlyph category={detailGlyphCategory} size="lg" />
+            )}
+          </div>
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <h3 className="text-sm font-bold leading-tight text-foreground">
+                {title}
+              </h3>
+              {status === "error" ? (
+                <span
+                  className="inline-block h-2 w-2 shrink-0 rounded-full bg-destructive"
+                  title="Error"
+                  aria-label="Error"
+                />
+              ) : null}
+            </div>
+
+            <div className="text-xs tabular-nums text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {formatDuration(durationMs)}
+              </span>
+              {row.kind === "prompt" && hasPromptTokenStats ? (
+                <>
+                  {typeof row.aggregatedInputTokens === "number"
+                    ? ` · ${row.aggregatedInputTokens} in`
+                    : ""}
+                  {typeof row.aggregatedOutputTokens === "number"
+                    ? ` → ${row.aggregatedOutputTokens} out`
+                    : ""}
+                  {typeof row.aggregatedTotalTokens === "number"
+                    ? ` (${row.aggregatedTotalTokens} total)`
+                    : ""}
+                </>
+              ) : row.kind === "span" && hasSpanTokenStats ? (
+                <>
+                  {typeof row.span.inputTokens === "number"
+                    ? ` · ${row.span.inputTokens} in`
+                    : ""}
+                  {typeof row.span.outputTokens === "number"
+                    ? ` → ${row.span.outputTokens} out`
+                    : ""}
+                  {typeof row.span.totalTokens === "number"
+                    ? ` (${row.span.totalTokens} total)`
+                    : ""}
+                </>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {showRevealInChat ? (
+          <div className="flex min-w-0 min-[400px]:flex-1 min-[400px]:justify-end min-[400px]:pt-0.5">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-full shrink-0 justify-center whitespace-nowrap min-[400px]:w-auto"
+              onClick={() => {
+                if (revealSelection && onRevealInTranscript) {
+                  onRevealInTranscript(revealSelection);
+                }
+              }}
+            >
+              <MessageSquareQuote className="h-3.5 w-3.5" />
+              Reveal in Chat
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      {row.kind === "prompt" && promptUserMessage ? (
+        <div className="min-h-0 max-h-[min(60vh,28rem)] flex-1 overflow-auto rounded-md border border-border/50 bg-muted/10 px-3 py-2 text-xs leading-relaxed text-foreground">
+          {promptUserMessage}
+        </div>
+      ) : null}
+
+      {row.kind === "span" ? (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              Input
+            </div>
+            <PayloadPreview value={tabInputValue ?? undefined} />
+          </div>
+          <div
+            className={cn(
+              "space-y-2",
+              row.span.category === "error" || toolErrorExcerpt
+                ? "rounded-md border border-destructive/50 bg-destructive/50 p-2"
+                : "",
+            )}
+          >
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              Output
+            </div>
+            <PayloadPreview value={tabOutputValue ?? undefined} />
+            {toolErrorExcerpt ? (
+              <pre className="max-h-40 overflow-auto rounded-md border border-destructive/50 bg-destructive/50 p-3 text-xs whitespace-pre-wrap break-words text-foreground">
+                {toolErrorExcerpt}
+              </pre>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export interface TraceTimelineProps {
+  recordedSpans?: EvalTraceSpan[] | null;
+  estimatedDurationMs?: number | null;
+  transcriptMessageCount?: number;
+  transcriptMessages?: TranscriptMessage[];
+  traceStartedAtMs?: number | null;
+  traceEndedAtMs?: number | null;
+  onRevealInTranscript?: (selection: TraceRevealSelection) => void;
+  /** When true, timeline does not render the recorded toolbar (host provides it). */
+  hideToolbar?: boolean;
+  timelineFilter?: TimelineFilter;
+  onTimelineFilterChange?: (filter: TimelineFilter) => void;
+  expandedPromptIds?: Set<string>;
+  onExpandedPromptIdsChange?: (next: Set<string>) => void;
+  expandedStepIds?: Set<string>;
+  onExpandedStepIdsChange?: (next: Set<string>) => void;
+  /** Timeline axis ends at this many ms (≥ max span end); used for zoom. */
+  viewportMaxMs?: number;
+  /** When true, timeline fills a flex parent (e.g. run detail) instead of using viewport-based max height alone. */
+  fillContent?: boolean;
+  /** Theme scope applied to the `.mcpjam-chat-ui` root, like ReadOnlyTranscript. */
+  themeMode?: ThemeMode;
+}
+
+export function TraceTimeline({
+  recordedSpans,
+  estimatedDurationMs,
+  transcriptMessageCount = 0,
+  transcriptMessages = [],
+  traceStartedAtMs = null,
+  traceEndedAtMs = null,
+  onRevealInTranscript,
+  hideToolbar = false,
+  timelineFilter: timelineFilterProp,
+  onTimelineFilterChange,
+  expandedPromptIds: expandedPromptIdsProp,
+  onExpandedPromptIdsChange,
+  expandedStepIds: expandedStepIdsProp,
+  onExpandedStepIdsChange,
+  viewportMaxMs: viewportMaxMsProp,
+  fillContent = false,
+  themeMode = "system",
+}: TraceTimelineProps) {
+  const scopeClassName = cn("mcpjam-chat-ui", themeClass(themeMode));
+  const mode =
+    recordedSpans && recordedSpans.length > 0
+      ? "recorded"
+      : (estimatedDurationMs ?? 0) > 0
+        ? "estimated"
+        : "none";
+  const groups = useMemo(
+    () => (recordedSpans?.length ? buildPromptGroups(recordedSpans) : []),
+    [recordedSpans],
+  );
+  const maxEndMs = recordedSpans?.length
+    ? recordedSpans.reduce((max, span) => Math.max(max, span.endMs), 1)
+    : Math.max(estimatedDurationMs ?? 0, 1);
+  const traceIdentity = useMemo(
+    () =>
+      recordedSpans
+        ?.map((span) => `${span.id}:${span.startMs}:${span.endMs}`)
+        .join("|") ?? mode,
+    [mode, recordedSpans],
+  );
+
+  const [internalViewportMaxMs, setInternalViewportMaxMs] = useState(1);
+  useEffect(() => {
+    if (viewportMaxMsProp === undefined) {
+      setInternalViewportMaxMs(maxEndMs);
+    }
+  }, [maxEndMs, traceIdentity, viewportMaxMsProp]);
+
+  const axisMaxMs = Math.max(
+    1,
+    viewportMaxMsProp !== undefined ? viewportMaxMsProp : internalViewportMaxMs,
+  );
+
+  const timelineZoomMinMs = Math.max(1, Math.round(maxEndMs / 50));
+  const traceStartAnchorMs = useMemo(
+    () =>
+      getTraceStartAnchorMs({
+        traceStartedAtMs,
+        traceEndedAtMs,
+        traceDurationMs: maxEndMs,
+      }),
+    [maxEndMs, traceEndedAtMs, traceStartedAtMs],
+  );
+
+  const [internalFilter, setInternalFilter] = useState<TimelineFilter>("all");
+  const filter =
+    timelineFilterProp !== undefined ? timelineFilterProp : internalFilter;
+  const setFilter = onTimelineFilterChange ?? setInternalFilter;
+
+  const [internalExpandedPromptIds, setInternalExpandedPromptIds] = useState<
+    Set<string>
+  >(new Set());
+  const [internalExpandedStepIds, setInternalExpandedStepIds] = useState<
+    Set<string>
+  >(new Set());
+  const expandedPromptIds =
+    expandedPromptIdsProp !== undefined
+      ? expandedPromptIdsProp
+      : internalExpandedPromptIds;
+  const setExpandedPromptIds =
+    onExpandedPromptIdsChange ?? setInternalExpandedPromptIds;
+  const expandedStepIds =
+    expandedStepIdsProp !== undefined
+      ? expandedStepIdsProp
+      : internalExpandedStepIds;
+  const setExpandedStepIds =
+    onExpandedStepIdsChange ?? setInternalExpandedStepIds;
+
+  const [selectedRowKey, setSelectedRowKey] = useState<string | null>(null);
+  const [hoveredRowKey, setHoveredRowKey] = useState<string | null>(null);
+  const [hoverPos, setHoverPos] = useState<{
+    anchorX: number;
+    anchorY: number;
+    anchorBottom: number;
+  } | null>(null);
+  const hoveredRowElRef = useRef<HTMLDivElement | null>(null);
+
+  const axisHeaderMeasureRef = useRef<HTMLDivElement>(null);
+  const [axisColumnWidthPx, setAxisColumnWidthPx] = useState(-1);
+
+  useLayoutEffect(() => {
+    const el = axisHeaderMeasureRef.current;
+    if (!el) return;
+
+    const readWidth = () => {
+      const w = el.getBoundingClientRect().width;
+      setAxisColumnWidthPx(Number.isFinite(w) ? w : 0);
+    };
+    readWidth();
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const ro = new ResizeObserver(readWidth);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const axisTicks = useMemo(
+    () => selectAxisTickPercents(axisColumnWidthPx),
+    [axisColumnWidthPx],
+  );
+
+  const collapseAxisToSingleRangeLabel = useMemo(() => {
+    if (axisTicks.length !== 2) {
+      return false;
+    }
+    if (axisColumnWidthPx < 0) {
+      return true;
+    }
+    if (axisColumnWidthPx === 0) {
+      return true;
+    }
+    return axisColumnWidthPx < AXIS_SINGLE_RANGE_LABEL_BELOW_PX;
+  }, [axisColumnWidthPx, axisTicks]);
+
+  useEffect(() => {
+    if (!hideToolbar) {
+      setInternalExpandedPromptIds(new Set(groups.map((group) => group.key)));
+      setInternalExpandedStepIds(collectStepSpanIdsWithChildren(groups));
+    }
+  }, [hideToolbar, groups]);
+
+  const rows = useMemo(() => {
+    if (mode !== "recorded") {
+      return [] as TimelineRow[];
+    }
+
+    const nextRows: TimelineRow[] = [];
+
+    function rowSelfVisible(span: EvalTraceSpan): boolean {
+      if (filter === "all") return true;
+      if (filter === "error") {
+        return spanIndicatesTranscriptFailure(span, transcriptMessages);
+      }
+      return span.category === filter;
+    }
+
+    function collectNodeRows(
+      node: TraceNode,
+      promptIndex: number,
+      depth: number,
+    ): {
+      hasVisibleContent: boolean;
+      rows: TimelineRow[];
+    } {
+      const isStep = node.span.category === "step";
+      // Steps are hidden — their children inherit the step's depth level
+      const childDepth = isStep ? depth : depth + 1;
+      const childResults = node.children.map((child) =>
+        collectNodeRows(child, promptIndex, childDepth),
+      );
+      const visibleChildRows = childResults.flatMap((result) => result.rows);
+      const hasVisibleChildren = childResults.some(
+        (result) => result.hasVisibleContent,
+      );
+
+      // Skip step rows entirely — just show their children promoted up
+      if (isStep) {
+        return {
+          hasVisibleContent: hasVisibleChildren || node.children.length > 0,
+          rows: visibleChildRows,
+        };
+      }
+
+      // Skip overhead LLM spans (framework routing/dispatch, no actual generation)
+      const isOverheadLlm =
+        node.span.category === "llm" &&
+        typeof node.span.totalTokens !== "number" &&
+        typeof node.span.inputTokens !== "number" &&
+        typeof node.span.outputTokens !== "number" &&
+        node.span.endMs - node.span.startMs < 50;
+      if (isOverheadLlm) {
+        return { hasVisibleContent: false, rows: [] };
+      }
+
+      const showSelf = rowSelfVisible(node.span) || hasVisibleChildren;
+
+      if (!showSelf) {
+        return {
+          hasVisibleContent: hasVisibleChildren,
+          rows: visibleChildRows,
+        };
+      }
+
+      const row: SpanRow = {
+        kind: "span",
+        key: node.span.id,
+        promptIndex,
+        depth,
+        span: node.span,
+        hasChildren: node.children.length > 0,
+        isExpanded: expandedStepIds.has(node.span.id),
+      };
+
+      return {
+        hasVisibleContent: true,
+        rows: [
+          row,
+          ...(row.hasChildren && row.isExpanded ? visibleChildRows : []),
+        ],
+      };
+    }
+
+    for (const group of groups) {
+      const rootResults = group.roots.map((root) =>
+        collectNodeRows(root, group.promptIndex, 0),
+      );
+      const childRows = rootResults.flatMap((result) => result.rows);
+      const hasVisibleContent =
+        childRows.length > 0 || (filter === "all" && group.spans.length > 0);
+
+      if (!hasVisibleContent) {
+        continue;
+      }
+
+      const hasAnyFailure = group.spans.some((span) =>
+        spanIndicatesTranscriptFailure(span, transcriptMessages),
+      );
+
+      const userPreview = promptPreviewForRange(
+        transcriptMessages,
+        group.messageStartIndex,
+        group.messageEndIndex,
+      );
+
+      const aggTokens = aggregateLlmTokenTotals(group.spans);
+
+      nextRows.push({
+        kind: "prompt",
+        key: group.key,
+        promptIndex: group.promptIndex,
+        label: group.label,
+        conversationLabel: userPreview ? `User: "${userPreview}"` : undefined,
+        startMs: group.startMs,
+        endMs: group.endMs,
+        messageStartIndex: group.messageStartIndex,
+        messageEndIndex: group.messageEndIndex,
+        counts: group.counts,
+        hasAnyFailure,
+        isExpanded: expandedPromptIds.has(group.key),
+        aggregatedInputTokens: aggTokens.inputTokens,
+        aggregatedOutputTokens: aggTokens.outputTokens,
+        aggregatedTotalTokens: aggTokens.totalTokens,
+      });
+
+      if (expandedPromptIds.has(group.key)) {
+        nextRows.push(...childRows);
+      }
+    }
+
+    return nextRows;
+  }, [
+    expandedPromptIds,
+    expandedStepIds,
+    filter,
+    groups,
+    mode,
+    transcriptMessages,
+  ]);
+
+  const fullyExpandedStepIds = useMemo(
+    () => collectStepSpanIdsWithChildren(groups),
+    [groups],
+  );
+  const isFullyExpanded = useMemo(() => {
+    if (groups.length === 0) return false;
+    for (const group of groups) {
+      if (!expandedPromptIds.has(group.key)) return false;
+    }
+    for (const id of fullyExpandedStepIds) {
+      if (!expandedStepIds.has(id)) return false;
+    }
+    return true;
+  }, [groups, expandedPromptIds, expandedStepIds, fullyExpandedStepIds]);
+
+  useEffect(() => {
+    if (rows.length === 0) {
+      setSelectedRowKey(null);
+      return;
+    }
+    if (!selectedRowKey || !rows.some((row) => row.key === selectedRowKey)) {
+      setSelectedRowKey(rows[0]!.key);
+    }
+  }, [rows, selectedRowKey]);
+
+  const selectedRow = rows.find((row) => row.key === selectedRowKey);
+  const hoveredRow = hoveredRowKey
+    ? rows.find((row) => row.key === hoveredRowKey)
+    : undefined;
+  const hoveredRowIndex = hoveredRowKey
+    ? rows.findIndex((row) => row.key === hoveredRowKey)
+    : -1;
+
+  useEffect(() => {
+    if (hoveredRowKey && !rows.some((row) => row.key === hoveredRowKey)) {
+      setHoveredRowKey(null);
+      setHoverPos(null);
+      hoveredRowElRef.current = null;
+    }
+  }, [hoveredRowKey, rows]);
+
+  const readHoverAnchor = useCallback((rowEl: HTMLElement) => {
+    const glyphEl = rowEl.querySelector(
+      '[data-testid="trace-row-glyph"]',
+    ) as HTMLElement | null;
+    const rect = (glyphEl ?? rowEl).getBoundingClientRect();
+    return {
+      anchorX: rect.left + rect.width / 2,
+      anchorY: rect.top,
+      anchorBottom: rect.bottom,
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!hoveredRowKey) return;
+    const handle = () => {
+      const el = hoveredRowElRef.current;
+      if (!el) return;
+      setHoverPos(readHoverAnchor(el));
+    };
+    window.addEventListener("scroll", handle, true);
+    window.addEventListener("resize", handle);
+    return () => {
+      window.removeEventListener("scroll", handle, true);
+      window.removeEventListener("resize", handle);
+    };
+  }, [hoveredRowKey, readHoverAnchor]);
+
+  const hoveredRowInfo = useMemo(() => {
+    if (!hoveredRow) return null;
+    const { startMs, endMs } = getRowTiming(hoveredRow);
+    const spanShowsFailure =
+      hoveredRow.kind === "span" &&
+      spanIndicatesTranscriptFailure(hoveredRow.span, transcriptMessages);
+    const derivedLabel =
+      hoveredRow.kind === "span"
+        ? deriveSpanLabel(hoveredRow, transcriptMessages)
+        : null;
+    const label =
+      hoveredRow.kind === "prompt"
+        ? (hoveredRow.conversationLabel ?? hoveredRow.label)
+        : derivedLabel!.title;
+    const tokenStats = getRowTokenStats(hoveredRow, recordedSpans);
+    return {
+      label,
+      spanShowsFailure,
+      tokenStats,
+      rowStartTimestamp:
+        traceStartAnchorMs !== null ? traceStartAnchorMs + startMs : null,
+      rowEndTimestamp:
+        traceStartAnchorMs !== null ? traceStartAnchorMs + endMs : null,
+      glyphCategory: (hoveredRow.kind === "prompt"
+        ? "prompt"
+        : hoveredRow.span.category === "tool" && spanShowsFailure
+          ? "error"
+          : hoveredRow.span.category) as EvalTraceSpanCategory | "prompt",
+    };
+  }, [hoveredRow, recordedSpans, traceStartAnchorMs, transcriptMessages]);
+
+  const handleWaterfallKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (rows.length === 0) return;
+      const idx = rows.findIndex((r) => r.key === selectedRowKey);
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        const next = idx < 0 ? 0 : Math.min(rows.length - 1, idx + 1);
+        setSelectedRowKey(rows[next]!.key);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        const next = idx <= 0 ? 0 : idx - 1;
+        setSelectedRowKey(rows[next]!.key);
+        return;
+      }
+      if (event.key === "Enter" && idx >= 0) {
+        const r = rows[idx]!;
+        if (r.kind === "prompt") {
+          event.preventDefault();
+          const next = new Set(expandedPromptIds);
+          if (next.has(r.key)) next.delete(r.key);
+          else next.add(r.key);
+          setExpandedPromptIds(next);
+          return;
+        }
+        if (r.kind === "span" && r.hasChildren) {
+          event.preventDefault();
+          const next = new Set(expandedStepIds);
+          if (next.has(r.key)) next.delete(r.key);
+          else next.add(r.key);
+          setExpandedStepIds(next);
+        }
+      }
+    },
+    [
+      expandedPromptIds,
+      expandedStepIds,
+      rows,
+      selectedRowKey,
+      setExpandedPromptIds,
+      setExpandedStepIds,
+    ],
+  );
+
+  if (mode === "none") {
+    return (
+      <div className={cn(scopeClassName, "text-xs text-muted-foreground")}>
+        No timing data recorded for this iteration.
+      </div>
+    );
+  }
+
+  if (mode === "estimated") {
+    return (
+      <div className={cn(scopeClassName, "space-y-3")}>
+        <div className="flex items-center gap-2">
+          <Badge className="border-warning/50 bg-warning/50 text-foreground">
+            Estimated total only
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            {formatDuration(estimatedDurationMs ?? 0)}
+          </span>
+        </div>
+        <div className="space-y-1 text-[11px] text-muted-foreground">
+          <p>Per-step timing was not recorded for this run.</p>
+          {transcriptMessageCount > 0 ? (
+            <p>
+              Conversation detail is in the Chat tab. Open{" "}
+              <span className="font-medium text-foreground/80">Raw</span> to
+              inspect the stored trace and confirm whether a{" "}
+              <code className="rounded border border-border/50 bg-muted/40 px-1 py-px font-mono text-[10px] text-foreground/90">
+                spans
+              </code>{" "}
+              array exists; only new runs that persist spans show a per-step
+              timeline here.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  const internalZoomCluster =
+    viewportMaxMsProp === undefined ? (
+      <>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-7 w-7 border-border/50"
+          title="Zoom in timeline"
+          aria-label="Zoom in timeline"
+          disabled={internalViewportMaxMs <= timelineZoomMinMs}
+          onClick={() =>
+            setInternalViewportMaxMs((v) =>
+              Math.max(timelineZoomMinMs, Math.round(v * 0.8)),
+            )
+          }
+        >
+          <Plus className="size-3.5" aria-hidden />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-7 w-7 border-border/50"
+          title="Zoom out timeline"
+          aria-label="Zoom out timeline"
+          disabled={internalViewportMaxMs >= maxEndMs * 4}
+          onClick={() =>
+            setInternalViewportMaxMs((v) =>
+              Math.min(maxEndMs * 4, Math.round(v * 1.25)),
+            )
+          }
+        >
+          <Minus className="size-3.5" aria-hidden />
+        </Button>
+      </>
+    ) : null;
+
+  return (
+    <div
+      className={cn(
+        scopeClassName,
+        "space-y-2",
+        fillContent && "flex min-h-0 flex-1 flex-col",
+      )}
+    >
+      {!hideToolbar ? (
+        <div className={fillContent ? "shrink-0" : undefined}>
+          <RecordedTraceToolbar
+            filter={filter}
+            onFilterChange={setFilter}
+            isFullyExpanded={isFullyExpanded}
+            expandDisabled={groups.length === 0}
+            zoomControls={internalZoomCluster}
+            onToggleExpandAll={() => {
+              if (isFullyExpanded) {
+                setExpandedPromptIds(new Set());
+                setExpandedStepIds(new Set());
+              } else {
+                setExpandedPromptIds(new Set(groups.map((group) => group.key)));
+                setExpandedStepIds(new Set(fullyExpandedStepIds));
+              }
+            }}
+          />
+          {/* Span type legend */}
+          <div className="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1 px-1 text-xs text-muted-foreground">
+            {(
+              [
+                { label: "User", cls: "trace-waterfall-bar-prompt" },
+                { label: "LLM",  cls: "trace-waterfall-bar-llm" },
+                { label: "Tool", cls: "trace-waterfall-bar-tool" },
+                { label: "Step", cls: "trace-waterfall-bar-step" },
+                { label: "Error", cls: "trace-waterfall-bar-error" },
+              ] as const
+            ).map(({ label, cls }) => (
+              <span key={label} className="flex items-center gap-1.5">
+                <span className={cn("h-2 w-2.5 rounded-sm", cls)} />
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div
+        className={cn(
+          "@container/trace-timeline min-w-0",
+          fillContent && "flex min-h-0 flex-1 flex-col",
+        )}
+      >
+        <ResizablePanelGroup
+          direction="vertical"
+          className={cn(
+            "rounded-lg border border-border/50 bg-background",
+            fillContent
+              ? "min-h-0 flex-1 overflow-hidden"
+              : "min-h-[min(25rem,calc(100dvh-8rem))]",
+          )}
+          style={fillContent ? undefined : { height: "auto" }}
+        >
+          <ResizablePanel
+            defaultSize={65}
+            minSize={0}
+            className="min-h-0 min-w-0 overflow-hidden"
+          >
+            <ScrollArea
+              className={cn(
+                fillContent
+                  ? "h-full min-h-0 overflow-hidden"
+                  : "max-h-[calc(100vh-8rem)] min-h-0",
+              )}
+            >
+              <div
+                tabIndex={0}
+                role="region"
+                aria-label="Trace timeline. Use arrow keys to change selection, Enter to expand."
+                onKeyDown={handleWaterfallKeyDown}
+                className="relative min-h-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <div
+                  className="grid pr-4"
+                  style={{
+                    gridTemplateColumns:
+                      "minmax(140px, 260px) minmax(0, 1fr) minmax(5.25rem, max-content)",
+                    gridTemplateRows: `auto repeat(${rows.length}, minmax(48px, auto))`,
+                  }}
+                >
+                  <div
+                    className="sticky top-0 z-20 border-b border-border/50 bg-background/95 px-4 py-1.5 backdrop-blur"
+                    style={{ gridColumn: "1 / 3", gridRow: 1 }}
+                  >
+                    <div className="flex min-h-6 min-w-0 items-center gap-3">
+                      <div className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+                        Trace
+                      </div>
+                      <div className="min-h-6 min-w-0 flex-1">
+                        <div
+                          ref={axisHeaderMeasureRef}
+                          className="relative h-6 min-w-0"
+                        >
+                          {collapseAxisToSingleRangeLabel ? (
+                            <div className="flex h-full min-w-0 items-center justify-center">
+                              <span
+                                className="min-w-0 max-w-full truncate text-center text-[10px] tabular-nums text-muted-foreground"
+                                title={formatAxisRangeLabel(axisMaxMs)}
+                              >
+                                {formatAxisRangeLabel(axisMaxMs)}
+                              </span>
+                            </div>
+                          ) : (
+                            axisTicks.map((tick) => {
+                              const left = tick >= 100 ? "100%" : `${tick}%`;
+                              return (
+                                <div
+                                  key={tick}
+                                  className="pointer-events-none absolute inset-y-0"
+                                  style={{ left }}
+                                >
+                                  <div
+                                    className={cn(
+                                      "absolute text-[10px] tabular-nums text-muted-foreground",
+                                      axisTickLabelAlignClass(tick),
+                                    )}
+                                  >
+                                    {formatAxisLabel((axisMaxMs * tick) / 100)}
+                                  </div>
+                                </div>
+                              );
+                            })
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="sticky top-0 z-20 flex min-h-0 items-center border-b border-l border-border/50 bg-background/95 px-3 py-1.5 pl-4 backdrop-blur"
+                    style={{ gridColumn: 3, gridRow: 1 }}
+                  >
+                    <div className="flex h-6 w-full min-w-0 items-center justify-start gap-1.5">
+                      <Clock
+                        className="size-3 shrink-0 text-muted-foreground"
+                        aria-hidden
+                      />
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        Latency
+                      </span>
+                    </div>
+                  </div>
+
+                  {rows.length > 0 ? (
+                    <div
+                      className="pointer-events-none relative z-0 bg-transparent"
+                      style={{
+                        gridColumn: 2,
+                        gridRow: `2 / ${rows.length + 2}`,
+                      }}
+                    >
+                      {axisTicks.map((tick) => (
+                        <div
+                          key={tick}
+                          className="absolute top-0 bottom-0 w-px bg-border/40"
+                          style={{
+                            left: tick >= 100 ? "100%" : `${tick}%`,
+                          }}
+                        />
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {rows.map((row, rowIndex) => {
+                    const isSelected = row.key === selectedRowKey;
+                    const { startMs, endMs, durationMs } = getRowTiming(row);
+                    const leftPercent = (startMs / axisMaxMs) * 100;
+                    const widthPercent = Math.max(
+                      ((endMs - startMs) / axisMaxMs) * 100,
+                      0.45,
+                    );
+                    const spanShowsFailure =
+                      row.kind === "span" &&
+                      spanIndicatesTranscriptFailure(
+                        row.span,
+                        transcriptMessages,
+                      );
+                    const rowGlyphCategory: EvalTraceSpanCategory | "prompt" =
+                      row.kind === "prompt"
+                        ? "prompt"
+                        : row.span.category === "tool" && spanShowsFailure
+                          ? "error"
+                          : row.span.category;
+                    const derivedLabel =
+                      row.kind === "span"
+                        ? deriveSpanLabel(row, transcriptMessages)
+                        : null;
+                    const label =
+                      row.kind === "prompt"
+                        ? (row.conversationLabel ?? row.label)
+                        : derivedLabel!.title;
+                    const durationLabel = formatDuration(durationMs);
+                    const canToggle =
+                      row.kind === "prompt"
+                        ? true
+                        : row.hasChildren || row.span.category === "llm";
+                    const gridRow = rowIndex + 2;
+                    const borderAccent = getRowBorderAccentClass(
+                      row,
+                      spanShowsFailure,
+                    );
+                    const waterfallBarClass = getWaterfallBarClass(
+                      row,
+                      spanShowsFailure,
+                    );
+                    const selectRow = () => {
+                      setSelectedRowKey(row.key);
+                    };
+                    const selectRowFromChild = (
+                      event: MouseEvent<HTMLButtonElement>,
+                    ) => {
+                      event.stopPropagation();
+                      selectRow();
+                    };
+                    const leftCellClass = isSelected
+                      ? cn("bg-transparent", borderAccent)
+                      : "border-l-transparent bg-background group-hover:bg-muted/20 hover:bg-muted/20";
+                    const sharedCellClass = isSelected
+                      ? "bg-transparent"
+                      : "bg-background group-hover:bg-muted/20 hover:bg-muted/20";
+
+                    return (
+                      <div
+                        key={row.key}
+                        data-testid="trace-row"
+                        data-state={isSelected ? "selected" : undefined}
+                        onClick={selectRow}
+                        onMouseEnter={(event) => {
+                          setHoveredRowKey(row.key);
+                          const rowEl = event.currentTarget;
+                          hoveredRowElRef.current = rowEl;
+                          setHoverPos(readHoverAnchor(rowEl));
+                        }}
+                        onMouseLeave={() => {
+                          setHoveredRowKey((current) =>
+                            current === row.key ? null : current,
+                          );
+                          setHoverPos(null);
+                          hoveredRowElRef.current = null;
+                        }}
+                        onFocus={(event: FocusEvent<HTMLDivElement>) => {
+                          setHoveredRowKey(row.key);
+                          const rowEl = event.currentTarget;
+                          hoveredRowElRef.current = rowEl;
+                          setHoverPos(readHoverAnchor(rowEl));
+                        }}
+                        onBlur={(event: FocusEvent<HTMLDivElement>) => {
+                          if (
+                            event.currentTarget.contains(
+                              event.relatedTarget as Node | null,
+                            )
+                          ) {
+                            return;
+                          }
+                          setHoveredRowKey((current) =>
+                            current === row.key ? null : current,
+                          );
+                          setHoverPos(null);
+                          hoveredRowElRef.current = null;
+                        }}
+                        style={{
+                          gridColumn: "1 / 4",
+                          gridRow,
+                          display: "grid",
+                          gridTemplateColumns: "subgrid",
+                        }}
+                        className={cn(
+                          "group min-h-0 min-w-0 cursor-pointer items-stretch",
+                          isSelected &&
+                            "trace-waterfall-row-selected ring-1 ring-inset ring-ring/40",
+                        )}
+                      >
+                        <div
+                          className={cn(
+                            "flex items-center gap-2 border-b border-border/40 px-4 py-2 transition-all duration-150 border-l-2",
+                            leftCellClass,
+                          )}
+                        >
+                          <div
+                            className="flex shrink-0 items-center"
+                            style={{
+                              paddingLeft:
+                                row.kind === "prompt" ? 0 : row.depth * 16,
+                            }}
+                          >
+                            {canToggle ? (
+                              <button
+                                type="button"
+                                className="mr-1 inline-flex h-5 w-5 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted/30 hover:text-foreground"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  if (row.kind === "prompt") {
+                                    const next = new Set(expandedPromptIds);
+                                    if (next.has(row.key))
+                                      next.delete(row.key);
+                                    else next.add(row.key);
+                                    setExpandedPromptIds(next);
+                                    return;
+                                  }
+                                  const next = new Set(expandedStepIds);
+                                  if (next.has(row.key)) next.delete(row.key);
+                                  else next.add(row.key);
+                                  setExpandedStepIds(next);
+                                }}
+                                aria-label={
+                                  row.kind === "prompt"
+                                    ? `${row.isExpanded ? "Collapse" : "Expand"} ${row.label}`
+                                    : `${row.isExpanded ? "Collapse" : "Expand"} ${label}`
+                                }
+                              >
+                                {row.isExpanded ? (
+                                  <ChevronDown className="h-3.5 w-3.5" />
+                                ) : (
+                                  <ChevronRight className="h-3.5 w-3.5" />
+                                )}
+                              </button>
+                            ) : (
+                              <span className="mr-1 h-5 w-5" />
+                            )}
+                          </div>
+                          <button
+                            type="button"
+                            data-testid="trace-row-label-button"
+                            className="min-w-0 flex-1 text-left"
+                            onClick={selectRowFromChild}
+                          >
+                            <div className="flex min-w-0 items-center gap-2">
+                              <span
+                                data-testid="trace-row-glyph"
+                                className="inline-flex shrink-0 items-center"
+                              >
+                                {row.kind === "prompt" ? (
+                                  <CategoryGlyph category="prompt" />
+                                ) : (
+                                  <CategoryGlyph category={rowGlyphCategory} />
+                                )}
+                              </span>
+                              <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                                {label}
+                              </span>
+                              {row.kind === "prompt" && row.hasAnyFailure ? (
+                                <span
+                                  className="inline-block h-2 w-2 shrink-0 rounded-full bg-destructive"
+                                  title="Contains errors"
+                                  aria-label="Contains errors"
+                                />
+                              ) : null}
+                              {row.kind === "span" && spanShowsFailure ? (
+                                <span
+                                  className="inline-block h-2 w-2 shrink-0 rounded-full bg-destructive"
+                                  title="Error"
+                                  aria-label="Error"
+                                />
+                              ) : null}
+                            </div>
+                          </button>
+                        </div>
+                        <button
+                          type="button"
+                          data-testid="trace-row-bar-hit"
+                          data-state={isSelected ? "selected" : undefined}
+                          className={cn(
+                            "relative z-[1] flex min-h-[48px] w-full items-center overflow-hidden border-b border-border/40 border-l-2 border-l-transparent px-4 py-2 text-left transition-all duration-150",
+                            sharedCellClass,
+                          )}
+                          aria-label={`Select on timeline (${formatDuration(durationMs)})`}
+                          onClick={selectRowFromChild}
+                        >
+                          <div
+                            data-testid={
+                              row.kind === "span" && spanShowsFailure
+                                ? "trace-row-bar-error"
+                                : "trace-row-bar"
+                            }
+                            className={cn(
+                              "absolute top-1/2 z-[1] h-4 min-w-0 -translate-y-1/2 rounded-[3px] transition-[left,width] duration-150",
+                              waterfallBarClass,
+                            )}
+                            style={{
+                              left: `${leftPercent}%`,
+                              width: `max(${widthPercent}%, 3px)`,
+                            }}
+                          />
+                        </button>
+                        <button
+                          type="button"
+                          data-testid="trace-row-duration-hit"
+                          data-state={isSelected ? "selected" : undefined}
+                          className={cn(
+                            "flex min-h-[48px] items-center justify-start gap-1.5 whitespace-nowrap border-b border-l border-border/40 px-3 py-2 pl-4 text-[11px] tabular-nums text-muted-foreground transition-all duration-150",
+                            sharedCellClass,
+                          )}
+                          aria-label={`Select row duration (${durationLabel})`}
+                          onClick={selectRowFromChild}
+                        >
+                          <Clock
+                            className="size-3 shrink-0 opacity-80"
+                            aria-hidden
+                          />
+                          {durationLabel}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </ScrollArea>
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel
+            defaultSize={35}
+            minSize={20}
+            className="min-h-0 min-w-0 overflow-hidden"
+          >
+            <div
+              data-testid="trace-timeline-detail-sticky"
+              className="h-full min-h-0 min-w-0 max-h-full overflow-y-auto"
+            >
+              <TimelineDetailPane
+                row={selectedRow}
+                transcriptMessages={transcriptMessages}
+                onRevealInTranscript={onRevealInTranscript}
+              />
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+      {hoveredRow && hoveredRowInfo && hoverPos ? (
+        <HoveredRowInspector
+          hoverPos={hoverPos}
+          info={hoveredRowInfo}
+          placement={hoveredRowIndex === 0 ? "bottom" : "top"}
+          rowKey={hoveredRow.key}
+          scopeClassName={scopeClassName}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+type HoveredRowInfo = {
+  label: string;
+  spanShowsFailure: boolean;
+  tokenStats: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+  rowStartTimestamp: number | null;
+  rowEndTimestamp: number | null;
+  glyphCategory: EvalTraceSpanCategory | "prompt";
+};
+
+function HoveredRowInspector({
+  hoverPos,
+  info,
+  placement,
+  rowKey,
+  scopeClassName,
+}: {
+  hoverPos: { anchorX: number; anchorY: number; anchorBottom: number };
+  info: HoveredRowInfo;
+  placement: "top" | "bottom";
+  rowKey: string;
+  // `.mcpjam-chat-ui` scope class — the card is portaled to document.body,
+  // outside the timeline root, so it must carry the scope itself.
+  scopeClassName: string;
+}) {
+  if (typeof document === "undefined") return null;
+  const CARD_WIDTH_PX = 304;
+  const EDGE_PADDING = 12;
+  const GAP_PX = 8;
+  const halfWidth = CARD_WIDTH_PX / 2;
+  const viewportWidth =
+    typeof window !== "undefined"
+      ? window.innerWidth
+      : hoverPos.anchorX + halfWidth + EDGE_PADDING;
+  const minCenter = EDGE_PADDING + halfWidth;
+  const maxCenter = Math.max(
+    minCenter,
+    viewportWidth - halfWidth - EDGE_PADDING,
+  );
+  const clampedCenter = Math.min(
+    Math.max(hoverPos.anchorX, minCenter),
+    maxCenter,
+  );
+
+  const wrapperStyle: React.CSSProperties = {
+    position: "fixed",
+    top:
+      placement === "top"
+        ? hoverPos.anchorY - GAP_PX
+        : hoverPos.anchorBottom + GAP_PX,
+    left: clampedCenter,
+    transform:
+      placement === "top" ? "translate(-50%, -100%)" : "translateX(-50%)",
+    zIndex: 9999,
+  };
+
+  return createPortal(
+    <div
+      className={cn(scopeClassName, "pointer-events-none")}
+      style={wrapperStyle}
+    >
+      <div
+        key={rowKey}
+        data-placement={placement}
+        data-testid="trace-row-hover-content"
+        className="w-[19rem] overflow-hidden rounded-md border border-border/60 bg-popover text-popover-foreground shadow-xl"
+      >
+        <div
+          data-testid="trace-row-hover-card"
+          className="space-y-3 p-3"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <CategoryGlyph category={info.glyphCategory} />
+            <span className="min-w-0 flex-1 truncate text-xs font-semibold text-popover-foreground">
+              {info.label}
+            </span>
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-[10px] font-semibold uppercase tracking-wide text-popover-foreground/65">
+              Time
+            </div>
+            <div className="space-y-1 text-xs">
+              <div className="flex min-w-0 items-baseline justify-between gap-3">
+                <span className="shrink-0 text-popover-foreground/70">
+                  Start
+                </span>
+                <span
+                  data-testid="trace-row-hover-start"
+                  className="min-w-0 text-right font-medium text-popover-foreground tabular-nums"
+                >
+                  {formatWallClockTimestamp(info.rowStartTimestamp)}
+                </span>
+              </div>
+              <div className="flex min-w-0 items-baseline justify-between gap-3">
+                <span className="shrink-0 text-popover-foreground/70">
+                  End
+                </span>
+                <span
+                  data-testid="trace-row-hover-end"
+                  className="min-w-0 text-right font-medium text-popover-foreground tabular-nums"
+                >
+                  {formatWallClockTimestamp(info.rowEndTimestamp)}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-[10px] font-semibold uppercase tracking-wide text-popover-foreground/65">
+              Tokens
+            </div>
+            <div className="space-y-1 text-xs">
+              <div className="flex min-w-0 items-baseline justify-between gap-3">
+                <span className="shrink-0 text-popover-foreground/70">
+                  Input
+                </span>
+                <span
+                  data-testid="trace-row-hover-input-tokens"
+                  className="min-w-0 text-right font-medium text-popover-foreground tabular-nums"
+                >
+                  {formatTokenCount(info.tokenStats.inputTokens)}
+                </span>
+              </div>
+              <div className="flex min-w-0 items-baseline justify-between gap-3">
+                <span className="shrink-0 text-popover-foreground/70">
+                  Output
+                </span>
+                <span
+                  data-testid="trace-row-hover-output-tokens"
+                  className="min-w-0 text-right font-medium text-popover-foreground tabular-nums"
+                >
+                  {formatTokenCount(info.tokenStats.outputTokens)}
+                </span>
+              </div>
+              <div className="flex min-w-0 items-baseline justify-between gap-3">
+                <span className="shrink-0 text-popover-foreground/70">
+                  Total
+                </span>
+                <span
+                  data-testid="trace-row-hover-total-tokens"
+                  className="min-w-0 text-right font-medium text-popover-foreground tabular-nums"
+                >
+                  {formatTokenCount(info.tokenStats.totalTokens)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/chat-ui/src/internal/trace-timeline/ui.tsx
+++ b/chat-ui/src/internal/trace-timeline/ui.tsx
@@ -1,0 +1,142 @@
+// Tier-A primitives for the trace timeline.
+//
+// The inspector's trace-timeline pulled these from `@mcpjam/design-system`
+// (Button/Badge/ScrollArea) and `@/components/ui/resizable`, both of which are
+// forbidden / unresolvable inside this provider-free package. These are minimal
+// drop-ins covering exactly the prop surface the timeline uses. The panel shims
+// render a STATIC vertical split (no drag) — the read-only timeline only needs
+// the layout proportions, not interactive resizing.
+
+import type {
+  ButtonHTMLAttributes,
+  CSSProperties,
+  ReactNode,
+} from "react";
+import { cn } from "../cn";
+
+type ButtonVariant = "secondary" | "outline";
+type ButtonSize = "sm" | "icon" | "default";
+
+const BUTTON_BASE =
+  "inline-flex items-center justify-center gap-1.5 rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50";
+
+const BUTTON_VARIANT: Record<ButtonVariant, string> = {
+  outline: "border border-border bg-transparent hover:bg-muted/50",
+  secondary: "bg-muted text-foreground hover:bg-muted/80",
+};
+
+const BUTTON_SIZE: Record<ButtonSize, string> = {
+  sm: "h-8 px-3 text-xs",
+  icon: "h-8 w-8",
+  default: "h-9 px-4 text-sm",
+};
+
+export function Button({
+  variant = "outline",
+  size = "default",
+  className,
+  ...rest
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}) {
+  return (
+    <button
+      className={cn(
+        BUTTON_BASE,
+        BUTTON_VARIANT[variant],
+        BUTTON_SIZE[size],
+        className,
+      )}
+      {...rest}
+    />
+  );
+}
+
+export function Badge({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-md border border-border px-2 py-0.5 text-xs font-medium",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function ScrollArea({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  // `overflow-auto` LAST so it wins the tailwind-merge conflict: callers (e.g.
+  // the timeline in fillContent mode) pass `overflow-hidden` expecting the
+  // design-system ScrollArea's separate scrollable viewport. This shim is a
+  // single element, so it must stay the scroll container itself — otherwise the
+  // caller's `overflow-hidden` would clip the waterfall with no way to scroll.
+  return <div className={cn(className, "overflow-auto")}>{children}</div>;
+}
+
+export function ResizablePanelGroup({
+  direction,
+  className,
+  style,
+  children,
+}: {
+  direction: "vertical" | "horizontal";
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 min-w-0",
+        direction === "vertical" ? "flex-col" : "flex-row",
+        className,
+      )}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function ResizablePanel({
+  defaultSize = 50,
+  className,
+  children,
+}: {
+  // `minSize` is accepted for API parity but unused (static split).
+  defaultSize?: number;
+  minSize?: number;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn("min-h-0 min-w-0", className)}
+      // flexBasis 'auto' (not 0): in a fixed-height parent (fillContent) flexGrow
+      // splits the free space proportionally; in an auto-height parent (the
+      // common embed) the panels size to their content and stack instead of
+      // collapsing to nothing (flexBasis 0 + no free space → zero height).
+      style={{ flexGrow: defaultSize, flexShrink: 1, flexBasis: "auto" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function ResizableHandle({ withHandle: _withHandle }: { withHandle?: boolean }) {
+  return <div className="h-px w-full shrink-0 bg-border" aria-hidden />;
+}

--- a/chat-ui/src/styles.css
+++ b/chat-ui/src/styles.css
@@ -32,6 +32,14 @@
   --border: 240 5.9% 90%;
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 0 0% 98%;
+  /* Trace-timeline-only tokens (popover tooltip, focus ring, warning badge). */
+  --popover: 0 0% 100%;
+  --popover-foreground: 240 10% 3.9%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --ring: 240 10% 3.9%;
+  --warning: 38 92% 50%;
+  --warning-foreground: 0 0% 98%;
 }
 
 .mcpjam-chat-ui {
@@ -57,6 +65,14 @@
   --border: 240 3.7% 15.9%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 0 0% 98%;
+  /* Trace-timeline-only tokens (popover tooltip, focus ring, warning badge). */
+  --popover: 240 10% 3.9%;
+  --popover-foreground: 0 0% 98%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --ring: 240 4.9% 83.9%;
+  --warning: 38 92% 50%;
+  --warning-foreground: 48 96% 9%;
 }
 
 /* Keep long tool input/output readable without a horizontal scrollbar war. */
@@ -68,4 +84,151 @@
 
 .mcpjam-chat-ui .mcpjam-chat-markdown {
   overflow-wrap: anywhere;
+}
+
+/*
+ * Trace timeline waterfall — category bar fills, glyph colors and row accents.
+ * Ported from the inspector's global `index.css`; here the classes + their
+ * `--trace-waterfall-*` color variables are scoped to `.mcpjam-chat-ui` so they
+ * travel with the package stylesheet. Light values are the base; the dark block
+ * overrides bar/accent tokens. Relative-color `oklch(from …)` darkens glyphs and
+ * row-accent borders to match the (lighter) bar fills.
+ */
+.mcpjam-chat-ui {
+  --trace-waterfall-bar-prompt: oklch(0.885 0.082 292);
+  --trace-waterfall-bar-llm: oklch(0.885 0.076 255);
+  --trace-waterfall-bar-tool: oklch(0.905 0.105 96);
+  --trace-waterfall-bar-step: oklch(0.88 0.055 250);
+  --trace-waterfall-bar-error: oklch(0.88 0.115 25);
+  --trace-waterfall-row-selected: oklch(0.67 0.1 288 / 0.12);
+}
+
+.mcpjam-chat-ui.dark,
+.dark .mcpjam-chat-ui:not(.light) {
+  --trace-waterfall-bar-prompt: oklch(0.79 0.11 292 / 0.58);
+  --trace-waterfall-bar-llm: oklch(0.79 0.1 255 / 0.58);
+  --trace-waterfall-bar-tool: oklch(0.83 0.12 88 / 0.58);
+  --trace-waterfall-bar-step: oklch(0.77 0.06 250 / 0.56);
+  --trace-waterfall-bar-error: oklch(0.78 0.14 25 / 0.58);
+  --trace-waterfall-row-selected: oklch(0.8 0.09 288 / 0.18);
+  --trace-waterfall-accent-prompt: oklch(0.84 0.11 292 / 0.82);
+  --trace-waterfall-accent-llm: oklch(0.84 0.1 255 / 0.82);
+  --trace-waterfall-accent-tool: oklch(0.87 0.11 88 / 0.82);
+  --trace-waterfall-accent-step: oklch(0.8 0.065 250 / 0.82);
+  --trace-waterfall-accent-error: oklch(0.84 0.12 25 / 0.82);
+}
+
+.mcpjam-chat-ui .trace-waterfall-bar-prompt {
+  background-color: var(--trace-waterfall-bar-prompt);
+}
+.mcpjam-chat-ui .trace-waterfall-bar-llm {
+  background-color: var(--trace-waterfall-bar-llm);
+}
+.mcpjam-chat-ui .trace-waterfall-bar-tool {
+  background-color: var(--trace-waterfall-bar-tool);
+}
+.mcpjam-chat-ui .trace-waterfall-bar-step {
+  background-color: var(--trace-waterfall-bar-step);
+}
+.mcpjam-chat-ui .trace-waterfall-bar-error {
+  background-color: var(--trace-waterfall-bar-error);
+}
+.mcpjam-chat-ui .trace-waterfall-bar-prompt,
+.mcpjam-chat-ui .trace-waterfall-bar-llm,
+.mcpjam-chat-ui .trace-waterfall-bar-tool,
+.mcpjam-chat-ui .trace-waterfall-bar-step,
+.mcpjam-chat-ui .trace-waterfall-bar-error {
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 0.28),
+    0 1px 3px rgb(15 23 42 / 0.08);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-bar-prompt,
+.mcpjam-chat-ui.dark .trace-waterfall-bar-llm,
+.mcpjam-chat-ui.dark .trace-waterfall-bar-tool,
+.mcpjam-chat-ui.dark .trace-waterfall-bar-step,
+.mcpjam-chat-ui.dark .trace-waterfall-bar-error,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-bar-prompt,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-bar-llm,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-bar-tool,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-bar-step,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-bar-error {
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 0.12),
+    0 1px 4px rgb(0 0 0 / 0.26);
+}
+.mcpjam-chat-ui .trace-waterfall-row-selected {
+  background-color: var(--trace-waterfall-row-selected);
+}
+
+.mcpjam-chat-ui .trace-waterfall-glyph-prompt {
+  color: oklch(from var(--trace-waterfall-bar-prompt) calc(l - 0.36) c h);
+}
+.mcpjam-chat-ui .trace-waterfall-glyph-llm {
+  color: oklch(from var(--trace-waterfall-bar-llm) calc(l - 0.36) c h);
+}
+.mcpjam-chat-ui .trace-waterfall-glyph-tool {
+  color: oklch(from var(--trace-waterfall-bar-tool) calc(l - 0.36) c h);
+}
+.mcpjam-chat-ui .trace-waterfall-glyph-step {
+  color: oklch(from var(--trace-waterfall-bar-step) calc(l - 0.36) c h);
+}
+.mcpjam-chat-ui .trace-waterfall-glyph-error {
+  color: oklch(from var(--trace-waterfall-bar-error) calc(l - 0.36) c h);
+}
+
+.mcpjam-chat-ui .trace-waterfall-row-accent-prompt {
+  border-left-color: oklch(from var(--trace-waterfall-bar-prompt) calc(l - 0.36) c h);
+}
+.mcpjam-chat-ui .trace-waterfall-row-accent-llm {
+  border-left-color: oklch(from var(--trace-waterfall-bar-llm) calc(l - 0.36) c h);
+}
+.mcpjam-chat-ui .trace-waterfall-row-accent-tool {
+  border-left-color: oklch(from var(--trace-waterfall-bar-tool) calc(l - 0.36) c h);
+}
+.mcpjam-chat-ui .trace-waterfall-row-accent-step {
+  border-left-color: oklch(from var(--trace-waterfall-bar-step) calc(l - 0.36) c h);
+}
+.mcpjam-chat-ui .trace-waterfall-row-accent-error {
+  border-left-color: oklch(from var(--trace-waterfall-bar-error) calc(l - 0.36) c h);
+}
+
+.mcpjam-chat-ui.dark .trace-waterfall-glyph-prompt,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-glyph-prompt {
+  color: var(--trace-waterfall-accent-prompt);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-glyph-llm,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-glyph-llm {
+  color: var(--trace-waterfall-accent-llm);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-glyph-tool,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-glyph-tool {
+  color: var(--trace-waterfall-accent-tool);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-glyph-step,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-glyph-step {
+  color: var(--trace-waterfall-accent-step);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-glyph-error,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-glyph-error {
+  color: var(--trace-waterfall-accent-error);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-row-accent-prompt,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-row-accent-prompt {
+  border-left-color: var(--trace-waterfall-accent-prompt);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-row-accent-llm,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-row-accent-llm {
+  border-left-color: var(--trace-waterfall-accent-llm);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-row-accent-tool,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-row-accent-tool {
+  border-left-color: var(--trace-waterfall-accent-tool);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-row-accent-step,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-row-accent-step {
+  border-left-color: var(--trace-waterfall-accent-step);
+}
+.mcpjam-chat-ui.dark .trace-waterfall-row-accent-error,
+.dark .mcpjam-chat-ui:not(.light) .trace-waterfall-row-accent-error {
+  border-left-color: var(--trace-waterfall-accent-error);
 }

--- a/chat-ui/src/trace-timeline.ts
+++ b/chat-ui/src/trace-timeline.ts
@@ -1,0 +1,24 @@
+// Public subpath: `@mcpjam/chat-ui/trace-timeline`.
+//
+// The recorded-trace waterfall (per-span latency + token timeline). Kept on its
+// own subpath so the heavier timeline graph (portal tooltip, axis measuring)
+// stays out of the default transcript bundle. Tier-A clean: provider-free, no
+// design-system / posthog / inspector imports.
+export {
+  TraceTimeline,
+  buildPromptGroups,
+  collectStepSpanIdsWithChildren,
+  selectAxisTickPercents,
+  type TraceTimelineProps,
+  type TraceRevealSelection,
+  type TimelineFilter,
+} from "./internal/trace-timeline/trace-timeline";
+export {
+  TRACE_TIMELINE_FILTERS,
+  timelineFilterLabel,
+} from "./internal/trace-timeline/recorded-trace-toolbar";
+export type {
+  TraceSpan,
+  TraceSpanCategory,
+  TraceSpanStatus,
+} from "./internal/trace-timeline/eval-trace";

--- a/chat-ui/tsup.config.ts
+++ b/chat-ui/tsup.config.ts
@@ -3,7 +3,12 @@ import { defineConfig } from "tsup";
 // Tier A: a single public entrypoint. The transcript renderer and its
 // supporting types/helpers are all re-exported from `src/index.ts`.
 export default defineConfig({
-  entry: ["src/index.ts", "src/thread-helpers.ts", "src/trace.ts"],
+  entry: [
+    "src/index.ts",
+    "src/thread-helpers.ts",
+    "src/trace.ts",
+    "src/trace-timeline.ts",
+  ],
   format: ["esm"],
   target: "es2022",
   platform: "browser",


### PR DESCRIPTION
## What

Extracts the recorded-trace **waterfall** into `@mcpjam/chat-ui` as a new `@mcpjam/chat-ui/trace-timeline` subpath, so any consumer of the package can render the per-step trace timeline (per-span latency + token counts, hover for wall-clock start/end) without pulling in app internals.

## Why

The trace timeline currently lives inside the app. Moving it into the shared package — alongside the existing read-only transcript renderer — makes it reusable across surfaces and is the first step toward the app consuming it from the package and deleting its local copy (follow-up).

## How

**Tier-A clean** (passes `check:tier-b`): provider-free, no `posthog` / `@mcpjam/design-system` / `convex` / widget-runtime imports.
- Reuses the package's own primitives (`JsonView`, `Markdown`, `tool-result-text`, `cn`) plus small local `Button`/`Badge`/`ScrollArea`/panel shims in place of the design-system + resizable deps.
- Drops the framer-motion entrance animation to keep the dependency set minimal — the waterfall is identical at rest.
- New `TraceSpan` rendering type: a structural subset of the richer span type used elsewhere, which assigns to it with no changes (the richer type stays put — it's also a server/persistence contract).
- `trace-waterfall-*` classes + extra semantic tokens (`popover`, `ring`, `warning`, `accent`) are scoped under `.mcpjam-chat-ui` in `styles.css`. **Dark overrides match both `.mcpjam-chat-ui.dark` and the inherited `.dark .mcpjam-chat-ui:not(.light)`** (system dark), consistent with the token block.

## Versioning / release

- **No manual version bump** — a `minor` changeset (`.changeset/chat-ui-trace-timeline.md`) drives the bump; `changeset version` will publish `@mcpjam/chat-ui@0.2.0`.
- MCPJam/mcpjam-backend #587 consumes the new subpath and is held until `0.2.0` is published.

## Verification

- `check:tier-b` ✓, `typecheck` ✓, `build` ✓.
- 25/25 tests pass, including a new jsdom smoke test that renders the waterfall and asserts per-span latency formatting (`96ms`, `2.42s`) and row labels.

## Notes for reviewers

- New subpath only; no existing exports change, so current consumers are unaffected.
- The app's own trace-timeline is **not** migrated here — focused follow-up once 0.2.0 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive package surface and UI-only code; existing consumers are unaffected unless they opt into the new subpath. Main follow-up risk is keeping `TraceSpan` fields aligned with inspector persistence types.
> 
> **Overview**
> Adds a **new optional subpath** `@mcpjam/chat-ui/trace-timeline` (minor changeset) so consumers can render the recorded-trace **waterfall** from shared `@mcpjam/chat-ui` without touching existing entrypoints.
> 
> **`TraceTimeline`** takes `TraceSpan[]` (and optional transcript messages) and shows prompt-grouped rows with per-span latency bars, token counts, filters/expand/zoom toolbar, a detail pane (I/O via existing `JsonView`/`Markdown`), hover tooltips with wall-clock start/end, and optional **Reveal in Chat** via `onRevealInTranscript`. It applies `.mcpjam-chat-ui` on its root (and portaled hover UI) like `ReadOnlyTranscript`. Tier-A implementation uses local UI shims instead of design-system/resizable deps; **`trace-waterfall-*` styles and extra CSS tokens** are added under `.mcpjam-chat-ui` in `styles.css`. Build adds a `tsup` entry; **smoke tests** cover latency labels and empty state.
> 
> Existing `./`, `./trace`, and `./thread-helpers` exports are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8a4d06aacde4ad263c2625accc278d89deae1a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->