### PR TITLE
fix(xaa): show full saved OAuth config (clientId, scopes, secret flag, issuer) in Configure modal

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1040,6 +1040,7 @@ export function XAAFlowRoute() {
   const {
     xaaEnabled,
     appState,
+    displayServerConfigs,
     activeOrganizationId,
     convexProjectId,
     setSelectedServer,
@@ -1056,7 +1057,11 @@ export function XAAFlowRoute() {
       }
     >
       <XAAFlowTab
-        serverConfigs={appState.servers}
+        // The saved project catalog (clientId, scopes, hasClientSecret,
+        // xaaAuthzIssuer), not the runtime connection entries — the latter
+        // drop the persisted OAuth config, so the Configure modal and the
+        // runner saw a confidential server as a public client with no issuer.
+        serverConfigs={displayServerConfigs}
         selectedServerName={appState.selectedServer}
         organizationId={activeOrganizationId ?? null}
         projectId={convexProjectId ?? null}

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/utils.test.ts
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/utils.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { deriveOAuthProfileFromServer } from "../utils";
+import type { ServerWithName } from "@/hooks/use-app-state";
+
+function httpServer(
+  overrides: Partial<ServerWithName> = {},
+): ServerWithName {
+  return {
+    name: "xaa",
+    enabled: true,
+    useOAuth: true,
+    retryCount: 0,
+    lastConnectionTime: new Date(),
+    connectionStatus: "disconnected",
+    config: { url: new URL("http://localhost:8787/mcp") },
+    ...overrides,
+  } as ServerWithName;
+}
+
+describe("deriveOAuthProfileFromServer stored-credential fallback", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("fills clientId and scopes from browser-stored OAuth state when oauthFlowProfile is empty", () => {
+    // What the Connect editor reads: a registered client id and the granted
+    // scopes that never made it into oauthFlowProfile.
+    localStorage.setItem(
+      "mcp-client-xaa",
+      JSON.stringify({ client_id: "client_bc147d46f04cb865" }),
+    );
+    localStorage.setItem(
+      "mcp-oauth-config-xaa",
+      JSON.stringify({ scopes: ["mcp.access"] }),
+    );
+
+    const profile = deriveOAuthProfileFromServer(httpServer());
+    expect(profile.clientId).toBe("client_bc147d46f04cb865");
+    expect(profile.scopes).toBe("mcp.access");
+  });
+
+  it("prefers the explicit oauthFlowProfile over stored state", () => {
+    localStorage.setItem(
+      "mcp-client-xaa",
+      JSON.stringify({ client_id: "stored-client" }),
+    );
+
+    const profile = deriveOAuthProfileFromServer(
+      httpServer({
+        oauthFlowProfile: {
+          serverUrl: "http://localhost:8787/mcp",
+          clientId: "profile-client",
+          clientSecret: "",
+          scopes: "read",
+          customHeaders: [],
+        } as ServerWithName["oauthFlowProfile"],
+      }),
+    );
+    expect(profile.clientId).toBe("profile-client");
+    expect(profile.scopes).toBe("read");
+  });
+
+  it("returns empty fields when nothing is stored", () => {
+    const profile = deriveOAuthProfileFromServer(httpServer());
+    expect(profile.clientId).toBe("");
+    expect(profile.scopes).toBe("");
+  });
+});

--- a/mcpjam-inspector/client/src/components/oauth/utils.ts
+++ b/mcpjam-inspector/client/src/components/oauth/utils.ts
@@ -4,6 +4,39 @@ import {
   EMPTY_OAUTH_TEST_PROFILE,
   type OAuthTestProfile,
 } from "@/lib/oauth/profile";
+import { getStoredTokens } from "@/lib/oauth/mcp-oauth";
+
+// The Connect editor (use-server-form) surfaces a server's clientId/scopes
+// from browser storage — a DCR-registered client id, the scopes the last
+// OAuth run was granted — even when those were never written to
+// oauthFlowProfile. Mirror that read so the OAuth/XAA modals don't show
+// those fields blank for a server the Connect page clearly knows about.
+const readStoredOAuthCredentials = (
+  serverName?: string,
+): { clientId: string; scopes: string } => {
+  if (!serverName) return { clientId: "", scopes: "" };
+  try {
+    const storedTokens = getStoredTokens(serverName);
+    const clientInfo = JSON.parse(
+      localStorage.getItem(`mcp-client-${serverName}`) || "{}",
+    );
+    const oauthConfig = JSON.parse(
+      localStorage.getItem(`mcp-oauth-config-${serverName}`) || "{}",
+    );
+    const clientId =
+      (typeof storedTokens?.client_id === "string" && storedTokens.client_id) ||
+      (typeof clientInfo?.client_id === "string" && clientInfo.client_id) ||
+      "";
+    const scopeList: string[] = Array.isArray(oauthConfig?.scopes)
+      ? oauthConfig.scopes
+      : typeof storedTokens?.scope === "string"
+        ? storedTokens.scope.split(/\s+/)
+        : [];
+    return { clientId, scopes: scopeList.filter(Boolean).join(" ") };
+  } catch {
+    return { clientId: "", scopes: "" };
+  }
+};
 
 const toUrlString = (value?: string | URL): string => {
   if (!value) return "";
@@ -55,13 +88,15 @@ export const deriveOAuthProfileFromServer = (
       ? (httpConfig as any).clientSecret
       : "";
 
+  const stored = readStoredOAuthCredentials(server.name);
+
   return {
     ...EMPTY_OAUTH_TEST_PROFILE,
     ...baseProfile,
     serverUrl: baseProfile.serverUrl || toUrlString(httpConfig.url),
-    clientId: baseProfile.clientId || clientIdFromConfig,
+    clientId: baseProfile.clientId || clientIdFromConfig || stored.clientId,
     clientSecret: baseProfile.clientSecret || clientSecretFromConfig,
-    scopes: baseProfile.scopes || scopesFromConfig,
+    scopes: baseProfile.scopes || scopesFromConfig || stored.scopes,
     customHeaders: baseProfile.customHeaders.length
       ? baseProfile.customHeaders
       : fallbackHeaders,


### PR DESCRIPTION
## TL;DR
The XAA **Configure Server to Test** modal showed Client ID / Scopes / Client Secret / Authorization Server Issuer blank for a server the **Connect** page clearly has saved. Two reasons, both fixed here.

## Root cause
The XAA tab fed the modal **and the flow runner** from `appState.servers` — the **runtime connection** entries — instead of the saved **project catalog** that Connect reads. Runtime entries drop the persisted OAuth config.

| Field | Where it lives | Why XAA missed it |
|---|---|---|
| Client Secret flag (`hasClientSecret`) | catalog (Convex) | runtime entry had it `false` |
| Authorization Server Issuer (`xaaAuthzIssuer`) | catalog (Convex) | runtime entry had it unset |
| Client ID / Scopes | catalog **and/or** browser storage (DCR client, last-granted scopes) | runtime `oauthFlowProfile` empty; not read from storage |

This wasn't only cosmetic: `useXaaTestTarget` read `hasClientSecret` from the runtime entry, so a **confidential server was treated as a public client** (`usesServerSideSecret = false`) and would run with no secret.

## Fixes
1. **Source from the catalog** — the XAA tab now uses `displayServerConfigs` (the saved catalog, same source as Connect) instead of `appState.servers`. This restores `hasClientSecret`, `xaaAuthzIssuer`, and the catalog's `clientId`/`scopes`, and makes the runner correctly treat confidential servers as confidential.
2. **Stored-credential fallback** — `deriveOAuthProfileFromServer` falls back to browser-stored client id / scopes (`mcp-client-*`, stored tokens, `mcp-oauth-config-*`) when `oauthFlowProfile`/config don't carry them, so a DCR-registered client id that only lives in storage still shows. Explicit values always win.

## Verification
- XAAFlowTab (14) + XAAServerModal (8) + new `deriveOAuthProfileFromServer` (3) + ConformancePanel (11) tests pass.
- Typecheck clean.

## Risk register
| Concern | Answer |
|---|---|
| Does the XAA runner still work off the catalog entry? | Yes — it reads only config fields (url, useOAuth, clientId, scopes, issuer, secret flag); no runtime-only fields. It already queries the flat server list separately for the server id. |
| Server connected but not yet in the catalog (sync lag)? | `displayServerConfigs` merges in runtime connected/connecting servers, so it isn't dropped. |
| Override an explicitly-set value? | No — catalog/profile take precedence; storage is a last fallback. |
| Hosted mode / missing localStorage | Reads are `try/catch`; missing keys → empty. |