### PR TITLE
fix(cli): detect Warp for inline eval screenshots

### DIFF
--- a/.changeset/cli-warp-inline-images.md
+++ b/.changeset/cli-warp-inline-images.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/cli": patch
+---
+
+Render `eval screenshot` images inline in Warp.
+
+Warp supports the iTerm2 inline-image protocol (OSC 1337) for normal command
+output, but its `TERM_PROGRAM=WarpTerminal` wasn't recognized, so `eval
+screenshot` fell back to printing the image URL. Warp is now detected and gets
+the inline image like iTerm2/WezTerm; piped/non-TTY runs still print the URL.

--- a/cli/src/lib/terminal-image.ts
+++ b/cli/src/lib/terminal-image.ts
@@ -39,10 +39,12 @@ export function detectInlineImageProtocol(
     return "kitty";
   }
 
-  // iTerm2 inline-image protocol: iTerm2 and WezTerm.
+  // iTerm2 inline-image protocol: iTerm2, WezTerm, and Warp (which renders
+  // OSC 1337 images for normal command output).
   if (
     termProgram === "iTerm.app" ||
     termProgram === "WezTerm" ||
+    termProgram === "WarpTerminal" ||
     env.LC_TERMINAL === "iTerm2"
   ) {
     return "iterm";

--- a/cli/tests/terminal-image.test.ts
+++ b/cli/tests/terminal-image.test.ts
@@ -31,6 +31,10 @@ test("detects iTerm-family terminals", () => {
     "iterm",
   );
   assert.equal(
+    detectInlineImageProtocol({ TERM_PROGRAM: "WarpTerminal" }, true),
+    "iterm",
+  );
+  assert.equal(
     detectInlineImageProtocol({ LC_TERMINAL: "iTerm2" }, true),
     "iterm",
   );


### PR DESCRIPTION
## What

Follow-up to #2828. `mcpjam eval screenshot` renders the widget image inline in terminals that speak a graphics protocol — but **Warp** wasn't in the detection list, so Warp users got the image *URL* instead of the *image*, even though Warp supports the protocol.

## Why

Warp renders the iTerm2 inline-image protocol (OSC 1337) for normal command output ([warpdotdev/warp#10020](https://github.com/warpdotdev/warp/issues/10020)), but it reports `TERM_PROGRAM=WarpTerminal`, which `detectInlineImageProtocol` didn't recognize → fell through to the URL fallback.

## Change

One line: map `WarpTerminal` to the `iterm` protocol alongside iTerm2 and WezTerm. Non-TTY / piped / agent runs still fall back to the URL (unchanged).

## Verification

- Probed a **real Warp session** (`TERM_PROGRAM=WarpTerminal`): TTY → `iterm`, piped → `null`. ✓
- Added a `WarpTerminal → "iterm"` unit test; terminal-image suite 5/5, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-terminal detection tweak with no change to auth, data, or non-TTY fallback behavior.
> 
> **Overview**
> **Warp** is now treated like iTerm2/WezTerm for `eval screenshot` inline rendering: when `TERM_PROGRAM=WarpTerminal` and stdout is a TTY, the CLI uses the **iTerm2 OSC 1337** path instead of printing the image URL.
> 
> Detection in `detectInlineImageProtocol` gains one `WarpTerminal` branch and an updated comment; piped/non-TTY behavior is unchanged. A unit test locks in `WarpTerminal → "iterm"`, plus a patch changeset for `@mcpjam/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 547e4f3f8eae5c345a1055225ca07f7e9ccda0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->