### PR TITLE
remove host styles from playground

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/multi-model-starters-empty.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/multi-model-starters-empty.tsx
@@ -61,6 +61,8 @@ export interface MultiModelStartersEmptyLayoutProps {
   isAuthLoading: boolean;
   /** When false, hides starter chips (e.g. auth upsell active). */
   showStarterPrompts: boolean;
+  /** Themed MCPJam logo, rendered above the starter prompts. */
+  logoSlot?: ReactNode;
   /** Loading spinner, upsell panel, or null — rendered above the starter row. */
   authPrimarySlot: ReactNode;
   onStarterPrompt: (text: string) => void;
@@ -76,6 +78,7 @@ export interface MultiModelStartersEmptyLayoutProps {
 export function MultiModelStartersEmptyLayout({
   isAuthLoading,
   showStarterPrompts,
+  logoSlot,
   authPrimarySlot,
   onStarterPrompt,
   chatInputSlot,
@@ -94,6 +97,7 @@ export function MultiModelStartersEmptyLayout({
           {authPrimarySlot}
           {showStarterPrompts ? (
             <div className="space-y-4">
+              {logoSlot}
               <MultiModelStarterPromptsBlock
                 onStarterPrompt={onStarterPrompt}
                 chipClassName={chipClassName}

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundPreviewedClientSync.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundPreviewedClientSync.tsx
@@ -17,12 +17,10 @@ interface PlaygroundPreviewedHostSyncProps {
  * persisted config via `useHost`, and snapshot its defaults into the
  * playground top-bar chip state whenever the resolved id changes.
  *
- * Mirrors `applyHostDefaultsToPlayground`'s behavior for the brand-pill
- * picker — both seams use the same underlying `applyHostConfigToPlayground`
- * helper. Differences:
- *   - Brand pill = synchronous template lookup, runs in user-action callback.
- *   - This component = async Convex query, runs in an effect when the
- *     resolved config first becomes available for a new id.
+ * Applies the same underlying `applyHostConfigToPlayground` helper used for
+ * playground host snapshots. This component resolves the persisted host config
+ * via Convex and runs in an effect when the resolved config first becomes
+ * available for a new id.
  *
  * Renders nothing.
  *
@@ -39,10 +37,10 @@ export function PlaygroundPreviewedClientSync({
   const { host } = useHost({ isAuthenticated, hostId: previewedHostId });
   const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
   const setHostCapabilitiesOverride = usePreferencesStore(
-    (state) => state.setHostCapabilitiesOverride,
+    (state) => state.setHostCapabilitiesOverride
   );
   const setChatUiOverride = usePreferencesStore(
-    (state) => state.setChatUiOverride,
+    (state) => state.setChatUiOverride
   );
 
   // Track the last (id, configId) tuple we applied so the effect only
@@ -51,7 +49,7 @@ export function PlaygroundPreviewedClientSync({
   // to hostId so an edit to the host's underlying config (re-saving from
   // the Hosts editor while the playground is open) triggers a re-snapshot.
   const lastAppliedRef = useRef<{ hostId: string; configId: string } | null>(
-    null,
+    null
   );
 
   useEffect(() => {
@@ -65,11 +63,7 @@ export function PlaygroundPreviewedClientSync({
     if (!host) return;
     const configId = host.config.id;
     const last = lastAppliedRef.current;
-    if (
-      last &&
-      last.hostId === previewedHostId &&
-      last.configId === configId
-    ) {
+    if (last && last.hostId === previewedHostId && last.configId === configId) {
       return;
     }
     applyHostConfigToPlayground(host.config, {

--- a/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
@@ -22,6 +22,7 @@ import {
   Cpu,
   Globe,
   Hand,
+  Info,
   Maximize2,
   Moon,
   MousePointer2,
@@ -48,12 +49,6 @@ import {
   extractHostTimeZone,
 } from "@/lib/client-config";
 import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
-import { listHostStyles } from "@/lib/client-styles";
-import {
-  getHostLogoSrc,
-  type ChatboxHostStyle,
-} from "@/lib/chatbox-client-style";
-import { applyHostDefaultsToPlayground } from "@/lib/playground/apply-client-defaults";
 import { cn } from "@/lib/utils";
 import { useHostContextStore } from "@/stores/client-context-store";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -69,7 +64,6 @@ import {
 import {
   CspPickerBody,
   DevicePickerBody,
-  HostStylePickerBody,
   LocalePickerBody,
   TimezonePickerBody,
 } from "@/components/shared/client-context-picker-bodies";
@@ -147,7 +141,6 @@ export function ClientContextHeader({
   const [localePopoverOpen, setLocalePopoverOpen] = useState(false);
   const [cspPopoverOpen, setCspPopoverOpen] = useState(false);
   const [timezonePopoverOpen, setTimezonePopoverOpen] = useState(false);
-  const [hostStylePopoverOpen, setHostStylePopoverOpen] = useState(false);
   const [hostContextDialogOpen, setHostContextDialogOpen] = useState(false);
   const [hostCapsDialogOpen, setHostCapsDialogOpen] = useState(false);
 
@@ -187,15 +180,11 @@ export function ClientContextHeader({
 
   const themeMode = usePreferencesStore((state) => state.themeMode);
   const hostStyle = usePreferencesStore((state) => state.hostStyle);
-  const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
   const hostCapabilitiesOverride = usePreferencesStore(
     (state) => state.hostCapabilitiesOverride
   );
   const setHostCapabilitiesOverride = usePreferencesStore(
     (state) => state.setHostCapabilitiesOverride
-  );
-  const setChatUiOverride = usePreferencesStore(
-    (state) => state.setChatUiOverride
   );
 
   const usesMcpAppsCsp =
@@ -249,11 +238,6 @@ export function ClientContextHeader({
     return PRESET_DEVICE_CONFIGS[deviceType];
   }, [customViewport, deviceType]);
 
-  const registeredHostStyles = useMemo(() => listHostStyles(), []);
-  const activeHostStyle = useMemo((): (typeof registeredHostStyles)[number] => {
-    const match = registeredHostStyles.find((h) => h.id === hostStyle);
-    return match ?? registeredHostStyles[0];
-  }, [hostStyle, registeredHostStyles]);
   const DeviceIcon =
     deviceType === "custom" || !("icon" in deviceConfig)
       ? null
@@ -291,6 +275,25 @@ export function ClientContextHeader({
   return (
     <div className={cn("min-w-0 max-w-full", className)}>
       <div className="flex min-w-0 max-w-full items-center gap-3 overflow-x-auto overflow-y-hidden overscroll-x-contain [scrollbar-width:none] @max-[860px]/playground-header:gap-2 [&::-webkit-scrollbar]:hidden">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="About these settings"
+              data-testid="host-toolbar-info"
+              className="flex shrink-0 cursor-help items-center text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <Info className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent
+            {...PLAYGROUND_HEADER_TOOLTIP}
+            className="max-w-none whitespace-nowrap"
+          >
+            These are temporary overrides applied to your current host.
+          </TooltipContent>
+        </Tooltip>
+
         <Popover
           open={devicePopoverOpen}
           onOpenChange={(next) => {
@@ -615,71 +618,6 @@ export function ClientContextHeader({
             </p>
           </TooltipContent>
         </Tooltip>
-
-        <Popover
-          open={hostStylePopoverOpen}
-          onOpenChange={(next) => {
-            if (next)
-              captureToolbar("host_toolbar_opened", {
-                control: "host_style",
-                current: hostStyle,
-              });
-            setHostStylePopoverOpen(next);
-          }}
-        >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="secondary"
-                  size="icon"
-                  aria-label="Client styles"
-                  data-testid="host-style-picker-trigger"
-                  className="h-7 w-7 shrink-0 border bg-background shadow-xs"
-                >
-                  <img
-                    src={getHostLogoSrc(activeHostStyle.chatUi, themeMode)}
-                    alt=""
-                    aria-hidden="true"
-                    className="h-3.5 w-3.5 object-contain"
-                  />
-                </Button>
-              </PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
-              <HeaderTooltipBody
-                label="Client styles"
-                leadHostHint={leadHostInMultiHost}
-              />
-              <p className="text-xs font-light text-muted-foreground">
-                {activeHostStyle.chatUi.label}
-              </p>
-            </TooltipContent>
-          </Tooltip>
-          <PopoverContent className="w-56 p-2" align="start">
-            <HostStylePickerBody
-              hostStyle={hostStyle}
-              onPickHost={(id: ChatboxHostStyle) => {
-                if (id !== hostStyle) {
-                  captureToolbar("host_style_changed", {
-                    from: hostStyle,
-                    to: id,
-                  });
-                }
-                applyHostDefaultsToPlayground(
-                  id,
-                  {
-                    setHostStyle,
-                    setHostCapabilitiesOverride,
-                    setChatUiOverride,
-                  },
-                  { theme: themeMode }
-                );
-                setHostStylePopoverOpen(false);
-              }}
-            />
-          </PopoverContent>
-        </Popover>
 
         {showThemeToggle ? (
           <Tooltip>

--- a/mcpjam-inspector/client/src/components/shared/__tests__/ClientContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/ClientContextHeader.test.tsx
@@ -9,7 +9,6 @@ const {
   mockHostContextState,
   mockPatchHostContext,
   mockApplyHostTemplate,
-  mockApplyHostDefaultsToPlayground,
 } = vi.hoisted(() => ({
   mockPreferencesState: {
     themeMode: "light",
@@ -47,7 +46,6 @@ const {
   },
   mockPatchHostContext: vi.fn(),
   mockApplyHostTemplate: vi.fn(),
-  mockApplyHostDefaultsToPlayground: vi.fn(),
 }));
 
 vi.mock("lucide-react", () => ({
@@ -64,6 +62,8 @@ vi.mock("lucide-react", () => ({
   MousePointer2: () => <span data-testid="icon-mouse" />,
   Hand: () => <span data-testid="icon-hand" />,
   Maximize2: () => <span data-testid="icon-maximize" />,
+  History: () => <span data-testid="icon-history" />,
+  Info: () => <span data-testid="icon-info" />,
 }));
 
 vi.mock("@mcpjam/design-system/button", () => ({
@@ -117,19 +117,21 @@ vi.mock("@/components/shared/client-context-constants", () => ({
   TIMEZONE_OPTIONS: [{ zone: "UTC", label: "UTC" }],
 }));
 
-vi.mock("@/components/shared/client-context-picker-bodies", async (importOriginal) => {
-  const actual =
-    await importOriginal<
+vi.mock(
+  "@/components/shared/client-context-picker-bodies",
+  async (importOriginal) => {
+    const actual = await importOriginal<
       typeof import("@/components/shared/client-context-picker-bodies")
     >();
-  return {
-    ...actual,
-    CspPickerBody: () => <div />,
-    DevicePickerBody: () => <div />,
-    LocalePickerBody: () => <div />,
-    TimezonePickerBody: () => <div />,
-  };
-});
+    return {
+      ...actual,
+      CspPickerBody: () => <div />,
+      DevicePickerBody: () => <div />,
+      LocalePickerBody: () => <div />,
+      TimezonePickerBody: () => <div />,
+    };
+  }
+);
 
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: (selector: any) =>
@@ -139,8 +141,6 @@ vi.mock("@/stores/preferences/preferences-provider", () => ({
 vi.mock("@/stores/ui-playground-store", () => {
   const useUIPlaygroundStore: any = (selector: any) =>
     selector ? selector(mockUIPlaygroundStore) : mockUIPlaygroundStore;
-  // `applyHostDefaultsToPlayground` reads via `.getState()` — expose the
-  // same shape as the hook selector consumers.
   useUIPlaygroundStore.getState = () => mockUIPlaygroundStore;
   return { useUIPlaygroundStore };
 });
@@ -163,8 +163,6 @@ vi.mock("@/stores/client-context-store", () => {
   });
   const useHostContextStore: any = (selector: any) =>
     selector ? selector(buildState()) : buildState();
-  // `applyHostDefaultsToPlayground` reads `applyHostTemplate` via
-  // `.getState()`; expose the same shape.
   useHostContextStore.getState = buildState;
   return { useHostContextStore };
 });
@@ -177,14 +175,6 @@ vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => ({
   },
 }));
 
-// Stub the helper so the test verifies the wire (pill onClick → helper)
-// without pulling in the helper's full dependency graph (host-templates →
-// host-config-v2 → ...). The helper's behavior is covered by its own unit
-// test at lib/playground/__tests__/apply-host-defaults.test.ts.
-vi.mock("@/lib/playground/apply-client-defaults", () => ({
-  applyHostDefaultsToPlayground: mockApplyHostDefaultsToPlayground,
-}));
-
 vi.mock("@/lib/client-config", () => ({
   extractEffectiveHostDisplayMode: (hostContext: Record<string, unknown>) =>
     hostContext.displayMode ?? "inline",
@@ -195,15 +185,12 @@ vi.mock("@/lib/client-config", () => ({
     },
   extractHostDisplayModes: (hostContext: Record<string, unknown>) =>
     hostContext.availableDisplayModes ?? ["inline", "pip", "fullscreen"],
-  extractHostLocale: (
-    hostContext: Record<string, unknown>,
-    fallback: string,
-  ) => hostContext.locale ?? fallback,
-  extractHostTheme: (hostContext: Record<string, unknown>) =>
-    hostContext.theme,
+  extractHostLocale: (hostContext: Record<string, unknown>, fallback: string) =>
+    hostContext.locale ?? fallback,
+  extractHostTheme: (hostContext: Record<string, unknown>) => hostContext.theme,
   extractHostTimeZone: (
     hostContext: Record<string, unknown>,
-    fallback: string,
+    fallback: string
   ) => hostContext.timeZone ?? fallback,
 }));
 
@@ -236,12 +223,12 @@ describe("ClientContextHeader", () => {
       <ClientContextHeader
         activeProjectId="project-1"
         protocol={UIType.MCP_APPS}
-      />,
+      />
     );
 
     await waitFor(() => {
       expect(mockUIPlaygroundStore.setCspMode).toHaveBeenCalledWith(
-        "permissive",
+        "permissive"
       );
     });
     expect(mockUIPlaygroundStore.setMcpAppsCspMode).not.toHaveBeenCalled();
@@ -253,7 +240,7 @@ describe("ClientContextHeader", () => {
         activeProjectId="project-1"
         protocol={null}
         showThemeToggle
-      />,
+      />
     );
 
     expect(screen.getByTestId("icon-sun")).toBeInTheDocument();
@@ -264,53 +251,17 @@ describe("ClientContextHeader", () => {
     expect(mockPreferencesState.setThemeMode).not.toHaveBeenCalled();
   });
 
-  it("invokes the playground snapshot helper for each pill click with the right host id", () => {
-    render(
-      <ClientContextHeader activeProjectId="project-1" protocol={null} />,
-    );
+  it("does not render the client style picker in the playground toolbar", () => {
+    render(<ClientContextHeader activeProjectId="project-1" protocol={null} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Claude" }));
-    fireEvent.click(screen.getByRole("button", { name: "ChatGPT" }));
-
-    // setHostStyle is no longer called directly from the pill onClick —
-    // the helper owns it (so a single seam writes the brand-pill id +
-    // chip stores together). Assert via the helper instead.
-    expect(mockPreferencesState.setHostStyle).not.toHaveBeenCalled();
-    expect(mockApplyHostDefaultsToPlayground).toHaveBeenCalledTimes(2);
-    expect(mockApplyHostDefaultsToPlayground.mock.calls[0]?.[0]).toBe(
-      "claude",
-    );
-    expect(mockApplyHostDefaultsToPlayground.mock.calls[1]?.[0]).toBe(
-      "chatgpt",
-    );
-  });
-
-  it("calls the playground snapshot helper with both preferences setters in a bag", () => {
-    render(
-      <ClientContextHeader activeProjectId="project-1" protocol={null} />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "ChatGPT" }));
-
-    expect(mockApplyHostDefaultsToPlayground).toHaveBeenCalledTimes(1);
-    expect(mockApplyHostDefaultsToPlayground.mock.calls[0]?.[0]).toBe(
-      "chatgpt",
-    );
-    // Second arg is the setters bag — the preferences-store setters that
-    // the helper writes through (preferences store is context-scoped, so
-    // the helper can't `getState()` on it).
-    expect(mockApplyHostDefaultsToPlayground.mock.calls[0]?.[1]).toEqual({
-      setHostStyle: mockPreferencesState.setHostStyle,
-      setHostCapabilitiesOverride:
-        mockPreferencesState.setHostCapabilitiesOverride,
-      setChatUiOverride: mockPreferencesState.setChatUiOverride,
-    });
+    expect(screen.queryByLabelText("Client styles")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("host-style-picker-trigger")
+    ).not.toBeInTheDocument();
   });
 
   it("opens the raw host context dialog when the host context button is clicked", () => {
-    render(
-      <ClientContextHeader activeProjectId="project-1" protocol={null} />,
-    );
+    render(<ClientContextHeader activeProjectId="project-1" protocol={null} />);
 
     fireEvent.click(screen.getByTestId("host-context-trigger"));
 
@@ -318,19 +269,15 @@ describe("ClientContextHeader", () => {
   });
 
   it("labels the host capabilities override control as Host Capabilities", () => {
-    render(
-      <ClientContextHeader activeProjectId="project-1" protocol={null} />,
-    );
+    render(<ClientContextHeader activeProjectId="project-1" protocol={null} />);
 
     expect(screen.getByTestId("host-capabilities-trigger")).toHaveTextContent(
-      "Host Capabilities",
+      "Host Capabilities"
     );
   });
 
   it("does not render the display-mode badge in the toolbar", () => {
-    render(
-      <ClientContextHeader activeProjectId="project-1" protocol={null} />,
-    );
+    render(<ClientContextHeader activeProjectId="project-1" protocol={null} />);
 
     expect(screen.queryByText("Display")).not.toBeInTheDocument();
     expect(screen.queryByText("Inline")).not.toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/shared/client-context-picker-bodies.tsx
+++ b/mcpjam-inspector/client/src/components/shared/client-context-picker-bodies.tsx
@@ -11,12 +11,6 @@ import {
   TIMEZONE_OPTIONS,
   CSP_MODE_OPTIONS,
 } from "@/components/shared/client-context-constants";
-import {
-  getHostLogoSrc,
-  type ChatboxHostStyle,
-} from "@/lib/chatbox-client-style";
-import { listHostStyles } from "@/lib/client-styles";
-import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import type {
   CustomViewport,
   CspMode,
@@ -219,39 +213,6 @@ export function TimezonePickerBody({
           <span className="ml-auto text-[10px] text-muted-foreground">
             {option.offset}
           </span>
-        </button>
-      ))}
-    </div>
-  );
-}
-
-export function HostStylePickerBody({
-  hostStyle,
-  onPickHost,
-}: {
-  hostStyle: ChatboxHostStyle;
-  onPickHost: (id: ChatboxHostStyle) => void;
-}) {
-  const themeMode = usePreferencesStore((s) => s.themeMode);
-
-  return (
-    <div className="space-y-1">
-      {listHostStyles().map((host) => (
-        <button
-          key={host.id}
-          type="button"
-          onClick={() => onPickHost(host.id)}
-          className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors hover:bg-accent ${
-            hostStyle === host.id ? "bg-accent text-accent-foreground" : ""
-          }`}
-        >
-          <img
-            src={getHostLogoSrc(host.chatUi, themeMode)}
-            alt=""
-            aria-hidden="true"
-            className="h-3.5 w-3.5 object-contain"
-          />
-          <span>{host.chatUi.label}</span>
         </button>
       ))}
     </div>

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -3322,6 +3322,18 @@ export function PlaygroundMain({
               <MultiModelStartersEmptyLayout
                 isAuthLoading={isAuthLoading}
                 showStarterPrompts={showMultiModelStarterPrompts}
+                logoSlot={
+                  <img
+                    src={
+                      effectiveThreadTheme === "dark"
+                        ? "/mcp_jam_dark.png"
+                        : "/mcp_jam_light.png"
+                    }
+                    alt="MCPJam"
+                    draggable={false}
+                    className="h-10 w-auto mx-auto"
+                  />
+                }
                 authPrimarySlot={
                   isAuthLoading ? (
                     <div className="text-center space-y-4">

--- a/mcpjam-inspector/client/src/lib/client-config-v2-helpers.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2-helpers.ts
@@ -1,8 +1,8 @@
 /**
  * Pure helpers for HostConfigInputV2 that don't touch any zustand stores.
  *
- * `lib/playground/apply-host-defaults.ts` exposes `applyHostConfigToPlayground`
- * / `applyHostDefaultsToPlayground` which fan out side effects across
+ * `lib/playground/apply-client-defaults.ts` exposes
+ * `applyHostConfigToPlayground`, which fans out side effects across
  * `useHostContextStore`, `useUIPlaygroundStore`, and a `preferencesStore`
  * setter bag. Useful in the playground; **wrong** anywhere else, because
  * those stores are shared with the playground surface — calling them from
@@ -14,9 +14,7 @@
  * HostConfigInputV2. Callers thread the result through their own state.
  */
 
-import {
-  type HostConfigInputV2,
-} from "@/lib/client-config-v2";
+import { type HostConfigInputV2 } from "@/lib/client-config-v2";
 import {
   seedFromHostTemplate,
   type HostTemplateId,
@@ -34,14 +32,14 @@ import {
  *   - `chatUiOverride`       = the host template's chat-ui override (may be undefined)
  *   - everything else        = preserved from `current`
  *
- * The `modelId` is NOT touched. In the playground, the brand-pill click
- * also pokes the persisted model selection — that's a separate concern and
- * not part of the per-eval-case tweak surface (the eval editor has its own
+ * The `modelId` is NOT touched. The playground host-sync path also pokes
+ * the persisted model selection — that's a separate concern and not part
+ * of the per-eval-case tweak surface (the eval editor has its own
  * `ModelSelector` in the editor body).
  */
 export function applyHostStyleToHostConfigInput(
   hostStyle: string,
-  current: HostConfigInputV2,
+  current: HostConfigInputV2
 ): HostConfigInputV2 {
   // `seedFromHostTemplate` is typed as `HostTemplateId` but the runtime
   // falls back to MCPJam on unknown ids; the cast keeps the call site

--- a/mcpjam-inspector/client/src/lib/playground/__tests__/apply-client-defaults.test.ts
+++ b/mcpjam-inspector/client/src/lib/playground/__tests__/apply-client-defaults.test.ts
@@ -4,15 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // seeding template clientInfo. Provide a stable test value before importing.
 (globalThis as { __APP_VERSION__?: string }).__APP_VERSION__ = "0.0.0-test";
 
-import {
-  applyHostConfigToPlayground,
-  applyHostDefaultsToPlayground,
-} from "../apply-client-defaults";
+import { applyHostConfigToPlayground } from "../apply-client-defaults";
 import * as selectedModelStorage from "@/lib/selected-model-storage";
 import { useHostContextStore } from "@/stores/client-context-store";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 
-describe("applyHostDefaultsToPlayground", () => {
+describe("applyHostConfigToPlayground", () => {
   let applyHostTemplateSpy: ReturnType<typeof vi.fn>;
   let setCustomViewportSpy: ReturnType<typeof vi.fn>;
   let setDeviceTypeSpy: ReturnType<typeof vi.fn>;
@@ -65,244 +62,136 @@ describe("applyHostDefaultsToPlayground", () => {
     vi.restoreAllMocks();
   });
 
-  it("snapshots Claude template defaults: hostStyle 'claude', model anthropic/claude-haiku-4.5 (guest-allowed), containerDimensions forwarded to View hostContext only, widget-declared CSP, override set", () => {
-    applyHostDefaultsToPlayground("claude", setters);
+  it("snapshots a named host's persisted config: hostStyle + model (canonical id passes through) + hostContext + container + CSP + override + chatUiOverride", () => {
+    const namedHostConfig = {
+      hostStyle: "claude",
+      // Canonical id that exists in SUPPORTED_MODELS — passes through
+      // the resolver as-is (no template fallback needed).
+      modelId: "anthropic/claude-opus-4.5",
+      hostContext: {
+        locale: "fr-FR",
+        timeZone: "Europe/Paris",
+        containerDimensions: { width: 900, maxHeight: 1200 },
+        theme: "light",
+      },
+      mcpProfile: {
+        profileVersion: 1 as const,
+        apps: { sandbox: { csp: { mode: "declared" as const } } },
+      },
+      hostCapabilitiesOverride: { openLinks: {} },
+      chatUiOverride: { palette: { accent: "#ff00aa" } },
+    };
 
-    // hostStyle is the first thing written so the brand-pill / loading
-    // indicator dispatch update before the chip stores repaint.
+    applyHostConfigToPlayground(namedHostConfig, setters);
+
+    // Picking a named "Claude" host should update the loading-indicator
+    // dispatch to "claude" and update the chat-composer model picker to
+    // the host's saved model.
     expect(setHostStyle).toHaveBeenCalledWith("claude");
-    expect(setHostStyle.mock.invocationCallOrder[0]).toBeLessThan(
-      applyHostTemplateSpy.mock.invocationCallOrder[0],
-    );
-
-    // Lead model id is persisted via the storage helper (which fires the
-    // same-tab event so usePersistedModel re-reads).
     expect(replaceLeadModelIdSpy).toHaveBeenCalledWith(
-      "anthropic/claude-haiku-4.5",
+      "anthropic/claude-opus-4.5"
     );
 
-    // containerDimensions still flow into the host-context store; Views
-    // receive them via ui/initialize.hostContext per SEP-1865.
-    expect(applyHostTemplateSpy).toHaveBeenCalledTimes(1);
-    expect(applyHostTemplateSpy.mock.calls[0]?.[0]).toMatchObject({
-      locale: "en-US",
-      timeZone: "America/Los_Angeles",
-      containerDimensions: { width: 720, maxHeight: 5000 },
+    expect(applyHostTemplateSpy).toHaveBeenCalledWith(
+      namedHostConfig.hostContext
+    );
+    // containerDimensions belongs to the View iframe (delivered via
+    // applyHostTemplate above), not the playground's device frame.
+    expect(setCustomViewportSpy).not.toHaveBeenCalled();
+    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
+    expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
+    expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
+    expect(setHostCapabilitiesOverride).toHaveBeenCalledWith({
+      openLinks: {},
     });
-
-    // But the playground's device-frame viewport is NOT shrunk to the
-    // View's container dimensions — chat stays full-width.
-    expect(setCustomViewportSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
-
-    expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
-    expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
-
-    // Claude's template sets a non-empty hostCapabilitiesOverride.
-    expect(setHostCapabilitiesOverride).toHaveBeenCalledTimes(1);
-    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
+    // chatUiOverride is snapshotted into preferences so the playground's
+    // ChatboxChatUiOverrideProvider picks up the host's custom palette /
+    // logo / indicator without per-surface wiring.
+    expect(setChatUiOverride).toHaveBeenCalledWith({
+      palette: { accent: "#ff00aa" },
+    });
   });
 
-  it("snapshots ChatGPT template defaults: container metadata stays in host context, playground viewport stays fill, model openai/gpt-5-nano (guest-allowed)", () => {
-    applyHostDefaultsToPlayground("chatgpt", setters);
-
-    expect(setHostStyle).toHaveBeenCalledWith("chatgpt");
-    expect(replaceLeadModelIdSpy).toHaveBeenCalledWith("openai/gpt-5-nano");
-    expect(setCustomViewportSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
-    expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
-    expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
-    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
-  });
-
-  it("snapshots Cursor template defaults: container metadata stays in host context, playground viewport stays fill, model anthropic/claude-sonnet-4.5 (guest-allowed)", () => {
-    applyHostDefaultsToPlayground("cursor", setters);
-
-    expect(setHostStyle).toHaveBeenCalledWith("cursor");
-    expect(replaceLeadModelIdSpy).toHaveBeenCalledWith(
-      "anthropic/claude-sonnet-4.5",
+  it("passes a BYOK bare id straight through when it resolves in SUPPORTED_MODELS (host is source of truth)", () => {
+    // "gpt-5" is a valid SUPPORTED_MODELS entry (BYOK; openai/gpt-5-nano
+    // is the MCPJam-provided cousin). Pre-everything-from-host behavior
+    // snapped this to the ChatGPT template default; that hides the
+    // host's actual saved pick. Trust the host: surface "gpt-5" and let
+    // the picker decide whether to render it as disabled (no key).
+    applyHostConfigToPlayground(
+      {
+        hostStyle: "chatgpt",
+        modelId: "gpt-5",
+        hostContext: {},
+        mcpProfile: undefined,
+        hostCapabilitiesOverride: undefined,
+      },
+      setters
     );
-    expect(setCustomViewportSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
-    expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
-    expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
-    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
+
+    expect(replaceLeadModelIdSpy).toHaveBeenCalledWith("gpt-5");
   });
 
-  it("snapshots MCPJam fallback: setDeviceType('fill'), widget-declared CSP, override set, model id NOT touched", () => {
-    applyHostDefaultsToPlayground("mcpjam", setters);
-
-    expect(setHostStyle).toHaveBeenCalledWith("mcpjam");
-
-    // MCPJam template has an empty modelId — we deliberately don't
-    // clear the user's last picked model on a no-op host config.
-    expect(replaceLeadModelIdSpy).not.toHaveBeenCalled();
-
-    expect(setCustomViewportSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
-
-    // MCPJam template advertises apps.sandbox.csp.mode "declared" so the
-    // Permissive chip resolves to widget-declared, same as Claude/ChatGPT.
-    expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
-    expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
-
-    // MCPJam template now ships its own hostCapabilitiesOverride
-    // (openLinks, updateModelContext, etc.) — the override is set, not
-    // cleared, so widgets see MCPJam's advertised host surface.
-    expect(setHostCapabilitiesOverride).toHaveBeenCalledTimes(1);
-    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
-  });
-
-  it("preserves the picked hostStyle for an unknown BYO host id even though template falls back to MCPJam", () => {
-    applyHostDefaultsToPlayground("some-byo-custom-host", setters);
-
-    // Brand-pill identity wins: the user's pick is what's advertised, not
-    // the MCPJam fallback the template resolution returned.
-    expect(setHostStyle).toHaveBeenCalledWith("some-byo-custom-host");
-    // Body-of-work still comes from MCPJam (no template entry); since
-    // MCPJam template's modelId is empty, the user's last picked model
-    // is preserved.
-    expect(replaceLeadModelIdSpy).not.toHaveBeenCalled();
-    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
-    // MCPJam fallback now stamps apps.sandbox.csp.mode "declared" and a
-    // hostCapabilitiesOverride, so the BYO unknown id inherits both like
-    // other branded templates.
-    expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
-    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
-  });
-
-  describe("applyHostConfigToPlayground (used by named-host picker sync)", () => {
-    it("snapshots a named host's persisted config: hostStyle + model (canonical id passes through) + hostContext + container + CSP + override + chatUiOverride", () => {
-      const namedHostConfig = {
+  it("falls back to the template default when the persisted modelId is whitespace-only", () => {
+    applyHostConfigToPlayground(
+      {
         hostStyle: "claude",
-        // Canonical id that exists in SUPPORTED_MODELS — passes through
-        // the resolver as-is (no template fallback needed).
-        modelId: "anthropic/claude-opus-4.5",
-        hostContext: {
-          locale: "fr-FR",
-          timeZone: "Europe/Paris",
-          containerDimensions: { width: 900, maxHeight: 1200 },
-          theme: "light",
-        },
-        mcpProfile: {
-          profileVersion: 1 as const,
-          apps: { sandbox: { csp: { mode: "declared" as const } } },
-        },
-        hostCapabilitiesOverride: { openLinks: {} },
-        chatUiOverride: { palette: { accent: "#ff00aa" } },
-      };
+        modelId: "   ",
+        hostContext: {},
+        mcpProfile: undefined,
+        hostCapabilitiesOverride: undefined,
+      },
+      setters
+    );
 
-      applyHostConfigToPlayground(namedHostConfig, setters);
+    // Empty/whitespace skips the configured id, then the resolver
+    // tries the host style's template default.
+    expect(replaceLeadModelIdSpy).toHaveBeenCalledWith(
+      "anthropic/claude-haiku-4.5"
+    );
+  });
 
-      // Picking a named "Claude" host should flip the brand pill / loading
-      // indicator dispatch to "claude" — and update the chat-composer
-      // model picker to the host's saved model.
-      expect(setHostStyle).toHaveBeenCalledWith("claude");
-      expect(replaceLeadModelIdSpy).toHaveBeenCalledWith(
-        "anthropic/claude-opus-4.5",
-      );
+  it("leaves the model picker alone when neither the configured id nor the template fallback resolves (BYO host, MCPJam template fallback)", () => {
+    applyHostConfigToPlayground(
+      {
+        hostStyle: "some-byo-host-style",
+        modelId: "totally-made-up-id",
+        hostContext: {},
+        mcpProfile: undefined,
+        hostCapabilitiesOverride: undefined,
+      },
+      setters
+    );
 
-      expect(applyHostTemplateSpy).toHaveBeenCalledWith(
-        namedHostConfig.hostContext,
-      );
-      // containerDimensions belongs to the View iframe (delivered via
-      // applyHostTemplate above), not the playground's device frame.
-      expect(setCustomViewportSpy).not.toHaveBeenCalled();
-      expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
-      expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
-      expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
-      expect(setHostCapabilitiesOverride).toHaveBeenCalledWith({
-        openLinks: {},
-      });
-      // chatUiOverride is snapshotted into preferences so the playground's
-      // ChatboxChatUiOverrideProvider picks up the host's custom palette /
-      // logo / indicator without per-surface wiring.
-      expect(setChatUiOverride).toHaveBeenCalledWith({
-        palette: { accent: "#ff00aa" },
-      });
-    });
+    // BYO style → seedFromHostTemplate falls through to MCPJam, whose
+    // modelId is empty → resolver returns undefined → no save.
+    expect(replaceLeadModelIdSpy).not.toHaveBeenCalled();
+  });
 
-    it("passes a BYOK bare id straight through when it resolves in SUPPORTED_MODELS (host is source of truth)", () => {
-      // "gpt-5" is a valid SUPPORTED_MODELS entry (BYOK; openai/gpt-5-nano
-      // is the MCPJam-provided cousin). Pre-everything-from-host behavior
-      // snapped this to the ChatGPT template default; that hides the
-      // host's actual saved pick. Trust the host: surface "gpt-5" and let
-      // the picker decide whether to render it as disabled (no key).
-      applyHostConfigToPlayground(
-        {
-          hostStyle: "chatgpt",
-          modelId: "gpt-5",
-          hostContext: {},
-          mcpProfile: undefined,
-          hostCapabilitiesOverride: undefined,
-        },
-        setters,
-      );
+  it("clears override and resets device when the config has no overrides / dims / sandbox; model resolves from template", () => {
+    // A "blank" host config — exercises every fallback branch. The
+    // model resolver picks up the Claude template's canonical default
+    // since the configured modelId is empty.
+    applyHostConfigToPlayground(
+      {
+        hostStyle: "claude",
+        modelId: "",
+        hostContext: {},
+        mcpProfile: undefined,
+        hostCapabilitiesOverride: undefined,
+      },
+      setters
+    );
 
-      expect(replaceLeadModelIdSpy).toHaveBeenCalledWith("gpt-5");
-    });
-
-    it("falls back to the template default when the persisted modelId is whitespace-only", () => {
-      applyHostConfigToPlayground(
-        {
-          hostStyle: "claude",
-          modelId: "   ",
-          hostContext: {},
-          mcpProfile: undefined,
-          hostCapabilitiesOverride: undefined,
-        },
-        setters,
-      );
-
-      // Empty/whitespace skips the configured id, then the resolver
-      // tries the host style's template default.
-      expect(replaceLeadModelIdSpy).toHaveBeenCalledWith(
-        "anthropic/claude-haiku-4.5",
-      );
-    });
-
-    it("leaves the model picker alone when neither the configured id nor the template fallback resolves (BYO host, MCPJam template fallback)", () => {
-      applyHostConfigToPlayground(
-        {
-          hostStyle: "some-byo-host-style",
-          modelId: "totally-made-up-id",
-          hostContext: {},
-          mcpProfile: undefined,
-          hostCapabilitiesOverride: undefined,
-        },
-        setters,
-      );
-
-      // BYO style → seedFromHostTemplate falls through to MCPJam, whose
-      // modelId is empty → resolver returns undefined → no save.
-      expect(replaceLeadModelIdSpy).not.toHaveBeenCalled();
-    });
-
-    it("clears override and resets device when the config has no overrides / dims / sandbox; model resolves from template", () => {
-      // A "blank" host config — exercises every fallback branch. The
-      // model resolver picks up the Claude template's canonical default
-      // since the configured modelId is empty.
-      applyHostConfigToPlayground(
-        {
-          hostStyle: "claude",
-          modelId: "",
-          hostContext: {},
-          mcpProfile: undefined,
-          hostCapabilitiesOverride: undefined,
-        },
-        setters,
-      );
-
-      expect(setHostStyle).toHaveBeenCalledWith("claude");
-      expect(replaceLeadModelIdSpy).toHaveBeenCalledWith(
-        "anthropic/claude-haiku-4.5",
-      );
-      expect(applyHostTemplateSpy).toHaveBeenCalledWith({});
-      expect(setCustomViewportSpy).not.toHaveBeenCalled();
-      expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
-      expect(setCspModeSpy).toHaveBeenCalledWith("permissive");
-      expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("permissive");
-      expect(setHostCapabilitiesOverride).toHaveBeenCalledWith(undefined);
-    });
+    expect(setHostStyle).toHaveBeenCalledWith("claude");
+    expect(replaceLeadModelIdSpy).toHaveBeenCalledWith(
+      "anthropic/claude-haiku-4.5"
+    );
+    expect(applyHostTemplateSpy).toHaveBeenCalledWith({});
+    expect(setCustomViewportSpy).not.toHaveBeenCalled();
+    expect(setDeviceTypeSpy).toHaveBeenCalledWith("fill");
+    expect(setCspModeSpy).toHaveBeenCalledWith("permissive");
+    expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("permissive");
+    expect(setHostCapabilitiesOverride).toHaveBeenCalledWith(undefined);
   });
 });

--- a/mcpjam-inspector/client/src/lib/playground/apply-client-defaults.ts
+++ b/mcpjam-inspector/client/src/lib/playground/apply-client-defaults.ts
@@ -1,4 +1,3 @@
-import type { ChatboxHostStyle } from "@/lib/chatbox-client-style";
 import {
   type HostConfigDtoV2,
   type HostConfigInputV2,
@@ -7,12 +6,9 @@ import {
   seedFromHostTemplate,
   type HostTemplateId,
 } from "@/lib/client-templates";
-import type { ChatUiOverride, HostThemeMode } from "@/lib/client-styles";
+import type { ChatUiOverride } from "@/lib/client-styles";
 import { replaceLeadModelId } from "@/lib/selected-model-storage";
-import {
-  getCanonicalModelId,
-  isModelSupported,
-} from "@/shared/types";
+import { getCanonicalModelId, isModelSupported } from "@/shared/types";
 import { useHostContextStore } from "@/stores/client-context-store";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 
@@ -49,7 +45,7 @@ type HostConfigForPlayground = Pick<
  */
 export function resolvePlaygroundModelId(
   desiredModelId: string | undefined,
-  hostStyle: string,
+  hostStyle: string
 ): string | undefined {
   const trimmed = desiredModelId?.trim();
   if (trimmed) {
@@ -57,7 +53,7 @@ export function resolvePlaygroundModelId(
     if (isModelSupported(canonical)) return canonical;
   }
   const fallback = seedFromHostTemplate(
-    hostStyle as HostTemplateId,
+    hostStyle as HostTemplateId
   ).modelId?.trim();
   if (!fallback) return undefined;
   const canonicalFallback = getCanonicalModelId(fallback);
@@ -73,7 +69,7 @@ export function resolvePlaygroundModelId(
 export interface ApplyHostPlaygroundSetters {
   setHostStyle: (hostStyle: string) => void;
   setHostCapabilitiesOverride: (
-    next: Record<string, unknown> | undefined,
+    next: Record<string, unknown> | undefined
   ) => void;
   setChatUiOverride: (next: ChatUiOverride | undefined) => void;
 }
@@ -85,16 +81,13 @@ export interface ApplyHostPlaygroundSetters {
  * host's defaults; users can tweak in-session for testing; tweaks are NOT
  * persisted back to the host (saving lives in the Hosts editor page).
  *
- * Two callers today:
- *   1. The brand-pill `onClick` in `ClientContextHeader` —
- *      via {@link applyHostDefaultsToPlayground}, seeded from a static template.
- *   2. The named-host picker in `PlaygroundHeader` (the `HostPicker`
- *      dropdown) — via `PlaygroundPreviewedClientSync`, seeded from the
- *      project's persisted host config.
+ * The caller today is the named-host picker sync in
+ * `PlaygroundPreviewedClientSync`, seeded from the project's persisted host
+ * config.
  *
  * Writes to multiple stores synchronously:
- *   - `setHostStyle(config.hostStyle)` (drives the brand-pill highlight,
- *     the loading-indicator dispatch, and any chat-v2 family-keyed visuals)
+ *   - `setHostStyle(config.hostStyle)` (drives the loading-indicator
+ *     dispatch and any chat-v2 family-keyed visuals)
  *   - `useHostContextStore.applyHostTemplate` (locale, timezone, container,
  *      theme, deviceCapabilities — the whole hostContext blob)
  *   - `useUIPlaygroundStore.setCustomViewport` / `setDeviceType` (Device chip)
@@ -111,7 +104,7 @@ export interface ApplyHostPlaygroundSetters {
  */
 export function applyHostConfigToPlayground(
   config: HostConfigForPlayground,
-  setters: ApplyHostPlaygroundSetters,
+  setters: ApplyHostPlaygroundSetters
 ): void {
   // Order: identity (hostStyle) first so any subscriber sees the new
   // active host before the chip stores are repainted.
@@ -167,36 +160,6 @@ export function applyHostConfigToPlayground(
   // playground show the host's custom logo / palette / indicator without
   // a separate provider per surface.
   setters.setChatUiOverride(config.chatUiOverride);
-}
-
-/**
- * Snapshot a host *style*'s template defaults into the playground chip
- * state. Wired to the brand-pill `onClick` in `ClientContextHeader`.
- *
- * BYO custom hosts (registered client-side via `lib/host-styles` but with
- * no `host-templates.ts` entry) fall through to the MCPJam template
- * (essentially empty defaults: clears the capability override, resets the
- * device to desktop, drops to permissive CSP).
- */
-export function applyHostDefaultsToPlayground(
-  hostStyle: ChatboxHostStyle,
-  setters: ApplyHostPlaygroundSetters,
-  opts?: { theme?: HostThemeMode },
-): void {
-  // `seedFromHostTemplate` is typed as `HostTemplateId` but the runtime
-  // falls through to MCPJam on unknown ids. The cast keeps the call site
-  // tolerant of arbitrary BYO host-style ids.
-  //
-  // Thread the caller's theme so the brand-pill click in the chat header
-  // seeds the new host with MCPJam's current global theme instead of the
-  // template's hardcoded "dark" fallback. Without this, picking Copilot/
-  // ChatGPT/etc. from the pill row always flipped the chat surface to
-  // dark even when MCPJam itself was in light mode.
-  const cfg = seedFromHostTemplate(hostStyle as HostTemplateId, opts);
-  // Override the template's `hostStyle` with the user's actual pick — for
-  // BYO ids the template falls back to MCPJam, but the brand pill that
-  // was clicked is the right identity to advertise.
-  applyHostConfigToPlayground({ ...cfg, hostStyle }, setters);
 }
 
 // HostConfigDtoV2 happens to share the same field shape on the three


### PR DESCRIPTION
<img width="2048" height="137" alt="image" src="https://github.com/user-attachments/assets/191c8d49-82b1-4e7a-a890-c174dd0dd402" />

- remove host style button from playground
- tool tip 
- mcpjam logo (big one in middle of chat thread) was going away when selecting multiple models.