### PR TITLE
test: repair inspector tests left red by #2820 and #2818

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
@@ -106,9 +106,11 @@ describe("OAuthFlowTab", () => {
       />,
     );
 
-    expect(screen.getByTestId("oauth-flow-logger")).toHaveTextContent(
-      "No target configured",
-    );
+    // A non-HTTP selection has no OAuth target, so the tab stays in its empty
+    // state (just the sequence diagram, no logs sidebar) rather than rendering
+    // the logger for an auto-selected HTTP server.
+    expect(screen.getByTestId("oauth-sequence-diagram")).toBeInTheDocument();
+    expect(screen.queryByTestId("oauth-flow-logger")).not.toBeInTheDocument();
 
     await new Promise((r) => setTimeout(r, 50));
 

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { XAAIdpCard } from "../XAAIdpCard";
@@ -35,16 +35,14 @@ describe("XAAIdpCard", () => {
     expect(
       screen.getByText("MCPJam is your identity provider")
     ).toBeInTheDocument();
-    expect(screen.getByText(issuer)).toBeInTheDocument();
-    expect(
-      screen.getByText(`${issuer}/.well-known/jwks.json`)
-    ).toBeInTheDocument();
+    // The chips show only a label; the full URL lives in the title attribute
+    // (and is copied on click) to keep the bar compact.
     expect(
       screen.getByRole("button", { name: /copy issuer url/i })
-    ).toBeInTheDocument();
+    ).toHaveAttribute("title", issuer);
     expect(
       screen.getByRole("button", { name: /copy jwks url/i })
-    ).toBeInTheDocument();
+    ).toHaveAttribute("title", `${issuer}/.well-known/jwks.json`);
   });
 
   it("copies a URL and shows inline confirmation", async () => {
@@ -101,10 +99,16 @@ describe("XAAIdpCard", () => {
 
     render(<XAAIdpCard />);
 
-    expect(await screen.findByText(serverIssuer)).toBeInTheDocument();
+    // The card swaps in the server-advertised issuer once discovery resolves;
+    // the URL surfaces via the chip's title attribute.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /copy issuer url/i })
+      ).toHaveAttribute("title", serverIssuer);
+    });
     expect(
-      screen.getByText(`${serverIssuer}/.well-known/jwks.json`)
-    ).toBeInTheDocument();
+      screen.getByRole("button", { name: /copy jwks url/i })
+    ).toHaveAttribute("title", `${serverIssuer}/.well-known/jwks.json`);
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
@@ -52,6 +52,9 @@ vi.mock("@/lib/config", () => ({
 vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
   buildAvailableModels: vi.fn(() => [baseModel]),
   getDefaultModel: vi.fn(() => baseModel),
+  isMCPJamProvidedModelMenuItem: vi.fn((model: { id: string }) =>
+    String(model.id).includes("/")
+  ),
 }));
 
 vi.mock("@/hooks/use-ai-provider-keys", () => ({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -103,6 +103,9 @@ vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
     guestModel,
   ]),
   getDefaultModel: vi.fn((models: Array<typeof guestModel>) => models[0]),
+  isMCPJamProvidedModelMenuItem: vi.fn((model: { id: string }) =>
+    String(model.id).includes("/")
+  ),
 }));
 
 vi.mock("@/hooks/use-ai-provider-keys", () => ({


### PR DESCRIPTION
## Summary

Two already-merged PRs changed source code without updating their tests, leaving **27 inspector test failures red on `main`**. This PR is **test-only** — it repairs those tests to match the shipped behavior. No source/runtime changes.

### Root causes

**#2820 — "Gray out free models when out of credits"** (25 failures)
`composeAvailableModels` started calling `isMCPJamProvidedModelMenuItem`, but the `@/components/chat-v2/shared/model-helpers` mock in the `use-chat-session` fork/hosted tests never exposed that export. Vitest threw `No "isMCPJamProvidedModelMenuItem" export is defined on the mock` at module load, failing every test in both files.
→ Added the export to both mocks, matching the existing pattern already present in `use-chat-session.minimal-mode.test.tsx` (`id.includes("/")`). All test model ids are real entries in `MCPJAM_PROVIDED_MODEL_IDS`, so the real gating split is preserved.

**#2818 — "XAA/OAuth debugger UX nits"** (2 failures)
- `XAAIdpCard` moved the issuer/JWKS URLs into compact chips (URL now lives in the chip's `title` attribute, not as visible text) and added an OpenID Config chip. Updated the two stale assertions to read the URL from `title`.
- `OAuthFlowTab` replaced the non-HTTP empty state with a diagram-only view (no `OAuthFlowLogger`). Updated the assertion to check the empty state via the sequence diagram, preserving the test's actual point (it must **not** auto-select the first HTTP server).

### Verification

- Affected files: all green.
- Full inspector suite: `6313 passed`, `0` of the targeted failures remain. (One unrelated server harness test, `mcp-app-browser-harness`, flakes under full-suite parallel load and passes in isolation — pre-existing, not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test files and assertions/mocks changed; no application logic, auth, or data paths were modified.
> 
> **Overview**
> **Test-only** updates bring inspector tests back in line with behavior already shipped in #2820 and #2818. There are **no production or runtime changes**.
> 
> For **`use-chat-session` fork/hosted tests**, the `@/components/chat-v2/shared/model-helpers` Vitest mock now exports **`isMCPJamProvidedModelMenuItem`** (same `id.includes("/")` heuristic used elsewhere), so module load no longer fails when **`composeAvailableModels`** calls that helper for out-of-credits model gating.
> 
> **`XAAIdpCard` tests** stop expecting issuer/JWKS URLs as visible text; they assert the compact copy chips expose the full URL via **`title`**, including/ or **`waitFor`** when discovery overrides the issuer.
> 
> **`OAuthFlowTab`** non-HTTP selection is asserted as diagram-only empty state (**`oauth-sequence-diagram` present**, **`oauth-flow-logger` absent**) while still verifying the tab does **not** auto-select the first HTTP OAuth server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413b4f3fd473a0a6c29ffa7bc4afb4f5146c67f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->