### PR TITLE
[XAA] Connect-page mint uses the hosted IdP issuer in hosted mode

### DIFF
--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -630,8 +630,14 @@ export async function resolveLocalServerForConnect(
       // The ID-JAG `iss` must match the live IdP issuer whose JWKS the resource
       // AS fetches. In hosted mode only the `/api/web/xaa` router is mounted
       // (`/api/mcp/*` returns 410), so the issuer base follows the deployment
-      // mode — same split the debugger uses.
-      issuer: getIssuerForRequest(c, HOSTED_MODE ? "/api/web" : "/api/mcp", false),
+      // mode. Trust `x-forwarded-proto` in hosted mode so the TLS-terminating
+      // edge yields an `https://` issuer (c.req.url is http:// internally) —
+      // same split the `/api/web` (trust) vs `/api/mcp` (no-trust) routers use.
+      issuer: getIssuerForRequest(
+        c,
+        HOSTED_MODE ? "/api/web" : "/api/mcp",
+        HOSTED_MODE,
+      ),
       serverId,
       projectId,
       bearerToken,

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -32,6 +32,7 @@ import {
   mintXaaAccessToken,
 } from "../services/xaa-mint.js";
 import type { ConnectionDefaults } from "../../shared/connection-defaults.js";
+import { HOSTED_MODE } from "../config.js";
 
 type LocalAuthorizeServerConfig =
   | {
@@ -622,11 +623,15 @@ export async function resolveLocalServerForConnect(
     const sc = result.serverConfig;
     const mintArgs = {
       resolveServerSecret: fetchServerClientSecret,
-      // Local connect path: non-HTTPS (localhost) auth servers are allowed,
-      // matching the local XAA router (`httpsOnlyProxy: false`). Hosted mode
-      // uses a separate path and would pin this to true.
-      httpsOnly: false,
-      issuer: getIssuerForRequest(c, "/api/mcp", false),
+      // Non-HTTPS (localhost) auth servers are allowed only off-hosted, matching
+      // the local XAA router (`httpsOnlyProxy: false`); hosted targets are
+      // always remote HTTPS.
+      httpsOnly: HOSTED_MODE,
+      // The ID-JAG `iss` must match the live IdP issuer whose JWKS the resource
+      // AS fetches. In hosted mode only the `/api/web/xaa` router is mounted
+      // (`/api/mcp/*` returns 410), so the issuer base follows the deployment
+      // mode — same split the debugger uses.
+      issuer: getIssuerForRequest(c, HOSTED_MODE ? "/api/web" : "/api/mcp", false),
       serverId,
       projectId,
       bearerToken,


### PR DESCRIPTION
## TL;DR

Connecting to an XAA server from the **/servers Connect page** on a hosted deployment returned a **401**. The connect-page mint signed the ID-JAG with the `/api/mcp` issuer, but hosted mode serves the IdP only under `/api/web/xaa` (`/api/mcp/*` is disabled, 410). The resource authorization server trusts `/api/web/xaa` and fetches its JWKS there, so it rejected the assertion. The XAA **Debugger** already mints under `/api/web`, which is why it worked and Connect didn't.

## Root cause

Confirmed by elimination — Debugger and Connect share the same IdP signing key, so the key wasn't the issue:

| Surface | Issuer base | Works on hosted? |
|---|---|---|
| XAA Debugger | `/api/web` | ✅ |
| Connect page (before) | `/api/mcp` | ❌ 401 |

In hosted mode `/api/mcp/xaa/.well-known/jwks.json` returns 410 and the IdP issuer is `/api/web/xaa`, so an ID-JAG minted with `iss=…/api/mcp/xaa` can't be validated by the resource AS.

## Fix

`resolveLocalServerForConnect` now picks the issuer base by deployment mode, matching the Debugger:

- `HOSTED_MODE` → `/api/web`
- otherwise (local self-host, where `/api/mcp/xaa` is the live router) → `/api/mcp`

Also pins `httpsOnly` to `HOSTED_MODE` — hosted targets are always remote HTTPS; localhost (non-HTTPS) auth servers remain allowed off-hosted.

## Before / after

| | Before | After (hosted) |
|---|---|---|
| Connect-page ID-JAG `iss` | `…/api/mcp/xaa` | `…/api/web/xaa` |
| Resource AS verification | rejected → 401 | matches trusted issuer + JWKS |
| Local self-host | `/api/mcp` | `/api/mcp` (unchanged) |

## Risk register

| Concern | Answer |
|---|---|
| Breaks local self-host connect? | No — off-hosted still uses `/api/mcp`, where that router and its JWKS are live. |
| Changes the Debugger? | No — Debugger was already `/api/web`; this only aligns Connect with it. |
| Affects OAuth / bearer / none servers? | No — gated on `useXaa === true && useOAuth !== true`. |
| httpsOnly change blocks anything? | Only non-HTTPS auth servers, and only on hosted, where all targets are remote HTTPS anyway. |