### PR TITLE
Gray out free models when out of credits

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MCPJamLimitDialog } from "../mcpjam-limit-dialog";
 import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
+import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 const signIn = vi.fn();
 const authState: { isLoading: boolean; user: { id: string } | null } = {
@@ -62,6 +63,7 @@ beforeEach(() => {
     organizationId: null,
     pendingInput: null,
   });
+  useModelPickerIntentStore.setState({ openProvidersTabNonce: 0 });
 });
 
 afterEach(() => {
@@ -152,19 +154,26 @@ describe("MCPJamLimitDialog", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("redirects to the org models page on BYOK click", async () => {
+  it("opens the model picker's Your providers tab on BYOK click (no org redirect)", async () => {
     const user = userEvent.setup();
     authState.user = { id: "user-1" };
     localStorage.setItem("active-organization-id:user-1", "org-active");
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    const nonceBefore =
+      useModelPickerIntentStore.getState().openProvidersTabNonce;
     render(<MCPJamLimitDialog />);
 
     await user.click(
       screen.getByRole("button", { name: /bring your own key/i })
     );
 
+    // Closes the dialog and asks the picker to open its "Your providers" tab —
+    // it must NOT navigate to the org models settings page.
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
-    expect(window.location.pathname).toBe("/organizations/org-active/models");
+    expect(useModelPickerIntentStore.getState().openProvidersTabNonce).toBe(
+      nonceBefore + 1
+    );
+    expect(window.location.pathname).not.toContain("/models");
   });
 
   it("redirects to the active org's billing page with the topup flag on CTA click", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -58,6 +58,8 @@ beforeEach(() => {
   useMCPJamLimitDialogStore.setState({
     authStatus: "loading",
     hasPendingLimit: false,
+    outOfCreditsHit: false,
+    outOfCreditsOrganizationId: null,
     isOpen: false,
     intent: null,
     organizationId: null,

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/error.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/error.test.tsx
@@ -7,6 +7,8 @@ beforeEach(() => {
   useMCPJamLimitDialogStore.setState({
     authStatus: "loading",
     hasPendingLimit: false,
+    outOfCreditsHit: false,
+    outOfCreditsOrganizationId: null,
     isOpen: false,
     intent: null,
     organizationId: null,
@@ -28,7 +30,7 @@ describe("ErrorBox daily-limit handling", () => {
     expect(container).toBeEmptyDOMElement();
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
     expect(
-      screen.queryByText(/Daily MCPJam model limit reached/i),
+      screen.queryByText(/Daily MCPJam model limit reached/i)
     ).not.toBeInTheDocument();
   });
 
@@ -46,7 +48,7 @@ describe("ErrorBox daily-limit handling", () => {
         code="user_rate_limit"
         limitKind="total"
         onResetChat={vi.fn()}
-      />,
+      />
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -60,11 +62,11 @@ describe("ErrorBox daily-limit handling", () => {
         limitKind="concurrency"
         retryAfterMs={3000}
         onResetChat={vi.fn()}
-      />,
+      />
     );
 
     expect(
-      screen.getByText(/Another credit-funded chat is finishing/i),
+      screen.getByText(/Another credit-funded chat is finishing/i)
     ).toBeInTheDocument();
   });
 
@@ -74,7 +76,7 @@ describe("ErrorBox daily-limit handling", () => {
         message="Something exploded"
         code="provider_error"
         onResetChat={vi.fn()}
-      />,
+      />
     );
 
     expect(screen.getByText(/Something exploded/i)).toBeInTheDocument();
@@ -82,13 +84,7 @@ describe("ErrorBox daily-limit handling", () => {
   });
 
   it("still renders the wallet-locked banner when walletLocked is set", () => {
-    render(
-      <ErrorBox
-        message="Locked"
-        walletLocked
-        onResetChat={vi.fn()}
-      />,
-    );
+    render(<ErrorBox message="Locked" walletLocked onResetChat={vi.fn()} />);
 
     expect(screen.getByText(/Account under review/i)).toBeInTheDocument();
   });

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-selector.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-selector.test.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ModelSelector } from "../chat-input/model-selector";
 import type { ModelDefinition } from "@/shared/types";
+import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({
@@ -19,7 +20,7 @@ vi.mock("../chat-input/model/provider-logo", () => ({
 
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: (
-    selector: (state: { themeMode: "light" | "dark" }) => unknown,
+    selector: (state: { themeMode: "light" | "dark" }) => unknown
   ) => selector({ themeMode: "light" }),
 }));
 
@@ -43,6 +44,21 @@ const models: ModelDefinition[] = [
     supportsTools: true,
     supportsVision: true,
     supportsStreaming: true,
+  },
+];
+
+const outOfCreditsModels: ModelDefinition[] = [
+  {
+    id: "anthropic/claude-haiku-4.5",
+    name: "Claude Haiku 4.5 (Free)",
+    provider: "anthropic",
+    disabled: true,
+    disabledReason: "You're out of credits. Top up or use your own key.",
+  },
+  {
+    id: "gpt-5-mini",
+    name: "GPT-5 Mini",
+    provider: "openai",
   },
 ];
 
@@ -96,7 +112,26 @@ function OpenChangeProbe({
   );
 }
 
+function ProviderIntentControlledModelSelector() {
+  const [currentModel, setCurrentModel] = useState<ModelDefinition>(
+    outOfCreditsModels[0]!
+  );
+
+  return (
+    <ModelSelector
+      currentModel={currentModel}
+      availableModels={outOfCreditsModels}
+      onModelChange={setCurrentModel}
+      respondToProviderTabIntent
+    />
+  );
+}
+
 describe("ModelSelector", () => {
+  beforeEach(() => {
+    useModelPickerIntentStore.setState({ openProvidersTabNonce: 0 });
+  });
+
   it("keeps the popover open when multiple models are enabled", async () => {
     const user = userEvent.setup();
 
@@ -106,13 +141,13 @@ describe("ModelSelector", () => {
     expect(screen.getByPlaceholderText("Search models")).toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("switch", { name: "Use multiple models" }),
+      screen.getByRole("switch", { name: "Use multiple models" })
     );
 
     expect(screen.getByPlaceholderText("Search models")).toBeInTheDocument();
     expect(screen.getByText("Multiple models")).toBeInTheDocument();
     expect(
-      screen.getByRole("switch", { name: "Use multiple models" }),
+      screen.getByRole("switch", { name: "Use multiple models" })
     ).toHaveAttribute("aria-checked", "true");
   });
 
@@ -126,8 +161,8 @@ describe("ModelSelector", () => {
 
     expect(
       screen.queryByText(
-        /Compare up to 3 models in one composer\. The first in your selection runs first\./i,
-      ),
+        /Compare up to 3 models in one composer\. The first in your selection runs first\./i
+      )
     ).not.toBeInTheDocument();
   });
 
@@ -137,7 +172,7 @@ describe("ModelSelector", () => {
     const secondCallback = vi.fn();
 
     const { rerender } = render(
-      <OpenChangeProbe onOpenChange={firstCallback} />,
+      <OpenChangeProbe onOpenChange={firstCallback} />
     );
 
     await user.click(screen.getByRole("button", { name: /gpt-4\.1/i }));
@@ -166,7 +201,7 @@ describe("ModelSelector", () => {
         selectedModels={[models[0]]}
         onSelectedModelsChange={onSelectedModelsChange}
         onMultiModelEnabledChange={onMultiModelEnabledChange}
-      />,
+      />
     );
 
     await user.click(screen.getByRole("button", { name: /gpt-4\.1/i }));
@@ -182,13 +217,29 @@ describe("ModelSelector", () => {
         selectedModels={[models[0], models[1]]}
         onSelectedModelsChange={onSelectedModelsChange}
         onMultiModelEnabledChange={onMultiModelEnabledChange}
-      />,
+      />
     );
 
     expect(screen.getByPlaceholderText("Search models")).toBeInTheDocument();
     expect(
-      screen.getByRole("switch", { name: "Use multiple models" }),
+      screen.getByRole("switch", { name: "Use multiple models" })
     ).toHaveAttribute("aria-checked", "true");
     expect(screen.getAllByText("Claude 3.7 Sonnet").length).toBeGreaterThan(0);
+  });
+
+  it("selects the first enabled provider model when the BYOK intent opens providers", async () => {
+    render(<ProviderIntentControlledModelSelector />);
+
+    act(() => {
+      useModelPickerIntentStore.getState().requestOpenProvidersTab();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /gpt-5 mini/i })).toBeVisible();
+    });
+
+    expect(screen.getByPlaceholderText("Search models")).toBeInTheDocument();
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+    expect(screen.queryByText("Anthropic")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -847,6 +847,7 @@ export function ChatInput({
                   selectedModels={effectiveSelectedModels}
                   onSelectedModelsChange={onSelectedModelsChange}
                   onMultiModelEnabledChange={onMultiModelEnabledChange}
+                  respondToProviderTabIntent
                 />
               )}
             </div>

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
@@ -31,6 +31,7 @@ import {
   getLogoProvider,
   getProviderDisplayName,
 } from "@/components/chat-v2/shared/model-helpers";
+import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 interface ModelSelectorProps {
   currentModel: ModelDefinition;
@@ -60,6 +61,12 @@ interface ModelSelectorProps {
    * clean.
    */
   analyticsLocation?: string;
+  /**
+   * When true, this picker listens for the global "open Your providers tab"
+   * intent (fired by the out-of-credits dialog's BYOK action) and pops open
+   * on the configured tab. Only the chat-input instance opts in.
+   */
+  respondToProviderTabIntent?: boolean;
 }
 
 type GroupKey = string;
@@ -125,6 +132,7 @@ export function ModelSelector({
   maxSelectedModels = 3,
   align = "start",
   analyticsLocation = "chat_input",
+  respondToProviderTabIntent = false,
 }: ModelSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [providerTab, setProviderTab] = useState<"provided" | "configured">(
@@ -138,6 +146,11 @@ export function ModelSelector({
   >(null);
   const posthog = usePostHog();
   const onOpenChangeRef = useRef(onOpenChange);
+  const forceConfiguredTabRef = useRef(false);
+  const handledProvidersTabNonceRef = useRef(0);
+  const providersTabNonce = useModelPickerIntentStore((state) =>
+    respondToProviderTabIntent ? state.openProvidersTabNonce : 0
+  );
 
   useEffect(() => {
     onOpenChangeRef.current = onOpenChange;
@@ -149,15 +162,37 @@ export function ModelSelector({
 
   useEffect(() => {
     if (isOpen) {
+      if (forceConfiguredTabRef.current) {
+        // A caller forced the "Your providers" tab (BYOK from the
+        // out-of-credits dialog). Keep it instead of resetting to the current
+        // model's tab; consume the flag so the next manual open resolves
+        // normally.
+        forceConfiguredTabRef.current = false;
+        return;
+      }
       setProviderTab(
         isMCPJamProvidedModel(String(currentModel.id), currentModel.provider)
           ? "provided"
           : "configured"
       );
     } else {
+      forceConfiguredTabRef.current = false;
       setSearch("");
     }
   }, [isOpen, currentModel]);
+
+  // React to the global "open Your providers tab" intent (out-of-credits
+  // BYOK). Only the opted-in instance subscribes to a live nonce; others read
+  // a constant 0 so this never fires for them.
+  useEffect(() => {
+    if (!respondToProviderTabIntent) return;
+    if (providersTabNonce === 0) return;
+    if (providersTabNonce === handledProvidersTabNonceRef.current) return;
+    handledProvidersTabNonceRef.current = providersTabNonce;
+    forceConfiguredTabRef.current = true;
+    setProviderTab("configured");
+    setIsOpen(true);
+  }, [providersTabNonce, respondToProviderTabIntent]);
 
   useEffect(() => {
     return () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
@@ -19,7 +19,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@mcpjam/design-system/command";
-import { ModelDefinition, isMCPJamProvidedModel } from "@/shared/types.js";
+import { ModelDefinition } from "@/shared/types.js";
 import {
   Tooltip,
   TooltipContent,
@@ -30,6 +30,7 @@ import {
   compactModelLabel,
   getLogoProvider,
   getProviderDisplayName,
+  isMCPJamProvidedModelMenuItem,
 } from "@/components/chat-v2/shared/model-helpers";
 import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
@@ -148,6 +149,7 @@ export function ModelSelector({
   const onOpenChangeRef = useRef(onOpenChange);
   const forceConfiguredTabRef = useRef(false);
   const handledProvidersTabNonceRef = useRef(0);
+  const selectedProvidersTabNonceRef = useRef(0);
   const providersTabNonce = useModelPickerIntentStore((state) =>
     respondToProviderTabIntent ? state.openProvidersTabNonce : 0
   );
@@ -171,28 +173,13 @@ export function ModelSelector({
         return;
       }
       setProviderTab(
-        isMCPJamProvidedModel(String(currentModel.id), currentModel.provider)
-          ? "provided"
-          : "configured"
+        isMCPJamProvidedModelMenuItem(currentModel) ? "provided" : "configured"
       );
     } else {
       forceConfiguredTabRef.current = false;
       setSearch("");
     }
   }, [isOpen, currentModel]);
-
-  // React to the global "open Your providers tab" intent (out-of-credits
-  // BYOK). Only the opted-in instance subscribes to a live nonce; others read
-  // a constant 0 so this never fires for them.
-  useEffect(() => {
-    if (!respondToProviderTabIntent) return;
-    if (providersTabNonce === 0) return;
-    if (providersTabNonce === handledProvidersTabNonceRef.current) return;
-    handledProvidersTabNonceRef.current = providersTabNonce;
-    forceConfiguredTabRef.current = true;
-    setProviderTab("configured");
-    setIsOpen(true);
-  }, [providersTabNonce, respondToProviderTabIntent]);
 
   useEffect(() => {
     return () => {
@@ -280,7 +267,7 @@ export function ModelSelector({
     for (const provider of sortedProviders) {
       const allModels = groupedModels.get(provider) || [];
       const filtered = hideProvidedModels
-        ? allModels.filter((model) => !isMCPJamProvidedModel(String(model.id)))
+        ? allModels.filter((model) => !isMCPJamProvidedModelMenuItem(model))
         : allModels;
 
       if (filtered.length === 0) {
@@ -288,10 +275,10 @@ export function ModelSelector({
       }
 
       const provided = filtered.filter((model) =>
-        isMCPJamProvidedModel(String(model.id))
+        isMCPJamProvidedModelMenuItem(model)
       );
       const configured = filtered.filter(
-        (model) => !isMCPJamProvidedModel(String(model.id))
+        (model) => !isMCPJamProvidedModelMenuItem(model)
       );
       const title = getProviderDisplayName(provider);
 
@@ -337,8 +324,43 @@ export function ModelSelector({
     );
     return { provided, configured };
   }, [modelGroups]);
+  const firstEnabledConfiguredModel = useMemo(
+    () =>
+      modelSections.configured
+        .flatMap((group) => group.models)
+        .find((model) => !model.disabled),
+    [modelSections]
+  );
   const selectedLimitReached =
     multiModelEnabled && selectedModelsData.length >= maxSelectedModels;
+
+  // React to the global "open Your providers tab" intent (out-of-credits
+  // BYOK). Only the opted-in instance subscribes to a live nonce; others read
+  // a constant 0 so this never fires for them.
+  useEffect(() => {
+    if (!respondToProviderTabIntent) return;
+    if (providersTabNonce === 0) return;
+
+    if (providersTabNonce !== handledProvidersTabNonceRef.current) {
+      handledProvidersTabNonceRef.current = providersTabNonce;
+      forceConfiguredTabRef.current = true;
+      setProviderTab("configured");
+      setIsOpen(true);
+    }
+
+    if (
+      providersTabNonce !== selectedProvidersTabNonceRef.current &&
+      firstEnabledConfiguredModel
+    ) {
+      selectedProvidersTabNonceRef.current = providersTabNonce;
+      onModelChange(firstEnabledConfiguredModel);
+    }
+  }, [
+    firstEnabledConfiguredModel,
+    onModelChange,
+    providersTabNonce,
+    respondToProviderTabIntent,
+  ]);
 
   const requestSelectionChange = (nextChange: PendingSelectionChange) => {
     const isSingleNoOp =

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/model-helpers.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/model-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAvailableModelsFromOrgConfig,
+  buildModelMenuGroups,
   isOrgProviderAvailable,
 } from "../model-helpers";
 
@@ -77,5 +78,31 @@ describe("org model helpers", () => {
         (m) => m.provider === "bedrock"
       )
     ).toBe(false);
+  });
+
+  it("keeps OpenRouter models with provider-prefixed ids under configured providers", () => {
+    const groups = buildModelMenuGroups([
+      {
+        id: "openai/gpt-5-mini",
+        name: "GPT-5 Mini (Free)",
+        provider: "openai",
+      },
+      {
+        id: "openai/gpt-5-mini",
+        name: "openai/gpt-5-mini",
+        provider: "openrouter",
+      },
+    ]);
+
+    expect(groups).toEqual([
+      expect.objectContaining({
+        provider: "openai",
+        providerType: "provided",
+      }),
+      expect.objectContaining({
+        provider: "openrouter",
+        providerType: "configured",
+      }),
+    ]);
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/out-of-credits-locks.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/out-of-credits-locks.test.ts
@@ -71,13 +71,14 @@ describe("isOutOfCredits", () => {
 });
 
 const model = (id: string, provider = "anthropic"): ModelDefinition =>
-  ({ id, name: id, provider }) as ModelDefinition;
+  ({ id, name: id, provider } as ModelDefinition);
 
 describe("applyOutOfCreditsLocks", () => {
   const models = [
     model("anthropic/claude-haiku-4.5"), // MCPJam-provided (free)
     model("anthropic/claude-opus-4.5"), // MCPJam-provided (free)
     model("amazon.nova-micro-v1:0", "bedrock"), // own-key / BYOK
+    model("openai/gpt-5-mini", "openrouter"), // own-key / BYOK with a provider-prefixed id
     model("custom:acme:acme-large", "custom"), // custom provider
   ];
 
@@ -97,6 +98,7 @@ describe("applyOutOfCreditsLocks", () => {
 
     // Own-key models stay usable — switching to them is the way out.
     expect(byId["amazon.nova-micro-v1:0"].disabled).toBeUndefined();
+    expect(byId["openai/gpt-5-mini"].disabled).toBeUndefined();
     expect(byId["custom:acme:acme-large"].disabled).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/out-of-credits-locks.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/out-of-credits-locks.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyOutOfCreditsLocks,
+  OUT_OF_CREDITS_MODEL_REASON,
+} from "../available-models";
+import {
+  isOutOfCredits,
+  type CreditBalanceState,
+} from "@/hooks/useCreditBalance";
+import type { ModelDefinition } from "@/shared/types";
+
+const makeBalance = (
+  overrides: Partial<CreditBalanceState> = {}
+): CreditBalanceState => ({
+  paidCreditsRemaining: 0,
+  hasPurchaseHistory: false,
+  freeDailyPercentUsed: 100,
+  freeDailyResetAt: 0,
+  freeDailyCreditsRemaining: 0,
+  freeDailyCreditsTotal: 300,
+  walletLocked: false,
+  billingModel: "daily",
+  ...overrides,
+});
+
+describe("isOutOfCredits", () => {
+  it("is false when the balance is unavailable (loading / signed out)", () => {
+    expect(isOutOfCredits(undefined)).toBe(false);
+  });
+
+  it("on a daily plan, is true only once both free daily and paid are spent", () => {
+    expect(
+      isOutOfCredits(
+        makeBalance({ freeDailyCreditsRemaining: 0, paidCreditsRemaining: 0 })
+      )
+    ).toBe(true);
+    expect(
+      isOutOfCredits(
+        makeBalance({ freeDailyCreditsRemaining: 0, paidCreditsRemaining: 5 })
+      )
+    ).toBe(false);
+    expect(
+      isOutOfCredits(
+        makeBalance({ freeDailyCreditsRemaining: 12, paidCreditsRemaining: 0 })
+      )
+    ).toBe(false);
+  });
+
+  it("on a team plan, uses the monthly allowance instead of the daily bucket", () => {
+    expect(
+      isOutOfCredits(
+        makeBalance({
+          billingModel: "monthly_per_seat",
+          monthlyAllowanceRemaining: 0,
+          paidCreditsRemaining: 0,
+          // A leftover daily figure must not keep a monthly team "in credits".
+          freeDailyCreditsRemaining: 50,
+        })
+      )
+    ).toBe(true);
+    expect(
+      isOutOfCredits(
+        makeBalance({
+          billingModel: "monthly_per_seat",
+          monthlyAllowanceRemaining: 100,
+          paidCreditsRemaining: 0,
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+const model = (id: string, provider = "anthropic"): ModelDefinition =>
+  ({ id, name: id, provider }) as ModelDefinition;
+
+describe("applyOutOfCreditsLocks", () => {
+  const models = [
+    model("anthropic/claude-haiku-4.5"), // MCPJam-provided (free)
+    model("anthropic/claude-opus-4.5"), // MCPJam-provided (free)
+    model("amazon.nova-micro-v1:0", "bedrock"), // own-key / BYOK
+    model("custom:acme:acme-large", "custom"), // custom provider
+  ];
+
+  it("returns the list untouched when the user still has credits", () => {
+    expect(applyOutOfCreditsLocks(models, false)).toBe(models);
+  });
+
+  it("locks only the MCPJam-provided (free) models when out of credits", () => {
+    const locked = applyOutOfCreditsLocks(models, true);
+    const byId = Object.fromEntries(locked.map((m) => [String(m.id), m]));
+
+    expect(byId["anthropic/claude-haiku-4.5"].disabled).toBe(true);
+    expect(byId["anthropic/claude-haiku-4.5"].disabledReason).toBe(
+      OUT_OF_CREDITS_MODEL_REASON
+    );
+    expect(byId["anthropic/claude-opus-4.5"].disabled).toBe(true);
+
+    // Own-key models stay usable — switching to them is the way out.
+    expect(byId["amazon.nova-micro-v1:0"].disabled).toBeUndefined();
+    expect(byId["custom:acme:acme-large"].disabled).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
@@ -1,7 +1,6 @@
 import type { ProviderTokens } from "@/hooks/use-ai-provider-keys";
 import {
   isMCPJamGuestAllowedModel,
-  isMCPJamProvidedModel,
   type ModelDefinition,
 } from "@/shared/types";
 import type { CustomProvider } from "@mcpjam/sdk/browser";
@@ -9,6 +8,7 @@ import { HOSTED_MODE } from "@/lib/config";
 import {
   buildAvailableModels,
   buildAvailableModelsFromOrgConfig,
+  isMCPJamProvidedModelMenuItem,
   type OrgVisibleConfig,
 } from "./model-helpers";
 
@@ -25,13 +25,16 @@ export const GUEST_LOCKED_MODEL_REASON =
  */
 export function applyGuestModelLocks(
   models: ModelDefinition[],
-  isAuthenticated: boolean,
+  isAuthenticated: boolean
 ): ModelDefinition[] {
   if (isAuthenticated) return models;
 
   return models.map((model) => {
     const modelId = String(model.id);
-    if (!isMCPJamProvidedModel(modelId) || isMCPJamGuestAllowedModel(modelId)) {
+    if (
+      !isMCPJamProvidedModelMenuItem(model) ||
+      isMCPJamGuestAllowedModel(modelId)
+    ) {
       return model;
     }
 
@@ -55,12 +58,12 @@ export const OUT_OF_CREDITS_MODEL_REASON =
  */
 export function applyOutOfCreditsLocks(
   models: ModelDefinition[],
-  outOfCredits: boolean,
+  outOfCredits: boolean
 ): ModelDefinition[] {
   if (!outOfCredits) return models;
 
   return models.map((model) => {
-    if (!isMCPJamProvidedModel(String(model.id))) {
+    if (!isMCPJamProvidedModelMenuItem(model)) {
       return model;
     }
     return {
@@ -78,14 +81,14 @@ export function applyOutOfCreditsLocks(
 export function appendDetectedLocalOllamaModels(
   models: ModelDefinition[],
   isOllamaRunning: boolean,
-  ollamaModels: ModelDefinition[],
+  ollamaModels: ModelDefinition[]
 ): ModelDefinition[] {
   if (!isOllamaRunning || ollamaModels.length === 0) return models;
   return models.concat(
     ollamaModels.filter(
       (ollamaModel) =>
-        !models.some((model) => String(model.id) === String(ollamaModel.id)),
-    ),
+        !models.some((model) => String(model.id) === String(ollamaModel.id))
+    )
   );
 }
 
@@ -126,11 +129,11 @@ export function composeAvailableModels(params: {
     const orgModelsWithLocalOllama = appendDetectedLocalOllamaModels(
       orgModels,
       isOllamaRunning,
-      ollamaModels,
+      ollamaModels
     );
     return applyOutOfCreditsLocks(
       applyGuestModelLocks(orgModelsWithLocalOllama, isAuthenticated),
-      outOfCredits,
+      outOfCredits
     );
   }
 
@@ -144,9 +147,7 @@ export function composeAvailableModels(params: {
   });
   const guestLockedModels = applyGuestModelLocks(localModels, isAuthenticated);
   const visibleModels = HOSTED_MODE
-    ? guestLockedModels.filter((model) =>
-        isMCPJamProvidedModel(String(model.id)),
-      )
+    ? guestLockedModels.filter((model) => isMCPJamProvidedModelMenuItem(model))
     : guestLockedModels;
   return applyOutOfCreditsLocks(visibleModels, outOfCredits);
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
@@ -43,6 +43,34 @@ export function applyGuestModelLocks(
   });
 }
 
+export const OUT_OF_CREDITS_MODEL_REASON =
+  "You're out of credits. Top up or use your own key.";
+
+/**
+ * Once the org/guest is out of MCPJam credits, MCPJam-provided ("free")
+ * models can't run — show them locked (grayed + tooltip) instead of letting
+ * the user pick one and only discover the limit on send. BYOK/custom and
+ * org-configured provider models stay enabled (that's the way out). Mirrors
+ * applyGuestModelLocks.
+ */
+export function applyOutOfCreditsLocks(
+  models: ModelDefinition[],
+  outOfCredits: boolean,
+): ModelDefinition[] {
+  if (!outOfCredits) return models;
+
+  return models.map((model) => {
+    if (!isMCPJamProvidedModel(String(model.id))) {
+      return model;
+    }
+    return {
+      ...model,
+      disabled: true,
+      disabledReason: OUT_OF_CREDITS_MODEL_REASON,
+    };
+  });
+}
+
 /**
  * Append locally-detected Ollama models that the base list doesn't already
  * contain (e.g. org-managed lists never include the user's local daemon).
@@ -78,6 +106,8 @@ export function composeAvailableModels(params: {
   getOpenRouterSelectedModels: () => string[];
   getAzureBaseUrl: () => string;
   customProviders: CustomProvider[];
+  /** Lock MCPJam-provided ("free") models when the org/guest has 0 credits. */
+  outOfCredits?: boolean;
 }): ModelDefinition[] {
   const {
     orgConfig,
@@ -88,6 +118,7 @@ export function composeAvailableModels(params: {
     getOpenRouterSelectedModels,
     getAzureBaseUrl,
     customProviders,
+    outOfCredits = false,
   } = params;
 
   if ((orgConfig?.providers.length ?? 0) > 0) {
@@ -97,7 +128,10 @@ export function composeAvailableModels(params: {
       isOllamaRunning,
       ollamaModels,
     );
-    return applyGuestModelLocks(orgModelsWithLocalOllama, isAuthenticated);
+    return applyOutOfCreditsLocks(
+      applyGuestModelLocks(orgModelsWithLocalOllama, isAuthenticated),
+      outOfCredits,
+    );
   }
 
   const localModels = buildAvailableModels({
@@ -108,11 +142,11 @@ export function composeAvailableModels(params: {
     getAzureBaseUrl,
     customProviders,
   });
-  const visibleModels = applyGuestModelLocks(localModels, isAuthenticated);
-  if (HOSTED_MODE) {
-    return visibleModels.filter((model) =>
-      isMCPJamProvidedModel(String(model.id)),
-    );
-  }
-  return visibleModels;
+  const guestLockedModels = applyGuestModelLocks(localModels, isAuthenticated);
+  const visibleModels = HOSTED_MODE
+    ? guestLockedModels.filter((model) =>
+        isMCPJamProvidedModel(String(model.id)),
+      )
+    : guestLockedModels;
+  return applyOutOfCreditsLocks(visibleModels, outOfCredits);
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
@@ -11,7 +11,7 @@ import type { OrgModelProvider } from "@/hooks/use-org-model-config";
 
 export function parseModelAliases(
   aliasString: string,
-  provider: ModelProvider,
+  provider: ModelProvider
 ): ModelDefinition[] {
   return aliasString
     .split(",")
@@ -47,7 +47,7 @@ export function buildAvailableModels(params: {
     azure: Boolean(getAzureBaseUrl()),
     ollama: isOllamaRunning,
     openrouter: Boolean(
-      hasToken("openrouter") && getOpenRouterSelectedModels().length > 0,
+      hasToken("openrouter") && getOpenRouterSelectedModels().length > 0
     ),
     meta: false,
   } as const;
@@ -71,7 +71,7 @@ export function buildAvailableModels(params: {
       name: modelId,
       provider: "custom" as const,
       customProviderName: cp.name,
-    })),
+    }))
   );
 
   let models: ModelDefinition[] = cloud;
@@ -94,7 +94,7 @@ export type OrgVisibleConfig = {
  */
 export function isOrgProviderAvailable(
   orgConfig: OrgVisibleConfig | undefined,
-  providerKey: string,
+  providerKey: string
 ): boolean {
   if (!orgConfig?.providers) return false;
   return orgConfig.providers.some((p) => {
@@ -118,7 +118,7 @@ export function isOrgProviderAvailable(
  * so hosted local-runtime Ollama providers appear in the model picker.
  */
 export function buildAvailableModelsFromOrgConfig(
-  orgConfig: OrgVisibleConfig | undefined,
+  orgConfig: OrgVisibleConfig | undefined
 ): ModelDefinition[] {
   if (!orgConfig?.providers) {
     // No org config loaded yet — return only MCPJam-provided models
@@ -142,16 +142,18 @@ export function buildAvailableModelsFromOrgConfig(
 
   // OpenRouter: include selectedModels from org config
   const openRouterConfig = orgConfig.providers.find(
-    (p) => p.providerKey === "openrouter" && p.enabled && p.hasSecret,
+    (p) => p.providerKey === "openrouter" && p.enabled && p.hasSecret
   );
-  if (openRouterConfig?.selectedModels && openRouterConfig.selectedModels.length > 0) {
-    const openRouterModels: ModelDefinition[] = openRouterConfig.selectedModels.map(
-      (id) => ({
+  if (
+    openRouterConfig?.selectedModels &&
+    openRouterConfig.selectedModels.length > 0
+  ) {
+    const openRouterModels: ModelDefinition[] =
+      openRouterConfig.selectedModels.map((id) => ({
         id,
         name: id,
         provider: "openrouter" as const,
-      }),
-    );
+      }));
     models.push(...openRouterModels);
   }
 
@@ -159,15 +161,18 @@ export function buildAvailableModelsFromOrgConfig(
   // the usable model set is org-specific (Bedrock model access is granted per
   // AWS account), so SUPPORTED_MODELS has no static bedrock entries.
   const bedrockConfig = orgConfig.providers.find(
-    (p) => p.providerKey === "bedrock" && p.enabled && p.hasSecret,
+    (p) => p.providerKey === "bedrock" && p.enabled && p.hasSecret
   );
-  if (bedrockConfig?.selectedModels && bedrockConfig.selectedModels.length > 0) {
+  if (
+    bedrockConfig?.selectedModels &&
+    bedrockConfig.selectedModels.length > 0
+  ) {
     const bedrockModels: ModelDefinition[] = bedrockConfig.selectedModels.map(
       (id) => ({
         id,
         name: id,
         provider: "bedrock" as const,
-      }),
+      })
     );
     models.push(...bedrockModels);
   }
@@ -272,6 +277,21 @@ export interface ModelMenuItem {
   customProviderName?: string;
 }
 
+const OWN_PROVIDER_SOURCES = new Set([
+  "azure",
+  "bedrock",
+  "custom",
+  "ollama",
+  "openrouter",
+]);
+
+export function isMCPJamProvidedModelMenuItem(model: ModelMenuItem): boolean {
+  if (OWN_PROVIDER_SOURCES.has(model.provider)) {
+    return false;
+  }
+  return isMCPJamProvidedModel(String(model.id));
+}
+
 export interface ModelMenuGroup<T extends ModelMenuItem> {
   /** Group key — provider name, or `custom:<slug>` for custom providers. */
   provider: string;
@@ -288,7 +308,7 @@ export interface ModelMenuGroup<T extends ModelMenuItem> {
  */
 export function buildModelMenuGroups<T extends ModelMenuItem>(
   models: T[],
-  options: { hideProvidedModels?: boolean } = {},
+  options: { hideProvidedModels?: boolean } = {}
 ): ModelMenuGroup<T>[] {
   const { hideProvidedModels = false } = options;
 
@@ -312,18 +332,23 @@ export function buildModelMenuGroups<T extends ModelMenuItem>(
   for (const provider of sortedKeys) {
     const list = byProvider.get(provider) ?? [];
     const filtered = hideProvidedModels
-      ? list.filter((m) => !isMCPJamProvidedModel(String(m.id)))
+      ? list.filter((m) => !isMCPJamProvidedModelMenuItem(m))
       : list;
     if (filtered.length === 0) continue;
 
-    const provided = filtered.filter((m) => isMCPJamProvidedModel(String(m.id)));
+    const provided = filtered.filter((m) => isMCPJamProvidedModelMenuItem(m));
     const configured = filtered.filter(
-      (m) => !isMCPJamProvidedModel(String(m.id)),
+      (m) => !isMCPJamProvidedModelMenuItem(m)
     );
     const title = getProviderDisplayName(provider);
 
     if (provided.length > 0) {
-      groups.push({ provider, title, providerType: "provided", models: provided });
+      groups.push({
+        provider,
+        title,
+        providerType: "provided",
+        models: provided,
+      });
     }
     if (configured.length > 0) {
       groups.push({
@@ -339,7 +364,7 @@ export function buildModelMenuGroups<T extends ModelMenuItem>(
 }
 
 export const getDefaultModel = (
-  availableModels: ModelDefinition[],
+  availableModels: ModelDefinition[]
 ): ModelDefinition => {
   const modelIdsByPriority: Array<Model | string> = [
     "anthropic/claude-haiku-4.5",

--- a/mcpjam-inspector/client/src/components/evals/__tests__/iteration-details.mcpjam-limit.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/iteration-details.mcpjam-limit.test.tsx
@@ -23,7 +23,7 @@ vi.mock("../trace-viewer", () => ({
 }));
 
 const makeIteration = (
-  overrides: Partial<EvalIteration> = {},
+  overrides: Partial<EvalIteration> = {}
 ): EvalIteration => ({
   _id: "iteration-1",
   actualToolCalls: [],
@@ -42,6 +42,8 @@ beforeEach(() => {
   useMCPJamLimitDialogStore.setState({
     authStatus: "loading",
     hasPendingLimit: false,
+    outOfCreditsHit: false,
+    outOfCreditsOrganizationId: null,
     isOpen: false,
     intent: null,
     organizationId: null,
@@ -61,7 +63,7 @@ describe("IterationDetails guest daily-limit handling", () => {
           }),
         })}
         testCase={null}
-      />,
+      />
     );
 
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/hooks/useOrganizations";
 import { readStoredActiveOrganizationId } from "@/lib/active-organization-storage";
 import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
+import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 import { useAppNavigate } from "@/lib/app-navigation";
 
 export function MCPJamLimitDialog() {
@@ -82,10 +83,11 @@ export function MCPJamLimitDialog() {
   };
 
   const handleBYOK = () => {
-    const orgId = resolveBillingOrgId();
-    if (!orgId) return;
+    // Don't yank the user to the org settings page — just close the dialog
+    // and pop open the chat model picker on its "Your providers" tab so they
+    // can switch to an own-key model in place. The free models stay grayed.
     close();
-    appNavigate(`/organizations/${orgId}/models`);
+    useModelPickerIntentStore.getState().requestOpenProvidersTab();
   };
 
   // Guest variant — only renders for unauthenticated users.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-available-models.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-available-models.test.tsx
@@ -66,6 +66,13 @@ vi.mock("@/state/app-state-context", () => ({
   useSharedAppState: () => sharedAppState,
 }));
 
+// useAvailableModels now reads the credit balance (to lock free models at 0
+// credits) which pulls in WorkOS auth — stub it as a signed-out session so the
+// balance query stays skipped and outOfCredits resolves false.
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: null, isLoading: false }),
+}));
+
 vi.mock("@/hooks/use-ai-provider-keys", () => ({
   useAiProviderKeys: () => ({
     hasToken: () => false,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
@@ -115,6 +115,9 @@ vi.mock("convex/react", () => ({
     isAuthenticated: true,
     isLoading: false,
   }),
+  // useChatSession reads the credit balance (to lock free models at 0
+  // credits); no balance in these tests → outOfCredits resolves false.
+  useQuery: () => undefined,
 }));
 
 vi.mock("@ai-sdk/react", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -201,6 +201,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => mockState.convexAuth,
+  // useChatSession reads the credit balance (to lock free models at 0
+  // credits); no balance in these tests → outOfCredits resolves false.
+  useQuery: () => undefined,
 }));
 
 vi.mock("@ai-sdk/react", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
@@ -119,6 +119,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => mockState.convexAuth,
+  // useChatSession reads the credit balance (to lock free models at 0
+  // credits); no balance in these tests → outOfCredits resolves false.
+  useQuery: () => undefined,
 }));
 
 vi.mock("@ai-sdk/react", () => ({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -102,7 +102,7 @@ vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
         (provider: any) =>
           provider.providerKey === "anthropic" &&
           provider.enabled &&
-          provider.hasSecret,
+          provider.hasSecret
       )
     ) {
       return [mcpJamModel, orgAnthropicModel];
@@ -110,6 +110,9 @@ vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
     return [mcpJamModel];
   }),
   getDefaultModel: vi.fn(() => baseModel),
+  isMCPJamProvidedModelMenuItem: vi.fn((model: { id: string }) =>
+    String(model.id).includes("/")
+  ),
 }));
 
 vi.mock("@/hooks/use-ai-provider-keys", () => ({
@@ -230,7 +233,7 @@ vi.mock("@ai-sdk/react", async () => {
           setMessages: mockSetMessages,
           addToolApprovalResponse: mockAddToolApprovalResponse,
         };
-      },
+      }
     ),
   };
 });
@@ -287,6 +290,8 @@ describe("useChatSession minimal mode parity", () => {
     useMCPJamLimitDialogStore.setState({
       authStatus: "guest",
       hasPendingLimit: false,
+      outOfCreditsHit: false,
+      outOfCreditsOrganizationId: null,
       isOpen: false,
       intent: null,
       organizationId: null,
@@ -311,7 +316,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "You are a helpful assistant.",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -319,7 +324,7 @@ describe("useChatSession minimal mode parity", () => {
     });
     expect(mockGetToolsMetadata).toHaveBeenCalledWith(
       ["server-1"],
-      "openai/gpt-4",
+      "openai/gpt-4"
     );
   });
 
@@ -332,13 +337,13 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Custom prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
       expect(mockCountTextTokens).toHaveBeenCalledWith(
         "Custom prompt",
-        "openai/gpt-4",
+        "openai/gpt-4"
       );
     });
   });
@@ -354,7 +359,7 @@ describe("useChatSession minimal mode parity", () => {
           temperature: 0.7,
           requireToolApproval: false,
         },
-      }),
+      })
     );
 
     expect(result.current.systemPrompt).toBe(DEFAULT_SYSTEM_PROMPT);
@@ -362,7 +367,7 @@ describe("useChatSession minimal mode parity", () => {
     await waitFor(() => {
       expect(mockCountTextTokens).toHaveBeenCalledWith(
         DEFAULT_SYSTEM_PROMPT,
-        "openai/gpt-4",
+        "openai/gpt-4"
       );
     });
 
@@ -374,7 +379,7 @@ describe("useChatSession minimal mode parity", () => {
       expect(getTransportRequests()).toContainEqual(
         expect.objectContaining({
           systemPrompt: DEFAULT_SYSTEM_PROMPT,
-        }),
+        })
       );
     });
   });
@@ -388,7 +393,7 @@ describe("useChatSession minimal mode parity", () => {
           minimalMode: true,
           respectToolVisibility,
         }),
-      { initialProps: { respectToolVisibility: false } },
+      { initialProps: { respectToolVisibility: false } }
     );
 
     act(() => {
@@ -399,7 +404,7 @@ describe("useChatSession minimal mode parity", () => {
       expect(getTransportRequests()).toContainEqual(
         expect.objectContaining({
           respectToolVisibility: false,
-        }),
+        })
       );
     });
 
@@ -413,7 +418,7 @@ describe("useChatSession minimal mode parity", () => {
       expect(getTransportRequests()).toContainEqual(
         expect.objectContaining({
           respectToolVisibility: true,
-        }),
+        })
       );
     });
   });
@@ -431,12 +436,13 @@ describe("useChatSession minimal mode parity", () => {
         selectedServers,
         minimalMode: true,
         hostedContext: {
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -462,7 +468,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -483,8 +489,8 @@ describe("useChatSession minimal mode parity", () => {
     await waitFor(() => {
       expect(
         mockTransportInstances.some(
-          (instance) => instance.sendMessages.mock.calls.length === 1,
-        ),
+          (instance) => instance.sendMessages.mock.calls.length === 1
+        )
       ).toBe(true);
     });
     expect(getUsedTransport().options.api).toBe("/api/mcp/chat-v2");
@@ -493,7 +499,7 @@ describe("useChatSession minimal mode parity", () => {
       expect.objectContaining({
         method: "POST",
         headers: { Authorization: "Bearer guest-token" },
-      }),
+      })
     );
     expect(mockAuthFetch).not.toHaveBeenCalled();
   });
@@ -516,7 +522,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     act(() => {
@@ -543,7 +549,7 @@ describe("useChatSession minimal mode parity", () => {
     });
 
     expect(getTransportRequests().at(-1)).not.toHaveProperty(
-      "widgetModelContext",
+      "widgetModelContext"
     );
   });
 
@@ -562,8 +568,8 @@ describe("useChatSession minimal mode parity", () => {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     const { result } = renderHook(() =>
@@ -573,7 +579,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -598,7 +604,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -608,8 +614,8 @@ describe("useChatSession minimal mode parity", () => {
     act(() => {
       mockUseChatErrorHandlers.at(-1)?.(
         new Error(
-          "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
-        ),
+          "Daily MCPJam model limit reached. Use BYOK or try again tomorrow."
+        )
       );
     });
 
@@ -620,6 +626,8 @@ describe("useChatSession minimal mode parity", () => {
     useMCPJamLimitDialogStore.setState({
       authStatus: "signedIn",
       hasPendingLimit: false,
+      outOfCreditsHit: false,
+      outOfCreditsOrganizationId: null,
       isOpen: false,
       intent: null,
       organizationId: null,
@@ -636,8 +644,8 @@ describe("useChatSession minimal mode parity", () => {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     const { result } = renderHook(() =>
@@ -647,7 +655,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -668,6 +676,8 @@ describe("useChatSession minimal mode parity", () => {
     useMCPJamLimitDialogStore.setState({
       authStatus: "signedIn",
       hasPendingLimit: false,
+      outOfCreditsHit: false,
+      outOfCreditsOrganizationId: null,
       isOpen: false,
       intent: null,
       organizationId: null,
@@ -684,8 +694,8 @@ describe("useChatSession minimal mode parity", () => {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     const { result } = renderHook(() =>
@@ -695,7 +705,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -733,7 +743,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -754,25 +764,25 @@ describe("useChatSession minimal mode parity", () => {
     ]);
     expect(
       result.current.availableModels.find((model) => model.id === "gpt-4")
-        ?.disabled,
+        ?.disabled
     ).toBeUndefined();
     expect(
       result.current.availableModels.find(
-        (model) => model.id === "openai/gpt-5.4-pro",
-      ),
+        (model) => model.id === "openai/gpt-5.4-pro"
+      )
     ).toMatchObject({
       disabled: true,
       disabledReason: "Sign in to use MCPJam provided models",
     });
     expect(
       result.current.availableModels.find(
-        (model) => model.id === "openai/gpt-5-mini",
-      )?.disabled,
+        (model) => model.id === "openai/gpt-5-mini"
+      )?.disabled
     ).toBeUndefined();
     expect(
       result.current.availableModels.find(
-        (model) => model.id === "anthropic/claude-haiku-4.5",
-      )?.disabled,
+        (model) => model.id === "anthropic/claude-haiku-4.5"
+      )?.disabled
     ).toBeUndefined();
     expect(result.current.selectedModel.id).toBe("openai/gpt-5-mini");
     expect(mockAuthFetch).not.toHaveBeenCalled();
@@ -798,7 +808,7 @@ describe("useChatSession minimal mode parity", () => {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -829,7 +839,7 @@ describe("useChatSession minimal mode parity", () => {
       "/api/web/chat-v2",
       expect.objectContaining({
         headers: { Authorization: "Bearer guest-token" },
-      }),
+      })
     );
     expect(mockAuthFetch).not.toHaveBeenCalled();
   });
@@ -847,7 +857,7 @@ describe("useChatSession minimal mode parity", () => {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -887,7 +897,7 @@ describe("useChatSession minimal mode parity", () => {
           systemPrompt: "Prompt",
           modelId: gatedMcpJamModel.id,
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -921,7 +931,7 @@ describe("useChatSession minimal mode parity", () => {
           systemPrompt: "Prompt",
           modelId: gatedMcpJamModel.id,
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -953,7 +963,7 @@ describe("useChatSession minimal mode parity", () => {
         initialProps: {
           selectedServers: ["server-1"],
         },
-      },
+      }
     );
 
     await waitFor(() => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -168,6 +168,9 @@ vi.mock("@workos-inc/authkit-react", () => ({
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => mockConvexAuth,
+  // useChatSession reads the credit balance (to lock free models at 0
+  // credits); no balance in these tests → outOfCredits resolves false.
+  useQuery: () => undefined,
 }));
 
 vi.mock("@ai-sdk/react", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
@@ -1,6 +1,7 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useCreditBalance } from "@/hooks/useCreditBalance";
+import { useCreditBalance, useOutOfCredits } from "@/hooks/useCreditBalance";
+import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 
 const mocks = vi.hoisted(() => ({
   convexAuth: {
@@ -43,6 +44,17 @@ describe("useCreditBalance", () => {
     mocks.useQuery.mockImplementation((_name: unknown, args: unknown) =>
       args === "skip" ? undefined : mocks.queryResult
     );
+    localStorage.clear();
+    useMCPJamLimitDialogStore.setState({
+      authStatus: "loading",
+      hasPendingLimit: false,
+      outOfCreditsHit: false,
+      outOfCreditsOrganizationId: null,
+      isOpen: false,
+      intent: null,
+      organizationId: null,
+      pendingInput: null,
+    });
   });
 
   it("skips guest Convex identities unless guests are included", () => {
@@ -159,5 +171,68 @@ describe("useCreditBalance", () => {
     // Monthly numerics stay undefined (not coerced to 0).
     expect(result.current.balance?.monthlyAllowanceTotal).toBeUndefined();
     expect(result.current.balance?.monthlyAllowanceRemaining).toBeUndefined();
+  });
+
+  it("treats a recent limit hit as out of credits before the balance query catches up", () => {
+    mocks.convexAuth.isAuthenticated = true;
+    mocks.workosAuth.user = { id: "user_123" };
+    localStorage.setItem("active-organization-id:user_123", "org-1");
+    mocks.queryResult = {
+      paidCreditsRemaining: 0,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 65,
+      freeDailyResetAt: 1_777_777_777_000,
+      freeDailyCreditsRemaining: 7,
+      freeDailyCreditsTotal: 20,
+      walletLocked: false,
+    };
+    useMCPJamLimitDialogStore.setState({
+      outOfCreditsHit: true,
+      outOfCreditsOrganizationId: "org-1",
+    });
+
+    const { result } = renderHook(() => useOutOfCredits());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("does not apply an org-specific limit hit to a different resolved org", () => {
+    mocks.convexAuth.isAuthenticated = true;
+    mocks.workosAuth.user = { id: "user_123" };
+    localStorage.setItem("active-organization-id:user_123", "org-2");
+    useMCPJamLimitDialogStore.setState({
+      outOfCreditsHit: true,
+      outOfCreditsOrganizationId: "org-1",
+    });
+
+    const { result } = renderHook(() => useOutOfCredits());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("clears the local limit hit once the balance query confirms the org is out", async () => {
+    mocks.convexAuth.isAuthenticated = true;
+    mocks.workosAuth.user = { id: "user_123" };
+    localStorage.setItem("active-organization-id:user_123", "org-1");
+    mocks.queryResult = {
+      paidCreditsRemaining: 0,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 100,
+      freeDailyResetAt: 1_777_777_777_000,
+      freeDailyCreditsRemaining: 0,
+      freeDailyCreditsTotal: 20,
+      walletLocked: false,
+    };
+    useMCPJamLimitDialogStore.setState({
+      outOfCreditsHit: true,
+      outOfCreditsOrganizationId: "org-1",
+    });
+
+    const { result } = renderHook(() => useOutOfCredits());
+
+    expect(result.current).toBe(true);
+    await waitFor(() => {
+      expect(useMCPJamLimitDialogStore.getState().outOfCreditsHit).toBe(false);
+    });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/use-available-models.ts
+++ b/mcpjam-inspector/client/src/hooks/use-available-models.ts
@@ -8,6 +8,7 @@ import { useCustomProviders } from "@/hooks/use-custom-providers";
 import { useHostedOrgModelConfig } from "@/hooks/use-hosted-org-model-config";
 import { useDetectedOllamaModels } from "@/hooks/use-detected-ollama-models";
 import { composeAvailableModels } from "@/components/chat-v2/shared/available-models";
+import { useOutOfCredits } from "@/hooks/useCreditBalance";
 
 /**
  * Models the current user can pick on any model-picker surface (eval suite
@@ -55,6 +56,7 @@ export function useAvailableModels(options?: {
   const { customProviders } = useCustomProviders();
   const { isOllamaRunning, ollamaModels } =
     useDetectedOllamaModels(getOllamaBaseUrl);
+  const outOfCredits = useOutOfCredits(organizationId);
 
   const availableModels = useMemo(
     () =>
@@ -67,6 +69,7 @@ export function useAvailableModels(options?: {
         getOpenRouterSelectedModels,
         getAzureBaseUrl,
         customProviders,
+        outOfCredits,
       }),
     [
       hostedOrgModelConfig,
@@ -77,6 +80,7 @@ export function useAvailableModels(options?: {
       getOpenRouterSelectedModels,
       getAzureBaseUrl,
       customProviders,
+      outOfCredits,
     ]
   );
 

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -53,6 +53,7 @@ import {
   GUEST_LOCKED_MODEL_REASON,
   composeAvailableModels,
 } from "@/components/chat-v2/shared/available-models";
+import { useOutOfCredits } from "@/hooks/useCreditBalance";
 import {
   isBedrockModelId,
   isMCPJamGuestAllowedModel,
@@ -1291,6 +1292,7 @@ export function useChatSession(
   // Build available models — the same composition every picker surface
   // uses (see `composeAvailableModels`); only the org-config source is
   // chat-specific (chatbox embeds resolve a host-provided project context).
+  const outOfCredits = useOutOfCredits();
   const availableModels = useMemo(
     () =>
       composeAvailableModels({
@@ -1302,6 +1304,7 @@ export function useChatSession(
         getOpenRouterSelectedModels,
         getAzureBaseUrl,
         customProviders,
+        outOfCredits,
       }),
     [
       hasToken,
@@ -1312,6 +1315,7 @@ export function useChatSession(
       isAuthenticated,
       customProviders,
       hostedOrgModelConfig,
+      outOfCredits,
     ]
   );
 

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -51,6 +51,7 @@ import {
 } from "@/components/chat-v2/shared/model-helpers";
 import {
   GUEST_LOCKED_MODEL_REASON,
+  OUT_OF_CREDITS_MODEL_REASON,
   composeAvailableModels,
 } from "@/components/chat-v2/shared/available-models";
 import { useOutOfCredits } from "@/hooks/useCreditBalance";
@@ -1352,7 +1353,14 @@ export function useChatSession(
 
       return (
         availableModels.find(
-          (model) => String(model.id) === modelId && !model.disabled
+          (model) =>
+            String(model.id) === modelId &&
+            // Keep an out-of-credits model selected so the existing send →
+            // limit-error → out-of-credits modal still fires. The gray-out
+            // must not silently switch the user off it. Other locks (guest,
+            // ollama-no-tools) stay unselectable.
+            (!model.disabled ||
+              model.disabledReason === OUT_OF_CREDITS_MODEL_REASON)
         ) ?? null
       );
     };

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -1,6 +1,7 @@
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useQuery } from "convex/react";
 import { useMemo } from "react";
+import { readStoredActiveOrganizationId } from "@/lib/active-organization-storage";
 
 export interface CreditBalanceState {
   /** Shared paid top-up credits currently available to the organization. */
@@ -119,4 +120,44 @@ export function useCreditBalance({
     isAuthenticated: hasConvexIdentity,
     hasWorkOsUser,
   };
+}
+
+/**
+ * True when the org (or guest) has no spendable MCPJam credits left — the
+ * state that makes MCPJam-provided ("free") models unusable. Mirrors the
+ * sidebar's daily-vs-monthly split: monthly teams spend their monthly
+ * allowance then shared paid top-ups; everyone else spends the free daily
+ * bucket then paid top-ups. Wallet-lock (spending paused for review) is
+ * deliberately NOT folded in here — that's a separate state with its own
+ * backend handling.
+ */
+export function isOutOfCredits(
+  balance: CreditBalanceState | undefined
+): boolean {
+  if (!balance) return false;
+  const paidRemaining = balance.paidCreditsRemaining;
+  if (balance.billingModel === "monthly_per_seat") {
+    return (balance.monthlyAllowanceRemaining ?? 0) <= 0 && paidRemaining <= 0;
+  }
+  return balance.freeDailyCreditsRemaining <= 0 && paidRemaining <= 0;
+}
+
+/**
+ * Convenience hook over useCreditBalance that returns just the "out of
+ * credits" boolean for the active organization — used to gray out
+ * MCPJam-provided models in the picker once the org/guest can no longer
+ * spend. Resolves the org from the caller-provided id, falling back to the
+ * stored active organization (the same source the limit dialog uses).
+ * Returns false while the balance is loading or unavailable so models never
+ * flash locked.
+ */
+export function useOutOfCredits(organizationId?: string | null): boolean {
+  const { user } = useAuth();
+  const resolvedOrganizationId =
+    organizationId ?? (user ? readStoredActiveOrganizationId(user.id) : null);
+  const { balance } = useCreditBalance({
+    organizationId: resolvedOrganizationId,
+    includeGuests: true,
+  });
+  return isOutOfCredits(balance);
 }

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -1,7 +1,8 @@
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useQuery } from "convex/react";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { readStoredActiveOrganizationId } from "@/lib/active-organization-storage";
+import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 
 export interface CreditBalanceState {
   /** Shared paid top-up credits currently available to the organization. */
@@ -148,8 +149,8 @@ export function isOutOfCredits(
  * MCPJam-provided models in the picker once the org/guest can no longer
  * spend. Resolves the org from the caller-provided id, falling back to the
  * stored active organization (the same source the limit dialog uses).
- * Returns false while the balance is loading or unavailable so models never
- * flash locked.
+ * Also honors the local limit-hit latch set by failed sends so the picker
+ * locks immediately instead of waiting for the balance query to catch up.
  */
 export function useOutOfCredits(organizationId?: string | null): boolean {
   const { user } = useAuth();
@@ -159,5 +160,29 @@ export function useOutOfCredits(organizationId?: string | null): boolean {
     organizationId: resolvedOrganizationId,
     includeGuests: true,
   });
-  return isOutOfCredits(balance);
+  const balanceOutOfCredits = isOutOfCredits(balance);
+  const outOfCreditsHit = useMCPJamLimitDialogStore(
+    (state) => state.outOfCreditsHit
+  );
+  const locallyLimited = useMCPJamLimitDialogStore((state) => {
+    if (!state.outOfCreditsHit) return false;
+    if (!state.outOfCreditsOrganizationId) return true;
+    if (!resolvedOrganizationId) return true;
+    return state.outOfCreditsOrganizationId === resolvedOrganizationId;
+  });
+  const clearOutOfCreditsHit = useMCPJamLimitDialogStore(
+    (state) => state.clearOutOfCreditsHit
+  );
+
+  useEffect(() => {
+    if (!outOfCreditsHit || !balanceOutOfCredits) return;
+    clearOutOfCreditsHit(resolvedOrganizationId ?? null);
+  }, [
+    balanceOutOfCredits,
+    clearOutOfCreditsHit,
+    outOfCreditsHit,
+    resolvedOrganizationId,
+  ]);
+
+  return balanceOutOfCredits || locallyLimited;
 }

--- a/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
@@ -2,10 +2,8 @@ import { useEffect } from "react";
 import { toast } from "sonner";
 import { usePostHog } from "posthog-js/react";
 
-import {
-  clearPendingTopup,
-  peekPendingTopup,
-} from "@/hooks/useCreditTopup";
+import { clearPendingTopup, peekPendingTopup } from "@/hooks/useCreditTopup";
+import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 
 interface UseCreditTopupReturnFlowOptions {
   /** Active chat session id used to validate the pending stash on success. */
@@ -46,8 +44,7 @@ export function useCreditTopupReturnFlow({
     params.delete("topup");
     params.delete("session_id");
     const search = params.toString();
-    const cleanedUrl =
-      window.location.pathname + (search ? `?${search}` : "");
+    const cleanedUrl = window.location.pathname + (search ? `?${search}` : "");
     window.history.replaceState(null, "", cleanedUrl);
 
     if (topupParam === "cancelled") {
@@ -57,6 +54,8 @@ export function useCreditTopupReturnFlow({
       });
       return;
     }
+
+    useMCPJamLimitDialogStore.getState().clearOutOfCreditsHit();
 
     const pending = peekPendingTopup();
     const hadPendingStash = pending !== null;
@@ -75,7 +74,7 @@ export function useCreditTopupReturnFlow({
           clearPendingTopup();
         } catch {
           toast.error(
-            "Credits added, but we couldn't resend your last message. Please send it again.",
+            "Credits added, but we couldn't resend your last message. Please send it again."
           );
         }
       }
@@ -118,14 +117,15 @@ export function useCreditTopupReturnFlowBilling({
     params.delete("topup");
     params.delete("session_id");
     const search = params.toString();
-    const cleanedUrl =
-      window.location.pathname + (search ? `?${search}` : "");
+    const cleanedUrl = window.location.pathname + (search ? `?${search}` : "");
     window.history.replaceState(null, "", cleanedUrl);
 
     if (topupParam === "cancelled") {
       posthog?.capture("credit_topup_return_cancelled");
       return;
     }
+
+    useMCPJamLimitDialogStore.getState().clearOutOfCreditsHit();
 
     toast.success("Credits added.");
     posthog?.capture("credit_topup_return_success");

--- a/mcpjam-inspector/client/src/lib/__tests__/mcpjam-limit.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/mcpjam-limit.test.ts
@@ -10,6 +10,8 @@ beforeEach(() => {
   useMCPJamLimitDialogStore.setState({
     authStatus: "loading",
     hasPendingLimit: false,
+    outOfCreditsHit: false,
+    outOfCreditsOrganizationId: null,
     isOpen: false,
     intent: null,
     organizationId: null,
@@ -31,7 +33,7 @@ describe("isMCPJamModelLimitError", () => {
       isMCPJamModelLimitError({
         code: "user_rate_limit",
         limitKind: "concurrency",
-      }),
+      })
     ).toBe(false);
   });
 
@@ -40,7 +42,7 @@ describe("isMCPJamModelLimitError", () => {
       isMCPJamModelLimitError({
         code: "user_rate_limit",
         limitKind: "total",
-      }),
+      })
     ).toBe(true);
   });
 
@@ -52,7 +54,7 @@ describe("isMCPJamModelLimitError", () => {
           code: "mcpjam_rate_limit",
           error: "Daily usage limit reached.",
         }),
-      }),
+      })
     ).toBe(true);
   });
 
@@ -61,7 +63,7 @@ describe("isMCPJamModelLimitError", () => {
       isMCPJamModelLimitError({
         message:
           'Backend stream error: 429 {"code":"mcpjam_rate_limit","error":"Daily usage limit reached."}',
-      }),
+      })
     ).toBe(true);
   });
 
@@ -70,7 +72,7 @@ describe("isMCPJamModelLimitError", () => {
       isMCPJamModelLimitError({
         message:
           'Backend stream error: 429 {"code":"user_rate_limit","error":"Daily credit limit reached.","limitKind":"total"}',
-      }),
+      })
     ).toBe(true);
   });
 
@@ -79,7 +81,7 @@ describe("isMCPJamModelLimitError", () => {
       isMCPJamModelLimitError({
         message:
           'Backend stream error: 429 {"code":"user_rate_limit","error":"Another credit-funded chat is finishing.","limitKind":"concurrency"}',
-      }),
+      })
     ).toBe(false);
   });
 
@@ -91,7 +93,7 @@ describe("isMCPJamModelLimitError", () => {
           error:
             "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
         },
-      }),
+      })
     ).toBe(true);
   });
 
@@ -100,7 +102,7 @@ describe("isMCPJamModelLimitError", () => {
       isMCPJamModelLimitError({
         message: "Provider unavailable",
         details: JSON.stringify({ code: "provider_error" }),
-      }),
+      })
     ).toBe(false);
   });
 
@@ -130,6 +132,7 @@ describe("isMCPJamModelLimitError", () => {
     expect(notifyMCPJamLimitError({ code: "user_rate_limit" })).toBe(true);
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(true);
     expect(useMCPJamLimitDialogStore.getState().intent).toBe("topup");
+    expect(useMCPJamLimitDialogStore.getState().outOfCreditsHit).toBe(true);
   });
 
   it("opens with topup intent for wrapped signed-in usage limit hits", () => {
@@ -145,7 +148,7 @@ describe("isMCPJamModelLimitError", () => {
       notifyMCPJamLimitError({
         message:
           'Backend stream error: 429 {"code":"user_rate_limit","error":"Daily credit limit reached.","limitKind":"total"}',
-      }),
+      })
     ).toBe(true);
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(true);
     expect(useMCPJamLimitDialogStore.getState().intent).toBe("topup");
@@ -165,9 +168,12 @@ describe("isMCPJamModelLimitError", () => {
       notifyMCPJamLimitError({
         message:
           'Backend stream error: 429 {"code":"user_rate_limit","error":"Daily credit limit reached.","limitKind":"total","organizationId":"org-a"}',
-      }),
+      })
     ).toBe(true);
     expect(useMCPJamLimitDialogStore.getState().organizationId).toBe("org-a");
+    expect(
+      useMCPJamLimitDialogStore.getState().outOfCreditsOrganizationId
+    ).toBe("org-a");
   });
 
   it("does not open the modal for concurrency-throttle errors", () => {
@@ -183,9 +189,10 @@ describe("isMCPJamModelLimitError", () => {
       notifyMCPJamLimitError({
         code: "user_rate_limit",
         limitKind: "concurrency",
-      }),
+      })
     ).toBe(false);
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
+    expect(useMCPJamLimitDialogStore.getState().outOfCreditsHit).toBe(false);
   });
 
   it("defers opening while auth state is still loading", () => {
@@ -240,15 +247,15 @@ describe("isMCPJamModelLimitError", () => {
         error: "Daily usage limit reached.",
         organizationId: "org-from-response",
       }),
-      { status: 429 },
+      { status: 429 }
     );
 
     await expect(notifyMCPJamLimitErrorFromResponse(response)).resolves.toBe(
-      true,
+      true
     );
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(true);
     expect(useMCPJamLimitDialogStore.getState().organizationId).toBe(
-      "org-from-response",
+      "org-from-response"
     );
     await expect(response.text()).resolves.toContain("mcpjam_rate_limit");
   });
@@ -268,11 +275,11 @@ describe("isMCPJamModelLimitError", () => {
         error: "Another credit-funded chat is finishing.",
         limitKind: "concurrency",
       }),
-      { status: 429 },
+      { status: 429 }
     );
 
     await expect(notifyMCPJamLimitErrorFromResponse(response)).resolves.toBe(
-      false,
+      false
     );
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
   });

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/evals-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/evals-api.hosted.test.ts
@@ -35,30 +35,30 @@ import {
 describe("evals-api hosted mode", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    buildServerBatchRequestMock.mockImplementation(
-      (serverNames: string[]) => {
-        const serverIds = serverNames.map((serverName) =>
-          serverName === "Server A"
-            ? "srv_a"
-            : serverName === "Server B"
-              ? "srv_b"
-              : serverName,
-        );
+    buildServerBatchRequestMock.mockImplementation((serverNames: string[]) => {
+      const serverIds = serverNames.map((serverName) =>
+        serverName === "Server A"
+          ? "srv_a"
+          : serverName === "Server B"
+          ? "srv_b"
+          : serverName
+      );
 
-        return {
-          projectId: "project-1",
-          serverIds,
-          oauthTokens: serverIds.includes("srv_a")
-            ? { srv_a: "oauth-token-a" }
-            : undefined,
-          clientCapabilities: { sampling: true },
-        };
-      },
-    );
+      return {
+        projectId: "project-1",
+        serverIds,
+        oauthTokens: serverIds.includes("srv_a")
+          ? { srv_a: "oauth-token-a" }
+          : undefined,
+        clientCapabilities: { sampling: true },
+      };
+    });
     authFetchMock.mockResolvedValue(createFetchResponse({ success: true }));
     useMCPJamLimitDialogStore.setState({
       authStatus: "guest",
       hasPendingLimit: false,
+      outOfCreditsHit: false,
+      outOfCreditsOrganizationId: null,
       isOpen: false,
       intent: null,
       organizationId: null,
@@ -83,7 +83,7 @@ describe("evals-api hosted mode", () => {
       "/api/web/evals/run",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -104,14 +104,12 @@ describe("evals-api hosted mode", () => {
       convexAuthToken: "guest-convex-token",
     });
 
-    expect(buildServerBatchRequestMock).toHaveBeenCalledWith([
-      "Guest Server",
-    ]);
+    expect(buildServerBatchRequestMock).toHaveBeenCalledWith(["Guest Server"]);
     expect(authFetchMock).toHaveBeenCalledWith(
       "/api/web/evals/run",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -136,7 +134,7 @@ describe("evals-api hosted mode", () => {
       "/api/web/evals/generate-tests",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -158,7 +156,7 @@ describe("evals-api hosted mode", () => {
       "/api/web/evals/generate-negative-tests",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -183,7 +181,7 @@ describe("evals-api hosted mode", () => {
       "/api/web/evals/run-test-case",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -204,8 +202,8 @@ describe("evals-api hosted mode", () => {
           code: "mcpjam_rate_limit",
           error: "Daily usage limit reached.",
         },
-        429,
-      ),
+        429
+      )
     );
 
     await expect(
@@ -216,7 +214,7 @@ describe("evals-api hosted mode", () => {
         provider: "openai",
         serverIds: ["Server A"],
         convexAuthToken: "convex-token",
-      }),
+      })
     ).rejects.toThrow("Daily usage limit reached.");
 
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(true);
@@ -226,6 +224,8 @@ describe("evals-api hosted mode", () => {
     useMCPJamLimitDialogStore.setState({
       authStatus: "signedIn",
       hasPendingLimit: false,
+      outOfCreditsHit: false,
+      outOfCreditsOrganizationId: null,
       isOpen: false,
       intent: null,
       organizationId: null,
@@ -238,8 +238,8 @@ describe("evals-api hosted mode", () => {
           error: "Daily credit limit reached.",
           limitKind: "total",
         },
-        429,
-      ),
+        429
+      )
     );
 
     await expect(
@@ -250,7 +250,7 @@ describe("evals-api hosted mode", () => {
         provider: "openai",
         serverIds: ["Server A"],
         convexAuthToken: "convex-token",
-      }),
+      })
     ).rejects.toThrow("Daily credit limit reached.");
 
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(true);
@@ -267,9 +267,7 @@ describe("evals-api hosted mode", () => {
       convexAuthToken: "guest-convex-token",
     });
 
-    expect(buildServerBatchRequestMock).toHaveBeenCalledWith([
-      "Guest Server",
-    ]);
+    expect(buildServerBatchRequestMock).toHaveBeenCalledWith(["Guest Server"]);
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
     expect(body).toMatchObject({
@@ -295,7 +293,7 @@ describe("evals-api hosted mode", () => {
       "/api/web/evals/generate-tests",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -319,7 +317,7 @@ describe("evals-api hosted mode", () => {
       "/api/web/evals/generate-negative-tests",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -344,8 +342,8 @@ describe("evals-api hosted mode", () => {
                   "",
                   'data: {"type":"complete","iteration":{"_id":"iter-1"}}',
                   "",
-                ].join("\n"),
-              ),
+                ].join("\n")
+              )
             );
             controller.close();
           },
@@ -353,8 +351,8 @@ describe("evals-api hosted mode", () => {
         {
           status: 200,
           headers: { "Content-Type": "text/event-stream" },
-        },
-      ),
+        }
+      )
     );
 
     const events: unknown[] = [];
@@ -369,14 +367,14 @@ describe("evals-api hosted mode", () => {
       },
       (event) => {
         events.push(event);
-      },
+      }
     );
 
     expect(authFetchMock).toHaveBeenCalledWith(
       "/api/web/evals/stream-test-case",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -410,17 +408,15 @@ describe("evals-api hosted mode", () => {
       new Response(
         new ReadableStream({
           start(controller) {
-            controller.enqueue(
-              encoder.encode('data: {"type":"complete"}\n\n'),
-            );
+            controller.enqueue(encoder.encode('data: {"type":"complete"}\n\n'));
             controller.close();
           },
         }),
         {
           status: 200,
           headers: { "Content-Type": "text/event-stream" },
-        },
-      ),
+        }
+      )
     );
 
     await streamEvalTestCase(
@@ -433,14 +429,14 @@ describe("evals-api hosted mode", () => {
         convexAuthToken: "guest-convex-token",
         compareRunId: "cmp_guest",
       },
-      () => {},
+      () => {}
     );
 
     expect(authFetchMock).toHaveBeenCalledWith(
       "/api/web/evals/stream-test-case",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
@@ -466,8 +462,8 @@ describe("evals-api hosted mode", () => {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     await expect(
@@ -480,8 +476,8 @@ describe("evals-api hosted mode", () => {
           serverIds: ["Server A"],
           convexAuthToken: "convex-token",
         },
-        () => {},
-      ),
+        () => {}
+      )
     ).rejects.toThrow("Daily usage limit reached.");
 
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(true);
@@ -498,8 +494,8 @@ describe("evals-api hosted mode", () => {
                 [
                   'data: {"type":"error","message":"Backend stream error: 429","details":"{\\"code\\":\\"mcpjam_rate_limit\\",\\"error\\":\\"Daily usage limit reached.\\"}"}',
                   "",
-                ].join("\n"),
-              ),
+                ].join("\n")
+              )
             );
             controller.close();
           },
@@ -507,8 +503,8 @@ describe("evals-api hosted mode", () => {
         {
           status: 200,
           headers: { "Content-Type": "text/event-stream" },
-        },
-      ),
+        }
+      )
     );
 
     const events: unknown[] = [];
@@ -521,7 +517,7 @@ describe("evals-api hosted mode", () => {
         serverIds: ["Server A"],
         convexAuthToken: "convex-token",
       },
-      (event) => events.push(event),
+      (event) => events.push(event)
     );
 
     expect(events).toEqual([
@@ -557,8 +553,8 @@ describe("evals-api hosted mode", () => {
     expect(result.tools.map((tool) => tool.name)).toEqual(["tool_a", "tool_b"]);
     expect(
       authFetchMock.mock.calls.some(
-        (call) => typeof call[0] === "string" && call[0].includes("/api/mcp/"),
-      ),
+        (call) => typeof call[0] === "string" && call[0].includes("/api/mcp/")
+      )
     ).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/stores/mcpjam-limit-dialog-store.ts
+++ b/mcpjam-inspector/client/src/stores/mcpjam-limit-dialog-store.ts
@@ -15,6 +15,8 @@ export interface MCPJamLimitNotifyInput {
 interface MCPJamLimitDialogState {
   isOpen: boolean;
   hasPendingLimit: boolean;
+  outOfCreditsHit: boolean;
+  outOfCreditsOrganizationId: string | null;
   authStatus: MCPJamLimitAuthStatus;
   intent: MCPJamLimitIntent | null;
   organizationId: string | null;
@@ -24,12 +26,13 @@ interface MCPJamLimitDialogState {
   pendingInput: MCPJamLimitNotifyInput | null;
   notifyLimitHit: (input?: MCPJamLimitNotifyInput) => void;
   setAuthStatus: (authStatus: MCPJamLimitAuthStatus) => void;
+  clearOutOfCreditsHit: (organizationId?: string | null) => void;
   close: () => void;
 }
 
 const intentForAuth = (
   authStatus: MCPJamLimitAuthStatus,
-  _input: MCPJamLimitNotifyInput,
+  _input: MCPJamLimitNotifyInput
 ): MCPJamLimitIntent | null => {
   if (authStatus === "guest") return "guest";
   if (authStatus === "signedIn") return "topup";
@@ -40,6 +43,8 @@ export const useMCPJamLimitDialogStore = create<MCPJamLimitDialogState>(
   (set) => ({
     isOpen: false,
     hasPendingLimit: false,
+    outOfCreditsHit: false,
+    outOfCreditsOrganizationId: null,
     authStatus: "loading",
     intent: null,
     organizationId: null,
@@ -47,12 +52,25 @@ export const useMCPJamLimitDialogStore = create<MCPJamLimitDialogState>(
     notifyLimitHit: (input = {}) =>
       set((state) => {
         if (state.authStatus === "loading") {
-          return { hasPendingLimit: true, pendingInput: input };
+          return {
+            hasPendingLimit: true,
+            outOfCreditsHit: true,
+            outOfCreditsOrganizationId: input.organizationId ?? null,
+            pendingInput: input,
+          };
         }
         const intent = intentForAuth(state.authStatus, input);
-        if (!intent) return { hasPendingLimit: false };
+        if (!intent) {
+          return {
+            hasPendingLimit: false,
+            outOfCreditsHit: true,
+            outOfCreditsOrganizationId: input.organizationId ?? null,
+          };
+        }
         return {
           hasPendingLimit: false,
+          outOfCreditsHit: true,
+          outOfCreditsOrganizationId: input.organizationId ?? null,
           isOpen: true,
           intent,
           organizationId: input.organizationId ?? null,
@@ -72,10 +90,27 @@ export const useMCPJamLimitDialogStore = create<MCPJamLimitDialogState>(
         return {
           authStatus,
           hasPendingLimit: false,
+          outOfCreditsHit: true,
+          outOfCreditsOrganizationId: input.organizationId ?? null,
           isOpen: true,
           intent,
           organizationId: input.organizationId ?? null,
           pendingInput: null,
+        };
+      }),
+    clearOutOfCreditsHit: (organizationId) =>
+      set((state) => {
+        if (!state.outOfCreditsHit) return {};
+        if (
+          organizationId !== undefined &&
+          state.outOfCreditsOrganizationId &&
+          state.outOfCreditsOrganizationId !== organizationId
+        ) {
+          return {};
+        }
+        return {
+          outOfCreditsHit: false,
+          outOfCreditsOrganizationId: null,
         };
       }),
     close: () =>
@@ -86,5 +121,5 @@ export const useMCPJamLimitDialogStore = create<MCPJamLimitDialogState>(
         organizationId: null,
         pendingInput: null,
       }),
-  }),
+  })
 );

--- a/mcpjam-inspector/client/src/stores/model-picker-intent-store.ts
+++ b/mcpjam-inspector/client/src/stores/model-picker-intent-store.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+
+interface ModelPickerIntentState {
+  /**
+   * Bumped to ask the chat model picker to open on its "Your providers"
+   * (configured) tab — e.g. from the out-of-credits dialog's "Bring your own
+   * key" action. A nonce (not a boolean) so repeat requests always re-fire,
+   * even if the picker was already opened to that tab once.
+   */
+  openProvidersTabNonce: number;
+  requestOpenProvidersTab: () => void;
+}
+
+export const useModelPickerIntentStore = create<ModelPickerIntentState>(
+  (set) => ({
+    openProvidersTabNonce: 0,
+    requestOpenProvidersTab: () =>
+      set((state) => ({
+        openProvidersTabNonce: state.openProvidersTabNonce + 1,
+      })),
+  }),
+);


### PR DESCRIPTION
When users run out of spendable MCPJam credits, make that state obvious in the model picker instead of letting MCPJam free models look usable and fail only after send.

- Gray out only MCPJam free models when the user has no usable MCPJam credits left.
- Keep MCPJam free models enabled if the user still has paid top-up credits, even if their free daily credits are exhausted.
- When the out-of-credits modal’s “Bring your own key” action is selected, open the picker to “Your providers” and select the first available provider model.
- Preserve org member/admin behavior: non-admin members still see the ask-admin copy and do not get BYOK/top-up CTAs.
