### PR TITLE
test(xaa): isolate the xaaAuthzIssuer resync comparison

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
@@ -178,9 +178,23 @@ describe("project-serialization xaaAuthzIssuer round-trip", () => {
   });
 
   it("treats an xaaAuthzIssuer change as a difference to resync", () => {
-    const local = makeOAuthHttpServer("read", {
-      xaaAuthzIssuer: "https://issuer.test",
-    });
+    // No oauthFlowProfile on either side, so the only thing that can differ
+    // is the issuer — otherwise the assertions could pass on an unrelated
+    // OAuth-profile mismatch and never exercise the issuer comparison.
+    const local: Record<string, ServerWithName> = {
+      s1: {
+        name: "s1",
+        enabled: true,
+        useOAuth: true,
+        retryCount: 0,
+        lastConnectionTime: new Date(),
+        connectionStatus: "disconnected",
+        config: { url: new URL("https://example.test/mcp") },
+        xaaAuthzIssuer: "https://issuer.test",
+      } as ServerWithName,
+    };
+
+    // Same issuer (otherwise identical) → no resync.
     expect(
       serversHaveChanged(local, [
         {
@@ -188,8 +202,19 @@ describe("project-serialization xaaAuthzIssuer round-trip", () => {
           enabled: true,
           useOAuth: true,
           url: "https://example.test/mcp",
-          clientId: "client-1",
-          oauthScopes: ["read"],
+          xaaAuthzIssuer: "https://issuer.test",
+        },
+      ])
+    ).toBe(false);
+
+    // Only the issuer differs → resync.
+    expect(
+      serversHaveChanged(local, [
+        {
+          name: "s1",
+          enabled: true,
+          useOAuth: true,
+          url: "https://example.test/mcp",
           xaaAuthzIssuer: "https://different.test",
         },
       ])


### PR DESCRIPTION
## TL;DR
Follow-up to [#2802](https://github.com/MCPJam/inspector/pull/2802) addressing a CodeRabbit review comment: the new `xaaAuthzIssuer` resync test didn't actually prove the issuer comparison.

## Problem
The test built `local` via `makeOAuthHttpServer`, which adds OAuth-profile fields the remote fixture omitted. `serversHaveChanged` then returned `true` from that profile mismatch — so the test would pass even if the `xaaAuthzIssuer` comparison didn't exist.

## Fix
- Drop the OAuth profile from both sides so the issuer is the only thing that can differ.
- Add a **same-issuer baseline** asserting `false`, then assert `true` when only the issuer differs.

## Verification
- `vitest run project-serialization.test.ts` → 10/10 pass.
- Typecheck clean.