### PR TITLE
feat(evals): suite computer-environment picker + run-detail surfacing

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -418,13 +418,21 @@ export function RunDetailView({
   // friendly name best-effort; fall back to the snapshot's environmentId if the
   // environment was deleted since the run.
   const runComputerEnv = selectedRunDetails.configSnapshot?.computerEnvironment;
+  // Durable id keyed off the frozen pin, falling back to the snapshot's
+  // environment.computerEnvironmentId — so a run that recorded the id without
+  // the newer frozen object still shows an Environment row.
+  const runComputerEnvId =
+    runComputerEnv?.environmentId ??
+    selectedRunDetails.configSnapshot?.environment?.computerEnvironmentId ??
+    null;
   const runEnvironments = useEnvironments(
-    runComputerEnv ? selectedRunDetails.projectId ?? null : null
+    runComputerEnvId ? selectedRunDetails.projectId ?? null : null
   );
-  const runComputerEnvName = runComputerEnv
-    ? runEnvironments?.find(
-        (e) => e.environmentId === runComputerEnv.environmentId
-      )?.name ?? null
+  // Friendly name when resolvable; otherwise the RAW id (never truncated — it's
+  // the only durable identifier once the environment is deleted).
+  const runComputerEnvLabel = runComputerEnvId
+    ? runEnvironments?.find((e) => e.environmentId === runComputerEnvId)
+        ?.name ?? runComputerEnvId
     : null;
   const {
     result: goalCompletionResult,
@@ -699,23 +707,27 @@ export function RunDetailView({
         </div>
       ) : null}
 
-      {runComputerEnv ? (
+      {runComputerEnvId ? (
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <span className={runDetailMetaLabelClass}>Environment</span>
           <span
             className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs"
-            title={`Image ${runComputerEnv.e2bTemplateId}${
-              runComputerEnv.baseImageDigests[0]
-                ? ` · ${runComputerEnv.baseImageDigests[0]}`
-                : ""
-            } · ${runComputerEnv.provider}`}
+            title={
+              runComputerEnv
+                ? `Image ${runComputerEnv.e2bTemplateId}${
+                    runComputerEnv.baseImageDigests[0]
+                      ? ` · ${runComputerEnv.baseImageDigests[0]}`
+                      : ""
+                  } · ${runComputerEnv.provider}`
+                : undefined
+            }
           >
-            <span className="text-foreground">
-              {runComputerEnvName ?? formatRunId(runComputerEnv.environmentId)}
-            </span>
-            <span className="font-mono text-[10px] text-muted-foreground">
-              {runComputerEnv.provider}
-            </span>
+            <span className="text-foreground">{runComputerEnvLabel}</span>
+            {runComputerEnv ? (
+              <span className="font-mono text-[10px] text-muted-foreground">
+                {runComputerEnv.provider}
+              </span>
+            ) : null}
           </span>
         </div>
       ) : null}

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -48,6 +48,7 @@ import {
   type RunTrendPoint,
 } from "./run-insight-rail";
 import { runDetailMetaLabelClass } from "./run-detail-typography";
+import { useEnvironments } from "@/hooks/useComputerEnvironments";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -412,6 +413,19 @@ export function RunDetailView({
   const { availableModels } = useAvailableModels({
     projectId: selectedRunDetails.projectId ?? null,
   });
+
+  // The frozen reproducible-env pin this run launched from (if any). Resolve a
+  // friendly name best-effort; fall back to the snapshot's environmentId if the
+  // environment was deleted since the run.
+  const runComputerEnv = selectedRunDetails.configSnapshot?.computerEnvironment;
+  const runEnvironments = useEnvironments(
+    runComputerEnv ? selectedRunDetails.projectId ?? null : null
+  );
+  const runComputerEnvName = runComputerEnv
+    ? runEnvironments?.find(
+        (e) => e.environmentId === runComputerEnv.environmentId
+      )?.name ?? null
+    : null;
   const {
     result: goalCompletionResult,
     pending: goalCompletionPending,
@@ -682,6 +696,27 @@ export function RunDetailView({
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <span className={runDetailMetaLabelClass}>Host</span>
           <HostChip name={runClient.displayName} hostId={runClient.hostId} />
+        </div>
+      ) : null}
+
+      {runComputerEnv ? (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <span className={runDetailMetaLabelClass}>Environment</span>
+          <span
+            className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs"
+            title={`Image ${runComputerEnv.e2bTemplateId}${
+              runComputerEnv.baseImageDigests[0]
+                ? ` · ${runComputerEnv.baseImageDigests[0]}`
+                : ""
+            } · ${runComputerEnv.provider}`}
+          >
+            <span className="text-foreground">
+              {runComputerEnvName ?? formatRunId(runComputerEnv.environmentId)}
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {runComputerEnv.provider}
+            </span>
+          </span>
         </div>
       ) : null}
 

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import { useMutation, useConvexAuth } from "convex/react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useHostList } from "@/hooks/useClients";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useEnvironments } from "@/hooks/useComputerEnvironments";
 import { toast } from "sonner";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { compareRunsBySequence } from "./helpers";
@@ -380,6 +382,12 @@ export function SuiteIterationsView({
 
   const updateSuite = useMutation("testSuites:updateTestSuite" as any);
   const { isAuthenticated } = useConvexAuth();
+  // Reproducible-evals env picker (gated by the computers feature flag). Only
+  // fetch the project's environments when the flag is on and we have a project.
+  const computersEnabled = useComputersEnabled();
+  const computerEnvironments = useEnvironments(
+    computersEnabled && projectId ? projectId : null
+  );
   // Hosts available to attach in the header's "+ Attach host" picker. The
   // query is owned here (not inside SuiteOverviewClientBar) so the bar stays
   // pure-props and renderable in test environments without a Convex provider.
@@ -1352,6 +1360,74 @@ export function SuiteIterationsView({
                   higher keeps its count; a per-run override still wins.
                 </p>
               </SettingsSection>
+
+              {/* ── Computer environment (reproducible evals) ──────────
+                  Gated behind the computers feature flag. Pins a built Docker
+                  environment so each eval iteration boots a fresh sandbox from
+                  the same image — comparable results across runs/edits. */}
+              {computersEnabled && projectId ? (
+                <SettingsSection
+                  label="Computer environment"
+                  layout="inline"
+                  inlineSlot={
+                    <select
+                      className="h-8 max-w-[16rem] rounded-md border border-input bg-background px-2 text-xs text-foreground"
+                      value={suite.environment?.computerEnvironmentId ?? ""}
+                      aria-label="Reproducible computer environment for eval runs"
+                      onChange={async (e) => {
+                        const next = e.target.value || undefined;
+                        try {
+                          await updateSuite({
+                            suiteId: suite._id,
+                            environment: {
+                              servers: suite.environment?.servers ?? [],
+                              serverBindings: suite.environment?.serverBindings,
+                              ...(next ? { computerEnvironmentId: next } : {}),
+                            },
+                          });
+                          toast.success(
+                            next
+                              ? "Computer environment set"
+                              : "Computer environment cleared"
+                          );
+                        } catch (error) {
+                          toast.error(
+                            getBillingErrorMessage(
+                              error,
+                              "Failed to update suite"
+                            )
+                          );
+                          console.error(
+                            "Failed to update computer environment:",
+                            error
+                          );
+                        }
+                      }}
+                    >
+                      <option value="">None (default image)</option>
+                      {(computerEnvironments ?? []).map((env) => {
+                        const ready = env.currentBuild?.status === "ready";
+                        return (
+                          <option
+                            key={env.environmentId}
+                            value={env.environmentId}
+                          >
+                            {env.name}
+                            {ready ? "" : " (not built)"}
+                          </option>
+                        );
+                      })}
+                    </select>
+                  }
+                >
+                  <p className="text-[11px] text-muted-foreground/60">
+                    Each eval iteration boots a fresh sandbox from this image
+                    and the agent gets a <span className="font-mono">bash</span>{" "}
+                    tool in it. Build the environment before running, or the run
+                    fails fast.
+                  </p>
+                </SettingsSection>
+              ) : null}
 
               {/* ── Tool calls ───────────────────────────────────────── */}
               <SettingsSection

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -114,6 +114,11 @@ export type EvalSuite = {
       serverName: string;
       projectServerId?: string;
     }>;
+    /**
+     * Reproducible-evals pin: the computer environment each eval iteration
+     * boots a fresh sandbox from. Set via the suite settings env-picker.
+     */
+    computerEnvironmentId?: string;
   };
   createdAt: number;
   updatedAt: number;
@@ -483,6 +488,20 @@ export type EvalSuiteRun = {
         serverName: string;
         projectServerId?: string;
       }>;
+      computerEnvironmentId?: string;
+    };
+    /**
+     * Frozen reproducible-env pin for this run: the exact built image each
+     * iteration's sandbox launched from. Surfaced in run-detail so users can
+     * see which environment a run used (and spot mismatches when comparing).
+     */
+    computerEnvironment?: {
+      environmentId: string;
+      environmentBuildId: string;
+      e2bTemplateId: string;
+      e2bBuildId?: string;
+      baseImageDigests: string[];
+      provider: "e2b" | "stub";
     };
     /**
      * Suite-level judge config snapshotted at run-create. The run-detail


### PR DESCRIPTION
## Last-mile UI for reproducible evals

Wires the reproducible-evals backend (mcpjam-backend #635/#636) + runner (#2948) into the app: a user can now **attach a built Docker `computerEnvironment` to an eval suite** from the UI, and **see which image a run used** in run-detail. Until now this was only settable via the `updateTestSuite` API.

### Changes
- **`types.ts`** — thread `computerEnvironmentId` onto `EvalSuite.environment` and `EvalSuiteRun.configSnapshot.environment`, and add the frozen `configSnapshot.computerEnvironment` pin (`{ environmentId, environmentBuildId, e2bTemplateId, e2bBuildId?, baseImageDigests, provider }`).
- **Suite settings — env picker** (`suite-iterations-view.tsx`): a new *"Computer environment"* row in the suite settings sheet. Reuses `useEnvironments(projectId)` (the same hook the Computer tab uses), writes `environment.computerEnvironmentId` via `updateTestSuite` while **preserving servers/serverBindings**, and labels envs without a ready build as *"(not built)"*. **Gated behind the `computers-enabled` feature flag** (`useComputersEnabled()`) — invisible unless the flag is on and the project has environments.
- **Run-detail surfacing** (`run-detail-view.tsx`): an always-rendered *"Environment"* line in the run metadata block, from `configSnapshot.computerEnvironment`. Resolves a friendly env name best-effort (falls back to the env id if the environment was deleted since the run); tooltip shows the image template / base digest / provider so users can spot mismatches when comparing runs.

### Gating
- The picker only renders when `computers-enabled` is on **and** a `projectId` is present. No backend/entitlement change — env *creation* is already `projectComputers`-entitlement-gated, so only entitled orgs have environments to pick (per the agreed UI-only gate).

### Verification
- Client typecheck (`tsconfig.typecheck.json`) **clean (0 errors)**; prettier clean.
- No new Convex/API surface — the UI calls the existing `updateTestSuite` (whose validator already accepts `environment.computerEnvironmentId`) and reads `configSnapshot.computerEnvironment` (already persisted by the backend).

### Not in scope (follow-ups)
- SDK/CLI wire field for the pin (Phase 2).
- Flipping `COMPUTERS_ENV_BUILDER=e2b` on the deployment so envs build to real images (separate ops step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and type annotations on existing `updateTestSuite` and run snapshots; behavior is gated by the computers feature flag with no new API surface.
> 
> **Overview**
> **Reproducible computer environments** are now configurable and visible in evals UI, wiring existing backend/runner pins into the inspector.
> 
> **Suite settings** adds a *Computer environment* dropdown (behind `computers-enabled` and a project id) that lists project environments via `useEnvironments`, marks non-ready builds as *(not built)*, and persists `environment.computerEnvironmentId` through `updateTestSuite` while keeping MCP `servers` / `serverBindings` intact. Clearing the selection omits the id from the payload.
> 
> **Run detail** shows an *Environment* metadata row when a run has a pinned env, resolving the name from live project data when possible and falling back to the stored id. Tooltip includes frozen snapshot details (template, digest, provider) when `configSnapshot.computerEnvironment` exists; older runs with only `environment.computerEnvironmentId` still get a row.
> 
> **Types** document `computerEnvironmentId` on suite and run snapshot `environment`, plus the frozen `configSnapshot.computerEnvironment` object for display/compare.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab87b0f0e60812fe9c5c401644356fabc89726ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->