### PR TITLE
[codex] Add hosted Mistral and GLM models

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/model-helpers.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/model-helpers.test.ts
@@ -2,10 +2,28 @@ import { describe, expect, it } from "vitest";
 import {
   buildAvailableModelsFromOrgConfig,
   buildModelMenuGroups,
+  getDefaultModel,
   isOrgProviderAvailable,
 } from "../model-helpers";
 
 describe("org model helpers", () => {
+  it("prefers Mistral Small 4 as the MCPJam default model", () => {
+    expect(
+      getDefaultModel([
+        {
+          id: "anthropic/claude-haiku-4.5",
+          name: "Claude Haiku 4.5",
+          provider: "anthropic",
+        },
+        {
+          id: "mistralai/mistral-small-2603",
+          name: "Mistral Small 4",
+          provider: "mistral",
+        },
+      ]).id,
+    ).toBe("mistralai/mistral-small-2603");
+  });
+
   it("includes enabled custom providers that do not require an API key", () => {
     const orgConfig = {
       providers: [

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
@@ -367,6 +367,7 @@ export const getDefaultModel = (
   availableModels: ModelDefinition[]
 ): ModelDefinition => {
   const modelIdsByPriority: Array<Model | string> = [
+    "mistralai/mistral-small-2603",
     "anthropic/claude-haiku-4.5",
     "openai/gpt-5-mini",
     "meta-llama/llama-4-scout",

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/drafts.test.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/drafts.test.ts
@@ -6,8 +6,8 @@ import {
 } from "../drafts";
 
 describe("getDefaultHostedModelId", () => {
-  it("defaults to GPT-5 Mini, not the first MCPJam model in the catalog (gpt-oss)", () => {
-    expect(getDefaultHostedModelId()).toBe("openai/gpt-5-mini");
+  it("defaults to Mistral Small 4, not the first MCPJam model by accident", () => {
+    expect(getDefaultHostedModelId()).toBe("mistralai/mistral-small-2603");
     expect(getDefaultHostedModelId()).not.toBe("openai/gpt-oss-120b");
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
@@ -24,8 +24,8 @@ const WELCOME_BODY_EXCALIDRAW_DEMO = [
   "This chatbox is pre-wired with the Excalidraw MCP server. Ask the assistant to sketch a diagram, walk through an idea visually, or just play with what the tools can do.",
 ].join("\n");
 
-/** Prefer a stable default; the first MCPJam model in SUPPORTED_MODELS is often gpt-oss-120b. */
-const DEFAULT_HOSTED_CHATBOX_MODEL_ID = "openai/gpt-5-mini";
+/** Prefer the hosted model chosen as the general MCPJam default. */
+const DEFAULT_HOSTED_CHATBOX_MODEL_ID = "mistralai/mistral-small-2603";
 
 export function getDefaultHostedModelId(): string {
   if (
@@ -37,7 +37,7 @@ export function getDefaultHostedModelId(): string {
   return (
     SUPPORTED_MODELS.find((model) =>
       isMCPJamProvidedModel(String(model.id)),
-    )?.id?.toString() ?? "openai/gpt-5-mini"
+    )?.id?.toString() ?? "mistralai/mistral-small-2603"
   );
 }
 

--- a/mcpjam-inspector/shared/__tests__/types.test.ts
+++ b/mcpjam-inspector/shared/__tests__/types.test.ts
@@ -20,7 +20,22 @@ describe("MCPJam-provided model classification", () => {
     expect(isMCPJamProvidedModel("deepseek/deepseek-v4-pro")).toBe(true);
     expect(isMCPJamProvidedModel("deepseek/deepseek-v4-flash")).toBe(true);
     expect(isMCPJamProvidedModel("qwen/qwen3.6-plus")).toBe(true);
+    expect(isMCPJamProvidedModel("mistralai/mistral-small-2603")).toBe(true);
+    expect(isMCPJamProvidedModel("mistralai/mistral-medium-3-5")).toBe(true);
+    expect(isMCPJamProvidedModel("mistralai/mistral-large-2512")).toBe(true);
+    expect(isMCPJamProvidedModel("mistralai/devstral-2512")).toBe(true);
+    expect(isMCPJamProvidedModel("z-ai/glm-5.2")).toBe(true);
     expect(isMCPJamGuestAllowedModel("openai/gpt-oss-120b")).toBe(true);
+    expect(isMCPJamGuestAllowedModel("mistralai/mistral-small-2603")).toBe(
+      true,
+    );
+    expect(isMCPJamGuestAllowedModel("mistralai/devstral-2512")).toBe(true);
+    expect(isMCPJamGuestAllowedModel("mistralai/mistral-medium-3-5")).toBe(
+      false,
+    );
+    expect(isMCPJamGuestAllowedModel("mistralai/mistral-large-2512")).toBe(
+      false,
+    );
     expect(isMCPJamGuestAllowedModel("openai/gpt-5.4")).toBe(false);
     expect(isMCPJamGuestAllowedModel("openai/gpt-5.4-mini")).toBe(false);
     expect(isMCPJamGuestAllowedModel("openai/gpt-5.4-nano")).toBe(false);
@@ -43,11 +58,15 @@ describe("MCPJam-provided model classification", () => {
       false,
     );
     expect(isMCPJamGuestAllowedModel("qwen/qwen3.6-plus")).toBe(true);
+    expect(isMCPJamGuestAllowedModel("z-ai/glm-5.2")).toBe(true);
   });
 
-  it("resolves provider metadata for new qwen and xAI hosted models", () => {
+  it("resolves provider metadata for new hosted models", () => {
     expect(getModelById("qwen/qwen3.6-plus")?.provider).toBe("qwen");
     expect(getModelById("x-ai/grok-4-fast")?.provider).toBe("xai");
+    expect(getModelById("mistralai/mistral-small-2603")?.provider).toBe(
+      "mistral",
+    );
   });
 
   it("normalizes bare model ids with provider metadata", () => {
@@ -70,5 +89,9 @@ describe("MCPJam-provided model classification", () => {
       "google",
     );
     expect(getModelById("z-ai/glm-4.6")?.provider).toBe("z-ai");
+    expect(getModelById("z-ai/glm-5.2")?.contextLength).toBe(1000000);
+    expect(getModelById("mistralai/devstral-2512")?.contextLength).toBe(
+      262144,
+    );
   });
 });

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -111,6 +111,10 @@ export type ModelProvider =
   | "custom";
 
 const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
+  "mistralai/mistral-small-2603",
+  "mistralai/mistral-medium-3-5",
+  "mistralai/mistral-large-2512",
+  "mistralai/devstral-2512",
   "openai/gpt-oss-120b",
   "openai/gpt-4o-mini",
   "openai/gpt-5-nano",
@@ -152,6 +156,7 @@ const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
   "z-ai/glm-4.7",
   "z-ai/glm-4.7-flash",
   "z-ai/glm-5.1",
+  "z-ai/glm-5.2",
   "minimax/minimax-m2.1",
   "minimax/minimax-m2.7",
   "qwen/qwen3.6-plus",
@@ -164,6 +169,8 @@ const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
 ];
 
 const MCPJAM_GUEST_GATED_MODEL_IDS = [
+  "mistralai/mistral-medium-3-5",
+  "mistralai/mistral-large-2512",
   "openai/gpt-5.4",
   "openai/gpt-5.4-mini",
   "openai/gpt-5.4-nano",
@@ -317,6 +324,10 @@ export enum Model {
   // Mistral models
   MISTRAL_LARGE_LATEST = "mistral-large-latest",
   MISTRAL_SMALL_LATEST = "mistral-small-latest",
+  MISTRAL_SMALL_2603 = "mistral-small-2603",
+  MISTRAL_MEDIUM_3_5 = "mistral-medium-3-5",
+  MISTRAL_LARGE_2512 = "mistral-large-2512",
+  DEVSTRAL_2512 = "devstral-2512",
   CODESTRAL_LATEST = "codestral-latest",
   MINISTRAL_8B_LATEST = "ministral-8b-latest",
   MINISTRAL_3B_LATEST = "ministral-3b-latest",
@@ -511,6 +522,30 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     provider: "openai",
     contextLength: 131072,
   },
+  freeModel(
+    "mistralai/mistral-small-2603",
+    "Mistral Small 4",
+    "mistral",
+    262144
+  ),
+  freeModel(
+    "mistralai/mistral-medium-3-5",
+    "Mistral Medium 3.5",
+    "mistral",
+    262144
+  ),
+  freeModel(
+    "mistralai/mistral-large-2512",
+    "Mistral Large 3 2512",
+    "mistral",
+    262144
+  ),
+  freeModel(
+    "mistralai/devstral-2512",
+    "Devstral 2 2512",
+    "mistral",
+    262144
+  ),
   freeModel("openai/gpt-4o-mini", "GPT-4o Mini", "openai", 128000),
   {
     id: "openai/gpt-5-nano",
@@ -644,6 +679,12 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     contextLength: 200000,
   },
   {
+    id: "z-ai/glm-5.2",
+    name: "GLM 5.2 (Free)",
+    provider: "z-ai",
+    contextLength: 1000000,
+  },
+  {
     id: "minimax/minimax-m2.1",
     name: "MiniMax M2.1 (Free)",
     provider: "minimax",
@@ -658,6 +699,30 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
   freeModel("qwen/qwen3.5-flash-02-23", "Qwen 3.5 Flash 02-23", "qwen"),
   freeModel("qwen/qwen3-max-thinking", "Qwen 3 Max Thinking", "qwen"),
   // Mistral models
+  {
+    id: Model.MISTRAL_SMALL_2603,
+    name: "Mistral Small 4",
+    provider: "mistral",
+    contextLength: 262144,
+  },
+  {
+    id: Model.MISTRAL_MEDIUM_3_5,
+    name: "Mistral Medium 3.5",
+    provider: "mistral",
+    contextLength: 262144,
+  },
+  {
+    id: Model.MISTRAL_LARGE_2512,
+    name: "Mistral Large 3 2512",
+    provider: "mistral",
+    contextLength: 262144,
+  },
+  {
+    id: Model.DEVSTRAL_2512,
+    name: "Devstral 2 2512",
+    provider: "mistral",
+    contextLength: 262144,
+  },
   {
     id: Model.MISTRAL_LARGE_LATEST,
     name: "Mistral Large",


### PR DESCRIPTION
## Summary
- add Mistral Small 4, Mistral Medium 3.5, Mistral Large 3 2512, Devstral 2 2512, and GLM 5.2 to the shared inspector model catalog
- make Mistral Small 4 the default hosted/default model
- preserve guest gating for premium hosted models while keeping Mistral Small, Devstral, and GLM 5.2 guest-allowed

## Validation
- npm run test -w @mcpjam/inspector -- shared/__tests__/types.test.ts client/src/components/chat-v2/shared/__tests__/model-helpers.test.ts client/src/components/chatboxes/builder/__tests__/drafts.test.ts