### PR TITLE
feat(evals): configurable Generate — case count, per-bucket mix, vary user styles

### DIFF
--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -696,11 +696,13 @@ export function registerEvalCommands(program: Command): void {
       ] as const) {
         const raw = options[key];
         if (raw !== undefined) {
-          const parsed = Number.parseInt(raw, 10);
-          if (!Number.isFinite(parsed)) {
+          // Number() (not parseInt) so partial junk like "2abc" is rejected
+          // rather than silently truncated to 2.
+          const parsed = Number(raw);
+          if (!Number.isInteger(parsed)) {
             const flag = key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
             throw usageError(
-              `--${flag} requires a numeric value, got "${raw}".`
+              `--${flag} requires an integer value, got "${raw}".`
             );
           }
           caseMix[key] = parsed;

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -660,6 +660,15 @@ export function registerEvalCommands(program: Command): void {
         "--case-model <id...>",
         "Execution model(s) for the generated cases"
       )
+      .option("--simple <n>", "How many easy, single-tool cases")
+      .option("--multi-tool <n>", "How many medium, 2+ tool cases")
+      .option("--multi-turn <n>", "How many multi-turn follow-up cases")
+      .option("--complex <n>", "How many hard / cross-server cases")
+      .option("--negative <n>", "How many negative (no-tool) cases")
+      .option(
+        "--vary-user-styles",
+        "Vary query phrasing across a realistic range of user styles"
+      )
   ).action(
     async (
       options: PlatformOptions & {
@@ -668,9 +677,29 @@ export function registerEvalCommands(program: Command): void {
         mode?: string;
         server?: string[];
         caseModel?: string[];
+        simple?: string;
+        multiTool?: string;
+        multiTurn?: string;
+        complex?: string;
+        negative?: string;
+        varyUserStyles?: boolean;
       },
       command
     ) => {
+      const caseMix: Record<string, number> = {};
+      for (const key of [
+        "simple",
+        "multiTool",
+        "multiTurn",
+        "complex",
+        "negative",
+      ] as const) {
+        const raw = options[key];
+        if (raw !== undefined) {
+          const parsed = Number.parseInt(raw, 10);
+          if (Number.isFinite(parsed)) caseMix[key] = parsed;
+        }
+      }
       const input = validateOpInput(generateEvalCasesOperation, {
         project: options.project,
         suite: options.suite,
@@ -679,6 +708,8 @@ export function registerEvalCommands(program: Command): void {
         ...(options.caseModel
           ? { caseModels: options.caseModel.map((model) => ({ model })) }
           : {}),
+        ...(Object.keys(caseMix).length > 0 ? { caseMix } : {}),
+        ...(options.varyUserStyles ? { varyUserStyles: true } : {}),
       });
       await executeOp(generateEvalCasesOperation, input, options, command);
     }

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -697,7 +697,13 @@ export function registerEvalCommands(program: Command): void {
         const raw = options[key];
         if (raw !== undefined) {
           const parsed = Number.parseInt(raw, 10);
-          if (Number.isFinite(parsed)) caseMix[key] = parsed;
+          if (!Number.isFinite(parsed)) {
+            const flag = key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+            throw usageError(
+              `--${flag} requires a numeric value, got "${raw}".`
+            );
+          }
+          caseMix[key] = parsed;
         }
       }
       const input = validateOpInput(generateEvalCasesOperation, {

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -19,6 +19,10 @@ import {
   runExcalidrawQuickstart,
   EXCALIDRAW_QUICKSTART_SUITE_NAME,
 } from "@/lib/evals/excalidraw-quickstart";
+import {
+  loadGenerateConfig,
+  toGenerationOptions,
+} from "@/lib/evals/eval-generation-config";
 import { EXCALIDRAW_SERVER_NAME } from "@/lib/excalidraw-quick-connect";
 import { isQuickstartSuite } from "./evals/constants";
 import type { ServerFormData } from "@/shared/types.js";
@@ -451,8 +455,15 @@ function EvalsTabContent({
           resolvedServerNames: suiteAttachment.resolvedServerNames,
         }
       : undefined;
+    // Per-suite generation config from the "Generate" popover (count, mix,
+    // vary-user-styles). Defaults reproduce today's behavior, so the one-click
+    // Generate keeps working unchanged when the popover was never touched.
+    const generationOptions = toGenerationOptions(
+      loadGenerateConfig(selectedSuite._id)
+    );
     await handlers.handleGenerateTests(selectedSuite._id, suiteServers, {
       ...(serverAttachment ? { serverAttachment } : {}),
+      generationOptions,
     });
   }, [handlers, selectedSuite]);
 

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -22,6 +22,7 @@ import {
 import {
   loadGenerateConfig,
   toGenerationOptions,
+  totalCases,
 } from "@/lib/evals/eval-generation-config";
 import { EXCALIDRAW_SERVER_NAME } from "@/lib/excalidraw-quick-connect";
 import { isQuickstartSuite } from "./evals/constants";
@@ -457,13 +458,17 @@ function EvalsTabContent({
       : undefined;
     // Per-suite generation config from the "Generate" popover (count, mix,
     // vary-user-styles). Defaults reproduce today's behavior, so the one-click
-    // Generate keeps working unchanged when the popover was never touched.
-    const generationOptions = toGenerationOptions(
-      loadGenerateConfig(selectedSuite._id)
-    );
+    // Generate keeps working unchanged when the popover was never touched. A
+    // degenerate all-zero persisted mix falls back to default generation rather
+    // than sending an empty caseMix (mirrors the popover's total >= 1 guard).
+    const generateConfig = loadGenerateConfig(selectedSuite._id);
+    const generationOptions =
+      totalCases(generateConfig) >= 1
+        ? toGenerationOptions(generateConfig)
+        : undefined;
     await handlers.handleGenerateTests(selectedSuite._id, suiteServers, {
       ...(serverAttachment ? { serverAttachment } : {}),
-      generationOptions,
+      ...(generationOptions ? { generationOptions } : {}),
     });
   }, [handlers, selectedSuite]);
 

--- a/mcpjam-inspector/client/src/components/evals/generate-cases-config-popover.tsx
+++ b/mcpjam-inspector/client/src/components/evals/generate-cases-config-popover.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import { Switch } from "@mcpjam/design-system/switch";
+import { ChevronDown, Loader2, Minus, Plus, Sparkles } from "lucide-react";
+
+import {
+  DEFAULT_GENERATE_CONFIG,
+  GENERATE_BUCKET_KEYS,
+  GENERATE_BUCKET_META,
+  type GenerateBucketKey,
+  type GenerateCasesConfig,
+  loadGenerateConfig,
+  MAX_BUCKET,
+  MAX_TOTAL,
+  MIN_BUCKET,
+  saveGenerateConfig,
+  totalCases,
+} from "@/lib/evals/eval-generation-config";
+
+interface GenerateCasesConfigPopoverProps {
+  suiteId: string;
+  /** Triggers the parent's generate action (reads the persisted config). */
+  onGenerate: () => void;
+  disabled?: boolean;
+  isGenerating?: boolean;
+  disabledReason?: string;
+}
+
+/**
+ * Chevron half of the "Generate" split button. Opens a config popover with
+ * per-bucket case-count steppers, a live total, and a "Vary user styles"
+ * toggle. The config is persisted per suite (localStorage) so the one-click
+ * Generate respects the last-used settings. Progressive disclosure: nothing
+ * here is required to generate — the plain Generate button uses the same
+ * persisted config.
+ */
+export function GenerateCasesConfigPopover({
+  suiteId,
+  onGenerate,
+  disabled = false,
+  isGenerating = false,
+  disabledReason,
+}: GenerateCasesConfigPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const [config, setConfig] = useState<GenerateCasesConfig>(
+    DEFAULT_GENERATE_CONFIG
+  );
+
+  // Seed from persisted config whenever the popover opens or the suite changes.
+  useEffect(() => {
+    if (open) setConfig(loadGenerateConfig(suiteId));
+  }, [open, suiteId]);
+
+  const total = totalCases(config);
+
+  const persist = (next: GenerateCasesConfig) => {
+    setConfig(next);
+    saveGenerateConfig(suiteId, next);
+  };
+
+  const adjustBucket = (key: GenerateBucketKey, delta: number) => {
+    const nextValue = Math.max(
+      MIN_BUCKET,
+      Math.min(MAX_BUCKET, config[key] + delta)
+    );
+    if (nextValue === config[key]) return;
+    if (delta > 0 && total >= MAX_TOTAL) return;
+    persist({ ...config, [key]: nextValue });
+  };
+
+  const handleGenerateClick = () => {
+    saveGenerateConfig(suiteId, config);
+    setOpen(false);
+    onGenerate();
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 w-7 rounded-l-none border-l-0 px-0"
+          disabled={disabled || isGenerating}
+          aria-label="Generation options"
+        >
+          <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72 p-3">
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs font-medium">Generate cases</p>
+            <p className="text-[11px] text-muted-foreground">
+              Choose how many of each kind to create.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            {GENERATE_BUCKET_KEYS.map((key) => (
+              <div
+                key={key}
+                className="flex items-center justify-between gap-2"
+              >
+                <div className="min-w-0">
+                  <span className="text-xs">
+                    {GENERATE_BUCKET_META[key].label}
+                  </span>
+                  <span className="ml-1.5 text-[11px] text-muted-foreground">
+                    {GENERATE_BUCKET_META[key].hint}
+                  </span>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-6 w-6 px-0"
+                    aria-label={`Fewer ${GENERATE_BUCKET_META[key].label} cases`}
+                    disabled={config[key] <= MIN_BUCKET}
+                    onClick={() => adjustBucket(key, -1)}
+                  >
+                    <Minus className="h-3 w-3" aria-hidden />
+                  </Button>
+                  <span className="w-5 text-center text-xs tabular-nums">
+                    {config[key]}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-6 w-6 px-0"
+                    aria-label={`More ${GENERATE_BUCKET_META[key].label} cases`}
+                    disabled={config[key] >= MAX_BUCKET || total >= MAX_TOTAL}
+                    onClick={() => adjustBucket(key, 1)}
+                  >
+                    <Plus className="h-3 w-3" aria-hidden />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex items-center justify-between border-t border-border/40 pt-2">
+            <span className="text-[11px] text-muted-foreground">Total</span>
+            <span className="text-xs font-medium tabular-nums">
+              {total} {total === 1 ? "case" : "cases"}
+            </span>
+          </div>
+
+          <label className="flex cursor-pointer items-start justify-between gap-3 border-t border-border/40 pt-2">
+            <span className="min-w-0">
+              <span className="text-xs">Vary user styles</span>
+              <span className="block text-[11px] text-muted-foreground">
+                More realistic, varied phrasing
+              </span>
+            </span>
+            <Switch
+              checked={config.varyUserStyles}
+              onCheckedChange={(checked) =>
+                persist({ ...config, varyUserStyles: checked })
+              }
+              aria-label="Vary user styles"
+            />
+          </label>
+
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 w-full gap-1.5"
+            disabled={disabled || isGenerating || total < 1}
+            aria-busy={isGenerating}
+            onClick={handleGenerateClick}
+          >
+            {isGenerating ? (
+              <Loader2
+                className="h-3.5 w-3.5 shrink-0 animate-spin"
+                aria-hidden
+              />
+            ) : (
+              <Sparkles className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            )}
+            Generate {total} {total === 1 ? "case" : "cases"}
+          </Button>
+          {disabled && disabledReason ? (
+            <p className="text-[11px] text-muted-foreground">
+              {disabledReason}
+            </p>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -44,6 +44,7 @@ import { useMutation } from "convex/react";
 import { toast } from "sonner";
 
 import { CiMetadataDisplay } from "./ci-metadata-display";
+import { GenerateCasesConfigPopover } from "./generate-cases-config-popover";
 import { PassCriteriaBadge } from "./pass-criteria-badge";
 import { ValidatorsSection } from "./validators-section";
 import {
@@ -772,48 +773,59 @@ export function SuiteHeader(props: SuiteHeaderProps) {
           <div className="flex min-w-0 flex-wrap items-center justify-end gap-2 border-l border-border/40 pl-3">
             {overviewRunAllCta}
             {showTestCaseCtas && onGenerateTestCases ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-8 gap-1.5"
-                      onClick={onGenerateTestCases}
-                      disabled={!canGenerateTestCases || isGeneratingTestCases}
-                      aria-busy={isGeneratingTestCases}
-                    >
-                      {isGeneratingTestCases ? (
-                        <Loader2
-                          className="h-3.5 w-3.5 shrink-0 animate-spin"
-                          aria-hidden
-                        />
-                      ) : (
-                        <Sparkles
-                          className="h-3.5 w-3.5 shrink-0"
-                          aria-hidden
-                        />
-                      )}
-                      Generate
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent
-                  variant="muted"
-                  side="bottom"
-                  align="start"
-                  sideOffset={8}
-                  className="max-w-[min(17rem,calc(100vw-1.5rem))] px-3 py-2 text-left font-normal leading-relaxed"
-                >
-                  {isGeneratingTestCases
-                    ? "Generating test cases…"
-                    : !canGenerateTestCases
-                    ? generateTestCasesDisabledReason ??
-                      "Configure suite servers before generating cases."
-                    : "Generate suggested cases from your server's tools."}
-                </TooltipContent>
-              </Tooltip>
+              <div className="inline-flex items-center">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-8 gap-1.5 rounded-r-none"
+                        onClick={onGenerateTestCases}
+                        disabled={
+                          !canGenerateTestCases || isGeneratingTestCases
+                        }
+                        aria-busy={isGeneratingTestCases}
+                      >
+                        {isGeneratingTestCases ? (
+                          <Loader2
+                            className="h-3.5 w-3.5 shrink-0 animate-spin"
+                            aria-hidden
+                          />
+                        ) : (
+                          <Sparkles
+                            className="h-3.5 w-3.5 shrink-0"
+                            aria-hidden
+                          />
+                        )}
+                        Generate
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    variant="muted"
+                    side="bottom"
+                    align="start"
+                    sideOffset={8}
+                    className="max-w-[min(17rem,calc(100vw-1.5rem))] px-3 py-2 text-left font-normal leading-relaxed"
+                  >
+                    {isGeneratingTestCases
+                      ? "Generating test cases…"
+                      : !canGenerateTestCases
+                      ? generateTestCasesDisabledReason ??
+                        "Configure suite servers before generating cases."
+                      : "Generate suggested cases from your server's tools. Use the arrow to set how many and what kind."}
+                  </TooltipContent>
+                </Tooltip>
+                <GenerateCasesConfigPopover
+                  suiteId={suite._id}
+                  onGenerate={onGenerateTestCases}
+                  disabled={!canGenerateTestCases}
+                  isGenerating={isGeneratingTestCases}
+                  disabledReason={generateTestCasesDisabledReason}
+                />
+              </div>
             ) : null}
             {showTestCaseCtas && onCreateTestCase ? (
               // One case type now. A render check is just a case whose turn is

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -28,6 +28,7 @@ import {
   getEvalApiEndpoints,
   runEvals,
   runEvalTestCase,
+  type GenerationOptions,
 } from "@/lib/apis/evals-api";
 import { isHostedMode } from "@/lib/apis/mode-client";
 import { normalizeHostedServerNames } from "@/lib/apis/web/context";
@@ -165,6 +166,11 @@ export type HandleGenerateEvalTestsOptions = {
     name?: string;
     resolvedServerNames: string[];
   };
+  /**
+   * Optional generation knobs (per-bucket case mix, vary-user-styles) forwarded
+   * to the backend. Absent → today's default generation.
+   */
+  generationOptions?: GenerationOptions;
 };
 
 interface UseEvalHandlersProps {
@@ -1539,6 +1545,9 @@ export function useEvalHandlers({
             }) as Promise<Array<Record<string, unknown>>>,
           ...(postOptions?.serverAttachment
             ? { serverAttachment: postOptions.serverAttachment }
+            : {}),
+          ...(postOptions?.generationOptions
+            ? { generationOptions: postOptions.generationOptions }
             : {}),
         });
 

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -168,9 +168,28 @@ export type ServerAttachmentInput = {
   resolvedServerNames: string[];
 };
 
+/**
+ * Per-bucket case counts for configurable generation. Field names mirror the
+ * backend `CaseMix`; omitted buckets inherit the backend's default mix.
+ */
+export type CaseMixInput = {
+  simple?: number;
+  multiTool?: number;
+  multiTurn?: number;
+  complex?: number;
+  negative?: number;
+};
+
+/** Optional generation knobs forwarded to the backend generate endpoint. */
+export type GenerationOptions = {
+  caseMix?: CaseMixInput;
+  varyUserStyles?: boolean;
+};
+
 type GenerateTestsRequest = EvalRequestWithServers & {
   convexAuthToken?: string | null;
   serverAttachment?: ServerAttachmentInput;
+  generationOptions?: GenerationOptions;
 };
 
 export type GeneratedEvalTestCase = {

--- a/mcpjam-inspector/client/src/lib/evals/eval-generation-config.ts
+++ b/mcpjam-inspector/client/src/lib/evals/eval-generation-config.ts
@@ -82,6 +82,10 @@ export function loadGenerateConfig(suiteId: string): GenerateCasesConfig {
     if (typeof parsed?.varyUserStyles === "boolean") {
       next.varyUserStyles = parsed.varyUserStyles;
     }
+    // Per-bucket clamping above doesn't bound the aggregate; a stale/tampered
+    // entry could exceed MAX_TOTAL. Fall back to defaults rather than forward an
+    // out-of-range mix the backend would reject.
+    if (totalCases(next) > MAX_TOTAL) return { ...DEFAULT_GENERATE_CONFIG };
     return next;
   } catch {
     return { ...DEFAULT_GENERATE_CONFIG };

--- a/mcpjam-inspector/client/src/lib/evals/eval-generation-config.ts
+++ b/mcpjam-inspector/client/src/lib/evals/eval-generation-config.ts
@@ -1,0 +1,120 @@
+import type { GenerationOptions } from "@/lib/apis/evals-api";
+
+/**
+ * Client-side, per-suite generation config for the "Generate" config popover.
+ *
+ * Progressive disclosure: the one-click Generate uses the suite's persisted
+ * config (defaults reproduce the backend's default 8-case mix). The popover
+ * edits this; nothing here is sent to the backend except via
+ * {@link toGenerationOptions}. Persisted in localStorage keyed by suite id so
+ * there is no backend schema for a UI preference.
+ */
+export type GenerateCasesConfig = {
+  simple: number;
+  multiTool: number;
+  multiTurn: number;
+  complex: number;
+  negative: number;
+  varyUserStyles: boolean;
+};
+
+export const GENERATE_BUCKET_KEYS = [
+  "simple",
+  "multiTool",
+  "multiTurn",
+  "complex",
+  "negative",
+] as const;
+
+export type GenerateBucketKey = (typeof GENERATE_BUCKET_KEYS)[number];
+
+/** Mirrors the backend's DEFAULT_NORMAL_MIX (2/2/1/1/2). */
+export const DEFAULT_GENERATE_CONFIG: GenerateCasesConfig = {
+  simple: 2,
+  multiTool: 2,
+  multiTurn: 1,
+  complex: 1,
+  negative: 2,
+  varyUserStyles: false,
+};
+
+export const GENERATE_BUCKET_META: Record<
+  GenerateBucketKey,
+  { label: string; hint: string }
+> = {
+  simple: { label: "Simple", hint: "Easy, single tool" },
+  multiTool: { label: "Multi-tool", hint: "Medium, 2+ tools" },
+  multiTurn: { label: "Multi-turn", hint: "Follow-up workflow" },
+  complex: { label: "Complex", hint: "Hard / cross-server" },
+  negative: { label: "Negative", hint: "Should not call tools" },
+};
+
+export const MIN_BUCKET = 0;
+export const MAX_BUCKET = 10;
+export const MAX_TOTAL = 20;
+
+const STORAGE_PREFIX = "mcpjam.evals.generateConfig.";
+
+function clampBucket(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.max(MIN_BUCKET, Math.min(MAX_BUCKET, Math.floor(value)));
+}
+
+export function totalCases(config: GenerateCasesConfig): number {
+  return GENERATE_BUCKET_KEYS.reduce((sum, key) => sum + config[key], 0);
+}
+
+function storageKey(suiteId: string): string {
+  return `${STORAGE_PREFIX}${suiteId}`;
+}
+
+export function loadGenerateConfig(suiteId: string): GenerateCasesConfig {
+  if (typeof window === "undefined") return { ...DEFAULT_GENERATE_CONFIG };
+  try {
+    const raw = window.localStorage.getItem(storageKey(suiteId));
+    if (!raw) return { ...DEFAULT_GENERATE_CONFIG };
+    const parsed = JSON.parse(raw) as Partial<GenerateCasesConfig>;
+    const next: GenerateCasesConfig = { ...DEFAULT_GENERATE_CONFIG };
+    for (const key of GENERATE_BUCKET_KEYS) {
+      const clamped = clampBucket(parsed?.[key]);
+      if (clamped !== null) next[key] = clamped;
+    }
+    if (typeof parsed?.varyUserStyles === "boolean") {
+      next.varyUserStyles = parsed.varyUserStyles;
+    }
+    return next;
+  } catch {
+    return { ...DEFAULT_GENERATE_CONFIG };
+  }
+}
+
+export function saveGenerateConfig(
+  suiteId: string,
+  config: GenerateCasesConfig
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey(suiteId), JSON.stringify(config));
+  } catch {
+    // Non-fatal: persistence is a convenience, not a requirement.
+  }
+}
+
+/**
+ * Convert UI config to the API `generationOptions`. Always sends the full
+ * caseMix (the popover is authoritative once touched) plus the toggle.
+ */
+export function toGenerationOptions(
+  config: GenerateCasesConfig
+): GenerationOptions {
+  return {
+    caseMix: {
+      simple: config.simple,
+      multiTool: config.multiTool,
+      multiTurn: config.multiTurn,
+      complex: config.complex,
+      negative: config.negative,
+    },
+    varyUserStyles: config.varyUserStyles,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
+++ b/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
@@ -2,6 +2,7 @@ import type { ConvexReactClient } from "convex/react";
 import {
   generateEvalTests,
   type GeneratedEvalTestCase,
+  type GenerationOptions,
   type ServerAttachmentInput,
 } from "@/lib/apis/evals-api";
 import { HOSTED_MODE } from "@/lib/config";
@@ -120,6 +121,11 @@ export type GenerateAndPersistEvalTestsOptions = {
    * cross-server coverage.
    */
   serverAttachment?: ServerAttachmentInput;
+  /**
+   * Optional generation knobs (per-bucket case mix, vary-user-styles) forwarded
+   * to the backend. Absent → today's default generation.
+   */
+  generationOptions?: GenerationOptions;
 };
 
 function getCreatedTestCaseId(created: unknown): string | null {
@@ -159,6 +165,7 @@ export async function generateAndPersistEvalTests(
     isDirectGuest = false,
     listExistingCases,
     serverAttachment,
+    generationOptions,
   } = options;
 
   let existingList: Array<Record<string, unknown>> = [];
@@ -201,6 +208,7 @@ export async function generateAndPersistEvalTests(
     serverIds,
     convexAuthToken: accessToken,
     ...(serverAttachment ? { serverAttachment } : {}),
+    ...(generationOptions ? { generationOptions } : {}),
   });
 
   const tests = result.tests ?? [];

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -478,6 +478,25 @@ export type ServerAttachmentInput = z.infer<
   typeof ServerAttachmentInputSchema
 >;
 
+// Per-bucket case counts for configurable generation. Field names mirror the
+// backend `CaseMix`. Each bucket is bounded; the backend additionally caps the
+// total. Omitted buckets inherit the backend's mode default.
+export const CaseMixSchema = z.object({
+  simple: z.number().int().min(0).max(10).optional(),
+  multiTool: z.number().int().min(0).max(10).optional(),
+  multiTurn: z.number().int().min(0).max(10).optional(),
+  complex: z.number().int().min(0).max(10).optional(),
+  negative: z.number().int().min(0).max(10).optional(),
+});
+
+// Optional generation knobs forwarded to the backend generate endpoint.
+export const GenerationOptionsSchema = z.object({
+  caseMix: CaseMixSchema.optional(),
+  varyUserStyles: z.boolean().optional(),
+});
+
+export type GenerationOptions = z.infer<typeof GenerationOptionsSchema>;
+
 // `serverNames` is the optional parallel array that pairs each `serverIds[i]`
 // (the manager key — Convex Id in hosted mode, display name in standalone)
 // with its runtime display name. The backend snapshot/attachment check is
@@ -494,6 +513,7 @@ export const GenerateTestsRequestSchema = z.object({
   convexAuthToken: z.string(),
   projectId: z.string().min(1).optional(),
   serverAttachment: ServerAttachmentInputSchema.optional(),
+  generationOptions: GenerationOptionsSchema.optional(),
 });
 
 export type GenerateTestsRequest = z.infer<typeof GenerateTestsRequestSchema>;
@@ -1697,6 +1717,7 @@ export async function generateEvalTestsWithManager(
     request.convexAuthToken,
     request.serverAttachment,
     request.projectId,
+    request.generationOptions,
   );
 
   return {

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -813,4 +813,35 @@ describe("v1 eval-edit routes", () => {
     const forwarded = generateEvalTestsMock.mock.calls.at(-1)?.[1];
     expect(forwarded?.generationOptions).toBeUndefined();
   });
+
+  it("caseMix supersedes mode:negative — uses the plan-driven generator and forwards generationOptions", async () => {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    generateEvalTestsMock.mockResolvedValue({ success: true, tests: [] });
+    generateNegativeEvalTestsMock.mockResolvedValue({
+      success: true,
+      tests: [],
+    });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({
+          serverIds: ["srv_1"],
+          serverNames: ["Excalidraw (App)"],
+        });
+      return defaultQueryImpl(name);
+    });
+
+    await request(
+      "POST",
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      { mode: "negative", caseMix: { negative: 4 } }
+    );
+    // Routed to the plan-driven generator, NOT the legacy negative-only one.
+    expect(generateNegativeEvalTestsMock).not.toHaveBeenCalled();
+    const forwarded = generateEvalTestsMock.mock.calls.at(-1)?.[1];
+    expect(forwarded?.generationOptions).toEqual({
+      caseMix: { negative: 4 },
+    });
+  });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -845,36 +845,52 @@ describe("v1 eval-edit routes", () => {
     });
   });
 
-  it("treats an empty caseMix as absent — mode:negative still uses the negative-only generator", async () => {
-    createAuthorizedManagerMock.mockResolvedValue({
-      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
-    });
-    generateEvalTestsMock.mockResolvedValue({ success: true, tests: [] });
-    generateNegativeEvalTestsMock.mockResolvedValue({
-      success: true,
-      tests: [],
-    });
-    convexQueryMock.mockImplementation((name: string) => {
-      if (name === "testSuites:getSuiteRunServerSelection")
-        return Promise.resolve({
-          serverIds: ["srv_1"],
-          serverNames: ["Excalidraw (App)"],
-        });
-      return defaultQueryImpl(name);
-    });
+  it.each([
+    { label: "empty {}", caseMix: {} },
+    { label: "zero-sum { negative: 0 }", caseMix: { negative: 0 } },
+    {
+      label: "all-zero buckets",
+      caseMix: {
+        simple: 0,
+        multiTool: 0,
+        multiTurn: 0,
+        complex: 0,
+        negative: 0,
+      },
+    },
+  ])(
+    "treats a bucketless caseMix ($label) as absent — mode:negative still uses the negative-only generator",
+    async ({ caseMix }) => {
+      createAuthorizedManagerMock.mockResolvedValue({
+        manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+      });
+      generateEvalTestsMock.mockResolvedValue({ success: true, tests: [] });
+      generateNegativeEvalTestsMock.mockResolvedValue({
+        success: true,
+        tests: [],
+      });
+      convexQueryMock.mockImplementation((name: string) => {
+        if (name === "testSuites:getSuiteRunServerSelection")
+          return Promise.resolve({
+            serverIds: ["srv_1"],
+            serverNames: ["Excalidraw (App)"],
+          });
+        return defaultQueryImpl(name);
+      });
 
-    await request(
-      "POST",
-      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
-      { mode: "negative", caseMix: {} }
-    );
-    // Empty caseMix must not supersede mode: negative-only generator is used,
-    // and no empty generationOptions leaks to the plan-driven generator.
-    expect(generateNegativeEvalTestsMock).toHaveBeenCalled();
-    expect(generateEvalTestsMock).not.toHaveBeenCalled();
-    const forwarded = generateNegativeEvalTestsMock.mock.calls.at(-1)?.[1];
-    expect(forwarded?.generationOptions).toBeUndefined();
-  });
+      await request(
+        "POST",
+        "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+        { mode: "negative", caseMix }
+      );
+      // A caseMix with no bucket > 0 must not supersede mode: the negative-only
+      // generator is used, and no empty generationOptions leaks downstream.
+      expect(generateNegativeEvalTestsMock).toHaveBeenCalled();
+      expect(generateEvalTestsMock).not.toHaveBeenCalled();
+      const forwarded = generateNegativeEvalTestsMock.mock.calls.at(-1)?.[1];
+      expect(forwarded?.generationOptions).toBeUndefined();
+    }
+  );
 
   it("mode:negative + caseMix persists per-draft negativity (positives keep tool calls)", async () => {
     createAuthorizedManagerMock.mockResolvedValue({

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -844,4 +844,62 @@ describe("v1 eval-edit routes", () => {
       caseMix: { negative: 4 },
     });
   });
+
+  it("mode:negative + caseMix persists per-draft negativity (positives keep tool calls)", async () => {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    // The plan-driven generator flags each draft; the request still carries
+    // mode:"negative", which must NOT force the positive draft negative.
+    generateEvalTestsMock.mockResolvedValue({
+      success: true,
+      tests: [
+        {
+          title: "Pos",
+          query: "do a thing",
+          runs: 1,
+          expectedToolCalls: [{ toolName: "list", arguments: {} }],
+          isNegativeTest: false,
+        },
+        {
+          title: "Neg",
+          query: "meta question",
+          runs: 1,
+          expectedToolCalls: [],
+          isNegativeTest: true,
+        },
+      ],
+    });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({
+          serverIds: ["srv_1"],
+          serverNames: ["Excalidraw (App)"],
+        });
+      return defaultQueryImpl(name);
+    });
+
+    const res = await request(
+      "POST",
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      { mode: "negative", caseMix: { simple: 1, negative: 1 } }
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.counts).toEqual({ normal: 1, negative: 1 });
+
+    const createArgs = convexMutationMock.mock.calls
+      .filter((c) => c[0] === "testSuites:createTestCase")
+      .map((c) => c[1]);
+    const posArgs = createArgs.find((a: any) => a.title === "Pos");
+    const negArgs = createArgs.find((a: any) => a.title === "Neg");
+    // Positive draft keeps its tool calls and is NOT marked negative.
+    expect(posArgs.isNegativeTest).toBeUndefined();
+    expect(posArgs.expectedToolCalls).toEqual([
+      { toolName: "list", arguments: {} },
+    ]);
+    // Negative draft is marked negative with no tool calls.
+    expect(negArgs.isNegativeTest).toBe(true);
+    expect(negArgs.expectedToolCalls).toEqual([]);
+  });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -845,6 +845,37 @@ describe("v1 eval-edit routes", () => {
     });
   });
 
+  it("treats an empty caseMix as absent — mode:negative still uses the negative-only generator", async () => {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    generateEvalTestsMock.mockResolvedValue({ success: true, tests: [] });
+    generateNegativeEvalTestsMock.mockResolvedValue({
+      success: true,
+      tests: [],
+    });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({
+          serverIds: ["srv_1"],
+          serverNames: ["Excalidraw (App)"],
+        });
+      return defaultQueryImpl(name);
+    });
+
+    await request(
+      "POST",
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      { mode: "negative", caseMix: {} }
+    );
+    // Empty caseMix must not supersede mode: negative-only generator is used,
+    // and no empty generationOptions leaks to the plan-driven generator.
+    expect(generateNegativeEvalTestsMock).toHaveBeenCalled();
+    expect(generateEvalTestsMock).not.toHaveBeenCalled();
+    const forwarded = generateNegativeEvalTestsMock.mock.calls.at(-1)?.[1];
+    expect(forwarded?.generationOptions).toBeUndefined();
+  });
+
   it("mode:negative + caseMix persists per-draft negativity (positives keep tool calls)", async () => {
     createAuthorizedManagerMock.mockResolvedValue({
       manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -760,4 +760,57 @@ describe("v1 eval-edit routes", () => {
       { title: "Bad draft", error: expect.any(String) },
     ]);
   });
+
+  it("generate forwards caseMix + varyUserStyles as generationOptions", async () => {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    generateEvalTestsMock.mockResolvedValue({ success: true, tests: [] });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({
+          serverIds: ["srv_1"],
+          serverNames: ["Excalidraw (App)"],
+        });
+      return defaultQueryImpl(name);
+    });
+
+    const res = await request(
+      "POST",
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      {
+        caseMix: { simple: 3, negative: 1 },
+        varyUserStyles: true,
+      }
+    );
+    expect(res.status).toBe(200);
+    const forwarded = generateEvalTestsMock.mock.calls.at(-1)?.[1];
+    expect(forwarded?.generationOptions).toEqual({
+      caseMix: { simple: 3, negative: 1 },
+      varyUserStyles: true,
+    });
+  });
+
+  it("generate omits generationOptions when no knobs are provided", async () => {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    generateEvalTestsMock.mockResolvedValue({ success: true, tests: [] });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({
+          serverIds: ["srv_1"],
+          serverNames: ["Excalidraw (App)"],
+        });
+      return defaultQueryImpl(name);
+    });
+
+    await request(
+      "POST",
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      { mode: "normal" }
+    );
+    const forwarded = generateEvalTestsMock.mock.calls.at(-1)?.[1];
+    expect(forwarded?.generationOptions).toBeUndefined();
+  });
 });

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -2114,14 +2114,16 @@ evals.post(
       { serverNames }
     );
 
-    // An empty `caseMix: {}` is treated as absent — same as backend #589, which
-    // ignores a bucketless mix. Without this, `{}` (truthy) would supersede
-    // `mode` here while the backend falls back to the default plan, so e.g.
-    // `{ mode: "negative", caseMix: {} }` would silently become normal
-    // generation.
+    // A caseMix only counts when it requests at least one case (a bucket > 0).
+    // An empty `{}` OR a zero-sum mix (`{ negative: 0 }`, all zeros) is treated
+    // as absent — matching backend #589, which reverts a zero-sum mix to the
+    // default plan, and the popover's `total >= 1` guard. Without this, a
+    // truthy-but-empty mix would supersede `mode` here while the backend
+    // ignored it, so e.g. `{ mode: "negative", caseMix: { negative: 0 } }`
+    // would silently become normal generation.
     const hasCaseMix =
       !!body.caseMix &&
-      Object.values(body.caseMix).some((v) => typeof v === "number");
+      Object.values(body.caseMix).some((v) => typeof v === "number" && v > 0);
     const generationOptions =
       hasCaseMix || body.varyUserStyles
         ? {

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -2122,6 +2122,15 @@ evals.post(
           }
         : undefined;
 
+    // caseMix supersedes mode: an explicit caseMix routes through the
+    // plan-driven generator (which expresses negative-only via its `negative`
+    // bucket and forwards generationOptions) and returns per-case
+    // `isNegativeTest` flags. The legacy negative-only path — which forces every
+    // draft negative — is used only when mode is "negative" AND no caseMix was
+    // given. This same flag gates persistence/counting below so a
+    // `mode: "negative"` + caseMix request doesn't mislabel its positive cases.
+    const legacyNegativeOnly = mode === "negative" && !body.caseMix;
+
     let drafts: any[];
     try {
       const request = {
@@ -2131,14 +2140,9 @@ evals.post(
         projectId,
         ...(generationOptions ? { generationOptions } : {}),
       } as unknown as RunEvalsRequest;
-      // caseMix supersedes mode: an explicit caseMix routes through the
-      // plan-driven generator (which expresses negative-only via its `negative`
-      // bucket and forwards generationOptions). The legacy negative-only
-      // generator is used only when mode is "negative" AND no caseMix was given.
-      const result =
-        mode === "negative" && !body.caseMix
-          ? await generateNegativeEvalTestsWithManager(manager, request as any)
-          : await generateEvalTestsWithManager(manager, request as any);
+      const result = legacyNegativeOnly
+        ? await generateNegativeEvalTestsWithManager(manager, request as any)
+        : await generateEvalTestsWithManager(manager, request as any);
       drafts = Array.isArray((result as any).tests)
         ? (result as any).tests
         : [];
@@ -2153,10 +2157,11 @@ evals.post(
     let normal = 0;
     let negative = 0;
     for (const draft of drafts) {
-      // Negative mode emits only negative cases; normal mode flags them per
-      // case. Negative cases must carry NO expected tool calls (the suite guard
-      // rejects that), so clear them on both the top level and prompt turns.
-      const isNeg = mode === "negative" || draft.isNegativeTest === true;
+      // The legacy negative-only path emits only negative cases; otherwise the
+      // plan-driven generator flags each draft. Negative cases must carry NO
+      // expected tool calls (the suite guard rejects that), so clear them on
+      // both the top level and prompt turns.
+      const isNeg = legacyNegativeOnly || draft.isNegativeTest === true;
       const mapCalls = (
         calls: any
       ): Array<{ toolName: string; arguments: any }> =>

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -2114,22 +2114,30 @@ evals.post(
       { serverNames }
     );
 
+    // An empty `caseMix: {}` is treated as absent — same as backend #589, which
+    // ignores a bucketless mix. Without this, `{}` (truthy) would supersede
+    // `mode` here while the backend falls back to the default plan, so e.g.
+    // `{ mode: "negative", caseMix: {} }` would silently become normal
+    // generation.
+    const hasCaseMix =
+      !!body.caseMix &&
+      Object.values(body.caseMix).some((v) => typeof v === "number");
     const generationOptions =
-      body.caseMix || body.varyUserStyles
+      hasCaseMix || body.varyUserStyles
         ? {
-            ...(body.caseMix ? { caseMix: body.caseMix } : {}),
+            ...(hasCaseMix ? { caseMix: body.caseMix } : {}),
             ...(body.varyUserStyles ? { varyUserStyles: true } : {}),
           }
         : undefined;
 
-    // caseMix supersedes mode: an explicit caseMix routes through the
+    // caseMix supersedes mode: a non-empty caseMix routes through the
     // plan-driven generator (which expresses negative-only via its `negative`
     // bucket and forwards generationOptions) and returns per-case
     // `isNegativeTest` flags. The legacy negative-only path — which forces every
-    // draft negative — is used only when mode is "negative" AND no caseMix was
-    // given. This same flag gates persistence/counting below so a
+    // draft negative — is used only when mode is "negative" AND no real caseMix
+    // was given. This same flag gates persistence/counting below so a
     // `mode: "negative"` + caseMix request doesn't mislabel its positive cases.
-    const legacyNegativeOnly = mode === "negative" && !body.caseMix;
+    const legacyNegativeOnly = mode === "negative" && !hasCaseMix;
 
     let drafts: any[];
     try {

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -913,6 +913,20 @@ const generateCasesSchema = z.object({
       })
     )
     .optional(),
+  // Per-bucket case counts. Omitted buckets inherit the default mix; the
+  // backend bounds each bucket and the total. `caseMix` supersedes `mode`.
+  caseMix: z
+    .object({
+      simple: z.number().int().min(0).max(10).optional(),
+      multiTool: z.number().int().min(0).max(10).optional(),
+      multiTurn: z.number().int().min(0).max(10).optional(),
+      complex: z.number().int().min(0).max(10).optional(),
+      negative: z.number().int().min(0).max(10).optional(),
+    })
+    .optional(),
+  // Condition the generated cases on a realistic range of user styles so the
+  // queries read like different users wrote them.
+  varyUserStyles: z.boolean().optional(),
 });
 
 /**
@@ -2100,6 +2114,14 @@ evals.post(
       { serverNames }
     );
 
+    const generationOptions =
+      body.caseMix || body.varyUserStyles
+        ? {
+            ...(body.caseMix ? { caseMix: body.caseMix } : {}),
+            ...(body.varyUserStyles ? { varyUserStyles: true } : {}),
+          }
+        : undefined;
+
     let drafts: any[];
     try {
       const request = {
@@ -2107,6 +2129,7 @@ evals.post(
         serverNames,
         convexAuthToken: token,
         projectId,
+        ...(generationOptions ? { generationOptions } : {}),
       } as unknown as RunEvalsRequest;
       const result =
         mode === "negative"

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -2131,8 +2131,12 @@ evals.post(
         projectId,
         ...(generationOptions ? { generationOptions } : {}),
       } as unknown as RunEvalsRequest;
+      // caseMix supersedes mode: an explicit caseMix routes through the
+      // plan-driven generator (which expresses negative-only via its `negative`
+      // bucket and forwards generationOptions). The legacy negative-only
+      // generator is used only when mode is "negative" AND no caseMix was given.
       const result =
-        mode === "negative"
+        mode === "negative" && !body.caseMix
           ? await generateNegativeEvalTestsWithManager(manager, request as any)
           : await generateEvalTestsWithManager(manager, request as any);
       drafts = Array.isArray((result as any).tests)

--- a/mcpjam-inspector/server/services/eval-agent.ts
+++ b/mcpjam-inspector/server/services/eval-agent.ts
@@ -16,12 +16,36 @@ export interface GenerateTestsRequest {
   serverIds: string[];
   toolSnapshot: ServerToolSnapshot;
   serverAttachment?: ServerAttachmentInput;
+  generationOptions?: GenerationOptions;
 }
 
 export interface ServerAttachmentInput {
   id?: string;
   name?: string;
   resolvedServerNames: string[];
+}
+
+/**
+ * Per-bucket case counts for configurable generation. Field names mirror the
+ * backend `CaseMix` (and the public SDK `caseMix`). Omitted buckets fall back to
+ * the backend's mode default.
+ */
+export interface CaseMixInput {
+  simple?: number;
+  multiTool?: number;
+  multiTurn?: number;
+  complex?: number;
+  negative?: number;
+}
+
+/**
+ * Optional generation knobs forwarded verbatim to the backend
+ * `/eval-generation/generate` body. Absent → today's default generation.
+ */
+export interface GenerationOptions {
+  caseMix?: CaseMixInput;
+  /** Condition cases on a generated persona slate for realistic phrasing. */
+  varyUserStyles?: boolean;
 }
 
 export interface GeneratedTestCase {
@@ -97,6 +121,7 @@ export async function generateTestCases(
   convexAuthToken: string,
   serverAttachment?: ServerAttachmentInput,
   projectId?: string,
+  generationOptions?: GenerationOptions
 ): Promise<GeneratedTestCase[]> {
   const response = await fetch(`${convexHttpUrl}/eval-generation/generate`, {
     method: "POST",
@@ -109,6 +134,10 @@ export async function generateTestCases(
       toolSnapshot,
       ...(projectId ? { projectId } : {}),
       ...(serverAttachment ? { serverAttachment } : {}),
+      ...(generationOptions?.caseMix
+        ? { caseMix: generationOptions.caseMix }
+        : {}),
+      ...(generationOptions?.varyUserStyles ? { varyUserStyles: true } : {}),
     }),
   });
 
@@ -125,7 +154,9 @@ export async function generateTestCases(
 
   if (!data.ok || !Array.isArray(data.tests)) {
     throw new Error(
-      `Invalid response from backend eval generation: ${data.error ?? "unknown error"}`,
+      `Invalid response from backend eval generation: ${
+        data.error ?? "unknown error"
+      }`
     );
   }
 

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -1623,6 +1623,54 @@ const generateEvalCasesInput = z.object({
     .array(caseModelSchema)
     .optional()
     .describe("Execution models to set on the generated cases."),
+  caseMix: z
+    .object({
+      simple: z
+        .number()
+        .int()
+        .min(0)
+        .max(10)
+        .optional()
+        .describe("Easy, single-tool, single-turn cases."),
+      multiTool: z
+        .number()
+        .int()
+        .min(0)
+        .max(10)
+        .optional()
+        .describe("Medium, 2+ tools, single-turn cases."),
+      multiTurn: z
+        .number()
+        .int()
+        .min(0)
+        .max(10)
+        .optional()
+        .describe("Medium, multi-turn follow-up cases."),
+      complex: z
+        .number()
+        .int()
+        .min(0)
+        .max(10)
+        .optional()
+        .describe("Hard, multi-turn, 3+ tools / cross-server cases."),
+      negative: z
+        .number()
+        .int()
+        .min(0)
+        .max(10)
+        .optional()
+        .describe("Cases that should NOT trigger any tools."),
+    })
+    .optional()
+    .describe(
+      "Per-bucket case counts. Omitted buckets inherit the default mix; supersedes `mode`. Each bucket and the total are bounded server-side."
+    ),
+  varyUserStyles: z
+    .boolean()
+    .optional()
+    .describe(
+      "Condition generated cases on a realistic range of user styles so the queries read like different users wrote them."
+    ),
 });
 export type GenerateEvalCasesInput = z.infer<typeof generateEvalCasesInput>;
 
@@ -1659,6 +1707,8 @@ export const generateEvalCasesOperation: PlatformOperation<
             ? { servers: overrideServers.map((server) => server.id) }
             : {}),
           ...(input.caseModels ? { caseModels: input.caseModels } : {}),
+          ...(input.caseMix ? { caseMix: input.caseMix } : {}),
+          ...(input.varyUserStyles ? { varyUserStyles: true } : {}),
         },
       },
       { signal }

--- a/sdk/tests/platform/operations-eval-edit.test.ts
+++ b/sdk/tests/platform/operations-eval-edit.test.ts
@@ -113,6 +113,25 @@ describe("eval-edit operation input validation", () => {
     ).toBe(true);
   });
 
+  it("generate_eval_cases accepts a per-bucket caseMix + varyUserStyles", () => {
+    expect(
+      generateEvalCasesOperation.inputSchema.safeParse({
+        suite: "s1",
+        caseMix: { simple: 3, negative: 1 },
+        varyUserStyles: true,
+      }).success
+    ).toBe(true);
+  });
+
+  it("generate_eval_cases rejects an out-of-range caseMix bucket", () => {
+    expect(
+      generateEvalCasesOperation.inputSchema.safeParse({
+        suite: "s1",
+        caseMix: { simple: 99 },
+      }).success
+    ).toBe(false);
+  });
+
   it("read ops are read-only; writes and deletes are not", () => {
     expect(getEvalSuiteOperation.readOnly).toBe(true);
     expect(getEvalCaseOperation.readOnly).toBe(true);
@@ -180,5 +199,32 @@ describe("eval-edit operation execution", () => {
       mode: "negative",
       caseModels: [{ model: "anthropic/claude-haiku-4.5" }],
     });
+  });
+
+  it("generate_eval_cases forwards caseMix + varyUserStyles into the body", async () => {
+    const { client, calls } = makeClient();
+    await generateEvalCasesOperation.execute(
+      {
+        suite: "s1",
+        caseMix: { simple: 3, negative: 1 },
+        varyUserStyles: true,
+      },
+      { client }
+    );
+    const gen = calls.find((c) => /\/cases\/generate$/.test(c.path));
+    expect(gen?.body).toEqual({
+      caseMix: { simple: 3, negative: 1 },
+      varyUserStyles: true,
+    });
+  });
+
+  it("generate_eval_cases omits varyUserStyles when not enabled", async () => {
+    const { client, calls } = makeClient();
+    await generateEvalCasesOperation.execute(
+      { suite: "s1", varyUserStyles: false },
+      { client }
+    );
+    const gen = calls.find((c) => /\/cases\/generate$/.test(c.path));
+    expect(gen?.body).toEqual({});
   });
 });


### PR DESCRIPTION
## What

Progressive-disclosure generation over the new backend contract (mcpjam-backend #589). One-click **Generate** is unchanged (uses the suite's persisted config; defaults reproduce today's 8-case mix); a chevron opens a config popover.

### Public API (extends `generate_eval_cases`)
`caseMix { simple, multiTool, multiTurn, complex, negative }` + `varyUserStyles`, threaded through every boundary so nothing is silently stripped:
- `eval-agent` backend body → shared `GenerateTestsRequestSchema` + `generateEvalTestsWithManager` → v1 `cases/generate` handler → client `evals-api` + `generate-and-persist` → SDK `generate_eval_cases` op.
- **CLI**: `--simple` / `--multi-tool` / `--multi-turn` / `--complex` / `--negative` + `--vary-user-styles`. **MCP** inherits via the op schema.

### UX
- **Generate** becomes a split button. New `GenerateCasesConfigPopover`: per-bucket steppers with a live total + a **"Vary user styles"** toggle (off by default).
- Config persists per suite in `localStorage` (`eval-generation-config.ts`); the one-click path reads it.
- **No persona chip** anywhere — personas are an invisible backend generation-time input only.

## Pairs with

mcpjam-backend #589 (honors `caseMix` / `varyUserStyles`). Built on top of #2804 (now merged).

## Tests
- SDK: op input validation + body forwarding (`operations-eval-edit.test.ts`).
- v1 route: `caseMix` / `varyUserStyles` translate into `generationOptions` (and are omitted when unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public generate API and persistence logic for negative vs positive cases; behavior changes when callers combine mode:negative with caseMix, though tests and guards limit regressions.
> 
> **Overview**
> **Configurable eval case generation** now accepts **`caseMix`** (simple, multi-tool, multi-turn, complex, negative counts) and **`varyUserStyles`**, threaded from the inspector UI and **`eval cases generate`** CLI through the SDK **`generate_eval_cases`** op, v1 **`cases/generate`**, shared eval routes, and **`eval-agent`** into the backend eval-generation contract.
> 
> The suite header **Generate** control is a **split button**: one-click generate still works, and a chevron opens **`GenerateCasesConfigPopover`** with per-bucket steppers (capped total), a live count, and **Vary user styles**. Settings persist **per suite in localStorage** (`eval-generation-config.ts`); both buttons read the same config, with an all-zero mix falling back to defaults.
> 
> **Routing fix:** a **`caseMix` with at least one bucket &gt; 0** supersedes **`mode: negative`**, using the plan-driven generator and per-draft **`isNegativeTest`** instead of forcing every case negative. Empty or zero-sum mixes are treated as absent so legacy negative-only generation still applies.
> 
> Tests cover SDK validation/forwarding and v1 **`generationOptions`** forwarding, omission, and mixed positive/negative persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4d360f0afe1aeff4f9bbc9e8145b1b74f0a2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->