### PR TITLE
feat(host-compat): Phase 2 — multi-server compatibility matrix

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -888,15 +888,12 @@ export function CompatibilityRoute() {
   const connectedServers = Object.values<ServerWithName>(
     appState.servers,
   ).filter((s) => s.connectionStatus === "connected");
-  // Only hand down a selected server that's actually in the matrix (connected);
-  // otherwise the detail pane could show a disconnected server the matrix
-  // doesn't list. The page falls back to the first connected one.
-  const selectedConnected =
-    connectedServers.find((s) => s.name === selectedServerEntry?.name) ?? null;
+  // The page resolves the detail against `servers` (ignoring a stale/
+  // disconnected global selection), so it's safe to pass the raw selection.
   return (
     <HostCompatPage
       servers={connectedServers}
-      selectedServer={selectedConnected}
+      selectedServer={selectedServerEntry ?? null}
       onSelectServer={setSelectedServer}
       projectId={activeProjectId}
     />

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -888,10 +888,15 @@ export function CompatibilityRoute() {
   const connectedServers = Object.values<ServerWithName>(
     appState.servers,
   ).filter((s) => s.connectionStatus === "connected");
+  // Only hand down a selected server that's actually in the matrix (connected);
+  // otherwise the detail pane could show a disconnected server the matrix
+  // doesn't list. The page falls back to the first connected one.
+  const selectedConnected =
+    connectedServers.find((s) => s.name === selectedServerEntry?.name) ?? null;
   return (
     <HostCompatPage
       servers={connectedServers}
-      selectedServer={selectedServerEntry ?? null}
+      selectedServer={selectedConnected}
       onSelectServer={setSelectedServer}
       projectId={activeProjectId}
     />

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -883,10 +883,16 @@ export function ConformanceRoute() {
 }
 
 export function CompatibilityRoute() {
-  const { selectedServerEntry, activeProjectId } = useAppRouteContext();
+  const { appState, selectedServerEntry, activeProjectId, setSelectedServer } =
+    useAppRouteContext();
+  const connectedServers = Object.values<ServerWithName>(
+    appState.servers,
+  ).filter((s) => s.connectionStatus === "connected");
   return (
     <HostCompatPage
-      server={selectedServerEntry ?? null}
+      servers={connectedServers}
+      selectedServer={selectedServerEntry ?? null}
+      onSelectServer={setSelectedServer}
       projectId={activeProjectId}
     />
   );

--- a/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
@@ -22,11 +22,11 @@ import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
 import { evaluateAllHosts } from "@/lib/host-compat/engine";
 import { useWidgetUsage } from "@/lib/host-compat/use-widget-usage";
 import { ConformanceGate } from "@/components/compat/ConformanceGate";
+import { VERDICT_META } from "@/components/compat/verdict-meta";
 import type {
   CompatFinding,
   CompatLane,
   CompatProvenance,
-  CompatVerdict,
   HostCompatReport,
 } from "@/lib/host-compat/types";
 import { standardEventProps } from "@/lib/PosthogUtils";
@@ -50,34 +50,6 @@ const COMPAT_TEMPLATE_LABEL = new Map<string, string>(
 
 const isHostTemplateId = (id: string): id is HostTemplateId =>
   COMPAT_TEMPLATE_LABEL.has(id);
-
-/** Lightweight verdict styling: a colored dot + colored label, no pill —
- * keeps each host row to a single quiet line. */
-const VERDICT_META: Record<
-  CompatVerdict,
-  { label: string; dot: string; text: string }
-> = {
-  works: {
-    label: "Works",
-    dot: "bg-emerald-500",
-    text: "text-emerald-600 dark:text-emerald-400",
-  },
-  degraded: {
-    label: "Degraded",
-    dot: "bg-amber-500",
-    text: "text-amber-600 dark:text-amber-400",
-  },
-  blocked: {
-    label: "Blocked",
-    dot: "bg-red-500",
-    text: "text-red-600 dark:text-red-400",
-  },
-  unknown: {
-    label: "Unknown",
-    dot: "bg-muted-foreground/40",
-    text: "text-muted-foreground",
-  },
-};
 
 const PROVENANCE_LABEL: Record<CompatProvenance, string> = {
   observed: "Observed from a live run",

--- a/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import type { ServerWithName } from "@/state/app-types";
+import { buildHostCompatProfiles } from "@/lib/host-compat/profiles";
+import { useHostCompatReports } from "@/lib/host-compat/use-host-compat";
+import type { HostCompatReport } from "@/lib/host-compat/types";
+import { VERDICT_META } from "@/components/compat/verdict-meta";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+
+type HostColumn = {
+  id: string;
+  label: string;
+  logoSrc: string;
+  logoSrcByTheme?: { light: string; dark: string };
+};
+
+export type ColumnSummary = { works: number; loaded: number };
+
+/**
+ * For one host column, count how many of the loaded servers "work" there.
+ * Pure + server-object-free so it unit-tests cleanly; the matrix feeds it
+ * `servers.map((s) => byServer[s.name])` so stale entries for removed servers
+ * never leak into the count.
+ */
+export function summarizeColumn(
+  perServerReports: Array<HostCompatReport[] | undefined>,
+  hostId: string,
+): ColumnSummary {
+  let works = 0;
+  let loaded = 0;
+  for (const reports of perServerReports) {
+    if (!reports) continue;
+    const r = reports.find((x) => x.hostId === hostId);
+    if (!r) continue;
+    loaded += 1;
+    if (r.verdict === "works") works += 1;
+  }
+  return { works, loaded };
+}
+
+/**
+ * One server row. Each row owns its own `useHostCompatReports` (per-server
+ * tool fetch + widget scan), so the matrix can map over a dynamic server list
+ * without breaking the rules of hooks. Verdicts bubble up via `onReports` so
+ * the matrix can roll up per-column summaries.
+ */
+function MatrixRow({
+  server,
+  hosts,
+  selected,
+  onSelect,
+  onReports,
+}: {
+  server: ServerWithName;
+  hosts: HostColumn[];
+  selected: boolean;
+  onSelect: (name: string) => void;
+  onReports: (name: string, reports: HostCompatReport[]) => void;
+}) {
+  const { reports } = useHostCompatReports(server);
+
+  const byHost = useMemo(() => {
+    const m = new Map<string, HostCompatReport>();
+    for (const r of reports) m.set(r.hostId, r);
+    return m;
+  }, [reports]);
+
+  // `reports` is memoized by useHostCompatReports, so this fires only when the
+  // server's evaluation actually changes — not on every parent re-render.
+  useEffect(() => {
+    onReports(server.name, reports);
+  }, [server.name, reports, onReports]);
+
+  return (
+    <tr
+      onClick={() => onSelect(server.name)}
+      className={`cursor-pointer border-t border-border/50 ${
+        selected ? "bg-muted/50" : "hover:bg-muted/30"
+      }`}
+    >
+      <td className="sticky left-0 z-10 max-w-[12rem] truncate bg-inherit px-3 py-2 text-xs font-medium text-foreground">
+        {server.name}
+      </td>
+      {hosts.map((h) => {
+        const verdict = byHost.get(h.id)?.verdict ?? "unknown";
+        const meta = VERDICT_META[verdict];
+        return (
+          <td key={h.id} className="px-2 py-2 text-center">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className={`inline-block h-2 w-2 rounded-full ${meta.dot}`}
+                  aria-label={`${meta.label} on ${h.label}`}
+                />
+              </TooltipTrigger>
+              <TooltipContent side="top" variant="muted">
+                {h.label}: {meta.label}
+              </TooltipContent>
+            </Tooltip>
+          </td>
+        );
+      })}
+    </tr>
+  );
+}
+
+/**
+ * Multi-server compatibility matrix — rows are connected servers, columns are
+ * hosts, each cell is the server's aggregate verdict on that host. Clicking a
+ * row selects that server (the page shows its full report below). Per-column
+ * footer summarizes "works in N/M".
+ */
+export function HostCompatMatrix({
+  servers,
+  selectedServerName,
+  onSelectServer,
+}: {
+  servers: ServerWithName[];
+  selectedServerName?: string;
+  onSelectServer: (name: string) => void;
+}) {
+  const themeMode = usePreferencesStore((s) => s.themeMode);
+  const hosts = useMemo<HostColumn[]>(
+    () =>
+      buildHostCompatProfiles().map((p) => ({
+        id: p.id,
+        label: p.label,
+        logoSrc: p.logoSrc,
+        logoSrcByTheme: p.logoSrcByTheme,
+      })),
+    [],
+  );
+
+  const [byServer, setByServer] = useState<Record<string, HostCompatReport[]>>(
+    {},
+  );
+  const handleReports = useCallback(
+    (name: string, reports: HostCompatReport[]) => {
+      setByServer((prev) =>
+        prev[name] === reports ? prev : { ...prev, [name]: reports },
+      );
+    },
+    [],
+  );
+
+  const perServerReports = servers.map((s) => byServer[s.name]);
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-border/60">
+      <table className="w-full border-collapse text-left">
+        <thead>
+          <tr className="bg-muted/30">
+            <th className="sticky left-0 z-10 bg-muted/30 px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Server
+            </th>
+            {hosts.map((h) => (
+              <th key={h.id} className="px-2 py-2 text-center">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <img
+                      src={h.logoSrcByTheme?.[themeMode] ?? h.logoSrc}
+                      alt={h.label}
+                      className="mx-auto h-4 w-4 rounded-[3px] object-contain"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" variant="muted">
+                    {h.label}
+                  </TooltipContent>
+                </Tooltip>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {servers.map((s) => (
+            <MatrixRow
+              key={s.name}
+              server={s}
+              hosts={hosts}
+              selected={s.name === selectedServerName}
+              onSelect={onSelectServer}
+              onReports={handleReports}
+            />
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="border-t border-border/50">
+            <td className="sticky left-0 z-10 bg-background px-3 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+              Works
+            </td>
+            {hosts.map((h) => {
+              const { works, loaded } = summarizeColumn(perServerReports, h.id);
+              return (
+                <td
+                  key={h.id}
+                  className="px-2 py-1.5 text-center text-[11px] text-muted-foreground"
+                >
+                  {loaded > 0 ? `${works}/${loaded}` : "—"}
+                </td>
+              );
+            })}
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
@@ -54,12 +54,14 @@ function MatrixRow({
   selected,
   onSelect,
   onReports,
+  onRemove,
 }: {
   server: ServerWithName;
   hosts: HostColumn[];
   selected: boolean;
   onSelect: (name: string) => void;
   onReports: (name: string, reports: HostCompatReport[]) => void;
+  onRemove: (name: string) => void;
 }) {
   const { reports } = useHostCompatReports(server);
 
@@ -74,6 +76,14 @@ function MatrixRow({
   useEffect(() => {
     onReports(server.name, reports);
   }, [server.name, reports, onReports]);
+
+  // Drop this server's rolled-up entry when the row leaves (disconnect /
+  // rename). Without this, a disconnected server's stale verdicts linger in
+  // `byServer` and resurface in the column footer for one render after it
+  // reconnects (before the remounted row's effect re-runs). Keyed on
+  // server.name only, so it fires on unmount/rename — not on every `reports`
+  // change.
+  useEffect(() => () => onRemove(server.name), [server.name, onRemove]);
 
   return (
     <tr
@@ -160,6 +170,14 @@ export function HostCompatMatrix({
     },
     [],
   );
+  const handleRemove = useCallback((name: string) => {
+    setByServer((prev) => {
+      if (!(name in prev)) return prev;
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+  }, []);
 
   const perServerReports = servers.map((s) => byServer[s.name]);
 
@@ -198,6 +216,7 @@ export function HostCompatMatrix({
               selected={s.name === selectedServerName}
               onSelect={onSelectServer}
               onReports={handleReports}
+              onRemove={handleRemove}
             />
           ))}
         </tbody>

--- a/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatMatrix.tsx
@@ -77,13 +77,27 @@ function MatrixRow({
 
   return (
     <tr
+      // Mouse convenience: click anywhere on the row to select. The real
+      // keyboard/AT control is the button in the server cell below — the row
+      // carries no button role so assistive tech isn't told a table row is a
+      // button.
       onClick={() => onSelect(server.name)}
-      className={`cursor-pointer border-t border-border/50 ${
+      className={`border-t border-border/50 ${
         selected ? "bg-muted/50" : "hover:bg-muted/30"
       }`}
     >
-      <td className="sticky left-0 z-10 max-w-[12rem] truncate bg-inherit px-3 py-2 text-xs font-medium text-foreground">
-        {server.name}
+      <td className="sticky left-0 z-10 bg-inherit px-3 py-2">
+        <button
+          type="button"
+          aria-pressed={selected}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect(server.name);
+          }}
+          className="block max-w-[11rem] truncate rounded text-left text-xs font-medium text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {server.name}
+        </button>
       </td>
       {hosts.map((h) => {
         const verdict = byHost.get(h.id)?.verdict ?? "unknown";

--- a/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
@@ -31,11 +31,13 @@ export function HostCompatPage({
   onSelectServer: (name: string) => void;
   projectId?: string | null;
 }) {
-  // Anchor the detail to a CONNECTED server (the matrix only lists connected
-  // ones), falling back to the first so the report is never blank — and so the
-  // matrix highlight (`detailServer.name`) always matches a real row. Hook runs
-  // unconditionally; it no-ops for a null/empty server.
-  const detailServer = selectedServer ?? servers[0] ?? null;
+  // Resolve the detail against the CONNECTED list (the matrix only lists
+  // connected servers): a stale/disconnected global selection that isn't in
+  // `servers` is ignored, falling back to the first connected server. The
+  // matrix highlight reads `detailServer.name`, so the two always agree. Hook
+  // runs unconditionally; it no-ops for a null/empty server.
+  const detailServer =
+    servers.find((s) => s.name === selectedServer?.name) ?? servers[0] ?? null;
   const toolsData = useServerToolsData(detailServer);
 
   if (servers.length === 0) {

--- a/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
@@ -31,10 +31,11 @@ export function HostCompatPage({
   onSelectServer: (name: string) => void;
   projectId?: string | null;
 }) {
-  // Fall back to the sole server so the detail isn't blank before the active
-  // server resolves. Hook runs unconditionally; it no-ops for a null server.
-  const detailServer =
-    selectedServer ?? (servers.length === 1 ? servers[0] : null);
+  // Anchor the detail to a CONNECTED server (the matrix only lists connected
+  // ones), falling back to the first so the report is never blank — and so the
+  // matrix highlight (`detailServer.name`) always matches a real row. Hook runs
+  // unconditionally; it no-ops for a null/empty server.
+  const detailServer = selectedServer ?? servers[0] ?? null;
   const toolsData = useServerToolsData(detailServer);
 
   if (servers.length === 0) {

--- a/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
@@ -2,39 +2,53 @@ import { Boxes } from "lucide-react";
 import type { ServerWithName } from "@/state/app-types";
 import { useServerToolsData } from "@/lib/host-compat/use-host-compat";
 import { HostCompatContent } from "@/components/compat/HostCompatContent";
+import { HostCompatMatrix } from "@/components/compat/HostCompatMatrix";
 import { EmptyState } from "@/components/ui/empty-state";
 
 /**
- * Standalone Compatibility destination — the full-page "does my server work on
- * these hosts?" report for the currently-selected server. Reuses the same
- * engine + `HostCompatContent` as the server-detail modal tab; the only extra
- * job here is fetching the tools list (the modal already holds one).
+ * Standalone Compatibility destination — "does my server work on these hosts?".
+ *
+ * With multiple connected servers it leads with a servers × hosts matrix
+ * (click a row to drill in); the selected server's full report (conformance
+ * gate + per-host apps/server findings) renders below. With a single server it
+ * is just that report. Reuses the same engine + `HostCompatContent` as the
+ * server-detail modal tab.
  *
  * The "Test in host" CTA is intentionally absent on this page: it needs the
- * project-server-ref id the modal resolves, so we pass no `serverId` and
- * `HostCompatContent` hides the CTA (`canCreateHosts` is false). The matrix +
- * conformance gate are the value here; creating a host stays in the modal.
+ * project-server-ref id the modal resolves, so `HostCompatContent` (passed no
+ * `serverId`) hides it.
  */
 export function HostCompatPage({
-  server,
+  servers,
+  selectedServer,
+  onSelectServer,
   projectId,
 }: {
-  server: ServerWithName | null;
+  /** Connected servers eligible for evaluation. */
+  servers: ServerWithName[];
+  /** The server whose full report shows below the matrix. */
+  selectedServer: ServerWithName | null;
+  onSelectServer: (name: string) => void;
   projectId?: string | null;
 }) {
-  // Hook runs unconditionally; it no-ops for a null/disconnected server.
-  const toolsData = useServerToolsData(server);
+  // Fall back to the sole server so the detail isn't blank before the active
+  // server resolves. Hook runs unconditionally; it no-ops for a null server.
+  const detailServer =
+    selectedServer ?? (servers.length === 1 ? servers[0] : null);
+  const toolsData = useServerToolsData(detailServer);
 
-  if (!server) {
+  if (servers.length === 0) {
     return (
       <EmptyState
         icon={Boxes}
-        title="No server selected"
-        description="Select a connected server above to check whether it works on each host."
+        title="No connected server"
+        description="Connect a server above to check whether it works on each host."
         className="h-full"
       />
     );
   }
+
+  const showMatrix = servers.length > 1;
 
   return (
     <div className="mx-auto w-full max-w-3xl px-6 py-5">
@@ -43,17 +57,39 @@ export function HostCompatPage({
           Compatibility
         </h1>
         <p className="text-xs text-muted-foreground">
-          Whether <span className="font-medium">{server.name}</span> works on
-          each host — spec conformance first, then per-host apps &amp; server
-          gaps.
+          Whether your servers work on each host — spec conformance first, then
+          per-host apps &amp; server gaps.
         </p>
       </div>
-      <HostCompatContent
-        server={server}
-        toolsData={toolsData}
-        projectId={projectId}
-        source="compat_page"
-      />
+
+      {showMatrix && (
+        <div className="mb-5">
+          <HostCompatMatrix
+            servers={servers}
+            selectedServerName={detailServer?.name}
+            onSelectServer={onSelectServer}
+          />
+          <p className="mt-1.5 text-[11px] text-muted-foreground">
+            Select a server to see its full report.
+          </p>
+        </div>
+      )}
+
+      {detailServer && (
+        <section>
+          {showMatrix && (
+            <h2 className="mb-1.5 text-sm font-medium text-foreground">
+              {detailServer.name}
+            </h2>
+          )}
+          <HostCompatContent
+            server={detailServer}
+            toolsData={toolsData}
+            projectId={projectId}
+            source="compat_page"
+          />
+        </section>
+      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/compat/__tests__/HostCompatMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/compat/__tests__/HostCompatMatrix.test.tsx
@@ -6,8 +6,8 @@ import type { ServerWithName } from "@/state/app-types";
 // Two-host registry keeps the rendered grid small and assertions tractable.
 vi.mock("@/lib/host-compat/profiles", () => ({
   buildHostCompatProfiles: () => [
-    { id: "claude", label: "Claude", logoSrc: "" },
-    { id: "codex", label: "Codex", logoSrc: "" },
+    { id: "claude", label: "Claude", logoSrc: "/claude.png" },
+    { id: "codex", label: "Codex", logoSrc: "/codex.svg" },
   ],
 }));
 
@@ -85,8 +85,9 @@ describe("HostCompatMatrix", () => {
     await waitFor(() => expect(screen.getByText("2/2")).toBeInTheDocument());
     expect(screen.getByText("0/2")).toBeInTheDocument();
 
-    // Clicking server b's row selects it.
-    fireEvent.click(screen.getByText("b").closest("tr")!);
+    // The per-server control is a real button (keyboard-reachable, not a
+    // mouse-only row handler) and selects on activation.
+    fireEvent.click(screen.getByRole("button", { name: "b" }));
     expect(onSelectServer).toHaveBeenCalledWith("b");
   });
 });

--- a/mcpjam-inspector/client/src/components/compat/__tests__/HostCompatMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/compat/__tests__/HostCompatMatrix.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { HostCompatReport } from "@/lib/host-compat/types";
+import type { ServerWithName } from "@/state/app-types";
+
+// Two-host registry keeps the rendered grid small and assertions tractable.
+vi.mock("@/lib/host-compat/profiles", () => ({
+  buildHostCompatProfiles: () => [
+    { id: "claude", label: "Claude", logoSrc: "" },
+    { id: "codex", label: "Codex", logoSrc: "" },
+  ],
+}));
+
+// Canned per-server verdicts (defined inside the factory — vi.mock is hoisted).
+vi.mock("@/lib/host-compat/use-host-compat", () => {
+  const rep = (hostId: string, verdict: string) => ({
+    hostId,
+    hostLabel: hostId,
+    logoSrc: "",
+    verdict,
+    provenance: "assumed",
+    lanes: {
+      apps: { verdict, provenance: "assumed" },
+      server: { verdict: "works", provenance: "assumed" },
+    },
+    findings: [],
+  });
+  const REPORTS: Record<string, unknown[]> = {
+    a: [rep("claude", "works"), rep("codex", "blocked")],
+    b: [rep("claude", "works"), rep("codex", "degraded")],
+  };
+  return {
+    useHostCompatReports: (server: { name: string }) => ({
+      reports: REPORTS[server.name] ?? [],
+      requirements: {},
+    }),
+  };
+});
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (selector: (s: { themeMode: string }) => unknown) =>
+    selector({ themeMode: "light" }),
+}));
+
+import { HostCompatMatrix, summarizeColumn } from "../HostCompatMatrix";
+
+const rep = (hostId: string, verdict: HostCompatReport["verdict"]) =>
+  ({ hostId, verdict }) as HostCompatReport;
+
+const server = (name: string): ServerWithName =>
+  ({ name, connectionStatus: "connected" }) as ServerWithName;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("summarizeColumn", () => {
+  it("counts works / loaded for a host, skipping unloaded servers", () => {
+    const a = [rep("claude", "works"), rep("codex", "blocked")];
+    const b = [rep("claude", "works"), rep("codex", "degraded")];
+    expect(summarizeColumn([a, b], "claude")).toEqual({ works: 2, loaded: 2 });
+    expect(summarizeColumn([a, b], "codex")).toEqual({ works: 0, loaded: 2 });
+    // An unloaded server (undefined) doesn't count toward the total.
+    expect(summarizeColumn([a, undefined], "claude")).toEqual({
+      works: 1,
+      loaded: 1,
+    });
+    // A host with no report on any server → nothing loaded.
+    expect(summarizeColumn([a, b], "cursor")).toEqual({ works: 0, loaded: 0 });
+  });
+});
+
+describe("HostCompatMatrix", () => {
+  it("renders per-column summaries and selects a server on row click", async () => {
+    const onSelectServer = vi.fn();
+    render(
+      <HostCompatMatrix
+        servers={[server("a"), server("b")]}
+        selectedServerName="a"
+        onSelectServer={onSelectServer}
+      />,
+    );
+
+    // Both servers work on Claude (2/2); neither works on Codex (0/2).
+    await waitFor(() => expect(screen.getByText("2/2")).toBeInTheDocument());
+    expect(screen.getByText("0/2")).toBeInTheDocument();
+
+    // Clicking server b's row selects it.
+    fireEvent.click(screen.getByText("b").closest("tr")!);
+    expect(onSelectServer).toHaveBeenCalledWith("b");
+  });
+});

--- a/mcpjam-inspector/client/src/components/compat/__tests__/HostCompatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/compat/__tests__/HostCompatPage.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ServerWithName } from "@/state/app-types";
+
+// Stub the heavy children so we can assert which server each surface targets.
+vi.mock("@/components/compat/HostCompatContent", () => ({
+  HostCompatContent: ({ server }: { server: ServerWithName }) => (
+    <div data-testid="detail">{server.name}</div>
+  ),
+}));
+vi.mock("@/components/compat/HostCompatMatrix", () => ({
+  HostCompatMatrix: ({ selectedServerName }: { selectedServerName?: string }) => (
+    <div data-testid="matrix-highlight">{selectedServerName}</div>
+  ),
+}));
+vi.mock("@/lib/host-compat/use-host-compat", () => ({
+  useServerToolsData: () => null,
+}));
+
+import { HostCompatPage } from "../HostCompatPage";
+
+const server = (name: string): ServerWithName =>
+  ({ name, connectionStatus: "connected" }) as ServerWithName;
+
+describe("HostCompatPage", () => {
+  it("shows the empty state when no server is connected", () => {
+    render(
+      <HostCompatPage servers={[]} selectedServer={null} onSelectServer={vi.fn()} />,
+    );
+    expect(screen.getByText("No connected server")).toBeInTheDocument();
+    expect(screen.queryByTestId("detail")).not.toBeInTheDocument();
+  });
+
+  it("anchors the detail to the first connected server when none is selected", () => {
+    // P2 regression: a disconnected global selection must not drive the detail
+    // pane to a server the matrix (connected-only) doesn't list. With no
+    // connected selection, the page falls back to the first connected server,
+    // and the matrix highlight matches it.
+    render(
+      <HostCompatPage
+        servers={[server("a"), server("b")]}
+        selectedServer={null}
+        onSelectServer={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("detail")).toHaveTextContent("a");
+    expect(screen.getByTestId("matrix-highlight")).toHaveTextContent("a");
+  });
+
+  it("uses the selected connected server for both detail and highlight", () => {
+    render(
+      <HostCompatPage
+        servers={[server("a"), server("b")]}
+        selectedServer={server("b")}
+        onSelectServer={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("detail")).toHaveTextContent("b");
+    expect(screen.getByTestId("matrix-highlight")).toHaveTextContent("b");
+  });
+
+  it("hides the matrix for a single connected server", () => {
+    render(
+      <HostCompatPage
+        servers={[server("solo")]}
+        selectedServer={server("solo")}
+        onSelectServer={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("matrix-highlight")).not.toBeInTheDocument();
+    expect(screen.getByTestId("detail")).toHaveTextContent("solo");
+  });
+});

--- a/mcpjam-inspector/client/src/components/compat/__tests__/HostCompatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/compat/__tests__/HostCompatPage.test.tsx
@@ -32,10 +32,6 @@ describe("HostCompatPage", () => {
   });
 
   it("anchors the detail to the first connected server when none is selected", () => {
-    // P2 regression: a disconnected global selection must not drive the detail
-    // pane to a server the matrix (connected-only) doesn't list. With no
-    // connected selection, the page falls back to the first connected server,
-    // and the matrix highlight matches it.
     render(
       <HostCompatPage
         servers={[server("a"), server("b")]}
@@ -44,6 +40,23 @@ describe("HostCompatPage", () => {
       />,
     );
     expect(screen.getByTestId("detail")).toHaveTextContent("a");
+    expect(screen.getByTestId("matrix-highlight")).toHaveTextContent("a");
+  });
+
+  it("ignores a stale/disconnected selection not in the connected list", () => {
+    // P2 regression (the real path): the global selection points at a server
+    // that just disconnected and is no longer in `servers`. The detail must NOT
+    // render that server — it falls back to the first connected one, and the
+    // matrix highlight (connected-only) agrees.
+    render(
+      <HostCompatPage
+        servers={[server("a"), server("b")]}
+        selectedServer={server("ghost")}
+        onSelectServer={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("detail")).toHaveTextContent("a");
+    expect(screen.getByTestId("detail")).not.toHaveTextContent("ghost");
     expect(screen.getByTestId("matrix-highlight")).toHaveTextContent("a");
   });
 

--- a/mcpjam-inspector/client/src/components/compat/verdict-meta.ts
+++ b/mcpjam-inspector/client/src/components/compat/verdict-meta.ts
@@ -1,0 +1,32 @@
+import type { CompatVerdict } from "@/lib/host-compat/types";
+
+/**
+ * Verdict styling shared across the compat surfaces (single-server report rows
+ * and the multi-server matrix): a colored dot + colored label, no pill — keeps
+ * each verdict to a single quiet visual.
+ */
+export const VERDICT_META: Record<
+  CompatVerdict,
+  { label: string; dot: string; text: string }
+> = {
+  works: {
+    label: "Works",
+    dot: "bg-emerald-500",
+    text: "text-emerald-600 dark:text-emerald-400",
+  },
+  degraded: {
+    label: "Degraded",
+    dot: "bg-amber-500",
+    text: "text-amber-600 dark:text-amber-400",
+  },
+  blocked: {
+    label: "Blocked",
+    dot: "bg-red-500",
+    text: "text-red-600 dark:text-red-400",
+  },
+  unknown: {
+    label: "Unknown",
+    dot: "bg-muted-foreground/40",
+    text: "text-muted-foreground",
+  },
+};


### PR DESCRIPTION
Follow-up to #2922 (merged). Adds the **multi-server matrix** — Phase 2 of the host-compatibility experience.

## What

The flag-gated `/compatibility` destination now leads with a **servers × hosts matrix** when more than one server is connected:

- Rows = connected servers, columns = hosts, each cell = the server's aggregate verdict on that host (works / degraded / blocked / unknown dot, tooltip names the host + verdict).
- A footer summarizes **"works in N/M"** per host column.
- Clicking a server row selects it; its full report (conformance gate + per-host apps/server findings) renders below.
- A single connected server shows just that report — unchanged from Phase 1.

## How

- **`HostCompatMatrix`** — one `MatrixRow` per server owns its own `useHostCompatReports` (per-server tool fetch + widget scan), so the matrix maps a *dynamic* server list without breaking the rules of hooks. Each row's verdicts bubble up via an `onReports` callback so the matrix can roll up the per-column summaries. Pure `summarizeColumn(perServerReports, hostId)` helper (server-object-free, so stale entries for removed servers can't leak into the count).
- **`verdict-meta.ts`** — extracted `VERDICT_META` (verdict → dot/label/text) out of `HostCompatContent` so the matrix and the single-server report share one source.
- **`CompatibilityRoute`** passes the connected-server list + `setSelectedServer` from the route context; **`HostCompatPage`** renders the matrix + the selected server's detail.

The host-compat **engine is reused unchanged** — this is a pure fan-out over `useHostCompatReports`. No backend changes. Still behind the `mcpjam-compatibility` flag (default off).

## Verification

- New tests: `summarizeColumn` unit (works/loaded counting, skips unloaded, missing host) + matrix render (per-column summaries, row-click selection).
- 64 client tests pass; `typecheck:client` clean.

## Notes

- The selected server is evaluated twice (once for its matrix row, once for the detail below) — minor; `listTools` is the only extra call and it's the same one the modal makes. Can dedupe later if it matters.
- Not click-tested in CI (flag default-off keeps blast radius zero); worth a manual pass with 2+ connected servers before enabling the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI behind the default-off `mcpjam-compatibility` flag; reuses existing host-compat hooks with no auth or backend changes. Minor extra per-server tool fetches when the matrix and detail both evaluate the selected server.
> 
> **Overview**
> **Phase 2** expands the flag-gated `/compatibility` page from a single-server report into a **multi-server overview** when more than one server is connected.
> 
> With **2+ connected servers**, the page now shows a **servers × hosts matrix**: each cell is a verdict dot (with tooltips), row clicks (and the server-name button) call **`setSelectedServer`**, and a footer shows **works N/M** per host via pure **`summarizeColumn`**. The **full report** (`HostCompatContent` + conformance gate) stays below for the selected row. With **one server**, behavior matches Phase 1 (matrix hidden).
> 
> **`CompatibilityRoute`** now passes the **connected-server list**, the global selection, and **`onSelectServer`** instead of a single server entry. **`HostCompatPage`** resolves **`detailServer`** against that list so a **stale/disconnected** global pick falls back to the first connected server (matrix highlight and detail stay aligned).
> 
> **`VERDICT_META`** moves to **`verdict-meta.ts`** so the matrix and single-server report share one styling map. New unit tests cover **`summarizeColumn`**, matrix summaries/selection, and page selection/empty-state behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ceab575300281b96a51ca94033c8f63cba4b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->