### PR TITLE
error connecting in hosted debugger

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -38,6 +38,7 @@ const {
   mockUpdateServer,
   mockUpdateServerWithClientSecret,
   mockUseDbUserReady,
+  mockHostedMode,
 } = vi.hoisted(() => ({
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
@@ -61,6 +62,7 @@ const {
   mockUpdateServer: vi.fn(),
   mockUpdateServerWithClientSecret: vi.fn(),
   mockUseDbUserReady: vi.fn(() => false),
+  mockHostedMode: vi.fn(() => false),
 }));
 
 vi.mock("sonner", () => ({
@@ -79,6 +81,19 @@ vi.mock("convex/react", () => ({
 vi.mock("@/contexts/db-user-ready-context", () => ({
   useDbUserReady: mockUseDbUserReady,
 }));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return {
+    ...actual,
+    get HOSTED_MODE() {
+      return mockHostedMode();
+    },
+    get SANITIZE_OAUTH_TRACES() {
+      return mockHostedMode();
+    },
+  };
+});
 
 vi.mock("@/state/mcp-api", () => ({
   testConnection: testConnectionMock,
@@ -276,6 +291,7 @@ async function flushAsyncWork(iterations = 5): Promise<void> {
 }
 
 beforeEach(() => {
+  mockHostedMode.mockReturnValue(false);
   mockUseDbUserReady.mockReturnValue(true);
   vi.mocked(authFetch).mockReset();
   vi.mocked(authFetch).mockResolvedValue({
@@ -716,7 +732,7 @@ describe("useServerState OAuth callback failures", () => {
     });
   });
 
-  it("imports debugger-applied OAuth tokens before reconnecting a synced local server", async () => {
+  it("imports debugger-applied OAuth tokens before reconnecting a synced server", async () => {
     reconnectServerMock.mockResolvedValueOnce({
       success: true,
       initInfo: null,
@@ -773,6 +789,55 @@ describe("useServerState OAuth callback failures", () => {
         serverName: "demo-server",
       })
     );
+    expect(toastSuccess).toHaveBeenCalledWith("Connected to demo-server!");
+  });
+
+  it("imports debugger-applied OAuth tokens before reconnecting in hosted mode", async () => {
+    mockHostedMode.mockReturnValue(true);
+    reconnectServerMock.mockResolvedValueOnce({
+      success: true,
+      initInfo: null,
+    });
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleConnectWithTokensFromOAuthFlow(
+        "demo-server",
+        {
+          accessToken: "hosted-access-token",
+          tokenType: "Bearer",
+          expiresIn: 3600,
+          clientId: "hosted-client-id",
+        },
+        "https://hosted.example.com/mcp"
+      );
+    });
+
+    expect(importHostedOAuthTokensMock).toHaveBeenCalledWith({
+      projectId: "project_default",
+      serverId: "srv_demo",
+      serverUrl: "https://hosted.example.com/mcp",
+      kind: "generic",
+      clientInformation: {
+        clientId: "hosted-client-id",
+      },
+      tokens: {
+        access_token: "hosted-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      },
+    });
+    expect(reconnectServerMock).toHaveBeenCalledWith(
+      "srv_demo",
+      expect.objectContaining({ url: "https://hosted.example.com/mcp" }),
+      expect.objectContaining({
+        projectId: "project_default",
+        serverName: "demo-server",
+      })
+    );
+    expect(localStorage.getItem("mcp-client-demo-server")).toBeNull();
+    expect(localStorage.getItem("mcp-serverUrl-demo-server")).toBeNull();
     expect(toastSuccess).toHaveBeenCalledWith("Connected to demo-server!");
   });
 

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2810,60 +2810,56 @@ export function useServerState({
         localStorage.setItem(`mcp-serverUrl-${serverName}`, serverUrl);
       }
 
-      if (!HOSTED_MODE) {
-        const resolved = tryResolveProjectServer(serverName);
-        const normalizedTokens = normalizeImportHostedOAuthTokens(tokenData);
-        if (!resolved) {
-          localStorage.removeItem(`mcp-tokens-${serverName}`);
-          return {
-            success: false,
-            error: "OAuth server is not synced; cannot store tokens securely",
-          };
-        }
-        if (!normalizedTokens) {
-          localStorage.removeItem(`mcp-tokens-${serverName}`);
-          return {
-            success: false,
-            error:
-              "OAuth token response missing access_token; cannot import tokens to Convex",
-          };
-        }
-        if (!tokens.clientId) {
-          localStorage.removeItem(`mcp-tokens-${serverName}`);
-          return {
-            success: false,
-            error:
-              "OAuth client information missing client_id; cannot import tokens to Convex",
-          };
-        }
-        const storedOAuthConfig = readStoredOAuthConfig(serverName);
-        const isRegistry =
-          !!storedOAuthConfig.registryServerId &&
-          storedOAuthConfig.useRegistryOAuthProxy === true;
-        await importHostedOAuthTokens({
-          projectId: resolved.projectId,
-          serverId: resolved.serverId,
-          serverUrl,
-          ...(storedOAuthConfig.resourceUrl
-            ? { oauthResourceUrl: storedOAuthConfig.resourceUrl }
-            : {}),
-          kind: isRegistry ? "registry" : "generic",
-          ...(isRegistry
-            ? {
-                registryServerId: storedOAuthConfig.registryServerId,
-                useRegistryOAuthProxy: true,
-              }
-            : {}),
-          clientInformation: {
-            clientId: tokens.clientId,
-            ...(tokens.clientSecret
-              ? { clientSecret: tokens.clientSecret }
-              : {}),
-          },
-          tokens: normalizedTokens,
-        });
+      const resolved = tryResolveProjectServer(serverName);
+      const normalizedTokens = normalizeImportHostedOAuthTokens(tokenData);
+      if (!resolved) {
         localStorage.removeItem(`mcp-tokens-${serverName}`);
+        return {
+          success: false,
+          error: "OAuth server is not synced; cannot store tokens securely",
+        };
       }
+      if (!normalizedTokens) {
+        localStorage.removeItem(`mcp-tokens-${serverName}`);
+        return {
+          success: false,
+          error:
+            "OAuth token response missing access_token; cannot import tokens to Convex",
+        };
+      }
+      if (!tokens.clientId) {
+        localStorage.removeItem(`mcp-tokens-${serverName}`);
+        return {
+          success: false,
+          error:
+            "OAuth client information missing client_id; cannot import tokens to Convex",
+        };
+      }
+      const storedOAuthConfig = readStoredOAuthConfig(serverName);
+      const isRegistry =
+        !!storedOAuthConfig.registryServerId &&
+        storedOAuthConfig.useRegistryOAuthProxy === true;
+      await importHostedOAuthTokens({
+        projectId: resolved.projectId,
+        serverId: resolved.serverId,
+        serverUrl,
+        ...(storedOAuthConfig.resourceUrl
+          ? { oauthResourceUrl: storedOAuthConfig.resourceUrl }
+          : {}),
+        kind: isRegistry ? "registry" : "generic",
+        ...(isRegistry
+          ? {
+              registryServerId: storedOAuthConfig.registryServerId,
+              useRegistryOAuthProxy: true,
+            }
+          : {}),
+        clientInformation: {
+          clientId: tokens.clientId,
+          ...(tokens.clientSecret ? { clientSecret: tokens.clientSecret } : {}),
+        },
+        tokens: normalizedTokens,
+      });
+      localStorage.removeItem(`mcp-tokens-${serverName}`);
 
       const serverConfig = {
         url: serverUrl,


### PR DESCRIPTION
## Summary

Fixes hosted OAuth Debugger reconnect after #2866.

#2866 correctly stopped putting the access token directly into the reconnect request. But hosted OAuth Debugger was not saving that token to the backend first, so hosted had no token to use.

This PR imports debugger-issued tokens into the hosted OAuth credential store before reconnecting.

Flow now:

1. Debugger gets token.
2. Frontend sends token once to backend import endpoint.
3. Backend stores it for that project/server.
4. Frontend reconnects normally.
5. Backend uses the stored token.

## Testing

- `npm run test -w @mcpjam/inspector -- client/src/hooks/__tests__/use-server-state.test.tsx`
- `npm run typecheck:client -w @mcpjam/inspector`