### PR TITLE
chore(billing): update daily-credit + eval-iteration plan copy

### DIFF
--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -72,11 +72,11 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     expect(evalIterations?.label).toBe("Eval iterations");
     expect(evalIterations?.free).toEqual({
       kind: "text",
-      text: "25 / day",
+      text: "1,000 / day",
     });
     expect(evalIterations?.team).toEqual({
       kind: "text",
-      text: "5,000 / mo",
+      text: "Unlimited",
       emphasize: true,
     });
     expect(evalIterations?.enterprise).toEqual({

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -49,7 +49,7 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     ]);
     expect(creditsAndSeats?.rows[0]?.free).toEqual({
       kind: "text",
-      text: "200 / day",
+      text: "400 / day",
     });
     expect(creditsAndSeats?.rows[0]?.team).toEqual({
       kind: "text",

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -39,7 +39,7 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     rows: [
       {
         label: "Included credits",
-        free: t("200 / day"),
+        free: t("400 / day"),
         team: t("10,000 / seat / mo", true),
         enterprise: t("Custom", true),
       },

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -56,8 +56,8 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     rows: [
       {
         label: "Eval iterations",
-        free: t("25 / day"),
-        team: t("5,000 / mo", true),
+        free: t("1,000 / day"),
+        team: t("Unlimited", true),
         enterprise: t("Custom", true),
       },
       {


### PR DESCRIPTION
- Free-plan "Included credits" cell: "200 / day" → "400 / day".
- Eval-iterations row: free "25 / day" → "1,000 / day", team "5,000 / mo" → "Unlimited".
- Mirrors the backend daily-credit and eval-iteration limit increases. Tests updated and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
