### PR TITLE
feat(tools): copy-all button on response panel + Tools tab returns to list

### DIFF
--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -336,7 +336,7 @@ export function ToolsTab({
       observer.unobserve(element);
       observer.disconnect();
     };
-  }, [filteredToolNames.length, activeTab, cursor, activeTab, fetchingTools]);
+  }, [filteredToolNames.length, activeTab, cursor, fetchingTools]);
 
   // Fetch task capabilities for the server
   const fetchTaskCapabilities = async () => {

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -384,6 +384,15 @@ export function ToolsTab({
     });
   }, []);
 
+  // Clicking the sidebar's "Tools" tab returns to the tool list (the tool
+  // menu): deselect any open tool, the same as the back arrow does.
+  const handleChangeTab = (tab: "tools" | "saved") => {
+    setActiveTab(tab);
+    if (tab === "tools") {
+      setSelectedTool("");
+    }
+  };
+
   const fetchTools = async (reset = false) => {
     if (!serverName) {
       logger.warn("Cannot fetch tools: no serverId available");
@@ -754,7 +763,7 @@ export function ToolsTab({
   const sidebarContent = (
     <ToolsSidebar
       activeTab={activeTab}
-      onChangeTab={setActiveTab}
+      onChangeTab={handleChangeTab}
       tools={tools}
       toolQuality={toolQualityByName}
       toolNames={toolNames}

--- a/mcpjam-inspector/client/src/components/playground/panes/MultiServerToolsPane.tsx
+++ b/mcpjam-inspector/client/src/components/playground/panes/MultiServerToolsPane.tsx
@@ -162,10 +162,11 @@ export function MultiServerToolsPaneInner({ activeServerNames }: InnerProps) {
 
   const handleTabChange = (tab: "tools" | "saved") => {
     setActiveTab(tab);
-    if (tab === "tools" && selected) {
-      // Returning to Tools while a selection exists: keep selection but show
-      // the parameters view. Mirrors single-server behavior.
-      setIsListExpanded(false);
+    if (tab === "tools") {
+      // Clicking the Tools tab returns to the tool list (the tool menu),
+      // deselecting any open tool — the same as the back arrow.
+      setSelected(null);
+      setIsListExpanded(true);
     }
   };
 

--- a/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
@@ -1,9 +1,18 @@
+import { useState } from "react";
 import type { CallToolResult } from "@modelcontextprotocol/client";
-import { CheckCircle, Info, ExternalLink, Clock3 } from "lucide-react";
+import {
+  CheckCircle,
+  Info,
+  ExternalLink,
+  Clock3,
+  Copy,
+  Check,
+} from "lucide-react";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import type { NormalizedError } from "@mcpjam/sdk/browser";
 import { detectUIType, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
+import { copyToClipboard } from "@/lib/clipboard";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { ErrorCard } from "@/components/ui/error-card";
 import { extractDisplayFromToolResult } from "@/components/chat-v2/shared/tool-result-text";
@@ -76,6 +85,22 @@ export function ResultsPanel({
       ? `${Math.round(responseDurationMs)} ms`
       : `${(responseDurationMs / 1000).toFixed(2)} s`;
 
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyAll = async () => {
+    let textToCopy: string;
+    try {
+      textToCopy = JSON.stringify(displayValue, null, 2) ?? "null";
+    } catch {
+      textToCopy = String(displayValue ?? "");
+    }
+    const success = await copyToClipboard(textToCopy);
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
   return (
     <div className="h-full flex flex-col bg-background break-all">
       {/* Header - fixed height */}
@@ -98,6 +123,21 @@ export function ResultsPanel({
             </span>
           )}
         </div>
+        {!error && rawResult && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs px-2 flex-shrink-0"
+            onClick={handleCopyAll}
+          >
+            {copied ? (
+              <Check className="h-3 w-3 mr-1 text-success" />
+            ) : (
+              <Copy className="h-3 w-3 mr-1" />
+            )}
+            {copied ? "Copied!" : "Copy all"}
+          </Button>
+        )}
       </div>
 
       {/* Content - fills remaining space */}


### PR DESCRIPTION
## Summary

Two small UX improvements to the tools experience:

- **Copy-all on the Response panel** — Adds a "Copy all" button to the tools Response panel header. It copies the full response as pretty-printed JSON (the same `displayValue` shown in the viewer, via the existing `copyToClipboard` util), shows a brief "Copied!" confirmation, and is hidden on errors and the empty state. This complements the existing per-value hover copy buttons with a single big "copy everything" affordance.
- **"Tools" tab returns to the tool list** — Clicking the sidebar **Tools** tab while a tool is selected now drops back to the tool list (deselecting the open tool), matching the back arrow. Applied in both:
  - the inspector `ToolsTab` (`onChangeTab` deselects on `"tools"`), and
  - the playground's multi-server tools pane (`MultiServerToolsPane`), which previously kept the selection and showed the params view.

## Files changed

- `client/src/components/tools/ResultsPanel.tsx` — Copy all button + handler.
- `client/src/components/ToolsTab.tsx` — `handleChangeTab` deselects the tool when switching to the Tools tab.
- `client/src/components/playground/panes/MultiServerToolsPane.tsx` — `handleTabChange` returns to the tool list on Tools.

## Testing

- Type diagnostics clean on all three files.
- Manual: verify Copy all copies the visible JSON; verify clicking Tools (inspector + playground) returns to the list when a tool is open.


Before:


https://github.com/user-attachments/assets/bbff657c-0603-4563-a71e-4e99787c9281


 after:

https://github.com/user-attachments/assets/a62d8614-9136-41c9-92b7-ab2de9224776

