### PR TITLE
test(cli): make tools-call-ui stderr assertions tolerant of Node warnings

### DIFF
--- a/cli/tests/tools-call-ui.test.ts
+++ b/cli/tests/tools-call-ui.test.ts
@@ -42,6 +42,7 @@ async function runCli(
           ...process.env,
           MCPJAM_CLI_DISABLE_BROWSER_OPEN: "1",
           MCPJAM_TELEMETRY_DISABLED: "1",
+          NODE_NO_WARNINGS: "1",
           ...options.env,
         },
       },
@@ -1426,9 +1427,11 @@ test("tools call --ui validates render flags before executing the tool", async (
     ]);
 
     assert.equal(result.exitCode, 2);
+    // stderr may carry Node/tsx warnings (e.g. DEP0205), so scan for the JSON line.
     assert.match(
-      (JSON.parse(result.stderr) as { error?: { message?: string } }).error
-        ?.message ?? "",
+      (JSON.parse(lastJsonLine(result.stderr)) as {
+        error?: { message?: string };
+      }).error?.message ?? "",
       /Invalid theme "blue"/,
     );
     assert.deepEqual(server.requests, []);
@@ -1460,9 +1463,11 @@ test("tools call --ui validates frontend-url before executing the tool", async (
     ]);
 
     assert.equal(result.exitCode, 2);
+    // stderr may carry Node/tsx warnings (e.g. DEP0205), so scan for the JSON line.
     assert.match(
-      (JSON.parse(result.stderr) as { error?: { message?: string } }).error
-        ?.message ?? "",
+      (JSON.parse(lastJsonLine(result.stderr)) as {
+        error?: { message?: string };
+      }).error?.message ?? "",
       /Invalid --frontend-url "not a url"/,
     );
     assert.deepEqual(server.requests, []);


### PR DESCRIPTION
## What
Two `tools call --ui` validation tests in `cli/tests/tools-call-ui.test.ts` parsed `result.stderr` strictly as JSON. Make them tolerant of stderr warning noise.

## Why
The tests run the CLI through `tsx`. On Node 26, tsx's loader emits a `(node:xxxxx) [DEP0205] DeprecationWarning: module.register() is deprecated` warning to **stderr** after the JSON error envelope. `JSON.parse(result.stderr)` then throws `Unexpected non-whitespace character after JSON`. On Node 20 (CI) the warning doesn't fire, so the suite passed there.

## Fixes (belt and suspenders, test-only)
1. Parse stderr via the file's existing `lastJsonLine` scanner, which skips non-JSON lines and returns the JSON envelope.
2. Set `NODE_NO_WARNINGS=1` in the `runCli` test runner env so Node/tsx deprecation warnings never pollute captured stderr in any test.

No behavior change.

## Test counts (local, Node 26 — reproduces the bug)
- Before: 315/317 (2 `tools-call-ui` validation tests failing)
- After: 317/317

Typecheck (`npm run typecheck -w @mcpjam/cli`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and assertion changes only; no production CLI or runtime behavior is modified.
> 
> **Overview**
> Fixes flaky **`tools call --ui`** validation tests on Node 26 where **tsx** can append deprecation warnings to **stderr** after the CLI’s JSON error line, breaking strict `JSON.parse(result.stderr)`.
> 
> The shared **`runCli`** helper now sets **`NODE_NO_WARNINGS=1`** so captured stderr stays clean across tests. The theme and **`--frontend-url`** validation cases parse errors via the existing **`lastJsonLine`** helper on stderr instead of treating all of stderr as JSON.
> 
> **Test-only**; no CLI product behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c84cacb83ef33dee6b11266c469a9b87f597f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->