### PR TITLE
feat(swarms): Phase 1 readiness UI + Phase 2 personas tab

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
@@ -14,6 +14,7 @@ import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { SegmentedControl } from "@/components/ui/json-editor/segmented-control";
 import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection";
 import { ChatboxUsagePanel } from "@/components/chatboxes/ChatboxUsagePanel";
+import { PersonasTab } from "@/components/chatboxes/PersonasTab";
 import { ChatboxPublishClientBar } from "@/components/chatboxes/ChatboxPublishClientBar";
 import { ChatboxHostCanvasPanel } from "@/components/chatboxes/ChatboxHostCanvasPanel";
 import {
@@ -53,10 +54,11 @@ interface ChatboxesTabProps {
   isAuthenticated: boolean;
 }
 
-type ChatboxTab = "publish" | "sessions" | "clusters";
+type ChatboxTab = "publish" | "personas" | "sessions" | "clusters";
 
 const TAB_OPTIONS: ReadonlyArray<{ value: ChatboxTab; label: string }> = [
   { value: "publish", label: "Publish" },
+  { value: "personas", label: "Personas" },
   { value: "sessions", label: "Sessions" },
   { value: "clusters", label: "Clusters" },
 ];
@@ -82,7 +84,7 @@ export function ChatboxesTab({
   // remount re-seeds tab and thread selection from it.
   const sessionDeepLinkThreadId = searchParams.get("session");
   const [tab, setTab] = useState<ChatboxTab>(() =>
-    sessionDeepLinkThreadId ? "sessions" : "publish",
+    sessionDeepLinkThreadId ? "sessions" : "publish"
   );
   const [panelView, setPanelView] = useState<PublishPanelView>("preview");
   const [previewedHostId, setPreviewedHostId] = usePreviewedHostId(projectId);
@@ -125,7 +127,7 @@ export function ChatboxesTab({
   // the new row. Latched per hostId so a transient null + concurrent
   // queries don't trigger duplicate mutations.
   const ensureChatboxForHost = useMutation(
-    "chatboxes:ensureChatboxForHost" as any,
+    "chatboxes:ensureChatboxForHost" as any
   );
   const ensureLatchRef = useRef<Set<string>>(new Set());
   // Tracks hostIds where ensure resolved successfully but the reactive
@@ -168,14 +170,20 @@ export function ChatboxesTab({
         toast.error(
           err instanceof Error
             ? err.message
-            : "Failed to provision swarm for host",
+            : "Failed to provision swarm for host"
         );
       });
     return () => {
       cancelled = true;
       if (stuckTimer !== undefined) clearTimeout(stuckTimer);
     };
-  }, [chatbox, effectiveAuth, ensureChatboxForHost, isLoading, previewedHostId]);
+  }, [
+    chatbox,
+    effectiveAuth,
+    ensureChatboxForHost,
+    isLoading,
+    previewedHostId,
+  ]);
   // Once the chatbox shows up, clear the stuck flag AND the per-host
   // ensure latch so a future drift (host's chatbox gets deleted later in
   // the same session) re-arms the ensure mutation instead of silently
@@ -216,8 +224,8 @@ export function ChatboxesTab({
           <Inbox className="mx-auto size-8 text-muted-foreground/70" />
           <p className="mt-3 text-sm font-medium">Pick a host</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Use the host bar at the top to choose which host's swarm you
-            want to manage.
+            Use the host bar at the top to choose which host's swarm you want to
+            manage.
           </p>
         </div>
       </div>
@@ -280,10 +288,7 @@ export function ChatboxesTab({
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
         {tab === "publish" ? (
-          <ResizablePanelGroup
-            direction="horizontal"
-            className="h-full"
-          >
+          <ResizablePanelGroup direction="horizontal" className="h-full">
             <ResizablePanel defaultSize={50} minSize={32}>
               <div className="h-full overflow-y-auto px-6 py-6">
                 <div className="mx-auto flex max-w-3xl flex-col gap-4">
@@ -348,7 +353,7 @@ export function ChatboxesTab({
                   <div
                     className={cn(
                       "absolute inset-0",
-                      panelView === "preview" ? "" : "hidden",
+                      panelView === "preview" ? "" : "hidden"
                     )}
                   >
                     <ChatboxPreviewPane
@@ -369,6 +374,8 @@ export function ChatboxesTab({
               </div>
             </ResizablePanel>
           </ResizablePanelGroup>
+        ) : tab === "personas" ? (
+          <PersonasTab chatbox={chatbox} />
         ) : tab === "sessions" ? (
           <ChatboxUsagePanel
             chatbox={chatbox}
@@ -423,8 +430,8 @@ function ChatboxPreviewPane({
           <Inbox className="mx-auto size-8 text-muted-foreground/70" />
           <p className="mt-3 text-sm font-medium">No share link yet</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Publish the swarm to generate a share link, then come back
-            here to preview it.
+            Publish the swarm to generate a share link, then come back here to
+            preview it.
           </p>
         </div>
       </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -23,6 +23,7 @@ import { ShareUsageThreadList } from "@/components/connection/share-usage/ShareU
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import { ChatboxTopicMapPanel } from "@/components/chatboxes/ChatboxTopicMapPanel";
 import { GenerateSessionsDialog } from "@/components/chatboxes/GenerateSessionsDialog";
+import { SessionReadinessStrip } from "@/components/chatboxes/session-readiness";
 import { buildChatboxSessionPath } from "@/lib/app-navigation";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
 
@@ -75,7 +76,7 @@ export function ChatboxUsagePanel({
   const setSelectedThreadId = useCallback(
     (threadId: string | null) =>
       setSelection({ chatboxId: chatbox.chatboxId, threadId }),
-    [chatbox.chatboxId],
+    [chatbox.chatboxId]
   );
 
   const { threads, rebuild } = useUsageInsights({
@@ -131,9 +132,15 @@ export function ChatboxUsagePanel({
     }
     setSelection((current) => {
       if (current.chatboxId !== chatbox.chatboxId) {
-        return { chatboxId: chatbox.chatboxId, threadId: sortedThreads[0]?._id ?? null };
+        return {
+          chatboxId: chatbox.chatboxId,
+          threadId: sortedThreads[0]?._id ?? null,
+        };
       }
-      if (current.threadId && sortedThreads.some((t) => t._id === current.threadId)) {
+      if (
+        current.threadId &&
+        sortedThreads.some((t) => t._id === current.threadId)
+      ) {
         return current;
       }
       return {
@@ -145,11 +152,11 @@ export function ChatboxUsagePanel({
 
   const handleToggleChip = useCallback(
     (chip: UsageFilterChip) => setFilter((prev) => toggleChip(prev, chip)),
-    [],
+    []
   );
   const handleClearChip = useCallback(
     (key: string) => setFilter((prev) => removeChipByKey(prev, key)),
-    [],
+    []
   );
 
   // Topic-map dot click → open that session in the Sessions tab. Clear the
@@ -161,7 +168,7 @@ export function ChatboxUsagePanel({
       setFilter(EMPTY_USAGE_FILTER);
       onOpenSession?.(sessionId);
     },
-    [chatbox.chatboxId, onOpenSession],
+    [chatbox.chatboxId, onOpenSession]
   );
 
   const handleRebuild = useCallback(async () => {
@@ -186,7 +193,7 @@ export function ChatboxUsagePanel({
       toast.error(
         error instanceof Error
           ? error.message
-          : "Rebuild failed. Try again in a few minutes.",
+          : "Rebuild failed. Try again in a few minutes."
       );
     } finally {
       if (rebuildNonceRef.current === myNonce) {
@@ -219,7 +226,7 @@ export function ChatboxUsagePanel({
     label: "Hide synthetic",
   };
   const isHideSyntheticActive = filter.chips.some(
-    (c) => chipKey(c) === chipKey(hideSyntheticChip),
+    (c) => chipKey(c) === chipKey(hideSyntheticChip)
   );
 
   return (
@@ -257,6 +264,7 @@ export function ChatboxUsagePanel({
                   Generate with AI
                 </Button>
               </div>
+              <SessionReadinessStrip chatboxId={chatbox.chatboxId} />
               <div className="min-h-0 flex-1 overflow-hidden">
                 <ShareUsageThreadList
                   threads={sortedThreads}
@@ -275,7 +283,7 @@ export function ChatboxUsagePanel({
                   threadId={selectedThreadId}
                   sessionLink={`${getShareableAppOrigin()}${buildChatboxSessionPath(
                     chatbox.namedHostId,
-                    selectedThreadId,
+                    selectedThreadId
                   )}`}
                 />
               ) : (

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -18,6 +18,11 @@ import {
   DialogTitle,
 } from "@mcpjam/design-system/dialog";
 import { standardEventProps } from "@/lib/PosthogUtils";
+import {
+  PersonaCard,
+  usePersonaRoster,
+  useSortedRoster,
+} from "@/components/chatboxes/personas";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:6274";
 
@@ -43,19 +48,26 @@ interface RunStatus {
   error?: string;
 }
 
-
 type DialogStage = "configure" | "review" | "running";
 
 interface GenerateSessionsDialogProps {
   isOpen: boolean;
   onClose: () => void;
   chatbox: ChatboxSettings;
+  /**
+   * Phase 2: when launched from the Personas tab "Run swarm" with characters
+   * already selected, the dialog opens straight at the Review stage seeded with
+   * these personas (skipping roster selection / generation). The `/start`
+   * payload is unchanged — these flow through as inline personas.
+   */
+  initialPersonas?: PersonaSlate[];
 }
 
 export function GenerateSessionsDialog({
   isOpen,
   onClose,
   chatbox,
+  initialPersonas,
 }: GenerateSessionsDialogProps) {
   const { getAccessToken } = useAuth();
   const posthog = usePostHog();
@@ -70,6 +82,9 @@ export function GenerateSessionsDialog({
   const [running, setRunning] = useState<RunStatus | null>(null);
   const [runId, setRunId] = useState<string | null>(null);
   const [pollError, setPollError] = useState<string | null>(null);
+  // Stage 1 roster selection (Phase 2).
+  const [rosterSelected, setRosterSelected] = useState<Set<string>>(new Set());
+  const roster = useSortedRoster(usePersonaRoster(chatbox.chatboxId));
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const runStartAt = useRef<number>(0);
   // Guards `chatbox_simulate_sessions_completed` against firing more than
@@ -86,13 +101,20 @@ export function GenerateSessionsDialog({
       setRunId(null);
       setPollError(null);
       setStarting(false);
+      setRosterSelected(new Set());
       completionAnalyticsFired.current = false;
       if (pollTimer.current) {
         clearInterval(pollTimer.current);
         pollTimer.current = null;
       }
+      return;
     }
-  }, [isOpen]);
+    // Opened from "Run swarm" with characters preselected — seed Review.
+    if (initialPersonas && initialPersonas.length > 0) {
+      setPersonas(initialPersonas.map((p) => ({ ...p, selected: true })));
+      setStage("review");
+    }
+  }, [isOpen, initialPersonas]);
 
   // Server selection lives on the backend: the dialog forwards the full
   // chatbox server list and the start route filters optionals out so the
@@ -124,7 +146,8 @@ export function GenerateSessionsDialog({
   const ESTIMATED_USD_PER_1K_TOKENS = 0.005; // coarse blended midpoint
   const totalTurnsUpperBound = personaCount * sessionsPerPersona * maxTurns;
   const estimatedCostUsd =
-    (totalTurnsUpperBound * ESTIMATED_TOKENS_PER_TURN *
+    (totalTurnsUpperBound *
+      ESTIMATED_TOKENS_PER_TURN *
       ESTIMATED_USD_PER_1K_TOKENS) /
     1000;
   const formatUsd = (value: number): string => {
@@ -132,6 +155,21 @@ export function GenerateSessionsDialog({
     if (value < 1) return `$${value.toFixed(2)}`;
     return `$${value.toFixed(2)}`;
   };
+
+  function handleUseRoster() {
+    const chosen = (roster ?? []).filter((p) => rosterSelected.has(p._id));
+    if (chosen.length === 0) return;
+    setPersonas(
+      chosen.map((p) => ({
+        id: p.personaId,
+        name: p.name,
+        role: p.role,
+        notes: p.notes,
+        selected: true,
+      }))
+    );
+    setStage("review");
+  }
 
   async function authHeader(): Promise<Record<string, string>> {
     const token = await getAccessToken();
@@ -160,16 +198,14 @@ export function GenerateSessionsDialog({
             personaCount,
             chatboxName: chatbox.name,
           }),
-        },
+        }
       );
       if (!response.ok) {
         const text = await response.text();
         throw new Error(text);
       }
       const data = (await response.json()) as { personas: PersonaSlate[] };
-      setPersonas(
-        data.personas.map((p) => ({ ...p, selected: true })),
-      );
+      setPersonas(data.personas.map((p) => ({ ...p, selected: true })));
       setStage("review");
       posthog.capture("chatbox_generate_personas_completed", {
         ...standardEventProps("chatbox_usage_panel"),
@@ -218,7 +254,7 @@ export function GenerateSessionsDialog({
             sessionsPerPersona,
             maxTurns,
           }),
-        },
+        }
       );
       if (!response.ok) {
         const text = await response.text();
@@ -258,13 +294,17 @@ export function GenerateSessionsDialog({
     pollTimer.current = setInterval(async () => {
       try {
         const response = await fetch(
-          `${API_BASE}/api/web/chatboxes/${chatbox.chatboxId}/simulate-sessions/${runId}?projectId=${encodeURIComponent(chatbox.projectId)}`,
+          `${API_BASE}/api/web/chatboxes/${
+            chatbox.chatboxId
+          }/simulate-sessions/${runId}?projectId=${encodeURIComponent(
+            chatbox.projectId
+          )}`,
           {
             method: "GET",
             headers: {
               ...(await authHeader()),
             },
-          },
+          }
         );
         if (!response.ok) {
           setPollError(`Last update failed (${response.status})`);
@@ -313,10 +353,10 @@ export function GenerateSessionsDialog({
 
   function updatePersona(
     index: number,
-    patch: Partial<PersonaEditState>,
+    patch: Partial<PersonaEditState>
   ): void {
     setPersonas((prev) =>
-      prev.map((p, i) => (i === index ? { ...p, ...patch } : p)),
+      prev.map((p, i) => (i === index ? { ...p, ...patch } : p))
     );
   }
 
@@ -336,6 +376,51 @@ export function GenerateSessionsDialog({
 
         {stage === "configure" ? (
           <div className="space-y-4">
+            {/* Stage 1 — roster selection. Pick saved characters to run, or
+                generate a fresh slate below. */}
+            {roster && roster.length > 0 ? (
+              <div className="space-y-2">
+                <Label>Run saved characters</Label>
+                <div className="grid max-h-[240px] grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
+                  {roster.map((persona) => (
+                    <PersonaCard
+                      key={persona._id}
+                      persona={persona}
+                      selected={rosterSelected.has(persona._id)}
+                      onToggle={() =>
+                        setRosterSelected((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(persona._id)) next.delete(persona._id);
+                          else next.add(persona._id);
+                          return next;
+                        })
+                      }
+                    />
+                  ))}
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs text-muted-foreground">
+                    {rosterSelected.size} selected
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={rosterSelected.size === 0}
+                    onClick={handleUseRoster}
+                  >
+                    Review selected ({rosterSelected.size})
+                  </Button>
+                </div>
+                <div className="flex items-center gap-2 pt-1">
+                  <div className="h-px flex-1 bg-border" />
+                  <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    or generate new
+                  </span>
+                  <div className="h-px flex-1 bg-border" />
+                </div>
+              </div>
+            ) : null}
+
             <div className="grid grid-cols-3 gap-3">
               <div className="space-y-1">
                 <Label htmlFor="persona-count">Personas</Label>
@@ -347,7 +432,7 @@ export function GenerateSessionsDialog({
                   value={personaCount}
                   onChange={(e) =>
                     setPersonaCount(
-                      Math.max(1, Math.min(10, Number(e.target.value) || 1)),
+                      Math.max(1, Math.min(10, Number(e.target.value) || 1))
                     )
                   }
                 />
@@ -362,7 +447,7 @@ export function GenerateSessionsDialog({
                   value={sessionsPerPersona}
                   onChange={(e) =>
                     setSessionsPerPersona(
-                      Math.max(1, Math.min(5, Number(e.target.value) || 1)),
+                      Math.max(1, Math.min(5, Number(e.target.value) || 1))
                     )
                   }
                 />
@@ -377,7 +462,7 @@ export function GenerateSessionsDialog({
                   value={maxTurns}
                   onChange={(e) =>
                     setMaxTurns(
-                      Math.max(1, Math.min(20, Number(e.target.value) || 1)),
+                      Math.max(1, Math.min(20, Number(e.target.value) || 1))
                     )
                   }
                 />
@@ -404,9 +489,9 @@ export function GenerateSessionsDialog({
                   </div>
                   <div className="mt-1 text-[11px] opacity-80">
                     {totalTurnsUpperBound} turns ({personaCount} ×{" "}
-                    {sessionsPerPersona} × {maxTurns}) at a coarse blended
-                    rate. Actuals depend on the model and conversation
-                    length and can vary above this number.
+                    {sessionsPerPersona} × {maxTurns}) at a coarse blended rate.
+                    Actuals depend on the model and conversation length and can
+                    vary above this number.
                   </div>
                 </div>
               </>
@@ -433,11 +518,7 @@ export function GenerateSessionsDialog({
               <Button variant="outline" size="sm" onClick={onClose}>
                 Cancel
               </Button>
-              <Button
-                size="sm"
-                onClick={handleGenerate}
-                disabled={generating}
-              >
+              <Button size="sm" onClick={handleGenerate} disabled={generating}>
                 {generating ? (
                   <>
                     <Loader2 className="mr-1 size-3 animate-spin" /> Generating
@@ -454,10 +535,7 @@ export function GenerateSessionsDialog({
           <div className="space-y-3">
             <div className="grid max-h-[400px] grid-cols-1 gap-2 overflow-y-auto pr-1">
               {personas.map((persona, index) => (
-                <div
-                  key={persona.id}
-                  className="rounded-md border p-3 text-sm"
-                >
+                <div key={persona.id} className="rounded-md border p-3 text-sm">
                   <div className="flex items-start gap-2">
                     <Checkbox
                       checked={persona.selected}
@@ -530,15 +608,16 @@ export function GenerateSessionsDialog({
                 {running.status === "running"
                   ? "Running…"
                   : running.status === "completed"
-                    ? "Done"
-                    : running.status === "partial"
-                      ? "Completed partially"
-                      : running.status === "rate_limited"
-                        ? "Rate-limited — budget reached"
-                        : "Failed"}
+                  ? "Done"
+                  : running.status === "partial"
+                  ? "Completed partially"
+                  : running.status === "rate_limited"
+                  ? "Rate-limited — budget reached"
+                  : "Failed"}
               </p>
               <p className="text-xs text-muted-foreground">
-                {running.summary.succeeded + running.summary.failed +
+                {running.summary.succeeded +
+                  running.summary.failed +
                   running.summary.rateLimited}{" "}
                 / {running.summary.total} sessions
                 {running.summary.failed > 0
@@ -569,8 +648,8 @@ export function GenerateSessionsDialog({
                 {running.status !== "running"
                   ? "View sessions"
                   : pollError
-                    ? "Close"
-                    : "Working…"}
+                  ? "Close"
+                  : "Working…"}
               </Button>
             </div>
           </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -92,6 +92,11 @@ export function GenerateSessionsDialog({
   // Ref (not state) so the guard is checked synchronously inside the poll
   // callback without depending on a re-render.
   const completionAnalyticsFired = useRef(false);
+  // Seed the preselected personas exactly once per open cycle. Without this,
+  // a Convex roster refetch (or any new `initialPersonas` array identity) while
+  // the dialog is open would re-run the effect and snap the stage back to
+  // "review" — clobbering an in-progress run, the "Back" navigation, or edits.
+  const seededForOpenRef = useRef(false);
 
   useEffect(() => {
     if (!isOpen) {
@@ -103,14 +108,20 @@ export function GenerateSessionsDialog({
       setStarting(false);
       setRosterSelected(new Set());
       completionAnalyticsFired.current = false;
+      seededForOpenRef.current = false;
       if (pollTimer.current) {
         clearInterval(pollTimer.current);
         pollTimer.current = null;
       }
       return;
     }
-    // Opened from "Run swarm" with characters preselected — seed Review.
-    if (initialPersonas && initialPersonas.length > 0) {
+    // Opened from "Run swarm" with characters preselected — seed Review once.
+    if (
+      !seededForOpenRef.current &&
+      initialPersonas &&
+      initialPersonas.length > 0
+    ) {
+      seededForOpenRef.current = true;
       setPersonas(initialPersonas.map((p) => ({ ...p, selected: true })));
       setStage("review");
     }

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -26,6 +26,9 @@ import {
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:6274";
 
+// Mirrors the backend MAX_PERSONA_COUNT and the /start `.max(10)` validator.
+const MAX_PERSONAS = 10;
+
 interface PersonaSlate {
   id: string;
   name: string;
@@ -167,9 +170,13 @@ export function GenerateSessionsDialog({
     return `$${value.toFixed(2)}`;
   };
 
+  // Personas marked to actually run in the Review stage; the /start endpoint
+  // caps this at MAX_PERSONAS, so the Run button guards on it.
+  const selectedReviewCount = personas.filter((p) => p.selected).length;
+
   function handleUseRoster() {
     const chosen = (roster ?? []).filter((p) => rosterSelected.has(p._id));
-    if (chosen.length === 0) return;
+    if (chosen.length === 0 || chosen.length > MAX_PERSONAS) return;
     setPersonas(
       chosen.map((p) => ({
         id: p.personaId,
@@ -412,11 +419,19 @@ export function GenerateSessionsDialog({
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-xs text-muted-foreground">
                     {rosterSelected.size} selected
+                    {rosterSelected.size > MAX_PERSONAS ? (
+                      <span className="ml-1 text-amber-600 dark:text-amber-400">
+                        · max {MAX_PERSONAS}
+                      </span>
+                    ) : null}
                   </span>
                   <Button
                     size="sm"
                     variant="outline"
-                    disabled={rosterSelected.size === 0}
+                    disabled={
+                      rosterSelected.size === 0 ||
+                      rosterSelected.size > MAX_PERSONAS
+                    }
                     onClick={handleUseRoster}
                   >
                     Review selected ({rosterSelected.size})
@@ -554,7 +569,7 @@ export function GenerateSessionsDialog({
                   This chatbox uses your organization&apos;s model key. Running
                   these sessions will consume your provider credits (~
                   {formatUsd(
-                    (personas.filter((p) => p.selected).length *
+                    (selectedReviewCount *
                       sessionsPerPersona *
                       maxTurns *
                       ESTIMATED_TOKENS_PER_TURN *
@@ -606,7 +621,7 @@ export function GenerateSessionsDialog({
                 </div>
               ))}
             </div>
-            <div className="flex justify-between">
+            <div className="flex items-center justify-between gap-2">
               <Button
                 variant="ghost"
                 size="sm"
@@ -614,15 +629,30 @@ export function GenerateSessionsDialog({
               >
                 Back
               </Button>
-              <Button size="sm" onClick={handleRun} disabled={starting}>
-                {starting ? (
-                  <>
-                    <Loader2 className="mr-1 size-3 animate-spin" /> Starting
-                  </>
-                ) : (
-                  "Run simulation"
-                )}
-              </Button>
+              <div className="flex items-center gap-2">
+                {selectedReviewCount > MAX_PERSONAS ? (
+                  <span className="text-[11px] text-amber-600 dark:text-amber-400">
+                    Select at most {MAX_PERSONAS}
+                  </span>
+                ) : null}
+                <Button
+                  size="sm"
+                  onClick={handleRun}
+                  disabled={
+                    starting ||
+                    selectedReviewCount === 0 ||
+                    selectedReviewCount > MAX_PERSONAS
+                  }
+                >
+                  {starting ? (
+                    <>
+                      <Loader2 className="mr-1 size-3 animate-spin" /> Starting
+                    </>
+                  ) : (
+                    "Run simulation"
+                  )}
+                </Button>
+              </div>
             </div>
           </div>
         ) : null}

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -580,6 +580,17 @@ export function GenerateSessionsDialog({
                 </span>
               </div>
             ) : null}
+            {/* Approval-mode warning — also surfaced here so the Personas-tab
+                "Run swarm" path doesn't bypass the configure-stage notice. */}
+            {chatbox.requireToolApproval ? (
+              <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                <span>
+                  Synthetic sessions cannot exercise approval-required tools.
+                  The persona will only see meta/discovery tools.
+                </span>
+              </div>
+            ) : null}
             <div className="grid max-h-[400px] grid-cols-1 gap-2 overflow-y-auto pr-1">
               {personas.map((persona, index) => (
                 <div key={persona.id} className="rounded-md border p-3 text-sm">

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -544,6 +544,27 @@ export function GenerateSessionsDialog({
 
         {stage === "review" ? (
           <div className="space-y-3">
+            {/* BYOK spend warning — also shown here because the Personas-tab
+                "Run swarm" path opens straight at Review, bypassing the
+                configure-stage warning. */}
+            {isByokChatbox ? (
+              <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                <span>
+                  This chatbox uses your organization&apos;s model key. Running
+                  these sessions will consume your provider credits (~
+                  {formatUsd(
+                    (personas.filter((p) => p.selected).length *
+                      sessionsPerPersona *
+                      maxTurns *
+                      ESTIMATED_TOKENS_PER_TURN *
+                      ESTIMATED_USD_PER_1K_TOKENS) /
+                      1000
+                  )}
+                  ).
+                </span>
+              </div>
+            ) : null}
             <div className="grid max-h-[400px] grid-cols-1 gap-2 overflow-y-auto pr-1">
               {personas.map((persona, index) => (
                 <div key={persona.id} className="rounded-md border p-3 text-sm">

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -34,6 +34,10 @@ interface PersonaSlate {
   name: string;
   role: string;
   notes: string;
+  /** Gradable objective (Phase 3); snapshotted into the run + driver prompt. */
+  goal?: string;
+  /** Durable roster row id; stamped onto the synthetic session at ingestion. */
+  personaRefId?: string;
 }
 
 interface PersonaEditState extends PersonaSlate {
@@ -183,6 +187,8 @@ export function GenerateSessionsDialog({
         name: p.name,
         role: p.role,
         notes: p.notes,
+        ...(p.goal ? { goal: p.goal } : {}),
+        personaRefId: p._id,
         selected: true,
       }))
     );

--- a/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
@@ -9,7 +9,7 @@
  *   - a track-record panel surfacing Phase 1 readiness aggregates per persona
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "convex/react";
 import { toast } from "sonner";
 import { Loader2, Plus, Sparkles, Users } from "lucide-react";
@@ -284,6 +284,16 @@ function NewCharacterDialog({
     setRole("");
     setNotes("");
   };
+
+  // Clear the draft whenever the dialog closes (Cancel or dismiss), so
+  // reopening "New character" always starts from an empty form.
+  useEffect(() => {
+    if (!isOpen) {
+      setName("");
+      setRole("");
+      setNotes("");
+    }
+  }, [isOpen]);
 
   const handleSave = async () => {
     if (!name.trim() || !role.trim()) {

--- a/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
@@ -114,6 +114,10 @@ export function PersonasTab({ chatbox }: { chatbox: ChatboxSettings }) {
         name: p.name,
         role: p.role,
         notes: p.notes,
+        // Thread durable identity + objective so the run pursues/grades the
+        // goal and the synthetic session is stamped with the durable ref.
+        ...(p.goal ? { goal: p.goal } : {}),
+        personaRefId: p._id,
       })),
     [selectedPersonas]
   );

--- a/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
@@ -1,0 +1,363 @@
+/**
+ * Phase 2 — the Personas tab (`/chatboxes` → Personas).
+ *
+ * Character-select grid over the chatbox's durable persona roster, with:
+ *   - "New character" (hand-authored persona)
+ *   - "Seed from traffic" chips wired to the chatbox's theme clusters
+ *   - "Run swarm" — launches synthetic sessions for the selected personas
+ *     (opens the shared GenerateSessionsDialog pre-seeded)
+ *   - a track-record panel surfacing Phase 1 readiness aggregates per persona
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { useQuery } from "convex/react";
+import { toast } from "sonner";
+import { Loader2, Plus, Sparkles, Users } from "lucide-react";
+import type { ChatboxSettings } from "@/hooks/useChatboxes";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import { Textarea } from "@mcpjam/design-system/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { ScrollArea } from "@mcpjam/design-system/scroll-area";
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from "@/components/ui/resizable";
+import {
+  PersonaCard,
+  PersonaTrackRecordPanel,
+  usePersonaMutations,
+  usePersonaRoster,
+  useSortedRoster,
+  type PersonaSlate,
+  type RosterPersona,
+} from "@/components/chatboxes/personas";
+import { GenerateSessionsDialog } from "@/components/chatboxes/GenerateSessionsDialog";
+
+interface ClusterSummary {
+  _id: string;
+  label: string;
+  summary?: string;
+  keywords?: string[];
+  memberCount?: number;
+}
+
+export function PersonasTab({ chatbox }: { chatbox: ChatboxSettings }) {
+  const roster = useSortedRoster(usePersonaRoster(chatbox.chatboxId));
+  const { create, seedFromClusters } = usePersonaMutations();
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [runOpen, setRunOpen] = useState(false);
+  const [seeding, setSeeding] = useState(false);
+
+  const clusterData = useQuery(
+    "chatSessions:listClustersByChatbox" as any,
+    { chatboxId: chatbox.chatboxId } as any
+  ) as { clusters: ClusterSummary[] } | null | undefined;
+
+  // Clusters that have not yet seeded a live persona — the seed-from-traffic
+  // chips. seedThemeClusterId on the roster marks the ones already used.
+  const seededClusterIds = useMemo(
+    () =>
+      new Set(
+        (roster ?? [])
+          .map((p) => p.seedThemeClusterId)
+          .filter((id): id is string => Boolean(id))
+      ),
+    [roster]
+  );
+  const seedableClusters = (clusterData?.clusters ?? []).filter(
+    (c) => !seededClusterIds.has(c._id)
+  );
+
+  const toggleSelect = useCallback((persona: RosterPersona) => {
+    setFocusedId(persona._id);
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(persona._id)) next.delete(persona._id);
+      else next.add(persona._id);
+      return next;
+    });
+  }, []);
+
+  const selectedPersonas = useMemo(
+    () => (roster ?? []).filter((p) => selectedIds.has(p._id)),
+    [roster, selectedIds]
+  );
+
+  const selectedSlates: PersonaSlate[] = useMemo(
+    () =>
+      selectedPersonas.map((p) => ({
+        id: p.personaId,
+        name: p.name,
+        role: p.role,
+        notes: p.notes,
+      })),
+    [selectedPersonas]
+  );
+
+  const handleSeedCluster = useCallback(
+    async (clusterId: string) => {
+      setSeeding(true);
+      try {
+        const result = (await seedFromClusters({
+          chatboxId: chatbox.chatboxId,
+          clusterIds: [clusterId],
+        } as any)) as { createdCount: number };
+        if (result.createdCount > 0) {
+          toast.success(`Added ${result.createdCount} character from traffic`);
+        } else {
+          toast.info("That theme already has a character");
+        }
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to seed character"
+        );
+      } finally {
+        setSeeding(false);
+      }
+    },
+    [seedFromClusters, chatbox.chatboxId]
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <NewCharacterDialog
+        isOpen={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreate={async (draft) => {
+          await create({ chatboxId: chatbox.chatboxId, ...draft } as any);
+        }}
+      />
+      <GenerateSessionsDialog
+        isOpen={runOpen}
+        onClose={() => setRunOpen(false)}
+        chatbox={chatbox}
+        initialPersonas={selectedSlates}
+      />
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2 border-b px-3 py-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="rounded-full"
+          onClick={() => setCreateOpen(true)}
+        >
+          <Plus className="mr-1 size-3" />
+          New character
+        </Button>
+        {seedableClusters.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[11px] text-muted-foreground">
+              Seed from traffic:
+            </span>
+            {seedableClusters.slice(0, 6).map((cluster) => (
+              <button
+                key={cluster._id}
+                type="button"
+                disabled={seeding}
+                onClick={() => void handleSeedCluster(cluster._id)}
+                className="inline-flex max-w-[160px] items-center gap-1 truncate rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/20 disabled:opacity-50"
+              >
+                <Sparkles className="size-2.5 shrink-0" />
+                <span className="truncate">{cluster.label}</span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+        <div className="ml-auto">
+          <Button
+            type="button"
+            size="sm"
+            className="rounded-full"
+            disabled={selectedPersonas.length === 0}
+            onClick={() => setRunOpen(true)}
+          >
+            <Sparkles className="mr-1 size-3" />
+            Run swarm
+            {selectedPersonas.length > 0 ? ` (${selectedPersonas.length})` : ""}
+          </Button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <ResizablePanelGroup direction="horizontal">
+          <ResizablePanel defaultSize={62} minSize={40}>
+            <PersonaGrid
+              roster={roster}
+              selectedIds={selectedIds}
+              onToggle={toggleSelect}
+              onNew={() => setCreateOpen(true)}
+            />
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={38} minSize={24}>
+            <PersonaTrackRecordPanel personaRefId={focusedId} />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    </div>
+  );
+}
+
+function PersonaGrid({
+  roster,
+  selectedIds,
+  onToggle,
+  onNew,
+}: {
+  roster: RosterPersona[] | undefined;
+  selectedIds: Set<string>;
+  onToggle: (persona: RosterPersona) => void;
+  onNew: () => void;
+}) {
+  if (roster === undefined) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+      </div>
+    );
+  }
+  if (roster.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <Users className="size-8 text-muted-foreground/50" />
+        <p className="text-sm text-muted-foreground">
+          No characters yet. Create one or seed from your chatbox traffic.
+        </p>
+        <Button size="sm" variant="outline" onClick={onNew}>
+          <Plus className="mr-1 size-3" />
+          New character
+        </Button>
+      </div>
+    );
+  }
+  return (
+    <ScrollArea className="h-full">
+      <div className="grid grid-cols-1 gap-2 p-3 sm:grid-cols-2 xl:grid-cols-3">
+        {roster.map((persona) => (
+          <PersonaCard
+            key={persona._id}
+            persona={persona}
+            selected={selectedIds.has(persona._id)}
+            onToggle={() => onToggle(persona)}
+          />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}
+
+function NewCharacterDialog({
+  isOpen,
+  onClose,
+  onCreate,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreate: (draft: {
+    name: string;
+    role: string;
+    notes: string;
+  }) => Promise<void>;
+}) {
+  const [name, setName] = useState("");
+  const [role, setRole] = useState("");
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const reset = () => {
+    setName("");
+    setRole("");
+    setNotes("");
+  };
+
+  const handleSave = async () => {
+    if (!name.trim() || !role.trim()) {
+      toast.error("Name and role are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      await onCreate({
+        name: name.trim(),
+        role: role.trim(),
+        notes: notes.trim(),
+      });
+      toast.success("Character added");
+      reset();
+      onClose();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to add character"
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => (open ? null : onClose())}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New character</DialogTitle>
+          <DialogDescription>
+            A reusable synthetic user this swarm can role-play.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 py-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="persona-name">Name</Label>
+            <Input
+              id="persona-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Curious First-Time User"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="persona-role">Role</Label>
+            <Input
+              id="persona-role"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              placeholder="Evaluating the product for their team"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="persona-notes">Notes</Label>
+            <Textarea
+              id="persona-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Background, goals, what they'll try…"
+              rows={3}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={saving}>
+            {saving ? <Loader2 className="mr-1 size-3 animate-spin" /> : null}
+            Add character
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
@@ -296,17 +296,20 @@ function NewCharacterDialog({
     name: string;
     role: string;
     notes: string;
+    goal: string;
   }) => Promise<void>;
 }) {
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
   const [notes, setNotes] = useState("");
+  const [goal, setGoal] = useState("");
   const [saving, setSaving] = useState(false);
 
   const reset = () => {
     setName("");
     setRole("");
     setNotes("");
+    setGoal("");
   };
 
   // Clear the draft whenever the dialog closes (Cancel or dismiss), so
@@ -316,6 +319,7 @@ function NewCharacterDialog({
       setName("");
       setRole("");
       setNotes("");
+      setGoal("");
     }
   }, [isOpen]);
 
@@ -330,6 +334,7 @@ function NewCharacterDialog({
         name: name.trim(),
         role: role.trim(),
         notes: notes.trim(),
+        goal: goal.trim(),
       });
       toast.success("Character added");
       reset();
@@ -372,12 +377,21 @@ function NewCharacterDialog({
             />
           </div>
           <div className="flex flex-col gap-1.5">
+            <Label htmlFor="persona-goal">Goal</Label>
+            <Input
+              id="persona-goal"
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              placeholder="What they're trying to accomplish (graded later)"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
             <Label htmlFor="persona-notes">Notes</Label>
             <Textarea
               id="persona-notes"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              placeholder="Background, goals, what they'll try…"
+              placeholder="Background, context, what they'll try…"
               rows={3}
             />
           </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
@@ -51,6 +51,10 @@ interface ClusterSummary {
   memberCount?: number;
 }
 
+// Mirrors the backend MAX_PERSONA_COUNT (and the /start `.max(10)` validator):
+// a single run accepts at most this many personas.
+const MAX_RUN_PERSONAS = 10;
+
 export function PersonasTab({ chatbox }: { chatbox: ChatboxSettings }) {
   const roster = useSortedRoster(usePersonaRoster(chatbox.chatboxId));
   const { create, seedFromClusters } = usePersonaMutations();
@@ -60,6 +64,13 @@ export function PersonasTab({ chatbox }: { chatbox: ChatboxSettings }) {
   const [createOpen, setCreateOpen] = useState(false);
   const [runOpen, setRunOpen] = useState(false);
   const [seeding, setSeeding] = useState(false);
+
+  // Selection/focus are per-chatbox; clear them on a chatbox switch so the
+  // track-record panel never renders a persona from the previous chatbox.
+  useEffect(() => {
+    setSelectedIds(new Set());
+    setFocusedId(null);
+  }, [chatbox.chatboxId]);
 
   const clusterData = useQuery(
     "chatSessions:listClustersByChatbox" as any,
@@ -178,13 +189,26 @@ export function PersonasTab({ chatbox }: { chatbox: ChatboxSettings }) {
             ))}
           </div>
         ) : null}
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-2">
+          {selectedPersonas.length > MAX_RUN_PERSONAS ? (
+            <span className="text-[11px] text-amber-600 dark:text-amber-400">
+              Select at most {MAX_RUN_PERSONAS}
+            </span>
+          ) : null}
           <Button
             type="button"
             size="sm"
             className="rounded-full"
-            disabled={selectedPersonas.length === 0}
+            disabled={
+              selectedPersonas.length === 0 ||
+              selectedPersonas.length > MAX_RUN_PERSONAS
+            }
             onClick={() => setRunOpen(true)}
+            title={
+              selectedPersonas.length > MAX_RUN_PERSONAS
+                ? `A run accepts at most ${MAX_RUN_PERSONAS} personas`
+                : undefined
+            }
           >
             <Sparkles className="mr-1 size-3" />
             Run swarm

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/GenerateSessionsDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/GenerateSessionsDialog.test.tsx
@@ -26,6 +26,15 @@ vi.mock("@/lib/PosthogUtils", () => ({
   standardEventProps: () => ({}),
 }));
 
+// The dialog reads the persona roster via Convex (usePersonaRoster -> useQuery).
+// These configure-stage tests render it without a ConvexProvider, so stub the
+// roster hooks: an undefined roster simply hides the stage-1 roster section.
+vi.mock("@/components/chatboxes/personas", () => ({
+  usePersonaRoster: () => undefined,
+  useSortedRoster: (roster: unknown) => roster,
+  PersonaCard: () => null,
+}));
+
 const baseChatbox: ChatboxSettings = {
   chatboxId: "cb_1",
   projectId: "proj_1",

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/session-readiness.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/session-readiness.test.tsx
@@ -45,6 +45,11 @@ describe("SessionReadinessBadge", () => {
     expect(screen.getByText(/Not ready/)).toBeInTheDocument();
     expect(screen.getByText(/· 2/)).toBeInTheDocument();
   });
+
+  it("shows a distinct failed state", () => {
+    render(<SessionReadinessBadge readiness={ready({ status: "failed" })} />);
+    expect(screen.getByText(/Readiness failed/i)).toBeInTheDocument();
+  });
 });
 
 describe("SessionInsightBar", () => {
@@ -91,5 +96,18 @@ describe("SessionInsightBar", () => {
   it("shows a progress state while pending", () => {
     render(<SessionInsightBar readiness={ready({ status: "pending" })} />);
     expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the error on a failed analysis", () => {
+    render(
+      <SessionInsightBar
+        readiness={ready({
+          status: "failed",
+          errorMessage: "trace unreadable",
+        })}
+      />
+    );
+    expect(screen.getByText(/Readiness analysis failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/trace unreadable/)).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/session-readiness.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/session-readiness.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  SessionInsightBar,
+  SessionReadinessBadge,
+  type SessionReadiness,
+} from "../session-readiness";
+
+function ready(overrides: Partial<SessionReadiness> = {}): SessionReadiness {
+  return {
+    status: "completed",
+    verdict: "ready",
+    issueCount: 0,
+    toolCallCount: 3,
+    toolErrorCount: 0,
+    advertisedToolCount: 4,
+    advertisedToolsKnown: true,
+    coverageRatio: 0.75,
+    hallucinatedTools: [],
+    failingTools: [],
+    issues: [],
+    ...overrides,
+  };
+}
+
+describe("SessionReadinessBadge", () => {
+  it("renders nothing without readiness", () => {
+    const { container } = render(
+      <SessionReadinessBadge readiness={undefined} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows an analyzing state while pending", () => {
+    render(<SessionReadinessBadge readiness={ready({ status: "pending" })} />);
+    expect(screen.getByText(/analyzing/i)).toBeInTheDocument();
+  });
+
+  it("shows the verdict and issue count", () => {
+    render(
+      <SessionReadinessBadge
+        readiness={ready({ verdict: "not_ready", issueCount: 2 })}
+      />
+    );
+    expect(screen.getByText(/Not ready/)).toBeInTheDocument();
+    expect(screen.getByText(/· 2/)).toBeInTheDocument();
+  });
+});
+
+describe("SessionInsightBar", () => {
+  it("renders findings from server-denormalized fields", () => {
+    render(
+      <SessionInsightBar
+        readiness={ready({
+          verdict: "not_ready",
+          issueCount: 1,
+          toolErrorCount: 2,
+          toolCallCount: 4,
+          hallucinatedTools: ["made_up_tool"],
+          issues: [
+            {
+              code: "hallucinated_tool",
+              severity: "error",
+              message:
+                'Called "made_up_tool", which is not an advertised tool.',
+              toolName: "made_up_tool",
+            },
+          ],
+        })}
+      />
+    );
+    expect(screen.getByText("Not ready")).toBeInTheDocument();
+    expect(screen.getByText(/2\/4 tool calls failed/)).toBeInTheDocument();
+    expect(screen.getByText(/1 undeclared tool/)).toBeInTheDocument();
+    expect(screen.getByText(/not an advertised tool/)).toBeInTheDocument();
+  });
+
+  it("flags partial readiness when the tool inventory was unavailable", () => {
+    render(
+      <SessionInsightBar
+        readiness={ready({
+          status: "partial",
+          coverageRatio: undefined,
+          advertisedToolsKnown: false,
+        })}
+      />
+    );
+    expect(screen.getByText(/tool inventory unavailable/)).toBeInTheDocument();
+  });
+
+  it("shows a progress state while pending", () => {
+    render(<SessionInsightBar readiness={ready({ status: "pending" })} />);
+    expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/session-readiness.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/session-readiness.test.tsx
@@ -80,6 +80,13 @@ describe("SessionInsightBar", () => {
     expect(screen.getByText(/not an advertised tool/)).toBeInTheDocument();
   });
 
+  it("renders host-response latency from the readiness record", () => {
+    render(
+      <SessionInsightBar readiness={ready({ hostLatencyMs: 3500 })} />
+    );
+    expect(screen.getByText(/3\.5s host latency/)).toBeInTheDocument();
+  });
+
   it("flags partial readiness when the tool inventory was unavailable", () => {
     render(
       <SessionInsightBar

--- a/mcpjam-inspector/client/src/components/chatboxes/personas.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/personas.tsx
@@ -23,6 +23,10 @@ export interface PersonaSlate {
   name: string;
   role: string;
   notes: string;
+  /** Gradable objective (Phase 3); rides into the run + driver prompt. */
+  goal?: string;
+  /** Durable roster row id; stamped onto the synthetic session at ingestion. */
+  personaRefId?: string;
 }
 
 export type PersonaSource = "manual" | "generated" | "cluster";

--- a/mcpjam-inspector/client/src/components/chatboxes/personas.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/personas.tsx
@@ -33,6 +33,8 @@ export interface RosterPersona {
   name: string;
   role: string;
   notes: string;
+  /** Phase 3 gradable objective (goal-completion judge target). */
+  goal?: string;
   source: PersonaSource;
   seedThemeClusterId?: string;
   seedKeywords?: string[];
@@ -262,6 +264,14 @@ export function PersonaTrackRecordPanel({
           </p>
         </div>
       </div>
+      {persona.goal ? (
+        <div className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Goal
+          </p>
+          <p className="mt-0.5 text-sm">{persona.goal}</p>
+        </div>
+      ) : null}
       {persona.notes ? (
         <p className="text-sm text-muted-foreground">{persona.notes}</p>
       ) : null}

--- a/mcpjam-inspector/client/src/components/chatboxes/personas.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/personas.tsx
@@ -1,0 +1,330 @@
+/**
+ * Phase 2 — persona roster building blocks (Inspector).
+ *
+ * `CharacterAvatar`, the selectable `PersonaCard`, the track-record panel, and
+ * the Convex hooks the Personas tab + the swarm launch dialog share. The track
+ * record renders Phase 1 readiness aggregates (run/session counts, issues,
+ * failing tools); goal-rate is omitted until Phase 3.
+ */
+
+import { useMemo } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Loader2, Wrench } from "lucide-react";
+import type {
+  SessionReadinessRollup,
+  ReadinessStatus,
+} from "@/components/chatboxes/session-readiness";
+
+// ── types (mirror chatboxPersonas serialization) ─────────────────────────────
+
+/** Inline persona payload (the slate shape the runner / `/start` consumes). */
+export interface PersonaSlate {
+  id: string;
+  name: string;
+  role: string;
+  notes: string;
+}
+
+export type PersonaSource = "manual" | "generated" | "cluster";
+
+export interface RosterPersona {
+  _id: string;
+  personaId: string;
+  name: string;
+  role: string;
+  notes: string;
+  source: PersonaSource;
+  seedThemeClusterId?: string;
+  seedKeywords?: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PersonaTrackRecord {
+  persona: RosterPersona;
+  runCount: number;
+  sessionCount: number;
+  readiness: SessionReadinessRollup;
+  sessionExamples: Array<{
+    _id: string;
+    chatSessionId: string;
+    startedAt: number;
+    lastActivityAt: number;
+    readiness?: {
+      status: ReadinessStatus;
+      verdict?: "ready" | "needs_attention" | "not_ready";
+      issueCount: number;
+    };
+  }>;
+}
+
+// ── convex hooks ───────────────────────────────────────────────────────────
+
+export function usePersonaRoster(chatboxId: string | null) {
+  return useQuery(
+    "chatboxPersonas:listChatboxPersonas" as any,
+    chatboxId ? ({ chatboxId } as any) : "skip"
+  ) as RosterPersona[] | undefined;
+}
+
+export function usePersonaTrackRecord(personaRefId: string | null) {
+  return useQuery(
+    "chatboxPersonas:getPersonaTrackRecord" as any,
+    personaRefId ? ({ personaRefId } as any) : "skip"
+  ) as PersonaTrackRecord | null | undefined;
+}
+
+export function usePersonaMutations() {
+  const create = useMutation("chatboxPersonas:createChatboxPersona" as any);
+  const update = useMutation("chatboxPersonas:updateChatboxPersona" as any);
+  const remove = useMutation("chatboxPersonas:deleteChatboxPersona" as any);
+  const seedFromClusters = useMutation(
+    "chatboxPersonas:seedPersonasFromClusters" as any
+  );
+  return { create, update, remove, seedFromClusters };
+}
+
+// ── CharacterAvatar ───────────────────────────────────────────────────────────
+
+const AVATAR_PALETTE = [
+  "bg-rose-500",
+  "bg-orange-500",
+  "bg-amber-500",
+  "bg-lime-500",
+  "bg-emerald-500",
+  "bg-teal-500",
+  "bg-sky-500",
+  "bg-indigo-500",
+  "bg-violet-500",
+  "bg-fuchsia-500",
+];
+
+function hashString(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 31 + input.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function initials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[words.length - 1][0]).toUpperCase();
+}
+
+export function CharacterAvatar({
+  name,
+  seed,
+  size = "md",
+  className = "",
+}: {
+  name: string;
+  /** Stable key for color selection (persona id); falls back to the name. */
+  seed?: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}) {
+  const color =
+    AVATAR_PALETTE[hashString(seed || name) % AVATAR_PALETTE.length];
+  const dims =
+    size === "lg"
+      ? "size-12 text-base"
+      : size === "sm"
+      ? "size-7 text-[10px]"
+      : "size-9 text-xs";
+  return (
+    <div
+      className={`flex shrink-0 items-center justify-center rounded-full font-semibold text-white ${color} ${dims} ${className}`}
+      aria-hidden
+    >
+      {initials(name)}
+    </div>
+  );
+}
+
+// ── PersonaCard (character-select grid item) ─────────────────────────────────
+
+const SOURCE_LABEL: Record<PersonaSource, string> = {
+  manual: "Custom",
+  generated: "AI",
+  cluster: "From traffic",
+};
+
+export function PersonaCard({
+  persona,
+  selected,
+  onToggle,
+  onOpenDetail,
+}: {
+  persona: RosterPersona;
+  selected: boolean;
+  onToggle: () => void;
+  onOpenDetail?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      onDoubleClick={onOpenDetail}
+      aria-pressed={selected}
+      className={`flex w-full flex-col gap-2 rounded-xl border p-3 text-left transition-colors ${
+        selected
+          ? "border-primary/60 bg-primary/5 ring-1 ring-primary/40"
+          : "border-border/60 hover:bg-muted/40"
+      }`}
+    >
+      <div className="flex items-center gap-2.5">
+        <CharacterAvatar name={persona.name} seed={persona.personaId} />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{persona.name}</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {persona.role}
+          </p>
+        </div>
+        <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          {SOURCE_LABEL[persona.source]}
+        </span>
+      </div>
+      {persona.notes ? (
+        <p className="line-clamp-2 text-xs text-muted-foreground/80">
+          {persona.notes}
+        </p>
+      ) : null}
+    </button>
+  );
+}
+
+// ── track record ───────────────────────────────────────────────────────────
+
+function Stat({ value, label }: { value: number | string; label: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-lg font-semibold tabular-nums">{value}</span>
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+/**
+ * Persona track record: run/session counts plus the Phase 1 readiness rollup
+ * for the persona's synthetic sessions. Goal-completion rate is intentionally
+ * omitted (Phase 3).
+ */
+export function PersonaTrackRecordPanel({
+  personaRefId,
+}: {
+  personaRefId: string | null;
+}) {
+  const record = usePersonaTrackRecord(personaRefId);
+
+  if (personaRefId === null) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        Select a character to see its track record
+      </div>
+    );
+  }
+  if (record === undefined) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+      </div>
+    );
+  }
+  if (record === null) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        Character not found
+      </div>
+    );
+  }
+
+  const { persona, readiness } = record;
+  const coverage =
+    typeof readiness.avgCoverageRatio === "number"
+      ? `${Math.round(readiness.avgCoverageRatio * 100)}%`
+      : "—";
+
+  return (
+    <div className="flex h-full flex-col gap-4 overflow-y-auto p-5">
+      <div className="flex items-center gap-3">
+        <CharacterAvatar
+          name={persona.name}
+          seed={persona.personaId}
+          size="lg"
+        />
+        <div className="min-w-0">
+          <h3 className="truncate text-base font-semibold">{persona.name}</h3>
+          <p className="truncate text-sm text-muted-foreground">
+            {persona.role}
+          </p>
+        </div>
+      </div>
+      {persona.notes ? (
+        <p className="text-sm text-muted-foreground">{persona.notes}</p>
+      ) : null}
+
+      <div className="grid grid-cols-4 gap-3 rounded-xl border p-4">
+        <Stat value={record.runCount} label="runs" />
+        <Stat value={record.sessionCount} label="sessions" />
+        <Stat value={readiness.totalIssues} label="issues" />
+        <Stat value={coverage} label="avg coverage" />
+      </div>
+
+      {record.sessionCount === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No synthetic sessions yet. Run a swarm to build this character's track
+          record.
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-3 text-xs">
+            <span className="text-emerald-600 dark:text-emerald-400">
+              {readiness.byVerdict.ready} ready
+            </span>
+            <span className="text-amber-600 dark:text-amber-400">
+              {readiness.byVerdict.needs_attention} needs attention
+            </span>
+            <span className="text-red-600 dark:text-red-400">
+              {readiness.byVerdict.not_ready} not ready
+            </span>
+          </div>
+          {readiness.topFailingTools.length > 0 ? (
+            <div>
+              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Most common failing tools
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {readiness.topFailingTools.map((t) => (
+                  <span
+                    key={t.toolName}
+                    className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-700 dark:text-red-400"
+                  >
+                    <Wrench className="size-3" />
+                    {t.toolName}
+                    <span className="text-red-700/60 dark:text-red-400/60">
+                      {t.errorCount}
+                    </span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Memoized sort: most-recently-updated personas first. */
+export function useSortedRoster(
+  roster: RosterPersona[] | undefined
+): RosterPersona[] | undefined {
+  return useMemo(
+    () =>
+      roster ? [...roster].sort((a, b) => b.updatedAt - a.updatedAt) : roster,
+    [roster]
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/session-readiness.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/session-readiness.tsx
@@ -1,0 +1,355 @@
+/**
+ * Phase 1 — synthetic-session "readiness" UI.
+ *
+ * All three surfaces render from the server-denormalized `chatSessions.readiness`
+ * fields (open decision: insight-bar source is server-denormalized readiness;
+ * client-side trace parsing is fallback/test-only). Nothing here re-parses the
+ * trace.
+ *
+ *   - `SessionReadinessBadge` — compact verdict pill for synthetic session rows
+ *   - `SessionInsightBar`      — findings strip atop a synthetic session detail
+ *   - `SessionReadinessStrip`  — chatbox-level rollup above the session list
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  ShieldAlert,
+  ShieldCheck,
+  Wrench,
+  XCircle,
+} from "lucide-react";
+import { useQuery } from "convex/react";
+
+// ── types (mirror convex/lib/sessionReadiness.ts) ─────────────────────────────
+
+export type ReadinessStatus = "pending" | "completed" | "partial" | "failed";
+export type ReadinessVerdict = "ready" | "needs_attention" | "not_ready";
+
+export interface SessionReadinessIssue {
+  code: string;
+  severity: "info" | "warning" | "error";
+  message: string;
+  toolName?: string;
+}
+
+export interface ReadinessToolError {
+  toolName: string;
+  errorCount: number;
+}
+
+/**
+ * Full readiness record (from `getSession`) — the list query returns only the
+ * `status`/`verdict`/`issueCount` subset, so the denormalized fields are
+ * optional here and consumers degrade gracefully when they're absent.
+ */
+export interface SessionReadiness {
+  status: ReadinessStatus;
+  verdict?: ReadinessVerdict;
+  issueCount: number;
+  issues?: SessionReadinessIssue[];
+  toolCallCount?: number;
+  toolErrorCount?: number;
+  usedToolCount?: number;
+  advertisedToolCount?: number;
+  advertisedToolsKnown?: boolean;
+  coverageRatio?: number;
+  hallucinatedTools?: string[];
+  failingTools?: ReadinessToolError[];
+  topFailingTool?: ReadinessToolError;
+  sessionDurationMs?: number;
+  analyzerVersion?: number;
+  generatedAt?: number;
+  errorMessage?: string;
+}
+
+export interface SessionReadinessRollup {
+  total: number;
+  analyzed: number;
+  byStatus: Record<ReadinessStatus, number>;
+  byVerdict: Record<ReadinessVerdict, number>;
+  totalIssues: number;
+  sessionsWithIssues: number;
+  totalToolCalls: number;
+  totalToolErrors: number;
+  topFailingTools: ReadinessToolError[];
+  avgCoverageRatio: number | null;
+}
+
+// ── shared verdict styling ────────────────────────────────────────────────────
+
+const VERDICT_META: Record<
+  ReadinessVerdict,
+  { label: string; pill: string; Icon: typeof ShieldCheck }
+> = {
+  ready: {
+    label: "Ready",
+    pill: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+    Icon: ShieldCheck,
+  },
+  needs_attention: {
+    label: "Needs attention",
+    pill: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+    Icon: AlertTriangle,
+  },
+  not_ready: {
+    label: "Not ready",
+    pill: "bg-red-500/10 text-red-700 dark:text-red-400",
+    Icon: ShieldAlert,
+  },
+};
+
+function coveragePct(ratio: number | null | undefined): string | null {
+  if (typeof ratio !== "number") return null;
+  return `${Math.round(ratio * 100)}%`;
+}
+
+// ── badge (session row) ───────────────────────────────────────────────────────
+
+export function SessionReadinessBadge({
+  readiness,
+}: {
+  readiness: SessionReadiness | undefined;
+}) {
+  if (!readiness) return null;
+
+  if (readiness.status === "pending") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+        <Loader2 className="size-2.5 animate-spin" />
+        Analyzing
+      </span>
+    );
+  }
+  if (readiness.status === "failed") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+        <XCircle className="size-2.5" />
+        Readiness failed
+      </span>
+    );
+  }
+
+  const verdict = readiness.verdict ?? "ready";
+  const meta = VERDICT_META[verdict];
+  const { Icon } = meta;
+  return (
+    <span
+      className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${meta.pill}`}
+      title={
+        readiness.status === "partial"
+          ? "Partial readiness — tool inventory was unavailable"
+          : undefined
+      }
+    >
+      <Icon className="size-2.5" />
+      {meta.label}
+      {readiness.issueCount > 0 ? ` · ${readiness.issueCount}` : ""}
+      {readiness.status === "partial" ? " · partial" : ""}
+    </span>
+  );
+}
+
+// ── insight bar (session detail) ──────────────────────────────────────────────
+
+const ISSUE_ICON: Record<
+  SessionReadinessIssue["severity"],
+  typeof AlertTriangle
+> = {
+  error: XCircle,
+  warning: AlertTriangle,
+  info: CheckCircle2,
+};
+
+const ISSUE_TONE: Record<SessionReadinessIssue["severity"], string> = {
+  error: "text-red-600 dark:text-red-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  info: "text-muted-foreground",
+};
+
+export function SessionInsightBar({
+  readiness,
+}: {
+  readiness: SessionReadiness | undefined;
+}) {
+  if (!readiness) return null;
+
+  if (readiness.status === "pending") {
+    return (
+      <div className="flex items-center gap-2 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+        <Loader2 className="size-3.5 animate-spin" />
+        Readiness analysis in progress…
+      </div>
+    );
+  }
+  if (readiness.status === "failed") {
+    return (
+      <div className="flex items-center gap-2 border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+        <XCircle className="size-3.5" />
+        Readiness analysis failed
+        {readiness.errorMessage ? `: ${readiness.errorMessage}` : ""}
+      </div>
+    );
+  }
+
+  const verdict = readiness.verdict ?? "ready";
+  const meta = VERDICT_META[verdict];
+  const { Icon } = meta;
+  const coverage = coveragePct(readiness.coverageRatio);
+  const issues = readiness.issues ?? [];
+
+  return (
+    <div className="border-b bg-muted/20 px-4 py-2.5">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span
+          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium ${meta.pill}`}
+        >
+          <Icon className="size-3" />
+          {meta.label}
+        </span>
+        {typeof readiness.toolCallCount === "number" ? (
+          <span className="text-muted-foreground">
+            {readiness.toolErrorCount ?? 0}/{readiness.toolCallCount} tool calls
+            failed
+          </span>
+        ) : null}
+        {coverage ? (
+          <>
+            <span className="text-muted-foreground/40">·</span>
+            <span className="text-muted-foreground">
+              {coverage} tool coverage
+            </span>
+          </>
+        ) : null}
+        {readiness.status === "partial" ? (
+          <>
+            <span className="text-muted-foreground/40">·</span>
+            <span className="text-muted-foreground/80">
+              tool inventory unavailable
+            </span>
+          </>
+        ) : null}
+        {(readiness.hallucinatedTools?.length ?? 0) > 0 ? (
+          <>
+            <span className="text-muted-foreground/40">·</span>
+            <span className="text-red-600 dark:text-red-400">
+              {readiness.hallucinatedTools!.length} undeclared tool
+              {readiness.hallucinatedTools!.length === 1 ? "" : "s"}
+            </span>
+          </>
+        ) : null}
+      </div>
+      {issues.length > 0 ? (
+        <ul className="mt-2 space-y-1">
+          {issues.map((issue, i) => {
+            const IssueIcon = ISSUE_ICON[issue.severity];
+            return (
+              <li
+                key={`${issue.code}-${i}`}
+                className={`flex items-start gap-1.5 text-xs ${
+                  ISSUE_TONE[issue.severity]
+                }`}
+              >
+                <IssueIcon className="mt-0.5 size-3 shrink-0" />
+                <span>{issue.message}</span>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+// ── rollup strip (above the session list) ─────────────────────────────────────
+
+export function useChatboxReadinessRollup(chatboxId: string | null) {
+  return useQuery(
+    "chatSessions:getChatboxReadinessRollup" as any,
+    chatboxId ? ({ chatboxId } as any) : "skip"
+  ) as SessionReadinessRollup | null | undefined;
+}
+
+function RollupStat({
+  count,
+  label,
+  tone,
+}: {
+  count: number;
+  label: string;
+  tone: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className={`text-sm font-semibold tabular-nums ${tone}`}>
+        {count}
+      </span>
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+    </span>
+  );
+}
+
+/**
+ * Chatbox-level readiness rollup over synthetic sessions. Renders nothing until
+ * at least one synthetic session has been analyzed, so non-synthetic chatboxes
+ * never show an empty strip.
+ */
+export function SessionReadinessStrip({
+  chatboxId,
+}: {
+  chatboxId: string | null;
+}) {
+  const rollup = useChatboxReadinessRollup(chatboxId);
+  if (!rollup || rollup.analyzed === 0) return null;
+
+  const coverage = coveragePct(rollup.avgCoverageRatio);
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b bg-muted/20 px-3 py-2">
+      <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        Readiness
+      </span>
+      <RollupStat
+        count={rollup.byVerdict.ready}
+        label="ready"
+        tone="text-emerald-600 dark:text-emerald-400"
+      />
+      <RollupStat
+        count={rollup.byVerdict.needs_attention}
+        label="needs attention"
+        tone="text-amber-600 dark:text-amber-400"
+      />
+      <RollupStat
+        count={rollup.byVerdict.not_ready}
+        label="not ready"
+        tone="text-red-600 dark:text-red-400"
+      />
+      <span className="text-muted-foreground/30">·</span>
+      <RollupStat
+        count={rollup.totalIssues}
+        label="issues"
+        tone="text-foreground"
+      />
+      {coverage ? (
+        <span className="text-[11px] text-muted-foreground">
+          avg coverage {coverage}
+        </span>
+      ) : null}
+      {rollup.topFailingTools.length > 0 ? (
+        <span className="flex flex-wrap items-center gap-1">
+          {rollup.topFailingTools.slice(0, 3).map((t) => (
+            <span
+              key={t.toolName}
+              className="inline-flex items-center gap-0.5 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:text-red-400"
+              title={`${t.errorCount} failure${t.errorCount === 1 ? "" : "s"}`}
+            >
+              <Wrench className="size-2.5" />
+              {t.toolName}
+            </span>
+          ))}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/session-readiness.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/session-readiness.tsx
@@ -58,7 +58,12 @@ export interface SessionReadiness {
   hallucinatedTools?: string[];
   failingTools?: ReadinessToolError[];
   topFailingTool?: ReadinessToolError;
-  sessionDurationMs?: number;
+  /** Host turns observed (per-turn trace samples). */
+  turnCount?: number;
+  /** Sum of per-turn host-response latencies (excludes persona-driver time). */
+  hostLatencyMs?: number;
+  /** Slowest single host turn. */
+  maxTurnLatencyMs?: number;
   analyzerVersion?: number;
   generatedAt?: number;
   errorMessage?: string;
@@ -103,6 +108,12 @@ const VERDICT_META: Record<
 function coveragePct(ratio: number | null | undefined): string | null {
   if (typeof ratio !== "number") return null;
   return `${Math.round(ratio * 100)}%`;
+}
+
+/** Host-response latency (server work time, excludes persona-driver time). */
+function formatLatency(ms: number | null | undefined): string | null {
+  if (typeof ms !== "number" || ms <= 0) return null;
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
 }
 
 // ── badge (session row) ───────────────────────────────────────────────────────
@@ -236,6 +247,17 @@ export function SessionInsightBar({
             <span className="text-red-600 dark:text-red-400">
               {readiness.hallucinatedTools!.length} undeclared tool
               {readiness.hallucinatedTools!.length === 1 ? "" : "s"}
+            </span>
+          </>
+        ) : null}
+        {formatLatency(readiness.hostLatencyMs) ? (
+          <>
+            <span className="text-muted-foreground/40">·</span>
+            <span
+              className="text-muted-foreground"
+              title="Host-response latency (server work time across turns; excludes the persona driver's own LLM time)"
+            >
+              {formatLatency(readiness.hostLatencyMs)} host latency
             </span>
           </>
         ) : null}

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -4,6 +4,7 @@ import { Copy, Loader2, MessageSquare } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
 import { copyToClipboard } from "@/lib/clipboard";
+import { SessionInsightBar } from "@/components/chatboxes/session-readiness";
 import type { ModelDefinition, ModelProvider } from "@/shared/types";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 import {
@@ -39,7 +40,7 @@ const EMPTY_SPANS: EvalTraceSpan[] = [];
  * named seam so future read-only consumers can reuse it.
  */
 function bridgeToolRenderOverrides(
-  overrides: Record<string, unknown> | undefined,
+  overrides: Record<string, unknown> | undefined
 ): Record<string, ChatUiToolRenderOverride> | undefined {
   return overrides as Record<string, ChatUiToolRenderOverride> | undefined;
 }
@@ -58,7 +59,7 @@ interface ShareUsageThreadDetailProps {
  * Fetch span blobs from turn trace URLs and flatten into a single span array.
  */
 async function hydrateSpans(
-  traces: SharedChatTurnTrace[],
+  traces: SharedChatTurnTrace[]
 ): Promise<EvalTraceSpan[]> {
   const results = await Promise.all(
     traces.map(async (trace) => {
@@ -71,7 +72,7 @@ async function hydrateSpans(
       } catch {
         return [];
       }
-    }),
+    })
   );
   return results.flat();
 }
@@ -124,7 +125,7 @@ export function ShareUsageThreadDetail({
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.error("Failed to load thread messages:", err);
         setError(
-          err instanceof Error ? err.message : "Failed to load messages",
+          err instanceof Error ? err.message : "Failed to load messages"
         );
       } finally {
         if (isActive) {
@@ -193,7 +194,13 @@ export function ShareUsageThreadDetail({
         ? { browserInteractionSteps: interactionSteps }
         : {}),
     };
-  }, [messages, widgetSnapshots, hydratedSpans, renderObservations, interactionSteps]);
+  }, [
+    messages,
+    widgetSnapshots,
+    hydratedSpans,
+    renderObservations,
+    interactionSteps,
+  ]);
 
   // Adapt trace to UI messages for the chat view
   const adaptedTrace = useMemo(() => {
@@ -211,7 +218,7 @@ export function ShareUsageThreadDetail({
       name: thread?.modelId ?? "Unknown",
       provider: "custom" as ModelProvider,
     }),
-    [thread?.modelId],
+    [thread?.modelId]
   );
 
   // Compute trace timing from turn traces
@@ -231,7 +238,7 @@ export function ShareUsageThreadDetail({
     const ok = await copyToClipboard(text);
     if (ok) {
       toast.success(
-        sessionLink ? "Session link copied" : "Session reference copied",
+        sessionLink ? "Session link copied" : "Session reference copied"
       );
     } else {
       toast.error("Failed to copy");
@@ -351,6 +358,12 @@ export function ShareUsageThreadDetail({
         </div>
       </div>
 
+      {/* Phase 1 readiness insight bar — synthetic sessions only, rendered from
+          server-denormalized readiness fields. */}
+      {thread.synthetic === true ? (
+        <SessionInsightBar readiness={thread.readiness} />
+      ) : null}
+
       {/* Trace / Chat / [Browser] / Raw tabs. The Browser tab appears when the
           session carries browser-rendered MCP App artifacts (synthetic runs);
           its active mode lives outside the shared TraceViewMode union. */}
@@ -378,7 +391,7 @@ export function ShareUsageThreadDetail({
               messages={adaptedTrace.messages}
               model={resolvedModel}
               toolRenderOverrides={bridgeToolRenderOverrides(
-                adaptedTrace.toolRenderOverrides,
+                adaptedTrace.toolRenderOverrides
               )}
               reasoningDisplayMode={reasoningDisplayMode}
               widgetPolicy="placeholder"

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
@@ -13,6 +13,7 @@ import {
   useSharedChatThreadList,
   type SharedChatThread,
 } from "@/hooks/useSharedChatThreads";
+import { SessionReadinessBadge } from "@/components/chatboxes/session-readiness";
 
 interface ShareUsageThreadListProps {
   /** Optional: when `threads` is provided (chatbox Usage panel) these are unused. */
@@ -46,7 +47,7 @@ export function ShareUsageThreadList({
   const legacyThreads = useSharedChatThreadList(
     providedThreads === undefined && sourceType && sourceId
       ? { sourceType, sourceId }
-      : { sourceType: sourceType ?? "chatbox", sourceId: null },
+      : { sourceType: sourceType ?? "chatbox", sourceId: null }
   );
 
   const threads = useMemo(() => {
@@ -56,8 +57,8 @@ export function ShareUsageThreadList({
     const filtered = filterState
       ? raw.filter((t) => threadMatchesFilterState(t, filterState))
       : usageFilter === "all"
-        ? raw
-        : raw.filter((t) => threadMatchesUsageFilter(t, usageFilter));
+      ? raw
+      : raw.filter((t) => threadMatchesUsageFilter(t, usageFilter));
     return [...filtered].sort(compareThreadsForUsageList);
   }, [providedThreads, legacyThreads.threads, filterState, usageFilter]);
 
@@ -162,7 +163,11 @@ function ThreadCard({
       <div className="mt-1 flex flex-wrap items-center gap-2">
         {rating != null ? (
           <span
-            className={`text-xs font-medium ${rating <= 2 ? "text-amber-700 dark:text-amber-400" : "text-muted-foreground"}`}
+            className={`text-xs font-medium ${
+              rating <= 2
+                ? "text-amber-700 dark:text-amber-400"
+                : "text-muted-foreground"
+            }`}
           >
             {rating}/5
           </span>
@@ -180,6 +185,15 @@ function ThreadCard({
             <Sparkles className="size-2.5 shrink-0" />
             <span className="truncate">{thread.themeClusterLabel}</span>
           </span>
+        ) : null}
+        {/* Synthetic rows: persona chip + Phase 1 readiness signal. */}
+        {thread.synthetic === true && thread.personaLabel ? (
+          <span className="inline-flex max-w-[140px] items-center gap-0.5 truncate rounded-full bg-violet-500/10 px-1.5 py-0.5 text-[10px] font-medium text-violet-700 dark:text-violet-300">
+            <span className="truncate">{thread.personaLabel}</span>
+          </span>
+        ) : null}
+        {thread.synthetic === true ? (
+          <SessionReadinessBadge readiness={thread.readiness} />
         ) : null}
       </div>
       {thread.firstMessagePreview ? (

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -3,6 +3,7 @@ import type {
   EvalTraceBrowserInteractionStepView,
   EvalTraceWidgetRenderObservationView,
 } from "@/shared/eval-trace";
+import type { SessionReadiness } from "@/components/chatboxes/session-readiness";
 
 export type SharedChatSourceType = "chatbox";
 
@@ -52,6 +53,12 @@ export interface SharedChatThread {
   personaId?: string;
   personaLabel?: string;
   synthesisRunId?: string;
+  /**
+   * Phase 1 deterministic readiness. The list query (`listByChatbox`) returns
+   * the compact `status`/`verdict`/`issueCount` signal; the detail query
+   * (`getSession`) returns the full record with denormalized findings.
+   */
+  readiness?: SessionReadiness;
 }
 
 /**
@@ -82,7 +89,7 @@ export function useSessionHistoricalHostConfig({
 }) {
   const config = useQuery(
     "chatSessions:getSessionHistoricalHostConfig" as any,
-    sessionId ? ({ sessionId } as any) : "skip",
+    sessionId ? ({ sessionId } as any) : "skip"
   ) as SessionHistoricalHostConfig | null | undefined;
 
   return { config };
@@ -113,10 +120,9 @@ export function useSharedChatThreadList({
     ? ({ chatboxId: sourceId, limit: 50, includeInternal: true } as any)
     : "skip";
 
-  const threads = useQuery(
-    "chatSessions:listByChatbox" as any,
-    queryArgs,
-  ) as SharedChatThread[] | undefined;
+  const threads = useQuery("chatSessions:listByChatbox" as any, queryArgs) as
+    | SharedChatThread[]
+    | undefined;
 
   return { threads };
 }
@@ -124,7 +130,7 @@ export function useSharedChatThreadList({
 export function useSharedChatThread({ threadId }: { threadId: string | null }) {
   const thread = useQuery(
     "chatSessions:getSession" as any,
-    threadId ? ({ sessionId: threadId } as any) : "skip",
+    threadId ? ({ sessionId: threadId } as any) : "skip"
   ) as SharedChatThread | null | undefined;
 
   return { thread };
@@ -137,7 +143,7 @@ export function useSharedChatWidgetSnapshots({
 }) {
   const snapshots = useQuery(
     "chatSessions:getWidgetSnapshots" as any,
-    threadId ? ({ sessionId: threadId } as any) : "skip",
+    threadId ? ({ sessionId: threadId } as any) : "skip"
   ) as SharedChatWidgetSnapshot[] | undefined;
 
   return { snapshots };
@@ -166,7 +172,7 @@ export function useSharedChatTurnTraces({
 }) {
   const traces = useQuery(
     "chatSessions:getSessionTurnTraces" as any,
-    threadId ? ({ sessionId: threadId } as any) : "skip",
+    threadId ? ({ sessionId: threadId } as any) : "skip"
   ) as SharedChatTurnTrace[] | undefined;
 
   return { traces };
@@ -190,7 +196,7 @@ export function useSessionBrowserArtifacts({
 }) {
   const artifacts = useQuery(
     "chatSessions:getBrowserArtifacts" as any,
-    threadId ? ({ sessionId: threadId } as any) : "skip",
+    threadId ? ({ sessionId: threadId } as any) : "skip"
   ) as SessionBrowserArtifacts | undefined;
 
   return { artifacts };

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -30,7 +30,7 @@ function requireConvexHttpUrl(): string {
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration",
+      "Server missing CONVEX_HTTP_URL configuration"
     );
   }
   return url;
@@ -65,6 +65,11 @@ const personaSlateSchema = z.object({
   name: z.string().min(1),
   role: z.string(),
   notes: z.string(),
+  // Optional gradable objective (Phase 3) + durable roster ref, present when
+  // launched from saved roster personas. `goal` rides into the run record /
+  // driver prompt; `personaRefId` is stamped onto the synthetic session.
+  goal: z.string().optional(),
+  personaRefId: z.string().optional(),
 });
 
 const startSimulationSchema = z.object({
@@ -77,7 +82,7 @@ const startSimulationSchema = z.object({
 });
 
 function resolveRequiredServers(
-  servers: Array<{ serverId: string; serverName?: string; optional?: boolean }>,
+  servers: Array<{ serverId: string; serverName?: string; optional?: boolean }>
 ): { selectedServerIds: string[]; selectedServerNames: string[] } {
   const required = servers.filter((s) => s.optional !== true);
   return {
@@ -96,19 +101,19 @@ chatboxSessions.post("/:chatboxId/generate-personas", async (c) =>
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "chatboxId required",
+        "chatboxId required"
       );
     }
     const body = parseWithSchema(
       generatePersonasSchema,
-      await readJsonBody<unknown>(c),
+      await readJsonBody<unknown>(c)
     );
     const convexHttpUrl = requireConvexHttpUrl();
     // selectedServerIds may be empty (no required servers): the manager
     // comes back connection-less, the snapshot captures zero servers, and
     // the backend grounds personas in the chatbox name instead of tools.
     const { selectedServerIds, selectedServerNames } = resolveRequiredServers(
-      body.servers,
+      body.servers
     );
 
     const result = await withManager(
@@ -125,13 +130,13 @@ chatboxSessions.post("/:chatboxId/generate-personas", async (c) =>
           chatboxId,
           accessVersion: body.accessVersion,
           serverNames: selectedServerNames,
-        },
+        }
       ),
       async (manager) => {
         const { toolSnapshot } = await captureToolSnapshotForEvalAuthoring(
           manager,
           selectedServerIds,
-          { logPrefix: "session-simulation.generate-personas" },
+          { logPrefix: "session-simulation.generate-personas" }
         );
         const personas = await generatePersonas(
           toolSnapshot,
@@ -149,14 +154,14 @@ chatboxSessions.post("/:chatboxId/generate-personas", async (c) =>
             id: chatboxId,
             ...(body.chatboxName ? { name: body.chatboxName } : {}),
             resolvedServerNames: selectedServerIds,
-          },
+          }
         );
         return { personas };
-      },
+      }
     );
 
     return result;
-  }),
+  })
 );
 
 chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
@@ -167,12 +172,12 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "chatboxId required",
+        "chatboxId required"
       );
     }
     const body = parseWithSchema(
       startSimulationSchema,
-      await readJsonBody<unknown>(c),
+      await readJsonBody<unknown>(c)
     );
     const convexHttpUrl = requireConvexHttpUrl();
     const authHeader = c.req.header("authorization");
@@ -180,7 +185,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       throw new WebRouteError(
         401,
         ErrorCode.UNAUTHORIZED,
-        "Authorization header required",
+        "Authorization header required"
       );
     }
 
@@ -192,7 +197,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       throw new WebRouteError(
         runtime.status,
         ErrorCode.INTERNAL_ERROR,
-        runtime.error,
+        runtime.error
       );
     }
 
@@ -200,7 +205,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     // factory returns a connection-less manager and the sessions run
     // toolless, exactly like a real no-opt-in visitor's chat.
     const { selectedServerIds, selectedServerNames } = resolveRequiredServers(
-      body.servers,
+      body.servers
     );
 
     // BYOK is now supported on synthetic runs: the runner's
@@ -225,7 +230,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
       chatboxId,
       body.personas as PersonaSlate[],
       body.sessionsPerPersona,
-      body.maxTurns,
+      body.maxTurns
     );
 
     const projectId = body.projectId;
@@ -247,8 +252,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     // payloads authorize against the right chatbox version. Falling back
     // to body.accessVersion keeps the door open for an explicit client
     // override should the dialog ever start sending one.
-    const accessVersion =
-      runtime.config.accessVersion ?? body.accessVersion;
+    const accessVersion = runtime.config.accessVersion ?? body.accessVersion;
 
     setImmediate(() => {
       startSimulation({
@@ -292,7 +296,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
               // access is authorized against the current version.
               accessVersion,
               serverNames: selectedServerNames,
-            },
+            }
           );
           return {
             manager,
@@ -312,52 +316,50 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     });
 
     return { runId };
-  }),
+  })
 );
 
-chatboxSessions.get(
-  "/:chatboxId/simulate-sessions/:runId",
-  async (c) =>
-    handleRoute(c, async () => {
-      const bearerToken = assertBearerToken(c);
-      const chatboxId = c.req.param("chatboxId");
-      const runId = c.req.param("runId");
-      if (!chatboxId) {
-        throw new WebRouteError(
-          400,
-          ErrorCode.VALIDATION_ERROR,
-          "chatboxId required",
-        );
-      }
-      if (!runId) {
-        throw new WebRouteError(
-          400,
-          ErrorCode.VALIDATION_ERROR,
-          "runId required",
-        );
-      }
-      const projectId = c.req.query("projectId");
-      if (!projectId) {
-        throw new WebRouteError(
-          400,
-          ErrorCode.VALIDATION_ERROR,
-          "projectId required",
-        );
-      }
-      const convexHttpUrl = requireConvexHttpUrl();
-      const { run, threadIds } = await getRun(
-        convexHttpUrl,
-        bearerToken,
-        projectId,
-        runId,
+chatboxSessions.get("/:chatboxId/simulate-sessions/:runId", async (c) =>
+  handleRoute(c, async () => {
+    const bearerToken = assertBearerToken(c);
+    const chatboxId = c.req.param("chatboxId");
+    const runId = c.req.param("runId");
+    if (!chatboxId) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "chatboxId required"
       );
-      // Use 404 (not 403) on mismatch so the response doesn't leak whether
-      // the runId exists under a different chatbox.
-      if (run.chatboxId !== chatboxId) {
-        throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Run not found");
-      }
-      return { run, threadIds };
-    }),
+    }
+    if (!runId) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "runId required"
+      );
+    }
+    const projectId = c.req.query("projectId");
+    if (!projectId) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "projectId required"
+      );
+    }
+    const convexHttpUrl = requireConvexHttpUrl();
+    const { run, threadIds } = await getRun(
+      convexHttpUrl,
+      bearerToken,
+      projectId,
+      runId
+    );
+    // Use 404 (not 403) on mismatch so the response doesn't leak whether
+    // the runId exists under a different chatbox.
+    if (run.chatboxId !== chatboxId) {
+      throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Run not found");
+    }
+    return { run, threadIds };
+  })
 );
 
 export default chatboxSessions;

--- a/mcpjam-inspector/server/services/session-agent.ts
+++ b/mcpjam-inspector/server/services/session-agent.ts
@@ -24,6 +24,36 @@ export interface PersonaSlate {
   notes: string;
 }
 
+/**
+ * Durable roster persona (Phase 2). Mirrors the `chatboxPersonas` row shape the
+ * backend's `chatboxPersonas.listChatboxPersonas` / `getPersonaTrackRecord`
+ * return. `personaId` is the slate-compatible string key; `_id` is the durable
+ * `personaRefId`. A roster persona maps to a `PersonaSlate`
+ * (`{ id: personaId, name, role, notes }`) when launched into a run.
+ */
+export interface Persona {
+  _id: string;
+  personaId: string;
+  name: string;
+  role: string;
+  notes: string;
+  source: "manual" | "generated" | "cluster";
+  seedThemeClusterId?: string;
+  seedKeywords?: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Project a durable roster persona into the inline slate payload. */
+export function personaToSlate(persona: Persona): PersonaSlate {
+  return {
+    id: persona.personaId,
+    name: persona.name,
+    role: persona.role,
+    notes: persona.notes,
+  };
+}
+
 export interface RunSummary {
   total: number;
   succeeded: number;
@@ -73,7 +103,7 @@ async function postJson<T>(
   url: string,
   convexAuthToken: string,
   body: unknown,
-  timeoutMs: number,
+  timeoutMs: number
 ): Promise<T> {
   const response = await fetch(url, {
     method: "POST",
@@ -87,7 +117,7 @@ async function postJson<T>(
   if (!response.ok) {
     const errorText = await response.text();
     throw new Error(
-      `session-agent ${url} failed (${response.status}): ${errorText}`,
+      `session-agent ${url} failed (${response.status}): ${errorText}`
     );
   }
   return (await response.json()) as T;
@@ -100,7 +130,7 @@ export async function generatePersonas(
   projectId: string,
   chatboxId: string,
   personaCount: number,
-  serverAttachment?: ServerAttachmentInput,
+  serverAttachment?: ServerAttachmentInput
 ): Promise<PersonaSlate[]> {
   const data = await postJson<{
     ok?: boolean;
@@ -116,11 +146,13 @@ export async function generatePersonas(
       personaCount,
       ...(serverAttachment ? { serverAttachment } : {}),
     },
-    LLM_TIMEOUT_MS,
+    LLM_TIMEOUT_MS
   );
   if (!data.ok || !Array.isArray(data.personas)) {
     throw new Error(
-      `Invalid response from backend generatePersonas: ${data.error ?? "unknown error"}`,
+      `Invalid response from backend generatePersonas: ${
+        data.error ?? "unknown error"
+      }`
     );
   }
   return data.personas;
@@ -134,6 +166,10 @@ export async function createRun(
   personas: PersonaSlate[],
   sessionsPerPersona: number,
   maxTurns: number,
+  // Phase 2: when the swarm is launched from selected roster personas, pass
+  // their durable refs. The backend resolves them into the same persona
+  // payload shape and merges with any inline `personas`.
+  personaRefIds?: string[]
 ): Promise<{ runId: string }> {
   const data = await postJson<{
     ok?: boolean;
@@ -148,12 +184,15 @@ export async function createRun(
       personas,
       sessionsPerPersona,
       maxTurns,
+      ...(personaRefIds && personaRefIds.length > 0 ? { personaRefIds } : {}),
     },
-    NON_LLM_TIMEOUT_MS,
+    NON_LLM_TIMEOUT_MS
   );
   if (!data.ok || typeof data.runId !== "string") {
     throw new Error(
-      `Invalid response from backend createRun: ${data.error ?? "unknown error"}`,
+      `Invalid response from backend createRun: ${
+        data.error ?? "unknown error"
+      }`
     );
   }
   return { runId: data.runId };
@@ -165,7 +204,7 @@ export async function personaNextTurn(
   projectId: string,
   runId: string,
   personaId: string,
-  transcriptSoFar: Array<{ role: "user" | "assistant"; content: string }>,
+  transcriptSoFar: Array<{ role: "user" | "assistant"; content: string }>
 ): Promise<PersonaNextTurnResponse> {
   const data = await postJson<{
     ok?: boolean;
@@ -176,11 +215,13 @@ export async function personaNextTurn(
     `${convexHttpUrl}/session-simulation/persona-next-turn`,
     convexAuthToken,
     { projectId, runId, personaId, transcriptSoFar },
-    LLM_TIMEOUT_MS,
+    LLM_TIMEOUT_MS
   );
   if (!data.ok || typeof data.message !== "string") {
     throw new Error(
-      `Invalid response from backend personaNextTurn: ${data.error ?? "unknown error"}`,
+      `Invalid response from backend personaNextTurn: ${
+        data.error ?? "unknown error"
+      }`
     );
   }
   return {
@@ -195,7 +236,7 @@ export async function updateRun(
   projectId: string,
   runId: string,
   deltaSummary: DeltaSummary,
-  status?: RunRecord["status"],
+  status?: RunRecord["status"]
 ): Promise<void> {
   const data = await postJson<{ ok?: boolean; error?: string }>(
     `${convexHttpUrl}/session-simulation/runs/update`,
@@ -206,14 +247,16 @@ export async function updateRun(
       deltaSummary,
       ...(status ? { status } : {}),
     },
-    NON_LLM_TIMEOUT_MS,
+    NON_LLM_TIMEOUT_MS
   );
   // Backend may return HTTP 200 with {ok: false} for soft validation
   // failures; treat that as an error so callers can decide whether to
   // retry or abort the batch.
   if (data.ok !== true) {
     throw new Error(
-      `Invalid response from backend updateRun: ${data.error ?? "unknown error"}`,
+      `Invalid response from backend updateRun: ${
+        data.error ?? "unknown error"
+      }`
     );
   }
 }
@@ -222,11 +265,9 @@ export async function getRun(
   convexHttpUrl: string,
   convexAuthToken: string,
   projectId: string,
-  runId: string,
+  runId: string
 ): Promise<{ run: RunRecord; threadIds: string[] }> {
-  const url = new URL(
-    `${convexHttpUrl}/session-simulation/runs`,
-  );
+  const url = new URL(`${convexHttpUrl}/session-simulation/runs`);
   url.searchParams.set("runId", runId);
   url.searchParams.set("projectId", projectId);
   const response = await fetch(url.toString(), {
@@ -239,7 +280,7 @@ export async function getRun(
   if (!response.ok) {
     const errorText = await response.text();
     throw new Error(
-      `session-agent getRun failed (${response.status}): ${errorText}`,
+      `session-agent getRun failed (${response.status}): ${errorText}`
     );
   }
   const data = (await response.json()) as {
@@ -250,7 +291,7 @@ export async function getRun(
   };
   if (!data.ok || !data.run) {
     throw new Error(
-      `Invalid response from backend getRun: ${data.error ?? "unknown error"}`,
+      `Invalid response from backend getRun: ${data.error ?? "unknown error"}`
     );
   }
   return { run: data.run, threadIds: data.threadIds ?? [] };

--- a/mcpjam-inspector/server/services/session-agent.ts
+++ b/mcpjam-inspector/server/services/session-agent.ts
@@ -22,6 +22,18 @@ export interface PersonaSlate {
   name: string;
   role: string;
   notes: string;
+  /**
+   * Optional gradable objective (Phase 3). Carried into the run so the backend
+   * persona-driver prompt pursues it and Phase 3 can grade against it. Absent
+   * for AI-generated (unsaved) slates.
+   */
+  goal?: string;
+  /**
+   * Durable roster row id this slate was projected from, when launched from a
+   * saved persona. Stamped onto the synthetic `chatSessions.personaRefId` at
+   * ingestion so the persona track record can join on the durable key.
+   */
+  personaRefId?: string;
 }
 
 /**
@@ -167,11 +179,7 @@ export async function createRun(
   chatboxId: string,
   personas: PersonaSlate[],
   sessionsPerPersona: number,
-  maxTurns: number,
-  // Phase 2: when the swarm is launched from selected roster personas, pass
-  // their durable refs. The backend resolves them into the same persona
-  // payload shape and merges with any inline `personas`.
-  personaRefIds?: string[]
+  maxTurns: number
 ): Promise<{ runId: string }> {
   const data = await postJson<{
     ok?: boolean;
@@ -181,12 +189,14 @@ export async function createRun(
     `${convexHttpUrl}/session-simulation/runs/create`,
     convexAuthToken,
     {
+      // Personas carry `goal` inline so it's snapshotted into the run and feeds
+      // the backend persona-driver prompt. (`personaRefId` rides the same slate
+      // for ingestion stamping; the backend ignores it on run-create.)
       projectId,
       chatboxId,
       personas,
       sessionsPerPersona,
       maxTurns,
-      ...(personaRefIds && personaRefIds.length > 0 ? { personaRefIds } : {}),
     },
     NON_LLM_TIMEOUT_MS
   );

--- a/mcpjam-inspector/server/services/session-agent.ts
+++ b/mcpjam-inspector/server/services/session-agent.ts
@@ -37,6 +37,8 @@ export interface Persona {
   name: string;
   role: string;
   notes: string;
+  /** Phase 3 gradable objective (goal-completion judge target). */
+  goal?: string;
   source: "manual" | "generated" | "cluster";
   seedThemeClusterId?: string;
   seedKeywords?: string[];

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -701,6 +701,7 @@ async function runOneSession(args: {
         synthetic: true,
         personaId: persona.id,
         personaLabel: persona.name,
+        ...(persona.personaRefId ? { personaRefId: persona.personaRefId } : {}),
         synthesisRunId: runId,
         turnTrace,
         resumeConfig,
@@ -780,6 +781,7 @@ async function runOneSession(args: {
         synthetic: true,
         personaId: persona.id,
         personaLabel: persona.name,
+        ...(persona.personaRefId ? { personaRefId: persona.personaRefId } : {}),
         synthesisRunId: runId,
         resumeConfig,
       });

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -143,11 +143,7 @@ export interface PersistedTurnTrace {
 // boundary so a new surface can't be added without explicitly choosing one.
 // Backend still accepts undefined for historical-row compatibility; the
 // inspector pins to the closed set.
-export type ChatOrigin =
-  | "playground"
-  | "mcpjam_agent"
-  | "chatbox"
-  | "eval";
+export type ChatOrigin = "playground" | "mcpjam_agent" | "chatbox" | "eval";
 
 interface PersistChatSessionOptions {
   chatSessionId: string;
@@ -200,6 +196,8 @@ interface PersistChatSessionOptions {
   synthetic?: boolean;
   personaId?: string;
   personaLabel?: string;
+  /** Durable roster row id; stamped onto `chatSessions.personaRefId`. */
+  personaRefId?: string;
   synthesisRunId?: string;
 }
 
@@ -386,14 +384,11 @@ export async function persistChatSessionToConvex(
           : {}),
         ...(options.turnTrace ? { turnTrace: options.turnTrace } : {}),
         ...(options.hostConfig ? { hostConfig: options.hostConfig } : {}),
-        ...(options.toolSnapshot
-          ? { toolSnapshot: options.toolSnapshot }
-          : {}),
+        ...(options.toolSnapshot ? { toolSnapshot: options.toolSnapshot } : {}),
         ...(options.synthetic ? { synthetic: true } : {}),
         ...(options.personaId ? { personaId: options.personaId } : {}),
-        ...(options.personaLabel
-          ? { personaLabel: options.personaLabel }
-          : {}),
+        ...(options.personaLabel ? { personaLabel: options.personaLabel } : {}),
+        ...(options.personaRefId ? { personaRefId: options.personaRefId } : {}),
         ...(options.synthesisRunId
           ? { synthesisRunId: options.synthesisRunId }
           : {}),


### PR DESCRIPTION
## Summary

Inspector half of the synthetic-session swarm work. Ships the **Phase 1 readiness UI** and the **Phase 2 personas tab**. Pairs with backend PR **MCPJam/mcpjam-backend#605** (same branch).

> The plan referenced a `swarm-mock` visual target that doesn't exist in this branch, so the UI is built directly against existing design-system conventions rather than ported.

### Phase 1 — synthetic-session readiness surfaces
All surfaces render from the **server-denormalized** `chatSessions.readiness` fields (no client-side trace parsing).
- **`session-readiness.tsx`** — `SessionReadinessBadge` (session-row verdict pill), `SessionInsightBar` (detail findings), `SessionReadinessStrip` (chatbox rollup), the `useChatboxReadinessRollup` hook, and shared client types
- Sessions list rows show a **persona chip + readiness signal**; the detail shows the **insight bar**; the **rollup strip** sits above the list. `pending` / `partial` / `failed` states render explicitly.
- `SharedChatThread` carries the compact signal (list) / full record (detail)

### Phase 2 — persona roster
- **`personas.tsx`** — `CharacterAvatar`, selectable `PersonaCard`, `PersonaTrackRecordPanel` (Phase 1 readiness aggregates; **goal rate omitted until Phase 3**), and the roster / track-record / mutation Convex hooks
- **`PersonasTab.tsx`** — character-select grid, **New character**, **seed-from-traffic** chips wired to the chatbox's theme clusters, and **Run swarm**. Added to `ChatboxesTab` `TAB_OPTIONS` / `ViewModeSelector`.
- **`GenerateSessionsDialog`** stage 1 becomes **roster selection** (pick saved characters, or generate new); **Review** + **Running** stages and the `/start` payload are unchanged. "Run swarm" opens the dialog pre-seeded with the selected personas.
- **`server/services/session-agent.ts`** mirrors the durable `Persona` type and `createRun` accepts roster `personaRefIds`.

## Verification
- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean (server `session-agent.ts` clean; remaining server tsc errors are pre-existing/unrelated)
- Vitest: new `session-readiness` component tests (6) pass; existing `ShareUsageThreadDetail` tests (5) still pass
- `prettier --write` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014wtWSMHxqT7tcvNCAr6Rgu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New UI depends on paired backend Convex APIs (`chatboxPersonas`, readiness rollups); synthetic runs can consume BYOK credits when launched from Personas. Mostly client-facing with narrow server payload extensions.
> 
> **Overview**
> Adds **Phase 1 synthetic-session readiness** in the Inspector: new `session-readiness` surfaces (row badge, detail insight bar, chatbox rollup strip) driven only by server `chatSessions.readiness`, wired into Sessions list/detail and `SharedChatThread`.
> 
> Adds a **Personas** tab on `/chatboxes` with a durable roster grid (create character, seed from theme clusters, track-record panel), plus shared `personas` building blocks and Convex hooks.
> 
> Extends **Generate sessions with AI** so configure can pick saved roster characters (or generate new), Review can open pre-seeded from **Run swarm**, and slates carry optional `goal` / `personaRefId` with a 10-persona cap. Server simulation start/ingestion now accepts and stamps `personaRefId` on synthetic sessions.
> 
> Includes component tests for readiness UI and a roster mock for dialog tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df10129c2c5de609596cde8679d127cee99f466f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->