### PR TITLE
Public API hardening: fix force-delete, project-scope hosts, route tests + OpenAPI drift check

### DIFF
--- a/cli/src/commands/hosts.ts
+++ b/cli/src/commands/hosts.ts
@@ -261,13 +261,11 @@ export function registerHostsCommands(program: Command): void {
       .description("Permanently delete a host from a project")
       .requiredOption("--host <id-or-name>", "Host name or ID")
       .option("--project <id-or-name>", "Project name or ID")
-      .option("--force", "Delete even if the host is still referenced")
   ).action(
     async (
       options: PlatformOptions & {
         project?: string;
         host: string;
-        force?: boolean;
       },
       command
     ) => {
@@ -280,7 +278,6 @@ export function registerHostsCommands(program: Command): void {
             {
               project: options.project,
               host: options.host,
-              ...(options.force ? { force: true } : {}),
             },
             { client, signal }
           )

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -168,24 +168,11 @@
         "operationId": "deleteHost",
         "tags": ["Hosts"],
         "summary": "Delete a host",
-        "description": "Permanently delete a host from the project. Pass `{ \"force\": true }` to delete a host that is still referenced (e.g. by an eval suite). Guest callers are denied (a write).",
+        "description": "Permanently delete a host from the project. Guest callers are denied (a write).",
         "parameters": [
           { "$ref": "#/components/parameters/projectId" },
           { "$ref": "#/components/parameters/hostId" }
         ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "force": { "type": "boolean", "description": "Delete even if the host is still referenced." }
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "The host was deleted.",

--- a/mcpjam-inspector/server/routes/v1/README.md
+++ b/mcpjam-inspector/server/routes/v1/README.md
@@ -1,0 +1,81 @@
+# MCPJam Public API — `/api/v1`
+
+This directory is the Inspector-hosted half of the MCPJam public API. It is a
+thin Hono gateway: routes here authenticate the caller, shape the public
+request/response envelope, and delegate domain logic to the same Convex
+functions the hosted UI uses. Business rules, authorization, and invariants
+live in `mcpjam-backend` (Convex), not here.
+
+## Where a new endpoint lives
+
+Pick the surface by what the endpoint does — match the existing split rather
+than adding forked logic:
+
+- **Read of product state** (lists, detail, catalog) → add a Convex-native
+  `/v1/*` HTTP route in `mcpjam-backend/convex/publicApi/routes.ts`, then a
+  thin proxy here. Pattern: `catalog.ts` (`fetchConvexV1Read`) and
+  `eval-ingest.ts` (`proxyIngest`). The gateway forwards; Convex owns the read.
+
+- **Write / domain mutation** (create, update, delete, state change) → add a
+  Convex `userMutation`/`userQuery` in `mcpjam-backend`, then a thin adapter
+  here that calls it. Pattern: `hosts.ts`. **Enforce project scope inside the
+  Convex function** by passing the path `projectId` (the function asserts the
+  resource belongs to it), not with a gateway preflight that lists-and-scans —
+  see the Phase 2 change to `hosts:getHost/updateHost/deleteHost`.
+
+- **Live MCP op or side effect** (connect to a server, run tools/prompts,
+  tunnels, OAuth token import, live eval runner) → Hono only, reusing the
+  shared connection layer (`routes/web/auth.ts`, `adapter.ts`). These touch the
+  network or long-lived process state and have no Convex-function equivalent.
+
+Guests get a default-deny allowlist (`index.ts` `GUEST_ALLOWED_V1_RULES`); a
+new route is closed to guests until it earns an entry and its own review.
+
+## Contract & envelope
+
+The wire contract — error-code union, code→HTTP-status map, and the
+`{ items }` / single-resource / `{ code, message }` envelopes — lives in
+`contract.ts` (framework-agnostic) and is adapted to Hono in `envelope.ts`. It
+is intentionally **duplicated** with `mcpjam-backend/convex/publicApi/contract.ts`
+and kept in sync via byte-identical golden fixtures (`__fixtures__/`). When you
+change the contract, update both copies and both fixtures.
+
+Two guards run in CI (`__tests__/`):
+
+- `contract.test.ts` — the contract matches the golden fixtures.
+- `openapi-drift.test.ts` — every route the router serves is in
+  `docs/reference/openapi.json` and vice versa (plus operationId / security /
+  requestBody checks). `openapi.json` is hand-authored; this is what stops it
+  drifting from the code.
+
+## Evals: what legitimately lives in this gateway vs. Convex
+
+Unlike hosts (a near-pure adapter), the eval routes still carry real
+gateway-side logic. Classifying it, so future work can move the right pieces:
+
+**Legitimately adapter concerns — keep here:**
+
+- **Public ↔ internal vocabulary mapping.** `buildCaseMutationArgs` renames
+  public fields onto the `testSuites` mutation shape (`iterations`→`runs`,
+  `isNegative`→`isNegativeTest`, `kind`→`caseType`). This is the public API's
+  naming, not a domain rule.
+- **REST PATCH → wholesale mutation.** The same helper implements partial-PATCH
+  semantics (forward only provided fields; merge a partial `matchOptions` /
+  `probeConfig` onto the persisted value). Convex mutations take wholesale
+  args; translating partial updates is an HTTP concern.
+
+**Candidates to push into Convex — currently here, arguably domain/data rules:**
+
+- **Name → id resolution.** `resolveHostAttachments` and
+  `resolveProjectServerSelectors` let callers reference hosts/servers by name,
+  resolving via a full `hosts:listHosts` / `servers:getProjectServers` round
+  trip plus ambiguity handling. This is the same list-and-scan anti-pattern
+  Phase 2 removed for host project-scoping; it would be better as Convex
+  queries (e.g. `hosts:resolveByNameOrId`) so the rule is owned once and the
+  gateway stops reaching into resource internals.
+- **Domain invariants.** Rules like "a case's kind is immutable after create"
+  are enforced in `buildCaseMutationArgs` today; they belong (at least as
+  defense in depth) in the Convex `updateTestCase` validator.
+
+These moves are intentionally **out of scope** for the current change — land
+them as separate, scoped PRs.

--- a/mcpjam-inspector/server/routes/v1/__tests__/hosts.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/hosts.test.ts
@@ -273,5 +273,19 @@ describe("v1 host routes", () => {
       expect(body.message).toContain("force");
       expect(convexMutationMock).not.toHaveBeenCalled();
     });
+
+    it("rejects a delete body even with only a synthesized-looking key (400)", async () => {
+      // The route reads the raw body, so a payload like `{ "projectId": "p1" }`
+      // is still a body and is rejected — DELETE is truly bodyless, not merely
+      // "no fields other than the ones synthesizeServerBody would inject".
+      const res = await request("DELETE", "/api/v1/projects/p1/hosts/h1", {
+        body: { projectId: "p1" },
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR"
+      );
+      expect(convexMutationMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/hosts.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/hosts.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Covers the v1 HOST surface (server/routes/v1/hosts.ts): auth + guest gating,
+// the public DTO mapping (no Convex `hostId` leak), the project-scoped Convex
+// calls (every detail/write forwards the path `projectId` so cross-project ids
+// 404 inside Convex), and the body contracts — create's template-XOR-config
+// rule and delete's "no body, reject stray fields like a legacy `force`".
+//
+// Convex is mocked at the `convex/browser` boundary, so these tests prove the
+// gateway's behavior and the ARGS it forwards — NOT that the backend accepts
+// those args. The backend validators + project scoping are covered separately
+// by mcpjam-backend/tests/convex/hostsProjectScope.test.ts.
+
+const {
+  validateGuestTokenMock,
+  validateApiKeyMock,
+  resolveUserByExternalIdMock,
+  lookupWorkosKeyBindingMock,
+  convexQueryMock,
+  convexMutationMock,
+} = vi.hoisted(() => ({
+  validateGuestTokenMock: vi.fn(),
+  validateApiKeyMock: vi.fn(),
+  resolveUserByExternalIdMock: vi.fn(),
+  lookupWorkosKeyBindingMock: vi.fn(),
+  convexQueryMock: vi.fn(),
+  convexMutationMock: vi.fn(),
+}));
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+// WorkOS API-key seams — only reached by `sk_` bearers (none here), but the
+// auth middleware imports them at module load, so stub them out.
+vi.mock("../../../services/workos-client.js", () => ({
+  getWorkOSClient: () => ({
+    apiKeys: { createValidation: validateApiKeyMock },
+  }),
+}));
+vi.mock("../../../services/identity.js", () => ({
+  resolveUserByExternalId: resolveUserByExternalIdMock,
+}));
+vi.mock("../../../services/workos-key-bindings.js", () => ({
+  lookupWorkosKeyBinding: lookupWorkosKeyBindingMock,
+}));
+
+// The host routes build their Convex clients via `new ConvexHttpClient(...)`
+// (directly and through `createConvexClients`), so a single mock here backs
+// both the read (`query`) and write (`mutation`) paths.
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+    mutation: convexMutationMock,
+  })),
+}));
+
+import v1Routes from "../index.js";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+function request(
+  method: string,
+  path: string,
+  opts: { body?: unknown; token?: string | null } = {}
+): Promise<Response> {
+  const { body, token = "tok" } = opts;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return Promise.resolve(
+    makeApp().request(path, {
+      method,
+      headers,
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    })
+  );
+}
+
+const LIST_ROW = {
+  hostId: "h1",
+  name: "Alpha",
+  hostConfigId: "hc1",
+  modelId: "gpt-4o-mini",
+  serverCount: 2,
+  createdAt: 1,
+  updatedAt: 2,
+};
+const DETAIL_ROW = {
+  hostId: "h1",
+  name: "Alpha",
+  config: { modelId: "gpt-4o-mini" },
+};
+
+/** Dispatch the mocked Convex query by function name. */
+function mockQuery(map: Record<string, unknown>) {
+  convexQueryMock.mockImplementation(async (fn: string) =>
+    fn in map ? map[fn] : null
+  );
+}
+
+describe("v1 host routes", () => {
+  const originalEnv = {
+    CONVEX_URL: process.env.CONVEX_URL,
+    CONVEX_HTTP_URL: process.env.CONVEX_HTTP_URL,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_URL = "https://convex.example.com";
+    process.env.CONVEX_HTTP_URL = "https://convex-http.example.com";
+    // Default: the bearer is neither a guest token nor an `sk_` key, so the
+    // middleware treats it as a WorkOS JWT and passes it through to Convex.
+    validateGuestTokenMock.mockResolvedValue({ valid: false });
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value) process.env[key] = value;
+      else delete process.env[key];
+    }
+  });
+
+  describe("auth", () => {
+    it("rejects a request with no bearer token (401)", async () => {
+      const res = await request("GET", "/api/v1/projects/p1/hosts", {
+        token: null,
+      });
+      expect(res.status).toBe(401);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "UNAUTHORIZED"
+      );
+    });
+
+    it("denies guest callers — hosts are not on the guest allowlist (401)", async () => {
+      validateGuestTokenMock.mockResolvedValue({
+        valid: true,
+        guestId: "guest_1",
+      });
+      const res = await request("GET", "/api/v1/projects/p1/hosts", {
+        token: "guest-jwt",
+      });
+      expect(res.status).toBe(401);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "UNAUTHORIZED"
+      );
+      expect(convexQueryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET list + detail", () => {
+    it("lists hosts in the public DTO shape (id, no hostId leak)", async () => {
+      mockQuery({ "hosts:listHosts": [LIST_ROW] });
+      const res = await request("GET", "/api/v1/projects/p1/hosts");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { items: Record<string, unknown>[] };
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0]).toMatchObject({ id: "h1", name: "Alpha" });
+      expect(body.items[0]).not.toHaveProperty("hostId");
+      expect(convexQueryMock).toHaveBeenCalledWith("hosts:listHosts", {
+        projectId: "p1",
+      });
+    });
+
+    it("returns host detail and forwards the path projectId to getHost", async () => {
+      mockQuery({ "hosts:getHost": DETAIL_ROW });
+      const res = await request("GET", "/api/v1/projects/p1/hosts/h1");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).toMatchObject({ id: "h1", name: "Alpha" });
+      expect(body).not.toHaveProperty("hostId");
+      // Project scope is enforced inside Convex — the route must pass projectId.
+      expect(convexQueryMock).toHaveBeenCalledWith("hosts:getHost", {
+        hostId: "h1",
+        projectId: "p1",
+      });
+    });
+
+    it("returns 404 when getHost yields null (missing or cross-project id)", async () => {
+      mockQuery({ "hosts:getHost": null });
+      const res = await request("GET", "/api/v1/projects/p1/hosts/other");
+      expect(res.status).toBe(404);
+      expect(((await res.json()) as { code?: string }).code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("POST create", () => {
+    it("creates a host from a full config and returns 201", async () => {
+      convexMutationMock.mockResolvedValue({ hostId: "h1" });
+      mockQuery({ "hosts:getHost": DETAIL_ROW });
+      const res = await request("POST", "/api/v1/projects/p1/hosts", {
+        body: { name: "Alpha", config: { modelId: "gpt-4o-mini" } },
+      });
+      expect(res.status).toBe(201);
+      expect((await res.json()) as Record<string, unknown>).toMatchObject({
+        id: "h1",
+      });
+      expect(convexMutationMock).toHaveBeenCalledWith("hosts:createHost", {
+        projectId: "p1",
+        name: "Alpha",
+        input: { modelId: "gpt-4o-mini" },
+      });
+    });
+
+    it("rejects a body with neither template nor config (400)", async () => {
+      const res = await request("POST", "/api/v1/projects/p1/hosts", {
+        body: { name: "Alpha" },
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR"
+      );
+      expect(convexMutationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("PATCH update", () => {
+    it("updates a host and forwards the path projectId to updateHost", async () => {
+      convexMutationMock.mockResolvedValue({ hostId: "h1" });
+      mockQuery({ "hosts:getHost": DETAIL_ROW });
+      const res = await request("PATCH", "/api/v1/projects/p1/hosts/h1", {
+        body: { name: "Renamed" },
+      });
+      expect(res.status).toBe(200);
+      expect(convexMutationMock).toHaveBeenCalledWith("hosts:updateHost", {
+        hostId: "h1",
+        projectId: "p1",
+        name: "Renamed",
+      });
+    });
+
+    it("rejects an empty update (no name or config) with 400", async () => {
+      const res = await request("PATCH", "/api/v1/projects/p1/hosts/h1", {
+        body: {},
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR"
+      );
+      expect(convexMutationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE", () => {
+    it("deletes a host, forwarding only { hostId, projectId } (no force)", async () => {
+      convexMutationMock.mockResolvedValue(undefined);
+      const res = await request("DELETE", "/api/v1/projects/p1/hosts/h1");
+      expect(res.status).toBe(200);
+      expect((await res.json()) as Record<string, unknown>).toEqual({
+        id: "h1",
+        deleted: true,
+      });
+      expect(convexMutationMock).toHaveBeenCalledWith("hosts:deleteHost", {
+        hostId: "h1",
+        projectId: "p1",
+      });
+    });
+
+    it("rejects a delete body carrying a legacy `force` field (400)", async () => {
+      const res = await request("DELETE", "/api/v1/projects/p1/hosts/h1", {
+        body: { force: true },
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string; message?: string };
+      expect(body.code).toBe("VALIDATION_ERROR");
+      expect(body.message).toContain("force");
+      expect(convexMutationMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
@@ -18,7 +18,13 @@ const spec = JSON.parse(
   )
 ) as {
   security?: unknown[];
-  paths: Record<string, Record<string, { operationId?: string; requestBody?: unknown }>>;
+  paths: Record<
+    string,
+    Record<
+      string,
+      { operationId?: string; requestBody?: unknown; security?: unknown[] }
+    >
+  >;
 };
 
 const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
@@ -122,8 +128,31 @@ describe("openapi.json ↔ /api/v1 route parity", () => {
     ).toEqual([]);
   });
 
-  it("requires a bearer-auth security scheme (global or per-op)", () => {
-    expect(Array.isArray(spec.security) && spec.security.length > 0).toBe(true);
+  it("requires bearerAuth security globally or per operation", () => {
+    const hasBearer = (entries: unknown): boolean =>
+      Array.isArray(entries) &&
+      entries.some(
+        (entry) =>
+          !!entry &&
+          typeof entry === "object" &&
+          "bearerAuth" in (entry as Record<string, unknown>)
+      );
+    const globalBearer = hasBearer(spec.security);
+    const missing: string[] = [];
+    for (const [path, item] of Object.entries(spec.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        if (!HTTP_METHODS.has(method.toUpperCase())) continue;
+        if (!globalBearer && !hasBearer(op.security)) {
+          missing.push(`${method} ${path}`);
+        }
+      }
+    }
+    expect(
+      missing,
+      `Operations without a bearerAuth security requirement:\n  ${missing.join(
+        "\n  "
+      )}`
+    ).toEqual([]);
   });
 
   it("gives every operation an operationId", () => {

--- a/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import v1Routes from "../index.js";
+
+// Guards docs/reference/openapi.json against drift from the actual Hono router.
+// The spec is hand-authored, so nothing otherwise stops a route from being
+// added/removed/renamed without a matching spec edit (the removed `force`
+// delete param is the cautionary tale). This builds a route inventory from the
+// mounted app and diffs it against the spec's paths+methods in BOTH directions.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const spec = JSON.parse(
+  readFileSync(
+    resolve(here, "../../../../../docs/reference/openapi.json"),
+    "utf8"
+  )
+) as {
+  security?: unknown[];
+  paths: Record<string, Record<string, { operationId?: string; requestBody?: unknown }>>;
+};
+
+const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+// POST actions that intentionally carry no request body (so the requestBody
+// assertion below doesn't flag them). Keep this list tiny and explicit.
+const BODYLESS_WRITES = new Set([
+  "post /projects/{projectId}/tunnels/{serverId}/close",
+]);
+
+// Pre-existing documentation gap: routes that the v1 router serves but that the
+// hand-authored openapi.json does not describe yet (the eval-suite/case
+// management surface and the SDK eval-ingest transport). The drift check fails
+// on any NEW undocumented route; these are baselined so the guard can land now
+// and the spec be backfilled separately. The test also keeps this list tight —
+// documenting or deleting a route must remove its entry here.
+const KNOWN_UNDOCUMENTED = new Set([
+  "get /projects/{projectId}/eval-suites/{suiteId}",
+  "patch /projects/{projectId}/eval-suites/{suiteId}",
+  "delete /projects/{projectId}/eval-suites/{suiteId}",
+  "patch /projects/{projectId}/eval-suites/{suiteId}/schedule",
+  "get /projects/{projectId}/eval-suites/{suiteId}/cases",
+  "post /projects/{projectId}/eval-suites/{suiteId}/cases",
+  "post /projects/{projectId}/eval-suites/{suiteId}/cases/generate",
+  "get /projects/{projectId}/eval-suites/{suiteId}/cases/{caseId}",
+  "patch /projects/{projectId}/eval-suites/{suiteId}/cases/{caseId}",
+  "delete /projects/{projectId}/eval-suites/{suiteId}/cases/{caseId}",
+  "post /projects/{projectId}/eval-ingest/runs/start",
+  "post /projects/{projectId}/eval-ingest/runs/iterations",
+  "post /projects/{projectId}/eval-ingest/runs/finalize",
+  "post /projects/{projectId}/eval-ingest/report",
+  "post /projects/{projectId}/eval-ingest/artifacts/upload-url",
+]);
+
+/** Hono `:param` + the `/api/v1` mount prefix -> OpenAPI `{param}`, unprefixed. */
+function normalizePath(path: string): string {
+  return path.replace(/^\/api\/v1/, "").replace(/:([A-Za-z0-9_]+)/g, "{$1}");
+}
+
+/** `{ method, path }` keys for every real HTTP route the v1 router serves. */
+function appInventory(): Set<string> {
+  const inventory = new Set<string>();
+  for (const route of v1Routes.routes) {
+    const method = route.method.toUpperCase();
+    // Skip middleware (registered as `ALL` via `.use("*")`) and non-HTTP verbs.
+    if (!HTTP_METHODS.has(method)) continue;
+    inventory.add(`${method.toLowerCase()} ${normalizePath(route.path)}`);
+  }
+  return inventory;
+}
+
+/** `{ method, path }` keys for every operation the spec documents. */
+function specInventory(): Set<string> {
+  const inventory = new Set<string>();
+  for (const [path, item] of Object.entries(spec.paths)) {
+    for (const method of Object.keys(item)) {
+      if (!HTTP_METHODS.has(method.toUpperCase())) continue;
+      inventory.add(`${method.toLowerCase()} ${path}`);
+    }
+  }
+  return inventory;
+}
+
+describe("openapi.json ↔ /api/v1 route parity", () => {
+  const appRoutes = appInventory();
+  const specRoutes = specInventory();
+
+  it("documents every route the router serves (modulo the baselined backlog)", () => {
+    const undocumented = [...appRoutes].filter((r) => !specRoutes.has(r));
+
+    const newlyUndocumented = undocumented
+      .filter((r) => !KNOWN_UNDOCUMENTED.has(r))
+      .sort();
+    expect(
+      newlyUndocumented,
+      `New /api/v1 routes missing from openapi.json — document them (or, if intentionally internal, add to KNOWN_UNDOCUMENTED with a reason):\n  ${newlyUndocumented.join(
+        "\n  "
+      )}`
+    ).toEqual([]);
+
+    // Keep the baseline honest: a baselined route that is now documented or
+    // removed should be dropped from KNOWN_UNDOCUMENTED.
+    const staleBaseline = [...KNOWN_UNDOCUMENTED]
+      .filter((r) => !undocumented.includes(r))
+      .sort();
+    expect(
+      staleBaseline,
+      `Stale KNOWN_UNDOCUMENTED entries (now documented or gone) — remove them:\n  ${staleBaseline.join(
+        "\n  "
+      )}`
+    ).toEqual([]);
+  });
+
+  it("documents only routes that exist (no phantom spec entries)", () => {
+    const phantom = [...specRoutes].filter((r) => !appRoutes.has(r)).sort();
+    expect(
+      phantom,
+      `openapi.json documents paths/methods with no matching route:\n  ${phantom.join(
+        "\n  "
+      )}`
+    ).toEqual([]);
+  });
+
+  it("requires a bearer-auth security scheme (global or per-op)", () => {
+    expect(Array.isArray(spec.security) && spec.security.length > 0).toBe(true);
+  });
+
+  it("gives every operation an operationId", () => {
+    const missing: string[] = [];
+    for (const [path, item] of Object.entries(spec.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        if (!HTTP_METHODS.has(method.toUpperCase())) continue;
+        if (!op.operationId) missing.push(`${method} ${path}`);
+      }
+    }
+    expect(missing, `Operations missing operationId:\n  ${missing.join("\n  ")}`).toEqual(
+      []
+    );
+  });
+
+  it("declares a requestBody for create/update writes", () => {
+    const missing: string[] = [];
+    for (const [path, item] of Object.entries(spec.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        if (method !== "post" && method !== "patch" && method !== "put") {
+          continue;
+        }
+        const key = `${method} ${path}`;
+        if (!op.requestBody && !BODYLESS_WRITES.has(key)) missing.push(key);
+      }
+    }
+    expect(
+      missing,
+      `Write operations missing a requestBody (add one, or allowlist a genuinely bodyless action):\n  ${missing.join(
+        "\n  "
+      )}`
+    ).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/hosts.ts
+++ b/mcpjam-inspector/server/routes/v1/hosts.ts
@@ -247,21 +247,41 @@ hosts.patch("/projects/:projectId/hosts/:hostId", async (c) => {
 hosts.delete("/projects/:projectId/hosts/:hostId", async (c) => {
   const projectId = c.req.param("projectId");
   const hostId = c.req.param("hostId");
-  // Delete takes no body. `synthesizeServerBody` merges the path's
-  // projectId/serverId in, so strip those and reject anything left over
-  // (e.g. a legacy `force`) as VALIDATION_ERROR rather than dropping it.
-  const deleteBody = await synthesizeServerBody(c);
-  const strayDeleteFields = Object.keys(deleteBody).filter(
-    (key) => key !== "projectId" && key !== "serverId"
-  );
-  if (strayDeleteFields.length > 0) {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      `Unexpected field(s) in delete body: ${strayDeleteFields
-        .sort()
-        .join(", ")}`
-    );
+  // Delete takes no body. Read the raw payload directly (NOT via
+  // synthesizeServerBody, which injects the path projectId/serverId) so the
+  // contract is truly bodyless: reject ANY field — a legacy `force`, or even a
+  // stray `projectId` — as VALIDATION_ERROR rather than accepting or dropping it.
+  const rawDeleteBody = await c.req.text();
+  if (rawDeleteBody.trim()) {
+    let parsedDeleteBody: unknown;
+    try {
+      parsedDeleteBody = JSON.parse(rawDeleteBody);
+    } catch {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "Invalid JSON body"
+      );
+    }
+    if (
+      !parsedDeleteBody ||
+      typeof parsedDeleteBody !== "object" ||
+      Array.isArray(parsedDeleteBody)
+    ) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "Request body must be a JSON object"
+      );
+    }
+    const strayDeleteFields = Object.keys(parsedDeleteBody).sort();
+    if (strayDeleteFields.length > 0) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        `Unexpected field(s) in delete body: ${strayDeleteFields.join(", ")}`
+      );
+    }
   }
   const token = await getConvexBearerForRequest(c);
   // `hosts:deleteHost` enforces project scope from `projectId`.

--- a/mcpjam-inspector/server/routes/v1/hosts.ts
+++ b/mcpjam-inspector/server/routes/v1/hosts.ts
@@ -190,7 +190,10 @@ const updateHostSchema = z
     message: "Provide at least one of `name` or `config` to update.",
   });
 
-const deleteHostSchema = z.object({ force: z.boolean().optional() });
+// Delete takes no body. A strict empty schema means a stray field (e.g. a
+// legacy `{ "force": true }`) is rejected as VALIDATION_ERROR rather than
+// silently accepted and dropped.
+const deleteHostSchema = z.object({}).strict();
 
 // ── Routes ───────────────────────────────────────────────────────────────────
 
@@ -273,16 +276,13 @@ hosts.patch("/projects/:projectId/hosts/:hostId", async (c) => {
 hosts.delete("/projects/:projectId/hosts/:hostId", async (c) => {
   const projectId = c.req.param("projectId");
   const hostId = c.req.param("hostId");
-  const body = parseWithSchema(deleteHostSchema, await synthesizeServerBody(c));
+  parseWithSchema(deleteHostSchema, await synthesizeServerBody(c));
   const token = await getConvexBearerForRequest(c);
   const readClient = createConvexReadClient(token);
   await requireHostInProject(readClient, projectId, hostId);
   const { convexClient } = createConvexClients(token);
   try {
-    await convexClient.mutation("hosts:deleteHost" as any, {
-      hostId,
-      ...(body.force ? { force: true } : {}),
-    });
+    await convexClient.mutation("hosts:deleteHost" as any, { hostId });
   } catch (error) {
     throw translateConvexWriteError(error);
   }

--- a/mcpjam-inspector/server/routes/v1/hosts.ts
+++ b/mcpjam-inspector/server/routes/v1/hosts.ts
@@ -4,10 +4,10 @@
  * Hosts are project-scoped identity rows that point at a content-addressed
  * host config (model + capabilities + host context). These routes are thin
  * proxies over the same Convex `hosts:*` functions the hosted UI uses, called
- * with the request's Convex bearer (Convex enforces project membership). Each
- * mutating/detail route additionally cross-checks the host against the path's
- * projectId (by listing the project's hosts) so a valid id from another
- * project reads as NOT_FOUND.
+ * with the request's Convex bearer (Convex enforces project membership). The
+ * detail/update/delete `hosts:*` functions take the path's projectId and scope
+ * the host to it inside Convex, so a valid id from another of the caller's
+ * projects reads as NOT_FOUND.
  *
  * `create` seeds the host config two ways: from a built-in template
  * (resolved server-side via `@mcpjam/sdk/host-config/templates` — the same
@@ -111,44 +111,20 @@ function translateConvexWriteError(error: unknown): WebRouteError {
   );
 }
 
-/**
- * List the project's hosts and return the row matching `hostId`. Throws 404
- * when the host doesn't exist in this project — the per-request project-scope
- * guard for detail/update/delete (Convex `hosts:getHost` is keyed by hostId
- * alone, so a bare getHost would leak a host from another of the caller's
- * projects under this path).
- */
-async function requireHostInProject(
-  readClient: ConvexHttpClient,
-  projectId: string,
-  hostId: string
-): Promise<HostListRow> {
-  let rows: HostListRow[] | null | undefined;
-  try {
-    rows = (await readClient.query("hosts:listHosts" as any, {
-      projectId,
-    } as any)) as HostListRow[] | null | undefined;
-  } catch (error) {
-    throw translateConvexWriteError(error);
-  }
-  const match = (rows ?? []).find((row) => row.hostId === hostId);
-  if (!match) {
-    throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Host not found");
-  }
-  return match;
-}
-
 async function readHostDetail(
   convexAuthToken: string,
   projectId: string,
   hostId: string
 ): Promise<HostDetailRow> {
   const readClient = createConvexReadClient(convexAuthToken);
-  await requireHostInProject(readClient, projectId, hostId);
   let detail: HostDetailRow | null;
   try {
+    // Convex `hosts:getHost` enforces project scope: passing `projectId` means
+    // a host id from another of the caller's projects returns null (→ 404
+    // below) instead of leaking across projects.
     detail = (await readClient.query("hosts:getHost" as any, {
       hostId,
+      projectId,
     } as any)) as HostDetailRow | null;
   } catch (error) {
     throw translateConvexWriteError(error);
@@ -189,11 +165,6 @@ const updateHostSchema = z
   .refine((value) => value.name !== undefined || value.config !== undefined, {
     message: "Provide at least one of `name` or `config` to update.",
   });
-
-// Delete takes no body. A strict empty schema means a stray field (e.g. a
-// legacy `{ "force": true }`) is rejected as VALIDATION_ERROR rather than
-// silently accepted and dropped.
-const deleteHostSchema = z.object({}).strict();
 
 // ── Routes ───────────────────────────────────────────────────────────────────
 
@@ -257,10 +228,10 @@ hosts.patch("/projects/:projectId/hosts/:hostId", async (c) => {
   const hostId = c.req.param("hostId");
   const body = parseWithSchema(updateHostSchema, await synthesizeServerBody(c));
   const token = await getConvexBearerForRequest(c);
-  const readClient = createConvexReadClient(token);
-  await requireHostInProject(readClient, projectId, hostId);
 
-  const updateArgs: Record<string, unknown> = { hostId };
+  // `hosts:updateHost` enforces project scope from `projectId` (a host from
+  // another project throws not-found → 404), so there is no separate preflight.
+  const updateArgs: Record<string, unknown> = { hostId, projectId };
   if (body.name !== undefined) updateArgs.name = body.name;
   if (body.config !== undefined) updateArgs.input = body.config;
   const { convexClient } = createConvexClients(token);
@@ -276,13 +247,30 @@ hosts.patch("/projects/:projectId/hosts/:hostId", async (c) => {
 hosts.delete("/projects/:projectId/hosts/:hostId", async (c) => {
   const projectId = c.req.param("projectId");
   const hostId = c.req.param("hostId");
-  parseWithSchema(deleteHostSchema, await synthesizeServerBody(c));
+  // Delete takes no body. `synthesizeServerBody` merges the path's
+  // projectId/serverId in, so strip those and reject anything left over
+  // (e.g. a legacy `force`) as VALIDATION_ERROR rather than dropping it.
+  const deleteBody = await synthesizeServerBody(c);
+  const strayDeleteFields = Object.keys(deleteBody).filter(
+    (key) => key !== "projectId" && key !== "serverId"
+  );
+  if (strayDeleteFields.length > 0) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      `Unexpected field(s) in delete body: ${strayDeleteFields
+        .sort()
+        .join(", ")}`
+    );
+  }
   const token = await getConvexBearerForRequest(c);
-  const readClient = createConvexReadClient(token);
-  await requireHostInProject(readClient, projectId, hostId);
+  // `hosts:deleteHost` enforces project scope from `projectId`.
   const { convexClient } = createConvexClients(token);
   try {
-    await convexClient.mutation("hosts:deleteHost" as any, { hostId });
+    await convexClient.mutation("hosts:deleteHost" as any, {
+      hostId,
+      projectId,
+    });
   } catch (error) {
     throw translateConvexWriteError(error);
   }

--- a/mcpjam-inspector/server/vitest.config.ts
+++ b/mcpjam-inspector/server/vitest.config.ts
@@ -22,6 +22,10 @@ const sdkHostConfigInternalEntry = path.resolve(
   rootDir,
   "../sdk/src/host-config/internal.ts",
 );
+const sdkHostConfigTemplatesEntry = path.resolve(
+  rootDir,
+  "../sdk/src/host-config/templates/index.ts",
+);
 const sdkPlatformEntry = path.resolve(rootDir, "../sdk/src/platform/index.ts");
 
 export default defineConfig({
@@ -61,6 +65,7 @@ export default defineConfig({
           "@mcpjam/sdk/matchers",
           "@mcpjam/sdk/predicates",
           "@mcpjam/sdk/host-config/internal",
+          "@mcpjam/sdk/host-config/templates",
           "@mcpjam/sdk/platform",
         ],
       },
@@ -90,6 +95,10 @@ export default defineConfig({
       {
         find: "@mcpjam/sdk/host-config/internal",
         replacement: sdkHostConfigInternalEntry,
+      },
+      {
+        find: "@mcpjam/sdk/host-config/templates",
+        replacement: sdkHostConfigTemplatesEntry,
       },
       { find: "@mcpjam/sdk/platform", replacement: sdkPlatformEntry },
       { find: "@mcpjam/sdk", replacement: sdkIndexEntry },

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -2426,10 +2426,6 @@ const deleteHostInput = z.object({
     .optional()
     .describe(PROJECT_SELECTOR_DESCRIPTION),
   host: z.string().trim().min(1).describe(HOST_SELECTOR_DESCRIPTION),
-  force: z
-    .boolean()
-    .optional()
-    .describe("Delete even if the host is still referenced (e.g. by suites)."),
 });
 export type DeleteHostInput = z.infer<typeof deleteHostInput>;
 
@@ -2454,7 +2450,6 @@ export const deleteHostOperation: PlatformOperation<
       {
         projectId: project.id,
         hostId: host.id,
-        body: input.force ? { force: true } : {},
       },
       { signal }
     );


### PR DESCRIPTION
Hardens the MCPJam public API (`/api/v1`), focused on the host surface plus two cross-cutting guards. Phases reference the approved plan.

## 1 — Remove the broken `force` delete param
`DELETE …/hosts/:id` accepted and forwarded a `force` flag to `hosts:deleteHost`, but that mutation only declares `{ hostId }`; Convex's strict validator rejected the unknown field, so `force: true` deletes failed with a 400. The flag also had no behavior to gate (eval refs are cascaded unconditionally). Removed end-to-end — route, CLI `--force`, SDK op, and `openapi.json`. Delete now validates a strict body, so a stray `{ "force": true }` returns `VALIDATION_ERROR` instead of being silently dropped.

## 2 — Project-scope hosts inside Convex
Replaced the per-request `requireHostInProject` list-and-scan preflight on get/update/delete with the path `projectId` threaded into `hosts:getHost/updateHost/deleteHost`, which now enforce scope themselves (see paired backend PR). A host id from another of the caller's projects reads as `NOT_FOUND` from Convex.

## 3 — Host route tests
New `server/routes/v1/__tests__/hosts.test.ts` (11 cases): auth + guest gating, DTO mapping (no `hostId` leak), `projectId` forwarding + null→404, create's template-XOR-config rule, and delete's `force` rejection. Also fixes `server/vitest.config.ts`, which lacked the `@mcpjam/sdk/host-config/templates` alias — the greedy root `@mcpjam/sdk` alias mangled the subpath, so **every** v1 route test that imports the router (e.g. `write-routes`) failed to resolve it here.

## 4 — OpenAPI drift check
New `server/routes/v1/__tests__/openapi-drift.test.ts` diffs the mounted router against `openapi.json` in both directions (+ operationId / global-security / requestBody checks). It immediately caught 15 genuinely undocumented routes (eval-suite/case management + eval-ingest), baselined in `KNOWN_UNDOCUMENTED` so the guard lands now and the spec is backfilled separately. Fails on any **new** drift and keeps the baseline tight.

## 6 — Docs
`server/routes/v1/README.md`: where new endpoints live (read → Convex `/v1` proxy; write → Convex mutation + thin adapter with scope enforced in Convex; side-effects → Hono only), and a classification of the eval routes' gateway logic (vocabulary mapping + REST PATCH translation stay; name→id resolution and domain invariants are candidates to move into Convex).

## Tests
All **150** v1 route tests pass: `vitest run server/routes/v1/__tests__/`.

## Coordination ⚠️
Pairs with **MCPJam/mcpjam-backend** branch `claude/nifty-bardeen-g7hliw`. **Deploy the backend first** — Phase 2 sends `projectId` to the host functions, which the current backend's strict validator would reject until it ships the optional arg.

## Not in this PR
Phase 5 (promote the duplicated public-API contract into a pure `@mcpjam/sdk/public-api` subpath) is deferred: it's gated on publishing a new SDK version and bumping the backend's pinned dependency, so it lands as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGuAoxiqicjL9MMq7uGGGK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGuAoxiqicjL9MMq7uGGGK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API and CLI behavior change (breaking for `force` delete) and host mutations now require the paired backend that accepts `projectId`; deploy backend before this gateway.
> 
> **Overview**
> Hardens the **`/api/v1` host surface** and related clients: broken **`force` delete** is removed everywhere, host **project scoping** moves into Convex, and CI gains **route + OpenAPI drift** guards.
> 
> **`force` delete removed end-to-end.** `DELETE …/hosts/:id` no longer accepts or forwards `force` (it previously failed against Convex’s strict validator). The CLI **`--force`**, SDK `deleteHost` input/body, and OpenAPI request body are aligned. Delete is **bodyless**: any JSON body (including legacy `{ "force": true }`) returns **`VALIDATION_ERROR`**.
> 
> **Gateway stops list-and-scan for host scope.** `requireHostInProject` is gone; get/update/delete pass the path **`projectId`** into `hosts:getHost` / `updateHost` / `deleteHost` so cross-project host IDs surface as **`NOT_FOUND`** in Convex (pairs with a backend deploy).
> 
> **New tests and docs.** `hosts.test.ts` covers auth, DTO mapping, `projectId` forwarding, and delete body rules. `openapi-drift.test.ts` diffs the mounted router against `openapi.json` (with a baselined backlog for undocumented eval routes). **`v1/README.md`** documents where new endpoints belong. **`vitest.config.ts`** adds the `@mcpjam/sdk/host-config/templates` alias so v1 route tests resolve templates correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30565a013e1ca5e91190ee8f46544151f7956eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->