### PR TITLE
chore(sidebar): remove guest free daily credits block

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -48,7 +48,6 @@ import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { MCPIcon } from "@/components/ui/mcp-icon";
 import { SidebarUser } from "@/components/sidebar/sidebar-user";
 import { SidebarContextSwitcher } from "@/components/sidebar/sidebar-context-switcher";
-import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
 import { SidebarTrialCountdown } from "@/components/sidebar/sidebar-trial-countdown";
 import { ShareProjectDialog } from "@/components/project/ShareProjectDialog";
 import { useUpdateNotification } from "@/hooks/useUpdateNotification";
@@ -870,9 +869,6 @@ export function MCPSidebar({
               onUpgradeClick={handleTrialUpgradeClick}
               className="mt-1"
             />
-          ) : null}
-          {!user && !authResolving ? (
-            <SidebarCreditUsage className="px-1" includeGuests />
           ) : null}
           <SidebarUser onBeforeSignOut={onBeforeSignOut} />
         </SidebarFooter>

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -62,22 +62,6 @@ vi.mock("@/components/sidebar/sidebar-context-switcher", () => ({
   SidebarContextSwitcher: () => <div data-testid="context-switcher" />,
 }));
 
-vi.mock("@/components/sidebar/sidebar-credit-usage", () => ({
-  SidebarCreditUsage: ({
-    className,
-    includeGuests,
-  }: {
-    className?: string;
-    includeGuests?: boolean;
-  }) => (
-    <div
-      data-testid="sidebar-credit-usage"
-      data-include-guests={String(includeGuests)}
-      className={className}
-    />
-  ),
-}));
-
 vi.mock("@/components/project/ShareProjectDialog", () => ({
   ShareProjectDialog: (props: unknown) => mockShareProjectDialog(props),
 }));
@@ -245,28 +229,6 @@ describe("sidebar invite CTA", () => {
     ).not.toBeInTheDocument();
     expect(
       inviteButton.compareDocumentPosition(sidebarUser) &
-        Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy();
-  });
-
-  it("pins credit usage above the account button for guests", () => {
-    mockUseConvexAuth.mockReturnValue({
-      isAuthenticated: false,
-      isLoading: false,
-    });
-    mockUseAuth.mockReturnValue({
-      user: null,
-    });
-
-    renderSidebar();
-
-    const creditUsage = screen.getByTestId("sidebar-credit-usage");
-    const sidebarUser = screen.getByTestId("sidebar-user");
-
-    expect(creditUsage).toHaveAttribute("data-include-guests", "true");
-    expect(creditUsage).toHaveClass("px-1");
-    expect(
-      creditUsage.compareDocumentPosition(sidebarUser) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
   });


### PR DESCRIPTION
Removes the not-signed-in "Free daily credits" panel from the sidebar footer. Single file change in `client/src/components/mcp-sidebar.tsx` (guest block + unused import).

And also corrected the git actions part that checked for that specific component