### PR TITLE
feat(cli): eval screenshot — view an iteration's rendered widget inline

### DIFF
--- a/.changeset/cli-eval-screenshot.md
+++ b/.changeset/cli-eval-screenshot.md
@@ -1,0 +1,16 @@
+---
+"@mcpjam/cli": minor
+---
+
+Add `mcpjam eval screenshot` to view the widget screenshot an eval iteration
+rendered.
+
+`eval screenshot --run <id> --iteration <id> --project <id>` pulls the rendered
+`widgetRenderObservations` out of the iteration trace and shows the image
+**inline** when the terminal supports a graphics protocol (iTerm2/WezTerm via
+OSC 1337, Kitty/Ghostty via the Kitty graphics protocol), and otherwise prints
+the image URL — so it degrades cleanly in plain terminals, pipes, and CI. Pass
+`--out <file|dir>` to save the PNG(s) to disk instead, `--index <n>` to pick one
+render. JSON output (default off-TTY) emits a structured `items[]` of
+`{ toolName, toolCallId, status, screenshotUrl, savedTo? }`. Inline rendering is
+dependency-free; no image libraries are added.

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -1,4 +1,11 @@
-import { readFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import type { Command } from "commander";
 import {
   createEvalCaseOperation,
@@ -22,9 +29,18 @@ import {
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { JsonInputContext } from "../lib/json-input.js";
-import { usageError, writeResult } from "../lib/output.js";
+import {
+  type RenderedScreenshot,
+  extractRenderedScreenshots,
+  screenshotFilename,
+} from "../lib/eval-screenshots.js";
+import { operationalError, usageError, writeResult } from "../lib/output.js";
 import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
-import { getGlobalOptions } from "../lib/server-config.js";
+import { getGlobalOptions, parsePositiveInteger } from "../lib/server-config.js";
+import {
+  detectInlineImageProtocol,
+  encodeInlineImage,
+} from "../lib/terminal-image.js";
 
 type PlatformOptions = {
   apiKey?: string;
@@ -285,6 +301,64 @@ function buildCaseInput(
   return input;
 }
 
+/** A screenshot entry as emitted in JSON output (and after an optional save). */
+type ScreenshotItem = RenderedScreenshot & { savedTo?: string };
+
+/** Fetch raw image bytes for a screenshot URL, bounded by the request timeout. */
+async function fetchScreenshotBytes(
+  url: string,
+  timeoutMs: number
+): Promise<Uint8Array> {
+  const controller = new AbortController();
+  const handle = setTimeout(() => controller.abort(), timeoutMs);
+  handle.unref?.();
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw operationalError(
+        `Failed to download screenshot (HTTP ${response.status}).`,
+        { url }
+      );
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw operationalError(
+        `Timed out downloading screenshot after ${timeoutMs}ms.`,
+        { url }
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(handle);
+  }
+}
+
+/**
+ * Resolve where a screenshot should be written for `--out`. A path that is (or
+ * looks like) a directory gets a generated per-render filename; otherwise the
+ * literal path is used — but only when saving a single image, so multiple
+ * renders never overwrite one file.
+ */
+function resolveScreenshotPath(
+  out: string,
+  shot: RenderedScreenshot,
+  index: number,
+  total: number
+): string {
+  const looksLikeDir =
+    out.endsWith("/") || (existsSync(out) && statSync(out).isDirectory());
+  if (looksLikeDir) {
+    return join(out, screenshotFilename(shot, index));
+  }
+  if (total > 1) {
+    throw usageError(
+      "--out must be a directory when the iteration rendered multiple screenshots."
+    );
+  }
+  return out;
+}
+
 export function registerEvalCommands(program: Command): void {
   const evals = program
     .command("eval")
@@ -490,6 +564,141 @@ export function registerEvalCommands(program: Command): void {
         options,
         command
       );
+    }
+  );
+
+  addPlatformOptions(
+    evals
+      .command("screenshot")
+      .description(
+        "Show the widget screenshot(s) an eval iteration rendered — inline when the terminal supports it, otherwise the image URL"
+      )
+      .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
+      .requiredOption(
+        "--iteration <id>",
+        "Iteration ID (from `eval iterations`)"
+      )
+      .requiredOption(
+        "--project <id-or-name>",
+        "Project the run belongs to (name or ID)"
+      )
+      .option(
+        "--out <path>",
+        "Save the PNG(s) to a file or directory instead of rendering inline"
+      )
+      .option("--index <n>", "Show only the Nth screenshot (1-based)")
+  ).action(
+    async (
+      options: PlatformOptions & {
+        project: string;
+        run: string;
+        iteration: string;
+        out?: string;
+        index?: string;
+      },
+      command
+    ) => {
+      const globalOptions = getGlobalOptions(command);
+      const index =
+        options.index !== undefined
+          ? parsePositiveInteger(options.index, "--index")
+          : undefined;
+
+      const result = await runPlatformCommand(
+        options,
+        globalOptions.timeout,
+        ({ client, signal }) =>
+          getEvalIterationTraceOperation.execute(
+            {
+              project: options.project,
+              runId: options.run,
+              iterationId: options.iteration,
+            },
+            { client, signal }
+          )
+      );
+
+      let shots = extractRenderedScreenshots(result);
+      if (index !== undefined) {
+        if (index > shots.length) {
+          throw usageError(
+            `--index ${index} is out of range; this iteration rendered ${shots.length} screenshot(s).`
+          );
+        }
+        shots = [shots[index - 1]];
+      }
+
+      const base = {
+        project: result.project,
+        runId: result.runId,
+        iterationId: result.iterationId,
+      };
+      const isJson = globalOptions.format === "json";
+
+      // Save mode: download each PNG to disk regardless of output format.
+      if (options.out !== undefined) {
+        const saved: ScreenshotItem[] = [];
+        for (let i = 0; i < shots.length; i += 1) {
+          const shot = shots[i];
+          const bytes = await fetchScreenshotBytes(
+            shot.screenshotUrl,
+            globalOptions.timeout
+          );
+          const path = resolveScreenshotPath(
+            options.out,
+            shot,
+            i,
+            shots.length
+          );
+          mkdirSync(dirname(path), { recursive: true });
+          writeFileSync(path, bytes);
+          saved.push({ ...shot, savedTo: path });
+        }
+        if (isJson) {
+          writeResult({ ...base, items: saved });
+          return;
+        }
+        if (saved.length === 0) {
+          process.stdout.write(
+            "No rendered widget screenshots for this iteration.\n"
+          );
+          return;
+        }
+        for (const shot of saved) {
+          process.stdout.write(
+            `Saved ${shot.toolName ?? "widget"} → ${shot.savedTo}\n`
+          );
+        }
+        return;
+      }
+
+      // JSON without --out: structured screenshot URLs, no image bytes.
+      if (isJson) {
+        writeResult({ ...base, items: shots });
+        return;
+      }
+
+      // Human: render inline if the terminal supports it, else print the URL.
+      if (shots.length === 0) {
+        process.stdout.write(
+          "No rendered widget screenshots for this iteration.\n"
+        );
+        return;
+      }
+      const protocol = detectInlineImageProtocol();
+      for (const shot of shots) {
+        const caption = `${shot.toolName ?? "widget"} · ${shot.status}`;
+        if (protocol) {
+          const bytes = await fetchScreenshotBytes(
+            shot.screenshotUrl,
+            globalOptions.timeout
+          );
+          process.stdout.write(`${caption}\n`);
+          process.stdout.write(encodeInlineImage(bytes, protocol));
+        } else {
+          process.stdout.write(`${caption}  ${shot.screenshotUrl}\n`);
+        }
+      }
     }
   );
 

--- a/cli/src/lib/eval-screenshots.ts
+++ b/cli/src/lib/eval-screenshots.ts
@@ -1,0 +1,74 @@
+/**
+ * Pull rendered widget screenshots out of an eval iteration trace.
+ *
+ * The trace payload is server-defined and reaches the CLI untyped, so we parse
+ * `trace.widgetRenderObservations` defensively and keep only entries that
+ * actually rendered an image (status "rendered" with a screenshot URL). Other
+ * statuses (e.g. "skipped") carry no image and are dropped here — the command
+ * layer decides how to report their absence.
+ */
+
+export type RenderedScreenshot = {
+  toolName?: string;
+  toolCallId?: string;
+  promptIndex?: number;
+  status: string;
+  screenshotUrl: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Extract rendered screenshots from a `get_eval_iteration_trace` result. Accepts
+ * either the full operation result (`{ trace: ... }`) or a bare trace object.
+ */
+export function extractRenderedScreenshots(result: unknown): RenderedScreenshot[] {
+  const root = asRecord(result);
+  if (!root) return [];
+
+  const trace = asRecord(root.trace) ?? root;
+  const observations = trace.widgetRenderObservations;
+  if (!Array.isArray(observations)) return [];
+
+  const screenshots: RenderedScreenshot[] = [];
+  for (const entry of observations) {
+    const obs = asRecord(entry);
+    if (!obs) continue;
+    const status = asString(obs.status);
+    const screenshotUrl = asString(obs.screenshotUrl);
+    if (status !== "rendered" || !screenshotUrl) continue;
+    screenshots.push({
+      status,
+      screenshotUrl,
+      toolName: asString(obs.toolName),
+      toolCallId: asString(obs.toolCallId),
+      promptIndex:
+        typeof obs.promptIndex === "number" ? obs.promptIndex : undefined,
+    });
+  }
+  return screenshots;
+}
+
+/**
+ * Build a filesystem-safe PNG filename for a screenshot. Keeps the tool name
+ * readable but strips anything that isn't alnum/dash/underscore so multi-render
+ * iterations don't collide and nothing escapes the target directory.
+ */
+export function screenshotFilename(
+  shot: RenderedScreenshot,
+  index: number,
+): string {
+  const tool = (shot.toolName ?? "widget").replace(/[^a-zA-Z0-9_-]+/g, "-");
+  const suffix = shot.toolCallId
+    ? shot.toolCallId.replace(/[^a-zA-Z0-9_-]+/g, "-")
+    : String(index + 1);
+  return `${tool}-${suffix}.png`;
+}

--- a/cli/src/lib/terminal-image.ts
+++ b/cli/src/lib/terminal-image.ts
@@ -1,0 +1,98 @@
+/**
+ * Dependency-free inline-image rendering for terminals that support a graphics
+ * protocol. Two protocols cover the common emulators:
+ *
+ *  - iTerm2's inline-image protocol (OSC 1337) — iTerm2, WezTerm.
+ *  - Kitty's graphics protocol (APC _G) — Kitty, Ghostty.
+ *
+ * Callers detect support first; when no protocol is available they fall back to
+ * printing the image URL instead. We never emit escape sequences to a
+ * non-interactive stream (pipes, CI), so structured/JSON output stays clean.
+ */
+
+export type InlineImageProtocol = "iterm" | "kitty";
+
+const ESC = "\x1b";
+const BEL = "\x07";
+
+/**
+ * Decide which inline-image protocol the current terminal supports, if any.
+ * Returns null when output is not an interactive TTY or the emulator is
+ * unknown — the caller should then print the URL.
+ */
+export function detectInlineImageProtocol(
+  env: NodeJS.ProcessEnv = process.env,
+  isTTY: boolean | undefined = process.stdout.isTTY,
+): InlineImageProtocol | null {
+  if (!isTTY) return null;
+
+  const termProgram = env.TERM_PROGRAM ?? "";
+  const term = env.TERM ?? "";
+
+  // Kitty graphics protocol: Kitty itself and Ghostty.
+  if (
+    term === "xterm-kitty" ||
+    env.KITTY_WINDOW_ID !== undefined ||
+    termProgram === "ghostty" ||
+    env.GHOSTTY_RESOURCES_DIR !== undefined
+  ) {
+    return "kitty";
+  }
+
+  // iTerm2 inline-image protocol: iTerm2 and WezTerm.
+  if (
+    termProgram === "iTerm.app" ||
+    termProgram === "WezTerm" ||
+    env.LC_TERMINAL === "iTerm2"
+  ) {
+    return "iterm";
+  }
+
+  return null;
+}
+
+function toBase64(data: Uint8Array): string {
+  return Buffer.from(data).toString("base64");
+}
+
+/** iTerm2 OSC 1337 inline image: a single escape carrying the whole payload. */
+function encodeIterm(data: Uint8Array): string {
+  const payload = toBase64(data);
+  const args = ["inline=1", `size=${data.byteLength}`, "preserveAspectRatio=1"].join(
+    ";",
+  );
+  // ESC ] 1337 ; File=<args> : <base64> BEL
+  return `${ESC}]1337;File=${args}:${payload}${BEL}\n`;
+}
+
+/**
+ * Kitty graphics protocol: transmit-and-display a PNG (f=100, a=T), chunking
+ * the base64 payload at 4096 bytes. Only the first chunk carries the format /
+ * action keys; every chunk sets m=1 except the last, which sets m=0.
+ */
+function encodeKitty(data: Uint8Array): string {
+  const payload = toBase64(data);
+  const CHUNK = 4096;
+  const chunks: string[] = [];
+  for (let offset = 0; offset < payload.length; offset += CHUNK) {
+    chunks.push(payload.slice(offset, offset + CHUNK));
+  }
+  if (chunks.length === 0) chunks.push("");
+
+  let out = "";
+  chunks.forEach((chunk, index) => {
+    const more = index < chunks.length - 1 ? 1 : 0;
+    const control = index === 0 ? `a=T,f=100,m=${more}` : `m=${more}`;
+    // ESC _ G <control> ; <chunk> ESC \
+    out += `${ESC}_G${control};${chunk}${ESC}\\`;
+  });
+  return `${out}\n`;
+}
+
+/** Encode raw image bytes as an inline-image escape sequence for `protocol`. */
+export function encodeInlineImage(
+  data: Uint8Array,
+  protocol: InlineImageProtocol,
+): string {
+  return protocol === "kitty" ? encodeKitty(data) : encodeIterm(data);
+}

--- a/cli/tests/eval-screenshots.test.ts
+++ b/cli/tests/eval-screenshots.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  extractRenderedScreenshots,
+  screenshotFilename,
+} from "../src/lib/eval-screenshots.js";
+
+const traceResult = {
+  project: { id: "p1" },
+  runId: "r1",
+  iterationId: "i1",
+  trace: {
+    widgetRenderObservations: [
+      {
+        status: "rendered",
+        screenshotUrl: "https://example.com/a.png",
+        toolName: "create_view",
+        toolCallId: "call_1",
+        promptIndex: 0,
+      },
+      // skipped render → no image, dropped
+      { status: "skipped", toolName: "create_view" },
+      // rendered but missing URL → dropped
+      { status: "rendered", toolName: "create_view" },
+    ],
+  },
+};
+
+test("extracts only rendered observations that carry a screenshot URL", () => {
+  const shots = extractRenderedScreenshots(traceResult);
+  assert.equal(shots.length, 1);
+  assert.deepEqual(shots[0], {
+    status: "rendered",
+    screenshotUrl: "https://example.com/a.png",
+    toolName: "create_view",
+    toolCallId: "call_1",
+    promptIndex: 0,
+  });
+});
+
+test("accepts a bare trace object as well as the full operation result", () => {
+  const shots = extractRenderedScreenshots(traceResult.trace);
+  assert.equal(shots.length, 1);
+  assert.equal(shots[0].screenshotUrl, "https://example.com/a.png");
+});
+
+test("returns an empty list for malformed or empty traces", () => {
+  assert.deepEqual(extractRenderedScreenshots(null), []);
+  assert.deepEqual(extractRenderedScreenshots({}), []);
+  assert.deepEqual(
+    extractRenderedScreenshots({ trace: { widgetRenderObservations: "nope" } }),
+    [],
+  );
+});
+
+test("builds collision-safe, sanitized filenames", () => {
+  assert.equal(
+    screenshotFilename(
+      { status: "rendered", screenshotUrl: "x", toolName: "create_view", toolCallId: "call_1" },
+      0,
+    ),
+    "create_view-call_1.png",
+  );
+  // No toolCallId → fall back to the 1-based index.
+  assert.equal(
+    screenshotFilename(
+      { status: "rendered", screenshotUrl: "x", toolName: "create/view" },
+      2,
+    ),
+    "create-view-3.png",
+  );
+  // No toolName → "widget".
+  assert.equal(
+    screenshotFilename({ status: "rendered", screenshotUrl: "x", toolCallId: "../etc" }, 0),
+    "widget--etc.png",
+  );
+});

--- a/cli/tests/terminal-image.test.ts
+++ b/cli/tests/terminal-image.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  detectInlineImageProtocol,
+  encodeInlineImage,
+} from "../src/lib/terminal-image.js";
+
+test("detects Kitty-family terminals", () => {
+  assert.equal(
+    detectInlineImageProtocol({ TERM: "xterm-kitty" }, true),
+    "kitty",
+  );
+  assert.equal(
+    detectInlineImageProtocol({ KITTY_WINDOW_ID: "1" }, true),
+    "kitty",
+  );
+  assert.equal(
+    detectInlineImageProtocol({ TERM_PROGRAM: "ghostty" }, true),
+    "kitty",
+  );
+});
+
+test("detects iTerm-family terminals", () => {
+  assert.equal(
+    detectInlineImageProtocol({ TERM_PROGRAM: "iTerm.app" }, true),
+    "iterm",
+  );
+  assert.equal(
+    detectInlineImageProtocol({ TERM_PROGRAM: "WezTerm" }, true),
+    "iterm",
+  );
+  assert.equal(
+    detectInlineImageProtocol({ LC_TERMINAL: "iTerm2" }, true),
+    "iterm",
+  );
+});
+
+test("returns null for unknown terminals and non-TTY streams", () => {
+  assert.equal(detectInlineImageProtocol({ TERM: "xterm-256color" }, true), null);
+  // Even a capable terminal yields null when output is not a TTY (pipe/CI).
+  assert.equal(detectInlineImageProtocol({ TERM: "xterm-kitty" }, false), null);
+  assert.equal(
+    detectInlineImageProtocol({ TERM_PROGRAM: "iTerm.app" }, undefined),
+    null,
+  );
+});
+
+test("encodes an iTerm2 OSC 1337 inline image", () => {
+  const data = new Uint8Array([1, 2, 3, 4]);
+  const seq = encodeInlineImage(data, "iterm");
+  const base64 = Buffer.from(data).toString("base64");
+  assert.equal(seq.startsWith("\x1b]1337;File="), true);
+  assert.equal(seq.includes("inline=1"), true);
+  assert.equal(seq.includes("size=4"), true);
+  assert.equal(seq.includes(`:${base64}\x07`), true);
+});
+
+test("encodes a Kitty graphics image and chunks large payloads", () => {
+  const small = encodeInlineImage(new Uint8Array([1, 2, 3]), "kitty");
+  assert.equal(small.startsWith("\x1b_G"), true);
+  assert.equal(small.includes("a=T,f=100"), true);
+  assert.equal(small.includes("m=0"), true); // single chunk → final
+  assert.equal(small.includes("\x1b\\"), true);
+
+  // 6KB of bytes → > 4096 base64 chars → multiple chunks, first m=1, last m=0.
+  const big = encodeInlineImage(new Uint8Array(6000).fill(7), "kitty");
+  const chunks = big.split("\x1b_G").length - 1;
+  assert.equal(chunks > 1, true);
+  assert.equal(big.includes("m=1"), true);
+  assert.match(big, /m=0;[^\x1b]*\x1b\\\n$/);
+});


### PR DESCRIPTION
## What

Adds `mcpjam eval screenshot` so you can actually *see* the widget an eval iteration drew, straight from the terminal.

Eval runs already render MCP App widgets headlessly and capture a screenshot per `create_view`/widget tool call (`trace.widgetRenderObservations[].screenshotUrl`). Until now the CLI surfaced none of it — a case that draws a diagram looked identical to one that returns text. This command closes that gap.

```
mcpjam eval screenshot --run <id> --iteration <id> --project <id-or-name> [--out <path>] [--index <n>]
```

## Behavior

- **Show the image if possible, else the URL.** In an interactive terminal that supports a graphics protocol, the PNG renders **inline**; otherwise (plain terminals, pipes, CI, `--format json`) it prints the image URL. One TTY/capability gate decides.
  - iTerm2 / WezTerm → iTerm2 inline-image protocol (OSC 1337)
  - Kitty / Ghostty → Kitty graphics protocol (chunked)
- **`--out <file|dir>`** saves the PNG(s) to disk instead (file path for a single render, directory for multiple, with collision-safe `toolName-toolCallId.png` names). Honored in both formats; JSON includes `savedTo`.
- **`--index <n>`** selects one render (1-based) when an iteration produced several.
- **JSON** (default off-TTY) emits a structured `items[]` of `{ toolName, toolCallId, promptIndex, status, screenshotUrl, savedTo? }`.
- Absence is handled cleanly: non-rendered / image-less observations are dropped, and "no screenshots" exits 0 with a plain message rather than a dead link.

## Implementation notes

- **Dependency-free** — no image library added. Terminal detection and the escape-sequence encoders are ~100 lines in `cli/src/lib/terminal-image.ts`; escape sequences never go to non-TTY streams, so structured output stays clean.
- Trace parsing (`cli/src/lib/eval-screenshots.ts`) is defensive — the trace reaches the CLI untyped, so only `status === "rendered"` entries with a string `screenshotUrl` are kept.
- New command reuses the existing `getEvalIterationTraceOperation` + `runPlatformCommand` plumbing.

## Testing

- New unit tests: terminal detection (iTerm/WezTerm/Kitty/Ghostty/unknown/non-TTY), OSC 1337 + Kitty chunked encoding, trace extraction + filename sanitization.
- Full CLI suite green (326 tests).
- Manually verified against a live failing "Excalidraw quickstart" iteration: inline (URL fallback when piped), `--out` file + directory, `--index`, and out-of-range usage error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only feature with bounded HTTP downloads and no server or auth changes; well-tested parsing and TTY gating limit blast radius.
> 
> **Overview**
> Adds **`mcpjam eval screenshot`** so you can inspect widget PNGs captured during an eval iteration. It reuses **`getEvalIterationTraceOperation`**, pulls **`widgetRenderObservations`** via defensive parsing in **`eval-screenshots.ts`**, and only keeps entries with **`status === "rendered"`** and a URL.
> 
> **Human TTY output** tries dependency-free inline images (**iTerm/WezTerm** OSC 1337, **Kitty/Ghostty** chunked graphics); otherwise it prints URLs. **JSON** and non-TTY paths emit structured **`items[]`** without escape sequences. **`--out`** downloads PNGs (file or directory with sanitized names; multi-render requires a directory). **`--index`** selects one render (1-based).
> 
> Unit tests cover trace extraction, filename sanitization, terminal detection, and protocol encoding. Minor CLI release via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda87be42f5b18bbde69a21021663502e0db1d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->