### PR TITLE
[XAA] Mint the access token on the hosted connect path

### DIFF
--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -794,8 +794,8 @@ export async function createAuthorizedManager(
     /**
      * Pre-resolved MCPJam test-IdP issuer (`resolveXaaIssuer(c, HOSTED_MODE)`)
      * for Cross-App Access servers. Supplied by callers that have the request
-     * `Context`; when absent, XAA servers fall through with no minted token
-     * (and the resource server returns 401), so connect surfaces must pass it.
+     * `Context`. Required whenever the batch contains a `useXaa` server — the
+     * builder throws a 500 rather than connecting tokenless if it's missing.
      */
     xaaIssuer?: string;
   }
@@ -897,7 +897,18 @@ export async function createAuthorizedManager(
         auth.serverConfig.transportType === "http" &&
         auth.serverConfig.useXaa === true &&
         auth.serverConfig.useOAuth !== true;
-      if (useXaa && options?.xaaIssuer) {
+      if (useXaa) {
+        if (!options?.xaaIssuer) {
+          // Caller-contract violation: a `useXaa` server reached a manager
+          // builder that didn't thread the issuer (only callers holding the
+          // request `Context` can resolve it). Fail loud here rather than
+          // connecting tokenless and surfacing a confusing downstream 401.
+          throw new WebRouteError(
+            500,
+            ErrorCode.INTERNAL_ERROR,
+            `Missing XAA issuer for server "${displayServerName}". This connect surface must pass options.xaaIssuer.`
+          );
+        }
         const mintArgs = buildXaaMintArgs({
           issuer: options.xaaIssuer,
           hostedMode: HOSTED_MODE,

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -18,6 +18,7 @@ import {
 } from "./hosted-rpc-logs.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { setRequestLogContext } from "../../utils/request-logger.js";
+import { logger } from "../../utils/logger.js";
 import type { RequestLogContext } from "../../utils/log-events.js";
 import {
   type InternalLogContext,
@@ -34,7 +35,15 @@ import {
   parseWithSchema,
 } from "./errors.js";
 import { buildHostedOAuthUnauthorizedHandler } from "../../utils/hosted-oauth-refresh.js";
-import { fetchRuntimeServerSecrets } from "../../utils/server-secrets.js";
+import {
+  fetchRuntimeServerSecrets,
+  fetchServerClientSecret,
+} from "../../utils/server-secrets.js";
+import {
+  buildXaaMintArgs,
+  mintXaaAccessToken,
+  resolveXaaIssuer,
+} from "../../services/xaa-mint.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 
 // ── Zod Schemas ──────────────────────────────────────────────────────
@@ -230,6 +239,13 @@ export type ConvexAuthorizeResponse = {
     headers?: Record<string, string>;
     hasHeaders?: boolean;
     useOAuth?: boolean;
+    // Cross-App Access (XAA) discriminator + non-secret config, surfaced by the
+    // hosted authorize endpoint. The confidential client secret + token endpoint
+    // are resolved separately at mint time via the hardened reveal-secret path.
+    useXaa?: boolean;
+    oauthScopes?: string[];
+    xaaSubject?: string;
+    xaaEmail?: string;
   };
   internalLogContext?: InternalLogContext;
 };
@@ -775,6 +791,13 @@ export async function createAuthorizedManager(
      * undefined (SDK chooses at request time).
      */
     mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+    /**
+     * Pre-resolved MCPJam test-IdP issuer (`resolveXaaIssuer(c, HOSTED_MODE)`)
+     * for Cross-App Access servers. Supplied by callers that have the request
+     * `Context`; when absent, XAA servers fall through with no minted token
+     * (and the resource server returns 401), so connect surfaces must pass it.
+     */
+    xaaIssuer?: string;
   }
 ): Promise<AuthorizedManagerResult> {
   const serverNamesById = buildServerNamesById(serverIds, options?.serverNames);
@@ -861,6 +884,55 @@ export async function createAuthorizedManager(
         }
       }
 
+      // Cross-App Access: mint the resource access token server-side (MCPJam as
+      // the test IdP) and inject it through the same `oauthAccessToken` channel
+      // that sets the Bearer header. Strictly gated on `useXaa === true &&
+      // useOAuth !== true` so it can never collide with the OAuth branch above.
+      // The XAA token always overrides whatever the authorize batch returned: a
+      // server converted from OAuth still has a stored OAuth token, and reusing
+      // it would inject the wrong credential.
+      let connectToken = oauthToken;
+      let connectOnUnauthorized = onUnauthorized;
+      const useXaa =
+        auth.serverConfig.transportType === "http" &&
+        auth.serverConfig.useXaa === true &&
+        auth.serverConfig.useOAuth !== true;
+      if (useXaa && options?.xaaIssuer) {
+        const mintArgs = buildXaaMintArgs({
+          issuer: options.xaaIssuer,
+          hostedMode: HOSTED_MODE,
+          serverConfig: auth.serverConfig,
+          serverId,
+          projectId,
+          bearerToken,
+          resolveServerSecret: fetchServerClientSecret,
+        });
+        try {
+          connectToken = (await mintXaaAccessToken(mintArgs)).accessToken;
+        } catch (error) {
+          logger.error("[XAA connect] mint failed", error, {
+            serverId,
+            serverName: displayServerName,
+            resource: auth.serverConfig.url,
+          });
+          throw error;
+        }
+        // Bounded re-mint: the SDK invokes this once on a 401 and retries; a
+        // second 401 surfaces rather than looping mint→401→mint.
+        let reMinted = false;
+        connectOnUnauthorized = async () => {
+          if (reMinted) {
+            throw new WebRouteError(
+              401,
+              ErrorCode.UNAUTHORIZED,
+              `Server "${displayServerName}" rejected the cross-app access token. Reconnect to retry.`
+            );
+          }
+          reMinted = true;
+          return { accessToken: (await mintXaaAccessToken(mintArgs)).accessToken };
+        };
+      }
+
       const effectiveInitializePins = resolveEffectiveInitializePinsForServer(
         serverId,
         options?.initializePins,
@@ -909,9 +981,9 @@ export async function createAuthorizedManager(
         toHttpConfig(
           authForConfig,
           timeoutMs,
-          oauthToken,
+          connectToken,
           clientCapabilities,
-          onUnauthorized,
+          connectOnUnauthorized,
           effectiveInitializePins
         ),
       ] as const;
@@ -1218,6 +1290,9 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
       serverNames,
       initializePins,
       mcpProtocolVersionsByServerId,
+      // Resolve the XAA issuer here (we hold the request `Context`) so the
+      // manager builder can mint Cross-App Access tokens for `useXaa` servers.
+      xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
     }
   );
 

--- a/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-mint.test.ts
@@ -5,7 +5,23 @@
  * stays identical regardless of which surface calls it.
  */
 import { describe, it, expect } from "vitest";
-import { buildJwtBearerBody } from "../xaa-mint.js";
+import type { Context } from "hono";
+import {
+  buildJwtBearerBody,
+  buildXaaMintArgs,
+  resolveXaaIssuer,
+} from "../xaa-mint.js";
+
+/** Minimal hono Context stub for the issuer derivation. */
+function ctxStub(url: string, forwardedProto?: string): Context {
+  return {
+    req: {
+      url,
+      header: (name: string) =>
+        name === "x-forwarded-proto" ? forwardedProto : undefined,
+    },
+  } as unknown as Context;
+}
 
 describe("buildJwtBearerBody", () => {
   it("emits the RFC 7523 jwt-bearer grant with only the populated fields", () => {
@@ -51,5 +67,67 @@ describe("buildJwtBearerBody", () => {
       resource: "https://r.example.com",
     };
     expect(buildJwtBearerBody(args)).toEqual(buildJwtBearerBody(args));
+  });
+});
+
+describe("resolveXaaIssuer", () => {
+  it("uses /api/web and the forwarded https scheme in hosted mode", () => {
+    // The TLS-terminating edge leaves c.req.url as http:// internally.
+    const c = ctxStub("http://staging.mcpjam.com/api/web/servers/validate", "https");
+    expect(resolveXaaIssuer(c, true)).toBe(
+      "https://staging.mcpjam.com/api/web/xaa"
+    );
+  });
+
+  it("uses /api/mcp and the request scheme off-hosted (no forwarded trust)", () => {
+    const c = ctxStub("http://localhost:3001/api/mcp/servers/validate", "https");
+    expect(resolveXaaIssuer(c, false)).toBe("http://localhost:3001/api/mcp/xaa");
+  });
+});
+
+describe("buildXaaMintArgs", () => {
+  const base = {
+    issuer: "https://staging.mcpjam.com/api/web/xaa",
+    serverId: "srv-1",
+    projectId: "proj-1",
+    bearerToken: "bearer-1",
+    resolveServerSecret: async () => ({}) as any,
+  };
+
+  it("pins httpsOnly to hosted mode and passes the issuer through", () => {
+    const args = buildXaaMintArgs({
+      ...base,
+      hostedMode: true,
+      serverConfig: { url: "https://mcp.example.com/mcp" },
+    });
+    expect(args.httpsOnly).toBe(true);
+    expect(args.issuer).toBe(base.issuer);
+    expect(args.resource).toBe("https://mcp.example.com/mcp");
+  });
+
+  it("joins scopes and defaults the mock-login identity", () => {
+    const args = buildXaaMintArgs({
+      ...base,
+      hostedMode: false,
+      serverConfig: { url: "https://mcp.example.com/mcp", oauthScopes: ["a", "b"] },
+    });
+    expect(args.httpsOnly).toBe(false);
+    expect(args.scope).toBe("a b");
+    expect(args.subject).toBe("user-12345");
+    expect(args.email).toBe("demo.user@example.com");
+  });
+
+  it("honors stored subject/email overrides", () => {
+    const args = buildXaaMintArgs({
+      ...base,
+      hostedMode: true,
+      serverConfig: {
+        url: "https://mcp.example.com/mcp",
+        xaaSubject: "alice@corp.com",
+        xaaEmail: "alice@corp.com",
+      },
+    });
+    expect(args.subject).toBe("alice@corp.com");
+    expect(args.email).toBe("alice@corp.com");
   });
 });

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -260,6 +260,61 @@ export function getIssuerForRequest(
   return getXAAIssuerUrl(`${parsed.origin}${issuerBasePath}`);
 }
 
+/** Minimal stored-server shape needed to assemble XAA mint args. */
+export interface XaaMintServerConfig {
+  url?: string;
+  oauthScopes?: string[];
+  xaaSubject?: string;
+  xaaEmail?: string;
+}
+
+/**
+ * Resolve the MCPJam test-IdP issuer for an XAA mint. In hosted mode only the
+ * `/api/web/xaa` router is mounted (`/api/mcp/*` returns 410), and the TLS-
+ * terminating edge means `c.req.url` is `http://` internally — so we trust
+ * `x-forwarded-proto` to keep the `https://` scheme. Off-hosted, the
+ * `/api/mcp/xaa` router is live and the request scheme is already correct.
+ */
+export function resolveXaaIssuer(c: Context, hostedMode: boolean): string {
+  return getIssuerForRequest(
+    c,
+    hostedMode ? "/api/web" : "/api/mcp",
+    hostedMode,
+  );
+}
+
+/**
+ * Assemble the full `mintXaaAccessToken` args from a stored server config so
+ * every connect surface (local resolver + hosted authorize) shares one identical
+ * shape and can't drift on the wire.
+ */
+export function buildXaaMintArgs(args: {
+  issuer: string;
+  hostedMode: boolean;
+  serverConfig: XaaMintServerConfig;
+  serverId: string;
+  projectId: string;
+  bearerToken: string;
+  resolveServerSecret: ResolveServerSecretFn;
+}): Parameters<typeof mintXaaAccessToken>[0] {
+  const sc = args.serverConfig;
+  return {
+    resolveServerSecret: args.resolveServerSecret,
+    // Hosted targets are always remote HTTPS; off-hosted allows localhost http.
+    httpsOnly: args.hostedMode,
+    issuer: args.issuer,
+    serverId: args.serverId,
+    projectId: args.projectId,
+    bearerToken: args.bearerToken,
+    resource: sc.url,
+    scope: sc.oauthScopes?.join(" ") || undefined,
+    // Mock-login identity: stored override if set, else the XAA IdP mock-login
+    // defaults.
+    subject: sc.xaaSubject || "user-12345",
+    email: sc.xaaEmail || "demo.user@example.com",
+  };
+}
+
 // Full server-side XAA mint for the connect path: resolve the target's
 // confidential credentials + token endpoint, sign an ID-JAG asserting the
 // supplied (already-authenticated) identity, then exchange it for a resource

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -28,8 +28,9 @@ import {
   fetchServerClientSecret,
 } from "./server-secrets.js";
 import {
-  getIssuerForRequest,
+  buildXaaMintArgs,
   mintXaaAccessToken,
+  resolveXaaIssuer,
 } from "../services/xaa-mint.js";
 import type { ConnectionDefaults } from "../../shared/connection-defaults.js";
 import { HOSTED_MODE } from "../config.js";
@@ -621,33 +622,15 @@ export async function resolveLocalServerForConnect(
     | undefined;
   if (useXaa && result.serverConfig.transportType === "http") {
     const sc = result.serverConfig;
-    const mintArgs = {
-      resolveServerSecret: fetchServerClientSecret,
-      // Non-HTTPS (localhost) auth servers are allowed only off-hosted, matching
-      // the local XAA router (`httpsOnlyProxy: false`); hosted targets are
-      // always remote HTTPS.
-      httpsOnly: HOSTED_MODE,
-      // The ID-JAG `iss` must match the live IdP issuer whose JWKS the resource
-      // AS fetches. In hosted mode only the `/api/web/xaa` router is mounted
-      // (`/api/mcp/*` returns 410), so the issuer base follows the deployment
-      // mode. Trust `x-forwarded-proto` in hosted mode so the TLS-terminating
-      // edge yields an `https://` issuer (c.req.url is http:// internally) —
-      // same split the `/api/web` (trust) vs `/api/mcp` (no-trust) routers use.
-      issuer: getIssuerForRequest(
-        c,
-        HOSTED_MODE ? "/api/web" : "/api/mcp",
-        HOSTED_MODE,
-      ),
+    const mintArgs = buildXaaMintArgs({
+      issuer: resolveXaaIssuer(c, HOSTED_MODE),
+      hostedMode: HOSTED_MODE,
+      serverConfig: sc,
       serverId,
       projectId,
       bearerToken,
-      resource: sc.url,
-      scope: sc.oauthScopes?.join(" ") || undefined,
-      // Mock-login identity: stored override if set, else the test defaults the
-      // XAA IdP's mock login already uses.
-      subject: sc.xaaSubject || "user-12345",
-      email: sc.xaaEmail || "demo.user@example.com",
-    };
+      resolveServerSecret: fetchServerClientSecret,
+    });
     // Always mint for XAA, overriding any access token the authorize batch
     // returned. A server converted from OAuth still has a stored OAuth token,
     // and reusing it here would inject the wrong credential — the XAA-protected


### PR DESCRIPTION
## TL;DR

Connecting to a Cross-App Access (XAA) server from the hosted **/servers** page returned **401**. The XAA token mint existed only on the *local* connect path, which is disabled in hosted mode — so the hosted path attached no token and the resource server saw no `Authorization` header. This wires the mint into the hosted connect flow.

## Root cause (proven, not theorized)

The resource server's own telemetry (`/inspect.json`) showed every failed connect as `mcp_unauthorized reason=no_token path=/mcp` — i.e. **no Bearer header arrived at all**, not a bad/expired/wrong token.

| | Local connect | Hosted connect (broken) |
|---|---|---|
| Route | `/api/mcp/*` | `/api/web/servers/validate` |
| In hosted mode | **410 disabled** | active |
| Builder | `resolveLocalServerForConnect` | `createAuthorizedManager` → `toHttpConfig` |
| XAA mint? | ✅ yes | ❌ none |

`mintXaaAccessToken` lived in one file reachable only via `/api/mcp/*`. The hosted manager builder attaches a `Bearer` only for OAuth/header servers — no `useXaa` branch — so XAA servers connected tokenless.

## Fix

- **Hosted mint**: `createAuthorizedManager` now mints the XAA token for `useXaa === true && useOAuth !== true` HTTP servers and injects it through the same `oauthAccessToken` → `Bearer` channel, with a bounded one-shot re-mint on 401. The issuer is resolved at the request-context boundary (`createManualHostedConnection`, which holds the hono `Context`) and threaded in via a new `xaaIssuer` option.
- **No drift**: extracted `resolveXaaIssuer` + `buildXaaMintArgs` into the shared `xaa-mint` service; the local resolver now uses them too, so both surfaces assemble identical mint args (hosted issuer base, `httpsOnly`, `trustForwardedHeaders`).
- **Type surface**: the hosted authorize response type now carries the XAA discriminator (`useXaa`/`oauthScopes`/`xaaSubject`/`xaaEmail`).

## ⚠️ Paired backend dependency

The hosted authorize endpoint (`/web/authorize-batch`) must **return** the XAA fields on `serverConfig` for the mint to trigger — the local endpoint already does; hosted needs the same. If the backend doesn't surface `useXaa: true`, this branch no-ops (server connects tokenless, same as today — no regression). Confirm via the resource server flipping from `no_token` to `access_token_issued` after deploy.

## Risk register

| Concern | Answer |
|---|---|
| Breaks OAuth / header / none / stdio servers? | No — strictly gated on `useXaa === true && useOAuth !== true`; every other server hits neither branch, byte-identical to today. |
| Backend not yet returning `useXaa`? | Branch no-ops; no regression. Connect stays 401 until the backend surfaces it. |
| Mint failure mid-connect? | Logged and surfaced as the connect error (same as the local path); no tokenless fallthrough for an XAA server. |
| Drift between local & hosted mints? | Prevented — both call `buildXaaMintArgs`. |

## Tests

`server/services/__tests__/xaa-mint.test.ts`: `resolveXaaIssuer` (hosted `/api/web` + forwarded-https vs local `/api/mcp`), and `buildXaaMintArgs` (httpsOnly pinning, scope join, identity defaults + overrides).

## Supersedes

Folds in #2914's hosted-issuer logic via the shared helper (that PR fixed the local path only).