### PR TITLE
[XAA Connect] Support XAA on the Connect page (MCPJam test IdP)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2986,6 +2986,7 @@ export default function App() {
           showOnlyOAuthServers:
             activeTab === "oauth-flow" ||
             (activeTab === "xaa-flow" && xaaEnabled === true),
+          includeXaaServers: activeTab === "xaa-flow" && xaaEnabled === true,
           autoSelectFilteredServer:
             activeTab !== "oauth-flow" &&
             !(activeTab === "xaa-flow" && xaaEnabled === true),

--- a/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
@@ -49,6 +49,12 @@ export interface ActiveServerSelectorProps {
   /** Disconnect a connected server (Playground toggle off = unplug). */
   onDisconnect?: (serverName: string) => void;
   showOnlyOAuthServers?: boolean; // Only show servers that use OAuth
+  /**
+   * When `showOnlyOAuthServers` is on, also admit Cross-App Access (XAA)
+   * servers (useXaa, useOAuth left false). Scoped to the XAA tab so XAA servers
+   * don't leak into the OAuth-flow tab's list.
+   */
+  includeXaaServers?: boolean;
   showOnlyServersWithViews?: boolean; // Only show servers that have saved views
   autoSelectFilteredServer?: boolean; // Auto-select when current selection is hidden by filters
   serversWithViews?: Set<string>; // Set of server names that have saved views
@@ -103,6 +109,7 @@ export function ActiveServerSelector({
   onAddServerRequested,
   onReconnect,
   showOnlyOAuthServers = false,
+  includeXaaServers = false,
   showOnlyServersWithViews = false,
   autoSelectFilteredServer = true,
   serversWithViews,
@@ -131,8 +138,16 @@ export function ActiveServerSelector({
     );
   };
 
+  const isXaaServer = (server: ServerWithName): boolean =>
+    "url" in server.config && server.useXaa === true;
+
   const servers = Object.entries(serverConfigs).filter(([name, server]) => {
-    if (showOnlyOAuthServers && !isOAuthServer(server)) return false;
+    if (
+      showOnlyOAuthServers &&
+      !isOAuthServer(server) &&
+      !(includeXaaServers && isXaaServer(server))
+    )
+      return false;
     if (showOnlyServersWithViews && !serversWithViews?.has(name)) return false;
     return true;
   });

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -17,6 +17,10 @@ vi.mock("@/lib/PosthogUtils", () => ({
   detectPlatform: vi.fn().mockReturnValue("web"),
 }));
 
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { email: "tester@example.com" } }),
+}));
+
 vi.mock("../xaa/XAAIdpCard", () => ({
   XAAIdpCard: () => <div data-testid="xaa-idp-card" />,
 }));

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -444,6 +444,12 @@ export function AddServerModal({
               }
               clientIdError={formState.clientIdError}
               clientSecretError={formState.clientSecretError}
+              xaaAuthzIssuer={formState.xaaAuthzIssuer}
+              onXaaAuthzIssuerChange={formState.setXaaAuthzIssuer}
+              xaaSubject={formState.xaaSubject}
+              onXaaSubjectChange={formState.setXaaSubject}
+              xaaEmail={formState.xaaEmail}
+              onXaaEmailChange={formState.setXaaEmail}
             />
           )}
 

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -17,6 +17,7 @@ import {
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { HOSTED_MODE } from "@/lib/config";
 import { usePostHog } from "posthog-js/react";
+import { useAuth } from "@workos-inc/authkit-react";
 import { useAppReady, useAppReadyMessage } from "@/hooks/use-app-ready";
 import { useServerForm } from "./hooks/use-server-form";
 import { AdvancedConnectionSettingsSection } from "./shared/AdvancedConnectionSettingsSection";
@@ -95,9 +96,11 @@ export function AddServerModal({
   projectClientConfig,
 }: AddServerModalProps) {
   const posthog = usePostHog();
+  const { user } = useAuth();
   const formState = useServerForm(undefined, {
     requireHttps,
     projectClientConfig,
+    signedInEmail: user?.email,
   });
   const hostedUrlPlaceholder = "https://example.com/mcp";
   const appReady = useAppReady();
@@ -450,6 +453,7 @@ export function AddServerModal({
               onXaaSubjectChange={formState.setXaaSubject}
               xaaEmail={formState.xaaEmail}
               onXaaEmailChange={formState.setXaaEmail}
+              signedInEmail={user?.email}
             />
           )}
 

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -266,6 +266,12 @@ export function EditServerFormContent({
             clientSecretError={formState.clientSecretError}
             projectId={projectId}
             hostedServerId={hostedServerId}
+            xaaAuthzIssuer={formState.xaaAuthzIssuer}
+            onXaaAuthzIssuerChange={formState.setXaaAuthzIssuer}
+            xaaSubject={formState.xaaSubject}
+            onXaaSubjectChange={formState.setXaaSubject}
+            xaaEmail={formState.xaaEmail}
+            onXaaEmailChange={formState.setXaaEmail}
           />
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -7,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
+import { useAuth } from "@workos-inc/authkit-react";
 import { AdvancedConnectionSettingsSection } from "./shared/AdvancedConnectionSettingsSection";
 import { AuthenticationSection } from "./shared/AuthenticationSection";
 import { EnvVarsSection } from "./shared/EnvVarsSection";
@@ -42,6 +43,7 @@ export function EditServerFormContent({
   mcpProtocolVersionOverride,
   onMcpProtocolVersionOverrideChange,
 }: EditServerFormContentProps) {
+  const { user: signedInUser } = useAuth();
   const hostedUrlPlaceholder = "https://example.com/mcp";
   const [revealingEnv, setRevealingEnv] = useState(false);
   const [revealingHeaders, setRevealingHeaders] = useState(false);
@@ -272,6 +274,7 @@ export function EditServerFormContent({
             onXaaSubjectChange={formState.setXaaSubject}
             xaaEmail={formState.xaaEmail}
             onXaaEmailChange={formState.setXaaEmail}
+            signedInEmail={signedInUser?.email}
           />
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/mcp-ui/mcp-apps-utils";
 import { getConnectionStatusMeta } from "./server-card-utils";
 import { useServerForm } from "./hooks/use-server-form";
+import { useAuth } from "@workos-inc/authkit-react";
 import { ServerInfoContent } from "./ServerInfoContent";
 import { ServerInfoToolsMetadataContent } from "./ServerInfoToolsMetadataContent";
 import { EditServerFormContent } from "./EditServerFormContent";
@@ -405,7 +406,11 @@ export function ServerDetailModal({
   const isOpenAIAppServer = isOpenAIApp(toolsData);
   const isOpenAIAppAndMCPAppServer = isOpenAIAppAndMCPApp(toolsData);
 
-  const formState = useServerForm(server, { projectClientConfig });
+  const { user: signedInUser } = useAuth();
+  const formState = useServerForm(server, {
+    projectClientConfig,
+    signedInEmail: signedInUser?.email,
+  });
   const trimmedName = formState.name.trim();
   const isDuplicateServerName =
     trimmedName !== "" &&

--- a/mcpjam-inspector/client/src/components/connection/__tests__/EditServerFormContent.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/EditServerFormContent.hosted.test.tsx
@@ -8,6 +8,10 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import { HOSTED_LOCAL_ONLY_TOOLTIP } from "@/lib/hosted-ui";
 
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { email: "tester@example.com" } }),
+}));
+
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: true,
 }));

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
@@ -5,6 +5,10 @@ import type { ServerWithName } from "@/hooks/use-app-state";
 
 const mockFetchHostedOAuthTokens = vi.hoisted(() => vi.fn());
 
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { email: "tester@example.com" } }),
+}));
+
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: true,
 }));

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -9,6 +9,10 @@ const mockUseFeatureFlagEnabled = vi.hoisted(() => vi.fn(() => false));
 const mockUseQuery = vi.hoisted(() => vi.fn(() => undefined));
 const mockSetProjectServerConfig = vi.hoisted(() => vi.fn());
 
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { email: "tester@example.com" } }),
+}));
+
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({
     capture: mockCapture,

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -112,6 +112,44 @@ describe("useServerForm", () => {
     });
   });
 
+  it("defaults the XAA simulated identity to the signed-in user when the fields are blank", () => {
+    const { result } = renderHook(() =>
+      useServerForm(undefined, { signedInEmail: "john@mcpjam.com" })
+    );
+
+    act(() => {
+      result.current.setName("XAA server");
+      result.current.setUrl("https://example.com/mcp");
+      result.current.setAuthType("xaa");
+      result.current.setClientId("resource-client-id");
+    });
+
+    expect(result.current.buildFormData()).toMatchObject({
+      useXaa: true,
+      xaaSubject: "john@mcpjam.com",
+      xaaEmail: "john@mcpjam.com",
+    });
+  });
+
+  it("uses an explicit XAA subject/email override instead of the signed-in default", () => {
+    const { result } = renderHook(() =>
+      useServerForm(undefined, { signedInEmail: "john@mcpjam.com" })
+    );
+
+    act(() => {
+      result.current.setName("XAA server");
+      result.current.setUrl("https://example.com/mcp");
+      result.current.setAuthType("xaa");
+      result.current.setClientId("resource-client-id");
+      result.current.setXaaSubject("john");
+    });
+
+    expect(result.current.buildFormData()).toMatchObject({
+      xaaSubject: "john",
+      xaaEmail: "john@mcpjam.com",
+    });
+  });
+
   it("resolves an XAA server (useXaa, useOAuth false) to authType=xaa and never downgrades it to oauth on save", async () => {
     const server = {
       name: "Saved XAA server",

--- a/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/__tests__/use-server-form.test.ts
@@ -83,6 +83,62 @@ describe("useServerForm", () => {
     });
   });
 
+  it("emits useXaa (not useOAuth) and the resource-AS credentials for the XAA auth type", () => {
+    const { result } = renderHook(() => useServerForm());
+
+    act(() => {
+      result.current.setName("XAA server");
+      result.current.setUrl("https://example.com/mcp");
+      result.current.setAuthType("xaa");
+      result.current.setShowAuthSettings(true);
+      result.current.setClientId("resource-client-id");
+      result.current.setOauthScopesInput("read:tools");
+      result.current.setXaaAuthzIssuer("https://idp.example.com");
+      result.current.setXaaSubject("alice");
+      result.current.setXaaEmail("alice@example.com");
+    });
+
+    expect(result.current.buildFormData()).toMatchObject({
+      name: "XAA server",
+      type: "http",
+      useXaa: true,
+      useOAuth: false,
+      authServerMode: "mcpjam",
+      clientId: "resource-client-id",
+      oauthScopes: ["read:tools"],
+      xaaAuthzIssuer: "https://idp.example.com",
+      xaaSubject: "alice",
+      xaaEmail: "alice@example.com",
+    });
+  });
+
+  it("resolves an XAA server (useXaa, useOAuth false) to authType=xaa and never downgrades it to oauth on save", async () => {
+    const server = {
+      name: "Saved XAA server",
+      config: { url: "https://example.com/mcp" },
+      useXaa: true,
+      useOAuth: false,
+      authServerMode: "mcpjam",
+      xaaAuthzIssuer: "https://idp.example.com",
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+      enabled: true,
+    } as any;
+
+    const { result } = renderHook(() => useServerForm(server));
+
+    await waitFor(() => {
+      expect(result.current.authType).toBe("xaa");
+    });
+
+    // The round-trip must keep it XAA — a silent rewrite to OAuth would be data
+    // corruption (see CLAUDE.local.md resolvedAuthType guard).
+    const built = result.current.buildFormData();
+    expect(built.useXaa).toBe(true);
+    expect(built.useOAuth).toBe(false);
+  });
+
   it("retains bearer authorization headers even without custom headers", () => {
     const { result } = renderHook(() => useServerForm());
 

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import {
   ServerFormData,
+  type ServerFormAuthType,
   type ServerFormOAuthProtocolMode,
   type ServerFormOAuthRegistrationMode,
 } from "@/shared/types.js";
@@ -15,7 +16,7 @@ interface InitialFormValues {
   type: "stdio" | "http";
   url: string;
   commandInput: string;
-  authType: "oauth" | "bearer" | "none";
+  authType: ServerFormAuthType;
   bearerToken: string;
   oauthScopesInput: string;
   oauthProtocolMode: ServerFormOAuthProtocolMode;
@@ -33,6 +34,9 @@ interface InitialFormValues {
   requestTimeout: string;
   clientCapabilitiesOverrideEnabled: boolean;
   clientCapabilitiesOverrideText: string;
+  xaaAuthzIssuer: string;
+  xaaSubject: string;
+  xaaEmail: string;
 }
 
 const DEFAULT_OAUTH_PROTOCOL_MODE: ServerFormOAuthProtocolMode = "2025-11-25";
@@ -137,8 +141,13 @@ export function useServerForm(
   // from the config (hosted/redacted load). The field stays blank but the form
   // knows auth is "bearer" and must not wipe the hidden token on save.
   const [hasStoredBearerToken, setHasStoredBearerToken] = useState(false);
-  const [authType, setAuthType] = useState<"oauth" | "bearer" | "none">("none");
+  const [authType, setAuthType] = useState<ServerFormAuthType>("none");
   const [useCustomClientId, setUseCustomClientId] = useState(false);
+  // Cross-App Access (XAA) fields. Client id / secret / scopes are shared with
+  // the OAuth preregistered path; these three are XAA-specific.
+  const [xaaAuthzIssuer, setXaaAuthzIssuer] = useState("");
+  const [xaaSubject, setXaaSubject] = useState("");
+  const [xaaEmail, setXaaEmail] = useState("");
 
   const [clientIdError, setClientIdError] = useState<string | null>(null);
   const [clientSecretError, setClientSecretError] = useState<string | null>(
@@ -315,13 +324,19 @@ export function useServerForm(
         !hasBearer &&
         (server.hasBearerToken === true ||
           getRedactedConfigFlag(config, "hasBearerToken"));
-      const resolvedAuthType: "oauth" | "bearer" | "none" = hasServerOAuth
-        ? "oauth"
-        : hasBearer || hasStoredBearerTokenValue
-        ? "bearer"
-        : hasOAuth
-        ? "oauth"
-        : "none";
+      // XAA is checked FIRST: an XAA server keeps `useOAuth === false`, so
+      // without this branch it would fall through to the "oauth" catch-all and
+      // a save would silently rewrite it to OAuth. See CLAUDE.local.md guard.
+      const resolvedAuthType: ServerFormAuthType =
+        server.useXaa === true
+          ? "xaa"
+          : hasServerOAuth
+          ? "oauth"
+          : hasBearer || hasStoredBearerTokenValue
+          ? "bearer"
+          : hasOAuth
+          ? "oauth"
+          : "none";
       const timeoutValue =
         typeof config.timeout === "number" && Number.isFinite(config.timeout)
           ? String(config.timeout)
@@ -352,8 +367,18 @@ export function useServerForm(
       );
       setClientCapabilitiesOverrideError(null);
 
+      // Read XAA-specific fields (issuer / simulated identity) from the server
+      // record so edit mode round-trips them. Client id / scopes reuse the
+      // OAuth-credential reads above.
+      setXaaAuthzIssuer(isHttpServer ? server.xaaAuthzIssuer ?? "" : "");
+      setXaaSubject(server.xaaSubject ?? "");
+      setXaaEmail(server.xaaEmail ?? "");
+
       // Set auth type based on multiple OAuth detection sources
-      if (resolvedAuthType === "oauth") {
+      if (resolvedAuthType === "xaa") {
+        setAuthType("xaa");
+        setShowAuthSettings(true);
+      } else if (resolvedAuthType === "oauth") {
         setAuthType("oauth");
         setShowAuthSettings(true);
       } else if (resolvedAuthType === "bearer") {
@@ -450,6 +475,9 @@ export function useServerForm(
           null,
           2
         ),
+        xaaAuthzIssuer: isHttpServer ? server.xaaAuthzIssuer ?? "" : "",
+        xaaSubject: server.xaaSubject ?? "",
+        xaaEmail: server.xaaEmail ?? "",
       };
     }
   }, [server]);
@@ -736,25 +764,33 @@ export function useServerForm(
       .filter((s) => s.length > 0);
     const shouldUsePreregisteredCredentials =
       authType === "oauth" && oauthRegistrationMode === "preregistered";
+    const isXaa = authType === "xaa";
+    // XAA also collects resource-authorization-server client id / secret, so it
+    // shares the preregistered-credential emission path.
+    const usesClientCredentials = shouldUsePreregisteredCredentials || isXaa;
     const normalizedClientSecret = clientSecret.trim();
     const hasReplacementClientSecret = normalizedClientSecret.length > 0;
     // A typed replacement always wins over the clear toggle — the backend
     // rejects payloads that try to do both at once.
     const submittedClearClientSecret =
-      shouldUsePreregisteredCredentials &&
+      usesClientCredentials &&
       clearClientSecret &&
       !hasReplacementClientSecret;
     const nextHasClientSecret =
-      shouldUsePreregisteredCredentials &&
+      usesClientCredentials &&
       !submittedClearClientSecret &&
       (hasStoredClientSecret || hasReplacementClientSecret);
 
-    // Handle authentication
+    // Handle authentication. useOAuth and useXaa are mutually exclusive by
+    // construction — this else-if chain sets at most one.
     let useOAuth = false;
+    let useXaa = false;
     if (authType === "bearer" && bearerToken.trim()) {
       headers["Authorization"] = `Bearer ${bearerToken.trim()}`;
     } else if (authType === "oauth") {
       useOAuth = true;
+    } else if (authType === "xaa") {
+      useXaa = true;
     }
     const explicitHeaders =
       Object.keys(headers).length > 0 ? headers : undefined;
@@ -771,21 +807,24 @@ export function useServerForm(
       ...(secretPatch ? { secretPatch } : {}),
       clientCapabilities,
       useOAuth,
+      useXaa,
+      authServerMode: useXaa ? "mcpjam" : undefined,
       oauthProtocolMode: useOAuth ? oauthProtocolMode : undefined,
       oauthRegistrationMode: useOAuth ? oauthRegistrationMode : undefined,
       oauthScopes: scopes.length > 0 ? scopes : undefined,
-      clientId: shouldUsePreregisteredCredentials
+      clientId: usesClientCredentials
         ? clientId.trim() || undefined
         : undefined,
-      clientSecret: shouldUsePreregisteredCredentials
+      clientSecret: usesClientCredentials
         ? normalizedClientSecret || undefined
         : undefined,
-      hasClientSecret: shouldUsePreregisteredCredentials
-        ? nextHasClientSecret
-        : undefined,
-      clearClientSecret: shouldUsePreregisteredCredentials
+      hasClientSecret: usesClientCredentials ? nextHasClientSecret : undefined,
+      clearClientSecret: usesClientCredentials
         ? submittedClearClientSecret
         : undefined,
+      xaaAuthzIssuer: useXaa ? xaaAuthzIssuer.trim() || undefined : undefined,
+      xaaSubject: useXaa ? xaaSubject.trim() || undefined : undefined,
+      xaaEmail: useXaa ? xaaEmail.trim() || undefined : undefined,
       requestTimeout: reqTimeout,
     };
   };
@@ -802,6 +841,9 @@ export function useServerForm(
     setClientSecret("");
     setHasStoredClientSecret(false);
     setClearClientSecret(false);
+    setXaaAuthzIssuer("");
+    setXaaSubject("");
+    setXaaEmail("");
     setBearerToken("");
     setHasStoredBearerToken(false);
     setAuthType("none");
@@ -852,6 +894,9 @@ export function useServerForm(
       clientCapabilitiesOverrideEnabled !==
         iv.clientCapabilitiesOverrideEnabled ||
       clientCapabilitiesOverrideText !== iv.clientCapabilitiesOverrideText ||
+      xaaAuthzIssuer !== iv.xaaAuthzIssuer ||
+      xaaSubject !== iv.xaaSubject ||
+      xaaEmail !== iv.xaaEmail ||
       JSON.stringify(envVars) !== JSON.stringify(iv.envVars) ||
       JSON.stringify(toComparableHeaders(customHeaders)) !==
         JSON.stringify(iv.customHeaders)
@@ -869,8 +914,8 @@ export function useServerForm(
 
   const preregisteredOauthBlocksSubmit =
     type === "http" &&
-    authType === "oauth" &&
-    oauthRegistrationMode === "preregistered" &&
+    ((authType === "oauth" && oauthRegistrationMode === "preregistered") ||
+      authType === "xaa") &&
     validateClientId(clientId) !== null;
   const oauthAuthorizationHeaderWarning =
     type === "http" &&
@@ -916,12 +961,19 @@ export function useServerForm(
       setBearerToken(value);
     },
     authType,
-    setAuthType: (value: "oauth" | "bearer" | "none") => {
+    setAuthType: (value: ServerFormAuthType) => {
       setAuthDirty(true);
       setAuthType(value);
     },
     useCustomClientId,
     setUseCustomClientId,
+    // XAA-specific fields (client id / secret / scopes are shared above)
+    xaaAuthzIssuer,
+    setXaaAuthzIssuer,
+    xaaSubject,
+    setXaaSubject,
+    xaaEmail,
+    setXaaEmail,
     requestTimeout,
     setRequestTimeout,
     inheritedRequestTimeout: projectConnectionDefaults.requestTimeout,

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -120,6 +120,11 @@ export function useServerForm(
   options?: {
     requireHttps?: boolean;
     projectClientConfig?: ProjectClientConfig;
+    /**
+     * Signed-in user's email, used as the default XAA simulated identity
+     * (subject + email) when the Advanced override fields are left blank.
+     */
+    signedInEmail?: string;
   }
 ) {
   const [name, setName] = useState("");
@@ -823,8 +828,16 @@ export function useServerForm(
         ? submittedClearClientSecret
         : undefined,
       xaaAuthzIssuer: useXaa ? xaaAuthzIssuer.trim() || undefined : undefined,
-      xaaSubject: useXaa ? xaaSubject.trim() || undefined : undefined,
-      xaaEmail: useXaa ? xaaEmail.trim() || undefined : undefined,
+      // Default the simulated identity to the signed-in user when blank, so the
+      // mint asserts a real subject instead of a placeholder test user. The
+      // resource server still decides what subject it accepts — this is just a
+      // sane, overridable default.
+      xaaSubject: useXaa
+        ? xaaSubject.trim() || options?.signedInEmail || undefined
+        : undefined,
+      xaaEmail: useXaa
+        ? xaaEmail.trim() || options?.signedInEmail || undefined
+        : undefined,
       requestTimeout: reqTimeout,
     };
   };

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -766,6 +766,10 @@ export function AuthenticationSection({
                           ? "Saved — enter a new value to replace"
                           : "Client secret (for confidential clients)"
                       }
+                      autoComplete="off"
+                      data-1p-ignore
+                      data-lpignore="true"
+                      data-form-type="other"
                       className="h-10 pr-10"
                     />
                     <button

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -69,6 +69,8 @@ interface AuthenticationSectionProps {
   onXaaSubjectChange?: (value: string) => void;
   xaaEmail?: string;
   onXaaEmailChange?: (value: string) => void;
+  /** Signed-in user's email — shown as the default for the simulated identity. */
+  signedInEmail?: string;
 }
 
 const PROTOCOL_OPTIONS: Array<{
@@ -127,6 +129,7 @@ export function AuthenticationSection({
   onXaaSubjectChange,
   xaaEmail = "",
   onXaaEmailChange,
+  signedInEmail,
 }: AuthenticationSectionProps) {
   const [showAdvancedOAuth, setShowAdvancedOAuth] = useState(false);
   const [showAdvancedXaa, setShowAdvancedXaa] = useState(false);
@@ -852,8 +855,9 @@ export function AuthenticationSection({
                 <div className="rounded-md border border-border bg-background/40 p-3 space-y-2">
                   <p className="text-xs text-muted-foreground">
                     Simulated identity — the test IdP mints a mock login for this
-                    user before the flow runs. Leave blank to use a test
-                    identity.
+                    user. Leave blank to use your signed-in identity; the
+                    resource server decides which subject it accepts, so override
+                    it if your server expects a specific value.
                   </p>
                   <div className="space-y-1">
                     <label className="block text-xs font-medium text-foreground">
@@ -862,7 +866,11 @@ export function AuthenticationSection({
                     <Input
                       value={xaaSubject}
                       onChange={(e) => onXaaSubjectChange?.(e.target.value)}
-                      placeholder="user-12345"
+                      placeholder={
+                        signedInEmail
+                          ? `Defaults to ${signedInEmail}`
+                          : "Defaults to your signed-in identity"
+                      }
                       spellCheck={false}
                       autoComplete="off"
                       className="h-9"
@@ -875,7 +883,11 @@ export function AuthenticationSection({
                     <Input
                       value={xaaEmail}
                       onChange={(e) => onXaaEmailChange?.(e.target.value)}
-                      placeholder="demo.user@example.com"
+                      placeholder={
+                        signedInEmail
+                          ? `Defaults to ${signedInEmail}`
+                          : "Defaults to your signed-in identity"
+                      }
                       spellCheck={false}
                       autoComplete="off"
                       className="h-9"

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -24,6 +24,7 @@ import type {
   ServerFormOAuthRegistrationMode,
 } from "@/shared/types.js";
 import { fetchOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-api";
+import { XaaCredentialFields } from "./XaaCredentialFields";
 
 interface AuthenticationSectionProps {
   serverUrl?: string;
@@ -132,8 +133,6 @@ export function AuthenticationSection({
   signedInEmail,
 }: AuthenticationSectionProps) {
   const [showAdvancedOAuth, setShowAdvancedOAuth] = useState(false);
-  const [showAdvancedXaa, setShowAdvancedXaa] = useState(false);
-  const [isXaaSecretVisible, setIsXaaSecretVisible] = useState(false);
   const [revealedClientSecret, setRevealedClientSecret] = useState<
     string | null
   >(null);
@@ -681,221 +680,28 @@ export function AuthenticationSection({
 
         {/* Cross-App Access (XAA) Settings */}
         {showAuthSettings && authType === "xaa" && (
-          <div className="px-3 pb-3 space-y-3 border-t border-border bg-muted/30">
-            {/* Identity provider — single option in v1; bring-your-own-IdP joins
-                here later without a relabel. */}
-            <div className="space-y-2 pt-3">
-              <label className="block text-sm font-medium text-foreground">
-                Identity provider
-              </label>
-              <Select value="mcpjam" disabled>
-                <SelectTrigger className="w-full h-10">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="mcpjam">
-                    MCPJam test identity provider
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                MCPJam signs a test identity for the cross-app access flow.
-              </p>
-            </div>
-
-            {/* Authorization server credentials (resource AS, leg 3) */}
-            <div className="space-y-3">
-              <div className="space-y-2">
-                <label className="block text-sm font-medium text-foreground">
-                  Client ID
-                  <span className="text-destructive" aria-hidden="true">
-                    {" *"}
-                  </span>
-                </label>
-                <Input
-                  value={clientId}
-                  onChange={(e) => onClientIdChange(e.target.value)}
-                  placeholder="Client ID registered with the server's authorization server"
-                  aria-required
-                  className={`h-10 ${clientIdError ? "border-red-500" : ""}`}
-                />
-                {clientIdError && (
-                  <p className="text-xs text-red-500">{clientIdError}</p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-3">
-                  <label className="block text-sm font-medium text-foreground">
-                    Client Secret (Optional)
-                  </label>
-                  <div className="flex items-center gap-1">
-                    {hasStoredClientSecret && !clearClientSecret && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 px-2 text-xs"
-                        onClick={onClearClientSecret}
-                      >
-                        Clear
-                      </Button>
-                    )}
-                    {hasStoredClientSecret && clearClientSecret && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-8 px-2 text-xs"
-                        onClick={onUndoClearClientSecret}
-                      >
-                        Undo
-                      </Button>
-                    )}
-                  </div>
-                </div>
-                {hasStoredClientSecret && clearClientSecret ? (
-                  <p className="text-xs text-muted-foreground">
-                    Saved client secret will be removed when you save.
-                  </p>
-                ) : (
-                  <div className="relative">
-                    <Input
-                      type={isXaaSecretVisible ? "text" : "password"}
-                      value={clientSecret}
-                      onChange={(e) => onClientSecretChange(e.target.value)}
-                      placeholder={
-                        hasStoredClientSecret
-                          ? "Saved — enter a new value to replace"
-                          : "Client secret (for confidential clients)"
-                      }
-                      autoComplete="off"
-                      data-1p-ignore
-                      data-lpignore="true"
-                      data-form-type="other"
-                      className="h-10 pr-10"
-                    />
-                    <button
-                      type="button"
-                      aria-label={
-                        isXaaSecretVisible
-                          ? "Hide client secret"
-                          : "Show client secret"
-                      }
-                      title={
-                        isXaaSecretVisible
-                          ? "Hide client secret"
-                          : "Show client secret"
-                      }
-                      onClick={() => setIsXaaSecretVisible((prev) => !prev)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
-                    >
-                      {isXaaSecretVisible ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </button>
-                  </div>
-                )}
-                {clientSecretError && (
-                  <p className="text-xs text-red-500">{clientSecretError}</p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <label className="block text-sm font-medium text-foreground">
-                  Scopes
-                </label>
-                <Input
-                  value={oauthScopesInput}
-                  onChange={(e) => onOauthScopesChange(e.target.value)}
-                  placeholder="Optional scopes separated by spaces"
-                  className="h-10"
-                />
-              </div>
-            </div>
-
-            {/* Advanced: issuer + simulated identity */}
-            <button
-              type="button"
-              onClick={() => setShowAdvancedXaa(!showAdvancedXaa)}
-              className="w-full flex items-center gap-2 py-2 hover:bg-muted/50 transition-colors cursor-pointer"
-            >
-              {showAdvancedXaa ? (
-                <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-              ) : (
-                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-              )}
-              <span className="text-xs font-medium text-muted-foreground">
-                Advanced
-              </span>
-            </button>
-
-            {showAdvancedXaa && (
-              <div className="space-y-3">
-                <div className="space-y-2">
-                  <label className="block text-sm font-medium text-foreground">
-                    Authorization Server Issuer
-                  </label>
-                  <Input
-                    value={xaaAuthzIssuer}
-                    onChange={(e) => onXaaAuthzIssuerChange?.(e.target.value)}
-                    placeholder="Auto-discovered if blank"
-                    spellCheck={false}
-                    autoComplete="off"
-                    className="h-10"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Leave blank to auto-discover it from the server&apos;s
-                    protected-resource metadata.
-                  </p>
-                </div>
-
-                <div className="rounded-md border border-border bg-background/40 p-3 space-y-2">
-                  <p className="text-xs text-muted-foreground">
-                    Simulated identity — the test IdP mints a mock login for this
-                    user. Leave blank to use your signed-in identity; the
-                    resource server decides which subject it accepts, so override
-                    it if your server expects a specific value.
-                  </p>
-                  <div className="space-y-1">
-                    <label className="block text-xs font-medium text-foreground">
-                      Subject (sub)
-                    </label>
-                    <Input
-                      value={xaaSubject}
-                      onChange={(e) => onXaaSubjectChange?.(e.target.value)}
-                      placeholder={
-                        signedInEmail
-                          ? `Defaults to ${signedInEmail}`
-                          : "Defaults to your signed-in identity"
-                      }
-                      spellCheck={false}
-                      autoComplete="off"
-                      className="h-9"
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <label className="block text-xs font-medium text-foreground">
-                      Email
-                    </label>
-                    <Input
-                      value={xaaEmail}
-                      onChange={(e) => onXaaEmailChange?.(e.target.value)}
-                      placeholder={
-                        signedInEmail
-                          ? `Defaults to ${signedInEmail}`
-                          : "Defaults to your signed-in identity"
-                      }
-                      spellCheck={false}
-                      autoComplete="off"
-                      className="h-9"
-                    />
-                  </div>
-                </div>
-              </div>
-            )}
+          <div className="px-3 pb-3 pt-3 border-t border-border bg-muted/30">
+            <XaaCredentialFields
+              clientId={clientId}
+              onClientIdChange={onClientIdChange}
+              clientIdError={clientIdError}
+              clientSecret={clientSecret}
+              onClientSecretChange={onClientSecretChange}
+              hasStoredClientSecret={hasStoredClientSecret}
+              clearClientSecret={clearClientSecret}
+              onClearClientSecret={onClearClientSecret}
+              onUndoClearClientSecret={onUndoClearClientSecret}
+              clientSecretError={clientSecretError}
+              scopes={oauthScopesInput}
+              onScopesChange={onOauthScopesChange}
+              xaaAuthzIssuer={xaaAuthzIssuer}
+              onXaaAuthzIssuerChange={(v) => onXaaAuthzIssuerChange?.(v)}
+              xaaSubject={xaaSubject}
+              onXaaSubjectChange={(v) => onXaaSubjectChange?.(v)}
+              xaaEmail={xaaEmail}
+              onXaaEmailChange={(v) => onXaaEmailChange?.(v)}
+              signedInEmail={signedInEmail}
+            />
           </div>
         )}
       </div>

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -701,6 +701,8 @@ export function AuthenticationSection({
               xaaEmail={xaaEmail}
               onXaaEmailChange={(v) => onXaaEmailChange?.(v)}
               signedInEmail={signedInEmail}
+              projectId={projectId}
+              hostedServerId={hostedServerId}
             />
           </div>
         )}

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -19,6 +19,7 @@ import {
 } from "@mcpjam/design-system/select";
 import { resolveAuthorizationPlan } from "@mcpjam/sdk/browser";
 import type {
+  ServerFormAuthType,
   ServerFormOAuthProtocolMode,
   ServerFormOAuthRegistrationMode,
 } from "@/shared/types.js";
@@ -26,8 +27,8 @@ import { fetchOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-ap
 
 interface AuthenticationSectionProps {
   serverUrl?: string;
-  authType: "oauth" | "bearer" | "none";
-  onAuthTypeChange: (value: "oauth" | "bearer" | "none") => void;
+  authType: ServerFormAuthType;
+  onAuthTypeChange: (value: ServerFormAuthType) => void;
   showAuthSettings: boolean;
   bearerToken: string;
   onBearerTokenChange: (value: string) => void;
@@ -60,6 +61,14 @@ interface AuthenticationSectionProps {
   /** Hosted-mode reveal context. Both must be provided to enable the Reveal button. */
   projectId?: string | null;
   hostedServerId?: string | null;
+  // Cross-App Access (XAA) fields. Client id / secret / scopes reuse the props
+  // above; these are XAA-specific.
+  xaaAuthzIssuer?: string;
+  onXaaAuthzIssuerChange?: (value: string) => void;
+  xaaSubject?: string;
+  onXaaSubjectChange?: (value: string) => void;
+  xaaEmail?: string;
+  onXaaEmailChange?: (value: string) => void;
 }
 
 const PROTOCOL_OPTIONS: Array<{
@@ -112,8 +121,16 @@ export function AuthenticationSection({
   clientSecretError,
   projectId = null,
   hostedServerId = null,
+  xaaAuthzIssuer = "",
+  onXaaAuthzIssuerChange,
+  xaaSubject = "",
+  onXaaSubjectChange,
+  xaaEmail = "",
+  onXaaEmailChange,
 }: AuthenticationSectionProps) {
   const [showAdvancedOAuth, setShowAdvancedOAuth] = useState(false);
+  const [showAdvancedXaa, setShowAdvancedXaa] = useState(false);
+  const [isXaaSecretVisible, setIsXaaSecretVisible] = useState(false);
   const [revealedClientSecret, setRevealedClientSecret] = useState<
     string | null
   >(null);
@@ -279,7 +296,7 @@ export function AuthenticationSection({
           </label>
           <Select
             value={authType}
-            onValueChange={(value: "oauth" | "bearer" | "none") => {
+            onValueChange={(value: ServerFormAuthType) => {
               if (value !== "oauth") {
                 setShowAdvancedOAuth(false);
               }
@@ -293,6 +310,7 @@ export function AuthenticationSection({
               <SelectItem value="none">No Authentication</SelectItem>
               <SelectItem value="bearer">Bearer Token</SelectItem>
               <SelectItem value="oauth">OAuth</SelectItem>
+              <SelectItem value="xaa">Cross-App Access (XAA)</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -653,6 +671,213 @@ export function AuthenticationSection({
                     </div>
                   </div>
                 )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Cross-App Access (XAA) Settings */}
+        {showAuthSettings && authType === "xaa" && (
+          <div className="px-3 pb-3 space-y-3 border-t border-border bg-muted/30">
+            {/* Identity provider — single option in v1; bring-your-own-IdP joins
+                here later without a relabel. */}
+            <div className="space-y-2 pt-3">
+              <label className="block text-sm font-medium text-foreground">
+                Identity provider
+              </label>
+              <Select value="mcpjam" disabled>
+                <SelectTrigger className="w-full h-10">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="mcpjam">
+                    MCPJam test identity provider
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                MCPJam signs a test identity for the cross-app access flow.
+              </p>
+            </div>
+
+            {/* Authorization server credentials (resource AS, leg 3) */}
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-foreground">
+                  Client ID
+                  <span className="text-destructive" aria-hidden="true">
+                    {" *"}
+                  </span>
+                </label>
+                <Input
+                  value={clientId}
+                  onChange={(e) => onClientIdChange(e.target.value)}
+                  placeholder="Client ID registered with the server's authorization server"
+                  aria-required
+                  className={`h-10 ${clientIdError ? "border-red-500" : ""}`}
+                />
+                {clientIdError && (
+                  <p className="text-xs text-red-500">{clientIdError}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <label className="block text-sm font-medium text-foreground">
+                    Client Secret (Optional)
+                  </label>
+                  <div className="flex items-center gap-1">
+                    {hasStoredClientSecret && !clearClientSecret && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 px-2 text-xs"
+                        onClick={onClearClientSecret}
+                      >
+                        Clear
+                      </Button>
+                    )}
+                    {hasStoredClientSecret && clearClientSecret && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 px-2 text-xs"
+                        onClick={onUndoClearClientSecret}
+                      >
+                        Undo
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                {hasStoredClientSecret && clearClientSecret ? (
+                  <p className="text-xs text-muted-foreground">
+                    Saved client secret will be removed when you save.
+                  </p>
+                ) : (
+                  <div className="relative">
+                    <Input
+                      type={isXaaSecretVisible ? "text" : "password"}
+                      value={clientSecret}
+                      onChange={(e) => onClientSecretChange(e.target.value)}
+                      placeholder={
+                        hasStoredClientSecret
+                          ? "Saved — enter a new value to replace"
+                          : "Client secret (for confidential clients)"
+                      }
+                      className="h-10 pr-10"
+                    />
+                    <button
+                      type="button"
+                      aria-label={
+                        isXaaSecretVisible
+                          ? "Hide client secret"
+                          : "Show client secret"
+                      }
+                      title={
+                        isXaaSecretVisible
+                          ? "Hide client secret"
+                          : "Show client secret"
+                      }
+                      onClick={() => setIsXaaSecretVisible((prev) => !prev)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
+                    >
+                      {isXaaSecretVisible ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                )}
+                {clientSecretError && (
+                  <p className="text-xs text-red-500">{clientSecretError}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-foreground">
+                  Scopes
+                </label>
+                <Input
+                  value={oauthScopesInput}
+                  onChange={(e) => onOauthScopesChange(e.target.value)}
+                  placeholder="Optional scopes separated by spaces"
+                  className="h-10"
+                />
+              </div>
+            </div>
+
+            {/* Advanced: issuer + simulated identity */}
+            <button
+              type="button"
+              onClick={() => setShowAdvancedXaa(!showAdvancedXaa)}
+              className="w-full flex items-center gap-2 py-2 hover:bg-muted/50 transition-colors cursor-pointer"
+            >
+              {showAdvancedXaa ? (
+                <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+              )}
+              <span className="text-xs font-medium text-muted-foreground">
+                Advanced
+              </span>
+            </button>
+
+            {showAdvancedXaa && (
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-foreground">
+                    Authorization Server Issuer
+                  </label>
+                  <Input
+                    value={xaaAuthzIssuer}
+                    onChange={(e) => onXaaAuthzIssuerChange?.(e.target.value)}
+                    placeholder="Auto-discovered if blank"
+                    spellCheck={false}
+                    autoComplete="off"
+                    className="h-10"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Leave blank to auto-discover it from the server&apos;s
+                    protected-resource metadata.
+                  </p>
+                </div>
+
+                <div className="rounded-md border border-border bg-background/40 p-3 space-y-2">
+                  <p className="text-xs text-muted-foreground">
+                    Simulated identity — the test IdP mints a mock login for this
+                    user before the flow runs. Leave blank to use a test
+                    identity.
+                  </p>
+                  <div className="space-y-1">
+                    <label className="block text-xs font-medium text-foreground">
+                      Subject (sub)
+                    </label>
+                    <Input
+                      value={xaaSubject}
+                      onChange={(e) => onXaaSubjectChange?.(e.target.value)}
+                      placeholder="user-12345"
+                      spellCheck={false}
+                      autoComplete="off"
+                      className="h-9"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs font-medium text-foreground">
+                      Email
+                    </label>
+                    <Input
+                      value={xaaEmail}
+                      onChange={(e) => onXaaEmailChange?.(e.target.value)}
+                      placeholder="demo.user@example.com"
+                      spellCheck={false}
+                      autoComplete="off"
+                      className="h-9"
+                    />
+                  </div>
+                </div>
               </div>
             )}
           </div>

--- a/mcpjam-inspector/client/src/components/connection/shared/XaaCredentialFields.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/XaaCredentialFields.tsx
@@ -1,0 +1,360 @@
+import { useId, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import {
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  Info,
+} from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+
+/**
+ * The Cross-App Access (XAA) credential fields, shared by the /servers Connect
+ * page (AuthenticationSection) and the XAA Debugger's "Configure Server to
+ * Test" modal so both surfaces have identical fields, ordering, and style.
+ *
+ * Presentational + fully controlled. The simulated-identity binding differs by
+ * surface (per-server on Connect, global run-settings in the Debugger), so the
+ * caller owns those values and the help copy.
+ */
+export interface XaaCredentialFieldsProps {
+  // Resource authorization-server credentials (jwt-bearer "leg 3").
+  clientId: string;
+  onClientIdChange: (value: string) => void;
+  clientIdError?: string | null;
+  clientSecret: string;
+  onClientSecretChange: (value: string) => void;
+  hasStoredClientSecret?: boolean;
+  clearClientSecret?: boolean;
+  onClearClientSecret?: () => void;
+  onUndoClearClientSecret?: () => void;
+  clientSecretError?: string | null;
+  scopes: string;
+  onScopesChange: (value: string) => void;
+
+  // Advanced
+  xaaAuthzIssuer: string;
+  onXaaAuthzIssuerChange: (value: string) => void;
+  xaaSubject: string;
+  onXaaSubjectChange: (value: string) => void;
+  xaaEmail: string;
+  onXaaEmailChange: (value: string) => void;
+  /** Shown as the simulated-identity default placeholder. */
+  signedInEmail?: string;
+  /** Per-surface copy under the "Simulated identity" heading. */
+  identityHelpText?: string;
+  /** Start the Advanced section expanded (Debugger wants identity visible). */
+  defaultAdvancedOpen?: boolean;
+}
+
+export function XaaCredentialFields({
+  clientId,
+  onClientIdChange,
+  clientIdError,
+  clientSecret,
+  onClientSecretChange,
+  hasStoredClientSecret = false,
+  clearClientSecret = false,
+  onClearClientSecret,
+  onUndoClearClientSecret,
+  clientSecretError,
+  scopes,
+  onScopesChange,
+  xaaAuthzIssuer,
+  onXaaAuthzIssuerChange,
+  xaaSubject,
+  onXaaSubjectChange,
+  xaaEmail,
+  onXaaEmailChange,
+  signedInEmail,
+  identityHelpText,
+  defaultAdvancedOpen = false,
+}: XaaCredentialFieldsProps) {
+  const [showAdvanced, setShowAdvanced] = useState(defaultAdvancedOpen);
+  const [isSecretVisible, setIsSecretVisible] = useState(false);
+  const baseId = useId();
+  const ids = {
+    clientId: `${baseId}-client-id`,
+    clientSecret: `${baseId}-client-secret`,
+    scopes: `${baseId}-scopes`,
+    issuer: `${baseId}-issuer`,
+    subject: `${baseId}-subject`,
+    email: `${baseId}-email`,
+  };
+
+  const identityPlaceholder = signedInEmail
+    ? `Defaults to ${signedInEmail}`
+    : "Defaults to your signed-in identity";
+
+  return (
+    <div className="space-y-3">
+      {/* Identity provider — single option in v1; bring-your-own-IdP joins
+          here later without a relabel. */}
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-foreground">
+          Identity provider
+        </label>
+        <Select value="mcpjam" disabled>
+          <SelectTrigger className="w-full h-10">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="mcpjam">
+              MCPJam test identity provider
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          MCPJam signs a test identity for the cross-app access flow.
+        </p>
+      </div>
+
+      {/* Authorization server credentials (resource AS, leg 3) */}
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <label
+            htmlFor={ids.clientId}
+            className="block text-sm font-medium text-foreground"
+          >
+            Client ID
+            <span className="text-destructive" aria-hidden="true">
+              {" *"}
+            </span>
+          </label>
+          <Input
+            id={ids.clientId}
+            value={clientId}
+            onChange={(e) => onClientIdChange(e.target.value)}
+            placeholder="Client ID registered with the server's authorization server"
+            aria-required
+            spellCheck={false}
+            autoComplete="off"
+            data-1p-ignore
+            data-lpignore="true"
+            data-form-type="other"
+            className={`h-10 ${clientIdError ? "border-red-500" : ""}`}
+          />
+          {clientIdError && (
+            <p className="text-xs text-red-500">{clientIdError}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <label
+              htmlFor={ids.clientSecret}
+              className="block text-sm font-medium text-foreground"
+            >
+              Client Secret (Optional)
+            </label>
+            <div className="flex items-center gap-1">
+              {hasStoredClientSecret && !clearClientSecret && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2 text-xs"
+                  onClick={onClearClientSecret}
+                >
+                  Clear
+                </Button>
+              )}
+              {hasStoredClientSecret && clearClientSecret && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2 text-xs"
+                  onClick={onUndoClearClientSecret}
+                >
+                  Undo
+                </Button>
+              )}
+            </div>
+          </div>
+          {hasStoredClientSecret && clearClientSecret ? (
+            <p className="text-xs text-muted-foreground">
+              Saved client secret will be removed when you save.
+            </p>
+          ) : (
+            <div className="relative">
+              <Input
+                id={ids.clientSecret}
+                type={isSecretVisible ? "text" : "password"}
+                value={clientSecret}
+                onChange={(e) => onClientSecretChange(e.target.value)}
+                placeholder={
+                  hasStoredClientSecret
+                    ? "Saved — enter a new value to replace"
+                    : "Client secret (for confidential clients)"
+                }
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                data-form-type="other"
+                className="h-10 pr-10"
+              />
+              <button
+                type="button"
+                aria-label={
+                  isSecretVisible ? "Hide client secret" : "Show client secret"
+                }
+                title={
+                  isSecretVisible ? "Hide client secret" : "Show client secret"
+                }
+                onClick={() => setIsSecretVisible((prev) => !prev)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
+              >
+                {isSecretVisible ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          )}
+          {clientSecretError && (
+            <p className="text-xs text-red-500">{clientSecretError}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label
+            htmlFor={ids.scopes}
+            className="block text-sm font-medium text-foreground"
+          >
+            Scopes
+          </label>
+          <Input
+            id={ids.scopes}
+            value={scopes}
+            onChange={(e) => onScopesChange(e.target.value)}
+            placeholder="Optional scopes separated by spaces"
+            spellCheck={false}
+            autoComplete="off"
+            className="h-10"
+          />
+        </div>
+      </div>
+
+      {/* Advanced: issuer + simulated identity */}
+      <button
+        type="button"
+        onClick={() => setShowAdvanced(!showAdvanced)}
+        className="w-full flex items-center gap-2 py-2 hover:bg-muted/50 transition-colors cursor-pointer"
+      >
+        {showAdvanced ? (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
+        <span className="text-xs font-medium text-muted-foreground">
+          Advanced
+        </span>
+      </button>
+
+      {showAdvanced && (
+        <div className="space-y-3">
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5">
+              <label
+                htmlFor={ids.issuer}
+                className="block text-sm font-medium text-foreground"
+              >
+                Authorization Server Issuer
+              </label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    aria-label="How the authorization server issuer is auto-discovered"
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent variant="muted" side="top" className="max-w-xs">
+                  Leave blank to auto-discover it: MCPJam reads the MCP
+                  server&apos;s protected-resource metadata (
+                  <code className="font-mono">
+                    /.well-known/oauth-protected-resource
+                  </code>
+                  ) to find which authorization server protects it.
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            <Input
+              id={ids.issuer}
+              value={xaaAuthzIssuer}
+              onChange={(e) => onXaaAuthzIssuerChange(e.target.value)}
+              placeholder="Auto-discovered if blank"
+              spellCheck={false}
+              autoComplete="off"
+              className="h-10"
+            />
+          </div>
+
+          <div className="rounded-md border border-border bg-background/40 p-3 space-y-2">
+            <p className="text-xs text-muted-foreground">
+              {identityHelpText ??
+                "Simulated identity — the test IdP mints a mock login for this user. Leave blank to use your signed-in identity; the resource server decides which subject it accepts, so override it if your server expects a specific value."}
+            </p>
+            <div className="space-y-1">
+              <label
+                htmlFor={ids.subject}
+                className="block text-xs font-medium text-foreground"
+              >
+                Subject (sub)
+              </label>
+              <Input
+                id={ids.subject}
+                value={xaaSubject}
+                onChange={(e) => onXaaSubjectChange(e.target.value)}
+                placeholder={identityPlaceholder}
+                spellCheck={false}
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                data-form-type="other"
+                className="h-9"
+              />
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor={ids.email}
+                className="block text-xs font-medium text-foreground"
+              >
+                Email
+              </label>
+              <Input
+                id={ids.email}
+                value={xaaEmail}
+                onChange={(e) => onXaaEmailChange(e.target.value)}
+                placeholder={identityPlaceholder}
+                spellCheck={false}
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                data-form-type="other"
+                className="h-9"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/connection/shared/XaaCredentialFields.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/XaaCredentialFields.tsx
@@ -1,13 +1,17 @@
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import {
+  Check,
   ChevronDown,
   ChevronRight,
+  Copy,
   Eye,
   EyeOff,
   Info,
+  Loader2,
 } from "lucide-react";
+import { fetchOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-api";
 import {
   Select,
   SelectContent,
@@ -58,6 +62,12 @@ export interface XaaCredentialFieldsProps {
   identityHelpText?: string;
   /** Start the Advanced section expanded (Debugger wants identity visible). */
   defaultAdvancedOpen?: boolean;
+  /**
+   * Hosted-mode reveal context. When both are present and a secret is stored,
+   * a "Reveal" button fetches the saved secret (same API + UX as OAuth).
+   */
+  projectId?: string | null;
+  hostedServerId?: string | null;
 }
 
 export function XaaCredentialFields({
@@ -82,9 +92,99 @@ export function XaaCredentialFields({
   signedInEmail,
   identityHelpText,
   defaultAdvancedOpen = false,
+  projectId = null,
+  hostedServerId = null,
 }: XaaCredentialFieldsProps) {
   const [showAdvanced, setShowAdvanced] = useState(defaultAdvancedOpen);
   const [isSecretVisible, setIsSecretVisible] = useState(false);
+  // Hosted-mode reveal — mirrors the OAuth client-secret reveal exactly, using
+  // the same endpoint (the secret lives in the same vault column).
+  const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
+  const [revealedContextKey, setRevealedContextKey] = useState<string | null>(
+    null,
+  );
+  const [isRevealedVisible, setIsRevealedVisible] = useState(false);
+  const [isRevealing, setIsRevealing] = useState(false);
+  const [revealError, setRevealError] = useState<string | null>(null);
+  const [didCopy, setDidCopy] = useState(false);
+  const [isReplacing, setIsReplacing] = useState(false);
+
+  const canReveal =
+    hasStoredClientSecret &&
+    !clearClientSecret &&
+    !!projectId &&
+    !!hostedServerId;
+  const revealContextKey = canReveal ? `${projectId}:${hostedServerId}` : null;
+  const visibleRevealedSecret =
+    revealedContextKey === revealContextKey ? revealedSecret : null;
+
+  // Drop any revealed value when the saved-secret context changes (replacement
+  // typed, Clear toggled, or a different server selected).
+  useEffect(() => {
+    if (revealedContextKey !== revealContextKey) {
+      setRevealedSecret(null);
+      setRevealedContextKey(null);
+      setIsRevealedVisible(false);
+      setRevealError(null);
+      setDidCopy(false);
+      setIsReplacing(false);
+    }
+  }, [revealContextKey, revealedContextKey]);
+
+  const handleReveal = async () => {
+    if (!projectId || !hostedServerId || !revealContextKey || isRevealing)
+      return;
+    setIsRevealing(true);
+    setRevealError(null);
+    setIsReplacing(false);
+    try {
+      const result = await fetchOAuthClientSecret({
+        projectId,
+        serverId: hostedServerId,
+      });
+      setRevealedSecret(result.clientSecret);
+      setRevealedContextKey(revealContextKey);
+      setIsRevealedVisible(true);
+    } catch (error) {
+      setRevealedSecret(null);
+      setRevealedContextKey(null);
+      setIsRevealedVisible(false);
+      setRevealError(
+        error instanceof Error
+          ? error.message
+          : "Failed to reveal client secret",
+      );
+    } finally {
+      setIsRevealing(false);
+    }
+  };
+
+  const handleHideRevealed = () => {
+    setRevealedSecret(null);
+    setRevealedContextKey(null);
+    setIsRevealedVisible(false);
+    setRevealError(null);
+    setDidCopy(false);
+    if (isReplacing) onClientSecretChange("");
+    setIsReplacing(false);
+  };
+
+  const handleCopyRevealed = async (value: string) => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setDidCopy(true);
+      setTimeout(() => setDidCopy(false), 2000);
+    } catch {
+      // Clipboard failures are non-fatal.
+    }
+  };
+
+  // While showing the saved secret (not yet edited) render the revealed value;
+  // once the user edits, track their replacement.
+  const secretFieldValue = isReplacing
+    ? clientSecret
+    : (visibleRevealedSecret ?? "");
   const baseId = useId();
   const ids = {
     clientId: `${baseId}-client-id`,
@@ -161,6 +261,33 @@ export function XaaCredentialFields({
               Client Secret (Optional)
             </label>
             <div className="flex items-center gap-1">
+              {canReveal && !visibleRevealedSecret && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2 text-xs"
+                  onClick={() => void handleReveal()}
+                  disabled={isRevealing}
+                >
+                  {isRevealing ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    "Reveal"
+                  )}
+                </Button>
+              )}
+              {visibleRevealedSecret && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2 text-xs"
+                  onClick={handleHideRevealed}
+                >
+                  Hide
+                </Button>
+              )}
               {hasStoredClientSecret && !clearClientSecret && (
                 <Button
                   type="button"
@@ -188,6 +315,71 @@ export function XaaCredentialFields({
           {hasStoredClientSecret && clearClientSecret ? (
             <p className="text-xs text-muted-foreground">
               Saved client secret will be removed when you save.
+            </p>
+          ) : visibleRevealedSecret !== null ? (
+            <>
+              <div className="relative">
+                <Input
+                  id={ids.clientSecret}
+                  type={isRevealedVisible ? "text" : "password"}
+                  value={secretFieldValue}
+                  onChange={(e) => {
+                    if (!isReplacing) setIsReplacing(true);
+                    onClientSecretChange(e.target.value);
+                  }}
+                  placeholder="Enter a new value to replace."
+                  autoComplete="off"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-form-type="other"
+                  className={`h-10 pr-16 font-mono ${clientSecretError ? "border-red-500" : ""}`}
+                />
+                <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+                  <button
+                    type="button"
+                    aria-label={
+                      isRevealedVisible
+                        ? "Hide client secret"
+                        : "Show client secret"
+                    }
+                    title={
+                      isRevealedVisible
+                        ? "Hide client secret"
+                        : "Show client secret"
+                    }
+                    onClick={() => setIsRevealedVisible((prev) => !prev)}
+                    className="p-1 text-muted-foreground/60 transition-colors hover:text-foreground cursor-pointer"
+                  >
+                    {isRevealedVisible ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Copy client secret"
+                    title="Copy client secret"
+                    onClick={() => void handleCopyRevealed(secretFieldValue)}
+                    className="p-1 text-muted-foreground/50 transition-colors hover:text-foreground cursor-pointer"
+                  >
+                    {didCopy ? (
+                      <Check className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+              </div>
+              {!isReplacing && (
+                <p className="text-xs text-muted-foreground">
+                  Editing this replaces the saved secret when you save.
+                </p>
+              )}
+            </>
+          ) : canReveal ? (
+            <p className="text-xs text-muted-foreground">
+              A client secret is saved. Reveal it to view or replace it.
             </p>
           ) : (
             <div className="relative">
@@ -228,6 +420,9 @@ export function XaaCredentialFields({
           )}
           {clientSecretError && (
             <p className="text-xs text-red-500">{clientSecretError}</p>
+          )}
+          {revealError && (
+            <p className="text-xs text-red-500">{revealError}</p>
           )}
         </div>
 

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
 import posthog from "posthog-js";
 import { Loader2, ShieldAlert } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -140,6 +141,7 @@ export function XAAFlowTab({
 
   // ── Global run settings + resolved target ──────────────────────────
   const runSettings = useXaaRunSettings();
+  const { user: signedInUser } = useAuth();
   const target = useXaaTestTarget({
     server: selectedServer,
     selectedServerName,
@@ -685,9 +687,7 @@ export function XAAFlowTab({
         onOpenChange={setIsServerModalOpen}
         server={selectedServer}
         existingServerNames={Object.keys(serverConfigs)}
-        simulatedUserId={runSettings.userId}
-        simulatedEmail={runSettings.email}
-        onIdentityChange={runSettings.setIdentity}
+        signedInEmail={signedInUser?.email}
         onSave={async ({ formData }) => {
           // Await so the modal can keep itself open (and preserve the entered
           // values) if the save rejects. Selection only follows a save that

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { Info } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@mcpjam/design-system/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -19,6 +13,7 @@ import { validateServerFormData } from "@/lib/server-form-validation";
 import type { ServerFormData } from "@/shared/types.js";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import { deriveOAuthProfileFromServer } from "../oauth/utils";
+import { XaaCredentialFields } from "../connection/shared/XaaCredentialFields";
 
 interface XAAServerModalProps {
   open: boolean;
@@ -36,11 +31,6 @@ interface XAAServerModalProps {
   simulatedEmail: string;
   onIdentityChange: (patch: { userId?: string; email?: string }) => void;
 }
-
-// "keep" the saved secret untouched, "replace" it with a new value, or
-// "clear" it (turn the target back into a public client). Only meaningful
-// when editing a server that already has a stored secret.
-type SecretAction = "keep" | "replace" | "clear";
 
 export function XAAServerModal({
   open,
@@ -64,8 +54,10 @@ export function XAAServerModal({
   const [clientId, setClientId] = useState("");
   const [scopes, setScopes] = useState("");
   const [authzIssuer, setAuthzIssuer] = useState("");
-  const [secretInput, setSecretInput] = useState("");
-  const [secretAction, setSecretAction] = useState<SecretAction>("keep");
+  // Client-secret state mirrors the Connect-page model (shared component):
+  // a typed value replaces the saved secret, the Clear toggle removes it.
+  const [clientSecret, setClientSecret] = useState("");
+  const [clearClientSecret, setClearClientSecret] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -78,11 +70,11 @@ export function XAAServerModal({
     // the space-separated form this modal edits.
     setScopes((derived.scopes ?? "").replace(/,/g, " ").trim());
     setAuthzIssuer(server?.xaaAuthzIssuer ?? "");
-    setSecretInput("");
-    setSecretAction(hasSavedSecret ? "keep" : "replace");
+    setClientSecret("");
+    setClearClientSecret(false);
     setError(null);
     setSaving(false);
-  }, [open, server, derived, hasSavedSecret]);
+  }, [open, server, derived]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -135,21 +127,10 @@ export function XAAServerModal({
       .map((scope) => scope.trim())
       .filter((scope) => scope.length > 0);
 
-    // Resolve the secret operation. A new server (or one without a saved
-    // secret) takes whatever was typed; an edit only changes the secret when
-    // the user explicitly replaces or clears it.
-    const trimmedSecret = secretInput.trim();
-    let clientSecret: string | undefined;
-    let clearClientSecret: boolean | undefined;
-    if (hasSavedSecret) {
-      if (secretAction === "replace" && trimmedSecret) {
-        clientSecret = trimmedSecret;
-      } else if (secretAction === "clear") {
-        clearClientSecret = true;
-      }
-    } else if (trimmedSecret) {
-      clientSecret = trimmedSecret;
-    }
+    // A typed value replaces the saved secret; the Clear toggle removes it. A
+    // typed replacement always wins over Clear (the save path rejects both).
+    const trimmedSecret = clientSecret.trim();
+    const submittedClearSecret = clearClientSecret && !trimmedSecret;
 
     setError(null);
 
@@ -157,14 +138,21 @@ export function XAAServerModal({
       name: trimmedName,
       type: "http",
       url: trimmedUrl,
-      useOAuth: true,
+      // Cross-App Access discriminator — identical to the /servers Connect
+      // page so a server configured in either surface is unambiguously XAA and
+      // editing it in one place never flips it back to plain OAuth.
+      useXaa: true,
+      useOAuth: false,
+      authServerMode: "mcpjam",
       clientId: trimmedClientId,
-      ...(clientSecret ? { clientSecret } : {}),
-      ...(clearClientSecret ? { clearClientSecret: true } : {}),
+      ...(trimmedSecret ? { clientSecret: trimmedSecret } : {}),
+      ...(submittedClearSecret ? { clearClientSecret: true } : {}),
       hasClientSecret: server?.hasClientSecret,
       oauthScopes: scopesArray,
       // Always send the issuer (possibly empty) so clearing it persists.
       xaaAuthzIssuer: trimmedIssuer,
+      // Simulated identity is NOT persisted per-server here — it's a global run
+      // setting owned by XAAFlowTab (see props) and applied to every target.
     };
 
     // Final gate: the exact validator the save path runs. Any rule added there
@@ -231,183 +219,33 @@ export function XAAServerModal({
               />
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="xaa-client-id">
-                Client ID <span className="text-red-500">*</span>
-              </Label>
-              <Input
-                id="xaa-client-id"
-                value={clientId}
-                onChange={(event) => setClientId(event.target.value)}
-                placeholder="mcpjam-debugger"
-                spellCheck={false}
-                autoComplete="off"
-                data-1p-ignore
-                data-lpignore="true"
-                data-form-type="other"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="xaa-client-secret">Client Secret</Label>
-              {hasSavedSecret && secretAction === "keep" ? (
-                <div className="flex items-center gap-2">
-                  <span className="flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-                    •••••••• saved
-                  </span>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setSecretAction("replace")}
-                  >
-                    Replace
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setSecretAction("clear")}
-                  >
-                    Clear
-                  </Button>
-                </div>
-              ) : hasSavedSecret && secretAction === "clear" ? (
-                <div className="flex items-center gap-2">
-                  <span className="flex-1 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-                    Secret will be cleared on save.
-                  </span>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setSecretAction("keep")}
-                  >
-                    Keep
-                  </Button>
-                </div>
-              ) : (
-                <Input
-                  id="xaa-client-secret"
-                  type="password"
-                  autoComplete="off"
-                  data-1p-ignore
-                  data-lpignore="true"
-                  data-form-type="other"
-                  value={secretInput}
-                  onChange={(event) => setSecretInput(event.target.value)}
-                  placeholder={
-                    hasSavedSecret
-                      ? "Enter a new client secret"
-                      : "Required by confidential-client auth servers"
-                  }
-                />
-              )}
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="xaa-scopes">Scopes</Label>
-              <Input
-                id="xaa-scopes"
-                value={scopes}
-                onChange={(event) => setScopes(event.target.value)}
-                placeholder="read:tools read:resources"
-                spellCheck={false}
-                autoComplete="off"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <div className="flex items-center gap-1.5">
-                <Label htmlFor="xaa-authz-issuer">
-                  Authorization Server Issuer
-                </Label>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="inline-flex items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      aria-label="How the authorization server issuer is auto-discovered"
-                    >
-                      <Info className="h-3.5 w-3.5" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent variant="muted" side="top" className="max-w-xs">
-                    Leave blank to auto-discover it: MCPJam reads the MCP
-                    server&apos;s protected-resource metadata (
-                    <code className="font-mono">
-                      /.well-known/oauth-protected-resource
-                    </code>
-                    ) to find which authorization server protects it.
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-              <Input
-                id="xaa-authz-issuer"
-                value={authzIssuer}
-                onChange={(event) => setAuthzIssuer(event.target.value)}
-                placeholder="Auto-discovered if blank"
-                spellCheck={false}
-                autoComplete="off"
-              />
-            </div>
-
-            <p className="text-xs text-muted-foreground">
-              Client ID, secret, and scopes are this server's OAuth credentials
-              (shared with the OAuth Debugger).
-            </p>
-
-            <div className="space-y-3 rounded-md border border-border bg-muted/20 p-3">
-              <div className="space-y-0.5">
-                <Label htmlFor="xaa-identity-sub">Simulated identity</Label>
-                <p className="text-xs text-muted-foreground">
-                  The IdP mints a mock login for this user before the flow runs.
-                  Applies to every server you test — not just this one.
-                </p>
-              </div>
-              <div className="space-y-1.5">
-                <Label
-                  htmlFor="xaa-identity-sub"
-                  className="text-xs text-muted-foreground"
-                >
-                  Subject (sub)
-                </Label>
-                <Input
-                  id="xaa-identity-sub"
-                  value={simulatedUserId}
-                  onChange={(event) =>
-                    onIdentityChange({ userId: event.target.value })
-                  }
-                  placeholder="user-12345"
-                  spellCheck={false}
-                  autoComplete="off"
-                  data-1p-ignore
-                  data-lpignore="true"
-                  data-form-type="other"
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label
-                  htmlFor="xaa-identity-email"
-                  className="text-xs text-muted-foreground"
-                >
-                  Email
-                </Label>
-                <Input
-                  id="xaa-identity-email"
-                  value={simulatedEmail}
-                  onChange={(event) =>
-                    onIdentityChange({ email: event.target.value })
-                  }
-                  placeholder="demo.user@example.com"
-                  spellCheck={false}
-                  autoComplete="off"
-                  data-1p-ignore
-                  data-lpignore="true"
-                  data-form-type="other"
-                />
-              </div>
-            </div>
+            {/* Shared with the /servers Connect page so both surfaces present
+                identical fields, ordering, and style. */}
+            <XaaCredentialFields
+              clientId={clientId}
+              onClientIdChange={setClientId}
+              clientSecret={clientSecret}
+              onClientSecretChange={(value) => {
+                setClientSecret(value);
+                if (value.trim()) setClearClientSecret(false);
+              }}
+              hasStoredClientSecret={hasSavedSecret}
+              clearClientSecret={clearClientSecret}
+              onClearClientSecret={() => setClearClientSecret(true)}
+              onUndoClearClientSecret={() => setClearClientSecret(false)}
+              scopes={scopes}
+              onScopesChange={setScopes}
+              xaaAuthzIssuer={authzIssuer}
+              onXaaAuthzIssuerChange={setAuthzIssuer}
+              xaaSubject={simulatedUserId}
+              onXaaSubjectChange={(value) =>
+                onIdentityChange({ userId: value })
+              }
+              xaaEmail={simulatedEmail}
+              onXaaEmailChange={(value) => onIdentityChange({ email: value })}
+              identityHelpText="The IdP mints a mock login for this user before the flow runs. Applies to every server you test — not just this one."
+              defaultAdvancedOpen
+            />
           </div>
 
           {error && (

--- a/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAServerModal.tsx
@@ -23,13 +23,12 @@ interface XAAServerModalProps {
   // May be async. The modal stays open (preserving the entered values) if this
   // rejects, so a downstream save failure never discards the form.
   onSave: (payload: { formData: ServerFormData }) => void | Promise<void>;
-  // Global simulated identity (sub/email). Owned by XAAFlowTab's run settings
-  // and edited here because it applies to every target, not just this server —
-  // editing it updates the live run immediately (it is not part of the form
-  // save). Single source of truth, so the running flow always sees the change.
-  simulatedUserId: string;
-  simulatedEmail: string;
-  onIdentityChange: (patch: { userId?: string; email?: string }) => void;
+  /**
+   * Signed-in user's email — the default simulated identity when the per-server
+   * subject/email fields are left blank. Same default as the /servers Connect
+   * page so the two surfaces stay in sync.
+   */
+  signedInEmail?: string;
 }
 
 export function XAAServerModal({
@@ -38,9 +37,7 @@ export function XAAServerModal({
   server,
   existingServerNames,
   onSave,
-  simulatedUserId,
-  simulatedEmail,
-  onIdentityChange,
+  signedInEmail,
 }: XAAServerModalProps) {
   const derived = useMemo(
     () => deriveOAuthProfileFromServer(server),
@@ -58,6 +55,11 @@ export function XAAServerModal({
   // a typed value replaces the saved secret, the Clear toggle removes it.
   const [clientSecret, setClientSecret] = useState("");
   const [clearClientSecret, setClearClientSecret] = useState(false);
+  // Per-server simulated identity — the single source of truth shared with the
+  // /servers Connect page (saved on the server, used by both the debugger run
+  // and the connect mint). Editing it here syncs to /servers and vice versa.
+  const [xaaSubject, setXaaSubject] = useState("");
+  const [xaaEmail, setXaaEmail] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -72,6 +74,8 @@ export function XAAServerModal({
     setAuthzIssuer(server?.xaaAuthzIssuer ?? "");
     setClientSecret("");
     setClearClientSecret(false);
+    setXaaSubject(server?.xaaSubject ?? "");
+    setXaaEmail(server?.xaaEmail ?? "");
     setError(null);
     setSaving(false);
   }, [open, server, derived]);
@@ -151,8 +155,10 @@ export function XAAServerModal({
       oauthScopes: scopesArray,
       // Always send the issuer (possibly empty) so clearing it persists.
       xaaAuthzIssuer: trimmedIssuer,
-      // Simulated identity is NOT persisted per-server here — it's a global run
-      // setting owned by XAAFlowTab (see props) and applied to every target.
+      // Per-server simulated identity, defaulting to the signed-in user when
+      // blank — identical to the Connect page so the two surfaces stay synced.
+      xaaSubject: xaaSubject.trim() || signedInEmail || undefined,
+      xaaEmail: xaaEmail.trim() || signedInEmail || undefined,
     };
 
     // Final gate: the exact validator the save path runs. Any rule added there
@@ -237,13 +243,11 @@ export function XAAServerModal({
               onScopesChange={setScopes}
               xaaAuthzIssuer={authzIssuer}
               onXaaAuthzIssuerChange={setAuthzIssuer}
-              xaaSubject={simulatedUserId}
-              onXaaSubjectChange={(value) =>
-                onIdentityChange({ userId: value })
-              }
-              xaaEmail={simulatedEmail}
-              onXaaEmailChange={(value) => onIdentityChange({ email: value })}
-              identityHelpText="The IdP mints a mock login for this user before the flow runs. Applies to every server you test — not just this one."
+              xaaSubject={xaaSubject}
+              onXaaSubjectChange={setXaaSubject}
+              xaaEmail={xaaEmail}
+              onXaaEmailChange={setXaaEmail}
+              signedInEmail={signedInEmail}
               defaultAdvancedOpen
             />
           </div>

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAServerModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAServerModal.test.tsx
@@ -13,20 +13,16 @@ function renderModal(
 ) {
   const onSave = vi.fn();
   const onOpenChange = vi.fn();
-  const onIdentityChange = vi.fn();
   render(
     <XAAServerModal
       open
       onOpenChange={onOpenChange}
       existingServerNames={[]}
       onSave={onSave}
-      simulatedUserId="user-12345"
-      simulatedEmail="demo.user@example.com"
-      onIdentityChange={onIdentityChange}
       {...props}
     />,
   );
-  return { onSave, onOpenChange, onIdentityChange };
+  return { onSave, onOpenChange };
 }
 
 describe("XAAServerModal", () => {
@@ -154,38 +150,41 @@ describe("XAAServerModal", () => {
     expect(formData.clientSecret).toBeUndefined();
   });
 
-  it("shows the global simulated identity prefilled from props", () => {
-    renderModal();
+  it("prefills the per-server simulated identity from the server config", () => {
+    const server = {
+      name: "prod-mcp",
+      config: { url: "https://prod.mcp.example.com/mcp" },
+      useXaa: true,
+      xaaSubject: "alice",
+      xaaEmail: "alice@example.com",
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+    } as unknown as ServerWithName;
 
-    expect(screen.getByLabelText("Subject (sub)")).toHaveValue("user-12345");
-    expect(screen.getByLabelText("Email")).toHaveValue(
-      "demo.user@example.com",
-    );
+    renderModal({ server });
+
+    expect(screen.getByLabelText("Subject (sub)")).toHaveValue("alice");
+    expect(screen.getByLabelText("Email")).toHaveValue("alice@example.com");
   });
 
-  it("reports identity edits through onIdentityChange, not the form save", async () => {
+  it("persists the per-server simulated identity in the saved form data", async () => {
     const user = userEvent.setup();
-    const { onIdentityChange, onSave } = renderModal();
+    const { onSave } = renderModal();
 
-    // Editing identity reports the change immediately (it's a global setting,
-    // not part of the server form).
-    await user.type(screen.getByLabelText("Subject (sub)"), "x");
-    expect(onIdentityChange).toHaveBeenLastCalledWith({ userId: "user-12345x" });
-
-    // Saving the server config carries no identity fields.
     await user.type(screen.getByLabelText(/Server Name/), "staging-mcp");
     await user.type(
       screen.getByLabelText(/Server URL/),
       "https://staging.mcp.example.com",
     );
     await user.type(screen.getByLabelText(/Client ID/), "staging-client");
+    await user.type(screen.getByLabelText("Subject (sub)"), "bob");
     await user.click(
       screen.getByRole("button", { name: "Save configuration" }),
     );
 
     const { formData } = onSave.mock.calls[0][0];
-    expect(formData).not.toHaveProperty("userId");
-    expect(formData).not.toHaveProperty("email");
+    expect(formData.xaaSubject).toBe("bob");
   });
 
   it("rejects a duplicate name when creating a new server", async () => {
@@ -216,9 +215,6 @@ describe("XAAServerModal", () => {
         onOpenChange={onOpenChange}
         existingServerNames={[]}
         onSave={onSave}
-        simulatedUserId="user-12345"
-        simulatedEmail="demo.user@example.com"
-        onIdentityChange={vi.fn()}
       />,
     );
 

--- a/mcpjam-inspector/client/src/components/xaa/__tests__/XAAServerModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/__tests__/XAAServerModal.test.tsx
@@ -30,7 +30,7 @@ function renderModal(
 }
 
 describe("XAAServerModal", () => {
-  it("emits ServerFormData with xaaAuthzIssuer and the OAuth credentials on save", async () => {
+  it("emits ServerFormData with the XAA discriminator + resource-AS credentials on save", async () => {
     const user = userEvent.setup();
     const { onSave, onOpenChange } = renderModal();
 
@@ -40,7 +40,7 @@ describe("XAAServerModal", () => {
       "https://staging.mcp.example.com",
     );
     await user.type(screen.getByLabelText(/Client ID/), "staging-client");
-    await user.type(screen.getByLabelText("Client Secret"), "super-secret");
+    await user.type(screen.getByLabelText(/Client Secret/), "super-secret");
     await user.type(screen.getByLabelText("Scopes"), "read:tools read:resources");
     await user.type(
       screen.getByLabelText("Authorization Server Issuer"),
@@ -55,7 +55,10 @@ describe("XAAServerModal", () => {
       name: "staging-mcp",
       type: "http",
       url: "https://staging.mcp.example.com",
-      useOAuth: true,
+      // Same discriminator the /servers Connect page writes — not plain OAuth.
+      useXaa: true,
+      useOAuth: false,
+      authServerMode: "mcpjam",
       clientId: "staging-client",
       clientSecret: "super-secret",
       oauthScopes: ["read:tools", "read:resources"],
@@ -84,7 +87,7 @@ describe("XAAServerModal", () => {
     expect(formData.oauthScopes).toEqual([]);
   });
 
-  it("prefills fields and masks the saved secret when editing", () => {
+  it("prefills fields and shows a Clear control for a saved secret when editing", () => {
     const server = {
       name: "prod-mcp",
       config: { url: "https://prod.mcp.example.com/mcp" },
@@ -114,10 +117,11 @@ describe("XAAServerModal", () => {
     expect(screen.getByLabelText("Authorization Server Issuer")).toHaveValue(
       "https://auth.prod.example.com",
     );
-    // A saved secret is masked behind Replace / Clear controls, not a field.
-    expect(screen.getByText(/saved/i)).toBeInTheDocument();
+    // A saved secret shows the replace-style input plus a Clear control
+    // (shared with the /servers Connect page), not masked placeholder text.
+    expect(screen.getByLabelText(/Client Secret/)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Replace" }),
+      screen.getByRole("button", { name: "Clear" }),
     ).toBeInTheDocument();
   });
 
@@ -224,7 +228,7 @@ describe("XAAServerModal", () => {
       "https://staging.mcp.example.com",
     );
     await user.type(screen.getByLabelText(/Client ID/), "staging-client");
-    await user.type(screen.getByLabelText("Client Secret"), "super-secret");
+    await user.type(screen.getByLabelText(/Client Secret/), "super-secret");
     await user.type(
       screen.getByLabelText("Scopes"),
       "read:tools read:resources",
@@ -247,7 +251,7 @@ describe("XAAServerModal", () => {
       "https://staging.mcp.example.com",
     );
     expect(screen.getByLabelText(/Client ID/)).toHaveValue("staging-client");
-    expect(screen.getByLabelText("Client Secret")).toHaveValue("super-secret");
+    expect(screen.getByLabelText(/Client Secret/)).toHaveValue("super-secret");
     expect(screen.getByLabelText("Scopes")).toHaveValue(
       "read:tools read:resources",
     );

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -468,7 +468,13 @@ function buildOAuthProfileFromFormData(
   formData: ServerFormData,
   existingProfile?: OAuthTestProfile
 ): OAuthTestProfile | undefined {
-  if (formData.type !== "http" || !formData.useOAuth || !formData.url) {
+  // XAA reuses this profile as the carrier for its resource-AS client id /
+  // scopes / resource url, so it is built for XAA too (not just OAuth).
+  if (
+    formData.type !== "http" ||
+    !(formData.useOAuth || formData.useXaa) ||
+    !formData.url
+  ) {
     return undefined;
   }
 
@@ -1338,6 +1344,18 @@ export function useServerState({
           storedOAuthConfig.resourceUrl,
         ...(serverEntry.xaaAuthzIssuer !== undefined
           ? { xaaAuthzIssuer: serverEntry.xaaAuthzIssuer }
+          : {}),
+        ...(serverEntry.useXaa !== undefined
+          ? { useXaa: serverEntry.useXaa }
+          : {}),
+        ...(serverEntry.authServerMode !== undefined
+          ? { authServerMode: serverEntry.authServerMode }
+          : {}),
+        ...(serverEntry.xaaSubject !== undefined
+          ? { xaaSubject: serverEntry.xaaSubject }
+          : {}),
+        ...(serverEntry.xaaEmail !== undefined
+          ? { xaaEmail: serverEntry.xaaEmail }
           : {}),
       } as const;
 
@@ -2362,7 +2380,7 @@ export function useServerState({
         existingServerForSave?.oauthFlowProfile
       );
       const nextHasClientSecret =
-        formData.useOAuth && !formData.clearClientSecret
+        (formData.useOAuth || formData.useXaa) && !formData.clearClientSecret
           ? Boolean(
               formData.clientSecret ||
                 formData.hasClientSecret ||
@@ -2406,6 +2424,16 @@ export function useServerState({
             : getServerBearerTokenState(existingServerForSave),
         xaaAuthzIssuer:
           formData.xaaAuthzIssuer ?? existingServerForSave?.xaaAuthzIssuer,
+        useXaa: formData.useXaa ?? false,
+        authServerMode: formData.useXaa
+          ? formData.authServerMode ?? "mcpjam"
+          : existingServerForSave?.authServerMode,
+        xaaSubject: formData.useXaa
+          ? formData.xaaSubject
+          : existingServerForSave?.xaaSubject,
+        xaaEmail: formData.useXaa
+          ? formData.xaaEmail
+          : existingServerForSave?.xaaEmail,
       };
       // Both modes: await Convex sync so the returned serverId is available
       // for OAuth binding (hosted) and for the new {projectId, serverId}
@@ -2738,16 +2766,17 @@ export function useServerState({
 
       const existingServer = appState.servers[serverName];
       const mcpConfig = toMCPConfig(formData);
-      const nextOAuthProfile = formData.useOAuth
-        ? options?.oauthProfile ??
-          buildOAuthProfileFromFormData(
-            formData,
+      const nextOAuthProfile =
+        formData.useOAuth || formData.useXaa
+          ? options?.oauthProfile ??
+            buildOAuthProfileFromFormData(
+              formData,
+              existingServer?.oauthFlowProfile
+            ) ??
             existingServer?.oauthFlowProfile
-          ) ??
-          existingServer?.oauthFlowProfile
-        : undefined;
+          : undefined;
       const nextHasClientSecret =
-        formData.useOAuth && !formData.clearClientSecret
+        (formData.useOAuth || formData.useXaa) && !formData.clearClientSecret
           ? Boolean(
               formData.clientSecret ||
                 formData.hasClientSecret ||
@@ -2780,6 +2809,16 @@ export function useServerState({
             : getServerBearerTokenState(existingServer),
         xaaAuthzIssuer:
           formData.xaaAuthzIssuer ?? existingServer?.xaaAuthzIssuer,
+        useXaa: formData.useXaa ?? false,
+        authServerMode: formData.useXaa
+          ? formData.authServerMode ?? "mcpjam"
+          : existingServer?.authServerMode,
+        xaaSubject: formData.useXaa
+          ? formData.xaaSubject
+          : existingServer?.xaaSubject,
+        xaaEmail: formData.useXaa
+          ? formData.xaaEmail
+          : existingServer?.xaaEmail,
       } as ServerWithName;
 
       const hasPendingOAuthCallback = new URLSearchParams(
@@ -4197,14 +4236,30 @@ export function useServerState({
           retryCount: originalServer?.retryCount ?? 0,
           enabled: originalServer?.enabled ?? false,
           oauthTokens: originalServer?.oauthTokens,
-          oauthFlowProfile: originalServer?.oauthFlowProfile,
+          oauthFlowProfile:
+            formData.useOAuth || formData.useXaa
+              ? buildOAuthProfileFromFormData(
+                  formData,
+                  originalServer?.oauthFlowProfile
+                ) ?? originalServer?.oauthFlowProfile
+              : undefined,
           initializationInfo: originalServer?.initializationInfo,
           useOAuth: formData.useOAuth ?? false,
           xaaAuthzIssuer:
             formData.xaaAuthzIssuer ?? originalServer?.xaaAuthzIssuer,
+          useXaa: formData.useXaa ?? false,
+          authServerMode: formData.useXaa
+            ? formData.authServerMode ?? "mcpjam"
+            : originalServer?.authServerMode,
+          xaaSubject: formData.useXaa
+            ? formData.xaaSubject
+            : originalServer?.xaaSubject,
+          xaaEmail: formData.useXaa
+            ? formData.xaaEmail
+            : originalServer?.xaaEmail,
         } as ServerWithName;
 
-        if (!formData.useOAuth) {
+        if (!formData.useOAuth && !formData.useXaa) {
           clearOAuthData(nextServerName);
         }
         dispatch({

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2706,7 +2706,11 @@ export function useServerState({
             serverName: formData.name,
             error: result.error,
           });
-          toast.error(`Failed to connect to ${formData.name}`);
+          toast.error(
+            `Failed to connect to ${formData.name}${
+              result.error ? `: ${result.error}` : ""
+            }`
+          );
         }
       } catch (error) {
         const errorMessage =

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2709,7 +2709,24 @@ export function useServerState({
           toast.error(
             `Failed to connect to ${formData.name}${
               result.error ? `: ${result.error}` : ""
-            }`
+            }`,
+            // For XAA servers, offer a shortcut to the XAA Debugger so the dev
+            // can step through the handshake and pinpoint the failing claim
+            // (subject not provisioned, audience/issuer mismatch, etc.).
+            formData.useXaa
+              ? {
+                  action: {
+                    label: "Open XAA Debugger",
+                    onClick: () => {
+                      dispatch({
+                        type: "SELECT_SERVER",
+                        name: formData.name,
+                      });
+                      navigateApp(routePaths.xaaFlow);
+                    },
+                  },
+                }
+              : undefined
           );
         }
       } catch (error) {

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -50,6 +50,11 @@ export interface RemoteServer {
   hasBearerToken?: boolean;
   oauthResourceUrl?: string;
   xaaAuthzIssuer?: string;
+  // Cross-App Access (XAA)
+  useXaa?: boolean;
+  authServerMode?: "mcpjam" | "own";
+  xaaSubject?: string;
+  xaaEmail?: string;
   createdAt: number;
   updatedAt: number;
 }

--- a/mcpjam-inspector/client/src/hooks/useXaaTestTarget.ts
+++ b/mcpjam-inspector/client/src/hooks/useXaaTestTarget.ts
@@ -209,8 +209,11 @@ export function useXaaTestTarget({
         // the browser; public clients simply have none.
         clientSecret: "",
         scope,
-        userId,
-        email,
+        // Per-server simulated identity is the source of truth (synced with the
+        // /servers Connect page); fall back to the global run-settings default
+        // when the server has no stored subject/email.
+        userId: server?.xaaSubject?.trim() ? server.xaaSubject : userId,
+        email: server?.xaaEmail?.trim() ? server.xaaEmail : email,
         negativeTestMode,
       },
       targetKey: `bar_server:${selectedServerName}`,

--- a/mcpjam-inspector/client/src/hooks/useXaaTestTarget.ts
+++ b/mcpjam-inspector/client/src/hooks/useXaaTestTarget.ts
@@ -115,7 +115,11 @@ export function useXaaTestTarget({
       : null;
   const serverUrl = httpConfig?.url ? String(httpConfig.url) : "";
   const isHttp = Boolean(httpConfig);
+  // A server is XAA-testable if it uses OAuth (legacy XAA targets carry
+  // useOAuth) OR it was configured with the Cross-App Access auth type on the
+  // Connect page (useXaa, useOAuth left false).
   const useOAuth = server?.useOAuth === true;
+  const useXaa = server?.useXaa === true;
   const clientId =
     server?.oauthFlowProfile?.clientId ??
     (typeof (httpConfig as any)?.clientId === "string"
@@ -173,7 +177,7 @@ export function useXaaTestTarget({
       };
     }
 
-    const isTestable = isHttp && Boolean(serverUrl) && useOAuth;
+    const isTestable = isHttp && Boolean(serverUrl) && (useOAuth || useXaa);
     if (!isTestable) {
       return {
         targetSource: "bar_server",

--- a/mcpjam-inspector/client/src/lib/project-serialization.ts
+++ b/mcpjam-inspector/client/src/lib/project-serialization.ts
@@ -55,6 +55,18 @@ function serializeServersInternal(
     if (server.xaaAuthzIssuer !== undefined) {
       serializedServer.xaaAuthzIssuer = server.xaaAuthzIssuer;
     }
+    if (server.useXaa !== undefined) {
+      serializedServer.useXaa = server.useXaa;
+    }
+    if (server.authServerMode !== undefined) {
+      serializedServer.authServerMode = server.authServerMode;
+    }
+    if (server.xaaSubject !== undefined) {
+      serializedServer.xaaSubject = server.xaaSubject;
+    }
+    if (server.xaaEmail !== undefined) {
+      serializedServer.xaaEmail = server.xaaEmail;
+    }
 
     if (server.config) {
       const config: Record<string, unknown> = {};
@@ -99,7 +111,7 @@ function serializeServersInternal(
       serializedServer.config = config;
     }
 
-    if (server.useOAuth && server.oauthFlowProfile) {
+    if ((server.useOAuth || server.useXaa) && server.oauthFlowProfile) {
       // OAuthTestProfile.scopes is a UI-shaped string ("read,write" or
       // "read write"); the Convex `servers.oauthScopes` field is
       // v.array(v.string()). Split here so syncProjectServers can pass the
@@ -228,6 +240,18 @@ export function deserializeServersFromConvex(
       serverData.xaaAuthzIssuer ?? serverData.config?.xaaAuthzIssuer;
     if (xaaAuthzIssuer !== undefined) {
       server.xaaAuthzIssuer = xaaAuthzIssuer;
+    }
+    if (serverData.useXaa !== undefined) {
+      server.useXaa = serverData.useXaa === true;
+    }
+    if (serverData.authServerMode !== undefined) {
+      server.authServerMode = serverData.authServerMode;
+    }
+    if (serverData.xaaSubject !== undefined) {
+      server.xaaSubject = serverData.xaaSubject;
+    }
+    if (serverData.xaaEmail !== undefined) {
+      server.xaaEmail = serverData.xaaEmail;
     }
 
     // Handle oauthFlowProfile from legacy nested structure

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -57,6 +57,15 @@ const buildProjectServerProjection = (
     ? { initializationInfo: server.initializationInfo }
     : {}),
   ...(server.useOAuth === undefined ? {} : { useOAuth: server.useOAuth }),
+  ...(server.useXaa === undefined ? {} : { useXaa: server.useXaa }),
+  ...(server.authServerMode === undefined
+    ? {}
+    : { authServerMode: server.authServerMode }),
+  ...(server.xaaAuthzIssuer === undefined
+    ? {}
+    : { xaaAuthzIssuer: server.xaaAuthzIssuer }),
+  ...(server.xaaSubject === undefined ? {} : { xaaSubject: server.xaaSubject }),
+  ...(server.xaaEmail === undefined ? {} : { xaaEmail: server.xaaEmail }),
   ...(server.hasClientSecret === undefined
     ? {}
     : { hasClientSecret: server.hasClientSecret }),

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -71,6 +71,17 @@ export interface ServerWithName {
    * XAA metadata only — intentionally NOT part of MCPServerConfig / toMCPConfig.
    */
   xaaAuthzIssuer?: string;
+  /**
+   * Cross-App Access (XAA) connect flag. When true the server authenticates via
+   * the XAA token-exchange flow (server mints the token) rather than standard
+   * OAuth. Mutually exclusive with `useOAuth`.
+   */
+  useXaa?: boolean;
+  /** Which IdP mints the XAA assertion. v1 only "mcpjam". */
+  authServerMode?: "mcpjam" | "own";
+  /** Optional simulated-identity overrides for the MCPJam test IdP. Blank = signed-in user. */
+  xaaSubject?: string;
+  xaaEmail?: string;
 }
 
 export interface Project {

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import type { Context, MiddlewareHandler } from "hono";
+import type { MiddlewareHandler } from "hono";
 import { z } from "zod";
 import {
   DEFAULT_NEGATIVE_TEST_MODE,
@@ -12,7 +12,6 @@ import {
 } from "../../../shared/xaa.js";
 import {
   getXAAIdpJwks,
-  getXAAIssuerUrl,
   initXAAIdpKeyPair,
 } from "../../services/xaa-idp-keypair.js";
 import {
@@ -21,6 +20,11 @@ import {
   issueNegativeIdJag,
 } from "../../services/xaa-idjag-signer.js";
 import {
+  buildJwtBearerBody,
+  getIssuerForRequest,
+  resolveServerTarget,
+} from "../../services/xaa-mint.js";
+import {
   executeOAuthProxy,
   fetchOAuthMetadata,
   OAuthProxyError,
@@ -28,11 +32,9 @@ import {
 } from "../../utils/oauth-proxy.js";
 import {
   buildDiscoveryCandidates,
-  buildResourceMetadataCandidates,
   evaluateDiscovery,
-  extractAuthorizationServer,
 } from "../../services/xaa-discovery.js";
-import { ErrorCode, WebRouteError } from "../web/errors.js";
+import { WebRouteError } from "../web/errors.js";
 import {
   fetchServerClientSecret,
   fetchXaaResourceAppSecret,
@@ -318,186 +320,6 @@ function parseRequest<T>(schema: z.ZodSchema<T>, data: unknown): T {
   return parsed.data;
 }
 
-// Resolved authorization-server target for a server-target run. Every field
-// is pinned server-side from the stored server config; nothing is taken from
-// the request body.
-interface ResolvedServerTarget {
-  tokenEndpoint: string;
-  clientId?: string;
-  clientSecret?: string;
-}
-
-// RFC 9728: ask the resource (the MCP server URL) which authorization server
-// protects it, by reading authorization_servers[0] from its protected-resource
-// metadata. The resource URL is NOT itself an AS issuer, so this is the only
-// spec-defined way to learn the issuer when one isn't configured. Returns
-// undefined (rather than throwing) when no PRM/issuer is found, so the caller
-// can fall back to probing the resource URL directly.
-async function discoverIssuerFromResourceMetadata(
-  resource: string,
-  httpsOnly: boolean
-): Promise<string | undefined> {
-  let candidates: string[];
-  try {
-    candidates = buildResourceMetadataCandidates(resource);
-  } catch {
-    return undefined;
-  }
-
-  for (const candidate of candidates) {
-    const result = await fetchOAuthMetadata(candidate, httpsOnly);
-    if ("metadata" in result) {
-      const issuer = extractAuthorizationServer(result.metadata);
-      if (issuer) {
-        return issuer;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-// Discover the token endpoint for a server target, reusing the same well-known
-// sweep as /discover-as. The issuer is resolved server-side (the client never
-// supplies it), in priority order:
-//   1. the stored xaaAuthzIssuer, if configured;
-//   2. otherwise the authorization server named in the resource's RFC 9728
-//      protected-resource metadata;
-//   3. otherwise the resource URL itself (legacy behavior — covers servers that
-//      self-host RFC 8414 metadata at the resource origin and serve no PRM).
-async function discoverServerTargetTokenEndpoint(
-  args: {
-    resource?: string;
-    explicitIssuer?: string;
-  },
-  httpsOnly: boolean
-): Promise<string> {
-  let issuer = args.explicitIssuer;
-  if (!issuer && args.resource) {
-    issuer = await discoverIssuerFromResourceMetadata(args.resource, httpsOnly);
-  }
-  // Legacy fallback: treat the resource URL as the issuer when neither a stored
-  // issuer nor a PRM-advertised one is available.
-  issuer = issuer || args.resource;
-
-  if (!issuer) {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "The server has no URL or issuer to discover an authorization server from"
-    );
-  }
-
-  let candidates: string[];
-  try {
-    candidates = buildDiscoveryCandidates(issuer);
-  } catch {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "The server's authorization issuer is not a valid URL"
-    );
-  }
-
-  for (const candidate of candidates) {
-    const result = await fetchOAuthMetadata(candidate, httpsOnly);
-    if ("metadata" in result) {
-      const verdict = evaluateDiscovery(result.metadata, {
-        requestedIssuer: issuer,
-        metadataUrl: candidate,
-      });
-      if (verdict.tokenEndpoint) {
-        return verdict.tokenEndpoint;
-      }
-    }
-  }
-
-  throw new WebRouteError(
-    404,
-    ErrorCode.NOT_FOUND,
-    "Couldn't discover an authorization server. Set the issuer in Configure Server to Test."
-  );
-}
-
-// Resolve a server target's secret AND token endpoint entirely server-side.
-// The browser sends only serverId + projectId; the stored config dictates the
-// secret, client id, and the endpoint the secret may be posted to — so a
-// caller can never redirect the confidential secret elsewhere.
-async function resolveServerTarget(
-  options: CreateXaaRouterOptions,
-  args: {
-    serverId: string;
-    projectId?: string;
-    bearerToken: string;
-  }
-): Promise<ResolvedServerTarget> {
-  if (!options.resolveServerSecret) {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "Server-target runs are not available on this instance"
-    );
-  }
-  if (!args.projectId) {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "projectId is required for server-target runs"
-    );
-  }
-
-  const resolved = await options.resolveServerSecret({
-    serverId: args.serverId,
-    projectId: args.projectId,
-    bearerToken: args.bearerToken,
-  });
-
-  if (!resolved.xaaAuthzIssuer && !resolved.serverUrl) {
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "The server has no URL or issuer to discover an authorization server from"
-    );
-  }
-
-  const tokenEndpoint = await discoverServerTargetTokenEndpoint(
-    {
-      resource: resolved.serverUrl ?? undefined,
-      explicitIssuer: resolved.xaaAuthzIssuer ?? undefined,
-    },
-    options.httpsOnlyProxy
-  );
-
-  return {
-    tokenEndpoint,
-    clientId: resolved.clientId ?? undefined,
-    clientSecret: resolved.clientSecret ?? undefined,
-  };
-}
-
-function getIssuerForRequest(
-  c: Context,
-  issuerBasePath: string,
-  trustForwardedHeaders: boolean
-): string {
-  const parsed = new URL(c.req.url);
-
-  if (trustForwardedHeaders) {
-    // Only the scheme is reconstructed from a forwarded header: the edge
-    // terminates TLS so c.req.url is http:// internally. The host already
-    // comes from the validated Host header in c.req.url, so we do NOT trust
-    // X-Forwarded-Host — honoring it would let a client inject an arbitrary
-    // issuer/jwks_uri (and a forged `iss` on the signed ID-JAG). Restrict to
-    // a known scheme so a forwarded value can't switch to another protocol.
-    const proto = c.req.header("x-forwarded-proto")?.split(",")[0]?.trim();
-    if (proto === "https" || proto === "http") {
-      parsed.protocol = proto;
-    }
-  }
-
-  return getXAAIssuerUrl(`${parsed.origin}${issuerBasePath}`);
-}
-
 function decodeJwtPayloadUnsafe(token: string): ParsedJwtPayload {
   const parts = token.split(".");
   if (parts.length !== 3) {
@@ -707,7 +529,9 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         // stored server config. Everything is pinned by ASSIGNMENT — the
         // client-supplied tokenEndpoint/clientId/clientSecret/headers are
         // discarded so the confidential secret can't be redirected.
-        const resolved = await resolveServerTarget(options, {
+        const resolved = await resolveServerTarget({
+          resolveServerSecret: options.resolveServerSecret,
+          httpsOnly: options.httpsOnlyProxy,
           serverId: parsed.serverId,
           projectId: parsed.projectId,
           bearerToken: authHeader.slice("Bearer ".length),
@@ -758,14 +582,13 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
       const result = await executeOAuthProxy({
         url,
         method: "POST",
-        body: {
-          grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        body: buildJwtBearerBody({
           assertion: parsed.assertion,
-          ...(clientId ? { client_id: clientId } : {}),
-          ...(clientSecret ? { client_secret: clientSecret } : {}),
-          ...(parsed.scope ? { scope: parsed.scope } : {}),
-          ...(parsed.resource ? { resource: parsed.resource } : {}),
-        },
+          clientId,
+          clientSecret,
+          scope: parsed.scope,
+          resource: parsed.resource,
+        }),
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
           ...(extraHeaders || {}),
@@ -967,7 +790,9 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         // resolved/discovered from the stored server config and pinned by
         // assignment; client-supplied endpoint/clientId/secret/headers are
         // discarded.
-        const resolved = await resolveServerTarget(options, {
+        const resolved = await resolveServerTarget({
+          resolveServerSecret: options.resolveServerSecret,
+          httpsOnly: options.httpsOnlyProxy,
           serverId: parsed.serverId,
           projectId: parsed.projectId,
           bearerToken: authHeader.slice("Bearer ".length),

--- a/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Drift guard for the XAA jwt-bearer request body. Both the debugger's
+ * `/proxy/token` endpoint and the connect-page mint build their token request
+ * via `buildJwtBearerBody`, so this asserts the wire shape stays stable and
+ * stays identical regardless of which surface calls it.
+ */
+import { describe, it, expect } from "vitest";
+import { buildJwtBearerBody } from "../xaa-mint.js";
+
+describe("buildJwtBearerBody", () => {
+  it("emits the RFC 7523 jwt-bearer grant with only the populated fields", () => {
+    expect(
+      buildJwtBearerBody({
+        assertion: "the-id-jag",
+        clientId: "client-1",
+        clientSecret: "secret-1",
+        scope: "read:tools",
+        resource: "https://mcp.example.com",
+      })
+    ).toEqual({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: "the-id-jag",
+      client_id: "client-1",
+      client_secret: "secret-1",
+      scope: "read:tools",
+      resource: "https://mcp.example.com",
+    });
+  });
+
+  it("omits empty/nullish optional fields (public client, no scope/resource)", () => {
+    expect(
+      buildJwtBearerBody({
+        assertion: "the-id-jag",
+        clientId: null,
+        clientSecret: undefined,
+        scope: "",
+        resource: null,
+      })
+    ).toEqual({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: "the-id-jag",
+    });
+  });
+
+  it("produces an identical body for the same inputs (connect vs debugger parity)", () => {
+    const args = {
+      assertion: "jag",
+      clientId: "c",
+      clientSecret: "s",
+      scope: "a b",
+      resource: "https://r.example.com",
+    };
+    expect(buildJwtBearerBody(args)).toEqual(buildJwtBearerBody(args));
+  });
+});

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -27,6 +27,12 @@ export interface ResolvedServerTarget {
    * must sign with it.
    */
   authzIssuer: string;
+  /**
+   * The protected resource (the stored server URL). Pinned server-side so the
+   * mint always exchanges for the target's own resource — never a
+   * caller-supplied one — when using the stored confidential client secret.
+   */
+  resource?: string;
   clientId?: string;
   clientSecret?: string;
 }
@@ -116,6 +122,22 @@ export async function discoverServerTargetTokenEndpoint(
         requestedIssuer: issuer,
         metadataUrl: candidate,
       });
+      // Fail closed on an issuer mismatch: the metadata's advertised issuer
+      // differs from the one we asked for, so its token endpoint can't be
+      // trusted with the stored confidential client secret.
+      if (verdict.issuerMismatch) {
+        throw new WebRouteError(
+          502,
+          ErrorCode.SERVER_UNREACHABLE,
+          "Authorization server metadata issuer does not match the requested issuer"
+        );
+      }
+      // The AS explicitly declares it doesn't support the jwt-bearer grant —
+      // skip its token endpoint and try the next candidate. (Missing
+      // grant_types is "warn", not "fail", so imperfect metadata isn't skipped.)
+      if (verdict.jwtBearerSupport === "fail") {
+        continue;
+      }
       if (verdict.tokenEndpoint) {
         // Prefer the AS's self-declared canonical issuer from metadata; fall
         // back to the requested issuer. This becomes the ID-JAG `aud`.
@@ -185,6 +207,7 @@ export async function resolveServerTarget(deps: {
   return {
     tokenEndpoint: discovered.tokenEndpoint,
     authzIssuer: discovered.issuer,
+    resource: resolved.serverUrl ?? undefined,
     clientId: resolved.clientId ?? undefined,
     clientSecret: resolved.clientSecret ?? undefined,
   };
@@ -265,6 +288,11 @@ export async function mintXaaAccessToken(args: {
     bearerToken: args.bearerToken,
   });
 
+  // Pin the grant resource to the resolved server target (its stored URL), so
+  // the stored confidential secret is only ever exchanged for the target's own
+  // resource. `args.resource` is only a fallback when the target has no URL.
+  const tokenResource = target.resource ?? args.resource ?? "";
+
   const idJag = issueIdJag({
     issuer: args.issuer,
     subject: args.subject,
@@ -272,7 +300,7 @@ export async function mintXaaAccessToken(args: {
     // The ID-JAG `aud` is the resource authorization server's issuer (what it
     // validates against), NOT its token endpoint.
     audience: target.authzIssuer,
-    resource: args.resource ?? "",
+    resource: tokenResource,
     clientId: target.clientId ?? "",
     scope: args.scope,
   });
@@ -285,7 +313,7 @@ export async function mintXaaAccessToken(args: {
       clientId: target.clientId,
       clientSecret: target.clientSecret,
       scope: args.scope,
-      resource: args.resource,
+      resource: tokenResource || undefined,
     }),
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -1,0 +1,308 @@
+// Cross-App Access (XAA) token-mint orchestration, extracted from the XAA
+// router so BOTH the debugger's `/proxy/token` endpoint AND the connect-page
+// server-side mint depend on one implementation. Keeping the jwt-bearer body
+// assembly here (see `buildJwtBearerBody`) is what prevents the two surfaces
+// from drifting on the wire.
+import type { Context } from "hono";
+import { issueIdJag } from "./xaa-idjag-signer.js";
+import { getXAAIssuerUrl } from "./xaa-idp-keypair.js";
+import {
+  buildDiscoveryCandidates,
+  buildResourceMetadataCandidates,
+  evaluateDiscovery,
+  extractAuthorizationServer,
+} from "./xaa-discovery.js";
+import { executeOAuthProxy, fetchOAuthMetadata } from "../utils/oauth-proxy.js";
+import { ErrorCode, WebRouteError } from "../routes/web/errors.js";
+import type { ServerClientSecretResult } from "../utils/server-secrets.js";
+
+// Resolved authorization-server target for a server-target run. Every field is
+// pinned server-side from the stored server config; nothing is taken from the
+// request body.
+export interface ResolvedServerTarget {
+  tokenEndpoint: string;
+  clientId?: string;
+  clientSecret?: string;
+}
+
+type ResolveServerSecretFn = (args: {
+  serverId: string;
+  projectId: string;
+  bearerToken: string;
+}) => Promise<ServerClientSecretResult>;
+
+// RFC 9728: ask the resource (the MCP server URL) which authorization server
+// protects it, by reading authorization_servers[0] from its protected-resource
+// metadata. The resource URL is NOT itself an AS issuer, so this is the only
+// spec-defined way to learn the issuer when one isn't configured. Returns
+// undefined (rather than throwing) when no PRM/issuer is found, so the caller
+// can fall back to probing the resource URL directly.
+async function discoverIssuerFromResourceMetadata(
+  resource: string,
+  httpsOnly: boolean
+): Promise<string | undefined> {
+  let candidates: string[];
+  try {
+    candidates = buildResourceMetadataCandidates(resource);
+  } catch {
+    return undefined;
+  }
+
+  for (const candidate of candidates) {
+    const result = await fetchOAuthMetadata(candidate, httpsOnly);
+    if ("metadata" in result) {
+      const issuer = extractAuthorizationServer(result.metadata);
+      if (issuer) {
+        return issuer;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+// Discover the token endpoint for a server target, reusing the same well-known
+// sweep as /discover-as. The issuer is resolved server-side (the client never
+// supplies it), in priority order:
+//   1. the stored xaaAuthzIssuer, if configured;
+//   2. otherwise the authorization server named in the resource's RFC 9728
+//      protected-resource metadata;
+//   3. otherwise the resource URL itself (legacy behavior — covers servers that
+//      self-host RFC 8414 metadata at the resource origin and serve no PRM).
+export async function discoverServerTargetTokenEndpoint(
+  args: {
+    resource?: string;
+    explicitIssuer?: string;
+  },
+  httpsOnly: boolean
+): Promise<string> {
+  let issuer = args.explicitIssuer;
+  if (!issuer && args.resource) {
+    issuer = await discoverIssuerFromResourceMetadata(args.resource, httpsOnly);
+  }
+  // Legacy fallback: treat the resource URL as the issuer when neither a stored
+  // issuer nor a PRM-advertised one is available.
+  issuer = issuer || args.resource;
+
+  if (!issuer) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "The server has no URL or issuer to discover an authorization server from"
+    );
+  }
+
+  let candidates: string[];
+  try {
+    candidates = buildDiscoveryCandidates(issuer);
+  } catch {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "The server's authorization issuer is not a valid URL"
+    );
+  }
+
+  for (const candidate of candidates) {
+    const result = await fetchOAuthMetadata(candidate, httpsOnly);
+    if ("metadata" in result) {
+      const verdict = evaluateDiscovery(result.metadata, {
+        requestedIssuer: issuer,
+        metadataUrl: candidate,
+      });
+      if (verdict.tokenEndpoint) {
+        return verdict.tokenEndpoint;
+      }
+    }
+  }
+
+  throw new WebRouteError(
+    404,
+    ErrorCode.NOT_FOUND,
+    "Couldn't discover an authorization server. Set the issuer in Configure Server to Test."
+  );
+}
+
+// Resolve a server target's secret AND token endpoint entirely server-side.
+// The browser sends only serverId + projectId; the stored config dictates the
+// secret, client id, and the endpoint the secret may be posted to — so a
+// caller can never redirect the confidential secret elsewhere.
+export async function resolveServerTarget(deps: {
+  resolveServerSecret?: ResolveServerSecretFn;
+  httpsOnly: boolean;
+  serverId: string;
+  projectId?: string;
+  bearerToken: string;
+}): Promise<ResolvedServerTarget> {
+  if (!deps.resolveServerSecret) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Server-target runs are not available on this instance"
+    );
+  }
+  if (!deps.projectId) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "projectId is required for server-target runs"
+    );
+  }
+
+  const resolved = await deps.resolveServerSecret({
+    serverId: deps.serverId,
+    projectId: deps.projectId,
+    bearerToken: deps.bearerToken,
+  });
+
+  if (!resolved.xaaAuthzIssuer && !resolved.serverUrl) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "The server has no URL or issuer to discover an authorization server from"
+    );
+  }
+
+  const tokenEndpoint = await discoverServerTargetTokenEndpoint(
+    {
+      resource: resolved.serverUrl ?? undefined,
+      explicitIssuer: resolved.xaaAuthzIssuer ?? undefined,
+    },
+    deps.httpsOnly
+  );
+
+  return {
+    tokenEndpoint,
+    clientId: resolved.clientId ?? undefined,
+    clientSecret: resolved.clientSecret ?? undefined,
+  };
+}
+
+// The jwt-bearer (RFC 7523) token-request body posted to the resource
+// authorization server. SINGLE SOURCE OF TRUTH — both `/proxy/token` (debugger)
+// and `mintXaaAccessToken` (connect) build their request body here so the two
+// surfaces stay byte-identical on the wire.
+export function buildJwtBearerBody(args: {
+  assertion: string;
+  clientId?: string | null;
+  clientSecret?: string | null;
+  scope?: string | null;
+  resource?: string | null;
+}): Record<string, string> {
+  return {
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: args.assertion,
+    ...(args.clientId ? { client_id: args.clientId } : {}),
+    ...(args.clientSecret ? { client_secret: args.clientSecret } : {}),
+    ...(args.scope ? { scope: args.scope } : {}),
+    ...(args.resource ? { resource: args.resource } : {}),
+  };
+}
+
+// Derive the MCPJam test-IdP issuer from the inbound request. Shared by the XAA
+// router endpoints and the connect-page mint so the signed ID-JAG `iss` matches
+// the published JWKS regardless of which surface mints it.
+export function getIssuerForRequest(
+  c: Context,
+  issuerBasePath: string,
+  trustForwardedHeaders: boolean
+): string {
+  const parsed = new URL(c.req.url);
+
+  if (trustForwardedHeaders) {
+    // Only the scheme is reconstructed from a forwarded header: the edge
+    // terminates TLS so c.req.url is http:// internally. The host already
+    // comes from the validated Host header in c.req.url, so we do NOT trust
+    // X-Forwarded-Host — honoring it would let a client inject an arbitrary
+    // issuer/jwks_uri (and a forged `iss` on the signed ID-JAG). Restrict to
+    // a known scheme so a forwarded value can't switch to another protocol.
+    const proto = c.req.header("x-forwarded-proto")?.split(",")[0]?.trim();
+    if (proto === "https" || proto === "http") {
+      parsed.protocol = proto;
+    }
+  }
+
+  return getXAAIssuerUrl(`${parsed.origin}${issuerBasePath}`);
+}
+
+// Full server-side XAA mint for the connect path: resolve the target's
+// confidential credentials + token endpoint, sign an ID-JAG asserting the
+// supplied (already-authenticated) identity, then exchange it for a resource
+// access token via the jwt-bearer grant. With MCPJam as the IdP we mint the
+// ID-JAG directly rather than first issuing a mock ID token — the resource AS
+// only ever sees the jwt-bearer request, which stays identical to the debugger.
+export async function mintXaaAccessToken(args: {
+  resolveServerSecret?: ResolveServerSecretFn;
+  httpsOnly: boolean;
+  issuer: string;
+  serverId: string;
+  projectId: string;
+  bearerToken: string;
+  /** The protected resource (the MCP server URL). */
+  resource?: string;
+  scope?: string;
+  /** Mock-login subject — already resolved (override or signed-in user). */
+  subject: string;
+  email?: string;
+}): Promise<{ accessToken: string; tokenEndpoint: string }> {
+  const target = await resolveServerTarget({
+    resolveServerSecret: args.resolveServerSecret,
+    httpsOnly: args.httpsOnly,
+    serverId: args.serverId,
+    projectId: args.projectId,
+    bearerToken: args.bearerToken,
+  });
+
+  const idJag = issueIdJag({
+    issuer: args.issuer,
+    subject: args.subject,
+    email: args.email,
+    audience: target.tokenEndpoint,
+    resource: args.resource ?? "",
+    clientId: target.clientId ?? "",
+    scope: args.scope,
+  });
+
+  const proxyResult = await executeOAuthProxy({
+    url: target.tokenEndpoint,
+    method: "POST",
+    body: buildJwtBearerBody({
+      assertion: idJag.token,
+      clientId: target.clientId,
+      clientSecret: target.clientSecret,
+      scope: args.scope,
+      resource: args.resource,
+    }),
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    httpsOnly: args.httpsOnly,
+  });
+
+  if (proxyResult.status < 200 || proxyResult.status >= 300) {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "The authorization server rejected the cross-app access grant.",
+      { status: proxyResult.status }
+    );
+  }
+
+  const body =
+    proxyResult.body && typeof proxyResult.body === "object"
+      ? (proxyResult.body as Record<string, unknown>)
+      : null;
+  const accessToken =
+    body && typeof body.access_token === "string"
+      ? body.access_token
+      : undefined;
+  if (!accessToken) {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "The authorization server response did not include an access_token."
+    );
+  }
+
+  return { accessToken, tokenEndpoint: target.tokenEndpoint };
+}

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -293,19 +293,37 @@ export async function mintXaaAccessToken(args: {
     httpsOnly: args.httpsOnly,
   });
 
-  if (proxyResult.status < 200 || proxyResult.status >= 300) {
-    throw new WebRouteError(
-      502,
-      ErrorCode.SERVER_UNREACHABLE,
-      "The authorization server rejected the cross-app access grant.",
-      { status: proxyResult.status }
-    );
-  }
-
   const body =
     proxyResult.body && typeof proxyResult.body === "object"
       ? (proxyResult.body as Record<string, unknown>)
       : null;
+
+  if (proxyResult.status < 200 || proxyResult.status >= 300) {
+    // Surface the authorization server's actual rejection (RFC 6749 error /
+    // error_description, or a raw string body) so the failure is debuggable
+    // instead of a generic "rejected".
+    const oauthError =
+      body && typeof body.error === "string" ? body.error : undefined;
+    const oauthDesc =
+      body && typeof body.error_description === "string"
+        ? body.error_description
+        : undefined;
+    const rawDetail =
+      !oauthError && typeof proxyResult.body === "string"
+        ? proxyResult.body.slice(0, 400)
+        : undefined;
+    const detail =
+      [oauthError, oauthDesc].filter(Boolean).join(": ") || rawDetail;
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      `XAA token exchange (jwt-bearer grant) was rejected by the authorization server at ${target.tokenEndpoint} (HTTP ${proxyResult.status})${
+        detail ? ` — ${detail}` : ""
+      }`,
+      { status: proxyResult.status, body: proxyResult.body }
+    );
+  }
+
   const accessToken =
     body && typeof body.access_token === "string"
       ? body.access_token
@@ -314,7 +332,7 @@ export async function mintXaaAccessToken(args: {
     throw new WebRouteError(
       502,
       ErrorCode.SERVER_UNREACHABLE,
-      "The authorization server response did not include an access_token."
+      `The authorization server at ${target.tokenEndpoint} accepted the grant (HTTP ${proxyResult.status}) but returned no access_token.`
     );
   }
 

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -21,6 +21,12 @@ import type { ServerClientSecretResult } from "../utils/server-secrets.js";
 // request body.
 export interface ResolvedServerTarget {
   tokenEndpoint: string;
+  /**
+   * The authorization server's canonical issuer. This — NOT the token endpoint
+   * — is the ID-JAG `aud` claim the resource AS validates against, so the mint
+   * must sign with it.
+   */
+  authzIssuer: string;
   clientId?: string;
   clientSecret?: string;
 }
@@ -75,7 +81,7 @@ export async function discoverServerTargetTokenEndpoint(
     explicitIssuer?: string;
   },
   httpsOnly: boolean
-): Promise<string> {
+): Promise<{ issuer: string; tokenEndpoint: string }> {
   let issuer = args.explicitIssuer;
   if (!issuer && args.resource) {
     issuer = await discoverIssuerFromResourceMetadata(args.resource, httpsOnly);
@@ -111,7 +117,12 @@ export async function discoverServerTargetTokenEndpoint(
         metadataUrl: candidate,
       });
       if (verdict.tokenEndpoint) {
-        return verdict.tokenEndpoint;
+        // Prefer the AS's self-declared canonical issuer from metadata; fall
+        // back to the requested issuer. This becomes the ID-JAG `aud`.
+        return {
+          issuer: verdict.issuer ?? issuer,
+          tokenEndpoint: verdict.tokenEndpoint,
+        };
       }
     }
   }
@@ -163,7 +174,7 @@ export async function resolveServerTarget(deps: {
     );
   }
 
-  const tokenEndpoint = await discoverServerTargetTokenEndpoint(
+  const discovered = await discoverServerTargetTokenEndpoint(
     {
       resource: resolved.serverUrl ?? undefined,
       explicitIssuer: resolved.xaaAuthzIssuer ?? undefined,
@@ -172,7 +183,8 @@ export async function resolveServerTarget(deps: {
   );
 
   return {
-    tokenEndpoint,
+    tokenEndpoint: discovered.tokenEndpoint,
+    authzIssuer: discovered.issuer,
     clientId: resolved.clientId ?? undefined,
     clientSecret: resolved.clientSecret ?? undefined,
   };
@@ -257,7 +269,9 @@ export async function mintXaaAccessToken(args: {
     issuer: args.issuer,
     subject: args.subject,
     email: args.email,
-    audience: target.tokenEndpoint,
+    // The ID-JAG `aud` is the resource authorization server's issuer (what it
+    // validates against), NOT its token endpoint.
+    audience: target.authzIssuer,
     resource: args.resource ?? "",
     clientId: target.clientId ?? "",
     scope: args.scope,

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -641,8 +641,17 @@ export async function resolveLocalServerForConnect(
     // returned. A server converted from OAuth still has a stored OAuth token,
     // and reusing it here would inject the wrong credential — the XAA-protected
     // server rejects it. The XAA token must come from the mint, full stop.
-    const minted = await mintXaaAccessToken(mintArgs);
-    resolvedOauthAccessToken = minted.accessToken;
+    try {
+      const minted = await mintXaaAccessToken(mintArgs);
+      resolvedOauthAccessToken = minted.accessToken;
+    } catch (error) {
+      logger.error("[XAA connect] mint failed", error, {
+        serverId,
+        serverName: options?.serverDisplayName ?? serverId,
+        resource: sc.url,
+      });
+      throw error;
+    }
     // Bounded re-mint: the SDK invokes this once on a 401 and retries; a second
     // 401 surfaces to the caller rather than looping mint→401→mint.
     let reMinted = false;

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -23,7 +23,14 @@ import {
   type InternalLogContext,
   mapInternalToRequestContext,
 } from "./internal-log-context.js";
-import { fetchRuntimeServerSecrets } from "./server-secrets.js";
+import {
+  fetchRuntimeServerSecrets,
+  fetchServerClientSecret,
+} from "./server-secrets.js";
+import {
+  getIssuerForRequest,
+  mintXaaAccessToken,
+} from "../services/xaa-mint.js";
 import type { ConnectionDefaults } from "../../shared/connection-defaults.js";
 
 type LocalAuthorizeServerConfig =
@@ -38,6 +45,12 @@ type LocalAuthorizeServerConfig =
       oauthScopes?: string[];
       clientId?: string;
       oauthResourceUrl?: string;
+      // Cross-App Access (XAA) non-secret config. The secret + token endpoint
+      // are resolved separately via the hardened reveal-secret path at mint time.
+      useXaa?: boolean;
+      authServerMode?: "mcpjam" | "own";
+      xaaSubject?: string;
+      xaaEmail?: string;
     }
   | {
       transportType: "stdio";
@@ -366,6 +379,13 @@ export function toMCPServerConfig(
       serverName: string;
     };
     /**
+     * XAA re-mint hook. When the server uses Cross-App Access, the connect
+     * resolver builds a bounded (one-shot) handler that re-mints the access
+     * token on a 401. Attached only when `serverConfig.useXaa === true` — the
+     * OAuth `refreshContext` path and this are mutually exclusive.
+     */
+    xaaUnauthorizedHandler?: () => Promise<{ accessToken: string }>;
+    /**
      * Per-connection MCP `initialize.params.clientInfo` override resolved
      * from `hostConfig.mcpProfile.initialize.clientInfo`. Undefined means
      * "use SDK defaults" (the inspector's hardcoded clientInfo). Forwarded
@@ -491,6 +511,13 @@ export function toMCPServerConfig(
       serverId: options.refreshContext.serverId,
       serverName: options.refreshContext.serverName,
     });
+  } else if (
+    oauthToken &&
+    serverConfig.useXaa === true &&
+    options?.xaaUnauthorizedHandler
+  ) {
+    // XAA re-mint on 401 — mutually exclusive with the OAuth hook above.
+    http.onUnauthorized = options.xaaUnauthorizedHandler;
   }
 
   return http as MCPServerConfig;
@@ -579,6 +606,60 @@ export async function resolveLocalServerForConnect(
     }
   }
 
+  // Cross-App Access: mint the resource access token server-side (MCPJam as the
+  // test IdP), then hand it to `toMCPServerConfig` through the same
+  // `oauthAccessToken` channel that injects the Bearer header. Gated strictly on
+  // `useXaa === true && useOAuth !== true` so it can never collide with the
+  // OAuth branch above.
+  const useXaa =
+    result.serverConfig.transportType === "http" &&
+    result.serverConfig.useXaa === true &&
+    result.serverConfig.useOAuth !== true;
+  let xaaUnauthorizedHandler:
+    | (() => Promise<{ accessToken: string }>)
+    | undefined;
+  if (useXaa && result.serverConfig.transportType === "http") {
+    const sc = result.serverConfig;
+    const mintArgs = {
+      resolveServerSecret: fetchServerClientSecret,
+      // Local connect path: non-HTTPS (localhost) auth servers are allowed,
+      // matching the local XAA router (`httpsOnlyProxy: false`). Hosted mode
+      // uses a separate path and would pin this to true.
+      httpsOnly: false,
+      issuer: getIssuerForRequest(c, "/api/mcp", false),
+      serverId,
+      projectId,
+      bearerToken,
+      resource: sc.url,
+      scope: sc.oauthScopes?.join(" ") || undefined,
+      // Mock-login identity: stored override if set, else the test defaults the
+      // XAA IdP's mock login already uses.
+      subject: sc.xaaSubject || "user-12345",
+      email: sc.xaaEmail || "demo.user@example.com",
+    };
+    if (!resolvedOauthAccessToken) {
+      const minted = await mintXaaAccessToken(mintArgs);
+      resolvedOauthAccessToken = minted.accessToken;
+    }
+    // Bounded re-mint: the SDK invokes this once on a 401 and retries; a second
+    // 401 surfaces to the caller rather than looping mint→401→mint.
+    let reMinted = false;
+    xaaUnauthorizedHandler = async () => {
+      if (reMinted) {
+        throw new WebRouteError(
+          401,
+          ErrorCode.UNAUTHORIZED,
+          `Server "${
+            options?.serverDisplayName ?? serverId
+          }" rejected the cross-app access token. Reconnect to retry.`
+        );
+      }
+      reMinted = true;
+      const minted = await mintXaaAccessToken(mintArgs);
+      return { accessToken: minted.accessToken };
+    };
+  }
+
   const needsRuntimeSecrets =
     (result.serverConfig.transportType === "stdio" &&
       result.serverConfig.hasEnv === true &&
@@ -633,6 +714,7 @@ export async function resolveLocalServerForConnect(
       serverId,
       serverName: options?.serverDisplayName ?? serverId,
     },
+    xaaUnauthorizedHandler,
   });
   return { config, authorizeResult: result };
 }

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -637,10 +637,12 @@ export async function resolveLocalServerForConnect(
       subject: sc.xaaSubject || "user-12345",
       email: sc.xaaEmail || "demo.user@example.com",
     };
-    if (!resolvedOauthAccessToken) {
-      const minted = await mintXaaAccessToken(mintArgs);
-      resolvedOauthAccessToken = minted.accessToken;
-    }
+    // Always mint for XAA, overriding any access token the authorize batch
+    // returned. A server converted from OAuth still has a stored OAuth token,
+    // and reusing it here would inject the wrong credential — the XAA-protected
+    // server rejects it. The XAA token must come from the mint, full stop.
+    const minted = await mintXaaAccessToken(mintArgs);
+    resolvedOauthAccessToken = minted.accessToken;
     // Bounded re-mint: the SDK invokes this once on a 401 and retries; a second
     // 401 surfaces to the caller rather than looping mint→401→mint.
     let reMinted = false;

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -854,6 +854,13 @@ export type ServerFormOAuthRegistrationMode =
   | "dcr"
   | "preregistered";
 
+/**
+ * The auth type a server-form row is configured with. "xaa" (Cross-App Access)
+ * is a distinct flow from "oauth": the inspector server mints the access token
+ * server-side via token-exchange rather than running a browser OAuth flow.
+ */
+export type ServerFormAuthType = "oauth" | "bearer" | "none" | "xaa";
+
 export interface ServerFormData {
   name: string;
   type: "stdio" | "http";
@@ -877,6 +884,22 @@ export interface ServerFormData {
   clearClientSecret?: boolean;
   /** Optional issuer override for the cross-app authorization test target. */
   xaaAuthzIssuer?: string;
+  /**
+   * Cross-App Access (XAA) connect flag. When true the server authenticates via
+   * the XAA token-exchange flow rather than standard OAuth. Mutually exclusive
+   * with `useOAuth` — the form only ever sets one.
+   */
+  useXaa?: boolean;
+  /**
+   * Which identity provider mints the XAA assertion. v1 only writes "mcpjam"
+   * (the built-in test IdP); "own" is reserved for the bring-your-own-IdP
+   * follow-up.
+   */
+  authServerMode?: "mcpjam" | "own";
+  /** Optional simulated-identity override (subject) for the MCPJam test IdP. Blank = signed-in user. */
+  xaaSubject?: string;
+  /** Optional simulated-identity override (email) for the MCPJam test IdP. Blank = signed-in user. */
+  xaaEmail?: string;
   /** Registry credential key for resolving OAuth client ID from env (e.g. "github") */
   oauthCredentialKey?: string;
   /** True for registry servers that use backend-managed preregistered OAuth credentials */


### PR DESCRIPTION
## TL;DR

You can now connect to an XAA-protected (Cross-App Access) MCP server from the **/servers Connect page** using MCPJam as the built-in test identity provider — previously this threw on connect. A server set up this way also works in the XAA Debugger. OAuth / bearer / none are untouched.

Scope: MCPJam-as-IdP only. Token is minted at connect and re-minted once on a 401; bring-your-own-IdP is a deliberate follow-up.

## What you get

- A 4th auth option, **"Cross-App Access (XAA)"**, in the Connect-page auth dropdown.
- Fields: an identity-provider selector (MCPJam test IdP), resource authorization-server credentials (client id / secret / scopes), and an Advanced group for the authz issuer (auto-discovered if blank) + an optional simulated identity.
- On connect, the inspector server runs the XAA token exchange and hands the resulting token to the normal transport.

## How it works

```
Pick XAA -> save (useXaa) -> connect
  -> server resolves the target + secret server-side
  -> signs an ID-JAG (MCPJam IdP) -> jwt-bearer grant -> access token
  -> injected as a Bearer header -> SDK connects
```

## Design notes

- **One discriminator, mutually exclusive.** An XAA server is `useXaa: true` with `useOAuth` left `false`. The connect resolver branches `if (useOAuth) … else if (useXaa) …`, the form's `buildFormData` sets at most one, and the edit-form `resolvedAuthType` checks XAA **first** so a re-save can never silently rewrite an XAA server to OAuth.
- **No drift with the debugger.** The jwt-bearer request body and the target/secret resolution were extracted into a shared `xaa-mint` service that both the debugger endpoint and the connect-page mint call. The confidential secret stays on the existing server-side secret endpoint; it never reaches the browser.
- **Bounded re-mint.** A 401 triggers exactly one re-mint, then surfaces to the caller — no mint/401 loop.
- **Debugger integration.** The two XAA-surface filters now admit `useXaa` servers, so a Connect-configured XAA server is selectable as a debugger target.

## Risk register

| Concern | Answer |
|---|---|
| Could an OAuth server take the XAA branch? | No — strict `useOAuth === true` checked first; XAA only on `useXaa === true`. |
| Could an XAA server trigger a browser OAuth flow? | No — `useOAuth` stays false, so it skips the OAuth orchestrator like bearer/none. |
| Re-save an XAA server -> silently OAuth? | Prevented by the XAA-first `resolvedAuthType` + a round-trip guard test. |
| Existing OAuth / bearer / none / stdio | Unchanged; they set neither flag and hit neither branch. |

## Tests

- Form-hook: XAA `buildFormData` emits `useXaa`/`authServerMode` (not `useOAuth`); a saved XAA server resolves to `authType=xaa` and round-trips without downgrading.
- Server: `buildJwtBearerBody` wire-shape / parity guard.
- Existing XAA router + auth-section suites stay green (extraction is behavior-preserving).

## Not in this PR (follow-ups)

- Bring-your-own-IdP (IdP credentials are an install/org-level concern, not per-server).
- Connect telemetry events.
- Defaulting the simulated identity to the signed-in user (currently a test identity when blank).

Depends on the paired backend change that persists and surfaces the XAA discriminator.