### PR TITLE
fix(cli): ad-hoc connect for apps render/session so --url targets work

### DIFF
--- a/cli/src/lib/inspector-api.ts
+++ b/cli/src/lib/inspector-api.ts
@@ -530,12 +530,19 @@ export class InspectorApiClient {
     return ensureInspectorBackend({ ...options, baseUrl: this.baseUrl });
   }
 
-  async connectServer(
+  /**
+   * Connect a fully-specified ad-hoc server (inline config, no project) into the
+   * local Inspector's manager. Backs the harness-render flows (`apps render`,
+   * `apps session`, inspector render) whose `--url`/`--command` target exists in
+   * no project, so the project-scoped `/api/mcp/connect` (which now requires a
+   * `projectId`) can't serve them. See `server/routes/mcp/connect-adhoc.ts`.
+   */
+  async connectServerAdhoc(
     serverId: string,
     serverConfig: unknown,
     options: { timeoutMs?: number } = {},
   ) {
-    return this.request("/api/mcp/connect", {
+    return this.request("/api/mcp/connect-adhoc", {
       method: "POST",
       body: { serverId, serverConfig },
       timeoutMs: options.timeoutMs,

--- a/cli/src/lib/inspector-render.ts
+++ b/cli/src/lib/inspector-render.ts
@@ -84,7 +84,7 @@ export async function runUiRender(options: {
     );
   }
 
-  await client.connectServer(options.serverName, options.config, {
+  await client.connectServerAdhoc(options.serverName, options.config, {
     timeoutMs: options.timeoutMs,
   });
 

--- a/cli/src/lib/widget-render.ts
+++ b/cli/src/lib/widget-render.ts
@@ -41,7 +41,7 @@ export interface WidgetRenderResponse {
 /** The slice of `InspectorApiClient` the render flow uses (injectable for tests). */
 export type WidgetRenderClient = Pick<
   InspectorApiClient,
-  "ensureBackend" | "connectServer" | "request"
+  "ensureBackend" | "connectServerAdhoc" | "request"
 >;
 
 export interface RunWidgetRenderOptions {
@@ -90,7 +90,7 @@ export async function runWidgetRender(
     timeoutMs: options.timeoutMs,
   });
 
-  await client.connectServer(options.serverName, options.config, {
+  await client.connectServerAdhoc(options.serverName, options.config, {
     timeoutMs: options.timeoutMs,
   });
 

--- a/cli/src/lib/widget-session.ts
+++ b/cli/src/lib/widget-session.ts
@@ -114,7 +114,7 @@ export async function runWidgetSessionStart(
     startIfNeeded: options.startIfNeeded ?? true,
     timeoutMs: options.timeoutMs,
   });
-  await client.connectServer(options.serverName, options.config, {
+  await client.connectServerAdhoc(options.serverName, options.config, {
     timeoutMs: options.timeoutMs,
   });
 

--- a/cli/tests/apps-render.test.ts
+++ b/cli/tests/apps-render.test.ts
@@ -125,7 +125,7 @@ test("runWidgetRender sends the render POST with the floored timeout", async () 
       hasActiveClient: false,
       started: false,
     }),
-    connectServer: async () => ({ success: true }),
+    connectServerAdhoc: async () => ({ success: true }),
     request: async (path: string, init?: { timeoutMs?: number }) => {
       calls.push({ path, timeoutMs: init?.timeoutMs });
       return { status: "rendered", elapsedMs: 1 } satisfies WidgetRenderResponse;
@@ -284,7 +284,7 @@ async function startMockInspector(options: {
       return;
     }
 
-    if (request.method === "POST" && request.url === "/api/mcp/connect") {
+    if (request.method === "POST" && request.url === "/api/mcp/connect-adhoc") {
       const body = await readJsonBody(request);
       requests.push({ method: request.method, url: request.url, body });
       response.writeHead(200, { "Content-Type": "application/json" });
@@ -376,7 +376,7 @@ test("apps render writes the screenshot to a file and keeps stdout clean", async
 
     // The render server-side path connects the target server first.
     const connect = server.requests.find(
-      (entry) => entry.url === "/api/mcp/connect",
+      (entry) => entry.url === "/api/mcp/connect-adhoc",
     );
     assert.equal(
       (connect?.body as { serverId?: string } | undefined)?.serverId,

--- a/cli/tests/apps-session.test.ts
+++ b/cli/tests/apps-session.test.ts
@@ -226,7 +226,7 @@ async function startMockInspector(
       response.end(JSON.stringify({ token: "test-token" }));
       return;
     }
-    if (request.method === "POST" && url === "/api/mcp/connect") {
+    if (request.method === "POST" && url === "/api/mcp/connect-adhoc") {
       requests.push({ method: "POST", url, body: await readJsonBody(request) });
       response.writeHead(200, { "Content-Type": "application/json" });
       response.end(JSON.stringify({ success: true, status: "connected" }));

--- a/cli/tests/inspector-api.test.ts
+++ b/cli/tests/inspector-api.test.ts
@@ -179,7 +179,10 @@ test("InspectorApiClient sends session token auth and supported endpoint payload
         return;
       }
 
-      if (request.method === "POST" && request.url === "/api/mcp/connect") {
+      if (
+        request.method === "POST" &&
+        request.url === "/api/mcp/connect-adhoc"
+      ) {
         const body = await readJsonBody(request);
         seen.push({
           url: request.url,
@@ -216,7 +219,7 @@ test("InspectorApiClient sends session token auth and supported endpoint payload
     },
     async (baseUrl) => {
       const client = new InspectorApiClient({ baseUrl });
-      await client.connectServer("demo", { url: "http://example.test/mcp" });
+      await client.connectServerAdhoc("demo", { url: "http://example.test/mcp" });
       const result = await client.executeTool("demo", "echo", {
         message: "hi",
       });
@@ -227,7 +230,7 @@ test("InspectorApiClient sends session token auth and supported endpoint payload
       });
       assert.deepEqual(seen, [
         {
-          url: "/api/mcp/connect",
+          url: "/api/mcp/connect-adhoc",
           auth: `Bearer ${token}`,
           body: {
             serverId: "demo",
@@ -248,7 +251,7 @@ test("InspectorApiClient sends session token auth and supported endpoint payload
   );
 });
 
-test("InspectorApiClient applies explicit timeout to connectServer", async () => {
+test("InspectorApiClient applies explicit timeout to connectServerAdhoc", async () => {
   await withServer(
     (request, response) => {
       if (request.method === "GET" && request.url === "/api/session-token") {
@@ -257,7 +260,10 @@ test("InspectorApiClient applies explicit timeout to connectServer", async () =>
         return;
       }
 
-      if (request.method === "POST" && request.url === "/api/mcp/connect") {
+      if (
+        request.method === "POST" &&
+        request.url === "/api/mcp/connect-adhoc"
+      ) {
         setTimeout(() => {
           response.writeHead(200, { "Content-Type": "application/json" });
           response.end(JSON.stringify({ success: true, status: "connected" }));
@@ -274,7 +280,7 @@ test("InspectorApiClient applies explicit timeout to connectServer", async () =>
 
       await assert.rejects(
         () =>
-          client.connectServer(
+          client.connectServerAdhoc(
             "slow",
             { url: "http://example.test/mcp" },
             { timeoutMs: 25 },

--- a/cli/tests/tools-call-ui.test.ts
+++ b/cli/tests/tools-call-ui.test.ts
@@ -212,7 +212,7 @@ async function startMockServer(options: {
       const body = await readJsonBody(request);
       requests.push({ method: request.method, url: request.url, body });
 
-      if (request.url === "/api/mcp/connect") {
+      if (request.url === "/api/mcp/connect-adhoc") {
         response.writeHead(200, { "Content-Type": "application/json" });
         response.end(JSON.stringify({ success: true, status: "connected" }));
         return;
@@ -407,7 +407,7 @@ test("tools call --ui executes once and sends the raw result to Inspector", asyn
     assert.equal(mcpMethods.includes("tools/list"), false);
 
     const connectRequest = server.requests.find(
-      (entry) => entry.url === "/api/mcp/connect",
+      (entry) => entry.url === "/api/mcp/connect-adhoc",
     );
     assert.equal(
       (connectRequest?.body as { serverId?: string } | undefined)?.serverId,

--- a/mcpjam-inspector/server/routes/mcp/__tests__/connect-adhoc.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/connect-adhoc.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Hono } from "hono";
+import {
+  createMockMcpClientManager,
+  createTestApp,
+  type MockMCPClientManager,
+} from "./helpers/index.js";
+
+const SERVER_ID = "excalidraw";
+const SERVER_CONFIG = { url: "https://mcp.excalidraw.com/mcp" };
+
+function headers() {
+  return { "Content-Type": "application/json" };
+}
+
+describe("POST /api/mcp/connect-adhoc", () => {
+  let mcpClientManager: MockMCPClientManager;
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mcpClientManager = createMockMcpClientManager();
+    app = createTestApp(mcpClientManager, "connect-adhoc");
+  });
+
+  describe("validation", () => {
+    it("returns 400 when serverId is missing", async () => {
+      const res = await app.request("/api/mcp/connect-adhoc", {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ serverConfig: SERVER_CONFIG }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error?: string }).error).toBe(
+        "serverId is required",
+      );
+      expect(mcpClientManager.connectToServer).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when serverConfig is missing or not an object", async () => {
+      for (const serverConfig of [undefined, "nope", ["arr"]]) {
+        const res = await app.request("/api/mcp/connect-adhoc", {
+          method: "POST",
+          headers: headers(),
+          body: JSON.stringify({ serverId: SERVER_ID, serverConfig }),
+        });
+        expect(res.status).toBe(400);
+        expect(((await res.json()) as { error?: string }).error).toBe(
+          "serverConfig must be a JSON object",
+        );
+      }
+      expect(mcpClientManager.connectToServer).not.toHaveBeenCalled();
+    });
+  });
+
+  it("connects the inline config directly (no project lookup) and returns the success envelope", async () => {
+    const res = await app.request("/api/mcp/connect-adhoc", {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        serverId: SERVER_ID,
+        serverConfig: SERVER_CONFIG,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { success: boolean; status: string };
+    expect(data.success).toBe(true);
+    expect(data.status).toBe("connected");
+
+    // The inline config is handed straight to the manager under serverId —
+    // no Convex/project resolution involved.
+    expect(mcpClientManager.connectToServer).toHaveBeenCalledWith(
+      SERVER_ID,
+      SERVER_CONFIG,
+    );
+    // Pre-connect disconnect is tolerated (idempotent re-connect under same id).
+    expect(mcpClientManager.disconnectServer).toHaveBeenCalledWith(SERVER_ID);
+  });
+
+  it("cleans up the manager entry and returns 502 when the connection fails", async () => {
+    mcpClientManager.connectToServer = vi
+      .fn()
+      .mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await app.request("/api/mcp/connect-adhoc", {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        serverId: SERVER_ID,
+        serverConfig: SERVER_CONFIG,
+      }),
+    });
+
+    expect(res.status).toBe(502);
+    const data = (await res.json()) as { success: boolean; error: string };
+    expect(data.success).toBe(false);
+    expect(data.error).toContain("ECONNREFUSED");
+    expect(mcpClientManager.removeServer).toHaveBeenCalledWith(SERVER_ID);
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/__tests__/helpers/test-app.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/helpers/test-app.ts
@@ -4,6 +4,7 @@ import type { MockMCPClientManager } from "./mock-mcp-client-manager.js";
 
 // Import route modules
 import connect from "../../connect.js";
+import connectAdhoc from "../../connect-adhoc.js";
 import tools from "../../tools.js";
 import resources from "../../resources.js";
 import servers from "../../servers.js";
@@ -24,6 +25,7 @@ import { CORS_ORIGINS } from "../../../../config.js";
  */
 export type RouteConfig =
   | "connect"
+  | "connect-adhoc"
   | "tools"
   | "resources"
   | "servers"
@@ -36,6 +38,7 @@ export type RouteConfig =
 
 const routeModules: Record<RouteConfig, { path: string; handler: Hono }> = {
   connect: { path: "/api/mcp/connect", handler: connect },
+  "connect-adhoc": { path: "/api/mcp/connect-adhoc", handler: connectAdhoc },
   tools: { path: "/api/mcp/tools", handler: tools },
   resources: { path: "/api/mcp/resources", handler: resources },
   servers: { path: "/api/mcp/servers", handler: servers },

--- a/mcpjam-inspector/server/routes/mcp/connect-adhoc.ts
+++ b/mcpjam-inspector/server/routes/mcp/connect-adhoc.ts
@@ -1,0 +1,111 @@
+import { Hono } from "hono";
+import "../../types/hono"; // Type extensions (c.mcpClientManager)
+import type { MCPServerConfig } from "@mcpjam/sdk";
+import { buildConnectSuccessEnvelope } from "../../utils/local-server-resolver.js";
+import { logger } from "../../utils/logger";
+
+/**
+ * connect-adhoc.ts — `POST /api/mcp/connect-adhoc`: register a fully-specified
+ * MCP server connection in the local manager from an INLINE config, with no
+ * project/Convex lookup.
+ *
+ * Why this exists separately from `/api/mcp/connect`: the project-scoped connect
+ * route resolves a server's config from Convex by `projectId` + `serverId` (the
+ * legacy inline `{serverConfig}` body was removed in the local-mode purge). The
+ * CLI's harness-render flows (`mcpjam apps render` / `apps session`, inspector
+ * render) target an ad-hoc `--url`/`--command` server that exists in no project,
+ * so they have no `projectId` to offer — `/connect` 400s with "projectId is
+ * required". This route restores the inline-config path for exactly those
+ * callers: it takes `{ serverId, serverConfig }` and connects it directly, the
+ * same way the CLI's in-process ephemeral manager (`tools list`) already does.
+ *
+ * Local-Inspector capability only: it lives under `/api/mcp/*`, which
+ * `server/app.ts` mounts solely when `!HOSTED_MODE`, so an inline config can
+ * never open a server-side connection (or spawn a stdio process) on the hosted
+ * image — only on the user's own machine.
+ */
+
+const connectAdhoc = new Hono();
+
+connectAdhoc.post("/", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch (error) {
+    return c.json(
+      {
+        success: false,
+        error: "Failed to parse request body",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      400,
+    );
+  }
+
+  const raw = (body ?? {}) as Record<string, unknown>;
+  const serverId =
+    typeof raw.serverId === "string" ? raw.serverId.trim() : "";
+  if (!serverId) {
+    return c.json({ success: false, error: "serverId is required" }, 400);
+  }
+  if (
+    typeof raw.serverConfig !== "object" ||
+    raw.serverConfig === null ||
+    Array.isArray(raw.serverConfig)
+  ) {
+    return c.json(
+      { success: false, error: "serverConfig must be a JSON object" },
+      400,
+    );
+  }
+  const serverConfig = raw.serverConfig as MCPServerConfig;
+
+  const mcpClientManager = c.mcpClientManager;
+
+  // Tolerate "nothing to disconnect" — a fresh ad-hoc connect has no manager
+  // entry yet, and a stale/already-disconnected entry under the same id
+  // shouldn't fail the call. Mirrors `executeLocalServerConnect`.
+  try {
+    await mcpClientManager.disconnectServer(serverId);
+  } catch (disconnectError) {
+    logger.debug("Failed to disconnect MCP server before ad-hoc connect", {
+      serverId,
+      error:
+        disconnectError instanceof Error
+          ? disconnectError.message
+          : String(disconnectError),
+    });
+  }
+
+  try {
+    await mcpClientManager.connectToServer(serverId, serverConfig);
+  } catch (error) {
+    // Clean up the doomed entry so it doesn't shadow a later connect/listServers
+    // under the same id (same as `/connect`'s first-time-connect path).
+    try {
+      await mcpClientManager.removeServer(serverId);
+    } catch (cleanupError) {
+      logger.debug("Failed to remove MCP server after ad-hoc connect failure", {
+        serverId,
+        error:
+          cleanupError instanceof Error
+            ? cleanupError.message
+            : String(cleanupError),
+      });
+    }
+    return c.json(
+      {
+        success: false,
+        error: `Connection failed for server ${serverId}: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      502,
+    );
+  }
+
+  return c.json(buildConnectSuccessEnvelope(mcpClientManager, serverId));
+});
+
+export default connectAdhoc;

--- a/mcpjam-inspector/server/routes/mcp/index.ts
+++ b/mcpjam-inspector/server/routes/mcp/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import connect from "./connect";
+import connectAdhoc from "./connect-adhoc";
 import servers from "./servers";
 import tools from "./tools";
 import resources from "./resources";
@@ -44,6 +45,11 @@ mcp.route("/elicitation", elicitation);
 
 // Connect endpoint - REAL IMPLEMENTATION
 mcp.route("/connect", connect);
+
+// Ad-hoc connect: inline {serverId, serverConfig}, no project lookup. Backs the
+// CLI harness-render flows (apps render/session) that target servers existing
+// in no project. See connect-adhoc.ts.
+mcp.route("/connect-adhoc", connectAdhoc);
 
 // Inspector command bus endpoints
 mcp.route("/command", command);


### PR DESCRIPTION
## Problem

`mcpjam apps render` / `apps session` (and inspector render via `tools call --ui`) connect their `--url`/`--command` target through `POST /api/mcp/connect`, but that route now resolves config from a **project** — it requires `projectId` + `serverName`, since the inline `serverConfig` body was removed in the local-mode purge. Ad-hoc CLI targets exist in no project, so connect 400s with **`projectId is required`** before the browser harness ever launches. The result: `apps render`/`session` are unusable against an ad-hoc server.

Reproduced live against `https://mcp.excalidraw.com/mcp` on the published CLI 3.9.0 **and** 3.10.0 → `{"error":{"message":"projectId is required"}}`. `mcpjam tools list` works only because it uses an in-process ephemeral manager that never calls the backend.

## Fix

Add a dedicated **`POST /api/mcp/connect-adhoc`** (`server/routes/mcp/connect-adhoc.ts`) that registers an inline `{ serverId, serverConfig }` directly in the manager via `connectToServer` — **no Convex/project lookup** — the same way the CLI's in-process ephemeral manager (`tools list`) already connects. Local-mode only (mounted under `/api/mcp/*`).

CLI: rename `connectServer` → `connectServerAdhoc` pointing at the new route, and switch its three harness-render callers (`widget-render`, `widget-session`, `inspector-render`). The project-scoped `/api/mcp/connect` route is **untouched**.

## Verification

End-to-end against live `mcp.excalidraw.com/mcp` (worktree-built CLI → local dev server):
- `apps render --tool-name create_view` → `status: rendered`, `bridgeInitialized: true`, real PNG written.
- `apps session` start → action (scroll) → close all succeed (incl. `widgetToolCalls` capture, `closed: true`).

Tests (all green):
- New `server/routes/mcp/__tests__/connect-adhoc.test.ts` (4) + existing `connect` (13) + `widget-render` (18).
- Full CLI suite (75) — updated connect/render/session/tools-ui endpoint assertions to `/api/mcp/connect-adhoc`.
- CLI typecheck clean; no server typecheck errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New local-only endpoint accepts arbitrary inline MCP configs (including stdio spawn), but it is gated to non-hosted Inspector; behavior mirrors the removed inline connect path with focused CLI/test coverage.
> 
> **Overview**
> Restores **ad-hoc MCP server registration** for CLI harness flows that target `--url`/`--command` servers outside any project. Project-scoped `POST /api/mcp/connect` now requires `projectId`, so `apps render`, `apps session`, and `tools call --ui` were failing before render/session ever ran.
> 
> The Inspector adds **`POST /api/mcp/connect-adhoc`**, which accepts inline `{ serverId, serverConfig }`, connects via the local manager (no Convex lookup), validates input, tolerates idempotent pre-disconnect, and cleans up on failure. It is mounted only under local `/api/mcp/*`.
> 
> On the CLI, **`connectServer` is renamed to `connectServerAdhoc`** and wired to that route from `widget-render`, `widget-session`, and `inspector-render`. Tests and mocks are updated accordingly; project-scoped `/connect` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2985999e75fdc919a1c991254f7269213cf075aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->