### PR TITLE
feat(evals): live grading helpers + agentic-interact design [6/7]

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/eval-live-grading.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/eval-live-grading.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import type { PromptTurn } from "@/shared/steps";
+import {
+  extractActualToolCalls,
+  extractActualToolCallsByTurn,
+  gradeLiveToolCalls,
+} from "../eval-live-grading";
+
+function userTurn(prompt: string, expectedToolCalls: PromptTurn["expectedToolCalls"]): PromptTurn {
+  return { id: prompt, prompt, expectedToolCalls };
+}
+
+function pinnedTurn(toolName: string): PromptTurn {
+  return {
+    id: `pinned-${toolName}`,
+    prompt: "",
+    expectedToolCalls: [],
+    pinnedToolCall: { toolName, arguments: {} },
+  } as unknown as PromptTurn;
+}
+
+function userText(id: string, text: string): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] } as unknown as UIMessage;
+}
+
+function widgetCheckTurn(
+  prompt: string,
+  expectedToolCalls: PromptTurn["expectedToolCalls"],
+): PromptTurn {
+  return {
+    id: prompt,
+    prompt,
+    expectedToolCalls,
+    widgetChecks: [{ kind: "assert" }],
+  } as unknown as PromptTurn;
+}
+
+function assistantWithTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  opts: { dynamic?: boolean } = {},
+): UIMessage {
+  const part = opts.dynamic
+    ? { type: "dynamic-tool", toolName, toolCallId: `${toolName}-1`, state: "output-available", input }
+    : { type: `tool-${toolName}`, toolCallId: `${toolName}-1`, state: "output-available", input };
+  return { id: `a-${toolName}`, role: "assistant", parts: [part] } as unknown as UIMessage;
+}
+
+const userMessage: UIMessage = {
+  id: "u-1",
+  role: "user",
+  parts: [{ type: "text", text: "show me a coke" }],
+} as unknown as UIMessage;
+
+describe("extractActualToolCalls", () => {
+  it("pulls typed and dynamic tool parts from assistant messages only", () => {
+    const calls = extractActualToolCalls([
+      userMessage,
+      assistantWithTool("search-products", { query: "Coca Cola" }),
+      assistantWithTool("add-to-cart", { id: 7 }, { dynamic: true }),
+    ]);
+    expect(calls).toEqual([
+      { toolName: "search-products", arguments: { query: "Coca Cola" } },
+      { toolName: "add-to-cart", arguments: { id: 7 } },
+    ]);
+  });
+
+  it("ignores user-side parts and non-tool parts", () => {
+    expect(extractActualToolCalls([userMessage])).toEqual([]);
+  });
+});
+
+describe("gradeLiveToolCalls", () => {
+  const turns = [
+    userTurn("show me a coke", [
+      { toolName: "search-products", arguments: { query: "Coca Cola" } },
+    ]),
+  ];
+
+  it("passes when the asserted tool call was made with matching args", () => {
+    const verdict = gradeLiveToolCalls({
+      promptTurns: turns,
+      messages: [userMessage, assistantWithTool("search-products", { query: "Coca Cola" })],
+    });
+    expect(verdict).toBe("passed");
+  });
+
+  it("fails when the asserted tool was not called", () => {
+    const verdict = gradeLiveToolCalls({
+      promptTurns: turns,
+      messages: [userMessage, assistantWithTool("browse", { page: 1 })],
+    });
+    expect(verdict).toBe("failed");
+  });
+
+  it("fails when a required argument mismatches under strict matching", () => {
+    const verdict = gradeLiveToolCalls({
+      promptTurns: turns,
+      matchOptions: { argumentMatching: "exact" },
+      messages: [userMessage, assistantWithTool("search-products", { query: "Pepsi" })],
+    });
+    expect(verdict).toBe("failed");
+  });
+
+  it("returns null when there are no model turns to grade", () => {
+    // No model turns at all => not a negative test and nothing asserted => defer
+    // to a full graded Run rather than claim a pass.
+    const verdict = gradeLiveToolCalls({
+      promptTurns: [],
+      messages: [userMessage, assistantWithTool("search-products", { query: "x" })],
+    });
+    expect(verdict).toBeNull();
+  });
+
+  it("grades a negative test (all model turns assert no calls): passes when no tools were called", () => {
+    const verdict = gradeLiveToolCalls({
+      promptTurns: [userTurn("don't call anything", [])],
+      messages: [userMessage],
+    });
+    expect(verdict).toBe("passed");
+  });
+
+  it("fails a negative test when a tool was called", () => {
+    const verdict = gradeLiveToolCalls({
+      promptTurns: [userTurn("don't call anything", [])],
+      messages: [userMessage, assistantWithTool("search-products", { query: "x" })],
+    });
+    expect(verdict).toBe("failed");
+  });
+});
+
+describe("extractActualToolCallsByTurn", () => {
+  it("buckets tool calls under the preceding user turn", () => {
+    const buckets = extractActualToolCallsByTurn([
+      userText("u1", "turn 1"),
+      assistantWithTool("search-products", { query: "Coca Cola" }),
+      userText("u2", "turn 2"),
+      assistantWithTool("add-to-cart", { id: 7 }, { dynamic: true }),
+    ]);
+    expect(buckets).toEqual([
+      [{ toolName: "search-products", arguments: { query: "Coca Cola" } }],
+      [{ toolName: "add-to-cart", arguments: { id: 7 } }],
+    ]);
+  });
+
+  it("ignores tool calls before the first user message", () => {
+    const buckets = extractActualToolCallsByTurn([
+      assistantWithTool("search-products", { query: "x" }),
+      userText("u1", "turn 1"),
+    ]);
+    expect(buckets).toEqual([[]]);
+  });
+});
+
+describe("gradeLiveToolCalls — multi-turn per-turn attribution", () => {
+  const turns = [
+    userTurn("turn 1", [{ toolName: "tool-a", arguments: {} }]),
+    userTurn("turn 2", [{ toolName: "tool-b", arguments: {} }]),
+  ];
+
+  it("fails when turn 2's expected tool was actually called on turn 1", () => {
+    // Both tools fire on turn 1; turn 2 makes no call. A global merge of all
+    // expected vs all actual would pass (order-agnostic), but per-turn grading
+    // (matching the runner's evaluateMultiTurnResults) must fail because turn 2
+    // is missing its expected tool.
+    const verdict = gradeLiveToolCalls({
+      promptTurns: turns,
+      messages: [
+        userText("u1", "turn 1"),
+        assistantWithTool("tool-a", {}),
+        assistantWithTool("tool-b", {}),
+        userText("u2", "turn 2"),
+      ],
+    });
+    expect(verdict).toBe("failed");
+  });
+
+  it("passes when each turn made its own expected call", () => {
+    const verdict = gradeLiveToolCalls({
+      promptTurns: turns,
+      messages: [
+        userText("u1", "turn 1"),
+        assistantWithTool("tool-a", {}),
+        userText("u2", "turn 2"),
+        assistantWithTool("tool-b", {}),
+      ],
+    });
+    expect(verdict).toBe("passed");
+  });
+
+  it("skips pinned (model-free) turns and grades model turns in order", () => {
+    const verdict = gradeLiveToolCalls({
+      promptTurns: [
+        pinnedTurn("render-widget"),
+        userTurn("turn 1", [{ toolName: "tool-a", arguments: {} }]),
+      ],
+      messages: [userText("u1", "turn 1"), assistantWithTool("tool-a", {})],
+    });
+    expect(verdict).toBe("passed");
+  });
+});
+
+describe("gradeLiveToolCalls — defers when it can't match the runner", () => {
+  it("defers (null) when a turn carries widget interaction checks", () => {
+    // The runner folds widget→host tool calls into the turn's actuals, but the
+    // live preview never executes authored widget steps, so a model-only verdict
+    // could disagree with a graded Run. Defer rather than show a badge.
+    const verdict = gradeLiveToolCalls({
+      promptTurns: [
+        widgetCheckTurn("show a coke", [
+          { toolName: "search-products", arguments: { query: "Coca Cola" } },
+        ]),
+      ],
+      messages: [
+        userText("u1", "show a coke"),
+        assistantWithTool("search-products", { query: "Coca Cola" }),
+      ],
+    });
+    expect(verdict).toBeNull();
+  });
+
+  it("defers (null) when a synthetic follow-up user turn over-segments the thread", () => {
+    // Two authored model turns, but three user turns in the thread (a widget
+    // ui/message follow-up the runner would fold into its parent turn). The 1:1
+    // mapping breaks, so attribution is unreliable — defer.
+    const verdict = gradeLiveToolCalls({
+      promptTurns: [
+        userTurn("turn 1", [{ toolName: "tool-a", arguments: {} }]),
+        userTurn("turn 2", [{ toolName: "tool-b", arguments: {} }]),
+      ],
+      messages: [
+        userText("u1", "turn 1"),
+        assistantWithTool("tool-a", {}),
+        userText("u2", "turn 2"),
+        assistantWithTool("tool-b", {}),
+        userText("u3", "widget follow-up"),
+        assistantWithTool("tool-c", {}),
+      ],
+    });
+    expect(verdict).toBeNull();
+  });
+
+  it("defers (null) on a partial run (fewer user turns than authored model turns)", () => {
+    const verdict = gradeLiveToolCalls({
+      promptTurns: [
+        userTurn("turn 1", [{ toolName: "tool-a", arguments: {} }]),
+        userTurn("turn 2", [{ toolName: "tool-b", arguments: {} }]),
+      ],
+      messages: [userText("u1", "turn 1"), assistantWithTool("tool-a", {})],
+    });
+    expect(verdict).toBeNull();
+  });
+
+  it("defers (null) for a pinned-only case instead of vacuously passing", () => {
+    // Every turn is pinned (model-free), but the pinned turn declares expected
+    // calls so the early "nothing to grade" gate doesn't fire. With no model
+    // turns the loop would run zero times and return "passed" without comparing
+    // anything — the live preview doesn't execute pinned fixtures, so it must
+    // defer to the graded Run.
+    const verdict = gradeLiveToolCalls({
+      promptTurns: [
+        {
+          id: "p1",
+          prompt: "",
+          expectedToolCalls: [{ toolName: "render-widget", arguments: {} }],
+          pinnedToolCall: { toolName: "render-widget", arguments: {} },
+        } as unknown as PromptTurn,
+      ],
+      messages: [],
+    });
+    expect(verdict).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/eval-live-grading.ts
+++ b/mcpjam-inspector/client/src/components/evals/eval-live-grading.ts
@@ -1,0 +1,222 @@
+/**
+ * eval-live-grading — grade a single-model Quick Run conversation in place.
+ *
+ * The Preview pane is a live, ungraded Playground chat (`EvalLivePreview` →
+ * `PlaygroundMain`): it never writes a test iteration, so the graded Run flow is
+ * the only thing that normally produces a verdict. But users expect "I hit Quick
+ * Run, did it pass?" answered right there. This derives the SAME deterministic
+ * tool-call verdict the real runner computes — reusing `computeIterationPassed`
+ * (→ `evaluateToolCalls`) so the live badge can never disagree with a graded Run
+ * on the tool-call dimension.
+ *
+ * Multi-turn parity: the real runner grades each prompt turn against only the
+ * tool calls made on THAT turn (`evaluateMultiTurnResults`), then passes the
+ * iteration iff every turn passes. We mirror that here — bucket the live thread
+ * by user turn and grade each turn with `computeIterationPassed` — so an
+ * order-agnostic match can't let a call made on turn 1 satisfy a tool expected
+ * on turn 2 (which would make the live badge show passed while a graded Run
+ * fails).
+ *
+ * Scope: tool-call assertions + match options (order / extras / arguments /
+ * negative-test) only. LLM-judge checks, predicates and `expectedOutput` are NOT
+ * evaluated here (the live preview can't run the judge) — a full graded Run still
+ * owns those. The caller surfaces that scoping in the badge tooltip.
+ */
+import type { UIMessage } from "ai";
+import {
+  getToolInfo,
+  isDynamicTool,
+  isToolPart,
+} from "@/components/chat-v2/thread/thread-helpers";
+import type { EvalMatchOptions } from "@/shared/eval-matching";
+import {
+  flattenAssertedExpectedToolCalls,
+  isPinnedTurn,
+  type PromptTurn,
+} from "@/shared/steps";
+import { computeIterationPassed } from "./pass-criteria";
+import type { EvalIteration } from "./types";
+
+export type LiveToolCall = {
+  toolName: string;
+  arguments: Record<string, unknown>;
+};
+
+export type LiveVerdict = "passed" | "failed";
+
+/**
+ * Minimal projection of {@link EvalIteration} that {@link computeIterationPassed}
+ * reads for the tool-call verdict. Typed against `EvalIteration` (rather than
+ * erased with `as never`) so a shape change in the grading contract surfaces as a
+ * type error here instead of letting the live badge silently diverge from a
+ * graded Run.
+ */
+type LiveGradingIteration = Pick<
+  EvalIteration,
+  "resultSource" | "actualToolCalls"
+> & {
+  testCaseSnapshot: Pick<
+    NonNullable<EvalIteration["testCaseSnapshot"]>,
+    "expectedToolCalls" | "isNegativeTest" | "matchOptions"
+  >;
+};
+
+/**
+ * Pull the tool calls out of a single message. Mirrors the recorder's part walk
+ * (`isToolPart`/`isDynamicTool` + `getToolInfo`) so a "call" here means the same
+ * thing the backend records on an iteration. Non-assistant messages contribute
+ * nothing.
+ */
+function collectToolCalls(message: UIMessage): LiveToolCall[] {
+  if (message.role !== "assistant") return [];
+  const calls: LiveToolCall[] = [];
+  for (const part of message.parts ?? []) {
+    if (!isToolPart(part) && !isDynamicTool(part)) continue;
+    const info = getToolInfo(part as never);
+    if (!info.toolName) continue;
+    calls.push({
+      toolName: info.toolName,
+      arguments: (info.input ?? {}) as Record<string, unknown>,
+    });
+  }
+  return calls;
+}
+
+/**
+ * Flatten the tool calls the model actually made in the live thread, in order.
+ */
+export function extractActualToolCalls(messages: UIMessage[]): LiveToolCall[] {
+  const calls: LiveToolCall[] = [];
+  for (const message of messages) {
+    calls.push(...collectToolCalls(message));
+  }
+  return calls;
+}
+
+/**
+ * Bucket the live thread's tool calls by model turn. Each `user` message opens a
+ * new turn; assistant tool calls accumulate into the open turn. This mirrors how
+ * the runner builds `toolsCalledByPrompt` (one bucket per model turn) so per-turn
+ * grading sees only the calls made in response to that turn's prompt — never a
+ * call from an earlier or later turn. Tool calls before the first user message
+ * (unusual in a Playground thread) are ignored.
+ */
+export function extractActualToolCallsByTurn(
+  messages: UIMessage[],
+): LiveToolCall[][] {
+  const turns: LiveToolCall[][] = [];
+  let current: LiveToolCall[] | null = null;
+  for (const message of messages) {
+    if (message.role === "user") {
+      current = [];
+      turns.push(current);
+      continue;
+    }
+    if (!current) continue;
+    current.push(...collectToolCalls(message));
+  }
+  return turns;
+}
+
+/**
+ * A negative test = the model is expected to call no tools. Pinned
+ * (render-check) turns are model-free, so exclude them when deciding. Mirrors
+ * `deriveIsNegativeTestFromPromptTurns` in the editor.
+ */
+function deriveIsNegativeTest(promptTurns: PromptTurn[]): boolean {
+  const modelTurns = promptTurns.filter((turn) => !isPinnedTurn(turn));
+  return (
+    modelTurns.length > 0 &&
+    modelTurns.every((turn) => turn.expectedToolCalls.length === 0)
+  );
+}
+
+/**
+ * Grade the live Quick-Run conversation against the current draft's tool-call
+ * assertions, per turn. Returns the deterministic Passed/Failed verdict, or
+ * `null` when the live preview can't faithfully reproduce what a graded Run would
+ * score — so the caller stays quiet instead of showing a badge that could
+ * disagree. We defer (return `null`) when:
+ *   - there's nothing to grade (no asserted tool calls and not a negative test);
+ *   - any turn carries widget interaction/assert steps (`widgetChecks`): the
+ *     runner folds widget→host tool calls into a turn's actuals
+ *     (`widgetToolCallsByPromptIndex`), but the live Playground preview never
+ *     executes those authored steps, so its model-only view would diverge;
+ *   - the thread's user turns don't line up 1:1 with the authored model turns —
+ *     e.g. a partial run, or a synthetic follow-up `user` turn from a widget
+ *     `ui/message` (which the runner folds into the PARENT turn, not a new one).
+ */
+export function gradeLiveToolCalls(params: {
+  promptTurns: PromptTurn[];
+  matchOptions?: EvalMatchOptions;
+  messages: UIMessage[];
+}): LiveVerdict | null {
+  const { promptTurns, matchOptions, messages } = params;
+  const isNegativeTest = deriveIsNegativeTest(promptTurns);
+
+  // Nothing the live preview can deterministically judge: no asserted calls on
+  // any turn and not a "should call nothing" test. Defer to a full graded Run.
+  if (
+    !isNegativeTest &&
+    flattenAssertedExpectedToolCalls({ promptTurns }).length === 0
+  ) {
+    return null;
+  }
+
+  // Widget-interaction cases are owned by the graded Run. The live Playground
+  // preview doesn't execute authored widget interact/assert steps, so it never
+  // sees the widget→host tool calls the runner folds into a turn's actuals
+  // (`widgetToolCallsByPromptIndex`). Grading tool-call assertions on a
+  // model-only view could disagree with a graded Run, so defer.
+  if (promptTurns.some((turn) => (turn.widgetChecks?.length ?? 0) > 0)) {
+    return null;
+  }
+
+  // Pinned (render-check) turns are model-free fixtures, exempt from matching —
+  // they always pass and emit no user message in the live thread. Grade only the
+  // model turns, in order.
+  const modelTurns = promptTurns.filter((turn) => !isPinnedTurn(turn));
+
+  // No model turns means a pinned-only (model-free) case. The early gate above
+  // can still pass here if a pinned turn declares `expectedToolCalls` (flattened
+  // for display but exempt from matching), and the loop below would then run zero
+  // times and vacuously return "passed". The live preview doesn't execute pinned
+  // fixtures, so defer to the graded Run rather than claim a pass.
+  if (modelTurns.length === 0) {
+    return null;
+  }
+
+  const actualByTurn = extractActualToolCallsByTurn(messages);
+
+  // The thread's user turns must line up 1:1 with the authored model turns. A
+  // mismatch means the run is partial (fewer) or the thread has a synthetic
+  // follow-up `user` turn — e.g. a widget `ui/message`, which the runner folds
+  // into the parent turn rather than treating as a new turn. Per-turn
+  // attribution would be unreliable, so defer instead of risking a wrong verdict.
+  if (actualByTurn.length !== modelTurns.length) {
+    return null;
+  }
+
+  for (let i = 0; i < modelTurns.length; i += 1) {
+    const turn = modelTurns[i]!;
+    const iteration: LiveGradingIteration = {
+      resultSource: "derived",
+      actualToolCalls: actualByTurn[i] ?? [],
+      testCaseSnapshot: {
+        expectedToolCalls: turn.expectedToolCalls ?? [],
+        isNegativeTest,
+        matchOptions,
+      },
+    };
+    const turnPassed = computeIterationPassed(
+      iteration as unknown as EvalIteration,
+      undefined,
+    );
+
+    // Overall verdict mirrors `evaluateMultiTurnResults`: passed iff every turn
+    // passed, so fail fast on the first failing turn.
+    if (!turnPassed) return "failed";
+  }
+
+  return "passed";
+}

--- a/mcpjam-inspector/docs/eval-agentic-interact-design.md
+++ b/mcpjam-inspector/docs/eval-agentic-interact-design.md
@@ -1,0 +1,155 @@
+# Design: per-step agentic interact (computer-use) in evals
+
+**Status:** DESIGN — no production code. This is R4 from the
+`eval-widget-interaction-replay` follow-ups; R1–R3 (observability, helper dedup,
+loop consolidation) shipped first. Per TL review, R4 is product surface area and
+must resolve three blockers before any implementation.
+
+## Goal
+
+Let an authored eval step *optionally* drive a widget **agentically** — the model
+drives by screenshots via the `computer` / `finish_widget` tools, the way
+Swarm/session-simulation does — **opt-in per step, never a global switch**, so
+deterministic grading is preserved for the default scripted `interact`.
+
+Today eval `interact` is always deterministic: `runInteractStep` →
+`browser.replayInteractStep` replays a recorded click/type
+(`step-executor.ts`, `browser-session-context.ts`). The invariant is explicit:
+the eval runner **never** passes `enableComputerUse: true` to
+`createBrowserSessionContext`; only the `sessionSimulation` runner does.
+
+## The three blockers (and recommended resolutions)
+
+### 1. Tool construction is gated at context-construction time
+
+**Problem.** `computerWidgetTools` (the `computer` + `finish_widget` tool set) and
+the `prepareAdvertisedTools` gate are built **once, at `createBrowserSessionContext`
+time**, only when `enableComputerUse === true`. An eval context is constructed
+`enableComputerUse`-free, so the tools don't exist — a per-step mode can't just
+"turn them on" later.
+
+**Recommendation — narrow, lazy capability, not the global flag.** Add a
+context-level capability that *can build* the computer tools on demand without
+flipping the global agentic default:
+- Keep `enableComputerUse` meaning "advertise computer tools for ALL turns"
+  (session simulation's behavior) — unchanged.
+- Add `allowAgenticSteps?: boolean` (eval sets this true). When set, the context
+  exposes a `buildComputerWidgetToolsLazily()` / `getComputerWidgetTools()` that
+  constructs the tool set + the mount-gated `prepareAdvertisedTools` **on first
+  use**, scoped to the caller. The capability probe
+  (`resolveComputerUseToolVersion` / `modelSupportsComputerUse`) runs once and is
+  cached, same as today.
+- Eval’s `createBrowserSessionContext` call still passes `enableComputerUse:
+  false`; it passes `allowAgenticSteps: true`. So normal `prompt`/`interact` turns
+  see no computer tools; only an `agentInteract` step pulls them in for its own
+  model turns.
+
+This keeps "computer tools off by default for evals" true, while making them
+constructible per step. (Alternative considered: build eagerly with
+`enableComputerUse: true` and filter at advertise — rejected, it re-introduces the
+global agentic surface the invariant forbids.)
+
+### 2. `InteractStep` schema — discriminated union, not optional fields
+
+**Problem.** `interactStepSchema` *requires* a scripted `action`. Bolting
+`driver: "computer"` + optional `goal` onto it means agentic steps carry a
+dummy/ambiguous scripted `action`.
+
+**Recommendation — a new `agentInteract` step kind** (discriminated union peer of
+`interact`), NOT a field on `InteractStep`:
+```ts
+// shared/steps.ts
+agentInteractStepSchema = z.object({
+  id: z.string(),
+  kind: z.literal("agentInteract"),
+  toolName: z.string().min(1),          // the widget to drive
+  // A goal is an eval directive, not recorded step text — give it its own cap
+  // (MAX_AGENTIC_GOAL_CHARS), don't reuse MAX_SCRIPTED_STEP_TEXT_CHARS.
+  goal: z.string().min(1).max(MAX_AGENTIC_GOAL_CHARS),
+  maxActions: z.number().int().positive().max(20).optional(),
+  budgetTokens: z.number().int().positive().optional(),
+  // Wall-clock bound. maxActions/budgetTokens cap iteration count and spend but
+  // NOT time; without this a model that stalls on tool execution or retries on
+  // transient failures could hang the runner. The loop aborts on elapsed time.
+  timeoutMs: z.number().int().positive().optional(),
+});
+// TEST_STEP_KINDS += "agentInteract"; TestStep union += agentInteractStepSchema
+```
+Rationale: scripted `interact` and agentic `agentInteract` have **disjoint**
+payloads (recorded `action` vs free-text `goal` + budgets). A discriminated union
+keeps each shape clean and lets the executor/authoring/replay narrow on `kind`
+(the same pattern `interact`/`assert`/`prompt`/`toolCall` already use). A
+`driver` field on one schema would make half its fields conditionally-required —
+exactly the ambiguity to avoid.
+
+### 3. Transcript semantics — decide BEFORE building
+
+**Problem.** Does the agentic step's `goal` (and the model's computer-tool actions)
+enter the chat transcript, or stay eval-harness-only? This drives grading, trace
+spans, usage/billing, and reproducibility — it must be settled up front.
+
+**Recommendation:**
+- **Goal → NOT a chat user turn.** The `goal` is an *eval directive*, not user
+  speech. Putting it in the transcript would pollute the conversation a
+  `toolCalledWith`/judge reads and mislead reproductions. Instead, the agentic
+  loop runs as harness-internal model turns whose *system* framing carries the
+  goal (mirrors how `interact` actions are artifacts, not transcript — see
+  `project_eval_interactions_are_artifacts`).
+- **Tool calls the agent makes → real, attributed.** Any `tools/call` the widget
+  issues during the agentic loop is a genuine protocol event: record it exactly
+  like a scripted interact's `widgetToolCalls` (PR1 plumbing) and bucket it into
+  the step's turn for `toolCalledWith` (the established interact contract). A
+  `ui/message` the widget sends → drives a follow-up turn (R3 path), same as
+  scripted.
+- **Spans + usage → attributed to the step's `turnOrdinal`.** Each agentic model
+  turn is a real billable turn (`feedback_evals_first_class_billable`); stamp its
+  spans with the step's promptIndex (the existing `onAction`/render pipeline
+  already records browser-interaction artifacts).
+- **Reproducibility caveat — state it loudly.** An `agentInteract` step is
+  **nondeterministic by construction** (model-driven). It is the one eval step
+  whose replay won't be byte-identical. Grading should target *outcomes*
+  (`toolCalledWith view-cart`), not exact action sequences. This is the core
+  trade vs scripted `interact` and must be surfaced in the authoring UI.
+
+## Implementation sketch (after the above are approved)
+
+- `shared/steps.ts`: add `agentInteractStepSchema` + union/kinds.
+- `server/services/evals/step-executor.ts`: a `runAgentInteractStep` branch that
+  loops bounded model turns through the existing `onPrompt`/engine seam with the
+  step-scoped computer tools advertised (blocker #1's lazy builder), capped by
+  `maxActions`, `budgetTokens`, **and `timeoutMs`** — the loop checks elapsed
+  wall-clock each turn and aborts once it exceeds `timeoutMs`, so a stalled tool
+  call or retry storm can't hang the runner. Actions are recorded via the
+  existing harness `onAction` callback, then `ui/message` follow-ups are drained
+  (R3). The step-scoped tool builder in `browser-session-context.ts` threads the
+  timeout through to the engine call.
+- `browser-session-context.ts`: the lazy/step-scoped tool builder (#1).
+- No global `enableComputerUse` change for evals.
+
+## Deferred surface (explicit follow-on, not in the first agentic PR)
+
+- **Authoring UI** (`add-step-picker`): an "agentic interact" option with goal +
+  budget inputs, and a clear "nondeterministic" badge.
+- **Recorder**: there's nothing to record for an agentic step (it's a goal, not a
+  script) — but the authoring flow should let you *convert* a scripted interact
+  into a goal, or seed a goal from a recorded session.
+- **Grading docs**: guidance that agentic steps assert outcomes, not sequences.
+
+## Open questions for the TL
+
+1. Budget unit: `maxActions` (simple, predictable) vs `budgetTokens` (cost-true)
+   vs both? Recommendation: both optional, `maxActions` default 20.
+2. Should a failed agentic step (goal not reached within budget/time) fail the
+   iteration fail-fast like a failed scripted `interact`, or record a soft
+   "goal-not-met" verdict? Recommendation: fail-fast (matches `interact`), with
+   the reason captured. Partial state is **retained, not rolled back** — unlike an
+   atomic scripted `interact`, an agentic loop may have issued several tool calls
+   and mutated browser state before failing, so: the iteration error records the
+   last attempted action; tool calls already issued stay in `toolCallsByTurn` for
+   grading (they are real, attributed protocol events — see the transcript rules
+   above); and the transcript keeps the partial agentic turns. A failed
+   `agentInteract` is therefore debuggable, not an opaque timeout.
+3. Do we gate the whole feature behind a flag for the first ship (given it's the
+   first nondeterministic eval step), even though R3's follow-up loop shipped
+   unflagged? Recommendation: yes — `agentInteract` is a new authored capability,
+   flag it until validated.


### PR DESCRIPTION
## PR 6/7 — Live grading helpers + agentic-interact design

### Purpose / context
Add the live-grading helpers that drive incremental verdict updates as a step-based run streams, plus the design note for agentic `interact` steps. Kept separate from the authoring UI (PR 4) so the grading logic is reviewable on its own.

### Before / after
- **Before:** grading state is computed in-line with the stream reducer.
- **After:** a dedicated `eval-live-grading` helper centralizes live grading, with focused unit coverage; design intent for agentic interact steps is documented.

### Reviewer map
- `client/src/components/evals/eval-live-grading.ts` (new) + `__tests__/eval-live-grading.test.ts`.
- `docs/eval-agentic-interact-design.md` — design note.

### Reviewer focus
- Do live grading transitions match the run stream (step statuses update correctly)?
- Is the helper a clean seam separable from the stream reducer?

### Test plan
- `npm run typecheck:client -w @mcpjam/inspector`
- `eval-live-grading` unit suite.

### Migration / deploy notes
Additive helpers + docs; depends on PR 5. No schema/runtime migration.
---

### 📚 Stacked PR series

This is part of a 7-PR stack that breaks the evals `TestStep[]` rework out of the `evals-ui-polish` branch into reviewable, subsystem-scoped slices. Each PR is based on the previous one — **review and merge top-to-bottom.**

| # | PR | Branch | Base | Scope |
|---|----|--------|------|-------|
| 1 | #2899 | `codex/evals-stack-1-shared-steps` | `main` | Shared `TestStep[]` contract + legacy conversion |
| 2 | #2900 | `codex/evals-stack-2-server-runtime` | #2899 | Inspector server executes step-based runs |
| 3 | #2901 | `codex/evals-stack-3-api-sdk-cli` | #2900 | API routes, SDK, CLI, OpenAPI/docs |
| 4 | #2902 | `codex/evals-stack-4-authoring-ui` | #2901 | Step authoring + replay/dashboard UI |
| 5 | #2903 | `codex/evals-stack-5-recorder-widget-capture` | #2902 | Recorder shim + widget interaction capture |
| 6 | #2904 | `codex/evals-stack-6-run-replay-artifacts` | #2903 | Live grading helpers + agentic-interact design |
| 7 | #2905 | `codex/evals-stack-7-dashboards-cross-host` | #2904 | Dashboard/cross-host regression coverage |

**Backend gate:** the backend `steps`-first cutover lives on `add-evals-backend-changes` (`b535e67e`). Its **destructive migration must not run** until inspector PRs **1–5** (#2899–#2903) are merged, deployed, and smoke-tested. Persisted rows are `steps`-first; `promptTurns` is a boundary-compat path only.

> Reconstructed by subsystem from `evals-ui-polish` (not cherry-picked commits). `.env.local`/`node_modules` are excluded from the stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client helpers and documentation only; grading logic delegates to existing `computeIterationPassed` with explicit null deferrals to avoid false live verdicts.
> 
> **Overview**
> Introduces **`eval-live-grading`**, a dedicated module so Quick Run / live preview can show a **passed/failed** badge for tool-call assertions without waiting on a graded Run. It walks live `UIMessage` threads (typed and dynamic tool parts, same helpers as the recorder), buckets calls **per user turn**, and grades each turn via existing **`computeIterationPassed`** so multi-turn behavior matches the runner’s **`evaluateMultiTurnResults`** (a call on turn 1 can’t satisfy turn 2). It returns **`null`** when a live verdict would be unreliable—widget checks, turn-count mismatch, partial runs, pinned-only cases—so the UI stays quiet instead of disagreeing with a full Run. Scope is tool-call + match options only; LLM judge / predicates stay on the graded path.
> 
> Adds a **Vitest** suite covering extraction, negative tests, per-turn attribution, pinned turns, and defer cases.
> 
> Also adds **`docs/eval-agentic-interact-design.md`** (design only, no runtime): optional per-step **`agentInteract`** (computer-use) with lazy tool construction, a discriminated step schema, and transcript/grading semantics—blocked on TL review before implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9abd8f55099f3bcc04173cc953cdde211bebbdae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->