### PR TITLE
docs(xaa): clearer welcome-screen instructions for newcomers

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -772,32 +772,38 @@ export function XAAFlowLogger({
                 Welcome to the XAA Debugger
               </h3>
               <p className="text-sm text-muted-foreground">
-                Step through the full cross-app access (XAA) authorization flow
-                against an MCP server.
+                Cross-app access (XAA) lets one app call another app&apos;s MCP
+                server on a user&apos;s behalf — without a second login. Step
+                through that flow here and see exactly where your authorization
+                server accepts or rejects it.
               </p>
             </div>
 
             <ol className="list-decimal space-y-2 pl-5 text-sm text-muted-foreground marker:font-medium marker:text-foreground">
               <li>
                 <span className="font-medium text-foreground">
-                  Add or pick a server in the bar above
+                  Pick a server to test
                 </span>{" "}
-                — each environment (beta/staging/prod) is its own server. Set
-                the simulated identity and negative-test Mode in the run bar.
-              </li>
-              <li>
-                <span className="font-medium text-foreground">
-                  Run the flow
-                </span>{" "}
-                — MCPJam mints an ID-JAG; your authorization server redeems it
-                for an access token, one step at a time.
+                — add or pick one in the bar above (each environment —
+                beta/staging/prod — is its own server), then set the simulated
+                user and test mode in the run bar.
               </li>
               <li>
                 <span className="font-medium text-foreground">
                   Trust MCPJam at your auth server
                 </span>{" "}
-                — register the IdP endpoints (the card at the top) so your
-                authorization server accepts the ID-JAG MCPJam mints.
+                — MCPJam acts as the identity provider. Register its Issuer and
+                JWKS URLs (the card at the top) so your authorization server
+                accepts the tokens MCPJam signs. Do this first, or the next step
+                gets rejected.
+              </li>
+              <li>
+                <span className="font-medium text-foreground">
+                  Run the flow
+                </span>{" "}
+                — MCPJam mints an ID-JAG (a signed assertion of who the user
+                is); your authorization server exchanges it for an access token.
+                Advance one step at a time to inspect each request.
               </li>
             </ol>
           </div>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -793,9 +793,9 @@ export function XAAFlowLogger({
                   Trust MCPJam at your auth server
                 </span>{" "}
                 — MCPJam acts as the identity provider. Register its Issuer and
-                JWKS URLs (the card at the top) so your authorization server
-                accepts the tokens MCPJam signs. Do this first, or the next step
-                gets rejected.
+                JWKS (public signing keys) URLs (the card at the top) so your
+                authorization server accepts the tokens MCPJam signs. Do this
+                first, or the next step gets rejected.
               </li>
               <li>
                 <span className="font-medium text-foreground">


### PR DESCRIPTION
## TL;DR
Rewrites the XAA Debugger welcome copy so someone new to XAA (or a junior engineer) can follow it. Fixes a misleading step order, adds a plain-English intro, and glosses the jargon.

## What was wrong
| Issue | Before | After |
|---|---|---|
| **Step order was backwards** | "Run the flow" (2) before "Trust MCPJam at your auth server" (3) | Trust setup is now step 2, run is step 3 — running before trust gets the ID-JAG rejected |
| **No "what/why"** | Jumped straight into "cross-app access flow" | One plain line: XAA lets one app call another app's MCP server on a user's behalf, no second login |
| **Unexplained jargon** | `ID-JAG`, `IdP` bare; `negative-test Mode` odd casing | `ID-JAG` glossed as "a signed assertion of who the user is"; "identity provider" spelled out; "test mode" |

## After (full copy)
**Cross-app access (XAA) lets one app call another app's MCP server on a user's behalf — without a second login. Step through that flow here and see exactly where your authorization server accepts or rejects it.**

1. **Pick a server to test** — add or pick one in the bar above (each environment — beta/staging/prod — is its own server), then set the simulated user and test mode in the run bar.
2. **Trust MCPJam at your auth server** — MCPJam acts as the identity provider. Register its Issuer and JWKS URLs (the card at the top) so your authorization server accepts the tokens MCPJam signs. Do this first, or the next step gets rejected.
3. **Run the flow** — MCPJam mints an ID-JAG (a signed assertion of who the user is); your authorization server exchanges it for an access token. Advance one step at a time to inspect each request.

Copy-only change; typecheck clean, no tests assert on this text.