### PR TITLE
ci: run tests in pinned Playwright container (~14m → ~7m)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci --legacy-peer-deps
 
+      - name: Install ripgrep (repo-guard checks in `npm test`)
+        # GitHub-hosted runners ship ripgrep, but the Playwright image does not.
+        # `npm test` opens with check:mcp-v1-runtime-imports / check:platform-
+        # runtime-safety, which are `! rg -n '...'`. With rg missing the shell
+        # returns 127 and `! 127` evaluates to 0 — the guards would vacuously
+        # pass instead of running. Installing one package is fast (~seconds),
+        # unlike the `--with-deps` browser libs we dropped.
+        run: apt-get update && apt-get install -y ripgrep
+
       - name: Run SDK → CLI → Inspector verification
         # Node 24 auto-scales heap to ~half system RAM (~4 GB on ubuntu-latest).
         # The vitest workspace (server + client + shared) runs concurrently and

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [main]
 
+# A newer push to the same ref makes in-flight runs obsolete — cancel them so
+# we don't burn runner minutes finishing tests for superseded commits.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: "24.14.0"
   # No CI job in this workflow launches Electron, so skip the (occasionally
@@ -16,6 +22,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Run Tests
+    # Pinned to the same Playwright version as the `@playwright/test` dependency.
+    # The image ships Chromium + every system library preinstalled, so we skip
+    # the `playwright install --with-deps` step entirely — that apt-driven step
+    # was costing up to ~7 min of variable, sometimes-stalling wall-clock time.
+    # When bumping @playwright/test, bump this tag in lockstep.
+    container: mcr.microsoft.com/playwright:v1.59.1-noble
 
     steps:
       - name: Checkout code
@@ -29,9 +41,6 @@ jobs:
 
       - name: Install workspace dependencies
         run: npm ci --legacy-peer-deps
-
-      - name: Install Playwright Chromium (MCP App browser-render eval harness)
-        run: npx playwright install --with-deps chromium
 
       - name: Run SDK → CLI → Inspector verification
         # Node 24 auto-scales heap to ~half system RAM (~4 GB on ubuntu-latest).
@@ -44,6 +53,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     name: E2E Smoke (Playwright)
+    # Same pinned Playwright image — Chromium + system deps are preinstalled.
+    container: mcr.microsoft.com/playwright:v1.59.1-noble
 
     steps:
       - name: Checkout code
@@ -57,9 +68,6 @@ jobs:
 
       - name: Install workspace dependencies
         run: npm ci --legacy-peer-deps
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
 
       - name: Build inspector
         # Playwright's webServer boots `npm run start`, which serves built artifacts.


### PR DESCRIPTION
## Problem

`.github/workflows/test.yml` takes ~12–14 min. Per-step timing from a recent run shows the critical-path `Run Tests` job spending **6m58s** in `npx playwright install --with-deps chromium` — vs **17s** for the same command in the `e2e` job in the *same run*. The variable cost is the `--with-deps` apt-get, which stalled (slow mirror / apt lock). That single step is ~half the wall-clock.

## Fix

- **Move both jobs into `mcr.microsoft.com/playwright:v1.59.1-noble`** (pinned to the `@playwright/test` 1.59.1 dependency). The image ships Chromium + all system libraries preinstalled, so the `playwright install --with-deps chromium` steps are **deleted entirely**.
- **Add a `concurrency` group** with `cancel-in-progress: true` so superseded pushes cancel in-flight runs instead of running to completion.

## Why it's safe

- The server browser-render harness already launches with `--no-sandbox` (`mcp-app-browser-harness.ts:546`, commented "required when running as root (CI / containers)"), so the in-container root launch works unchanged.
- The image sets `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` as a Docker `ENV`, inherited by all steps, so `chromium.executablePath()` resolves to the preinstalled binary.
- `setup-node` still installs the pinned Node 24.14.0 (overriding the image's Node) and the npm cache works in-container.

## Impact

- `Run Tests` critical path: **~14 min → ~7 min**.
- Fewer wasted runner minutes from canceled superseded runs.

## Maintenance

The container tag is pinned and must be bumped in lockstep when `@playwright/test` is upgraded (noted in a comment in the workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI runner setup and guard tooling; no application auth, data, or runtime behavior is modified.
> 
> **Overview**
> **Speeds up the Tests workflow** by running the `test` and `e2e` jobs inside **`mcr.microsoft.com/playwright:v1.59.1-noble`**, aligned with `@playwright/test` 1.59.1, so **Chromium and system deps are preinstalled** and the **`npx playwright install --with-deps chromium` steps are removed** from both jobs.
> 
> Adds a **workflow `concurrency` group** with **`cancel-in-progress: true`** so new pushes to the same ref cancel in-flight runs instead of finishing obsolete work.
> 
> In the **`test` job only**, adds a short **`apt-get install ripgrep`** step because the Playwright image lacks `rg`; without it, the **`npm test` repo-guard scripts** that rely on `! rg ...` would **vacuously pass** when `rg` is missing.
> 
> Comments in the workflow note that the **container tag must stay in lockstep** when `@playwright/test` is upgraded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 186049f5f910f91f53effbd3f669500166d8b1e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->