### PR TITLE
refactor(evals): de-duplicate the runner's post-loop verdict pipeline

### DIFF
--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -8,7 +8,6 @@ import {
 import {
   evaluateMultiTurnResults,
   type EvaluationResult,
-  type MultiTurnEvaluationResult,
   type UsageTotals,
 } from "./evals/types";
 import { buildIterationMetadata } from "./evals/iteration-metadata";
@@ -19,7 +18,7 @@ import {
   type HostExecutionPolicy,
   type ToolExposureSignals,
 } from "@mcpjam/sdk/host-config/internal";
-import { finalizePassedForEval, type MCPClientManager } from "@mcpjam/sdk";
+import type { MCPClientManager } from "@mcpjam/sdk";
 import {
   createLlmModel,
   type BaseUrls,
@@ -50,16 +49,9 @@ import {
   type ModelProvider,
 } from "@/shared/types";
 import {
-  buildIterationTranscript,
-  buildTurnTranscript,
-  evaluatePredicates,
-  evaluateTurnChecks,
   extractFinalAssistantMessage,
   extractToolErrors,
-  summarizeRenderObservations,
-  type PredicateResult,
   type ToolErrorRecord,
-  type TurnChecksInput,
 } from "@/shared/eval-matching";
 import type { ConvexHttpClient } from "convex/browser";
 import { ErrorCode, WebRouteError } from "../routes/web/errors";
@@ -68,6 +60,10 @@ import {
   type SuiteRunRecorder,
 } from "./evals/recorder";
 import { runPinnedTurn } from "./evals/pinned-turn";
+import {
+  buildPromptTraceSummaries,
+  computeIterationVerdict,
+} from "./evals/iteration-verdict";
 import {
   createAiSdkEvalTraceContext,
   emitAiSdkOnStepFinish,
@@ -80,7 +76,6 @@ import type {
   EvalTraceSpan,
   PromptTraceSummary,
   EvalTraceWidgetSnapshot,
-  RunnerWidgetRenderObservation,
 } from "@/shared/eval-trace";
 import { appendDedupedModelMessages } from "@/shared/eval-trace";
 import {
@@ -276,21 +271,6 @@ export type EvalIterationOutcome = {
   evaluation: EvaluationResult;
   iterationId?: string;
 };
-
-/**
- * True when the provider/backend actually reported token usage. `accumulatedUsage`
- * is initialized to a zero object, so a zero total is indistinguishable from
- * "unmetered" — passing that into the transcript would let `tokenBudgetUnder`
- * pass on runs with no usage data. Only forward usage when something was
- * reported so the predicate can fail closed otherwise.
- */
-function hasReportedUsage(usage: UsageTotals): boolean {
-  return (
-    (usage.totalTokens ?? 0) > 0 ||
-    (usage.inputTokens ?? 0) > 0 ||
-    (usage.outputTokens ?? 0) > 0
-  );
-}
 
 export type RunEvalSuiteWithAiSdkResult = {
   /** Only set when `runId === null` (quick run); one entry per (test × run index) in suite order. */
@@ -535,73 +515,10 @@ function resolvePinnedServerKey(
  * carries what each runner already has per turn (tool calls, this turn's
  * assistant message + tool errors, and this turn's render observations).
  */
-function buildTurnCheckResults(
-  promptTurns: PromptTurn[],
-  perTurnSignals: {
-    toolsCalledByPrompt: ToolCall[][];
-    assistantMessageByPrompt: (string | undefined)[];
-    toolErrorsByPrompt: ToolErrorRecord[][];
-    renderObservations: readonly RunnerWidgetRenderObservation[];
-  }
-): PredicateResult[] {
-  const inputs: TurnChecksInput[] = promptTurns.map((turn, i) => ({
-    promptIndex: i,
-    checks: turn.checks,
-    transcript: buildTurnTranscript({
-      toolCalls: perTurnSignals.toolsCalledByPrompt[i] ?? [],
-      finalAssistantMessage: perTurnSignals.assistantMessageByPrompt[i],
-      toolErrors: perTurnSignals.toolErrorsByPrompt[i] ?? [],
-      renderObservations: summarizeRenderObservations(
-        perTurnSignals.renderObservations.filter((o) => o.promptIndex === i)
-      ),
-    }),
-  }));
-  return evaluateTurnChecks(inputs);
-}
-
-function buildPromptTraceSummaries(
-  evaluation: MultiTurnEvaluationResult,
-  turnCheckResults: PredicateResult[] = []
-): PromptTraceSummary[] {
-  return evaluation.promptSummaries.map((summary) => {
-    const perTurn = turnCheckResults.filter(
-      (r) => r.scope?.kind === "turn" && r.scope.promptIndex === summary.promptIndex
-    );
-    return {
-    promptIndex: summary.promptIndex,
-    prompt: summary.prompt,
-    expectedToolCalls: summary.expectedToolCalls,
-    actualToolCalls: summary.actualToolCalls,
-    expectedOutput: summary.expectedOutput,
-    passed: summary.passed,
-    ...(perTurn.length ? { predicateResults: perTurn } : {}),
-    missing: summary.missing,
-    unexpected: summary.unexpected,
-    argumentMismatches: summary.argumentMismatches.map((mismatch) => {
-      const mismatchedArguments = new Set<string>([
-        ...Object.keys(mismatch.expectedArgs ?? {}),
-        ...Object.keys(mismatch.actualArgs ?? {}),
-      ]);
-
-      return {
-        expected: {
-          toolName: mismatch.toolName,
-          arguments: mismatch.expectedArgs,
-        },
-        actual: {
-          toolName: mismatch.toolName,
-          arguments: mismatch.actualArgs,
-        },
-        mismatchedArguments: Array.from(mismatchedArguments).filter(
-          (key) =>
-            JSON.stringify(mismatch.expectedArgs?.[key]) !==
-            JSON.stringify(mismatch.actualArgs?.[key])
-        ),
-      };
-    }),
-    };
-  });
-}
+// `buildTurnCheckResults`, `buildPromptTraceSummaries`, and the post-loop
+// verdict pipeline (`computeIterationVerdict`) live in ./evals/iteration-verdict
+// so all four runner paths (local/hosted × batch/stream) share ONE
+// implementation instead of copy-pasting it (and silently drifting).
 
 function extractToolCallsFromConversation(params: {
   steps?: ReadonlyArray<any>;
@@ -1765,27 +1682,6 @@ const runIterationWithAiSdk = async ({
       activeCompletedStepCount = 0;
     }
 
-    const evaluation = evaluateMultiTurnResults(
-      promptTurns,
-      toolsCalledByPrompt,
-      test.isNegativeTest,
-      test.matchOptions
-    );
-    // Per-turn checks: each turn's `checks` evaluated against its own slice
-    // of the transcript (tool calls / assistant message / tool errors /
-    // render observations for that turn). Independent of the suite/case
-    // predicate layering; runs whenever a turn authored checks.
-    const turnCheckResults = buildTurnCheckResults(promptTurns, {
-      toolsCalledByPrompt,
-      assistantMessageByPrompt,
-      toolErrorsByPrompt,
-      renderObservations: browser.widgetRenderObservations,
-    });
-    const promptTraceSummaries = buildPromptTraceSummaries(
-      evaluation,
-      turnCheckResults
-    );
-
     const failOnToolError =
       (advancedConfig as { failOnToolError?: boolean } | undefined)
         ?.failOnToolError !== false;
@@ -1799,62 +1695,27 @@ const runIterationWithAiSdk = async ({
             }>,
           }
         : undefined;
-    // A pinned-only case (today's render check) with no authored predicates
-    // defaults to "the widget rendered" — the model-free equivalent of the
-    // legacy probe verdict (`toolCallOk && rendered`). An errored/non-renderable
-    // pinned call produces no `rendered` observation, so this fails closed.
-    // Hybrid/model cases keep the normal match-driven verdict when unauthored.
-    const effectivePredicates = test.successPredicates?.length
-      ? test.successPredicates
-      : isPinnedOnly({ caseType: test.caseType, promptTurns })
-        ? ([{ type: "widgetRendered" }] as NonNullable<
-            typeof test.successPredicates
-          >)
-        : undefined;
-    const casePredicateResults = effectivePredicates?.length
-      ? evaluatePredicates(
-          buildIterationTranscript({
-            trace: traceForGate,
-            toolCalls: evaluation.toolsCalled,
-            usage: hasReportedUsage(accumulatedUsage)
-              ? accumulatedUsage
-              : undefined,
-            renderObservations: summarizeRenderObservations(
-              browser.widgetRenderObservations,
-            ),
-            // Pinned turns have no trace; thread their tool errors explicitly.
-            toolErrors: pinnedToolErrors,
-          }),
-          effectivePredicates
-        )
-      : [];
-    // Case-level + per-turn (scope-tagged) results gate the verdict and
-    // persist together (testIteration.metadata.predicates).
-    const predicateResults = [...casePredicateResults, ...turnCheckResults];
-    let passed = finalizePassedForEval({
-      matchPassed: evaluation.passed,
-      trace: traceForGate,
-      // PR 4b (mirrors PR 3 invariant): if the per-turn loop set
-      // `iterationError` via the failure-detection branch (no new
-      // messages, non-tool error span), feed it to the gate so a
-      // failed cycle doesn't sneak through as a verdict pass on
-      // negative tests / zero-expected-tool cases.
-      iterationError,
-      failOnToolError,
-      predicateResults,
-    });
-    // A pinned (model-free) tool call's error never enters the trace, so
-    // `finalizePassedForEval`'s `failOnToolError` gate (which inspects the
-    // trace) is blind to it. Apply the gate explicitly to pinned tool errors
-    // so a failing pinned call can't pass when tool-error gating is on and no
-    // widget/`noToolErrors` predicate happened to catch it.
-    if (passed && failOnToolError && pinnedToolErrors.length > 0) {
-      passed = false;
-    }
-    // Reflect the gated verdict (match AND tool-error gate AND predicates) in
-    // the returned evaluation so totals built from `evaluation.passed` agree
-    // with the persisted iteration result.
-    evaluation.passed = passed;
+    // Shared post-loop verdict: tool-call scoring + per-turn checks +
+    // case-level predicates + gate (incl. pinned-only widget default and the
+    // pinned-tool-error gate). The local batch path captures per-turn signals.
+    const { evaluation, promptTraceSummaries, allPredicateResults, passed } =
+      computeIterationVerdict({
+        test,
+        promptTurns,
+        toolsCalledByPrompt,
+        perTurnSignals: {
+          kind: "captured",
+          assistantMessageByPrompt,
+          toolErrorsByPrompt,
+        },
+        renderObservations: browser.widgetRenderObservations,
+        traceForGate,
+        accumulatedUsage,
+        pinnedToolErrors,
+        failOnToolError,
+        iterationError,
+      });
+    const predicateResults = allPredicateResults;
 
     const usage: UsageTotals = {
       inputTokens: accumulatedUsage.inputTokens,
@@ -2216,6 +2077,9 @@ const runIterationViaBackendWithBrowser = async (
 
   const messageHistory: ModelMessage[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
+  // Per-turn signals for per-turn checks (captured by driveHostedEvalTurn).
+  const assistantMessageByPrompt: (string | undefined)[] = [];
+  const toolErrorsByPrompt: ToolErrorRecord[][] = [];
   const runStartedAt = Date.now();
   const iterationMetadataBase: Record<string, string | number | boolean> = {};
   if (promptTurns.length > 1) {
@@ -2439,6 +2303,8 @@ const runIterationViaBackendWithBrowser = async (
         capturedSpans,
         accumulatedUsage,
         toolsCalledByPrompt,
+        assistantMessageByPrompt,
+        toolErrorsByPrompt,
       },
     });
     if (outcome.kind === "cancelled") return returnCancelled();
@@ -2448,14 +2314,6 @@ const runIterationViaBackendWithBrowser = async (
       break;
     }
   }
-
-  const evaluation = evaluateMultiTurnResults(
-    promptTurns,
-    toolsCalledByPrompt,
-    test.isNegativeTest,
-    test.matchOptions
-  );
-  const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
   const failOnToolError =
     (advancedConfig as { failOnToolError?: boolean } | undefined)
@@ -2470,32 +2328,26 @@ const runIterationViaBackendWithBrowser = async (
           }>,
         }
       : undefined;
-  const predicateResults = test.successPredicates?.length
-    ? evaluatePredicates(
-        buildIterationTranscript({
-          trace: traceForGate,
-          toolCalls: evaluation.toolsCalled,
-          usage: hasReportedUsage(accumulatedUsage)
-            ? accumulatedUsage
-            : undefined,
-          renderObservations: summarizeRenderObservations(
-            browser.widgetRenderObservations,
-          ),
-        }),
-        test.successPredicates
-      )
-    : [];
-  const passed = finalizePassedForEval({
-    matchPassed: evaluation.passed,
-    trace: traceForGate,
-    iterationError,
-    failOnToolError,
-    predicateResults,
-  });
-  // Reflect the gated verdict (match AND tool-error gate AND predicates) in the
-  // returned evaluation so totals built from `evaluation.passed` agree with the
-  // persisted iteration result.
-  evaluation.passed = passed;
+  // Shared post-loop verdict (see computeIterationVerdict). Hosted paths now
+  // capture per-turn signals via driveHostedEvalTurn, so per-turn checks run
+  // here too. Hosted paths run no pinned turns (no pinnedToolErrors).
+  const { evaluation, promptTraceSummaries, allPredicateResults, passed } =
+    computeIterationVerdict({
+      test,
+      promptTurns,
+      toolsCalledByPrompt,
+      perTurnSignals: {
+        kind: "captured",
+        assistantMessageByPrompt,
+        toolErrorsByPrompt,
+      },
+      renderObservations: browser.widgetRenderObservations,
+      traceForGate,
+      accumulatedUsage,
+      failOnToolError,
+      iterationError,
+    });
+  const predicateResults = allPredicateResults;
   const widgetSnapshots = await captureMcpAppWidgetSnapshots({
     injectOpenAiCompat,
     messages: messageHistory,
@@ -3879,24 +3731,6 @@ const streamIterationWithAiSdk = async ({
       }
     }
 
-    const evaluation = evaluateMultiTurnResults(
-      promptTurns,
-      toolsCalledByPrompt,
-      test.isNegativeTest,
-      test.matchOptions
-    );
-    // Per-turn checks: each turn's `checks` evaluated against its own slice.
-    const turnCheckResults = buildTurnCheckResults(promptTurns, {
-      toolsCalledByPrompt,
-      assistantMessageByPrompt,
-      toolErrorsByPrompt,
-      renderObservations: browser.widgetRenderObservations,
-    });
-    const promptTraceSummaries = buildPromptTraceSummaries(
-      evaluation,
-      turnCheckResults
-    );
-
     const failOnToolError =
       (advancedConfig as { failOnToolError?: boolean } | undefined)
         ?.failOnToolError !== false;
@@ -3910,39 +3744,26 @@ const streamIterationWithAiSdk = async ({
             }>,
           }
         : undefined;
-    const casePredicateResults = test.successPredicates?.length
-      ? evaluatePredicates(
-          buildIterationTranscript({
-            trace: traceForGate,
-            toolCalls: evaluation.toolsCalled,
-            usage: hasReportedUsage(accumulatedUsage)
-              ? accumulatedUsage
-              : undefined,
-            renderObservations: summarizeRenderObservations(
-              browser.widgetRenderObservations,
-            ),
-          }),
-          test.successPredicates
-        )
-      : [];
-    // Case-level + per-turn (scope-tagged) results gate the verdict and
-    // persist together.
-    const predicateResults = [...casePredicateResults, ...turnCheckResults];
-    const passed = finalizePassedForEval({
-      matchPassed: evaluation.passed,
-      trace: traceForGate,
-      // PR 5a (mirror PR 4b): if the per-turn loop set `iterationError`
-      // via the failure-detection branch, feed it to the gate so a
-      // failed cycle doesn't sneak through as a verdict pass on
-      // negative tests / zero-expected-tool cases.
-      iterationError,
-      failOnToolError,
-      predicateResults,
-    });
-    // Reflect the gated verdict (match AND tool-error gate AND predicates) in
-    // the returned evaluation so totals built from `evaluation.passed` agree
-    // with the persisted iteration result.
-    evaluation.passed = passed;
+    // Shared post-loop verdict (see computeIterationVerdict). Streaming local
+    // path captures per-turn signals; it rejects pinned turns earlier, so the
+    // pinned-only default never fires and there are no pinned tool errors.
+    const { evaluation, promptTraceSummaries, allPredicateResults, passed } =
+      computeIterationVerdict({
+        test,
+        promptTurns,
+        toolsCalledByPrompt,
+        perTurnSignals: {
+          kind: "captured",
+          assistantMessageByPrompt,
+          toolErrorsByPrompt,
+        },
+        renderObservations: browser.widgetRenderObservations,
+        traceForGate,
+        accumulatedUsage,
+        failOnToolError,
+        iterationError,
+      });
+    const predicateResults = allPredicateResults;
 
     const usageFinal: UsageTotals = {
       inputTokens: accumulatedUsage.inputTokens,
@@ -4325,6 +4146,9 @@ const streamIterationViaBackendWithBrowser = async (
 
   const messageHistory: ModelMessage[] = [];
   const toolsCalledByPrompt: ToolCall[][] = [];
+  // Per-turn signals for per-turn checks (captured by driveHostedEvalTurn).
+  const assistantMessageByPrompt: (string | undefined)[] = [];
+  const toolErrorsByPrompt: ToolErrorRecord[][] = [];
   const runStartedAt = Date.now();
   const iterationMetadataBase: Record<string, string | number | boolean> = {};
   if (promptTurns.length > 1) {
@@ -4557,6 +4381,8 @@ const streamIterationViaBackendWithBrowser = async (
         capturedSpans,
         accumulatedUsage,
         toolsCalledByPrompt,
+        assistantMessageByPrompt,
+        toolErrorsByPrompt,
       },
       buildSinks: ({ baselineUsage, traceCtx, promptToolsCalled }) => {
         // Track engine-emitted step events so the post-turn `turn_finish`
@@ -4787,14 +4613,6 @@ const streamIterationViaBackendWithBrowser = async (
     }
   }
 
-  const evaluation = evaluateMultiTurnResults(
-    promptTurns,
-    toolsCalledByPrompt,
-    test.isNegativeTest,
-    test.matchOptions
-  );
-  const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
-
   const failOnToolError =
     (advancedConfig as { failOnToolError?: boolean } | undefined)
       ?.failOnToolError !== false;
@@ -4808,32 +4626,26 @@ const streamIterationViaBackendWithBrowser = async (
           }>,
         }
       : undefined;
-  const predicateResults = test.successPredicates?.length
-    ? evaluatePredicates(
-        buildIterationTranscript({
-          trace: traceForGate,
-          toolCalls: evaluation.toolsCalled,
-          usage: hasReportedUsage(accumulatedUsage)
-            ? accumulatedUsage
-            : undefined,
-          renderObservations: summarizeRenderObservations(
-            browser.widgetRenderObservations,
-          ),
-        }),
-        test.successPredicates
-      )
-    : [];
-  const passed = finalizePassedForEval({
-    matchPassed: evaluation.passed,
-    trace: traceForGate,
-    iterationError,
-    failOnToolError,
-    predicateResults,
-  });
-  // Reflect the gated verdict (match AND tool-error gate AND predicates) in the
-  // returned evaluation so totals built from `evaluation.passed` agree with the
-  // persisted iteration result.
-  evaluation.passed = passed;
+  // Shared post-loop verdict (see computeIterationVerdict). Hosted paths now
+  // capture per-turn signals via driveHostedEvalTurn, so per-turn checks run
+  // here too. Hosted paths run no pinned turns (no pinnedToolErrors).
+  const { evaluation, promptTraceSummaries, allPredicateResults, passed } =
+    computeIterationVerdict({
+      test,
+      promptTurns,
+      toolsCalledByPrompt,
+      perTurnSignals: {
+        kind: "captured",
+        assistantMessageByPrompt,
+        toolErrorsByPrompt,
+      },
+      renderObservations: browser.widgetRenderObservations,
+      traceForGate,
+      accumulatedUsage,
+      failOnToolError,
+      iterationError,
+    });
+  const predicateResults = allPredicateResults;
   const widgetSnapshots = await captureMcpAppWidgetSnapshots({
     injectOpenAiCompat,
     messages: messageHistory,

--- a/mcpjam-inspector/server/services/evals/__tests__/iteration-verdict.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/iteration-verdict.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { computeIterationVerdict } from "../iteration-verdict";
+import type { PromptTurn } from "@/shared/prompt-turns";
+
+// The shared post-loop verdict pipeline used by all four runner paths. These
+// tests lock in the behavior that the four copies used to drift on: per-turn
+// checks evaluate + merge + scope-tag, and a runner that authored per-turn
+// checks but supplied no signals fails LOUDLY rather than silently dropping them.
+
+function turn(over: Partial<PromptTurn> & { id: string }): PromptTurn {
+  return { prompt: "", expectedToolCalls: [], ...over };
+}
+
+const baseInput = {
+  test: {},
+  toolsCalledByPrompt: [[]] as { toolName: string; arguments: Record<string, unknown> }[][],
+  renderObservations: [],
+  traceForGate: undefined,
+  accumulatedUsage: {},
+  failOnToolError: true,
+} as const;
+
+describe("computeIterationVerdict", () => {
+  it("evaluates per-turn checks, scope-tags them, and merges into allPredicateResults", () => {
+    const promptTurns = [
+      turn({ id: "t1", prompt: "weather?", checks: [{ type: "responseContains", needle: "sunny" }] }),
+    ];
+    const result = computeIterationVerdict({
+      ...baseInput,
+      promptTurns,
+      perTurnSignals: {
+        kind: "captured",
+        assistantMessageByPrompt: ["it is sunny today"],
+        toolErrorsByPrompt: [[]],
+      },
+    });
+    expect(result.turnCheckResults).toHaveLength(1);
+    expect(result.turnCheckResults[0]).toMatchObject({
+      passed: true,
+      scope: { kind: "turn", promptIndex: 0 },
+    });
+    // case (none here) ++ per-turn
+    expect(result.allPredicateResults).toEqual(result.turnCheckResults);
+    // per-turn verdict surfaces on the trace summary for that turn
+    expect(result.promptTraceSummaries[0].predicateResults).toHaveLength(1);
+  });
+
+  it("throws when a turn authored checks but the runner passed kind:'none'", () => {
+    const promptTurns = [
+      turn({ id: "t1", checks: [{ type: "responseContains", needle: "x" }] }),
+    ];
+    expect(() =>
+      computeIterationVerdict({
+        ...baseInput,
+        promptTurns,
+        perTurnSignals: { kind: "none" },
+      }),
+    ).toThrow(/per-turn checks/i);
+  });
+
+  it("does not throw for kind:'none' when no turn authored checks", () => {
+    const promptTurns = [turn({ id: "t1", prompt: "hi" })];
+    const result = computeIterationVerdict({
+      ...baseInput,
+      promptTurns,
+      perTurnSignals: { kind: "none" },
+    });
+    expect(result.turnCheckResults).toEqual([]);
+    expect(result.allPredicateResults).toEqual([]);
+  });
+
+  it("returns a NEW evaluation (does not depend on a caller-mutated object)", () => {
+    const promptTurns = [turn({ id: "t1", prompt: "hi" })];
+    const result = computeIterationVerdict({
+      ...baseInput,
+      promptTurns,
+      perTurnSignals: { kind: "none" },
+    });
+    expect(typeof result.evaluation.passed).toBe("boolean");
+    expect(result.evaluation.passed).toBe(result.passed);
+  });
+});

--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -47,6 +47,11 @@ import {
   wrapToolSetForEvalTrace,
 } from "./eval-trace-capture";
 import type { UsageTotals } from "./types";
+import {
+  extractFinalAssistantMessage,
+  extractToolErrors,
+  type ToolErrorRecord,
+} from "@/shared/eval-matching";
 
 type ToolCall = { toolName: string; arguments: Record<string, any> };
 
@@ -141,6 +146,11 @@ export interface DriveHostedEvalTurnParams {
     capturedSpans: EvalTraceSpan[];
     accumulatedUsage: UsageTotals;
     toolsCalledByPrompt: ToolCall[][];
+    // Per-turn signals for per-turn checks (PromptTurn.checks), indexed by
+    // promptIndex parallel to toolsCalledByPrompt. Populated on turn success;
+    // a turn that fails before capture leaves its slot unset (fail-closed).
+    assistantMessageByPrompt: (string | undefined)[];
+    toolErrorsByPrompt: ToolErrorRecord[][];
   };
   buildSinks?: (ctx: HostedEvalTurnSinkContext) => HostedEvalTurnSinks;
 }
@@ -415,6 +425,17 @@ export async function driveHostedEvalTurn(
   const canonicalPromptToolsCalled = params.extractToolCalls(newMessages);
   promptToolsCalled.length = 0;
   promptToolsCalled.push(...canonicalPromptToolsCalled);
+
+  // Per-turn signals for per-turn checks — same capture the local runners do,
+  // so the shared verdict helper evaluates PromptTurn.checks on hosted evals
+  // too. This turn's assistant text + tool errors, scoped to this turn's new
+  // messages and spans (wrap tool spans + the engine's turnTrace spans).
+  acc.assistantMessageByPrompt[promptIndex] =
+    extractFinalAssistantMessage(newMessages);
+  acc.toolErrorsByPrompt[promptIndex] = extractToolErrors({
+    spans: [...traceCtx.recordedSpans, ...(turnResult.turnTrace?.spans ?? [])],
+    messages: newMessages as Array<{ role: string; content: unknown }>,
+  });
 
   // Roll the engine's transcript forward as the next turn's starting point.
   acc.messageHistory.length = 0;

--- a/mcpjam-inspector/server/services/evals/iteration-verdict.ts
+++ b/mcpjam-inspector/server/services/evals/iteration-verdict.ts
@@ -1,0 +1,285 @@
+/**
+ * The shared post-loop verdict pipeline for an eval iteration.
+ *
+ * The four runner variants (local/hosted × batch/stream in `evals-runner.ts`)
+ * differ only in HOW a turn is executed and whether SSE is emitted. Everything
+ * AFTER the turn loop — score tool calls, run per-turn checks, run case-level
+ * predicates, gate the verdict, build the per-turn trace summaries — is the
+ * same, and used to be copy-pasted ~4× (which silently drifted: backend paths
+ * dropped per-turn checks and the pinned-render default). It lives here once.
+ *
+ * The turn loop and persistence (`finishParams`) stay per-path; this module is
+ * purely the verdict computation, kept as pure as practical (no I/O, returns a
+ * NEW evaluation rather than mutating the caller's).
+ */
+
+import { finalizePassedForEval } from "@mcpjam/sdk";
+import {
+  evaluateMultiTurnResults,
+  type MultiTurnEvaluationResult,
+  type ToolCall,
+  type UsageTotals,
+} from "../evals/types";
+import {
+  buildIterationTranscript,
+  buildTurnTranscript,
+  evaluatePredicates,
+  evaluateTurnChecks,
+  summarizeRenderObservations,
+  type MatchOptionsDTO,
+  type Predicate,
+  type PredicateResult,
+  type ToolErrorRecord,
+  type TurnChecksInput,
+} from "@/shared/eval-matching";
+import { isPinnedOnly, type PromptTurn } from "@/shared/prompt-turns";
+import type {
+  PromptTraceSummary,
+  RunnerWidgetRenderObservation,
+} from "@/shared/eval-trace";
+import type { TestCaseType } from "@/shared/probe-config";
+
+/**
+ * Per-turn check verdicts, evaluated by `evaluateTurnChecks` against each
+ * turn's slice of the transcript. `perTurnSignals` carries what a runner
+ * captured per turn (tool calls, this turn's assistant message + tool errors,
+ * and this turn's render observations — grouped by promptIndex).
+ */
+export function buildTurnCheckResults(
+  promptTurns: PromptTurn[],
+  perTurnSignals: {
+    toolsCalledByPrompt: ToolCall[][];
+    assistantMessageByPrompt: (string | undefined)[];
+    toolErrorsByPrompt: ToolErrorRecord[][];
+    renderObservations: readonly RunnerWidgetRenderObservation[];
+  }
+): PredicateResult[] {
+  const inputs: TurnChecksInput[] = promptTurns.map((turn, i) => ({
+    promptIndex: i,
+    checks: turn.checks,
+    transcript: buildTurnTranscript({
+      toolCalls: perTurnSignals.toolsCalledByPrompt[i] ?? [],
+      finalAssistantMessage: perTurnSignals.assistantMessageByPrompt[i],
+      toolErrors: perTurnSignals.toolErrorsByPrompt[i] ?? [],
+      renderObservations: summarizeRenderObservations(
+        perTurnSignals.renderObservations.filter((o) => o.promptIndex === i)
+      ),
+    }),
+  }));
+  return evaluateTurnChecks(inputs);
+}
+
+export function buildPromptTraceSummaries(
+  evaluation: MultiTurnEvaluationResult,
+  turnCheckResults: PredicateResult[] = []
+): PromptTraceSummary[] {
+  return evaluation.promptSummaries.map((summary) => {
+    const perTurn = turnCheckResults.filter(
+      (r) =>
+        r.scope?.kind === "turn" && r.scope.promptIndex === summary.promptIndex
+    );
+    return {
+      promptIndex: summary.promptIndex,
+      prompt: summary.prompt,
+      expectedToolCalls: summary.expectedToolCalls,
+      actualToolCalls: summary.actualToolCalls,
+      expectedOutput: summary.expectedOutput,
+      passed: summary.passed,
+      ...(perTurn.length ? { predicateResults: perTurn } : {}),
+      missing: summary.missing,
+      unexpected: summary.unexpected,
+      argumentMismatches: summary.argumentMismatches.map((mismatch) => {
+        const mismatchedArguments = new Set<string>([
+          ...Object.keys(mismatch.expectedArgs ?? {}),
+          ...Object.keys(mismatch.actualArgs ?? {}),
+        ]);
+        return {
+          expected: {
+            toolName: mismatch.toolName,
+            arguments: mismatch.expectedArgs,
+          },
+          actual: {
+            toolName: mismatch.toolName,
+            arguments: mismatch.actualArgs,
+          },
+          mismatchedArguments: Array.from(mismatchedArguments).filter(
+            (key) =>
+              JSON.stringify(mismatch.expectedArgs?.[key]) !==
+              JSON.stringify(mismatch.actualArgs?.[key])
+          ),
+        };
+      }),
+    };
+  });
+}
+
+/**
+ * Whether the runner captured per-turn signals for this iteration.
+ *
+ * EXPLICIT discriminator, not silently-optional: a runner that ran turns but
+ * couldn't capture per-turn data passes `{ kind: "none" }`, and
+ * `computeIterationVerdict` then refuses to silently drop authored per-turn
+ * checks (it throws — see below). That silent drop is the exact regression this
+ * extraction exists to make impossible.
+ */
+export type PerTurnSignals =
+  | { kind: "none" }
+  | {
+      kind: "captured";
+      assistantMessageByPrompt: (string | undefined)[];
+      toolErrorsByPrompt: ToolErrorRecord[][];
+    };
+
+/** The resolved-snapshot fields of a test case the verdict depends on. */
+export type VerdictTestInput = {
+  isNegativeTest?: boolean;
+  matchOptions?: MatchOptionsDTO;
+  /** Resolved predicate list pinned on the iteration snapshot — NOT live state. */
+  successPredicates?: Predicate[];
+  caseType?: TestCaseType;
+};
+
+export type ComputeIterationVerdictInput = {
+  test: VerdictTestInput;
+  promptTurns: PromptTurn[];
+  toolsCalledByPrompt: ToolCall[][];
+  perTurnSignals: PerTurnSignals;
+  /**
+   * Full iteration render-observation list, each entry promptIndex-stamped by
+   * the runner (`RunnerWidgetRenderObservation.promptIndex` is always set).
+   * Used for both case-level `widget*` checks and per-turn grouping.
+   */
+  renderObservations: readonly RunnerWidgetRenderObservation[];
+  traceForGate: Parameters<typeof buildIterationTranscript>[0]["trace"];
+  accumulatedUsage: UsageTotals;
+  /** Pinned (model-free) tool errors — local batch only; absent elsewhere. */
+  pinnedToolErrors?: ToolErrorRecord[];
+  failOnToolError: boolean;
+  iterationError?: string;
+};
+
+export type ComputeIterationVerdictResult = {
+  /** A NEW evaluation with the gated verdict applied — caller's input is untouched. */
+  evaluation: MultiTurnEvaluationResult;
+  passed: boolean;
+  casePredicateResults: PredicateResult[];
+  turnCheckResults: PredicateResult[];
+  /** case ++ per-turn — the flattened blob persisted to metadata.predicates. */
+  allPredicateResults: PredicateResult[];
+  promptTraceSummaries: PromptTraceSummary[];
+};
+
+function usageReported(usage: UsageTotals): boolean {
+  return (
+    (usage.totalTokens ?? 0) > 0 ||
+    (usage.inputTokens ?? 0) > 0 ||
+    (usage.outputTokens ?? 0) > 0
+  );
+}
+
+/**
+ * Score an iteration and produce its verdict + persisted results, shared by all
+ * four runner paths. Pure: no I/O, returns new values.
+ */
+export function computeIterationVerdict(
+  input: ComputeIterationVerdictInput
+): ComputeIterationVerdictResult {
+  const {
+    test,
+    promptTurns,
+    toolsCalledByPrompt,
+    perTurnSignals,
+    renderObservations,
+    traceForGate,
+    accumulatedUsage,
+    pinnedToolErrors,
+    failOnToolError,
+    iterationError,
+  } = input;
+
+  const baseEvaluation = evaluateMultiTurnResults(
+    promptTurns,
+    toolsCalledByPrompt,
+    test.isNegativeTest,
+    test.matchOptions
+  );
+
+  const turnCheckResults =
+    perTurnSignals.kind === "captured"
+      ? buildTurnCheckResults(promptTurns, {
+          toolsCalledByPrompt,
+          assistantMessageByPrompt: perTurnSignals.assistantMessageByPrompt,
+          toolErrorsByPrompt: perTurnSignals.toolErrorsByPrompt,
+          renderObservations,
+        })
+      : [];
+
+  // Loud, not silent: never drop authored per-turn checks just because the
+  // caller didn't capture per-turn signals. (Backend paths used to do exactly
+  // that — silently. This guard turns that latent bug into a hard failure.)
+  if (
+    perTurnSignals.kind === "none" &&
+    promptTurns.some((t) => (t.checks?.length ?? 0) > 0)
+  ) {
+    throw new Error(
+      "computeIterationVerdict: promptTurns authored per-turn checks but the " +
+        "runner passed perTurnSignals { kind: 'none' }. Capture per-turn " +
+        "signals (assistant message + tool errors) or those checks would be " +
+        "silently ignored."
+    );
+  }
+
+  const promptTraceSummaries = buildPromptTraceSummaries(
+    baseEvaluation,
+    turnCheckResults
+  );
+
+  // Effective predicates come ONLY from the resolved test snapshot, never
+  // recomputed from live suite/case state. A pinned-only case with no authored
+  // predicates defaults to "the widget rendered" (fails closed if nothing did).
+  const effectivePredicates: Predicate[] | undefined = test.successPredicates
+    ?.length
+    ? test.successPredicates
+    : isPinnedOnly({ caseType: test.caseType, promptTurns })
+      ? [{ type: "widgetRendered" }]
+      : undefined;
+
+  const casePredicateResults = effectivePredicates?.length
+    ? evaluatePredicates(
+        buildIterationTranscript({
+          trace: traceForGate,
+          toolCalls: baseEvaluation.toolsCalled,
+          usage: usageReported(accumulatedUsage) ? accumulatedUsage : undefined,
+          renderObservations: summarizeRenderObservations(renderObservations),
+          // Pinned turns have no trace; thread their tool errors explicitly.
+          ...(pinnedToolErrors ? { toolErrors: pinnedToolErrors } : {}),
+        }),
+        effectivePredicates
+      )
+    : [];
+
+  const allPredicateResults = [...casePredicateResults, ...turnCheckResults];
+
+  let passed = finalizePassedForEval({
+    matchPassed: baseEvaluation.passed,
+    trace: traceForGate,
+    iterationError,
+    failOnToolError,
+    predicateResults: allPredicateResults,
+  });
+  // A pinned (model-free) tool call's error never enters the trace, so the
+  // `failOnToolError` gate (which inspects the trace) is blind to it. Apply it
+  // explicitly so a failing pinned call can't pass.
+  if (passed && failOnToolError && (pinnedToolErrors?.length ?? 0) > 0) {
+    passed = false;
+  }
+
+  return {
+    evaluation: { ...baseEvaluation, passed },
+    passed,
+    casePredicateResults,
+    turnCheckResults,
+    allPredicateResults,
+    promptTraceSummaries,
+  };
+}


### PR DESCRIPTION
## Context

The four eval iteration runners (`runIterationWithAiSdk`, `runIterationViaBackendWithBrowser`, `streamIterationWithAiSdk`, `streamIterationViaBackendWithBrowser`) genuinely differ in only two ways — **how a turn is executed** (local AI-SDK vs hosted `driveHostedEvalTurn`) and **whether SSE is emitted**. Everything *after* the turn loop (score tool calls → per-turn checks → case-level predicates → gate verdict → trace summaries) was **copy-pasted ~4×** and had drifted: the two backend paths silently ignored `PromptTurn.checks`, and the `isPinnedOnly → widgetRendered` default lived in only one path.

This extracts that post-loop sequence into one shared helper and, as a result, makes per-turn checks work on every path (the work we'd been calling "Phase 2c" — now subsumed, not a 4th copy).

Two commits, kept on one branch (see "Sequencing").

## Commit 1 — extract `computeIterationVerdict` (behavior-preserving)

- New `server/services/evals/iteration-verdict.ts`: `computeIterationVerdict` + the moved `buildTurnCheckResults` / `buildPromptTraceSummaries`. All four runners now call it.
- The helper is **pure** (returns a NEW `evaluation`, no in-place mutation), reads `effectivePredicates` only from the resolved test snapshot, and takes an **explicit `perTurnSignals` discriminator**. A runner that authored per-turn checks but passes `{ kind: "none" }` **throws loudly** rather than silently dropping them — the exact drift this extraction exists to prevent.
- Returns broken-out `casePredicateResults` / `turnCheckResults` / `allPredicateResults` (flattened blob persisted at the boundary).

## Commit 2 — per-turn checks on hosted runners (the old "Phase 2c")

- `driveHostedEvalTurn` captures each turn's assistant message + tool errors into `acc`; both backend runners pass `{ kind: "captured" }`. One change, both hosted paths fixed (they share the helper).

## Sequencing

Because the guard makes commit 1 *alone* throw for a hosted case that authored per-turn checks, both commits ship together — no window where hosted+checks breaks. Happy to split into stacked PRs if preferred.

## Testing

- **All 71 `evals-runner` tests pass unchanged** — the behavior-preservation gate for the extraction.
- New `iteration-verdict.test.ts` (4): loud guard, per-turn merge + scope tagging, `kind:"none"` no-op, pure evaluation.
- `drive-hosted-eval-turn` + `finalize-iteration` tests green.
- Typecheck adds no new errors (only the pre-existing unused-import / `testCaseSnapshot` ones remain; the new module is clean).

## Not in scope

The per-turn execution loop + local↔hosted split (the genuinely irreducible difference) and the stream/batch consumption difference — that's the separate in-flight `runAssistantTurn` engine-consolidation effort. This PR deliberately stops at the post-loop seam, complementary to that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how pass/fail is computed across all eval runner paths; behavior is intended to be preserved for local runners while fixing hosted per-turn checks and verdict drift, so regression risk sits in eval grading and persistence metadata.
> 
> **Overview**
> **Consolidates** the duplicated post-turn-loop scoring logic from four eval runner variants into a single **`computeIterationVerdict`** module (`buildTurnCheckResults`, `buildPromptTraceSummaries`, multi-turn match, case/turn predicates, `finalizePassedForEval`, pinned-only `widgetRendered` default, pinned tool-error gate).
> 
> All four paths (local/hosted × batch/stream) now call that helper instead of inline copies, with an explicit **`perTurnSignals`** discriminator: **`{ kind: "none" }`** when signals weren’t captured throws if any turn has **`checks`**, so per-turn assertions can’t be dropped silently.
> 
> **Hosted runners** now populate per-turn assistant text and tool errors in **`driveHostedEvalTurn`** and pass **`{ kind: "captured" }`**, so **`PromptTurn.checks`** run on backend batch and stream paths the same as local runners. New **`iteration-verdict.test.ts`** locks merge/scope-tag behavior and the loud guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f698abbe17dbfc6b8ed8ce0aa2019a4a61ca8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->