### PR TITLE
feat(swarm): run synthetic sessions on the host Computer + Cloud Skills

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.byok.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatbox-sessions.byok.test.ts
@@ -122,4 +122,40 @@ describe("web routes — chatbox-sessions BYOK gate removed", () => {
     expect(status).toBe(200);
     expect(data.runId).toBe("run-1");
   });
+
+  it("threads computer-backed built-ins into swarm simulation", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        chatboxId: "cbx-computer",
+        accessVersion: 0,
+        modelId: "openai/gpt-4o-mini",
+        systemPrompt: "",
+        temperature: 0.7,
+        requireToolApproval: true,
+        hostStyle: "default",
+        builtInToolIds: ["bash"],
+        computer: { kind: "personal", workdir: "/workspace" },
+      },
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/cbx-computer/simulate-sessions/start",
+      validBody,
+      token,
+    );
+    const { status, data } = await expectJson<{ runId?: string }>(response);
+
+    expect(status).toBe(200);
+    expect(data.runId).toBe("run-1");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(startSimulationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        builtInToolIds: ["bash"],
+        computer: { kind: "personal", workdir: "/workspace" },
+        requireToolApproval: true,
+      })
+    );
+  });
 });

--- a/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
+++ b/mcpjam-inspector/server/routes/web/chatbox-sessions.ts
@@ -244,6 +244,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
     const respectToolVisibility = runtime.config.respectToolVisibility;
     const progressiveToolDiscovery = runtime.config.progressiveToolDiscovery;
     const builtInToolIds = runtime.config.builtInToolIds;
+    const computer = runtime.config.computer;
     const harness = runtime.config.harness;
     // `runtime.config.accessVersion` is the server-resolved value the
     // chatbox redeem produced (vs the client-supplied `body.accessVersion`,
@@ -269,6 +270,7 @@ chatboxSessions.post("/:chatboxId/simulate-sessions/start", async (c) =>
         respectToolVisibility,
         progressiveToolDiscovery,
         ...(builtInToolIds ? { builtInToolIds } : {}),
+        ...(computer ? { computer } : {}),
         ...(harness ? { harness } : {}),
         // Threaded into the runner's per-tool widget snapshot capture so
         // `chatSessions:createWidgetSnapshot` can authenticate against the

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
@@ -444,6 +444,19 @@ describe("synthetic-session runner — browser pipeline wiring", () => {
     expect(prepareOpts.cloudSkills).toBeUndefined();
   });
 
+  it("omits Cloud Skills under tool approval (headless can't approve)", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: false });
+    createBrowserSessionContextMock.mockReturnValue(fake);
+
+    // A synthetic visitor can't grant approval; the local-BYOK path fail-closes
+    // on any non-empty tool set, so the always-present listSkills/loadSkill
+    // meta-tools must not be injected when requireToolApproval is on.
+    await startSimulation({ ...baseOptions(), requireToolApproval: true });
+
+    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
+    expect(prepareOpts.cloudSkills).toBeUndefined();
+  });
+
   it("disposes the context when the turn throws (session failure path)", async () => {
     const fake = buildFakeBrowserContext({ computerUse: true });
     createBrowserSessionContextMock.mockReturnValue(fake);

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
@@ -196,7 +196,7 @@ function baseOptions() {
     runId: "run-1",
     chatboxId: "chatbox-1",
     projectId: "proj-1",
-    personas: [{ id: "p1", name: "Persona One", role: "tester" }],
+    personas: [{ id: "p1", name: "Persona One", role: "tester", notes: "" }],
     sessionsPerPersona: 1,
     maxTurns: 3,
     modelId: "anthropic/claude-haiku-4.5",
@@ -400,6 +400,48 @@ describe("synthetic-session runner — browser pipeline wiring", () => {
     expect(artifactCall).toBeDefined();
     expect((artifactCall![1] as any).widgetRenderObservations).toHaveLength(1);
     expect((artifactCall![1] as any).browserInteractionSteps).toBeUndefined();
+  });
+
+  it("passes chatbox computer resources to the built-in tool resolver", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: false });
+    createBrowserSessionContextMock.mockReturnValue(fake);
+
+    await startSimulation({
+      ...baseOptions(),
+      builtInToolIds: ["bash"],
+      computer: { kind: "personal", workdir: "/workspace" },
+      requireToolApproval: true,
+    });
+
+    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
+    expect(Object.keys(prepareOpts.builtInTools ?? {})).toEqual(["bash"]);
+    expect(prepareOpts.builtInTools.bash).toBeDefined();
+  });
+
+  it("wires Cloud Skills on the emulated synthetic path (member, no harness)", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: false });
+    createBrowserSessionContextMock.mockReturnValue(fake);
+
+    await startSimulation({ ...baseOptions() });
+
+    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
+    expect(prepareOpts.cloudSkills).toEqual({
+      authHeader: "Bearer token",
+      projectId: "proj-1",
+    });
+  });
+
+  it("omits Cloud Skills tools on the harness path (delivered natively)", async () => {
+    const fake = buildFakeBrowserContext({ computerUse: false });
+    createBrowserSessionContextMock.mockReturnValue(fake);
+
+    // claude-code + an MCPJam-provided model ⇒ the turn runs the real harness,
+    // which writes skills into the sandbox itself; the emulated listSkills/
+    // loadSkill tools must NOT also be advertised.
+    await startSimulation({ ...baseOptions(), harness: "claude-code" });
+
+    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
+    expect(prepareOpts.cloudSkills).toBeUndefined();
   });
 
   it("disposes the context when the turn throws (session failure path)", async () => {

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -548,7 +548,16 @@ async function runOneSession(args: {
     // tools otherwise. `shouldEnableCloudSkillTools` returns false on the
     // harness path (it delivers skills itself), so this only wires the emulated
     // tools, mirroring `web/chat-v2.ts`.
+    //
+    // BUT skip skills entirely when the chatbox requires tool approval. A
+    // synthetic visitor is headless and can't grant approval: the local-runtime
+    // BYOK path fail-closes on ANY non-empty tool set when approval is on (see
+    // `drainAssistantTurn` below), and the cloud/MCPJam paths auto-deny every
+    // call — so advertising the `listSkills`/`loadSkill` meta-tools (always 2
+    // tools, even for a project with no skills) would turn an otherwise-toolless
+    // approval simulation into one that fails every session for no benefit.
     const cloudSkillsEnabled =
+      !requireToolApproval &&
       Boolean(authHeader) &&
       Boolean(projectId) &&
       shouldEnableCloudSkillTools({

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -23,7 +23,11 @@ import {
   type SyntheticModelSource,
 } from "../../utils/org-model-config.js";
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
-import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
+import {
+  resolveHostTools,
+  type HostComputerResource,
+} from "../../utils/built-in-tools/registry.js";
+import { shouldEnableCloudSkillTools } from "../../utils/computers/cloud-skill-tools.js";
 import {
   persistChatSessionToConvex,
   type PersistedTurnTrace,
@@ -172,6 +176,12 @@ export interface RunSimulationOptions {
    */
   builtInToolIds?: string[];
   /**
+   * Personal-computer attachment from the chatbox's pinned HostConfigV2. This
+   * is the resource gate for computer-backed built-ins like `bash`; capabilities
+   * still ride `builtInToolIds`.
+   */
+  computer?: HostComputerResource;
+  /**
    * Host harness selector mirrored from the chatbox's pinned HostConfigV2.
    * When "claude-code" the synthetic visitor's turns run the real Claude Code
    * runtime; absent ⇒ emulated. Forward-compatible: only activates once the
@@ -308,6 +318,7 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
     respectToolVisibility,
     progressiveToolDiscovery,
     builtInToolIds,
+    computer,
     harness,
     accessVersion,
     convexHttpUrl,
@@ -358,6 +369,7 @@ async function runSimulationLoop(opts: RunSimulationOptions): Promise<void> {
           respectToolVisibility,
           progressiveToolDiscovery,
           builtInToolIds,
+          computer,
           harness,
           accessVersion,
           convexHttpUrl,
@@ -448,6 +460,7 @@ async function runOneSession(args: {
   respectToolVisibility?: boolean;
   progressiveToolDiscovery?: boolean;
   builtInToolIds?: string[];
+  computer?: HostComputerResource;
   harness?: Harness;
   accessVersion?: number;
   convexHttpUrl: string;
@@ -470,6 +483,7 @@ async function runOneSession(args: {
     respectToolVisibility,
     progressiveToolDiscovery,
     builtInToolIds,
+    computer,
     harness,
     accessVersion,
     convexHttpUrl,
@@ -516,13 +530,33 @@ async function runOneSession(args: {
     // the same way a real visitor's chat-v2 turn would: billed via Convex
     // against this project, namespaced under the synthetic session id.
     const builtInTools = resolveHostTools(
-      { builtInToolIds },
+      { builtInToolIds, computer },
       {
         authHeader,
         projectId,
         chatSessionId,
+        isChatboxSession: true,
+        requireToolApproval,
       }
     );
+
+    // Cloud Skills parity with a real chat-v2 visitor: a synthetic session is
+    // always member-initiated (the route authenticates the generator), so the
+    // guest gate never trips here. Skills are delivered the same two ways chat
+    // does — natively via the harness `skills` param when the turn runs the
+    // real Claude Code runtime, or as the emulated `listSkills`/`loadSkill`
+    // tools otherwise. `shouldEnableCloudSkillTools` returns false on the
+    // harness path (it delivers skills itself), so this only wires the emulated
+    // tools, mirroring `web/chat-v2.ts`.
+    const cloudSkillsEnabled =
+      Boolean(authHeader) &&
+      Boolean(projectId) &&
+      shouldEnableCloudSkillTools({
+        isGuest: false,
+        harness,
+        modelId: String(modelDefinition.id),
+        hasProjectId: Boolean(projectId),
+      });
 
     const prepared = await prepareChatV2({
       mcpClientManager: manager,
@@ -540,6 +574,9 @@ async function runOneSession(args: {
           }
         : {}),
       ...(builtInTools ? { builtInTools } : {}),
+      ...(cloudSkillsEnabled
+        ? { cloudSkills: { authHeader, projectId } }
+        : {}),
     });
 
     // One browser context per session: renders MCP App tool results in the


### PR DESCRIPTION
## What

Synthetic **swarm / session-simulation** runs go through a separate engine (`server/services/sessionSimulation/runner.ts`) from the live published-chatbox chat (`server/routes/web/chat-v2.ts`). That engine never wired the host's **personal Computer**, so a Claude Code / computer-host's `bash` tool — and Cloud Skills — were silently dropped for synthetic visitors, even though a real chat visitor gets them.

This PR brings synthetic sessions to parity with a real chat-v2 turn:

1. **Computer-backed built-ins** — thread the chatbox runtime-config `computer` resource from the `simulate-sessions/start` route into `startSimulation`, then hand it (with `builtInToolIds`) to `resolveHostTools` in the runner. `bash` now resolves exactly as on a real turn (`isChatboxSession: true` suppresses workspace tools but not `bash`; `requireToolApproval` honored).
2. **Cloud Skills** — wire `cloudSkills` into the runner's `prepareChatV2` call, gated by `shouldEnableCloudSkillTools`. Synthetic sessions are always member-initiated (the route authenticates the generator), so the guest gate never trips. The gate returns false on the harness path (Claude Code delivers skills natively via the `skills` param), so this only adds the emulated `listSkills`/`loadSkill` tools on the non-harness path.

## Why it's safe

- **Harness turns are unaffected** — they resolve/wake the Computer inside `runHarnessTurn` and run native tools, independent of these emulated tools.
- **Guests** — backend still strips `computer`/`harness` for guest actors; this only affects member-run synthetic generation, which is the only way swarms are produced.

## Tests

Both boundaries are covered:
- `chatbox-sessions.byok.test.ts` — runtime-config `computer` → `startSimulation` (with `builtInToolIds` + `requireToolApproval`).
- `runner.browser.test.ts` — `startSimulation` → `prepareChatV2` with `bash` present; `cloudSkills` present on the emulated path and **omitted** on the harness path.

```
npx vitest run \
  server/routes/web/__tests__/chatbox-sessions.byok.test.ts \
  server/services/sessionSimulation/__tests__/runner.browser.test.ts
# 10 passed
```

Typecheck: no new errors in touched files (the pre-existing `runner.ts` `providerKey` TS error exists on `main` and is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes synthetic swarm tool advertisement and execution parity with live chat; mis-gating could expose skills/bash in approval-only or harness paths, but behavior mirrors chat-v2 with explicit fail-closed gates and test coverage.
> 
> **Overview**
> **Synthetic session simulation** previously ignored the chatbox host’s **personal Computer** and **Cloud Skills**, so tools like `bash` and emulated `listSkills`/`loadSkill` never appeared for swarm runs even though real visitors get them on chat-v2.
> 
> The **`simulate-sessions/start`** route now reads `runtime.config.computer` and forwards it (with existing `builtInToolIds`) into **`startSimulation`**. The runner passes **`computer`** into **`resolveHostTools`** with **`isChatboxSession: true`** and **`requireToolApproval`**, so computer-backed built-ins resolve the same way as a live turn.
> 
> **Cloud Skills** are wired into the runner’s **`prepareChatV2`** call when **`shouldEnableCloudSkillTools`** allows it (member-initiated synthetic runs, non-harness path). Skills are **skipped** when the chatbox uses the **Claude Code harness** (skills delivered natively) or when **`requireToolApproval`** is on, because headless personas cannot approve and extra meta-tools would break otherwise-toolless approval runs.
> 
> Tests cover the route → **`startSimulation`** threading and runner → **`prepareChatV2`** behavior for bash, cloud skills, harness, and tool-approval cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45daebc018687f25e854bdc37b69982ce54152ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->