### PR TITLE
[XAA] TEMP diagnostic: log hosted authorize flags on connect

### DIFF
--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -897,6 +897,19 @@ export async function createAuthorizedManager(
         auth.serverConfig.transportType === "http" &&
         auth.serverConfig.useXaa === true &&
         auth.serverConfig.useOAuth !== true;
+      // TEMP diagnostic (XAA connect debugging): log exactly what the backend
+      // returned for this server so we can see whether `useXaa` arrives and the
+      // issuer is threaded. Remove once the hosted XAA connect path is verified.
+      if (auth.serverConfig.transportType === "http") {
+        logger.info("[XAA debug] authorize flags", {
+          serverId,
+          useXaa: (auth.serverConfig as { useXaa?: unknown }).useXaa ?? null,
+          useOAuth: auth.serverConfig.useOAuth ?? null,
+          hasXaaIssuer: Boolean(options?.xaaIssuer),
+          willMint: useXaa,
+          serverConfigKeys: Object.keys(auth.serverConfig),
+        });
+      }
       if (useXaa) {
         if (!options?.xaaIssuer) {
           // Caller-contract violation: a `useXaa` server reached a manager


### PR DESCRIPTION
## Purpose (temporary)

Diagnostic-only. Every static check says the hosted XAA connect mint should fire, but staging connects still send no token (`no_token` at the resource server). This logs exactly what the inspector receives from the backend for an HTTP server on connect, so we can see ground truth instead of inferring:

- `useXaa` — what the backend actually returned (the whole question)
- `useOAuth`, `hasXaaIssuer`, `willMint`
- `serverConfigKeys` — the literal field set that arrived from `/web/authorize-batch`

One `logger.info("[XAA debug] authorize flags", …)` in `createAuthorizedManager`, gated to HTTP servers. No behavior change.

## Plan

1. Merge → staging auto-deploys via `deploy-staging.yml`.
2. Connect to the XAA server once.
3. Read `[XAA debug] authorize flags` in `inspector-logs` → it tells us whether `useXaa` arrives (backend issue) or arrives-but-isn't-minted (inspector bug).
4. Revert this PR once root-caused.