### PR TITLE
[XAA BYO-IDP] PR-I1: versioned XAA grant URN constants + idpMode axis

### DIFF
--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -79,6 +79,12 @@ export interface ServerWithName {
   useXaa?: boolean;
   /** Which IdP mints the XAA assertion. v1 only "mcpjam". */
   authServerMode?: "mcpjam" | "own";
+  /**
+   * Which identity provider mints the XAA assertion — orthogonal to
+   * `authServerMode`. "mcpjam" (default) self-mints; "external" runs legs 1+2
+   * against a real OIDC IdP. See `shared/xaa-grants.ts`.
+   */
+  idpMode?: "mcpjam" | "external";
   /** Optional simulated-identity overrides for the MCPJam test IdP. Blank = signed-in user. */
   xaaSubject?: string;
   xaaEmail?: string;

--- a/mcpjam-inspector/shared/__tests__/xaa-grants.test.ts
+++ b/mcpjam-inspector/shared/__tests__/xaa-grants.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  XAA_DRAFT_VERSION,
+  TOKEN_EXCHANGE_GRANT,
+  JWT_BEARER_GRANT,
+  ID_JAG_TOKEN_TYPE,
+  ID_TOKEN_TOKEN_TYPE,
+  REFRESH_TOKEN_TOKEN_TYPE,
+  ID_JAG_JWT_TYP,
+  XAA_IDP_MODES,
+  DEFAULT_XAA_IDP_MODE,
+  isIdJagTokenType,
+} from "../xaa-grants.js";
+
+// These values are wire-format constants pinned to the XAA draft. Locking them
+// here catches an accidental edit that would silently break the 3-leg flow.
+describe("xaa-grants URN constants", () => {
+  it("pins the draft version", () => {
+    expect(XAA_DRAFT_VERSION).toBe(
+      "draft-ietf-oauth-identity-assertion-authz-grant-04",
+    );
+  });
+
+  it("exposes the two distinct grant types (leg 2 vs leg 3)", () => {
+    expect(TOKEN_EXCHANGE_GRANT).toBe(
+      "urn:ietf:params:oauth:grant-type:token-exchange",
+    );
+    expect(JWT_BEARER_GRANT).toBe(
+      "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    );
+    expect(TOKEN_EXCHANGE_GRANT).not.toBe(JWT_BEARER_GRANT);
+  });
+
+  it("exposes the token types", () => {
+    expect(ID_JAG_TOKEN_TYPE).toBe("urn:ietf:params:oauth:token-type:id-jag");
+    expect(ID_TOKEN_TOKEN_TYPE).toBe(
+      "urn:ietf:params:oauth:token-type:id_token",
+    );
+    expect(REFRESH_TOKEN_TOKEN_TYPE).toBe(
+      "urn:ietf:params:oauth:token-type:refresh_token",
+    );
+  });
+
+  it("pins the id-jag JOSE typ discriminator", () => {
+    expect(ID_JAG_JWT_TYP).toBe("oauth-id-jag+jwt");
+  });
+});
+
+describe("XaaIdpMode axis", () => {
+  it("offers exactly mcpjam and external", () => {
+    expect(XAA_IDP_MODES).toEqual(["mcpjam", "external"]);
+  });
+
+  it("defaults to the built-in test IdP", () => {
+    expect(DEFAULT_XAA_IDP_MODE).toBe("mcpjam");
+  });
+});
+
+describe("isIdJagTokenType", () => {
+  it("matches the canonical lowercase value", () => {
+    expect(isIdJagTokenType(ID_JAG_TOKEN_TYPE)).toBe(true);
+  });
+
+  it("matches case-insensitively (IdP casing varies)", () => {
+    expect(
+      isIdJagTokenType("urn:ietf:params:oauth:token-type:ID-JAG"),
+    ).toBe(true);
+  });
+
+  it("rejects other token types and empty input", () => {
+    expect(isIdJagTokenType(ID_TOKEN_TOKEN_TYPE)).toBe(false);
+    expect(isIdJagTokenType(undefined)).toBe(false);
+    expect(isIdJagTokenType(null)).toBe(false);
+    expect(isIdJagTokenType("")).toBe(false);
+  });
+});

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -896,6 +896,13 @@ export interface ServerFormData {
    * follow-up.
    */
   authServerMode?: "mcpjam" | "own";
+  /**
+   * Which identity provider mints the XAA assertion (orthogonal axis to
+   * `authServerMode`, which selects the resource's authorization server).
+   * "mcpjam" (default) self-mints via the built-in test IdP; "external" runs
+   * legs 1+2 against a real OIDC IdP. See `shared/xaa-grants.ts`.
+   */
+  idpMode?: "mcpjam" | "external";
   /** Optional simulated-identity override (subject) for the MCPJam test IdP. Blank = signed-in user. */
   xaaSubject?: string;
   /** Optional simulated-identity override (email) for the MCPJam test IdP. Blank = signed-in user. */

--- a/mcpjam-inspector/shared/xaa-grants.ts
+++ b/mcpjam-inspector/shared/xaa-grants.ts
@@ -1,0 +1,69 @@
+// Versioned XAA (Cross-App Access) grant / token URNs and JOSE constants.
+//
+// Pinned to draft-ietf-oauth-identity-assertion-authz-grant-04. The draft is
+// still unstable, so every wire URN the three-leg flow depends on lives here in
+// one place — when the draft revs, this module is the only one to update.
+//
+// The three legs use TWO different grant types (the most common implementation
+// mistake is conflating them):
+//   leg 2 — mint the id-jag at the IdP  -> token-exchange (RFC 8693)
+//   leg 3 — redeem the id-jag at the AS -> jwt-bearer     (RFC 7523)
+
+/** The XAA draft these constants are verified against. */
+export const XAA_DRAFT_VERSION =
+  "draft-ietf-oauth-identity-assertion-authz-grant-04";
+
+// --- Grant types -----------------------------------------------------------
+
+/** Leg 2: RFC 8693 token-exchange grant (id_token -> id-jag at the IdP). */
+export const TOKEN_EXCHANGE_GRANT =
+  "urn:ietf:params:oauth:grant-type:token-exchange";
+
+/** Leg 3: RFC 7523 jwt-bearer grant (id-jag -> access token at the resource AS). */
+export const JWT_BEARER_GRANT =
+  "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+// --- Token types -----------------------------------------------------------
+
+/** The cross-app assertion type. Leg 2 requests and returns this. */
+export const ID_JAG_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag";
+
+/** Leg 2 `subject_token_type` when the subject is an OIDC id_token. */
+export const ID_TOKEN_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id_token";
+
+/** Leg 2 `subject_token_type` when the subject is a refresh token (draft §4.3.2). */
+export const REFRESH_TOKEN_TOKEN_TYPE =
+  "urn:ietf:params:oauth:token-type:refresh_token";
+
+// --- JOSE ------------------------------------------------------------------
+
+/**
+ * The JOSE header `typ` that identifies an id-jag assertion. The resource AS
+ * uses this as its validation discriminator (draft requires it).
+ */
+export const ID_JAG_JWT_TYP = "oauth-id-jag+jwt";
+
+// --- IdP selector axis -----------------------------------------------------
+
+/**
+ * Which identity provider mints the XAA assertion. This is orthogonal to
+ * `authServerMode` (which selects the resource's authorization server for
+ * leg 3) — do NOT conflate them.
+ *   - "mcpjam":   the built-in test IdP self-mints the id-jag; legs 1+2 skipped.
+ *   - "external": a real OIDC IdP (Okta, Auth0, …) mints it via legs 1+2.
+ */
+export const XAA_IDP_MODES = ["mcpjam", "external"] as const;
+export type XaaIdpMode = (typeof XAA_IDP_MODES)[number];
+
+/** Default IdP mode — the built-in test IdP, so the existing path is unchanged. */
+export const DEFAULT_XAA_IDP_MODE: XaaIdpMode = "mcpjam";
+
+// --- Helpers ---------------------------------------------------------------
+
+/**
+ * Case-insensitive check that a token-exchange response's `issued_token_type`
+ * is the id-jag type. Casing varies across IdPs, so never compare with `===`.
+ */
+export function isIdJagTokenType(value: string | undefined | null): boolean {
+  return (value ?? "").toLowerCase() === ID_JAG_TOKEN_TYPE;
+}


### PR DESCRIPTION
## TL;DR

First PR of the XAA bring-your-own-IDP stack. **Pure types/constants — no behavior change.** Adds a single versioned home for the Cross-App Access wire URNs and introduces the new `idpMode` axis so later PRs can branch the mint on it.

Behind flag `xaa-external-idp` (no runtime surface here yet).

## What changes

| Change | File |
|---|---|
| New module: versioned XAA grant/token URNs + JOSE `typ` + `XaaIdpMode` axis + `isIdJagTokenType` helper | `shared/xaa-grants.ts` |
| `idpMode?: "mcpjam" \| "external"` on the server-form type | `shared/types.ts` |
| `idpMode?` on the client server-state type | `client/src/state/app-types.ts` |
| Unit test locking the URN values + axis + helper | `shared/__tests__/xaa-grants.test.ts` |

## Why a new axis (not a reuse)

`idpMode` selects **which identity provider mints the assertion** (built-in test IDP vs. a real external OIDC IDP). It is **orthogonal** to the existing `authServerMode`, which selects the resource's authorization server. They are not the same control and must not be conflated.

- `idpMode` defaults to `"mcpjam"`, so every existing path is unchanged.
- The two grant types the flow depends on (token-exchange vs jwt-bearer) now live in one module, pinned to the draft version, so a draft rev is a one-file edit.

## Will this break X? / Risk register

| Concern | Answer |
|---|---|
| Does this change any runtime behavior? | No — additive optional field + new constants module. Nothing imports the new module yet. |
| Existing `authServerMode` / built-in IDP flow affected? | No — untouched; `idpMode` is a separate optional field defaulting to the built-in IDP. |
| Existing duplicated grant literals rewired? | No — left in place; each later PR points its own file at the new module as it touches it. Keeps this PR pure. |
| Typecheck | Client typecheck passes; new field is optional so no call-site churn. |
