### PR TITLE
[XAA] Revert temp connect diagnostic (#2917)

### DIFF
--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -897,19 +897,6 @@ export async function createAuthorizedManager(
         auth.serverConfig.transportType === "http" &&
         auth.serverConfig.useXaa === true &&
         auth.serverConfig.useOAuth !== true;
-      // TEMP diagnostic (XAA connect debugging): log exactly what the backend
-      // returned for this server so we can see whether `useXaa` arrives and the
-      // issuer is threaded. Remove once the hosted XAA connect path is verified.
-      if (auth.serverConfig.transportType === "http") {
-        logger.info("[XAA debug] authorize flags", {
-          serverId,
-          useXaa: (auth.serverConfig as { useXaa?: unknown }).useXaa ?? null,
-          useOAuth: auth.serverConfig.useOAuth ?? null,
-          hasXaaIssuer: Boolean(options?.xaaIssuer),
-          willMint: useXaa,
-          serverConfigKeys: Object.keys(auth.serverConfig),
-        });
-      }
       if (useXaa) {
         if (!options?.xaaIssuer) {
           // Caller-contract violation: a `useXaa` server reached a manager


### PR DESCRIPTION
Reverts the temporary `[XAA debug] authorize flags` log from #2917.

It served its purpose: it captured ground truth that the hosted `/web/authorize-batch` response was dropping `useXaa` (the field was missing from `serverConfigKeys`), which located the root cause — the hosted normalizer whitelist in the backend (fixed in mcpjam-backend #616). Hosted XAA `/servers` connect is now verified working end-to-end (`willMint: true`, resource server `access_token_issued`).