### PR TITLE
feat(cli): run commands "as a host" with --host <id>

### DIFF
--- a/cli/src/commands/prompts.ts
+++ b/cli/src/commands/prompts.ts
@@ -4,6 +4,7 @@ import { withEphemeralManager } from "../lib/ephemeral.js";
 import { createCliRpcLogCollector } from "../lib/rpc-logs.js";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers.js";
 import {
+  addHostOption,
   addRetryOptions,
   addSharedServerOptions,
   describeTarget,
@@ -13,6 +14,7 @@ import {
   parseServerConfig,
   resolveAliasedStringOption,
 } from "../lib/server-config.js";
+import { resolveHostFromOptions } from "../lib/host-resolve.js";
 import { writeResult } from "../lib/output.js";
 
 export function registerPromptCommands(program: Command): void {
@@ -20,16 +22,19 @@ export function registerPromptCommands(program: Command): void {
     .command("prompts")
     .description("List and fetch MCP prompts");
 
-  addRetryOptions(
+  addHostOption(
+    addRetryOptions(
     addSharedServerOptions(
       prompts
         .command("list")
         .description("List prompts exposed by an MCP server")
         .option("--cursor <cursor>", "Pagination cursor"),
     ),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const retryPolicy = parseRetryPolicy(options);
+    const host = resolveHostFromOptions(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -47,6 +52,7 @@ export function registerPromptCommands(program: Command): void {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
         retryPolicy,
+        host: host?.connection,
       },
     );
 
@@ -56,7 +62,8 @@ export function registerPromptCommands(program: Command): void {
     );
   });
 
-  addRetryOptions(
+  addHostOption(
+    addRetryOptions(
     addSharedServerOptions(
       prompts
         .command("get")
@@ -68,9 +75,11 @@ export function registerPromptCommands(program: Command): void {
           "Prompt arguments as JSON, @path, or - for stdin",
         ),
     ),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const retryPolicy = parseRetryPolicy(options);
+    const host = resolveHostFromOptions(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -102,6 +111,7 @@ export function registerPromptCommands(program: Command): void {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
         retryPolicy,
+        host: host?.connection,
       },
     );
 

--- a/cli/src/commands/resources.ts
+++ b/cli/src/commands/resources.ts
@@ -4,6 +4,7 @@ import { withEphemeralManager } from "../lib/ephemeral.js";
 import { createCliRpcLogCollector } from "../lib/rpc-logs.js";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers.js";
 import {
+  addHostOption,
   addRetryOptions,
   addSharedServerOptions,
   describeTarget,
@@ -12,6 +13,7 @@ import {
   parseServerConfig,
   resolveAliasedStringOption,
 } from "../lib/server-config.js";
+import { resolveHostFromOptions } from "../lib/host-resolve.js";
 import { writeResult } from "../lib/output.js";
 
 export function registerResourcesCommands(program: Command): void {
@@ -19,16 +21,19 @@ export function registerResourcesCommands(program: Command): void {
     .command("resources")
     .description("List and read MCP resources");
 
-  addRetryOptions(
+  addHostOption(
+    addRetryOptions(
     addSharedServerOptions(
       resources
         .command("list")
         .description("List resources exposed by an MCP server")
         .option("--cursor <cursor>", "Pagination cursor"),
     ),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const retryPolicy = parseRetryPolicy(options);
+    const host = resolveHostFromOptions(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -46,6 +51,7 @@ export function registerResourcesCommands(program: Command): void {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
         retryPolicy,
+        host: host?.connection,
       },
     );
 
@@ -55,7 +61,8 @@ export function registerResourcesCommands(program: Command): void {
     );
   });
 
-  addRetryOptions(
+  addHostOption(
+    addRetryOptions(
     addSharedServerOptions(
       resources
         .command("read")
@@ -63,9 +70,11 @@ export function registerResourcesCommands(program: Command): void {
         .option("--resource-uri <uri>", "Resource URI")
         .option("--uri <uri>", "Alias for --resource-uri"),
     ),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const retryPolicy = parseRetryPolicy(options);
+    const host = resolveHostFromOptions(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -92,6 +101,7 @@ export function registerResourcesCommands(program: Command): void {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
         retryPolicy,
+        host: host?.connection,
       },
     );
 
@@ -101,16 +111,19 @@ export function registerResourcesCommands(program: Command): void {
     );
   });
 
-  addRetryOptions(
+  addHostOption(
+    addRetryOptions(
     addSharedServerOptions(
       resources
         .command("templates")
         .description("List resource templates exposed by an MCP server")
         .option("--cursor <cursor>", "Pagination cursor"),
     ),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const retryPolicy = parseRetryPolicy(options);
+    const host = resolveHostFromOptions(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -131,6 +144,7 @@ export function registerResourcesCommands(program: Command): void {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
         retryPolicy,
+        host: host?.connection,
       },
     );
 

--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -304,9 +304,9 @@ export function registerToolsCommands(program: Command): void {
     try {
       result = await withEphemeralManager(
         config,
-        (manager, serverId) => {
+        async (manager, serverId) => {
           // As a host: an app-only tool isn't callable by that host's model.
-          if (host) assertToolVisibleToHost(manager, serverId, toolName, host);
+          if (host) await assertToolVisibleToHost(manager, serverId, toolName, host);
           return manager.executeTool(serverId, toolName, params);
         },
         {

--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -19,7 +19,10 @@ import { parseReporterFormat, writeReporterResult } from "../lib/reporting.js";
 import { createCliRpcLogCollector } from "../lib/rpc-logs.js";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers.js";
 import { normalizeInspectorFrontendUrl } from "../lib/inspector-api.js";
-import { listToolsWithMetadata } from "../lib/server-ops.js";
+import {
+  estimateTokensFromChars,
+  listToolsWithMetadata,
+} from "../lib/server-ops.js";
 import { summarizeServerDoctorTarget } from "../lib/server-doctor.js";
 import {
   addHostOption,
@@ -109,6 +112,9 @@ export function registerToolsCommands(program: Command): void {
         });
         if (!host) return listed;
         // As a host: drop tools its model can't see (app-only) and report it.
+        // Scope the SIBLING metadata + token count to the visible set too, so
+        // `tools list --host` is consistently host-scoped (no app-only leak via
+        // toolsMetadata/tokenCount).
         const { tools: visibleTools, toolsDroppedVisibility } =
           applyHostVisibility(
             listed.tools as Array<Record<string, unknown>>,
@@ -116,9 +122,20 @@ export function registerToolsCommands(program: Command): void {
             serverId,
             host.policy,
           );
+        const visibleNames = new Set(
+          visibleTools.map((tool) => String(tool.name)),
+        );
         return {
           ...listed,
           tools: visibleTools,
+          toolsMetadata: Object.fromEntries(
+            Object.entries(listed.toolsMetadata).filter(([name]) =>
+              visibleNames.has(name),
+            ),
+          ),
+          ...(listed.tokenCount === undefined
+            ? {}
+            : { tokenCount: estimateTokensFromChars(JSON.stringify(visibleTools)) }),
           host: host.id,
           toolsDroppedVisibility,
         };

--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -22,6 +22,7 @@ import { normalizeInspectorFrontendUrl } from "../lib/inspector-api.js";
 import { listToolsWithMetadata } from "../lib/server-ops.js";
 import { summarizeServerDoctorTarget } from "../lib/server-doctor.js";
 import {
+  addHostOption,
   addRetryOptions,
   addSharedServerOptions,
   describeTarget,
@@ -33,6 +34,11 @@ import {
   type GlobalOptions,
   type SharedServerTargetOptions,
 } from "../lib/server-config.js";
+import {
+  applyHostVisibility,
+  assertToolVisibleToHost,
+  resolveHostFromOptions,
+} from "../lib/host-resolve.js";
 import {
   normalizeCliError,
   setProcessExitCode,
@@ -70,17 +76,20 @@ export function registerToolsCommands(program: Command): void {
     .command("tools")
     .description("List and invoke MCP server tools");
 
-  addRetryOptions(
-    addSharedServerOptions(
-      tools
-        .command("list")
-        .description("List tools exposed by an MCP server")
-        .option("--cursor <cursor>", "Pagination cursor")
-        .option("--model-id <model>", "Model id used for token counting"),
+  addHostOption(
+    addRetryOptions(
+      addSharedServerOptions(
+        tools
+          .command("list")
+          .description("List tools exposed by an MCP server")
+          .option("--cursor <cursor>", "Pagination cursor")
+          .option("--model-id <model>", "Model id used for token counting"),
+      ),
     ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const retryPolicy = parseRetryPolicy(options);
+    const host = resolveHostFromOptions(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -92,16 +101,33 @@ export function registerToolsCommands(program: Command): void {
 
     const result = await withEphemeralManager(
       config,
-      (manager, serverId) =>
-        listToolsWithMetadata(manager, {
+      async (manager, serverId) => {
+        const listed = await listToolsWithMetadata(manager, {
           serverId,
           cursor: options.cursor,
           modelId: options.modelId,
-        }),
+        });
+        if (!host) return listed;
+        // As a host: drop tools its model can't see (app-only) and report it.
+        const { tools: visibleTools, toolsDroppedVisibility } =
+          applyHostVisibility(
+            listed.tools as Array<Record<string, unknown>>,
+            manager,
+            serverId,
+            host.policy,
+          );
+        return {
+          ...listed,
+          tools: visibleTools,
+          host: host.id,
+          toolsDroppedVisibility,
+        };
+      },
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
         retryPolicy,
+        host: host?.connection,
       },
     );
 
@@ -111,7 +137,8 @@ export function registerToolsCommands(program: Command): void {
     );
   });
 
-  addSharedServerOptions(
+  addHostOption(
+    addSharedServerOptions(
     tools
       .command("call")
       .description("Call an MCP tool")
@@ -179,8 +206,10 @@ export function registerToolsCommands(program: Command): void {
       .option("--theme <theme>", 'Render theme: "light" or "dark" (with --ui)')
       .option("--locale <locale>", "Render locale (with --ui)")
       .option("--time-zone <iana>", "Render IANA timezone (with --ui)"),
+    ),
   ).action(async (options: ToolsCallOptions, command) => {
     const globalOptions = getGlobalOptions(command);
+    const host = resolveHostFromOptions(options);
     const target = describeTarget(options);
     const primaryCollector =
       globalOptions.rpc || options.debugOut
@@ -258,10 +287,15 @@ export function registerToolsCommands(program: Command): void {
     try {
       result = await withEphemeralManager(
         config,
-        (manager, serverId) => manager.executeTool(serverId, toolName, params),
+        (manager, serverId) => {
+          // As a host: an app-only tool isn't callable by that host's model.
+          if (host) assertToolVisibleToHost(manager, serverId, toolName, host);
+          return manager.executeTool(serverId, toolName, params);
+        },
         {
           timeout: globalOptions.timeout,
           rpcLogger: primaryCollector?.rpcLogger,
+          host: host?.connection,
         },
       );
     } catch (error) {

--- a/cli/src/lib/ephemeral.ts
+++ b/cli/src/lib/ephemeral.ts
@@ -4,11 +4,19 @@ import {
   type RetryPolicy,
   type RpcLogger,
 } from "@mcpjam/sdk";
+import type { HostConnectionProfile } from "@mcpjam/sdk/host-config/internal";
+import { applyHostToConfig } from "./host-resolve.js";
 
 export interface EphemeralManagerOptions {
   timeout?: number;
   rpcLogger?: RpcLogger;
   retryPolicy?: RetryPolicy;
+  /**
+   * Connect "as a host" — merge the host's `clientInfo`/`clientCapabilities`/
+   * protocol pins onto the config so the `initialize` handshake advertises that
+   * host's identity. Resolve via `resolveHostFromOptions` in `host-resolve`.
+   */
+  host?: HostConnectionProfile;
 }
 
 export async function withEphemeralManager<T>(
@@ -19,7 +27,10 @@ export async function withEphemeralManager<T>(
   ) => Promise<T>,
   options?: EphemeralManagerOptions,
 ): Promise<T> {
-  return withEphemeralClient(config, fn, {
+  const resolvedConfig = options?.host
+    ? applyHostToConfig(config, options.host)
+    : config;
+  return withEphemeralClient(resolvedConfig, fn, {
     serverId: "__cli__",
     clientName: "mcpjam",
     timeout: options?.timeout ?? 30_000,

--- a/cli/src/lib/host-resolve.ts
+++ b/cli/src/lib/host-resolve.ts
@@ -1,0 +1,129 @@
+import { type MCPClientManager, type MCPServerConfig } from "@mcpjam/sdk";
+import {
+  HOST_TEMPLATE_IDS,
+  seedHostTemplate,
+  type HostTemplateId,
+} from "@mcpjam/sdk/host-config/templates";
+import {
+  applyVisibilityPolicyAndCountSignals,
+  extractHostExecutionPolicy,
+  hostConnectionProfile,
+  isAppOnlyTool,
+  type HostConnectionProfile,
+  type HostExecutionPolicy,
+  type ToolMetadataSource,
+} from "@mcpjam/sdk/host-config/internal";
+import { usageError } from "./output.js";
+
+export interface ResolvedHost {
+  id: HostTemplateId;
+  /** Pins for the `initialize` handshake (clientInfo/capabilities/protocol). */
+  connection: HostConnectionProfile;
+  /** Execution policy — drives tool-visibility filtering. */
+  policy: HostExecutionPolicy;
+}
+
+/** Seed a host by id and derive its connection profile + execution policy. */
+export function resolveHostConnection(hostId: string): ResolvedHost {
+  if (!(HOST_TEMPLATE_IDS as readonly string[]).includes(hostId)) {
+    throw usageError(
+      `Unknown host "${hostId}". Valid hosts: ${HOST_TEMPLATE_IDS.join(", ")}.`,
+    );
+  }
+  const id = hostId as HostTemplateId;
+  const seeded = seedHostTemplate(id) as unknown as Record<string, unknown>;
+  return {
+    id,
+    connection: hostConnectionProfile(seeded),
+    policy: extractHostExecutionPolicy(seeded, id),
+  };
+}
+
+/**
+ * Resolve `--host`, rejecting the conflict with `--client-capabilities` (both
+ * set the *exact* advertised client capabilities, so they're mutually
+ * exclusive). Returns `undefined` when `--host` is absent.
+ */
+export function resolveHostFromOptions(options: {
+  host?: string;
+  clientCapabilities?: unknown;
+}): ResolvedHost | undefined {
+  if (!options.host) return undefined;
+  if (options.clientCapabilities !== undefined) {
+    throw usageError(
+      "--host advertises the host's client capabilities; pass --host or --client-capabilities, not both.",
+    );
+  }
+  return resolveHostConnection(options.host);
+}
+
+/** Merge a host's connection pins onto a parsed server config. */
+export function applyHostToConfig(
+  config: MCPServerConfig,
+  host: HostConnectionProfile,
+): MCPServerConfig {
+  const identity = {
+    ...(host.clientInfo ? { clientInfo: host.clientInfo } : {}),
+    ...(host.clientCapabilities
+      ? { clientCapabilities: host.clientCapabilities }
+      : {}),
+    ...(host.supportedProtocolVersions
+      ? { supportedProtocolVersions: host.supportedProtocolVersions }
+      : {}),
+  };
+  // `mcpProtocolVersion` is HTTP-only (the stateless wire-mode pin).
+  const httpOnly =
+    "url" in config && host.mcpProtocolVersion
+      ? { mcpProtocolVersion: host.mcpProtocolVersion }
+      : {};
+  return { ...config, ...identity, ...httpOnly } as MCPServerConfig;
+}
+
+/**
+ * Apply a host's tool-visibility policy to a listed tool array, dropping
+ * app-only tools the host's model can't see, and report how many were dropped.
+ * Reuses the shared `applyVisibilityPolicyAndCountSignals` (no-op when the host
+ * opts out via `respectToolVisibility: false`) so counts match chat/eval.
+ */
+export function applyHostVisibility(
+  tools: Array<Record<string, unknown>>,
+  manager: MCPClientManager,
+  serverId: string,
+  policy: HostExecutionPolicy,
+): { tools: Array<Record<string, unknown>>; toolsDroppedVisibility: number } {
+  const record: Record<string, Record<string, unknown>> = {};
+  for (const tool of tools) {
+    record[String(tool.name)] = { ...tool, _serverId: serverId };
+  }
+  const signals = applyVisibilityPolicyAndCountSignals(
+    record,
+    manager as unknown as ToolMetadataSource,
+    policy,
+  );
+  const visible = tools.filter((tool) => String(tool.name) in record);
+  return { tools: visible, toolsDroppedVisibility: signals.toolsDroppedVisibility };
+}
+
+/**
+ * Reject calling an app-only tool when running as a host whose model can't see
+ * it — `--host` simulates that host. (No-op when the host opts out of
+ * visibility, or when the tool is model-visible.)
+ */
+export function assertToolVisibleToHost(
+  manager: MCPClientManager,
+  serverId: string,
+  toolName: string,
+  host: ResolvedHost,
+): void {
+  if (host.policy.respectToolVisibility === false) return;
+  // getAllToolsMetadata returns name → the tool's `_meta` (with `.ui` at top
+  // level), which is exactly what isAppOnlyTool reads.
+  const meta = manager.getAllToolsMetadata(serverId)[toolName] as
+    | Record<string, unknown>
+    | undefined;
+  if (isAppOnlyTool(meta)) {
+    throw usageError(
+      `Tool "${toolName}" is app-only — not visible to host "${host.id}"'s model. Omit --host to call it as an operator.`,
+    );
+  }
+}

--- a/cli/src/lib/host-resolve.ts
+++ b/cli/src/lib/host-resolve.ts
@@ -123,6 +123,7 @@ export async function assertToolVisibleToHost(
   host: ResolvedHost,
 ): Promise<void> {
   if (host.policy.respectToolVisibility === false) return;
+  const seenCursors = new Set<string>();
   let cursor: string | undefined;
   for (let page = 0; page < TOOLS_PAGE_CAP; page++) {
     const result = await manager.listTools(
@@ -141,8 +142,15 @@ export async function assertToolVisibleToHost(
       return; // found and model-visible
     }
     cursor = result.nextCursor;
-    if (!cursor) break;
+    // Paged through the WHOLE list without finding it → genuinely unlisted;
+    // allow the call (the server may still expose it).
+    if (!cursor) return;
+    if (seenCursors.has(cursor)) break; // server looping on a cursor
+    seenCursors.add(cursor);
   }
-  // Tool not among the listed tools → not a listed app-only tool; allow the
-  // call (the server may still expose it).
+  // Couldn't page through the full tool list (page cap or cursor loop) and the
+  // tool hasn't appeared — can't confirm it's model-visible, so fail CLOSED.
+  throw usageError(
+    `Could not verify "${toolName}" is visible to host "${host.id}" — the server's tool list is too long to page through. Omit --host to call it as an operator.`,
+  );
 }

--- a/cli/src/lib/host-resolve.ts
+++ b/cli/src/lib/host-resolve.ts
@@ -104,26 +104,45 @@ export function applyHostVisibility(
   return { tools: visible, toolsDroppedVisibility: signals.toolsDroppedVisibility };
 }
 
+// Bound the tools pagination so a pathological server can't loop forever.
+const TOOLS_PAGE_CAP = 50;
+
 /**
  * Reject calling an app-only tool when running as a host whose model can't see
  * it — `--host` simulates that host. (No-op when the host opts out of
- * visibility, or when the tool is model-visible.)
+ * visibility, or when the tool is model-visible / unlisted.)
+ *
+ * `executeTool` connects but does NOT list tools, so the manager's metadata map
+ * is empty here — we list the tools ourselves (across pages) and read the
+ * requested tool's inline `_meta` directly.
  */
-export function assertToolVisibleToHost(
+export async function assertToolVisibleToHost(
   manager: MCPClientManager,
   serverId: string,
   toolName: string,
   host: ResolvedHost,
-): void {
+): Promise<void> {
   if (host.policy.respectToolVisibility === false) return;
-  // getAllToolsMetadata returns name → the tool's `_meta` (with `.ui` at top
-  // level), which is exactly what isAppOnlyTool reads.
-  const meta = manager.getAllToolsMetadata(serverId)[toolName] as
-    | Record<string, unknown>
-    | undefined;
-  if (isAppOnlyTool(meta)) {
-    throw usageError(
-      `Tool "${toolName}" is app-only — not visible to host "${host.id}"'s model. Omit --host to call it as an operator.`,
+  let cursor: string | undefined;
+  for (let page = 0; page < TOOLS_PAGE_CAP; page++) {
+    const result = await manager.listTools(
+      serverId,
+      cursor ? { cursor } : undefined,
     );
+    const tool = (result.tools ?? []).find(
+      (t) => (t as { name?: unknown }).name === toolName,
+    ) as { _meta?: Record<string, unknown> } | undefined;
+    if (tool) {
+      if (isAppOnlyTool(tool._meta)) {
+        throw usageError(
+          `Tool "${toolName}" is app-only — not visible to host "${host.id}"'s model. Omit --host to call it as an operator.`,
+        );
+      }
+      return; // found and model-visible
+    }
+    cursor = result.nextCursor;
+    if (!cursor) break;
   }
+  // Tool not among the listed tools → not a listed app-only tool; allow the
+  // call (the server may still expose it).
 }

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -40,6 +40,8 @@ export interface SharedServerTargetOptions {
   timeout?: number;
   retries?: number;
   retryDelayMs?: number;
+  /** Connect as this host (added by `addHostOption`, resolved separately). */
+  host?: string;
 }
 
 const DEFAULT_CLI_RETRY_POLICY: RetryPolicy = {
@@ -98,6 +100,20 @@ export function addSharedServerOptions(command: Command): Command {
       'Stdio environment assignment in "KEY=VALUE" format. Pass multiple values or repeat the flag.',
     )
     .option("--cwd <path>", "Working directory for the stdio MCP server process");
+}
+
+/**
+ * Add `--host <id>` — connect "as" a host: send its identity, advertised client
+ * capabilities, and protocol version in `initialize`, and apply its tool
+ * visibility. Kept separate from {@link addSharedServerOptions} so it can be
+ * applied only to the commands where running as a host makes sense, and to
+ * avoid colliding with `compat`'s own (report-filter) `--host`.
+ */
+export function addHostOption(command: Command): Command {
+  return command.option(
+    "--host <id>",
+    "Connect as this host (e.g. claude, chatgpt, cursor) — sends its identity/capabilities/protocol and applies its tool visibility",
+  );
 }
 
 export function getGlobalOptions(command: Command): GlobalOptions {

--- a/cli/src/lib/server-ops.ts
+++ b/cli/src/lib/server-ops.ts
@@ -42,6 +42,6 @@ export async function exportServerSnapshot(
   return serializeServerSnapshot(snapshot, options);
 }
 
-function estimateTokensFromChars(text: string): number {
+export function estimateTokensFromChars(text: string): number {
   return Math.ceil(text.length / 4);
 }

--- a/cli/tests/host-resolve.test.ts
+++ b/cli/tests/host-resolve.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { MCPClientManager, MCPServerConfig } from "@mcpjam/sdk";
+import {
+  applyHostToConfig,
+  applyHostVisibility,
+  assertToolVisibleToHost,
+  resolveHostConnection,
+  resolveHostFromOptions,
+} from "../src/lib/host-resolve.js";
+import { CliError } from "../src/lib/output.js";
+
+// Mock the duck-typed ToolMetadataSource the visibility helper reads:
+// getAllToolsMetadata(serverId) → name → the tool's `_meta` (with `.ui`).
+function mockManager(
+  metadata: Record<string, Record<string, unknown>>,
+): MCPClientManager {
+  return {
+    getAllToolsMetadata: () => metadata,
+  } as unknown as MCPClientManager;
+}
+
+// getAllToolsMetadata returns name → the tool's `_meta` (with `.ui` at top
+// level) — that's what the visibility helpers read.
+const appOnly = { ui: { visibility: ["app"] } };
+const modelVisible = {};
+
+test("resolveHostConnection derives Claude's identity + UI capability", () => {
+  const h = resolveHostConnection("claude");
+  assert.equal(h.connection.clientInfo?.name, "claude-ai");
+  const ext = (h.connection.clientCapabilities?.extensions ?? {}) as Record<
+    string,
+    unknown
+  >;
+  assert.ok(ext["io.modelcontextprotocol/ui"]);
+  assert.notEqual(h.policy.respectToolVisibility, false);
+});
+
+test("resolveHostConnection rejects an unknown host", () => {
+  assert.throws(() => resolveHostConnection("bogus"), CliError);
+});
+
+test("resolveHostFromOptions rejects --host together with --client-capabilities", () => {
+  assert.throws(
+    () =>
+      resolveHostFromOptions({ host: "claude", clientCapabilities: "{}" }),
+    CliError,
+  );
+});
+
+test("resolveHostFromOptions returns undefined without --host", () => {
+  assert.equal(resolveHostFromOptions({}), undefined);
+});
+
+test("applyHostToConfig merges identity pins onto an http config", () => {
+  const base = { url: "https://example.com/mcp" } as MCPServerConfig;
+  const merged = applyHostToConfig(
+    base,
+    resolveHostConnection("claude").connection,
+  ) as Record<string, unknown>;
+  assert.equal((merged.clientInfo as { name?: string }).name, "claude-ai");
+  assert.ok(merged.clientCapabilities);
+});
+
+test("applyHostVisibility drops app-only tools for a visibility-respecting host", () => {
+  const tools = [
+    { name: "open_widget", ...appOnly },
+    { name: "search", ...modelVisible },
+  ];
+  const manager = mockManager({ open_widget: appOnly, search: modelVisible });
+  const result = applyHostVisibility(
+    tools,
+    manager,
+    "__cli__",
+    resolveHostConnection("claude").policy,
+  );
+  assert.equal(result.toolsDroppedVisibility, 1);
+  assert.deepEqual(
+    result.tools.map((t) => t.name),
+    ["search"],
+  );
+});
+
+test("applyHostVisibility keeps app-only tools when the host opts out (cursor)", () => {
+  const tools = [{ name: "open_widget", ...appOnly }];
+  const manager = mockManager({ open_widget: appOnly });
+  const result = applyHostVisibility(
+    tools,
+    manager,
+    "__cli__",
+    resolveHostConnection("cursor").policy,
+  );
+  assert.equal(result.toolsDroppedVisibility, 0);
+  assert.equal(result.tools.length, 1);
+});
+
+test("assertToolVisibleToHost rejects an app-only call as a visibility-respecting host", () => {
+  const claude = resolveHostConnection("claude");
+  assert.throws(
+    () =>
+      assertToolVisibleToHost(
+        mockManager({ open_widget: appOnly }),
+        "__cli__",
+        "open_widget",
+        claude,
+      ),
+    CliError,
+  );
+  // A model-visible tool is allowed.
+  assert.doesNotThrow(() =>
+    assertToolVisibleToHost(
+      mockManager({ search: modelVisible }),
+      "__cli__",
+      "search",
+      claude,
+    ),
+  );
+  // The host opting out of visibility never rejects.
+  assert.doesNotThrow(() =>
+    assertToolVisibleToHost(
+      mockManager({ open_widget: appOnly }),
+      "__cli__",
+      "open_widget",
+      resolveHostConnection("cursor"),
+    ),
+  );
+});

--- a/cli/tests/host-resolve.test.ts
+++ b/cli/tests/host-resolve.test.ts
@@ -10,17 +10,25 @@ import {
 } from "../src/lib/host-resolve.js";
 import { CliError } from "../src/lib/output.js";
 
-// Mock the duck-typed ToolMetadataSource the visibility helper reads:
-// getAllToolsMetadata(serverId) → name → the tool's `_meta` (with `.ui`).
-// Enforces the serverId so the server-scoped lookup stays tested.
-function mockManager(
-  metadata: Record<string, Record<string, unknown>>,
-  expectedServerId = "__cli__",
-): MCPClientManager {
+// Mock the manager surfaces the host helpers use, enforcing the serverId so the
+// server-scoped lookups stay tested:
+//  - getAllToolsMetadata(serverId) → name → the tool's `_meta` (applyHostVisibility)
+//  - listTools(serverId) → { tools: [{ name, _meta }] } (assertToolVisibleToHost,
+//    which lists tools itself — executeTool doesn't populate the metadata map).
+function mockManager(opts: {
+  metadata?: Record<string, Record<string, unknown>>;
+  tools?: Array<Record<string, unknown>>;
+  expectedServerId?: string;
+}): MCPClientManager {
+  const expected = opts.expectedServerId ?? "__cli__";
   return {
     getAllToolsMetadata: (serverId: string) => {
-      assert.equal(serverId, expectedServerId);
-      return metadata;
+      assert.equal(serverId, expected);
+      return opts.metadata ?? {};
+    },
+    listTools: async (serverId: string) => {
+      assert.equal(serverId, expected);
+      return { tools: opts.tools ?? [], nextCursor: undefined };
     },
   } as unknown as MCPClientManager;
 }
@@ -72,7 +80,9 @@ test("applyHostVisibility drops app-only tools for a visibility-respecting host"
     { name: "open_widget", ...appOnly },
     { name: "search", ...modelVisible },
   ];
-  const manager = mockManager({ open_widget: appOnly, search: modelVisible });
+  const manager = mockManager({
+    metadata: { open_widget: appOnly, search: modelVisible },
+  });
   const result = applyHostVisibility(
     tools,
     manager,
@@ -88,7 +98,7 @@ test("applyHostVisibility drops app-only tools for a visibility-respecting host"
 
 test("applyHostVisibility keeps app-only tools when the host opts out (cursor)", () => {
   const tools = [{ name: "open_widget", ...appOnly }];
-  const manager = mockManager({ open_widget: appOnly });
+  const manager = mockManager({ metadata: { open_widget: appOnly } });
   const result = applyHostVisibility(
     tools,
     manager,
@@ -99,12 +109,14 @@ test("applyHostVisibility keeps app-only tools when the host opts out (cursor)",
   assert.equal(result.tools.length, 1);
 });
 
-test("assertToolVisibleToHost rejects an app-only call as a visibility-respecting host", () => {
+test("assertToolVisibleToHost rejects an app-only call as a visibility-respecting host", async () => {
   const claude = resolveHostConnection("claude");
-  assert.throws(
+  // executeTool doesn't list tools, so the check must list them itself — the
+  // mock serves listTools, not a pre-populated metadata map.
+  await assert.rejects(
     () =>
       assertToolVisibleToHost(
-        mockManager({ open_widget: appOnly }),
+        mockManager({ tools: [{ name: "open_widget", _meta: appOnly }] }),
         "__cli__",
         "open_widget",
         claude,
@@ -112,18 +124,27 @@ test("assertToolVisibleToHost rejects an app-only call as a visibility-respectin
     CliError,
   );
   // A model-visible tool is allowed.
-  assert.doesNotThrow(() =>
+  await assert.doesNotReject(() =>
     assertToolVisibleToHost(
-      mockManager({ search: modelVisible }),
+      mockManager({ tools: [{ name: "search", _meta: modelVisible }] }),
       "__cli__",
       "search",
       claude,
     ),
   );
-  // The host opting out of visibility never rejects.
-  assert.doesNotThrow(() =>
+  // A tool not in the listed set is allowed (not a listed app-only tool).
+  await assert.doesNotReject(() =>
     assertToolVisibleToHost(
-      mockManager({ open_widget: appOnly }),
+      mockManager({ tools: [] }),
+      "__cli__",
+      "missing",
+      claude,
+    ),
+  );
+  // The host opting out of visibility never rejects.
+  await assert.doesNotReject(() =>
+    assertToolVisibleToHost(
+      mockManager({ tools: [{ name: "open_widget", _meta: appOnly }] }),
       "__cli__",
       "open_widget",
       resolveHostConnection("cursor"),

--- a/cli/tests/host-resolve.test.ts
+++ b/cli/tests/host-resolve.test.ts
@@ -18,6 +18,7 @@ import { CliError } from "../src/lib/output.js";
 function mockManager(opts: {
   metadata?: Record<string, Record<string, unknown>>;
   tools?: Array<Record<string, unknown>>;
+  nextCursor?: string;
   expectedServerId?: string;
 }): MCPClientManager {
   const expected = opts.expectedServerId ?? "__cli__";
@@ -28,7 +29,7 @@ function mockManager(opts: {
     },
     listTools: async (serverId: string) => {
       assert.equal(serverId, expected);
-      return { tools: opts.tools ?? [], nextCursor: undefined };
+      return { tools: opts.tools ?? [], nextCursor: opts.nextCursor };
     },
   } as unknown as MCPClientManager;
 }
@@ -132,7 +133,7 @@ test("assertToolVisibleToHost rejects an app-only call as a visibility-respectin
       claude,
     ),
   );
-  // A tool not in the listed set is allowed (not a listed app-only tool).
+  // A tool not in a fully-paged list is allowed (genuinely unlisted).
   await assert.doesNotReject(() =>
     assertToolVisibleToHost(
       mockManager({ tools: [] }),
@@ -140,6 +141,21 @@ test("assertToolVisibleToHost rejects an app-only call as a visibility-respectin
       "missing",
       claude,
     ),
+  );
+  // Fail CLOSED: the list never drains (server keeps returning a cursor) and the
+  // tool hasn't appeared — can't confirm visibility, so reject.
+  await assert.rejects(
+    () =>
+      assertToolVisibleToHost(
+        mockManager({
+          tools: [{ name: "other", _meta: modelVisible }],
+          nextCursor: "more",
+        }),
+        "__cli__",
+        "open_widget",
+        claude,
+      ),
+    CliError,
   );
   // The host opting out of visibility never rejects.
   await assert.doesNotReject(() =>

--- a/cli/tests/host-resolve.test.ts
+++ b/cli/tests/host-resolve.test.ts
@@ -12,11 +12,16 @@ import { CliError } from "../src/lib/output.js";
 
 // Mock the duck-typed ToolMetadataSource the visibility helper reads:
 // getAllToolsMetadata(serverId) → name → the tool's `_meta` (with `.ui`).
+// Enforces the serverId so the server-scoped lookup stays tested.
 function mockManager(
   metadata: Record<string, Record<string, unknown>>,
+  expectedServerId = "__cli__",
 ): MCPClientManager {
   return {
-    getAllToolsMetadata: () => metadata,
+    getAllToolsMetadata: (serverId: string) => {
+      assert.equal(serverId, expectedServerId);
+      return metadata;
+    },
   } as unknown as MCPClientManager;
 }
 

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -1,0 +1,79 @@
+import { extractHostExecutionPolicy } from "./host-policy.js";
+
+/**
+ * The MCP connection facts a host advertises — what to send in the `initialize`
+ * handshake (`clientInfo`, `clientCapabilities`, protocol version) and whether
+ * the host filters app-only tools from its model's view.
+ *
+ * Lets a non-browser surface (CLI, MCP server, API) connect to an MCP server
+ * "as a host" using the same facts the playground does. The wire fields map
+ * directly onto `MCPServerConfig` (`clientInfo` / `clientCapabilities` /
+ * `supportedProtocolVersions` / `mcpProtocolVersion`); `respectToolVisibility`
+ * drives `applyVisibilityPolicyAndCountSignals` on a tool list.
+ */
+export interface HostConnectionProfile {
+  clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+  clientCapabilities?: Record<string, unknown>;
+  supportedProtocolVersions?: string[];
+  mcpProtocolVersion?: string;
+  /** undefined = spec default (filter app-only tools); false = host opts out. */
+  respectToolVisibility: boolean | undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Derive a {@link HostConnectionProfile} from a seeded host config — exactly
+ * what `seedHostTemplate(id)` returns, or a `Host.toJSON()` shape. Pure read,
+ * no I/O. The handshake pins live under `mcpProfile.initialize`; the advertised
+ * capabilities and visibility policy live at the top level.
+ */
+export function hostConnectionProfile(
+  hostConfig: Record<string, unknown>,
+): HostConnectionProfile {
+  const mcpProfile = isRecord(hostConfig.mcpProfile)
+    ? hostConfig.mcpProfile
+    : undefined;
+  const initialize =
+    mcpProfile && isRecord(mcpProfile.initialize)
+      ? mcpProfile.initialize
+      : undefined;
+
+  const clientInfo = isRecord(initialize?.clientInfo)
+    ? (initialize.clientInfo as {
+        name?: string;
+        version?: string;
+      } & Record<string, unknown>)
+    : undefined;
+
+  const supportedProtocolVersions = Array.isArray(
+    initialize?.supportedProtocolVersions,
+  )
+    ? (initialize.supportedProtocolVersions as unknown[]).filter(
+        (v): v is string => typeof v === "string",
+      )
+    : undefined;
+
+  const mcpProtocolVersion =
+    typeof initialize?.mcpProtocolVersion === "string"
+      ? initialize.mcpProtocolVersion
+      : undefined;
+
+  const clientCapabilities = isRecord(hostConfig.clientCapabilities)
+    ? hostConfig.clientCapabilities
+    : undefined;
+
+  const { respectToolVisibility } = extractHostExecutionPolicy(hostConfig);
+
+  return {
+    ...(clientInfo ? { clientInfo } : {}),
+    ...(clientCapabilities ? { clientCapabilities } : {}),
+    ...(supportedProtocolVersions && supportedProtocolVersions.length > 0
+      ? { supportedProtocolVersions }
+      : {}),
+    ...(mcpProtocolVersion ? { mcpProtocolVersion } : {}),
+    respectToolVisibility,
+  };
+}

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -25,10 +25,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Derive a {@link HostConnectionProfile} from a seeded host config — exactly
- * what `seedHostTemplate(id)` returns, or a `Host.toJSON()` shape. Pure read,
- * no I/O. The handshake pins live under `mcpProfile.initialize`; the advertised
+ * Derive a {@link HostConnectionProfile} from a **seeded host config** — the
+ * internal `mcpProfile` shape that `seedHostTemplate(id)` returns. Pure read, no
+ * I/O. `clientInfo` + `supportedProtocolVersions` live under
+ * `mcpProfile.initialize`; the protocol-version pin lives at
+ * `mcpProfile.mcpProtocolVersion` (sibling of `initialize`); the advertised
  * capabilities and visibility policy live at the top level.
+ *
+ * (Not the public `Host.toJSON()` shape, which uses `mcp.protocolVersion` etc.)
  */
 export function hostConnectionProfile(
   hostConfig: Record<string, unknown>,
@@ -57,8 +61,8 @@ export function hostConnectionProfile(
     : undefined;
 
   const mcpProtocolVersion =
-    typeof initialize?.mcpProtocolVersion === "string"
-      ? initialize.mcpProtocolVersion
+    typeof mcpProfile?.mcpProtocolVersion === "string"
+      ? mcpProfile.mcpProtocolVersion
       : undefined;
 
   const clientCapabilities = isRecord(hostConfig.clientCapabilities)

--- a/sdk/src/host-config/internal.ts
+++ b/sdk/src/host-config/internal.ts
@@ -57,6 +57,8 @@ export type {
   HostExecutionPolicy,
   ToolExposureSignals,
 } from "./host-policy.js";
+export { hostConnectionProfile } from "./host-connection.js";
+export type { HostConnectionProfile } from "./host-connection.js";
 export {
   readOpenAiCompatOverride,
   compatPresetForHostStyle,

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -41,4 +41,20 @@ describe("hostConnectionProfile", () => {
   it("returns respectToolVisibility undefined for a config with no host fields", () => {
     expect(hostConnectionProfile({}).respectToolVisibility).toBeUndefined();
   });
+
+  it("reads the protocol-version pin from mcpProfile (sibling of initialize)", () => {
+    const p = hostConnectionProfile({
+      mcpProfile: {
+        mcpProtocolVersion: "2026-07-28",
+        initialize: { clientInfo: { name: "x" } },
+      },
+    });
+    expect(p.mcpProtocolVersion).toBe("2026-07-28");
+    // A value mistakenly placed under initialize must NOT be read.
+    expect(
+      hostConnectionProfile({
+        mcpProfile: { initialize: { mcpProtocolVersion: "2026-07-28" } },
+      }).mcpProtocolVersion,
+    ).toBeUndefined();
+  });
 });

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { hostConnectionProfile } from "../src/host-config/internal";
+import {
+  seedHostTemplate,
+  type HostTemplateId,
+} from "../src/host-config/templates/seed-host-template";
+
+const profileFor = (id: HostTemplateId) =>
+  hostConnectionProfile(
+    seedHostTemplate(id) as unknown as Record<string, unknown>,
+  );
+
+const extensions = (caps: Record<string, unknown> | undefined) =>
+  (caps?.extensions ?? {}) as Record<string, unknown>;
+
+describe("hostConnectionProfile", () => {
+  it("derives Claude's identity + the MCP Apps UI capability", () => {
+    const p = profileFor("claude");
+    expect(p.clientInfo?.name).toBe("claude-ai");
+    expect(extensions(p.clientCapabilities)["io.modelcontextprotocol/ui"]).toBeDefined();
+    // Claude's model filters app-only tools (default visibility policy).
+    expect(p.respectToolVisibility).not.toBe(false);
+  });
+
+  it("pins Goose's advertised protocol version", () => {
+    expect(profileFor("goose").supportedProtocolVersions).toContain(
+      "2025-03-26",
+    );
+  });
+
+  it("Cursor opts out of tool-visibility filtering", () => {
+    expect(profileFor("cursor").respectToolVisibility).toBe(false);
+  });
+
+  it("ChatGPT advertises its experimental visibility capability", () => {
+    const p = profileFor("chatgpt");
+    expect(p.clientCapabilities).toBeDefined();
+    expect(JSON.stringify(p.clientCapabilities)).toContain("openai");
+  });
+
+  it("returns respectToolVisibility undefined for a config with no host fields", () => {
+    expect(hostConnectionProfile({}).respectToolVisibility).toBeUndefined();
+  });
+});

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -32,10 +32,10 @@ describe("hostConnectionProfile", () => {
     expect(profileFor("cursor").respectToolVisibility).toBe(false);
   });
 
-  it("ChatGPT advertises its experimental visibility capability", () => {
-    const p = profileFor("chatgpt");
-    expect(p.clientCapabilities).toBeDefined();
-    expect(JSON.stringify(p.clientCapabilities)).toContain("openai");
+  it("ChatGPT advertises its experimental openai/visibility capability", () => {
+    const experimental = (profileFor("chatgpt").clientCapabilities
+      ?.experimental ?? {}) as Record<string, { enabled?: boolean }>;
+    expect(experimental["openai/visibility"]?.enabled).toBe(true);
   });
 
   it("returns respectToolVisibility undefined for a config with no host fields", () => {


### PR DESCRIPTION
In the playground you pick a host (MCPJam, Claude, ChatGPT, Cursor, …) and everything runs **as that host**. The CLI connected **generically** (hardcoded `clientName: "mcpjam"`). This adds `--host <id>` so `tools` / `resources` / `prompts` connect **as that host** — the same wire-level emulation the playground does.

## What "as a host" does (non-render)
1. **`initialize` handshake** — sends the host's `clientInfo` (e.g. `claude-ai`) + advertised `clientCapabilities` (the `io.modelcontextprotocol/ui` MCP-Apps extension; ChatGPT's experimental visibility; …) + protocol version.
2. **Tool visibility** — `tools list` hides app-only tools (`_meta.ui.visibility: ["app"]`) the host's *model* can't see.

## SDK (the shared abstraction)
`hostConnectionProfile(hostConfig)` in `@mcpjam/sdk/host-config/internal` derives the connection pins + `respectToolVisibility` from a seeded host config — what the CLI/MCP/API use instead of the inspector-only `extractMcpInitializeOptions`. The plumbing already existed (`MCPServerConfig` carries `clientInfo`/`clientCapabilities`/protocol); this was the missing derivation.

## CLI decisions (semantics pinned per review)
- **`--host` + `--client-capabilities` → usage error** (both set the *exact* capabilities; no silent merge).
- **`tools list --host`** drops app-only tools via the shared `applyVisibilityPolicyAndCountSignals` (not a hand-rolled predicate, so counts match chat/eval) + reports `toolsDroppedVisibility`. A host that opts out (Cursor) keeps them.
- **`tools call --host <app-only>` is rejected** — the host's model can't call it; omit `--host` to call as an operator.
- **`compat`'s own `--host`** (report filter) is left untouched; **`server` snapshot/probe is out of v1** (raw-vs-host-view deserves its own decision).

## Verification
- **Live** (built per `cli-development.md`): `tools list --url … --host claude --rpc` → the `initialize` request shows `clientInfo.name: "claude-ai"` + the `io.modelcontextprotocol/ui` capability; `--host bogus` → usage error listing valid ids (no connection); `--host claude --client-capabilities …` → usage error.
- **Unit tests** (8 CLI + 5 SDK): host derivation (Claude/Goose/Cursor/ChatGPT), visibility drop + count, opt-out, `tools call` rejection, config merge, flag conflict. _(These caught a real `_meta`-unwrap bug the live handshake test couldn't.)_
- typecheck clean; **340 CLI tests** + SDK packaging green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP initialize identity and tool visibility semantics for CLI operations; incorrect host derivation or visibility filtering could misrepresent server behavior vs real hosts, though behavior is aligned with existing playground/eval paths and heavily tested.
> 
> **Overview**
> Adds **`--host <id>`** so CLI `tools`, `resources`, and `prompts` connect like playground hosts (Claude, ChatGPT, Cursor, etc.) instead of a generic `mcpjam` client.
> 
> **Handshake:** `withEphemeralManager` merges the seeded host’s `clientInfo`, `clientCapabilities`, and protocol pins onto the server config before connect. **`--host` and `--client-capabilities` are mutually exclusive** (usage error).
> 
> **SDK:** New `hostConnectionProfile()` derives connection + visibility policy from seeded host templates; exported from `@mcpjam/sdk/host-config/internal`.
> 
> **Tool visibility:** `tools list --host` filters app-only tools via shared `applyVisibilityPolicyAndCountSignals`, scopes metadata/token counts, and adds `host` + `toolsDroppedVisibility`. Hosts that opt out (e.g. Cursor) keep all tools. **`tools call --host`** blocks app-only tools (with paginated verification and fail-closed when the list is too long). Prompts/resources only get handshake emulation.
> 
> Unit tests cover host resolution, config merge, visibility, and call rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d26b4216033196569b916d73dc62b6faa5631769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->