### PR TITLE
mistral csp

### DIFF
--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -991,14 +991,6 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
           sandbox: {
             csp: {
               mode: "declared",
-              restrictTo: {
-                connectDomains: [
-                  "https://api.openai.com",
-                  "https://api.anthropic.com",
-                  "https://cdn.jsdelivr.net",
-                ],
-                resourceDomains: ["https://cdn.jsdelivr.net"],
-              },
             },
             permissions: {
               mode: "custom",

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -2443,16 +2443,6 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         "sandbox": {
           "csp": {
             "mode": "declared",
-            "restrictTo": {
-              "connectDomains": [
-                "https://api.openai.com",
-                "https://api.anthropic.com",
-                "https://cdn.jsdelivr.net",
-              ],
-              "resourceDomains": [
-                "https://cdn.jsdelivr.net",
-              ],
-            },
           },
           "permissions": {
             "allow": {
@@ -2603,16 +2593,6 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         "sandbox": {
           "csp": {
             "mode": "declared",
-            "restrictTo": {
-              "connectDomains": [
-                "https://api.openai.com",
-                "https://api.anthropic.com",
-                "https://cdn.jsdelivr.net",
-              ],
-              "resourceDomains": [
-                "https://cdn.jsdelivr.net",
-              ],
-            },
           },
           "permissions": {
             "allow": {


### PR DESCRIPTION
OpenAI
Anthropic
jsDelivr
We were incorrectly using those 3 extracted test domains as a host-level allowlist for Mistral.