### PR TITLE
feat(phase3): thread executionScope through the computer reserve path (V1 §6)

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -68,6 +68,7 @@ import {
 import { buildDirectChatTraceCallbacks } from "../../utils/direct-chat-sse-callbacks";
 import { resolveExecutionContext } from "../../utils/host-execution-context";
 import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
+import { type ExecutionScope } from "../../utils/execution-scope.js";
 
 function formatStreamError(error: unknown, provider?: ModelProvider): string {
   if (!(error instanceof Error)) {
@@ -601,6 +602,16 @@ chatV2.post("/", async (c) => {
     // requests without either (anonymous local mode, no project) omit the
     // tools — same degradation as a host that never enabled them.
     const builtInAuthHeader = mcpJamAuthHeader ?? requestAuthHeader;
+    // Phase 3: thread the server-resolved runtime config's executionScope into
+    // the computer-backed (bash) tool so the reserve call re-resolves live
+    // access (per-swarm isolation/caps). Absent ⇒ legacy projectId reserve.
+    const executionScope = (
+      hostRuntimeConfig as
+        | { executionScope?: ExecutionScope }
+        | null
+        | undefined
+    )?.executionScope;
+
     const builtInTools = resolveHostTools(
       {
         builtInToolIds: resolvedExecution.builtInToolIds,
@@ -614,6 +625,7 @@ chatV2.post("/", async (c) => {
         ? {
             authHeader: builtInAuthHeader,
             projectId: body.projectId,
+            ...(executionScope ? { executionScope } : {}),
             ...(body.chatSessionId
               ? { chatSessionId: body.chatSessionId }
               : {}),

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -30,6 +30,7 @@ import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
 import { fetchHostRuntimeConfig } from "../../utils/host-runtime-config.js";
+import { type ExecutionScope } from "../../utils/execution-scope.js";
 import { checkHarnessRuntimeAvailable } from "../../utils/harness/harness-availability.js";
 import { resolveExecutionContext } from "../../utils/host-execution-context.js";
 import { resolveHostTools } from "../../utils/built-in-tools/registry.js";
@@ -302,6 +303,17 @@ chatV2.post("/", async (c) => {
       }
     }
 
+    // Phase 3: the server-resolved runtime config (chatbox OR host-by-id) carries
+    // an opaque executionScope; thread it into the computer-backed (bash) tool so
+    // the reserve call re-resolves live access (per-swarm isolation/caps). Absent
+    // (pre-Phase-3 backend) ⇒ the tools fall back to the legacy projectId reserve.
+    const executionScope = (
+      hostRuntimeConfig as
+        | { executionScope?: ExecutionScope }
+        | null
+        | undefined
+    )?.executionScope;
+
     const builtInTools = resolveHostTools(
       {
         builtInToolIds: resolvedExecution.builtInToolIds,
@@ -314,6 +326,7 @@ chatV2.post("/", async (c) => {
       {
         authHeader: bearerToken,
         projectId: hostedBody.projectId,
+        ...(executionScope ? { executionScope } : {}),
         ...(body.chatSessionId ? { chatSessionId: body.chatSessionId } : {}),
         isGuest: Boolean(c.get("guestId")),
         isChatboxSession,

--- a/mcpjam-inspector/server/routes/web/computers.ts
+++ b/mcpjam-inspector/server/routes/web/computers.ts
@@ -27,6 +27,7 @@
  */
 import { Hono } from "hono";
 import { z } from "zod";
+import { executionScopeSchema } from "../../utils/execution-scope.js";
 import { isComputersDataPlaneConfigured } from "../../utils/computers/control-plane-client.js";
 import { getComputersRemoteDataPlaneUrl } from "../../utils/computers/remote-data-plane.js";
 import {
@@ -40,6 +41,10 @@ import { assertBearerToken } from "./errors.js";
 
 const execSchema = z.object({
   projectId: z.string().min(1),
+  // Phase 3: a delegating server forwards the opaque execution scope so this
+  // data plane's reserve re-resolves live access. Shape-validated only; the
+  // backend authorizes it. Absent ⇒ legacy projectId reserve.
+  executionScope: executionScopeSchema.optional(),
   command: z.string().min(1).max(10_000),
   /** Idempotency key for the durable command log (the tool call id). */
   commandId: z.string().min(1).max(200),
@@ -65,6 +70,9 @@ export function createComputersRoutes(runner: BashRunner = e2bRunner): Hono {
         {
           authHeader: `Bearer ${bearerToken}`,
           projectId: body.projectId,
+          ...(body.executionScope
+            ? { executionScope: body.executionScope }
+            : {}),
           command: body.command,
           commandId: body.commandId,
           source: "chat",

--- a/mcpjam-inspector/server/utils/built-in-tools/bash.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/bash.ts
@@ -24,6 +24,7 @@
  */
 import { tool, type ToolSet } from "ai";
 import { z } from "zod";
+import { type ExecutionScope } from "../execution-scope.js";
 import { isComputersDataPlaneConfigured } from "../computers/control-plane-client.js";
 import { execViaRemoteDataPlane } from "../computers/remote-data-plane.js";
 import {
@@ -42,6 +43,11 @@ export interface BashToolOptions {
   authHeader: string;
   /** Project whose (project, user) computer this turn runs on. */
   projectId: string;
+  /**
+   * Phase 3 execution scope from the server-resolved runtime config; forwarded
+   * to the reserve call so the backend re-resolves live access. Absent ⇒ legacy.
+   */
+  executionScope?: ExecutionScope;
   /** Host-pinned initial working directory, if any. */
   workdir?: string;
   /** Mirrors the host's requireToolApproval — a root shell must honor it. */
@@ -85,6 +91,7 @@ export function buildBashTool(
       const execArgs = {
         authHeader: opts.authHeader,
         projectId: opts.projectId,
+        executionScope: opts.executionScope,
         command,
         commandId: toolCallId,
         workdir: opts.workdir,

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -42,6 +42,7 @@
 import type { ToolSet } from "ai";
 import type { PlatformApiClient } from "@mcpjam/sdk/platform";
 import { logger } from "../logger.js";
+import { type ExecutionScope } from "../execution-scope.js";
 import {
   buildExaWebSearchTool,
   WEB_SEARCH_TOOL_NAME,
@@ -54,6 +55,13 @@ export interface BuiltInToolContext {
   authHeader: string;
   /** Project the built-in tool's usage bills against / executes in. */
   projectId: string;
+  /**
+   * Phase 3 execution scope from the server-resolved runtime config. Threaded
+   * into the computer-backed (bash) reserve call so the backend re-resolves
+   * live access and applies per-swarm isolation/caps. Absent ⇒ legacy
+   * `projectId` reserve (a backend that predates Phase 3, or a non-computer turn).
+   */
+  executionScope?: ExecutionScope;
   /** Optional chat session, used by Convex for idempotency namespacing. */
   chatSessionId?: string;
   /**
@@ -177,6 +185,10 @@ export function resolveHostTools(
       out[BASH_TOOL_NAME] = buildBashTool({
         authHeader,
         projectId: ctx.projectId,
+        // Phase 3: thread the server-resolved execution scope so the reserve
+        // call re-resolves live access (per-swarm isolation/caps). Absent ⇒
+        // legacy projectId reserve.
+        ...(ctx.executionScope ? { executionScope: ctx.executionScope } : {}),
         workdir: computer.workdir,
         requireToolApproval: ctx.requireToolApproval,
       });

--- a/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
@@ -15,8 +15,9 @@
 
 import { type Harness } from "@mcpjam/sdk/host-config/internal";
 import { logger } from "./logger.js";
+import { type RuntimeExecutionFields } from "./execution-scope.js";
 
-export type ChatboxRuntimeConfig = {
+export type ChatboxRuntimeConfig = RuntimeExecutionFields & {
   chatboxId: string;
   accessVersion: number;
   modelId: string;

--- a/mcpjam-inspector/server/utils/computers/__tests__/control-plane-reserve.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/control-plane-reserve.test.ts
@@ -10,9 +10,11 @@ import type { ExecutionScope } from "../../execution-scope.js";
  */
 describe("reserveComputer body (Phase 3 executionScope)", () => {
   const realFetch = global.fetch;
+  let previousConvexHttpUrl: string | undefined;
   let bodies: unknown[];
 
   beforeEach(() => {
+    previousConvexHttpUrl = process.env.CONVEX_HTTP_URL;
     process.env.CONVEX_HTTP_URL = "https://example.convex.site";
     bodies = [];
     global.fetch = vi.fn(async (_url: unknown, init: { body: string }) => {
@@ -25,6 +27,11 @@ describe("reserveComputer body (Phase 3 executionScope)", () => {
   });
 
   afterEach(() => {
+    if (previousConvexHttpUrl === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = previousConvexHttpUrl;
+    }
     global.fetch = realFetch;
     vi.restoreAllMocks();
   });

--- a/mcpjam-inspector/server/utils/computers/__tests__/control-plane-reserve.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/control-plane-reserve.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { reserveComputer } from "../control-plane-client.js";
+import type { ExecutionScope } from "../../execution-scope.js";
+
+/**
+ * Phase 3: reserveComputer sends the opaque executionScope when present (so the
+ * backend re-resolves live access + applies per-swarm isolation/caps), else the
+ * legacy { projectId } body. Backward-compatible: a pre-Phase-3 caller (no
+ * executionScope) is byte-identical to before.
+ */
+describe("reserveComputer body (Phase 3 executionScope)", () => {
+  const realFetch = global.fetch;
+  let bodies: unknown[];
+
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+    bodies = [];
+    global.fetch = vi.fn(async (_url: unknown, init: { body: string }) => {
+      bodies.push(JSON.parse(init.body));
+      return new Response(
+        JSON.stringify({ computerId: "c1", status: "ready", provider: "e2b" }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("sends { projectId } when no executionScope (legacy path)", async () => {
+    await reserveComputer({ bearer: "t", projectId: "p1" });
+    expect(bodies[0]).toEqual({ projectId: "p1" });
+  });
+
+  it("sends { executionScope } for a project scope (no leaked projectId)", async () => {
+    const executionScope: ExecutionScope = { kind: "project", projectId: "p1" };
+    await reserveComputer({ bearer: "t", projectId: "p1", executionScope });
+    expect(bodies[0]).toEqual({ executionScope });
+  });
+
+  it("forwards the swarm executionScope verbatim", async () => {
+    const executionScope: ExecutionScope = {
+      kind: "swarm",
+      swarmId: "cb1",
+      accessVersion: 7,
+      projectId: "p1",
+      workspaceId: "ws1",
+    };
+    await reserveComputer({ bearer: "t", projectId: "p1", executionScope });
+    expect(bodies[0]).toEqual({ executionScope });
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/control-plane-client.ts
+++ b/mcpjam-inspector/server/utils/computers/control-plane-client.ts
@@ -16,6 +16,7 @@
  *   terminal-sessions shared-secret auth — session open/close records
  */
 import { logger } from "../logger.js";
+import { type ExecutionScope } from "../execution-scope.js";
 
 const SECRET_HEADER = "x-computers-data-plane-secret";
 
@@ -165,16 +166,25 @@ export async function releaseEvalSandbox(args: {
   }
 }
 
-/** Reserve/wake the acting user's computer (user-bearer auth). */
+/**
+ * Reserve/wake the acting user's computer (user-bearer auth). Phase 3: when an
+ * `executionScope` is supplied (from runtime-config), send it so the backend
+ * re-resolves live access and applies per-swarm isolation/caps; otherwise fall
+ * back to the legacy `{ projectId }` body. The scope is opaque to the client —
+ * the backend is authoritative.
+ */
 export async function reserveComputer(args: {
   bearer: string;
   projectId: string;
+  executionScope?: ExecutionScope;
   signal?: AbortSignal;
 }): Promise<ControlPlaneResult<ReservedComputer>> {
   return postJson<ReservedComputer>(
     "/computers/reserve",
     bearerHeader(args.bearer),
-    { projectId: args.projectId },
+    args.executionScope
+      ? { executionScope: args.executionScope }
+      : { projectId: args.projectId },
     args.signal
   );
 }
@@ -256,6 +266,8 @@ export async function recordTerminalSession(args: {
 export async function ensureComputerReady(args: {
   bearer: string;
   projectId: string;
+  /** Phase 3 scope; forwarded verbatim to reserveComputer (legacy when absent). */
+  executionScope?: ExecutionScope;
   signal?: AbortSignal;
   /** Overall budget. E2B cold provision is seconds; waking ~1s. */
   timeoutMs?: number;

--- a/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
+++ b/mcpjam-inspector/server/utils/computers/remote-data-plane.ts
@@ -24,6 +24,7 @@ import {
   COMPUTERS_NOT_CONFIGURED_ERROR,
   type RunComputerCommandResult,
 } from "./run-command.js";
+import { type ExecutionScope } from "../execution-scope.js";
 
 /** Origin of the deployed data plane, or null when unset/invalid. */
 export function getComputersRemoteDataPlaneUrl(): string | null {
@@ -53,6 +54,8 @@ export async function execViaRemoteDataPlane(args: {
   /** Bearer authorization forwarded verbatim (the remote re-validates it). */
   authHeader: string;
   projectId: string;
+  /** Phase 3 scope forwarded so the remote reserve re-resolves live access. */
+  executionScope?: ExecutionScope;
   command: string;
   commandId: string;
   workdir?: string;
@@ -76,6 +79,7 @@ export async function execViaRemoteDataPlane(args: {
       headers: { "content-type": "application/json", authorization },
       body: JSON.stringify({
         projectId: args.projectId,
+        ...(args.executionScope ? { executionScope: args.executionScope } : {}),
         command: args.command,
         commandId: args.commandId,
         ...(args.workdir ? { workdir: args.workdir } : {}),

--- a/mcpjam-inspector/server/utils/computers/run-command.ts
+++ b/mcpjam-inspector/server/utils/computers/run-command.ts
@@ -21,6 +21,7 @@ import {
 } from "./control-plane-client.js";
 import { detectAuthUrls } from "./auth-urls.js";
 import { logger } from "../logger.js";
+import { type ExecutionScope } from "../execution-scope.js";
 
 // Caps on what the model sees; the Convex log stores its own (smaller)
 // preview and full-output archival is a backend follow-up.
@@ -93,6 +94,11 @@ export interface RunComputerCommandArgs {
   authHeader: string;
   /** Project whose (project, user) computer this command runs on. */
   projectId: string;
+  /**
+   * Phase 3 execution scope from runtime-config; forwarded to the reserve call
+   * so the backend re-resolves live access. Absent ⇒ legacy `projectId` reserve.
+   */
+  executionScope?: ExecutionScope;
   command: string;
   /** Idempotency key for the durable command log (tool call id). */
   commandId: string;
@@ -113,6 +119,7 @@ export async function runComputerCommand(
   const ready = await ensureComputerReady({
     bearer: args.authHeader,
     projectId: args.projectId,
+    executionScope: args.executionScope,
     signal: args.signal,
   });
   if (!ready.ok) {

--- a/mcpjam-inspector/server/utils/execution-scope.ts
+++ b/mcpjam-inspector/server/utils/execution-scope.ts
@@ -15,16 +15,25 @@
  * starts serving it.
  */
 
-/** Opaque downstream scope echoed back to execution endpoints, never trusted. */
-export type ExecutionScope =
-  | { kind: "project"; projectId: string }
-  | {
-      kind: "swarm";
-      swarmId: string;
-      accessVersion: number;
-      projectId: string;
-      workspaceId: string;
-    };
+import { z } from "zod";
+
+/**
+ * Opaque downstream scope echoed back to execution endpoints, never trusted by
+ * the client. The schema validates SHAPE only (so the data-plane exec route can
+ * accept a forwarded scope); the backend re-resolves and authorizes it.
+ */
+export const executionScopeSchema = z.union([
+  z.object({ kind: z.literal("project"), projectId: z.string().min(1) }),
+  z.object({
+    kind: z.literal("swarm"),
+    swarmId: z.string().min(1),
+    accessVersion: z.number(),
+    projectId: z.string().min(1),
+    workspaceId: z.string().min(1),
+  }),
+]);
+
+export type ExecutionScope = z.infer<typeof executionScopeSchema>;
 
 export type ExecutionAccessKind =
   | "project_member"

--- a/mcpjam-inspector/server/utils/execution-scope.ts
+++ b/mcpjam-inspector/server/utils/execution-scope.ts
@@ -17,23 +17,38 @@
 
 import { z } from "zod";
 
+/** Opaque downstream scope echoed back to execution endpoints, never trusted. */
+export type ExecutionScope =
+  | { kind: "project"; projectId: string }
+  | {
+      kind: "swarm";
+      swarmId: string;
+      accessVersion: number;
+      projectId: string;
+      workspaceId: string;
+    };
+
 /**
- * Opaque downstream scope echoed back to execution endpoints, never trusted by
- * the client. The schema validates SHAPE only (so the data-plane exec route can
- * accept a forwarded scope); the backend re-resolves and authorizes it.
+ * Boundary validator for a FORWARDED scope (the data-plane exec route). The
+ * scope is OPAQUE — the backend re-resolves and authorizes it — so this checks
+ * the discriminant + the V1 fields but `.passthrough()`es any extra/future
+ * backend-only keys rather than stripping them, preserving the value verbatim.
+ * The clean `ExecutionScope` type above is what client code constructs/reads.
  */
 export const executionScopeSchema = z.union([
-  z.object({ kind: z.literal("project"), projectId: z.string().min(1) }),
-  z.object({
-    kind: z.literal("swarm"),
-    swarmId: z.string().min(1),
-    accessVersion: z.number(),
-    projectId: z.string().min(1),
-    workspaceId: z.string().min(1),
-  }),
+  z
+    .object({ kind: z.literal("project"), projectId: z.string().min(1) })
+    .passthrough(),
+  z
+    .object({
+      kind: z.literal("swarm"),
+      swarmId: z.string().min(1),
+      accessVersion: z.number(),
+      projectId: z.string().min(1),
+      workspaceId: z.string().min(1),
+    })
+    .passthrough(),
 ]);
-
-export type ExecutionScope = z.infer<typeof executionScopeSchema>;
 
 export type ExecutionAccessKind =
   | "project_member"

--- a/mcpjam-inspector/server/utils/execution-scope.ts
+++ b/mcpjam-inspector/server/utils/execution-scope.ts
@@ -1,0 +1,57 @@
+/**
+ * Phase 3 guest execution — client-side mirror of the backend's execution-scope
+ * contract (docs/plans/phase3-guest-execution-v1.md, mcpjam-backend
+ * convex/lib/executionAccess.ts).
+ *
+ * The backend's runtime-config routes return an `executionScope` (plus advisory
+ * accessKind / actorKind / capabilities / runtimeSkills). The inspector threads
+ * the OPAQUE `executionScope` back into side-effectful calls (`/computers/reserve`,
+ * runtime skills) so the backend RE-RESOLVES live access. The client carries NO
+ * enforcement logic — these fields are advisory; the backend is authoritative.
+ *
+ * All fields are optional on the runtime-config types: a backend that predates
+ * Phase 3 omits them, and the inspector falls back to the legacy `{ projectId }`
+ * calls — so wiring `executionScope` is behavior-preserving until the backend
+ * starts serving it.
+ */
+
+/** Opaque downstream scope echoed back to execution endpoints, never trusted. */
+export type ExecutionScope =
+  | { kind: "project"; projectId: string }
+  | {
+      kind: "swarm";
+      swarmId: string;
+      accessVersion: number;
+      projectId: string;
+      workspaceId: string;
+    };
+
+export type ExecutionAccessKind =
+  | "project_member"
+  | "guest_owned_project"
+  | "swarm_grant";
+
+export type ExecutionActorKind = "signedIn" | "guest";
+
+/** Sanitized capability booleans the backend derived for this actor. */
+export type ExecutionCapabilities = {
+  computer: boolean;
+  sharedSkills: boolean;
+  personalSkills: boolean;
+  harness: boolean;
+};
+
+/**
+ * Advisory Phase 3 fields added to BOTH runtime-config responses. All optional
+ * so a pre-Phase-3 backend omits them and the inspector stays on the legacy
+ * path. The inspector reads `executionScope` (to thread into reserve/skills) and
+ * may read `capabilities` / `runtimeSkills` for display, but never enforces with
+ * them — the backend re-resolves on every side effect.
+ */
+export type RuntimeExecutionFields = {
+  executionScope?: ExecutionScope;
+  accessKind?: ExecutionAccessKind;
+  actorKind?: ExecutionActorKind;
+  capabilities?: ExecutionCapabilities;
+  runtimeSkills?: { shared: boolean; personal: boolean };
+};

--- a/mcpjam-inspector/server/utils/host-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/host-runtime-config.ts
@@ -15,8 +15,9 @@
 
 import { type Harness } from "@mcpjam/sdk/host-config/internal";
 import { logger } from "./logger.js";
+import { type RuntimeExecutionFields } from "./execution-scope.js";
 
-export type HostRuntimeConfig = {
+export type HostRuntimeConfig = RuntimeExecutionFields & {
   hostId: string;
   modelId: string;
   systemPrompt: string;


### PR DESCRIPTION
## Phase 3 Guest Execution — V1, Section 6 (inspector client cutover)

Client adoption (rollout **step 2**) of the Phase 3 guest-execution stack. Pairs with the backend stack on **MCPJam/mcpjam-backend**: #640 (§1) → #641 (§2) → #642 (§3) → #643 (§4) → #644 (§5). Build spec: `docs/plans/phase3-guest-execution-v1.md` (backend repo).

The backend runtime-config routes now return an opaque **`executionScope`**; this PR threads it back into the bash tool's `/computers/reserve` call so the backend **re-resolves live access** (per-swarm isolation + caps). The client carries **no enforcement logic** and never sees a provider sandbox id.

### Behavior-preserving by construction
`executionScope` is **optional at every hop** and falls back to the legacy `{ projectId }` reserve when absent. Against the **current production backend** (which doesn't yet serve `executionScope`) **nothing changes**. Once the backend stack deploys, members send their scope (`project_member` → identical backend behavior) and the path is ready for swarm grants.

### Changes
- **`server/utils/execution-scope.ts`** (new) — client mirror of the backend contract (`ExecutionScope` + advisory `accessKind`/`actorKind`/`capabilities`/`runtimeSkills`).
- **`chatbox-runtime-config.ts` / `host-runtime-config.ts`** — response types gain the optional execution fields.
- **`control-plane-client.ts`** — `reserveComputer` + `ensureComputerReady` take an optional `executionScope`, send `{ executionScope }` when present else `{ projectId }`.
- **`run-command.ts` / `bash.ts` / `registry.ts`** — thread the optional scope from `BuiltInToolContext` → `BashToolOptions` → `RunComputerCommandArgs` → `ensureComputerReady`.
- **`chat-v2.ts`** — pass the server-resolved runtime config's `executionScope` into the built-in-tool context.

### Scope notes (deliberate)
- The **simulation-runner path** (`runner.ts`) is left on the legacy fallback — untouched, as it's under concurrent edit. The optional param means it keeps working unchanged.
- **Deferred follow-ups**, entangled with the just-landed **#2969 Cloud Skills** gating and best owned by that work: (1) the runtime-skills fetch → `listSkillsForRuntimeExecution(executionScope)` cutover; (2) replacing the `isGuest` tool gates with capability-derived gates to actually *enable* guests/swarms; (3) forwarding `executionScope` through the remote data-plane exec path.

### Gates
- `npm run typecheck:client` clean; the changed server files are type-clean (the server project's strict `tsc` has unrelated pre-existing errors on `main`); prettier clean.
- vitest **36** green: `built-in-tools-registry` (20), `computers-bash-tool` (8), `host-runtime-config` (5), + **3 new** `control-plane-reserve` body tests (legacy `{projectId}` vs project/swarm `{executionScope}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the authorization payload for computer reserve/wake, a security-sensitive path, but scope is optional, backend-authoritative, and legacy reserve is unchanged when omitted.
> 
> **Overview**
> **Phase 3 guest execution (§6):** When chatbox/host **runtime-config** includes an opaque **`executionScope`**, both **web** and **MCP** `chat-v2` routes pass it into **`resolveHostTools`** so the **`bash`** tool’s Convex **`/computers/reserve`** call sends **`{ executionScope }`** instead of legacy **`{ projectId }`**, letting the backend re-resolve live access (including per-swarm isolation/caps). The inspector does not enforce scope locally.
> 
> Adds **`execution-scope.ts`** (types, zod schema, advisory runtime fields) and extends **chatbox/host runtime-config** typings. The scope flows **`BuiltInToolContext` → `runComputerCommand` → `ensureComputerReady` → `reserveComputer`**, and through **remote data-plane** **`/computers/exec`** when local OSS delegates exec. If scope is missing (pre-Phase-3 backend), behavior stays on the **`projectId`** reserve path.
> 
> New vitest coverage asserts reserve POST bodies for legacy vs project/swarm scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5df106af800602c556f2945f807267dfa4a0bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads the server-provided `executionScope` through both local and remote computer execution paths (web + MCP chat) so the backend re-resolves live access. Backward-compatible: falls back to `{ projectId }` when scope is absent; no client-side enforcement.

- **New Features**
  - Added `executionScopeSchema` (zod) and advisory execution fields; extended chatbox/host runtime-config types.
  - Control-plane client: `reserveComputer`/`ensureComputerReady` accept `executionScope`; send `{ executionScope }` else `{ projectId }`; request-body tests added.
  - Threaded `executionScope` from runtime config through tools → bash → `runComputerCommand`; forwarded via `/computers/exec` and `execViaRemoteDataPlane`.

- **Bug Fixes**
  - `/computers/exec` now validates and forwards the opaque `executionScope` verbatim (`.passthrough()`), avoiding dropped future fields on the remote path.
  - Tests restore `CONVEX_HTTP_URL` after each run to prevent env leakage across suites.

<sup>Written for commit e5df106af800602c556f2945f807267dfa4a0bb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

