### PR TITLE
feat(cli): mcpjam compat --url host-compatibility command (Phase D)

### DIFF
--- a/cli/src/commands/compat.ts
+++ b/cli/src/commands/compat.ts
@@ -1,0 +1,114 @@
+import { Command } from "commander";
+import { listTools, readResource } from "@mcpjam/sdk";
+import {
+  evaluateMarketHosts,
+  scanWidgetUsage,
+  type HostCompatToolsInput,
+  type ReadResourceResult,
+} from "@mcpjam/sdk/host-compat";
+import { withEphemeralManager } from "../lib/ephemeral.js";
+import {
+  addRetryOptions,
+  addSharedServerOptions,
+  describeTarget,
+  getGlobalOptions,
+  parseRetryPolicy,
+  parseServerConfig,
+} from "../lib/server-config.js";
+import { writeResult } from "../lib/output.js";
+
+export function registerCompatCommands(program: Command): void {
+  addRetryOptions(
+    addSharedServerOptions(
+      program
+        .command("compat")
+        .description(
+          "Check whether an MCP server's tools and widgets work on each AI host (Claude, ChatGPT, Cursor, Copilot, Codex, Goose, …)",
+        )
+        .option(
+          "--host <id>",
+          "Only report this host id. Repeat for several. Default: all.",
+          (value: string, previous: string[] = []) => [...previous, value],
+          [],
+        ),
+    ),
+  ).action(async (options, command) => {
+    const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
+    const config = parseServerConfig({
+      ...options,
+      timeout: globalOptions.timeout,
+    });
+
+    const result = await withEphemeralManager(
+      config,
+      async (manager, serverId) => {
+        // Gather every tool (with its inline `_meta`) across all pages.
+        const tools: Array<{ name: string; _meta?: Record<string, unknown> }> =
+          [];
+        let cursor: string | undefined;
+        for (let page = 0; page < 50; page++) {
+          const result = await listTools(manager, { serverId, cursor });
+          tools.push(
+            ...(result.tools as Array<{
+              name: string;
+              _meta?: Record<string, unknown>;
+            }>),
+          );
+          cursor = result.nextCursor;
+          if (!cursor) break;
+        }
+        const toolsData: HostCompatToolsInput = { tools };
+
+        // Apps lane: read each widget's resource through the live connection
+        // and scan it for the host APIs it uses.
+        const widgetUsage = await scanWidgetUsage(toolsData, async (uri) => {
+          // The SDK helper wraps the MCP read as `{ content }`; scanWidgetUsage
+          // wants the inner result (with `contents`).
+          const { content } = await readResource(manager, { serverId, uri });
+          return content as ReadResourceResult;
+        });
+
+        const { requirements, reports } = evaluateMarketHosts(toolsData, {
+          widgetUsage,
+        });
+
+        const hostFilter = new Set(options.host as string[]);
+        const hosts = (
+          hostFilter.size > 0
+            ? reports.filter((r) => hostFilter.has(r.hostId))
+            : reports
+        ).map((r) => ({
+          hostId: r.hostId,
+          hostLabel: r.hostLabel,
+          verdict: r.verdict,
+          provenance: r.provenance,
+          findings: r.findings,
+        }));
+
+        const summary = { works: 0, degraded: 0, blocked: 0, unknown: 0 };
+        for (const h of hosts) summary[h.verdict] += 1;
+
+        return {
+          target: describeTarget(options),
+          widgets: {
+            total:
+              requirements.widgets.mcpAppsOnly.length +
+              requirements.widgets.openaiAppsOnly.length +
+              requirements.widgets.dual.length,
+            appOnly: requirements.appOnlyWidgets.length,
+          },
+          unknownDimensions: requirements.unknownDimensions,
+          summary,
+          hosts,
+        };
+      },
+      {
+        timeout: globalOptions.timeout,
+        retryPolicy,
+      },
+    );
+
+    writeResult(result, globalOptions.format);
+  });
+}

--- a/cli/src/commands/compat.ts
+++ b/cli/src/commands/compat.ts
@@ -93,8 +93,12 @@ export function registerCompatCommands(program: Command): void {
           return content as ReadResourceResult;
         });
 
+        // `toolsTruncated` makes the engine demote any `works` to `unknown` and
+        // record why — so the summary below (and each verdict) reflects the
+        // incomplete tool list, not just a top-level warning.
         const { requirements, reports } = evaluateMarketHosts(toolsData, {
           widgetUsage,
+          toolsTruncated: truncated,
         });
 
         const hostFilter = new Set(options.host as string[]);
@@ -122,12 +126,7 @@ export function registerCompatCommands(program: Command): void {
               requirements.widgets.dual.length,
             appOnly: requirements.appOnlyWidgets.length,
           },
-          unknownDimensions: truncated
-            ? [
-                ...requirements.unknownDimensions,
-                `tools pagination truncated at ${TOOLS_PAGE_CAP} pages — report may be incomplete`,
-              ]
-            : requirements.unknownDimensions,
+          unknownDimensions: requirements.unknownDimensions,
           summary,
           hosts,
         };

--- a/cli/src/commands/compat.ts
+++ b/cli/src/commands/compat.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { listTools, readResource } from "@mcpjam/sdk";
 import {
+  buildMarketHostProfiles,
   evaluateMarketHosts,
   scanWidgetUsage,
   type HostCompatToolsInput,
@@ -15,7 +16,11 @@ import {
   parseRetryPolicy,
   parseServerConfig,
 } from "../lib/server-config.js";
-import { writeResult } from "../lib/output.js";
+import { usageError, writeResult } from "../lib/output.js";
+
+// Cap pagination so a pathological server can't loop forever; flag truncation
+// rather than silently dropping later tools.
+const TOOLS_PAGE_CAP = 50;
 
 export function registerCompatCommands(program: Command): void {
   addRetryOptions(
@@ -35,6 +40,22 @@ export function registerCompatCommands(program: Command): void {
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const retryPolicy = parseRetryPolicy(options);
+
+    // Validate --host up front (before connecting) so a typo fails fast with the
+    // valid ids, instead of silently returning an empty report.
+    const validHostIds = buildMarketHostProfiles().map((p) => p.id);
+    const requestedHosts = options.host as string[];
+    const unknownHosts = requestedHosts.filter(
+      (id) => !validHostIds.includes(id),
+    );
+    if (unknownHosts.length > 0) {
+      throw usageError(
+        `Unknown host id${unknownHosts.length === 1 ? "" : "s"}: ${unknownHosts.join(
+          ", ",
+        )}. Valid: ${validHostIds.join(", ")}`,
+      );
+    }
+
     const config = parseServerConfig({
       ...options,
       timeout: globalOptions.timeout,
@@ -47,7 +68,8 @@ export function registerCompatCommands(program: Command): void {
         const tools: Array<{ name: string; _meta?: Record<string, unknown> }> =
           [];
         let cursor: string | undefined;
-        for (let page = 0; page < 50; page++) {
+        let truncated = false;
+        for (let page = 0; page < TOOLS_PAGE_CAP; page++) {
           const result = await listTools(manager, { serverId, cursor });
           tools.push(
             ...(result.tools as Array<{
@@ -57,6 +79,8 @@ export function registerCompatCommands(program: Command): void {
           );
           cursor = result.nextCursor;
           if (!cursor) break;
+          // Cap hit with tools still pending — flag rather than drop them.
+          if (page === TOOLS_PAGE_CAP - 1) truncated = true;
         }
         const toolsData: HostCompatToolsInput = { tools };
 
@@ -98,7 +122,12 @@ export function registerCompatCommands(program: Command): void {
               requirements.widgets.dual.length,
             appOnly: requirements.appOnlyWidgets.length,
           },
-          unknownDimensions: requirements.unknownDimensions,
+          unknownDimensions: truncated
+            ? [
+                ...requirements.unknownDimensions,
+                `tools pagination truncated at ${TOOLS_PAGE_CAP} pages — report may be incomplete`,
+              ]
+            : requirements.unknownDimensions,
           summary,
           hosts,
         };

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 import packageJson from "../package.json" with { type: "json" };
 import { registerAppsCommands } from "./commands/apps.js";
 import { registerAuthCommands } from "./commands/auth.js";
+import { registerCompatCommands } from "./commands/compat.js";
 import { registerEnvironmentsCommands } from "./commands/environments.js";
 import { registerEvalCommands } from "./commands/eval.js";
 import { registerHostsCommands } from "./commands/hosts.js";
@@ -72,6 +73,7 @@ export async function main(
   registerServerCommands(program);
   registerToolsCommands(program);
   registerResourcesCommands(program);
+  registerCompatCommands(program);
   registerPromptCommands(program);
   registerAppsCommands(program);
   registerOAuthCommands(program);


### PR DESCRIPTION
**Phase D** — the last surface. Stacked on #2944 (the platform operation); targets `host-compat-mcp-tool`, retargets down as the stack merges.

`mcpjam compat --url <server>` answers "does my server work on each AI host?" straight from the terminal — **SDK-local, no Inspector/login**. It connects to the MCP server directly via the ephemeral manager and runs the *same* composition as the platform operation:

```
listTools (all pages; tools carry _meta)
  → scanWidgetUsage(readResource)   ← apps-lane widget scan
  → evaluateMarketHosts             ← the SDK brain
  → per-host verdict + findings
```

Options: the shared server options (`--url` / `--header` / OAuth / stdio) + retry, plus `--host <id>` to filter; honors the global `--format json|human`.

### Verified live (built the CLI per `cli-development.md` and ran it)
- **DeepWiki** (no widgets) → all 10 hosts **works** (correct — nothing to render).
- **A local MCP Apps server** whose widget calls `window.openai.sendFollowUpMessage`:

  | Host | Verdict | Finding |
  |---|---|---|
  | Claude, ChatGPT, Mistral, Copilot | works | — |
  | Goose, Cursor | degraded | `capability_unsupported` (message) |
  | Codex, n8n, Perplexity, Cline | degraded | `widget_text_fallback` |

The live run **caught a real bug**: the SDK's `readResource` wraps its result as `{ content }`, so the scan must use the inner value — without unwrapping, the capability scan silently no-ops (every rendering host falsely "works"). Fixed; the differentiated table above is post-fix.

CLI builds + typechecks clean.

### Stack
`main` → #2938 (scan) → #2944 (operation/MCP tool) → **this** (CLI). With this, the host-compat brain (engine + catalog + scan) is consumed by **all three** non-UI surfaces: API, MCP tool, CLI. Only Phase B-2 (inspector re-consume / de-dup) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only CLI surface that reuses existing SDK host-compat logic; no auth or persistence changes, with bounded tool pagination to limit runaway servers.
> 
> **Overview**
> Adds a new **`mcpjam compat`** command so you can check whether an MCP server’s tools and widgets work on each supported AI host from the terminal (no Inspector), using the same `@mcpjam/sdk/host-compat` pipeline as the platform.
> 
> The command connects via the ephemeral manager and shared server options (`--url`, headers, OAuth, stdio, retry), paginates **`listTools`** (cap 50 pages; sets **`toolsTruncated`** so verdicts demote to unknown instead of silently ignoring missing tools), runs **`scanWidgetUsage`** with live **`readResource`** (unwraps SDK `{ content }` to the inner result), then **`evaluateMarketHosts`**. Optional repeatable **`--host`** is validated before connect; output includes widget counts, unknown dimensions, per-host verdicts/findings, and a summary—via global **`--format`**.
> 
> **`registerCompatCommands`** is wired into the CLI entrypoint alongside other server commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3910ea468e994a2b34bf98f566e958aa98a235c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->