### PR TITLE
make nux clean

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1792,12 +1792,44 @@ export default function App() {
     typeof currentUser?.createdAt === "number" &&
     currentUser.createdAt >= FIRST_RUN_PLAYGROUND_ROLLOUT_MS;
   const isHostedDefaultRoute =
-    activeTab === "servers" || activeTab === "clients";
+    activeTab === "home" || activeTab === "servers" || activeTab === "clients";
   const shouldHoldHostedDefaultRouteForAuth =
     HOSTED_MODE &&
     !isHostedChatRoute &&
     isHostedDefaultRoute &&
     hostedShellGateState === "auth-loading";
+  const shouldHoldHostedHomeRouteForAppReady =
+    HOSTED_MODE &&
+    !isHostedChatRoute &&
+    activeTab === "home" &&
+    effectiveHostedShellGateState === "ready" &&
+    (isAuthLoading ||
+      !isAuthenticated ||
+      isLoadingRemoteProjects ||
+      !areServersHydrated ||
+      !activeProjectId ||
+      activeProjectId === "none");
+  const shouldRouteToFirstRunOnboarding =
+    !isHostedChatRoute &&
+    !isWorkOsLoading &&
+    effectiveHostedShellGateState === "ready" &&
+    !(isAuthenticated && currentUser === undefined) &&
+    !hasSeenFirstRunOnboarding &&
+    (!HOSTED_MODE ||
+      (isAuthenticated &&
+        !isLoadingRemoteProjects &&
+        areServersHydrated &&
+        !!activeProjectId &&
+        activeProjectId !== "none")) &&
+    isFirstRunEligible(
+      hasAnyFirstRunBlockingProjectServers,
+      activeTab,
+      !!workOsUser,
+      remoteFirstRunOnboardingShown,
+      isNewSignedInAccount
+    );
+  const shouldHoldHostedHomeRouteForFirstRunRedirect =
+    HOSTED_MODE && activeTab === "home" && shouldRouteToFirstRunOnboarding;
 
   const previousConnectedServersRef = useRef<Set<string> | null>(null);
   useEffect(() => {
@@ -2357,64 +2389,10 @@ export default function App() {
   ]);
 
   useLayoutEffect(() => {
-    if (isHostedChatRoute) {
-      return;
-    }
-
-    if (isWorkOsLoading) {
-      return;
-    }
-
-    if (effectiveHostedShellGateState !== "ready") {
-      return;
-    }
-
-    if (isAuthenticated && currentUser === undefined) {
-      return;
-    }
-
-    if (hasSeenFirstRunOnboarding) {
-      return;
-    }
-
-    // Hosted guests need Convex auth and their actor-owned project before
-    // Playground can auto-connect Excalidraw against the right project.
-    if (
-      HOSTED_MODE &&
-      (!isAuthenticated ||
-        isLoadingRemoteProjects ||
-        !activeProjectId ||
-        activeProjectId === "none")
-    ) {
-      return;
-    }
-
-    if (
-      isFirstRunEligible(
-        hasAnyFirstRunBlockingProjectServers,
-        activeTab,
-        !!workOsUser,
-        remoteFirstRunOnboardingShown,
-        isNewSignedInAccount
-      )
-    ) {
+    if (shouldRouteToFirstRunOnboarding) {
       navigateApp(routePaths.playground);
     }
-  }, [
-    activeProjectId,
-    activeTab,
-    currentUser,
-    effectiveHostedShellGateState,
-    hasSeenFirstRunOnboarding,
-    hasAnyFirstRunBlockingProjectServers,
-    isAuthenticated,
-    isHostedChatRoute,
-    isLoadingRemoteProjects,
-    isNewSignedInAccount,
-    isWorkOsLoading,
-    remoteFirstRunOnboardingShown,
-    workOsUser,
-  ]);
+  }, [shouldRouteToFirstRunOnboarding]);
 
   // When the active project changes (org switch, project delete, manual switch),
   // snap to Servers — staying on App Builder/Chat would leave the user pointed
@@ -2919,7 +2897,11 @@ export default function App() {
     billingEntitlementsUiEnabled !== false &&
     pendingCheckoutIntent !== null;
 
-  if (shouldHoldHostedDefaultRouteForAuth) {
+  if (
+    shouldHoldHostedDefaultRouteForAuth ||
+    shouldHoldHostedHomeRouteForAppReady ||
+    shouldHoldHostedHomeRouteForFirstRunRedirect
+  ) {
     return <LoadingScreen />;
   }
 
@@ -2996,8 +2978,8 @@ export default function App() {
             activeTab === "xaa-flow" && xaaEnabled === true
               ? () => setXaaServerModalNonce((n) => n + 1)
               : activeTab === "oauth-flow"
-                ? () => setOauthServerModalNonce((n) => n + 1)
-                : undefined,
+              ? () => setOauthServerModalNonce((n) => n + 1)
+              : undefined,
           isMultiSelectEnabled: activeTab === "chat",
           onMultiServerToggle: toggleServerSelection,
           selectedMultipleServers: appState.selectedMultipleServers,

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -74,6 +74,7 @@ const {
     },
     isLoading: false,
     isLoadingRemoteProjects: false,
+    areServersHydrated: true,
     projectServers: {},
     connectedOrConnectingServerConfigs: {},
     selectedMCPConfig: null,
@@ -2352,6 +2353,27 @@ describe("App hosted OAuth callback handling", () => {
     );
   });
 
+  it("auto-routes a Convex-authenticated hosted guest from the default route into Playground onboarding", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    mockUnseenOnboardingState();
+    window.history.replaceState({}, "", "/");
+    mockHandleOAuthCallback.mockReset();
+    mockConvexAuthState.isAuthenticated = true;
+    mockWorkOsAuthState.user = null;
+    mockHostedShellGateState.value = "ready";
+    mockFreshGuestUser();
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("playground-tab")).toBeInTheDocument();
+    });
+
+    expect(window.location.pathname).toBe("/playground");
+    expect(screen.queryByTestId("home-tab")).not.toBeInTheDocument();
+  });
+
   it("does not auto-route a guest row already marked as having seen onboarding", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
@@ -2507,6 +2529,75 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByText("Servers Tab")).not.toBeInTheDocument();
   });
 
+  it("does not flash Home while hosted auth is still loading on the default route", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    mockUnseenOnboardingState();
+    window.history.replaceState({}, "", "/");
+    mockHandleOAuthCallback.mockReset();
+    mockHostedShellGateState.value = "auth-loading";
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hosted-oauth-loading")).toBeInTheDocument();
+    });
+
+    expect(window.location.pathname).toBe("/");
+    expect(screen.queryByTestId("home-tab")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("playground-tab")).not.toBeInTheDocument();
+  });
+
+  it("does not flash Home while hosted guest auth is unresolved on the default route", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    mockUnseenOnboardingState();
+    window.history.replaceState({}, "", "/");
+    mockHandleOAuthCallback.mockReset();
+    mockHostedShellGateState.value = "ready";
+    mockConvexAuthState.isAuthenticated = false;
+    mockConvexAuthState.isLoading = false;
+    mockWorkOsAuthState.user = null;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hosted-oauth-loading")).toBeInTheDocument();
+    });
+
+    expect(window.location.pathname).toBe("/");
+    expect(screen.queryByTestId("home-tab")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("playground-tab")).not.toBeInTheDocument();
+  });
+
+  it("does not flash Home while hosted project and server state hydrate on the default route", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    mockUnseenOnboardingState();
+    window.history.replaceState({}, "", "/");
+    mockHandleOAuthCallback.mockReset();
+    mockHostedShellGateState.value = "ready";
+    mockConvexAuthState.isAuthenticated = true;
+    mockWorkOsAuthState.user = null;
+    mockFreshGuestUser();
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      isLoadingRemoteProjects: true,
+      areServersHydrated: false,
+      activeProjectId: "ws_local",
+    }));
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hosted-oauth-loading")).toBeInTheDocument();
+    });
+
+    expect(window.location.pathname).toBe("/");
+    expect(screen.queryByTestId("home-tab")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("playground-tab")).not.toBeInTheDocument();
+  });
+
   it("does not hijack a non-default hash route for first-run guests", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
@@ -2572,8 +2663,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/evals");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) =>
-        flag === "playground-enabled" || flag === "evaluate-ui"
+      (flag: string) => flag === "playground-enabled" || flag === "evaluate-ui"
     );
 
     render(<App />);

--- a/mcpjam-inspector/client/src/components/LoadingScreen.tsx
+++ b/mcpjam-inspector/client/src/components/LoadingScreen.tsx
@@ -1,8 +1,27 @@
+import { useRef } from "react";
+
+const SPINNER_ROTATION_MS = 1000;
+
+function getSpinnerAnimationDelay() {
+  const now =
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+      ? performance.now()
+      : Date.now();
+
+  return `-${now % SPINNER_ROTATION_MS}ms`;
+}
+
 export default function LoadingScreen() {
+  const animationDelayRef = useRef(getSpinnerAnimationDelay());
+
   return (
     <div className="min-h-screen bg-background flex items-center justify-center">
       <div className="text-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-4 border-gray-200 border-t-primary mx-auto"></div>
+        <div
+          className="animate-spin rounded-full h-12 w-12 border-4 border-gray-200 border-t-primary mx-auto"
+          style={{ animationDelay: animationDelayRef.current }}
+        ></div>
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -14,6 +14,7 @@ import {
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
 import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capabilities-context";
+import LoadingScreen from "@/components/LoadingScreen";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -218,6 +219,14 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   // user clicks the corresponding `CollapsedPanelStrip` peek button.
   const leftPanelRef = useRef<ImperativePanelHandle | null>(null);
   const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
+
+  if (playgroundState.loadingState.kind === "skeleton") {
+    return (
+      <div className="fixed inset-0 z-[100] bg-background">
+        <LoadingScreen />
+      </div>
+    );
+  }
 
   return (
     <PlaygroundStateProvider value={playgroundState}>

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -39,6 +39,7 @@ import { ModelDefinition } from "@/shared/types";
 import { cn } from "@/lib/utils";
 import { Thread } from "@/components/chat-v2/thread";
 import { ChatInput } from "@/components/chat-v2/chat-input";
+import LoadingScreen from "@/components/LoadingScreen";
 import { StickToBottom } from "use-stick-to-bottom";
 import { ScrollToBottomButton } from "@/components/chat-v2/shared/scroll-to-bottom-button";
 import {
@@ -2573,6 +2574,8 @@ export function PlaygroundMain({
 
   const shouldShowUpsell = disableForAuthentication && !isAuthLoading;
   const showMultiModelStarterPrompts = !shouldShowUpsell && !isAuthLoading;
+  const shouldShowFirstRunLoadingScreen =
+    isAuthLoading && initialInputTypewriter && Boolean(initialInput);
   const handleSignUp = () => {
     posthog.capture("sign_up_button_clicked", {
       location: "app_builder_tab",
@@ -3041,6 +3044,11 @@ export function PlaygroundMain({
     // synchronously on the first render, so the fetch-source key is
     // stable from mount #1.
     <WidgetSurfaceProvider value="playground">
+      {shouldShowFirstRunLoadingScreen && (
+        <div className="fixed inset-0 z-[100] bg-background">
+          <LoadingScreen />
+        </div>
+      )}
     <div
       className={cn(
         "relative h-full flex flex-col overflow-hidden",

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
@@ -813,6 +813,9 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
   }, [serverName, isServerSyncing]);
 
   const isResolvingRemoteCompletion = onboarding.isResolvingRemoteCompletion;
+  const isConnectingFirstRunExcalidraw =
+    onboarding.phase === "connecting_excalidraw" &&
+    !onboarding.isGuidedPostConnect;
   const isBootstrappingFirstRunConnection =
     onboarding.isBootstrappingFirstRunConnection && !!onConnect;
   const isWaitingForServerSync =
@@ -833,6 +836,7 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
 
   const loadingState: PlaygroundLoadingState =
     isResolvingRemoteCompletion ||
+    isConnectingFirstRunExcalidraw ||
     isBootstrappingFirstRunConnection ||
     isWaitingForServerSync
       ? { kind: "skeleton" }


### PR DESCRIPTION
- Fixed hosted by showing a spinner instead of Home while NUX is being decided.
- Also made the same startup/NUX flow smoother in local so local also waits cleanly instead of showing the wrong intermediate UI.