### PR TITLE
fix(xaa): clean up debugger UI and auto-recover stale local session token

### DIFF
--- a/mcpjam-inspector/client/src/components/oauth/InfoLogEntry.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/InfoLogEntry.tsx
@@ -51,7 +51,7 @@ export function InfoLogEntry({
   > = {
     info: {
       icon: Info,
-      accent: "border-blue-300 dark:border-blue-600",
+      accent: "border-border",
       text: "text-blue-600 dark:text-blue-300",
     },
     warning: {

--- a/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
@@ -98,6 +98,7 @@ export function IdJagInspector({
           data-testid="idjag-inspector-toggle"
           onClick={() => setExpanded((value) => !value)}
           aria-expanded={expanded}
+          aria-controls="idjag-inspector-body"
           className="flex min-w-0 flex-1 items-start gap-2 text-left"
         >
           {expanded ? (
@@ -138,7 +139,10 @@ export function IdJagInspector({
       </div>
 
       {expanded && (
-        <div className="space-y-4 border-t border-border px-4 pb-4 pt-4">
+        <div
+          id="idjag-inspector-body"
+          className="space-y-4 border-t border-border px-4 pb-4 pt-4"
+        >
           <div className="grid gap-2">
             {decoded.issues.length === 0 ? (
               <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
@@ -1,5 +1,11 @@
 import { useMemo, useState } from "react";
-import { AlertTriangle, CheckCircle2, Copy } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+} from "lucide-react";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { ScrollableJsonView } from "@/components/ui/json-editor";
@@ -20,51 +26,28 @@ interface IdJagInspectorProps {
   lintContext?: IdJagLintContext;
 }
 
-const LINT_STATUS_STYLES: Record<
-  IdJagLintVerdict["status"],
-  { row: string; icon: string }
-> = {
-  pass: {
-    row: "border-green-200 dark:border-green-900 bg-green-50/50 dark:bg-green-950/10",
-    icon: "text-green-600 dark:text-green-400",
-  },
-  warn: {
-    row: "border-amber-200 dark:border-amber-900 bg-amber-50/50 dark:bg-amber-950/10",
-    icon: "text-amber-600 dark:text-amber-400",
-  },
-  fail: {
-    row: "border-red-300 dark:border-red-900 bg-red-50/50 dark:bg-red-950/10",
-    icon: "text-red-600 dark:text-red-400",
-  },
-};
-
 function LintVerdictRow({ verdict }: { verdict: IdJagLintVerdict }) {
-  const styles = LINT_STATUS_STYLES[verdict.status];
-  const Icon = verdict.status === "pass" ? CheckCircle2 : AlertTriangle;
-
   return (
     <div
       data-testid={`idjag-lint-${verdict.id}`}
-      className={`border rounded-md px-3 py-2 ${styles.row}`}
+      className="min-w-0 px-3 py-2"
     >
-      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-        <Icon className={`h-3.5 w-3.5 shrink-0 ${styles.icon}`} />
+      <div className="flex min-w-0 items-baseline justify-between gap-3">
         <code className="shrink-0 text-xs font-mono font-medium">
           {verdict.claim}
         </code>
-        {verdict.actual !== undefined && (
-          <code className="min-w-0 flex-1 truncate text-[11px] font-mono text-muted-foreground">
-            {verdict.actual}
-          </code>
-        )}
         <Badge
           variant="outline"
-          className="ml-auto max-w-full whitespace-normal text-left text-[10px] font-normal"
+          className="h-auto shrink whitespace-normal break-words text-right text-[10px] font-normal leading-snug text-muted-foreground"
         >
           {verdict.citation.spec} {verdict.citation.section}
         </Badge>
       </div>
-      <p className="mt-1 text-xs text-muted-foreground">{verdict.detail}</p>
+      {verdict.actual !== undefined && (
+        <code className="mt-1 block min-w-0 break-all text-[11px] font-mono text-muted-foreground">
+          {verdict.actual}
+        </code>
+      )}
     </div>
   );
 }
@@ -75,6 +58,7 @@ export function IdJagInspector({
   negativeTestMode,
   lintContext,
 }: IdJagInspectorProps) {
+  const [expanded, setExpanded] = useState(true);
   const [copied, setCopied] = useState(false);
 
   const lintVerdicts = useMemo(
@@ -83,6 +67,15 @@ export function IdJagInspector({
   );
   const failCount = lintVerdicts.filter((v) => v.status === "fail").length;
   const warnCount = lintVerdicts.filter((v) => v.status === "warn").length;
+  const lintSummary =
+    failCount === 0 && warnCount === 0
+      ? "All claims pass"
+      : [
+          failCount > 0 ? `${failCount} failing` : null,
+          warnCount > 0 ? `${warnCount} warning` : null,
+        ]
+          .filter(Boolean)
+          .join(", ");
 
   const handleCopy = async () => {
     const success = await copyToClipboard(rawJwt);
@@ -95,104 +88,133 @@ export function IdJagInspector({
   };
 
   return (
-    <div className="bg-background border border-border rounded-lg shadow-sm p-4 space-y-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <h3 className="text-sm font-semibold">ID-JAG Inspector</h3>
-            <Badge variant="secondary" className="text-[10px]">
-              {NEGATIVE_TEST_MODE_DETAILS[negativeTestMode].label}
-            </Badge>
+    <div
+      data-testid="idjag-inspector"
+      className="min-w-0 bg-background border border-border rounded-lg shadow-sm"
+    >
+      <div className="flex min-w-0 items-start gap-2 px-4 py-3">
+        <button
+          type="button"
+          data-testid="idjag-inspector-toggle"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          className="flex min-w-0 flex-1 items-start gap-2 text-left"
+        >
+          {expanded ? (
+            <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          )}
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <h3 className="text-sm font-semibold">ID-JAG Inspector</h3>
+              <Badge variant="secondary" className="text-[10px]">
+                {NEGATIVE_TEST_MODE_DETAILS[negativeTestMode].label}
+              </Badge>
+              {!expanded && (
+                <span className="text-[11px] text-muted-foreground">
+                  {lintSummary}
+                </span>
+              )}
+            </div>
+            {expanded && (
+              <p className="text-xs text-muted-foreground">
+                Decode the assertion before sending it to the authorization
+                server. Broken claims are called out explicitly below.
+              </p>
+            )}
           </div>
-          <p className="text-xs text-muted-foreground">
-            Decode the assertion before sending it to the authorization server.
-            Broken claims are called out explicitly below.
-          </p>
-        </div>
+        </button>
 
-        <Button variant="outline" size="sm" onClick={handleCopy}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleCopy}
+          className="shrink-0 self-start"
+        >
           <Copy className="h-3.5 w-3.5 mr-1" />
           {copied ? "Copied" : "Copy JWT"}
         </Button>
       </div>
 
-      <div className="grid gap-2">
-        {decoded.issues.length === 0 ? (
-          <div className="flex items-center gap-2 text-xs text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-900 rounded-md px-3 py-2">
-            <CheckCircle2 className="h-4 w-4" />
-            No structural issues detected in the decoded ID-JAG.
+      {expanded && (
+        <div className="space-y-4 border-t border-border px-4 pb-4 pt-4">
+          <div className="grid gap-2">
+            {decoded.issues.length === 0 ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
+                No structural issues detected in the decoded ID-JAG.
+              </div>
+            ) : (
+              decoded.issues.map((issue) => (
+                <div
+                  key={`${issue.section}-${issue.field}`}
+                  className="border border-red-300 dark:border-red-900 rounded-md bg-red-50 dark:bg-red-950/20 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 text-xs font-medium text-red-700 dark:text-red-300">
+                    <AlertTriangle className="h-4 w-4" />
+                    {issue.label}
+                  </div>
+                  <div className="mt-1 text-xs text-red-700/90 dark:text-red-300/90">
+                    Expected: {issue.expected}
+                  </div>
+                  <div className="text-xs text-red-700/90 dark:text-red-300/90">
+                    Actual: {issue.actual}
+                  </div>
+                </div>
+              ))
+            )}
           </div>
-        ) : (
-          decoded.issues.map((issue) => (
-            <div
-              key={`${issue.section}-${issue.field}`}
-              className="border border-red-300 dark:border-red-900 rounded-md bg-red-50 dark:bg-red-950/20 px-3 py-2"
-            >
-              <div className="flex items-center gap-2 text-xs font-medium text-red-700 dark:text-red-300">
-                <AlertTriangle className="h-4 w-4" />
-                {issue.label}
-              </div>
-              <div className="mt-1 text-xs text-red-700/90 dark:text-red-300/90">
-                Expected: {issue.expected}
-              </div>
-              <div className="text-xs text-red-700/90 dark:text-red-300/90">
-                Actual: {issue.actual}
-              </div>
+
+          <div className="min-w-0 space-y-2">
+            <div className="flex items-center gap-2">
+              <h4 className="text-xs font-semibold">Claim lint</h4>
+              <span className="text-[11px] text-muted-foreground">
+                {lintSummary}
+              </span>
             </div>
-          ))
-        )}
-      </div>
-
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <h4 className="text-xs font-semibold">Claim lint</h4>
-          <span className="text-[11px] text-muted-foreground">
-            {failCount === 0 && warnCount === 0
-              ? "All claims pass"
-              : [
-                  failCount > 0 ? `${failCount} failing` : null,
-                  warnCount > 0 ? `${warnCount} warning` : null,
-                ]
-                  .filter(Boolean)
-                  .join(", ")}
-          </span>
-        </div>
-        <div className="grid gap-1.5">
-          {lintVerdicts.map((verdict) => (
-            <LintVerdictRow key={verdict.id} verdict={verdict} />
-          ))}
-        </div>
-      </div>
-
-      <div className="grid gap-3 lg:grid-cols-2">
-        <div>
-          <div className="text-xs font-medium text-muted-foreground mb-1">
-            Header
+            <div className="min-w-0 divide-y divide-border rounded-md border border-border">
+              {lintVerdicts.map((verdict) => (
+                <LintVerdictRow key={verdict.id} verdict={verdict} />
+              ))}
+            </div>
           </div>
-          <ScrollableJsonView
-            value={decoded.header ?? { error: "Header could not be decoded" }}
-            containerClassName="rounded-sm bg-muted/20 p-2 max-h-[280px]"
-          />
-        </div>
-        <div>
-          <div className="text-xs font-medium text-muted-foreground mb-1">
-            Payload
-          </div>
-          <ScrollableJsonView
-            value={decoded.payload ?? { error: "Payload could not be decoded" }}
-            containerClassName="rounded-sm bg-muted/20 p-2 max-h-[280px]"
-          />
-        </div>
-      </div>
 
-      <div>
-        <div className="text-xs font-medium text-muted-foreground mb-1">
-          Signature
+          <div className="grid min-w-0 gap-3">
+            <div className="min-w-0">
+              <div className="text-xs font-medium text-muted-foreground mb-1">
+                Header
+              </div>
+              <ScrollableJsonView
+                value={
+                  decoded.header ?? { error: "Header could not be decoded" }
+                }
+                containerClassName="min-w-0 rounded-sm bg-muted/20 p-2 max-h-[280px]"
+              />
+            </div>
+            <div className="min-w-0">
+              <div className="text-xs font-medium text-muted-foreground mb-1">
+                Payload
+              </div>
+              <ScrollableJsonView
+                value={
+                  decoded.payload ?? { error: "Payload could not be decoded" }
+                }
+                containerClassName="min-w-0 rounded-sm bg-muted/20 p-2 max-h-[280px]"
+              />
+            </div>
+          </div>
+
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-muted-foreground mb-1">
+              Signature
+            </div>
+            <div className="rounded-sm bg-muted/20 p-2 text-[11px] font-mono break-all text-muted-foreground">
+              {decoded.signature || "(missing)"}
+            </div>
+          </div>
         </div>
-        <div className="rounded-sm bg-muted/20 p-2 text-[11px] font-mono break-all text-muted-foreground">
-          {decoded.signature || "(missing)"}
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/NegativeTestScorecard.tsx
@@ -9,7 +9,6 @@ import {
   Lock,
   ShieldAlert,
 } from "lucide-react";
-import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { Card } from "@mcpjam/design-system/card";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
@@ -130,8 +129,8 @@ export function NegativeTestScorecard({
   const [overrideAccepted, setOverrideAccepted] = useState(false);
 
   // Reset the last run whenever the target changes — including when config is
-  // cleared (input → null). Without this, a stale "N failing" badge from a
-  // previous target lingers and contradicts the empty/locked body.
+  // cleared (input → null). Without this, stale result rows from a previous
+  // target linger and contradict the empty/locked body.
   const targetKey = input
     ? [
         input.registrationId ?? input.serverId ?? input.tokenEndpoint ?? "",
@@ -182,16 +181,6 @@ export function NegativeTestScorecard({
             rejects them.
           </p>
         </div>
-        {run.status === "done" && (
-          <Badge
-            variant={run.result.failures > 0 ? "destructive" : "secondary"}
-            className="shrink-0 text-[10px]"
-          >
-            {run.result.failures > 0
-              ? `${run.result.failures} failing`
-              : "all rejected"}
-          </Badge>
-        )}
         {expanded ? (
           <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
         ) : (

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -6,7 +6,6 @@ import {
   ChevronDown,
   ChevronRight,
   Circle,
-  Lightbulb,
   Loader2,
   Pencil,
   Play,
@@ -23,13 +22,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@mcpjam/design-system/dropdown-menu";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@mcpjam/design-system/select";
 import { cn } from "@/lib/utils";
 import { HTTPHistoryEntry } from "@/components/oauth/HTTPHistoryEntry";
 import { InfoLogEntry } from "@/components/oauth/InfoLogEntry";
@@ -55,7 +47,6 @@ import type {
   XAACompatibilityReport,
 } from "@/lib/xaa/capability-preflight";
 import {
-  NEGATIVE_TEST_MODES,
   NEGATIVE_TEST_MODE_DETAILS,
   type NegativeTestMode,
 } from "@/shared/xaa.js";
@@ -64,14 +55,12 @@ interface XAAFlowLoggerProps {
   flowState: XAAFlowState;
   hasProfile: boolean;
   activeStep?: XAAFlowStep | null;
-  onFocusStep?: (step: XAAFlowStep) => void;
   actions: {
     onConfigure: () => void;
     onReset?: () => void;
     onContinue?: () => void;
     /** Run the whole flow — surfaced in the Continue split-button's menu. */
     onRunAll?: () => void;
-    onChangeNegativeTestMode?: (mode: NegativeTestMode) => void;
     continueLabel: string;
     continueDisabled?: boolean;
     runAllDisabled?: boolean;
@@ -84,7 +73,6 @@ interface XAAFlowLoggerProps {
     authzServerIssuer?: string;
     clientId?: string;
     scope?: string;
-    negativeTestMode: XAAFlowState["negativeTestMode"];
   };
 }
 
@@ -270,13 +258,9 @@ function PhaseHeader({
         <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
           Phase {number} · {info.title}
         </span>
-        {info.specStep === null ? (
+        {info.specStep === null && (
           <Badge variant="outline" className="text-[10px] h-4 px-1.5">
             not part of the XAA grant
-          </Badge>
-        ) : (
-          <Badge variant="outline" className="text-[10px] h-4 px-1.5">
-            spec step {info.specStep}
           </Badge>
         )}
         {skipped && (
@@ -285,7 +269,6 @@ function PhaseHeader({
           </Badge>
         )}
       </div>
-      <p className="mt-1 text-xs text-muted-foreground">{info.blurb}</p>
     </div>
   );
 }
@@ -334,12 +317,12 @@ function PhaseRail({ currentStep }: { currentStep: XAAFlowStep }) {
                 "flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px]",
                 state === "active" &&
                   "bg-blue-500/10 font-medium text-blue-600 dark:text-blue-400",
-                state === "done" && "text-green-600 dark:text-green-400",
+                state === "done" && "text-foreground",
                 state === "pending" && "text-muted-foreground"
               )}
             >
               {state === "done" ? (
-                <CheckCircle2 className="h-3 w-3 shrink-0" />
+                <CheckCircle2 className="h-3 w-3 shrink-0 text-green-600 dark:text-green-400" />
               ) : (
                 <span className="font-mono">{number}</span>
               )}
@@ -406,29 +389,10 @@ function NegativeProbeCallout({
   );
 }
 
-/** A "Tip" callout — visually distinct from diagnostics so static teaching
- * copy can't be mistaken for an error explanation. */
-function TeachableMoments({ moments }: { moments: string[] }) {
-  return (
-    <div className="space-y-1.5 border-l-2 border-blue-400/40 pl-3">
-      {moments.map((moment) => (
-        <p
-          key={moment}
-          className="flex items-start gap-1.5 text-xs text-muted-foreground"
-        >
-          <Lightbulb className="h-3.5 w-3.5 mt-px shrink-0 text-blue-400" />
-          <span>{moment}</span>
-        </p>
-      ))}
-    </div>
-  );
-}
-
 export function XAAFlowLogger({
   flowState,
   hasProfile,
   activeStep,
-  onFocusStep,
   actions,
   summary,
 }: XAAFlowLoggerProps) {
@@ -511,8 +475,6 @@ export function XAAFlowLogger({
   }, [groups]);
 
   const currentStepIndex = getXAAStepIndex(flowState.currentStep);
-  const negativeModeSummary =
-    NEGATIVE_TEST_MODE_DETAILS[summary.negativeTestMode];
 
   const toggleStep = (step: XAAFlowStep) => {
     setExpandedSteps((previous) => {
@@ -660,45 +622,30 @@ export function XAAFlowLogger({
           <>
             <PhaseRail currentStep={flowState.currentStep} />
 
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="flex items-center gap-1.5">
-                <span className="text-xs text-muted-foreground">Mode</span>
-                <Select
-                  value={summary.negativeTestMode}
-                  onValueChange={(nextValue) =>
-                    actions.onChangeNegativeTestMode?.(
-                      nextValue as NegativeTestMode
-                    )
-                  }
-                  disabled={!actions.onChangeNegativeTestMode}
-                >
-                  <SelectTrigger className="h-7 w-[180px] text-xs">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {NEGATIVE_TEST_MODES.map((mode) => (
-                      <SelectItem key={mode} value={mode} className="text-xs">
-                        {NEGATIVE_TEST_MODE_DETAILS[mode].label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+            {(summary.clientId || summary.scope) && (
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+                {summary.clientId && (
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="shrink-0 text-muted-foreground">
+                      Client ID
+                    </span>
+                    <Badge variant="outline" className="font-mono text-xs">
+                      {summary.clientId}
+                    </Badge>
+                  </div>
+                )}
+                {summary.scope && (
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="shrink-0 text-muted-foreground">
+                      Scope
+                    </span>
+                    <Badge variant="outline" className="font-mono text-xs">
+                      {summary.scope}
+                    </Badge>
+                  </div>
+                )}
               </div>
-              {summary.clientId && (
-                <Badge variant="outline" className="text-xs">
-                  {summary.clientId}
-                </Badge>
-              )}
-              {summary.scope && (
-                <Badge variant="outline" className="text-xs">
-                  {summary.scope}
-                </Badge>
-              )}
-            </div>
-
-            <p className="text-xs text-muted-foreground">
-              {negativeModeSummary.description}
-            </p>
+            )}
           </>
         )}
       </div>
@@ -883,20 +830,6 @@ export function XAAFlowLogger({
                           {stepInfo.summary}
                         </p>
                       </div>
-                      {onFocusStep && (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          className="h-7"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            onFocusStep(group.step);
-                          }}
-                        >
-                          Focus
-                        </Button>
-                      )}
                     </button>
 
                     {expandedSteps.has(group.step) && (
@@ -952,11 +885,6 @@ export function XAAFlowLogger({
                           />
                         ))}
 
-                        {stepInfo.teachableMoments?.length ? (
-                          <TeachableMoments
-                            moments={stepInfo.teachableMoments}
-                          />
-                        ) : null}
                       </div>
                     )}
                   </div>

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -37,7 +37,6 @@ import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
   type XAAFlowState,
-  type XAAFlowStep,
 } from "@/lib/xaa/types";
 import { createInspectorXAAStateMachine } from "@/lib/xaa/debug-state-machine-adapter";
 import { fetchXaaIdpUrls } from "@/lib/xaa/idp-endpoints";
@@ -92,7 +91,6 @@ export function XAAFlowTab({
   openServerModalSignal,
 }: XAAFlowTabProps) {
   const [isServerModalOpen, setIsServerModalOpen] = useState(false);
-  const [focusedStep, setFocusedStep] = useState<XAAFlowStep | null>(null);
   const [isRunningAll, setIsRunningAll] = useState(false);
 
   // Open the modal when the shell bumps the signal (header "Add Server"). Skip
@@ -338,7 +336,6 @@ export function XAAFlowTab({
       email: runInput.email,
     };
     applyFlowState(buildFlowStateFromInput(runInput));
-    setFocusedStep(null);
   }, [applyFlowState, runInput]);
 
   const applyTargetReset = useCallback(
@@ -402,10 +399,6 @@ export function XAAFlowTab({
   }, [runSettings.userId, runSettings.email, rebuildFlow]);
 
   useEffect(() => {
-    setFocusedStep(null);
-  }, [flowState.currentStep]);
-
-  useEffect(() => {
     posthog.capture("xaa_tab_viewed", {
       location: "xaa_flow_tab",
       target_count: resourceApps.length + Object.keys(serverConfigs).length,
@@ -419,14 +412,6 @@ export function XAAFlowTab({
   const resetFlow = useCallback(() => {
     rebuildFlow();
   }, [rebuildFlow]);
-
-  const handleChangeNegativeTestMode = useCallback(
-    (mode: NegativeTestMode) => {
-      runSettings.setNegativeTestMode(mode);
-      setFocusedStep(null);
-    },
-    [runSettings]
-  );
 
   // Resolve the real IdP issuer from the server's OpenID config so the ID-JAG
   // inspection step lints against the issuer actually stamped into `iss`, not
@@ -630,7 +615,6 @@ export function XAAFlowTab({
             <ResizablePanel defaultSize={52} minSize={30} className="min-w-0">
               <XAASequenceDiagram
                 flowState={flowState}
-                focusedStep={focusedStep}
                 hasProfile={isTestable}
                 onConfigure={() => setIsServerModalOpen(true)}
               />
@@ -647,14 +631,12 @@ export function XAAFlowTab({
               <XAAFlowLogger
                 flowState={flowState}
                 hasProfile={isTestable}
-                activeStep={focusedStep ?? flowState.currentStep}
-                onFocusStep={setFocusedStep}
+                activeStep={flowState.currentStep}
                 actions={{
                   onConfigure: () => setIsServerModalOpen(true),
                   onReset: isTestable ? () => resetFlow() : undefined,
                   onContinue: continueDisabled ? undefined : handleAdvance,
                   onRunAll: isTestable ? handleRunAll : undefined,
-                  onChangeNegativeTestMode: handleChangeNegativeTestMode,
                   continueLabel,
                   continueDisabled,
                   runAllDisabled,
@@ -667,7 +649,6 @@ export function XAAFlowTab({
                   authzServerIssuer: runInput.authzServerIssuer || undefined,
                   clientId: runInput.clientId || undefined,
                   scope: runInput.scope || undefined,
-                  negativeTestMode: runInput.negativeTestMode,
                 }}
               />
             </ResizablePanel>
@@ -679,7 +660,6 @@ export function XAAFlowTab({
           // there's a testable server, so they stay hidden until then.
           <XAASequenceDiagram
             flowState={flowState}
-            focusedStep={focusedStep}
             hasProfile={false}
             onConfigure={() => setIsServerModalOpen(true)}
           />

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -181,7 +181,7 @@ export function XAAIdpCard() {
       </div>
 
       {!HOSTED_MODE && (
-        <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-muted-foreground">
+        <div className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
           <span>
             These are local URLs. Your authorization server can only fetch them

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/IdJagInspector.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/IdJagInspector.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { IdJagInspector } from "../IdJagInspector";
 import type { XAADecodedJwt } from "@/lib/xaa/types";
@@ -79,8 +80,32 @@ describe("IdJagInspector claim lint", () => {
 
     expect(screen.getByText(/2 failing/)).toBeInTheDocument();
     expect(screen.getByTestId("idjag-lint-aud")).toHaveTextContent(
-      "exactly match",
+      "https://wrong-audience.example.com",
     );
-    expect(screen.getByTestId("idjag-lint-exp")).toHaveTextContent("expired");
+    expect(screen.getByTestId("idjag-lint-exp")).toHaveTextContent(
+      "RFC 7523",
+    );
+  });
+
+  it("collapses and expands the inspector body", async () => {
+    const user = userEvent.setup();
+    render(
+      <IdJagInspector
+        rawJwt="aaa.bbb.ccc"
+        decoded={buildDecoded()}
+        negativeTestMode="valid"
+      />,
+    );
+
+    expect(screen.getByText("Claim lint")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("idjag-inspector-toggle"));
+
+    expect(screen.queryByText("Claim lint")).toBeNull();
+    expect(screen.getByText("All claims pass")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("idjag-inspector-toggle"));
+
+    expect(screen.getByText("Claim lint")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/NegativeTestScorecard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/NegativeTestScorecard.test.tsx
@@ -137,7 +137,7 @@ describe("NegativeTestScorecard", () => {
     await waitFor(() => expect(runMock).toHaveBeenCalledTimes(1));
   });
 
-  it("clears a stale result badge when the target changes (e.g. config cleared)", async () => {
+  it("clears stale results when the target changes (e.g. config cleared)", async () => {
     runMock.mockResolvedValue({
       failures: 1,
       results: [
@@ -162,13 +162,10 @@ describe("NegativeTestScorecard", () => {
       screen.getByRole("button", { name: /run negative tests/i }),
     );
 
-    // Badge reflects the completed run against this target.
     await waitFor(() =>
-      expect(screen.getByText("1 failing")).toBeInTheDocument(),
+      expect(screen.getByTestId("xaa-negtest-row-expired")).toBeInTheDocument(),
     );
 
-    // Clearing the configuration drops the target (input → null). The stale
-    // "1 failing" badge must not linger over the now-empty/locked body.
     rerender(
       <NegativeTestScorecard
         input={null}
@@ -178,7 +175,7 @@ describe("NegativeTestScorecard", () => {
     );
 
     await waitFor(() =>
-      expect(screen.queryByText("1 failing")).toBeNull(),
+      expect(screen.queryByTestId("xaa-negtest-row-expired")).toBeNull(),
     );
   });
 

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAFlowLogger.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAFlowLogger.test.tsx
@@ -30,7 +30,7 @@ function renderLogger(
         continueLabel: "Continue",
         ...actions,
       }}
-      summary={{ serverUrl: "https://mcp.example.com", negativeTestMode: "valid" }}
+      summary={{ serverUrl: "https://mcp.example.com" }}
     />,
   );
   return { onContinue, onRunAll };
@@ -68,5 +68,33 @@ describe("XAAFlowLogger run controls", () => {
     expect(
       screen.getByRole("button", { name: /running/i }),
     ).toBeDisabled();
+  });
+
+  it("labels client id and scope in the run bar", () => {
+    render(
+      <XAAFlowLogger
+        flowState={createInitialXAAFlowState({
+          serverUrl: "https://mcp.example.com",
+          currentStep: "received_id_jag",
+        })}
+        hasProfile
+        actions={{
+          onConfigure: vi.fn(),
+          onReset: vi.fn(),
+          onContinue: vi.fn(),
+          continueLabel: "Continue",
+        }}
+        summary={{
+          serverUrl: "https://mcp.example.com",
+          clientId: "client_bc147d46f04cb865",
+          scope: "mcp.access",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Client ID")).toBeInTheDocument();
+    expect(screen.getByText("client_bc147d46f04cb865")).toBeInTheDocument();
+    expect(screen.getByText("Scope")).toBeInTheDocument();
+    expect(screen.getByText("mcp.access")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.local-retry.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.local-retry.test.ts
@@ -1,0 +1,191 @@
+/**
+ * authFetch Local 401 Retry Tests
+ *
+ * In local (non-hosted) mode the backend regenerates its session token on every
+ * restart. If it restarted since page load the browser holds a stale token and
+ * every /api/* call 401s ("Backend debug proxy error: 401 Unauthorized") until
+ * a manual refresh. authFetch should re-fetch the token and retry once.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: false,
+}));
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
+vi.mock("@/lib/guest-session", () => ({
+  getGuestBearerToken: vi.fn(),
+  forceRefreshGuestSession: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/web/context", () => ({
+  getApiAuthorizationHeader: vi.fn(),
+  resetTokenCache: vi.fn(),
+  shouldRetryApiAuth401: vi.fn().mockReturnValue(true),
+}));
+
+const PROXY_PATH = "/api/mcp/oauth/debug/proxy";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: new Headers(),
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function isSessionTokenCall(input: RequestInfo | URL): boolean {
+  return String(input).includes("/api/session-token");
+}
+
+describe("authFetch local 401 retry", () => {
+  let sessionToken: typeof import("../session-token");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete (window as any).__MCP_SESSION_TOKEN__;
+    vi.mocked(global.fetch).mockReset();
+    sessionToken = await import("../session-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes the session token and retries once after a 401", async () => {
+    // The backend's current token. Starts "stale" (matches what the page
+    // cached), then a simulated restart rotates it to "fresh-token". The proxy
+    // only accepts requests carrying the backend's current token.
+    let backendToken = "stale-token";
+    vi.mocked(global.fetch).mockImplementation((input, init) => {
+      if (isSessionTokenCall(input)) {
+        return Promise.resolve(jsonResponse(200, { token: backendToken }));
+      }
+      const auth = (init?.headers as Record<string, string> | undefined)?.[
+        "X-MCP-Session-Auth"
+      ];
+      return Promise.resolve(
+        auth === `Bearer ${backendToken}`
+          ? jsonResponse(200, { ok: true })
+          : jsonResponse(401, { error: "Unauthorized" }),
+      );
+    });
+
+    // Page load cached the (then-current) token, then the backend restarted.
+    await sessionToken.initializeSessionToken();
+    backendToken = "fresh-token";
+
+    const response = await sessionToken.authFetch(PROXY_PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(200);
+
+    const proxyCalls = vi
+      .mocked(global.fetch)
+      .mock.calls.filter(([input]) => !isSessionTokenCall(input));
+    expect(proxyCalls).toHaveLength(2);
+
+    // The retry carries the refreshed token.
+    expect(proxyCalls[1][1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-MCP-Session-Auth": "Bearer fresh-token",
+        }),
+      }),
+    );
+  });
+
+  it("does not retry when the refreshed token is unchanged", async () => {
+    (window as any).__MCP_SESSION_TOKEN__ = "injected-token";
+    vi.mocked(global.fetch).mockResolvedValue(
+      jsonResponse(401, { error: "Unauthorized" }),
+    );
+
+    const response = await sessionToken.authFetch(PROXY_PATH, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+    // Injected token can't change, so no retry.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the original 401 when the token refresh fails", async () => {
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (isSessionTokenCall(input)) {
+        return Promise.resolve(jsonResponse(500, {}));
+      }
+      return Promise.resolve(jsonResponse(401, { error: "Unauthorized" }));
+    });
+
+    const response = await sessionToken.authFetch(PROXY_PATH, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+    const proxyCalls = vi
+      .mocked(global.fetch)
+      .mock.calls.filter(([input]) => !isSessionTokenCall(input));
+    expect(proxyCalls).toHaveLength(1);
+  });
+
+  it("does not retry when the caller provided an Authorization header", async () => {
+    let sessionTokenValue = "stale-token";
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (isSessionTokenCall(input)) {
+        return Promise.resolve(jsonResponse(200, { token: sessionTokenValue }));
+      }
+      return Promise.resolve(jsonResponse(401, { error: "Unauthorized" }));
+    });
+
+    await sessionToken.initializeSessionToken();
+    sessionTokenValue = "fresh-token";
+
+    const response = await sessionToken.authFetch(PROXY_PATH, {
+      method: "POST",
+      headers: { Authorization: "Bearer caller-token" },
+    });
+
+    expect(response.status).toBe(401);
+    const proxyCalls = vi
+      .mocked(global.fetch)
+      .mock.calls.filter(([input]) => !isSessionTokenCall(input));
+    expect(proxyCalls).toHaveLength(1);
+  });
+
+  it("does not retry when the 401 is flagged X-MCP-Auth-Required: oauth", async () => {
+    let sessionTokenValue = "stale-token";
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (isSessionTokenCall(input)) {
+        return Promise.resolve(jsonResponse(200, { token: sessionTokenValue }));
+      }
+      return Promise.resolve({
+        status: 401,
+        ok: false,
+        headers: new Headers({ "X-MCP-Auth-Required": "oauth" }),
+        json: () => Promise.resolve({ error: "Unauthorized" }),
+      } as unknown as Response);
+    });
+
+    await sessionToken.initializeSessionToken();
+    sessionTokenValue = "fresh-token";
+
+    const response = await sessionToken.authFetch(PROXY_PATH, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+    const proxyCalls = vi
+      .mocked(global.fetch)
+      .mock.calls.filter(([input]) => !isSessionTokenCall(input));
+    expect(proxyCalls).toHaveLength(1);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -164,6 +164,38 @@ export async function initializeSessionToken(): Promise<string> {
 }
 
 /**
+ * Force a re-fetch of the dev session token.
+ *
+ * The local backend mints a fresh session token on every restart (see
+ * `services/session-token.ts#generateSessionToken`). After a dev-server
+ * restart the browser still holds the token cached at page load, so every
+ * `/api/*` call 401s until a hard refresh. Clearing the cache and re-fetching
+ * recovers transparently.
+ *
+ * In production the token is injected into the HTML and can't be refreshed at
+ * runtime, so the injected value is returned as-is.
+ *
+ * @returns The refreshed token, or null if it couldn't be obtained.
+ */
+export async function refreshSessionToken(): Promise<string | null> {
+  if (window.__MCP_SESSION_TOKEN__) {
+    cachedToken = window.__MCP_SESSION_TOKEN__;
+    return cachedToken;
+  }
+
+  // Drop the stale cache + any in-flight init so initializeSessionToken
+  // actually hits /api/session-token again instead of returning the old token.
+  cachedToken = null;
+  initPromise = null;
+
+  try {
+    return await initializeSessionToken();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Get the session token synchronously.
  * Returns empty string if not yet initialized (will cause 401).
  *
@@ -391,6 +423,28 @@ export async function authFetch(
     : null;
   const mergedInit = buildAuthFetchInit(input, init, hostedAuthHeader);
   const response = await fetch(input, mergedInit);
+
+  // Local session-token recovery (non-hosted). The dev backend regenerates its
+  // session token on every restart; if it restarted since page load the
+  // browser holds a stale token and each /api/* call 401s with a cryptic
+  // "Backend debug proxy error: 401 Unauthorized" until a manual page refresh.
+  // Re-fetch the current token and retry once so a backend restart doesn't
+  // strand the session. Skipped when the caller set its own Authorization, and
+  // when the 401 is the upstream MCP server demanding OAuth (refreshing the
+  // session token wouldn't change that outcome).
+  if (
+    response.status === 401 &&
+    shouldAttachSessionHeaders(input) &&
+    !callerProvidedAuthorization &&
+    response.headers?.get("X-MCP-Auth-Required") !== "oauth"
+  ) {
+    const staleToken = getSessionToken();
+    const refreshedToken = await refreshSessionToken();
+    if (refreshedToken && refreshedToken !== staleToken) {
+      const retryInit = buildAuthFetchInit(input, init, hostedAuthHeader);
+      return fetch(input, retryInit);
+    }
+  }
 
   // Retry on 401 only for paths we actually attached a hosted bearer to —
   // a 401 from `/api/health` shouldn't trigger a guest-session refresh.


### PR DESCRIPTION
## Summary

Two related improvements to the **XAA Debugger**:

1. **UI cleanup** of the run bar, ID-JAG inspector, and notice cards so the flow reads more clearly and stops shouting with colored callouts.
2. **A real bug fix** for the cryptic `Backend debug proxy error: 401 Unauthorized` that appears when re-running the flow after the local dev backend has rotated its session token.

## The 401 bug (root cause)

The error was **not** the XAA flow or the upstream authorization server — it came from the inspector's own backend. Reproduced directly:

- `GET http://localhost:8787/.well-known/oauth-authorization-server` → `200` (upstream is fine)
- `POST /api/mcp/oauth/debug/proxy` with a **valid** session token → `200`
- `POST /api/mcp/oauth/debug/proxy` with a **stale** session token → `401 {"error":"Unauthorized"}`

The local backend mints a brand-new session token on every startup. In dev the backend restarts (file watch / HMR) between runs, so the browser keeps the token it cached at page load and every `/api/*` call 401s — the XAA discovery step is just the first proxied call to hit it. A hard refresh "fixed" it, which is the tell-tale sign of a stale in-memory token.

Previously `authFetch` only auto-recovered 401s for the **hosted** guest-token path; a stale **local** session token had no recovery, surfacing as this confusing proxy error.

### Fix
- New `refreshSessionToken()` clears the cached token (and any in-flight init) and re-fetches `/api/session-token`. In production (injected token) it's a no-op.
- `authFetch` now refreshes the token and retries **once** on a local `401`, gated so it does not fire when:
  - the refreshed token is unchanged (e.g. production injected token),
  - the caller supplied its own `Authorization` header, or
  - the 401 is an upstream OAuth challenge (`X-MCP-Auth-Required: oauth`).

## UI cleanup

**XAAFlowLogger (run panel)**
- Removed phase header blurbs, teachable-moment tips, the Mode selector + description, the per-step Focus button, and the "spec step N" badges (kept the Phase 0 "not part of the XAA grant" note).
- Labeled the client ID and scope chips so they're self-explanatory instead of bare values.
- Neutral done-phase rail text; green reserved for the checkmark icon.

**IdJagInspector**
- Made the inspector collapsible (default expanded, compact lint summary when collapsed, Copy JWT always visible).
- Regrouped each claim-lint row: the claim name + its spec citation share one line, with the value as subordinate evidence below; replaced the brittle container-query subgrid with a simple divided list so rows align at any width.
- Neutral structural-success copy (green only on the checkmark); stacked Header/Payload JSON vertically.
- Fixed the Header/Payload JSON containers overflowing the panel on narrow widths (`min-w-0` so `overflow-auto` engages instead of stretching the parent).

**Notices**
- `XAAIdpCard`, `InfoLogEntry`, `NegativeTestScorecard`: dropped loud amber/blue backgrounds and the header summary badge for a calmer, neutral look.

## Test plan

- [x] `npm run test -- client/src/components/xaa` — XAA component tests updated for the new layout/labels (84 passing)
- [x] `npm run test -- client/src/lib/__tests__/session-token.local-retry.test.ts` — new coverage for refresh-and-retry, no-retry-when-unchanged, refresh-failure, caller-provided Authorization, and the OAuth-challenge case
- [x] Existing `session-token.test.ts` and `session-token.hosted-retry.test.ts` still pass
- [ ] Manual: restart the local backend mid-session, then re-run the XAA flow — discovery now recovers transparently instead of erroring

Made with [Cursor](https://cursor.com)