### PR TITLE
feat(evals): restore dropped eval-UI redesigns (suite-redirect landing + insights/run-detail)

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -50,7 +50,8 @@ import { useEvalMutations } from "./evals/use-eval-mutations";
 import { useEvalHandlers } from "./evals/use-eval-handlers";
 import { isDraftTestCaseId } from "./evals/draft-test-case";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
-import { EvalsSuiteListSidebar } from "./evals/evals-suite-list-sidebar";
+import { SuiteSwitcher } from "./evals/suite-switcher";
+import { stripTimestampSuffix } from "./evals/suite-overview-presentation";
 import {
   CreateSuiteDialog,
   type CreateSuitePayload,
@@ -311,6 +312,25 @@ function EvalsTabContent({
     selectedSuiteId,
   ]);
 
+  // No standalone suites list: landing on /evals jumps straight into the most
+  // recent suite's dashboard (suites are switched via the breadcrumb dropdown).
+  // Only the empty-state (no suites) keeps the bare list route.
+  useEffect(() => {
+    if (route.type !== "list") {
+      return;
+    }
+    if (overviewQueries.isOverviewLoading) {
+      return;
+    }
+    const mostRecent = visibleSuites[0];
+    if (mostRecent) {
+      navigatePlaygroundEvalsRoute(
+        { type: "suite-overview", suiteId: mostRecent.suite._id },
+        { replace: true }
+      );
+    }
+  }, [route.type, overviewQueries.isOverviewLoading, visibleSuites]);
+
   // Wait for auth to settle before firing view events. The parent
   // ErrorBoundary keys on (projectId, isAuthenticated), so projectId
   // resolving null→"x" remounts this component and would otherwise
@@ -440,6 +460,16 @@ function EvalsTabContent({
     navigatePlaygroundEvalsRoute({ type: "suite-overview", suiteId });
   }, []);
 
+  const handleNavigateToSuiteOverview = useCallback(() => {
+    if (!selectedSuiteId) return;
+    navigatePlaygroundEvalsRoute({
+      type: "suite-overview",
+      suiteId: selectedSuiteId,
+    });
+  }, [selectedSuiteId]);
+
+  const isSuiteOverviewRoute = route.type === "suite-overview";
+
   const handleGenerateMore = useCallback(async () => {
     if (!selectedSuite) return;
     const suiteServers = getEffectiveSuiteServers(selectedSuite);
@@ -552,53 +582,6 @@ function EvalsTabContent({
     [directDeleteTestCase, selectedSuiteId, selectedTestId]
   );
 
-  const handleDeleteSuitesBatch = useCallback(
-    async (suiteIds: string[]) => {
-      const settledDeletes = await Promise.allSettled(
-        suiteIds.map((suiteId) => mutations.deleteSuiteMutation({ suiteId }))
-      );
-      const succeededIds = new Set<string>();
-      settledDeletes.forEach((result, i) => {
-        if (result.status === "fulfilled") {
-          succeededIds.add(suiteIds[i]);
-        }
-      });
-      const failedDeletes = settledDeletes.filter(
-        (result): result is PromiseRejectedResult =>
-          result.status === "rejected"
-      );
-
-      if (failedDeletes.length > 0) {
-        console.error("Failed to delete some suites:", failedDeletes);
-        if (succeededIds.size > 0) {
-          toast.error(
-            `Deleted ${succeededIds.size} suite${
-              succeededIds.size === 1 ? "" : "s"
-            }; ${failedDeletes.length} failed.`
-          );
-        } else {
-          toast.error(
-            getBillingErrorMessage(
-              failedDeletes[0]?.reason,
-              "Failed to delete suites"
-            )
-          );
-        }
-      } else {
-        toast.success(
-          suiteIds.length === 1
-            ? "Suite deleted"
-            : `Deleted ${suiteIds.length} suites`
-        );
-      }
-
-      if (selectedSuiteId && succeededIds.has(selectedSuiteId)) {
-        navigatePlaygroundEvalsRoute({ type: "list" }, { replace: true });
-      }
-    },
-    [mutations.deleteSuiteMutation, selectedSuiteId]
-  );
-
   const hasDetailRoute =
     selectedSuiteId &&
     (route.type === "suite-overview" ||
@@ -616,46 +599,41 @@ function EvalsTabContent({
 
   const renderPlaygroundBreadcrumb = () => {
     if (!hasDetailRoute || !selectedSuite) return null;
-    const suiteCrumbAsLink = route.type !== "suite-overview";
+    const selectedSuiteName =
+      stripTimestampSuffix(selectedSuite.name || "") || "Untitled suite";
+
     return (
       <Breadcrumb className="min-w-0 flex-1">
         <BreadcrumbList className="min-w-0 flex-nowrap">
           <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <button
-                type="button"
-                onClick={() => navigatePlaygroundEvalsRoute({ type: "list" })}
-                className="inline-flex border-0 bg-transparent p-0 font-medium"
-              >
-                Suites
-              </button>
-            </BreadcrumbLink>
+            <SuiteSwitcher
+              suites={visibleSuites}
+              currentSuiteId={selectedSuite._id}
+              onSelectSuite={handleSelectSuite}
+              onCreateSuite={handleOpenCreateSuite}
+              onDeleteSuite={canDeleteSuite ? handlers.handleDelete : undefined}
+            />
           </BreadcrumbItem>
           <BreadcrumbSeparator />
-          <BreadcrumbItem className="max-w-[min(200px,28vw)] min-w-0 sm:max-w-[240px]">
-            {suiteCrumbAsLink ? (
+          <BreadcrumbItem className="max-w-[min(220px,32vw)] min-w-0 sm:max-w-[280px]">
+            {isSuiteOverviewRoute ? (
+              <BreadcrumbPage
+                className="truncate font-medium"
+                title={selectedSuiteName}
+              >
+                {selectedSuiteName}
+              </BreadcrumbPage>
+            ) : (
               <BreadcrumbLink asChild>
                 <button
                   type="button"
-                  onClick={() =>
-                    navigatePlaygroundEvalsRoute({
-                      type: "suite-overview",
-                      suiteId: selectedSuite._id,
-                    })
-                  }
-                  title={selectedSuite.name}
+                  onClick={handleNavigateToSuiteOverview}
+                  title={selectedSuiteName}
                   className="inline-flex max-w-full border-0 bg-transparent p-0 font-medium truncate"
                 >
-                  {selectedSuite.name}
+                  {selectedSuiteName}
                 </button>
               </BreadcrumbLink>
-            ) : (
-              <BreadcrumbPage
-                className="truncate font-medium"
-                title={selectedSuite.name}
-              >
-                {selectedSuite.name}
-              </BreadcrumbPage>
             )}
           </BreadcrumbItem>
           {route.type === "run-detail" ? (
@@ -752,24 +730,12 @@ function EvalsTabContent({
       );
     }
 
+    // List route with suites: the redirect effect above is about to send us
+    // into the most recent suite's dashboard. Show a spinner instead of the
+    // (now removed) standalone list so there's no flash of an empty table.
     return (
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden px-5 pb-5 pt-3">
-        <EvalsSuiteListSidebar
-          suites={visibleSuites}
-          selectedSuiteId={selectedSuiteId}
-          onSelectSuite={handleSelectSuite}
-          onCreateSuite={handleOpenCreateSuite}
-          isLoading={false}
-          canDeleteSuites={canDeleteSuite}
-          onDeleteSuitesBatch={handleDeleteSuitesBatch}
-          deleteInProgress={Boolean(handlers.deletingSuiteId)}
-          onRunAll={handlers.handleRerun}
-          runAllDisabledReason={evalRunsDisabledReason}
-          onEditSuite={playgroundNavigation.toSuiteEdit}
-          rerunningSuiteId={handlers.rerunningSuiteId}
-          replayingRunId={handlers.replayingRunId}
-          runningTestCaseId={handlers.runningTestCaseId}
-        />
+      <div className="flex min-h-0 flex-1 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
       </div>
     );
   };

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -262,8 +262,12 @@ describe("EvalsTab", () => {
     render(<EvalsTab projectId="ws-1" />);
 
     expect(mocks.navigatePlaygroundEvalsRoute).not.toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: "Suites" })).toBeInTheDocument();
-    expect(screen.getByTitle("Suite suite-a")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /Switch suite \(current: Suite suite-a\)/,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Suite suite-a")).toBeInTheDocument();
     expect(mocks.suiteIterationsView).toHaveBeenCalled();
     expect(mocks.suiteIterationsView.mock.calls.at(-1)?.[0]).toMatchObject({
       suite: expect.objectContaining({ _id: "suite-a" }),
@@ -274,23 +278,57 @@ describe("EvalsTab", () => {
     });
   });
 
-  it("shows the suite list on the Suites tab when the route is the eval list", () => {
+  it("redirects the bare eval list route into the most recent suite", async () => {
     mocks.route.current = { type: "list" };
     render(<EvalsTab projectId="ws-1" />);
 
-    expect(screen.getByTestId("suite-sidebar")).toBeInTheDocument();
-    expect(screen.queryByTestId("suite-iterations-view")).toBeNull();
+    await waitFor(() => {
+      expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith(
+        { type: "suite-overview", suiteId: "suite-a" },
+        { replace: true }
+      );
+    });
+    expect(screen.queryByTestId("suite-sidebar")).toBeNull();
   });
 
-  it("navigates to the eval list when the Suites breadcrumb is clicked while a suite is open", async () => {
+  it("switches suites from the breadcrumb dropdown", async () => {
     const user = userEvent.setup();
     render(<EvalsTab projectId="ws-1" />);
     expect(mocks.navigatePlaygroundEvalsRoute).not.toHaveBeenCalled();
 
-    await user.click(screen.getByRole("button", { name: "Suites" }));
+    // Open the switcher from Suites and pick another suite.
+    await user.click(
+      screen.getByRole("button", {
+        name: /Switch suite \(current: Suite suite-a\)/,
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: /Suite suite-b/ }));
 
     expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith({
-      type: "list",
+      type: "suite-overview",
+      suiteId: "suite-b",
+    });
+  });
+
+  it("navigates back to suite overview from the breadcrumb on test detail", async () => {
+    mocks.route.current = {
+      type: "test-detail",
+      suiteId: "suite-a",
+      testId: "tc-1",
+    };
+    mocks.useEvalQueries.mockImplementation(
+      ({ selectedSuiteId }: { selectedSuiteId: string | null }) =>
+        makeQueryState(selectedSuiteId),
+    );
+
+    const user = userEvent.setup();
+    render(<EvalsTab projectId="ws-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Suite suite-a" }));
+
+    expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith({
+      type: "suite-overview",
+      suiteId: "suite-a",
     });
   });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/ai-triage-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/ai-triage-card.test.tsx
@@ -135,8 +135,11 @@ describe("AiTriageCard", () => {
       />,
     );
 
-    const section = screen.getByRole("heading", { name: "AI insights" }).closest("section");
+    const section = screen
+      .getByRole("heading", { name: "Suggested fixes" })
+      .closest("section");
     expect(section).not.toHaveClass("rounded-lg");
     expect(section).not.toHaveClass("border");
+    expect(screen.queryByText(/^Accuracy$/)).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-view.test.tsx
@@ -299,6 +299,46 @@ describe("RunDetailView", () => {
     expect(root).not.toHaveClass("p-4");
   });
 
+  it("omits the Host metadata row when folded into the suite results split", () => {
+    render(
+      <RunDetailView
+        selectedRunDetails={makeRun({ namedHostId: "host-copilot" })}
+        caseGroupsForSelectedRun={[makeIteration()]}
+        source="ui"
+        runDetailSortBy="test"
+        onSortChange={() => {}}
+        selectedIterationId={null}
+        onSelectIteration={() => {}}
+        hideKpiStrip
+        hideAccuracyHero
+        hostNamesById={new Map([["host-copilot", "Copilot"]])}
+      />,
+    );
+
+    expect(screen.queryByText("Host")).not.toBeInTheDocument();
+    expect(screen.queryByText("Copilot")).not.toBeInTheDocument();
+  });
+
+  it("shows the Host metadata row when not embedded and the accuracy hero is hidden", () => {
+    render(
+      <RunDetailView
+        selectedRunDetails={makeRun({ namedHostId: "host-copilot" })}
+        caseGroupsForSelectedRun={[makeIteration()]}
+        source="ui"
+        runDetailSortBy="test"
+        onSortChange={() => {}}
+        selectedIterationId={null}
+        onSelectIteration={() => {}}
+        hideAccuracyHero
+        omitIterationList
+        hostNamesById={new Map([["host-copilot", "Copilot"]])}
+      />,
+    );
+
+    expect(screen.getByText("Host")).toBeInTheDocument();
+    expect(screen.getByText("Copilot")).toBeInTheDocument();
+  });
+
   it("does not surface per-iteration case insight captions in the run view (open a test from the list to inspect a case)", () => {
     render(
       <RunDetailView

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-insight-band.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-insight-band.test.tsx
@@ -19,7 +19,7 @@ describe("RunInsightBand", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("full insight cards")).not.toBeInTheDocument();
 
-    const toggle = screen.getByRole("button", { name: /expand ai insights/i });
+    const toggle = screen.getByRole("button", { name: /expand run insights/i });
     await user.click(toggle);
     expect(toggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByText("full insight cards")).toBeInTheDocument();
@@ -42,7 +42,7 @@ describe("RunInsightBand", () => {
     );
     const band = container.querySelector("[data-severity]");
     expect(band).toHaveAttribute("data-severity", "warn");
-    expect(band?.className).toContain("bg-warning/10");
+    expect(band?.className).toContain("border-l-warning");
   });
 
   it("can default to open", () => {
@@ -53,7 +53,7 @@ describe("RunInsightBand", () => {
     );
     expect(screen.getByText("cards")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /collapse ai insights/i }),
+      screen.getByRole("button", { name: /collapse run insights/i }),
     ).toHaveAttribute("aria-expanded", "true");
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ai-triage-card.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Copy, Loader2, RotateCw, Sparkles } from "lucide-react";
+import { Copy, Loader2, RotateCw } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
 import { cn } from "@/lib/utils";
@@ -59,11 +59,11 @@ function CategoryChip({ row }: { row: TriageRow }) {
 
 function TriageRowItem({ row }: { row: TriageRow }) {
   return (
-    <li className="px-3 py-2.5">
+    <li className="group px-3 py-2">
       <div className="flex items-start gap-2">
         <div className="min-w-0 flex-1">
           <p className="text-sm leading-snug text-foreground">{row.title}</p>
-          <div className="mt-1.5">
+          <div className="mt-1">
             <CategoryChip row={row} />
           </div>
         </div>
@@ -71,7 +71,7 @@ function TriageRowItem({ row }: { row: TriageRow }) {
           type="button"
           variant="ghost"
           size="sm"
-          className="h-7 w-7 shrink-0 px-0 text-muted-foreground hover:text-foreground"
+          className="h-7 w-7 shrink-0 px-0 text-muted-foreground opacity-70 hover:text-foreground group-hover:opacity-100"
           title={`Copy a fix prompt for your coding agent (${row.title})`}
           aria-label={`${COPY_FIX_PROMPT_LABEL}: ${row.title}`}
           onClick={() =>
@@ -161,11 +161,107 @@ export function AiTriageCard({
     if (!serverQuality && requested) return "Requesting analysis…";
     if (!serverQuality) return "Waiting for analysis…";
     if (!hasRows) return noInsights ? "Summary only" : "All clean";
+    if (embedded) {
+      if (rows.length > TOP_N) {
+        return `Showing top ${TOP_N} of ${rows.length}`;
+      }
+      return null;
+    }
     if (rows.length > TOP_N) {
       return `Top ${TOP_N} of ${rows.length} suggested fix${rows.length === 1 ? "" : "es"}`;
     }
     return `${rows.length} suggested fix${rows.length === 1 ? "" : "es"}`;
   })();
+
+  const sectionTitle = embedded ? "Suggested fixes" : "Server quality";
+  const showAccuracyBlock = !embedded;
+
+  const copyAllButton = hasRows ? (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "h-7 shrink-0 gap-1 text-xs text-muted-foreground hover:text-foreground",
+        embedded ? "px-2" : "gap-1.5",
+      )}
+      disabled={pending}
+      title={`Copy the top ${topRows.length} fix prompt${topRows.length === 1 ? "" : "s"} to paste into your coding agent`}
+      aria-label={copyTopFixPromptsLabel(topRows.length)}
+      onClick={() =>
+        copyWithToast(
+          buildTopNPrompt(topRows),
+          `Copied ${topRows.length} fix prompt${topRows.length === 1 ? "" : "s"} — paste into your agent`,
+        )
+      }
+    >
+      <Copy className="h-3 w-3 shrink-0" aria-hidden />
+      {embedded ? (
+        <span>Copy top {topRows.length}</span>
+      ) : (
+        <span className="truncate">{copyTopFixPromptsLabel(topRows.length)}</span>
+      )}
+    </Button>
+  ) : null;
+
+  const statusBody = (
+    <>
+      {pending ? (
+        <div className="flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Analyzing server quality…
+        </div>
+      ) : error ? (
+        <div className="px-3 py-3 text-sm text-destructive">{error}</div>
+      ) : failedGeneration ? (
+        <div className="px-3 py-3 text-sm text-muted-foreground">
+          We could not finish this analysis. Retry above, or open a test for the
+          full trace.
+        </div>
+      ) : !serverQuality ? (
+        <div className="px-3 py-3 text-sm text-muted-foreground">
+          {requested
+            ? "Requesting server quality analysis…"
+            : "Tool and workflow suggestions will appear here after analysis."}
+        </div>
+      ) : !hasRows ? (
+        noInsights ? (
+          <div className="px-3 py-3 text-sm text-muted-foreground">
+            {serverQuality.summary?.trim() ||
+              "The analysis produced no per-tool or per-workflow insights."}
+            <p className="mt-1 text-xs text-warning">
+              No per-tool/workflow breakdown was produced — the analysis may
+              have been truncated. Re-run to retry.
+            </p>
+          </div>
+        ) : (
+          <div className="px-3 py-3 text-sm text-muted-foreground">
+            No actionable issues — all tools rated good and workflows optimal.
+          </div>
+        )
+      ) : (
+        <>
+          <ul className="divide-y divide-border/40">
+            {visibleRows.map((row) => (
+              <TriageRowItem key={row.id} row={row} />
+            ))}
+          </ul>
+          {hasMoreSuggestions ? (
+            <button
+              type="button"
+              className="w-full border-t border-border/40 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground"
+              aria-expanded={showAllSuggestions}
+              onClick={() => setShowAllSuggestions((v) => !v)}
+            >
+              {showAllSuggestions
+                ? "Show less"
+                : `Show ${rows.length - TOP_N} more`}
+            </button>
+          ) : null}
+        </>
+      )}
+    </>
+  );
 
   return (
     <section
@@ -176,12 +272,38 @@ export function AiTriageCard({
           : "rounded-lg border border-border bg-card",
       )}
     >
-      <header className="flex flex-col gap-2 px-3 py-2.5">
-        <div className="flex min-w-0 items-center gap-2">
-          <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <h3 className="text-sm font-medium text-foreground">AI insights</h3>
+      <header
+        className={cn(
+          "flex flex-col gap-2",
+          embedded ? "px-3 py-2" : "px-3 py-2.5",
+        )}
+      >
+        <div className="flex min-w-0 items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium text-foreground">{sectionTitle}</h3>
+            {headerSubtitle ? (
+              <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+                {headerSubtitle}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {error || failedGeneration ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => onRetry()}
+              >
+                <RotateCw className="h-3 w-3" />
+                Retry
+              </Button>
+            ) : null}
+            {copyAllButton}
+          </div>
         </div>
-        {hostLabel ? (
+        {!embedded && hostLabel ? (
           <p
             className="truncate font-mono text-[11px] leading-snug text-muted-foreground"
             title={hostLabel}
@@ -189,144 +311,67 @@ export function AiTriageCard({
             {hostLabel}
           </p>
         ) : null}
-        <p className="text-xs leading-snug text-muted-foreground">
-          {headerSubtitle}
-        </p>
-        <div className="flex items-center gap-2">
-          {error || failedGeneration ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
-              onClick={() => onRetry()}
-            >
-              <RotateCw className="h-3 w-3" />
-              Retry
-            </Button>
-          ) : null}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
-            disabled={!hasRows || pending}
-            title={`Copy the top ${topRows.length} fix prompt${topRows.length === 1 ? "" : "s"} to paste into your coding agent`}
-            aria-label={copyTopFixPromptsLabel(topRows.length)}
-            onClick={() =>
-              copyWithToast(
-                buildTopNPrompt(topRows),
-                `Copied ${topRows.length} fix prompt${topRows.length === 1 ? "" : "s"} — paste into your agent`,
-              )
-            }
-          >
-            <Copy className="h-3 w-3 shrink-0" aria-hidden />
-            <span className="truncate">{copyTopFixPromptsLabel(topRows.length)}</span>
-          </Button>
-        </div>
       </header>
 
-      <div className="border-t border-border/50 px-3 py-2.5">
-        <div className="flex flex-col gap-1">
-          <div className="flex items-baseline gap-2">
-            <span className={runDetailSectionLabelClass}>{metricLabel}</span>
-            <span
-              className={cn(
-                "text-sm tabular-nums",
-                passFailStats.total === 0
-                  ? "text-muted-foreground"
-                  : passRateColorClass(passRate),
-              )}
-            >
-              {passFailStats.total === 0 ? "—" : `${passRate}%`}
+      {showAccuracyBlock ? (
+        <div className="border-t border-border/50 px-3 py-2.5">
+          <div className="flex flex-col gap-1">
+            <div className="flex items-baseline gap-2">
+              <span className={runDetailSectionLabelClass}>{metricLabel}</span>
+              <span
+                className={cn(
+                  "text-sm tabular-nums",
+                  passFailStats.total === 0
+                    ? "text-muted-foreground"
+                    : passRateColorClass(passRate),
+                )}
+              >
+                {passFailStats.total === 0 ? "—" : `${passRate}%`}
+              </span>
+            </div>
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {passFailStats.total === 0
+                ? "No cases recorded yet"
+                : `${passFailStats.passed} passed · ${passFailStats.failed} failed`}
             </span>
           </div>
-          <span className="text-xs tabular-nums text-muted-foreground">
-            {passFailStats.total === 0
-              ? "No cases recorded yet"
-              : `${passFailStats.passed} passed · ${passFailStats.failed} failed`}
-          </span>
+          <div
+            className="mt-2 flex h-1 w-full overflow-hidden rounded-full bg-muted/60"
+            role="img"
+            aria-label={
+              passFailStats.total === 0
+                ? `${metricLabel} not yet measured`
+                : `${metricLabel} ${passRate}%`
+            }
+          >
+            {passFailStats.total === 0 ? null : (
+              <div
+                className={cn("h-full", passRateSegmentColorClass(passRate))}
+                style={{ width: `${passRate}%` }}
+                title={`${metricLabel}: ${passRate}%`}
+              />
+            )}
+          </div>
         </div>
-        <div
-          className="mt-2 flex h-1 w-full overflow-hidden rounded-full bg-muted/60"
-          role="img"
-          aria-label={
-            passFailStats.total === 0
-              ? `${metricLabel} not yet measured`
-              : `${metricLabel} ${passRate}%`
-          }
-        >
-          {passFailStats.total === 0 ? null : (
-            <div
-              className={cn("h-full", passRateSegmentColorClass(passRate))}
-              style={{ width: `${passRate}%` }}
-              title={`${metricLabel}: ${passRate}%`}
-            />
-          )}
-        </div>
-      </div>
+      ) : null}
 
       <div
         className={cn(
-          "border-t border-border/50",
+          "border-t border-border/40",
           hasRows && "max-h-[min(50vh,24rem)] overflow-y-auto overscroll-y-contain",
         )}
       >
-        {pending ? (
-          <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            Analyzing server quality…
-          </div>
-        ) : error ? (
-          <div className="px-3 py-4 text-sm text-destructive">{error}</div>
-        ) : failedGeneration ? (
-          <div className="px-3 py-4 text-sm text-muted-foreground">
-            We could not finish this analysis. Retry above, or open a test for
-            the full trace.
-          </div>
-        ) : !serverQuality ? (
-          <div className="px-3 py-4 text-sm text-muted-foreground">
-            {requested
-              ? "Requesting server quality analysis…"
-              : "We will analyze your MCP server's tool quality and workflow efficiency here."}
-          </div>
-        ) : !hasRows ? (
-          noInsights ? (
-            <div className="px-3 py-4 text-sm text-muted-foreground">
-              {serverQuality.summary?.trim() ||
-                "The analysis produced no per-tool or per-workflow insights."}
-              <p className="mt-1 text-xs text-warning">
-                No per-tool/workflow breakdown was produced — the analysis may
-                have been truncated. Re-run to retry.
-              </p>
-            </div>
-          ) : (
-            <div className="px-3 py-4 text-sm text-muted-foreground">
-              No actionable issues — all tools rated good and workflows optimal.
-            </div>
-          )
-        ) : (
-          <>
-            <ul className="divide-y divide-border/50">
-              {visibleRows.map((row) => (
-                <TriageRowItem key={row.id} row={row} />
-              ))}
-            </ul>
-            {hasMoreSuggestions ? (
-              <button
-                type="button"
-                className="w-full border-t border-border/50 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
-                aria-expanded={showAllSuggestions}
-                onClick={() => setShowAllSuggestions((v) => !v)}
-              >
-                {showAllSuggestions
-                  ? "Show less"
-                  : `Show ${rows.length - TOP_N} more`}
-              </button>
-            ) : null}
-          </>
-        )}
+        {statusBody}
       </div>
+
+      {embedded && hostLabel ? (
+        <p
+          className="border-t border-border/40 px-3 py-1.5 font-mono text-[10px] text-muted-foreground/80"
+          title={hostLabel}
+        >
+          {hostLabel}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/cross-host/__tests__/cross-host-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/__tests__/cross-host-matrix.test.tsx
@@ -68,6 +68,29 @@ function makeData(): CrossHostData {
   };
 }
 
+function makeMultiHostData(): CrossHostData {
+  const matrix = new Map<string, Map<string, CellData>>([
+    [
+      "c1",
+      new Map([
+        ["h1", makeCell(5000, 1000, 1)],
+        ["h2", makeCell(6000, 1100, 1)],
+      ]),
+    ],
+  ]);
+
+  return {
+    hostColumns: [
+      { hostId: "h1", hostName: "MCPJam", isHistorical: false },
+      { hostId: "h2", hostName: "Copilot", isHistorical: false },
+    ],
+    caseRows: [{ caseId: "c1", caseTitle: "Shared case" }],
+    matrix,
+    hasAnyData: true,
+    hasHostAttachments: true,
+  };
+}
+
 describe("CrossHostMatrix row sort and summaries", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -95,6 +118,17 @@ describe("CrossHostMatrix row sort and summaries", () => {
       "style",
       expect.stringContaining("width: 300"),
     );
+  });
+
+  it("hides host column headers when only one host is shown", () => {
+    render(<CrossHostMatrix data={makeData()} expanded />);
+    expect(screen.queryByText("MCPJam")).not.toBeInTheDocument();
+  });
+
+  it("renders host column headers when comparing multiple hosts", () => {
+    render(<CrossHostMatrix data={makeMultiHostData()} expanded />);
+    expect(screen.getByText("MCPJam")).toBeInTheDocument();
+    expect(screen.getByText("Copilot")).toBeInTheDocument();
   });
 
   it("reorders rows when sorting by latency", async () => {

--- a/mcpjam-inspector/client/src/components/evals/cross-host/cross-host-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/cross-host-matrix.tsx
@@ -191,6 +191,7 @@ export function CrossHostMatrix({
     : HOST_COLUMN_WIDTH_PX.snapshot;
   const tableMinWidthPx =
     CASE_COLUMN_WIDTH_PX + hostColumns.length * hostMinColumnWidthPx;
+  const showHostColumnHeaders = hostColumns.length > 1;
 
   return (
     <div
@@ -239,12 +240,15 @@ export function CrossHostMatrix({
                 className={cn(
                   "border-b border-r border-border/60 text-center align-bottom",
                   evalSurfaceHeaderClass,
+                  !showHostColumnHeaders && "px-0 py-2",
                 )}
               >
-                <HostColumnHeader
-                  col={col}
-                  verdict={hostVerdicts?.get(col.hostId)}
-                />
+                {showHostColumnHeaders ? (
+                  <HostColumnHeader
+                    col={col}
+                    verdict={hostVerdicts?.get(col.hostId)}
+                  />
+                ) : null}
               </th>
             ))}
           </tr>

--- a/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
+++ b/mcpjam-inspector/client/src/components/evals/goal-completion-card.tsx
@@ -212,12 +212,12 @@ export function GoalCompletionCard({
           : "rounded-lg border border-border bg-card",
       )}
     >
-      <header className="flex flex-wrap items-center justify-between gap-2 px-3 py-2.5">
+      <header className="flex flex-wrap items-center justify-between gap-2 px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
           <span className="text-sm font-medium text-foreground">
-            LLM as Judge
+            {embedded ? "Goal judge" : "LLM as Judge"}
           </span>
-          <span className="truncate text-sm text-muted-foreground">
+          <span className="truncate text-xs text-muted-foreground">
             {headerSubtitle}
           </span>
         </div>

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -20,6 +20,10 @@ import { useRunInsights } from "./use-run-insights";
 import { useServerQuality } from "./use-server-quality";
 import { useGoalCompletion } from "./use-goal-completion";
 import { AiTriageCard } from "./ai-triage-card";
+import {
+  computeRunPassRatePercent,
+  unifyTriageRows,
+} from "./ai-triage-helpers";
 import { GoalCompletionCard } from "./goal-completion-card";
 import {
   buildJudgeCaseMap,
@@ -585,23 +589,84 @@ export function RunDetailView({
 
   const hasInsightContent = Boolean(serverQualityTriage || goalCompletionPanel);
 
-  // Collapsed summary for the run-level band (replaces the side rail in the
-  // embedded results view). The per-case detail now lives in the matrix cells.
-  const insightBandSummary = (
-    <>
-      <span className="font-medium text-foreground">AI insights</span>
-      {judgeHeadline ? (
-        <span className="truncate text-muted-foreground">
-          · Judge {judgeHeadline.meet}/{judgeHeadline.total} meet goal
-          {judgeHeadline.disagreements > 0
-            ? ` · ${judgeHeadline.disagreements} disagree${
-                judgeHeadline.disagreements === 1 ? "s" : ""
-              } with pass/fail`
-            : ""}
-        </span>
-      ) : null}
-    </>
+  const triageFixCount = useMemo(
+    () =>
+      unifyTriageRows({
+        serverQuality: serverQualityResult ?? null,
+        iterations: caseGroupsForSelectedRun,
+      }).length,
+    [serverQualityResult, caseGroupsForSelectedRun],
   );
+
+  const bandPassRatePercent = useMemo(() => {
+    if (!hideAccuracyHero) return null;
+    return computeRunPassRatePercent({
+      selectedRunDetails,
+      caseGroupsForSelectedRun,
+    });
+  }, [hideAccuracyHero, selectedRunDetails, caseGroupsForSelectedRun]);
+
+  // Collapsed summary for the run-level band (replaces the side rail in the
+  // embedded results view). Lead with the actionable signal; secondary line is
+  // context (pass rate, judge headline) the user can ignore until they expand.
+  const insightBandSummary = useMemo(() => {
+    const metricWord = metricLabel.toLowerCase();
+    const primary = (() => {
+      if (triageFixCount > 0) {
+        return `${triageFixCount} suggested fix${triageFixCount === 1 ? "" : "es"}`;
+      }
+      if ((judgeHeadline?.disagreements ?? 0) > 0) {
+        const n = judgeHeadline!.disagreements;
+        return `${n} judge disagreement${n === 1 ? "" : "s"}`;
+      }
+      if (judgeHeadline) {
+        return `Judge ${judgeHeadline.meet}/${judgeHeadline.total} meet goal`;
+      }
+      return "Run insights";
+    })();
+
+    const secondaryParts: string[] = [];
+    if (bandPassRatePercent !== null) {
+      secondaryParts.push(`${bandPassRatePercent}% ${metricWord}`);
+    }
+    if (judgeHeadline && triageFixCount > 0) {
+      if (judgeHeadline.disagreements > 0) {
+        secondaryParts.push(
+          `${judgeHeadline.disagreements} judge disagreement${
+            judgeHeadline.disagreements === 1 ? "" : "s"
+          }`,
+        );
+      } else {
+        secondaryParts.push(
+          `Judge ${judgeHeadline.meet}/${judgeHeadline.total} meet goal`,
+        );
+      }
+    } else if (
+      judgeHeadline &&
+      triageFixCount === 0 &&
+      judgeHeadline.disagreements === 0
+    ) {
+      secondaryParts.push(
+        `${judgeHeadline.meet}/${judgeHeadline.total} meet goal`,
+      );
+    }
+
+    return (
+      <>
+        <span className="font-medium text-foreground">{primary}</span>
+        {secondaryParts.length > 0 ? (
+          <span className="truncate text-xs text-muted-foreground">
+            {secondaryParts.join(" · ")}
+          </span>
+        ) : null}
+      </>
+    );
+  }, [
+    bandPassRatePercent,
+    judgeHeadline,
+    metricLabel,
+    triageFixCount,
+  ]);
 
   const insightBand = hasInsightContent ? (
     <RunInsightBand summary={insightBandSummary} severity={insightSeverity}>
@@ -620,7 +685,7 @@ export function RunDetailView({
           </div>
         )}
 
-      {runClient && !showAccuracyHero ? (
+      {runClient && !showAccuracyHero && !embeddedInResultsSplit ? (
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <span className={runDetailMetaLabelClass}>Host</span>
           <HostChip

--- a/mcpjam-inspector/client/src/components/evals/run-insight-band.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-insight-band.tsx
@@ -1,27 +1,21 @@
 import { useState, type ReactNode } from "react";
-import { AlertTriangle, ChevronDown, Sparkles } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
- * Severity drives the band's color, NOT its presence — progressive discovery:
- * neutral stays muted and easy to ignore; the band only "lights up" (amber/red)
- * when there's something worth a click (a judge disagreement, a quality flag, a
- * regression). Mirrors how Sentry/Datadog use color as the attention signal.
+ * Severity drives a subtle left accent, NOT the band's presence — progressive
+ * discovery: neutral stays quiet; warn/alert add a thin border cue when there's
+ * something worth expanding (judge disagreement, quality flag, regression).
  */
 export type InsightSeverity = "neutral" | "warn" | "alert";
 
-const SEVERITY_STYLES: Record<
-  InsightSeverity,
-  { wrap: string; icon: string }
-> = {
-  neutral: { wrap: "border-border/60 bg-card", icon: "text-muted-foreground" },
+const SEVERITY_STYLES: Record<InsightSeverity, { wrap: string }> = {
+  neutral: { wrap: "border-border/50 bg-muted/5" },
   warn: {
-    wrap: "border-warning/60 bg-warning/10",
-    icon: "text-warning",
+    wrap: "border-border/50 border-l-2 border-l-warning bg-muted/5",
   },
   alert: {
-    wrap: "border-destructive/60 bg-destructive/10",
-    icon: "text-destructive",
+    wrap: "border-border/50 border-l-2 border-l-destructive bg-muted/5",
   },
 };
 
@@ -48,12 +42,11 @@ export function RunInsightBand({
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const styles = SEVERITY_STYLES[severity];
-  const Icon = severity === "neutral" ? Sparkles : AlertTriangle;
   return (
     <div
       data-severity={severity}
       className={cn(
-        "mb-3 shrink-0 overflow-hidden rounded-lg border",
+        "mb-3 shrink-0 overflow-hidden rounded-md border",
         styles.wrap,
       )}
     >
@@ -61,21 +54,22 @@ export function RunInsightBand({
         type="button"
         onClick={() => setOpen((value) => !value)}
         aria-expanded={open}
-        aria-label={open ? "Collapse AI insights" : "Expand AI insights"}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-muted/20"
+        aria-label={open ? "Collapse run insights" : "Expand run insights"}
+        className="flex w-full items-start gap-2.5 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/20"
       >
-        <Icon className={cn("size-3.5 shrink-0", styles.icon)} aria-hidden />
-        <div className="flex min-w-0 flex-1 items-center gap-2">{summary}</div>
         <ChevronDown
           className={cn(
-            "ml-auto size-4 shrink-0 text-muted-foreground transition-transform",
+            "mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform",
             open && "rotate-180",
           )}
           aria-hidden
         />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-x-2 sm:gap-y-0">
+          {summary}
+        </div>
       </button>
       {open ? (
-        <div className="border-t border-border/50">{children}</div>
+        <div className="border-t border-border/40">{children}</div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## What & why

While reconstructing the eval work into `main` (the 7-stack series #2899–#2905), several UI redesigns that existed on `evals-ui-polish` were **silently left behind** — the files auto-merged through the stacks and `main` kept the pre-redesign versions. None had failing tests to flag them. This PR restores them.

### Restored
- **Suite-redirect landing** (`EvalsTab.tsx`): `/evals` no longer renders the standalone `EvalsSuiteListSidebar`; it **redirects to the most-recent suite's dashboard** (spinner while redirecting) with `SuiteSwitcher` in the breadcrumb (jump / new / delete). Empty state still shows the create-hero. `EvalsSuiteListSidebar` is now unused by `EvalsTab`.
- **Insights / run-detail polish** (`ai-triage-card`, `run-detail-view`, `run-insight-band`, `goal-completion-card`, `cross-host-matrix`): restored the intended presentation that didn't survive reconstruction.

All dependencies (`suite-switcher`, `stripTimestampSuffix`) already existed on `main`. Kept `main`'s `@/lib/toast` import (the persist-toast fix).

## Verification
- `typecheck:client` clean.
- Tests green for all touched areas (EvalsTab, suite-switcher, ai-triage-card, run-detail-view, run-insight-band, cross-host-matrix).

## Note
This is part of a broader pattern: the stack reconstruction dropped some shipped/intended work that auto-merged without conflicts (also seen with #2886 client picker and #2877 persist-toasts, recovered during the stack merges). Worth a follow-up audit of the remaining eval redesigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only eval navigation and presentation changes; no backend, auth, or data-model changes. Main user-facing shift is losing the full suite list page in favor of redirect + dropdown.
> 
> **Overview**
> **Evals landing and navigation** no longer show the standalone suite list sidebar. Visiting `/evals` with suites **redirects** to the most recent suite’s overview (spinner while redirecting); empty projects still get the create hero. The breadcrumb replaces the “Suites” link with **`SuiteSwitcher`** (switch / create / single-suite delete). Suite names use **`stripTimestampSuffix`**. Batch suite delete from the list is removed; invalid suite routes still fall back to list.
> 
> **Run and insights presentation** is tightened for the embedded suite-results split: **`AiTriageCard`** uses “Suggested fixes” / “Server quality”, drops the accuracy block when embedded, and refactors header/actions; **`RunInsightBand`** is subtler (left accent vs full tint), renames expand/collapse to “run insights”, and **`RunDetailView`** builds a richer collapsed summary (fix count, judge disagreements, pass rate). Host metadata is hidden when folded into the split. **`GoalCompletionCard`** shortens embedded copy (“Goal judge”). **`CrossHostMatrix`** hides host column headers when only one host is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d9d9fbc03e7f441d72661588d3131942462410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->