### PR TITLE
[XAA] Send the flow's subject in negative-test scorecard runs

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -255,6 +255,10 @@ export function XAAFlowTab({
           registrationId: selectedRegistration.id,
           audience,
           resource,
+          // Use the flow's simulated identity (not the server's user-12345
+          // default) so an app with Allowed Users set doesn't reject every
+          // negative test on `sub` before its own check is evaluated.
+          subject: runInput.userId || undefined,
           clientId: runInput.clientId || undefined,
           scope: runInput.scope || undefined,
         },
@@ -277,6 +281,7 @@ export function XAAFlowTab({
           projectId: target.projectId,
           audience,
           resource,
+          subject: runInput.userId || undefined,
           clientId: runInput.clientId || undefined,
           scope: runInput.scope || undefined,
         },
@@ -299,6 +304,7 @@ export function XAAFlowTab({
         tokenEndpoint: flowState.tokenEndpoint,
         audience,
         resource,
+        subject: runInput.userId || undefined,
         clientId: runInput.clientId || undefined,
         scope: runInput.scope || undefined,
       },


### PR DESCRIPTION
## TL;DR

The negative-test scorecard never sent a `subject`, so the auth server defaulted every forged ID-JAG to `user-12345` while the positive flow uses the simulated identity (e.g. `john`). On a target app with **Allowed Users** (subject resolution) configured, the auth server rejects every negative assertion with `subject_not_allowed` **before** the check under test runs — so all rows show "rejected as expected" and toggling an individual check (e.g. Wrong Audience) has no visible effect, even though the valid flow passes.

## Root cause

`XAAFlowTab.tsx` builds the `NegativeTestsInput` with `audience`, `resource`, `clientId`, `scope` — but not `subject`. Server-side (`server/routes/mcp/xaa.ts`) the negative-test runner does `subject = parsed.subject || "user-12345"`, so all forged assertions carry `sub=user-12345`. The positive flow mints `sub` from the signed-in identity instead, so the two diverge.

## Fix

Include `subject: runInput.userId` in all three scorecard input branches (registration-backed, server-side-secret, public token-endpoint) so negative tests use the same provisioned identity as the flow.

The `unknown_sub` mode still overrides `sub` to `unknown-user-00000` in the signer, so it continues to test subject resolution correctly (and an app with Allowed Users set will still — correctly — reject that one case).

## Testing

- `npx vitest run client/src/components/xaa client/src/hooks/__tests__/useXaaTestTarget.test.ts` → 53 passing.
- No new type errors introduced (the change reuses `runInput.userId`, already used elsewhere in the component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)