### PR TITLE
test(host-compat): restore real timers in afterEach (no fake-timer leak)

### DIFF
--- a/mcpjam-inspector/client/src/lib/host-compat/__tests__/use-host-compat.test.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/__tests__/use-host-compat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { ServerWithName } from "@/state/app-types";
 
@@ -28,6 +28,13 @@ const disconnected = (name: string): ServerWithName =>
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+// Always restore real timers, even if a fake-timer test throws before its own
+// cleanup — otherwise a later test runs under fake timers and hangs/flakes.
+// `useRealTimers()` is a safe no-op when real timers are already active.
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("useServerToolsData", () => {
@@ -75,6 +82,7 @@ describe("useServerToolsData", () => {
     // Flush the rejection + backoff timers for the two retries.
     await vi.runAllTimersAsync();
     expect(mockListTools).toHaveBeenCalledTimes(3); // TOOLS_FETCH_MAX_ATTEMPTS
-    vi.useRealTimers();
+    // Restoration is handled by afterEach, so an early throw above can't leave
+    // fake timers active for the next test.
   });
 });


### PR DESCRIPTION
Follow-up to #2922 (merged) — addresses the P3 test-hygiene finding from the re-review.

## Problem
`use-host-compat.test.ts`'s retry test called `vi.useRealTimers()` only at the end of its body. If `runAllTimersAsync()` or an assertion threw first, fake timers stayed active and a later test in the file could run under them (hang/flake).

## Fix
Move timer restoration into an `afterEach` — `vi.useRealTimers()` is a safe no-op when real timers are already active, so it cleans up regardless of whether the fake-timer test threw. Drop the now-redundant inline call.

No production code changed; test-only.

Verification: `use-host-compat` suite (4 tests) passes; `typecheck:client` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior impact.
> 
> **Overview**
> **Test hygiene for `use-host-compat.test.ts`:** fake timers used in the retry test are now reset in a file-level **`afterEach`** via `vi.useRealTimers()`, so a failure mid-test (e.g. during `runAllTimersAsync()` or an assertion) cannot leave fake timers on for later cases.
> 
> The retry test no longer calls `vi.useRealTimers()` inline; comments note that **`afterEach`** owns cleanup and that restoring real timers is safe when they are already active.
> 
> No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38dda68325c251040c812c88eac4bf2eb3e1a1a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->