### PR TITLE
feat(host-compat): Phase 3 (1/2) — live "observed" widget render

### DIFF
--- a/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
@@ -279,7 +279,7 @@ export function HostCompatContent({
                 <div className="flex flex-shrink-0 items-center">
                   {live.available &&
                     report.rendersWidgets &&
-                    live.toolFor(report.hostId) && (
+                    live.widgetTool && (
                     <Button
                       size="sm"
                       variant="ghost"

--- a/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
@@ -277,7 +277,9 @@ export function HostCompatContent({
                 )}
 
                 <div className="flex flex-shrink-0 items-center">
-                  {live.available && report.rendersWidgets && (
+                  {live.available &&
+                    report.rendersWidgets &&
+                    live.toolFor(report.hostId) && (
                     <Button
                       size="sm"
                       variant="ghost"

--- a/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatContent.tsx
@@ -6,6 +6,7 @@ import {
   ChevronDown,
   Info,
   Loader2,
+  MonitorPlay,
   Wrench,
 } from "lucide-react";
 import { useNavigate } from "react-router";
@@ -23,6 +24,10 @@ import { evaluateAllHosts } from "@/lib/host-compat/engine";
 import { useWidgetUsage } from "@/lib/host-compat/use-widget-usage";
 import { ConformanceGate } from "@/components/compat/ConformanceGate";
 import { VERDICT_META } from "@/components/compat/verdict-meta";
+import {
+  LiveRenderRow,
+  useLiveRenders,
+} from "@/components/compat/LiveRenderRow";
 import type {
   CompatFinding,
   CompatLane,
@@ -111,6 +116,9 @@ export function HostCompatContent({
     () => evaluateAllHosts(toolsData, widgetUsage, { protocolVersion }),
     [toolsData, widgetUsage, protocolVersion]
   );
+
+  // Tier-2: render the server's widget live in each host's emulation.
+  const live = useLiveRenders(server.name, requirements);
 
   const posthog = usePostHog();
   const navigate = useNavigate();
@@ -269,6 +277,27 @@ export function HostCompatContent({
                 )}
 
                 <div className="flex flex-shrink-0 items-center">
+                  {live.available && report.rendersWidgets && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+                      disabled={live.runningHostId !== null}
+                      onClick={() => live.run(report)}
+                    >
+                      {live.runningHostId === report.hostId ? (
+                        <>
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                          Rendering…
+                        </>
+                      ) : (
+                        <>
+                          <MonitorPlay className="h-3 w-3" />
+                          Run live
+                        </>
+                      )}
+                    </Button>
+                  )}
                   {canCreateHosts && isHostTemplateId(report.hostId) && (
                     <Button
                       size="sm"
@@ -292,6 +321,10 @@ export function HostCompatContent({
                   )}
                 </div>
               </div>
+
+              {live.results[report.hostId] && (
+                <LiveRenderRow outcome={live.results[report.hostId]} />
+              )}
 
               {hasFindings && isOpen && (
                 <div className="mt-2 space-y-2.5 pl-6">

--- a/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
+++ b/mcpjam-inspector/client/src/components/compat/HostCompatPage.tsx
@@ -80,11 +80,13 @@ export function HostCompatPage({
 
       {detailServer && (
         <section>
-          {showMatrix && (
-            <h2 className="mb-1.5 text-sm font-medium text-foreground">
-              {detailServer.name}
-            </h2>
-          )}
+          {/* Always name the server the report is for — HostCompatContent
+              renders no visible server identity, so without this a
+              single-connected-server report (matrix hidden) could be read as
+              a different, globally-selected server's. */}
+          <h2 className="mb-1.5 text-sm font-medium text-foreground">
+            {detailServer.name}
+          </h2>
           <HostCompatContent
             server={detailServer}
             toolsData={toolsData}

--- a/mcpjam-inspector/client/src/components/compat/LiveRenderRow.tsx
+++ b/mcpjam-inspector/client/src/components/compat/LiveRenderRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { isHostedMode } from "@/lib/apis/mode-client";
 import { getCompatRuntimeForStyle } from "@/lib/client-styles/registry";
 import {
@@ -6,6 +6,7 @@ import {
   type WidgetRenderResult,
   type WidgetRenderStatus,
 } from "@/lib/apis/mcp-widget-render-api";
+import { TONE_META, type CompatTone } from "@/components/compat/verdict-meta";
 import type {
   HostCompatReport,
   ServerRequirements,
@@ -18,14 +19,32 @@ export type LiveRenderOutcome = {
 };
 
 /**
+ * Keep only the newest render's screenshot resident. Older hosts keep their
+ * status/metadata but drop the (potentially hundreds-of-KB) base64 PNG, so
+ * running live across many hosts doesn't pile MBs of image data into state.
+ */
+function withResult(
+  prev: Record<string, LiveRenderOutcome>,
+  hostId: string,
+  outcome: LiveRenderOutcome,
+): Record<string, LiveRenderOutcome> {
+  const trimmed: Record<string, LiveRenderOutcome> = {};
+  for (const [k, v] of Object.entries(prev)) {
+    trimmed[k] = v.result?.screenshotBase64
+      ? { ...v, result: { ...v.result, screenshotBase64: undefined } }
+      : v;
+  }
+  trimmed[hostId] = outcome;
+  return trimmed;
+}
+
+/**
  * Tier-2 "observed" apps-lane render. Renders one of the server's widget tools
  * in the local headless harness under a given host's `injectOpenAiCompat`, and
  * tracks the observed status per host. Local-Inspector only (the render route
- * is `!HOSTED_MODE`); `available` is false in hosted mode or when the server
- * has no widget to render.
+ * is `!HOSTED_MODE`).
  *
- * v1 renders the server's FIRST widget tool as a representative observation;
- * multi-widget servers report on that one tool.
+ * v1 renders a single representative widget tool per host.
  */
 export function useLiveRenders(
   serverName: string,
@@ -34,81 +53,83 @@ export function useLiveRenders(
   const [runningHostId, setRunningHostId] = useState<string | null>(null);
   const [results, setResults] = useState<Record<string, LiveRenderOutcome>>({});
 
-  // Drop results when the server changes so one server's renders never show
-  // under another.
+  // Generation token: bumped on every server switch so an in-flight render from
+  // the previous server can't write its result/screenshot under the new one
+  // (Chromium renders take seconds — plenty of room to switch mid-flight).
+  const genRef = useRef(0);
   useEffect(() => {
+    genRef.current += 1;
     setResults({});
     setRunningHostId(null);
   }, [serverName]);
 
-  const widgetTool = useMemo(
-    () =>
-      [
-        ...requirements.widgets.mcpAppsOnly,
-        ...requirements.widgets.dual,
-        ...requirements.widgets.openaiAppsOnly,
-      ][0],
+  const available = !isHostedMode() && requirements.hasWidgets;
+
+  /**
+   * The widget tool to render FOR A GIVEN HOST. An OpenAI-shim host can render
+   * any widget; a non-shim host can't run an OpenAI-only widget (no
+   * `window.openai`), so only its MCP-Apps / dual widgets are renderable.
+   * `undefined` ⇒ this host can't render any of the server's widgets (the
+   * static verdict already covers that), so the caller hides "Run live" rather
+   * than producing a misleading render failure.
+   */
+  const toolFor = useCallback(
+    (hostId: string): string | undefined => {
+      const { mcpAppsOnly, dual, openaiAppsOnly } = requirements.widgets;
+      const candidates = getCompatRuntimeForStyle(hostId).injected
+        ? [...mcpAppsOnly, ...dual, ...openaiAppsOnly]
+        : [...mcpAppsOnly, ...dual];
+      return candidates[0];
+    },
     [requirements.widgets],
   );
 
-  const available = !isHostedMode() && !!widgetTool;
-
   const run = useCallback(
     async (report: HostCompatReport) => {
-      if (!widgetTool) return;
+      const tool = toolFor(report.hostId);
+      if (!tool) return;
       const injectOpenAiCompat = getCompatRuntimeForStyle(
         report.hostId,
       ).injected;
+      const gen = genRef.current;
       setRunningHostId(report.hostId);
       try {
         const result = await renderWidget({
           serverId: serverName,
-          toolName: widgetTool,
+          toolName: tool,
           injectOpenAiCompat,
         });
-        setResults((prev) => ({ ...prev, [report.hostId]: { result } }));
+        if (genRef.current !== gen) return; // server switched mid-render
+        setResults((prev) => withResult(prev, report.hostId, { result }));
       } catch (err) {
-        setResults((prev) => ({
-          ...prev,
-          [report.hostId]: {
+        if (genRef.current !== gen) return;
+        setResults((prev) =>
+          withResult(prev, report.hostId, {
             error: err instanceof Error ? err.message : String(err),
-          },
-        }));
+          }),
+        );
       } finally {
-        setRunningHostId(null);
+        if (genRef.current === gen) setRunningHostId(null);
       }
     },
-    [serverName, widgetTool],
+    [serverName, toolFor],
   );
 
-  return { available, runningHostId, results, run, widgetTool };
+  return { available, runningHostId, results, run, toolFor };
 }
 
-const STATUS_META: Record<
-  WidgetRenderStatus,
-  { label: string; tone: "ok" | "bad" | "neutral" }
-> = {
-  rendered: { label: "Rendered", tone: "ok" },
-  no_ui_resource: { label: "No widget resource", tone: "neutral" },
-  resource_read_failed: { label: "Resource read failed", tone: "bad" },
-  mount_failed: { label: "Failed to mount", tone: "bad" },
-  bridge_timeout: { label: "Bridge timed out", tone: "bad" },
-  render_error: { label: "Render error", tone: "bad" },
-  blank_screenshot: { label: "Rendered blank", tone: "bad" },
-  screenshot_failed: { label: "Screenshot failed", tone: "neutral" },
-  browser_unavailable: { label: "Browser unavailable", tone: "neutral" },
-};
-
-const TONE_TEXT: Record<"ok" | "bad" | "neutral", string> = {
-  ok: "text-emerald-600 dark:text-emerald-400",
-  bad: "text-red-600 dark:text-red-400",
-  neutral: "text-muted-foreground",
-};
-const TONE_DOT: Record<"ok" | "bad" | "neutral", string> = {
-  ok: "bg-emerald-500",
-  bad: "bg-red-500",
-  neutral: "bg-muted-foreground/40",
-};
+const STATUS_META: Record<WidgetRenderStatus, { label: string; tone: CompatTone }> =
+  {
+    rendered: { label: "Rendered", tone: "ok" },
+    no_ui_resource: { label: "No widget resource", tone: "neutral" },
+    resource_read_failed: { label: "Resource read failed", tone: "bad" },
+    mount_failed: { label: "Failed to mount", tone: "bad" },
+    bridge_timeout: { label: "Bridge timed out", tone: "bad" },
+    render_error: { label: "Render error", tone: "bad" },
+    blank_screenshot: { label: "Rendered blank", tone: "bad" },
+    screenshot_failed: { label: "Screenshot failed", tone: "neutral" },
+    browser_unavailable: { label: "Browser unavailable", tone: "neutral" },
+  };
 
 /** Compact observed-render result for one host row. */
 export function LiveRenderRow({ outcome }: { outcome: LiveRenderOutcome }) {
@@ -124,8 +145,10 @@ export function LiveRenderRow({ outcome }: { outcome: LiveRenderOutcome }) {
   const meta = STATUS_META[r.status];
   return (
     <div className="mt-2 space-y-1.5 pl-6 text-xs">
-      <div className={`flex items-center gap-1.5 ${TONE_TEXT[meta.tone]}`}>
-        <span className={`h-1.5 w-1.5 rounded-full ${TONE_DOT[meta.tone]}`} />
+      <div className={`flex items-center gap-1.5 ${TONE_META[meta.tone].text}`}>
+        <span
+          className={`h-1.5 w-1.5 rounded-full ${TONE_META[meta.tone].dot}`}
+        />
         <span className="font-medium">Live: {meta.label}</span>
         <span className="text-muted-foreground">
           · {r.elapsedMs}ms · observed
@@ -137,9 +160,7 @@ export function LiveRenderRow({ outcome }: { outcome: LiveRenderOutcome }) {
           {r.consoleErrors.length} console error
           {r.consoleErrors.length === 1 ? "" : "s"} —{" "}
           <span className="font-mono">{r.consoleErrors[0]}</span>
-          {r.consoleErrors.length > 1
-            ? ` +${r.consoleErrors.length - 1}`
-            : ""}
+          {r.consoleErrors.length > 1 ? ` +${r.consoleErrors.length - 1}` : ""}
         </div>
       )}
       {r.screenshotBase64 && (

--- a/mcpjam-inspector/client/src/components/compat/LiveRenderRow.tsx
+++ b/mcpjam-inspector/client/src/components/compat/LiveRenderRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isHostedMode } from "@/lib/apis/mode-client";
 import { getCompatRuntimeForStyle } from "@/lib/client-styles/registry";
 import {
@@ -53,53 +53,54 @@ export function useLiveRenders(
   const [runningHostId, setRunningHostId] = useState<string | null>(null);
   const [results, setResults] = useState<Record<string, LiveRenderOutcome>>({});
 
-  // Generation token: bumped on every server switch so an in-flight render from
-  // the previous server can't write its result/screenshot under the new one
-  // (Chromium renders take seconds — plenty of room to switch mid-flight).
+  /**
+   * The widget tool that will be rendered. The local render route renders MCP
+   * Apps resources (`_meta.ui.resourceUri`) only — it can't run an OpenAI-only
+   * widget (it would just return `no_ui_resource`, misleading "observed"
+   * evidence), so OpenAI-only tools are excluded. Dual tools carry a resourceUri
+   * too, so they render (with the host's `injectOpenAiCompat` shim when
+   * applicable). Host-agnostic: the host only changes the shim flag, not which
+   * tool renders. `undefined` ⇒ nothing renderable, so the caller hides "Run
+   * live".
+   */
+  const widgetTool = useMemo(() => {
+    const { mcpAppsOnly, dual } = requirements.widgets;
+    return [...mcpAppsOnly, ...dual][0];
+  }, [requirements.widgets]);
+
+  // Generation token: bumped when the server OR the rendered tool changes, so an
+  // in-flight render from a prior server/tool can't write its result/screenshot
+  // under the current one (Chromium renders take seconds). A `runningRef` mirrors
+  // the in-flight host so a fast double-click can't start parallel jobs before
+  // React re-disables the buttons.
   const genRef = useRef(0);
+  const runningRef = useRef<string | null>(null);
   useEffect(() => {
     genRef.current += 1;
+    runningRef.current = null;
     setResults({});
     setRunningHostId(null);
-  }, [serverName]);
+  }, [serverName, widgetTool]);
 
   const available = !isHostedMode() && requirements.hasWidgets;
 
-  /**
-   * The widget tool to render FOR A GIVEN HOST. An OpenAI-shim host can render
-   * any widget; a non-shim host can't run an OpenAI-only widget (no
-   * `window.openai`), so only its MCP-Apps / dual widgets are renderable.
-   * `undefined` ⇒ this host can't render any of the server's widgets (the
-   * static verdict already covers that), so the caller hides "Run live" rather
-   * than producing a misleading render failure.
-   */
-  const toolFor = useCallback(
-    (hostId: string): string | undefined => {
-      const { mcpAppsOnly, dual, openaiAppsOnly } = requirements.widgets;
-      const candidates = getCompatRuntimeForStyle(hostId).injected
-        ? [...mcpAppsOnly, ...dual, ...openaiAppsOnly]
-        : [...mcpAppsOnly, ...dual];
-      return candidates[0];
-    },
-    [requirements.widgets],
-  );
-
   const run = useCallback(
     async (report: HostCompatReport) => {
-      const tool = toolFor(report.hostId);
-      if (!tool) return;
+      if (!widgetTool) return;
+      if (runningRef.current !== null) return; // a render is already in flight
       const injectOpenAiCompat = getCompatRuntimeForStyle(
         report.hostId,
       ).injected;
       const gen = genRef.current;
+      runningRef.current = report.hostId;
       setRunningHostId(report.hostId);
       try {
         const result = await renderWidget({
           serverId: serverName,
-          toolName: tool,
+          toolName: widgetTool,
           injectOpenAiCompat,
         });
-        if (genRef.current !== gen) return; // server switched mid-render
+        if (genRef.current !== gen) return; // server/tool changed mid-render
         setResults((prev) => withResult(prev, report.hostId, { result }));
       } catch (err) {
         if (genRef.current !== gen) return;
@@ -109,13 +110,18 @@ export function useLiveRenders(
           }),
         );
       } finally {
-        if (genRef.current === gen) setRunningHostId(null);
+        // Only the still-current run clears the in-flight markers; a render
+        // abandoned by a server/tool switch leaves them to the reset effect.
+        if (genRef.current === gen) {
+          runningRef.current = null;
+          setRunningHostId(null);
+        }
       }
     },
-    [serverName, toolFor],
+    [serverName, widgetTool],
   );
 
-  return { available, runningHostId, results, run, toolFor };
+  return { available, runningHostId, results, run, widgetTool };
 }
 
 const STATUS_META: Record<WidgetRenderStatus, { label: string; tone: CompatTone }> =
@@ -142,7 +148,12 @@ export function LiveRenderRow({ outcome }: { outcome: LiveRenderOutcome }) {
   }
   const r = outcome.result;
   if (!r) return null;
-  const meta = STATUS_META[r.status];
+  // Resilient to status drift — a server shipping a new WidgetRenderStatus ahead
+  // of the client must not crash the row.
+  const meta = STATUS_META[r.status] ?? {
+    label: r.status,
+    tone: "neutral" as const,
+  };
   return (
     <div className="mt-2 space-y-1.5 pl-6 text-xs">
       <div className={`flex items-center gap-1.5 ${TONE_META[meta.tone].text}`}>

--- a/mcpjam-inspector/client/src/components/compat/LiveRenderRow.tsx
+++ b/mcpjam-inspector/client/src/components/compat/LiveRenderRow.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { isHostedMode } from "@/lib/apis/mode-client";
+import { getCompatRuntimeForStyle } from "@/lib/client-styles/registry";
+import {
+  renderWidget,
+  type WidgetRenderResult,
+  type WidgetRenderStatus,
+} from "@/lib/apis/mcp-widget-render-api";
+import type {
+  HostCompatReport,
+  ServerRequirements,
+} from "@/lib/host-compat/types";
+
+/** A single host's live-render outcome: a render result, or a request error. */
+export type LiveRenderOutcome = {
+  result?: WidgetRenderResult;
+  error?: string;
+};
+
+/**
+ * Tier-2 "observed" apps-lane render. Renders one of the server's widget tools
+ * in the local headless harness under a given host's `injectOpenAiCompat`, and
+ * tracks the observed status per host. Local-Inspector only (the render route
+ * is `!HOSTED_MODE`); `available` is false in hosted mode or when the server
+ * has no widget to render.
+ *
+ * v1 renders the server's FIRST widget tool as a representative observation;
+ * multi-widget servers report on that one tool.
+ */
+export function useLiveRenders(
+  serverName: string,
+  requirements: ServerRequirements,
+) {
+  const [runningHostId, setRunningHostId] = useState<string | null>(null);
+  const [results, setResults] = useState<Record<string, LiveRenderOutcome>>({});
+
+  // Drop results when the server changes so one server's renders never show
+  // under another.
+  useEffect(() => {
+    setResults({});
+    setRunningHostId(null);
+  }, [serverName]);
+
+  const widgetTool = useMemo(
+    () =>
+      [
+        ...requirements.widgets.mcpAppsOnly,
+        ...requirements.widgets.dual,
+        ...requirements.widgets.openaiAppsOnly,
+      ][0],
+    [requirements.widgets],
+  );
+
+  const available = !isHostedMode() && !!widgetTool;
+
+  const run = useCallback(
+    async (report: HostCompatReport) => {
+      if (!widgetTool) return;
+      const injectOpenAiCompat = getCompatRuntimeForStyle(
+        report.hostId,
+      ).injected;
+      setRunningHostId(report.hostId);
+      try {
+        const result = await renderWidget({
+          serverId: serverName,
+          toolName: widgetTool,
+          injectOpenAiCompat,
+        });
+        setResults((prev) => ({ ...prev, [report.hostId]: { result } }));
+      } catch (err) {
+        setResults((prev) => ({
+          ...prev,
+          [report.hostId]: {
+            error: err instanceof Error ? err.message : String(err),
+          },
+        }));
+      } finally {
+        setRunningHostId(null);
+      }
+    },
+    [serverName, widgetTool],
+  );
+
+  return { available, runningHostId, results, run, widgetTool };
+}
+
+const STATUS_META: Record<
+  WidgetRenderStatus,
+  { label: string; tone: "ok" | "bad" | "neutral" }
+> = {
+  rendered: { label: "Rendered", tone: "ok" },
+  no_ui_resource: { label: "No widget resource", tone: "neutral" },
+  resource_read_failed: { label: "Resource read failed", tone: "bad" },
+  mount_failed: { label: "Failed to mount", tone: "bad" },
+  bridge_timeout: { label: "Bridge timed out", tone: "bad" },
+  render_error: { label: "Render error", tone: "bad" },
+  blank_screenshot: { label: "Rendered blank", tone: "bad" },
+  screenshot_failed: { label: "Screenshot failed", tone: "neutral" },
+  browser_unavailable: { label: "Browser unavailable", tone: "neutral" },
+};
+
+const TONE_TEXT: Record<"ok" | "bad" | "neutral", string> = {
+  ok: "text-emerald-600 dark:text-emerald-400",
+  bad: "text-red-600 dark:text-red-400",
+  neutral: "text-muted-foreground",
+};
+const TONE_DOT: Record<"ok" | "bad" | "neutral", string> = {
+  ok: "bg-emerald-500",
+  bad: "bg-red-500",
+  neutral: "bg-muted-foreground/40",
+};
+
+/** Compact observed-render result for one host row. */
+export function LiveRenderRow({ outcome }: { outcome: LiveRenderOutcome }) {
+  if (outcome.error) {
+    return (
+      <div className="mt-2 pl-6 text-xs text-red-600 dark:text-red-400">
+        Live render failed: {outcome.error}
+      </div>
+    );
+  }
+  const r = outcome.result;
+  if (!r) return null;
+  const meta = STATUS_META[r.status];
+  return (
+    <div className="mt-2 space-y-1.5 pl-6 text-xs">
+      <div className={`flex items-center gap-1.5 ${TONE_TEXT[meta.tone]}`}>
+        <span className={`h-1.5 w-1.5 rounded-full ${TONE_DOT[meta.tone]}`} />
+        <span className="font-medium">Live: {meta.label}</span>
+        <span className="text-muted-foreground">
+          · {r.elapsedMs}ms · observed
+        </span>
+      </div>
+      {r.hint && <div className="text-muted-foreground">{r.hint}</div>}
+      {r.consoleErrors && r.consoleErrors.length > 0 && (
+        <div className="text-muted-foreground">
+          {r.consoleErrors.length} console error
+          {r.consoleErrors.length === 1 ? "" : "s"} —{" "}
+          <span className="font-mono">{r.consoleErrors[0]}</span>
+          {r.consoleErrors.length > 1
+            ? ` +${r.consoleErrors.length - 1}`
+            : ""}
+        </div>
+      )}
+      {r.screenshotBase64 && (
+        <img
+          src={`data:image/png;base64,${r.screenshotBase64}`}
+          alt="Live render screenshot"
+          className="max-h-40 rounded border border-border/60"
+        />
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/compat/__tests__/LiveRenderRow.test.tsx
+++ b/mcpjam-inspector/client/src/components/compat/__tests__/LiveRenderRow.test.tsx
@@ -127,14 +127,60 @@ describe("useLiveRenders", () => {
     expect(result.current.results.claude).toEqual({ error: "no chromium" });
   });
 
-  it("offers no tool for a non-shim host when only OpenAI widgets exist", () => {
+  it("offers no widget tool for OpenAI-only widgets (route renders MCP Apps only)", () => {
     const { result } = renderHook(() =>
       useLiveRenders("srv", reqs({ openaiAppsOnly: ["o1"] })),
     );
-    // claude has no window.openai shim → can't render an OpenAI-only widget.
-    expect(result.current.toolFor("claude")).toBeUndefined();
-    // chatgpt injects the shim → renderable.
-    expect(result.current.toolFor("chatgpt")).toBe("o1");
+    // The local render route renders `_meta.ui.resourceUri` only — an
+    // OpenAI-only widget would deterministically return no_ui_resource, so it's
+    // never offered for live render (even on a shim host).
+    expect(result.current.widgetTool).toBeUndefined();
+  });
+
+  it("picks an MCP Apps / dual tool, skipping OpenAI-only", () => {
+    const { result } = renderHook(() =>
+      useLiveRenders("srv", reqs({ openaiAppsOnly: ["o1"], dual: ["d1"] })),
+    );
+    expect(result.current.widgetTool).toBe("d1");
+  });
+
+  it("ignores a second run while one is in flight (no parallel Chromium jobs)", async () => {
+    let resolveRender!: (v: unknown) => void;
+    mockRenderWidget.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveRender = r;
+      }),
+    );
+    const { result } = renderHook(() =>
+      useLiveRenders("srv", reqs({ mcpAppsOnly: ["w1"] })),
+    );
+    act(() => {
+      void result.current.run(report("claude"));
+    });
+    // A fast second click before the first resolves must be a no-op.
+    act(() => {
+      void result.current.run(report("cursor"));
+    });
+    expect(mockRenderWidget).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveRender({ status: "rendered", elapsedMs: 1 });
+    });
+  });
+
+  it("clears results when the rendered tool changes (tools reloaded)", async () => {
+    mockRenderWidget.mockResolvedValue({ status: "rendered", elapsedMs: 1 });
+    const { result, rerender } = renderHook(
+      ({ r }: { r: ServerRequirements }) => useLiveRenders("srv", r),
+      { initialProps: { r: reqs({ mcpAppsOnly: ["w1"] }) } },
+    );
+    await act(async () => {
+      await result.current.run(report("claude"));
+    });
+    expect(result.current.results.claude).toBeDefined();
+
+    // Tools reload → a different representative widget tool → stale clears.
+    rerender({ r: reqs({ mcpAppsOnly: ["w2"] }) });
+    expect(result.current.results.claude).toBeUndefined();
   });
 
   it("keeps only the most recent render's screenshot", async () => {

--- a/mcpjam-inspector/client/src/components/compat/__tests__/LiveRenderRow.test.tsx
+++ b/mcpjam-inspector/client/src/components/compat/__tests__/LiveRenderRow.test.tsx
@@ -26,12 +26,16 @@ import {
 
 const reqs = (
   widgets: Partial<ServerRequirements["widgets"]> = {},
-): ServerRequirements => ({
-  widgets: { mcpAppsOnly: [], openaiAppsOnly: [], dual: [], ...widgets },
-  appOnlyWidgets: [],
-  hasWidgets: true,
-  unknownDimensions: [],
-});
+): ServerRequirements => {
+  const w = { mcpAppsOnly: [], openaiAppsOnly: [], dual: [], ...widgets };
+  return {
+    widgets: w,
+    appOnlyWidgets: [],
+    hasWidgets:
+      w.mcpAppsOnly.length + w.dual.length + w.openaiAppsOnly.length > 0,
+    unknownDimensions: [],
+  };
+};
 
 const report = (hostId: string): HostCompatReport =>
   ({ hostId }) as HostCompatReport;
@@ -121,5 +125,76 @@ describe("useLiveRenders", () => {
       await result.current.run(report("claude"));
     });
     expect(result.current.results.claude).toEqual({ error: "no chromium" });
+  });
+
+  it("offers no tool for a non-shim host when only OpenAI widgets exist", () => {
+    const { result } = renderHook(() =>
+      useLiveRenders("srv", reqs({ openaiAppsOnly: ["o1"] })),
+    );
+    // claude has no window.openai shim → can't render an OpenAI-only widget.
+    expect(result.current.toolFor("claude")).toBeUndefined();
+    // chatgpt injects the shim → renderable.
+    expect(result.current.toolFor("chatgpt")).toBe("o1");
+  });
+
+  it("keeps only the most recent render's screenshot", async () => {
+    mockRenderWidget
+      .mockResolvedValueOnce({
+        status: "rendered",
+        elapsedMs: 1,
+        screenshotBase64: "AAA",
+      })
+      .mockResolvedValueOnce({
+        status: "rendered",
+        elapsedMs: 2,
+        screenshotBase64: "BBB",
+      });
+    const { result } = renderHook(() =>
+      useLiveRenders("srv", reqs({ mcpAppsOnly: ["w1"] })),
+    );
+    await act(async () => {
+      await result.current.run(report("claude"));
+    });
+    expect(result.current.results.claude.result?.screenshotBase64).toBe("AAA");
+
+    await act(async () => {
+      await result.current.run(report("cursor"));
+    });
+    // Newest keeps its screenshot; the older one is trimmed but keeps status.
+    expect(result.current.results.cursor.result?.screenshotBase64).toBe("BBB");
+    expect(
+      result.current.results.claude.result?.screenshotBase64,
+    ).toBeUndefined();
+    expect(result.current.results.claude.result?.status).toBe("rendered");
+  });
+
+  it("drops an in-flight render's result after the server switches", async () => {
+    let resolveRender!: (v: unknown) => void;
+    mockRenderWidget.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveRender = r;
+      }),
+    );
+    const { result, rerender } = renderHook(
+      ({ s }: { s: string }) => useLiveRenders(s, reqs({ mcpAppsOnly: ["w1"] })),
+      { initialProps: { s: "A" } },
+    );
+
+    let runPromise: Promise<void>;
+    act(() => {
+      runPromise = result.current.run(report("claude"));
+    });
+
+    // Switch server while server A's render is still in flight.
+    rerender({ s: "B" });
+
+    // Now let the stale (server A) render resolve.
+    await act(async () => {
+      resolveRender({ status: "rendered", elapsedMs: 1, screenshotBase64: "STALE" });
+      await runPromise;
+    });
+
+    // The generation guard drops the stale write — no server-A result lingers.
+    expect(result.current.results.claude).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/components/compat/__tests__/LiveRenderRow.test.tsx
+++ b/mcpjam-inspector/client/src/components/compat/__tests__/LiveRenderRow.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, renderHook, act } from "@testing-library/react";
+import type {
+  ServerRequirements,
+  HostCompatReport,
+} from "@/lib/host-compat/types";
+
+const mockRenderWidget = vi.fn();
+const hosted = vi.hoisted(() => ({ value: false }));
+
+vi.mock("@/lib/apis/mcp-widget-render-api", () => ({
+  renderWidget: (...args: unknown[]) => mockRenderWidget(...args),
+}));
+vi.mock("@/lib/apis/mode-client", () => ({
+  isHostedMode: () => hosted.value,
+}));
+vi.mock("@/lib/client-styles/registry", () => ({
+  // Only chatgpt injects the OpenAI shim in this fixture.
+  getCompatRuntimeForStyle: (id: string) => ({ injected: id === "chatgpt" }),
+}));
+
+import {
+  LiveRenderRow,
+  useLiveRenders,
+} from "@/components/compat/LiveRenderRow";
+
+const reqs = (
+  widgets: Partial<ServerRequirements["widgets"]> = {},
+): ServerRequirements => ({
+  widgets: { mcpAppsOnly: [], openaiAppsOnly: [], dual: [], ...widgets },
+  appOnlyWidgets: [],
+  hasWidgets: true,
+  unknownDimensions: [],
+});
+
+const report = (hostId: string): HostCompatReport =>
+  ({ hostId }) as HostCompatReport;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hosted.value = false;
+});
+
+describe("LiveRenderRow", () => {
+  it("shows an observed 'rendered' result", () => {
+    render(
+      <LiveRenderRow outcome={{ result: { status: "rendered", elapsedMs: 12 } }} />,
+    );
+    expect(screen.getByText(/Live: Rendered/)).toBeInTheDocument();
+    expect(screen.getByText(/observed/)).toBeInTheDocument();
+  });
+
+  it("shows a failed render status", () => {
+    render(
+      <LiveRenderRow
+        outcome={{ result: { status: "bridge_timeout", elapsedMs: 9 } }}
+      />,
+    );
+    expect(screen.getByText(/Bridge timed out/)).toBeInTheDocument();
+  });
+
+  it("shows a request error", () => {
+    render(<LiveRenderRow outcome={{ error: "boom" }} />);
+    expect(screen.getByText(/Live render failed: boom/)).toBeInTheDocument();
+  });
+
+  it("renders the screenshot when present", () => {
+    render(
+      <LiveRenderRow
+        outcome={{
+          result: { status: "rendered", elapsedMs: 1, screenshotBase64: "AAAA" },
+        }}
+      />,
+    );
+    const img = screen.getByAltText("Live render screenshot") as HTMLImageElement;
+    expect(img.src).toContain("data:image/png;base64,AAAA");
+  });
+});
+
+describe("useLiveRenders", () => {
+  it("is unavailable in hosted mode", () => {
+    hosted.value = true;
+    const { result } = renderHook(() =>
+      useLiveRenders("srv", reqs({ mcpAppsOnly: ["w"] })),
+    );
+    expect(result.current.available).toBe(false);
+  });
+
+  it("is unavailable when the server has no widget", () => {
+    const { result } = renderHook(() => useLiveRenders("srv", reqs()));
+    expect(result.current.available).toBe(false);
+  });
+
+  it("renders the first widget tool with the host's compat flag", async () => {
+    mockRenderWidget.mockResolvedValue({ status: "rendered", elapsedMs: 5 });
+    const { result } = renderHook(() =>
+      useLiveRenders("srv", reqs({ mcpAppsOnly: ["w1"], dual: ["w2"] })),
+    );
+    expect(result.current.available).toBe(true);
+
+    await act(async () => {
+      await result.current.run(report("chatgpt"));
+    });
+
+    expect(mockRenderWidget).toHaveBeenCalledWith({
+      serverId: "srv",
+      toolName: "w1",
+      injectOpenAiCompat: true,
+    });
+    expect(result.current.results.chatgpt).toEqual({
+      result: { status: "rendered", elapsedMs: 5 },
+    });
+  });
+
+  it("captures a request error per host", async () => {
+    mockRenderWidget.mockRejectedValue(new Error("no chromium"));
+    const { result } = renderHook(() =>
+      useLiveRenders("srv", reqs({ mcpAppsOnly: ["w1"] })),
+    );
+    await act(async () => {
+      await result.current.run(report("claude"));
+    });
+    expect(result.current.results.claude).toEqual({ error: "no chromium" });
+  });
+});

--- a/mcpjam-inspector/client/src/components/compat/verdict-meta.ts
+++ b/mcpjam-inspector/client/src/components/compat/verdict-meta.ts
@@ -1,6 +1,20 @@
 import type { CompatVerdict } from "@/lib/host-compat/types";
 
 /**
+ * Three-way semantic tone (good / bad / neutral) → dot + text colors. Shared
+ * by surfaces that key on pass/fail rather than a compat verdict (e.g. the
+ * live-render status row), so the emerald/red/muted tokens live in one place.
+ * (Verdict styling keeps its own `degraded`=amber tone, so the two maps
+ * deliberately don't fully collapse.)
+ */
+export type CompatTone = "ok" | "bad" | "neutral";
+export const TONE_META: Record<CompatTone, { dot: string; text: string }> = {
+  ok: { dot: "bg-emerald-500", text: "text-emerald-600 dark:text-emerald-400" },
+  bad: { dot: "bg-red-500", text: "text-red-600 dark:text-red-400" },
+  neutral: { dot: "bg-muted-foreground/40", text: "text-muted-foreground" },
+};
+
+/**
  * Verdict styling shared across the compat surfaces (single-server report rows
  * and the multi-server matrix): a colored dot + colored label, no pill — keeps
  * each verdict to a single quiet visual.

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-widget-render-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-widget-render-api.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const state = vi.hoisted(() => ({ mode: "local" as "local" | "hosted" }));
+const mockAuthFetch = vi.fn();
+
+vi.mock("@/lib/apis/mode-client", () => ({
+  runByMode: <T,>(h: { local: () => T; hosted: () => T }) =>
+    state.mode === "local" ? h.local() : h.hosted(),
+}));
+vi.mock("@/lib/session-token", () => ({
+  authFetch: (...args: unknown[]) => mockAuthFetch(...args),
+}));
+
+import { renderWidget } from "@/lib/apis/mcp-widget-render-api";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.mode = "local";
+});
+
+describe("renderWidget", () => {
+  it("POSTs to the local widget-render route with the render request", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "rendered", elapsedMs: 12 }),
+    });
+    const result = await renderWidget({
+      serverId: "srv",
+      toolName: "show_cart",
+      injectOpenAiCompat: true,
+    });
+    expect(result.status).toBe("rendered");
+    const [path, init] = mockAuthFetch.mock.calls[0];
+    expect(path).toBe("/api/mcp/widget-render");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      serverId: "srv",
+      toolName: "show_cart",
+      injectOpenAiCompat: true,
+    });
+  });
+
+  it("defaults injectOpenAiCompat to false", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "rendered", elapsedMs: 1 }),
+    });
+    await renderWidget({ serverId: "srv", toolName: "t" });
+    const [, init] = mockAuthFetch.mock.calls[0];
+    expect(
+      JSON.parse((init as RequestInit).body as string).injectOpenAiCompat,
+    ).toBe(false);
+  });
+
+  it("throws the server error message on a non-ok response", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "harness exploded" }),
+    });
+    await expect(
+      renderWidget({ serverId: "srv", toolName: "t" }),
+    ).rejects.toThrow("harness exploded");
+  });
+
+  it("throws in hosted mode (route is local-only)", async () => {
+    state.mode = "hosted";
+    await expect(
+      renderWidget({ serverId: "srv", toolName: "t" }),
+    ).rejects.toThrow(/local inspector/);
+    expect(mockAuthFetch).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/local-post.ts
+++ b/mcpjam-inspector/client/src/lib/apis/local-post.ts
@@ -12,9 +12,12 @@ export async function localPost<T>(path: string, body: unknown): Promise<T> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  const data = await response.json();
+  // Guard the parse: an upstream error that returns HTML (proxy 502, gateway
+  // timeout page) would otherwise throw an opaque SyntaxError instead of the
+  // crafted status message.
+  const data = await response.json().catch(() => null);
   if (!response.ok) {
-    throw new Error(data.error || `Request failed (${response.status})`);
+    throw new Error(data?.error || `Request failed (${response.status})`);
   }
   return data as T;
 }

--- a/mcpjam-inspector/client/src/lib/apis/local-post.ts
+++ b/mcpjam-inspector/client/src/lib/apis/local-post.ts
@@ -1,0 +1,20 @@
+import { authFetch } from "@/lib/session-token";
+
+/**
+ * POST JSON to a local-Inspector (`!HOSTED_MODE`) route, returning the parsed
+ * body and throwing the server's `error` message on a non-ok response. Shared
+ * by the local-only API wrappers (conformance, widget-render, …) so the
+ * fetch/error contract stays in one place.
+ */
+export async function localPost<T>(path: string, body: unknown): Promise<T> {
+  const response = await authFetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.error || `Request failed (${response.status})`);
+  }
+  return data as T;
+}

--- a/mcpjam-inspector/client/src/lib/apis/mcp-conformance-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-conformance-api.ts
@@ -6,7 +6,7 @@ import type {
 import { isHostedMode, runByMode } from "@/lib/apis/mode-client";
 import { buildServerRequest } from "@/lib/apis/web/context";
 import { webPost } from "@/lib/apis/web/base";
-import { authFetch } from "@/lib/session-token";
+import { localPost } from "@/lib/apis/local-post";
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -37,21 +37,6 @@ export interface OAuthStartInput {
   };
   runNegativeChecks?: boolean;
   callbackOrigin?: string;
-}
-
-// ── Local API helpers ───────────────────────────────────────────────────
-
-async function localPost<T>(path: string, body: unknown): Promise<T> {
-  const response = await authFetch(path, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  const data = await response.json();
-  if (!response.ok) {
-    throw new Error(data.error || `Request failed (${response.status})`);
-  }
-  return data as T;
 }
 
 // ── Public API ──────────────────────────────────────────────────────────

--- a/mcpjam-inspector/client/src/lib/apis/mcp-widget-render-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-widget-render-api.ts
@@ -1,0 +1,76 @@
+import { runByMode } from "@/lib/apis/mode-client";
+import { authFetch } from "@/lib/session-token";
+
+/**
+ * Client wrapper for the local headless widget-render route
+ * (`POST /api/mcp/widget-render`). It mounts a server's MCP App tool result in
+ * the eval browser harness (real Chromium running the production host bridge)
+ * and returns a render verdict + screenshot — the "observed" apps-lane signal
+ * for host compatibility.
+ *
+ * Local-Inspector only: the route is mounted solely when `!HOSTED_MODE`, so the
+ * hosted branch throws (callers gate the affordance behind `!isHostedMode()`).
+ */
+
+/** Mirrors the server's `WidgetRenderStatus` (mcp-app-browser-harness.ts). */
+export type WidgetRenderStatus =
+  | "rendered"
+  | "no_ui_resource"
+  | "resource_read_failed"
+  | "mount_failed"
+  | "bridge_timeout"
+  | "render_error"
+  | "blank_screenshot"
+  | "screenshot_failed"
+  | "browser_unavailable";
+
+/** Mirrors `buildWidgetRenderResponseBody` (widget-render-core.ts). */
+export interface WidgetRenderResult {
+  status: WidgetRenderStatus;
+  resourceUri?: string;
+  bridgeInitialized?: boolean;
+  screenshotBase64?: string;
+  consoleErrors?: string[];
+  blockedRequests?: string[];
+  elapsedMs: number;
+  /** e.g. "npx playwright install chromium" when `browser_unavailable`. */
+  hint?: string;
+}
+
+export interface RenderWidgetInput {
+  serverId: string;
+  toolName: string;
+  /** Inject the `window.openai` shim (for ChatGPT/Copilot-style hosts). */
+  injectOpenAiCompat?: boolean;
+  viewport?: { width: number; height: number };
+}
+
+async function localPost<T>(path: string, body: unknown): Promise<T> {
+  const response = await authFetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.error || `Request failed (${response.status})`);
+  }
+  return data as T;
+}
+
+export async function renderWidget(
+  input: RenderWidgetInput,
+): Promise<WidgetRenderResult> {
+  return runByMode({
+    local: () =>
+      localPost<WidgetRenderResult>("/api/mcp/widget-render", {
+        serverId: input.serverId,
+        toolName: input.toolName,
+        injectOpenAiCompat: input.injectOpenAiCompat ?? false,
+        ...(input.viewport ? { viewport: input.viewport } : {}),
+      }),
+    hosted: () => {
+      throw new Error("Live render is only available in the local inspector.");
+    },
+  });
+}

--- a/mcpjam-inspector/client/src/lib/apis/mcp-widget-render-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-widget-render-api.ts
@@ -1,5 +1,5 @@
 import { runByMode } from "@/lib/apis/mode-client";
-import { authFetch } from "@/lib/session-token";
+import { localPost } from "@/lib/apis/local-post";
 
 /**
  * Client wrapper for the local headless widget-render route
@@ -43,19 +43,6 @@ export interface RenderWidgetInput {
   /** Inject the `window.openai` shim (for ChatGPT/Copilot-style hosts). */
   injectOpenAiCompat?: boolean;
   viewport?: { width: number; height: number };
-}
-
-async function localPost<T>(path: string, body: unknown): Promise<T> {
-  const response = await authFetch(path, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  const data = await response.json();
-  if (!response.ok) {
-    throw new Error(data.error || `Request failed (${response.status})`);
-  }
-  return data as T;
 }
 
 export async function renderWidget(

--- a/mcpjam-inspector/client/src/lib/host-compat/engine.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/engine.ts
@@ -319,6 +319,7 @@ export function evaluateHostCompat(
     verdict,
     provenance: profile.provenance,
     lanes: { apps, server },
+    rendersWidgets: profile.rendersMcpApps || profile.rendersOpenAiApps,
     findings,
   };
 }

--- a/mcpjam-inspector/client/src/lib/host-compat/types.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/types.ts
@@ -74,6 +74,12 @@ export type HostCompatReport = {
   provenance: CompatProvenance;
   /** Per-lane verdicts (`apps`, `server`). */
   lanes: Record<CompatLane, CompatLaneVerdict>;
+  /**
+   * Whether this host renders widgets at all (MCP Apps or the OpenAI shim) —
+   * a CLI host (Codex) renders neither. Gates the "Run live render" affordance:
+   * there's nothing to observe for a host with no rendering surface.
+   */
+  rendersWidgets?: boolean;
   findings: CompatFinding[];
 };
 


### PR DESCRIPTION
Phase 3 of the host-compatibility experience — the **live "observed" tier**, the differentiator. This is **part 1 of 2**: the apps-lane render observation. (The LLM/tool observation half is the next PR.)

## What

A per-host **"Run live"** button on the Compatibility report. It renders the server's widget *live* in that host's emulation and shows what actually happens — upgrading the apps lane from **predicted** to **observed**.

Reuses the **existing** local headless render route (`POST /api/mcp/widget-render` — real Chromium running the production host bridge). **No new server route, no LLM agent loop, no model key.** The button:
- is gated to **local Inspector only** (the route is `!HOSTED_MODE`), hosts that actually render widgets (`report.rendersWidgets`), and servers that have a widget;
- renders the server's first widget tool with that host's `injectOpenAiCompat` (so ChatGPT/Copilot get the `window.openai` shim);
- shows the observed `WidgetRenderStatus` (`rendered` / `bridge_timeout` / `blank_screenshot` / `mount_failed` / …), console errors, and a screenshot.

## How

- **`mcp-widget-render-api.ts`** — `renderWidget()` client wrapper (`runByMode`; hosted branch throws, matching the local-only route).
- **`LiveRenderRow.tsx`** — `useLiveRenders` hook (per-host results, picks the first widget tool, resets on server switch) + a compact observed-status row (status + console errors + screenshot).
- **engine** — adds `report.rendersWidgets` so the affordance hides for a CLI host (Codex) that renders nothing.

## Scope notes (intentional, for the next PR)

- **No verdict mutation yet** — the observed render shows as evidence *alongside* the static verdict, with the `observed` provenance. Folding it into the aggregate verdict is a deliberate follow-up.
- **One representative widget tool** per server is rendered in v1; multi-widget coverage can come later.
- The render route renders in the inspector's faithful bridge parameterized by `injectOpenAiCompat` only — so the observation varies by the OpenAI-shim dimension, not a full per-host rendering emulation.

## Verification

- `renderWidget` API: local POST body, default `injectOpenAiCompat: false`, non-ok error propagation, hosted-mode throw.
- `LiveRenderRow`: rendered / failed-status / request-error / screenshot; `useLiveRenders`: hosted+no-widget gating, first-tool pick + compat flag, per-host error capture.
- 64 client tests pass; `typecheck:client` clean.
- Still behind the `mcpjam-compatibility` flag (default off). Not click-tested in CI — the live render needs local Chromium (`npx playwright install chromium`), surfaced as a `browser_unavailable` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New client flow triggers headless browser work and holds base64 screenshots, but it’s local-only, gated, single-flight, and does not alter verdict logic yet.
> 
> **Overview**
> Adds **Tier-2 “observed”** evidence on the host compatibility report: a per-host **Run live** control calls the existing local `POST /api/mcp/widget-render` via new **`renderWidget`** API, using each host’s **`injectOpenAiCompat`** from the style registry.
> 
> **`useLiveRenders`** picks the first MCP Apps/dual widget (skips OpenAI-only), gates on local inspector + widgets + **`report.rendersWidgets`**, serializes Chromium jobs, and drops stale results on server/tool switches while trimming old screenshots from state. **`LiveRenderRow`** shows status, timing, console errors, and PNG.
> 
> Also extracts shared **`localPost`** for local MCP routes (conformance uses it), adds **`rendersWidgets`** on compat reports, always shows the server name on **`HostCompatPage`**, and shared **`TONE_META`** for live status styling. Observed output is **evidence only**—static verdicts are unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 158708ef80d7c6ba065785a36f0e7ddd22fdab2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->