### PR TITLE
feat(host-compare): mobile-friendly compare + subtle 'open full app' entry point

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -645,6 +645,9 @@ export function HostsRoute() {
   );
 }
 
+/** Where the embed (caniuse.dev) entry point sends people for the full product. */
+const MAIN_PRODUCT_URL = "https://app.mcpjam.com";
+
 export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
   const { convexProjectId, isAuthenticated } = useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
@@ -3294,14 +3297,33 @@ export default function App() {
   // Still nested inside every provider in the return below, so auth, project,
   // and the guest session resolve exactly as on the normal route.
   const bareCompareContent = (
-    <div className="h-screen w-screen overflow-auto bg-background">
-      <AppRouteReactContext.Provider value={routeContext}>
-        {locationContext ? (
-          <Outlet context={routeContext} />
-        ) : (
-          <NoRouterRouteBody activeTab={activeTab} />
-        )}
-      </AppRouteReactContext.Provider>
+    <div className="flex h-screen w-screen flex-col overflow-hidden bg-background">
+      {/* Subtle branding + entry point back to the full product. */}
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-2">
+        <a
+          href={MAIN_PRODUCT_URL}
+          className="text-[15px] font-semibold tracking-tight text-foreground"
+          aria-label="MCPJam home"
+        >
+          MCP<span className="text-primary">Jam</span>
+        </a>
+        <a
+          href={MAIN_PRODUCT_URL}
+          className="inline-flex items-center gap-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Open the full app
+          <span aria-hidden>↗</span>
+        </a>
+      </div>
+      <div className="min-h-0 flex-1">
+        <AppRouteReactContext.Provider value={routeContext}>
+          {locationContext ? (
+            <Outlet context={routeContext} />
+          ) : (
+            <NoRouterRouteBody activeTab={activeTab} />
+          )}
+        </AppRouteReactContext.Provider>
+      </div>
     </div>
   );
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCapabilityListView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCapabilityListView.tsx
@@ -84,7 +84,9 @@ export function HostCapabilityListView({
     <div
       className="grid gap-4"
       style={{
-        gridTemplateColumns: `repeat(${subjects.length}, minmax(260px, 1fr))`,
+        // auto-fit + min(100%, …) → one full-width column on phones, packing to
+        // multiple columns as the viewport widens (collapses empty tracks).
+        gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 260px), 1fr))",
       }}
     >
       {subjects.map((subject) => (

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -405,7 +405,7 @@ function CompareSearchBar({
         onValueChange={onQueryChange}
         placeholder="Search capabilities, fields, descriptions…"
         aria-label="Search host config fields"
-        className="min-w-[240px] flex-1"
+        className="order-last w-full sm:order-none sm:w-auto sm:min-w-[240px] sm:flex-1"
       />
       {showCount && (
         <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -113,20 +113,23 @@ export function HostConfigComparisonMatrix({
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-      className="overflow-auto rounded-xl border border-border bg-card shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_30px_-18px_rgba(0,0,0,0.18)]"
+      className="overflow-hidden rounded-xl border border-border bg-card shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_30px_-18px_rgba(0,0,0,0.18)]"
     >
+      {/* Legend sits outside the horizontal scroll so it never slides off-screen on mobile. */}
       <SupportLegend />
+      {/* Only the table scrolls horizontally; field column stays sticky. */}
+      <div className="overflow-auto">
       <table className="w-full border-collapse text-[13px]">
         <colgroup>
-          <col style={{ width: 300 }} />
+          <col className="w-[168px] sm:w-[300px]" />
           {subjects.map((s) => (
-            <col key={s.hostId} style={{ width: 220 }} />
+            <col key={s.hostId} className="w-[148px] sm:w-[220px]" />
           ))}
         </colgroup>
 
         <thead>
           <tr>
-            <th className="sticky left-0 top-0 z-30 bg-card border-b border-r border-border px-5 py-4 text-left">
+            <th className="sticky left-0 top-0 z-30 bg-card border-b border-r border-border px-3 py-3 sm:px-5 sm:py-4 text-left">
               <span className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                 Field
               </span>
@@ -169,6 +172,7 @@ export function HostConfigComparisonMatrix({
           })}
         </tbody>
       </table>
+      </div>
     </motion.div>
   );
 }
@@ -312,7 +316,7 @@ function FieldRow({
     <tr className="border-b border-border last:border-b-0">
       <td
         className={cn(
-          "sticky left-0 z-10 bg-card border-r border-border px-5 py-2.5",
+          "sticky left-0 z-10 bg-card border-r border-border px-3 sm:px-5 py-2.5",
           "relative",
         )}
       >
@@ -372,7 +376,7 @@ function FieldRow({
       {subjects.map((s) => (
         <td
           key={s.hostId}
-          className="border-l border-border px-4 py-2.5 align-top"
+          className="border-l border-border px-3 sm:px-4 py-2.5 align-top"
         >
           <FieldCell field={field} subject={s} />
         </td>
@@ -599,7 +603,7 @@ function HostColumnHeader({
   const reduceMotion = useReducedMotion();
 
   return (
-    <th className="sticky top-0 z-20 bg-card border-b border-l border-border px-4 py-4 text-left align-top">
+    <th className="sticky top-0 z-20 bg-card border-b border-l border-border px-3 py-3 sm:px-4 sm:py-4 text-left align-top">
       <motion.div
         key={subject.hostId}
         className="flex items-start gap-2"


### PR DESCRIPTION
Follow-up to the caniuse.dev embed route (#2911, merged). Two asks from testing the embed on a phone:

## 1. Mobile-friendly
- **Matrix:** the support legend was sliding off-screen on phones (it lived inside the horizontal scroll). Moved it out so it stays put; only the table scrolls now, with the field column still sticky. Responsive column widths (168/148px on mobile → 300/220 on `sm`+) and tighter cell padding.
- **Toolbar:** the "Can I use…" search input drops to its own full-width line on mobile.
- **List view:** grid switched to `auto-fit minmax(min(100%, 260px), 1fr)` so host cards stack to one full-width column on phones and pack into columns as the viewport widens.

## 2. Subtle entry point to the main product
The chrome-less embed (caniuse.dev) gets a slim top strip — MCPJam wordmark + an "Open the full app ↗" link to `app.mcpjam.com` — a quiet path back to the product without reintroducing the sidebar/nav.

Pure presentation; no backend/DTO changes. Typecheck clean; comparison + navigation tests pass (69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and layout-only changes to the embed shell and host compare components; no API, auth, or data-layer changes.
> 
> **Overview**
> Improves the **caniuse.dev** chrome-less host compare embed for phones and adds a quiet path back to the full product.
> 
> The bare embed shell is now a **column layout** with a slim top bar: MCPJam wordmark and an **“Open the full app”** link to `https://app.mcpjam.com`, with the compare route in a flex child below (replacing a single full-screen scroll container).
> 
> **Compare UI** gets responsive tweaks: matrix **legend** stays fixed while only the table scrolls horizontally; narrower column widths and tighter padding on small breakpoints; sticky field column unchanged. The **“Can I use…”** search moves to a full-width row on mobile. **List view** uses `auto-fit` / `minmax(min(100%, 260px), 1fr)` so host cards stack on narrow viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 353967b5cef758efbb6b8ff46891e31425d53cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->