### PR TITLE
feat(evals): dashboard & cross-host regression coverage [7/7]

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/cell-metric-strip-data.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/cell-metric-strip-data.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCellMetricStripData,
+  MIN_TREND_POINTS,
+} from "../metric-strip-data";
+
+describe("buildCellMetricStripData", () => {
+  it("maps cell run history into metric strip points with run labels", () => {
+    const data = buildCellMetricStripData([
+      {
+        runLabel: "abc1",
+        result: "passed",
+        latencyMs: 8000,
+        latencyP95Ms: 9000,
+        tokens: 1500,
+        toolCalls: 2,
+      },
+      {
+        runLabel: "abc2",
+        result: "failed",
+        latencyMs: 10_000,
+        latencyP95Ms: 11_000,
+        tokens: 1900,
+        toolCalls: 1,
+      },
+    ]);
+
+    expect(data).not.toBeNull();
+    expect(data?.series).toHaveLength(2);
+    expect(data?.latest.passRate).toBe(0);
+    expect(data?.latest.failed).toBe(1);
+    expect(data?.latest.latencyP50).toBe(9000);
+    expect(data?.latest.latencyP95).toBe(10_900);
+    expect(data?.latest.tokens).toBe(1900);
+    expect(data?.latest.toolCalls).toBe(1);
+    expect(data?.runLabels).toEqual(["Run abc1", "Run abc2"]);
+    expect(data?.showTrend).toBe(true);
+  });
+
+  it("returns null for empty input", () => {
+    expect(buildCellMetricStripData([])).toBeNull();
+  });
+
+  it("hides trend sparklines below minimum points", () => {
+    const data = buildCellMetricStripData([
+      {
+        runLabel: "only",
+        result: "passed",
+        latencyMs: 1000,
+        latencyP95Ms: 1000,
+        tokens: 500,
+        toolCalls: 1,
+      },
+    ]);
+    expect(data?.showTrend).toBe(false);
+    expect(MIN_TREND_POINTS).toBe(2);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/group-case-iterations.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/group-case-iterations.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  groupCaseIterations,
+  caseRunBatchKey,
+} from "../runs/group-case-iterations";
+import type { EvalIteration } from "../types";
+
+function makeIteration(over: Partial<EvalIteration>): EvalIteration {
+  return {
+    _id: "it",
+    createdBy: "u1",
+    createdAt: 0,
+    iterationNumber: 1,
+    updatedAt: 0,
+    status: "completed",
+    result: "passed",
+    actualToolCalls: [],
+    tokensUsed: 0,
+    ...over,
+  } as EvalIteration;
+}
+
+describe("group-case-iterations", () => {
+  it("groups suite-run iterations by suiteRunId", () => {
+    const iters = [
+      makeIteration({ _id: "a", suiteRunId: "run1", iterationNumber: 1, createdAt: 10 }),
+      makeIteration({ _id: "b", suiteRunId: "run1", iterationNumber: 2, createdAt: 11 }),
+    ];
+    const batches = groupCaseIterations(iters);
+    expect(batches).toHaveLength(1);
+    expect(batches[0].key).toBe("suite:run1");
+    expect(batches[0].iterations.map((i) => i._id)).toEqual(["a", "b"]);
+  });
+
+  it("groups quick-run iterations by metadata.compareRunId", () => {
+    const iters = [
+      makeIteration({ _id: "a", metadata: { compareRunId: "c1" }, createdAt: 5 }),
+      makeIteration({ _id: "b", metadata: { compareRunId: "c1" }, createdAt: 6 }),
+    ];
+    const batches = groupCaseIterations(iters);
+    expect(batches).toHaveLength(1);
+    expect(batches[0].key).toBe("compare:c1");
+  });
+
+  it("keeps iterations with no batch key standalone (by id)", () => {
+    const iters = [
+      makeIteration({ _id: "a", createdAt: 1 }),
+      makeIteration({ _id: "b", createdAt: 2 }),
+    ];
+    const batches = groupCaseIterations(iters);
+    expect(batches).toHaveLength(2);
+    expect(caseRunBatchKey(iters[0])).toBe("solo:a");
+  });
+
+  it("orders iterations by iterationNumber and batches newest-first", () => {
+    const iters = [
+      makeIteration({ _id: "old", suiteRunId: "r1", iterationNumber: 2, createdAt: 100 }),
+      makeIteration({ _id: "older", suiteRunId: "r1", iterationNumber: 1, createdAt: 90 }),
+      makeIteration({ _id: "new", suiteRunId: "r2", iterationNumber: 1, createdAt: 200 }),
+    ];
+    const batches = groupCaseIterations(iters);
+    expect(batches.map((b) => b.key)).toEqual(["suite:r2", "suite:r1"]);
+    // within r1, iterationNumber asc
+    expect(batches[1].iterations.map((i) => i._id)).toEqual(["older", "old"]);
+  });
+
+  it("returns empty for no iterations", () => {
+    expect(groupCaseIterations([])).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/trace-repair-banner.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-repair-banner.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { Badge } from "@mcpjam/design-system/badge";
 import { cn } from "@/lib/utils";
-import { Loader2, Sparkles, X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import {
   activeAutoFixSentence,
   terminalAutoFixSentence,
@@ -27,9 +27,11 @@ function setOutcomeDismissedStorage(jobId: string) {
 }
 
 const cardClass =
-  "rounded-md border border-violet-200/70 bg-violet-50/40 dark:border-violet-900/45 dark:bg-violet-950/20";
+  "rounded-md border border-border/60 bg-muted/20 dark:bg-muted/10";
 const headerDividerClass =
-  "flex flex-wrap items-center justify-between gap-2 border-b border-violet-200/50 px-3 py-2 dark:border-violet-900/40";
+  "flex flex-wrap items-center justify-between gap-2 border-b border-border/60 px-3 py-2";
+const aiBadgeClass =
+  "border-border bg-muted text-muted-foreground text-[10px] font-bold uppercase tracking-wider shrink-0";
 
 export interface TraceRepairBannerProps {
   scope: "suite" | "case";
@@ -77,11 +79,7 @@ export function TraceRepairBanner({
       <div className={cn(cardClass, className)}>
         <div className={headerDividerClass}>
           <div className="flex flex-wrap items-center gap-2 min-w-0">
-            <Badge
-              variant="outline"
-              className="border-violet-300/70 bg-violet-100/60 text-violet-800 text-[10px] font-bold uppercase tracking-wider shrink-0 dark:border-violet-800/50 dark:bg-violet-900/35 dark:text-violet-300"
-            >
-              <Sparkles className="mr-1 h-3 w-3" />
+            <Badge variant="outline" className={aiBadgeClass}>
               AI
             </Badge>
             <span className="text-xs font-medium text-foreground">
@@ -114,11 +112,7 @@ export function TraceRepairBanner({
       <div className={cn("relative", cardClass, className)}>
         <div className={cn(headerDividerClass, "pr-10")}>
           <div className="flex flex-wrap items-center gap-2 min-w-0">
-            <Badge
-              variant="outline"
-              className="border-violet-300/70 bg-violet-100/60 text-violet-800 text-[10px] font-bold uppercase tracking-wider shrink-0 dark:border-violet-800/50 dark:bg-violet-900/35 dark:text-violet-300"
-            >
-              <Sparkles className="mr-1 h-3 w-3" />
+            <Badge variant="outline" className={aiBadgeClass}>
               AI
             </Badge>
             <span className="text-xs font-medium text-foreground">
@@ -128,7 +122,7 @@ export function TraceRepairBanner({
         </div>
         <button
           type="button"
-          className="absolute right-2 top-2 rounded p-0.5 text-muted-foreground hover:bg-violet-100/50 hover:text-foreground dark:hover:bg-violet-950/40"
+          className="absolute right-2 top-2 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
           aria-label="Dismiss auto fix outcome"
           onClick={() => {
             setDismissedId(latestOutcome.jobId);


### PR DESCRIPTION
## PR 7/7 — Dashboard & cross-host regression coverage

### Purpose / context
Final polish slice: regression coverage for the cross-host/dashboard cell metrics and grouped case iterations introduced in PR 4, plus a small trace-repair banner refinement. Lands aggregate-view safety nets after the core eval flow is reviewable, keeping foundational contract/runtime changes out of presentation polish.

### Before / after
- **Before:** cell metric-strip data and grouped case-iteration helpers have no direct regression tests; trace-repair banner has a rough edge.
- **After:** focused tests pin cell metric-strip data and group-case-iteration behavior; trace-repair banner refined.

### Reviewer map
- `client/src/components/evals/__tests__/cell-metric-strip-data.test.ts` (new)
- `client/src/components/evals/__tests__/group-case-iterations.test.ts` (new)
- `client/src/components/evals/trace-repair-banner.tsx`

### Reviewer focus
- Are aggregate/cross-host views correct with step-based runs?
- Is this PR free of foundational contract/runtime changes (presentation + tests only)?

### Test plan
- `npm run typecheck:client -w @mcpjam/inspector`
- Cell metric-strip + group-case-iterations regression suites.

### Migration / deploy notes
Tests + presentation only; depends on PR 6. No migration.
---

### 📚 Stacked PR series

This is part of a 7-PR stack that breaks the evals `TestStep[]` rework out of the `evals-ui-polish` branch into reviewable, subsystem-scoped slices. Each PR is based on the previous one — **review and merge top-to-bottom.**

| # | PR | Branch | Base | Scope |
|---|----|--------|------|-------|
| 1 | #2899 | `codex/evals-stack-1-shared-steps` | `main` | Shared `TestStep[]` contract + legacy conversion |
| 2 | #2900 | `codex/evals-stack-2-server-runtime` | #2899 | Inspector server executes step-based runs |
| 3 | #2901 | `codex/evals-stack-3-api-sdk-cli` | #2900 | API routes, SDK, CLI, OpenAPI/docs |
| 4 | #2902 | `codex/evals-stack-4-authoring-ui` | #2901 | Step authoring + replay/dashboard UI |
| 5 | #2903 | `codex/evals-stack-5-recorder-widget-capture` | #2902 | Recorder shim + widget interaction capture |
| 6 | #2904 | `codex/evals-stack-6-run-replay-artifacts` | #2903 | Live grading helpers + agentic-interact design |
| 7 | #2905 | `codex/evals-stack-7-dashboards-cross-host` | #2904 | Dashboard/cross-host regression coverage |

**Backend gate:** the backend `steps`-first cutover lives on `add-evals-backend-changes` (`b535e67e`). Its **destructive migration must not run** until inspector PRs **1–5** (#2899–#2903) are merged, deployed, and smoke-tested. Persisted rows are `steps`-first; `promptTurns` is a boundary-compat path only.

> Reconstructed by subsystem from `evals-ui-polish` (not cherry-picked commits). `.env.local`/`node_modules` are excluded from the stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests and CSS-only banner changes; no runtime or API behavior modified in this diff.
> 
> **Overview**
> Adds **Vitest regression coverage** for dashboard/cross-host helpers introduced earlier in the stack, plus a small **trace-repair banner** visual tweak.
> 
> **`buildCellMetricStripData`** tests assert run history maps to metric-strip series and latest aggregates (pass rate, latency percentiles, tokens, tool calls, `Run …` labels), empty input returns null, and **`showTrend`** is false when fewer than **`MIN_TREND_POINTS`** (2) runs exist.
> 
> **`groupCaseIterations`** / **`caseRunBatchKey`** tests pin batch keys for suite runs (`suite:…`), quick/compare runs (`compare:…`), standalone iterations (`solo:…`), iteration ordering within a batch, and newest-batch-first ordering.
> 
> **`TraceRepairBanner`** drops the violet/sparkles styling in favor of muted **`border`** / **`bg-muted`** tokens; the AI badge is text-only and dismiss hover matches the neutral palette.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f5a50e31a3568e45b7bd9bc93197d2211e8b62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->