### PR TITLE
feat(skills): enable Cloud Skills via the project Computer (hosted mode)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -963,7 +963,29 @@ export function PromptsRoute() {
 }
 
 export function SkillsRoute() {
-  return <SkillsTab />;
+  const { convexProjectId } = useAppRouteContext();
+  const computersEnabled = useComputersEnabledState();
+
+  // In hosted mode skills live on the project's Computer, so the route is
+  // gated on the Computer flag — mirror ComputerRoute's tri-state: redirect
+  // only on an explicit `false`, render nothing while PostHog hydrates (so a
+  // flagged-in user cold-loading /skills isn't bounced before the flag
+  // resolves). Local mode is ungated (local FS skills always work).
+  if (HOSTED_MODE) {
+    if (computersEnabled === false) {
+      return <Navigate to={routePaths.servers} replace />;
+    }
+    if (computersEnabled === undefined) {
+      return null;
+    }
+  }
+
+  return (
+    <SkillsTab
+      projectId={convexProjectId}
+      computersEnabled={computersEnabled === true}
+    />
+  );
 }
 
 export function LearningRoute() {

--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -103,13 +103,15 @@ export function SkillsTab({ projectId, computersEnabled }: SkillsTabProps = {}) 
   };
 
   // Refetch whenever the data source switches (Local⇄Cloud), clearing the
-  // selection + per-skill file cache so stale entries from the other source
-  // never bleed across.
+  // per-skill file cache so stale entries from the other source never bleed
+  // across. `resetSelection` forces fetchSkills to pick a fresh selection from
+  // the new list rather than honoring the (now-stale) prior selection — a same-
+  // named skill in both sources would otherwise leave the tab with nothing
+  // selected.
   useEffect(() => {
-    setSelectedSkillName("");
     setSelectedSkill(null);
     setSkillFiles({});
-    fetchSkills();
+    fetchSkills({ resetSelection: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [skillsSource]);
 
@@ -130,20 +132,23 @@ export function SkillsTab({ projectId, computersEnabled }: SkillsTabProps = {}) 
     }
   }, [selectedSkillName, selectedFilePath]);
 
-  const fetchSkills = async () => {
+  const fetchSkills = async (opts?: { resetSelection?: boolean }) => {
     setFetchingSkills(true);
 
     try {
       const skillsList = await listSkills(skillsSource);
       setSkills(skillsList);
 
+      // On a source switch the prior selection is stale, so ignore it and pick
+      // the first skill. On a plain refresh, keep the current selection if it
+      // still exists.
+      const currentName = opts?.resetSelection ? "" : selectedSkillName;
       if (skillsList.length === 0) {
         setSelectedSkillName("");
         setSelectedSkill(null);
       } else if (
-        !skillsList.some(
-          (skill: SkillListItem) => skill.name === selectedSkillName,
-        )
+        !currentName ||
+        !skillsList.some((skill: SkillListItem) => skill.name === currentName)
       ) {
         setSelectedSkillName(skillsList[0].name);
       }
@@ -307,7 +312,7 @@ export function SkillsTab({ projectId, computersEnabled }: SkillsTabProps = {}) 
                   <Plus className="h-3 w-3 cursor-pointer" />
                 </Button>
                 <Button
-                  onClick={fetchSkills}
+                  onClick={() => fetchSkills()}
                   variant="ghost"
                   size="sm"
                   disabled={fetchingSkills}

--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { Badge } from "@mcpjam/design-system/badge";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
@@ -26,7 +26,10 @@ import {
   deleteSkill,
   listSkillFiles,
   readSkillFile,
+  type SkillsSource,
 } from "@/lib/apis/mcp-skills-api";
+import { HOSTED_MODE } from "@/lib/config";
+import { ViewModeSelector } from "./shared/view-mode-selector";
 import type {
   Skill,
   SkillListItem,
@@ -47,8 +50,28 @@ import {
 import { SkillsFileTree } from "./skills/SkillsFileTree";
 import { SkillFileViewer } from "./skills/SkillFileViewer";
 
-export function SkillsTab() {
+interface SkillsTabProps {
+  /** Convex project id — required to address the cloud (computer) skill store. */
+  projectId?: string;
+  /** Whether the Computer feature is enabled for this user (PostHog gate). */
+  computersEnabled?: boolean;
+}
+
+export function SkillsTab({ projectId, computersEnabled }: SkillsTabProps = {}) {
   const posthog = usePostHog();
+  // Skills data source. Hosted mode has no local FS, so it's always cloud.
+  // Locally, when the Computer feature is on, the user can toggle Local⇄Cloud.
+  const showSourceToggle = !HOSTED_MODE && !!computersEnabled && !!projectId;
+  const [source, setSource] = useState<"local" | "cloud">(
+    HOSTED_MODE ? "cloud" : "local",
+  );
+  const skillsSource: SkillsSource = useMemo(
+    () =>
+      source === "cloud" && projectId
+        ? { kind: "cloud", projectId }
+        : { kind: "local" },
+    [source, projectId],
+  );
   const [skills, setSkills] = useState<SkillListItem[]>([]);
   const [selectedSkillName, setSelectedSkillName] = useState<string>("");
   const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
@@ -79,9 +102,16 @@ export function SkillsTab() {
     }
   };
 
+  // Refetch whenever the data source switches (Local⇄Cloud), clearing the
+  // selection + per-skill file cache so stale entries from the other source
+  // never bleed across.
   useEffect(() => {
+    setSelectedSkillName("");
+    setSelectedSkill(null);
+    setSkillFiles({});
     fetchSkills();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skillsSource]);
 
   useEffect(() => {
     if (selectedSkillName) {
@@ -104,7 +134,7 @@ export function SkillsTab() {
     setFetchingSkills(true);
 
     try {
-      const skillsList = await listSkills();
+      const skillsList = await listSkills(skillsSource);
       setSkills(skillsList);
 
       if (skillsList.length === 0) {
@@ -126,7 +156,7 @@ export function SkillsTab() {
 
   const fetchSkillContent = async (name: string) => {
     try {
-      const skill = await getSkill(name);
+      const skill = await getSkill(name, skillsSource);
       setSelectedSkill(skill);
     } catch (err) {
       console.error("Error getting skill:", err);
@@ -142,7 +172,7 @@ export function SkillsTab() {
 
       setLoadingFiles((prev) => ({ ...prev, [name]: true }));
       try {
-        const files = await listSkillFiles(name);
+        const files = await listSkillFiles(name, skillsSource);
         setSkillFiles((prev) => ({ ...prev, [name]: files }));
       } catch (err) {
         console.error("Error fetching skill files:", err);
@@ -151,7 +181,7 @@ export function SkillsTab() {
         setLoadingFiles((prev) => ({ ...prev, [name]: false }));
       }
     },
-    [skillFiles],
+    [skillFiles, skillsSource],
   );
 
   const fetchFileContent = async (name: string, filePath: string) => {
@@ -159,7 +189,7 @@ export function SkillsTab() {
     setFileError("");
 
     try {
-      const content = await readSkillFile(name, filePath);
+      const content = await readSkillFile(name, filePath, skillsSource);
       setFileContent(content);
     } catch (err) {
       const message =
@@ -176,7 +206,7 @@ export function SkillsTab() {
 
     setIsDeleting(true);
     try {
-      await deleteSkill(skillToDelete);
+      await deleteSkill(skillToDelete, skillsSource);
       posthog.capture("skill_deleted", {
         ...standardEventProps("skills_tab"),
         skill_name: skillToDelete,
@@ -255,6 +285,19 @@ export function SkillsTab() {
                 </Badge>
               </div>
               <div className="flex items-center gap-1">
+                {showSourceToggle && (
+                  <ViewModeSelector
+                    value={source}
+                    ariaLabel="Skills source"
+                    indicatorId="skills-source"
+                    onChange={(next) => setSource(next)}
+                    options={[
+                      { value: "local", label: "Local" },
+                      { value: "cloud", label: "Cloud" },
+                    ]}
+                    className="mr-1"
+                  />
+                )}
                 <Button
                   onClick={() => setIsUploadDialogOpen(true)}
                   variant="ghost"
@@ -437,6 +480,7 @@ export function SkillsTab() {
         open={isUploadDialogOpen}
         onOpenChange={setIsUploadDialogOpen}
         onSkillCreated={handleSkillCreated}
+        source={skillsSource}
       />
 
       {/* Delete Confirmation Dialog */}

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -254,7 +254,7 @@ export function SkillUploadDialog({
               {source?.kind === "cloud" ? "~/.claude/skills/" : "~/.mcpjam/skills/"}
               {skillInfo?.name || "{name}"}/
             </code>
-            {source?.kind === "cloud" ? " on your computer" : ""}
+            {source?.kind === "cloud" ? " on your personal computer" : ""}
           </DialogDescription>
         </DialogHeader>
 

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -8,7 +8,10 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@mcpjam/design-system/dialog";
-import { uploadSkillFolder } from "@/lib/apis/mcp-skills-api";
+import {
+  uploadSkillFolder,
+  type SkillsSource,
+} from "@/lib/apis/mcp-skills-api";
 import type { SkillResult } from "./skill-types";
 import { isValidSkillName } from "../../../../../../shared/skill-types";
 import { usePostHog } from "posthog-js/react";
@@ -17,6 +20,8 @@ interface SkillUploadDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSkillCreated?: (skill: SkillResult) => void;
+  /** Where the skill is written — local FS or the project's Computer. */
+  source?: SkillsSource;
 }
 
 interface ParsedSkillInfo {
@@ -47,6 +52,7 @@ export function SkillUploadDialog({
   open,
   onOpenChange,
   onSkillCreated,
+  source,
 }: SkillUploadDialogProps) {
   const posthog = usePostHog();
   const [files, setFiles] = useState<File[]>([]);
@@ -200,7 +206,7 @@ export function SkillUploadDialog({
     setIsLoading(true);
 
     try {
-      const skill = await uploadSkillFolder(files, skillInfo.name);
+      const skill = await uploadSkillFolder(files, skillInfo.name, source);
       posthog.capture("skill_uploaded", {
         skill_name: skillInfo.name,
         file_count: files.length,
@@ -245,8 +251,10 @@ export function SkillUploadDialog({
             Upload a skill folder containing a SKILL.md file. The folder will be
             saved to{" "}
             <code className="text-xs bg-muted px-1 py-0.5 rounded">
-              ~/.mcpjam/skills/{skillInfo?.name || "{name}"}/
+              {source?.kind === "cloud" ? "~/.claude/skills/" : "~/.mcpjam/skills/"}
+              {skillInfo?.name || "{name}"}/
             </code>
+            {source?.kind === "cloud" ? " on your computer" : ""}
           </DialogDescription>
         </DialogHeader>
 

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -72,6 +72,7 @@ import {
   useAppNavigate,
 } from "@/lib/app-navigation";
 import { HOSTED_LOCAL_ONLY_TOOLTIP } from "@/lib/hosted-ui";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
 import {
@@ -380,6 +381,28 @@ export function getHostedNavigationSections(
 const hostedNavigationSections =
   getHostedNavigationSections(navigationSections);
 
+/**
+ * Render-time gate for hosted Skills. `getHostedNavigationSections` runs at
+ * module load (no hooks), so it marks Skills disabled by default. Once the
+ * Computer feature flag resolves, flip Skills to enabled — in hosted mode
+ * skills live on the project's Computer, so the Computer flag governs them.
+ * Flag off keeps the existing disabled + "available locally" affordance.
+ */
+function withCloudSkillsGate(
+  sections: NavSection[],
+  computersEnabled: boolean,
+): NavSection[] {
+  if (!computersEnabled) return sections;
+  return sections.map((section) => ({
+    ...section,
+    items: section.items.map((item) =>
+      normalizeHostedHashTab(item.url.replace(/^[#/]+/, "")) === "skills"
+        ? { ...item, disabled: false, disabledTooltip: undefined }
+        : item,
+    ),
+  }));
+}
+
 interface MCPSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNavigate?: (section: string) => void;
   activeTab?: string;
@@ -658,8 +681,11 @@ export function MCPSidebar({
     ]
   );
   const hubNavHash = "#servers";
+  const computersEnabled = useComputersEnabled();
   const visibleNavigationSections = filterByFeatureFlags(
-    HOSTED_MODE ? hostedNavigationSections : navigationSections,
+    HOSTED_MODE
+      ? withCloudSkillsGate(hostedNavigationSections, computersEnabled)
+      : navigationSections,
     featureFlags
   );
 

--- a/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
@@ -1,11 +1,32 @@
 import { authFetch } from "@/lib/session-token";
 import { runByMode } from "@/lib/apis/mode-client";
+import { webPost } from "@/lib/apis/web/base";
 import type {
   Skill,
   SkillListItem,
   SkillFile,
   SkillFileContent,
 } from "../../../../shared/skill-types";
+
+/**
+ * Where skills are read from / written to:
+ *   - `local`: the inspector's own filesystem (`/api/mcp/skills/*`). The
+ *     default and the only option for local builds without a computer.
+ *   - `cloud`: the project's Computer (E2B sandbox) via `/api/web/skills/*`.
+ *     Used in hosted mode, and locally when the user toggles to Cloud.
+ *
+ * Passing `source` is optional and backward-compatible: omitting it preserves
+ * the original local behavior (and the hosted `listSkills() → []` contract).
+ */
+export type SkillsSource =
+  | { kind: "local" }
+  | { kind: "cloud"; projectId: string };
+
+function isCloud(
+  source?: SkillsSource,
+): source is { kind: "cloud"; projectId: string } {
+  return source?.kind === "cloud";
+}
 
 export interface ListSkillsResponse {
   skills: SkillListItem[];
@@ -21,9 +42,19 @@ export interface UploadSkillResponse {
 }
 
 /**
- * List all available skills from .mcpjam/skills/
+ * List all available skills.
  */
-export async function listSkills(): Promise<SkillListItem[]> {
+export async function listSkills(
+  source?: SkillsSource,
+): Promise<SkillListItem[]> {
+  if (isCloud(source)) {
+    const body = await webPost<{ projectId: string }, ListSkillsResponse>(
+      "/api/web/skills/list",
+      { projectId: source.projectId },
+    );
+    return Array.isArray(body?.skills) ? body.skills : [];
+  }
+
   return runByMode({
     hosted: async () => [],
     local: async () => {
@@ -53,7 +84,18 @@ export async function listSkills(): Promise<SkillListItem[]> {
 /**
  * Get full skill content by name
  */
-export async function getSkill(name: string): Promise<Skill> {
+export async function getSkill(
+  name: string,
+  source?: SkillsSource,
+): Promise<Skill> {
+  if (isCloud(source)) {
+    const body = await webPost<
+      { projectId: string; name: string },
+      GetSkillResponse
+    >("/api/web/skills/get", { projectId: source.projectId, name });
+    return body.skill;
+  }
+
   const res = await authFetch("/api/mcp/skills/get", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -76,11 +118,22 @@ export async function getSkill(name: string): Promise<Skill> {
 /**
  * Upload/create a new skill (legacy - JSON body)
  */
-export async function uploadSkill(data: {
-  name: string;
-  description: string;
-  content: string;
-}): Promise<Skill> {
+export async function uploadSkill(
+  data: {
+    name: string;
+    description: string;
+    content: string;
+  },
+  source?: SkillsSource,
+): Promise<Skill> {
+  if (isCloud(source)) {
+    const body = await webPost<
+      { projectId: string; name: string; description: string; content: string },
+      UploadSkillResponse
+    >("/api/web/skills/upload", { projectId: source.projectId, ...data });
+    return body.skill;
+  }
+
   const res = await authFetch("/api/mcp/skills/upload", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -106,9 +159,13 @@ export async function uploadSkill(data: {
 export async function uploadSkillFolder(
   files: File[],
   skillName: string,
+  source?: SkillsSource,
 ): Promise<Skill> {
   const formData = new FormData();
   formData.append("skillName", skillName);
+  if (isCloud(source)) {
+    formData.append("projectId", source.projectId);
+  }
 
   for (const file of files) {
     // Use webkitRelativePath if available, otherwise just the filename
@@ -121,7 +178,10 @@ export async function uploadSkillFolder(
     formData.append("files", file, pathWithinSkill);
   }
 
-  const res = await authFetch("/api/mcp/skills/upload-folder", {
+  const endpoint = isCloud(source)
+    ? "/api/web/skills/upload-folder"
+    : "/api/mcp/skills/upload-folder";
+  const res = await authFetch(endpoint, {
     method: "POST",
     body: formData,
   });
@@ -132,7 +192,8 @@ export async function uploadSkillFolder(
   } catch {}
 
   if (!res.ok) {
-    const message = body?.error || `Upload skill failed (${res.status})`;
+    const message =
+      body?.error || body?.message || `Upload skill failed (${res.status})`;
     throw new Error(message);
   }
 
@@ -142,7 +203,18 @@ export async function uploadSkillFolder(
 /**
  * Delete a skill by name
  */
-export async function deleteSkill(name: string): Promise<void> {
+export async function deleteSkill(
+  name: string,
+  source?: SkillsSource,
+): Promise<void> {
+  if (isCloud(source)) {
+    await webPost<{ projectId: string; name: string }, { success: boolean }>(
+      "/api/web/skills/delete",
+      { projectId: source.projectId, name },
+    );
+    return;
+  }
+
   const res = await authFetch("/api/mcp/skills/delete", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -163,7 +235,18 @@ export async function deleteSkill(name: string): Promise<void> {
 /**
  * List all files in a skill directory
  */
-export async function listSkillFiles(name: string): Promise<SkillFile[]> {
+export async function listSkillFiles(
+  name: string,
+  source?: SkillsSource,
+): Promise<SkillFile[]> {
+  if (isCloud(source)) {
+    const body = await webPost<
+      { projectId: string; name: string },
+      { files: SkillFile[] }
+    >("/api/web/skills/files", { projectId: source.projectId, name });
+    return Array.isArray(body?.files) ? body.files : [];
+  }
+
   const res = await authFetch("/api/mcp/skills/files", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -189,7 +272,20 @@ export async function listSkillFiles(name: string): Promise<SkillFile[]> {
 export async function readSkillFile(
   name: string,
   filePath: string,
+  source?: SkillsSource,
 ): Promise<SkillFileContent> {
+  if (isCloud(source)) {
+    const body = await webPost<
+      { projectId: string; name: string; filePath: string },
+      { file: SkillFileContent }
+    >("/api/web/skills/read-file", {
+      projectId: source.projectId,
+      name,
+      filePath,
+    });
+    return body.file;
+  }
+
   const res = await authFetch("/api/mcp/skills/read-file", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -39,14 +39,15 @@ export const HOSTED_HASH_ALLOWED_TABS = [
   // server-side, not by this list). Reached via the Connect tab switcher, not
   // a standalone sidebar item, so it needs the hash allow-list only — see PR.
   "computer",
+  // Cloud Skills are supported in hosted mode when the Computer feature is on
+  // (skills live on the project's Computer). Kept OUT of the sidebar-allowed
+  // list so the nav item stays disabled-by-default until the Computer flag
+  // flips it on at render time (see `withCloudSkillsGate`); the route guard
+  // (`SkillsRoute`) enforces the flag on direct navigation.
+  "skills",
 ] as const;
 
-export const HOSTED_HASH_BLOCKED_TABS = [
-  "skills",
-  "tasks",
-  "tracing",
-  "auth",
-] as const;
+export const HOSTED_HASH_BLOCKED_TABS = ["tasks", "tracing", "auth"] as const;
 
 const hostedSidebarAllowedSet = new Set<string>(HOSTED_SIDEBAR_ALLOWED_TABS);
 const hostedHashAllowedSet = new Set<string>(HOSTED_HASH_ALLOWED_TABS);

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import fixPath from "fix-path";
 import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
+import { webBodyLimit } from "./middleware/web-body-limit.js";
 import { logger } from "hono/logger";
 import { logger as appLogger } from "./utils/logger.js";
 import { serveStatic } from "@hono/node-server/serve-static";
@@ -210,21 +211,10 @@ export function createHonoApp() {
     }),
   );
 
-  // Hosted web APIs enforce a 1MB max JSON body.
-  app.use(
-    "/api/web/*",
-    bodyLimit({
-      maxSize: 1024 * 1024,
-      onError: (c) =>
-        c.json(
-          {
-            code: "VALIDATION_ERROR",
-            message: "Request body exceeds 1MB limit",
-          },
-          400,
-        ),
-    }),
-  );
+  // Hosted web APIs enforce a 1MB max JSON body — except the cloud-skills
+  // folder upload, which is multipart and bounded by the service caps. See
+  // `webBodyLimit`.
+  app.use("/api/web/*", webBodyLimit());
 
   // API Routes
   if (!HOSTED_MODE) {

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
+import { webBodyLimit } from "./middleware/web-body-limit.js";
 import { logger } from "hono/logger";
 import { logger as appLogger } from "./utils/logger";
 import { serveStatic } from "@hono/node-server/serve-static";
@@ -336,20 +337,9 @@ app.use(
   })
 );
 
-app.use(
-  "/api/web/*",
-  bodyLimit({
-    maxSize: 1024 * 1024,
-    onError: (c) =>
-      c.json(
-        {
-          code: "VALIDATION_ERROR",
-          message: "Request body exceeds 1MB limit",
-        },
-        400
-      ),
-  })
-);
+// 1MB JSON cap for /api/web/*, with a multipart carve-out for the cloud-skills
+// folder upload (bounded by the service caps instead). See `webBodyLimit`.
+app.use("/api/web/*", webBodyLimit());
 
 // Typed event logging context (matches app.ts)
 app.use("/api/*", requestLogContextMiddleware);

--- a/mcpjam-inspector/server/middleware/__tests__/web-body-limit.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/web-body-limit.test.ts
@@ -17,16 +17,23 @@ function appUnderTest() {
   return app;
 }
 
-function postBytes(app: Hono, path: string, size: number) {
+function postBytes(
+  app: Hono,
+  path: string,
+  size: number,
+  contentType = "application/octet-stream",
+) {
   return app.request(path, {
     method: "POST",
     headers: {
-      "content-type": "application/octet-stream",
+      "content-type": contentType,
       "content-length": String(size),
     },
     body: new Uint8Array(size),
   });
 }
+
+const MULTIPART = "multipart/form-data; boundary=----test";
 
 describe("webBodyLimit", () => {
   it("sizes the skills upload carve-out from the service total cap", () => {
@@ -39,21 +46,35 @@ describe("webBodyLimit", () => {
     expect(await res.json()).toMatchObject({ code: "VALIDATION_ERROR" });
   });
 
-  it("allows a multi-MB body on the skills folder-upload route", async () => {
+  it("allows a multi-MB multipart body on the skills folder-upload route", async () => {
     const res = await postBytes(
       appUnderTest(),
       "/api/web/skills/upload-folder",
       2 * 1024 * 1024, // > 1MB, well under the carve-out
+      MULTIPART,
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
   });
 
-  it("still rejects a body over the skills carve-out", async () => {
+  it("still rejects a multipart body over the skills carve-out", async () => {
     const res = await postBytes(
       appUnderTest(),
       "/api/web/skills/upload-folder",
       SKILLS_UPLOAD_BODY_LIMIT + 1024,
+      MULTIPART,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("does NOT extend the carve-out to a non-multipart request on that path", async () => {
+    // A JSON (non-multipart) POST to the upload path keeps the default 1MB cap,
+    // so the larger limit can't be abused by anything but a real upload.
+    const res = await postBytes(
+      appUnderTest(),
+      "/api/web/skills/upload-folder",
+      2 * 1024 * 1024,
+      "application/json",
     );
     expect(res.status).toBe(400);
   });

--- a/mcpjam-inspector/server/middleware/__tests__/web-body-limit.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/web-body-limit.test.ts
@@ -78,4 +78,16 @@ describe("webBodyLimit", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it("is not fooled by multipart/form-data appearing as a content-type param", async () => {
+    // The media type must be compared exactly — a header whose media type is
+    // application/json but carries `x=multipart/form-data` must keep the 1MB cap.
+    const res = await postBytes(
+      appUnderTest(),
+      "/api/web/skills/upload-folder",
+      2 * 1024 * 1024,
+      "application/json; x=multipart/form-data",
+    );
+    expect(res.status).toBe(400);
+  });
 });

--- a/mcpjam-inspector/server/middleware/__tests__/web-body-limit.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/web-body-limit.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import {
+  webBodyLimit,
+  DEFAULT_WEB_BODY_LIMIT,
+  SKILLS_UPLOAD_BODY_LIMIT,
+} from "../web-body-limit";
+
+// The carve-out exists so the cloud-skills service caps (5MB/20MB) are
+// reachable: a blanket 1MB limit would 400 every skill upload first.
+
+function appUnderTest() {
+  const app = new Hono();
+  app.use("/api/web/*", webBodyLimit());
+  app.post("/api/web/skills/upload-folder", (c) => c.json({ ok: true }));
+  app.post("/api/web/other", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function postBytes(app: Hono, path: string, size: number) {
+  return app.request(path, {
+    method: "POST",
+    headers: {
+      "content-type": "application/octet-stream",
+      "content-length": String(size),
+    },
+    body: new Uint8Array(size),
+  });
+}
+
+describe("webBodyLimit", () => {
+  it("sizes the skills upload carve-out from the service total cap", () => {
+    expect(SKILLS_UPLOAD_BODY_LIMIT).toBeGreaterThan(DEFAULT_WEB_BODY_LIMIT);
+  });
+
+  it("rejects a >1MB body on a normal /api/web route", async () => {
+    const res = await postBytes(appUnderTest(), "/api/web/other", 2 * 1024 * 1024);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("allows a multi-MB body on the skills folder-upload route", async () => {
+    const res = await postBytes(
+      appUnderTest(),
+      "/api/web/skills/upload-folder",
+      2 * 1024 * 1024, // > 1MB, well under the carve-out
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("still rejects a body over the skills carve-out", async () => {
+    const res = await postBytes(
+      appUnderTest(),
+      "/api/web/skills/upload-folder",
+      SKILLS_UPLOAD_BODY_LIMIT + 1024,
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/mcpjam-inspector/server/middleware/web-body-limit.ts
+++ b/mcpjam-inspector/server/middleware/web-body-limit.ts
@@ -31,8 +31,14 @@ const SKILLS_UPLOAD_PATH = "/api/web/skills/upload-folder";
 function isSkillsFolderUpload(c: Context): boolean {
   if (c.req.path !== SKILLS_UPLOAD_PATH) return false;
   if (c.req.method !== "POST") return false;
-  const contentType = (c.req.header("content-type") ?? "").toLowerCase();
-  return contentType.includes("multipart/form-data");
+  // Compare ONLY the media type, not a substring of the whole header: a
+  // `Content-Type: application/json; x=multipart/form-data` must NOT match and
+  // sneak past the 1MB cap.
+  const mediaType = (c.req.header("content-type") ?? "")
+    .split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+  return mediaType === "multipart/form-data";
 }
 
 /**

--- a/mcpjam-inspector/server/middleware/web-body-limit.ts
+++ b/mcpjam-inspector/server/middleware/web-body-limit.ts
@@ -1,0 +1,51 @@
+/**
+ * Body-size limit for `/api/web/*`.
+ *
+ * The blanket cap is 1MB (hosted web APIs are JSON). The one exception is
+ * **cloud skill folder uploads** (`/api/web/skills/upload-folder`), which are
+ * multipart and bounded by the service-level caps in `cloud-skills.ts`. Without
+ * a carve-out the 1MB middleware would reject any skill over 1MB BEFORE the
+ * service caps (per-file 5MB / total 20MB) could ever run — making them dead
+ * code and surfacing a generic middleware error instead of a specific 400.
+ *
+ * The carve-out is sized from `MAX_SKILL_TOTAL_BYTES` (+ headroom for multipart
+ * boundaries/part headers) so the two can't drift.
+ */
+import { bodyLimit } from "hono/body-limit";
+import type { Context, Next } from "hono";
+import { MAX_SKILL_TOTAL_BYTES } from "../utils/computers/cloud-skills.js";
+
+export const DEFAULT_WEB_BODY_LIMIT = 1024 * 1024; // 1MB
+
+/** Skill upload: total-bytes cap plus 1MB headroom for multipart framing. */
+export const SKILLS_UPLOAD_BODY_LIMIT = MAX_SKILL_TOTAL_BYTES + 1024 * 1024;
+
+const SKILLS_UPLOAD_PATH = "/api/web/skills/upload-folder";
+
+function limitForPath(path: string): number {
+  return path === SKILLS_UPLOAD_PATH
+    ? SKILLS_UPLOAD_BODY_LIMIT
+    : DEFAULT_WEB_BODY_LIMIT;
+}
+
+/**
+ * Per-request body limit for `/api/web/*`: 1MB everywhere except the skills
+ * folder-upload path. Mount once with `app.use("/api/web/*", webBodyLimit())`.
+ */
+export function webBodyLimit() {
+  return (c: Context, next: Next) => {
+    const maxSize = limitForPath(c.req.path);
+    const limitMb = Math.round(maxSize / 1024 / 1024);
+    return bodyLimit({
+      maxSize,
+      onError: (ctx) =>
+        ctx.json(
+          {
+            code: "VALIDATION_ERROR",
+            message: `Request body exceeds ${limitMb}MB limit`,
+          },
+          400,
+        ),
+    })(c, next);
+  };
+}

--- a/mcpjam-inspector/server/middleware/web-body-limit.ts
+++ b/mcpjam-inspector/server/middleware/web-body-limit.ts
@@ -22,19 +22,29 @@ export const SKILLS_UPLOAD_BODY_LIMIT = MAX_SKILL_TOTAL_BYTES + 1024 * 1024;
 
 const SKILLS_UPLOAD_PATH = "/api/web/skills/upload-folder";
 
-function limitForPath(path: string): number {
-  return path === SKILLS_UPLOAD_PATH
-    ? SKILLS_UPLOAD_BODY_LIMIT
-    : DEFAULT_WEB_BODY_LIMIT;
+/**
+ * The carve-out applies ONLY to the real upload request shape — a multipart
+ * POST to the upload path. Anything else hitting that exact path (a GET, a JSON
+ * POST) keeps the default 1MB cap, so the larger limit can't be used to slip a
+ * non-multipart oversized body past the blanket cap.
+ */
+function isSkillsFolderUpload(c: Context): boolean {
+  if (c.req.path !== SKILLS_UPLOAD_PATH) return false;
+  if (c.req.method !== "POST") return false;
+  const contentType = (c.req.header("content-type") ?? "").toLowerCase();
+  return contentType.includes("multipart/form-data");
 }
 
 /**
- * Per-request body limit for `/api/web/*`: 1MB everywhere except the skills
- * folder-upload path. Mount once with `app.use("/api/web/*", webBodyLimit())`.
+ * Per-request body limit for `/api/web/*`: 1MB everywhere except a multipart
+ * POST to the skills folder-upload path. Mount once with
+ * `app.use("/api/web/*", webBodyLimit())`.
  */
 export function webBodyLimit() {
   return (c: Context, next: Next) => {
-    const maxSize = limitForPath(c.req.path);
+    const maxSize = isSkillsFolderUpload(c)
+      ? SKILLS_UPLOAD_BODY_LIMIT
+      : DEFAULT_WEB_BODY_LIMIT;
     const limitMb = Math.round(maxSize / 1024 / 1024);
     return bodyLimit({
       maxSize,

--- a/mcpjam-inspector/server/routes/web/__tests__/skills.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/skills.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+
+// Route-level tests for /api/web/skills/*. The cloud-skills SERVICE (E2B +
+// control plane) is mocked; these tests cover request parsing, bearer-gating,
+// the success envelopes, and CloudSkillsError → HTTP status mapping.
+
+vi.mock("../../../utils/computers/cloud-skills", () => {
+  class CloudSkillsError extends Error {
+    status: number;
+    constructor(message: string, status = 500) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    CloudSkillsError,
+    listCloudSkills: vi.fn(),
+    getCloudSkill: vi.fn(),
+    uploadCloudSkill: vi.fn(),
+    uploadCloudSkillFolder: vi.fn(),
+    deleteCloudSkill: vi.fn(),
+    listCloudSkillFiles: vi.fn(),
+    readCloudSkillFile: vi.fn(),
+  };
+});
+
+import skillsRouter from "../skills";
+import {
+  CloudSkillsError,
+  listCloudSkills,
+  getCloudSkill,
+  deleteCloudSkill,
+} from "../../../utils/computers/cloud-skills";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/api/web/skills", skillsRouter);
+  return app;
+}
+
+function post(
+  path: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = { authorization: "Bearer user-token" },
+) {
+  return createApp().request(path, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/web/skills/list", () => {
+  it("returns the computer's skills", async () => {
+    vi.mocked(listCloudSkills).mockResolvedValue([
+      { name: "pdf", description: "PDFs", path: "~/.claude/skills/pdf" },
+    ]);
+    const res = await post("/api/web/skills/list", { projectId: "proj_1" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      skills: [{ name: "pdf", description: "PDFs", path: "~/.claude/skills/pdf" }],
+    });
+    expect(vi.mocked(listCloudSkills)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authHeader: "Bearer user-token",
+        projectId: "proj_1",
+      }),
+    );
+  });
+
+  it("rejects requests without a bearer token", async () => {
+    const res = await post("/api/web/skills/list", { projectId: "proj_1" }, {});
+    expect(res.status).toBe(401);
+    expect(vi.mocked(listCloudSkills)).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing projectId", async () => {
+    const res = await post("/api/web/skills/list", {});
+    expect(res.status).toBe(400);
+  });
+
+  it("maps a service 503 to FEATURE_NOT_SUPPORTED", async () => {
+    vi.mocked(listCloudSkills).mockRejectedValue(
+      new CloudSkillsError("Computers are not configured on this server.", 503),
+    );
+    const res = await post("/api/web/skills/list", { projectId: "proj_1" });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ code: "FEATURE_NOT_SUPPORTED" });
+  });
+});
+
+describe("POST /api/web/skills/get", () => {
+  it("404s when the skill is absent", async () => {
+    vi.mocked(getCloudSkill).mockResolvedValue(null);
+    const res = await post("/api/web/skills/get", {
+      projectId: "proj_1",
+      name: "nope",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/web/skills/delete", () => {
+  it("404s when nothing was deleted", async () => {
+    vi.mocked(deleteCloudSkill).mockResolvedValue(false);
+    const res = await post("/api/web/skills/delete", {
+      projectId: "proj_1",
+      name: "nope",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns success when deleted", async () => {
+    vi.mocked(deleteCloudSkill).mockResolvedValue(true);
+    const res = await post("/api/web/skills/delete", {
+      projectId: "proj_1",
+      name: "temp",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+  });
+});

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -28,7 +28,10 @@ import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
 import { resolveExecutionContext } from "../../utils/host-execution-context.js";
-import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
+import {
+  resolveHostTools,
+  narrowHostComputer,
+} from "../../utils/built-in-tools/registry.js";
 import { buildMcpjamPlatformClient } from "./mcpjam-platform-client.js";
 import { logger } from "../../utils/logger.js";
 
@@ -237,6 +240,15 @@ chatV2.post("/", async (c) => {
       }
     );
 
+    // Cloud Skills: only when the (server-resolved) host actually has a
+    // computer. Skills then come from that E2B sandbox; loaded lazily so no
+    // wake happens unless the model calls a skill tool ("advertise == enforce").
+    const hostComputer = narrowHostComputer(
+      hostRuntimeConfig
+        ? (hostRuntimeConfig as { computer?: unknown }).computer
+        : undefined
+    );
+
     // Membership chat (no share/chatbox token) is the default — the backend
     // authorizes via project ownership for both guest and authed users.
     // accessScope is only set when a token is in play (shared chat / chatbox)
@@ -319,6 +331,14 @@ chatV2.post("/", async (c) => {
           appTools: validatedAppTools,
           widgetModelContext: validatedWidgetModelContext,
           ...(builtInTools ? { builtInTools } : {}),
+          ...(hostComputer
+            ? {
+                cloudSkills: {
+                  authHeader: `Bearer ${bearerToken}`,
+                  projectId: hostedBody.projectId,
+                },
+              }
+            : {}),
         },
         persist: {
           chatSessionId: body.chatSessionId,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -241,13 +241,21 @@ chatV2.post("/", async (c) => {
     );
 
     // Cloud Skills: only when the (server-resolved) host actually has a
-    // computer. Skills then come from that E2B sandbox; loaded lazily so no
-    // wake happens unless the model calls a skill tool ("advertise == enforce").
-    const hostComputer = narrowHostComputer(
-      hostRuntimeConfig
-        ? (hostRuntimeConfig as { computer?: unknown }).computer
-        : undefined
-    );
+    // computer — the SAME source the bash/computer built-in tool resolves from
+    // (`resolveHostTools` above), so skills wire wherever computer tools do.
+    // Today that's chatbox sessions (the only path that resolves
+    // hostRuntimeConfig); playground/direct host-config resolution lands later.
+    // Guests are excluded, mirroring the `isGuest` gate already applied to the
+    // computer-backed bash tool — a guest share-link/chatbox session must not
+    // be handed E2B skill tools. Loaded lazily so no wake unless a skill tool
+    // is called ("advertise == enforce").
+    const hostComputer = c.get("guestId")
+      ? null
+      : narrowHostComputer(
+          hostRuntimeConfig
+            ? (hostRuntimeConfig as { computer?: unknown }).computer
+            : undefined
+        );
 
     // Membership chat (no share/chatbox token) is the default — the backend
     // authorizes via project ownership for both guest and authed users.

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -23,6 +23,7 @@ import conformanceWeb from "./conformance.js";
 import checks from "./checks.js";
 import apiKeys from "./api-keys.js";
 import computers from "./computers.js";
+import skills from "./skills.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -49,6 +50,9 @@ web.use("/server/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // deliberately open: it returns only a boolean and a public URL, and the
 // client needs it before any authed flow to know where the terminal lives.
 web.use("/computers/exec", bearerAuthMiddleware, guestRateLimitMiddleware);
+// Cloud Skills live on the caller's Computer (E2B sandbox); every op needs a
+// bearer (forwarded to Convex for reserve/wake + authz).
+web.use("/skills/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use(
   "/apps/mcp-apps/widget-content",
   bearerAuthMiddleware,
@@ -80,6 +84,7 @@ web.route("/checks", checks);
 // `/computers/terminal` (the WS) is registered on the root app in
 // server/index.ts — only /config and /exec live on this sub-router.
 web.route("/computers", computers);
+web.route("/skills", skills);
 // `/api-keys` carries its own bearer-auth `.use()` because
 // `sessionAuthMiddleware` bypasses `/api/web/*` entirely. Nothing on this
 // sub-router is reachable without a session JWT (WorkOS `sk_…` keys are

--- a/mcpjam-inspector/server/routes/web/skills.ts
+++ b/mcpjam-inspector/server/routes/web/skills.ts
@@ -130,7 +130,7 @@ skills.post("/upload-folder", async (c) =>
     const formData = await c.req.formData();
     const projectId = formData.get("projectId");
     const skillName = formData.get("skillName");
-    const rawFiles = formData.getAll("files") as File[];
+    const rawFiles = formData.getAll("files");
 
     if (typeof projectId !== "string" || !projectId) {
       throw new WebRouteError(
@@ -153,9 +153,23 @@ skills.post("/upload-folder", async (c) =>
         "No files uploaded",
       );
     }
+    // Each "files" part must be a real File (with bytes + a name). A malformed
+    // multipart entry (e.g. a stray text field named "files") would otherwise
+    // fall through to `.arrayBuffer()` and throw an opaque 500 — reject cleanly.
+    const fileParts: File[] = [];
+    for (const part of rawFiles) {
+      if (!(part instanceof File) || typeof part.name !== "string") {
+        throw new WebRouteError(
+          400,
+          ErrorCode.VALIDATION_ERROR,
+          'Each "files" part must be an uploaded file',
+        );
+      }
+      fileParts.push(part);
+    }
 
     const files: CloudSkillUploadFile[] = await Promise.all(
-      rawFiles.map(async (f) => ({
+      fileParts.map(async (f) => ({
         path: f.name,
         bytes: new Uint8Array(await f.arrayBuffer()),
       })),

--- a/mcpjam-inspector/server/routes/web/skills.ts
+++ b/mcpjam-inspector/server/routes/web/skills.ts
@@ -1,0 +1,211 @@
+/**
+ * Cloud Skills — hosted/`/web` routes. The horizontally-scaled counterpart of
+ * the local filesystem skills routes (`routes/mcp/skills.ts`). Every operation
+ * runs against the caller's **Computer** (E2B sandbox) via
+ * `utils/computers/cloud-skills.ts`; there is no local FS in hosted mode.
+ *
+ * Auth: bearer end-to-end (forwarded to Convex for reserve/wake + authz, which
+ * only ever resolves the (project, user) computer of the bearer's owner). The
+ * `projectId` in each request body selects which computer. Mirrors
+ * `routes/web/computers.ts`.
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import "../../types/hono"; // Type extensions
+import {
+  ErrorCode,
+  WebRouteError,
+  handleRoute,
+  parseWithSchema,
+  readJsonBody,
+  assertBearerToken,
+} from "./auth.js";
+import {
+  CloudSkillsError,
+  listCloudSkills,
+  getCloudSkill,
+  uploadCloudSkill,
+  uploadCloudSkillFolder,
+  deleteCloudSkill,
+  listCloudSkillFiles,
+  readCloudSkillFile,
+  type CloudSkillsContext,
+  type CloudSkillUploadFile,
+} from "../../utils/computers/cloud-skills.js";
+
+const skills = new Hono();
+
+/** Map a service-layer status to the closest web ErrorCode. */
+function codeForStatus(status: number): ErrorCode {
+  switch (status) {
+    case 400:
+    case 409:
+      return ErrorCode.VALIDATION_ERROR;
+    case 401:
+      return ErrorCode.UNAUTHORIZED;
+    case 403:
+      return ErrorCode.FORBIDDEN;
+    case 404:
+      return ErrorCode.NOT_FOUND;
+    case 502:
+      return ErrorCode.SERVER_UNREACHABLE;
+    case 503:
+      return ErrorCode.FEATURE_NOT_SUPPORTED;
+    default:
+      return ErrorCode.INTERNAL_ERROR;
+  }
+}
+
+/** Run a service op, translating CloudSkillsError → WebRouteError. */
+async function run<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof CloudSkillsError) {
+      throw new WebRouteError(err.status, codeForStatus(err.status), err.message);
+    }
+    throw err;
+  }
+}
+
+function ctxFrom(c: any, projectId: string): CloudSkillsContext {
+  return {
+    authHeader: `Bearer ${assertBearerToken(c)}`,
+    projectId,
+    signal: c.req.raw.signal,
+  };
+}
+
+const projectOnly = z.object({ projectId: z.string().min(1) });
+const nameSchema = projectOnly.extend({ name: z.string().min(1) });
+
+skills.post("/list", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(projectOnly, await readJsonBody(c));
+    const list = await run(() => listCloudSkills(ctxFrom(c, body.projectId)));
+    return { skills: list };
+  }),
+);
+
+skills.post("/get", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(nameSchema, await readJsonBody(c));
+    const skill = await run(() =>
+      getCloudSkill(ctxFrom(c, body.projectId), body.name),
+    );
+    if (!skill) {
+      throw new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        `Skill '${body.name}' not found`,
+      );
+    }
+    return { skill };
+  }),
+);
+
+skills.post("/upload", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(
+      projectOnly.extend({
+        name: z.string().min(1),
+        description: z.string().min(1),
+        content: z.string().min(1),
+      }),
+      await readJsonBody(c),
+    );
+    const skill = await run(() =>
+      uploadCloudSkill(ctxFrom(c, body.projectId), {
+        name: body.name,
+        description: body.description,
+        content: body.content,
+      }),
+    );
+    return { success: true, skill };
+  }),
+);
+
+skills.post("/upload-folder", async (c) =>
+  handleRoute(c, async () => {
+    const formData = await c.req.formData();
+    const projectId = formData.get("projectId");
+    const skillName = formData.get("skillName");
+    const rawFiles = formData.getAll("files") as File[];
+
+    if (typeof projectId !== "string" || !projectId) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "projectId is required",
+      );
+    }
+    if (typeof skillName !== "string" || !skillName) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "skillName is required",
+      );
+    }
+    if (!rawFiles || rawFiles.length === 0) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "No files uploaded",
+      );
+    }
+
+    const files: CloudSkillUploadFile[] = await Promise.all(
+      rawFiles.map(async (f) => ({
+        path: f.name,
+        bytes: new Uint8Array(await f.arrayBuffer()),
+      })),
+    );
+
+    const skill = await run(() =>
+      uploadCloudSkillFolder(ctxFrom(c, projectId), skillName, files),
+    );
+    return { success: true, skill };
+  }),
+);
+
+skills.post("/delete", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(nameSchema, await readJsonBody(c));
+    const deleted = await run(() =>
+      deleteCloudSkill(ctxFrom(c, body.projectId), body.name),
+    );
+    if (!deleted) {
+      throw new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        `Skill '${body.name}' not found`,
+      );
+    }
+    return { success: true };
+  }),
+);
+
+skills.post("/files", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(nameSchema, await readJsonBody(c));
+    const files = await run(() =>
+      listCloudSkillFiles(ctxFrom(c, body.projectId), body.name),
+    );
+    return { files };
+  }),
+);
+
+skills.post("/read-file", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(
+      nameSchema.extend({ filePath: z.string().min(1) }),
+      await readJsonBody(c),
+    );
+    const file = await run(() =>
+      readCloudSkillFile(ctxFrom(c, body.projectId), body.name, body.filePath),
+    );
+    return { file };
+  }),
+);
+
+export default skills;

--- a/mcpjam-inspector/server/utils/__tests__/cloud-skills.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/cloud-skills.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// ── Fake E2B sandbox filesystem ──────────────────────────────────────────
+// cloud-skills.ts talks to the computer only through `Sandbox.connect(...)` +
+// `sandbox.files.*`. We mock the `e2b` module with an in-memory FS so the
+// whole service is exercised without a vendor account. The control plane
+// (reserve / sandbox-info) is stubbed via global fetch, exactly like
+// computers-bash-tool.test.ts.
+
+class FakeFs {
+  files = new Map<string, string | Uint8Array>();
+  dirs = new Set<string>();
+
+  mkdir(p: string) {
+    const parts = p.split("/").filter(Boolean);
+    let cur = "";
+    for (const part of parts) {
+      cur += "/" + part;
+      this.dirs.add(cur);
+    }
+  }
+  writeText(p: string, data: string) {
+    this.mkdir(p.slice(0, p.lastIndexOf("/")));
+    this.files.set(p, data);
+  }
+
+  list(dir: string) {
+    const prefix = dir.endsWith("/") ? dir : dir + "/";
+    const seen = new Map<string, "file" | "dir">();
+    for (const f of this.files.keys()) {
+      if (f.startsWith(prefix)) {
+        const rest = f.slice(prefix.length);
+        const name = rest.split("/")[0];
+        seen.set(name, rest.includes("/") ? "dir" : "file");
+      }
+    }
+    for (const d of this.dirs) {
+      if (d.startsWith(prefix)) {
+        const name = d.slice(prefix.length).split("/")[0];
+        if (name && !seen.has(name)) seen.set(name, "dir");
+      }
+    }
+    return Array.from(seen.entries()).map(([name, type]) => ({
+      name,
+      type,
+      path: prefix + name,
+      size:
+        type === "file"
+          ? byteLen(this.files.get(prefix + name) ?? "")
+          : 0,
+    }));
+  }
+}
+
+function byteLen(v: string | Uint8Array): number {
+  return typeof v === "string" ? new TextEncoder().encode(v).length : v.byteLength;
+}
+
+let fs: FakeFs;
+
+vi.mock("e2b", () => {
+  // Defined inside the factory: vi.mock is hoisted above top-level class
+  // declarations, so a class referenced here would hit the TDZ.
+  class FakeFileNotFoundError extends Error {}
+  return {
+    FileNotFoundError: FakeFileNotFoundError,
+    Sandbox: {
+      connect: vi.fn(async () => ({
+        files: {
+          list: vi.fn(async (dir: string) => {
+            const exists =
+              fs.dirs.has(dir) ||
+              [...fs.files.keys()].some((f) => f.startsWith(dir + "/"));
+            if (!exists) throw new FakeFileNotFoundError(dir);
+            return fs.list(dir);
+          }),
+          read: vi.fn(async (p: string, opts?: { format?: string }) => {
+            const v = fs.files.get(p);
+            if (v === undefined) throw new FakeFileNotFoundError(p);
+            if (opts?.format === "bytes") {
+              return typeof v === "string" ? new TextEncoder().encode(v) : v;
+            }
+            return typeof v === "string" ? v : new TextDecoder().decode(v);
+          }),
+          write: vi.fn(async (p: string, data: string | ArrayBuffer) => {
+            fs.mkdir(p.slice(0, p.lastIndexOf("/")));
+            fs.files.set(
+              p,
+              typeof data === "string" ? data : new Uint8Array(data),
+            );
+          }),
+          makeDir: vi.fn(async (p: string) => {
+            fs.mkdir(p);
+            return true;
+          }),
+          remove: vi.fn(async (p: string) => {
+            for (const k of [...fs.files.keys()]) {
+              if (k === p || k.startsWith(p + "/")) fs.files.delete(k);
+            }
+            for (const d of [...fs.dirs]) {
+              if (d === p || d.startsWith(p + "/")) fs.dirs.delete(d);
+            }
+          }),
+          getInfo: vi.fn(async (p: string) => {
+            if (fs.files.has(p)) {
+              return { type: "file", size: byteLen(fs.files.get(p)!) };
+            }
+            if (fs.dirs.has(p)) return { type: "dir", size: 0 };
+            throw new FakeFileNotFoundError(p);
+          }),
+        },
+      })),
+    },
+  };
+});
+
+import {
+  listCloudSkills,
+  getCloudSkill,
+  uploadCloudSkill,
+  uploadCloudSkillFolder,
+  deleteCloudSkill,
+  listCloudSkillFiles,
+  readCloudSkillFile,
+  CloudSkillsError,
+} from "../computers/cloud-skills";
+
+const CLAUDE_SKILLS = "/home/user/.claude/skills";
+
+function installControlPlaneStub() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL) => {
+      const path = new URL(String(url)).pathname;
+      if (path === "/computers/reserve") {
+        return json({ computerId: "comp_1", status: "ready", provider: "e2b" });
+      }
+      if (path === "/computers/sandbox-info") {
+        return json({
+          computerId: "comp_1",
+          providerComputerId: "sbx_42",
+          provider: "e2b",
+          status: "ready",
+        });
+      }
+      throw new Error(`unexpected path ${path}`);
+    }),
+  );
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const ctx = { authHeader: "Bearer user-token", projectId: "proj_1" };
+
+function seedSkill(name: string, description: string, body = "do the thing") {
+  fs.writeText(
+    `${CLAUDE_SKILLS}/${name}/SKILL.md`,
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n${body}`,
+  );
+}
+
+describe("cloud-skills service", () => {
+  beforeEach(() => {
+    fs = new FakeFs();
+    process.env.CONVEX_HTTP_URL = "https://convex.example";
+    process.env.COMPUTERS_DATA_PLANE_SECRET = "secret";
+    process.env.E2B_API_KEY = "e2b-key";
+    installControlPlaneStub();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("lists skills across dirs, deduped by name", async () => {
+    seedSkill("pdf-tools", "Process PDFs");
+    fs.writeText(
+      `/home/user/.mcpjam/skills/data-viz/SKILL.md`,
+      `---\nname: data-viz\ndescription: Make charts\n---\n\nchart it`,
+    );
+    const list = await listCloudSkills(ctx);
+    expect(list.map((s) => s.name).sort()).toEqual(["data-viz", "pdf-tools"]);
+    expect(list.find((s) => s.name === "pdf-tools")?.path).toBe(
+      "~/.claude/skills/pdf-tools",
+    );
+  });
+
+  it("returns empty when no skills dirs exist", async () => {
+    expect(await listCloudSkills(ctx)).toEqual([]);
+  });
+
+  it("gets a skill's full content", async () => {
+    seedSkill("pdf-tools", "Process PDFs", "step 1\nstep 2");
+    const skill = await getCloudSkill(ctx, "pdf-tools");
+    expect(skill?.content).toBe("step 1\nstep 2");
+    expect(await getCloudSkill(ctx, "missing")).toBeNull();
+  });
+
+  it("uploads a new skill to ~/.claude/skills", async () => {
+    const skill = await uploadCloudSkill(ctx, {
+      name: "greeter",
+      description: "Say hi",
+      content: "wave",
+    });
+    expect(skill.path).toBe("~/.claude/skills/greeter");
+    expect(fs.files.has(`${CLAUDE_SKILLS}/greeter/SKILL.md`)).toBe(true);
+  });
+
+  it("rejects an invalid skill name on upload", async () => {
+    await expect(
+      uploadCloudSkill(ctx, { name: "Bad Name", description: "x", content: "y" }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects a duplicate skill", async () => {
+    seedSkill("dupe", "first");
+    await expect(
+      uploadCloudSkill(ctx, { name: "dupe", description: "x", content: "y" }),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("uploads a folder with supporting files", async () => {
+    const enc = (s: string) => new TextEncoder().encode(s);
+    const skill = await uploadCloudSkillFolder(ctx, "kit", [
+      { path: "SKILL.md", bytes: enc("---\nname: kit\ndescription: A kit\n---\n\nuse it") },
+      { path: "scripts/run.py", bytes: enc("print('hi')") },
+    ]);
+    expect(skill.name).toBe("kit");
+    expect(fs.files.has(`${CLAUDE_SKILLS}/kit/scripts/run.py`)).toBe(true);
+  });
+
+  it("rejects a folder whose SKILL.md name mismatches", async () => {
+    const enc = (s: string) => new TextEncoder().encode(s);
+    await expect(
+      uploadCloudSkillFolder(ctx, "kit", [
+        { path: "SKILL.md", bytes: enc("---\nname: other\ndescription: x\n---\n\ny") },
+      ]),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("blocks path traversal in folder upload", async () => {
+    const enc = (s: string) => new TextEncoder().encode(s);
+    await uploadCloudSkillFolder(ctx, "safe", [
+      { path: "SKILL.md", bytes: enc("---\nname: safe\ndescription: x\n---\n\ny") },
+      { path: "../../escape.txt", bytes: enc("nope") },
+    ]);
+    expect(fs.files.has("/home/user/escape.txt")).toBe(false);
+    expect([...fs.files.keys()].some((k) => k.includes("escape.txt"))).toBe(
+      false,
+    );
+  });
+
+  it("lists and reads skill files; blocks traversal on read", async () => {
+    seedSkill("docs", "Docs skill");
+    fs.writeText(`${CLAUDE_SKILLS}/docs/notes/readme.md`, "hello");
+    const files = await listCloudSkillFiles(ctx, "docs");
+    const flat = JSON.stringify(files);
+    expect(flat).toContain("SKILL.md");
+    expect(flat).toContain("notes");
+
+    const file = await readCloudSkillFile(ctx, "docs", "notes/readme.md");
+    expect(file.content).toBe("hello");
+    expect(file.isText).toBe(true);
+
+    await expect(
+      readCloudSkillFile(ctx, "docs", "../../../etc/passwd"),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("deletes a skill", async () => {
+    seedSkill("temp", "Temporary");
+    expect(await deleteCloudSkill(ctx, "temp")).toBe(true);
+    expect(await deleteCloudSkill(ctx, "temp")).toBe(false);
+    expect(fs.files.has(`${CLAUDE_SKILLS}/temp/SKILL.md`)).toBe(false);
+  });
+
+  it("fails closed when the data plane is not configured", async () => {
+    delete process.env.E2B_API_KEY;
+    await expect(listCloudSkills(ctx)).rejects.toBeInstanceOf(CloudSkillsError);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/cloud-skills.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/cloud-skills.test.ts
@@ -325,10 +325,12 @@ describe("cloud-skills service", () => {
         { path: "blob.bin", bytes: big },
       ]),
     ).rejects.toMatchObject({ status: 400 });
-    expect(fs.files.has(`${CLAUDE_SKILLS}/big/SKILL.md`)).toBe(false);
+    // Rejected before withSandbox → nothing written/created.
+    expect([...fs.files.keys()].some((k) => k.includes("/big/"))).toBe(false);
+    expect([...fs.dirs].some((d) => d.includes("/big"))).toBe(false);
   });
 
-  it("rejects too many files", async () => {
+  it("rejects too many files without creating anything", async () => {
     const enc = (s: string) => new TextEncoder().encode(s);
     const many = Array.from({ length: 101 }, (_, i) => ({
       path: `f${i}.txt`,
@@ -341,6 +343,8 @@ describe("cloud-skills service", () => {
     await expect(
       uploadCloudSkillFolder(ctx, "many", many),
     ).rejects.toMatchObject({ status: 400 });
+    expect([...fs.files.keys()].some((k) => k.includes("/many"))).toBe(false);
+    expect([...fs.dirs].some((d) => d.includes("/many"))).toBe(false);
   });
 
   it("fails closed (503) when the data plane is not configured", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/cloud-skills.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/cloud-skills.test.ts
@@ -10,6 +10,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 class FakeFs {
   files = new Map<string, string | Uint8Array>();
   dirs = new Set<string>();
+  /** When set, the next `files.list` throws a non-not-found error. */
+  failListOnce = false;
 
   mkdir(p: string) {
     const parts = p.split("/").filter(Boolean);
@@ -60,14 +62,24 @@ let fs: FakeFs;
 
 vi.mock("e2b", () => {
   // Defined inside the factory: vi.mock is hoisted above top-level class
-  // declarations, so a class referenced here would hit the TDZ.
-  class FakeFileNotFoundError extends Error {}
+  // declarations, so a class referenced here would hit the TDZ. Mirror the real
+  // e2b hierarchy: FileNotFoundError extends NotFoundError — safeList catches
+  // NotFoundError, so the fake "missing" errors must be instances of it.
+  class FakeNotFoundError extends Error {}
+  class FakeFileNotFoundError extends FakeNotFoundError {}
   return {
+    NotFoundError: FakeNotFoundError,
     FileNotFoundError: FakeFileNotFoundError,
     Sandbox: {
       connect: vi.fn(async () => ({
         files: {
           list: vi.fn(async (dir: string) => {
+            // Simulate a transient provider/transport failure (NOT not-found)
+            // to prove safeList propagates rather than swallowing it.
+            if (fs.failListOnce) {
+              fs.failListOnce = false;
+              throw new Error("transient E2B list failure");
+            }
             const exists =
               fs.dirs.has(dir) ||
               [...fs.files.keys()].some((f) => f.startsWith(dir + "/"));
@@ -122,7 +134,6 @@ import {
   deleteCloudSkill,
   listCloudSkillFiles,
   readCloudSkillFile,
-  CloudSkillsError,
 } from "../computers/cloud-skills";
 
 const CLAUDE_SKILLS = "/home/user/.claude/skills";
@@ -167,13 +178,16 @@ function seedSkill(name: string, description: string, body = "do the thing") {
 describe("cloud-skills service", () => {
   beforeEach(() => {
     fs = new FakeFs();
-    process.env.CONVEX_HTTP_URL = "https://convex.example";
-    process.env.COMPUTERS_DATA_PLANE_SECRET = "secret";
-    process.env.E2B_API_KEY = "e2b-key";
+    // vi.stubEnv is restored by vi.unstubAllEnvs() — don't mutate process.env
+    // directly or these leak into sibling test files.
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example");
+    vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "secret");
+    vi.stubEnv("E2B_API_KEY", "e2b-key");
     installControlPlaneStub();
   });
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("lists skills across dirs, deduped by name", async () => {
@@ -278,8 +292,61 @@ describe("cloud-skills service", () => {
     expect(fs.files.has(`${CLAUDE_SKILLS}/temp/SKILL.md`)).toBe(false);
   });
 
-  it("fails closed when the data plane is not configured", async () => {
-    delete process.env.E2B_API_KEY;
-    await expect(listCloudSkills(ctx)).rejects.toBeInstanceOf(CloudSkillsError);
+  it("propagates a transient list failure instead of returning []", async () => {
+    seedSkill("pdf-tools", "Process PDFs");
+    fs.failListOnce = true;
+    // A non-not-found list error must surface, not silently hide skills.
+    await expect(listCloudSkills(ctx)).rejects.toThrow(
+      /transient E2B list failure/,
+    );
+  });
+
+  it("normalizes a nested folder so SKILL.md lands at the skill root", async () => {
+    const enc = (s: string) => new TextEncoder().encode(s);
+    await uploadCloudSkillFolder(ctx, "kit", [
+      {
+        path: "kit/SKILL.md",
+        bytes: enc("---\nname: kit\ndescription: A kit\n---\n\nuse it"),
+      },
+      { path: "kit/scripts/run.py", bytes: enc("print('hi')") },
+    ]);
+    // SKILL.md must be discoverable at the root, not buried under `kit/`.
+    expect(fs.files.has(`${CLAUDE_SKILLS}/kit/SKILL.md`)).toBe(true);
+    expect(fs.files.has(`${CLAUDE_SKILLS}/kit/scripts/run.py`)).toBe(true);
+    expect(fs.files.has(`${CLAUDE_SKILLS}/kit/kit/SKILL.md`)).toBe(false);
+  });
+
+  it("rejects an over-large folder upload before touching the sandbox", async () => {
+    const enc = (s: string) => new TextEncoder().encode(s);
+    const big = new Uint8Array(6 * 1024 * 1024); // > 5MB per-file cap
+    await expect(
+      uploadCloudSkillFolder(ctx, "big", [
+        { path: "SKILL.md", bytes: enc("---\nname: big\ndescription: x\n---\n\ny") },
+        { path: "blob.bin", bytes: big },
+      ]),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(fs.files.has(`${CLAUDE_SKILLS}/big/SKILL.md`)).toBe(false);
+  });
+
+  it("rejects too many files", async () => {
+    const enc = (s: string) => new TextEncoder().encode(s);
+    const many = Array.from({ length: 101 }, (_, i) => ({
+      path: `f${i}.txt`,
+      bytes: enc("x"),
+    }));
+    many[0] = {
+      path: "SKILL.md",
+      bytes: enc("---\nname: many\ndescription: x\n---\n\ny"),
+    };
+    await expect(
+      uploadCloudSkillFolder(ctx, "many", many),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("fails closed (503) when the data plane is not configured", async () => {
+    vi.stubEnv("E2B_API_KEY", ""); // unconfigured (restored by unstubAllEnvs)
+    await expect(listCloudSkills(ctx)).rejects.toMatchObject({
+      status: 503,
+    });
   });
 });

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -28,6 +28,7 @@ import {
   type CustomProviderConfig,
 } from "./chat-helpers.js";
 import { getSkillToolsAndPrompt } from "./skill-tools.js";
+import { getCloudSkillToolsAndPrompt } from "./computers/cloud-skill-tools.js";
 import { logger } from "./logger.js";
 import { isGPT5Model, type ModelDefinition } from "@/shared/types";
 import { HOSTED_MODE } from "../config.js";
@@ -479,6 +480,13 @@ export interface PrepareChatV2Options {
   appTools?: AppToolEntry[];
   /** Server-side built-in tools (e.g. web_search) with their own execute. */
   builtInTools?: ToolSet;
+  /**
+   * When set, skills are sourced from the caller's **Computer** (E2B sandbox)
+   * instead of the local filesystem — the hosted/`/web` path. Only set by
+   * callers whose host actually has a computer, so "advertise == enforce".
+   * Takes precedence over the local/HOSTED_MODE skill branches.
+   */
+  cloudSkills?: { authHeader: string; projectId: string };
 }
 
 /**
@@ -545,6 +553,7 @@ export async function prepareChatV2(
     customProviders,
     appTools,
     builtInTools,
+    cloudSkills,
   } = options;
 
   // Drop ids the manager hasn't registered (server disabled/disconnected, or
@@ -583,10 +592,20 @@ export async function prepareChatV2(
   if (respectToolVisibility !== false) {
     filterAppOnlyTools(mcpTools, mcpClientManager);
   }
+  // Skills source, in precedence order:
+  //   1. cloudSkills set ⇒ the caller's Computer (E2B sandbox) — hosted path
+  //      with a provisioned computer. Lazy discovery (no upfront wake).
+  //   2. HOSTED_MODE without a computer ⇒ no skills (local FS unavailable).
+  //   3. local ⇒ the inspector's own filesystem.
   const { tools: skillTools, systemPromptSection: skillsPromptSection } =
-    HOSTED_MODE
-      ? { tools: {}, systemPromptSection: "" }
-      : await getSkillToolsAndPrompt();
+    cloudSkills
+      ? getCloudSkillToolsAndPrompt({
+          authHeader: cloudSkills.authHeader,
+          projectId: cloudSkills.projectId,
+        })
+      : HOSTED_MODE
+        ? { tools: {}, systemPromptSection: "" }
+        : await getSkillToolsAndPrompt();
 
   const finalSkillTools: Record<string, unknown> = requireToolApproval
     ? Object.fromEntries(

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -169,9 +169,9 @@ export function createCloudSkillTools(ctx: CloudSkillsContext) {
 }
 
 const CLOUD_SKILLS_PROMPT_SECTION =
-  `\n\n## Skills (on your computer)\n\n` +
-  `Your computer may have skills installed — reusable instruction packages for ` +
-  `specific tasks. Call the \`listSkills\` tool to see what's available, then ` +
+  `\n\n## Skills (on your personal computer)\n\n` +
+  `Your personal computer may have skills installed — reusable instruction ` +
+  `packages for specific tasks. Call the \`listSkills\` tool to see what's available, then ` +
   `\`loadSkill\` to load a skill's full instructions when a task matches its ` +
   `purpose. After loading, use \`listSkillFiles\` and \`readSkillFile\` to access ` +
   `any supporting files (rules, templates, scripts) the skill provides.`;

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -1,0 +1,192 @@
+/**
+ * Cloud skill tools for the AI SDK — the hosted/`/web` chat counterpart of
+ * `server/utils/skill-tools.ts`. Where the local tools read the inspector's
+ * own filesystem, these read the caller's **Computer** (E2B sandbox) via
+ * `cloud-skills.ts`.
+ *
+ * Progressive disclosure, hosted-aware: unlike the local path we do NOT
+ * pre-list skills into the system prompt, because listing reads the computer's
+ * filesystem and would force a sandbox **wake** on every turn — even when the
+ * user never touches a skill. Instead we advertise a cheap `listSkills`
+ * discovery tool; the model wakes the box only when it decides to look. This
+ * keeps "advertise == enforce": the tools are only wired in when the host
+ * actually has a computer (see `chat-v2-orchestration.ts`).
+ */
+import { tool } from "ai";
+import { z } from "zod";
+import {
+  CloudSkillsError,
+  listCloudSkills,
+  getCloudSkill,
+  listCloudSkillFiles,
+  readCloudSkillFile,
+  type CloudSkillsContext,
+} from "./cloud-skills.js";
+import type { SkillFile } from "../../../shared/skill-types.js";
+
+const NAME_RE = /^[a-z0-9-]+$/;
+
+function errMessage(err: unknown): string {
+  if (err instanceof CloudSkillsError) return err.message;
+  return err instanceof Error ? err.message : "Unknown error";
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}
+
+function formatFileTree(files: SkillFile[], indent = ""): string {
+  let result = "";
+  for (const file of files) {
+    if (file.type === "directory") {
+      result += `${indent}${file.name}/\n`;
+      if (file.children) result += formatFileTree(file.children, indent + "  ");
+    } else {
+      const size = file.size ? ` (${formatSize(file.size)})` : "";
+      result += `${indent}${file.name}${size}\n`;
+    }
+  }
+  return result;
+}
+
+function flattenFiles(files: SkillFile[]): SkillFile[] {
+  const out: SkillFile[] = [];
+  for (const file of files) {
+    out.push(file);
+    if (file.type === "directory" && file.children) {
+      out.push(...flattenFiles(file.children));
+    }
+  }
+  return out;
+}
+
+export function createCloudSkillTools(ctx: CloudSkillsContext) {
+  return {
+    listSkills: tool({
+      description:
+        "List the skills installed on your computer (reusable instruction packages). Returns each skill's name and description. Call this first to discover what skills are available, then `loadSkill` to load one.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        try {
+          const skills = await listCloudSkills(ctx);
+          if (skills.length === 0) {
+            return "No skills are installed on your computer.";
+          }
+          return (
+            `Available skills:\n\n` +
+            skills.map((s) => `- **${s.name}**: ${s.description}`).join("\n")
+          );
+        } catch (err) {
+          return `Error listing skills: ${errMessage(err)}`;
+        }
+      },
+    }),
+
+    loadSkill: tool({
+      description:
+        "Load a skill's full content and instructions from your computer. Use when a task matches a skill's purpose.",
+      inputSchema: z.object({
+        name: z
+          .string()
+          .describe("The skill name to load (e.g., 'pdf-processing')."),
+      }),
+      execute: async ({ name }) => {
+        if (!NAME_RE.test(name)) {
+          return `Error: Invalid skill name format "${name}". Skill names contain only lowercase letters, numbers, and hyphens.`;
+        }
+        try {
+          const skill = await getCloudSkill(ctx, name);
+          if (!skill) return `Error: Skill "${name}" not found.`;
+
+          let response = `# Skill: ${skill.name}\n\n${skill.content}`;
+          const files = await listCloudSkillFiles(ctx, name).catch(
+            () => [] as SkillFile[],
+          );
+          const supporting = flattenFiles(files).filter(
+            (f) => f.name !== "SKILL.md" && f.type === "file",
+          );
+          if (supporting.length > 0) {
+            response += `\n\n## Supporting Files\n\nThis skill includes the following supporting files:\n\n`;
+            response += formatFileTree(
+              files.filter((f) => f.name !== "SKILL.md"),
+            );
+            response += `\nUse the \`listSkillFiles\` tool to explore directories and \`readSkillFile\` to read file contents.`;
+          }
+          return response;
+        } catch (err) {
+          return `Error loading skill "${name}": ${errMessage(err)}`;
+        }
+      },
+    }),
+
+    listSkillFiles: tool({
+      description:
+        "List all files and directories in a skill's directory on your computer.",
+      inputSchema: z.object({
+        name: z.string().describe("The skill name"),
+      }),
+      execute: async ({ name }) => {
+        if (!NAME_RE.test(name)) {
+          return `Error: Invalid skill name format "${name}".`;
+        }
+        try {
+          const files = await listCloudSkillFiles(ctx, name);
+          if (files.length === 0) return `No files found in skill "${name}".`;
+          return `Files in skill "${name}":\n\n${formatFileTree(files)}`;
+        } catch (err) {
+          return `Error listing files for skill "${name}": ${errMessage(err)}`;
+        }
+      },
+    }),
+
+    readSkillFile: tool({
+      description:
+        "Read the content of a specific file from a skill directory on your computer.",
+      inputSchema: z.object({
+        name: z.string().describe("The skill name"),
+        path: z
+          .string()
+          .describe("Relative file path within the skill (e.g. 'scripts/run.py')."),
+      }),
+      execute: async ({ name, path: filePath }) => {
+        if (!NAME_RE.test(name)) {
+          return `Error: Invalid skill name format "${name}".`;
+        }
+        try {
+          const file = await readCloudSkillFile(ctx, name, filePath);
+          if (!file.isText) {
+            return `File "${filePath}" is a binary file (${file.mimeType}, ${formatSize(file.size)}). Cannot display content directly.`;
+          }
+          return `# File: ${filePath}\n\n\`\`\`\n${file.content ?? ""}\n\`\`\``;
+        } catch (err) {
+          return `Error reading file "${filePath}" from skill "${name}": ${errMessage(err)}`;
+        }
+      },
+    }),
+  };
+}
+
+const CLOUD_SKILLS_PROMPT_SECTION =
+  `\n\n## Skills (on your computer)\n\n` +
+  `Your computer may have skills installed — reusable instruction packages for ` +
+  `specific tasks. Call the \`listSkills\` tool to see what's available, then ` +
+  `\`loadSkill\` to load a skill's full instructions when a task matches its ` +
+  `purpose. After loading, use \`listSkillFiles\` and \`readSkillFile\` to access ` +
+  `any supporting files (rules, templates, scripts) the skill provides.`;
+
+/**
+ * Cloud equivalent of `getSkillToolsAndPrompt`. Always returns the tools +
+ * prompt section (the gate is "host has a computer", enforced by the caller);
+ * discovery is lazy via `listSkills` so no sandbox wake happens up front.
+ */
+export function getCloudSkillToolsAndPrompt(ctx: CloudSkillsContext): {
+  tools: ReturnType<typeof createCloudSkillTools>;
+  systemPromptSection: string;
+} {
+  return {
+    tools: createCloudSkillTools(ctx),
+    systemPromptSection: CLOUD_SKILLS_PROMPT_SECTION,
+  };
+}

--- a/mcpjam-inspector/server/utils/computers/cloud-skills.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skills.ts
@@ -22,7 +22,7 @@
  * via its native filesystem discovery — one source of truth for both the
  * non-harness chat tools here and the in-sandbox harness.
  */
-import { Sandbox, FileNotFoundError } from "e2b";
+import { Sandbox, FileNotFoundError, NotFoundError } from "e2b";
 import path from "path";
 import {
   ensureComputerReady,
@@ -60,6 +60,15 @@ const SKILLS_DIRS = [
   path.posix.join(SANDBOX_HOME, ".agents", "skills"),
 ];
 const PRIMARY_SKILLS_DIR = SKILLS_DIRS[0];
+
+/**
+ * Upload caps enforced by the service BEFORE connecting to the sandbox. The
+ * global `/api/web/*` body limit is a coarse backstop; these give a clean 400
+ * with a specific reason and bound how much we ever write to the computer.
+ */
+export const MAX_SKILL_FILES = 100;
+export const MAX_SKILL_FILE_BYTES = 5 * 1024 * 1024; // 5 MB per file
+export const MAX_SKILL_TOTAL_BYTES = 20 * 1024 * 1024; // 20 MB per skill
 
 export interface CloudSkillsContext {
   /** Bearer authorization forwarded to Convex (authz + wake). */
@@ -137,12 +146,19 @@ async function withSandbox<T>(
   return fn(sandbox);
 }
 
-/** List a directory; a missing directory yields `[]` (not an error). */
+/**
+ * List a directory. A genuinely missing directory yields `[]` (the skills dirs
+ * are optional — a user may have none). Any OTHER failure (transport, auth,
+ * sandbox gone) propagates: swallowing those would make a user's skills
+ * silently "disappear" during a transient provider/filesystem blip.
+ */
 async function safeList(sandbox: Sandbox, dir: string) {
   try {
     return await sandbox.files.list(dir);
-  } catch {
-    return [];
+  } catch (err) {
+    // FileNotFoundError extends NotFoundError, so this covers both.
+    if (err instanceof NotFoundError) return [];
+    throw err;
   }
 }
 
@@ -295,6 +311,12 @@ export async function uploadCloudSkill(
       400,
     );
   }
+  if (Buffer.byteLength(data.content, "utf8") > MAX_SKILL_FILE_BYTES) {
+    throw new CloudSkillsError(
+      `Skill content too large (max ${MAX_SKILL_FILE_BYTES / 1024 / 1024}MB)`,
+      400,
+    );
+  }
   return withSandbox(ctx, async (sandbox) => {
     if (await skillExists(sandbox, data.name)) {
       throw new CloudSkillsError(`Skill '${data.name}' already exists`, 409);
@@ -333,15 +355,59 @@ export async function uploadCloudSkillFolder(
       400,
     );
   }
-  const skillMd = files.find(
+
+  // Enforce caps BEFORE touching the sandbox (cheap reject; bounds writes).
+  if (files.length === 0) {
+    throw new CloudSkillsError("No files uploaded", 400);
+  }
+  if (files.length > MAX_SKILL_FILES) {
+    throw new CloudSkillsError(
+      `Too many files (max ${MAX_SKILL_FILES})`,
+      400,
+    );
+  }
+  let total = 0;
+  for (const f of files) {
+    if (f.bytes.byteLength > MAX_SKILL_FILE_BYTES) {
+      throw new CloudSkillsError(
+        `File "${f.path}" too large (max ${MAX_SKILL_FILE_BYTES / 1024 / 1024}MB)`,
+        400,
+      );
+    }
+    total += f.bytes.byteLength;
+  }
+  if (total > MAX_SKILL_TOTAL_BYTES) {
+    throw new CloudSkillsError(
+      `Skill too large (max ${MAX_SKILL_TOTAL_BYTES / 1024 / 1024}MB total)`,
+      400,
+    );
+  }
+
+  // Normalize: an uploaded folder often nests everything under a single root
+  // dir, so SKILL.md arrives as `<root>/SKILL.md`. Strip that common prefix so
+  // SKILL.md lands at the skill root (where discovery looks) rather than
+  // succeeding with a buried SKILL.md that's then invisible. The client strips
+  // it today, but the service contract must own this.
+  const skillMdRaw = files.find(
     (f) => f.path === "SKILL.md" || f.path.endsWith("/SKILL.md"),
   );
-  if (!skillMd) {
+  if (!skillMdRaw) {
     throw new CloudSkillsError(
       "No SKILL.md file found in uploaded files",
       400,
     );
   }
+  const rootPrefix = skillMdRaw.path.slice(
+    0,
+    skillMdRaw.path.length - "SKILL.md".length,
+  ); // "" or "<root>/"
+  const normalized: CloudSkillUploadFile[] = files.map((f) =>
+    rootPrefix && f.path.startsWith(rootPrefix)
+      ? { ...f, path: f.path.slice(rootPrefix.length) }
+      : f,
+  );
+  const skillMd = normalized.find((f) => f.path === "SKILL.md")!;
+
   const parsed = parseSkillFile(
     new TextDecoder().decode(skillMd.bytes),
     skillName,
@@ -366,7 +432,7 @@ export async function uploadCloudSkillFolder(
     const skillDir = path.posix.join(PRIMARY_SKILLS_DIR, skillName);
     await sandbox.files.makeDir(skillDir);
 
-    for (const file of files) {
+    for (const file of normalized) {
       // Security: never let an uploaded path escape the skill directory.
       if (!isPathWithinDirectory(skillDir, file.path)) {
         logger.warn(`Skipping skill file with invalid path: ${file.path}`);

--- a/mcpjam-inspector/server/utils/computers/cloud-skills.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skills.ts
@@ -1,0 +1,474 @@
+/**
+ * Cloud Skills — Project-Computer-backed equivalent of the local
+ * filesystem skills (`server/utils/skill-parser.ts` + `routes/mcp/skills.ts`).
+ *
+ * Local skills read `~/.mcpjam/skills` etc. on the machine running the
+ * inspector. In hosted / horizontally-scaled mode there is no durable local
+ * FS, but a project's **Computer** (an E2B sandbox) is a persistent
+ * workstation whose files survive between sessions — exactly what skills need.
+ *
+ * This module performs the same operations (list / get / upload / delete /
+ * files / read-file) against the computer's filesystem, reusing:
+ *   - the parser + validators in `../skill-parser.ts` (one source of truth for
+ *     SKILL.md frontmatter, name rules, mime/text detection, path-traversal);
+ *   - the control-plane resolution + wake pipeline in `./control-plane-client`
+ *     (`ensureComputerReady` → `getComputerSandboxInfo`), identical to
+ *     `run-command.ts` / `resolve-sandbox.ts`;
+ *   - the E2B Filesystem API (`sandbox.files.*`), the same surface the harness
+ *     sandbox provider uses (`harness/e2b-sandbox-provider.ts`).
+ *
+ * Skills are stored under `~/.claude/skills` (PRIMARY) so that Claude Code
+ * running *inside* the computer (the harness) discovers the very same skills
+ * via its native filesystem discovery — one source of truth for both the
+ * non-harness chat tools here and the in-sandbox harness.
+ */
+import { Sandbox, FileNotFoundError } from "e2b";
+import path from "path";
+import {
+  ensureComputerReady,
+  getComputerSandboxInfo,
+  isComputersDataPlaneConfigured,
+} from "./control-plane-client.js";
+import {
+  parseSkillFile,
+  skillToListItem,
+  generateSkillFileContent,
+  getMimeType,
+  isTextMimeType,
+  isPathWithinDirectory,
+  isValidSkillName,
+} from "../skill-parser.js";
+import { logger } from "../logger.js";
+import type {
+  Skill,
+  SkillListItem,
+  SkillFile,
+  SkillFileContent,
+} from "../../../shared/skill-types.js";
+
+/** E2B computer-template home (matches `harness/e2b-sandbox-provider.ts`). */
+const SANDBOX_HOME = "/home/user";
+
+/**
+ * Directories scanned for skills inside the computer. PRIMARY (uploads) first.
+ * `~/.claude/skills` is primary so the in-sandbox Claude Code harness discovers
+ * the same skills natively.
+ */
+const SKILLS_DIRS = [
+  path.posix.join(SANDBOX_HOME, ".claude", "skills"),
+  path.posix.join(SANDBOX_HOME, ".mcpjam", "skills"),
+  path.posix.join(SANDBOX_HOME, ".agents", "skills"),
+];
+const PRIMARY_SKILLS_DIR = SKILLS_DIRS[0];
+
+export interface CloudSkillsContext {
+  /** Bearer authorization forwarded to Convex (authz + wake). */
+  authHeader: string;
+  /** Project whose (project, user) computer the skills live on. */
+  projectId: string;
+  signal?: AbortSignal;
+}
+
+/** Carries an HTTP-ish status so the web route can map it faithfully. */
+export class CloudSkillsError extends Error {
+  readonly status: number;
+  constructor(message: string, status = 500) {
+    super(message);
+    this.name = "CloudSkillsError";
+    this.status = status;
+  }
+}
+
+/** `~/...` display path for a skill dir, mirroring the local route. */
+function displayPath(skillsDir: string, skillName: string): string {
+  const full = path.posix.join(skillsDir, skillName);
+  return full.startsWith(SANDBOX_HOME)
+    ? full.replace(SANDBOX_HOME, "~")
+    : full;
+}
+
+/**
+ * Resolve + wake the caller's computer, connect to the E2B sandbox, and run
+ * `fn` against it. One connection per top-level operation (skills counts are
+ * small, so N+1 `files.read` within an operation is acceptable). Throws
+ * `CloudSkillsError` with a status the route can surface.
+ */
+async function withSandbox<T>(
+  ctx: CloudSkillsContext,
+  fn: (sandbox: Sandbox) => Promise<T>,
+): Promise<T> {
+  if (!isComputersDataPlaneConfigured()) {
+    throw new CloudSkillsError(
+      "Computers are not configured on this server.",
+      503,
+    );
+  }
+
+  const ready = await ensureComputerReady({
+    bearer: ctx.authHeader,
+    projectId: ctx.projectId,
+    signal: ctx.signal,
+  });
+  if (!ready.ok) {
+    throw new CloudSkillsError(
+      `Computer unavailable: ${ready.error}`,
+      ready.status || 502,
+    );
+  }
+
+  const info = await getComputerSandboxInfo({
+    computerId: ready.value.computerId,
+    signal: ctx.signal,
+  });
+  if (!info.ok) {
+    throw new CloudSkillsError(
+      `Computer unavailable: ${info.error}`,
+      info.status || 502,
+    );
+  }
+  if (!info.value.providerComputerId) {
+    throw new CloudSkillsError(
+      "Computer is still provisioning — try again in a moment.",
+      503,
+    );
+  }
+
+  const sandbox = await Sandbox.connect(info.value.providerComputerId);
+  return fn(sandbox);
+}
+
+/** List a directory; a missing directory yields `[]` (not an error). */
+async function safeList(sandbox: Sandbox, dir: string) {
+  try {
+    return await sandbox.files.list(dir);
+  } catch {
+    return [];
+  }
+}
+
+/** Read a file; a genuinely missing file yields `null`, real errors throw. */
+async function readTextOrNull(
+  sandbox: Sandbox,
+  filePath: string,
+): Promise<string | null> {
+  try {
+    return await sandbox.files.read(filePath);
+  } catch (err) {
+    if (err instanceof FileNotFoundError) return null;
+    throw err;
+  }
+}
+
+/** Find the absolute computer path of a skill directory by skill name. */
+async function findSkillDir(
+  sandbox: Sandbox,
+  name: string,
+): Promise<string | null> {
+  for (const dir of SKILLS_DIRS) {
+    const entries = await safeList(sandbox, dir);
+    for (const entry of entries) {
+      if (entry.type !== "dir") continue;
+      const skillDir = path.posix.join(dir, entry.name);
+      const content = await readTextOrNull(
+        sandbox,
+        path.posix.join(skillDir, "SKILL.md"),
+      );
+      if (!content) continue;
+      const skill = parseSkillFile(content, entry.name);
+      if (skill && skill.name === name) return skillDir;
+    }
+  }
+  return null;
+}
+
+/** True if a skill with `name` already exists in any scanned directory. */
+async function skillExists(sandbox: Sandbox, name: string): Promise<boolean> {
+  return (await findSkillDir(sandbox, name)) !== null;
+}
+
+/** Recursive file tree of one skill dir, mirroring `listFilesRecursive`. */
+async function listFilesRecursiveE2B(
+  sandbox: Sandbox,
+  dirPath: string,
+  relativeTo: string = dirPath,
+): Promise<SkillFile[]> {
+  const files: SkillFile[] = [];
+  const entries = await safeList(sandbox, dirPath);
+
+  for (const entry of entries) {
+    const fullPath = path.posix.join(dirPath, entry.name);
+    const relativePath = path.posix.relative(relativeTo, fullPath);
+    const ext = path.posix.extname(entry.name).toLowerCase();
+
+    if (entry.type === "dir") {
+      const children = await listFilesRecursiveE2B(
+        sandbox,
+        fullPath,
+        relativeTo,
+      );
+      files.push({
+        path: relativePath,
+        name: entry.name,
+        type: "directory",
+        children,
+      });
+    } else {
+      files.push({
+        path: relativePath,
+        name: entry.name,
+        type: "file",
+        size: entry.size,
+        mimeType: getMimeType(entry.name),
+        extension: ext || undefined,
+      });
+    }
+  }
+
+  // SKILL.md first, then dirs, then files; alphabetical within each group —
+  // identical ordering to the local `listFilesRecursive`.
+  return files.sort((a, b) => {
+    if (a.name === "SKILL.md") return -1;
+    if (b.name === "SKILL.md") return 1;
+    if (a.type === "directory" && b.type !== "directory") return -1;
+    if (a.type !== "directory" && b.type === "directory") return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+// ── public service operations ────────────────────────────────────────────
+
+export async function listCloudSkills(
+  ctx: CloudSkillsContext,
+): Promise<SkillListItem[]> {
+  return withSandbox(ctx, async (sandbox) => {
+    const out: SkillListItem[] = [];
+    const seen = new Set<string>();
+    for (const dir of SKILLS_DIRS) {
+      const entries = await safeList(sandbox, dir);
+      for (const entry of entries) {
+        if (entry.type !== "dir") continue;
+        const content = await readTextOrNull(
+          sandbox,
+          path.posix.join(dir, entry.name, "SKILL.md"),
+        );
+        if (!content) continue;
+        const skill = parseSkillFile(content, displayPath(dir, entry.name));
+        if (skill && !seen.has(skill.name)) {
+          seen.add(skill.name);
+          out.push(skillToListItem(skill));
+        }
+      }
+    }
+    return out;
+  });
+}
+
+export async function getCloudSkill(
+  ctx: CloudSkillsContext,
+  name: string,
+): Promise<Skill | null> {
+  return withSandbox(ctx, async (sandbox) => {
+    for (const dir of SKILLS_DIRS) {
+      const entries = await safeList(sandbox, dir);
+      for (const entry of entries) {
+        if (entry.type !== "dir") continue;
+        const content = await readTextOrNull(
+          sandbox,
+          path.posix.join(dir, entry.name, "SKILL.md"),
+        );
+        if (!content) continue;
+        const skill = parseSkillFile(content, displayPath(dir, entry.name));
+        if (skill && skill.name === name) return skill;
+      }
+    }
+    return null;
+  });
+}
+
+export async function uploadCloudSkill(
+  ctx: CloudSkillsContext,
+  data: { name: string; description: string; content: string },
+): Promise<Skill> {
+  if (!isValidSkillName(data.name)) {
+    throw new CloudSkillsError(
+      "name must contain only lowercase letters, numbers, and hyphens",
+      400,
+    );
+  }
+  return withSandbox(ctx, async (sandbox) => {
+    if (await skillExists(sandbox, data.name)) {
+      throw new CloudSkillsError(`Skill '${data.name}' already exists`, 409);
+    }
+    const skillDir = path.posix.join(PRIMARY_SKILLS_DIR, data.name);
+    await sandbox.files.makeDir(skillDir);
+    const fileContent = generateSkillFileContent(
+      data.name,
+      data.description,
+      data.content,
+    );
+    await sandbox.files.write(path.posix.join(skillDir, "SKILL.md"), fileContent);
+    return {
+      name: data.name,
+      description: data.description,
+      content: data.content,
+      path: displayPath(PRIMARY_SKILLS_DIR, data.name),
+    };
+  });
+}
+
+export interface CloudSkillUploadFile {
+  /** Path of the file relative to the skill root (e.g. "scripts/run.py"). */
+  path: string;
+  bytes: Uint8Array;
+}
+
+export async function uploadCloudSkillFolder(
+  ctx: CloudSkillsContext,
+  skillName: string,
+  files: CloudSkillUploadFile[],
+): Promise<Skill> {
+  if (!isValidSkillName(skillName)) {
+    throw new CloudSkillsError(
+      "Skill name must contain only lowercase letters, numbers, and hyphens",
+      400,
+    );
+  }
+  const skillMd = files.find(
+    (f) => f.path === "SKILL.md" || f.path.endsWith("/SKILL.md"),
+  );
+  if (!skillMd) {
+    throw new CloudSkillsError(
+      "No SKILL.md file found in uploaded files",
+      400,
+    );
+  }
+  const parsed = parseSkillFile(
+    new TextDecoder().decode(skillMd.bytes),
+    skillName,
+  );
+  if (!parsed) {
+    throw new CloudSkillsError(
+      "Invalid SKILL.md format. Must contain valid frontmatter with 'name' and 'description' fields.",
+      400,
+    );
+  }
+  if (parsed.name !== skillName) {
+    throw new CloudSkillsError(
+      `Skill name mismatch: provided "${skillName}" but SKILL.md contains "${parsed.name}"`,
+      400,
+    );
+  }
+
+  return withSandbox(ctx, async (sandbox) => {
+    if (await skillExists(sandbox, skillName)) {
+      throw new CloudSkillsError(`Skill '${skillName}' already exists`, 409);
+    }
+    const skillDir = path.posix.join(PRIMARY_SKILLS_DIR, skillName);
+    await sandbox.files.makeDir(skillDir);
+
+    for (const file of files) {
+      // Security: never let an uploaded path escape the skill directory.
+      if (!isPathWithinDirectory(skillDir, file.path)) {
+        logger.warn(`Skipping skill file with invalid path: ${file.path}`);
+        continue;
+      }
+      const fullPath = path.posix.join(skillDir, file.path);
+      const parentDir = path.posix.dirname(fullPath);
+      if (parentDir !== skillDir) {
+        await sandbox.files.makeDir(parentDir);
+      }
+      // Copy into an exactly-sized ArrayBuffer (Buffer.slice would expose the
+      // pool) — same care as `harness/e2b-sandbox-provider.ts`.
+      const buf = new ArrayBuffer(file.bytes.byteLength);
+      new Uint8Array(buf).set(file.bytes);
+      await sandbox.files.write(fullPath, buf);
+    }
+
+    return {
+      name: parsed.name,
+      description: parsed.description,
+      content: parsed.content,
+      path: displayPath(PRIMARY_SKILLS_DIR, skillName),
+    };
+  });
+}
+
+export async function deleteCloudSkill(
+  ctx: CloudSkillsContext,
+  name: string,
+): Promise<boolean> {
+  return withSandbox(ctx, async (sandbox) => {
+    const skillDir = await findSkillDir(sandbox, name);
+    if (!skillDir) return false;
+    await sandbox.files.remove(skillDir);
+    return true;
+  });
+}
+
+export async function listCloudSkillFiles(
+  ctx: CloudSkillsContext,
+  name: string,
+): Promise<SkillFile[]> {
+  return withSandbox(ctx, async (sandbox) => {
+    const skillDir = await findSkillDir(sandbox, name);
+    if (!skillDir) {
+      throw new CloudSkillsError(`Skill '${name}' not found`, 404);
+    }
+    return listFilesRecursiveE2B(sandbox, skillDir);
+  });
+}
+
+export async function readCloudSkillFile(
+  ctx: CloudSkillsContext,
+  name: string,
+  filePath: string,
+): Promise<SkillFileContent> {
+  return withSandbox(ctx, async (sandbox) => {
+    const skillDir = await findSkillDir(sandbox, name);
+    if (!skillDir) {
+      throw new CloudSkillsError(`Skill '${name}' not found`, 404);
+    }
+    if (!isPathWithinDirectory(skillDir, filePath)) {
+      throw new CloudSkillsError("Invalid file path", 400);
+    }
+    const fullPath = path.posix.join(skillDir, filePath);
+
+    let info;
+    try {
+      info = await sandbox.files.getInfo(fullPath);
+    } catch (err) {
+      if (err instanceof FileNotFoundError) {
+        throw new CloudSkillsError("File not found", 404);
+      }
+      throw err;
+    }
+    if (info.type !== "file") {
+      throw new CloudSkillsError("Path is not a file", 400);
+    }
+
+    const mimeType = getMimeType(filePath);
+    const isText = isTextMimeType(mimeType);
+    const maxSize = isText ? 1024 * 1024 : 5 * 1024 * 1024;
+    if (info.size > maxSize) {
+      throw new CloudSkillsError(
+        `File too large (${(info.size / 1024 / 1024).toFixed(2)}MB). Maximum is ${maxSize / 1024 / 1024}MB`,
+        400,
+      );
+    }
+
+    const content: SkillFileContent = {
+      path: filePath,
+      name: path.posix.basename(filePath),
+      mimeType,
+      size: info.size,
+      isText,
+    };
+    if (isText) {
+      content.content = await sandbox.files.read(fullPath);
+    } else {
+      const bytes = await sandbox.files.read(fullPath, { format: "bytes" });
+      content.base64 = Buffer.from(bytes).toString("base64");
+    }
+    return content;
+  });
+}

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -150,6 +150,12 @@ export interface WebChatTurnPrepareInputs {
   /** Server-side built-in tools (e.g. web_search) to merge into the tool set. */
   builtInTools?: ToolSet;
   widgetModelContext?: WidgetModelContextEntry[];
+  /**
+   * When set, skills are sourced from the caller's Computer (E2B sandbox)
+   * rather than the local FS. Set by the hosted chat route only when the host
+   * actually has a computer. See `chat-v2-orchestration.ts`.
+   */
+  cloudSkills?: { authHeader: string; projectId: string };
 }
 
 /** Runtime knobs (auth, abort, rpc collector, Hono context for cleanup). */
@@ -217,6 +223,7 @@ export async function streamWebChatTurn(
         : {}),
       appTools: prepare.appTools,
       builtInTools: prepare.builtInTools,
+      ...(prepare.cloudSkills ? { cloudSkills: prepare.cloudSkills } : {}),
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Why

Skills (reusable `SKILL.md` instruction packages) were **local-only** — every operation read the inspector's own filesystem (`~/.mcpjam/skills`, etc.). In hosted / horizontally-scaled mode there's no durable local FS, so the feature was hard-disabled (Skills nav grayed out, skill tools stripped from chat).

We now have **Computers** — per-project E2B sandboxes that persist files between sessions. That's exactly what skills need. This PR sources skills from the project's Computer so they work in hosted mode, with a Local/Cloud toggle when running locally.

## Design

Skills are stored at `~/.claude/skills` on the computer (PRIMARY dir). That's the same directory Claude Code natively scans *inside* the sandbox, so the in-sandbox harness and the non-harness chat tools share **one source of truth** — no Convex blob store, no prompt bloat.

## Server

- `server/utils/computers/cloud-skills.ts` — list/get/upload/delete/files/read-file over the sandbox via E2B `sandbox.files.*`, reusing the existing control-plane wake (`ensureComputerReady` → `getComputerSandboxInfo`) and `skill-parser.ts` (validation, mime/text detection, path-traversal guard).
- `cloud-skill-tools.ts` — AI-SDK chat tools with a **lazy `listSkills` discovery tool** so a hosted turn never forces a sandbox wake unless the model actually reaches for a skill.
- `routes/web/skills.ts` (bearer-gated, `projectId`-keyed) + registration in `web/index.ts`.
- Wired via `prepareChatV2({ cloudSkills })`, set in `web/chat-v2.ts` **only when the host has a computer** (`narrowHostComputer`) — advertise == enforce.
- Harness path unchanged (relies on Claude Code native discovery).

## Client

- Skills nav un-gated in hosted mode under the existing `computers-enabled` flag (render-time `withCloudSkillsGate`); `SkillsRoute` tri-state guard mirroring `ComputerRoute`; `skills` moved blocked → hash-allowed (kept out of sidebar-allowed so the flag governs it).
- `SkillsTab` gains a Local/Cloud `ViewModeSelector` toggle (local mode + flag on); `mcp-skills-api.ts` functions take an optional, backward-compatible `SkillsSource`.

## Tests

- New: cloud-skills service (12) + web route (7).
- Existing orchestration / sidebar / hosted-tab-policy / skills-api suites stay green; `tsc` clean on client and server for all touched files.

## To verify on a real box

Whether the in-sandbox Claude Code adapter auto-discovers `~/.claude/skills`. If not, the harness needs its `skills` param populated (plumbing already exists in `run-harness-turn.ts`); the non-harness chat path works regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated web APIs, E2B sandbox filesystem writes, and chat tool wiring; misconfiguration could affect uploads or expose skills to wrong project scope, though bearer auth and existing computer resolution mirror computers routes.
> 
> **Overview**
> **Cloud Skills** move skill CRUD off the inspector's local filesystem onto the project's **Computer** (E2B sandbox), primarily under `~/.claude/skills`, so hosted mode can list, upload, browse, and delete skills the same way local builds do.
> 
> The client adds an optional **`SkillsSource`** (`local` vs `cloud`) through `mcp-skills-api`, a **Local/Cloud** toggle on `SkillsTab` when Computers are enabled locally, and **hosted gating** for `/skills` and sidebar nav tied to the Computers feature flag (tri-state like `ComputerRoute`). Hosted tab policy now allows direct navigation to `skills` while keeping the sidebar item disabled until the flag enables it.
> 
> The server introduces **`/api/web/skills/*`** (bearer + `projectId`), **`cloud-skills.ts`** (wake sandbox, E2B filesystem ops, upload caps, path traversal guards), and **`cloud-skill-tools.ts`** for chat with lazy **`listSkills`** so turns don't wake the sandbox upfront. Hosted chat v2 passes **`cloudSkills`** into orchestration only when the host has a computer and the caller isn't a guest. **`webBodyLimit`** replaces the blanket 1MB cap with a multipart carve-out for skill folder uploads aligned to service size limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ed71e35e55007104c9d475042c9aafa5862c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->