### PR TITLE
feat(turn): route hosted eval through the facade — PR 2 of 6

### DIFF
--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -33,7 +33,7 @@ import type { EvalTraceSpan } from "@/shared/eval-trace";
 import type { ModelDefinition } from "@/shared/types";
 import type { EvalToolChoice } from "@/shared/tool-choice";
 import { logger } from "../../utils/logger";
-import { runAssistantTurn } from "../../utils/assistant-turn.js";
+import { runUnifiedAssistantTurn } from "../../utils/turn-execution.js";
 import type {
   MCPJamEngineErrorEvent,
   MCPJamStepFinishEvent,
@@ -191,7 +191,6 @@ export async function driveHostedEvalTurn(
   // failed turn still persists the user side of the transcript (Cursor
   // review round-2 — the transcript stays honest about WHICH turn errored).
   acc.messageHistory.push({ role: "user", content: params.prompt });
-  const messageCountBeforeTurn = acc.messageHistory.length;
   const inputMessages: ModelMessage[] = [...acc.messageHistory];
 
   const baselineUsage = {
@@ -300,9 +299,17 @@ export async function driveHostedEvalTurn(
     ...(params.toolChoice ? { toolChoice: params.toolChoice } : {}),
   };
 
-  let turnResult: Awaited<ReturnType<typeof runAssistantTurn>>;
+  let turnResult: Awaited<ReturnType<typeof runUnifiedAssistantTurn>>;
   try {
-    turnResult = await runAssistantTurn({
+    turnResult = await runUnifiedAssistantTurn({
+      // Hosted runtime: routing (endpoint, extra body fields, harness) is an
+      // explicit part of the discriminator, not hidden behind a string.
+      runtime: {
+        kind: "hosted",
+        endpointPath: params.endpointPath,
+        extraBodyFields: mergedExtraBodyFields,
+        ...(params.harness ? { harness: params.harness } : {}),
+      },
       messages: inputMessages,
       // Eval's `runTestCase` already resolved the canonical model id
       // (`getCanonicalModelId(modelDefinition.id, provider)`) and threads it
@@ -330,20 +337,18 @@ export async function driveHostedEvalTurn(
       // requireToolApproval host (it can't do interactive approval yet) while
       // still running non-approval hosts under allow-all. Gated on harness so
       // emulated evals stay byte-identical (they forward neither today).
+      // `harness` moved to `runtime` above; `requireToolApproval` + `projectId`
+      // stay top-level engine options (still harness-gated so emulated evals
+      // remain byte-identical — runHarnessTurn needs projectId for the host's
+      // computer; authHeader rides authContext.token).
       ...(params.harness
         ? {
-            harness: params.harness,
             ...(params.requireToolApproval !== undefined
               ? { requireToolApproval: params.requireToolApproval }
               : {}),
-            // runHarnessTurn needs projectId to resolve the host's computer
-            // (authHeader already rides authContext.token). Harness-gated so
-            // emulated evals stay byte-identical.
             ...(params.projectId ? { projectId: params.projectId } : {}),
           }
         : {}),
-      endpointPath: params.endpointPath,
-      extraBodyFields: mergedExtraBodyFields,
       ...(abortSignal ? { abortSignal } : {}),
       maxSteps: params.maxSteps,
       progressivePlan: prepared.progressivePlan,
@@ -417,11 +422,11 @@ export async function driveHostedEvalTurn(
       baselineUsage.totalTokens + (turnResult.usage.totalTokens ?? 0);
   }
 
-  // Per-turn tool calls — rebuild from the new messages only (the engine
-  // returns the FULL transcript; slice from `messageCountBeforeTurn` so
-  // prior turns' calls aren't double-counted). Replaces whatever the live
-  // `onToolCall` sink accumulated so the grader sees the canonical shape.
-  const newMessages = turnResult.messages.slice(messageCountBeforeTurn);
+  // Per-turn tool calls — rebuild from THIS turn's new messages only (the
+  // facade computes the slice once as `newMessages`, so prior turns' calls
+  // aren't double-counted). Replaces whatever the live `onToolCall` sink
+  // accumulated so the grader sees the canonical shape.
+  const newMessages = turnResult.newMessages;
   const canonicalPromptToolsCalled = params.extractToolCalls(newMessages);
   promptToolsCalled.length = 0;
   promptToolsCalled.push(...canonicalPromptToolsCalled);


### PR DESCRIPTION
## Context

PR 2 of the Shared Turn Execution Core (PR 1 = #2850, merged). Routes the
**hosted** eval path through `runUnifiedAssistantTurn` — the near-no-op that
proves the facade seam end-to-end before the riskier migrations.

## What this does

`driveHostedEvalTurn` (shared by **both** hosted runners — batch + stream) now
calls `runUnifiedAssistantTurn({ runtime: { kind: "hosted", … } })` instead of
`runAssistantTurn` directly, and consumes the facade's `newMessages` instead of
re-slicing the transcript.

- Routing (`endpointPath`, `extraBodyFields`, `harness`) moves into the explicit
  hosted runtime discriminator. `requireToolApproval` + `projectId` stay
  top-level engine options (still harness-gated, so emulated evals remain
  byte-identical).
- Drops the local `messageCountBeforeTurn` slice in favor of
  `turnResult.newMessages` (computed once by the facade).

No behavior change intended — same engine underneath; the facade is a thin
dispatch layer.

## Testing

- `drive-hosted-eval-turn` (3) + `evals-runner` (71) + `turn-execution` (7) green.
- Server typecheck adds no new errors.

## Ladder

PR 1 facade ✅ (#2850) · **PR 2 hosted eval (this)** · PR 3 local eval + delete
stream-adapter · PR 4 chat-SSE parity harness · PR 5 chat/playground · PR 6 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only wiring through an existing thin facade; harness-gating preserves emulated eval parity, with tests covering hosted eval and turn-execution paths.
> 
> **Overview**
> **Hosted eval** (batch + stream via `driveHostedEvalTurn`) now calls **`runUnifiedAssistantTurn`** instead of **`runAssistantTurn`**, with routing folded into an explicit **`runtime: { kind: "hosted", endpointPath, extraBodyFields, harness? }`** block rather than top-level `endpointPath` / `extraBodyFields` / `harness`.
> 
> Harness-only options **`requireToolApproval`** and **`projectId`** stay on the top-level turn options (still gated so emulated evals stay unchanged). Per-turn grading uses **`turnResult.newMessages`** from the facade instead of a local **`messageCountBeforeTurn`** transcript slice.
> 
> This is a seam migration only—the version 2 of the shared turn-execution ladder, intended to be behavior-neutral with the same engine underneath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa1a12252fa4086473246f593ef96c3d18c3f744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->