### PR TITLE
feat(server): land caniuse.dev on the host-compare showcase

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -642,7 +642,7 @@ export function HostsRoute() {
   );
 }
 
-export function HostCompareRoute() {
+export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
   const { convexProjectId, isAuthenticated } = useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
   const navigate = useAppNavigate();
@@ -655,8 +655,9 @@ export function HostCompareRoute() {
   );
 
   // Mirror the gating HostsRoute uses: when signed out, Compare has no peer
-  // Servers/Client tabs to switch to, so render bare.
-  if (!isAuthenticated) {
+  // Servers/Client tabs to switch to, so render bare. `bare` forces the same
+  // for the chrome-less embed route (caniuse.dev) regardless of auth.
+  if (bare || !isAuthenticated) {
     return compareView;
   }
 
@@ -1313,6 +1314,12 @@ export default function App() {
   const isChatboxChatRoute =
     !exitedChatboxChat && hostedRouteKind === "chatbox";
 
+  // Chrome-less host-compare for vanity domains (caniuse.dev): rendered
+  // full-bleed without the sidebar/header, and the first-run onboarding
+  // redirect is suppressed so guests land directly on the comparison.
+  const isBareCompareRoute =
+    window.location.pathname === routePaths.embedHostCompare;
+
   useEffect(() => {
     setEvaluateRunsFlagsLoaded(posthog.featureFlags?.hasLoadedFlags === true);
 
@@ -1811,6 +1818,7 @@ export default function App() {
       activeProjectId === "none");
   const shouldRouteToFirstRunOnboarding =
     !isHostedChatRoute &&
+    !isBareCompareRoute &&
     !isWorkOsLoading &&
     effectiveHostedShellGateState === "ready" &&
     !(isAuthenticated && currentUser === undefined) &&
@@ -3247,6 +3255,22 @@ export default function App() {
     </SidebarProvider>
   );
 
+  // Vanity-domain embed (caniuse.dev): render the matched route
+  // (`HostCompareRoute bare`) full-bleed without the sidebar/header chrome.
+  // Still nested inside every provider in the return below, so auth, project,
+  // and the guest session resolve exactly as on the normal route.
+  const bareCompareContent = (
+    <div className="h-screen w-screen overflow-auto bg-background">
+      <AppRouteReactContext.Provider value={routeContext}>
+        {locationContext ? (
+          <Outlet context={routeContext} />
+        ) : (
+          <NoRouterRouteBody activeTab={activeTab} />
+        )}
+      </AppRouteReactContext.Provider>
+    </div>
+  );
+
   return (
     <PreferencesStoreProvider
       themeMode={initialThemeMode}
@@ -3318,6 +3342,8 @@ export default function App() {
                     pathToken={chatboxPathToken}
                     onExitChatboxChat={() => setExitedChatboxChat(true)}
                   />
+                ) : isBareCompareRoute ? (
+                  bareCompareContent
                 ) : (
                   appContent
                 )}

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -26,6 +26,8 @@ export const routePaths = {
   servers: "/servers",
   hosts: "/hosts",
   hostCompare: "/host-compare",
+  /** Chrome-less host-compare for vanity domains (caniuse.dev) — no sidebar/nav, bypasses NUX. */
+  embedHostCompare: "/embed/host-compare",
   computer: "/computer",
   registry: "/registry",
   tools: "/tools",

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -77,6 +77,11 @@ export function createAppRouter(): AppRouter {
           loader: ({ params }) => redirect(buildHostsPath(params.hostId)),
         },
         { path: "host-compare", element: <HostCompareRoute /> },
+        // Chrome-less host-compare surface for vanity domains (caniuse.dev):
+        // App renders this full-bleed (no sidebar/header) and skips the
+        // first-run onboarding redirect. `bare` forces the no-sub-nav render
+        // even for signed-in users.
+        { path: "embed/host-compare", element: <HostCompareRoute bare /> },
         { path: "computer", element: <ComputerRoute /> },
         { path: "hosts", element: <HostsRoute /> },
         { path: "hosts/:hostId", element: <HostsRoute /> },

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -93,3 +93,12 @@ export const ALLOWED_HOSTS = process.env.MCPJAM_ALLOWED_HOSTS
       h.trim().toLowerCase()
     )
   : [];
+
+// Vanity domains whose root path ("/") should land on the host-compare
+// showcase ("Can I use" for MCP hosts). Override via env if more are added.
+export const CANIUSE_LANDING_HOSTS = new Set(
+  (process.env.CANIUSE_LANDING_HOSTS ?? "caniuse.dev,www.caniuse.dev")
+    .split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter((h) => h.length > 0),
+);

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -129,6 +129,7 @@ import {
   CORS_ORIGINS,
   HOSTED_MODE,
   ALLOWED_HOSTS,
+  CANIUSE_LANDING_HOSTS,
 } from "./config";
 import "./types/hono"; // Type extensions
 import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair";
@@ -500,6 +501,18 @@ if (process.env.NODE_ENV === "production") {
 
   // In-app browser redirect (before SPA fallback)
   app.use("/*", inAppBrowserMiddleware);
+
+  // Vanity-domain landing: caniuse.dev (the "Can I use" host-compare showcase)
+  // points at this same service, so send its root straight to the comparison
+  // page. Deep links pass through untouched. Host-gated so app.mcpjam.com and
+  // every other domain keep their normal home.
+  app.use("/*", async (c, next) => {
+    const host = (c.req.header("Host") ?? "").toLowerCase().split(":")[0];
+    if (CANIUSE_LANDING_HOSTS.has(host) && c.req.path === "/") {
+      return c.redirect("/host-compare", 302);
+    }
+    return next();
+  });
 
   // Serve all static files from client root (images, svgs, etc.)
   // This handles files like /mcp_jam_light.png, /favicon.ico, etc.

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -503,13 +503,14 @@ if (process.env.NODE_ENV === "production") {
   app.use("/*", inAppBrowserMiddleware);
 
   // Vanity-domain landing: caniuse.dev (the "Can I use" host-compare showcase)
-  // points at this same service, so send its root straight to the comparison
-  // page. Deep links pass through untouched. Host-gated so app.mcpjam.com and
-  // every other domain keep their normal home.
+  // points at this same service, so send its root straight to the chrome-less
+  // comparison page (no sidebar/nav, NUX-bypassed). Deep links pass through
+  // untouched. Host-gated so app.mcpjam.com and every other domain keep their
+  // normal home.
   app.use("/*", async (c, next) => {
     const host = (c.req.header("Host") ?? "").toLowerCase().split(":")[0];
     if (CANIUSE_LANDING_HOSTS.has(host) && c.req.path === "/") {
-      return c.redirect("/host-compare", 302);
+      return c.redirect("/embed/host-compare", 302);
     }
     return next();
   });


### PR DESCRIPTION
## Why

We bought **caniuse.dev** and want it to land on the host comparison page (`/host-compare`) — the "Can I use ___" showcase for MCP hosts. The domain will be added as a custom domain on the **same** inspector Railway service (app.mcpjam.com), so we need its root to route to the compare page.

## What

A small, host-gated redirect in the production SPA block (`server/index.ts`): when the `Host` is a caniuse landing host and the path is `/`, 302 → `/host-compare`. Deep links pass through untouched; every other domain keeps its normal home.

Landing hosts are configurable via `CANIUSE_LANDING_HOSTS` (default `caniuse.dev,www.caniuse.dev`) in `server/config.ts`, alongside the existing `ALLOWED_HOSTS`.

Guest-friendly by design: `/host-compare` already renders preset hosts (Claude, ChatGPT, Copilot, …) without login, so this works as a public showcase without any auth/cookie changes.

## Not in this PR
- Adding the Railway custom domain + Squarespace DNS records (ops steps, done separately).
- Any auth/WorkOS changes (intentionally avoided — caniuse.dev serves the guest compare view; login stays on app.mcpjam.com).

## Notes
- Pre-existing server `tsc` noise (unused `logBox`, generated `SandboxProxyHtml.bundled`) is unrelated; this change adds no new type errors.
- Holding merge/deploy per request while other work lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Host-gated production redirect and UI shell branching only; no auth or API contract changes, with deep links and other domains unaffected.
> 
> **Overview**
> Routes **caniuse.dev** (and **www.caniuse.dev**, overridable via `CANIUSE_LANDING_HOSTS`) so a visit to `/` **302s to `/embed/host-compare`** in production, while other hosts and non-root paths are unchanged.
> 
> The client adds **`/embed/host-compare`**, wired to `HostCompareRoute` with a **`bare`** flag that drops sidebar/header and Connect sub-nav even for signed-in users. **`App`** detects that path and renders the route **full-bleed** inside existing providers, and **skips first-run Playground onboarding** so guests land on the comparison immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3349e0e1f226d584471d0aaa088dbaeaf0ac693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->