### PR TITLE
feat(chatboxes): rename user-facing "Chatboxes" to "Swarms"

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1442,7 +1442,7 @@ export default function App() {
               return {
                 success: false,
                 error:
-                  "Your guest session expired. Reopen the chatbox link and try again.",
+                  "Your guest session expired. Reopen the swarm link and try again.",
               };
             }
             authorizationHeader = `Bearer ${guestBearerToken}`;

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -709,7 +709,7 @@ describe("App hosted OAuth callback handling", () => {
 
     await waitFor(() => {
       expect(readHostedOAuthResumeMarker("chatbox")?.errorMessage).toBe(
-        "Your guest session expired. Reopen the chatbox link and try again."
+        "Your guest session expired. Reopen the swarm link and try again."
       );
     });
     expect(mockCompleteHostedOAuthCallback).not.toHaveBeenCalled();

--- a/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
@@ -168,7 +168,7 @@ export function ChatboxesTab({
         toast.error(
           err instanceof Error
             ? err.message
-            : "Failed to provision chatbox for host",
+            : "Failed to provision swarm for host",
         );
       });
     return () => {
@@ -216,7 +216,7 @@ export function ChatboxesTab({
           <Inbox className="mx-auto size-8 text-muted-foreground/70" />
           <p className="mt-3 text-sm font-medium">Pick a host</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Use the host bar at the top to choose which host's chatbox you
+            Use the host bar at the top to choose which host's swarm you
             want to manage.
           </p>
         </div>
@@ -228,7 +228,7 @@ export function ChatboxesTab({
     return (
       <div className="flex h-full items-center justify-center text-muted-foreground">
         <Loader2 className="mr-2 size-4 animate-spin" />
-        <span className="text-sm">Loading chatbox…</span>
+        <span className="text-sm">Loading swarm…</span>
       </div>
     );
   }
@@ -241,7 +241,7 @@ export function ChatboxesTab({
     if (previewedHostId && ensureCompletedNullHosts.has(previewedHostId)) {
       return (
         <ChatboxLoadFailure
-          title="Couldn't load this host's chatbox"
+          title="Couldn't load this host's swarm"
           body="The backfill mutation succeeded but the chatbox query still returned nothing. Check the Convex logs for getChatboxByHostId on this host."
         />
       );
@@ -251,7 +251,7 @@ export function ChatboxesTab({
     return (
       <div className="flex h-full items-center justify-center text-muted-foreground">
         <Loader2 className="mr-2 size-4 animate-spin" />
-        <span className="text-sm">Provisioning chatbox for this host…</span>
+        <span className="text-sm">Provisioning swarm for this host…</span>
       </div>
     );
   }
@@ -265,7 +265,7 @@ export function ChatboxesTab({
         <div className="flex min-w-0 items-center justify-center">
           <ViewModeSelector
             value={tab}
-            ariaLabel="Chatbox view"
+            ariaLabel="Swarm view"
             onChange={(next) => {
               setTab(next as ChatboxTab);
               // Manual navigation supersedes the deep link — drop the params
@@ -300,7 +300,7 @@ export function ChatboxesTab({
                           onClick={() =>
                             window.open(publishLink, "_blank", "noopener")
                           }
-                          title="Open the published chatbox in a new tab"
+                          title="Open the published swarm in a new tab"
                         >
                           <ExternalLink className="mr-1.5 size-4" />
                           Open preview
@@ -423,7 +423,7 @@ function ChatboxPreviewPane({
           <Inbox className="mx-auto size-8 text-muted-foreground/70" />
           <p className="mt-3 text-sm font-medium">No share link yet</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Publish the chatbox to generate a share link, then come back
+            Publish the swarm to generate a share link, then come back
             here to preview it.
           </p>
         </div>
@@ -435,7 +435,7 @@ function ChatboxPreviewPane({
       <iframe
         key={publishLink}
         src={publishLink}
-        title="Chatbox preview"
+        title="Swarm preview"
         className="size-full flex-1 border-0 bg-background"
         allow={allow}
       />

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxDeleteConfirmDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxDeleteConfirmDialog.tsx
@@ -62,15 +62,15 @@ export function ChatboxDeleteConfirmDialog({
         className="gap-4 sm:max-w-md"
       >
         <DialogHeader className="gap-2 text-left">
-          <DialogTitle className="text-foreground">Delete chatbox?</DialogTitle>
+          <DialogTitle className="text-foreground">Delete swarm?</DialogTitle>
           <DialogDescription asChild>
             <div className="space-y-2 text-sm text-muted-foreground">
               <p>
                 <span className="font-medium text-foreground">
-                  {chatboxName || "This chatbox"}
+                  {chatboxName || "This swarm"}
                 </span>{" "}
                 will be removed from this project. The hosted link will stop
-                working and saved usage history for this chatbox will be
+                working and saved usage history for this swarm will be
                 cleared.
               </p>
               <p>You cannot undo this.</p>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxPublishClientBar.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxPublishClientBar.tsx
@@ -80,7 +80,7 @@ export function ChatboxPublishClientBar({
         selectedServerIds: attachment.serverIds,
       });
       toast.success(
-        `Chatbox now connects to ${attachment.serverIds.length} server${attachment.serverIds.length === 1 ? "" : "s"} via "${attachment.name}".`,
+        `Swarm now connects to ${attachment.serverIds.length} server${attachment.serverIds.length === 1 ? "" : "s"} via "${attachment.name}".`,
       );
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
@@ -182,7 +182,7 @@ export function ChatboxShareSection({
   if (!isAuthenticated) {
     return (
       <p className="pt-4 text-sm text-muted-foreground">
-        Sign in to manage chatbox access.
+        Sign in to manage swarm access.
       </p>
     );
   }
@@ -256,7 +256,7 @@ export function ChatboxShareSection({
                     {projectLabel}
                   </div>
                   <p className="text-xs font-normal text-muted-foreground">
-                    Signed-in members of this project can open the chatbox
+                    Signed-in members of this project can open the swarm
                     with the link. Guests cannot.
                   </p>
                 </div>
@@ -271,7 +271,7 @@ export function ChatboxShareSection({
                     Invited users only
                   </div>
                   <p className="text-xs font-normal text-muted-foreground">
-                    Only people you invite by email can open this chatbox.
+                    Only people you invite by email can open this swarm.
                   </p>
                 </div>
               </DropdownMenuRadioItem>
@@ -285,7 +285,7 @@ export function ChatboxShareSection({
                     Anyone with the link (guests included)
                   </div>
                   <p className="text-xs font-normal text-muted-foreground">
-                    Anyone with the link can open the chatbox, including guests
+                    Anyone with the link can open the swarm, including guests
                     without an account.
                   </p>
                 </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/ShareChatboxDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ShareChatboxDialog.tsx
@@ -35,7 +35,7 @@ export function ShareChatboxDialog({
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="sm:max-w-[520px]">
         <DialogHeader>
-          <DialogTitle>Share &ldquo;{settings.name}&rdquo; Chatbox</DialogTitle>
+          <DialogTitle>Share &ldquo;{settings.name}&rdquo; Swarm</DialogTitle>
           <DialogDescription className="sr-only">
             Invite people and manage access for this chatbox.
           </DialogDescription>

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPublishClientBar.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPublishClientBar.test.tsx
@@ -100,7 +100,7 @@ describe("ChatboxPublishClientBar", () => {
       selectedServerIds: ["s1"],
     });
     expect(toastMock.success).toHaveBeenCalledWith(
-      'Chatbox now connects to 1 server via "Excalidraw".',
+      'Swarm now connects to 1 server via "Excalidraw".',
     );
   });
 

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxCanvas.tsx
@@ -407,7 +407,7 @@ const ChatboxNode = memo((props: NodeProps<Node<ChatboxBuilderNodeData>>) => {
                 <PopoverTrigger asChild>
                   <button
                     type="button"
-                    aria-label="Add project servers to chatbox"
+                    aria-label="Add project servers to swarm"
                     onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => e.stopPropagation()}
                     className={plusHandleButtonClass}
@@ -422,7 +422,7 @@ const ChatboxNode = memo((props: NodeProps<Node<ChatboxBuilderNodeData>>) => {
                   className="w-80 p-0 z-[100]"
                 >
                   <p className="border-b border-border/60 px-3 py-2 text-xs text-muted-foreground">
-                    Pick HTTPS servers from your project for this chatbox.
+                    Pick HTTPS servers from your project for this swarm.
                   </p>
                   <div className="p-1">
                     <ProjectServerPickerList
@@ -702,7 +702,7 @@ export function ChatboxCanvas({
                 variant="ghost"
                 size="icon"
                 className="pointer-events-auto size-10 shrink-0 text-muted-foreground"
-                aria-label="About the chatbox layout"
+                aria-label="About the swarm layout"
               >
                 <CircleHelp className="size-5" />
               </Button>

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxCanvas.test.tsx
@@ -262,14 +262,14 @@ describe("ChatboxCanvas", () => {
     );
 
     const addTrigger = document.querySelector<HTMLButtonElement>(
-      '[aria-label="Add project servers to chatbox"]',
+      '[aria-label="Add project servers to swarm"]',
     );
     expect(addTrigger).not.toBeNull();
     fireEvent.click(addTrigger!);
 
     expect(
       screen.getByText(
-        "Pick HTTPS servers from your project for this chatbox.",
+        "Pick HTTPS servers from your project for this swarm.",
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("HTTPS Server")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/setup-checklist-panel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/setup-checklist-panel.test.tsx
@@ -161,7 +161,7 @@ describe("SetupChecklistPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Access/i }));
     expect(
-      screen.getByText(/Save the chatbox to invite people by email/i),
+      screen.getByText(/Save the swarm to invite people by email/i),
     ).toBeInTheDocument();
     const emailInput = screen.getByLabelText(/email address/i);
     expect(emailInput).toBeDisabled();

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
@@ -175,7 +175,7 @@ export function ProjectServerPickerList({
           <label
             key={server._id}
             className={`flex items-center gap-3 rounded-md px-2 py-1.5 ${insecure ? "cursor-not-allowed opacity-50" : "hover:bg-muted/50"}`}
-            title={insecure ? "Chatboxes require HTTPS server URLs" : undefined}
+            title={insecure ? "Swarms require HTTPS server URLs" : undefined}
           >
             <Checkbox
               checked={!insecure && selectedServerSet.has(server._id)}
@@ -482,7 +482,7 @@ export function SetupChecklistPanel({
               <CollapsibleContent className="pt-3 pb-1">
                 <div className="space-y-4 rounded-xl border border-border/50 bg-card/40 p-4">
                   <div className="space-y-2">
-                    <Label htmlFor="setup-chatbox-name">Chatbox name</Label>
+                    <Label htmlFor="setup-chatbox-name">Swarm name</Label>
                     <Input
                       id="setup-chatbox-name"
                       value={chatboxDraft.name}
@@ -589,7 +589,7 @@ export function SetupChecklistPanel({
                               </span>
                               <span className="mt-0.5 block text-xs text-muted-foreground">
                                 Signed-in members of this project can open the
-                                chatbox with the link. Guests cannot.
+                                swarm with the link. Guests cannot.
                               </span>
                             </span>
                           </label>
@@ -608,7 +608,7 @@ export function SetupChecklistPanel({
                               </span>
                               <span className="mt-0.5 block text-xs text-muted-foreground">
                                 Only people you invite by email can open this
-                                chatbox.
+                                swarm.
                               </span>
                             </span>
                           </label>
@@ -626,7 +626,7 @@ export function SetupChecklistPanel({
                                 Anyone with the link (guests included)
                               </span>
                               <span className="mt-0.5 block text-xs text-muted-foreground">
-                                Anyone with the link can open the chatbox,
+                                Anyone with the link can open the swarm,
                                 including guests without an account.
                               </span>
                             </span>
@@ -638,7 +638,7 @@ export function SetupChecklistPanel({
                             <p className="text-xs text-muted-foreground">
                               Invite-only is email-based. Project membership
                               does not auto-include everyone—you invite each
-                              address (or use the section below once the chatbox
+                              address (or use the section below once the swarm
                               is saved).
                             </p>
                             <div className="space-y-2">
@@ -689,7 +689,7 @@ export function SetupChecklistPanel({
                               </div>
                               {!inviteChatboxMember ? (
                                 <p className="text-xs text-muted-foreground">
-                                  Save the chatbox to invite people by email.
+                                  Save the swarm to invite people by email.
                                 </p>
                               ) : null}
                             </div>
@@ -697,7 +697,7 @@ export function SetupChecklistPanel({
                         ) : null}
                       </div>
                       <p className="text-sm text-muted-foreground">
-                        Save the chatbox to manage invitations and access
+                        Save the swarm to manage invitations and access
                         settings for the hosted link.
                       </p>
                     </>
@@ -729,7 +729,7 @@ export function SetupChecklistPanel({
                       <p className="text-sm font-medium">Shown on first open</p>
                       <p className="text-xs text-muted-foreground">
                         A short intro shown the first time someone opens your
-                        chatbox link.
+                        swarm link.
                       </p>
                     </div>
                     <Switch
@@ -777,7 +777,7 @@ export function SetupChecklistPanel({
                       />
                       <p className="text-xs text-muted-foreground">
                         {chatboxDraft.chatUi.surfaces.welcome.body.trim()
-                          ? "Shown once, the first time someone opens your chatbox link."
+                          ? "Shown once, the first time someone opens your swarm link."
                           : "Leave blank to skip — no welcome will be shown."}
                       </p>
                     </div>

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -74,9 +74,9 @@ interface ChatboxDisplayError {
 }
 
 const INVALID_CHATBOX_LINK_MESSAGE =
-  "This chatbox link is invalid or expired. Ask the owner to share a new link if you still need access.";
+  "This swarm link is invalid or expired. Ask the owner to share a new link if you still need access.";
 const UNEXPECTED_CHATBOX_ERROR_MESSAGE =
-  "We couldn't open this chatbox right now. Please try again or open MCPJam.";
+  "We couldn't open this swarm right now. Please try again or open MCPJam.";
 
 type ChatboxBootstrapAuthMode = "workos" | "guest";
 type ChatboxLandingState =
@@ -159,7 +159,7 @@ function getChatboxDisplayError(
   if (!error) {
     return {
       kind: "invalid_link",
-      title: "Chatbox Link Unavailable",
+      title: "Swarm Link Unavailable",
       message: INVALID_CHATBOX_LINK_MESSAGE,
     };
   }
@@ -208,14 +208,14 @@ function getChatboxDisplayError(
   if (isInvalidLink) {
     return {
       kind: "invalid_link",
-      title: "Chatbox Link Unavailable",
+      title: "Swarm Link Unavailable",
       message: INVALID_CHATBOX_LINK_MESSAGE,
     };
   }
 
   return {
     kind: "unexpected",
-    title: "Chatbox Link Unavailable",
+    title: "Swarm Link Unavailable",
     message: UNEXPECTED_CHATBOX_ERROR_MESSAGE,
   };
 }
@@ -546,7 +546,7 @@ export function ChatboxChatPage({
           if (!nextSession) {
             throw createChatboxRouteError(
               502,
-              "Chatbox redeem returned an incomplete bootstrap payload."
+              "Swarm redeem returned an incomplete bootstrap payload."
             );
           }
 
@@ -767,7 +767,7 @@ export function ChatboxChatPage({
     // Copy link work across reloads.
     const token = shareableToken;
     if (!session || !token) {
-      toast.error("Chatbox link unavailable");
+      toast.error("Swarm link unavailable");
       return;
     }
 
@@ -780,9 +780,9 @@ export function ChatboxChatPage({
       await navigator.clipboard.writeText(
         buildChatboxLink(token, session.payload.name)
       );
-      toast.success("Chatbox link copied");
+      toast.success("Swarm link copied");
     } catch {
-      toast.error("Failed to copy chatbox link");
+      toast.error("Failed to copy swarm link");
     }
   }, [session, shareableToken]);
 

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -345,11 +345,11 @@ describe("ChatboxChatPage", () => {
     render(<ChatboxChatPage pathToken="stale-token" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Chatbox Link Unavailable" })
+      await screen.findByRole("heading", { name: "Swarm Link Unavailable" })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This chatbox link is invalid or expired. Ask the owner to share a new link if you still need access."
+        "This swarm link is invalid or expired. Ask the owner to share a new link if you still need access."
       )
     ).toBeInTheDocument();
     expect(screen.queryByText(/Uncaught Error:/)).not.toBeInTheDocument();
@@ -612,11 +612,11 @@ describe("ChatboxChatPage", () => {
     render(<ChatboxChatPage pathToken="broken-token" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Chatbox Link Unavailable" })
+      await screen.findByRole("heading", { name: "Swarm Link Unavailable" })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "We couldn't open this chatbox right now. Please try again or open MCPJam."
+        "We couldn't open this swarm right now. Please try again or open MCPJam."
       )
     ).toBeInTheDocument();
     expect(

--- a/mcpjam-inspector/client/src/components/hosts/HostIndexPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostIndexPage.tsx
@@ -84,7 +84,7 @@ export function HostIndexPage({
         <EmptyState
           icon={Server}
           title="No hosts yet"
-          description="Create a named host to reuse across Chat, Chatboxes, and Evals."
+          description="Create a named host to reuse across Chat, Swarms, and Evals."
         >
           <Button onClick={() => setShowCreate(true)}>
             <Plus className="mr-2 h-4 w-4" />

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -210,7 +210,7 @@ const navigationSections: NavSection[] = [
         icon: Layers,
       },
       {
-        title: "Chatboxes",
+        title: "Swarms",
         url: "/chatboxes",
         icon: Box,
         featureFlag: "sandboxes-enabled",

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -133,7 +133,7 @@ describe("getBillingErrorMessage", () => {
     );
 
     expect(message).toBe(
-      "This project has reached its chatbox limit (5). Upgrade to continue."
+      "This project has reached its swarm limit (5). Upgrade to continue."
     );
   });
 
@@ -221,7 +221,7 @@ describe("getBillingErrorMessage", () => {
     );
 
     expect(message).toBe(
-      "Chatboxes is not included in the Free plan. Upgrade to Team to continue."
+      "Swarms is not included in the Free plan. Upgrade to Team to continue."
     );
   });
 
@@ -240,7 +240,7 @@ describe("getBillingErrorMessage", () => {
     );
 
     expect(message).toBe(
-      "Chatboxes is not included in the Free plan. Ask an organization owner to upgrade to Team."
+      "Swarms is not included in the Free plan. Ask an organization owner to upgrade to Team."
     );
   });
 

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -133,7 +133,7 @@ export function formatBillingFeatureName(feature: BillingFeatureName): string {
     case "cicd":
       return "Evals CI/CD";
     case "chatboxes":
-      return "Chatboxes";
+      return "Swarms";
     case "auditLog":
       return "Audit Log";
     case "customDomains":
@@ -161,7 +161,7 @@ export function formatPremiumnessGateKey(gateKey: PremiumnessGateKey): string {
     case "maxServersPerProject":
       return "Servers per project";
     case "maxChatboxesPerProject":
-      return "Chatboxes per project";
+      return "Swarms per project";
     case "maxEvalRunsPerMonth":
       return "Eval runs per month";
     case "maxEvalIterationsPerMonth":
@@ -303,8 +303,8 @@ export function formatBillingLimitReachedMessage(
   }
   if (limitName === "maxChatboxesPerProject") {
     return canManageBilling
-      ? `This project has reached its chatbox limit (${allowedValue}). Upgrade to continue.`
-      : `This project has reached its chatbox limit (${allowedValue}). Ask an organization owner to upgrade.`;
+      ? `This project has reached its swarm limit (${allowedValue}). Upgrade to continue.`
+      : `This project has reached its swarm limit (${allowedValue}). Ask an organization owner to upgrade.`;
   }
   if (limitName === "insightsPerDay") {
     return canManageBilling

--- a/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
@@ -297,7 +297,7 @@ export const CLAUDE_HOST_STYLE: HostStyleDefinition = {
   chatUi: {
     label: "Claude",
     shortLabel: "Claude-style host",
-    pickerDescription: "Claude-style chatbox chrome",
+    pickerDescription: "Claude-style swarm chrome",
     logoSrc: claudeLogo,
     family: "claude",
     resolveChatBackground: (theme) => CLAUDE_DESKTOP_CHAT_BACKGROUND[theme],
@@ -364,7 +364,7 @@ export const CHATGPT_HOST_STYLE: HostStyleDefinition = {
   chatUi: {
     label: "ChatGPT",
     shortLabel: "ChatGPT-style host",
-    pickerDescription: "OpenAI-style chatbox chrome",
+    pickerDescription: "OpenAI-style swarm chrome",
     logoSrc: openaiLogo,
     family: "chatgpt",
     resolveChatBackground: (theme) => CHATGPT_CHAT_BACKGROUND[theme],


### PR DESCRIPTION
## What

Renames the user-facing product term **Chatbox(es) → Swarm(s)** everywhere it's shown to users. This is a **wording-only** change — no behavior, no logic, no schema.

## Internal code is untouched
All identifiers stay `chatbox`, so URLs, deep links, persisted data, and the Convex contract are stable:
- Routes (`/chatboxes`, `/chatbox/<slug>/<token>`)
- Component / type / hook / constant names
- Object keys & discriminants (`chatboxId`, `chatboxAccess`, `sourceType: "chatbox"`)
- Billing feature **keys** (`"chatboxes"`, `"maxChatboxesPerProject"`) — only their display labels change
- Feature flag `sandboxes-enabled`, `htmlFor`/`id` attributes

## Where the copy changed
- Sidebar nav label → **Swarms**
- Billing labels + limit-reached messages
- Tab headings, empty/loading states, aria-labels, iframe titles
- Setup checklist ("Swarm name", HTTPS tooltip)
- Share / delete dialogs, publish toast, access-mode descriptions
- Hosted chat page error dialogs & toasts
- Hosts empty-state ("Chat, Swarms, and Evals")

13 files, 49 lines — all string literals (grammatical number preserved: plural → "Swarms", singular → "Swarm").

## Verification
`npm run typecheck:client` passes. Suggested manual check: sidebar reads "Swarms" and still routes to `/chatboxes`; tab headings/toasts/dialogs say "swarm".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only UI copy and test assertion updates with no logic, API, or routing changes.
> 
> **Overview**
> Rebrands the product label **Chatbox(es) → Swarm(s)** across the client UI while leaving routes (`/chatboxes`), types, and billing feature keys unchanged.
> 
> **Navigation & billing:** Sidebar shows **Swarms**; `formatBillingFeatureName` and limit messages say swarm/swarm limit instead of chatbox.
> 
> **Product surfaces:** Copy updates in the host swarm tab (loading, provisioning, preview, aria-labels), builder/setup checklist, share/delete dialogs, publish toasts, and access presets.
> 
> **Hosted experience:** Guest OAuth expiry, link errors, copy-link toasts, and error headings use swarm wording.
> 
> **Tests:** Expectations aligned with the new strings in App hosted OAuth, ChatboxCanvas, publish bar, setup checklist, and `ChatboxChatPage` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64905c134110095509580aca6f821d4b6767a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->