### PR TITLE
feat(trace): capture + show MCP JSON-RPC error code on tool spans

### DIFF
--- a/chat-ui/src/__tests__/trace-timeline.test.tsx
+++ b/chat-ui/src/__tests__/trace-timeline.test.tsx
@@ -78,4 +78,27 @@ describe("TraceTimeline (recorded waterfall)", () => {
     expect(meta.textContent).toContain("anthropic");
     expect(meta.textContent).toContain("length");
   });
+
+  it("shows the JSON-RPC error code on a failed tool span", () => {
+    const spans: TraceSpan[] = [
+      {
+        id: "p0-tool",
+        name: "create_view",
+        category: "tool",
+        startMs: 0,
+        endMs: 96,
+        promptIndex: 0,
+        status: "error",
+        toolCallId: "tc1",
+        toolName: "create_view",
+        mcpErrorCode: -32602,
+      },
+    ];
+    const { getAllByTestId, getByTestId } = render(
+      <TraceTimeline recordedSpans={spans} />,
+    );
+    const labelButtons = getAllByTestId("trace-row-label-button");
+    fireEvent.click(labelButtons[labelButtons.length - 1]);
+    expect(getByTestId("trace-mcp-error-code").textContent).toContain("-32602");
+  });
 });

--- a/chat-ui/src/__tests__/trace-timeline.test.tsx
+++ b/chat-ui/src/__tests__/trace-timeline.test.tsx
@@ -99,6 +99,8 @@ describe("TraceTimeline (recorded waterfall)", () => {
     );
     const labelButtons = getAllByTestId("trace-row-label-button");
     fireEvent.click(labelButtons[labelButtons.length - 1]);
-    expect(getByTestId("trace-mcp-error-code").textContent).toContain("-32602");
+    const codeEl = getByTestId("trace-mcp-error-code");
+    expect(codeEl.textContent).toContain("-32602");
+    expect(codeEl.textContent).toContain("Invalid params");
   });
 });

--- a/chat-ui/src/internal/trace-timeline/eval-trace.ts
+++ b/chat-ui/src/internal/trace-timeline/eval-trace.ts
@@ -42,6 +42,8 @@ export type TraceSpan = {
   responseId?: string;
   responseTimestamp?: string;
   ttfcMs?: number;
+  // MCP server-contract metadata (tool spans).
+  mcpErrorCode?: number;
 };
 
 // Internal aliases so the ported timeline keeps its original identifiers

--- a/chat-ui/src/internal/trace-timeline/eval-trace.ts
+++ b/chat-ui/src/internal/trace-timeline/eval-trace.ts
@@ -42,9 +42,35 @@ export type TraceSpan = {
   responseId?: string;
   responseTimestamp?: string;
   ttfcMs?: number;
-  // MCP server-contract metadata (tool spans).
+  // MCP error metadata (tool spans). Negative MCP-layer error code from a
+  // failed tools/call — server JSON-RPC errors (-32602) OR SDK-local transport
+  // failures (-32001 timeout, -32000 connection closed). See mcpErrorCodeLabel.
   mcpErrorCode?: number;
 };
+
+/**
+ * Error-code names. Source of truth = the MCP SDK `ErrorCode` enum
+ * (@modelcontextprotocol/sdk). -32700/-32600/-32601/-32602/-32603 are JSON-RPC
+ * 2.0 spec standard; -32000/-32001/-32042 are MCP-SDK additions (-32000/-32001
+ * are client-side transport conditions, not server faults). Unmapped codes fall
+ * back to the raw number, so drift degrades to "show the code".
+ */
+const MCP_ERROR_CODE_NAMES: Record<number, string> = {
+  [-32700]: "Parse error",
+  [-32600]: "Invalid request",
+  [-32601]: "Method not found",
+  [-32602]: "Invalid params",
+  [-32603]: "Internal error",
+  [-32000]: "Connection closed",
+  [-32001]: "Request timeout",
+  [-32042]: "URL elicitation required",
+};
+
+/** Human label for an MCP error code, e.g. "-32602 · Invalid params". */
+export function mcpErrorCodeLabel(code: number): string {
+  const name = MCP_ERROR_CODE_NAMES[code];
+  return name ? `${code} · ${name}` : String(code);
+}
 
 // Internal aliases so the ported timeline keeps its original identifiers
 // (`EvalTraceSpan`, `EvalTraceSpanCategory`) without churn. The public export

--- a/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
+++ b/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
@@ -25,6 +25,7 @@ import {
   Wrench,
 } from "lucide-react";
 import type { EvalTraceSpan, EvalTraceSpanCategory } from "./eval-trace";
+import { mcpErrorCodeLabel } from "./eval-trace";
 import { Markdown } from "../markdown";
 import { JsonView } from "../../parts/json-view";
 import { extractTextFromToolResult } from "../tool-result-text";
@@ -1678,13 +1679,11 @@ function TimelineDetailPane({
               <div
                 data-testid="trace-mcp-error-code"
                 className="text-[11px] tabular-nums text-muted-foreground"
-                title="JSON-RPC error code returned by the MCP server (rpc.response.status_code) — a protocol contract violation"
+                title="MCP-layer error code. -32602/-32601 etc. are server JSON-RPC errors; -32000 (connection closed) / -32001 (request timeout) are transport/client failures, not server faults."
               >
-                <span className="text-muted-foreground/70">
-                  JSON-RPC error code:{" "}
-                </span>
+                <span className="text-muted-foreground/70">MCP error: </span>
                 <span className="font-medium text-foreground">
-                  {row.span.mcpErrorCode}
+                  {mcpErrorCodeLabel(row.span.mcpErrorCode)}
                 </span>
               </div>
             ) : null}

--- a/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
+++ b/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
@@ -1674,6 +1674,20 @@ function TimelineDetailPane({
                 {toolErrorExcerpt}
               </pre>
             ) : null}
+            {typeof row.span.mcpErrorCode === "number" ? (
+              <div
+                data-testid="trace-mcp-error-code"
+                className="text-[11px] tabular-nums text-muted-foreground"
+                title="JSON-RPC error code returned by the MCP server (rpc.response.status_code) — a protocol contract violation"
+              >
+                <span className="text-muted-foreground/70">
+                  JSON-RPC error code:{" "}
+                </span>
+                <span className="font-medium text-foreground">
+                  {row.span.mcpErrorCode}
+                </span>
+              </div>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -142,9 +142,11 @@ describe("harness span metadata", () => {
       .getAllByTestId("trace-row")
       .find((el) => el.textContent?.includes("create_view"));
     fireEvent.click(within(toolRow!).getByTestId("trace-row-label-button"));
-    expect(screen.getByTestId("trace-mcp-error-code").textContent).toContain(
-      "-32602",
-    );
+    const codeEl = screen.getByTestId("trace-mcp-error-code");
+    // Neutral "MCP error" label + standard code name (not "JSON-RPC … server").
+    expect(codeEl.textContent).toContain("-32602");
+    expect(codeEl.textContent).toContain("Invalid params");
+    expect(codeEl.textContent).not.toContain("JSON-RPC error code");
   });
 
   it("omits the error-code line when no mcpErrorCode is present", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -119,6 +119,56 @@ describe("harness span metadata", () => {
     fireEvent.click(within(toolRow!).getByTestId("trace-row-label-button"));
     expect(screen.queryByText(/tok\/s/)).toBeNull();
   });
+
+  it("shows the JSON-RPC error code on a failed tool span", () => {
+    const spans: EvalTraceSpan[] = [
+      { id: "step-0", name: "Step 1", category: "step", startMs: 0, endMs: 500, stepIndex: 0 },
+      {
+        id: "tool-0",
+        parentId: "step-0",
+        name: "create_view",
+        category: "tool",
+        startMs: 100,
+        endMs: 300,
+        stepIndex: 0,
+        status: "error",
+        toolCallId: "c1",
+        toolName: "create_view",
+        mcpErrorCode: -32602,
+      },
+    ];
+    render(<TraceTimeline recordedSpans={spans} transcriptMessages={[]} />);
+    const toolRow = screen
+      .getAllByTestId("trace-row")
+      .find((el) => el.textContent?.includes("create_view"));
+    fireEvent.click(within(toolRow!).getByTestId("trace-row-label-button"));
+    expect(screen.getByTestId("trace-mcp-error-code").textContent).toContain(
+      "-32602",
+    );
+  });
+
+  it("omits the error-code line when no mcpErrorCode is present", () => {
+    const spans: EvalTraceSpan[] = [
+      { id: "step-0", name: "Step 1", category: "step", startMs: 0, endMs: 500, stepIndex: 0 },
+      {
+        id: "tool-0",
+        parentId: "step-0",
+        name: "read_me",
+        category: "tool",
+        startMs: 100,
+        endMs: 300,
+        stepIndex: 0,
+        toolCallId: "c1",
+        toolName: "read_me",
+      },
+    ];
+    render(<TraceTimeline recordedSpans={spans} transcriptMessages={[]} />);
+    const toolRow = screen
+      .getAllByTestId("trace-row")
+      .find((el) => el.textContent?.includes("read_me"));
+    fireEvent.click(within(toolRow!).getByTestId("trace-row-label-button"));
+    expect(screen.queryByTestId("trace-mcp-error-code")).toBeNull();
+  });
 });
 
 describe("selectAxisTickPercents", () => {

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -28,6 +28,7 @@ import {
   Wrench,
 } from "lucide-react";
 import type { EvalTraceSpan, EvalTraceSpanCategory } from "@/shared/eval-trace";
+import { mcpErrorCodeLabel } from "@/shared/eval-trace";
 import { MemoizedMarkdown } from "@/components/chat-v2/thread/memomized-markdown";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
@@ -1672,13 +1673,11 @@ function TimelineDetailPane({
               <div
                 data-testid="trace-mcp-error-code"
                 className="text-[11px] tabular-nums text-muted-foreground"
-                title="JSON-RPC error code returned by the MCP server (rpc.response.status_code) — a protocol contract violation"
+                title="MCP-layer error code. -32602/-32601 etc. are server JSON-RPC errors; -32000 (connection closed) / -32001 (request timeout) are transport/client failures, not server faults."
               >
-                <span className="text-muted-foreground/70">
-                  JSON-RPC error code:{" "}
-                </span>
+                <span className="text-muted-foreground/70">MCP error: </span>
                 <span className="font-medium text-foreground">
-                  {row.span.mcpErrorCode}
+                  {mcpErrorCodeLabel(row.span.mcpErrorCode)}
                 </span>
               </div>
             ) : null}

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -1668,6 +1668,20 @@ function TimelineDetailPane({
                 {toolErrorExcerpt}
               </pre>
             ) : null}
+            {typeof row.span.mcpErrorCode === "number" ? (
+              <div
+                data-testid="trace-mcp-error-code"
+                className="text-[11px] tabular-nums text-muted-foreground"
+                title="JSON-RPC error code returned by the MCP server (rpc.response.status_code) — a protocol contract violation"
+              >
+                <span className="text-muted-foreground/70">
+                  JSON-RPC error code:{" "}
+                </span>
+                <span className="font-medium text-foreground">
+                  {row.span.mcpErrorCode}
+                </span>
+              </div>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
@@ -431,4 +431,34 @@ describe("eval-trace-capture", () => {
     expect(toolSpan?.status).toBe("error");
     expect(toolSpan?.mcpErrorCode).toBeUndefined();
   });
+
+  it("does not record a transport HTTP status (positive .code) as mcpErrorCode", async () => {
+    let wall = runAt;
+    vi.spyOn(Date, "now").mockImplementation(() => wall);
+
+    const spans: EvalTraceSpan[] = [];
+    // StreamableHTTPError / SseError carry an HTTP status on `.code` (e.g. 401).
+    const httpError = Object.assign(new Error("Unauthorized"), { code: 401 });
+    const backendTools = wrapBackendToolsForTrace(
+      {
+        secured: {
+          execute: async () => {
+            throw httpError;
+          },
+          _serverId: "server-1",
+        },
+      },
+      { runStartedAt: runAt, promptIndex: 0, stepIndex: 0, spans },
+    ) as any;
+
+    wall = runAt + 5;
+    await expect(
+      backendTools.secured.execute({}, { toolCallId: "call-401" }),
+    ).rejects.toBe(httpError);
+
+    const toolSpan = spans.find((s) => s.category === "tool");
+    expect(toolSpan?.status).toBe("error");
+    // 401 is an HTTP status, not a JSON-RPC code — must not be recorded/mislabeled.
+    expect(toolSpan?.mcpErrorCode).toBeUndefined();
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
@@ -371,4 +371,64 @@ describe("eval-trace-capture", () => {
       }),
     ]);
   });
+
+  it("captures the JSON-RPC error code when a backend tool throws with .code", async () => {
+    let wall = runAt;
+    vi.spyOn(Date, "now").mockImplementation(() => wall);
+
+    const spans: EvalTraceSpan[] = [];
+    const rpcError = Object.assign(new Error("Invalid params"), {
+      code: -32602,
+    });
+    const backendTools = wrapBackendToolsForTrace(
+      {
+        create_view: {
+          execute: async () => {
+            throw rpcError;
+          },
+          _serverId: "server-1",
+        },
+      },
+      { runStartedAt: runAt, promptIndex: 0, stepIndex: 0, spans },
+    ) as any;
+
+    wall = runAt + 5;
+    await expect(
+      backendTools.create_view.execute({}, { toolCallId: "call-err" }),
+    ).rejects.toBe(rpcError);
+
+    // Both the tool span and the synthesized error span carry the code.
+    const toolSpan = spans.find((s) => s.category === "tool");
+    const errSpan = spans.find((s) => s.category === "error");
+    expect(toolSpan?.status).toBe("error");
+    expect(toolSpan?.mcpErrorCode).toBe(-32602);
+    expect(errSpan?.mcpErrorCode).toBe(-32602);
+  });
+
+  it("leaves mcpErrorCode unset when a thrown error has no numeric code", async () => {
+    let wall = runAt;
+    vi.spyOn(Date, "now").mockImplementation(() => wall);
+
+    const spans: EvalTraceSpan[] = [];
+    const backendTools = wrapBackendToolsForTrace(
+      {
+        boom: {
+          execute: async () => {
+            throw new Error("plain failure");
+          },
+          _serverId: "server-1",
+        },
+      },
+      { runStartedAt: runAt, promptIndex: 0, stepIndex: 0, spans },
+    ) as any;
+
+    wall = runAt + 5;
+    await expect(
+      backendTools.boom.execute({}, { toolCallId: "call-plain" }),
+    ).rejects.toThrow("plain failure");
+
+    const toolSpan = spans.find((s) => s.category === "tool");
+    expect(toolSpan?.status).toBe("error");
+    expect(toolSpan?.mcpErrorCode).toBeUndefined();
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
@@ -461,4 +461,35 @@ describe("eval-trace-capture", () => {
     // 401 is an HTTP status, not a JSON-RPC code — must not be recorded/mislabeled.
     expect(toolSpan?.mcpErrorCode).toBeUndefined();
   });
+
+  it("captures SDK-local lifecycle codes too (e.g. request timeout -32001)", async () => {
+    let wall = runAt;
+    vi.spyOn(Date, "now").mockImplementation(() => wall);
+
+    const spans: EvalTraceSpan[] = [];
+    // MCP SDK raises McpError(RequestTimeout, -32001) client-side. We keep it
+    // (negative code); the UI labels it neutrally, not as a server fault.
+    const timeout = Object.assign(new Error("Request timed out"), {
+      code: -32001,
+    });
+    const backendTools = wrapBackendToolsForTrace(
+      {
+        slow: {
+          execute: async () => {
+            throw timeout;
+          },
+          _serverId: "server-1",
+        },
+      },
+      { runStartedAt: runAt, promptIndex: 0, stepIndex: 0, spans },
+    ) as any;
+
+    wall = runAt + 5;
+    await expect(
+      backendTools.slow.execute({}, { toolCallId: "call-timeout" }),
+    ).rejects.toBe(timeout);
+
+    const toolSpan = spans.find((s) => s.category === "tool");
+    expect(toolSpan?.mcpErrorCode).toBe(-32001);
+  });
 });

--- a/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
+++ b/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
@@ -7,18 +7,19 @@ import {
 import type { ModelMessage } from "ai";
 
 /**
- * Pull the JSON-RPC error code off a thrown MCP tool error (OTel
- * `rpc.response.status_code`). Present only on protocol-level failures — a
- * `tools/call` that returns `isError: true` (domain error) has no code per the
- * MCP spec.
+ * Pull the MCP error code off a thrown tool error. This is an MCP-LAYER code,
+ * not necessarily a server JSON-RPC *response*: the MCP SDK raises `McpError`
+ * with the same negative-code shape for both server error responses
+ * (`-32602` invalid params, `-32601` method not found) AND client-side
+ * lifecycle failures (`-32001` request timeout, `-32000` connection closed).
+ * We can't reliably distinguish those by code, so we capture all of them and
+ * the UI labels them neutrally as "MCP error" rather than claiming the server
+ * returned them.
  *
- * Accepts only NEGATIVE integers: MCP/JSON-RPC error codes are all negative
- * (`-32602` invalid params, `-32601` method not found, `-32000..-32099`
- * server-defined). Transport errors (`StreamableHTTPError`, `SseError`) also
- * carry a numeric `.code`, but it's an HTTP status (e.g. `401`, `404`, `500`) —
- * a positive number. Excluding non-negatives keeps us from mislabeling a
- * transport/HTTP failure as a JSON-RPC code (those still surface via the
- * existing error-text + red dot, just without a code).
+ * Accepts only NEGATIVE integers — every MCP/JSON-RPC code is negative.
+ * Transport errors (`StreamableHTTPError`, `SseError`) carry an HTTP status on
+ * `.code` (e.g. `401`, a positive number); excluding non-negatives keeps those
+ * out (they still surface via the existing error text + red dot).
  */
 function extractMcpErrorCode(error: unknown): number | undefined {
   const code = (error as { code?: unknown } | null)?.code;

--- a/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
+++ b/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
@@ -10,11 +10,21 @@ import type { ModelMessage } from "ai";
  * Pull the JSON-RPC error code off a thrown MCP tool error (OTel
  * `rpc.response.status_code`). Present only on protocol-level failures — a
  * `tools/call` that returns `isError: true` (domain error) has no code per the
- * MCP spec. Returns undefined for anything without a numeric `.code`.
+ * MCP spec.
+ *
+ * Accepts only NEGATIVE integers: MCP/JSON-RPC error codes are all negative
+ * (`-32602` invalid params, `-32601` method not found, `-32000..-32099`
+ * server-defined). Transport errors (`StreamableHTTPError`, `SseError`) also
+ * carry a numeric `.code`, but it's an HTTP status (e.g. `401`, `404`, `500`) —
+ * a positive number. Excluding non-negatives keeps us from mislabeling a
+ * transport/HTTP failure as a JSON-RPC code (those still surface via the
+ * existing error-text + red dot, just without a code).
  */
 function extractMcpErrorCode(error: unknown): number | undefined {
   const code = (error as { code?: unknown } | null)?.code;
-  return typeof code === "number" && Number.isFinite(code) ? code : undefined;
+  return typeof code === "number" && Number.isInteger(code) && code < 0
+    ? code
+    : undefined;
 }
 
 type StepSpanMeta = {

--- a/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
+++ b/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
@@ -6,6 +6,17 @@ import {
 } from "@/shared/eval-trace";
 import type { ModelMessage } from "ai";
 
+/**
+ * Pull the JSON-RPC error code off a thrown MCP tool error (OTel
+ * `rpc.response.status_code`). Present only on protocol-level failures — a
+ * `tools/call` that returns `isError: true` (domain error) has no code per the
+ * MCP spec. Returns undefined for anything without a numeric `.code`.
+ */
+function extractMcpErrorCode(error: unknown): number | undefined {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === "number" && Number.isFinite(code) ? code : undefined;
+}
+
 type StepSpanMeta = {
   modelId?: string;
   inputTokens?: number;
@@ -251,6 +262,7 @@ export function wrapToolSetForEvalTrace<T extends Record<string, unknown>>(
           promptIndex: resolvedPromptIndex,
         });
         let success = true;
+        let mcpErrorCode: number | undefined;
         try {
           const result = await origExecute(input, options);
           if (isCallToolResultError(result)) {
@@ -259,6 +271,7 @@ export function wrapToolSetForEvalTrace<T extends Record<string, unknown>>(
           return result;
         } catch (err) {
           success = false;
+          mcpErrorCode = extractMcpErrorCode(err);
           throw err;
         } finally {
           const toolFinishedAt = Date.now();
@@ -274,6 +287,7 @@ export function wrapToolSetForEvalTrace<T extends Record<string, unknown>>(
             toolName: name,
             serverId,
             status: success ? "ok" : "error",
+            ...(mcpErrorCode !== undefined ? { mcpErrorCode } : {}),
             ...createOffsetInterval(
               ctx.runStartedAt,
               toolStartedAt,
@@ -292,6 +306,7 @@ export function wrapToolSetForEvalTrace<T extends Record<string, unknown>>(
               toolName: name,
               serverId,
               status: "error",
+              ...(mcpErrorCode !== undefined ? { mcpErrorCode } : {}),
               ...createOffsetInterval(
                 ctx.runStartedAt,
                 toolStartedAt,
@@ -758,6 +773,7 @@ export function wrapBackendToolsForTrace<T extends Record<string, unknown>>(
             ? options.toolCallId
             : `backend-tool-${params.stepIndex}-${startedAt}`;
         let success = true;
+        let mcpErrorCode: number | undefined;
         try {
           const result = await origExecute(input, options);
           if (isCallToolResultError(result)) {
@@ -766,6 +782,7 @@ export function wrapBackendToolsForTrace<T extends Record<string, unknown>>(
           return result;
         } catch (error) {
           success = false;
+          mcpErrorCode = extractMcpErrorCode(error);
           throw error;
         } finally {
           const finishedAt = Date.now();
@@ -783,6 +800,7 @@ export function wrapBackendToolsForTrace<T extends Record<string, unknown>>(
             toolName: name,
             serverId: raw._serverId,
             status: success ? "ok" : "error",
+            ...(mcpErrorCode !== undefined ? { mcpErrorCode } : {}),
             ...createOffsetInterval(params.runStartedAt, startedAt, finishedAt),
           });
           if (!success) {
@@ -800,6 +818,7 @@ export function wrapBackendToolsForTrace<T extends Record<string, unknown>>(
               toolName: name,
               serverId: raw._serverId,
               status: "error",
+              ...(mcpErrorCode !== undefined ? { mcpErrorCode } : {}),
               ...createOffsetInterval(
                 params.runStartedAt,
                 startedAt,

--- a/mcpjam-inspector/shared/__tests__/eval-trace.test.ts
+++ b/mcpjam-inspector/shared/__tests__/eval-trace.test.ts
@@ -179,13 +179,15 @@ describe("trace-span parity fixtures (inspector evalTraceSpanZ side)", () => {
           `Expected accept for "${row.label}":\n${JSON.stringify(parsed.error.issues, null, 2)}`,
         );
       }
-      // Harness metadata must round-trip through the Zod mirror unchanged.
+      // OTel metadata (harness gen_ai.* + mcp.* tool fields) must round-trip
+      // through the Zod mirror unchanged.
       for (const field of [
         "finishReason",
         "provider",
         "responseId",
         "responseTimestamp",
         "ttfcMs",
+        "mcpErrorCode",
       ] as const) {
         if (row.value[field] !== undefined) {
           expect((parsed.data as Record<string, unknown>)[field]).toEqual(

--- a/mcpjam-inspector/shared/__tests__/fixtures/trace-span-parity-fixtures.json
+++ b/mcpjam-inspector/shared/__tests__/fixtures/trace-span-parity-fixtures.json
@@ -60,6 +60,22 @@
         "toolName": "draw_rectangle",
         "serverId": "excalidraw"
       }
+    },
+    {
+      "label": "failed tool span with JSON-RPC error code",
+      "value": {
+        "id": "p0-s0-tool-def",
+        "parentId": "p0-s0",
+        "name": "create_view",
+        "category": "tool",
+        "startMs": 1300,
+        "endMs": 1320,
+        "status": "error",
+        "toolCallId": "def",
+        "toolName": "create_view",
+        "serverId": "excalidraw",
+        "mcpErrorCode": -32602
+      }
     }
   ],
   "reject": [

--- a/mcpjam-inspector/shared/eval-trace.ts
+++ b/mcpjam-inspector/shared/eval-trace.ts
@@ -43,6 +43,14 @@ export type EvalTraceSpan = {
   responseTimestamp?: string;
   /** Time to first streamed chunk, ms. OTel `gen_ai.response.time_to_first_chunk` (seconds — export as ttfcMs/1000). Undefined on non-streaming paths; advisory only. */
   ttfcMs?: number;
+  // ── MCP server-contract metadata (tool spans) ──
+  /**
+   * JSON-RPC error code from a failed `tools/call` (OTel
+   * `rpc.response.status_code`, e.g. -32602 invalid params). Present only on
+   * protocol-level failures — a tool returning `isError: true` (domain error)
+   * has no code per the MCP spec. Surfaces a server contract violation.
+   */
+  mcpErrorCode?: number;
 };
 
 /**
@@ -103,6 +111,9 @@ export const OTEL_ATTR = {
   modelId: "gen_ai.request.model",
   inputTokens: "gen_ai.usage.input_tokens",
   outputTokens: "gen_ai.usage.output_tokens",
+  // MCP tool-span fields. `rpc.response.status_code` is a string at export →
+  // String(mcpErrorCode).
+  mcpErrorCode: "rpc.response.status_code",
 } as const;
 
 export type PromptTraceSummary = {
@@ -382,6 +393,8 @@ export const evalTraceSpanZ = z.object({
   responseId: z.string().optional(),
   responseTimestamp: z.string().optional(),
   ttfcMs: z.number().optional(),
+  // MCP server-contract metadata (tool spans).
+  mcpErrorCode: z.number().optional(),
 });
 
 const traceToolCallZ = z.object({

--- a/mcpjam-inspector/shared/eval-trace.ts
+++ b/mcpjam-inspector/shared/eval-trace.ts
@@ -43,15 +43,47 @@ export type EvalTraceSpan = {
   responseTimestamp?: string;
   /** Time to first streamed chunk, ms. OTel `gen_ai.response.time_to_first_chunk` (seconds — export as ttfcMs/1000). Undefined on non-streaming paths; advisory only. */
   ttfcMs?: number;
-  // ── MCP server-contract metadata (tool spans) ──
+  // ── MCP error metadata (tool spans) ──
   /**
-   * JSON-RPC error code from a failed `tools/call` (OTel
-   * `rpc.response.status_code`, e.g. -32602 invalid params). Present only on
-   * protocol-level failures — a tool returning `isError: true` (domain error)
-   * has no code per the MCP spec. Surfaces a server contract violation.
+   * MCP-layer error code from a failed `tools/call` (negative integer). Covers
+   * both server JSON-RPC error responses (e.g. -32602 invalid params) and
+   * SDK-local lifecycle failures (-32001 request timeout, -32000 connection
+   * closed) — we can't distinguish source by code, so the UI labels it
+   * neutrally as an "MCP error" rather than claiming the server returned it.
+   * Absent for `isError: true` domain errors (no code per spec). See
+   * `mcpErrorCodeLabel`.
    */
   mcpErrorCode?: number;
 };
+
+/**
+ * Error-code names. Source of truth = the MCP SDK `ErrorCode` enum
+ * (@modelcontextprotocol/sdk types.ts). Of these:
+ *   - -32700/-32600/-32601/-32602/-32603 are JSON-RPC 2.0 spec standard errors
+ *     (MCP is built on JSON-RPC 2.0, so it inherits them);
+ *   - -32000 (connection closed), -32001 (request timeout), -32042 (url
+ *     elicitation required) are MCP-SDK additions, NOT the JSON-RPC spec.
+ *     -32000/-32001 are client-side transport/lifecycle conditions, not server
+ *     faults.
+ * Unmapped codes fall back to the raw number (see mcpErrorCodeLabel), so this
+ * map drifting behind the SDK degrades to "show the code", never a wrong name.
+ */
+const MCP_ERROR_CODE_NAMES: Record<number, string> = {
+  [-32700]: "Parse error",
+  [-32600]: "Invalid request",
+  [-32601]: "Method not found",
+  [-32602]: "Invalid params",
+  [-32603]: "Internal error",
+  [-32000]: "Connection closed",
+  [-32001]: "Request timeout",
+  [-32042]: "URL elicitation required",
+};
+
+/** Human label for an MCP error code, e.g. "-32602 · Invalid params" (or just the code when unknown). */
+export function mcpErrorCodeLabel(code: number): string {
+  const name = MCP_ERROR_CODE_NAMES[code];
+  return name ? `${code} · ${name}` : String(code);
+}
 
 /**
  * Canonical finish-reason vocabulary. The AI SDK already normalizes to most of
@@ -111,8 +143,10 @@ export const OTEL_ATTR = {
   modelId: "gen_ai.request.model",
   inputTokens: "gen_ai.usage.input_tokens",
   outputTokens: "gen_ai.usage.output_tokens",
-  // MCP tool-span fields. `rpc.response.status_code` is a string at export →
-  // String(mcpErrorCode).
+  // MCP tool-span fields. `rpc.response.status_code` (string at export) applies
+  // to genuine JSON-RPC *responses*; SDK-local codes (-32000/-32001) are
+  // transport/lifecycle errors and would map to span status / error.type
+  // instead. The exporter (deferred) must branch on that.
   mcpErrorCode: "rpc.response.status_code",
 } as const;
 

--- a/sdk/src/eval-reporting-types.ts
+++ b/sdk/src/eval-reporting-types.ts
@@ -44,6 +44,9 @@ export type EvalTraceSpanInput = {
   responseId?: string;
   responseTimestamp?: string;
   ttfcMs?: number;
+  // MCP server-contract metadata (tool spans). JSON-RPC error code from a
+  // failed tools/call (OTel rpc.response.status_code).
+  mcpErrorCode?: number;
 };
 
 export type EvalTraceInput =


### PR DESCRIPTION
## What
When a `tools/call` fails at the protocol level, capture the thrown error's **JSON-RPC code** (OTel `rpc.response.status_code`, e.g. `-32602`) and surface it in the trace viewer's tool detail pane (`JSON-RPC error code: -32602`). A server contract violation not surfaced today.

Pairs with the backend half: https://github.com/MCPJam/mcpjam-backend/pull/595

## Scope (deliberately minimal)
We dropped the other two originally-planned tool fields after exploration:
- `mcpMethod` — constant `"tools/call"`, useless until we trace resources/prompts.
- `mcpIsError` — already covered by the existing red dot + error-text surfacing.

`mcpErrorCode` is the one genuinely new, on-mission signal.

## Changes
- `mcpErrorCode` added to the span shape (`shared/eval-trace.ts` type + Zod + `OTEL_ATTR`, `sdk` input type, chat-ui `TraceSpan` subset); parity fixture/test extended.
- Captured in `wrapToolSetForEvalTrace` + `wrapBackendToolsForTrace` catch blocks (the only sites with the thrown error's `.code`; the AI SDK `onToolCallFinish` path can't see it).
- Displayed in the inspector **and** chat-ui (Backstage) tool detail panes.

## Verification
Typechecks clean (sdk, client, chat-ui; Tier-A guard passes). Green: backend parity (12), shared eval-trace (22), inspector trace-timeline (34), chat-ui trace-timeline (4), eval-trace-capture (18, incl. new throw-with-code + no-code cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional span metadata and eval trace capture/UI only; negative-code filtering avoids misrecording HTTP statuses, with broad test coverage.
> 
> **Overview**
> Adds **`mcpErrorCode`** to eval trace spans so protocol-level `tools/call` failures expose the MCP/JSON-RPC code (e.g. `-32602`) in the trace viewer, alongside existing error text.
> 
> **Capture:** `eval-trace-capture` reads negative integer `error.code` from thrown tool errors in both live tool wrapping and backend eval wrapping, and copies it onto the tool span and synthesized error span. Positive codes (e.g. HTTP `401` on transport errors) are ignored so they are not mislabeled as JSON-RPC.
> 
> **Schema parity:** Optional field on shared `EvalTraceSpan`, Zod validation, `OTEL_ATTR` (`rpc.response.status_code`), SDK reporting types, and chat-ui’s structural `TraceSpan` subset; **`mcpErrorCodeLabel`** maps known MCP SDK codes to readable names.
> 
> **UI:** Inspector and chat-ui trace timelines show **MCP error: `{code} · {name}`** in the tool detail output section when the field is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790292529b4c86f7966d880ab4befde888ce4469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->