### PR TITLE
feat(computer): environments UI on the Computer tab (Part A)

### DIFF
--- a/docs/computer-environments-ui-cli.md
+++ b/docs/computer-environments-ui-cli.md
@@ -1,0 +1,177 @@
+# Plan: Computer Environments — Inspector UI + CLI API
+
+Branch: `feat/computer-environments` (off current `origin/main`).
+
+## Context
+
+The Convex backend (mcpjam-backend, merged #618–#629) ships a complete, live-
+verified "Computer environments" feature: a project-owned Dockerfile is built
+into an immutable E2B image that a member's personal Computer can boot from
+(`setComputerEnvironment`), plus reset-to-image (`resetComputer`). It's fully
+tested but **unreachable** — no UI surfaces it and the CLI can't drive it. This
+adds both, entirely in the inspector repo. **No backend changes** — every Convex
+function already exists and is reachable as-is.
+
+## Repo layout (this is a monorepo — get the package right)
+
+| Package | Path |
+|---|---|
+| Inspector app (frontend) | `mcpjam-inspector/client/…` |
+| Inspector server (Hono) | `mcpjam-inspector/server/…` |
+| CLI | `cli/…` (top-level) |
+| Platform SDK | `sdk/…` (top-level) |
+| Public API spec | `docs/reference/openapi.json` (top-level) |
+
+> An agent editing `client/…` or `server/…` at the repo root will edit the wrong
+> place — those exist only on the older flat-layout branches.
+
+## How each consumer reaches the backend (verified)
+
+- **UI** calls Convex **directly by string id**, like the existing Computer tab
+  (`mcpjam-inspector/client/src/hooks/useProjectComputer.ts` →
+  `useQuery("projectComputers:getComputerStatus", { projectId })`,
+  `useMutation("projectComputers:getOrReserveComputer")`,
+  `useAction("projectComputers:mintTerminalToken")`).
+- **CLI** rides the existing bridge (precedent: `mcpjam-inspector/server/routes/web/servers.ts`,
+  `…/routes/shared/evals.ts`): a `v1` Hono route →
+  `new ConvexHttpClient(CONVEX_URL); client.setAuth(await getConvexBearerForRequest(c))`
+  → `client.query/mutation("computerEnvironments:…")`. The delegated JWT (minted
+  from the caller's `sk_` key in `mcpjam-inspector/server/utils/v1-convex-token.ts`)
+  makes the `userMutation` resolve the acting user. Mirror the `hosts` stack.
+
+## Backend functions consumed (all deployed; no changes)
+
+`computerEnvironments`: `listEnvironments(projectId)`, `getEnvironment(environmentId)`,
+`listEnvironmentBuilds(environmentId)`, `createEnvironment(projectId,name,dockerfile)`,
+`updateEnvironment(environmentId,name?,dockerfile?)`, `startEnvironmentBuild(environmentId)`,
+`promoteEnvironmentToProject(environmentId)`, `deleteEnvironment(environmentId)`.
+`projectComputers`: `getComputerStatus(projectId)` (→ `environmentId`),
+`setComputerEnvironment(projectId, environmentId | null)`, `resetComputer(projectId)`.
+
+`EnvironmentView` (returned by list/get) includes: `environmentId`, `projectId`,
+`name`, `dockerfile`, `sharing` (`'user'|'project'`), `isOwner`, `currentBuild`
+(status/error/logPreview/…). **Note it does NOT expose a "can manage shared" /
+admin flag** — see UI step 6.
+
+> Builder/runtime compatibility: a build's vendor template can only be launched
+> by the SAME provider that built it (#626). With `COMPUTERS_PROVIDER=e2b` and the
+> default `COMPUTERS_ENV_BUILDER=stub`, **attach FAILS by design** — the backend
+> rejects the incompatible pin. So custom images are only attachable once real
+> builds are enabled. The UI/CLI must surface that rejection cleanly, not assume
+> "stub behaves identically."
+
+---
+
+## Part A — UI (frontend only, `mcpjam-inspector/client/`)
+
+Reference files (current `origin/main`):
+`…/components/computer/ComputerView.tsx` (the tab), `…/hooks/useProjectComputer.ts`
+(hook + view-type pattern), `…/components/computer/ComputerStatusChip.tsx`.
+Design system `@mcpjam/design-system`: `Button`, `Badge`, `Sheet`, `Dialog`,
+`Tabs`. Editor: CodeMirror 6 (`…/client/src/components/ui/json-editor/`), not
+Monaco. `projectId` comes from `useAppRouteContext()` and is passed into
+`ComputerView` as a prop today.
+
+1. **`…/client/src/hooks/useComputerEnvironments.ts`** — mirror
+   `useProjectComputer.ts` (string-id `useQuery`/`useMutation`): `useEnvironments`,
+   `useEnvironment`, `useEnvironmentBuilds`, `useCreateEnvironment`,
+   `useUpdateEnvironment`, `useStartEnvironmentBuild`, `usePromoteEnvironment`,
+   `useDeleteEnvironment`, `useSetComputerEnvironment`, `useResetComputer`. Declare
+   matching TS view types.
+2. **`ComputerView.tsx`** — add an **Image** strip between the subtitle and the
+   usage meter: current image name (resolve `getComputerStatus().environmentId`
+   via `useEnvironments`), **[Change ▾]** (opens drawer), **[Reset]** (confirm →
+   `resetComputer`, enabled only Ready/asleep).
+3. **`…/components/computer/EnvironmentsDrawer.tsx`** — design-system `Sheet`.
+   - **Create is first-class**: an empty state ("No environments yet — create one
+     to customize your computer's image. [+ New environment]") AND a persistent
+     **[+ New environment]** in the list. New opens a fresh editor (name +
+     Dockerfile) → `createEnvironment` → land on the new env's detail with **Build**
+     ready.
+   - **List**: own drafts + project-shared, status badges from `currentBuild`, ✓ on
+     the attached one, ⋯ = Promote/Delete.
+   - **Detail**: name, **Dockerfile editor** (CodeMirror), **Build** (+ live
+     status/log tail by polling `getEnvironment`/`listEnvironmentBuilds`), **Use on
+     computer** (`setComputerEnvironment`, disabled until a Ready build), **sharing**
+     toggle (Just me / Project → `promoteEnvironmentToProject`), **Delete**.
+4. **Confirms** (`Dialog`): attach/change ("rebuilds your computer; installed
+   files are wiped") and reset — both wipe mutable computer state.
+5. **States**: empty, building (spinner + log), failed (error + log + retry), and
+   **attach-rejected** (surface the backend's incompatible-builder / not-ready
+   error as a clean toast).
+6. **Admin controls — optimistic, not pre-disabled.** `EnvironmentView` has
+   `isOwner` but no "can manage shared." So: for a **draft**, gate edit/build/
+   delete on `isOwner`; for a **shared** env, render the controls **optimistically**
+   and map the backend's permission error (thrown by `canManageSharedEnvironments`)
+   to a clean toast ("Only project admins can manage shared environments"). Do not
+   pretend the client knows admin status. (Follow-up option: add a `canManage`
+   field to `EnvironmentView` in the backend for nicer UX — out of scope here.)
+7. **Tests**: mirror `…/components/computer/__tests__/ComputerView.test.tsx` —
+   render states, hook mocks, the attach-rejected toast path.
+
+No server/CLI/SDK/backend changes for Part A.
+
+---
+
+## Part B — CLI API (`mcpjam-inspector/server/`, `sdk/`, `cli/`)
+
+Mirror the `hosts` stack: command (`cli/src/commands/hosts.ts`) → SDK operation
+(`sdk/src/platform/operations.ts`) → client method (`sdk/src/platform/client.ts`)
+→ v1 route (`mcpjam-inspector/server/routes/v1/hosts.ts`, mounted in
+`…/routes/v1/index.ts`).
+
+1. **`mcpjam-inspector/server/routes/v1/computer-environments.ts`** (Hono), mounted
+   in `…/routes/v1/index.ts`, **kept off the guest allowlist**. Each handler:
+   `getConvexBearerForRequest(c)` → `ConvexHttpClient.setAuth` →
+   `client.query/mutation("computerEnvironments:…" | "projectComputers:…")` → v1
+   envelope (reuse `v1Resource`/`v1PageJson`/`v1Error`). Endpoints under
+   `/projects/:projectId/computer-environments`:
+   - `GET` (list), `POST` (create), `GET/PATCH/DELETE /:envId`,
+     `POST /:envId/build`, `GET /:envId/builds`, `POST /:envId/promote`,
+     `POST /:envId/use` → `setComputerEnvironment`, plus
+     `POST /projects/:projectId/computer/reset` → `resetComputer`.
+   - **PROJECT-SCOPE GUARD (required):** the backend env mutations
+     (`update`/`build`/`promote`/`delete`) authorize by the *env's* project, not
+     the URL's `:projectId`. So before any `/:envId` call, the adapter MUST
+     `getEnvironment(envId)` and assert `env.projectId === :projectId`, else `404`
+     — otherwise a user with access to projects A and B could `PATCH
+     /projects/A/.../envB` and mutate B's env via an A-scoped URL. (Cleaner
+     long-term: backend project-scoped variants that take `(projectId, envId)`;
+     tracked as a follow-up, not needed for this PR.)
+2. **`sdk/src/platform/client.ts`** — HTTP methods: `listEnvironments`,
+   `getEnvironment`, `createEnvironment`, `updateEnvironment`, `deleteEnvironment`,
+   `buildEnvironment`, `listEnvironmentBuilds`, `promoteEnvironment`,
+   `useEnvironment`, `resetComputer`.
+3. **`sdk/src/platform/operations.ts`** — operations with zod input schemas +
+   `resolveProjectOrThrow(client, input.project, signal)`.
+4. **`cli/src/commands/environments.ts`**, registered in `cli/src/index.ts`:
+   `mcpjam env list|get|create|edit|build|logs|use|reset|promote|delete`.
+   `create`/`edit` read the Dockerfile from `--file <path>` or stdin (the "edit
+   them with the CLI" requirement); `--format json` like the rest.
+5. **OpenAPI:** add entries for every new route to **`docs/reference/openapi.json`**
+   — the drift test `mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts`
+   fails otherwise.
+6. **Tests**: server-route suite (mirror `…/routes/v1/__tests__`), incl. a test
+   that **guests get 401** on these routes; the project-scope guard (env-B via
+   project-A URL → 404); plus a CLI command test.
+
+---
+
+## Verification
+
+- **UI**: run the inspector against the dev backend; create env → edit Dockerfile
+  → build (stub ⇒ instant on dev) → attach → reset → delete. With
+  `COMPUTERS_PROVIDER=e2b` + default stub builder, confirm attach is rejected with
+  a clean error. Real builds need `COMPUTERS_ENV_BUILDER=e2b` on the deployment.
+- **CLI**: with an `sk_` key — `mcpjam env create --file Dockerfile`,
+  `mcpjam env build <name>`, `mcpjam env logs <name>`, `mcpjam env use <name>`;
+  guest token → 401.
+- typecheck + lint each package; **openapi-drift** + the new route/CLI tests pass.
+
+## Sequencing / hygiene
+
+1. Branch stays based on current `origin/main` — keep the diff to *only* this
+   feature (no unrelated compat-UI churn).
+2. Part A (UI) first — self-contained, highest user value.
+3. Part B (CLI): v1 route (+ scope guard + openapi) → sdk client → sdk op → cli
+   command.

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -2,7 +2,7 @@ import { Component, useCallback, useState } from "react";
 import { toast } from "@/lib/toast";
 import { usePostHog } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
-import { Loader2, RotateCcw, TerminalSquare, Trash2 } from "lucide-react";
+import { Boxes, Loader2, RotateCcw, TerminalSquare, Trash2 } from "lucide-react";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import {
   useComputersDataPlaneConfig,
@@ -12,6 +12,11 @@ import {
   useMintTerminalToken,
   useReserveComputer,
 } from "@/hooks/useProjectComputer";
+import {
+  useEnvironments,
+  useResetComputer,
+} from "@/hooks/useComputerEnvironments";
+import { EnvironmentsDrawer } from "./EnvironmentsDrawer";
 import { toTerminalWsBase } from "@/lib/computer-terminal-connection";
 import {
   getBillingErrorMessage,
@@ -46,6 +51,18 @@ export function ComputerView({
   const [starting, setStarting] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [envDrawerOpen, setEnvDrawerOpen] = useState(false);
+  const [confirmingReset, setConfirmingReset] = useState(false);
+  const [resetting, setResetting] = useState(false);
+
+  const resetComputer = useResetComputer();
+  const environments = useEnvironments(effectiveProjectId);
+  const attachedEnvironmentId = status?.environmentId ?? null;
+  const attachedEnvName =
+    attachedEnvironmentId == null
+      ? null
+      : environments?.find((e) => e.environmentId === attachedEnvironmentId)
+          ?.name ?? null;
 
   // Where the terminal lives: this server (local data plane), a deployed
   // data plane (remote URL → cross-origin WS), or nowhere (honest empty
@@ -121,6 +138,26 @@ export function ComputerView({
       setConfirmingDelete(false);
     }
   }, [effectiveProjectId, deleteComputer]);
+
+  const onReset = useCallback(async () => {
+    if (!effectiveProjectId) return;
+    setResetting(true);
+    try {
+      const res = await resetComputer({ projectId: effectiveProjectId });
+      toast.success(
+        res.reset ? "Resetting your computer to its image…" : "Nothing to reset."
+      );
+    } catch (err) {
+      toast.error(getBillingErrorMessage(err, "Could not reset the computer."));
+    } finally {
+      setResetting(false);
+      setConfirmingReset(false);
+    }
+  }, [effectiveProjectId, resetComputer]);
+
+  // Reset and image changes both rebuild the box, so only offer them when it's
+  // settled (not mid-provision).
+  const canReset = isReady || liveStatus === "hibernating";
 
   if (!isAuthenticated) {
     return <Empty>Sign in to use a personal computer for this project.</Empty>;
@@ -302,6 +339,80 @@ export function ComputerView({
         A personal Linux workstation for this project — files and installed
         tools persist between sessions; it sleeps when idle and wakes on use.
       </p>
+
+      {status !== undefined ? (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border bg-muted/10 px-3 py-2 text-sm">
+          <span className="flex min-w-0 items-center gap-2 text-muted-foreground">
+            <Boxes className="h-4 w-4 shrink-0" />
+            Image:
+            <span className="truncate font-medium text-foreground">
+              {attachedEnvName ?? "Base image"}
+            </span>
+            {attachedEnvName ? null : (
+              <span className="hidden sm:inline">Debian + Node + Python</span>
+            )}
+          </span>
+          <span className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setEnvDrawerOpen(true)}
+            >
+              Change
+            </Button>
+            {hasComputer ? (
+              confirmingReset ? (
+                <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                  Reset to the image? Installed files are wiped.
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => void onReset()}
+                    disabled={resetting}
+                  >
+                    {resetting ? (
+                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    ) : null}
+                    Reset
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setConfirmingReset(false)}
+                    disabled={resetting}
+                  >
+                    Cancel
+                  </Button>
+                </span>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setConfirmingReset(true)}
+                  disabled={!canReset}
+                  title={
+                    canReset
+                      ? undefined
+                      : "Reset is available once the computer is ready or asleep"
+                  }
+                >
+                  <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+                  Reset
+                </Button>
+              )
+            ) : null}
+          </span>
+        </div>
+      ) : null}
+
+      {effectiveProjectId ? (
+        <EnvironmentsDrawer
+          open={envDrawerOpen}
+          onOpenChange={setEnvDrawerOpen}
+          projectId={effectiveProjectId}
+          attachedEnvironmentId={attachedEnvironmentId}
+        />
+      ) : null}
 
       <UsageMeterBoundary>
         <ComputerUsageMeter projectId={projectId} />

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -161,8 +161,10 @@ export function ComputerView({
   }, [effectiveProjectId, resetComputer]);
 
   // Reset and image changes both rebuild the box, so only offer them when it's
-  // settled (not mid-provision).
+  // settled (not mid-provision). Attaching is also allowed when there's no
+  // computer yet (the backend provisions-with-pin on first use).
   const canReset = isReady || liveStatus === "hibernating";
+  const canAttach = liveStatus === null || canReset;
 
   if (!isAuthenticated) {
     return <Empty>Sign in to use a personal computer for this project.</Empty>;
@@ -416,6 +418,7 @@ export function ComputerView({
           onOpenChange={setEnvDrawerOpen}
           projectId={effectiveProjectId}
           attachedEnvironmentId={attachedEnvironmentId}
+          canAttach={canAttach}
         />
       ) : null}
 

--- a/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerView.tsx
@@ -58,11 +58,16 @@ export function ComputerView({
   const resetComputer = useResetComputer();
   const environments = useEnvironments(effectiveProjectId);
   const attachedEnvironmentId = status?.environmentId ?? null;
-  const attachedEnvName =
-    attachedEnvironmentId == null
-      ? null
-      : environments?.find((e) => e.environmentId === attachedEnvironmentId)
-          ?.name ?? null;
+  const hasCustomImage = attachedEnvironmentId != null;
+  const attachedEnvName = hasCustomImage
+    ? environments?.find((e) => e.environmentId === attachedEnvironmentId)
+        ?.name ?? null
+    : null;
+  // A custom image is attached but its name hasn't resolved yet (list still
+  // loading, or it's not visible to this caller) — don't mislabel it as base.
+  const imageLabel = !hasCustomImage
+    ? "Base image"
+    : attachedEnvName ?? "Custom image";
 
   // Where the terminal lives: this server (local data plane), a deployed
   // data plane (remote URL → cross-origin WS), or nowhere (honest empty
@@ -346,9 +351,9 @@ export function ComputerView({
             <Boxes className="h-4 w-4 shrink-0" />
             Image:
             <span className="truncate font-medium text-foreground">
-              {attachedEnvName ?? "Base image"}
+              {imageLabel}
             </span>
-            {attachedEnvName ? null : (
+            {hasCustomImage ? null : (
               <span className="hidden sm:inline">Debian + Node + Python</span>
             )}
           </span>

--- a/mcpjam-inspector/client/src/components/computer/EnvironmentBuildBadge.tsx
+++ b/mcpjam-inspector/client/src/components/computer/EnvironmentBuildBadge.tsx
@@ -1,0 +1,21 @@
+import { Badge } from "@mcpjam/design-system/badge";
+import type { EnvironmentBuildView } from "@/hooks/useComputerEnvironments";
+
+/** Build-status chip for an environment, mirroring `ComputerStatusChip`. */
+export function EnvironmentBuildBadge({
+  build,
+}: {
+  build: EnvironmentBuildView | null | undefined;
+}) {
+  if (!build) return <Badge variant="outline">Not built</Badge>;
+  switch (build.status) {
+    case "ready":
+      return <Badge variant="default">Ready</Badge>;
+    case "failed":
+      return <Badge variant="destructive">Build failed</Badge>;
+    case "queued":
+    case "building":
+    default:
+      return <Badge variant="secondary">Building…</Badge>;
+  }
+}

--- a/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
+++ b/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
@@ -1,0 +1,529 @@
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "@/lib/toast";
+import { Button } from "@mcpjam/design-system/button";
+import { Badge } from "@mcpjam/design-system/badge";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@mcpjam/design-system/sheet";
+import {
+  Check,
+  Loader2,
+  Plus,
+  Trash2,
+  Hammer,
+  Users,
+  ChevronLeft,
+} from "lucide-react";
+import {
+  useCreateEnvironment,
+  useDeleteEnvironment,
+  useEnvironments,
+  usePromoteEnvironment,
+  useSetComputerEnvironment,
+  useStartEnvironmentBuild,
+  useUpdateEnvironment,
+  type EnvironmentView,
+} from "@/hooks/useComputerEnvironments";
+import { EnvironmentBuildBadge } from "./EnvironmentBuildBadge";
+
+const NEW_ENVIRONMENT_TEMPLATE = `# Base must be an allowlisted official image (debian, ubuntu, node, python)
+# pinned by @sha256 digest. Only FROM + RUN are supported today.
+FROM debian:bookworm-slim@sha256:REPLACE_WITH_DIGEST
+RUN echo "customize me"
+`;
+
+function errMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message) {
+    // Convex surfaces the thrown message; strip the noisy server prefix.
+    return err.message.replace(/^\[.*?\]\s*/, "").slice(0, 400) || fallback;
+  }
+  return fallback;
+}
+
+/**
+ * Manage the project's Computer environments and which one this computer boots
+ * from. Opened from the Computer tab's "Change image" control. Builds stream
+ * reactively via Convex queries, so no manual polling.
+ */
+export function EnvironmentsDrawer({
+  open,
+  onOpenChange,
+  projectId,
+  attachedEnvironmentId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  attachedEnvironmentId: string | null;
+}) {
+  const environments = useEnvironments(open ? projectId : null);
+  const setComputerEnvironment = useSetComputerEnvironment();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const selected = useMemo(
+    () => environments?.find((e) => e.environmentId === selectedId) ?? null,
+    [environments, selectedId]
+  );
+
+  // Detail / new-env editor lives below the list on mobile-narrow drawers.
+  const showDetail = creating || selected !== null;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 sm:max-w-xl"
+      >
+        <SheetHeader className="border-b px-4 py-3">
+          <SheetTitle>Environments</SheetTitle>
+          <SheetDescription>
+            A custom Docker image your computer boots from. Changing the image
+            rebuilds the computer.
+          </SheetDescription>
+        </SheetHeader>
+
+        {!showDetail ? (
+          <EnvironmentList
+            environments={environments}
+            attachedEnvironmentId={attachedEnvironmentId}
+            onSelect={(id) => {
+              setCreating(false);
+              setSelectedId(id);
+            }}
+            onNew={() => {
+              setSelectedId(null);
+              setCreating(true);
+            }}
+            onUseBase={() => void detachToBase()}
+            attachToBaseDisabled={attachedEnvironmentId === null}
+          />
+        ) : creating ? (
+          <NewEnvironmentForm
+            projectId={projectId}
+            onCancel={() => setCreating(false)}
+            onCreated={(env) => {
+              setCreating(false);
+              setSelectedId(env.environmentId);
+            }}
+          />
+        ) : selected ? (
+          <EnvironmentDetail
+            key={selected.environmentId}
+            env={selected}
+            projectId={projectId}
+            isAttached={attachedEnvironmentId === selected.environmentId}
+            onBack={() => setSelectedId(null)}
+            onDeleted={() => setSelectedId(null)}
+          />
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+
+  async function detachToBase() {
+    try {
+      await setComputerEnvironment({ projectId, environmentId: null });
+      toast.success("Switched to the base image. Rebuilding your computer…");
+    } catch (err) {
+      toast.error(errMessage(err, "Could not switch to the base image."));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+function EnvironmentList({
+  environments,
+  attachedEnvironmentId,
+  onSelect,
+  onNew,
+  onUseBase,
+  attachToBaseDisabled,
+}: {
+  environments: EnvironmentView[] | undefined;
+  attachedEnvironmentId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  onUseBase: () => void;
+  attachToBaseDisabled: boolean;
+}) {
+  if (environments === undefined) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading environments…
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex-1 overflow-y-auto p-2">
+        {/* Base image row */}
+        <button
+          type="button"
+          onClick={onUseBase}
+          disabled={attachToBaseDisabled}
+          className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50 disabled:cursor-default disabled:opacity-100"
+        >
+          <span className="flex items-center gap-2">
+            {attachedEnvironmentId === null ? (
+              <Check className="h-4 w-4 text-primary" />
+            ) : (
+              <span className="h-4 w-4" />
+            )}
+            <span className="font-medium text-foreground">Base image</span>
+            <span className="text-muted-foreground">
+              Debian + Node + Python
+            </span>
+          </span>
+          {attachedEnvironmentId !== null ? (
+            <span className="text-xs text-muted-foreground">Use</span>
+          ) : null}
+        </button>
+
+        {environments.length === 0 ? (
+          <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+            No custom environments yet — create one to customize your computer's
+            image.
+          </div>
+        ) : (
+          environments.map((env) => (
+            <button
+              key={env.environmentId}
+              type="button"
+              onClick={() => onSelect(env.environmentId)}
+              className="flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50"
+            >
+              <span className="flex min-w-0 items-center gap-2">
+                {attachedEnvironmentId === env.environmentId ? (
+                  <Check className="h-4 w-4 shrink-0 text-primary" />
+                ) : (
+                  <span className="h-4 w-4 shrink-0" />
+                )}
+                <span className="truncate font-medium text-foreground">
+                  {env.name}
+                </span>
+                {env.sharing === "project" ? (
+                  <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                ) : null}
+              </span>
+              <EnvironmentBuildBadge build={env.currentBuild} />
+            </button>
+          ))
+        )}
+      </div>
+      <div className="border-t p-2">
+        <Button size="sm" variant="outline" className="w-full" onClick={onNew}>
+          <Plus className="mr-1.5 h-3.5 w-3.5" /> New environment
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function NewEnvironmentForm({
+  projectId,
+  onCancel,
+  onCreated,
+}: {
+  projectId: string;
+  onCancel: () => void;
+  onCreated: (env: EnvironmentView) => void;
+}) {
+  const createEnvironment = useCreateEnvironment();
+  const [name, setName] = useState("");
+  const [dockerfile, setDockerfile] = useState(NEW_ENVIRONMENT_TEMPLATE);
+  const [saving, setSaving] = useState(false);
+
+  const create = async () => {
+    if (!name.trim()) {
+      toast.error("Give the environment a name.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const env = await createEnvironment({
+        projectId,
+        name: name.trim(),
+        dockerfile,
+      });
+      toast.success(`Created “${env.name}”. Build it to use it.`);
+      onCreated(env);
+    } catch (err) {
+      toast.error(errMessage(err, "Could not create the environment."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="flex w-fit items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="h-3.5 w-3.5" /> Back
+      </button>
+      <input
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Environment name"
+        className="rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring"
+      />
+      <DockerfileEditor value={dockerfile} onChange={setDockerfile} />
+      <div className="flex justify-end gap-2">
+        <Button size="sm" variant="ghost" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={() => void create()} disabled={saving}>
+          {saving ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
+          Create
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function EnvironmentDetail({
+  env,
+  projectId,
+  isAttached,
+  onBack,
+  onDeleted,
+}: {
+  env: EnvironmentView;
+  projectId: string;
+  isAttached: boolean;
+  onBack: () => void;
+  onDeleted: () => void;
+}) {
+  const updateEnvironment = useUpdateEnvironment();
+  const startBuild = useStartEnvironmentBuild();
+  const promote = usePromoteEnvironment();
+  const deleteEnvironment = useDeleteEnvironment();
+  const setComputerEnvironment = useSetComputerEnvironment();
+
+  const [name, setName] = useState(env.name);
+  const [dockerfile, setDockerfile] = useState(env.dockerfile);
+  const [saving, setSaving] = useState(false);
+  const [building, setBuilding] = useState(false);
+  const [attaching, setAttaching] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  // Re-seed local buffers if the underlying env changes identity (the parent
+  // remounts via `key`, but guard the reactive name/dockerfile too).
+  useEffect(() => {
+    setName(env.name);
+    setDockerfile(env.dockerfile);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [env.environmentId]);
+
+  const build = env.currentBuild;
+  const isShared = env.sharing === "project";
+  const dirty = name !== env.name || dockerfile !== env.dockerfile;
+  const readyToAttach = build?.status === "ready" && !dirty;
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      await updateEnvironment({
+        environmentId: env.environmentId,
+        ...(name !== env.name ? { name: name.trim() } : {}),
+        ...(dockerfile !== env.dockerfile ? { dockerfile } : {}),
+      });
+      toast.success("Saved.");
+    } catch (err) {
+      toast.error(errMessage(err, "Could not save."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const runBuild = async () => {
+    if (dirty) {
+      await save();
+    }
+    setBuilding(true);
+    try {
+      const res = await startBuild({ environmentId: env.environmentId });
+      toast.success(res.reused ? "Reused an existing build." : "Build started.");
+    } catch (err) {
+      toast.error(errMessage(err, "Could not start the build."));
+    } finally {
+      setBuilding(false);
+    }
+  };
+
+  const useOnComputer = async () => {
+    setAttaching(true);
+    try {
+      await setComputerEnvironment({
+        projectId,
+        environmentId: env.environmentId,
+      });
+      toast.success(`Using “${env.name}”. Rebuilding your computer…`);
+    } catch (err) {
+      // Includes the by-design rejection when the builder/computer providers
+      // are incompatible (e.g. stub build + e2b computer).
+      toast.error(errMessage(err, "Could not use this environment."));
+    } finally {
+      setAttaching(false);
+    }
+  };
+
+  const onPromote = async () => {
+    try {
+      await promote({ environmentId: env.environmentId });
+      toast.success("Shared with the project.");
+    } catch (err) {
+      toast.error(
+        errMessage(err, "Only project admins can share environments.")
+      );
+    }
+  };
+
+  const onDelete = async () => {
+    try {
+      await deleteEnvironment({ environmentId: env.environmentId });
+      toast.success("Environment deleted.");
+      onDeleted();
+    } catch (err) {
+      toast.error(
+        errMessage(err, "Only project admins can delete shared environments.")
+      );
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" /> All environments
+        </button>
+        <div className="flex items-center gap-2">
+          <EnvironmentBuildBadge build={build} />
+          {isAttached ? <Badge variant="outline">In use</Badge> : null}
+        </div>
+      </div>
+
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="rounded-md border bg-background px-3 py-2 text-sm font-medium outline-none focus:ring-1 focus:ring-ring"
+      />
+
+      <DockerfileEditor value={dockerfile} onChange={setDockerfile} />
+
+      {build?.status === "failed" && build.error ? (
+        <div className="rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
+          {build.error}
+        </div>
+      ) : null}
+      {build?.logPreview ? (
+        <pre className="max-h-32 overflow-auto rounded border bg-muted/30 p-2 font-mono text-[11px] leading-snug text-muted-foreground">
+          {build.logPreview}
+        </pre>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {dirty ? (
+          <Button size="sm" variant="outline" onClick={() => void save()} disabled={saving}>
+            {saving ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : null}
+            Save
+          </Button>
+        ) : null}
+        <Button size="sm" onClick={() => void runBuild()} disabled={building}>
+          {building ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Hammer className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          Build
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => void useOnComputer()}
+          disabled={!readyToAttach || attaching || isAttached}
+          title={
+            readyToAttach
+              ? undefined
+              : "Build the environment (and save changes) before using it"
+          }
+        >
+          {attaching ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : null}
+          {isAttached ? "In use" : "Use on computer"}
+        </Button>
+      </div>
+
+      <div className="mt-auto flex items-center justify-between border-t pt-3">
+        {isShared ? (
+          <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Users className="h-3.5 w-3.5" /> Shared with the project
+          </span>
+        ) : (
+          <Button size="sm" variant="ghost" onClick={() => void onPromote()}>
+            <Users className="mr-1.5 h-3.5 w-3.5" /> Share with project
+          </Button>
+        )}
+        {confirmingDelete ? (
+          <span className="inline-flex items-center gap-2 text-xs">
+            <span className="text-muted-foreground">Delete?</span>
+            <Button size="sm" variant="destructive" onClick={() => void onDelete()}>
+              Delete
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => setConfirmingDelete(false)}>
+              Cancel
+            </Button>
+          </span>
+        ) : (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-destructive hover:text-destructive"
+            onClick={() => setConfirmingDelete(true)}
+          >
+            <Trash2 className="mr-1.5 h-3.5 w-3.5" /> Delete
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function DockerfileEditor({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <textarea
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      spellCheck={false}
+      className="min-h-[180px] flex-1 resize-y rounded-md border bg-muted/20 p-3 font-mono text-xs leading-relaxed text-foreground outline-none focus:ring-1 focus:ring-ring"
+    />
+  );
+}
+

--- a/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
+++ b/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
@@ -54,11 +54,15 @@ export function EnvironmentsDrawer({
   onOpenChange,
   projectId,
   attachedEnvironmentId,
+  canAttach,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   projectId: string;
   attachedEnvironmentId: string | null;
+  /** Whether the computer is in a state that can accept an image change
+   * (settled or not-yet-provisioned) — mirrors Reset's gating. */
+  canAttach: boolean;
 }) {
   const environments = useEnvironments(open ? projectId : null);
   const setComputerEnvironment = useSetComputerEnvironment();
@@ -105,7 +109,7 @@ export function EnvironmentsDrawer({
               setCreating(true);
             }}
             onUseBase={() => void detachToBase()}
-            attachToBaseDisabled={attachedEnvironmentId === null}
+            attachToBaseDisabled={attachedEnvironmentId === null || !canAttach}
           />
         ) : creating ? (
           <NewEnvironmentForm
@@ -123,6 +127,7 @@ export function EnvironmentsDrawer({
             env={selected}
             projectId={projectId}
             isAttached={attachedEnvironmentId === selected.environmentId}
+            canAttach={canAttach}
             onBack={() => setSelectedId(null)}
             onDeleted={() => setSelectedId(null)}
           />
@@ -305,12 +310,14 @@ function EnvironmentDetail({
   env,
   projectId,
   isAttached,
+  canAttach,
   onBack,
   onDeleted,
 }: {
   env: EnvironmentView;
   projectId: string;
   isAttached: boolean;
+  canAttach: boolean;
   onBack: () => void;
   onDeleted: () => void;
 }) {
@@ -394,6 +401,9 @@ function EnvironmentDetail({
   };
 
   const onPromote = async () => {
+    // Persist unsaved edits first so the project gets what the editor shows,
+    // not the last-saved definition (mirrors Build's save-first behavior).
+    if (dirty && !(await save())) return;
     try {
       await promote({ environmentId: env.environmentId });
       toast.success("Shared with the project.");
@@ -470,9 +480,11 @@ function EnvironmentDetail({
           size="sm"
           variant="outline"
           onClick={() => void useOnComputer()}
-          disabled={!readyToAttach || attaching || isAttached}
+          disabled={!readyToAttach || attaching || isAttached || !canAttach}
           title={
-            readyToAttach
+            !canAttach
+              ? "Wait for the computer to be ready or asleep before changing its image"
+              : readyToAttach
               ? undefined
               : "Build the environment (and save changes) before using it"
           }

--- a/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
+++ b/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
@@ -334,7 +334,7 @@ function EnvironmentDetail({
   const dirty = name !== env.name || dockerfile !== env.dockerfile;
   const readyToAttach = build?.status === "ready" && !dirty;
 
-  const save = async () => {
+  const save = async (): Promise<boolean> => {
     setSaving(true);
     try {
       await updateEnvironment({
@@ -343,17 +343,19 @@ function EnvironmentDetail({
         ...(dockerfile !== env.dockerfile ? { dockerfile } : {}),
       });
       toast.success("Saved.");
+      return true;
     } catch (err) {
       toast.error(errMessage(err, "Could not save."));
+      return false;
     } finally {
       setSaving(false);
     }
   };
 
   const runBuild = async () => {
-    if (dirty) {
-      await save();
-    }
+    // Don't build the previously-persisted Dockerfile if saving the edits
+    // failed — that would forge an image the user didn't actually save.
+    if (dirty && !(await save())) return;
     setBuilding(true);
     try {
       const res = await startBuild({ environmentId: env.environmentId });

--- a/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
+++ b/mcpjam-inspector/client/src/components/computer/EnvironmentsDrawer.tsx
@@ -64,10 +64,15 @@ export function EnvironmentsDrawer({
   const setComputerEnvironment = useSetComputerEnvironment();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+  // A just-created env, kept until the (reactive) list query includes it — so
+  // we land on its detail immediately instead of bouncing back to the list.
+  const [justCreated, setJustCreated] = useState<EnvironmentView | null>(null);
 
   const selected = useMemo(
-    () => environments?.find((e) => e.environmentId === selectedId) ?? null,
-    [environments, selectedId]
+    () =>
+      environments?.find((e) => e.environmentId === selectedId) ??
+      (justCreated?.environmentId === selectedId ? justCreated : null),
+    [environments, selectedId, justCreated]
   );
 
   // Detail / new-env editor lives below the list on mobile-narrow drawers.
@@ -108,6 +113,7 @@ export function EnvironmentsDrawer({
             onCancel={() => setCreating(false)}
             onCreated={(env) => {
               setCreating(false);
+              setJustCreated(env);
               setSelectedId(env.environmentId);
             }}
           />
@@ -331,7 +337,10 @@ function EnvironmentDetail({
 
   const build = env.currentBuild;
   const isShared = env.sharing === "project";
-  const dirty = name !== env.name || dockerfile !== env.dockerfile;
+  // Compare against the TRIMMED name (what the backend stores), so trailing
+  // whitespace never counts as a pending change and "dirty" clears after a save.
+  const trimmedName = name.trim();
+  const dirty = trimmedName !== env.name || dockerfile !== env.dockerfile;
   const readyToAttach = build?.status === "ready" && !dirty;
 
   const save = async (): Promise<boolean> => {
@@ -339,7 +348,7 @@ function EnvironmentDetail({
     try {
       await updateEnvironment({
         environmentId: env.environmentId,
-        ...(name !== env.name ? { name: name.trim() } : {}),
+        ...(trimmedName !== env.name ? { name: trimmedName } : {}),
         ...(dockerfile !== env.dockerfile ? { dockerfile } : {}),
       });
       toast.success("Saved.");

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -23,6 +23,19 @@ vi.mock("@/hooks/useProjectComputer", () => ({
   useComputersDataPlaneConfig: () => mockDataPlane,
 }));
 
+let mockEnvironments: Array<{ environmentId: string; name: string }> = [];
+const resetComputer = vi.fn(async () => ({ reset: true }));
+vi.mock("@/hooks/useComputerEnvironments", () => ({
+  useEnvironments: () => mockEnvironments,
+  useResetComputer: () => resetComputer,
+}));
+
+// The drawer calls its own Convex hooks; stub it (its own tests cover it).
+vi.mock("../EnvironmentsDrawer", () => ({
+  EnvironmentsDrawer: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="env-drawer" /> : null,
+}));
+
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: (sel: (s: { themeMode: string }) => unknown) =>
     sel({ themeMode: "dark" }),
@@ -45,6 +58,7 @@ afterEach(() => {
   vi.clearAllMocks();
   mockStatus = undefined;
   mockUsage = undefined;
+  mockEnvironments = [];
   mockDataPlane = { localConfigured: true, remoteDataPlaneUrl: null };
 });
 
@@ -232,6 +246,63 @@ describe("ComputerView", () => {
     expect(queryByTestId("terminal-stub")).toBeNull();
     expect(queryByText(/Starting your computer/i)).toBeNull();
     expect(getByText(/no longer available/i)).toBeTruthy();
+  });
+});
+
+describe("ComputerView image strip", () => {
+  it("shows the base image when no environment is attached", () => {
+    mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
+    const { getByText } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    expect(getByText("Base image")).toBeTruthy();
+  });
+
+  it("shows the attached environment's name", () => {
+    mockStatus = {
+      computerId: "c1",
+      status: "ready",
+      provider: "e2b",
+      environmentId: "env1",
+    };
+    mockEnvironments = [{ environmentId: "env1", name: "ml-toolkit" }];
+    const { getByText } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    expect(getByText("ml-toolkit")).toBeTruthy();
+  });
+
+  it("Change opens the environments drawer", () => {
+    mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
+    const { getByText, queryByTestId, getByTestId } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    expect(queryByTestId("env-drawer")).toBeNull();
+    fireEvent.click(getByText("Change"));
+    expect(getByTestId("env-drawer")).toBeTruthy();
+  });
+
+  it("Reset confirms then resets the computer to its image", async () => {
+    mockStatus = { computerId: "c1", status: "ready", provider: "e2b" };
+    const { getByText } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    fireEvent.click(getByText("Reset"));
+    expect(getByText(/Installed files are wiped/i)).toBeTruthy();
+    fireEvent.click(getByText("Reset", { selector: "button" }));
+    await waitFor(() =>
+      expect(resetComputer).toHaveBeenCalledWith({ projectId: "p1" })
+    );
+  });
+
+  it("disables Reset while the computer is mid-provision", () => {
+    mockStatus = { computerId: "c1", status: "provisioning", provider: "e2b" };
+    const { getByText } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    expect(
+      (getByText("Reset", { selector: "button" }) as HTMLButtonElement).disabled
+    ).toBe(true);
   });
 });
 

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerView.test.tsx
@@ -258,6 +258,21 @@ describe("ComputerView image strip", () => {
     expect(getByText("Base image")).toBeTruthy();
   });
 
+  it("labels an attached env whose name hasn't resolved as a custom image, not base", () => {
+    mockStatus = {
+      computerId: "c1",
+      status: "ready",
+      provider: "e2b",
+      environmentId: "envX",
+    };
+    mockEnvironments = []; // still loading / not visible to this caller
+    const { getByText, queryByText } = render(
+      <ComputerView projectId="p1" isAuthenticated />
+    );
+    expect(getByText("Custom image")).toBeTruthy();
+    expect(queryByText("Base image")).toBeNull();
+  });
+
   it("shows the attached environment's name", () => {
     mockStatus = {
       computerId: "c1",

--- a/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
@@ -70,13 +70,17 @@ function env(over: Partial<EnvironmentView> = {}): EnvironmentView {
   };
 }
 
-function renderDrawer(attachedEnvironmentId: string | null = null) {
+function renderDrawer(
+  attachedEnvironmentId: string | null = null,
+  canAttach = true
+) {
   return render(
     <EnvironmentsDrawer
       open
       onOpenChange={() => {}}
       projectId="p1"
       attachedEnvironmentId={attachedEnvironmentId}
+      canAttach={canAttach}
     />
   );
 }
@@ -164,6 +168,40 @@ describe("EnvironmentsDrawer", () => {
     fireEvent.click(getByText("Build"));
     await waitFor(() => expect(updateEnvironment).toHaveBeenCalled());
     expect(startBuild).not.toHaveBeenCalled();
+  });
+
+  it("disables 'Use on computer' while the computer is mid-provision (canAttach=false)", () => {
+    mockEnvironments = [env()]; // ready build
+    const { getByText } = renderDrawer(null, false);
+    fireEvent.click(getByText("ml-toolkit"));
+    expect(
+      (getByText("Use on computer") as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  it("saves unsaved edits before sharing to the project", async () => {
+    mockEnvironments = [env()];
+    const { getByText, getByDisplayValue } = renderDrawer();
+    fireEvent.click(getByText("ml-toolkit"));
+    fireEvent.change(getByDisplayValue("ml-toolkit"), {
+      target: { value: "renamed" },
+    });
+    fireEvent.click(getByText("Share with project"));
+    await waitFor(() => expect(updateEnvironment).toHaveBeenCalled());
+    await waitFor(() => expect(promote).toHaveBeenCalled());
+  });
+
+  it("does not share when the pre-share save fails", async () => {
+    updateEnvironment.mockRejectedValueOnce(new Error("save failed"));
+    mockEnvironments = [env()];
+    const { getByText, getByDisplayValue } = renderDrawer();
+    fireEvent.click(getByText("ml-toolkit"));
+    fireEvent.change(getByDisplayValue("ml-toolkit"), {
+      target: { value: "renamed" },
+    });
+    fireEvent.click(getByText("Share with project"));
+    await waitFor(() => expect(updateEnvironment).toHaveBeenCalled());
+    expect(promote).not.toHaveBeenCalled();
   });
 
   it("attaches a ready environment to the computer", async () => {

--- a/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
@@ -115,6 +115,34 @@ describe("EnvironmentsDrawer", () => {
     );
   });
 
+  it("lands on the new env's detail right after create, before the list refreshes", async () => {
+    createEnvironment.mockResolvedValueOnce(
+      env({ environmentId: "new1", name: "fresh", currentBuild: null })
+    );
+    mockEnvironments = []; // the reactive list hasn't picked up the new row yet
+    const { getByText, getByPlaceholderText } = renderDrawer();
+    fireEvent.click(getByText("New environment"));
+    fireEvent.change(getByPlaceholderText("Environment name"), {
+      target: { value: "fresh" },
+    });
+    fireEvent.click(getByText("Create"));
+    // The detail view (its Build button) shows even though `environments` is [].
+    await waitFor(() => expect(getByText("Build")).toBeTruthy());
+  });
+
+  it("trailing whitespace in the name doesn't count as an unsaved change", () => {
+    mockEnvironments = [env()]; // ready build, name "ml-toolkit"
+    const { getByText, getByDisplayValue } = renderDrawer();
+    fireEvent.click(getByText("ml-toolkit"));
+    fireEvent.change(getByDisplayValue("ml-toolkit"), {
+      target: { value: "ml-toolkit  " },
+    });
+    // dirty stays false (trimmed === env.name) → attach is not blocked by it.
+    expect((getByText("Use on computer") as HTMLButtonElement).disabled).toBe(
+      false
+    );
+  });
+
   it("disables 'Use on computer' until there is a ready build", () => {
     mockEnvironments = [env({ currentBuild: build({ status: "building" }) })];
     const { getByText } = renderDrawer();

--- a/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
@@ -124,6 +124,20 @@ describe("EnvironmentsDrawer", () => {
     ).toBe(true);
   });
 
+  it("does not start a build when the dirty save fails", async () => {
+    updateEnvironment.mockRejectedValueOnce(new Error("save failed"));
+    mockEnvironments = [env()];
+    const { getByText, getByDisplayValue } = renderDrawer();
+    fireEvent.click(getByText("ml-toolkit"));
+    // Rename to make the editor dirty so Build saves first.
+    fireEvent.change(getByDisplayValue("ml-toolkit"), {
+      target: { value: "renamed" },
+    });
+    fireEvent.click(getByText("Build"));
+    await waitFor(() => expect(updateEnvironment).toHaveBeenCalled());
+    expect(startBuild).not.toHaveBeenCalled();
+  });
+
   it("attaches a ready environment to the computer", async () => {
     mockEnvironments = [env()];
     const { getByText } = renderDrawer();

--- a/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
@@ -1,0 +1,154 @@
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  EnvironmentView,
+  EnvironmentBuildView,
+} from "@/hooks/useComputerEnvironments";
+
+let mockEnvironments: EnvironmentView[] | undefined = [];
+const createEnvironment = vi.fn(async () => env({ environmentId: "new" }));
+const updateEnvironment = vi.fn(async () => env());
+const startBuild = vi.fn(async () => ({ buildId: "b1", reused: false }));
+const promote = vi.fn(async () => env());
+const deleteEnvironment = vi.fn(async () => ({ deleted: true as const }));
+const setComputerEnvironment = vi.fn(async () => ({
+  computerId: "c1",
+  status: "provisioning",
+}));
+
+const { toastError, toastSuccess } = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/hooks/useComputerEnvironments", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/useComputerEnvironments")
+  >("@/hooks/useComputerEnvironments");
+  return {
+    ...actual,
+    useEnvironments: () => mockEnvironments,
+    useCreateEnvironment: () => createEnvironment,
+    useUpdateEnvironment: () => updateEnvironment,
+    useStartEnvironmentBuild: () => startBuild,
+    usePromoteEnvironment: () => promote,
+    useDeleteEnvironment: () => deleteEnvironment,
+    useSetComputerEnvironment: () => setComputerEnvironment,
+  };
+});
+
+vi.mock("@/lib/toast", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}));
+
+import { EnvironmentsDrawer } from "../EnvironmentsDrawer";
+
+function build(over: Partial<EnvironmentBuildView> = {}): EnvironmentBuildView {
+  return {
+    buildId: "b1",
+    status: "ready",
+    provider: "stub",
+    baseImageDigests: [],
+    createdAt: 0,
+    ...over,
+  };
+}
+
+function env(over: Partial<EnvironmentView> = {}): EnvironmentView {
+  return {
+    environmentId: "env1",
+    projectId: "p1",
+    name: "ml-toolkit",
+    dockerfile: "FROM debian@sha256:x\nRUN echo hi",
+    contentHash: "h",
+    sharing: "user",
+    isOwner: true,
+    currentBuild: build(),
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+function renderDrawer(attachedEnvironmentId: string | null = null) {
+  return render(
+    <EnvironmentsDrawer
+      open
+      onOpenChange={() => {}}
+      projectId="p1"
+      attachedEnvironmentId={attachedEnvironmentId}
+    />
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockEnvironments = [];
+});
+
+describe("EnvironmentsDrawer", () => {
+  it("lists the base image + environments", () => {
+    mockEnvironments = [env({ name: "ml-toolkit" })];
+    const { getByText } = renderDrawer();
+    expect(getByText("Base image")).toBeTruthy();
+    expect(getByText("ml-toolkit")).toBeTruthy();
+  });
+
+  it("shows an empty state with a create affordance", () => {
+    mockEnvironments = [];
+    const { getByText } = renderDrawer();
+    expect(getByText(/No custom environments yet/i)).toBeTruthy();
+    expect(getByText("New environment")).toBeTruthy();
+  });
+
+  it("creates an environment from the new form", async () => {
+    const { getByText, getByPlaceholderText } = renderDrawer();
+    fireEvent.click(getByText("New environment"));
+    fireEvent.change(getByPlaceholderText("Environment name"), {
+      target: { value: "scraper" },
+    });
+    fireEvent.click(getByText("Create"));
+    await waitFor(() =>
+      expect(createEnvironment).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: "p1", name: "scraper" })
+      )
+    );
+  });
+
+  it("disables 'Use on computer' until there is a ready build", () => {
+    mockEnvironments = [env({ currentBuild: build({ status: "building" }) })];
+    const { getByText } = renderDrawer();
+    fireEvent.click(getByText("ml-toolkit"));
+    expect(
+      (getByText("Use on computer") as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  it("attaches a ready environment to the computer", async () => {
+    mockEnvironments = [env()];
+    const { getByText } = renderDrawer();
+    fireEvent.click(getByText("ml-toolkit"));
+    fireEvent.click(getByText("Use on computer"));
+    await waitFor(() =>
+      expect(setComputerEnvironment).toHaveBeenCalledWith({
+        projectId: "p1",
+        environmentId: "env1",
+      })
+    );
+  });
+
+  it("surfaces an attach rejection as an error toast", async () => {
+    setComputerEnvironment.mockRejectedValueOnce(
+      new Error("[CONVEX] incompatible builder")
+    );
+    mockEnvironments = [env()];
+    const { getByText } = renderDrawer();
+    fireEvent.click(getByText("ml-toolkit"));
+    fireEvent.click(getByText("Use on computer"));
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        expect.stringContaining("incompatible builder")
+      )
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/EnvironmentsDrawer.test.tsx
@@ -187,8 +187,11 @@ describe("EnvironmentsDrawer", () => {
       target: { value: "renamed" },
     });
     fireEvent.click(getByText("Share with project"));
-    await waitFor(() => expect(updateEnvironment).toHaveBeenCalled());
     await waitFor(() => expect(promote).toHaveBeenCalled());
+    // Order matters: the save must complete before the promote.
+    expect(updateEnvironment.mock.invocationCallOrder[0]).toBeLessThan(
+      promote.mock.invocationCallOrder[0]!
+    );
   });
 
   it("does not share when the pre-share save fails", async () => {

--- a/mcpjam-inspector/client/src/hooks/useComputerEnvironments.ts
+++ b/mcpjam-inspector/client/src/hooks/useComputerEnvironments.ts
@@ -1,0 +1,132 @@
+import { useMutation, useQuery } from "convex/react";
+
+/**
+ * Client hooks for Computer **environments** (mcpjam-backend
+ * `convex/computerEnvironments.ts` + the `projectComputers` attach/reset
+ * functions). Like `useProjectComputer`, the inspector references Convex
+ * functions by string id — it does not import the backend's generated `api`.
+ *
+ * An environment is a project-owned Dockerfile, built into an immutable image
+ * that a member's Computer can boot from. Builds run under the deployment's
+ * configured builder (`stub` by default; real images only when an operator sets
+ * `COMPUTERS_ENV_BUILDER=e2b`).
+ */
+
+export type BuildStatus = "queued" | "building" | "ready" | "failed";
+
+export interface EnvironmentBuildView {
+  buildId: string;
+  status: BuildStatus;
+  provider: "e2b" | "stub";
+  e2bBuildId?: string;
+  baseImageDigests: string[];
+  logPreview?: string;
+  error?: string;
+  createdAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+}
+
+export interface EnvironmentView {
+  environmentId: string;
+  projectId: string;
+  name: string;
+  dockerfile: string;
+  contentHash: string;
+  sharing: "user" | "project";
+  /** True only for a per-user draft the caller owns. Project-shared envs are
+   * admin-managed; the backend (not the client) is the authority on that, so
+   * shared-env controls are optimistic — see the drawer. */
+  isOwner: boolean;
+  currentBuildId?: string;
+  currentBuild: EnvironmentBuildView | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Visible environments for a project: the caller's own drafts + the
+ * project-shared ones. `undefined` while loading / when `projectId` is absent. */
+export function useEnvironments(
+  projectId: string | null
+): EnvironmentView[] | undefined {
+  return useQuery(
+    "computerEnvironments:listEnvironments" as never,
+    projectId ? ({ projectId } as never) : "skip"
+  ) as EnvironmentView[] | undefined;
+}
+
+/** One environment (with its current build), or `null` if not visible. */
+export function useEnvironment(
+  environmentId: string | null
+): EnvironmentView | null | undefined {
+  return useQuery(
+    "computerEnvironments:getEnvironment" as never,
+    environmentId ? ({ environmentId } as never) : "skip"
+  ) as EnvironmentView | null | undefined;
+}
+
+/** All builds for an environment, newest first. */
+export function useEnvironmentBuilds(
+  environmentId: string | null
+): EnvironmentBuildView[] | undefined {
+  return useQuery(
+    "computerEnvironments:listEnvironmentBuilds" as never,
+    environmentId ? ({ environmentId } as never) : "skip"
+  ) as EnvironmentBuildView[] | undefined;
+}
+
+export function useCreateEnvironment(): (args: {
+  projectId: string;
+  name: string;
+  dockerfile: string;
+}) => Promise<EnvironmentView> {
+  return useMutation("computerEnvironments:createEnvironment" as never) as never;
+}
+
+export function useUpdateEnvironment(): (args: {
+  environmentId: string;
+  name?: string;
+  dockerfile?: string;
+}) => Promise<EnvironmentView> {
+  return useMutation("computerEnvironments:updateEnvironment" as never) as never;
+}
+
+export function useStartEnvironmentBuild(): (args: {
+  environmentId: string;
+}) => Promise<{ buildId: string; reused: boolean }> {
+  return useMutation(
+    "computerEnvironments:startEnvironmentBuild" as never
+  ) as never;
+}
+
+export function usePromoteEnvironment(): (args: {
+  environmentId: string;
+}) => Promise<EnvironmentView> {
+  return useMutation(
+    "computerEnvironments:promoteEnvironmentToProject" as never
+  ) as never;
+}
+
+export function useDeleteEnvironment(): (args: {
+  environmentId: string;
+}) => Promise<{ deleted: true }> {
+  return useMutation("computerEnvironments:deleteEnvironment" as never) as never;
+}
+
+/** Attach an environment to the caller's computer (or detach with `null`),
+ * which re-provisions the box from the pinned image. */
+export function useSetComputerEnvironment(): (args: {
+  projectId: string;
+  environmentId: string | null;
+}) => Promise<{ computerId: string; status: string; environmentId?: string }> {
+  return useMutation(
+    "projectComputers:setComputerEnvironment" as never
+  ) as never;
+}
+
+/** Reset the computer to its image (wipes mutable state). */
+export function useResetComputer(): (args: {
+  projectId: string;
+}) => Promise<{ reset: boolean }> {
+  return useMutation("projectComputers:resetComputer" as never) as never;
+}

--- a/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
@@ -25,6 +25,9 @@ export interface ComputerView {
   lastError?: string;
   provisionedAt?: number;
   lastActiveAt?: number;
+  /** The custom environment this computer boots from, if any (absent ⇒ base
+   * image). See `computerEnvironments` / the Image picker. */
+  environmentId?: string;
 }
 
 export interface TerminalTokenResult {


### PR DESCRIPTION
## Context

The backend for **Computer environments** is merged in mcpjam-backend (#618–#629, live-verified against E2B): a project-owned Dockerfile is built into an immutable image that a member's personal Computer can boot from, plus reset-to-image. It was complete but **unreachable** — no UI surfaced it.

This PR is **Part A: the UI**, on the Computer tab. Frontend-only — it calls the existing Convex functions directly by string id (the same pattern as `useProjectComputer`). **No backend changes.**

## Flag gating

All of this lives inside `ComputerView`, which only renders when the **`computers-enabled`** PostHog flag resolves `true` (`ComputerRoute`, `App.tsx`). So the environments UI is invisible unless the computer feature is enabled — it inherits the existing gate (`useComputersEnabled.ts`: "the visibility gate for ALL Project Computers UI").

## What's added

- **`useComputerEnvironments.ts`** — hooks for list/get/builds + create/update/build/promote/delete + `setComputerEnvironment`/`resetComputer`. Builds stream **reactively** via Convex queries (no polling).
- **`ComputerView`** — an **Image** strip (current image, **Change ▸**, **Reset** with inline confirm) between the subtitle and usage meter; `environmentId` added to the `ComputerView` type.
- **`EnvironmentsDrawer`** (design-system `Sheet`):
  - first-class **create** (empty state + "New environment")
  - list: own drafts + project-shared, status badges, ✓ on the attached one, a Base-image row
  - Dockerfile editor, **Build** with live status + log tail
  - **Use on computer** (disabled until a ready build; surfaces the by-design attach rejection — e.g. an `e2b` computer + default `stub` builder — as a clean toast)
  - share-to-project + delete (optimistic; the backend stays the admin authority, since `EnvironmentView` has `isOwner` but no `canManage`)
- **`EnvironmentBuildBadge`**.

## Notes

- Builds run under the **stub** builder until an operator sets `COMPUTERS_ENV_BUILDER=e2b` on the deployment, so on dev a "build" completes instantly with a placeholder image.
- The **CLI API** (`mcpjam env …` + `/api/v1` routes) is **Part B**, a separate follow-up. Plan: `docs/computer-environments-ui-cli.md`.

## Verification

- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean.
- **33 computer tests pass** (existing + 11 new: image-strip + drawer, incl. the attach-rejected toast and Reset-disabled-mid-provision).
- Client files aren't in this package's eslint scope (`server/routes/web/**` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Frontend-only but triggers computer re-provision and reset via Convex mutations; incorrect gating or attach flows could wipe user data or confuse provisioning, though behavior is delegated to existing backend APIs.
> 
> **Overview**
> **Part A** exposes the already-deployed Computer **environments** feature in the inspector client only—no backend, server, CLI, or SDK changes.
> 
> New **`useComputerEnvironments`** hooks call existing Convex functions by string id (list/create/update/build/promote/delete, **`setComputerEnvironment`**, **`resetComputer`**) with matching view types. **`ComputerView`** gains an **Image** strip (base vs custom label, **Change**, inline **Reset** confirm), gates reset/attach on ready/hibernating (or no computer yet), and wires **`environmentId`** on the computer status type.
> 
> **`EnvironmentsDrawer`** (Sheet) covers list + create, Dockerfile editing, build status/log preview, attach/detach to base, share-to-project, and delete—with save-before-build/promote, optimistic shared-env admin errors as toasts, and attach failures (e.g. incompatible stub builder) surfaced cleanly. **`EnvironmentBuildBadge`** and expanded **ComputerView** / **EnvironmentsDrawer** tests cover the new flows; **`docs/computer-environments-ui-cli.md`** documents the planned Part B CLI/API work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d34afa770715669204f4c22d8178c884a2840c9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->