### PR TITLE
test(chat): cloud-path SSE wire-parity net — PR 4 (part 2)

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/__snapshots__/chat-v2.test.ts.snap
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/__snapshots__/chat-v2.test.ts.snap
@@ -1,5 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`POST /api/mcp/chat-v2 > MCPJam model persistence > cloud (MCPJam-provided) path: exact trace-event sequence is stable (wire parity) 1`] = `
+[
+  "turn_start",
+  "request_payload",
+  "text_delta",
+  "trace_snapshot",
+  "turn_finish",
+]
+`;
+
 exports[`POST /api/mcp/chat-v2 > success cases > direct path: exact trace-event sequence is stable (wire parity) 1`] = `
 [
   "turn_start",

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -934,6 +934,57 @@ describe("POST /api/mcp/chat-v2", () => {
       delete process.env.CONVEX_HTTP_URL;
     });
 
+    // PR 4 part 2 (cloud SSE wire-parity net): lock the exact trace-event
+    // sequence for the MCPJam-provided cloud path. PR 5 collapses this handler
+    // — and cloud BYOK, which wraps it (handleHostedOrgChatModel calls
+    // handleMCPJamFreeChatModel with /stream/org) — onto one facade hosted
+    // call; this snapshot proves the wire shape is unchanged.
+    it("cloud (MCPJam-provided) path: exact trace-event sequence is stable (wire parity)", async () => {
+      const originalFetch = global.fetch;
+      global.fetch = vi
+        .fn()
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
+          const url = String(input);
+          if (url === "https://test-convex.example.com/stream") {
+            return createSseResponse([
+              { type: "text-start", id: "text-1" },
+              { type: "text-delta", id: "text-1", delta: "Hello" },
+              { type: "text-end", id: "text-1" },
+              {
+                type: "finish",
+                finishReason: "stop",
+                messageMetadata: {
+                  inputTokens: 1,
+                  outputTokens: 1,
+                  totalTokens: 2,
+                },
+              },
+            ]);
+          }
+          if (url === "https://test-convex.example.com/ingest-chat") {
+            return new Response(null, { status: 200 });
+          }
+          throw new Error(`Unexpected fetch URL: ${url}`);
+        });
+
+      try {
+        const res = await postAuthenticatedJson({
+          messages: [{ role: "user", content: "Hello" }],
+          model: { id: "google/gemini-2.5-flash", provider: "google" },
+          projectId: "project_123",
+        });
+        expect(res.status).toBe(200);
+        await lastStreamExecution;
+
+        const traceEventSequence = capturedStreamEvents
+          .filter((event) => event?.type === "data-trace-event")
+          .map((event) => event.data?.type);
+        expect(traceEventSequence).toMatchSnapshot();
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+
     it("persists completed MCPJam conversations when chatSessionId is present", async () => {
       const originalFetch = global.fetch;
       global.fetch = vi


### PR DESCRIPTION
## Context

Completes the chat SSE parity net before the facade migration (PR 5). Part 1
(#2855, merged) locked the **direct** (user-key) path; this locks the
**MCPJam-provided cloud** path's exact trace-event sequence.

## What this does

Snapshots the exact ordered `data-trace-event` sequence for the cloud path,
mocking the Convex `/stream` fetch (reuses the existing "MCPJam model
persistence" setup: `isMCPJamProvidedModel → true` + `CONVEX_HTTP_URL`).

Cloud BYOK shares this path — `handleHostedOrgChatModel` wraps
`handleMCPJamFreeChatModel` with `/stream/org` — so this single snapshot gates
**both** cloud handlers that PR 5 collapses onto one
`runUnifiedAssistantTurn({ runtime: { kind: "hosted", endpointPath } })` call.

Recorded: `turn_start → request_payload → text_delta → trace_snapshot → turn_finish`
— identical to the direct path (same `LiveChatTraceEvent` vocabulary).

Test-only — zero production risk.

## Status

Chat parity net complete (direct + cloud). Next: **PR 5** — migrate
chat/playground onto the facade, gated by these snapshots.

## Testing
Full `chat-v2.test.ts` suite green (57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or runtime behavior modifications.
> 
> **Overview**
> Adds a **wire-parity snapshot** for the MCPJam-provided **cloud** `chat-v2` path, mirroring the existing direct-path test from PR 4 part 1.
> 
> The new test runs under the MCPJam model persistence setup (`isMCPJamProvidedModel` + `CONVEX_HTTP_URL`), mocks Convex `/stream` (and `/ingest-chat`) SSE, and asserts the ordered `data-trace-event` types match a Vitest snapshot: `turn_start → request_payload → text_delta → trace_snapshot → turn_finish` — the same sequence as the direct path.
> 
> This completes the chat SSE parity net before PR 5 collapses cloud and org-hosted handlers onto a unified facade; **test and snapshot only**, no production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e61c27a48a4a73aaaccf07cd54f760e2f39aea17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->