### PR TITLE
fix(sdk): surface MCP tool outputSchema to the model

### DIFF
--- a/sdk/src/mcp-client-manager/tool-converters.ts
+++ b/sdk/src/mcp-client-manager/tool-converters.ts
@@ -193,6 +193,72 @@ export function scrubMetaAndStructuredContentFromToolResult(
 }
 
 /**
+ * Renders a tool's MCP `outputSchema` into a compact, human-readable summary
+ * that can be appended to the model-facing tool description.
+ *
+ * Provider tool definitions (Anthropic, OpenAI, …) only carry an input schema,
+ * so a declared `outputSchema` never reaches the model. Without it the model
+ * sees the raw structured result but has no idea what the individual fields
+ * mean, and silently drops anything that isn't self-explanatory (e.g. a field
+ * named `x` documented only in the output schema). Folding the output shape
+ * into the description gives the model that context back.
+ *
+ * The summary intentionally covers only top-level properties — the common flat
+ * structured-output case — to keep descriptions small; nested object fields are
+ * listed by name/type so the model still knows they exist.
+ *
+ * @param outputSchema - The tool's `outputSchema` (MCP object schema) or undefined
+ * @returns A summary string, or undefined when there is nothing useful to add
+ */
+export function describeOutputSchemaForModel(
+  outputSchema: unknown
+): string | undefined {
+  if (!outputSchema || typeof outputSchema !== "object") return undefined;
+
+  const schema = outputSchema as JSONSchema7;
+  const properties = schema.properties;
+  if (!properties || typeof properties !== "object") return undefined;
+
+  const required = new Set(
+    Array.isArray(schema.required) ? schema.required : []
+  );
+
+  const lines: string[] = [];
+  for (const [name, definition] of Object.entries(properties)) {
+    if (definition === true || definition === false) {
+      lines.push(`- ${name}`);
+      continue;
+    }
+
+    const prop = definition as JSONSchema7;
+    const type = Array.isArray(prop.type) ? prop.type.join(" | ") : prop.type;
+    const meta = [type, required.has(name) ? "required" : undefined]
+      .filter(Boolean)
+      .join(", ");
+    const head = meta ? `- ${name} (${meta})` : `- ${name}`;
+    lines.push(prop.description ? `${head}: ${prop.description}` : head);
+  }
+
+  if (lines.length === 0) return undefined;
+
+  return `Returns structured output with the following fields:\n${lines.join("\n")}`;
+}
+
+/**
+ * Builds the model-facing description for a tool, appending a summary of its
+ * `outputSchema` when present. Tools without an output schema are returned
+ * unchanged.
+ */
+export function buildModelFacingDescription(
+  description: string | undefined,
+  outputSchema: unknown
+): string | undefined {
+  const outputSummary = describeOutputSchemaForModel(outputSchema);
+  if (!outputSummary) return description;
+  return description ? `${description}\n\n${outputSummary}` : outputSummary;
+}
+
+/**
  * Converts MCP tools to Vercel AI SDK format.
  *
  * @param listToolsResult - The result from listTools()
@@ -231,6 +297,14 @@ export async function convertMCPToolsToVercelTools(
     const toolMeta = toolDescription._meta as
       | Record<string, unknown>
       | undefined;
+
+    // Provider tool definitions are input-only, so a declared outputSchema
+    // never reaches the model. Fold it into the description so the model can
+    // interpret the structured result it gets back.
+    const modelDescription = buildModelFacingDescription(
+      description,
+      (toolDescription as { outputSchema?: unknown }).outputSchema
+    );
 
     // SEP-1865: hosts that negotiate `io.modelcontextprotocol/ui` MUST NOT
     // include tools whose visibility omits `"model"` in the agent's tool list.
@@ -272,7 +346,7 @@ export async function convertMCPToolsToVercelTools(
       // Automatic mode: normalize the schema and create a dynamic tool
       const normalizedInputSchema = ensureJsonSchemaObject(inputSchema);
       vercelTool = dynamicTool({
-        description,
+        description: modelDescription,
         inputSchema: jsonSchema(normalizedInputSchema),
         execute,
         ...(toModelOutput ? { toModelOutput } : {}),
@@ -285,7 +359,7 @@ export async function convertMCPToolsToVercelTools(
         continue;
       }
       vercelTool = defineTool<unknown, CallToolResult>({
-        description,
+        description: modelDescription,
         inputSchema: overrides[name].inputSchema,
         execute,
         ...(toModelOutput ? { toModelOutput } : {}),

--- a/sdk/tests/tool-converters.test.ts
+++ b/sdk/tests/tool-converters.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { ListToolsResult } from "@modelcontextprotocol/client";
 import {
   convertMCPToolsToVercelTools,
+  describeOutputSchemaForModel,
   isAppOnlyTool,
 } from "../src/mcp-client-manager/tool-converters.js";
 
@@ -91,5 +92,88 @@ describe("convertMCPToolsToVercelTools — SEP-1865 visibility filtering", () =>
     expect(tools.model_only).toBeDefined();
     expect(tools.model_and_app).toBeDefined();
     expect(tools.default_visibility).toBeDefined();
+  });
+});
+
+const weatherToolFixture: ListToolsResult = {
+  tools: [
+    {
+      name: "get_weather",
+      description: "Get weather for a city",
+      inputSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      },
+      outputSchema: {
+        type: "object",
+        properties: {
+          temperature: {
+            type: "number",
+            description: "Temperature in Celsius",
+          },
+          condition: { type: "string" },
+          x: { type: "integer", description: "Density of seagulls in the sky" },
+        },
+        required: ["temperature", "condition", "x"],
+      },
+    },
+    {
+      name: "no_output_schema",
+      description: "Plain tool",
+      inputSchema: { type: "object", properties: {} },
+    },
+  ],
+} as unknown as ListToolsResult;
+
+describe("describeOutputSchemaForModel", () => {
+  it("lists fields with type, required flag, and descriptions", () => {
+    const summary = describeOutputSchemaForModel({
+      type: "object",
+      properties: {
+        temperature: { type: "number", description: "Temperature in Celsius" },
+        x: { type: "integer", description: "Density of seagulls in the sky" },
+      },
+      required: ["temperature"],
+    });
+
+    expect(summary).toContain(
+      "temperature (number, required): Temperature in Celsius"
+    );
+    expect(summary).toContain("x (integer): Density of seagulls in the sky");
+  });
+
+  it("returns undefined when there is no usable schema", () => {
+    expect(describeOutputSchemaForModel(undefined)).toBeUndefined();
+    expect(describeOutputSchemaForModel(null)).toBeUndefined();
+    expect(describeOutputSchemaForModel({})).toBeUndefined();
+    expect(
+      describeOutputSchemaForModel({ type: "object", properties: {} })
+    ).toBeUndefined();
+  });
+});
+
+describe("convertMCPToolsToVercelTools — outputSchema in description", () => {
+  it("folds the output schema into the model-facing description", async () => {
+    const tools = await convertMCPToolsToVercelTools(weatherToolFixture, {
+      callTool,
+    });
+
+    const description = (tools.get_weather as { description?: string })
+      .description;
+    expect(description).toContain("Get weather for a city");
+    expect(description).toContain("Returns structured output");
+    // The field the model previously ignored is now documented for it.
+    expect(description).toContain("Density of seagulls in the sky");
+  });
+
+  it("leaves descriptions untouched when no outputSchema is present", async () => {
+    const tools = await convertMCPToolsToVercelTools(weatherToolFixture, {
+      callTool,
+    });
+
+    expect(
+      (tools.no_output_schema as { description?: string }).description
+    ).toBe("Plain tool");
   });
 });


### PR DESCRIPTION
## Problem

Fixes #1956.

When an MCP tool declares an `outputSchema`, the model never learns about it. In `convertMCPToolsToVercelTools` (`sdk/src/mcp-client-manager/tool-converters.ts`) only `description` + `inputSchema` are passed to the AI SDK `tool()`/`dynamicTool()`. Provider tool definitions (Anthropic, OpenAI, …) are input-only — there is no field that carries an output schema to the model.

As a result the model gets the structured result back but has no descriptions for its fields, so it silently drops anything that isn't self-explanatory. In the linked issue a `get_weather` tool returns a field `x` documented in the output schema as *"Density of seagulls in the sky"*; the model never mentions it because that description never reached it.

## Solution

Fold a compact summary of the `outputSchema` into the model-facing tool description. For each top-level property the summary lists its name, type, `required` flag, and description, e.g.:

```
Get weather for a city

Returns structured output with the following fields:
- temperature (number, required): Temperature in Celsius
- condition (string, required)
- x (integer, required): Density of seagulls in the sky
```

- The summary covers top-level properties (the common flat structured-output case) to keep descriptions small; nested object fields are still listed by name/type so the model knows they exist.
- Tools **without** an `outputSchema` keep their original description byte-for-byte.
- Only the description string the model sees changes — the executed tool result that reaches the UI stream is untouched, and there is no behavior change for tools that don't declare an output schema.

Applied in both the `automatic` (`dynamicTool`) and override (`defineTool`) paths via a small `buildModelFacingDescription` helper.

## Testing

- New unit tests for `describeOutputSchemaForModel` (field rendering, empty/missing schema) and for `convertMCPToolsToVercelTools` (output schema folded into the description; schemaless tools left untouched).
- `npx vitest run` — 87 files, 1516 passed / 1 skipped.
- `npx tsc --noEmit` clean; `prettier --check` clean on changed files.