### PR TITLE
XAA/OAuth debugger UX nits: IdP discovery chips, tighter empty state, debugger-aware Add Server

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -976,6 +976,7 @@ export function OAuthFlowRoute() {
     saveServerConfigWithoutConnecting,
     handleConnectWithTokensFromOAuthFlow,
     handleRefreshTokensFromOAuthFlow,
+    oauthServerModalNonce,
     posthog,
   } = useAppRouteContext();
 
@@ -1031,6 +1032,7 @@ export function OAuthFlowRoute() {
         onSaveServerConfig={saveServerConfigWithoutConnecting}
         onConnectWithTokens={handleConnectWithTokensFromOAuthFlow}
         onRefreshTokens={handleRefreshTokensFromOAuthFlow}
+        openProfileModalSignal={oauthServerModalNonce}
       />
     </ErrorBoundary>
   );
@@ -1045,6 +1047,7 @@ export function XAAFlowRoute() {
     convexProjectId,
     setSelectedServer,
     saveServerConfigWithoutConnecting,
+    xaaServerModalNonce,
   } = useAppRouteContext();
   if (xaaEnabled !== true) return null;
 
@@ -1067,6 +1070,7 @@ export function XAAFlowRoute() {
         projectId={convexProjectId ?? null}
         onSelectServer={setSelectedServer}
         onSaveServerConfig={saveServerConfigWithoutConnecting}
+        openServerModalSignal={xaaServerModalNonce}
       />
     </ErrorBoundary>
   );
@@ -1242,6 +1246,11 @@ export default function App() {
     setOptimisticallyDeletedOrganizationIds,
   ] = useState<string[]>([]);
   const [playgroundOnboarding, setPlaygroundOnboarding] = useState(false);
+  // Bumped to ask the active debugger route to open its own "configure server"
+  // modal (XAA / OAuth) instead of the generic Add Server modal — see the
+  // onAddServerRequested wiring on the header server picker below.
+  const [xaaServerModalNonce, setXaaServerModalNonce] = useState(0);
+  const [oauthServerModalNonce, setOauthServerModalNonce] = useState(0);
   const [callbackCompleted, setCallbackCompleted] = useState(false);
   const [callbackRecoveryExpired, setCallbackRecoveryExpired] = useState(false);
   const billingDeepLinkNavRef = useRef(false);
@@ -2978,6 +2987,17 @@ export default function App() {
                 }
               : handleConnect,
           onReconnect: handleReconnect,
+          // The XAA / OAuth debuggers add servers through their own purpose-built
+          // modals (target URL + client credentials + simulated identity), not
+          // the generic Add Server modal. Route the header "Add Server" click to
+          // the active debugger's modal so it matches the in-canvas "Configure"
+          // button; other tabs fall back to the generic modal (prop omitted).
+          onAddServerRequested:
+            activeTab === "xaa-flow" && xaaEnabled === true
+              ? () => setXaaServerModalNonce((n) => n + 1)
+              : activeTab === "oauth-flow"
+                ? () => setOauthServerModalNonce((n) => n + 1)
+                : undefined,
           isMultiSelectEnabled: activeTab === "chat",
           onMultiServerToggle: toggleServerSelection,
           selectedMultipleServers: appState.selectedMultipleServers,
@@ -3121,6 +3141,8 @@ export default function App() {
     upgradePlanForActiveTab,
     workOsUser,
     xaaEnabled,
+    xaaServerModalNonce,
+    oauthServerModalNonce,
   };
 
   const appContent = (

--- a/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
@@ -39,6 +39,12 @@ export interface ActiveServerSelectorProps {
    */
   onSelectMultipleServers?: (serverNames: string[]) => void;
   onConnect: (formData: ServerFormData) => void;
+  /**
+   * Override the "Add Server" click. When provided, the button calls this
+   * instead of opening the generic Add Server modal — used by the XAA / OAuth
+   * debuggers to open their own purpose-built "configure server" modals.
+   */
+  onAddServerRequested?: () => void;
   onReconnect?: (serverName: string) => Promise<void>;
   /** Disconnect a connected server (Playground toggle off = unplug). */
   onDisconnect?: (serverName: string) => void;
@@ -94,6 +100,7 @@ export function ActiveServerSelector({
   onServerChange,
   onMultiServerToggle,
   onConnect,
+  onAddServerRequested,
   onReconnect,
   showOnlyOAuthServers = false,
   showOnlyServersWithViews = false,
@@ -316,6 +323,10 @@ export function ActiveServerSelector({
           {/* Add Server Button */}
           <button
             onClick={() => {
+              if (onAddServerRequested) {
+                onAddServerRequested();
+                return;
+              }
               setIsAddModalOpen(true);
             }}
             className={cn(

--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -507,73 +507,92 @@ export const OAuthFlowTab = ({
   return (
     <div className="h-full flex flex-col bg-background">
       <div className="flex-1 overflow-hidden">
-        <ResizablePanelGroup direction="horizontal" className="h-full">
-          <ResizablePanel defaultSize={50} minSize={30}>
-            <OAuthSequenceDiagram
-              flowState={oauthFlowState}
-              registrationStrategy={registrationStrategy}
-              protocolVersion={protocolVersion}
-              focusedStep={focusedStep}
-              hasProfile={hasProfile}
-              onConfigure={() => setIsProfileModalOpen(true)}
-            />
-          </ResizablePanel>
+        {hasProfile ? (
+          <ResizablePanelGroup direction="horizontal" className="h-full">
+            <ResizablePanel defaultSize={50} minSize={30}>
+              <OAuthSequenceDiagram
+                flowState={oauthFlowState}
+                registrationStrategy={registrationStrategy}
+                protocolVersion={protocolVersion}
+                focusedStep={focusedStep}
+                hasProfile={hasProfile}
+                onConfigure={() => setIsProfileModalOpen(true)}
+              />
+            </ResizablePanel>
 
-          <ResizableHandle withHandle />
+            <ResizableHandle withHandle />
 
-          <ResizablePanel defaultSize={50} minSize={20} maxSize={50}>
-            <OAuthFlowLogger
-              oauthFlowState={oauthFlowState}
-              onClearLogs={clearInfoLogs}
-              onClearHttpHistory={clearHttpHistory}
-              activeStep={focusedStep ?? oauthFlowState.currentStep}
-              onFocusStep={setFocusedStep}
-              hasProfile={hasProfile}
-              summary={{
-                label: hasProfile ? serverIdentifier : "No target configured",
-                description: headerDescription,
-                protocol: hasProfile ? protocolVersion : undefined,
-                registration: hasProfile
-                  ? describeRegistrationStrategy(registrationStrategy)
-                  : undefined,
-                step: oauthFlowState.currentStep,
-                serverUrl: hasProfile ? profile.serverUrl : undefined,
-                scopes:
-                  hasProfile && profile.scopes.trim()
-                    ? profile.scopes.trim()
+            <ResizablePanel defaultSize={50} minSize={20} maxSize={50}>
+              <OAuthFlowLogger
+                oauthFlowState={oauthFlowState}
+                onClearLogs={clearInfoLogs}
+                onClearHttpHistory={clearHttpHistory}
+                activeStep={focusedStep ?? oauthFlowState.currentStep}
+                onFocusStep={setFocusedStep}
+                hasProfile={hasProfile}
+                summary={{
+                  label: hasProfile
+                    ? serverIdentifier
+                    : "No target configured",
+                  description: headerDescription,
+                  protocol: hasProfile ? protocolVersion : undefined,
+                  registration: hasProfile
+                    ? describeRegistrationStrategy(registrationStrategy)
                     : undefined,
-                clientId:
-                  hasProfile && profile.clientId.trim()
-                    ? profile.clientId.trim()
+                  step: oauthFlowState.currentStep,
+                  serverUrl: hasProfile ? profile.serverUrl : undefined,
+                  scopes:
+                    hasProfile && profile.scopes.trim()
+                      ? profile.scopes.trim()
+                      : undefined,
+                  clientId:
+                    hasProfile && profile.clientId.trim()
+                      ? profile.clientId.trim()
+                      : undefined,
+                  customHeadersCount: hasProfile
+                    ? profile.customHeaders.filter((h) => h.key.trim()).length
                     : undefined,
-                customHeadersCount: hasProfile
-                  ? profile.customHeaders.filter((h) => h.key.trim()).length
-                  : undefined,
-              }}
-              actions={{
-                onConfigure: () => setIsProfileModalOpen(true),
-                onReset: hasProfile ? () => resetOAuthFlow() : undefined,
-                // Hide Continue button when showing Connect/Refresh buttons
-                onContinue:
-                  canApplyTokens || continueDisabled
-                    ? undefined
-                    : handleAdvance,
-                continueLabel,
-                continueDisabled: Boolean(canApplyTokens || continueDisabled),
-                resetDisabled: !hasProfile || oauthFlowState.isInitiatingAuth,
-                onConnectServer:
-                  canApplyTokens && !isServerConnected
-                    ? handleConnectServer
-                    : undefined,
-                onRefreshTokens:
-                  canApplyTokens && isServerConnected
-                    ? () => setIsRefreshTokensModalOpen(true)
-                    : undefined,
-                isApplyingTokens,
-              }}
-            />
-          </ResizablePanel>
-        </ResizablePanelGroup>
+                }}
+                actions={{
+                  onConfigure: () => setIsProfileModalOpen(true),
+                  onReset: hasProfile ? () => resetOAuthFlow() : undefined,
+                  // Hide Continue button when showing Connect/Refresh buttons
+                  onContinue:
+                    canApplyTokens || continueDisabled
+                      ? undefined
+                      : handleAdvance,
+                  continueLabel,
+                  continueDisabled: Boolean(
+                    canApplyTokens || continueDisabled
+                  ),
+                  resetDisabled:
+                    !hasProfile || oauthFlowState.isInitiatingAuth,
+                  onConnectServer:
+                    canApplyTokens && !isServerConnected
+                      ? handleConnectServer
+                      : undefined,
+                  onRefreshTokens:
+                    canApplyTokens && isServerConnected
+                      ? () => setIsRefreshTokensModalOpen(true)
+                      : undefined,
+                  isApplyingTokens,
+                }}
+              />
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        ) : (
+          // Empty / unconfigured: keep progressive disclosure tight — just the
+          // diagram with its centered "Configure OAuth Target" overlay. The
+          // logs sidebar only earns its space once a target is configured.
+          <OAuthSequenceDiagram
+            flowState={oauthFlowState}
+            registrationStrategy={registrationStrategy}
+            protocolVersion={protocolVersion}
+            focusedStep={focusedStep}
+            hasProfile={false}
+            onConfigure={() => setIsProfileModalOpen(true)}
+          />
+        )}
       </div>
 
       {oauthFlowState.authorizationUrl && (

--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -89,6 +89,12 @@ interface OAuthFlowTabProps {
     tokens: OAuthTokensFromFlow,
     serverUrl: string,
   ) => Promise<void>;
+  /**
+   * Bumped by the shell when the header "Add Server" button is clicked while
+   * this tab is active, so the Configure-OAuth-Target modal opens instead of
+   * the generic Add Server modal. Each new value (not the initial one) opens it.
+   */
+  openProfileModalSignal?: number;
 }
 
 export const OAuthFlowTab = ({
@@ -98,8 +104,18 @@ export const OAuthFlowTab = ({
   onSaveServerConfig,
   onConnectWithTokens,
   onRefreshTokens,
+  openProfileModalSignal,
 }: OAuthFlowTabProps) => {
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+
+  // Open the modal when the shell bumps the signal (header "Add Server"). Skip
+  // the initial value so it doesn't pop open on mount.
+  const prevOpenSignalRef = useRef(openProfileModalSignal);
+  useEffect(() => {
+    if (openProfileModalSignal === prevOpenSignalRef.current) return;
+    prevOpenSignalRef.current = openProfileModalSignal;
+    setIsProfileModalOpen(true);
+  }, [openProfileModalSignal]);
   const [pendingServerSelection, setPendingServerSelection] = useState<
     string | null
   >(null);

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -74,6 +74,12 @@ interface XAAFlowTabProps {
   // Shared server-bar callbacks (mirror the OAuth Debugger).
   onSelectServer?: (serverName: string) => void;
   onSaveServerConfig?: (formData: ServerFormData) => void | Promise<void>;
+  /**
+   * Bumped by the shell when the header "Add Server" button is clicked while
+   * this tab is active, so the Configure-Server-to-Test modal opens instead of
+   * the generic Add Server modal. Each new value (not the initial one) opens it.
+   */
+  openServerModalSignal?: number;
 }
 
 export function XAAFlowTab({
@@ -83,10 +89,20 @@ export function XAAFlowTab({
   projectId,
   onSelectServer,
   onSaveServerConfig,
+  openServerModalSignal,
 }: XAAFlowTabProps) {
   const [isServerModalOpen, setIsServerModalOpen] = useState(false);
   const [focusedStep, setFocusedStep] = useState<XAAFlowStep | null>(null);
   const [isRunningAll, setIsRunningAll] = useState(false);
+
+  // Open the modal when the shell bumps the signal (header "Add Server"). Skip
+  // the initial value so it doesn't pop open on mount.
+  const prevOpenSignalRef = useRef(openServerModalSignal);
+  useEffect(() => {
+    if (openServerModalSignal === prevOpenSignalRef.current) return;
+    prevOpenSignalRef.current = openServerModalSignal;
+    setIsServerModalOpen(true);
+  }, [openServerModalSignal]);
 
   const selectedServer =
     selectedServerName !== "none"

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -609,7 +609,7 @@ export function XAAFlowTab({
               </div>
             </div>
           </div>
-        ) : (
+        ) : isTestable ? (
           <ResizablePanelGroup direction="horizontal" className="h-full">
             <ResizablePanel defaultSize={52} minSize={30} className="min-w-0">
               <XAASequenceDiagram
@@ -656,14 +656,27 @@ export function XAAFlowTab({
               />
             </ResizablePanel>
           </ResizablePanelGroup>
+        ) : (
+          // Empty / unconfigured: keep progressive disclosure tight — just the
+          // diagram with its centered "Configure Server to Test" overlay. The
+          // run sidebar and negative-test footer only earn their space once
+          // there's a testable server, so they stay hidden until then.
+          <XAASequenceDiagram
+            flowState={flowState}
+            focusedStep={focusedStep}
+            hasProfile={false}
+            onConfigure={() => setIsServerModalOpen(true)}
+          />
         )}
       </div>
 
-      <NegativeTestScorecard
-        input={scorecard.input}
-        unlocked={positiveRunTargets.has(targetKey)}
-        unavailableReason={scorecard.unavailableReason}
-      />
+      {isTestable && (
+        <NegativeTestScorecard
+          input={scorecard.input}
+          unlocked={positiveRunTargets.has(targetKey)}
+          unavailableReason={scorecard.unavailableReason}
+        />
+      )}
 
       <XAAServerModal
         open={isServerModalOpen}

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { AlertTriangle, Check, Copy, Info, KeyRound } from "lucide-react";
-import { Button } from "@mcpjam/design-system/button";
 import {
   HoverCard,
   HoverCardContent,
@@ -10,9 +9,9 @@ import { HOSTED_MODE } from "@/lib/config";
 import { copyToClipboard } from "@/lib/clipboard";
 import { fetchXaaIdpUrls, getXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
 
-// Inline label + value + copy button, sized to share one horizontal bar with
-// the sibling field. The URL is truncated (the copy button carries the full
-// value); the native title surfaces it on hover for a quick read.
+// A compact click-to-copy chip: shows only the label to keep the bar minimal —
+// the long URL stays hidden (revealed on hover via the native title) and the
+// whole chip copies the full value. The icon flips to a check on copy.
 function CopyField({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
   const resetTimerRef = useRef<number | null>(null);
@@ -42,32 +41,20 @@ function CopyField({ label, value }: { label: string; value: string }) {
   }, []);
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-2">
-      <span className="shrink-0 text-xs font-medium text-muted-foreground">
-        {label}
-      </span>
-      <div
-        className="min-w-0 flex-1 truncate rounded-md border border-border bg-muted/30 px-2.5 py-1.5 font-mono text-xs"
-        title={value}
-      >
-        {value}
-      </div>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="shrink-0"
-        onClick={handleCopy}
-        aria-label={`Copy ${label}`}
-      >
-        {copied ? (
-          <Check className="h-3.5 w-3.5" />
-        ) : (
-          <Copy className="h-3.5 w-3.5" />
-        )}
-        <span className="ml-1">{copied ? "Copied" : "Copy"}</span>
-      </Button>
-    </div>
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={value}
+      aria-label={`Copy ${label}`}
+      className="group inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span>{copied ? "Copied" : label}</span>
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-emerald-500" />
+      ) : (
+        <Copy className="h-3.5 w-3.5 opacity-60 transition-opacity group-hover:opacity-100" />
+      )}
+    </button>
   );
 }
 
@@ -161,7 +148,7 @@ export function XAAIdpCard() {
   // Start from the browser-origin guess, then swap in the server-advertised
   // issuer once resolved — see fetchXaaIdpUrls for why the guess can be wrong.
   const [urls, setUrls] = useState(() => getXaaIdpUrls());
-  const { issuerBaseUrl, jwksUrl } = urls;
+  const { issuerBaseUrl, openidConfigUrl, jwksUrl } = urls;
 
   // Resolve the real issuer from the server's discovery doc once on mount —
   // the URLs are always visible now, so there's no expand to defer it to.
@@ -186,8 +173,9 @@ export function XAAIdpCard() {
           </span>
           <IdpInfo />
         </div>
-        <div className="flex min-w-[20rem] flex-[1_1_24rem] flex-wrap items-center gap-x-4 gap-y-2">
+        <div className="flex flex-wrap items-center gap-2">
           <CopyField label="Issuer URL" value={issuerBaseUrl} />
+          <CopyField label="OpenID Config" value={openidConfigUrl} />
           <CopyField label="JWKS URL" value={jwksUrl} />
         </div>
       </div>


### PR DESCRIPTION
## Summary

A few UX refinements to the XAA and OAuth debuggers.

### 1. XAA IdP card — click-to-copy chips + OpenID Config
- The IdP bar's `Issuer URL` / `JWKS URL` fields are now compact **click-to-copy chips** (label only; full URL on hover, copied on click) instead of long truncated URL boxes.
- Added an **OpenID Config** chip (`/.well-known/openid-configuration`) between Issuer and JWKS — it's the doc you hand a counterparty to federate ("be an OIDC IDP"), and it was already computed but never surfaced. Order reads Issuer → OpenID Config → JWKS.

### 2. Tighter empty state (both debuggers)
When no server is configured, the page now shows **only** the faded sequence diagram with its centered "Configure…" card:
- **XAA**: hides the right-hand run sidebar (Welcome/instructions) and the Negative-test scorecard footer until a server is testable.
- **OAuth**: hides the right-hand logs sidebar (Welcome/instructions, Guide/Raw) until a target is configured.

Both come back exactly as before once a server is selected/testable. Progressive disclosure: one action in the empty state, full instrumentation once there's something to test.

### 3. Header "Add Server" opens the debugger's own modal
On the XAA/OAuth debuggers, clicking **Add Server** in the header server picker now opens that debugger's purpose-built modal (Configure Server to Test / Configure OAuth Target) instead of the generic "Add MCP Server" modal — matching the in-canvas Configure button. Every other tab is unchanged.

Wiring: `ActiveServerSelector` gains an optional `onAddServerRequested` override; App.tsx routes it per `activeTab` via a small nonce signal through the existing route context, which each flow tab consumes to open its own modal (a `prevRef` guard skips opening on mount).

## Test plan
- `npx tsc --noEmit -p client/tsconfig.typecheck.json` passes (0 errors).
- Manual: empty state shows only the diagram + Configure card on both debuggers; header Add Server opens the XAA/OAuth modal; IdP chips copy the right URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and navigation wiring in debugger tabs; no changes to auth, token handling, or server APIs.
> 
> **Overview**
> **XAA and OAuth debugger UX** — tighter empty states, IdP bar copy affordances, and header **Add Server** aligned with each debugger’s configure flow.
> 
> On **XAA/OAuth** tabs, **Add Server** in the header server picker now opens that tab’s **Configure Server to Test** / **Configure OAuth Target** modal (via incremented nonce signals through route context) instead of the generic Add MCP Server modal. `ActiveServerSelector` adds an optional `onAddServerRequested` override; other tabs behave as before.
> 
> When no target is configured, **OAuth** shows only the sequence diagram with its configure overlay; the logs sidebar appears after a profile exists. **XAA** does the same for the run sidebar and hides the **NegativeTestScorecard** until the server is testable.
> 
> The **XAA IdP** bar replaces long URL fields with **click-to-copy chips** (label visible, full URL on hover/title) and surfaces a new **OpenID Config** chip between Issuer and JWKS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e6ed07672a9909dc0bfc79c5bc32fb00159426a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->