### PR TITLE
feat(cli): eval iterations + trace subcommands

### DIFF
--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -443,19 +443,13 @@ export function registerEvalCommands(program: Command): void {
       },
       command
     ) => {
-      await executeOp(
-        listEvalRunIterationsOperation,
-        {
-          project: options.project,
-          runId: options.run,
-          ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
-          ...(options.limit !== undefined
-            ? { limit: Number(options.limit) }
-            : {}),
-        },
-        options,
-        command
-      );
+      const input = validateOpInput(listEvalRunIterationsOperation, {
+        project: options.project,
+        runId: options.run,
+        ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
+        ...(options.limit !== undefined ? { limit: Number(options.limit) } : {}),
+      });
+      await executeOp(listEvalRunIterationsOperation, input, options, command);
     }
   );
 

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -430,13 +430,16 @@ export function registerEvalCommands(program: Command): void {
         "List per-iteration results for an eval run (pass/fail, tool calls, tokens, latency)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .option("--project <id-or-name>", PROJECT_OPT)
+      .requiredOption(
+        "--project <id-or-name>",
+        "Project the run belongs to (name or ID)"
+      )
       .option("--cursor <cursor>", "Pagination cursor from a previous response")
       .option("--limit <n>", "Max iterations per page (1–200)")
   ).action(
     async (
       options: PlatformOptions & {
-        project?: string;
+        project: string;
         run: string;
         cursor?: string;
         limit?: string;
@@ -464,11 +467,14 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .option("--project <id-or-name>", PROJECT_OPT)
+      .requiredOption(
+        "--project <id-or-name>",
+        "Project the run belongs to (name or ID)"
+      )
   ).action(
     async (
       options: PlatformOptions & {
-        project?: string;
+        project: string;
         run: string;
         iteration: string;
       },

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -7,9 +7,11 @@ import {
   deleteEvalSuiteOperation,
   generateEvalCasesOperation,
   getEvalCaseOperation,
+  getEvalIterationTraceOperation,
   getEvalRunOperation,
   getEvalSuiteOperation,
   listEvalCasesOperation,
+  listEvalRunIterationsOperation,
   listEvalSuitesOperation,
   PlatformApiError,
   runEvalSuiteOperation,
@@ -419,6 +421,77 @@ export function registerEvalCommands(program: Command): void {
   );
 
   const PROJECT_OPT = "Project name or ID (defaults to most recently updated)";
+
+  // ── Eval run iterations + traces ───────────────────────────────────
+  addPlatformOptions(
+    evals
+      .command("iterations")
+      .description(
+        "List per-iteration results for an eval run (pass/fail, tool calls, tokens, latency)"
+      )
+      .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
+      .option("--project <id-or-name>", PROJECT_OPT)
+      .option("--cursor <cursor>", "Pagination cursor from a previous response")
+      .option("--limit <n>", "Max iterations per page (1–200)")
+  ).action(
+    async (
+      options: PlatformOptions & {
+        project?: string;
+        run: string;
+        cursor?: string;
+        limit?: string;
+      },
+      command
+    ) => {
+      await executeOp(
+        listEvalRunIterationsOperation,
+        {
+          project: options.project,
+          runId: options.run,
+          ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
+          ...(options.limit !== undefined
+            ? { limit: Number(options.limit) }
+            : {}),
+        },
+        options,
+        command
+      );
+    }
+  );
+
+  addPlatformOptions(
+    evals
+      .command("trace")
+      .description(
+        "Fetch the full trace for one eval iteration (large: full message history + spans)"
+      )
+      .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
+      .requiredOption(
+        "--iteration <id>",
+        "Iteration ID (from `eval iterations`)"
+      )
+      .option("--project <id-or-name>", PROJECT_OPT)
+  ).action(
+    async (
+      options: PlatformOptions & {
+        project?: string;
+        run: string;
+        iteration: string;
+      },
+      command
+    ) => {
+      await executeOp(
+        getEvalIterationTraceOperation,
+        {
+          project: options.project,
+          runId: options.run,
+          iterationId: options.iteration,
+        },
+        options,
+        command
+      );
+    }
+  );
 
   // ── Suite settings: get / update / delete / schedule ───────────────
   addPlatformOptions(


### PR DESCRIPTION
## What

Adds two new subcommands to the `mcpjam eval` command group, wrapping SDK platform operations that already existed but were previously only reachable via the MCP server / SDK:

- **`mcpjam eval iterations`** → `listEvalRunIterationsOperation`
  Lists per-iteration results for an eval run: pass/fail, expected vs actual tool calls, token usage, and latency. Paginated.
- **`mcpjam eval trace`** → `getEvalIterationTraceOperation`
  Fetches the full trace for ONE iteration (complete message history + spans + render observations). Can be large.

## Why

Per-iteration pass/fail, tokens, latency, and full traces were only available through the MCP server or the SDK. This makes them first-class CLI commands, mirroring the existing `eval status` / `eval cases` wiring (shared `executeOp` helper, `--project` defaulting to the most recently updated project).

## Usage

```bash
# List per-iteration results for a run (paginated)
mcpjam eval iterations --run <runId>
mcpjam eval iterations --run <runId> --limit 50 --cursor <nextCursor>

# Fetch the full trace for one iteration
mcpjam eval trace --run <runId> --iteration <iterationId>
```

## Verification

- `npm run build -w @mcpjam/sdk` — ok
- `npm run typecheck -w @mcpjam/cli` — ok (no errors)
- `npm run build -w @mcpjam/cli` — ok
- `--help` for both new commands renders correctly, and both appear in `mcpjam eval --help`.
- `npm run test -w @mcpjam/cli` — 315/317 pass. The 2 failures are pre-existing and unrelated (`tools call --ui` JSON-stderr parsing in `tests/tools-call-ui.test.ts`); verified they fail identically on a clean tree without this change. `tests/eval.test.ts` passes 6/6.
- No live API calls were made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI wrappers around existing SDK operations; no new server logic or auth changes.
> 
> **Overview**
> Adds **`mcpjam eval iterations`** and **`mcpjam eval trace`** to the eval command group, exposing existing platform SDK operations from the CLI.
> 
> **`eval iterations`** lists per-iteration results for a run (pass/fail, tool calls, tokens, latency) with optional **`--cursor`** and **`--limit`** pagination. Input is validated via **`validateOpInput`** before **`listEvalRunIterationsOperation`** runs through the shared **`executeOp`** path.
> 
> **`eval trace`** fetches the full trace for a single iteration via **`getEvalIterationTraceOperation`**, requiring **`--run`**, **`--iteration`**, and **`--project`**. Both commands use the same **`addPlatformOptions`** / API-key wiring as other eval subcommands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6733243be7e032453e76f86bbae8909661cd9705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->