### PR TITLE
make home tab be able to use users mcp servers

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -89,13 +89,12 @@ import {
   type ChatHistoryTurnTrace,
   type ChatHistoryWidgetSnapshot,
 } from "@/lib/apis/web/chat-history-api";
-import { useProjectServers } from "@/hooks/useViews";
 import { useProjectMembers } from "@/hooks/useProjects";
 import { buildProjectOwnerProfileByUserId } from "@/components/chat-v2/history/project-thread-owner-avatar";
 import { buildSenderAvatarResolver } from "@/components/chat-v2/shared/sender-avatar";
 import { HOSTED_MODE } from "@/lib/config";
-import { buildOAuthTokensByServerId } from "@/lib/oauth/oauth-tokens";
 import { useHostedOrgModelConfig } from "@/hooks/use-hosted-org-model-config";
+import { useResolvedSelectedMcpServers } from "@/hooks/use-resolved-selected-mcp-servers";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import type { ExecutionConfig } from "@/lib/chat-execution-config";
@@ -317,26 +316,14 @@ export function ChatTabV2({
     projectId: effectiveHostedProjectId,
     organizationId: modelConfigOrganizationId,
   });
-  const { serversById, serversByName } = useProjectServers({
-    isAuthenticated: isConvexAuthenticated,
+  const {
+    serversById,
+    selectedServerIds: hostedSelectedServerIds,
+    oauthTokens: hostedOAuthTokens,
+  } = useResolvedSelectedMcpServers({
     projectId: convexProjectId,
+    selectedServerNames: selectedConnectedServerNames,
   });
-  const hostedSelectedServerIds = useMemo(
-    () =>
-      selectedConnectedServerNames
-        .map((serverName) => serversByName.get(serverName))
-        .filter((serverId): serverId is string => !!serverId),
-    [selectedConnectedServerNames, serversByName]
-  );
-  const hostedOAuthTokens = useMemo(
-    () =>
-      buildOAuthTokensByServerId(
-        selectedConnectedServerNames,
-        (name) => serversByName.get(name),
-        (name) => appState.servers[name]?.oauthTokens?.access_token
-      ),
-    [selectedConnectedServerNames, serversByName, appState.servers]
-  );
   const effectiveHostedSelectedServerIds =
     hostedContext?.selectedServerIds ?? hostedSelectedServerIds;
   const effectiveHostedOAuthTokens = hostedChatboxId

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -127,8 +127,8 @@ vi.mock("@/lib/oauth/oauth-tokens", () => ({
   buildOAuthTokensByServerId: vi.fn(() => ({})),
 }));
 
-vi.mock("@/state/app-state-context", () => ({
-  useSharedAppState: () => ({
+vi.mock("@/state/app-state-context", () => {
+  const appState = {
     servers: {
       "server-1": {
         connectionStatus: "connected",
@@ -140,8 +140,12 @@ vi.mock("@/state/app-state-context", () => ({
       },
     },
     activeProjectId: "project-1",
-  }),
-}));
+  };
+  return {
+    useSharedAppState: () => appState,
+    useOptionalSharedAppState: () => appState,
+  };
+});
 
 vi.mock("@/components/ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children: ReactNode }) => (

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
@@ -63,8 +63,8 @@ vi.mock("@/lib/oauth/oauth-tokens", () => ({
   buildOAuthTokensByServerId: vi.fn(() => ({})),
 }));
 
-vi.mock("@/state/app-state-context", () => ({
-  useSharedAppState: () => ({
+vi.mock("@/state/app-state-context", () => {
+  const appState = {
     servers: {
       "server-1": {
         connectionStatus: "connected",
@@ -72,8 +72,12 @@ vi.mock("@/state/app-state-context", () => ({
     },
     projects: {},
     activeProjectId: "project-1",
-  }),
-}));
+  };
+  return {
+    useSharedAppState: () => appState,
+    useOptionalSharedAppState: () => appState,
+  };
+});
 
 vi.mock("@/components/ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children: ReactNode }) => (

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/McpjamAgentThread.tsx
@@ -24,6 +24,7 @@ import {
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-client-style-context";
+import { WebManagedServersProvider } from "@/contexts/web-managed-servers-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { useMcpjamAgentSession } from "@/hooks/use-mcpjam-agent-session";
@@ -103,7 +104,8 @@ export function McpjamAgentThread({
   // Both the backend route and the persistence path require a resolved
   // model + projectId. On cold load either can be undefined for a few
   // frames; gate every submit affordance on both being present.
-  const isReady = session.model != null && projectId != null;
+  const isReady =
+    session.model != null && projectId != null && session.serversReady;
 
   const handleSubmit = useCallback(
     (text: string) => {
@@ -205,7 +207,9 @@ export function McpjamAgentThread({
       onChange={setDraft}
       onSubmit={() => handleSubmit(draft)}
       ready={isReady}
-      loadingMessage="Loading project…"
+      loadingMessage={
+        session.serversReady ? "Loading project…" : "Loading MCP servers…"
+      }
       placeholder="Continue the conversation…"
       isStreaming={isStreaming}
       onStop={() => session.stop()}
@@ -300,31 +304,33 @@ export function McpjamAgentThread({
     <MarkdownLinkBaseProvider base="https://docs.mcpjam.com" trustLinks>
       <ChatboxHostStyleProvider value="mcpjam">
         <ChatboxHostThemeProvider value={themeMode}>
-        <div
-          className={cn(
-            "chatbox-host-shell flex flex-col gap-4 min-h-0",
-            fillsParent
-              ? "h-full"
-              : "min-h-[36rem] rounded-2xl border border-border/70 bg-card/30 p-4 shadow-sm",
-            className
-          )}
-          data-host-style="mcpjam"
-          style={shellStyle}
-        >
-          {body}
-          {composer}
-          {session.error && (
-            <p
+          <WebManagedServersProvider value>
+            <div
               className={cn(
-                "text-xs text-destructive",
-                isFull && "mx-auto w-full max-w-4xl px-4",
-                isSidebar && "w-full px-3"
+                "chatbox-host-shell flex flex-col gap-4 min-h-0",
+                fillsParent
+                  ? "h-full"
+                  : "min-h-[36rem] rounded-2xl border border-border/70 bg-card/30 p-4 shadow-sm",
+                className
               )}
+              data-host-style="mcpjam"
+              style={shellStyle}
             >
-              {session.error.message ?? "Something went wrong."}
-            </p>
-          )}
-        </div>
+              {body}
+              {composer}
+              {session.error && (
+                <p
+                  className={cn(
+                    "text-xs text-destructive",
+                    isFull && "mx-auto w-full max-w-4xl px-4",
+                    isSidebar && "w-full px-3"
+                  )}
+                >
+                  {session.error.message ?? "Something went wrong."}
+                </p>
+              )}
+            </div>
+          </WebManagedServersProvider>
         </ChatboxHostThemeProvider>
       </ChatboxHostStyleProvider>
     </MarkdownLinkBaseProvider>

--- a/mcpjam-inspector/client/src/components/mcpjam-agent/__tests__/McpjamAgentThread.test.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-agent/__tests__/McpjamAgentThread.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
+import { useWebManagedServers } from "@/contexts/web-managed-servers-context";
+import { McpjamAgentThread } from "../McpjamAgentThread";
+
+const sessionMock = vi.hoisted(() => ({
+  current: {
+    status: "ready",
+    model: { id: "gpt-5" },
+    serversReady: true,
+    hydrating: false,
+    messages: [{ id: "m1", role: "assistant", parts: [] }],
+    error: null,
+    submit: vi.fn(),
+    stop: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/use-mcpjam-agent-session", () => ({
+  useMcpjamAgentSession: () => sessionMock.current,
+}));
+
+vi.mock("@/components/mcpjam-agent/McpjamAgentComposer", () => ({
+  McpjamAgentComposer: () => <div data-testid="composer" />,
+}));
+
+vi.mock("@/components/chat-v2/thread", () => ({
+  Thread: () => {
+    const webManagedServers = useWebManagedServers();
+    return (
+      <div data-testid="thread-web-managed">{String(webManagedServers)}</div>
+    );
+  },
+}));
+
+vi.mock("use-stick-to-bottom", () => {
+  const StickToBottom = Object.assign(
+    ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="stick-to-bottom">{children}</div>
+    ),
+    {
+      Content: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+      ),
+    }
+  );
+  return { StickToBottom };
+});
+
+vi.mock("@/components/chat-v2/shared/scroll-to-bottom-button", () => ({
+  ScrollToBottomButton: () => null,
+}));
+
+function renderThread() {
+  return render(
+    <PreferencesStoreProvider themeMode="light" themePreset="default">
+      <McpjamAgentThread
+        sessionId="session-1"
+        projectId="project-1"
+        organizationId="org-1"
+        surface="home"
+      />
+    </PreferencesStoreProvider>
+  );
+}
+
+describe("McpjamAgentThread", () => {
+  beforeEach(() => {
+    sessionMock.current = {
+      status: "ready",
+      model: { id: "gpt-5" },
+      serversReady: true,
+      hydrating: false,
+      messages: [{ id: "m1", role: "assistant", parts: [] }],
+      error: null,
+      submit: vi.fn(),
+      stop: vi.fn(),
+    };
+  });
+
+  it("marks its chat widget surface as web-managed", () => {
+    renderThread();
+
+    expect(screen.getByTestId("thread-web-managed").textContent).toBe("true");
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -98,12 +98,11 @@ import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { usePersistedHost } from "@/hooks/use-persisted-host";
 import { usePlaygroundHostSlots } from "@/hooks/use-playground-host-slots";
 import { replaceLeadHostId } from "@/lib/selected-host-storage";
-import { useProjectServers } from "@/hooks/useViews";
 import { useProjectMembers } from "@/hooks/useProjects";
 import { buildProjectOwnerProfileByUserId } from "@/components/chat-v2/history/project-thread-owner-avatar";
 import { buildSenderAvatarResolver } from "@/components/chat-v2/shared/sender-avatar";
 import { useHostedOrgModelConfig } from "@/hooks/use-hosted-org-model-config";
-import { buildOAuthTokensByServerId } from "@/lib/oauth/oauth-tokens";
+import { useResolvedSelectedMcpServers } from "@/hooks/use-resolved-selected-mcp-servers";
 import {
   snapshotFromHostConfig,
   type HostSnapshot,
@@ -540,26 +539,14 @@ export function PlaygroundMain({
     projectId: convexProjectId,
     organizationId: activeProject?.organizationId ?? null,
   });
-  const { serversById, serversByName } = useProjectServers({
-    isAuthenticated: isConvexAuthenticated,
+  const {
+    serversById,
+    selectedServerIds: hostedSelectedServerIds,
+    oauthTokens: hostedOAuthTokens,
+  } = useResolvedSelectedMcpServers({
     projectId: convexProjectId,
+    selectedServerNames: selectedServers,
   });
-  const hostedSelectedServerIds = useMemo(
-    () =>
-      selectedServers
-        .map((name) => serversByName.get(name))
-        .filter((serverId): serverId is string => !!serverId),
-    [selectedServers, serversByName]
-  );
-  const hostedOAuthTokens = useMemo(
-    () =>
-      buildOAuthTokensByServerId(
-        selectedServers,
-        (name) => serversByName.get(name),
-        (name) => appState.servers[name]?.oauthTokens?.access_token
-      ),
-    [selectedServers, serversByName, appState.servers]
-  );
 
   // Mirror the previewed host's chat-execution fields (system prompt,
   // temperature, tool approval, selected servers) into the chat session

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -378,6 +378,7 @@ const mockSharedAppState = {
 
 vi.mock("@/state/app-state-context", () => ({
   useSharedAppState: () => mockSharedAppState,
+  useOptionalSharedAppState: () => mockSharedAppState,
 }));
 
 vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -531,6 +531,7 @@ const mockSharedAppState = {
 
 vi.mock("@/state/app-state-context", () => ({
   useSharedAppState: () => mockSharedAppState,
+  useOptionalSharedAppState: () => mockSharedAppState,
 }));
 
 // Mock chat-helpers (keep real placeholders; stub formatError + empty starters for stable tests)

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-mcpjam-agent-session.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-mcpjam-agent-session.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useMcpjamAgentSession } from "../use-mcpjam-agent-session";
+
+const model = {
+  id: "anthropic/claude-haiku-4.5",
+  name: "Claude Haiku 4.5",
+  provider: "anthropic" as const,
+};
+
+const mockState = vi.hoisted(() => ({
+  sendMessage: vi.fn(),
+  stop: vi.fn(),
+  setMessages: vi.fn(),
+  capture: vi.fn(),
+  lastTransportOptions: null as null | {
+    body: () => Record<string, unknown>;
+  },
+  projectServers: {
+    serversByName: new Map<string, string>(),
+    isLoading: false,
+  },
+  appState: {
+    projects: {},
+    activeProjectId: "project-local",
+    selectedServer: "",
+    selectedMultipleServers: [] as string[],
+    isMultiSelectMode: false,
+    servers: {} as Record<string, any>,
+  },
+}));
+
+vi.mock("ai", () => ({
+  generateId: () => "generated-session",
+  DefaultChatTransport: class MockTransport {
+    constructor(options: { body: () => Record<string, unknown> }) {
+      mockState.lastTransportOptions = options;
+    }
+  },
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: () => ({
+    messages: [],
+    sendMessage: mockState.sendMessage,
+    status: "ready",
+    error: undefined,
+    stop: mockState.stop,
+    setMessages: mockState.setMessages,
+  }),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: mockState.capture }),
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: vi.fn(),
+}));
+
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServers: () => mockState.projectServers,
+}));
+
+vi.mock("@/state/app-state-context", () => ({
+  useOptionalSharedAppState: () => mockState.appState,
+}));
+
+vi.mock("@/hooks/use-hosted-org-model-config", () => ({
+  useHostedOrgModelConfig: () => ({}),
+}));
+
+vi.mock("@/hooks/use-persisted-model", () => ({
+  usePersistedModel: () => ({ selectedModelId: model.id }),
+}));
+
+vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
+  buildAvailableModelsFromOrgConfig: () => [model],
+  getDefaultModel: () => model,
+}));
+
+vi.mock("@/lib/apis/web/chat-history-api", () => ({
+  getChatHistoryDetail: vi.fn(),
+}));
+
+describe("useMcpjamAgentSession project server selection", () => {
+  beforeEach(() => {
+    mockState.sendMessage.mockClear();
+    mockState.stop.mockClear();
+    mockState.setMessages.mockClear();
+    mockState.capture.mockClear();
+    mockState.lastTransportOptions = null;
+    mockState.projectServers = {
+      serversByName: new Map<string, string>(),
+      isLoading: false,
+    };
+    mockState.appState = {
+      projects: {},
+      activeProjectId: "project-local",
+      selectedServer: "",
+      selectedMultipleServers: [],
+      isMultiSelectMode: false,
+      servers: {},
+    };
+  });
+
+  it("does not submit while connected server ids are still loading", () => {
+    mockState.projectServers = {
+      serversByName: new Map<string, string>(),
+      isLoading: true,
+    };
+    mockState.appState.selectedMultipleServers = ["asana"];
+    mockState.appState.servers = {
+      asana: {
+        connectionStatus: "connected",
+        oauthTokens: { access_token: "asana-token" },
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useMcpjamAgentSession({ projectId: "proj_1" })
+    );
+
+    expect(result.current.serversReady).toBe(false);
+    act(() => result.current.submit("use asana"));
+
+    expect(mockState.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("posts the app-selected connected servers and OAuth tokens once ids resolve", () => {
+    mockState.projectServers = {
+      serversByName: new Map<string, string>([
+        ["asana", "srv_asana"],
+        ["github", "srv_github"],
+      ]),
+      isLoading: false,
+    };
+    mockState.appState.selectedMultipleServers = ["asana"];
+    mockState.appState.servers = {
+      asana: {
+        connectionStatus: "connected",
+        oauthTokens: { access_token: "asana-token" },
+      },
+      github: {
+        connectionStatus: "connected",
+        oauthTokens: { access_token: "github-token" },
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useMcpjamAgentSession({ projectId: "proj_1" })
+    );
+
+    expect(result.current.serversReady).toBe(true);
+    act(() => result.current.submit("use asana"));
+
+    expect(mockState.sendMessage).toHaveBeenCalledWith({ text: "use asana" });
+    expect(mockState.lastTransportOptions?.body()).toMatchObject({
+      projectId: "proj_1",
+      chatSessionId: "generated-session",
+      selectedServerIds: ["srv_asana"],
+      selectedServerNames: ["asana"],
+      oauthTokens: { srv_asana: "asana-token" },
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-resolved-selected-mcp-servers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-resolved-selected-mcp-servers.test.tsx
@@ -1,0 +1,98 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useResolvedSelectedMcpServers } from "../use-resolved-selected-mcp-servers";
+
+const mockState = vi.hoisted(() => ({
+  projectServers: {
+    serversById: new Map<string, string>(),
+    serversByName: new Map<string, string>(),
+    isLoading: false,
+  },
+  appState: {
+    selectedMultipleServers: [] as string[],
+    servers: {} as Record<string, any>,
+  },
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServers: () => mockState.projectServers,
+}));
+
+vi.mock("@/state/app-state-context", () => ({
+  useOptionalSharedAppState: () => mockState.appState,
+}));
+
+describe("useResolvedSelectedMcpServers", () => {
+  beforeEach(() => {
+    mockState.projectServers = {
+      serversById: new Map<string, string>([
+        ["srv_asana", "asana"],
+        ["srv_github", "github"],
+      ]),
+      serversByName: new Map<string, string>([
+        ["asana", "srv_asana"],
+        ["github", "srv_github"],
+      ]),
+      isLoading: false,
+    };
+    mockState.appState = {
+      selectedMultipleServers: [],
+      servers: {
+        asana: {
+          connectionStatus: "connected",
+          oauthTokens: { access_token: "asana-token" },
+        },
+        github: {
+          connectionStatus: "connected",
+          oauthTokens: { access_token: "github-token" },
+        },
+      },
+    };
+  });
+
+  it("resolves explicit selected names to server ids and OAuth tokens", () => {
+    const { result } = renderHook(() =>
+      useResolvedSelectedMcpServers({
+        projectId: "proj_1",
+        selectedServerNames: ["github"],
+      })
+    );
+
+    expect(result.current.selectedServerNames).toEqual(["github"]);
+    expect(result.current.selectedServerIds).toEqual(["srv_github"]);
+    expect(result.current.oauthTokens).toEqual({
+      srv_github: "github-token",
+    });
+    expect(result.current.isReady).toBe(true);
+  });
+
+  it("derives Home selection from shared selected/connected server state", () => {
+    mockState.appState.selectedMultipleServers = ["asana"];
+
+    const { result } = renderHook(() =>
+      useResolvedSelectedMcpServers({ projectId: "proj_1" })
+    );
+
+    expect(result.current.selectedServerNames).toEqual(["asana"]);
+    expect(result.current.selectedServerIds).toEqual(["srv_asana"]);
+    expect(result.current.oauthTokens).toEqual({
+      srv_asana: "asana-token",
+    });
+  });
+
+  it("falls back to all connected servers when shared multi-select is empty", () => {
+    const { result } = renderHook(() =>
+      useResolvedSelectedMcpServers({ projectId: "proj_1" })
+    );
+
+    expect(result.current.selectedServerNames).toEqual(["asana", "github"]);
+    expect(result.current.selectedServerIds).toEqual([
+      "srv_asana",
+      "srv_github",
+    ]);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -15,6 +15,7 @@ import { useChat, type UIMessage } from "@ai-sdk/react";
 import { DefaultChatTransport, generateId } from "ai";
 import { usePostHog } from "posthog-js/react";
 import { authFetch } from "@/lib/session-token";
+import { useResolvedSelectedMcpServers } from "@/hooks/use-resolved-selected-mcp-servers";
 import { useHostedOrgModelConfig } from "@/hooks/use-hosted-org-model-config";
 import { usePersistedModel } from "@/hooks/use-persisted-model";
 import {
@@ -66,6 +67,8 @@ export interface UseMcpjamAgentSessionResult {
   model: ModelDefinition | undefined;
   /** True while the persisted transcript is being seeded on mount. */
   hydrating: boolean;
+  /** True once connected MCP server names have been resolved to hosted ids. */
+  serversReady: boolean;
 }
 
 export function useMcpjamAgentSession(
@@ -112,6 +115,26 @@ export function useMcpjamAgentSession(
   useEffect(() => {
     modelRef.current = resolvedModel;
   }, [resolvedModel]);
+
+  // The servers the agent should be able to call tools on: the app-level
+  // selected server set that `ActiveHostServerReconciler` keeps aligned with
+  // connected/reconnecting servers, falling back to currently connected names
+  // for isolated surfaces. Then resolve names → hosted ids, same as
+  // Playground/chat-v2. The backend authorizes each id against the project
+  // (membership + ownership) before connecting, strictly — no "send
+  // everything" fallback.
+  const selectedServers = useResolvedSelectedMcpServers({ projectId });
+  const serversReady = selectedServers.isReady;
+  const serversReadyRef = useRef(serversReady);
+  useEffect(() => {
+    serversReadyRef.current = serversReady;
+  }, [serversReady]);
+  // Read through a ref so the transport body always sees the latest server
+  // list without rebuilding the transport (which would churn `useChat`).
+  const selectedServersRef = useRef(selectedServers);
+  useEffect(() => {
+    selectedServersRef.current = selectedServers;
+  }, [selectedServers]);
 
   // Transcript hydration: when we mount with a known session id, fetch the
   // persisted transcript and seed `useChat`. Without this, reload would
@@ -177,6 +200,11 @@ export function useMcpjamAgentSession(
           model: modelRef.current,
           projectId,
           chatSessionId,
+          selectedServerIds: selectedServersRef.current.selectedServerIds,
+          selectedServerNames: selectedServersRef.current.selectedServerNames,
+          ...(selectedServersRef.current.oauthTokens
+            ? { oauthTokens: selectedServersRef.current.oauthTokens }
+            : {}),
         }),
       }),
     [chatSessionId, projectId]
@@ -245,6 +273,7 @@ export function useMcpjamAgentSession(
     (text: string) => {
       const trimmed = text.trim();
       if (!trimmed) return;
+      if (!serversReadyRef.current) return;
       // Mint an id on first submit when the caller didn't provide one,
       // so the persistence path has something to dedupe on.
       if (!providedSessionId && seededForRef.current === null) {
@@ -274,5 +303,6 @@ export function useMcpjamAgentSession(
     stop,
     model: resolvedModel,
     hydrating,
+    serversReady,
   };
 }

--- a/mcpjam-inspector/client/src/hooks/use-resolved-selected-mcp-servers.ts
+++ b/mcpjam-inspector/client/src/hooks/use-resolved-selected-mcp-servers.ts
@@ -1,0 +1,91 @@
+import { useMemo } from "react";
+import { useConvexAuth } from "convex/react";
+import { useProjectServers } from "@/hooks/useViews";
+import { useOptionalSharedAppState } from "@/state/app-state-context";
+import { buildOAuthTokensByServerId } from "@/lib/oauth/oauth-tokens";
+
+export interface UseResolvedSelectedMcpServersArgs {
+  projectId: string | null | undefined;
+  /**
+   * Optional surface-owned selected names. Chat and Playground pass their
+   * already-filtered runtime selection here. When omitted, the hook derives the
+   * Home/agent selection from shared app state.
+   */
+  selectedServerNames?: readonly string[] | null;
+}
+
+export interface ResolvedSelectedMcpServers {
+  selectedServerIds: string[];
+  selectedServerNames: string[];
+  oauthTokens: Record<string, string> | undefined;
+  serversById: Map<string, string>;
+  serversByName: Map<string, string>;
+  isLoading: boolean;
+  isReady: boolean;
+}
+
+export function useResolvedSelectedMcpServers({
+  projectId,
+  selectedServerNames,
+}: UseResolvedSelectedMcpServersArgs): ResolvedSelectedMcpServers {
+  const { isAuthenticated } = useConvexAuth();
+  const { serversById, serversByName, isLoading } = useProjectServers({
+    isAuthenticated,
+    projectId: projectId ?? null,
+  });
+  const appState = useOptionalSharedAppState();
+
+  const effectiveSelectedServerNames = useMemo(() => {
+    if (selectedServerNames) {
+      return [...selectedServerNames];
+    }
+
+    const serverMap = appState?.servers ?? {};
+    const activeSelectedNames = (appState?.selectedMultipleServers ?? []).filter(
+      (name) => {
+        const status = serverMap[name]?.connectionStatus;
+        return status === "connected" || status === "connecting";
+      }
+    );
+    if (activeSelectedNames.length > 0) return activeSelectedNames;
+
+    return Object.entries(serverMap)
+      .filter(([, server]) => server?.connectionStatus === "connected")
+      .map(([name]) => name);
+  }, [
+    appState?.selectedMultipleServers,
+    appState?.servers,
+    selectedServerNames,
+  ]);
+
+  const selectedServers = useMemo(() => {
+    const serverMap = appState?.servers ?? {};
+    const ids: string[] = [];
+    const names: string[] = [];
+
+    for (const name of effectiveSelectedServerNames) {
+      const id = serversByName.get(name);
+      if (!id) continue;
+      ids.push(id);
+      names.push(name);
+    }
+
+    const oauthTokens = buildOAuthTokensByServerId(
+      names,
+      (name) => serversByName.get(name),
+      (name) => serverMap[name]?.oauthTokens?.access_token
+    );
+
+    return { ids, names, oauthTokens };
+  }, [appState?.servers, effectiveSelectedServerNames, serversByName]);
+
+  return {
+    selectedServerIds: selectedServers.ids,
+    selectedServerNames: selectedServers.names,
+    oauthTokens: selectedServers.oauthTokens,
+    serversById,
+    serversByName,
+    isLoading,
+    isReady: !isLoading,
+  };
+}

--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -156,6 +156,58 @@ describe("web auth manager batching", () => {
     );
   });
 
+  it("rejects additional server configs that collide with authorized project servers", async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          results: {
+            "server-1": {
+              ok: true,
+              role: "member",
+              accessLevel: "project_member",
+              permissions: { chatOnly: false },
+              serverConfig: {
+                transportType: "http",
+                url: "https://server-1.example.com/mcp",
+                headers: {},
+                useOAuth: false,
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }) as typeof fetch;
+
+    await expect(
+      createAuthorizedManager(
+        callerContextFromHono(mockContext),
+        "bearer-token",
+        "project-1",
+        ["server-1"],
+        10_000,
+        undefined,
+        undefined,
+        {
+          additionalServerConfigs: {
+            "server-1": {
+              transportType: "http",
+              url: "https://injected.example.com/mcp",
+            },
+          },
+        }
+      )
+    ).rejects.toMatchObject<WebRouteError>({
+      status: 500,
+      code: "INTERNAL_ERROR",
+      details: { serverIds: ["server-1"] },
+    });
+    expect(mcpClientManagerMock).not.toHaveBeenCalled();
+  });
+
   it("attaches hosted OAuth onUnauthorized and force-refreshes through Convex", async () => {
     global.fetch = vi.fn(async (input, init) => {
       const url = fetchUrl(input);

--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent-widget-content.test.ts
@@ -19,15 +19,23 @@ const managerState = vi.hoisted(() => ({
   disconnectAllServers: vi.fn(async () => {}),
 }));
 
+// The route authorizes the caller's project servers through this helper
+// (same path chat-v2 uses). The default impl stands up a fake manager that
+// owns both the requested project servers and the injected built-ins.
+const authMocks = vi.hoisted(() => ({ createAuthorizedManager: vi.fn() }));
+
 vi.mock("@mcpjam/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@mcpjam/sdk")>();
   class FakeMCPClientManager {
+    configs: Record<string, any>;
     constructor(configs: Record<string, any>) {
+      this.configs = configs;
       managerState.constructedConfigs.push(configs);
     }
     readResource = managerState.readResource;
     disconnectAllServers = managerState.disconnectAllServers;
     listTools = managerState.listTools;
+    listServers = () => Object.keys(this.configs);
   }
   return { ...actual, MCPClientManager: FakeMCPClientManager };
 });
@@ -69,6 +77,8 @@ vi.mock("../auth.js", () => {
       message: error?.message ?? "Internal error",
       details: error?.details,
     }),
+    callerContextFromHono: () => ({}),
+    createAuthorizedManager: authMocks.createAuthorizedManager,
   };
 });
 
@@ -108,6 +118,35 @@ beforeEach(() => {
   managerState.listTools.mockResolvedValue({ tools: [] });
   managerState.disconnectAllServers.mockClear();
   streamWebChatTurn.mockClear();
+  authMocks.createAuthorizedManager.mockReset();
+  // Default: authorize every requested project server and merge the injected
+  // built-ins, returning a manager that owns the union.
+  authMocks.createAuthorizedManager.mockImplementation(
+    async (
+      _caller: unknown,
+      _bearer: unknown,
+      _projectId: unknown,
+      serverIds: string[],
+      _timeout: unknown,
+      _oauth: unknown,
+      _caps: unknown,
+      opts?: { additionalServerConfigs?: Record<string, unknown> }
+    ) => {
+      const configs: Record<string, unknown> = {
+        ...(opts?.additionalServerConfigs ?? {}),
+        ...Object.fromEntries((serverIds ?? []).map((id) => [id, {}])),
+      };
+      managerState.constructedConfigs.push(configs);
+      return {
+        manager: {
+          listServers: () => Object.keys(configs),
+          listTools: managerState.listTools,
+          disconnectAllServers: managerState.disconnectAllServers,
+        },
+        oauthServerUrls: {},
+      };
+    }
+  );
 });
 
 describe("POST /api/web/mcpjam-agent ambient project context", () => {
@@ -175,6 +214,95 @@ describe("POST /api/web/mcpjam-agent ambient project context", () => {
     // about them either.
     expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs"]);
     expect(args.prepare.systemPrompt).toBe("Be terse.");
+  });
+});
+
+describe("POST /api/web/mcpjam-agent project servers", () => {
+  it("authorizes the caller's project servers and advertises their tools alongside the built-ins", async () => {
+    const app = makeApp();
+    const response = await app.request("/api/web/mcpjam-agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
+        model: { id: "anthropic/claude-haiku-4.5" },
+        chatSessionId: "session_1",
+        projectId: "proj_ambient",
+        // Synthetic ids are dropped and duplicate project ids are deduped;
+        // names must stay aligned with the surviving ids.
+        selectedServerIds: [
+          MCPJAM_PLATFORM_SERVER_ID,
+          "srv_real_1",
+          "srv_real_1",
+          "srv_real_2",
+        ],
+        selectedServerNames: [
+          "platform",
+          "My Server",
+          "Duplicate Label",
+          "Other Server",
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    // The project server is authorized through the same Convex check chat-v2
+    // uses (strict), with the two MCPJam-owned servers injected as
+    // `additionalServerConfigs` (which skip project authorization).
+    expect(authMocks.createAuthorizedManager).toHaveBeenCalledTimes(1);
+    const callArgs = authMocks.createAuthorizedManager.mock.calls[0]!;
+    expect(callArgs[3]).toEqual(["srv_real_1", "srv_real_2"]);
+    const opts = callArgs[7] as {
+      serverNames?: string[];
+      additionalServerConfigs?: Record<string, unknown>;
+    };
+    expect(opts.serverNames).toEqual(["My Server", "Other Server"]);
+    expect(opts.additionalServerConfigs).toHaveProperty("mcpjam-docs");
+    expect(opts.additionalServerConfigs).toHaveProperty(
+      MCPJAM_PLATFORM_SERVER_ID
+    );
+
+    // The user's server tools reach the model alongside the built-ins.
+    const streamArgs = streamWebChatTurn.mock.calls[0]![0] as unknown as {
+      prepare: { selectedServerIds: string[] };
+    };
+    expect(streamArgs.prepare.selectedServerIds).toContain("srv_real_1");
+    expect(streamArgs.prepare.selectedServerIds).toContain("srv_real_2");
+    expect(streamArgs.prepare.selectedServerIds).toContain(
+      MCPJAM_PLATFORM_SERVER_ID
+    );
+    expect(streamArgs.prepare.selectedServerIds).toContain("mcpjam-docs");
+  });
+
+  it("skips the Convex authorize round trip when no project servers are sent", async () => {
+    const app = makeApp();
+    const response = await app.request("/api/web/mcpjam-agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        messages: [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
+        model: { id: "anthropic/claude-haiku-4.5" },
+        chatSessionId: "session_1",
+        projectId: "proj_ambient",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(authMocks.createAuthorizedManager).not.toHaveBeenCalled();
+    const streamArgs = streamWebChatTurn.mock.calls[0]![0] as unknown as {
+      prepare: { selectedServerIds: string[] };
+    };
+    expect(streamArgs.prepare.selectedServerIds).toEqual([
+      "mcpjam-docs",
+      MCPJAM_PLATFORM_SERVER_ID,
+    ]);
   });
 });
 

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -926,8 +926,23 @@ export async function createAuthorizedManager(
     })
   );
 
+  const authorizedConfigs = Object.fromEntries(configEntries);
+  const overlappingAdditionalServerIds = Object.keys(
+    additionalServerConfigs
+  ).filter((serverId) =>
+    Object.prototype.hasOwnProperty.call(authorizedConfigs, serverId)
+  );
+  if (overlappingAdditionalServerIds.length > 0) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Additional MCP server configs cannot override authorized project servers.",
+      { serverIds: overlappingAdditionalServerIds }
+    );
+  }
+
   const manager = new MCPClientManager(
-    { ...Object.fromEntries(configEntries), ...additionalServerConfigs },
+    { ...authorizedConfigs, ...additionalServerConfigs },
     {
       defaultTimeout: timeoutMs,
       rpcLogger: options?.rpcLogger,

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -775,14 +775,22 @@ export async function createAuthorizedManager(
      * undefined (SDK chooses at request time).
      */
     mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+    /**
+     * Extra pre-built server configs merged into the manager alongside the
+     * authorized project servers. Used by the MCPJam Agent to bolt its
+     * MCPJam-owned servers (docs + platform) onto the caller's own project
+     * servers — these are NOT routed through project authorization.
+     */
+    additionalServerConfigs?: Record<string, HttpServerConfig>;
   }
 ): Promise<AuthorizedManagerResult> {
   const serverNamesById = buildServerNamesById(serverIds, options?.serverNames);
   const uniqueServerIds = Array.from(new Set(serverIds));
+  const additionalServerConfigs = options?.additionalServerConfigs ?? {};
   if (uniqueServerIds.length === 0) {
     return {
       manager: new MCPClientManager(
-        {},
+        { ...additionalServerConfigs },
         {
           defaultTimeout: timeoutMs,
           rpcLogger: options?.rpcLogger,
@@ -918,11 +926,14 @@ export async function createAuthorizedManager(
     })
   );
 
-  const manager = new MCPClientManager(Object.fromEntries(configEntries), {
-    defaultTimeout: timeoutMs,
-    rpcLogger: options?.rpcLogger,
-    retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
-  });
+  const manager = new MCPClientManager(
+    { ...Object.fromEntries(configEntries), ...additionalServerConfigs },
+    {
+      defaultTimeout: timeoutMs,
+      rpcLogger: options?.rpcLogger,
+      retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
+    }
+  );
   return {
     manager,
     oauthServerUrls,

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -28,18 +28,28 @@
  * `http://localhost:8787/mcp`. If the worker is down the preflight below
  * degrades the agent to docs + web_search.
  *
+ * The agent also connects to whichever of the caller's OWN project MCP
+ * servers the client passes as `selectedServerIds`, so the same tools the
+ * user can call in Playground are callable here. The client sends only the
+ * servers it shows as CONNECTED (same client-side filter chat-v2 uses), and
+ * those ids are authorized through `createAuthorizedManager` (project
+ * membership + ownership, exactly like chat-v2) — strict, no special
+ * tolerance. The two MCPJam-owned servers ride alongside as
+ * `additionalServerConfigs`, which skip that project authorization because
+ * they aren't project-registered.
+ *
  * Differences vs `/api/web/chat-v2`:
- *   - The agent owns its own `MCPClientManager` hardcoded to the two
- *     servers. It does NOT go through `createAuthorizedManager`'s
- *     project-server resolution and does NOT register either server into
- *     any user's project.
+ *   - The two MCPJam-owned servers are NOT registered into any user's
+ *     project; they're injected as `additionalServerConfigs`.
  *   - Persists as `sourceType: "direct"` with `hostConfig: null` — the
  *     synthetic `"mcpjam-docs"` / `"mcpjam-platform"` ids would fail
  *     backend `selectedServerIds` validation against the project's
  *     `servers` rows. The chat appears in the user's history alongside
  *     other direct sessions; per-surface differentiation is client-side.
- *   - Rejects chatbox / appTools / selectedServerIds fields up front — this
- *     surface owns its tool set.
+ *   - Skips the eval-authoring tool snapshot (`captureToolSnapshot: false`)
+ *     because the persisted id list mixes synthetic and project ids.
+ *   - Rejects chatbox / appTools fields — this surface owns its tool set
+ *     beyond the user's own servers.
  */
 import { Hono } from "hono";
 import { z } from "zod";
@@ -71,6 +81,8 @@ import {
   ErrorCode,
   webError,
   mapRuntimeError,
+  createAuthorizedManager,
+  callerContextFromHono,
 } from "./auth.js";
 import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
@@ -117,10 +129,10 @@ function buildPlatformConfig(bearerToken: string): HttpServerConfig {
 // (`id`, `trigger`, `messageId`, …) on every turn. `hostedChatSchema` in
 // `auth.ts` tolerates this via `.passthrough()`; we match that pattern so
 // the AI SDK extras are silently passed through instead of rejected as
-// validation errors. Server-side use of the parsed body still only reads
-// the explicitly-declared fields below — there's no path here that routes
-// a tampered selectedServerIds / appTools / chatbox field into the
-// streamWebChatTurn call because we don't read them at all.
+// validation errors. Server-side use of the parsed body is limited to the
+// explicitly-declared fields below; user project `selectedServerIds` are still
+// authorized through `createAuthorizedManager` before any tool reaches the
+// model.
 const mcpjamAgentSchema = z
   .object({
     messages: z.array(z.any()).min(1),
@@ -137,6 +149,16 @@ const mcpjamAgentSchema = z
     temperature: z.number().optional(),
     requireToolApproval: z.boolean().optional(),
     respectToolVisibility: z.boolean().optional(),
+    // The caller's own CONNECTED project MCP servers to connect alongside the
+    // two MCPJam-owned servers. These ARE authorized against the project (the
+    // user must be a member and the servers must belong to it) via
+    // `createAuthorizedManager` below — the client can't reach a server it
+    // wouldn't be allowed to connect in Playground. Names are index-aligned
+    // display labels used only for OAuth/error messaging; `oauthTokens` maps
+    // serverId → access token for OAuth servers (same shape chat-v2 forwards).
+    selectedServerIds: z.array(z.string()).optional(),
+    selectedServerNames: z.array(z.string()).optional(),
+    oauthTokens: z.record(z.string(), z.string()).optional(),
   })
   .passthrough();
 
@@ -151,29 +173,87 @@ mcpjamAgent.post("/", async (c) => {
     rpcCollector = createHostedRpcLogCollector(rawBody);
     const body = parseWithSchema(mcpjamAgentSchema, rawBody);
 
-    manager = new MCPClientManager(
-      {
-        [DOCS_SERVER_ID]: buildDocsConfig(),
-        [PLATFORM_SERVER_ID]: buildPlatformConfig(bearerToken),
-      },
-      {
+    // The caller's CONNECTED project servers (the client sends only the ones
+    // it shows as connected, exactly like Playground/chat-v2 do — see
+    // `use-mcpjam-agent-session.ts`). Drop empties and the synthetic ids
+    // defensively so a malformed body can't shadow a built-in server.
+    const requestedServerEntries: Array<{ id: string; name?: string }> = [];
+    const seenRequestedServerIds = new Set<string>();
+    for (const [index, id] of (body.selectedServerIds ?? []).entries()) {
+      if (
+        typeof id !== "string" ||
+        id.length === 0 ||
+        id === DOCS_SERVER_ID ||
+        id === PLATFORM_SERVER_ID ||
+        seenRequestedServerIds.has(id)
+      ) {
+        continue;
+      }
+      seenRequestedServerIds.add(id);
+      const rawName = body.selectedServerNames?.[index];
+      const name =
+        typeof rawName === "string" && rawName.trim().length > 0
+          ? rawName.trim()
+          : undefined;
+      requestedServerEntries.push({ id, ...(name ? { name } : {}) });
+    }
+    const requestedServerIds = requestedServerEntries.map((entry) => entry.id);
+    const requestedServerNames = requestedServerEntries.map(
+      (entry) => entry.name ?? entry.id
+    );
+
+    // The two MCPJam-owned servers, always present.
+    const builtInServerConfigs = {
+      [DOCS_SERVER_ID]: buildDocsConfig(),
+      [PLATFORM_SERVER_ID]: buildPlatformConfig(bearerToken),
+    };
+
+    if (requestedServerIds.length === 0) {
+      // No project servers connected — skip the Convex authorize round trip
+      // and stand up just the built-ins, as before.
+      manager = new MCPClientManager(builtInServerConfigs, {
         defaultTimeout: WEB_STREAM_TIMEOUT_MS,
         rpcLogger: rpcCollector.rpcLogger,
         retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
-      }
-    );
+      });
+    } else {
+      // Build ONE manager owning both the user's project servers — authorized
+      // through the SAME Convex membership/ownership check chat-v2 uses, so
+      // this surface can't reach a server the user couldn't connect in
+      // Playground — and the two MCPJam-owned servers (injected as
+      // `additionalServerConfigs`, which skip project authorization). Strict,
+      // exactly like chat-v2: the client already filtered to connected
+      // servers, so there's nothing to tolerate here.
+      const authorized = await createAuthorizedManager(
+        callerContextFromHono(c),
+        bearerToken,
+        body.projectId,
+        requestedServerIds,
+        WEB_STREAM_TIMEOUT_MS,
+        body.oauthTokens,
+        MCP_APPS_CLIENT_CAPABILITIES,
+        {
+          serverNames: requestedServerNames,
+          rpcLogger: rpcCollector.rpcLogger,
+          additionalServerConfigs: builtInServerConfigs,
+        }
+      );
+      manager = authorized.manager;
+    }
 
     try {
-      // Preflight both servers in parallel: `getToolsForAiSdk` (inside
-      // `prepareChatV2`) fails the WHOLE turn when any selected server
-      // errors at connect/list time, so either server's outage (or the
-      // platform worker rejecting local dev's untrusted issuer) would
-      // otherwise take down the entire agent. Select only the servers that
-      // responded; connections and tool metadata are cached on the manager,
-      // so the later prepare doesn't repeat the round trips. With both
-      // down, the turn still runs on web_search + the bare model.
+      // Preflight every registered server in parallel: `getToolsForAiSdk`
+      // (inside `prepareChatV2`) fails the WHOLE turn when any selected server
+      // errors at connect/list time, so one server's outage (the platform
+      // worker rejecting local dev's untrusted issuer, or a flaky project
+      // server) would otherwise take down the entire agent. Select only the
+      // servers that responded; connections and tool metadata are cached on
+      // the manager, so the later prepare doesn't repeat the round trips. With
+      // everything down, the turn still runs on web_search + the bare model.
       const mcp = manager;
-      const candidateServerIds = [DOCS_SERVER_ID, PLATFORM_SERVER_ID];
+      // Every server registered on the manager: the two MCPJam-owned ones
+      // plus whichever of the caller's project servers authorized above.
+      const candidateServerIds = mcp.listServers();
       const preflights = await Promise.allSettled(
         candidateServerIds.map((serverId) => mcp.listTools(serverId))
       );


### PR DESCRIPTION
- Reused Playground/Chat’s existing connected-server flow for the Home tab agent
- Extracted the shared server-resolution logic so Home, Chat, and Playground use the same path
- Added regression tests covering Home agent use of connected MCP servers