### PR TITLE
Add OAuth Debugger e2e smoke

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Run Playwright smoke
         run: npm run test:e2e -w @mcpjam/inspector
 
+      - name: Run OAuth Debugger e2e
+        run: npm run test:e2e:oauth-debugger -w @mcpjam/inspector
+
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -31,6 +31,16 @@ export interface OAuthTokensFromFlow {
   clientSecret?: string;
 }
 
+declare global {
+  interface Window {
+    __oauthDebuggerE2EFlowState?: {
+      authorizationUrl?: string;
+      currentStep: OAuthFlowStep;
+      state?: string;
+    };
+  }
+}
+
 const deriveServerIdentifier = (profile: OAuthTestProfile): string => {
   const trimmedUrl = profile.serverUrl.trim();
   if (!trimmedUrl) {
@@ -178,6 +188,25 @@ export const OAuthFlowTab = ({
   useEffect(() => {
     oauthFlowStateRef.current = oauthFlowState;
   }, [oauthFlowState]);
+
+  useEffect(() => {
+    if (
+      !import.meta.env.DEV ||
+      !window.location.pathname.startsWith("/__e2e/oauth-debugger")
+    ) {
+      return;
+    }
+
+    window.__oauthDebuggerE2EFlowState = {
+      authorizationUrl: oauthFlowState.authorizationUrl,
+      currentStep: oauthFlowState.currentStep,
+      state: oauthFlowState.state,
+    };
+  }, [
+    oauthFlowState.authorizationUrl,
+    oauthFlowState.currentStep,
+    oauthFlowState.state,
+  ]);
 
   useEffect(() => {
     setFocusedStep(null);

--- a/mcpjam-inspector/client/src/components/e2e/OAuthDebuggerE2EHarness.tsx
+++ b/mcpjam-inspector/client/src/components/e2e/OAuthDebuggerE2EHarness.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  OAuthFlowTab,
+  type OAuthTokensFromFlow,
+} from "@/components/OAuthFlowTab";
+import type { ServerWithName } from "@/hooks/use-app-state";
+import {
+  importHostedOAuthTokens,
+  normalizeImportHostedOAuthTokens,
+} from "@/lib/apis/hosted-oauth-import-tokens-api";
+import type { OAuthTestProfile } from "@/lib/oauth/profile";
+import type { ServerFormData } from "@/shared/types.js";
+
+type OAuthDebuggerE2EEvent =
+  | { type: "saved"; serverName: string; serverUrl: string }
+  | { type: "imported"; serverName: string; serverUrl: string }
+  | { type: "reconnected"; serverName: string; serverUrl: string };
+
+declare global {
+  interface Window {
+    __oauthDebuggerE2EEvents?: OAuthDebuggerE2EEvent[];
+  }
+}
+
+const PROJECT_ID = "oauth-debugger-e2e-project";
+const SERVER_ID = "oauth-debugger-e2e-server";
+
+function recordE2EEvent(event: OAuthDebuggerE2EEvent) {
+  window.__oauthDebuggerE2EEvents = [
+    ...(window.__oauthDebuggerE2EEvents ?? []),
+    event,
+  ];
+}
+
+function createServerFromProfile(
+  formData: ServerFormData,
+  oauthProfile?: OAuthTestProfile
+): ServerWithName {
+  return {
+    name: formData.name,
+    config: {
+      url: formData.url ?? "",
+    },
+    oauthFlowProfile: oauthProfile,
+    connectionStatus: "disconnected",
+    enabled: true,
+    retryCount: 0,
+    useOAuth: true,
+    lastConnectionTime: new Date(0),
+  } as ServerWithName;
+}
+
+export function OAuthDebuggerE2EHarness() {
+  const [serverConfigs, setServerConfigs] = useState<
+    Record<string, ServerWithName>
+  >({});
+  const [selectedServerName, setSelectedServerName] = useState("none");
+  const [status, setStatus] = useState("idle");
+
+  const handleSaveServerConfig = useCallback(
+    (
+      formData: ServerFormData,
+      options?: { oauthProfile?: OAuthTestProfile }
+    ) => {
+      const server = createServerFromProfile(formData, options?.oauthProfile);
+      setServerConfigs((current) => ({
+        ...current,
+        [formData.name]: server,
+      }));
+      setSelectedServerName(formData.name);
+      setStatus("saved");
+      recordE2EEvent({
+        type: "saved",
+        serverName: formData.name,
+        serverUrl: formData.url ?? "",
+      });
+    },
+    []
+  );
+
+  const handleConnectWithTokens = useCallback(
+    async (
+      serverName: string,
+      tokens: OAuthTokensFromFlow,
+      serverUrl: string
+    ) => {
+      setStatus("importing");
+
+      const normalizedTokens = normalizeImportHostedOAuthTokens({
+        access_token: tokens.accessToken,
+        refresh_token: tokens.refreshToken,
+        token_type: tokens.tokenType ?? "Bearer",
+        expires_in: tokens.expiresIn,
+      });
+
+      if (!normalizedTokens) {
+        throw new Error(
+          "OAuth debugger e2e flow did not receive an access token"
+        );
+      }
+      if (!tokens.clientId) {
+        throw new Error("OAuth debugger e2e flow did not receive a client id");
+      }
+
+      await importHostedOAuthTokens({
+        projectId: PROJECT_ID,
+        serverId: SERVER_ID,
+        serverUrl,
+        kind: "generic",
+        clientInformation: {
+          clientId: tokens.clientId,
+          ...(tokens.clientSecret ? { clientSecret: tokens.clientSecret } : {}),
+        },
+        tokens: normalizedTokens,
+      });
+
+      setStatus("imported");
+      recordE2EEvent({ type: "imported", serverName, serverUrl });
+
+      const response = await fetch("/__e2e/oauth/reconnect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          projectId: PROJECT_ID,
+          serverId: SERVER_ID,
+          serverName,
+          serverUrl,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `OAuth debugger e2e reconnect failed: ${response.status}`
+        );
+      }
+
+      setServerConfigs((current) => {
+        const server = current[serverName];
+        if (!server) return current;
+        return {
+          ...current,
+          [serverName]: {
+            ...server,
+            connectionStatus: "connected",
+            lastConnectionTime: new Date(),
+          },
+        };
+      });
+      setStatus("connected");
+      recordE2EEvent({ type: "reconnected", serverName, serverUrl });
+    },
+    []
+  );
+
+  const selectedServer = useMemo(
+    () => serverConfigs[selectedServerName],
+    [serverConfigs, selectedServerName]
+  );
+
+  return (
+    <div className="h-screen w-screen bg-background text-foreground">
+      <div
+        data-testid="oauth-e2e-status"
+        data-status={status}
+        data-selected-server={selectedServer?.name ?? "none"}
+        className="sr-only"
+      >
+        {status}
+      </div>
+      <OAuthFlowTab
+        serverConfigs={serverConfigs}
+        selectedServerName={selectedServerName}
+        onSelectServer={setSelectedServerName}
+        onSaveServerConfig={handleSaveServerConfig}
+        onConnectWithTokens={handleConnectWithTokens}
+      />
+    </div>
+  );
+}
+
+export default OAuthDebuggerE2EHarness;

--- a/mcpjam-inspector/client/src/components/e2e/OAuthDebuggerE2EHarness.tsx
+++ b/mcpjam-inspector/client/src/components/e2e/OAuthDebuggerE2EHarness.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { type FormEvent, useCallback, useMemo, useState } from "react";
 import {
   OAuthFlowTab,
   type OAuthTokensFromFlow,
@@ -11,10 +11,35 @@ import {
 import type { OAuthTestProfile } from "@/lib/oauth/profile";
 import type { ServerFormData } from "@/shared/types.js";
 
+type E2EServerKind = "plain" | "oauth";
+type E2EServerStatus = "disconnected" | "connecting" | "connected" | "failed";
+
+interface PersistedE2EServer {
+  name: string;
+  url: string;
+  kind: E2EServerKind;
+  hasConnected: boolean;
+  oauthProfile?: OAuthTestProfile;
+}
+
+interface E2EServer extends PersistedE2EServer {
+  status: E2EServerStatus;
+}
+
 type OAuthDebuggerE2EEvent =
-  | { type: "saved"; serverName: string; serverUrl: string }
+  | {
+      type: "saved";
+      serverName: string;
+      serverUrl: string;
+      kind: E2EServerKind;
+    }
   | { type: "imported"; serverName: string; serverUrl: string }
-  | { type: "reconnected"; serverName: string; serverUrl: string };
+  | {
+      type: "connected";
+      serverName: string;
+      serverUrl: string;
+      intent: string;
+    };
 
 declare global {
   interface Window {
@@ -24,6 +49,11 @@ declare global {
 
 const PROJECT_ID = "oauth-debugger-e2e-project";
 const SERVER_ID = "oauth-debugger-e2e-server";
+const STORAGE_KEY = "oauth-debugger-e2e-servers-v1";
+
+function serverIdForName(serverName: string): string {
+  return serverName === "oauth-e2e-target" ? SERVER_ID : `server-${serverName}`;
+}
 
 function recordE2EEvent(event: OAuthDebuggerE2EEvent) {
   window.__oauthDebuggerE2EEvents = [
@@ -32,17 +62,54 @@ function recordE2EEvent(event: OAuthDebuggerE2EEvent) {
   ];
 }
 
-function createServerFromProfile(
-  formData: ServerFormData,
-  oauthProfile?: OAuthTestProfile
-): ServerWithName {
+function readPersistedServers(): E2EServer[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((server): server is PersistedE2EServer => {
+        return (
+          server &&
+          typeof server === "object" &&
+          typeof server.name === "string" &&
+          typeof server.url === "string" &&
+          (server.kind === "plain" || server.kind === "oauth")
+        );
+      })
+      .map((server) => ({
+        ...server,
+        hasConnected: Boolean(server.hasConnected),
+        status: "disconnected",
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function writePersistedServers(servers: E2EServer[]) {
+  const persisted = servers.map(
+    ({ name, url, kind, hasConnected, oauthProfile }) =>
+      ({
+        name,
+        url,
+        kind,
+        hasConnected,
+        ...(oauthProfile ? { oauthProfile } : {}),
+      } satisfies PersistedE2EServer)
+  );
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
+}
+
+function toOAuthServerWithName(server: E2EServer): ServerWithName {
   return {
-    name: formData.name,
+    name: server.name,
     config: {
-      url: formData.url ?? "",
+      url: server.url,
     },
-    oauthFlowProfile: oauthProfile,
-    connectionStatus: "disconnected",
+    oauthFlowProfile: server.oauthProfile,
+    connectionStatus: server.status,
     enabled: true,
     retryCount: 0,
     useOAuth: true,
@@ -51,31 +118,144 @@ function createServerFromProfile(
 }
 
 export function OAuthDebuggerE2EHarness() {
-  const [serverConfigs, setServerConfigs] = useState<
-    Record<string, ServerWithName>
-  >({});
-  const [selectedServerName, setSelectedServerName] = useState("none");
+  const [servers, setServers] = useState<E2EServer[]>(() =>
+    readPersistedServers()
+  );
+  const [plainName, setPlainName] = useState("plain-e2e-target");
+  const [plainUrl, setPlainUrl] = useState("");
+  const [selectedOAuthServerName, setSelectedOAuthServerName] =
+    useState("none");
+  const [showOAuthDebugger, setShowOAuthDebugger] = useState(false);
+  const [openProfileModalSignal, setOpenProfileModalSignal] = useState(0);
   const [status, setStatus] = useState("idle");
 
-  const handleSaveServerConfig = useCallback(
+  const updateServers = useCallback(
+    (updater: (servers: E2EServer[]) => E2EServer[]) => {
+      setServers((current) => {
+        const next = updater(current);
+        writePersistedServers(next);
+        return next;
+      });
+    },
+    []
+  );
+
+  const upsertServer = useCallback(
+    (server: E2EServer) => {
+      updateServers((current) => {
+        const withoutServer = current.filter(
+          (item) => item.name !== server.name
+        );
+        return [...withoutServer, server];
+      });
+      recordE2EEvent({
+        type: "saved",
+        serverName: server.name,
+        serverUrl: server.url,
+        kind: server.kind,
+      });
+    },
+    [updateServers]
+  );
+
+  const setServerStatus = useCallback(
+    (serverName: string, status: E2EServerStatus, hasConnected?: boolean) => {
+      updateServers((current) =>
+        current.map((server) =>
+          server.name === serverName
+            ? {
+                ...server,
+                status,
+                hasConnected: hasConnected ?? server.hasConnected,
+              }
+            : server
+        )
+      );
+    },
+    [updateServers]
+  );
+
+  const connectServer = useCallback(
+    async (
+      serverName: string,
+      intent: "connect" | "reconnect" | "oauth-debugger"
+    ) => {
+      const server = servers.find((item) => item.name === serverName);
+      if (!server) return;
+
+      setStatus(`${serverName}:connecting`);
+      setServerStatus(serverName, "connecting");
+
+      const response = await fetch("/__e2e/servers/connect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          projectId: PROJECT_ID,
+          serverId: serverIdForName(serverName),
+          serverName,
+          serverUrl: server.url,
+          kind: server.kind,
+          intent,
+        }),
+      });
+
+      if (!response.ok) {
+        setStatus(`${serverName}:failed`);
+        setServerStatus(serverName, "failed");
+        throw new Error(
+          `OAuth debugger e2e connect failed: ${response.status}`
+        );
+      }
+
+      setStatus(`${serverName}:connected`);
+      setServerStatus(serverName, "connected", true);
+      recordE2EEvent({
+        type: "connected",
+        serverName,
+        serverUrl: server.url,
+        intent,
+      });
+    },
+    [servers, setServerStatus]
+  );
+
+  const handleAddPlainServer = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const server: E2EServer = {
+        name: plainName.trim(),
+        url: plainUrl.trim(),
+        kind: "plain",
+        status: "disconnected",
+        hasConnected: false,
+      };
+      if (!server.name || !server.url) return;
+      upsertServer(server);
+      setStatus(`${server.name}:saved`);
+    },
+    [plainName, plainUrl, upsertServer]
+  );
+
+  const handleSaveOAuthServerConfig = useCallback(
     (
       formData: ServerFormData,
       options?: { oauthProfile?: OAuthTestProfile }
     ) => {
-      const server = createServerFromProfile(formData, options?.oauthProfile);
-      setServerConfigs((current) => ({
-        ...current,
-        [formData.name]: server,
-      }));
-      setSelectedServerName(formData.name);
-      setStatus("saved");
-      recordE2EEvent({
-        type: "saved",
-        serverName: formData.name,
-        serverUrl: formData.url ?? "",
-      });
+      const server: E2EServer = {
+        name: formData.name,
+        url: formData.url ?? "",
+        kind: "oauth",
+        status: "disconnected",
+        hasConnected: false,
+        oauthProfile: options?.oauthProfile,
+      };
+      upsertServer(server);
+      setSelectedOAuthServerName(formData.name);
+      setStatus(`${formData.name}:saved`);
     },
-    []
+    [upsertServer]
   );
 
   const handleConnectWithTokens = useCallback(
@@ -84,7 +264,7 @@ export function OAuthDebuggerE2EHarness() {
       tokens: OAuthTokensFromFlow,
       serverUrl: string
     ) => {
-      setStatus("importing");
+      setStatus(`${serverName}:importing`);
 
       const normalizedTokens = normalizeImportHostedOAuthTokens({
         access_token: tokens.accessToken,
@@ -104,7 +284,7 @@ export function OAuthDebuggerE2EHarness() {
 
       await importHostedOAuthTokens({
         projectId: PROJECT_ID,
-        serverId: SERVER_ID,
+        serverId: serverIdForName(serverName),
         serverUrl,
         kind: "generic",
         clientInformation: {
@@ -114,68 +294,122 @@ export function OAuthDebuggerE2EHarness() {
         tokens: normalizedTokens,
       });
 
-      setStatus("imported");
+      setStatus(`${serverName}:imported`);
       recordE2EEvent({ type: "imported", serverName, serverUrl });
-
-      const response = await fetch("/__e2e/oauth/reconnect", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          projectId: PROJECT_ID,
-          serverId: SERVER_ID,
-          serverName,
-          serverUrl,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          `OAuth debugger e2e reconnect failed: ${response.status}`
-        );
-      }
-
-      setServerConfigs((current) => {
-        const server = current[serverName];
-        if (!server) return current;
-        return {
-          ...current,
-          [serverName]: {
-            ...server,
-            connectionStatus: "connected",
-            lastConnectionTime: new Date(),
-          },
-        };
-      });
-      setStatus("connected");
-      recordE2EEvent({ type: "reconnected", serverName, serverUrl });
+      await connectServer(serverName, "oauth-debugger");
     },
-    []
+    [connectServer]
   );
 
-  const selectedServer = useMemo(
-    () => serverConfigs[selectedServerName],
-    [serverConfigs, selectedServerName]
+  const oauthServerConfigs = useMemo(
+    () =>
+      Object.fromEntries(
+        servers
+          .filter((server) => server.kind === "oauth")
+          .map((server) => [server.name, toOAuthServerWithName(server)])
+      ),
+    [servers]
   );
+
+  const handleOpenOAuthDebugger = () => {
+    setShowOAuthDebugger(true);
+    setOpenProfileModalSignal((signal) => signal + 1);
+  };
 
   return (
-    <div className="h-screen w-screen bg-background text-foreground">
+    <div className="h-screen w-screen bg-background text-foreground flex flex-col">
       <div
         data-testid="oauth-e2e-status"
         data-status={status}
-        data-selected-server={selectedServer?.name ?? "none"}
         className="sr-only"
       >
         {status}
       </div>
-      <OAuthFlowTab
-        serverConfigs={serverConfigs}
-        selectedServerName={selectedServerName}
-        onSelectServer={setSelectedServerName}
-        onSaveServerConfig={handleSaveServerConfig}
-        onConnectWithTokens={handleConnectWithTokens}
-      />
+
+      <div className="border-b border-border p-4 space-y-4">
+        <form
+          aria-label="Add plain HTTP server"
+          className="flex flex-wrap items-end gap-3"
+          onSubmit={handleAddPlainServer}
+        >
+          <label className="grid gap-1 text-sm">
+            Plain server name
+            <input
+              className="h-9 rounded-md border border-border bg-background px-3"
+              value={plainName}
+              onChange={(event) => setPlainName(event.target.value)}
+            />
+          </label>
+          <label className="grid gap-1 text-sm min-w-[280px]">
+            Plain server URL
+            <input
+              className="h-9 rounded-md border border-border bg-background px-3"
+              value={plainUrl}
+              onChange={(event) => setPlainUrl(event.target.value)}
+            />
+          </label>
+          <button
+            type="submit"
+            className="h-9 rounded-md border border-border px-3 text-sm"
+          >
+            Add plain HTTP server
+          </button>
+          <button
+            type="button"
+            className="h-9 rounded-md border border-border px-3 text-sm"
+            onClick={handleOpenOAuthDebugger}
+          >
+            Add OAuth server through debugger
+          </button>
+        </form>
+
+        <div aria-label="Saved servers" className="grid gap-2">
+          {servers.map((server) => (
+            <div
+              key={server.name}
+              data-testid={`server-row-${server.name}`}
+              data-kind={server.kind}
+              data-status={server.status}
+              className="flex flex-wrap items-center gap-3 rounded-md border border-border px-3 py-2 text-sm"
+            >
+              <span className="font-medium">{server.name}</span>
+              <span>{server.kind}</span>
+              <span>{server.url}</span>
+              <span data-testid={`server-status-${server.name}`}>
+                {server.status}
+              </span>
+              <button
+                type="button"
+                className="h-8 rounded-md border border-border px-3"
+                onClick={() =>
+                  connectServer(
+                    server.name,
+                    server.hasConnected ? "reconnect" : "connect"
+                  )
+                }
+                disabled={server.status === "connecting"}
+              >
+                {server.hasConnected ? "Reconnect" : "Connect"} {server.name}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {showOAuthDebugger ? (
+        <div className="min-h-0 flex-1">
+          <OAuthFlowTab
+            serverConfigs={oauthServerConfigs}
+            selectedServerName={selectedOAuthServerName}
+            onSelectServer={setSelectedOAuthServerName}
+            onSaveServerConfig={handleSaveOAuthServerConfig}
+            onConnectWithTokens={handleConnectWithTokens}
+            openProfileModalSignal={openProfileModalSignal}
+          />
+        </div>
+      ) : (
+        <div className="flex-1" />
+      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -204,6 +204,8 @@ if (isInIframe) {
   // Async bootstrap to initialize session token before rendering
   async function bootstrap() {
     const root = createRoot(document.getElementById("root")!);
+    const skipLocalSessionBootstrap =
+      import.meta.env.DEV && window.location.pathname.startsWith("/__e2e/");
 
     if (electronHostedAuthCallbackUrl) {
       root.render(
@@ -217,7 +219,7 @@ if (isInIframe) {
     }
 
     try {
-      if (!HOSTED_MODE) {
+      if (!HOSTED_MODE && !skipLocalSessionBootstrap) {
         // Initialize session token BEFORE rendering in local mode.
         await initializeSessionToken();
         console.log("[Auth] Session token initialized");

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -47,6 +47,19 @@ export function createAppRouter(): AppRouter {
   const existing = getAppRouter();
   if (existing) return existing;
   const router = createBrowserRouter([
+    ...(import.meta.env.DEV
+      ? [
+          {
+            path: "__e2e/oauth-debugger",
+            lazy: async () => {
+              const { OAuthDebuggerE2EHarness } = await import(
+                "./components/e2e/OAuthDebuggerE2EHarness"
+              );
+              return { Component: OAuthDebuggerE2EHarness };
+            },
+          },
+        ]
+      : []),
     {
       element: <App />,
       children: [

--- a/mcpjam-inspector/e2e/fixtures/fake-oauth-mcp-server.ts
+++ b/mcpjam-inspector/e2e/fixtures/fake-oauth-mcp-server.ts
@@ -1,0 +1,220 @@
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import { once } from "node:events";
+
+export interface FakeOAuthMcpServer {
+  origin: string;
+  serverUrl: string;
+  requests: Array<{
+    method: string;
+    path: string;
+    authorization?: string;
+    body?: unknown;
+  }>;
+  close: () => Promise<void>;
+}
+
+const ACCESS_TOKEN = "e2e-access-token";
+const REFRESH_TOKEN = "e2e-refresh-token";
+const CLIENT_ID = "e2e-client-id";
+const AUTH_CODE = "e2e-auth-code";
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function sendJson(
+  response: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {}
+) {
+  response.writeHead(status, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    ...headers,
+  });
+  response.end(JSON.stringify(body));
+}
+
+function sendRedirect(response: ServerResponse, location: string) {
+  response.writeHead(302, {
+    Location: location,
+    "Access-Control-Allow-Origin": "*",
+  });
+  response.end();
+}
+
+function parseBody(rawBody: string, contentType: string | undefined): unknown {
+  if (!rawBody) return undefined;
+  if (contentType?.includes("application/json")) {
+    try {
+      return JSON.parse(rawBody);
+    } catch {
+      return rawBody;
+    }
+  }
+  if (contentType?.includes("application/x-www-form-urlencoded")) {
+    return Object.fromEntries(new URLSearchParams(rawBody).entries());
+  }
+  return rawBody;
+}
+
+export async function startFakeOAuthMcpServer(): Promise<FakeOAuthMcpServer> {
+  const requests: FakeOAuthMcpServer["requests"] = [];
+
+  const server = http.createServer(
+    async (request: IncomingMessage, response: ServerResponse) => {
+      const host = request.headers.host;
+      const origin = `http://${host}`;
+      const url = new URL(request.url ?? "/", origin);
+      const rawBody = await readRequestBody(request);
+      const parsedBody = parseBody(rawBody, request.headers["content-type"]);
+
+      requests.push({
+        method: request.method ?? "GET",
+        path: url.pathname,
+        authorization: request.headers.authorization,
+        body: parsedBody,
+      });
+
+      if (request.method === "OPTIONS") {
+        response.writeHead(204, {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+          "Access-Control-Allow-Headers": "Authorization,Content-Type,Accept",
+        });
+        response.end();
+        return;
+      }
+
+      if (url.pathname === "/mcp") {
+        if (request.headers.authorization !== `Bearer ${ACCESS_TOKEN}`) {
+          sendJson(
+            response,
+            401,
+            {
+              error: "missing_token",
+            },
+            {
+              "WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
+            }
+          );
+          return;
+        }
+
+        sendJson(response, 200, {
+          jsonrpc: "2.0",
+          id:
+            typeof parsedBody === "object" && parsedBody
+              ? (parsedBody as { id?: unknown }).id
+              : 1,
+          result: {
+            protocolVersion: "2025-11-25",
+            capabilities: {
+              tools: {},
+            },
+            serverInfo: {
+              name: "fake-oauth-mcp",
+              version: "0.0.0",
+            },
+          },
+        });
+        return;
+      }
+
+      if (url.pathname.startsWith("/.well-known/oauth-protected-resource")) {
+        sendJson(response, 200, {
+          resource: `${origin}/mcp`,
+          authorization_servers: [origin],
+          scopes_supported: ["openid", "profile", "email"],
+        });
+        return;
+      }
+
+      if (
+        url.pathname === "/.well-known/oauth-authorization-server" ||
+        url.pathname === "/.well-known/openid-configuration"
+      ) {
+        sendJson(response, 200, {
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+          registration_endpoint: `${origin}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["none"],
+          code_challenge_methods_supported: ["S256"],
+          scopes_supported: ["openid", "profile", "email"],
+        });
+        return;
+      }
+
+      if (url.pathname === "/register") {
+        const body =
+          typeof parsedBody === "object" && parsedBody
+            ? (parsedBody as Record<string, unknown>)
+            : {};
+        sendJson(response, 201, {
+          client_id: CLIENT_ID,
+          token_endpoint_auth_method: "none",
+          redirect_uris: body.redirect_uris ?? [],
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+          client_name: body.client_name ?? "MCPJam OAuth Debugger E2E",
+        });
+        return;
+      }
+
+      if (url.pathname === "/authorize") {
+        const redirectUri = url.searchParams.get("redirect_uri");
+        const state = url.searchParams.get("state");
+        if (!redirectUri) {
+          sendJson(response, 400, { error: "missing_redirect_uri" });
+          return;
+        }
+
+        const callbackUrl = new URL(redirectUri);
+        callbackUrl.searchParams.set("code", AUTH_CODE);
+        if (state) {
+          callbackUrl.searchParams.set("state", state);
+        }
+        sendRedirect(response, callbackUrl.toString());
+        return;
+      }
+
+      if (url.pathname === "/token") {
+        sendJson(response, 200, {
+          access_token: ACCESS_TOKEN,
+          refresh_token: REFRESH_TOKEN,
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+        return;
+      }
+
+      sendJson(response, 404, { error: "not_found" });
+    }
+  );
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Fake OAuth MCP server did not receive a TCP address");
+  }
+
+  const origin = `http://127.0.0.1:${address.port}`;
+  return {
+    origin,
+    serverUrl: `${origin}/mcp`,
+    requests,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}

--- a/mcpjam-inspector/e2e/fixtures/fake-oauth-mcp-server.ts
+++ b/mcpjam-inspector/e2e/fixtures/fake-oauth-mcp-server.ts
@@ -1,7 +1,7 @@
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import { once } from "node:events";
 
-export interface FakeOAuthMcpServer {
+export interface FakeMcpServer {
   origin: string;
   serverUrl: string;
   requests: Array<{
@@ -17,6 +17,26 @@ const ACCESS_TOKEN = "e2e-access-token";
 const REFRESH_TOKEN = "e2e-refresh-token";
 const CLIENT_ID = "e2e-client-id";
 const AUTH_CODE = "e2e-auth-code";
+
+function createInitializeResult(parsedBody: unknown, serverName: string) {
+  return {
+    jsonrpc: "2.0",
+    id:
+      typeof parsedBody === "object" && parsedBody
+        ? (parsedBody as { id?: unknown }).id
+        : 1,
+    result: {
+      protocolVersion: "2025-11-25",
+      capabilities: {
+        tools: {},
+      },
+      serverInfo: {
+        name: serverName,
+        version: "0.0.0",
+      },
+    },
+  };
+}
 
 async function readRequestBody(request: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
@@ -63,8 +83,8 @@ function parseBody(rawBody: string, contentType: string | undefined): unknown {
   return rawBody;
 }
 
-export async function startFakeOAuthMcpServer(): Promise<FakeOAuthMcpServer> {
-  const requests: FakeOAuthMcpServer["requests"] = [];
+export async function startFakeOAuthMcpServer(): Promise<FakeMcpServer> {
+  const requests: FakeMcpServer["requests"] = [];
 
   const server = http.createServer(
     async (request: IncomingMessage, response: ServerResponse) => {
@@ -106,23 +126,11 @@ export async function startFakeOAuthMcpServer(): Promise<FakeOAuthMcpServer> {
           return;
         }
 
-        sendJson(response, 200, {
-          jsonrpc: "2.0",
-          id:
-            typeof parsedBody === "object" && parsedBody
-              ? (parsedBody as { id?: unknown }).id
-              : 1,
-          result: {
-            protocolVersion: "2025-11-25",
-            capabilities: {
-              tools: {},
-            },
-            serverInfo: {
-              name: "fake-oauth-mcp",
-              version: "0.0.0",
-            },
-          },
-        });
+        sendJson(
+          response,
+          200,
+          createInitializeResult(parsedBody, "fake-oauth-mcp")
+        );
         return;
       }
 
@@ -205,6 +213,66 @@ export async function startFakeOAuthMcpServer(): Promise<FakeOAuthMcpServer> {
   const address = server.address();
   if (!address || typeof address === "string") {
     throw new Error("Fake OAuth MCP server did not receive a TCP address");
+  }
+
+  const origin = `http://127.0.0.1:${address.port}`;
+  return {
+    origin,
+    serverUrl: `${origin}/mcp`,
+    requests,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}
+
+export async function startFakePlainMcpServer(): Promise<FakeMcpServer> {
+  const requests: FakeMcpServer["requests"] = [];
+
+  const server = http.createServer(
+    async (request: IncomingMessage, response: ServerResponse) => {
+      const host = request.headers.host;
+      const origin = `http://${host}`;
+      const url = new URL(request.url ?? "/", origin);
+      const rawBody = await readRequestBody(request);
+      const parsedBody = parseBody(rawBody, request.headers["content-type"]);
+
+      requests.push({
+        method: request.method ?? "GET",
+        path: url.pathname,
+        authorization: request.headers.authorization,
+        body: parsedBody,
+      });
+
+      if (request.method === "OPTIONS") {
+        response.writeHead(204, {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+          "Access-Control-Allow-Headers": "Authorization,Content-Type,Accept",
+        });
+        response.end();
+        return;
+      }
+
+      if (url.pathname === "/mcp") {
+        sendJson(
+          response,
+          200,
+          createInitializeResult(parsedBody, "fake-plain-mcp")
+        );
+        return;
+      }
+
+      sendJson(response, 404, { error: "not_found" });
+    }
+  );
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Fake plain MCP server did not receive a TCP address");
   }
 
   const origin = `http://127.0.0.1:${address.port}`;

--- a/mcpjam-inspector/e2e/oauth-debugger.spec.ts
+++ b/mcpjam-inspector/e2e/oauth-debugger.spec.ts
@@ -1,0 +1,240 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+import { startFakeOAuthMcpServer } from "./fixtures/fake-oauth-mcp-server";
+
+type ProxyPayload = {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+};
+
+type OAuthE2EFlowState = {
+  authorizationUrl?: string;
+  currentStep?: string;
+  state?: string;
+};
+
+function toBodyInit(payload: ProxyPayload): string | undefined {
+  if (payload.body === undefined || payload.body === null) {
+    return undefined;
+  }
+
+  const headers = new Headers(payload.headers ?? {});
+  const contentType = headers.get("content-type") ?? "";
+  if (contentType.includes("application/x-www-form-urlencoded")) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(
+      payload.body as Record<string, unknown>
+    )) {
+      if (value !== undefined && value !== null) {
+        params.set(key, String(value));
+      }
+    }
+    return params.toString();
+  }
+
+  return typeof payload.body === "string"
+    ? payload.body
+    : JSON.stringify(payload.body);
+}
+
+async function fulfillDebugProxy(route: Route) {
+  const payload = JSON.parse(
+    route.request().postData() ?? "{}"
+  ) as ProxyPayload;
+  const headers = new Headers(payload.headers ?? {});
+  headers.delete("host");
+  headers.delete("content-length");
+
+  const upstream = await fetch(payload.url, {
+    method: payload.method ?? "GET",
+    headers,
+    body: toBodyInit(payload),
+  });
+
+  const text = await upstream.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: Object.fromEntries(upstream.headers.entries()),
+      body,
+    }),
+  });
+}
+
+async function advanceUntilAuthorize(page: Page) {
+  const authorizeButton = page.getByRole("button", { name: /^Authorize$/ });
+
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    if (await authorizeButton.isVisible().catch(() => false)) {
+      return authorizeButton;
+    }
+
+    await page.getByRole("button", { name: /^Continue$/ }).click();
+    await page.waitForTimeout(300);
+  }
+
+  await expect(authorizeButton).toBeVisible({ timeout: 10_000 });
+  return authorizeButton;
+}
+
+async function advanceUntilConnectServer(page: Page) {
+  const connectServerButton = page.getByRole("button", {
+    name: /^Connect Server$/,
+  });
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    if (await connectServerButton.isVisible().catch(() => false)) {
+      return connectServerButton;
+    }
+
+    const continueButton = page.getByRole("button", { name: /^Continue$/ });
+    if (await continueButton.isVisible().catch(() => false)) {
+      await continueButton.click();
+    }
+    await page.waitForTimeout(500);
+  }
+
+  await expect(connectServerButton).toBeVisible({ timeout: 10_000 });
+  return connectServerButton;
+}
+
+test.describe("OAuth Debugger smoke", () => {
+  test("completes OAuth, imports tokens, then reconnects without a bearer shortcut", async ({
+    page,
+  }) => {
+    const fakeServer = await startFakeOAuthMcpServer();
+    const importRequests: unknown[] = [];
+    const reconnectRequests: Array<{
+      headers: Record<string, string>;
+      body: unknown;
+    }> = [];
+
+    await page.route("**/api/**/oauth/debug/proxy", fulfillDebugProxy);
+    await page.route("**/api/web/oauth/import-tokens", async (route) => {
+      importRequests.push(JSON.parse(route.request().postData() ?? "{}"));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          kind: "generic",
+          expiresAt: Date.now() + 3600_000,
+        }),
+      });
+    });
+    await page.route("**/__e2e/oauth/reconnect", async (route) => {
+      reconnectRequests.push({
+        headers: route.request().headers(),
+        body: JSON.parse(route.request().postData() ?? "{}"),
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    try {
+      await page.goto("/__e2e/oauth-debugger");
+
+      await expect(
+        page.getByRole("heading", { name: "Configure Server to Test" })
+      ).toBeVisible();
+      await page.getByLabel("Server Name").fill("oauth-e2e-target");
+      await page.getByLabel("Server URL").fill(fakeServer.serverUrl);
+      await page.getByRole("button", { name: "Save configuration" }).click();
+      const activeConfigDialog = page.getByRole("dialog", {
+        name: "Configure Server to Test",
+      });
+      await page.keyboard.press("Escape");
+      await expect(activeConfigDialog).toBeHidden({ timeout: 10_000 });
+
+      await expect(
+        page.getByRole("button", { name: `${fakeServer.serverUrl} Edit` })
+      ).toBeVisible();
+
+      const authorizeButton = await advanceUntilAuthorize(page);
+
+      page.on("popup", (popup) => {
+        void popup.close().catch(() => {});
+      });
+      await authorizeButton.click();
+      const flowStateHandle = await page.waitForFunction(() => {
+        const state = window.__oauthDebuggerE2EFlowState;
+        return state?.authorizationUrl && state?.state ? state : null;
+      });
+      const flowState =
+        (await flowStateHandle.jsonValue()) as OAuthE2EFlowState;
+      expect(flowState.authorizationUrl).toContain(fakeServer.origin);
+      expect(flowState.state).toBeTruthy();
+
+      await page.evaluate((state) => {
+        const message = {
+          type: "OAUTH_CALLBACK",
+          code: "e2e-auth-code",
+          state,
+        };
+        window.postMessage(message, window.location.origin);
+        const channel = new BroadcastChannel("oauth_callback_channel");
+        channel.postMessage(message);
+        channel.close();
+      }, flowState.state);
+
+      const connectServerButton = await advanceUntilConnectServer(page);
+      await connectServerButton.click();
+
+      await expect(page.getByTestId("oauth-e2e-status")).toHaveAttribute(
+        "data-status",
+        "connected",
+        { timeout: 10_000 }
+      );
+
+      expect(importRequests).toHaveLength(1);
+      expect(importRequests[0]).toMatchObject({
+        projectId: "oauth-debugger-e2e-project",
+        serverId: "oauth-debugger-e2e-server",
+        serverUrl: fakeServer.serverUrl,
+        kind: "generic",
+        clientInformation: {
+          clientId: "e2e-client-id",
+        },
+        tokens: {
+          access_token: "e2e-access-token",
+          refresh_token: "e2e-refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        },
+      });
+
+      expect(reconnectRequests).toHaveLength(1);
+      expect(reconnectRequests[0].headers.authorization).toBeUndefined();
+      expect(JSON.stringify(reconnectRequests[0].body)).not.toContain(
+        "Bearer e2e-access-token"
+      );
+      expect(JSON.stringify(reconnectRequests[0].body)).not.toContain(
+        "e2e-access-token"
+      );
+
+      expect(
+        fakeServer.requests.some(
+          (request) =>
+            request.path === "/mcp" &&
+            request.authorization === "Bearer e2e-access-token"
+        )
+      ).toBe(true);
+    } finally {
+      await fakeServer.close();
+    }
+  });
+});

--- a/mcpjam-inspector/e2e/oauth-debugger.spec.ts
+++ b/mcpjam-inspector/e2e/oauth-debugger.spec.ts
@@ -1,5 +1,10 @@
 import { expect, type Page, type Route, test } from "@playwright/test";
-import { startFakeOAuthMcpServer } from "./fixtures/fake-oauth-mcp-server";
+import {
+  startFakeOAuthMcpServer,
+  startFakePlainMcpServer,
+} from "./fixtures/fake-oauth-mcp-server";
+
+type ServerKind = "plain" | "oauth";
 
 type ProxyPayload = {
   url: string;
@@ -12,6 +17,24 @@ type OAuthE2EFlowState = {
   authorizationUrl?: string;
   currentStep?: string;
   state?: string;
+};
+
+type ConnectRequestRecord = {
+  headers: Record<string, string>;
+  body: {
+    projectId?: string;
+    serverId?: string;
+    serverName?: string;
+    serverUrl?: string;
+    kind?: ServerKind;
+    intent?: string;
+  };
+};
+
+type BackendCredentialUseRecord = {
+  serverName?: string;
+  serverUrl?: string;
+  authorization: string;
 };
 
 function toBodyInit(payload: ProxyPayload): string | undefined {
@@ -36,6 +59,22 @@ function toBodyInit(payload: ProxyPayload): string | undefined {
   return typeof payload.body === "string"
     ? payload.body
     : JSON.stringify(payload.body);
+}
+
+function initializeBody(serverName: string) {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: `${serverName}-initialize`,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: {
+        name: "mcpjam-e2e-backend",
+        version: "0.0.0",
+      },
+    },
+  });
 }
 
 async function fulfillDebugProxy(route: Route) {
@@ -68,6 +107,65 @@ async function fulfillDebugProxy(route: Route) {
       statusText: upstream.statusText,
       headers: Object.fromEntries(upstream.headers.entries()),
       body,
+    }),
+  });
+}
+
+async function fulfillBackendConnect(
+  route: Route,
+  storedCredentials: Map<string, string>,
+  backendCredentialUses: BackendCredentialUseRecord[]
+) {
+  const body = JSON.parse(
+    route.request().postData() ?? "{}"
+  ) as ConnectRequestRecord["body"];
+  const serverName = body.serverName ?? "unknown-server";
+  const serverUrl = body.serverUrl;
+
+  if (!serverUrl) {
+    await route.fulfill({
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ success: false, error: "missing_server_url" }),
+    });
+    return;
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+
+  if (body.kind === "oauth") {
+    const storedToken = storedCredentials.get(body.serverId ?? "");
+    if (!storedToken) {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ success: false, error: "missing_credential" }),
+      });
+      return;
+    }
+    headers.Authorization = `Bearer ${storedToken}`;
+    backendCredentialUses.push({
+      serverName: body.serverName,
+      serverUrl,
+      authorization: headers.Authorization,
+    });
+  }
+
+  const upstream = await fetch(serverUrl, {
+    method: "POST",
+    headers,
+    body: initializeBody(serverName),
+  });
+
+  await route.fulfill({
+    status: upstream.ok ? 200 : 502,
+    contentType: "application/json",
+    body: JSON.stringify({
+      success: upstream.ok,
+      upstreamStatus: upstream.status,
     }),
   });
 }
@@ -109,20 +207,74 @@ async function advanceUntilConnectServer(page: Page) {
   return connectServerButton;
 }
 
-test.describe("OAuth Debugger smoke", () => {
-  test("completes OAuth, imports tokens, then reconnects without a bearer shortcut", async ({
+async function completeOAuthDebuggerFlow(page: Page, fakeOAuthOrigin: string) {
+  const authorizeButton = await advanceUntilAuthorize(page);
+
+  page.on("popup", (popup) => {
+    void popup.close().catch(() => {});
+  });
+  await authorizeButton.click();
+  const flowStateHandle = await page.waitForFunction(() => {
+    const state = window.__oauthDebuggerE2EFlowState;
+    return state?.authorizationUrl && state?.state ? state : null;
+  });
+  const flowState = (await flowStateHandle.jsonValue()) as OAuthE2EFlowState;
+  expect(flowState.authorizationUrl).toContain(fakeOAuthOrigin);
+  expect(flowState.state).toBeTruthy();
+
+  await page.evaluate((state) => {
+    const message = {
+      type: "OAUTH_CALLBACK",
+      code: "e2e-auth-code",
+      state,
+    };
+    window.postMessage(message, window.location.origin);
+    const channel = new BroadcastChannel("oauth_callback_channel");
+    channel.postMessage(message);
+    channel.close();
+  }, flowState.state);
+
+  const connectServerButton = await advanceUntilConnectServer(page);
+  await connectServerButton.click();
+}
+
+function expectNoFrontendBearerShortcut(record: ConnectRequestRecord) {
+  expect(record.headers.authorization).toBeUndefined();
+  const serializedBody = JSON.stringify(record.body);
+  expect(serializedBody).not.toContain("Bearer e2e-access-token");
+  expect(serializedBody).not.toContain("e2e-access-token");
+}
+
+test.describe("OAuth Debugger e2e", () => {
+  test("covers first connect and reconnect for plain and OAuth MCP servers", async ({
     page,
   }) => {
-    const fakeServer = await startFakeOAuthMcpServer();
+    await page.addInitScript(() => {
+      if (!sessionStorage.getItem("oauth-debugger-e2e-started")) {
+        localStorage.removeItem("oauth-debugger-e2e-servers-v1");
+        sessionStorage.setItem("oauth-debugger-e2e-started", "true");
+      }
+      delete window.__oauthDebuggerE2EEvents;
+      delete window.__oauthDebuggerE2EFlowState;
+    });
+
+    const fakePlainServer = await startFakePlainMcpServer();
+    const fakeOAuthServer = await startFakeOAuthMcpServer();
     const importRequests: unknown[] = [];
-    const reconnectRequests: Array<{
-      headers: Record<string, string>;
-      body: unknown;
-    }> = [];
+    const connectRequests: ConnectRequestRecord[] = [];
+    const storedCredentials = new Map<string, string>();
+    const backendCredentialUses: BackendCredentialUseRecord[] = [];
 
     await page.route("**/api/**/oauth/debug/proxy", fulfillDebugProxy);
     await page.route("**/api/web/oauth/import-tokens", async (route) => {
-      importRequests.push(JSON.parse(route.request().postData() ?? "{}"));
+      const request = JSON.parse(route.request().postData() ?? "{}");
+      importRequests.push(request);
+      if (
+        typeof request.serverId === "string" &&
+        typeof request.tokens?.access_token === "string"
+      ) {
+        storedCredentials.set(request.serverId, request.tokens.access_token);
+      }
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -133,78 +285,77 @@ test.describe("OAuth Debugger smoke", () => {
         }),
       });
     });
-    await page.route("**/__e2e/oauth/reconnect", async (route) => {
-      reconnectRequests.push({
+    await page.route("**/__e2e/servers/connect", async (route) => {
+      const body = JSON.parse(
+        route.request().postData() ?? "{}"
+      ) as ConnectRequestRecord["body"];
+      connectRequests.push({
         headers: route.request().headers(),
-        body: JSON.parse(route.request().postData() ?? "{}"),
+        body,
       });
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ success: true }),
-      });
+      await fulfillBackendConnect(
+        route,
+        storedCredentials,
+        backendCredentialUses
+      );
     });
 
     try {
       await page.goto("/__e2e/oauth-debugger");
 
+      await page.getByLabel("Plain server name").fill("plain-e2e-target");
+      await page.getByLabel("Plain server URL").fill(fakePlainServer.serverUrl);
+      await page.getByRole("button", { name: "Add plain HTTP server" }).click();
       await expect(
-        page.getByRole("heading", { name: "Configure Server to Test" })
-      ).toBeVisible();
-      await page.getByLabel("Server Name").fill("oauth-e2e-target");
-      await page.getByLabel("Server URL").fill(fakeServer.serverUrl);
-      await page.getByRole("button", { name: "Save configuration" }).click();
+        page.getByTestId("server-row-plain-e2e-target")
+      ).toHaveAttribute("data-status", "disconnected");
+
+      await page
+        .getByRole("button", { name: "Connect plain-e2e-target" })
+        .click();
+      await expect(
+        page.getByTestId("server-row-plain-e2e-target")
+      ).toHaveAttribute("data-status", "connected");
+      const plainRequestsBeforeReconnect = fakePlainServer.requests.filter(
+        (request) => request.path === "/mcp"
+      ).length;
+      expect(
+        fakePlainServer.requests.some(
+          (request) => request.path === "/mcp" && !request.authorization
+        )
+      ).toBe(true);
+
+      await page
+        .getByRole("button", { name: "Add OAuth server through debugger" })
+        .click();
       const activeConfigDialog = page.getByRole("dialog", {
         name: "Configure Server to Test",
       });
+      await expect(
+        page.getByRole("heading", { name: "Configure Server to Test" })
+      ).toBeVisible();
+      await activeConfigDialog
+        .getByRole("textbox", { name: "Server Name" })
+        .fill("oauth-e2e-target");
+      await activeConfigDialog
+        .getByRole("textbox", { name: "Server URL" })
+        .fill(fakeOAuthServer.serverUrl);
+      await activeConfigDialog
+        .getByRole("button", { name: "Save configuration" })
+        .click();
       await page.keyboard.press("Escape");
       await expect(activeConfigDialog).toBeHidden({ timeout: 10_000 });
 
+      await completeOAuthDebuggerFlow(page, fakeOAuthServer.origin);
       await expect(
-        page.getByRole("button", { name: `${fakeServer.serverUrl} Edit` })
-      ).toBeVisible();
-
-      const authorizeButton = await advanceUntilAuthorize(page);
-
-      page.on("popup", (popup) => {
-        void popup.close().catch(() => {});
-      });
-      await authorizeButton.click();
-      const flowStateHandle = await page.waitForFunction(() => {
-        const state = window.__oauthDebuggerE2EFlowState;
-        return state?.authorizationUrl && state?.state ? state : null;
-      });
-      const flowState =
-        (await flowStateHandle.jsonValue()) as OAuthE2EFlowState;
-      expect(flowState.authorizationUrl).toContain(fakeServer.origin);
-      expect(flowState.state).toBeTruthy();
-
-      await page.evaluate((state) => {
-        const message = {
-          type: "OAUTH_CALLBACK",
-          code: "e2e-auth-code",
-          state,
-        };
-        window.postMessage(message, window.location.origin);
-        const channel = new BroadcastChannel("oauth_callback_channel");
-        channel.postMessage(message);
-        channel.close();
-      }, flowState.state);
-
-      const connectServerButton = await advanceUntilConnectServer(page);
-      await connectServerButton.click();
-
-      await expect(page.getByTestId("oauth-e2e-status")).toHaveAttribute(
-        "data-status",
-        "connected",
-        { timeout: 10_000 }
-      );
+        page.getByTestId("server-row-oauth-e2e-target")
+      ).toHaveAttribute("data-status", "connected");
 
       expect(importRequests).toHaveLength(1);
       expect(importRequests[0]).toMatchObject({
         projectId: "oauth-debugger-e2e-project",
         serverId: "oauth-debugger-e2e-server",
-        serverUrl: fakeServer.serverUrl,
+        serverUrl: fakeOAuthServer.serverUrl,
         kind: "generic",
         clientInformation: {
           clientId: "e2e-client-id",
@@ -216,25 +367,83 @@ test.describe("OAuth Debugger smoke", () => {
           expires_in: 3600,
         },
       });
-
-      expect(reconnectRequests).toHaveLength(1);
-      expect(reconnectRequests[0].headers.authorization).toBeUndefined();
-      expect(JSON.stringify(reconnectRequests[0].body)).not.toContain(
-        "Bearer e2e-access-token"
-      );
-      expect(JSON.stringify(reconnectRequests[0].body)).not.toContain(
+      expect(storedCredentials.get("oauth-debugger-e2e-server")).toBe(
         "e2e-access-token"
       );
-
+      const oauthFirstConnect = connectRequests.find(
+        (request) =>
+          request.body.serverName === "oauth-e2e-target" &&
+          request.body.intent === "oauth-debugger"
+      );
+      expect(oauthFirstConnect).toBeTruthy();
+      expectNoFrontendBearerShortcut(oauthFirstConnect!);
+      expect(backendCredentialUses).toContainEqual({
+        serverName: "oauth-e2e-target",
+        serverUrl: fakeOAuthServer.serverUrl,
+        authorization: "Bearer e2e-access-token",
+      });
       expect(
-        fakeServer.requests.some(
-          (request) =>
-            request.path === "/mcp" &&
-            request.authorization === "Bearer e2e-access-token"
+        await page.evaluate(() =>
+          JSON.stringify(
+            Object.fromEntries(
+              Array.from({ length: localStorage.length }, (_, index) => {
+                const key = localStorage.key(index);
+                return [key, key ? localStorage.getItem(key) : null];
+              })
+            )
+          )
         )
-      ).toBe(true);
+      ).not.toContain("e2e-access-token");
+
+      await page.evaluate(() => {
+        delete window.__oauthDebuggerE2EEvents;
+        delete window.__oauthDebuggerE2EFlowState;
+      });
+      await page.reload();
+
+      await expect(
+        page.getByTestId("server-row-plain-e2e-target")
+      ).toHaveAttribute("data-status", "disconnected");
+      await expect(
+        page.getByTestId("server-row-oauth-e2e-target")
+      ).toHaveAttribute("data-status", "disconnected");
+
+      await page
+        .getByRole("button", { name: "Reconnect plain-e2e-target" })
+        .click();
+      await expect(
+        page.getByTestId("server-row-plain-e2e-target")
+      ).toHaveAttribute("data-status", "connected");
+      expect(
+        fakePlainServer.requests.filter((request) => request.path === "/mcp")
+      ).toHaveLength(plainRequestsBeforeReconnect + 1);
+
+      const oauthCredentialUsesBeforeReconnect = backendCredentialUses.length;
+      await page
+        .getByRole("button", { name: "Reconnect oauth-e2e-target" })
+        .click();
+      await expect(
+        page.getByTestId("server-row-oauth-e2e-target")
+      ).toHaveAttribute("data-status", "connected");
+
+      const oauthReconnect = connectRequests.find(
+        (request) =>
+          request.body.serverName === "oauth-e2e-target" &&
+          request.body.intent === "reconnect"
+      );
+      expect(oauthReconnect).toBeTruthy();
+      expectNoFrontendBearerShortcut(oauthReconnect!);
+      expect(backendCredentialUses.length).toBe(
+        oauthCredentialUsesBeforeReconnect + 1
+      );
+      expect(backendCredentialUses.at(-1)).toEqual({
+        serverName: "oauth-e2e-target",
+        serverUrl: fakeOAuthServer.serverUrl,
+        authorization: "Bearer e2e-access-token",
+      });
     } finally {
-      await fakeServer.close();
+      await fakePlainServer.close();
+      await fakeOAuthServer.close();
     }
   });
 });

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -97,6 +97,7 @@
     "test:watch": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest",
     "test:coverage": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:oauth-debugger": "npm run sdk:build && playwright test -c playwright.oauth-debugger.config.ts",
     "ship": "bash scripts/ship.sh"
   },
   "dependencies": {

--- a/mcpjam-inspector/playwright.config.ts
+++ b/mcpjam-inspector/playwright.config.ts
@@ -13,6 +13,7 @@ const packageRoot = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
   testDir: "./e2e",
+  testIgnore: /oauth-debugger\.spec\.ts/,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/mcpjam-inspector/playwright.oauth-debugger.config.ts
+++ b/mcpjam-inspector/playwright.oauth-debugger.config.ts
@@ -1,0 +1,73 @@
+import { defineConfig, devices } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = fileURLToPath(new URL(".", import.meta.url));
+
+const commonEnv = {
+  MCPJAM_INSPECTOR_SUPPRESS_AUTO_OPEN: "1",
+  VITE_WORKOS_CLIENT_ID: "oauth-debugger-e2e-workos-client",
+  VITE_CONVEX_URL: "https://oauth-debugger-e2e.convex.cloud",
+};
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /oauth-debugger\.spec\.ts/,
+  timeout: 90_000,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "dev",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: "http://localhost:5373",
+      },
+    },
+    {
+      name: "hosted",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: "http://localhost:5374",
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: "npm run dev:app:default",
+      url: "http://localhost:5373/__e2e/oauth-debugger",
+      cwd: packageRoot,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        ...commonEnv,
+        CLIENT_PORT: "5373",
+        SERVER_PORT: "6473",
+        VITE_API_BASE_URL: "http://localhost:6473",
+        WEB_ALLOWED_ORIGINS: "http://localhost:5373,http://127.0.0.1:5373",
+      },
+    },
+    {
+      command: "npm run dev:app:default",
+      url: "http://localhost:5374/__e2e/oauth-debugger",
+      cwd: packageRoot,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        ...commonEnv,
+        CLIENT_PORT: "5374",
+        SERVER_PORT: "6474",
+        VITE_API_BASE_URL: "http://localhost:6474",
+        VITE_MCPJAM_HOSTED_MODE: "true",
+        WEB_ALLOWED_ORIGINS: "http://localhost:5374,http://127.0.0.1:5374",
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds e2e coverage for the already-merged OAuth Debugger hosted-webapp fix, plus normal server connection coverage.

The tests use fake local servers, so they do not need a real email login, real OAuth provider, or third-party MCP server.

The tests cover:

- Normal HTTP MCP server first connect.
- OAuth Debugger first connect.
- OAuth token import into backend storage.
- Normal HTTP MCP server reconnect after reload.
- OAuth MCP server reconnect after reload.
- OAuth reconnect does not send the access token from frontend state.
- Backend uses the saved OAuth credential instead.
- The flow runs in both local dev mode and hosted-webapp mode.

This also adds a dev-only OAuth Debugger e2e harness and runs it in its own CI step, separate from the normal production Playwright smoke tests.