### PR TITLE
chore(billing): update team credits copy to 30,000 / seat / mo

### DIFF
--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -53,7 +53,7 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     });
     expect(creditsAndSeats?.rows[0]?.team).toEqual({
       kind: "text",
-      text: "10,000 / seat / mo",
+      text: "30,000 / seat / mo",
       emphasize: true,
     });
     expect(creditsAndSeats?.rows[1]?.team).toEqual({

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -40,7 +40,7 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
       {
         label: "Included credits",
         free: t("200 / day"),
-        team: t("10,000 / seat / mo", true),
+        team: t("30,000 / seat / mo", true),
         enterprise: t("Custom", true),
       },
       {


### PR DESCRIPTION
- Updates the plan-comparison table so the Team plan shows "30,000 / seat / mo" instead of "10,000".
- Mirrors the backend change that tripled the team monthly credit allowance.
- Updated the matching test; the compare-plan table test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Team plan credits copy in the compare-plan table to "30,000 / seat / mo" (was "10,000") to mirror the backend increase. Updated the matching test to reflect the new value.

<sup>Written for commit e302805dc72514d72cf56c0706ef585a79fc9402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

