### PR TITLE
test(mcp): add check_host_compatibility to platform catalog assertions

### DIFF
--- a/mcp/tests/platformTools.test.ts
+++ b/mcp/tests/platformTools.test.ts
@@ -96,6 +96,8 @@ const PLAIN_TOOLS = [
   "get_server_prompt",
   "list_server_resources",
   "read_server_resource",
+  // Host-compat check: agent-oriented per-host verdict payload, no widget view.
+  "check_host_compatibility",
   "run_eval_case",
   "run_eval_suite",
   "create_eval_suite",
@@ -175,6 +177,7 @@ describe("platform tool registration", () => {
       "get_server_prompt",
       "list_server_resources",
       "read_server_resource",
+      "check_host_compatibility",
       "list_eval_suites",
       "list_eval_suite_runs",
       "run_eval_case",


### PR DESCRIPTION
Fixes "Run Tests" red on main: the `check_host_compatibility` operation (#2949) was added to `PLATFORM_CATALOG_OPERATIONS` but the mcp `platformTools` catalog tests weren't updated. Adds it to the expected catalog order (after `read_server_resource`) and to `PLAIN_TOOLS` (non-widget tool). 11/11 platformTools tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only expectation updates; no production or runtime behavior changes.
> 
> **Overview**
> Updates **`platformTools.test.ts`** so expectations match the platform catalog after **`check_host_compatibility`** was registered (non-widget, agent-oriented tool).
> 
> **`check_host_compatibility`** is added to **`PLAIN_TOOLS`** (after **`read_server_resource`**) and to the ordered tool-name list in the “registers the whole operation catalog in order” test, with a short comment that it has no widget view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9808e1e5ce9ecfa3812c018c636e37dbe3a2a91d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->