### PR TITLE
Persist error toasts until dismissed

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -12,7 +12,7 @@ import {
 } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { AlertTriangle, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { MCPJamLimitDialog } from "./components/mcpjam-limit-dialog";
 import { HomeTab } from "./components/HomeTab";
 import { ServersTab } from "./components/ServersTab";

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -16,7 +16,7 @@ import {
   useOrganizationQueries,
 } from "@/hooks/useOrganizations";
 import type { ContentBlock } from "@modelcontextprotocol/client";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { ModelDefinition } from "@/shared/types";
 import { LoggerView } from "./logger-view";
 import {

--- a/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
@@ -8,7 +8,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { useConvexAuth, useMutation } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { SegmentedControl } from "@/components/ui/json-editor/segmented-control";

--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
 import { GitBranch, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   Breadcrumb,
   BreadcrumbItem,

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvex, useConvexAuth, useMutation } from "convex/react";
 import { FlaskConical, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBoundary } from "@/components/ui/error-boundary";

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -32,7 +32,7 @@ import {
   UserPlus,
   Users,
 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   Card,
   CardContent,

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -123,7 +123,7 @@ import {
   SNAPPY_RAIL,
 } from "./hosts/transition-tokens";
 import { compareQuickConnectCatalogCards } from "@/lib/quick-connect-catalog-sort";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 const ORDER_STORAGE_KEY = "mcp-server-order";
 const LOGGER_FOCUS_STORAGE_KEY = "mcp-server-logger-focus";

--- a/mcpjam-inspector/client/src/components/ViewsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ViewsTab.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import { useConvexAuth } from "convex/react";
 import { usePostHog } from "posthog-js/react";
 import { Layers } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { detectPlatform, detectEnvironment } from "@/lib/PosthogUtils";
 import { EmptyState } from "@/components/ui/empty-state";
 import {

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -704,7 +704,8 @@ describe("ChatTabV2 history sync", () => {
     );
     expect(mockUseChatSession.syncResumedVersion).toHaveBeenCalledWith(null);
     expect(mockToastError).toHaveBeenCalledWith(
-      "This chat changed elsewhere. This reply stayed local, and your next send will continue in a new thread."
+      "This chat changed elsewhere. This reply stayed local, and your next send will continue in a new thread.",
+      { duration: Infinity }
     );
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -890,6 +890,7 @@ describe("OrganizationsTab billing", () => {
     });
     expect(toast.error).toHaveBeenCalledWith(
       "This organization has reached its member limit (3). Ask an organization owner to upgrade.",
+      { duration: Infinity },
     );
   });
 

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { CoinStackIcon } from "@/components/ui/coin-stack-icon";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,

--- a/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/convert-chat-session-dialog.tsx
@@ -1,7 +1,7 @@
 import { useAction, useConvexAuth, useQuery } from "convex/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   Dialog,
   DialogContent,

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/save-as-test-case-action.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/save-as-test-case-action.tsx
@@ -1,7 +1,7 @@
 import { useAction, useConvexAuth, useQuery } from "convex/react";
 import { useEffect, useMemo, useState } from "react";
 import { FlaskConical, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   Dialog,
   DialogContent,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/BlockedRequestCard.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/csp-workbench/BlockedRequestCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { ChevronRight, Copy, Check, ExternalLink } from "lucide-react";
 import { copyToClipboard } from "@/lib/clipboard";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type { Diagnosis } from "./types";
 
 interface BlockedRequestCardProps {

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxPublishClientBar.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxPublishClientBar.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Settings2 } from "lucide-react";
 import { useMutation } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
 import { ServerAttachmentPicker } from "@/components/evals/server-attachment-picker";
 import type { EvalServerAttachment } from "@/components/evals/types";

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ChevronDown, Clock, Globe, Lock, Users } from "lucide-react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useProfilePicture } from "@/hooks/useProfilePicture";
 import {
   type ChatboxMember,

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MessageSquare, Sparkles } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 import {
   EMPTY_USAGE_FILTER,

--- a/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/GenerateSessionsDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
 import { useAuth } from "@workos-inc/authkit-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { AlertTriangle, Loader2, Sparkles } from "lucide-react";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 import { isMCPJamProvidedModel } from "@/shared/types";

--- a/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/PersonasTab.tsx
@@ -11,7 +11,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Loader2, Plus, Sparkles, Users } from "lucide-react";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 import { Button } from "@mcpjam/design-system/button";

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPublishClientBar.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPublishClientBar.test.tsx
@@ -114,6 +114,7 @@ describe("ChatboxPublishClientBar", () => {
 
     expect(toastMock.error).toHaveBeenCalledWith(
       "Failed to save servers: nope",
+      { duration: Infinity },
     );
   });
 

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown, Loader2, Plus } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { Card } from "@mcpjam/design-system/card";

--- a/mcpjam-inspector/client/src/components/client-config/ProjectDefaultClientConfigSection.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/ProjectDefaultClientConfigSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { Loader2, RotateCcw, Save } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { ClientConfigEditor } from "./ClientConfigEditor";
 import {

--- a/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { useNavigate } from "react-router";
 import { usePostHog } from "posthog-js/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Tooltip,

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -1,5 +1,5 @@
 import { Component, useCallback, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { usePostHog } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Loader2, RotateCcw, TerminalSquare, Trash2 } from "lucide-react";

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@mcpjam/design-system/dialog";

--- a/mcpjam-inspector/client/src/components/connection/JsonImportModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/JsonImportModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@mcpjam/design-system/dialog";
 import { Label } from "@mcpjam/design-system/label";

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -4,7 +4,7 @@ import {
   useCallback,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Card } from "@mcpjam/design-system/card";
 import { Button } from "@mcpjam/design-system/button";
 import { Separator } from "@mcpjam/design-system/separator";

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useMutation, useQuery } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
 import {

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.hosted.test.tsx
@@ -101,7 +101,8 @@ describe("ServerConnectionCard hosted reconnect guard", () => {
     fireEvent.click(toggle);
 
     expect(toast.error).toHaveBeenCalledWith(
-      "HTTP servers are not supported in hosted mode"
+      "HTTP servers are not supported in hosted mode",
+      { duration: Infinity }
     );
     expect(onReconnect).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { Copy, Loader2, MessageSquare } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { copyToClipboard } from "@/lib/clipboard";
 import { SessionInsightBar } from "@/components/chatboxes/session-readiness";

--- a/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Copy, Loader2, RotateCw, Sparkles } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { cn } from "@/lib/utils";
 import { copyToClipboard } from "@/lib/clipboard";

--- a/mcpjam-inspector/client/src/components/evals/copyable-code-block.tsx
+++ b/mcpjam-inspector/client/src/components/evals/copyable-code-block.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState, type ReactNode } from "react";
 import { Check, Copy } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { copyToClipboard } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 

--- a/mcpjam-inspector/client/src/components/evals/eval-runner.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-runner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight, Plus, X } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { navigateApp } from "@/lib/app-navigation";

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -9,7 +9,7 @@ import {
   TagGroupAggregate,
 } from "./types";
 import { computeIterationResult } from "./pass-criteria";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { RESULT_STATUS } from "./constants";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 

--- a/mcpjam-inspector/client/src/components/evals/run-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-overview.tsx
@@ -37,7 +37,7 @@ import {
   EVAL_DESTRUCTIVE_BUTTON_CLASS,
   EVAL_LOW_PASS_RATE_TEXT_CLASS,
 } from "./constants";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 const RUN_ROW_STAGGER_CAP = 20;
 

--- a/mcpjam-inspector/client/src/components/evals/schedule-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/schedule-editor.tsx
@@ -10,7 +10,7 @@
 
 import { useEffect, useState } from "react";
 import { useMutation } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { Switch } from "@mcpjam/design-system/switch";
 import {

--- a/mcpjam-inspector/client/src/components/evals/server-attachment-picker.tsx
+++ b/mcpjam-inspector/client/src/components/evals/server-attachment-picker.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { useMutation, useConvexAuth } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, RotateCcw, Save, Settings2 } from "lucide-react";
 import { useMutation, useQuery } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { ClientConfigEditor } from "@/components/client-config/ClientConfigEditor";
 import {

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -42,7 +42,7 @@ import {
   SuiteAggregate,
 } from "./types";
 import { useMutation } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 import { CiMetadataDisplay } from "./ci-metadata-display";
 import { GenerateCasesConfigPopover } from "./generate-cases-config-popover";

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import { useMutation, useConvexAuth } from "convex/react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useHostList } from "@/hooks/useClients";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { compareRunsBySequence } from "./helpers";
 import { SuiteHeader } from "./suite-header";

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useConvex, useQuery } from "convex/react";
 import posthog from "posthog-js";
 import { Loader2, Play, Plus, Puzzle, Sparkles, Trash2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
 import { EmptyState } from "@/components/ui/empty-state";

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -18,7 +18,7 @@ import {
   Save,
   Square,
 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import {
   listEvalTools,

--- a/mcpjam-inspector/client/src/components/evals/trace-raw-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-raw-view.tsx
@@ -13,7 +13,7 @@
 
 import { Copy, Loader2, ScanSearch } from "lucide-react";
 import type { ModelMessage } from "ai";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { usePostHog } from "posthog-js/react";
 import { standardEventProps } from "@/lib/PosthogUtils";
 import { JsonEditor } from "@/components/ui/json-editor";

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { useConvex } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import posthog from "posthog-js";
 import { detectPlatform, detectEnvironment } from "@/lib/PosthogUtils";
 import { isMCPJamProvidedModel } from "@/shared/types";

--- a/mcpjam-inspector/client/src/components/home/RecommendedHosts.tsx
+++ b/mcpjam-inspector/client/src/components/home/RecommendedHosts.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Loader2, Plus } from "lucide-react";
 import { useAppNavigate, buildHostsPath } from "@/lib/app-navigation";
 import { useHostMutations } from "@/hooks/useClients";

--- a/mcpjam-inspector/client/src/components/home/RecommendedServers.tsx
+++ b/mcpjam-inspector/client/src/components/home/RecommendedServers.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   Loader2,
   Plus,

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -3,7 +3,7 @@ import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
 import { usePostHog } from "posthog-js/react";
 import { Loader2, Link2Off, ShieldX } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { ChatTabV2 } from "@/components/ChatTabV2";
 import type { ServerWithName } from "@/hooks/use-app-state";

--- a/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useConvexAuth } from "convex/react";
 import { usePostHog } from "posthog-js/react";
 import { standardEventProps } from "@/lib/PosthogUtils";

--- a/mcpjam-inspector/client/src/components/hosts/HostIndexPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostIndexPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Plus, Loader2, Server } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useHostList, useHostMutations, type HostListItem } from "@/hooks/useClients";

--- a/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { useConvexAuth } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { Loader2, Save } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useConvexAuth } from "convex/react";
 import { usePostHog } from "posthog-js/react";
 import { ReactFlowProvider } from "@xyflow/react";

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/stores/traffic-log-store";
 import type { LoggingLevel } from "@modelcontextprotocol/client";
 import { setServerLoggingLevel } from "@/state/mcp-api";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useSharedAppState } from "@/state/app-state-context";
 import type { ServerWithName } from "@/state/app-types";
 import {

--- a/mcpjam-inspector/client/src/components/organization/CreateOrganizationDialog.tsx
+++ b/mcpjam-inspector/client/src/components/organization/CreateOrganizationDialog.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { useOrganizationMutations } from "@/hooks/useOrganizations";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 interface CreateOrganizationDialogProps {
   open: boolean;

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
 import { Check, CheckCircle2, CreditCard, Info, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { Card, CardContent, CardTitle } from "@mcpjam/design-system/card";

--- a/mcpjam-inspector/client/src/components/organization/OrganizationModelsSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationModelsSection.tsx
@@ -9,7 +9,7 @@ import {
   Settings2,
   Trash2,
 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import {

--- a/mcpjam-inspector/client/src/components/organization/__tests__/CreateOrganizationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/CreateOrganizationDialog.test.tsx
@@ -56,6 +56,7 @@ describe("CreateOrganizationDialog", () => {
     });
     expect(toast.error).toHaveBeenCalledWith(
       "This organization has reached its project limit (1). Upgrade to create more projects.",
+      { duration: Infinity },
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/project/ShareProjectDialog.tsx
+++ b/mcpjam-inspector/client/src/components/project/ShareProjectDialog.tsx
@@ -14,7 +14,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@mcpjam/design-system/avata
 import { Alert, AlertDescription, AlertTitle } from "@mcpjam/design-system/alert";
 import { getInitials } from "@/lib/utils";
 import { ChevronDown, Clock, CreditCard, Globe, Lock } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/mcpjam-inspector/client/src/components/setting/ProjectSlackIntegrationSection.tsx
+++ b/mcpjam-inspector/client/src/components/setting/ProjectSlackIntegrationSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";

--- a/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { Key, Plus, Trash2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { SettingsSection } from "../setting/SettingsSection";
 import { CreateApiKeyDialog } from "./api-keys/CreateApiKeyDialog";

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -34,7 +34,7 @@ import {
 import { useAuth } from "@workos-inc/authkit-react";
 import type { ContentBlock } from "@modelcontextprotocol/client";
 import type { UIMessage } from "ai";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { ModelDefinition } from "@/shared/types";
 import { cn } from "@/lib/utils";
 import { Thread } from "@/components/chat-v2/thread";

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -492,6 +492,7 @@ describe("useProjectState automatic project creation", () => {
     expect(createProjectMock).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       "Create or join an organization to create projects.",
+      { duration: Infinity },
     );
   });
 
@@ -530,6 +531,7 @@ describe("useProjectState automatic project creation", () => {
     expect(createProjectMock).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       "Create or join an organization to create projects.",
+      { duration: Infinity },
     );
   });
 
@@ -559,6 +561,7 @@ describe("useProjectState automatic project creation", () => {
     expect(createProjectMock).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       "Create or join an organization to create projects.",
+      { duration: Infinity },
     );
   });
 
@@ -1476,6 +1479,7 @@ describe("useProjectState automatic project creation", () => {
 
     expect(toast.error).toHaveBeenCalledWith(
       "This organization has reached its project limit (1). Upgrade to create more projects.",
+      { duration: Infinity },
     );
   });
 
@@ -1519,6 +1523,7 @@ describe("useProjectState automatic project creation", () => {
 
     expect(toast.error).toHaveBeenCalledWith(
       "This organization has reached its project limit (1). Ask an organization owner to upgrade.",
+      { duration: Infinity },
     );
   });
 
@@ -1559,6 +1564,7 @@ describe("useProjectState automatic project creation", () => {
     expect(toast.error).toHaveBeenCalledTimes(1);
     expect(toast.error).toHaveBeenCalledWith(
       "This organization has reached its project limit (1). Ask an organization owner to upgrade.",
+      { duration: Infinity },
     );
     expect(logger.error).toHaveBeenCalledTimes(2);
   });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -862,7 +862,8 @@ describe("useServerState OAuth callback failures", () => {
     });
 
     expect(toastError).toHaveBeenCalledWith(
-      "OAuth authorization failed: access_denied: User denied access"
+      "OAuth authorization failed: access_denied: User denied access",
+      { duration: Infinity }
     );
     expect(localStorage.getItem("mcp-oauth-pending")).toBeNull();
     expect(window.location.pathname).toBe("/servers");
@@ -891,7 +892,8 @@ describe("useServerState OAuth callback failures", () => {
     });
 
     expect(toastError).toHaveBeenCalledWith(
-      "Error completing OAuth flow: Token exchange failed"
+      "Error completing OAuth flow: Token exchange failed",
+      { duration: Infinity }
     );
     expect(localStorage.getItem("mcp-oauth-pending")).toBeNull();
   });
@@ -1270,7 +1272,8 @@ describe("useServerState OAuth callback failures", () => {
     });
 
     expect(toastError).toHaveBeenCalledWith(
-      CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE
+      CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
+      { duration: Infinity }
     );
     expect(
       dispatch.mock.calls.some(([action]) => action.type === "CONNECT_REQUEST")
@@ -1293,7 +1296,8 @@ describe("useServerState OAuth callback failures", () => {
     });
 
     expect(toastError).toHaveBeenCalledWith(
-      PROJECT_NOT_PROVISIONED_ERROR_MESSAGE
+      PROJECT_NOT_PROVISIONED_ERROR_MESSAGE,
+      { duration: Infinity }
     );
     expect(testConnectionMock).not.toHaveBeenCalled();
     expect(mockCreateServer).not.toHaveBeenCalled();
@@ -1329,7 +1333,8 @@ describe("useServerState OAuth callback failures", () => {
       error: PROJECT_NOT_PROVISIONED_ERROR_MESSAGE,
     });
     expect(toastError).toHaveBeenCalledWith(
-      PROJECT_NOT_PROVISIONED_ERROR_MESSAGE
+      PROJECT_NOT_PROVISIONED_ERROR_MESSAGE,
+      { duration: Infinity }
     );
   });
 
@@ -1682,7 +1687,8 @@ describe("useServerState OAuth callback failures", () => {
       error: "Failed to resolve registry OAuth config: registry lookup failed",
     });
     expect(toastError).toHaveBeenCalledWith(
-      "Network error: Failed to resolve registry OAuth config: registry lookup failed"
+      "Network error: Failed to resolve registry OAuth config: registry lookup failed",
+      { duration: Infinity }
     );
   });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -349,7 +349,8 @@ describe("useAutoConnectProjectServers", () => {
       { serverName: "beta", error: "beta exploded" }
     );
     expect(mocks.toastError).toHaveBeenCalledWith(
-      "Failed to reconnect 1 server."
+      "Failed to reconnect 1 server.",
+      { duration: Infinity }
     );
   });
 

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { useConvexAuth, useQuery } from "convex/react";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 import { useLogger } from "./use-logger";

--- a/mcpjam-inspector/client/src/hooks/use-onboarding.ts
+++ b/mcpjam-inspector/client/src/hooks/use-onboarding.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { useMutation } from "convex/react";
 import { usePostHog } from "posthog-js/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type { OnboardingPhase } from "@/lib/onboarding-state";
 import {
   markOnboardingShown,

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -6,7 +6,7 @@ import {
   useState,
   type Dispatch,
 } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   createLocalProjectId,
   type AppAction,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, type Dispatch } from "react";
 import { useConvex } from "convex/react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type {
   HttpServerConfig,
   MCPServerConfig,

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type { EnsureServersReadyResult } from "@/hooks/use-server-state";
 import { useLogger } from "@/hooks/use-logger";
 import { useSharedAppState } from "@/state/app-state-context";

--- a/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { usePostHog } from "posthog-js/react";
 
 import { clearPendingTopup, peekPendingTopup } from "@/hooks/useCreditTopup";

--- a/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
@@ -16,7 +16,7 @@ import {
   getExistingGuestBearerToken,
 } from "@/lib/guest-session";
 import { resetTokenCache } from "@/lib/apis/web/context";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 
 /**
  * Dev-only mock registry servers for local UI testing.

--- a/mcpjam-inspector/client/src/hooks/useSaveView.ts
+++ b/mcpjam-inspector/client/src/hooks/useSaveView.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   useViewMutations,
   useProjectServers,

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type { UpdateStatus } from "@/types/electron";
 
 // Public releases page — repo is github.com/MCPJam/inspector (verified from

--- a/mcpjam-inspector/client/src/lib/evals/excalidraw-quickstart.ts
+++ b/mcpjam-inspector/client/src/lib/evals/excalidraw-quickstart.ts
@@ -1,4 +1,4 @@
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import posthog from "posthog-js";
 import type { ConvexReactClient } from "convex/react";
 import {

--- a/mcpjam-inspector/client/src/lib/toast.ts
+++ b/mcpjam-inspector/client/src/lib/toast.ts
@@ -1,0 +1,25 @@
+import { toast as sonnerToast } from "sonner";
+
+/**
+ * App-wide toast.
+ *
+ * Identical to Sonner's `toast`, except error toasts persist until the user
+ * dismisses them (the global `<Toaster>` enables a close button) instead of
+ * auto-dismissing on Sonner's ~4s default. Errors are the one toast type users
+ * must read and usually act on, so they shouldn't vanish on a timer the way
+ * success/info toasts do.
+ *
+ * Callers can still override the duration per-call by passing `duration`
+ * explicitly in the options.
+ *
+ * Import `toast` from here rather than from "sonner" directly so error toasts
+ * stay consistent across the app.
+ */
+const error: typeof sonnerToast.error = (message, data) =>
+  sonnerToast.error(message, { duration: Infinity, ...data });
+
+export const toast: typeof sonnerToast = Object.assign(
+  (...args: Parameters<typeof sonnerToast>) => sonnerToast(...args),
+  sonnerToast,
+  { error }
+);


### PR DESCRIPTION
- Error toasts now stay on screen until you close them, instead of vanishing after ~4s. Success and info toasts are unchanged.
- Errors are the one toast type users usually need to read and act on, so auto-dismissing them on a timer was the wrong default (matches common SaaS/accessibility guidance).
- Implemented in one place: a small `@/lib/toast` wrapper sets `duration: Infinity` for `toast.error`; the 65 files that show error toasts now import `toast` from there instead of `sonner`. Any call can still pass an explicit `duration` to override.
- Updated the few tests that asserted the old `toast.error` arguments. Client typecheck and the affected tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)