### PR TITLE
test(chat): SSE wire-parity net for the facade migration — PR 4 (part 1)

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/__snapshots__/chat-v2.test.ts.snap
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/__snapshots__/chat-v2.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`POST /api/mcp/chat-v2 > success cases > direct path: exact trace-event sequence is stable (wire parity) 1`] = `
+[
+  "turn_start",
+  "request_payload",
+  "text_delta",
+  "trace_snapshot",
+  "turn_finish",
+]
+`;

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -426,6 +426,26 @@ describe("POST /api/mcp/chat-v2", () => {
       });
     });
 
+    // PR 4 (chat SSE wire-parity net): the test above checks presence + relative
+    // order via arrayContaining; this snapshots the EXACT ordered trace-event
+    // sequence so the upcoming facade migration (PR 5) can't change the wire
+    // shape unnoticed. Direct (user-key) path — whose facade `direct + ui` path
+    // is brand-new, so the highest-risk half to protect.
+    it("direct path: exact trace-event sequence is stable (wire parity)", async () => {
+      const res = await postJson(app, "/api/mcp/chat-v2", {
+        messages: [{ role: "user", content: "Hello" }],
+        model: { id: "gpt-4", provider: "openai" },
+        apiKey: "test-key",
+      });
+      expect(res.status).toBe(200);
+      await lastStreamExecution;
+
+      const traceEventSequence = capturedStreamEvents
+        .filter((event) => event?.type === "data-trace-event")
+        .map((event) => event.data?.type);
+      expect(traceEventSequence).toMatchSnapshot();
+    });
+
     it("uses provided temperature", async () => {
       const { streamText } = await import("ai");
 


### PR DESCRIPTION
## Context

The chat migration onto `runUnifiedAssistantTurn` (PR 5 of the Shared Turn
Execution Core) touches the **highest-traffic surface**, and chat had **no
exact-sequence SSE parity test**. This lands the safety net **first** — test-only,
zero production risk — so PR 5 can be proven byte-for-byte equivalent on the wire.

## What this does

Snapshots the EXACT ordered `data-trace-event` sequence for the **direct
(user-key) chat path** — the riskiest half to protect, because the facade's
`direct + streamSink:"ui"` path is brand-new and must reproduce today's
`streamDirectChatWithLiveTrace` output. The existing test only checks presence +
relative order (`arrayContaining`); this is a stricter exact snapshot.

Recorded sequence: `turn_start → request_payload → text_delta → trace_snapshot → turn_finish`.

## Note on the "same cloud path" requirement

Verified: `handleHostedOrgChatModel` (cloud BYOK) already *calls*
`handleMCPJamFreeChatModel` with `endpointPath: "/stream/org"` + `providerKey` —
so BYOK-cloud and MCPJam-provided already run the **same engine path**, differing
only by endpoint. PR 5 collapses both onto one `runUnifiedAssistantTurn({ runtime:
{ kind: "hosted", endpointPath } })` call, preserving that.

## Follow-ups
- **PR 4 part 2:** same snapshot for the cloud handlers (needs the Convex
  `/stream` fetch mocked).
- **PR 5:** migrate chat/playground onto the facade, gated by these snapshots.

## Testing
Full `chat-v2.test.ts` suite green (56); snapshot recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests and a snapshot file; no production or API behavior is modified.
> 
> **Overview**
> Adds a **wire-parity safety net** for the upcoming chat facade migration: a new test on the **direct (user API key)** `POST /api/mcp/chat-v2` path that asserts the **full ordered** list of `data-trace-event` types via `toMatchSnapshot()`, not just presence and relative order like the existing live-trace test.
> 
> The committed snapshot locks the sequence to `turn_start` → `request_payload` → `text_delta` → `trace_snapshot` → `turn_finish`, so refactors that change SSE trace shape should fail CI before clients see a drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2286823668b6d77c6c4c31970ff7b7deb735d2c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->