### PR TITLE
Fix XAA Debugger auto-discovery: resolve auth server from protected-resource metadata

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -248,6 +248,18 @@ const navigationSections: NavSection[] = [
         // this is an internal-only flag (same convention as `mcpjam-learning`).
         featureFlag: "mcpjam-conformance",
       },
+      // {
+      //   title: "Tracing",
+      //   url: "/tracing",
+      //   icon: Activity,
+      // },
+    ],
+  },
+  {
+    // Auth-flow debuggers get their own section so they read as a related
+    // pair, separated from the surrounding nav by the section dividers.
+    id: "debuggers",
+    items: [
       {
         title: "OAuth Debugger",
         url: "/oauth-flow",
@@ -259,11 +271,6 @@ const navigationSections: NavSection[] = [
         icon: ShieldCheck,
         featureFlag: "xaa",
       },
-      // {
-      //   title: "Tracing",
-      //   url: "/tracing",
-      //   icon: Activity,
-      // },
     ],
   },
   {

--- a/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAIdpCard.tsx
@@ -186,8 +186,8 @@ export function XAAIdpCard() {
           <span>
             These are local URLs. Your authorization server can only fetch them
             if it can reach this machine — a cloud-hosted Okta or Auth0 tenant
-            cannot reach <code className="font-mono">localhost</code>. Expose the
-            inspector with a public tunnel (e.g. ngrok) first.
+            cannot reach <code className="font-mono">localhost</code>. Expose
+            MCPJam with a public tunnel (e.g. ngrok) first.
           </span>
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -333,9 +333,12 @@ export function XAAServerModal({
                     </button>
                   </TooltipTrigger>
                   <TooltipContent variant="muted" side="top" className="max-w-xs">
-                    Leave blank to read it from the MCP server&apos;s OAuth
-                    metadata (its <code className="font-mono">.well-known</code>{" "}
-                    discovery endpoints).
+                    Leave blank to auto-discover it: the inspector reads the MCP
+                    server&apos;s protected-resource metadata (
+                    <code className="font-mono">
+                      /.well-known/oauth-protected-resource
+                    </code>
+                    ) to find which authorization server protects it.
                   </TooltipContent>
                 </Tooltip>
               </div>

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -333,7 +333,7 @@ export function XAAServerModal({
                     </button>
                   </TooltipTrigger>
                   <TooltipContent variant="muted" side="top" className="max-w-xs">
-                    Leave blank to auto-discover it: the inspector reads the MCP
+                    Leave blank to auto-discover it: MCPJam reads the MCP
                     server&apos;s protected-resource metadata (
                     <code className="font-mono">
                       /.well-known/oauth-protected-resource

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAIdpCard.test.tsx
@@ -129,7 +129,7 @@ describe("XAAIdpCard (non-hosted mode)", () => {
     render(<LocalIdpCard />);
 
     expect(
-      screen.getByText(/Expose the\s+inspector with a public tunnel/i)
+      screen.getByText(/Expose\s+MCPJam with a public tunnel/i)
     ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
@@ -172,6 +172,85 @@ describe("server-target /proxy/token", () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 
+  it("resolves the issuer from RFC 9728 protected-resource metadata when none is stored", async () => {
+    // The resource URL is NOT the AS issuer: PRM points at a separate issuer,
+    // and the token endpoint is only discoverable from that issuer's metadata.
+    const resolver = vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      clientId: "stored-client-id",
+      serverUrl: "https://stored-server.example.com/mcp",
+      xaaAuthzIssuer: null,
+    }));
+    const app = buildApp(resolver);
+
+    const getUrls: string[] = [];
+    let tokenUrl = "";
+    const fetchMock = vi.fn(async (url: any, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      const href = String(url);
+      if (method === "GET") {
+        getUrls.push(href);
+        // PRM document: names the protecting authorization server.
+        if (href.includes("oauth-protected-resource")) {
+          return new Response(
+            JSON.stringify({
+              resource: "https://stored-server.example.com/mcp",
+              authorization_servers: ["https://issuer.example.com"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        // AS metadata: only served at the discovered issuer's well-known.
+        if (href.startsWith("https://issuer.example.com/")) {
+          return new Response(
+            JSON.stringify({
+              issuer: "https://issuer.example.com",
+              token_endpoint: DISCOVERED_TOKEN_ENDPOINT,
+              grant_types_supported: [
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+        return new Response(JSON.stringify({ error: "not_found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      tokenUrl = href;
+      return new Response(
+        JSON.stringify({ access_token: "tok", token_type: "Bearer" }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    // Probed the resource's PRM well-known (path-inserted, RFC 9728 §3.1)...
+    expect(getUrls).toContain(
+      "https://stored-server.example.com/.well-known/oauth-protected-resource/mcp"
+    );
+    // ...then the discovered issuer's AS metadata, and posted there.
+    expect(getUrls.some((u) => u.startsWith("https://issuer.example.com/"))).toBe(
+      true
+    );
+    expect(tokenUrl).toBe(DISCOVERED_TOKEN_ENDPOINT);
+  });
+
   it("prefers the stored xaaAuthzIssuer over the server URL for discovery", async () => {
     const resolver = vi.fn(async () => ({
       clientSecret: "stored-secret",

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -28,7 +28,9 @@ import {
 } from "../../utils/oauth-proxy.js";
 import {
   buildDiscoveryCandidates,
+  buildResourceMetadataCandidates,
   evaluateDiscovery,
+  extractAuthorizationServer,
 } from "../../services/xaa-discovery.js";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
 import {
@@ -325,13 +327,67 @@ interface ResolvedServerTarget {
   clientSecret?: string;
 }
 
-// Discover the token endpoint for a server target's issuer, reusing the same
-// well-known sweep as /discover-as. The issuer is the stored xaaAuthzIssuer
-// (or the server URL); the client never supplies it.
+// RFC 9728: ask the resource (the MCP server URL) which authorization server
+// protects it, by reading authorization_servers[0] from its protected-resource
+// metadata. The resource URL is NOT itself an AS issuer, so this is the only
+// spec-defined way to learn the issuer when one isn't configured. Returns
+// undefined (rather than throwing) when no PRM/issuer is found, so the caller
+// can fall back to probing the resource URL directly.
+async function discoverIssuerFromResourceMetadata(
+  resource: string,
+  httpsOnly: boolean
+): Promise<string | undefined> {
+  let candidates: string[];
+  try {
+    candidates = buildResourceMetadataCandidates(resource);
+  } catch {
+    return undefined;
+  }
+
+  for (const candidate of candidates) {
+    const result = await fetchOAuthMetadata(candidate, httpsOnly);
+    if ("metadata" in result) {
+      const issuer = extractAuthorizationServer(result.metadata);
+      if (issuer) {
+        return issuer;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+// Discover the token endpoint for a server target, reusing the same well-known
+// sweep as /discover-as. The issuer is resolved server-side (the client never
+// supplies it), in priority order:
+//   1. the stored xaaAuthzIssuer, if configured;
+//   2. otherwise the authorization server named in the resource's RFC 9728
+//      protected-resource metadata;
+//   3. otherwise the resource URL itself (legacy behavior — covers servers that
+//      self-host RFC 8414 metadata at the resource origin and serve no PRM).
 async function discoverServerTargetTokenEndpoint(
-  issuer: string,
+  args: {
+    resource?: string;
+    explicitIssuer?: string;
+  },
   httpsOnly: boolean
 ): Promise<string> {
+  let issuer = args.explicitIssuer;
+  if (!issuer && args.resource) {
+    issuer = await discoverIssuerFromResourceMetadata(args.resource, httpsOnly);
+  }
+  // Legacy fallback: treat the resource URL as the issuer when neither a stored
+  // issuer nor a PRM-advertised one is available.
+  issuer = issuer || args.resource;
+
+  if (!issuer) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "The server has no URL or issuer to discover an authorization server from"
+    );
+  }
+
   let candidates: string[];
   try {
     candidates = buildDiscoveryCandidates(issuer);
@@ -396,8 +452,7 @@ async function resolveServerTarget(
     bearerToken: args.bearerToken,
   });
 
-  const issuer = resolved.xaaAuthzIssuer || resolved.serverUrl;
-  if (!issuer) {
+  if (!resolved.xaaAuthzIssuer && !resolved.serverUrl) {
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
@@ -406,7 +461,10 @@ async function resolveServerTarget(
   }
 
   const tokenEndpoint = await discoverServerTargetTokenEndpoint(
-    issuer,
+    {
+      resource: resolved.serverUrl ?? undefined,
+      explicitIssuer: resolved.xaaAuthzIssuer ?? undefined,
+    },
     options.httpsOnlyProxy
   );
 

--- a/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildDiscoveryCandidates,
+  buildResourceMetadataCandidates,
   evaluateDiscovery,
+  extractAuthorizationServer,
   JWT_BEARER_GRANT,
 } from "../xaa-discovery.js";
 
@@ -37,6 +39,47 @@ describe("buildDiscoveryCandidates", () => {
   it("uses an explicit well-known URL verbatim", () => {
     const url = "https://issuer.example.com/.well-known/openid-configuration";
     expect(buildDiscoveryCandidates(url)).toEqual([url]);
+  });
+});
+
+describe("buildResourceMetadataCandidates", () => {
+  it("inserts the well-known segment before the resource path (RFC 9728 §3.1)", () => {
+    expect(
+      buildResourceMetadataCandidates("https://mcp.example.com/mcp"),
+    ).toEqual([
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+      "https://mcp.example.com/.well-known/oauth-protected-resource",
+    ]);
+  });
+
+  it("uses the bare root form for a path-less resource", () => {
+    expect(buildResourceMetadataCandidates("https://mcp.example.com")).toEqual([
+      "https://mcp.example.com/.well-known/oauth-protected-resource",
+    ]);
+  });
+});
+
+describe("extractAuthorizationServer", () => {
+  it("returns the first issuer from authorization_servers", () => {
+    expect(
+      extractAuthorizationServer({
+        resource: "https://mcp.example.com/mcp",
+        authorization_servers: [
+          "https://as.example.com",
+          "https://other.example.com",
+        ],
+      }),
+    ).toBe("https://as.example.com");
+  });
+
+  it("returns undefined when no authorization server is advertised", () => {
+    expect(extractAuthorizationServer({ resource: "x" })).toBeUndefined();
+    expect(
+      extractAuthorizationServer({ authorization_servers: [] }),
+    ).toBeUndefined();
+    expect(
+      extractAuthorizationServer({ authorization_servers: [""] }),
+    ).toBeUndefined();
   });
 });
 

--- a/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-discovery.test.ts
@@ -72,6 +72,14 @@ describe("extractAuthorizationServer", () => {
     ).toBe("https://as.example.com");
   });
 
+  it("skips malformed entries and returns the first parseable issuer URL", () => {
+    expect(
+      extractAuthorizationServer({
+        authorization_servers: ["not a url", "  ", "https://as.example.com"],
+      }),
+    ).toBe("https://as.example.com");
+  });
+
   it("returns undefined when no authorization server is advertised", () => {
     expect(extractAuthorizationServer({ resource: "x" })).toBeUndefined();
     expect(
@@ -79,6 +87,9 @@ describe("extractAuthorizationServer", () => {
     ).toBeUndefined();
     expect(
       extractAuthorizationServer({ authorization_servers: [""] }),
+    ).toBeUndefined();
+    expect(
+      extractAuthorizationServer({ authorization_servers: ["not a url"] }),
     ).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/services/xaa-discovery.ts
+++ b/mcpjam-inspector/server/services/xaa-discovery.ts
@@ -75,10 +75,21 @@ export function buildResourceMetadataCandidates(input: string): string[] {
   return [root];
 }
 
+function isParseableUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Read the first authorization-server issuer out of an RFC 9728 PRM document.
- * Returns undefined when the document doesn't advertise one (e.g. the fetched
- * URL wasn't actually PRM), so callers can fall back to another discovery path.
+ * Read the first usable authorization-server issuer out of an RFC 9728 PRM
+ * document. Skips entries that aren't parseable URLs so a malformed entry
+ * doesn't abort discovery when a later entry is valid. Returns undefined when
+ * the document advertises none (e.g. the fetched URL wasn't actually PRM), so
+ * callers can fall back to another discovery path.
  */
 export function extractAuthorizationServer(
   metadata: Record<string, unknown>,
@@ -87,10 +98,16 @@ export function extractAuthorizationServer(
   if (!Array.isArray(servers)) {
     return undefined;
   }
-  const first = servers.find(
-    (s): s is string => typeof s === "string" && s.trim().length > 0,
-  );
-  return first?.trim();
+  for (const entry of servers) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (trimmed && isParseableUrl(trimmed)) {
+      return trimmed;
+    }
+  }
+  return undefined;
 }
 
 export type GrantSupportStatus = "pass" | "warn" | "fail";

--- a/mcpjam-inspector/server/services/xaa-discovery.ts
+++ b/mcpjam-inspector/server/services/xaa-discovery.ts
@@ -50,6 +50,49 @@ export function buildDiscoveryCandidates(input: string): string[] {
   return Array.from(new Set(candidates));
 }
 
+const PRM_SUFFIX = "/.well-known/oauth-protected-resource";
+
+/**
+ * Build the ordered list of RFC 9728 protected-resource-metadata (PRM) URLs to
+ * probe for a resource (the MCP server URL). PRM is the document that names the
+ * authorization server(s) protecting the resource — the issuer is NOT the
+ * resource URL itself, so we read it from here rather than guessing.
+ *
+ * RFC 9728 §3.1 inserts the well-known segment between the host and the
+ * resource's path (`https://host/mcp` → `https://host/.well-known/oauth-protected-resource/mcp`);
+ * the path-less root form is the fallback some servers serve at the origin.
+ */
+export function buildResourceMetadataCandidates(input: string): string[] {
+  const url = new URL(input);
+  const origin = url.origin;
+  const root = `${origin}${PRM_SUFFIX}`;
+
+  const path = stripTrailingSlash(url.pathname);
+  if (path && path !== "") {
+    return Array.from(new Set([`${origin}${PRM_SUFFIX}${path}`, root]));
+  }
+
+  return [root];
+}
+
+/**
+ * Read the first authorization-server issuer out of an RFC 9728 PRM document.
+ * Returns undefined when the document doesn't advertise one (e.g. the fetched
+ * URL wasn't actually PRM), so callers can fall back to another discovery path.
+ */
+export function extractAuthorizationServer(
+  metadata: Record<string, unknown>,
+): string | undefined {
+  const servers = metadata.authorization_servers;
+  if (!Array.isArray(servers)) {
+    return undefined;
+  }
+  const first = servers.find(
+    (s): s is string => typeof s === "string" && s.trim().length > 0,
+  );
+  return first?.trim();
+}
+
 export type GrantSupportStatus = "pass" | "warn" | "fail";
 
 export interface IssuerMismatch {


### PR DESCRIPTION
## TL;DR

The XAA Debugger failed with **"Couldn't discover an authorization server"** whenever you ran against a configured server target without manually setting an issuer. The discovery step treated the MCP server URL as if it were the authorization-server issuer and probed OAuth/OIDC well-known endpoints directly on it — which only works for servers that self-host that metadata at the resource path. This PR makes discovery follow the spec: read the server's protected-resource metadata to learn which authorization server protects it, then discover the token endpoint from there. Also groups the two auth-flow debuggers into their own sidebar section.

## The bug

When no issuer is configured, the server-side discovery used the server URL itself as the issuer and swept only authorization-server / OIDC well-knowns on it. For a server that advertises its authorization server via protected-resource metadata (the standard MCP pattern) rather than self-hosting auth-server metadata at the resource path, none of those probes match → 404.

```
{
  "code": "NOT_FOUND",
  "message": "Couldn't discover an authorization server. Set the issuer in Configure Server to Test."
}
```

## What discovery does now

Issuer is resolved server-side (never from client input), in priority order:

| Order | Source | Notes |
|---|---|---|
| 1 | Configured issuer | Unchanged — explicit issuer wins |
| 2 | **Protected-resource metadata** | **New** — fetch the resource's metadata, read its advertised authorization server |
| 3 | Resource URL itself | Legacy fallback — covers servers that self-host auth-server metadata at the resource path and publish no protected-resource metadata |

Then the existing well-known sweep runs against the resolved issuer to find the token endpoint.

### Before / after (blank issuer, server advertises its auth server via metadata)

| | Before | After |
|---|---|---|
| Issuer used for discovery | the resource URL (a guess) | the auth server named in the resource's metadata |
| Result | 404 "Couldn't discover an authorization server" | token endpoint discovered, run proceeds |

## Why this is the right layer

Per the relevant specs, *how a client obtains the authorization-server issuer* is out of scope for the auth-server-metadata spec (RFC 8414) — it assumes you already hold an issuer. The step that maps a resource URL to its issuer is RFC 9728 (protected-resource metadata). The debugger was skipping that step on the server-target path and guessing instead. This restores the standard chain: resource metadata → issuer → auth-server metadata → token endpoint.

## Also in this PR

- **Sidebar:** moved OAuth Debugger + XAA Debugger out of the "others" section into a dedicated "debuggers" section so the two auth-flow debuggers read as a related pair.

## Risk register

| Concern | Answer |
|---|---|
| Breaks servers that self-host auth-server metadata at the resource URL? | No — that's the legacy fallback (order 3). Existing tests cover it and pass unchanged. |
| New SSRF surface from a metadata-advertised issuer? | No — the metadata fetch and the subsequent sweep both go through the same URL-validation guard already used by discovery. |
| Client-supplied values trusted? | No — issuer/secret/endpoint stay pinned server-side; the browser still only sends server + project identifiers. |
| URL-target (non-server) flow affected? | No — that path already resolves the issuer from protected-resource metadata client-side. This fix is scoped to the server-target path that produced the error. |

## Tests

- New unit tests for the metadata-URL builder (path-insertion + root forms) and the issuer extractor.
- New integration test: resource URL ≠ issuer — asserts the debugger probes the resource's metadata, then the discovered issuer's well-known, then posts to the discovered token endpoint.
- Existing server-target and route tests pass unchanged (they exercise the legacy fallback).
