### PR TITLE
feat(skills): cloud skills in the "/" picker + review follow-ups

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -966,24 +966,14 @@ export function SkillsRoute() {
   const { convexProjectId } = useAppRouteContext();
   const computersEnabled = useComputersEnabledState();
 
-  // In hosted mode skills live on the project's Computer, so the route is
-  // gated on the Computer flag — mirror ComputerRoute's tri-state: redirect
-  // only on an explicit `false`, render nothing while PostHog hydrates (so a
-  // flagged-in user cold-loading /skills isn't bounced before the flag
-  // resolves). Local mode is ungated (local FS skills always work).
-  if (HOSTED_MODE) {
-    if (computersEnabled === false) {
-      return <Navigate to={routePaths.servers} replace />;
-    }
-    if (computersEnabled === undefined) {
-      return null;
-    }
-    // Hosted skills are a project resource and have no local FS to fall back to.
-    // Don't render SkillsTab until the project resolves, or it would briefly run
-    // in local mode and hit unavailable /api/mcp/skills/* routes.
-    if (!convexProjectId) {
-      return null;
-    }
+  // Hosted skills are a project-MEMBERSHIP resource (authored in Convex,
+  // available even without a Computer) — NOT gated on the Computer flag. Access
+  // is enforced server-side. We only wait for the project to resolve, since
+  // hosted skills have no local FS to fall back to (rendering early would hit
+  // the unavailable /api/mcp/skills/* routes). `computersEnabled` is passed
+  // through only for the local-mode Local/Cloud toggle.
+  if (HOSTED_MODE && !convexProjectId) {
+    return null;
   }
 
   return (

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -3,7 +3,10 @@ import {
   useState,
   useCallback,
   useLayoutEffect,
+  useMemo,
 } from "react";
+import { HOSTED_MODE } from "@/lib/config";
+import type { SkillsSource } from "@/lib/apis/mcp-skills-api";
 import type {
   ChangeEvent,
   ClipboardEvent,
@@ -287,6 +290,17 @@ export function ChatInput({
   chatboxAttachableServers,
   onAttachChatboxServer,
 }: ChatInputProps) {
+  // Cloud skill source for the `/` picker: in hosted mode, list/load skills
+  // from the project's Convex/Computer source (Playground carries projectId via
+  // `clientSelector`). Local mode keeps the default (filesystem) path. Memoized
+  // so the popover's fetch effects don't re-run every render.
+  const skillsSource = useMemo<SkillsSource | undefined>(
+    () =>
+      HOSTED_MODE && clientSelector?.projectId
+        ? { kind: "cloud", projectId: clientSelector.projectId }
+        : undefined,
+    [clientSelector?.projectId],
+  );
   const chatboxHostStyle = useChatboxHostStyle();
   const chatboxHostTheme = useChatboxHostTheme();
   const globalThemeMode = usePreferencesStore((s) => s.themeMode);
@@ -585,6 +599,7 @@ export function ChatInput({
             <SkillResultCard
               key={`skill-${index}`}
               skillResult={skillResult}
+              skillsSource={skillsSource}
               onRemove={() => removeSkillResult(index)}
               onUpdate={(updatedSkill) => {
                 const newSkillResults = [...skillResults];
@@ -694,6 +709,7 @@ export function ChatInput({
             value={value}
             caretIndex={caretIndex}
             minimalMode={minimalMode}
+            skillsSource={skillsSource}
           />
 
           {minimalMode &&

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/prompts/mcp-prompts-popover.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/prompts/mcp-prompts-popover.tsx
@@ -29,7 +29,7 @@ import {
 import { SkillsPopoverSection } from "../skills/skills-popover-section";
 import { SkillUploadDialog } from "../skills/skill-upload-dialog";
 import type { SkillResult } from "../skills/skill-types";
-import { listSkills } from "@/lib/apis/mcp-skills-api";
+import { listSkills, type SkillsSource } from "@/lib/apis/mcp-skills-api";
 
 export interface MCPPromptResult extends PromptListItem {
   result: PromptContentResponse;
@@ -51,6 +51,8 @@ interface PromptsPopoverProps {
   caretIndex: number;
   /** Shared chat-only mode – skips prompts/skills fetch to avoid auth-denied noise */
   minimalMode?: boolean;
+  /** When set, list/load skills from the cloud (Convex/Computer) source. */
+  skillsSource?: SkillsSource;
 }
 
 // Utility function to check if MCP prompts are requested
@@ -75,6 +77,7 @@ export function PromptsPopover({
   value,
   caretIndex,
   minimalMode = false,
+  skillsSource,
 }: PromptsPopoverProps) {
   const [open, setOpen] = useState(false);
   const [promptListItems, setPromptListItems] = useState<PromptListItem[]>([]);
@@ -140,7 +143,7 @@ export function PromptsPopover({
     let active = true;
     (async () => {
       try {
-        const skills = await listSkills();
+        const skills = await listSkills(skillsSource);
         if (!active) return;
         setSkillsCount(skills.length);
       } catch {
@@ -150,7 +153,7 @@ export function PromptsPopover({
     return () => {
       active = false;
     };
-  }, [skillsEnabled]);
+  }, [skillsEnabled, skillsSource]);
 
   // Total items for navigation (prompts + skills)
   const totalItems = promptListItems.length + skillsCount;
@@ -329,6 +332,7 @@ export function PromptsPopover({
               isHovering={isHovering}
               actionTrigger={actionTrigger}
               onOpenUploadDialog={handleOpenUploadDialog}
+              skillsSource={skillsSource}
             />
           )}
         </PopoverContent>
@@ -343,9 +347,10 @@ export function PromptsPopover({
       <SkillUploadDialog
         open={isSkillUploadDialogOpen}
         onOpenChange={setIsSkillUploadDialogOpen}
+        source={skillsSource}
         onSkillCreated={(skill) => {
           // Refresh skills count after creation
-          listSkills()
+          listSkills(skillsSource)
             .then((skills) => setSkillsCount(skills.length))
             .catch(() => {});
           // Optionally select the newly created skill

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-result-card.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-result-card.tsx
@@ -22,6 +22,10 @@ export function SkillResultCard({
   onUpdate,
   skillsSource,
 }: SkillResultCardProps) {
+  // Prefer the source stamped on the skill at selection time; fall back to the
+  // current prop for legacy/local selections. This keeps file reads pinned to
+  // the project the skill was selected from, even if the active project changed.
+  const effectiveSource = skillResult.source ?? skillsSource;
   const [isExpanded, setIsExpanded] = useState(false);
   const [files, setFiles] = useState<SkillFile[]>([]);
   const [loading, setLoading] = useState(false);
@@ -38,7 +42,7 @@ export function SkillResultCard({
     if (isExpanded && files.length === 0 && !loading) {
       setLoading(true);
       setError(null);
-      listSkillFiles(skillResult.name, skillsSource)
+      listSkillFiles(skillResult.name, effectiveSource)
         .then((fetchedFiles: SkillFile[]) => {
           setFiles(fetchedFiles);
         })
@@ -49,7 +53,7 @@ export function SkillResultCard({
           setLoading(false);
         });
     }
-  }, [isExpanded, skillResult.name, files.length, loading, skillsSource]);
+  }, [isExpanded, skillResult.name, files.length, loading, effectiveSource]);
 
   // Handle file selection toggle
   const handleFileToggle = useCallback(
@@ -77,7 +81,7 @@ export function SkillResultCard({
           const fileContent = await readSkillFile(
             skillResult.name,
             filePath,
-            skillsSource,
+            effectiveSource,
           );
           if (!fileContent.isText || !fileContent.content) {
             // Skip non-text files
@@ -103,7 +107,7 @@ export function SkillResultCard({
         }
       }
     },
-    [skillResult, selectedPaths, onUpdate, skillsSource],
+    [skillResult, selectedPaths, onUpdate, effectiveSource],
   );
 
   // Count of additional files selected (not counting SKILL.md which is always included)

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-result-card.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-result-card.tsx
@@ -1,19 +1,26 @@
 import { X, ChevronDown, ChevronUp, SquareSlash, Loader2 } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 import type { SkillResult, SelectedSkillFile, SkillFile } from "./skill-types";
-import { listSkillFiles, readSkillFile } from "@/lib/apis/mcp-skills-api";
+import {
+  listSkillFiles,
+  readSkillFile,
+  type SkillsSource,
+} from "@/lib/apis/mcp-skills-api";
 import { SkillFileTreeSelectable } from "./skill-file-tree-selectable";
 
 interface SkillResultCardProps {
   skillResult: SkillResult;
   onRemove: () => void;
   onUpdate?: (updatedSkill: SkillResult) => void;
+  /** Source the skill came from (cloud → fetch files from Convex/Computer). */
+  skillsSource?: SkillsSource;
 }
 
 export function SkillResultCard({
   skillResult,
   onRemove,
   onUpdate,
+  skillsSource,
 }: SkillResultCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [files, setFiles] = useState<SkillFile[]>([]);
@@ -31,8 +38,8 @@ export function SkillResultCard({
     if (isExpanded && files.length === 0 && !loading) {
       setLoading(true);
       setError(null);
-      listSkillFiles(skillResult.name)
-        .then((fetchedFiles) => {
+      listSkillFiles(skillResult.name, skillsSource)
+        .then((fetchedFiles: SkillFile[]) => {
           setFiles(fetchedFiles);
         })
         .catch((err) => {
@@ -42,7 +49,7 @@ export function SkillResultCard({
           setLoading(false);
         });
     }
-  }, [isExpanded, skillResult.name, files.length, loading]);
+  }, [isExpanded, skillResult.name, files.length, loading, skillsSource]);
 
   // Handle file selection toggle
   const handleFileToggle = useCallback(
@@ -67,7 +74,11 @@ export function SkillResultCard({
         // Add file to selection - need to fetch content first
         setLoadingFile(filePath);
         try {
-          const fileContent = await readSkillFile(skillResult.name, filePath);
+          const fileContent = await readSkillFile(
+            skillResult.name,
+            filePath,
+            skillsSource,
+          );
           if (!fileContent.isText || !fileContent.content) {
             // Skip non-text files
             setLoadingFile(null);
@@ -92,7 +103,7 @@ export function SkillResultCard({
         }
       }
     },
-    [skillResult, selectedPaths, onUpdate],
+    [skillResult, selectedPaths, onUpdate, skillsSource],
   );
 
   // Count of additional files selected (not counting SKILL.md which is always included)

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-types.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-types.ts
@@ -4,6 +4,7 @@ import type {
   SkillFile,
   SkillFileContent,
 } from "../../../../../../shared/skill-types";
+import type { SkillsSource } from "@/lib/apis/mcp-skills-api";
 
 /**
  * A selected file from a skill directory
@@ -23,6 +24,14 @@ export interface SkillResult extends Skill {
   // Skill already has all needed fields: name, description, content, path
   // Additional files selected by the user
   selectedFiles?: SelectedSkillFile[];
+  /**
+   * The source this skill was selected from, captured at selection time. Later
+   * file reads (expanding the card) use THIS, not whatever project is active
+   * now — so switching projects can't make a card fetch the wrong project's
+   * files. Absent for legacy/local selections (card falls back to the current
+   * source prop).
+   */
+  source?: SkillsSource;
 }
 
 // Re-export for convenience

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -248,13 +248,21 @@ export function SkillUploadDialog({
         <DialogHeader>
           <DialogTitle>Upload Skill</DialogTitle>
           <DialogDescription>
-            Upload a skill folder containing a SKILL.md file. The folder will be
-            saved to{" "}
-            <code className="text-xs bg-muted px-1 py-0.5 rounded">
-              {source?.kind === "cloud" ? "~/.claude/skills/" : "~/.mcpjam/skills/"}
-              {skillInfo?.name || "{name}"}/
-            </code>
-            {source?.kind === "cloud" ? " on your personal computer" : ""}
+            {source?.kind === "cloud" ? (
+              <>
+                Upload a skill folder containing a SKILL.md file. Cloud skills are{" "}
+                <strong>SKILL.md-only for now</strong> — folders with supporting
+                files are rejected (inline anything SKILL.md needs).
+              </>
+            ) : (
+              <>
+                Upload a skill folder containing a SKILL.md file. The folder will
+                be saved to{" "}
+                <code className="text-xs bg-muted px-1 py-0.5 rounded">
+                  ~/.mcpjam/skills/{skillInfo?.name || "{name}"}/
+                </code>
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
@@ -74,7 +74,9 @@ export function SkillsPopoverSection({
           skill_name: skill.name,
           ...standardEventProps("chat_input_skills_popover"),
         });
-        onSkillSelected(fullSkill);
+        // Stamp the source onto the result so later file reads (expanding the
+        // card) stay pinned to the project it was selected from.
+        onSkillSelected({ ...fullSkill, source: skillsSource });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         console.error("[SkillsPopoverSection] Failed to get skill", message);

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
@@ -6,7 +6,11 @@ import {
 import { cn } from "@/lib/chat-utils";
 import { SquareSlash, Loader2 } from "lucide-react";
 import { useEffect, useState, useCallback } from "react";
-import { listSkills, getSkill } from "@/lib/apis/mcp-skills-api";
+import {
+  listSkills,
+  getSkill,
+  type SkillsSource,
+} from "@/lib/apis/mcp-skills-api";
 import type { SkillListItem, SkillResult } from "./skill-types";
 import { usePostHog } from "posthog-js/react";
 import { standardEventProps } from "@/lib/PosthogUtils";
@@ -19,6 +23,8 @@ interface SkillsPopoverSectionProps {
   isHovering: boolean;
   actionTrigger: string | null;
   onOpenUploadDialog?: () => void;
+  /** When set, list/load skills from the cloud (Convex/Computer) source. */
+  skillsSource?: SkillsSource;
 }
 
 export function SkillsPopoverSection({
@@ -29,6 +35,7 @@ export function SkillsPopoverSection({
   isHovering,
   actionTrigger,
   onOpenUploadDialog,
+  skillsSource,
 }: SkillsPopoverSectionProps) {
   const posthog = usePostHog();
   const [skills, setSkills] = useState<SkillListItem[]>([]);
@@ -41,7 +48,7 @@ export function SkillsPopoverSection({
     (async () => {
       try {
         setIsLoading(true);
-        const skillsList = await listSkills();
+        const skillsList = await listSkills(skillsSource);
         if (!active) return;
         setSkills(skillsList);
       } catch (err) {
@@ -56,13 +63,13 @@ export function SkillsPopoverSection({
     return () => {
       active = false;
     };
-  }, []);
+  }, [skillsSource]);
 
   const handleSkillClick = useCallback(
     async (skill: SkillListItem) => {
       try {
         setLoadingSkillName(skill.name);
-        const fullSkill = await getSkill(skill.name);
+        const fullSkill = await getSkill(skill.name, skillsSource);
         posthog.capture("skill_injected", {
           skill_name: skill.name,
           ...standardEventProps("chat_input_skills_popover"),
@@ -75,7 +82,7 @@ export function SkillsPopoverSection({
         setLoadingSkillName(null);
       }
     },
-    [onSkillSelected],
+    [onSkillSelected, skillsSource],
   );
 
   // Handle Enter key on highlighted skill
@@ -164,7 +171,10 @@ export function SkillsPopoverSection({
 }
 
 // Export the skill count getter for the parent popover to calculate navigation
-export function useSkillsCount(): { count: number; isLoading: boolean } {
+export function useSkillsCount(skillsSource?: SkillsSource): {
+  count: number;
+  isLoading: boolean;
+} {
   const [count, setCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -172,7 +182,7 @@ export function useSkillsCount(): { count: number; isLoading: boolean } {
     let active = true;
     (async () => {
       try {
-        const skills = await listSkills();
+        const skills = await listSkills(skillsSource);
         if (!active) return;
         setCount(skills.length);
       } catch {
@@ -186,7 +196,7 @@ export function useSkillsCount(): { count: number; isLoading: boolean } {
     return () => {
       active = false;
     };
-  }, []);
+  }, [skillsSource]);
 
   return { count, isLoading };
 }

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -72,7 +72,6 @@ import {
   useAppNavigate,
 } from "@/lib/app-navigation";
 import { HOSTED_LOCAL_ONLY_TOOLTIP } from "@/lib/hosted-ui";
-import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
 import {
@@ -382,17 +381,13 @@ const hostedNavigationSections =
   getHostedNavigationSections(navigationSections);
 
 /**
- * Render-time gate for hosted Skills. `getHostedNavigationSections` runs at
- * module load (no hooks), so it marks Skills disabled by default. Once the
- * Computer feature flag resolves, flip Skills to enabled — in hosted mode
- * skills live on the project's Computer, so the Computer flag governs them.
- * Flag off keeps the existing disabled + "available locally" affordance.
+ * Enable the hosted Skills nav item. `getHostedNavigationSections` runs at
+ * module load (no hooks) and marks Skills disabled by default; hosted skills are
+ * a **project-membership** resource (authored in Convex, available even without
+ * a Computer), so for any hosted member we flip it to enabled. Access is
+ * enforced server-side, not by this nav state.
  */
-function withCloudSkillsGate(
-  sections: NavSection[],
-  computersEnabled: boolean,
-): NavSection[] {
-  if (!computersEnabled) return sections;
+function enableHostedSkillsNav(sections: NavSection[]): NavSection[] {
   return sections.map((section) => ({
     ...section,
     items: section.items.map((item) =>
@@ -681,10 +676,9 @@ export function MCPSidebar({
     ]
   );
   const hubNavHash = "#servers";
-  const computersEnabled = useComputersEnabled();
   const visibleNavigationSections = filterByFeatureFlags(
     HOSTED_MODE
-      ? withCloudSkillsGate(hostedNavigationSections, computersEnabled)
+      ? enableHostedSkillsNav(hostedNavigationSections)
       : navigationSections,
     featureFlags
   );

--- a/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
@@ -195,14 +195,27 @@ export async function uploadSkillFolder(
   sharing: SkillSharing = "user",
 ): Promise<Skill> {
   if (isCloud(source)) {
-    // v1 cloud skills are SKILL.md-only: read the SKILL.md, create from it
-    // (supporting files in the folder are ignored until v2).
+    // v1 cloud skills are SKILL.md-only. Rather than silently drop supporting
+    // files (which would create a broken skill if SKILL.md references them),
+    // reject a folder that contains anything besides SKILL.md.
     const skillMdFile = files.find(
       (f) =>
         f.name === "SKILL.md" ||
         ((f as any).webkitRelativePath || "").endsWith("/SKILL.md"),
     );
     if (!skillMdFile) throw new Error("No SKILL.md found in the folder");
+    const supporting = files.filter((f) => f !== skillMdFile);
+    if (supporting.length > 0) {
+      const names = supporting
+        .slice(0, 3)
+        .map((f) => f.name)
+        .join(", ");
+      throw new Error(
+        `Cloud skills are SKILL.md-only for now — this folder has ` +
+          `${supporting.length} other file(s) (${names}${supporting.length > 3 ? ", …" : ""}). ` +
+          `Remove them (inline anything SKILL.md needs) or add this skill to a local build.`,
+      );
+    }
     const { description, body } = parseSkillMd(await skillMdFile.text());
     return uploadSkill(
       { name: skillName, description, content: body },


### PR DESCRIPTION
Rebased onto `main` (post-#2960). One follow-up PR for the remaining cloud-skills review items.

## 1. Cloud skills in the chat `/` picker (original P2#2)
The `/` slash-skill picker called the skills API with no source → `[]` in hosted. Now threads a memoized cloud `skillsSource` ({kind:"cloud", projectId}) from the Playground's `clientSelector.projectId` through `PromptsPopover` → `SkillsPopoverSection`/`useSkillsCount` → `SkillResultCard` (+ upload dialog). Local mode unchanged.

## 2. Review fixes (folded in)
- **[P2] Card source drift** — a selected skill's file reads used the *current* `skillsSource`, so switching projects could fetch the wrong project's files. Now the source is **stamped onto each `SkillResult` at selection** and the card uses `skillResult.source ?? skillsSource`.
- **[P2] Hosted Skills UI over-gated** — `/skills` route + sidebar were gated on `computers-enabled`, but the new model makes skills **project-membership** gated (available without a Computer). Ungated: `SkillsRoute` only waits for the project; the sidebar always enables Skills in hosted. Access stays enforced server-side.
- **[P2] Cloud folder upload dropped files** — v1 is SKILL.md-only; it silently ignored supporting files (broken skills if SKILL.md references them). Now **rejects** folders with extra files (clear error) and the dialog states the limitation up front.

## Tests
`tsc` clean; 78 affected client unit tests pass. UI — needs a browser smoke (hosted `/` picker lists/injects a cloud skill; project switch keeps a card's files pinned; Skills tab reachable without the Computers flag).