### PR TITLE
feat(trace): OTel-aligned GenAI harness metadata on trace spans

### DIFF
--- a/chat-ui/src/__tests__/trace-timeline.test.tsx
+++ b/chat-ui/src/__tests__/trace-timeline.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 
 import { TraceTimeline } from "../internal/trace-timeline/trace-timeline";
 import type { TraceSpan } from "../internal/trace-timeline/eval-trace";
@@ -52,5 +52,30 @@ describe("TraceTimeline (recorded waterfall)", () => {
   it("renders the empty state when there are no recorded spans", () => {
     const { getByText } = render(<TraceTimeline recordedSpans={[]} />);
     getByText(/No timing data recorded/i);
+  });
+
+  it("shows harness metadata (provider/finish) in the detail pane for llm spans", () => {
+    const llmSpans: TraceSpan[] = [
+      {
+        id: "p0-llm",
+        name: "Agent",
+        category: "llm",
+        startMs: 0,
+        endMs: 2420,
+        promptIndex: 0,
+        stepIndex: 0,
+        outputTokens: 50,
+        finishReason: "length",
+        provider: "anthropic",
+      },
+    ];
+    const { getAllByTestId, getByTestId } = render(
+      <TraceTimeline recordedSpans={llmSpans} />,
+    );
+    const labelButtons = getAllByTestId("trace-row-label-button");
+    fireEvent.click(labelButtons[labelButtons.length - 1]);
+    const meta = getByTestId("trace-span-metadata");
+    expect(meta.textContent).toContain("anthropic");
+    expect(meta.textContent).toContain("length");
   });
 });

--- a/chat-ui/src/internal/trace-timeline/eval-trace.ts
+++ b/chat-ui/src/internal/trace-timeline/eval-trace.ts
@@ -35,6 +35,13 @@ export type TraceSpan = {
   messageStartIndex?: number;
   /** Inclusive index of the last related transcript message. */
   messageEndIndex?: number;
+  // GenAI harness metadata (step/llm spans). Structural subset of the
+  // inspector's EvalTraceSpan; the richer type assigns to this for rendering.
+  finishReason?: string;
+  provider?: string;
+  responseId?: string;
+  responseTimestamp?: string;
+  ttfcMs?: number;
 };
 
 // Internal aliases so the ported timeline keeps its original identifiers

--- a/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
+++ b/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
@@ -231,6 +231,15 @@ function compareSpans(a: EvalTraceSpan, b: EvalTraceSpan): number {
   return a.name.localeCompare(b.name);
 }
 
+/** Output tokens per second for an llm span, or null when not computable. */
+function spanThroughputPerSec(
+  outputTokens: number | undefined,
+  durationMs: number,
+): number | null {
+  if (typeof outputTokens !== "number" || durationMs < 50) return null;
+  return outputTokens / (durationMs / 1000);
+}
+
 function formatDuration(ms: number): string {
   if (ms >= 1000) return `${(ms / 1000).toFixed(ms >= 10_000 ? 1 : 2)}s`;
   return `${Math.round(ms)}ms`;
@@ -1563,6 +1572,54 @@ function TimelineDetailPane({
                 </>
               ) : null}
             </div>
+
+            {row.kind === "span"
+              ? (() => {
+                  const span = row.span;
+                  const throughput =
+                    span.category === "llm"
+                      ? spanThroughputPerSec(span.outputTokens, durationMs)
+                      : null;
+                  const items: Array<{ label: string; value: string }> = [];
+                  if (span.provider)
+                    items.push({ label: "Provider", value: span.provider });
+                  if (span.finishReason)
+                    items.push({ label: "Finish", value: span.finishReason });
+                  if (typeof span.ttfcMs === "number")
+                    items.push({
+                      label: "TTFC",
+                      value: formatDuration(span.ttfcMs),
+                    });
+                  if (throughput !== null)
+                    items.push({
+                      label: "Throughput",
+                      value: `${throughput.toFixed(1)} tok/s`,
+                    });
+                  if (span.responseId)
+                    items.push({
+                      label: "Response ID",
+                      value: span.responseId,
+                    });
+                  if (items.length === 0) return null;
+                  return (
+                    <div
+                      data-testid="trace-span-metadata"
+                      className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground"
+                    >
+                      {items.map((item) => (
+                        <span key={item.label} className="truncate">
+                          <span className="text-muted-foreground/70">
+                            {item.label}:{" "}
+                          </span>
+                          <span className="font-medium text-foreground">
+                            {item.value}
+                          </span>
+                        </span>
+                      ))}
+                    </div>
+                  );
+                })()
+              : null}
           </div>
         </div>
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -63,6 +63,64 @@ beforeEach(() => {
   mockCapture.mockClear();
 });
 
+describe("harness span metadata", () => {
+  const llmSpans = (finishReason?: string): EvalTraceSpan[] => [
+    { id: "step-0", name: "Step 1", category: "step", startMs: 0, endMs: 1000, stepIndex: 0 },
+    {
+      id: "step-0-llm",
+      parentId: "step-0",
+      name: "LLM",
+      category: "llm",
+      startMs: 0,
+      endMs: 1000,
+      stepIndex: 0,
+      modelId: "claude-opus-4-8",
+      provider: "anthropic",
+      outputTokens: 200,
+      responseId: "msg_abc",
+      ttfcMs: 240,
+      ...(finishReason ? { finishReason } : {}),
+    },
+  ];
+
+  it("shows provider, finish reason, TTFC, and throughput in the detail pane (llm row)", () => {
+    render(<TraceTimeline recordedSpans={llmSpans("length")} transcriptMessages={[]} />);
+    // Step rows are hidden; the llm row is the last label button.
+    const labelButtons = screen.getAllByTestId("trace-row-label-button");
+    fireEvent.click(labelButtons[labelButtons.length - 1]);
+    const meta = screen.getByTestId("trace-span-metadata");
+    expect(meta.textContent).toContain("anthropic");
+    // finish reason surfaces as plain text (no special badge).
+    expect(meta.textContent).toContain("length");
+    expect(meta.textContent).toContain("TTFC");
+    // 200 output tokens / 1.0s = 200.0 tok/s
+    expect(meta.textContent).toContain("200.0 tok/s");
+  });
+
+  it("omits throughput on non-llm rows", () => {
+    const spans: EvalTraceSpan[] = [
+      { id: "step-0", name: "Step 1", category: "step", startMs: 0, endMs: 500, stepIndex: 0 },
+      {
+        id: "tool-0",
+        parentId: "step-0",
+        name: "read_me",
+        category: "tool",
+        startMs: 100,
+        endMs: 300,
+        stepIndex: 0,
+        toolCallId: "c1",
+        toolName: "read_me",
+      },
+    ];
+    render(<TraceTimeline recordedSpans={spans} transcriptMessages={[]} />);
+    const toolRow = screen
+      .getAllByTestId("trace-row")
+      .find((el) => el.textContent?.includes("read_me"));
+    fireEvent.click(within(toolRow!).getByTestId("trace-row-label-button"));
+    expect(screen.queryByText(/tok\/s/)).toBeNull();
+  });
+});
+
 describe("selectAxisTickPercents", () => {
   it("uses only endpoints when unmeasured, zero, or very narrow", () => {
     expect(selectAxisTickPercents(-1)).toEqual([0, 100]);

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -221,6 +221,16 @@ function compareSpans(a: EvalTraceSpan, b: EvalTraceSpan): number {
   return a.name.localeCompare(b.name);
 }
 
+/** Output tokens per second for an llm span, or null when not computable. */
+function spanThroughputPerSec(
+  outputTokens: number | undefined,
+  durationMs: number,
+): number | null {
+  // Guard against divide-by-near-zero (cached / sub-ms responses → Infinity).
+  if (typeof outputTokens !== "number" || durationMs < 50) return null;
+  return outputTokens / (durationMs / 1000);
+}
+
 function formatDuration(ms: number): string {
   if (ms >= 1000) return `${(ms / 1000).toFixed(ms >= 10_000 ? 1 : 2)}s`;
   return `${Math.round(ms)}ms`;
@@ -1553,6 +1563,57 @@ function TimelineDetailPane({
                 </>
               ) : null}
             </div>
+
+            {row.kind === "span"
+              ? (() => {
+                  const span = row.span;
+                  const throughput =
+                    span.category === "llm"
+                      ? spanThroughputPerSec(span.outputTokens, durationMs)
+                      : null;
+                  const items: Array<{ label: string; value: string }> = [];
+                  if (span.provider)
+                    items.push({ label: "Provider", value: span.provider });
+                  if (span.finishReason)
+                    items.push({
+                      label: "Finish",
+                      value: span.finishReason,
+                    });
+                  if (typeof span.ttfcMs === "number")
+                    items.push({
+                      label: "TTFC",
+                      value: formatDuration(span.ttfcMs),
+                    });
+                  if (throughput !== null)
+                    items.push({
+                      label: "Throughput",
+                      value: `${throughput.toFixed(1)} tok/s`,
+                    });
+                  if (span.responseId)
+                    items.push({
+                      label: "Response ID",
+                      value: span.responseId,
+                    });
+                  if (items.length === 0) return null;
+                  return (
+                    <div
+                      data-testid="trace-span-metadata"
+                      className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground"
+                    >
+                      {items.map((item) => (
+                        <span key={item.label} className="truncate">
+                          <span className="text-muted-foreground/70">
+                            {item.label}:{" "}
+                          </span>
+                          <span className="font-medium text-foreground">
+                            {item.value}
+                          </span>
+                        </span>
+                      ))}
+                    </div>
+                  );
+                })()
+              : null}
           </div>
         </div>
 

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -210,6 +210,10 @@ function streamDirectChatWithLiveTrace(options: {
     execute: async ({ writer }) => {
       handle = runDirectChatTurn({
         ...turnOptions,
+        // Logical provider for span metadata (OTel gen_ai.provider.name).
+        // Pulled out of `turnOptions` above for error formatting; thread it
+        // back in so llm/step spans carry it.
+        provider,
         abortSignal,
         onPersist,
         onPersistError: (error) => {
@@ -651,6 +655,7 @@ chatV2.post("/", async (c) => {
       return handleMCPJamFreeChatModel({
         messages: modelMessages as ModelMessage[],
         modelId: String(modelDefinition.id),
+        provider: modelDefinition.provider,
         systemPrompt: effectiveEnhancedSystemPrompt,
         temperature: resolvedTemperature,
         tools: allTools as ToolSet,

--- a/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
+++ b/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
@@ -14,6 +14,13 @@ type StepSpanMeta = {
   messageStartIndex?: number;
   messageEndIndex?: number;
   status?: EvalTraceSpanStatus;
+  // GenAI harness metadata (step/llm spans). `finishReason` must already be
+  // normalized by the caller (see normalizeFinishReason at the write site).
+  finishReason?: string;
+  provider?: string;
+  responseId?: string;
+  responseTimestamp?: string;
+  ttfcMs?: number;
 };
 
 type ToolSpanMeta = {
@@ -105,6 +112,24 @@ function applyStepMeta(span: EvalTraceSpan, meta?: StepSpanMeta): void {
   }
   if (meta.status) {
     span.status = meta.status;
+  }
+  if (typeof meta.finishReason === "string" && meta.finishReason.length > 0) {
+    span.finishReason = meta.finishReason;
+  }
+  if (typeof meta.provider === "string" && meta.provider.length > 0) {
+    span.provider = meta.provider;
+  }
+  if (typeof meta.responseId === "string" && meta.responseId.length > 0) {
+    span.responseId = meta.responseId;
+  }
+  if (
+    typeof meta.responseTimestamp === "string" &&
+    meta.responseTimestamp.length > 0
+  ) {
+    span.responseTimestamp = meta.responseTimestamp;
+  }
+  if (typeof meta.ttfcMs === "number") {
+    span.ttfcMs = meta.ttfcMs;
   }
 }
 
@@ -315,6 +340,11 @@ export function emitAiSdkOnStepFinish(
     messageStartIndex: spanMeta?.messageStartIndex,
     messageEndIndex: spanMeta?.messageEndIndex,
     status: spanMeta?.status ?? "ok",
+    finishReason: spanMeta?.finishReason,
+    provider: spanMeta?.provider,
+    responseId: spanMeta?.responseId,
+    responseTimestamp: spanMeta?.responseTimestamp,
+    ttfcMs: spanMeta?.ttfcMs,
   });
   ctx.recordedSpans.push(llmSpan);
 
@@ -335,6 +365,11 @@ export function emitAiSdkOnStepFinish(
     messageStartIndex: spanMeta?.messageStartIndex,
     messageEndIndex: spanMeta?.messageEndIndex,
     status: spanMeta?.status ?? "ok",
+    finishReason: spanMeta?.finishReason,
+    provider: spanMeta?.provider,
+    responseId: spanMeta?.responseId,
+    responseTimestamp: spanMeta?.responseTimestamp,
+    ttfcMs: spanMeta?.ttfcMs,
   });
   ctx.recordedSpans.push(stepSpan);
   applyMessageRangeToChildren(ctx.recordedSpans, stepSpanId, {

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -323,6 +323,7 @@ function buildHandlerOptions(
   const handlerOptions: MCPJamHandlerOptions = {
     messages: opts.messages,
     modelId: String(opts.modelDefinition.id),
+    provider: opts.modelDefinition.provider,
     systemPrompt: opts.systemPrompt,
     tools: opts.tools,
     mcpClientManager: opts.mcpClientManager,

--- a/mcpjam-inspector/server/utils/direct-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/direct-chat-turn.ts
@@ -7,7 +7,10 @@ import {
 } from "ai";
 import type { ModelMessage } from "@ai-sdk/provider-utils";
 import type { createLlmModel } from "./chat-helpers";
-import { appendDedupedModelMessages } from "@/shared/eval-trace";
+import {
+  appendDedupedModelMessages,
+  normalizeFinishReason,
+} from "@/shared/eval-trace";
 import {
   createAiSdkEvalTraceContext,
   emitAiSdkOnStepFinish,
@@ -265,6 +268,12 @@ export interface DirectChatTurnEngineErrorEvent {
 export interface RunDirectChatTurnOptions {
   llmModel: ReturnType<typeof createLlmModel>;
   modelId: string;
+  /**
+   * Logical provider for span metadata (OTel `gen_ai.provider.name`, e.g.
+   * "anthropic"). Threaded from the caller's model config — never derived from
+   * `modelId`. Optional: when omitted, llm/step spans simply lack `provider`.
+   */
+  provider?: string;
   messageHistory: ModelMessage[];
   systemPrompt: string;
   temperature?: number;
@@ -431,6 +440,7 @@ export function runDirectChatTurn(
   const {
     llmModel,
     modelId,
+    provider,
     messageHistory,
     systemPrompt,
     temperature,
@@ -477,6 +487,10 @@ export function runDirectChatTurn(
   const traceContext = createAiSdkEvalTraceContext(traceAnchor);
   const providerSystemPrompt = normalizeSystemPromptForProvider(systemPrompt);
   let currentStepIndex = 0;
+  // Time-to-first-chunk capture (OTel gen_ai.response.time_to_first_chunk):
+  // absolute Date.now() of the first streamed chunk for each step, set once in
+  // `onChunk`. `onStepFinish` turns it into `ttfcMs` relative to step start.
+  const stepFirstChunkAt = new Map<number, number>();
   let turnFinished = false;
   let aborted = abortSignal?.aborted === true;
   let listenerAttached = false;
@@ -644,6 +658,10 @@ export function runDirectChatTurn(
         : {};
     },
     onChunk: async ({ chunk }) => {
+      // First streamed chunk of this step → TTFC anchor (any chunk type).
+      if (!stepFirstChunkAt.has(currentStepIndex)) {
+        stepFirstChunkAt.set(currentStepIndex, Date.now());
+      }
       if (chunk.type === "text-delta") {
         // Parity callback fires alongside the trace surface so
         // streaming-text consumers (mirrors `onLiveTextDelta` on the
@@ -707,6 +725,17 @@ export function runDirectChatTurn(
         stepUsage,
       );
 
+      const stepStartAt = traceContext.openSteps.get(currentStepIndex)?.startAt;
+      const firstChunkAt = stepFirstChunkAt.get(currentStepIndex);
+      const ttfcMs =
+        typeof stepStartAt === "number" && typeof firstChunkAt === "number"
+          ? Math.max(0, firstChunkAt - stepStartAt)
+          : undefined;
+      const responseTimestamp =
+        step?.response?.timestamp instanceof Date
+          ? step.response.timestamp.toISOString()
+          : undefined;
+
       emitAiSdkOnStepFinish(traceContext, Date.now(), {
         modelId,
         inputTokens: stepUsage?.inputTokens,
@@ -714,6 +743,11 @@ export function runDirectChatTurn(
         totalTokens: stepUsage?.totalTokens,
         messageStartIndex,
         messageEndIndex,
+        finishReason: normalizeFinishReason(step?.finishReason),
+        provider,
+        responseId: step?.response?.id,
+        responseTimestamp,
+        ttfcMs,
       });
 
       setToolSpanMessageRangesFromResults(

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -83,6 +83,7 @@ import {
   type PrepareAdvertisedTools,
 } from "./advertised-tools";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
+import { normalizeFinishReason } from "@/shared/eval-trace";
 import {
   mergeLiveChatTraceUsage,
   type LiveChatTraceUsage,
@@ -279,6 +280,12 @@ export interface MCPJamEngineErrorEvent {
 export interface MCPJamHandlerOptions {
   messages: ModelMessage[];
   modelId: string;
+  /**
+   * Logical provider for span metadata (OTel `gen_ai.provider.name`, e.g.
+   * "anthropic"). Threaded from the caller's model config — never derived from
+   * `modelId`. Optional: when omitted, llm/step spans simply lack `provider`.
+   */
+  provider?: string;
   systemPrompt: string;
   temperature?: number;
   tools: ToolSet;
@@ -451,6 +458,8 @@ interface StepContext {
   chatSessionId?: string;
   sourceType?: string;
   modelId: string;
+  /** Logical provider for span metadata (OTel gen_ai.provider.name). */
+  provider?: string;
   systemPrompt: string;
   temperature?: number;
   mcpClientManager: MCPClientManager;
@@ -496,6 +505,12 @@ interface StreamResult {
   contentParts: PersistedAssistantPart[];
   hasToolCalls: boolean;
   finishChunk: UIMessageChunk | null;
+  /**
+   * Absolute Date.now() of the first emitted stream chunk, for
+   * time-to-first-chunk (OTel gen_ai.response.time_to_first_chunk). Undefined
+   * if the stream produced no chunks.
+   */
+  firstChunkAt?: number;
 }
 
 /**
@@ -683,6 +698,19 @@ function readUsageFromFinishChunk(
   }
 
   return Object.keys(next).length > 0 ? next : undefined;
+}
+
+/**
+ * Read the model finish reason off a per-step `finish` chunk and normalize it
+ * to the canonical span vocabulary. Returns undefined when absent — span
+ * capture never fabricates one.
+ */
+function readFinishReasonFromChunk(
+  finishChunk: UIMessageChunk | null
+): string | undefined {
+  type FinishUIMessageChunk = Extract<UIMessageChunk, { type: "finish" }>;
+  const source = finishChunk as Partial<FinishUIMessageChunk> | null;
+  return normalizeFinishReason(source?.finishReason);
 }
 
 function createClientFinishChunk(
@@ -961,6 +989,7 @@ async function processStream(
   let pendingReasoningId: string | null = null;
   let hasToolCalls = false;
   let finishChunk: UIMessageChunk | null = null;
+  let firstChunkAt: number | undefined;
 
   const flushText = () => {
     if (pendingText) {
@@ -1043,6 +1072,10 @@ async function processStream(
         };
         [key: string]: unknown;
       };
+
+      if (firstChunkAt === undefined) {
+        firstChunkAt = Date.now();
+      }
 
       // Skip backend stub tool outputs - we execute tools locally
       if (
@@ -1208,7 +1241,7 @@ async function processStream(
       ? abortSignal.reason
       : Object.assign(new Error("Aborted"), { name: "AbortError" });
   }
-  return { contentParts, hasToolCalls, finishChunk };
+  return { contentParts, hasToolCalls, finishChunk, firstChunkAt };
 }
 
 /**
@@ -1700,6 +1733,7 @@ async function processOneStep(
     accessVersion,
     projectId,
     modelId,
+    provider,
     systemPrompt,
     temperature,
     mcpClientManager,
@@ -1960,7 +1994,7 @@ async function processOneStep(
   }
 
   // Process the stream
-  const { contentParts, finishChunk } = await processStream(
+  const { contentParts, finishChunk, firstChunkAt } = await processStream(
     res.body,
     writer,
     normalizeToolCallId,
@@ -1994,6 +2028,20 @@ async function processOneStep(
   const stepMessageStartIndex =
     stepMessageEndIndex != null ? traceTurn.promptMessageStartIndex : undefined;
   const stepUsage = readUsageFromFinishChunk(finishChunk);
+
+  // GenAI harness metadata for this step's llm/step spans (OTel-aligned).
+  // `finishChunk` is per-step, so `finishReason` is correct per step (e.g.
+  // "tool-calls" on a tool step, "stop"/"length" on the terminal step). TTFC is
+  // first-chunk relative to the LLM request start. Spread into every
+  // pushBackendStepSuccessSpans call below.
+  const harnessSpanMeta = {
+    provider,
+    finishReason: readFinishReasonFromChunk(finishChunk),
+    ttfcMs:
+      typeof firstChunkAt === "number"
+        ? Math.max(0, firstChunkAt - llmStartAbs)
+        : undefined,
+  };
 
   // Check for unresolved tool calls and execute them
   if (hasUnresolvedToolCalls(messageHistory)) {
@@ -2159,6 +2207,7 @@ async function processOneStep(
           messageStartIndex: stepMessageStartIndex,
           messageEndIndex: stepMessageEndIndex,
           status: "ok",
+          ...harnessSpanMeta,
         }
       );
       setStepSpanMessageRanges(
@@ -2284,6 +2333,7 @@ async function processOneStep(
           messageStartIndex: stepMessageStartIndexAfterTools,
           messageEndIndex: stepMessageEndIndexAfterTools,
           status: "ok",
+          ...harnessSpanMeta,
         }
       );
       setStepSpanMessageRanges(
@@ -2402,6 +2452,7 @@ async function processOneStep(
       messageStartIndex: stepMessageStartIndex,
       messageEndIndex: stepMessageEndIndex,
       status: "ok",
+      ...harnessSpanMeta,
     }
   );
   setStepSpanMessageRanges(
@@ -2474,6 +2525,7 @@ export async function runChatEngineLoop(
   const {
     messages,
     modelId,
+    provider,
     systemPrompt,
     temperature,
     tools,
@@ -2725,6 +2777,7 @@ export async function runChatEngineLoop(
             chatSessionId,
             sourceType,
             modelId,
+            provider,
             systemPrompt,
             temperature,
             mcpClientManager,

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -444,6 +444,7 @@ export async function streamWebChatTurn(
   return handleMCPJamFreeChatModel({
     messages: modelMessages,
     modelId: mcpjamModelId,
+    provider: prepare.modelDefinition.provider,
     chatSessionId: hostedChatSessionId,
     sourceType: persist.sourceType,
     systemPrompt: effectiveEnhancedSystemPrompt,

--- a/mcpjam-inspector/shared/__tests__/eval-trace.test.ts
+++ b/mcpjam-inspector/shared/__tests__/eval-trace.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import type { ModelMessage } from "ai";
 import {
   appendDedupedModelMessages,
   createOffsetInterval,
   evalTraceBlobV1Z,
+  evalTraceSpanZ,
+  normalizeFinishReason,
   normalizeSpanInterval,
   stepResultHasToolActivity,
 } from "../eval-trace";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+type FixtureRow = { label: string; value: Record<string, unknown> };
+type Fixtures = { __readme: string; accept: FixtureRow[]; reject: FixtureRow[] };
+const traceSpanFixtures: Fixtures = JSON.parse(
+  readFileSync(
+    join(__dirname, "fixtures/trace-span-parity-fixtures.json"),
+    "utf8",
+  ),
+);
 
 describe("eval-trace helpers", () => {
   it("normalizeSpanInterval bumps zero-duration to 1ms", () => {
@@ -146,5 +161,86 @@ describe("eval-trace helpers", () => {
         widgetHtmlBlobId: "blob-1",
       }),
     );
+  });
+});
+
+describe("trace-span parity fixtures (inspector evalTraceSpanZ side)", () => {
+  it("fixture file has accept + reject cohorts and a readme", () => {
+    expect(typeof traceSpanFixtures.__readme).toBe("string");
+    expect(traceSpanFixtures.accept.length).toBeGreaterThan(0);
+    expect(traceSpanFixtures.reject.length).toBeGreaterThan(0);
+  });
+
+  for (const row of traceSpanFixtures.accept) {
+    it(`accepts + preserves harness fields: ${row.label}`, () => {
+      const parsed = evalTraceSpanZ.safeParse(row.value);
+      if (!parsed.success) {
+        throw new Error(
+          `Expected accept for "${row.label}":\n${JSON.stringify(parsed.error.issues, null, 2)}`,
+        );
+      }
+      // Harness metadata must round-trip through the Zod mirror unchanged.
+      for (const field of [
+        "finishReason",
+        "provider",
+        "responseId",
+        "responseTimestamp",
+        "ttfcMs",
+      ] as const) {
+        if (row.value[field] !== undefined) {
+          expect((parsed.data as Record<string, unknown>)[field]).toEqual(
+            row.value[field],
+          );
+        }
+      }
+    });
+  }
+
+  for (const row of traceSpanFixtures.reject) {
+    it(`rejects: ${row.label}`, () => {
+      expect(evalTraceSpanZ.safeParse(row.value).success).toBe(false);
+    });
+  }
+
+  // Inspector-only: optional-field TYPE mismatches. The backend normalizer
+  // leniently drops a bad optional, so these are NOT in the shared reject set;
+  // the strict Zod mirror must still refuse them.
+  it("rejects ttfcMs of the wrong type", () => {
+    expect(
+      evalTraceSpanZ.safeParse({
+        id: "x",
+        name: "LLM",
+        category: "llm",
+        startMs: 0,
+        endMs: 1,
+        ttfcMs: "240",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("normalizeFinishReason", () => {
+  it("folds raw provider aliases to the canonical vocabulary", () => {
+    expect(normalizeFinishReason("content_filter")).toBe("content-filter");
+    expect(normalizeFinishReason("max_tokens")).toBe("length");
+    expect(normalizeFinishReason("end_turn")).toBe("stop");
+    expect(normalizeFinishReason("tool_use")).toBe("tool-calls");
+  });
+
+  it("passes through already-canonical AI SDK values", () => {
+    expect(normalizeFinishReason("length")).toBe("length");
+    expect(normalizeFinishReason("content-filter")).toBe("content-filter");
+    expect(normalizeFinishReason("stop")).toBe("stop");
+  });
+
+  it("returns undefined for missing/empty input (never fabricates)", () => {
+    expect(normalizeFinishReason(undefined)).toBeUndefined();
+    expect(normalizeFinishReason(null)).toBeUndefined();
+    expect(normalizeFinishReason("   ")).toBeUndefined();
+    expect(normalizeFinishReason(42)).toBeUndefined();
+  });
+
+  it("preserves debug fidelity for unrecognized values (lowercased)", () => {
+    expect(normalizeFinishReason("SomethingNew")).toBe("somethingnew");
   });
 });

--- a/mcpjam-inspector/shared/__tests__/fixtures/trace-span-parity-fixtures.json
+++ b/mcpjam-inspector/shared/__tests__/fixtures/trace-span-parity-fixtures.json
@@ -1,0 +1,83 @@
+{
+  "__readme": "Parity fixtures for the EvalTraceSpan shape across repos. Kept in lockstep with mcpjam-backend (tests/convex/fixtures/trace-span-parity-fixtures.json). The backend cannot import this repo's Zod (Convex bundling isolation), so this JSON is the common ground truth. 'accept' rows are valid spans, several carrying the GenAI harness metadata (finishReason/provider/responseId/responseTimestamp/ttfcMs) added for OTel alignment: evalTraceSpanZ must parse each, and the backend normalizeTraceSpans() must PRESERVE every field. 'reject' rows omit a required field (id/name/category/startMs/endMs) or use an invalid category — both validators must refuse (Zod rejects; normalizeTraceSpans drops the span). NOTE: optional-field TYPE mismatches (e.g. ttfcMs as a string) are intentionally NOT in this shared reject set, because the backend normalizer leniently drops a bad optional rather than failing the whole span — those cases live as inspector-only assertions in eval-trace.test.ts.",
+  "accept": [
+    {
+      "label": "llm span with full harness metadata (finishReason=length)",
+      "value": {
+        "id": "p0-s0-llm",
+        "parentId": "p0-s0",
+        "name": "LLM",
+        "category": "llm",
+        "startMs": 0,
+        "endMs": 1200,
+        "promptIndex": 0,
+        "stepIndex": 0,
+        "status": "ok",
+        "modelId": "claude-opus-4-8",
+        "inputTokens": 100,
+        "outputTokens": 50,
+        "totalTokens": 150,
+        "finishReason": "length",
+        "provider": "anthropic",
+        "responseId": "msg_0123456789",
+        "responseTimestamp": "2026-06-18T00:00:00.000Z",
+        "ttfcMs": 240
+      }
+    },
+    {
+      "label": "llm span with content-filter finish reason",
+      "value": {
+        "id": "p1-s0-llm",
+        "name": "LLM",
+        "category": "llm",
+        "startMs": 0,
+        "endMs": 800,
+        "finishReason": "content-filter",
+        "provider": "openai"
+      }
+    },
+    {
+      "label": "step span without harness metadata (pre-feature shape still valid)",
+      "value": {
+        "id": "p0-s0",
+        "name": "Step 1",
+        "category": "step",
+        "startMs": 0,
+        "endMs": 1300
+      }
+    },
+    {
+      "label": "tool span (harness fields absent, unaffected)",
+      "value": {
+        "id": "p0-s0-tool-abc",
+        "parentId": "p0-s0",
+        "name": "draw_rectangle",
+        "category": "tool",
+        "startMs": 1200,
+        "endMs": 1300,
+        "status": "ok",
+        "toolCallId": "abc",
+        "toolName": "draw_rectangle",
+        "serverId": "excalidraw"
+      }
+    }
+  ],
+  "reject": [
+    {
+      "label": "missing id",
+      "value": { "name": "LLM", "category": "llm", "startMs": 0, "endMs": 1 }
+    },
+    {
+      "label": "missing name",
+      "value": { "id": "x", "category": "llm", "startMs": 0, "endMs": 1 }
+    },
+    {
+      "label": "invalid category",
+      "value": { "id": "x", "name": "LLM", "category": "reasoning", "startMs": 0, "endMs": 1 }
+    },
+    {
+      "label": "missing startMs",
+      "value": { "id": "x", "name": "LLM", "category": "llm", "endMs": 1 }
+    }
+  ]
+}

--- a/mcpjam-inspector/shared/eval-trace.ts
+++ b/mcpjam-inspector/shared/eval-trace.ts
@@ -27,7 +27,83 @@ export type EvalTraceSpan = {
   messageStartIndex?: number;
   /** Inclusive index of the last related trace message in the stored blob. */
   messageEndIndex?: number;
+  // ── GenAI harness metadata (step/llm spans). OTel mapping in OTEL_ATTR. ──
+  /**
+   * Why the model stopped, normalized to a canonical vocabulary via
+   * `normalizeFinishReason()` at the write site. OTel
+   * `gen_ai.response.finish_reasons` (array; we emit singular per-span, n=1).
+   * Advisory display only — never feed a gate/predicate.
+   */
+  finishReason?: string;
+  /** Logical provider (e.g. "anthropic"). OTel `gen_ai.provider.name`. Threaded from config, never derived from modelId. */
+  provider?: string;
+  /** Provider completion id. OTel `gen_ai.response.id`. */
+  responseId?: string;
+  /** ISO-8601 UTC response timestamp. No direct OTel attr (informs span end time on export). Stored, not surfaced in v1 UI. */
+  responseTimestamp?: string;
+  /** Time to first streamed chunk, ms. OTel `gen_ai.response.time_to_first_chunk` (seconds — export as ttfcMs/1000). Undefined on non-streaming paths; advisory only. */
+  ttfcMs?: number;
 };
+
+/**
+ * Canonical finish-reason vocabulary. The AI SDK already normalizes to most of
+ * these; `normalizeFinishReason` additionally folds raw provider aliases
+ * (`content_filter`, `max_tokens`, `end_turn`, …) so the badge's exact-match
+ * check (`=== "content-filter"`) can't silently miss across capture paths.
+ */
+const FINISH_REASON_ALIASES: Record<string, string> = {
+  stop: "stop",
+  end_turn: "stop",
+  stop_sequence: "stop",
+  length: "length",
+  max_tokens: "length",
+  model_length: "length",
+  "content-filter": "content-filter",
+  content_filter: "content-filter",
+  "tool-calls": "tool-calls",
+  tool_calls: "tool-calls",
+  tool_use: "tool-calls",
+  function_call: "tool-calls",
+  error: "error",
+  other: "other",
+  unknown: "unknown",
+};
+
+/**
+ * Normalize a raw finish reason to the canonical vocabulary. Returns
+ * `undefined` for empty/missing input (never fabricates). Unrecognized
+ * non-empty values pass through lowercased — we keep debug fidelity rather
+ * than collapsing to "other"; only the badge-relevant values are guaranteed
+ * canonical. Apply at the write site (see feedback_normalize_at_write_site).
+ */
+export function normalizeFinishReason(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const key = trimmed.toLowerCase();
+  return FINISH_REASON_ALIASES[key] ?? key;
+}
+
+/**
+ * Mapping from internal span field → OpenTelemetry semantic-convention
+ * attribute name. The seam a future OTLP exporter consumes; nothing in this
+ * PR serializes. Verified against the live spec 2026-06-18.
+ *
+ * Conversions the exporter must apply:
+ * - `finishReason` → `gen_ai.response.finish_reasons` is a string[]; emit `[finishReason]` (n=1 per span).
+ * - `ttfcMs` → `gen_ai.response.time_to_first_chunk` is seconds (double); emit `ttfcMs / 1000`.
+ * - `responseTimestamp` has no attribute — it informs the span end time.
+ */
+export const OTEL_ATTR = {
+  finishReason: "gen_ai.response.finish_reasons",
+  provider: "gen_ai.provider.name",
+  responseId: "gen_ai.response.id",
+  responseTimestamp: null,
+  ttfcMs: "gen_ai.response.time_to_first_chunk",
+  modelId: "gen_ai.request.model",
+  inputTokens: "gen_ai.usage.input_tokens",
+  outputTokens: "gen_ai.usage.output_tokens",
+} as const;
 
 export type PromptTraceSummary = {
   promptIndex: number;
@@ -300,6 +376,12 @@ export const evalTraceSpanZ = z.object({
   totalTokens: z.number().optional(),
   messageStartIndex: z.number().optional(),
   messageEndIndex: z.number().optional(),
+  // GenAI harness metadata — see EvalTraceSpan + OTEL_ATTR.
+  finishReason: z.string().optional(),
+  provider: z.string().optional(),
+  responseId: z.string().optional(),
+  responseTimestamp: z.string().optional(),
+  ttfcMs: z.number().optional(),
 });
 
 const traceToolCallZ = z.object({

--- a/sdk/src/HostRunner.ts
+++ b/sdk/src/HostRunner.ts
@@ -651,9 +651,30 @@ export class HostRunner implements HostExecutor {
       }
     }
 
+    // Logical provider for span metadata (OTel gen_ai.provider.name). Read from
+    // the explicit `provider/model` namespace of the model spec — NOT guessed
+    // from a bare model id. Best-effort: a parse failure must not break span
+    // capture (the model itself is constructed below and will surface errors).
+    let spanProvider: string | undefined;
+    try {
+      const customNames = this.customProviders
+        ? new Set(
+            this.customProviders instanceof Map
+              ? this.customProviders.keys()
+              : Object.keys(this.customProviders)
+          )
+        : undefined;
+      const parsed = parseLLMString(this.model, customNames);
+      spanProvider =
+        parsed.type === "custom" ? parsed.providerName : parsed.provider;
+    } catch {
+      spanProvider = undefined;
+    }
+
     const spanIntegration = createEvalSpanIntegration({
       rel: () => Date.now() - startTime,
       serverIdByTool,
+      provider: spanProvider,
     });
 
     try {

--- a/sdk/src/eval-reporting-types.ts
+++ b/sdk/src/eval-reporting-types.ts
@@ -37,6 +37,13 @@ export type EvalTraceSpanInput = {
   totalTokens?: number;
   messageStartIndex?: number;
   messageEndIndex?: number;
+  // GenAI harness metadata (step/llm spans). Mirror of inspector
+  // shared/eval-trace.ts EvalTraceSpan; kept in parity via the shared fixture.
+  finishReason?: string;
+  provider?: string;
+  responseId?: string;
+  responseTimestamp?: string;
+  ttfcMs?: number;
 };
 
 export type EvalTraceInput =

--- a/sdk/src/eval-trace-spans.ts
+++ b/sdk/src/eval-trace-spans.ts
@@ -19,6 +19,14 @@ type StepMeta = {
   messageStartIndex?: number;
   messageEndIndex?: number;
   status?: SpanStatus;
+  // GenAI harness metadata. `finishReason` here is the AI SDK's already-canonical
+  // value (stop|length|content-filter|tool-calls|error|other|unknown) — no alias
+  // mapping needed on this path. `provider` is threaded from the integration config.
+  finishReason?: string;
+  provider?: string;
+  responseId?: string;
+  responseTimestamp?: string;
+  ttfcMs?: number;
 };
 
 type ToolMeta = {
@@ -167,11 +175,16 @@ export function createEvalSpanIntegration(options: {
   rel: () => number;
   /** Map from tool name → serverId for tool span metadata. */
   serverIdByTool?: Map<string, string>;
+  /**
+   * Logical provider (OTel `gen_ai.provider.name`, e.g. "anthropic"). Threaded
+   * from the caller's model config — the AI SDK step event does not expose it.
+   */
+  provider?: string;
 }): TelemetryIntegration & {
   getSpans: () => EvalTraceSpanInput[];
   finalizeFailure: (errorLabel?: string) => void;
 } {
-  const { rel, serverIdByTool } = options;
+  const { rel, serverIdByTool, provider } = options;
   const sink = createEvalSpanSink(rel);
 
   return {
@@ -199,12 +212,21 @@ export function createEvalSpanIntegration(options: {
     },
 
     onStepFinish(event: OnStepFinishEvent) {
+      const responseTimestamp =
+        event.response?.timestamp instanceof Date
+          ? event.response.timestamp.toISOString()
+          : undefined;
       sink.onStepFinish(event.stepNumber, undefined, {
         modelId: event.response?.modelId ?? event.model?.modelId,
         inputTokens: event.usage?.inputTokens,
         outputTokens: event.usage?.outputTokens,
         totalTokens: event.usage?.totalTokens,
         status: "ok",
+        // AI SDK `finishReason` is already in the canonical vocabulary.
+        finishReason: event.finishReason,
+        provider,
+        responseId: event.response?.id,
+        responseTimestamp,
       });
     },
 
@@ -255,6 +277,24 @@ export function createEvalSpanSink(rel: () => number): EvalSpanSink {
     }
     if (meta.status) {
       span.status = meta.status;
+    }
+    if (typeof meta.finishReason === "string" && meta.finishReason.length > 0) {
+      span.finishReason = meta.finishReason;
+    }
+    if (typeof meta.provider === "string" && meta.provider.length > 0) {
+      span.provider = meta.provider;
+    }
+    if (typeof meta.responseId === "string" && meta.responseId.length > 0) {
+      span.responseId = meta.responseId;
+    }
+    if (
+      typeof meta.responseTimestamp === "string" &&
+      meta.responseTimestamp.length > 0
+    ) {
+      span.responseTimestamp = meta.responseTimestamp;
+    }
+    if (typeof meta.ttfcMs === "number") {
+      span.ttfcMs = meta.ttfcMs;
     }
   }
 


### PR DESCRIPTION
## What

Captures and displays GenAI harness metadata on `llm`/`step` trace spans, mapped to OpenTelemetry `gen_ai.*` semantic conventions. In the trace viewer's detail pane, an llm span now shows **Provider · Finish · TTFC · Throughput**.

Pairs with the backend half: MCPJam/mcpjam-backend#593.

| Field | OTel attribute |
|---|---|
| `finishReason` | `gen_ai.response.finish_reasons` (singular per-span) |
| `provider` | `gen_ai.provider.name` |
| `responseId` | `gen_ai.response.id` |
| `responseTimestamp` | (stored; informs span timing on export) |
| `ttfcMs` | `gen_ai.response.time_to_first_chunk` |

## Changes
- **Span shape** extended in `shared/eval-trace.ts` (type + `evalTraceSpanZ` + `normalizeFinishReason()` + `OTEL_ATTR` mapping), `sdk/src/eval-reporting-types.ts`, and chat-ui's structural `TraceSpan` subset.
- **Capture**: SDK `onStepFinish` (`eval-trace-spans.ts`, provider from `parseLLMString`), direct-chat (`direct-chat-turn.ts` via `chat-v2.ts`), and the manual stream handler (`mcpjam-stream-handler.ts`, per-step `finishReason` from the finish chunk + TTFC from first stream chunk). `provider` threaded at the chat/web/eval call sites.
- **Display**: detail-pane metadata line on llm rows (throughput guarded against divide-by-near-zero); rendered identically in chat-ui (Backstage) — Tier-A safe, no provider/flag imports.
- **Parity test** (`shared/__tests__`) mirrors the backend `traceSpanValidator`.

## Notes
- `finishReason` surfaces as plain text under "Finish" — real tool/server errors keep their existing red-dot treatment; no warning badge was added.
- **Org-BYOK path** (`org-model-stream-handler.ts`) has no provider source, so spans there omit `provider` (graceful) — follow-up.

## Verification
Typechecks clean (sdk, client, chat-ui). Green: shared `eval-trace` (21), inspector `trace-timeline` (32), `mcpjam-stream-handler` (41), `assistant-turn-eval-contract` (7), chat-ui `trace-timeline` (3), full SDK suite (1512).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat streaming and trace capture across multiple handlers; changes are additive metadata with optional provider, but span shape and persistence must stay in sync with the backend PR.
> 
> **Overview**
> Adds **GenAI harness fields** (`finishReason`, `provider`, `responseId`, `responseTimestamp`, `ttfcMs`) to `llm`/`step` trace spans, aligned with OpenTelemetry `gen_ai.*` semantics via shared types, `evalTraceSpanZ`, `normalizeFinishReason()`, and `OTEL_ATTR`.
> 
> **Capture** threads logical `provider` from model config through chat-v2, direct-chat, MCPJam stream handler, assistant/web turns, and SDK eval spans; records normalized finish reason, response id/timestamp, and **TTFC** from the first streamed chunk on AI SDK and manual stream paths.
> 
> **UI** shows a detail-pane metadata line on span rows (**Provider**, **Finish**, **TTFC**, **Throughput**, **Response ID**) in inspector and chat-ui, with throughput guarded for very short spans.
> 
> **Tests** add harness display coverage and shared JSON parity fixtures for span validation across repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6f43c7eca362e8dc4064782fd8b858ec9717fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->