### PR TITLE
feat(evals): per-turn checks in the streaming AI-SDK runner (Phase 2b)

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -3335,6 +3335,10 @@ const streamIterationWithAiSdk = async ({
   let conversationMessages: ModelMessage[] = [];
   const recordedSpans: EvalTraceSpan[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
+  // Per-turn signals for per-turn checks (parallel to toolsCalledByPrompt,
+  // assigned by promptIndex). See runIterationWithAiSdk for the rationale.
+  const assistantMessageByPrompt: (string | undefined)[] = [];
+  const toolErrorsByPrompt: ToolErrorRecord[][] = [];
   const accumulatedUsage = {
     inputTokens: 0,
     outputTokens: 0,
@@ -3718,6 +3722,16 @@ const streamIterationWithAiSdk = async ({
           );
           recordedSpans.push(...activeTraceCtx.recordedSpans);
           toolsCalledByPrompt.push([]);
+          assistantMessageByPrompt[promptIndex] = extractFinalAssistantMessage(
+            promptResponseMessages
+          );
+          toolErrorsByPrompt[promptIndex] = extractToolErrors({
+            spans: activeTraceCtx.recordedSpans,
+            messages: promptResponseMessages as Array<{
+              role: string;
+              content: unknown;
+            }>,
+          });
           // Cursor PR 5a review fix (Medium "Soft failure skips streaming
           // error events"): emit the failure trace_snapshot + error event
           // before `break` so live SSE consumers see the failure signal
@@ -3770,6 +3784,16 @@ const streamIterationWithAiSdk = async ({
               messages: promptResponseMessages,
             })
           );
+          assistantMessageByPrompt[promptIndex] = extractFinalAssistantMessage(
+            promptResponseMessages
+          );
+          toolErrorsByPrompt[promptIndex] = extractToolErrors({
+            spans: activeTraceCtx.recordedSpans,
+            messages: promptResponseMessages as Array<{
+              role: string;
+              content: unknown;
+            }>,
+          });
           // PR 4b review fix (Cursor "Step error drops assistant
           // transcript"): merge the partial response into
           // `conversationMessages` so persisted iterations include
@@ -3806,6 +3830,16 @@ const streamIterationWithAiSdk = async ({
           messages: promptResponseMessages,
         });
         toolsCalledByPrompt.push(promptToolsCalled);
+        assistantMessageByPrompt[promptIndex] = extractFinalAssistantMessage(
+          promptResponseMessages
+        );
+        toolErrorsByPrompt[promptIndex] = extractToolErrors({
+          spans: activeTraceCtx.recordedSpans,
+          messages: promptResponseMessages as Array<{
+            role: string;
+            content: unknown;
+          }>,
+        });
         recordedSpans.push(...activeTraceCtx.recordedSpans);
 
         conversationMessages = [
@@ -3851,7 +3885,17 @@ const streamIterationWithAiSdk = async ({
       test.isNegativeTest,
       test.matchOptions
     );
-    const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
+    // Per-turn checks: each turn's `checks` evaluated against its own slice.
+    const turnCheckResults = buildTurnCheckResults(promptTurns, {
+      toolsCalledByPrompt,
+      assistantMessageByPrompt,
+      toolErrorsByPrompt,
+      renderObservations: browser.widgetRenderObservations,
+    });
+    const promptTraceSummaries = buildPromptTraceSummaries(
+      evaluation,
+      turnCheckResults
+    );
 
     const failOnToolError =
       (advancedConfig as { failOnToolError?: boolean } | undefined)
@@ -3866,7 +3910,7 @@ const streamIterationWithAiSdk = async ({
             }>,
           }
         : undefined;
-    const predicateResults = test.successPredicates?.length
+    const casePredicateResults = test.successPredicates?.length
       ? evaluatePredicates(
           buildIterationTranscript({
             trace: traceForGate,
@@ -3881,6 +3925,9 @@ const streamIterationWithAiSdk = async ({
           test.successPredicates
         )
       : [];
+    // Case-level + per-turn (scope-tagged) results gate the verdict and
+    // persist together.
+    const predicateResults = [...casePredicateResults, ...turnCheckResults];
     const passed = finalizePassedForEval({
       matchPassed: evaluation.passed,
       trace: traceForGate,


### PR DESCRIPTION
## Context

**Phase 2b** of per-turn checks. Phase 2a (#2840) wired the non-streaming local runner (`runIterationWithAiSdk`). This wires the **streaming** local AI-SDK runner (`streamIterationWithAiSdk`) — the interactive single-case / live test-runner path.

## What this does

Mirrors the Phase 2a wiring in `streamIterationWithAiSdk`:
- Captures each turn's assistant message + tool errors in the loop (model-completion + both early-break branches, so failed turns evaluate against their real partial transcript — same fix as #2840's Cursor follow-up).
- Evaluates via the shared `buildTurnCheckResults`, merges with case-level results so per-turn checks gate the verdict and persist to `metadata.predicates`, and attaches per-turn verdicts to `PromptTraceSummary.predicateResults`.

**Both local AI-SDK runners (stream + non-stream) now evaluate per-turn checks.**

## Deferred → Phase 2c

The two backend-driven paths (`runIterationViaBackendWithBrowser`, `streamIterationViaBackendWithBrowser`) delegate per-turn execution to a shared backend-turn helper that doesn't yet surface per-turn assistant message / tool errors. Wiring them requires that helper to return the per-turn signals — a focused follow-up. No per-turn authoring UI exists until Phase 3, so user-facing coverage stays consistent meanwhile.

## Testing

- evals-runner suite green (71); typecheck clean on the changed file (only pre-existing unused-import / `testCaseSnapshot` errors remain, on untouched lines).
- Per-turn evaluation logic itself is covered by the SDK `predicate-turn-checks` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pass/fail gating and persisted predicate metadata for the live streaming eval path; behavior mirrors the already-wired non-stream runner but affects interactive quick-run verdicts.
> 
> **Overview**
> Extends **per-turn predicate checks** to the streaming local AI-SDK eval path (`streamIterationWithAiSdk`), matching Phase 2a on the non-streaming runner.
> 
> Each model turn now records **assistant text** and **tool errors** (indexed by `promptIndex`) on the happy path and on both early-exit failure paths (empty stream, non-tool step error), so checks run against partial transcripts instead of empty slices.
> 
> After multi-turn tool matching, the runner calls **`buildTurnCheckResults`**, attaches turn-scoped verdicts to **`PromptTraceSummary.predicateResults`**, and merges case-level **`successPredicates`** with per-turn results so **`finalizePassedForEval`** and **`metadata.predicates`** reflect both scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b59c061566da84502273f72356d11e2801696a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->