### PR TITLE
refactor(inspector): consume @mcpjam/sdk/host-compat — full de-dup (Phase B-2)

### DIFF
--- a/mcpjam-inspector/client/src/lib/client-styles/__tests__/sdk-matrix-parity.test.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/__tests__/sdk-matrix-parity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  MCP_APPS_COPILOT_SURFACE,
+  MCP_APPS_FULL_SURFACE,
+  MCP_APPS_GOOSE_SURFACE,
+  MCP_APPS_NO_CLAIMS_SURFACE,
+  MCP_APPS_SLACK_SURFACE,
+} from "../built-ins";
+
+/**
+ * The FULL / COPILOT / GOOSE / NO_CLAIMS surfaces are imported from
+ * `@mcpjam/sdk/host-compat` (one source for the compat engine + this playground
+ * emulation). The SDK types them sparse, so built-ins.ts casts them to the
+ * client's resolved (all-required) shape. This guards that cast: if the SDK
+ * ever drops a dimension, a cast would silently leave it `undefined` — these
+ * assertions fail instead.
+ *
+ * `MCP_APPS_SLACK_SURFACE` stays a local, fully-typed resolved literal, so its
+ * key set is the canonical reference.
+ */
+const RESOLVED_KEYS = Object.keys(MCP_APPS_SLACK_SURFACE).sort();
+
+const SDK_SOURCED = {
+  MCP_APPS_FULL_SURFACE,
+  MCP_APPS_COPILOT_SURFACE,
+  MCP_APPS_GOOSE_SURFACE,
+  MCP_APPS_NO_CLAIMS_SURFACE,
+};
+
+describe("SDK-sourced MCP Apps matrices are complete resolved surfaces", () => {
+  for (const [name, surface] of Object.entries(SDK_SOURCED)) {
+    it(`${name} defines exactly the resolved dimensions (no SDK drift)`, () => {
+      expect(Object.keys(surface).sort()).toEqual(RESOLVED_KEYS);
+      for (const key of RESOLVED_KEYS) {
+        expect((surface as Record<string, unknown>)[key]).toBeDefined();
+      }
+    });
+  }
+});

--- a/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
@@ -77,6 +77,18 @@ import type {
   ResolvedMcpAppsCapabilities,
   ResolvedOpenAiAppsCapabilities,
 } from "./types";
+// Canonical MCP Apps capability matrices live in the SDK so the compat engine
+// and this playground emulation share ONE source. The SDK types them sparse
+// (`McpAppsCapabilities`); they are complete surfaces, so we present them as
+// the client's resolved (all-required) shape. The cast is guarded by a
+// completeness test (built-ins matrix-parity). SLACK + the OpenAI surfaces stay
+// local — the SDK catalog doesn't carry them.
+import {
+  MCP_APPS_FULL,
+  MCP_APPS_COPILOT,
+  MCP_APPS_GOOSE,
+  MCP_APPS_NO_CLAIMS,
+} from "@mcpjam/sdk/host-compat";
 
 /**
  * Full `window.openai.*` method surface — every method on, every display
@@ -144,31 +156,8 @@ export const OPENAI_APPS_COPILOT_SURFACE: ResolvedOpenAiAppsCapabilities = {
  * model different APIs (`window.openai.*` shim vs `app.*` spec) and never
  * cross-gate.
  */
-export const MCP_APPS_FULL_SURFACE: ResolvedMcpAppsCapabilities = {
-  availableDisplayModes: ["inline", "fullscreen", "pip"],
-  toolInputPartial: true,
-  toolCancelled: true,
-  hostContextChanged: true,
-  resourceTeardown: true,
-  toolInfo: true,
-  openLinks: true,
-  serverTools: true,
-  serverResources: true,
-  logging: true,
-  updateModelContext: true,
-  message: true,
-  sandboxPermissions: true,
-  cspFrameDomains: true,
-  cspBaseUriDomains: true,
-  resourcePrefersBorder: true,
-  downloadFile: true,
-  requestTeardown: true,
-  // Default to today's behavior — host accepts widget-initiated
-  // `ui/request-display-mode` calls. Set to "user-initiated-only" or
-  // "decline" per-preset (or via user override) to harden against
-  // widgets that re-request fullscreen on every host-context-changed.
-  widgetDisplayModeRequests: "accept",
-};
+export const MCP_APPS_FULL_SURFACE: ResolvedMcpAppsCapabilities =
+  MCP_APPS_FULL as ResolvedMcpAppsCapabilities;
 
 /**
  * Spec-default "no claims" surface — every advertise key off, no
@@ -179,27 +168,8 @@ export const MCP_APPS_FULL_SURFACE: ResolvedMcpAppsCapabilities = {
  * silently advertise near-full support on hosts that don't exist
  * (mirrors `SPEC_DEFAULT_HOST_CAPABILITIES` in `registry.ts`).
  */
-export const MCP_APPS_NO_CLAIMS_SURFACE: ResolvedMcpAppsCapabilities = {
-  availableDisplayModes: ["inline"],
-  toolInputPartial: false,
-  toolCancelled: false,
-  hostContextChanged: false,
-  resourceTeardown: false,
-  toolInfo: false,
-  openLinks: false,
-  serverTools: false,
-  serverResources: false,
-  logging: false,
-  updateModelContext: false,
-  message: false,
-  sandboxPermissions: false,
-  cspFrameDomains: false,
-  cspBaseUriDomains: false,
-  resourcePrefersBorder: false,
-  downloadFile: false,
-  requestTeardown: false,
-  widgetDisplayModeRequests: "accept",
-};
+export const MCP_APPS_NO_CLAIMS_SURFACE: ResolvedMcpAppsCapabilities =
+  MCP_APPS_NO_CLAIMS as ResolvedMcpAppsCapabilities;
 
 /**
  * Microsoft 365 Copilot's published MCP Apps spec-bridge surface, verbatim
@@ -231,30 +201,8 @@ export const MCP_APPS_NO_CLAIMS_SURFACE: ResolvedMcpAppsCapabilities = {
  *
  * Note: `updateModelContext` and `message` stay on (Copilot honors both).
  */
-export const MCP_APPS_COPILOT_SURFACE: ResolvedMcpAppsCapabilities = {
-  availableDisplayModes: ["inline", "fullscreen"],
-  toolInputPartial: false,
-  toolCancelled: false,
-  hostContextChanged: false,
-  resourceTeardown: false,
-  toolInfo: false,
-  openLinks: true,
-  serverTools: true,
-  serverResources: false,
-  logging: false,
-  updateModelContext: true,
-  message: true,
-  sandboxPermissions: false,
-  cspFrameDomains: false,
-  cspBaseUriDomains: false,
-  resourcePrefersBorder: false,
-  // Copilot's published spec-bridge table does not list downloadFile or
-  // a request-teardown ack — leave off until Microsoft publishes
-  // otherwise.
-  downloadFile: false,
-  requestTeardown: false,
-  widgetDisplayModeRequests: "accept",
-};
+export const MCP_APPS_COPILOT_SURFACE: ResolvedMcpAppsCapabilities =
+  MCP_APPS_COPILOT as ResolvedMcpAppsCapabilities;
 
 /**
  * Goose Desktop 1.38.0 captured MCP Apps surface. Goose renders MCP Apps and
@@ -262,27 +210,8 @@ export const MCP_APPS_COPILOT_SURFACE: ResolvedMcpAppsCapabilities = {
  * captured `ui/initialize.hostCapabilities` only advertised `openLinks`.
  * Keep the rest off until a probe demonstrates those bridge methods.
  */
-export const MCP_APPS_GOOSE_SURFACE: ResolvedMcpAppsCapabilities = {
-  availableDisplayModes: ["inline", "fullscreen", "pip"],
-  toolInputPartial: false,
-  toolCancelled: false,
-  hostContextChanged: false,
-  resourceTeardown: false,
-  toolInfo: true,
-  openLinks: true,
-  serverTools: false,
-  serverResources: false,
-  logging: false,
-  updateModelContext: false,
-  message: false,
-  sandboxPermissions: false,
-  cspFrameDomains: false,
-  cspBaseUriDomains: false,
-  resourcePrefersBorder: false,
-  downloadFile: false,
-  requestTeardown: false,
-  widgetDisplayModeRequests: "accept",
-};
+export const MCP_APPS_GOOSE_SURFACE: ResolvedMcpAppsCapabilities =
+  MCP_APPS_GOOSE as ResolvedMcpAppsCapabilities;
 
 /**
  * Slackbot MCP host surface captured on 2026-06-24. Slackbot renders MCP Apps and

--- a/mcpjam-inspector/client/src/lib/host-compat/__tests__/engine.test.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/__tests__/engine.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from "vitest";
-import {
-  deriveServerRequirements,
-  evaluateAllHosts,
-  evaluateHostCompat,
-} from "../engine";
+import { evaluateAllHosts } from "../engine";
+import { buildHostCompatProfiles } from "../profiles";
 import { summarizeReports } from "@/components/compat/HostCompatStrip";
 import type {
   CompatVerdict,
-  HostCompatProfile,
   HostCompatReport,
-  ServerRequirements,
 } from "../types";
-import type { ResolvedMcpAppsCapabilities } from "@/lib/client-styles/types";
 import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
+
+// The verdict logic itself (deriveServerRequirements / evaluateHostCompat /
+// evaluateMarketHosts / scanWidgetUsage) now lives in the SDK and is tested
+// there (`sdk/tests/host-compat-*`). These tests cover only the CLIENT adapter:
+// joining presentation (logos + `rendersWidgets`) onto the SDK's logo-free
+// reports, plus the `summarizeReports` UI rollup.
 
 const toolsWith = (
   toolsMetadata: Record<string, Record<string, unknown>>,
@@ -28,50 +28,8 @@ const toolsWith = (
 const mcpAppsMeta = (extra: Record<string, unknown> = {}) => ({
   ui: { resourceUri: "ui://widget", ...extra },
 });
-const openaiMeta = { "openai/outputTemplate": "ui://widget" };
 
-const FULL_CAPS: ResolvedMcpAppsCapabilities = {
-  availableDisplayModes: ["inline", "fullscreen", "pip"],
-  toolInputPartial: true,
-  toolCancelled: true,
-  hostContextChanged: true,
-  resourceTeardown: true,
-  toolInfo: true,
-  openLinks: true,
-  serverTools: true,
-  serverResources: true,
-  logging: true,
-  updateModelContext: true,
-  message: true,
-  sandboxPermissions: true,
-  cspFrameDomains: true,
-  cspBaseUriDomains: true,
-  resourcePrefersBorder: true,
-  downloadFile: true,
-  requestTeardown: true,
-  widgetDisplayModeRequests: "accept",
-};
-
-const profile = (over: Partial<HostCompatProfile> = {}): HostCompatProfile => ({
-  id: "x",
-  label: "TestHost",
-  logoSrc: "",
-  provenance: "assumed",
-  rendersMcpApps: true,
-  rendersOpenAiApps: false,
-  capabilities: FULL_CAPS,
-  ...over,
-});
-
-const reqs = (over: Partial<ServerRequirements> = {}): ServerRequirements => ({
-  widgets: { mcpAppsOnly: [], openaiAppsOnly: [], dual: [] },
-  appOnlyWidgets: [],
-  hasWidgets: false,
-  unknownDimensions: [],
-  ...over,
-});
-
-// Minimal report fixture for verdict-rollup tests (only `verdict` is read).
+// Minimal report fixture for the verdict-rollup tests (only `verdict` is read).
 const report = (
   over: Pick<HostCompatReport, "hostId" | "verdict"> & Partial<HostCompatReport>,
 ): HostCompatReport => ({
@@ -86,332 +44,73 @@ const report = (
   ...over,
 });
 
-describe("deriveServerRequirements", () => {
-  it("reports unknown widget usage when tools aren't loaded", () => {
-    const r = deriveServerRequirements(undefined);
-    expect(r.hasWidgets).toBe(false);
-    expect(r.unknownDimensions.length).toBe(1);
-  });
-
-  it("buckets widgets by bridge and flags app-only tools", () => {
-    const r = deriveServerRequirements(
-      toolsWith({
-        mcpTool: mcpAppsMeta(),
-        openaiTool: openaiMeta,
-        dualTool: { ...mcpAppsMeta(), ...openaiMeta },
-        plainTool: {},
-        appOnlyTool: mcpAppsMeta({ visibility: ["app"] }),
-      }),
+describe("buildHostCompatProfiles (client logo join)", () => {
+  it("attaches a per-host logoSrc by id", () => {
+    const byId = Object.fromEntries(
+      buildHostCompatProfiles().map((p) => [p.id, p]),
     );
-    expect(r.widgets.mcpAppsOnly).toEqual(["mcpTool", "appOnlyTool"]);
-    expect(r.widgets.openaiAppsOnly).toEqual(["openaiTool"]);
-    expect(r.widgets.dual).toEqual(["dualTool"]);
-    expect(r.appOnlyWidgets).toEqual(["appOnlyTool"]);
-    expect(r.hasWidgets).toBe(true);
+    expect(byId.claude?.logoSrc).toBe("/claude_logo.png");
+    expect(byId.chatgpt?.logoSrc).toBe("/openai_logo.png");
+    expect(byId.codex?.logoSrc).toBe("/codex-logo.svg");
   });
 
-  it("treats a model+app tool as not app-only", () => {
-    const r = deriveServerRequirements(
-      toolsWith({ t: mcpAppsMeta({ visibility: ["model", "app"] }) }),
+  it("attaches themed logos where the host declares them", () => {
+    const goose = buildHostCompatProfiles().find((p) => p.id === "goose");
+    expect(goose?.logoSrcByTheme).toEqual({
+      light: "/goose_logo_light.png",
+      dark: "/goose_logo_dark.png",
+    });
+    const cline = buildHostCompatProfiles().find((p) => p.id === "cline");
+    expect(cline?.logoSrcByTheme).toEqual({
+      light: "/cline_logo_light.svg",
+      dark: "/cline_logo_dark.svg",
+    });
+  });
+
+  it("carries the SDK facts through (rendersMcpApps, capabilities)", () => {
+    const byId = Object.fromEntries(
+      buildHostCompatProfiles().map((p) => [p.id, p]),
     );
-    expect(r.appOnlyWidgets).toEqual([]);
-  });
-
-  it("marks widget capabilities unknown when widgets aren't scanned", () => {
-    const r = deriveServerRequirements(toolsWith({ w: mcpAppsMeta() }), undefined);
-    expect(
-      r.unknownDimensions.some((d) => /widget capabilities/.test(d)),
-    ).toBe(true);
-  });
-
-  it("treats a clean scan ({}) as conclusive — no unknown dimension", () => {
-    const r = deriveServerRequirements(toolsWith({ w: mcpAppsMeta() }), {});
-    expect(
-      r.unknownDimensions.some((d) => /widget capabilities/.test(d)),
-    ).toBe(false);
-  });
-
-  it("does not mark widget capabilities unknown for a server with no widgets", () => {
-    const r = deriveServerRequirements(toolsWith({ plain: {} }), undefined);
-    expect(
-      r.unknownDimensions.some((d) => /widget capabilities/.test(d)),
-    ).toBe(false);
+    // A rendering host keeps its capability matrix; a CLI host renders no MCP
+    // Apps and carries no matrix.
+    expect(byId.claude?.rendersMcpApps).toBe(true);
+    expect(byId.claude?.capabilities).toBeDefined();
+    expect(byId.codex?.rendersMcpApps).toBe(false);
+    expect(byId.codex?.capabilities).toBeUndefined();
   });
 });
 
-describe("evaluateHostCompat", () => {
-  it("a plain (no-widget) server works everywhere with no findings", () => {
-    const report = evaluateHostCompat(reqs(), profile());
-    expect(report.verdict).toBe("works");
-    expect(report.findings).toEqual([]);
-  });
-
-  it("degrades a widget to text on a host that renders no widgets", () => {
-    const report = evaluateHostCompat(
-      reqs({ widgets: { mcpAppsOnly: ["w"], openaiAppsOnly: [], dual: [] }, hasWidgets: true }),
-      profile({ rendersMcpApps: false, rendersOpenAiApps: false, capabilities: undefined }),
-    );
-    expect(report.verdict).toBe("degraded");
-    expect(report.findings[0].title).toMatch(/fall back to text/);
-  });
-
-  it("blocks an app-only widget that can't render (no text fallback)", () => {
-    const report = evaluateHostCompat(
-      reqs({
-        widgets: { mcpAppsOnly: ["w"], openaiAppsOnly: [], dual: [] },
-        appOnlyWidgets: ["w"],
-        hasWidgets: true,
-      }),
-      profile({ rendersMcpApps: false, rendersOpenAiApps: false, capabilities: undefined }),
-    );
-    expect(report.verdict).toBe("blocked");
-    expect(report.findings[0].title).toMatch(/app-only/);
-  });
-
-  it("degrades an OpenAI-only widget on an MCP-Apps-only host, advising the MCP Apps bridge", () => {
-    const report = evaluateHostCompat(
-      reqs({ widgets: { mcpAppsOnly: [], openaiAppsOnly: ["w"], dual: [] }, hasWidgets: true }),
-      profile({ rendersMcpApps: true, rendersOpenAiApps: false }),
-    );
-    expect(report.verdict).toBe("degraded");
-    // The host renders MCP Apps, so the fix is to add that bridge.
-    expect(report.findings[0].remediation).toMatch(/MCP Apps template/);
-  });
-
-  it("fires a server-specific capability finding when a scanned widget uses an unsupported API", () => {
-    const report = evaluateHostCompat(
-      reqs({
-        widgets: { mcpAppsOnly: ["w"], openaiAppsOnly: [], dual: [] },
-        hasWidgets: true,
-        widgetUsage: { message: ["w"] },
-      }),
-      profile({ capabilities: { ...FULL_CAPS, message: false } }),
-    );
-    expect(report.verdict).toBe("degraded");
-    const finding = report.findings.find((f) => /ui\/message/.test(f.detail));
-    expect(finding?.detail).toMatch(/`w`/);
-  });
-
-  it("reads Unknown (not Works) when a widget server hasn't been scanned", () => {
-    // Mirrors what deriveServerRequirements produces for an unscanned widget
-    // server: an unknown dimension and no capability findings.
-    const report = evaluateHostCompat(
-      reqs({
-        widgets: { mcpAppsOnly: ["w"], openaiAppsOnly: [], dual: [] },
-        hasWidgets: true,
-        unknownDimensions: ["widget capabilities (widget HTML not analyzed)"],
-      }),
-      profile({ capabilities: { ...FULL_CAPS, message: false } }),
-    );
-    expect(report.verdict).toBe("unknown");
-    expect(report.findings).toEqual([]);
-  });
-
-  it("does not fire a capability finding the widget doesn't actually use", () => {
-    const report = evaluateHostCompat(
-      reqs({
-        widgets: { mcpAppsOnly: ["w"], openaiAppsOnly: [], dual: [] },
-        hasWidgets: true,
-        widgetUsage: { serverTools: ["w"] }, // uses serverTools, not message
-      }),
-      profile({ capabilities: { ...FULL_CAPS, message: false } }),
-    );
-    expect(report.findings).toEqual([]);
-    expect(report.verdict).toBe("works");
-  });
-
-  it("does not report capability gaps for a server with no widgets", () => {
-    const report = evaluateHostCompat(
-      reqs({ widgetUsage: { message: ["w"] } }),
-      profile({ capabilities: { ...FULL_CAPS, message: false } }),
-    );
-    expect(report.findings).toEqual([]);
-  });
-});
-
-describe("evaluateAllHosts (real registry)", () => {
-  it("a dual-bridge widget works in Claude but degrades in Codex (CLI)", () => {
-    const { reports } = evaluateAllHosts(
-      toolsWith({ w: { ...mcpAppsMeta(), ...openaiMeta } }),
-      {}, // conclusive clean scan — isolate the render verdict
-    );
+describe("evaluateAllHosts (client presentation join)", () => {
+  it("joins logoSrc + rendersWidgets onto every SDK report by host id", () => {
+    const { reports } = evaluateAllHosts(toolsWith({ w: mcpAppsMeta() }), {});
     const claude = reports.find((r) => r.hostId === "claude");
     const codex = reports.find((r) => r.hostId === "codex");
-    expect(claude?.verdict).toBe("works");
-    expect(codex?.verdict).toBe("degraded");
+
+    // Logo joined from the client map.
+    expect(claude?.logoSrc).toBe("/claude_logo.png");
+    expect(codex?.logoSrc).toBe("/codex-logo.svg");
+
+    // A rendering host reports rendersWidgets true; a CLI host false.
+    expect(claude?.rendersWidgets).toBe(true);
+    expect(codex?.rendersWidgets).toBe(false);
   });
 
-  it("treats n8n as a headless tools-only client", () => {
-    const { reports } = evaluateAllHosts(toolsWith({ w: mcpAppsMeta() }), {});
-    const n8n = reports.find((r) => r.hostId === "n8n");
-    expect(n8n?.verdict).toBe("degraded");
-    expect(n8n?.findings[0].title).toMatch(/fall back to text/);
-  });
-
-  it("treats Perplexity as a headless tools-only client", () => {
-    const { reports } = evaluateAllHosts(toolsWith({ w: mcpAppsMeta() }), {});
-    const perplexity = reports.find((r) => r.hostId === "perplexity");
-    expect(perplexity?.verdict).toBe("degraded");
-    expect(perplexity?.findings[0].title).toMatch(/fall back to text/);
-  });
-
-  it("treats Cline as a headless tools-only client", () => {
-    const { reports } = evaluateAllHosts(toolsWith({ w: mcpAppsMeta() }), {});
-    const cline = reports.find((r) => r.hostId === "cline");
-    expect(cline?.verdict).toBe("degraded");
-    expect(cline?.findings[0].title).toMatch(/fall back to text/);
-  });
-
-  it("renders MCP Apps widgets in ChatGPT (does NOT fall back to text)", () => {
-    const { reports } = evaluateAllHosts(toolsWith({ w: mcpAppsMeta() }), {});
-    const chatgpt = reports.find((r) => r.hostId === "chatgpt");
-    // ChatGPT renders both bridges — an MCP Apps widget must render here.
-    expect(
-      chatgpt?.findings.some((f) => /fall back to text/.test(f.title)),
-    ).toBe(false);
-    // Its only gaps are info-level (serverResources / logging), so: Works.
-    expect(chatgpt?.verdict).toBe("works");
-  });
-
-  it("renders MCP Apps widgets in Goose but reports scanned bridge gaps", () => {
-    const clean = evaluateAllHosts(toolsWith({ w: mcpAppsMeta() }), {});
-    const gooseClean = clean.reports.find((r) => r.hostId === "goose");
-    expect(
-      gooseClean?.findings.some((f) => /fall back to text/.test(f.title)),
-    ).toBe(false);
-    expect(gooseClean?.verdict).toBe("works");
-
-    const scanned = evaluateAllHosts(toolsWith({ w: mcpAppsMeta() }), {
-      message: ["w"],
+  it("themed logos ride along on the joined reports", () => {
+    const { reports } = evaluateAllHosts();
+    const goose = reports.find((r) => r.hostId === "goose");
+    expect(goose?.logoSrcByTheme).toEqual({
+      light: "/goose_logo_light.png",
+      dark: "/goose_logo_dark.png",
     });
-    const gooseScanned = scanned.reports.find((r) => r.hostId === "goose");
-    expect(gooseScanned?.verdict).toBe("degraded");
-    expect(
-      gooseScanned?.findings.some((f) => /ui\/message/.test(f.detail)),
-    ).toBe(true);
   });
 
-  it("surfaces Cursor's follow-up gap only for a widget that actually uses it", () => {
-    const { reports } = evaluateAllHosts(toolsWith({ w: mcpAppsMeta() }), {
-      message: ["w"],
-    });
-    const cursor = reports.find((r) => r.hostId === "cursor");
-    // Cursor renders MCP Apps, so no text-fallback finding…
-    expect(cursor?.findings.some((f) => /fall back to text/.test(f.title))).toBe(
-      false,
+  it("returns the SDK requirements alongside the joined reports", () => {
+    const { requirements, reports } = evaluateAllHosts(
+      toolsWith({ w: mcpAppsMeta() }),
+      {},
     );
-    // …and its matrix has `message` off, so the scanned widget's use of it
-    // surfaces a server-specific finding naming the tool.
-    const finding = cursor?.findings.find((f) => /ui\/message/.test(f.detail));
-    expect(finding?.detail).toMatch(/`w`/);
-    // Claude supports `message` → no such finding even though the widget uses it.
-    const claude = reports.find((r) => r.hostId === "claude");
-    expect(claude?.findings.some((f) => /ui\/message/.test(f.detail))).toBe(false);
-  });
-});
-
-describe("evaluateHostCompat — server lane (protocol version)", () => {
-  it("surfaces a version difference as an info finding but an 'unknown' verdict", () => {
-    const r = evaluateHostCompat(
-      reqs({ connectionFacts: { protocolVersion: "2099-01-01" } }),
-      profile({ supportedProtocolVersions: ["2025-11-25"] }),
-    );
-    const f = r.findings.find((x) => x.lane === "server");
-    // The finding itself stays non-alarmist (info), but the lane can't claim
-    // a confident "works" when the negotiated version isn't in the host's set.
-    expect(f?.severity).toBe("info");
-    expect(f?.title).toMatch(/Protocol version differs/);
-    expect(r.lanes.server.verdict).toBe("unknown");
-    expect(r.verdict).toBe("unknown");
-  });
-
-  it("stays 'works' on a version match (no server-lane finding)", () => {
-    const r = evaluateHostCompat(
-      reqs({ connectionFacts: { protocolVersion: "2025-11-25" } }),
-      profile({ supportedProtocolVersions: ["2025-06-18", "2025-11-25"] }),
-    );
-    expect(r.lanes.server.verdict).toBe("works");
-    expect(r.verdict).toBe("works");
-  });
-
-  it("no finding when the server's version is in the host's set", () => {
-    const r = evaluateHostCompat(
-      reqs({ connectionFacts: { protocolVersion: "2025-11-25" } }),
-      profile({ supportedProtocolVersions: ["2025-06-18", "2025-11-25"] }),
-    );
-    expect(r.findings.some((x) => x.lane === "server")).toBe(false);
-  });
-
-  it("skips the check when host versions are unknown", () => {
-    const r = evaluateHostCompat(
-      reqs({ connectionFacts: { protocolVersion: "2099-01-01" } }),
-      profile({ supportedProtocolVersions: undefined }),
-    );
-    expect(r.findings.some((x) => x.lane === "server")).toBe(false);
-  });
-
-  it("skips the check when the server version is unknown (no live connection)", () => {
-    const r = evaluateHostCompat(
-      reqs(),
-      profile({ supportedProtocolVersions: ["2025-11-25"] }),
-    );
-    expect(r.findings.some((x) => x.lane === "server")).toBe(false);
-  });
-});
-
-describe("lane model + aggregation", () => {
-  it("stamps lane + provenance on every finding", () => {
-    const r = evaluateHostCompat(
-      reqs({
-        widgets: { mcpAppsOnly: ["w"], openaiAppsOnly: [], dual: [] },
-        hasWidgets: true,
-      }),
-      profile({
-        rendersMcpApps: false,
-        rendersOpenAiApps: false,
-        capabilities: undefined,
-        provenance: "probe",
-      }),
-    );
-    expect(r.findings.length).toBeGreaterThan(0);
-    expect(r.findings.every((f) => f.lane === "apps")).toBe(true);
-    expect(r.findings.every((f) => f.provenance === "probe")).toBe(true);
-  });
-
-  it("top-level verdict is worst-wins across lanes (apps blocked beats server works)", () => {
-    const r = evaluateHostCompat(
-      reqs({
-        widgets: { mcpAppsOnly: ["w"], openaiAppsOnly: [], dual: [] },
-        appOnlyWidgets: ["w"],
-        hasWidgets: true,
-        connectionFacts: { protocolVersion: "2025-11-25" },
-      }),
-      profile({
-        rendersMcpApps: false,
-        rendersOpenAiApps: false,
-        capabilities: undefined,
-        supportedProtocolVersions: ["2025-11-25"],
-      }),
-    );
-    expect(r.lanes.apps.verdict).toBe("blocked");
-    expect(r.lanes.server.verdict).toBe("works");
-    expect(r.verdict).toBe("blocked");
-  });
-
-  it("lane provenance reflects the weakest finding source", () => {
-    const r = evaluateHostCompat(
-      reqs({
-        widgets: { mcpAppsOnly: ["w"], openaiAppsOnly: [], dual: [] },
-        hasWidgets: true,
-      }),
-      profile({
-        rendersMcpApps: false,
-        rendersOpenAiApps: false,
-        capabilities: undefined,
-        provenance: "vendor-doc",
-      }),
-    );
-    expect(r.lanes.apps.provenance).toBe("vendor-doc");
+    expect(requirements.hasWidgets).toBe(true);
+    expect(reports.length).toBeGreaterThan(0);
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/host-compat/engine.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/engine.ts
@@ -1,348 +1,64 @@
+/**
+ * Client adapter over the shared host-compat engine (`@mcpjam/sdk/host-compat`).
+ *
+ * The verdict logic — deriving server requirements and evaluating them against
+ * each host's capability matrix — lives in the SDK so every surface (inspector
+ * UI, `mcpjam` CLI, public API, MCP server) shares one implementation. This
+ * module is a thin presentation adapter: it runs the SDK's market-host
+ * evaluation and joins the client-only presentation fields (per-host logos +
+ * `rendersWidgets`) onto the SDK's logo-free reports, by host id.
+ */
+
 import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
-import { detectUIType, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
-import { buildHostCompatProfiles } from "./profiles";
-import type { WidgetCapabilityNeed, WidgetUsage } from "./widget-scan";
+import {
+  deriveServerRequirements,
+  evaluateHostCompat,
+  evaluateMarketHosts,
+} from "@mcpjam/sdk/host-compat";
+import { PROFILE_BY_ID } from "./profiles";
+import type { WidgetUsage } from "./widget-scan";
 import type {
-  CompatFinding,
-  CompatLane,
-  CompatLaneVerdict,
-  CompatProvenance,
-  CompatVerdict,
   ConnectionFacts,
-  HostCompatProfile,
   HostCompatReport,
   ServerRequirements,
 } from "./types";
 
-/**
- * L0/L1 static compatibility engine (prototype).
- *
- * Two lanes:
- *  - **apps**: `deriveServerRequirements` reads the tools list (widget bridges
- *    + `visibility`) plus an optional `widgetUsage` map (L1 — which host APIs
- *    the widgets actually call). `evaluateHostCompat` joins that against the
- *    host's SEP-1865 capability matrix. Every apps finding is server-specific.
- *  - **server**: protocol-version compatibility from `connectionFacts`
- *    (`initialize`) vs the host template's advertised versions. Transport/auth
- *    stay out — a local dev server is expected not to reach a cloud host — but
- *    a host *advertising a different protocol version* is a real gap.
- *
- * The top-level verdict is the worst of the two lane verdicts; each finding
- * and each lane carries its own provenance so a Tier-2 `observed` fact never
- * makes the whole report read as observed.
- */
-
-/** A tool is app-only when its `_meta.ui.visibility` excludes `"model"`. */
-function isAppOnlyTool(meta: Record<string, unknown> | undefined): boolean {
-  const ui = meta?.ui as { visibility?: unknown } | undefined;
-  const visibility = ui?.visibility;
-  return Array.isArray(visibility) && !visibility.includes("model");
-}
-
-export function deriveServerRequirements(
-  toolsData?: ListToolsResultWithMetadata | null,
-  widgetUsage?: WidgetUsage,
-  connectionFacts?: ConnectionFacts,
-): ServerRequirements {
-  const unknownDimensions: string[] = [];
-
-  if (!toolsData?.tools) {
-    unknownDimensions.push("widget usage (tools metadata not loaded)");
-    return {
-      widgets: { mcpAppsOnly: [], openaiAppsOnly: [], dual: [] },
-      appOnlyWidgets: [],
-      hasWidgets: false,
-      widgetUsage,
-      connectionFacts,
-      unknownDimensions,
-    };
-  }
-
-  const mcpAppsOnly: string[] = [];
-  const openaiAppsOnly: string[] = [];
-  const dual: string[] = [];
-  const appOnlyWidgets: string[] = [];
-
-  for (const tool of toolsData.tools) {
-    const meta =
-      toolsData.toolsMetadata?.[tool.name] ??
-      (tool._meta as Record<string, unknown> | undefined);
-    let isWidget = true;
-    switch (detectUIType(meta, undefined)) {
-      case UIType.MCP_APPS:
-        mcpAppsOnly.push(tool.name);
-        break;
-      case UIType.OPENAI_SDK:
-        openaiAppsOnly.push(tool.name);
-        break;
-      case UIType.OPENAI_SDK_AND_MCP_APPS:
-        dual.push(tool.name);
-        break;
-      default:
-        isWidget = false;
-        break;
-    }
-    if (isWidget && isAppOnlyTool(meta)) appOnlyWidgets.push(tool.name);
-  }
-
-  const hasWidgets =
-    mcpAppsOnly.length + openaiAppsOnly.length + dual.length > 0;
-
-  // A widget server whose widgets haven't been conclusively scanned (scan
-  // pending, or every `resources/read` failed) must read as Unknown, not a
-  // false Works — we can't claim "no capability gaps" without analyzing the
-  // HTML. `{}` IS conclusive (scanned, clean); `undefined` is not.
-  if (hasWidgets && !widgetUsage) {
-    unknownDimensions.push("widget capabilities (widget HTML not analyzed)");
-  }
-
-  return {
-    widgets: { mcpAppsOnly, openaiAppsOnly, dual },
-    appOnlyWidgets,
-    hasWidgets,
-    widgetUsage,
-    connectionFacts,
-    unknownDimensions,
-  };
-}
-
-const formatToolNames = (names: string[]): string => {
-  const shown = names.slice(0, 3).map((name) => `\`${name}\``);
-  const rest = names.length - shown.length;
-  return rest > 0 ? `${shown.join(", ")} +${rest} more` : shown.join(", ");
-};
-
-/**
- * Per-capability finding copy, keyed by the same dimensions the L1 scan
- * detects. A finding fires only when (a) the widget needs the capability
- * and (b) the host's matrix lacks it. `degraded` for real functional loss,
- * `info` for cosmetic.
- */
-const CAPABILITY_CHECKS: ReadonlyArray<{
-  key: WidgetCapabilityNeed;
-  severity: CompatFinding["severity"];
-  title: string;
-  api: string;
-  consequence: string;
-}> = [
-  { key: "serverTools", severity: "degraded", title: "Server tool calls won't work", api: "tools/call", consequence: "its interactive actions won't reach the server" },
-  { key: "serverResources", severity: "degraded", title: "Resource reads won't work", api: "resources/read", consequence: "it won't get the MCP resources it fetches" },
-  { key: "message", severity: "degraded", title: "Follow-up messages won't work", api: "ui/message", consequence: "it can't send follow-up chat messages" },
-  { key: "updateModelContext", severity: "degraded", title: "Model-context updates won't work", api: "ui/update-model-context", consequence: "it can't push state into the model's context" },
-  { key: "openLinks", severity: "degraded", title: "Links won't open", api: "ui/open-link", consequence: "its external links won't open" },
-  { key: "downloadFile", severity: "degraded", title: "Downloads won't work", api: "ui/download-file", consequence: "its export/download won't work" },
-  { key: "sandboxPermissions", severity: "degraded", title: "Device permissions denied", api: "sandbox permissions", consequence: "the camera/mic/geo/clipboard access it requests won't be granted" },
-  { key: "cspFrameDomains", severity: "degraded", title: "Nested iframes blocked", api: "csp.frameDomains", consequence: "the nested iframes it declares won't load" },
-  { key: "logging", severity: "info", title: "Widget logs dropped", api: "notifications/message", consequence: "its log messages won't surface" },
-];
-
-/** Worst-wins ordering for verdict aggregation across lanes. */
-const VERDICT_RANK: Record<CompatVerdict, number> = {
-  works: 0,
-  unknown: 1,
-  degraded: 2,
-  blocked: 3,
-};
-
-/** Trust ordering — `observed` (live) strongest, `assumed` weakest. */
-const PROVENANCE_RANK: Record<CompatProvenance, number> = {
-  assumed: 0,
-  probe: 1,
-  "vendor-doc": 2,
-  observed: 3,
-};
-
-/** Weakest provenance among a lane's findings, falling back to the host baseline. */
-function weakestProvenance(
-  findings: CompatFinding[],
-  fallback: CompatProvenance,
-): CompatProvenance {
-  return findings.reduce<CompatProvenance>(
-    (weak, f) =>
-      PROVENANCE_RANK[f.provenance] < PROVENANCE_RANK[weak] ? f.provenance : weak,
-    fallback,
-  );
-}
-
-/**
- * Roll a lane's findings into a verdict. `degraded` outranks `unknown` (a real
- * functional loss beats an unanalyzed dimension); `unknown` only when the lane
- * has an undetermined dimension and no harder finding.
- */
-function laneVerdict(
-  findings: CompatFinding[],
-  lane: CompatLane,
-  unknown: boolean,
-  baseProvenance: CompatProvenance,
-): CompatLaneVerdict {
-  const laneFindings = findings.filter((f) => f.lane === lane);
-  const hasBlocker = laneFindings.some((f) => f.severity === "blocker");
-  const hasDegraded = laneFindings.some((f) => f.severity === "degraded");
-  const verdict: CompatVerdict = hasBlocker
-    ? "blocked"
-    : hasDegraded
-      ? "degraded"
-      : unknown
-        ? "unknown"
-        : "works";
-  return { verdict, provenance: weakestProvenance(laneFindings, baseProvenance) };
-}
-
-export function evaluateHostCompat(
-  requirements: ServerRequirements,
-  profile: HostCompatProfile,
-): HostCompatReport {
-  const findings: CompatFinding[] = [];
-
-  if (requirements.hasWidgets) {
-    // 1. Render failures: widgets whose bridge this host can't render.
-    const unrenderable = [
-      ...(profile.rendersMcpApps ? [] : requirements.widgets.mcpAppsOnly),
-      ...(profile.rendersOpenAiApps
-        ? []
-        : requirements.widgets.openaiAppsOnly),
-      ...(profile.rendersMcpApps || profile.rendersOpenAiApps
-        ? []
-        : requirements.widgets.dual),
-    ];
-
-    const remediation =
-      profile.rendersMcpApps && !profile.rendersOpenAiApps
-        ? "Declare an MCP Apps template (`_meta.ui.resourceUri`) alongside the OpenAI one."
-        : !profile.rendersMcpApps && profile.rendersOpenAiApps
-          ? "Declare an OpenAI Apps template (`openai/outputTemplate`) alongside the MCP Apps one."
-          : undefined; // host renders neither (CLI) — nothing to declare.
-
-    // App-only widgets have no text fallback: unrenderable = unusable tool.
-    const blockedAppOnly = unrenderable.filter((name) =>
-      requirements.appOnlyWidgets.includes(name),
-    );
-    const degradedFallback = unrenderable.filter(
-      (name) => !requirements.appOnlyWidgets.includes(name),
-    );
-
-    if (blockedAppOnly.length > 0) {
-      const count = blockedAppOnly.length;
-      findings.push({
-        lane: "apps",
-        severity: "blocker",
-        title: `${count} app-only tool${count === 1 ? "" : "s"} unusable`,
-        detail: `${formatToolNames(blockedAppOnly)} ${count === 1 ? "is" : "are"} app-only (hidden from the model, no text fallback) and need${count === 1 ? "s" : ""} a UI ${profile.label} can't render — so ${count === 1 ? "it's" : "they're"} dead here.`,
-        remediation,
-        provenance: profile.provenance,
-      });
-    }
-    if (degradedFallback.length > 0) {
-      const count = degradedFallback.length;
-      findings.push({
-        lane: "apps",
-        severity: "degraded",
-        title: `${count} widget${count === 1 ? "" : "s"} fall back to text`,
-        detail: `${formatToolNames(degradedFallback)} declare${count === 1 ? "s" : ""} a UI ${profile.label} won't render — users get the plain-text result instead.`,
-        remediation,
-        provenance: profile.provenance,
-      });
-    }
-
-    // 2. Capability gaps — SERVER-SPECIFIC: only for widgets that actually
-    //    use a capability (from the L1 scan) the host lacks.
-    if (profile.capabilities && requirements.widgetUsage) {
-      for (const check of CAPABILITY_CHECKS) {
-        const tools = requirements.widgetUsage[check.key];
-        if (tools && tools.length > 0 && profile.capabilities[check.key] !== true) {
-          findings.push({
-            lane: "apps",
-            severity: check.severity,
-            title: check.title,
-            detail: `${formatToolNames(tools)} need \`${check.api}\`, which ${profile.label} doesn't support — ${check.consequence}.`,
-            provenance: profile.provenance,
-          });
-        }
-      }
-    }
-  }
-
-  // 3. Server lane — protocol-version compatibility. `info`, not `degraded`:
-  //    we only sampled ONE version the server negotiated with the inspector;
-  //    the host may still negotiate a shared version. Surfaced, never alarmist.
-  const serverVersion = requirements.connectionFacts?.protocolVersion;
-  const hostVersions = profile.supportedProtocolVersions;
-  if (
-    serverVersion &&
-    hostVersions &&
-    hostVersions.length > 0 &&
-    !hostVersions.includes(serverVersion)
-  ) {
-    findings.push({
-      lane: "server",
-      severity: "info",
-      title: "Protocol version differs",
-      detail: `This server negotiated MCP \`${serverVersion}\`; ${profile.label} advertises ${hostVersions
-        .map((v) => `\`${v}\``)
-        .join(
-          ", ",
-        )}. The host may negotiate a shared version — but if the server can't speak one of these, the connection won't establish.`,
-      remediation: `Confirm the server also supports ${hostVersions.length === 1 ? "this version" : "one of these versions"}.`,
-      provenance: profile.provenance,
-    });
-  }
-
-  const apps = laneVerdict(
-    findings,
-    "apps",
-    requirements.unknownDimensions.length > 0,
-    profile.provenance,
-  );
-  // A server-lane finding (today: a protocol-version difference) means we
-  // can't confirm the host will accept this server — it MAY negotiate a shared
-  // version, but we only sampled one. Surface that as "unknown" rather than a
-  // confident green "works"; the finding itself stays `info` (non-alarmist) in
-  // the list. With no finding (version matches, or no live version), the lane
-  // is quiet → "works".
-  const serverHasFinding = findings.some((f) => f.lane === "server");
-  const server = laneVerdict(
-    findings,
-    "server",
-    serverHasFinding,
-    profile.provenance,
-  );
-  const verdict =
-    VERDICT_RANK[apps.verdict] >= VERDICT_RANK[server.verdict]
-      ? apps.verdict
-      : server.verdict;
-
-  return {
-    hostId: profile.id,
-    hostLabel: profile.label,
-    logoSrc: profile.logoSrc,
-    logoSrcByTheme: profile.logoSrcByTheme,
-    verdict,
-    provenance: profile.provenance,
-    lanes: { apps, server },
-    rendersWidgets: profile.rendersMcpApps || profile.rendersOpenAiApps,
-    findings,
-  };
-}
+// Re-export the SDK's pure verdict primitives so existing client importers keep
+// a stable path. `evaluateHostCompat` here returns the SDK's logo-free report;
+// surfaces that need logos go through `evaluateAllHosts` below.
+export { deriveServerRequirements, evaluateHostCompat };
 
 export type HostCompatEvaluation = {
   requirements: ServerRequirements;
   reports: HostCompatReport[];
 };
 
+/**
+ * Evaluate the connected server against the market-host catalog, then join the
+ * client presentation fields (logos + `rendersWidgets`) onto each logo-free SDK
+ * report by host id.
+ */
 export function evaluateAllHosts(
   toolsData?: ListToolsResultWithMetadata | null,
   widgetUsage?: WidgetUsage,
   connectionFacts?: ConnectionFacts,
 ): HostCompatEvaluation {
-  const requirements = deriveServerRequirements(
-    toolsData,
+  const { requirements, reports } = evaluateMarketHosts(toolsData, {
     widgetUsage,
     connectionFacts,
-  );
+  });
   return {
     requirements,
-    reports: buildHostCompatProfiles().map((profile) =>
-      evaluateHostCompat(requirements, profile),
-    ),
+    reports: reports.map((r) => {
+      const profile = PROFILE_BY_ID[r.hostId];
+      return {
+        ...r,
+        logoSrc: profile?.logoSrc ?? "",
+        logoSrcByTheme: profile?.logoSrcByTheme,
+        rendersWidgets: profile
+          ? profile.rendersMcpApps || profile.rendersOpenAiApps
+          : undefined,
+      };
+    }),
   };
 }

--- a/mcpjam-inspector/client/src/lib/host-compat/profiles.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/profiles.ts
@@ -1,170 +1,63 @@
-import {
-  findHostStyle,
-  getCompatRuntimeForStyle,
-} from "@/lib/client-styles/registry";
-import { getHostTemplateSupportedProtocolVersions } from "@/lib/client-templates";
-import type { HostTemplateId } from "@/lib/client-templates";
-import type { CompatProvenance, HostCompatProfile } from "./types";
+import { buildMarketHostProfiles } from "@mcpjam/sdk/host-compat";
+import type { HostCompatProfile } from "./types";
 
 /**
- * The "market view" host list — the real shipping targets a developer asks
- * "where can I ship this?" about. MCPJam is omitted (compatible by
- * construction — it's the surface you're already on).
+ * Client presentation join for the SDK's market-host catalog.
  *
- * Each entry carries the facts the registry can't give us:
- *   - identity (label/logo) and `provenance` (how much to trust the matrix).
- *   - `rendersMcpApps`: does this host render MCP Apps (`ui://`) widgets at
- *     all? Headless clients such as Codex, n8n, Perplexity, and Cline carry
- *     capability matrices for protocol-bucket reasons but have no rendering
- *     surface. That "is it headless?" fact isn't in the registry, so it's
- *     explicit here.
- *     (ChatGPT/Copilot render BOTH MCP Apps and the OpenAI bridge —
- *     `rendersOpenAiApps` is resolved separately below.)
- *
- * The granular *capabilities* (which widget features each host supports —
- * serverResources, message, sandbox, …) still come live from the registry,
- * so the report never drifts from the playground's emulation.
- *
- * Provenance: probe = captured from a real host;
- * vendor-doc = published vendor table (Copilot; ChatGPT's OpenAI surface);
- * assumed = best-effort preset, unverified.
+ * The host *facts* (which bridges each host renders, its capability matrix,
+ * advertised protocol versions, provenance) come from the SDK's logo-free
+ * `buildMarketHostProfiles()`. The inspector adds the per-host logos here — the
+ * one piece of presentation the SDK deliberately doesn't carry — joined by
+ * host id.
  */
-type MarketHost = {
-  // `HostTemplateId` (not `string`) so a market-host id that isn't a real host
-  // template is a compile error here, and `getHostTemplateSupportedProtocolVersions`
-  // can resolve it strictly without a cast.
-  id: HostTemplateId;
-  label: string;
-  logoSrc: string;
-  logoSrcByTheme?: { light: string; dark: string };
-  provenance: CompatProvenance;
-  rendersMcpApps: boolean;
-};
-
-const MARKET_HOSTS: readonly MarketHost[] = [
-  {
-    id: "claude",
-    label: "Claude",
-    logoSrc: "/claude_logo.png",
-    provenance: "assumed",
-    rendersMcpApps: true,
-  },
-  {
-    id: "chatgpt",
-    label: "ChatGPT",
-    logoSrc: "/openai_logo.png",
-    provenance: "vendor-doc",
-    rendersMcpApps: true,
-  },
-  // Le Chat renders MCP Apps (via `ui/initialize`) and the normalized
-  // template advertises the standard MCP UI extension for that surface.
-  // Captured from a probe.
-  {
-    id: "mistral",
-    label: "Mistral",
-    logoSrc: "/mistral_logo.png",
-    provenance: "probe",
-    rendersMcpApps: true,
-  },
-  {
-    id: "goose",
-    label: "Goose",
+const LOGO_BY_ID: Record<
+  string,
+  { logoSrc: string; logoSrcByTheme?: { light: string; dark: string } }
+> = {
+  claude: { logoSrc: "/claude_logo.png" },
+  chatgpt: { logoSrc: "/openai_logo.png" },
+  mistral: { logoSrc: "/mistral_logo.png" },
+  goose: {
     logoSrc: "/goose_logo_light.png",
     logoSrcByTheme: {
       light: "/goose_logo_light.png",
       dark: "/goose_logo_dark.png",
     },
-    provenance: "probe",
-    rendersMcpApps: true,
   },
-  {
-    id: "cursor",
-    label: "Cursor",
-    logoSrc: "/cursor_logo.png",
-    provenance: "probe",
-    rendersMcpApps: true,
-  },
-  {
-    id: "copilot",
-    label: "Copilot",
-    logoSrc: "/copilot_logo.png",
-    provenance: "vendor-doc",
-    rendersMcpApps: true,
-  },
-  // Codex is a CLI — it renders no widgets, of either flavor.
-  {
-    id: "codex",
-    label: "Codex",
-    logoSrc: "/codex-logo.svg",
-    provenance: "assumed",
-    rendersMcpApps: false,
-  },
-  {
-    id: "n8n",
-    label: "n8n",
-    logoSrc: "/n8n_logo.svg",
-    provenance: "probe",
-    rendersMcpApps: false,
-  },
-  {
-    id: "perplexity",
-    label: "Perplexity",
-    logoSrc: "/perplexity_logo.svg",
-    provenance: "probe",
-    rendersMcpApps: false,
-  },
-  {
-    id: "cline",
-    label: "Cline",
+  cursor: { logoSrc: "/cursor_logo.png" },
+  copilot: { logoSrc: "/copilot_logo.png" },
+  codex: { logoSrc: "/codex-logo.svg" },
+  n8n: { logoSrc: "/n8n_logo.svg" },
+  perplexity: { logoSrc: "/perplexity_logo.svg" },
+  cline: {
     logoSrc: "/cline_logo_light.svg",
     logoSrcByTheme: {
       light: "/cline_logo_light.svg",
       dark: "/cline_logo_dark.svg",
     },
-    provenance: "probe",
-    rendersMcpApps: false,
   },
-];
+};
 
-/**
- * Build the compat profiles by joining the market-host facts with the
- * registry's live capability matrix. `rendersOpenAiApps` is the one render
- * flag the registry CAN give us cleanly (the `window.openai` shim toggle),
- * so it stays derived; `rendersMcpApps` is the explicit CLI-aware fact.
- */
-// The profile array has no per-server input — it's a pure function of the
-// static market list + registry — so build it once. Every connected server's
-// memoized `useHostCompatReports` calls `evaluateAllHosts` on each tools/
-// widget/protocol change, which would otherwise rebuild this byte-identical
-// array (registry lookups + spreads) every time.
+// The joined profile array is a pure function of the SDK catalog + the static
+// logo map, so build it once. Every connected server's memoized
+// `useHostCompatReports` calls into `evaluateAllHosts` on each tools/widget/
+// protocol change, which would otherwise rebuild this byte-identical array
+// (SDK calls + logo joins) every time.
 let cachedProfiles: HostCompatProfile[] | null = null;
 
 export function buildHostCompatProfiles(): HostCompatProfile[] {
   if (cachedProfiles) return cachedProfiles;
-  cachedProfiles = MARKET_HOSTS.map((host) => {
-    const rendersOpenAiApps = getCompatRuntimeForStyle(host.id).injected;
-    const rendersWidgets = host.rendersMcpApps || rendersOpenAiApps;
-    return {
-      ...host,
-      rendersOpenAiApps,
-      supportedProtocolVersions: supportedProtocolVersionsFor(host.id),
-      capabilities: rendersWidgets
-        ? findHostStyle(host.id)?.mcp.mcpAppsCapabilities
-        : undefined,
-    };
-  });
+  cachedProfiles = buildMarketHostProfiles().map((p) => ({
+    ...p,
+    logoSrc: LOGO_BY_ID[p.id]?.logoSrc ?? "",
+    logoSrcByTheme: LOGO_BY_ID[p.id]?.logoSrcByTheme,
+  }));
   return cachedProfiles;
 }
 
-// Seeding a template builds a full HostConfigInputV2, so cache the
-// protocol-version read per id (templates are static for the session). Uses
-// the strict resolver — an unknown market-host id throws on first evaluation.
-const protocolVersionCache = new Map<HostTemplateId, string[] | undefined>();
-function supportedProtocolVersionsFor(
-  id: HostTemplateId,
-): string[] | undefined {
-  if (!protocolVersionCache.has(id)) {
-    protocolVersionCache.set(id, getHostTemplateSupportedProtocolVersions(id));
-  }
-  return protocolVersionCache.get(id);
-}
+/**
+ * Profiles keyed by host id — used by the engine adapter to join logos +
+ * `rendersWidgets` onto the SDK's logo-free reports.
+ */
+export const PROFILE_BY_ID: Record<string, HostCompatProfile> =
+  Object.fromEntries(buildHostCompatProfiles().map((p) => [p.id, p]));

--- a/mcpjam-inspector/client/src/lib/host-compat/types.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/types.ts
@@ -1,155 +1,50 @@
 /**
- * Host compatibility report — L0 static checks (prototype of the design in
- * `design-explorations/host-compat-report.md`).
+ * Host compatibility types.
  *
- * The engine joins `ServerRequirements` (what the server's widgets need,
- * derived from connect-time tool metadata) against per-host
- * `HostCompatProfile`s. Profiles are sourced directly from the host-style
- * registry's SEP-1865 capability matrix (`mcpAppsCapabilities`) — the same
- * facts the playground uses to *emulate* each host — so the report never
- * drifts from the emulation.
+ * The verdict vocabulary and report shapes now live in the shared SDK engine
+ * (`@mcpjam/sdk/host-compat`) so the inspector UI, the `mcpjam` CLI, the public
+ * API, and the MCP server all evaluate against one engine. The SDK is
+ * framework-free and logo-free — it owns the compatibility *facts*.
+ *
+ * This module re-exports those SDK types (so existing client importers keep
+ * working) and adds the client-only *presentation* extensions: the per-host
+ * logos and the `rendersWidgets` convenience flag the UI joins by host id.
  */
 
-import type { ResolvedMcpAppsCapabilities } from "@/lib/client-styles/types";
-import type { WidgetUsage } from "./widget-scan";
+import type {
+  HostCompatProfile as SdkHostCompatProfile,
+  HostCompatReport as SdkHostCompatReport,
+} from "@mcpjam/sdk/host-compat";
 
-export type CompatVerdict = "works" | "degraded" | "blocked" | "unknown";
-
-export type CompatFindingSeverity = "blocker" | "degraded" | "info";
+export type {
+  CompatVerdict,
+  CompatFindingSeverity,
+  CompatLane,
+  CompatProvenance,
+  ConnectionFacts,
+  CompatFinding,
+  CompatLaneVerdict,
+  ServerRequirements,
+} from "@mcpjam/sdk/host-compat";
 
 /**
- * Which axis a finding belongs to. `apps` = widget/rendering (does the host
- * render this widget + expose the host APIs it calls). `server` = capability
- * negotiation (protocol version today; elicitation/sampling/roots once
- * observed live). They fail for different reasons and aggregate independently.
+ * SDK host profile (logo-free facts) plus the client presentation join: the
+ * per-host logo, optionally themed (light/dark).
  */
-export type CompatLane = "apps" | "server";
-
-/**
- * Where a host-profile fact comes from. Surfaced in the UI so a verdict
- * never reads as more authoritative than its weakest source. `observed` is
- * the strongest — earned by a Tier-2 live run (Phase 3); the rest are static.
- */
-export type CompatProvenance = "observed" | "vendor-doc" | "probe" | "assumed";
-
-/**
- * Connection-derived facts about the *server under test* (not the host).
- * Threaded into the engine separately from tool metadata because they come
- * from the live `initialize` handshake, not the tools list.
- */
-export type ConnectionFacts = {
-  /** Protocol version the server negotiated at connect (`initialize`). */
-  protocolVersion?: string;
-};
-
-export type CompatFinding = {
-  lane: CompatLane;
-  severity: CompatFindingSeverity;
-  title: string;
-  detail: string;
-  remediation?: string;
-  /**
-   * Source of THIS finding's host fact — so a Tier-2 `observed` fact reads as
-   * stronger than an `assumed` preset without implying every host fact was
-   * observed. In Phase 1 all findings inherit the host profile's provenance.
-   */
-  provenance: CompatProvenance;
-};
-
-/** Per-lane rollup so the UI can show apps vs server verdicts independently. */
-export type CompatLaneVerdict = {
-  verdict: CompatVerdict;
-  /** Weakest provenance among this lane's findings (host baseline if none). */
-  provenance: CompatProvenance;
-};
-
-export type HostCompatReport = {
-  hostId: string;
-  hostLabel: string;
+export type HostCompatProfile = SdkHostCompatProfile & {
   logoSrc: string;
   logoSrcByTheme?: { light: string; dark: string };
-  /** Worst-wins aggregate across lanes. */
-  verdict: CompatVerdict;
-  /** Host's baseline provenance (dominant source for its facts). */
-  provenance: CompatProvenance;
-  /** Per-lane verdicts (`apps`, `server`). */
-  lanes: Record<CompatLane, CompatLaneVerdict>;
-  /**
-   * Whether this host renders widgets at all (MCP Apps or the OpenAI shim) —
-   * a CLI host (Codex) renders neither. Gates the "Run live render" affordance:
-   * there's nothing to observe for a host with no rendering surface.
-   */
+};
+
+/**
+ * SDK report (logo-free facts) plus the client presentation join: the per-host
+ * logo (optionally themed) and `rendersWidgets` — whether this host renders
+ * widgets at all (MCP Apps or the OpenAI shim). A CLI host (Codex) renders
+ * neither; the flag gates the "Run live render" affordance (nothing to observe
+ * for a host with no rendering surface).
+ */
+export type HostCompatReport = SdkHostCompatReport & {
+  logoSrc: string;
+  logoSrcByTheme?: { light: string; dark: string };
   rendersWidgets?: boolean;
-  findings: CompatFinding[];
-};
-
-/**
- * What the server demands of a host. Two lanes:
- *  - **apps** (widget-shaped): derived from the tools list + L1 widget scan —
- *    where hosts most visibly differ.
- *  - **server** (capability negotiation): `connectionFacts` from the live
- *    `initialize`. Today just the protocol version — a host *advertising a
- *    different protocol version* is a real capability gap, distinct from a
- *    local server merely not reaching a cloud host (the reason transport/auth
- *    stay out). Richer server-lane facts (elicitation/sampling/roots) are
- *    observed live in Phase 3, not derivable statically.
- */
-export type ServerRequirements = {
-  /** Tools that declare a UI, grouped by the bridge they render through. */
-  widgets: {
-    /** MCP Apps only (`_meta.ui.resourceUri`). */
-    mcpAppsOnly: string[];
-    /** OpenAI Apps only (`openai/outputTemplate`). */
-    openaiAppsOnly: string[];
-    /** Declares both bridges — renderable wherever either exists. */
-    dual: string[];
-  };
-  /**
-   * Widget tools that are app-only (`_meta.ui.visibility` excludes
-   * `"model"`). These have no text fallback — a host that can't render them
-   * makes the tool unusable, not merely degraded.
-   */
-  appOnlyWidgets: string[];
-  hasWidgets: boolean;
-  /**
-   * L1 scan result: which host capabilities this server's widgets actually
-   * use, mapped to the tools that need them. `undefined` = not scanned yet
-   * (the engine withholds capability findings rather than guess); `{}` =
-   * scanned, nothing notable used.
-   */
-  widgetUsage?: WidgetUsage;
-  /**
-   * Server-lane connection facts (protocol version). Separate from widget data
-   * because it comes from `initialize`, not the tools list. Absent when the
-   * caller has no live connection — the protocol check is then skipped.
-   */
-  connectionFacts?: ConnectionFacts;
-  /** Human-readable dimensions we could not derive yet. */
-  unknownDimensions: string[];
-};
-
-export type HostCompatProfile = {
-  id: string;
-  label: string;
-  logoSrc: string;
-  logoSrcByTheme?: { light: string; dark: string };
-  /** Dominant provenance for this profile's facts. */
-  provenance: CompatProvenance;
-  /** Renders MCP Apps widgets (`_meta.ui.resourceUri`). */
-  rendersMcpApps: boolean;
-  /** Renders OpenAI Apps widgets (`openai/outputTemplate` via the shim). */
-  rendersOpenAiApps: boolean;
-  /**
-   * MCP base-protocol versions this host advertises, sourced from its
-   * host-template seed (`mcpProfile.initialize.supportedProtocolVersions`).
-   * Undefined when the template doesn't pin versions — the server-lane
-   * protocol check is then skipped.
-   */
-  supportedProtocolVersions?: string[];
-  /**
-   * The host's SEP-1865 MCP Apps capability matrix (from the registry).
-   * Present only when the host renders widgets at all — a CLI host (Codex)
-   * leaves this undefined.
-   */
-  capabilities?: ResolvedMcpAppsCapabilities;
 };

--- a/mcpjam-inspector/client/src/lib/host-compat/use-widget-usage.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/use-widget-usage.ts
@@ -1,54 +1,22 @@
 import { useEffect, useState } from "react";
 import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
 import { readResource } from "@/lib/apis/mcp-resources-api";
-import { detectUIType, getUIResourceUri } from "@/lib/mcp-ui/mcp-apps-utils";
 import {
-  scanWidgetMeta,
-  scanWidgetSource,
-  type WidgetCapabilityNeed,
+  scanWidgetUsage,
+  type ReadResourceResult,
   type WidgetUsage,
-} from "./widget-scan";
-
-type WidgetTarget = { toolName: string; uri: string };
-
-function collectWidgetTargets(
-  toolsData: ListToolsResultWithMetadata,
-): WidgetTarget[] {
-  const targets: WidgetTarget[] = [];
-  for (const tool of toolsData.tools ?? []) {
-    const meta =
-      toolsData.toolsMetadata?.[tool.name] ??
-      (tool._meta as Record<string, unknown> | undefined);
-    const uri = getUIResourceUri(detectUIType(meta, undefined), meta);
-    if (uri) targets.push({ toolName: tool.name, uri });
-  }
-  return targets;
-}
-
-function htmlFromResource(resource: {
-  text?: string;
-  blob?: string;
-}): string {
-  if (typeof resource.text === "string") return resource.text;
-  if (typeof resource.blob === "string") {
-    try {
-      return atob(resource.blob);
-    } catch {
-      return "";
-    }
-  }
-  return "";
-}
+} from "@mcpjam/sdk/host-compat";
 
 /**
- * L1 widget scan for one server's tools: reads each widget's HTML via
- * `resources/read` and scans it (plus the resource's declared `_meta.ui`)
- * for the host APIs it uses. Returns `undefined` until the scan resolves so
- * the engine can withhold capability findings rather than guess; `{}` means
- * "scanned, nothing notable used".
+ * L1 widget scan for one server's tools — a thin React wrapper over the shared
+ * SDK `scanWidgetUsage`. For each widget-bearing tool it reads the widget's
+ * HTML via `resources/read` (the browser implementation) and scans it (plus the
+ * resource's declared `_meta.ui`) for the host APIs it uses. Returns `undefined`
+ * until the scan resolves so the engine can withhold capability findings rather
+ * than guess; `{}` means "scanned, nothing notable used".
  *
- * Each widget URI is read once even when several tools share it; every
- * tool pointing at that widget inherits its needs.
+ * Each widget URI is read once even when several tools share it; every tool
+ * pointing at that widget inherits its needs.
  */
 export function useWidgetUsage(
   serverName: string,
@@ -61,51 +29,12 @@ export function useWidgetUsage(
     setUsage(undefined);
     if (!toolsData?.tools) return;
 
-    const targets = collectWidgetTargets(toolsData);
-    if (targets.length === 0) {
-      setUsage({});
-      return;
-    }
-
-    // Group tools by widget URI so each resource is fetched once.
-    const toolsByUri = new Map<string, string[]>();
-    for (const { uri, toolName } of targets) {
-      toolsByUri.set(uri, [...(toolsByUri.get(uri) ?? []), toolName]);
-    }
-
-    (async () => {
-      const acc: WidgetUsage = {};
-      const add = (need: WidgetCapabilityNeed, tools: string[]) => {
-        acc[need] = Array.from(new Set([...(acc[need] ?? []), ...tools]));
-      };
-      // Track whether ANY widget was actually read. If every read fails we
-      // must NOT report `{}` (which reads as a conclusive "scanned, clean"
-      // and lets a host show Works) — return `undefined` so the engine keeps
-      // the capability dimension Unknown instead of guessing.
-      const readResults = await Promise.all(
-        Array.from(toolsByUri.entries()).map(async ([uri, toolNames]) => {
-          try {
-            const result = (await readResource(serverName, uri)) as {
-              contents?: Array<{ text?: string; blob?: string; _meta?: unknown }>;
-            };
-            const content = result?.contents?.[0];
-            if (content) {
-              const needs = new Set<WidgetCapabilityNeed>([
-                ...scanWidgetSource(htmlFromResource(content)),
-                ...scanWidgetMeta(content._meta),
-              ]);
-              for (const need of needs) add(need, toolNames);
-            }
-            return true; // the read itself succeeded
-          } catch {
-            return false; // couldn't read this widget
-          }
-        }),
-      );
-      if (cancelled) return;
-      const anyRead = readResults.some(Boolean);
-      setUsage(anyRead ? acc : undefined);
-    })();
+    scanWidgetUsage(
+      toolsData,
+      (uri) => readResource(serverName, uri) as Promise<ReadResourceResult>,
+    ).then((result) => {
+      if (!cancelled) setUsage(result);
+    });
 
     return () => {
       cancelled = true;

--- a/mcpjam-inspector/client/src/lib/host-compat/widget-scan.ts
+++ b/mcpjam-inspector/client/src/lib/host-compat/widget-scan.ts
@@ -1,98 +1,14 @@
 /**
- * L1 widget scan — turns the generic host-capability matrix into
- * *server-specific* findings.
- *
- * At L0 we only know a host's limitations; we can't say whether THIS
- * server's widget hits them. This module statically scans a widget's HTML
- * (and its declared `_meta.ui`) for the host APIs it actually uses, so a
- * finding only fires when the widget genuinely needs a capability the host
- * lacks. Pure string scanning — no execution.
- *
- * Heuristic by nature: it matches both the raw MCP Apps wire methods
- * (`ui/message`, `tools/call`, …) and the OpenAI Apps SDK surface
- * (`window.openai.sendFollowUpMessage`, …). False positives are possible
- * (a method name in a comment); we accept that over masquerading general
- * host knowledge as a per-server finding.
+ * L1 widget scan — re-exported from the shared SDK engine
+ * (`@mcpjam/sdk/host-compat`). The verdict logic, including the static widget
+ * scan, lives in the SDK so every surface (inspector UI, `mcpjam` CLI, public
+ * API, MCP server) shares one implementation. This module stays as a stable
+ * import path for the existing client consumers.
  */
 
-/** Capability dimensions a widget can depend on (subset of the host matrix). */
-export type WidgetCapabilityNeed =
-  | "serverTools"
-  | "serverResources"
-  | "openLinks"
-  | "downloadFile"
-  | "updateModelContext"
-  | "message"
-  | "logging"
-  | "sandboxPermissions"
-  | "cspFrameDomains";
-
-/** capability key → tool names whose widget actually needs it. */
-export type WidgetUsage = Partial<Record<WidgetCapabilityNeed, string[]>>;
-
-const SOURCE_PATTERNS: ReadonlyArray<{
-  key: WidgetCapabilityNeed;
-  patterns: RegExp[];
-}> = [
-  {
-    key: "serverTools",
-    patterns: [/tools\/call/, /\bcallTool\b/, /\bcallServerTool\b/],
-  },
-  {
-    key: "serverResources",
-    patterns: [/resources\/read/, /\breadResource\b/],
-  },
-  {
-    key: "message",
-    patterns: [/ui\/message/, /\bsendFollowUpMessage\b/i],
-  },
-  {
-    key: "updateModelContext",
-    patterns: [/ui\/update-model-context/, /\bsetWidgetState\b/],
-  },
-  {
-    key: "openLinks",
-    patterns: [/ui\/open-link/, /\bopenExternal\b/],
-  },
-  {
-    key: "downloadFile",
-    patterns: [/ui\/download-file/, /\bgetFileDownloadUrl\b/, /\buploadFile\b/],
-  },
-  {
-    key: "logging",
-    patterns: [/notifications\/message/],
-  },
-];
-
-/** Scan widget HTML/JS source for the host APIs it calls. */
-export function scanWidgetSource(source: string): Set<WidgetCapabilityNeed> {
-  const needs = new Set<WidgetCapabilityNeed>();
-  for (const { key, patterns } of SOURCE_PATTERNS) {
-    if (patterns.some((pattern) => pattern.test(source))) needs.add(key);
-  }
-  return needs;
-}
-
-/**
- * Read declared needs straight off the resource's `_meta.ui` — CSP frame
- * domains and sandbox permissions are declared, not called, so they don't
- * show up in a source scan.
- */
-export function scanWidgetMeta(meta: unknown): Set<WidgetCapabilityNeed> {
-  const needs = new Set<WidgetCapabilityNeed>();
-  const ui = (meta as { ui?: { csp?: unknown; permissions?: unknown } })?.ui;
-  const frameDomains = (ui?.csp as { frameDomains?: unknown } | undefined)
-    ?.frameDomains;
-  if (Array.isArray(frameDomains) && frameDomains.length > 0) {
-    needs.add("cspFrameDomains");
-  }
-  const permissions = ui?.permissions;
-  if (
-    permissions &&
-    typeof permissions === "object" &&
-    Object.keys(permissions).length > 0
-  ) {
-    needs.add("sandboxPermissions");
-  }
-  return needs;
-}
+export {
+  scanWidgetSource,
+  scanWidgetMeta,
+  type WidgetCapabilityNeed,
+  type WidgetUsage,
+} from "@mcpjam/sdk/host-compat";


### PR DESCRIPTION
**Phase B-2 (complete)** — the inspector re-consume. The client `host-compat` module had a full duplicate of the verdict engine, types, widget scan, and market-host catalog now in `@mcpjam/sdk/host-compat`. This re-points the inspector at the shared brain so the **UI, CLI, MCP tool, and API all evaluate against one implementation** — and removes the *last* duplicate (the playground's capability matrices).

### Part 1 — engine re-consume (`client/src/lib/host-compat/`)
- **engine.ts** — deletes the local verdict logic; `evaluateAllHosts` is now a thin wrapper over the SDK's `evaluateMarketHosts` that joins the client-only presentation fields (per-host **logos** + **`rendersWidgets`**) onto the SDK's logo-free reports, by id. Caller signatures unchanged.
- **types.ts / profiles.ts / widget-scan.ts / use-widget-usage.ts** — re-exports + a `LOGO_BY_ID` join + a thin `scanWidgetUsage` wrapper. (Net for Part 1: 198 added / 1150 deleted.)

### Part 2 — playground shares the SDK matrices (`client/src/lib/client-styles/built-ins.ts`)
The FULL / COPILOT / GOOSE / NO_CLAIMS MCP Apps capability matrices were byte-identical copies of the SDK's. Now imported from `@mcpjam/sdk/host-compat`, so the compat engine and the playground emulation share **one** matrix source. The SDK types them sparse → built-ins casts to the client's resolved (all-required) shape, **guarded by a matrix-parity test** (each SDK-sourced surface must define exactly the resolved key set, so SDK drift can't slip a missing field past the cast). SLACK + the OpenAI surfaces stay local (the SDK catalog doesn't carry them).

### Verification
- `npm run typecheck:client` → clean.
- **130 tests green** across host-compat + compat-UI + client-styles (registry, resolveEffectiveClientStyle) + mcp-ui playground + the 4 new parity tests. The deleted verdict-logic tests are covered in `sdk/tests/host-compat-*`.

### One intended behavior change
Widget usage now reads **Unknown unless every widget was analyzed** (the SDK's stricter contract — same P1 fix that landed for CLI/MCP), so a partial scan can't yield a false confident verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large deletion of local compat logic with reliance on SDK behavior; the stricter partial widget-scan rule can change displayed verdicts until all widgets load.
> 
> **Overview**
> **Phase B-2** removes the inspector’s duplicate host-compat engine and points the UI at **`@mcpjam/sdk/host-compat`**, so inspector, CLI, API, and MCP server share one verdict implementation.
> 
> The client **`host-compat`** layer is now a thin adapter: **`evaluateAllHosts`** calls the SDK’s **`evaluateMarketHosts`**, then joins **`logoSrc`**, themed logos, and **`rendersWidgets`** from a static **`LOGO_BY_ID`** map. **`profiles`** builds on **`buildMarketHostProfiles()`** instead of a local market-host list tied to the registry. Types, widget scan helpers, and **`deriveServerRequirements` / `evaluateHostCompat`** are re-exported from the SDK; **`useWidgetUsage`** delegates to SDK **`scanWidgetUsage`** with browser **`readResource`**. Verdict-logic tests were removed from the client; remaining tests cover the logo join and UI rollup.
> 
> Playground **`built-ins`** imports **`MCP_APPS_FULL`**, **`COPIL/required shape, with a new **matrix-parity** test so SDK drift can’t leave dimensions **`undefined`** after the cast. **Slack** and OpenAI surfaces stay local.
> 
> **Intended behavior change:** widget capability usage stays **Unknown** unless **every** widget was analyzed (stricter SDK contract; partial scans no longer imply a confident “clean” result).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be36fbb4c9728734b94a36fa6a921a0a339b985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->