### PR TITLE
feat(evals): per-turn "Add check" UI + per-turn results (Phase 3)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/predicates-list.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/predicates-list.test.ts
@@ -118,4 +118,32 @@ describe("summarizePredicate", () => {
     expect(() => summarizePredicate(future)).not.toThrow();
     expect(summarizePredicate(future)).toBe("");
   });
+
+  it("preserves a valid per-turn scope and drops a malformed one", () => {
+    const parsed = parseIterationPredicates({
+      predicates: [
+        {
+          predicate: { type: "responseContains", needle: "weather" },
+          passed: true,
+          reason: "turn 1 contains weather",
+          scope: { kind: "turn", promptIndex: 1 },
+        },
+        {
+          predicate: { type: "noToolErrors" },
+          passed: true,
+          reason: "bad scope dropped, row still case-level",
+          scope: { kind: "iteration", promptIndex: 0 },
+        },
+        {
+          predicate: { type: "noToolErrors" },
+          passed: true,
+          reason: "case level",
+        },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed![0].scope).toEqual({ kind: "turn", promptIndex: 1 });
+    expect(parsed![1].scope).toBeUndefined();
+    expect(parsed![2].scope).toBeUndefined();
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -134,6 +134,12 @@ export interface ChecksSectionProps {
   description?: string;
   /** Hide the Add-check button (used by the inherited read-only summary). */
   readOnly?: boolean;
+  /**
+   * Restrict the Add-check menu to these kinds. Used for per-turn checks, which
+   * only allow turn-scopable kinds (`TURN_SCOPABLE_PREDICATE_KINDS`). Existing
+   * rows of other kinds still render — only the menu is filtered.
+   */
+  allowedKinds?: readonly Predicate["type"][];
 }
 
 export function ChecksSection({
@@ -145,6 +151,7 @@ export function ChecksSection({
   readOnly = false,
   hideAddButton = false,
   hideEmptyState = false,
+  allowedKinds,
 }: ChecksSectionProps & { hideAddButton?: boolean; hideEmptyState?: boolean }) {
   const updateAt = (index: number, next: Predicate) => {
     const copy = value.slice();
@@ -197,24 +204,32 @@ export function ChecksSection({
         </ul>
       )}
 
-      {!readOnly && !hideAddButton ? <AddCheckMenu onAdd={addOfKind} /> : null}
+      {!readOnly && !hideAddButton ? (
+        <AddCheckMenu onAdd={addOfKind} allowedKinds={allowedKinds} />
+      ) : null}
     </div>
   );
 }
 
 export function AddCheckMenu({
   onAdd,
+  allowedKinds,
 }: {
   onAdd: (kind: Predicate["type"]) => void;
+  /** When set, restrict the menu to these kinds (e.g. turn-scopable only). */
+  allowedKinds?: readonly Predicate["type"][];
 }) {
   // A controlled Select where picking a value fires `onAdd` and resets to
   // the placeholder — simpler than a popover menu and reuses design-system
   // primitives that already render correctly inside dialogs/sheets.
   const [open, setOpen] = useState(false);
   const syntheticMonitorsEnabled = useFeatureFlagEnabled("synthetic-monitors");
-  const kinds = syntheticMonitorsEnabled
-    ? KIND_ORDER
-    : KIND_ORDER.filter((kind) => !SYNTHETIC_MONITOR_KINDS.has(kind));
+  const allowed = allowedKinds ? new Set(allowedKinds) : null;
+  const kinds = KIND_ORDER.filter(
+    (kind) =>
+      (syntheticMonitorsEnabled || !SYNTHETIC_MONITOR_KINDS.has(kind)) &&
+      (!allowed || allowed.has(kind)),
+  );
   return (
     <div className="flex items-center gap-2">
       <Select

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -805,14 +805,22 @@ export function IterationDetails({
     () => parseIterationPredicates(iteration.metadata),
     [iteration.metadata],
   );
-  const predicatesSection = predicates ? (
-    <div className="space-y-2" data-testid="iteration-predicates-section">
-      <div className="flex items-center justify-between border-b border-border/40 pb-2">
-        <div className="text-xs font-semibold">Predicate Gate</div>
+  // Case-level checks only — per-turn checks (scope.kind === "turn") render
+  // under their turn in the per-turn summary list below, so they aren't
+  // duplicated here.
+  const caseLevelPredicates = useMemo(
+    () => (predicates ? predicates.filter((p) => !p.scope) : null),
+    [predicates],
+  );
+  const predicatesSection =
+    caseLevelPredicates && caseLevelPredicates.length > 0 ? (
+      <div className="space-y-2" data-testid="iteration-predicates-section">
+        <div className="flex items-center justify-between border-b border-border/40 pb-2">
+          <div className="text-xs font-semibold">Predicate Gate</div>
+        </div>
+        <PredicatesList predicates={caseLevelPredicates} />
       </div>
-      <PredicatesList predicates={predicates} />
-    </div>
-  ) : null;
+    ) : null;
 
   // Widget probes get an artifacts-first layout: checks + the rendered
   // widget. Tool-call diff (expected vs actual is meaningless for a pinned
@@ -975,6 +983,14 @@ export function IterationDetails({
                   )}
                 </div>
               ) : null}
+              {(() => {
+                const turnChecks = predicates?.filter(
+                  (p) => p.scope?.promptIndex === summary.promptIndex,
+                );
+                return turnChecks && turnChecks.length > 0 ? (
+                  <PredicatesList predicates={turnChecks} />
+                ) : null;
+              })()}
             </div>
           ))}
         </div>

--- a/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
@@ -25,13 +25,30 @@ export function parseIterationPredicates(
     if (!row.predicate || typeof row.predicate !== "object") continue;
     const predicate = row.predicate as Record<string, unknown>;
     if (typeof predicate.type !== "string") continue;
+    // Preserve a per-turn scope when present so the UI can group a turn's
+    // checks under that turn (and the case-level list can exclude them).
+    const scope = parseTurnScope(row.scope);
     out.push({
       predicate: predicate as unknown as Predicate,
       passed: row.passed,
       reason: row.reason,
+      ...(scope ? { scope } : {}),
     });
   }
   return out.length > 0 ? out : null;
+}
+
+/** Validate `{ kind: "turn", promptIndex }` defensively (metadata is unknown). */
+function parseTurnScope(
+  value: unknown,
+): { kind: "turn"; promptIndex: number } | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const s = value as Record<string, unknown>;
+  if (s.kind !== "turn") return undefined;
+  if (typeof s.promptIndex !== "number" || !Number.isInteger(s.promptIndex)) {
+    return undefined;
+  }
+  return { kind: "turn", promptIndex: s.promptIndex };
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/evals/test-case-prompt-flow.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-case-prompt-flow.tsx
@@ -12,10 +12,12 @@ import { Button } from "@mcpjam/design-system/button";
 import { Label } from "@mcpjam/design-system/label";
 import { Textarea } from "@mcpjam/design-system/textarea";
 import { isPinnedTurn, type PromptTurn } from "@/shared/prompt-turns";
+import { TURN_SCOPABLE_PREDICATE_KINDS } from "@/shared/eval-matching";
 import type { RemoteServer } from "@/hooks/useProjects";
 import { cn } from "@/lib/utils";
 import { ExpectedToolsEditor } from "./expected-tools-editor";
 import { PinnedToolCallFields } from "./pinned-tool-call-fields";
+import { ChecksSection } from "./checks-section";
 
 type AvailableTool = {
   name: string;
@@ -423,6 +425,39 @@ export function TestCasePromptFlow({
                                   </section>
                                 </>
                               )}
+
+                              {/* Per-turn checks: deterministic assertions
+                                  evaluated against THIS turn's slice of the
+                                  transcript (not the whole iteration). Restricted
+                                  to turn-scopable kinds. Shown for both prompt and
+                                  render-check turns. */}
+                              <section className="space-y-2">
+                                <Label className="text-xs font-medium text-foreground">
+                                  Checks
+                                </Label>
+                                <p className="text-xs text-muted-foreground">
+                                  Evaluated against this turn only.
+                                </p>
+                                <ChecksSection
+                                  value={turn.checks ?? []}
+                                  onChange={(next) =>
+                                    updatePromptTurn(index, (currentTurn) => {
+                                      if (next.length === 0) {
+                                        const { checks: _omit, ...rest } =
+                                          currentTurn;
+                                        return rest;
+                                      }
+                                      return { ...currentTurn, checks: next };
+                                    })
+                                  }
+                                  availableTools={availableTools.map(
+                                    (t) => t.name,
+                                  )}
+                                  allowedKinds={TURN_SCOPABLE_PREDICATE_KINDS}
+                                  title=""
+                                  hideEmptyState
+                                />
+                              </section>
                             </div>
                           </motion.div>
                         )}


### PR DESCRIPTION
## Context

**Phase 3** — the user-facing payoff of per-turn checks. Phases 1–2 added the contract, evaluator, and runner wiring; this adds **authoring** (an "Add check" per turn) and **display** (per-turn verdicts in the trace).

## Authoring

- `test-case-prompt-flow.tsx`: each expanded turn (prompt or render-check) gets a **Checks** section reusing `ChecksSection`, with the Add-check menu restricted to **turn-scopable** kinds (`TURN_SCOPABLE_PREDICATE_KINDS`). Wired through the existing `updatePromptTurn`; clearing the list removes `turn.checks`.
- The save payload already sends `promptTurns` verbatim and the request schema accepts `checks` (Phase 1), so per-turn checks round-trip to Convex with no extra plumbing.
- `checks-section.tsx`: `AddCheckMenu` / `ChecksSection` gain an optional `allowedKinds` to filter the menu (composes with the existing synthetic-monitors gate). Existing rows of other kinds still render.

## Results display

- `predicates-list.tsx`: `parseIterationPredicates` now preserves a valid per-turn `scope` (drops malformed ones defensively).
- `iteration-details.tsx`: the case-level "Predicate Gate" list shows **only** case-level results; per-turn verdicts render **under their turn** in the per-turn summary list — no duplication.

## Testing

- Client typecheck clean.
- `predicates-list` (incl. a new scope-preservation case) + `iteration-details` tests green.
- End-to-end: add a per-turn check in the case editor → run → the verdict shows under that turn and gates the case (runner wiring from #2840/#2842).

## Stacking

Branches from `main` (depends only on Phase 1, merged). Independent of the open Phase 2b (#2842) and the deferred Phase 2c (backend runner paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only eval UI and metadata parsing changes; no auth or runner logic in this diff.
> 
> **Overview**
> Adds **per-turn check authoring** and **scoped result display** so eval cases can assert on a single turn’s transcript without duplicating verdicts at case level.
> 
> Each expanded prompt/render-check turn in the case editor now has a **Checks** section backed by `ChecksSection`, persisting `turn.checks` and limiting **Add check** to `TURN_SCOPABLE_PREDICATE_KINDS` via a new optional `allowedKinds` on `ChecksSection` / `AddCheckMenu` (still composes with the synthetic-monitors menu gate).
> 
> On iteration review, `parseIterationPredicates` now keeps valid `{ kind: "turn", promptIndex }` scope and drops malformed scope. **Predicate Gate** shows only case-level rows; per-turn predicate results render under the matching turn in **Turn Breakdown**. A unit test covers scope preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88d6febd798e9f02cdb9af7bb51f5c061ff8293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->