### PR TITLE
Land newly-signed-up invited users in the invited org

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -183,6 +183,12 @@ import {
   readApiKeysSignInReturnPath,
 } from "./lib/api-keys-signin-return-path";
 import {
+  capturePendingInviteOrgFromUrl,
+  clearPendingInviteOrgMarker,
+  readPendingInviteOrgMarker,
+  writePendingInviteOrgMarkerForPath,
+} from "./lib/pending-invite-org";
+import {
   sanitizeHostedOAuthErrorMessage,
   clearHostedOAuthResumeMarker,
   writeHostedOAuthResumeMarker,
@@ -1301,6 +1307,7 @@ export default function App() {
   const {
     getAccessToken,
     signIn,
+    signUp,
     signOut,
     user: workOsUser,
     isLoading: isWorkOsLoading,
@@ -1574,6 +1581,81 @@ export default function App() {
   );
   const isOAuthCallback = window.location.pathname === "/callback";
   const electronMcpCallbackUrl = buildElectronMcpCallbackUrl();
+  const hasWorkOsDbUser =
+    !!workOsUser &&
+    currentUser !== undefined &&
+    currentUser !== null &&
+    currentUser.isAnonymous !== true &&
+    currentUser.externalId === workOsUser.id;
+  const inviteSignupPathRef = useRef<string | null>(null);
+  const organizationSignInPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (isOAuthCallback || isDebugCallback || isHostedChatRoute) {
+      return;
+    }
+
+    const pendingInviteMarker =
+      capturePendingInviteOrgFromUrl() ?? readPendingInviteOrgMarker();
+    if (!pendingInviteMarker) {
+      return;
+    }
+
+    if (workOsUser || isWorkOsLoading) {
+      return;
+    }
+
+    if (inviteSignupPathRef.current === pendingInviteMarker.returnPath) {
+      return;
+    }
+
+    inviteSignupPathRef.current = pendingInviteMarker.returnPath;
+    void signUp();
+  }, [
+    isDebugCallback,
+    isHostedChatRoute,
+    isOAuthCallback,
+    isWorkOsLoading,
+    signUp,
+    workOsUser,
+  ]);
+
+  useEffect(() => {
+    if (
+      !routeOrganizationId ||
+      isOAuthCallback ||
+      isDebugCallback ||
+      isHostedChatRoute
+    ) {
+      return;
+    }
+
+    const returnPath = buildOrganizationPath(
+      routeOrganizationId,
+      routeOrganizationSection
+    );
+
+    if (workOsUser || isWorkOsLoading) {
+      return;
+    }
+
+    if (organizationSignInPathRef.current === returnPath) {
+      return;
+    }
+
+    organizationSignInPathRef.current = returnPath;
+    writePendingInviteOrgMarkerForPath(returnPath);
+    void signIn();
+  }, [
+    isDebugCallback,
+    isHostedChatRoute,
+    isOAuthCallback,
+    isWorkOsLoading,
+    routeOrganizationId,
+    routeOrganizationSection,
+    signIn,
+    workOsUser,
+  ]);
 
   useEffect(() => {
     if (!isOAuthCallback) {
@@ -1599,8 +1681,15 @@ export default function App() {
       return;
     }
 
+    const pendingInviteMarker = readPendingInviteOrgMarker();
+    const inviteReturnPath = pendingInviteMarker?.returnPath ?? null;
+    const canRestoreCallbackReturnPath =
+      !isAuthLoading &&
+      isAuthenticated &&
+      (!inviteReturnPath || hasWorkOsDbUser);
+
     // Let AuthKit + Convex auth settle before leaving /callback.
-    if (!isAuthLoading && isAuthenticated) {
+    if (canRestoreCallbackReturnPath) {
       const chatboxReturnPath = readChatboxSignInReturnPath();
       const persistedCheckoutIntent = readPersistedCheckoutIntent();
       const billingReturnPath = persistedCheckoutIntent
@@ -1612,6 +1701,7 @@ export default function App() {
       clearBillingSignInReturnPath();
       clearCliSignInReturnPath();
       clearApiKeysSignInReturnPath();
+      clearPendingInviteOrgMarker();
       window.history.replaceState(
         {},
         "",
@@ -1619,6 +1709,7 @@ export default function App() {
           billingReturnPath ??
           cliReturnPath ??
           apiKeysReturnPath ??
+          inviteReturnPath ??
           "/"
       );
       setCallbackCompleted(true);
@@ -1636,6 +1727,7 @@ export default function App() {
     isAuthLoading,
     isAuthenticated,
     isWorkOsLoading,
+    hasWorkOsDbUser,
     workOsUser,
   ]);
 

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -23,6 +23,10 @@ import {
   writeBillingSignInReturnPath,
 } from "../lib/billing-deep-link";
 import {
+  readPendingInviteOrgMarker,
+  writePendingInviteOrgMarkerForPath,
+} from "../lib/pending-invite-org";
+import {
   clearChatboxSession,
   readChatboxSignInReturnPath,
   writeChatboxSignInReturnPath,
@@ -159,6 +163,7 @@ const {
     mockWorkOsAuthState: {
       getAccessToken: vi.fn(),
       signIn: vi.fn(),
+      signUp: vi.fn(),
       user: null as { id: string } | null,
       isLoading: false,
     },
@@ -500,6 +505,7 @@ describe("App hosted OAuth callback handling", () => {
     mockConvexAuthState.isLoading = false;
     mockWorkOsAuthState.getAccessToken = vi.fn();
     mockWorkOsAuthState.signIn = vi.fn();
+    mockWorkOsAuthState.signUp = vi.fn();
     mockWorkOsAuthState.user = null;
     mockWorkOsAuthState.isLoading = false;
     mockCompleteHostedOAuthCallback.mockReset();
@@ -794,6 +800,103 @@ describe("App hosted OAuth callback handling", () => {
     ).not.toBeInTheDocument();
     expect(mockWorkOsAuthState.signIn).not.toHaveBeenCalled();
     expect(readChatboxSignInReturnPath()).toBe("/chatbox/asana/token-123");
+  });
+
+  it("starts sign-up for a signed-out org invite link", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    localStorage.removeItem("mcp-oauth-pending");
+    localStorage.removeItem("mcp-serverUrl-asana");
+    window.history.replaceState({}, "", "/?invite_org=org-invite_1");
+    mockConvexAuthState.isAuthenticated = false;
+    mockConvexAuthState.isLoading = false;
+    mockWorkOsAuthState.user = null;
+    mockWorkOsAuthState.isLoading = false;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockWorkOsAuthState.signUp).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockWorkOsAuthState.signIn).not.toHaveBeenCalled();
+    expect(readPendingInviteOrgMarker()).toMatchObject({
+      organizationId: "org-invite_1",
+      returnPath: "/organizations/org-invite_1",
+      startedAt: expect.any(Number),
+    });
+    expect(window.location.pathname).toBe("/");
+    expect(window.location.search).toBe("");
+  });
+
+  it("starts sign-in for a signed-out organization route", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    localStorage.removeItem("mcp-oauth-pending");
+    localStorage.removeItem("mcp-serverUrl-asana");
+    window.history.replaceState({}, "", "/organizations/org-invite_1");
+    mockConvexAuthState.isAuthenticated = false;
+    mockConvexAuthState.isLoading = false;
+    mockWorkOsAuthState.user = null;
+    mockWorkOsAuthState.isLoading = false;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockWorkOsAuthState.signIn).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockWorkOsAuthState.signUp).not.toHaveBeenCalled();
+    expect(readPendingInviteOrgMarker()).toMatchObject({
+      organizationId: "org-invite_1",
+      returnPath: "/organizations/org-invite_1",
+      startedAt: expect.any(Number),
+    });
+  });
+
+  it("does not consume an organization return path while Convex still has a guest user", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    localStorage.removeItem("mcp-oauth-pending");
+    localStorage.removeItem("mcp-serverUrl-asana");
+    window.history.replaceState({}, "", "/callback?code=oauth-code");
+    writePendingInviteOrgMarkerForPath("/organizations/org-invite_1");
+    mockWorkOsAuthState.user = { id: "workos-user-1" };
+    mockConvexAuthState.isAuthenticated = true;
+    mockConvexAuthState.isLoading = false;
+    mockUseQuery.mockImplementation((ref: string) =>
+      ref === "users:getCurrentUser"
+        ? {
+            ...existingConvexUser,
+            _id: "guest-seen-1",
+            externalId: "guest-seen-1",
+            isAnonymous: true,
+          }
+        : undefined
+    );
+
+    const { rerender } = render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(window.location.pathname).toBe("/callback");
+    expect(readPendingInviteOrgMarker()).toMatchObject({
+      organizationId: "org-invite_1",
+      returnPath: "/organizations/org-invite_1",
+      startedAt: expect.any(Number),
+    });
+
+    mockUseQuery.mockImplementation((ref: string) =>
+      ref === "users:getCurrentUser" ? existingConvexUser : undefined
+    );
+    rerender(<App />);
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/organizations/org-invite_1");
+    });
+    expect(readPendingInviteOrgMarker()).toBeNull();
   });
 
   it("clears stale client auth state before retrying a timed-out callback", async () => {
@@ -1496,6 +1599,7 @@ describe("App hosted OAuth callback handling", () => {
     mockUseAuth.mockReturnValue({
       getAccessToken: vi.fn(),
       signIn,
+      signUp: vi.fn(),
       user: null,
       isLoading: false,
     });

--- a/mcpjam-inspector/client/src/components/project/ShareProjectDialog.tsx
+++ b/mcpjam-inspector/client/src/components/project/ShareProjectDialog.tsx
@@ -66,9 +66,13 @@ interface ShareProjectDialogProps {
 const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function buildInviteToastMessage(
-  result: { kind: string },
+  result: { kind: string; requiresSeatPayment?: boolean },
   email: string,
 ): string {
+  if (result.requiresSeatPayment) {
+    return `Invitation saved for ${email}. Finish paid seat payment in organization settings before they get access.`;
+  }
+
   switch (result.kind) {
     case "organization_member_added":
       return `${email} added to the organization. They now have access to this project.`;

--- a/mcpjam-inspector/client/src/components/project/__tests__/ShareProjectDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/project/__tests__/ShareProjectDialog.test.tsx
@@ -377,6 +377,30 @@ describe("ShareProjectDialog", () => {
     );
   });
 
+  it("tells admins to finish paid seat payment before invitees get access", async () => {
+    mockInviteProjectMember.mockResolvedValueOnce({
+      changed: true,
+      kind: "project_invite_pending",
+      isPending: true,
+      requiresSeatPayment: true,
+    });
+
+    renderDialog({
+      visibility: "private",
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Add people, emails..."), {
+      target: { value: "invitee@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Invitation saved for invitee@example.com. Finish paid seat payment in organization settings before they get access.",
+      );
+    });
+  });
+
   it("shows a project picker only when multiple projects are available", () => {
     renderDialog({
       availableProjects: {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
@@ -9,6 +9,8 @@ const {
   useProjectStateMock,
   useServerStateMock,
   disconnectAllRuntimeServersMock,
+  toastInfoMock,
+  toastSuccessMock,
   convexAuthState,
   projectStateValue,
   serverStateValue,
@@ -18,6 +20,8 @@ const {
   useProjectStateMock: vi.fn(),
   useServerStateMock: vi.fn(),
   disconnectAllRuntimeServersMock: vi.fn(),
+  toastInfoMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
   convexAuthState: {
     isAuthenticated: true,
     isLoading: false,
@@ -79,6 +83,13 @@ vi.mock("convex/react", () => ({
 
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: false,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    info: toastInfoMock,
+    success: toastSuccessMock,
+  },
 }));
 
 vi.mock("../use-logger", () => ({
@@ -171,6 +182,7 @@ describe("useAppState active organization recovery", () => {
     vi.useRealTimers();
     vi.clearAllMocks();
     localStorage.clear();
+    sessionStorage.clear();
     window.history.replaceState({}, "", "/");
     loadAppStateMock.mockReturnValue(initialAppState);
     disconnectAllRuntimeServersMock.mockResolvedValue({
@@ -273,6 +285,76 @@ describe("useAppState active organization recovery", () => {
     });
 
     expect(localStorage.getItem("active-organization-id:user-1")).toBe("org-b");
+  });
+
+  it("keeps an invited org stashed while the org membership is still pending", async () => {
+    localStorage.setItem("mcpjam:pending-invite-org", "org-invite");
+
+    renderHook(() =>
+      useAppState({
+        currentUserId: "user-1",
+        currentActorKey: "user-1",
+        routeOrganizationId: undefined,
+        hasOrganizations: true,
+        isLoadingOrganizations: false,
+        validOrganizations: [
+          { _id: "org-personal", myRole: "owner" },
+          { _id: "org-invite", myRole: "member", isPendingInvite: true },
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(toastInfoMock).toHaveBeenCalledWith(
+        "You've been invited to an organization. You'll get access once your seat is set up.",
+      );
+    });
+
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem("mcpjam:pending-invite-org")).toBe(
+      "org-invite",
+    );
+  });
+
+  it("clears an invited org stash once the membership is confirmed", async () => {
+    localStorage.setItem("mcpjam:pending-invite-org", "org-invite");
+
+    const { result } = renderHook(() =>
+      useAppState({
+        currentUserId: "user-1",
+        currentActorKey: "user-1",
+        routeOrganizationId: undefined,
+        hasOrganizations: true,
+        isLoadingOrganizations: false,
+        validOrganizations: [
+          { _id: "org-personal", myRole: "owner" },
+          { _id: "org-invite", myRole: "member" },
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "You're in! Switch to the organization you were invited to.",
+        expect.objectContaining({
+          action: expect.objectContaining({
+            label: "Switch organization",
+          }),
+        }),
+      );
+    });
+
+    expect(toastInfoMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem("mcpjam:pending-invite-org")).toBeNull();
+
+    const toastAction = toastSuccessMock.mock.calls[0]?.[1]?.action;
+    act(() => {
+      toastAction?.onClick();
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeOrganizationId).toBe("org-invite");
+    });
   });
 
   it("clears a stale stored org when no valid organizations remain", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -200,7 +200,11 @@ export function useAppState({
   routeOrganizationId?: string;
   hasOrganizations: boolean;
   isLoadingOrganizations: boolean;
-  validOrganizations: Array<{ _id: string; myRole?: string }>;
+  validOrganizations: Array<{
+    _id: string;
+    myRole?: string;
+    isPendingInvite?: boolean;
+  }>;
   requestSignIn?: () => void | Promise<void>;
 }) {
   const logger = useLogger("Connections");
@@ -346,10 +350,10 @@ export function useAppState({
     if (!pendingInviteOrgId) {
       return;
     }
-    const isMemberOfInviteOrg = validOrganizations.some(
+    const inviteOrganization = validOrganizations.find(
       (organization) => organization._id === pendingInviteOrgId
     );
-    if (!isMemberOfInviteOrg) {
+    if (!inviteOrganization || inviteOrganization.isPendingInvite) {
       // Not a member yet — keep the stash and let them know once per session.
       if (
         typeof window !== "undefined" &&

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -22,6 +22,10 @@ import {
   writeStoredActiveOrganizationId,
 } from "@/lib/active-organization-storage";
 import {
+  clearPendingInviteOrgId,
+  readPendingInviteOrgId,
+} from "@/lib/pending-invite-org";
+import {
   clearHostedOAuthPendingState,
   HOSTED_OAUTH_PENDING_STORAGE_KEY,
 } from "@/lib/hosted-oauth-callback";
@@ -318,6 +322,47 @@ export function useAppState({
     isLoadingOrganizations,
     isRouteOrganizationValid,
     routeOrganizationId,
+  ]);
+
+  // Land newly-signed-up invited users in the org they were invited to. The
+  // signup email carries `?invite_org`, stashed at boot; apply it once the user
+  // is authenticated and a confirmed member, then clear it so it fires once.
+  useEffect(() => {
+    if (!hasHydratedStoredActiveOrganization) {
+      return;
+    }
+    if (activeOrganizationSelection.userId !== currentUserId) {
+      return;
+    }
+    if (!currentUserId || isLoadingOrganizations) {
+      return;
+    }
+    const pendingInviteOrgId = readPendingInviteOrgId();
+    if (!pendingInviteOrgId) {
+      return;
+    }
+    const isMemberOfInviteOrg = validOrganizations.some(
+      (organization) => organization._id === pendingInviteOrgId
+    );
+    if (!isMemberOfInviteOrg) {
+      // Not a member yet (e.g. a paid seat still pending) — leave it stashed
+      // so a later load (once membership lands) can apply it.
+      return;
+    }
+    clearPendingInviteOrgId();
+    if (activeOrganizationSelection.organizationId !== pendingInviteOrgId) {
+      setActiveOrganizationSelection({
+        organizationId: pendingInviteOrgId,
+        userId: currentUserId,
+      });
+    }
+  }, [
+    activeOrganizationSelection.organizationId,
+    activeOrganizationSelection.userId,
+    currentUserId,
+    hasHydratedStoredActiveOrganization,
+    isLoadingOrganizations,
+    validOrganizations,
   ]);
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -48,6 +48,10 @@ export interface PendingDashboardOAuthState {
 
 const PENDING_DASHBOARD_OAUTH_UI_TIMEOUT_MS = 30 * 1000;
 
+// Session flag so the "seat still being set up" invite notice is shown at most
+// once per browser session instead of on every render/reload while pending.
+const INVITE_PENDING_TOAST_SESSION_KEY = "mcpjam:invite-pending-toast-shown";
+
 interface ActiveOrganizationSelection {
   organizationId?: string;
   userId: string | null;
@@ -324,9 +328,10 @@ export function useAppState({
     routeOrganizationId,
   ]);
 
-  // Land newly-signed-up invited users in the org they were invited to. The
-  // signup email carries `?invite_org`, stashed at boot; apply it once the user
-  // is authenticated and a confirmed member, then clear it so it fires once.
+  // Nudge a user invited to an org to switch into it once they're a confirmed
+  // member. The invited org is stashed from `?invite_org` at boot. While they
+  // aren't a member yet (e.g. a paid team seat still resolving) we tell them
+  // once; when membership lands we offer a one-click switch. We never force it.
   useEffect(() => {
     if (!hasHydratedStoredActiveOrganization) {
       return;
@@ -345,16 +350,32 @@ export function useAppState({
       (organization) => organization._id === pendingInviteOrgId
     );
     if (!isMemberOfInviteOrg) {
-      // Not a member yet (e.g. a paid seat still pending) — leave it stashed
-      // so a later load (once membership lands) can apply it.
+      // Not a member yet — keep the stash and let them know once per session.
+      if (
+        typeof window !== "undefined" &&
+        !window.sessionStorage.getItem(INVITE_PENDING_TOAST_SESSION_KEY)
+      ) {
+        window.sessionStorage.setItem(INVITE_PENDING_TOAST_SESSION_KEY, "1");
+        toast.info(
+          "You've been invited to an organization. You'll get access once your seat is set up."
+        );
+      }
       return;
     }
     clearPendingInviteOrgId();
+    if (typeof window !== "undefined") {
+      window.sessionStorage.removeItem(INVITE_PENDING_TOAST_SESSION_KEY);
+    }
     if (activeOrganizationSelection.organizationId !== pendingInviteOrgId) {
-      setActiveOrganizationSelection({
-        organizationId: pendingInviteOrgId,
-        userId: currentUserId,
-      });
+      toast.success(
+        "You're in! Switch to the organization you were invited to.",
+        {
+          action: {
+            label: "Switch organization",
+            onClick: () => setActiveOrganizationId(pendingInviteOrgId),
+          },
+        }
+      );
     }
   }, [
     activeOrganizationSelection.organizationId,
@@ -362,6 +383,7 @@ export function useAppState({
     currentUserId,
     hasHydratedStoredActiveOrganization,
     isLoadingOrganizations,
+    setActiveOrganizationId,
     validOrganizations,
   ]);
 

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -22,8 +22,8 @@ import {
   writeStoredActiveOrganizationId,
 } from "@/lib/active-organization-storage";
 import {
-  clearPendingInviteOrgId,
-  readPendingInviteOrgId,
+  clearPendingInviteOrgMarker,
+  readPendingInviteOrgMarker,
 } from "@/lib/pending-invite-org";
 import {
   clearHostedOAuthPendingState,
@@ -346,7 +346,7 @@ export function useAppState({
     if (!currentUserId || isLoadingOrganizations) {
       return;
     }
-    const pendingInviteOrgId = readPendingInviteOrgId();
+    const pendingInviteOrgId = readPendingInviteOrgMarker()?.organizationId;
     if (!pendingInviteOrgId) {
       return;
     }
@@ -366,7 +366,7 @@ export function useAppState({
       }
       return;
     }
-    clearPendingInviteOrgId();
+    clearPendingInviteOrgMarker();
     if (typeof window !== "undefined") {
       window.sessionStorage.removeItem(INVITE_PENDING_TOAST_SESSION_KEY);
     }

--- a/mcpjam-inspector/client/src/hooks/useOrganizations.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizations.ts
@@ -14,6 +14,7 @@ export interface Organization {
   createdAt: number;
   updatedAt: number;
   myRole?: string;
+  isPendingInvite?: boolean;
   isCreator?: boolean;
 }
 

--- a/mcpjam-inspector/client/src/lib/__tests__/pending-invite-org.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/pending-invite-org.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  capturePendingInviteOrgFromUrl,
+  clearPendingInviteOrgMarker,
+  readPendingInviteOrgMarker,
+  writePendingInviteOrgMarker,
+  writePendingInviteOrgMarkerForPath,
+} from "../pending-invite-org";
+
+describe("pending invite org", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("captures invite_org and strips it from the URL", () => {
+    window.history.replaceState({}, "", "/?invite_org=org_123&x=1");
+
+    expect(capturePendingInviteOrgFromUrl()).toMatchObject({
+      organizationId: "org_123",
+      returnPath: "/organizations/org_123",
+      startedAt: expect.any(Number),
+    });
+    expect(readPendingInviteOrgMarker()).toMatchObject({
+      organizationId: "org_123",
+      returnPath: "/organizations/org_123",
+      startedAt: expect.any(Number),
+    });
+    expect(window.location.pathname).toBe("/");
+    expect(window.location.search).toBe("?x=1");
+  });
+
+  it("ignores unsafe org ids", () => {
+    window.history.replaceState({}, "", "/?invite_org=../bad");
+
+    expect(capturePendingInviteOrgFromUrl()).toBeNull();
+    expect(readPendingInviteOrgMarker()).toBeNull();
+  });
+
+  it("round-trips stored invite markers", () => {
+    writePendingInviteOrgMarker({
+      organizationId: "org-abc_123",
+      returnPath: "/organizations/org-abc_123",
+      startedAt: 123,
+    });
+
+    expect(readPendingInviteOrgMarker()).toEqual({
+      organizationId: "org-abc_123",
+      returnPath: "/organizations/org-abc_123",
+      startedAt: 123,
+    });
+
+    clearPendingInviteOrgMarker();
+    expect(readPendingInviteOrgMarker()).toBeNull();
+  });
+
+  it("creates a marker from allowed organization paths", () => {
+    expect(
+      writePendingInviteOrgMarkerForPath("/organizations/org_123/billing")
+    ).toMatchObject({
+      organizationId: "org_123",
+      returnPath: "/organizations/org_123/billing",
+      startedAt: expect.any(Number),
+    });
+    expect(readPendingInviteOrgMarker()).toMatchObject({
+      organizationId: "org_123",
+      returnPath: "/organizations/org_123/billing",
+      startedAt: expect.any(Number),
+    });
+  });
+
+  it("rejects non-organization and nested paths", () => {
+    expect(writePendingInviteOrgMarkerForPath("/servers")).toBeNull();
+    expect(
+      writePendingInviteOrgMarkerForPath("/organizations/org_123/admin")
+    ).toBeNull();
+    expect(
+      writePendingInviteOrgMarkerForPath("/organizations/org_123/models/x")
+    ).toBeNull();
+    expect(readPendingInviteOrgMarker()).toBeNull();
+  });
+
+  it("rejects markers whose org and return path disagree", () => {
+    writePendingInviteOrgMarker({
+      organizationId: "org_a",
+      returnPath: "/organizations/org_b",
+      startedAt: 123,
+    });
+
+    expect(readPendingInviteOrgMarker()).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/pending-invite-org.ts
+++ b/mcpjam-inspector/client/src/lib/pending-invite-org.ts
@@ -1,0 +1,45 @@
+// When a brand-new user signs up from an organization invite email, that email
+// links to `/?invite_org={orgId}`. We capture the id at boot — before the WorkOS
+// auth redirect can drop the URL — stash it, and apply it as the active org once
+// the user is authenticated and actually a member of it (see use-app-state).
+
+const INVITE_ORG_PARAM = "invite_org";
+const PENDING_INVITE_ORG_STORAGE_KEY = "mcpjam:pending-invite-org";
+
+// Read `?invite_org=` from the current URL, stash it, and strip it from the URL
+// so it does not linger or get re-applied. Safe to call once at app boot.
+export function capturePendingInviteOrgFromUrl(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const url = new URL(window.location.href);
+    const inviteOrgId = url.searchParams.get(INVITE_ORG_PARAM);
+    if (!inviteOrgId) return;
+    localStorage.setItem(PENDING_INVITE_ORG_STORAGE_KEY, inviteOrgId);
+    url.searchParams.delete(INVITE_ORG_PARAM);
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {
+    // Malformed URL or unavailable storage — nothing to capture.
+  }
+}
+
+export function readPendingInviteOrgId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage.getItem(PENDING_INVITE_ORG_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingInviteOrgId(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(PENDING_INVITE_ORG_STORAGE_KEY);
+  } catch {
+    // Storage unavailable — leave it; the apply step is idempotent.
+  }
+}

--- a/mcpjam-inspector/client/src/lib/pending-invite-org.ts
+++ b/mcpjam-inspector/client/src/lib/pending-invite-org.ts
@@ -1,45 +1,195 @@
-// When a brand-new user signs up from an organization invite email, that email
-// links to `/?invite_org={orgId}`. We capture the id at boot — before the WorkOS
-// auth redirect can drop the URL — stash it, and apply it as the active org once
-// the user is authenticated and actually a member of it (see use-app-state).
+import {
+  buildOrganizationPath,
+  type OrganizationRouteSection,
+} from "./app-navigation";
 
-const INVITE_ORG_PARAM = "invite_org";
-const PENDING_INVITE_ORG_STORAGE_KEY = "mcpjam:pending-invite-org";
+export interface PendingInviteOrgMarker {
+  organizationId: string;
+  returnPath: string;
+  startedAt: number;
+}
 
-// Read `?invite_org=` from the current URL, stash it, and strip it from the URL
-// so it does not linger or get re-applied. Safe to call once at app boot.
-export function capturePendingInviteOrgFromUrl(): void {
-  if (typeof window === "undefined") return;
+const PENDING_INVITE_ORG_STORAGE_KEY = "mcpjam:pending-invite-org-marker";
+
+function normalizeInviteOrgId(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed || !/^[A-Za-z0-9_-]+$/.test(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
+function parseOrganizationReturnPath(path: string | null | undefined): {
+  orgId: string;
+  section?: OrganizationRouteSection;
+} | null {
+  const trimmed = path?.trim() ?? "";
+  if (!trimmed) {
+    return null;
+  }
+
+  let url: URL;
   try {
-    const url = new URL(window.location.href);
-    const inviteOrgId = url.searchParams.get(INVITE_ORG_PARAM);
-    if (!inviteOrgId) return;
-    localStorage.setItem(PENDING_INVITE_ORG_STORAGE_KEY, inviteOrgId);
-    url.searchParams.delete(INVITE_ORG_PARAM);
-    window.history.replaceState(
-      window.history.state,
-      "",
-      `${url.pathname}${url.search}${url.hash}`,
+    url = new URL(trimmed, "https://app.mcpjam.local");
+  } catch {
+    return null;
+  }
+
+  const segments = url.pathname.replace(/^\/+/, "").split("/");
+  const orgId = normalizeInviteOrgId(segments[1]);
+  const sectionSegment = segments[2];
+  if (segments[0] !== "organizations" || !orgId || segments.length > 3) {
+    return null;
+  }
+
+  if (sectionSegment === undefined || sectionSegment === "") {
+    return { orgId };
+  }
+
+  if (sectionSegment !== "billing" && sectionSegment !== "models") {
+    return null;
+  }
+
+  return { orgId, section: sectionSegment };
+}
+
+function createPendingInviteOrgMarker(
+  organizationId: string,
+  section?: OrganizationRouteSection
+): PendingInviteOrgMarker | null {
+  const normalizedOrgId = normalizeInviteOrgId(organizationId);
+  if (!normalizedOrgId) {
+    return null;
+  }
+
+  return {
+    organizationId: normalizedOrgId,
+    returnPath: buildOrganizationPath(normalizedOrgId, section),
+    startedAt: Date.now(),
+  };
+}
+
+function normalizePendingInviteOrgMarker(
+  value: unknown
+): PendingInviteOrgMarker | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const raw = value as {
+    organizationId?: unknown;
+    returnPath?: unknown;
+    startedAt?: unknown;
+  };
+  if (
+    typeof raw.organizationId !== "string" ||
+    typeof raw.returnPath !== "string" ||
+    typeof raw.startedAt !== "number" ||
+    !Number.isFinite(raw.startedAt)
+  ) {
+    return null;
+  }
+
+  const parsedReturnPath = parseOrganizationReturnPath(raw.returnPath);
+  if (!parsedReturnPath || parsedReturnPath.orgId !== raw.organizationId) {
+    return null;
+  }
+
+  return {
+    organizationId: parsedReturnPath.orgId,
+    returnPath: buildOrganizationPath(
+      parsedReturnPath.orgId,
+      parsedReturnPath.section
+    ),
+    startedAt: raw.startedAt,
+  };
+}
+
+export function writePendingInviteOrgMarker(
+  marker: PendingInviteOrgMarker
+): void {
+  if (typeof sessionStorage === "undefined") {
+    return;
+  }
+
+  const normalizedMarker = normalizePendingInviteOrgMarker(marker);
+  if (!normalizedMarker) {
+    return;
+  }
+
+  try {
+    sessionStorage.setItem(
+      PENDING_INVITE_ORG_STORAGE_KEY,
+      JSON.stringify(normalizedMarker)
     );
   } catch {
-    // Malformed URL or unavailable storage — nothing to capture.
+    // Ignore storage failures.
   }
 }
 
-export function readPendingInviteOrgId(): string | null {
-  if (typeof window === "undefined") return null;
+export function writePendingInviteOrgMarkerForPath(
+  path: string | null | undefined
+): PendingInviteOrgMarker | null {
+  const parsed = parseOrganizationReturnPath(path);
+  if (!parsed) {
+    return null;
+  }
+
+  const marker = createPendingInviteOrgMarker(parsed.orgId, parsed.section);
+  if (!marker) {
+    return null;
+  }
+
+  writePendingInviteOrgMarker(marker);
+  return marker;
+}
+
+export function readPendingInviteOrgMarker(): PendingInviteOrgMarker | null {
+  if (typeof sessionStorage === "undefined") {
+    return null;
+  }
+
   try {
-    return localStorage.getItem(PENDING_INVITE_ORG_STORAGE_KEY);
+    const raw = sessionStorage.getItem(PENDING_INVITE_ORG_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    return normalizePendingInviteOrgMarker(JSON.parse(raw));
   } catch {
     return null;
   }
 }
 
-export function clearPendingInviteOrgId(): void {
-  if (typeof window === "undefined") return;
-  try {
-    localStorage.removeItem(PENDING_INVITE_ORG_STORAGE_KEY);
-  } catch {
-    // Storage unavailable — leave it; the apply step is idempotent.
+export function clearPendingInviteOrgMarker(): void {
+  if (typeof sessionStorage === "undefined") {
+    return;
   }
+
+  try {
+    sessionStorage.removeItem(PENDING_INVITE_ORG_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+export function capturePendingInviteOrgFromUrl(): PendingInviteOrgMarker | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const url = new URL(window.location.href);
+  const orgId = normalizeInviteOrgId(url.searchParams.get("invite_org"));
+  if (!orgId) {
+    return null;
+  }
+
+  const marker = createPendingInviteOrgMarker(orgId);
+  if (!marker) {
+    return null;
+  }
+
+  writePendingInviteOrgMarker(marker);
+  url.searchParams.delete("invite_org");
+  window.history.replaceState({}, "", url.pathname + url.search + url.hash);
+  return marker;
 }

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -10,6 +10,7 @@ import { ConvexProviderWithAuthKit } from "@convex-dev/workos";
 import { initSentry } from "./lib/sentry.js";
 import { IframeRouterError } from "./components/IframeRouterError.jsx";
 import { initializeSessionToken } from "./lib/session-token.js";
+import { capturePendingInviteOrgFromUrl } from "./lib/pending-invite-org";
 import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
 import { HOSTED_MODE } from "./lib/config";
 import {
@@ -29,6 +30,10 @@ import {
 
 // Initialize Sentry before React mounts
 initSentry();
+
+// Capture an `?invite_org` invite deep link before the WorkOS auth redirect can
+// drop the URL; it is applied as the active org post-signup (see use-app-state).
+capturePendingInviteOrgFromUrl();
 
 function AuthBootstrap({ children }: { children: ReactNode }) {
   const { isEnsuringUser, isUserReady } = useEnsureDbUser();


### PR DESCRIPTION
Pairs with the backend change ([mcpjam-backend#652](https://github.com/MCPJam/mcpjam-backend/pull/652)). When a brand-new user signs up from an org invite, they used to land in their own auto-created personal org instead of the org they were invited to. This drops them into the right one.

- The signup invite email now links to `/?invite_org={id}` (backend PR). This captures that id at boot — before the WorkOS redirect drops the URL — stashes it, and strips it from the URL.
- After signup, once the user is authenticated and actually a member of that org, it's set as their active org (then the stash is cleared so it only fires once).
- Safe fallback: if they're not a member yet (e.g. a paid seat still pending), nothing happens and the stash waits for a later load. No effect on existing users.

Reuses the existing active-org machinery — no routing or auth changes.

Draft / do not merge — needs the backend PR first, and wants a quick test in the WorkOS signup flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Newly signed-up invited users now land in the org they were invited to, with a one-click “Switch organization” prompt once membership is confirmed. Signed-out users hitting invite links or org routes are guided through the right auth flow and returned to the org.

- **New Features**
  - Capture `?invite_org` at boot, stash a return-path marker in `sessionStorage`, and strip it from the URL.
  - Signed out on an invite link: start WorkOS sign-up; signed out on an org route: start sign-in and stash the org return path.
  - OAuth callback restores the invite/org return path only after the Convex user is real (not guest) and linked to the WorkOS user, then clears the marker.
  - If membership is pending, show a one-per-session info toast; once confirmed, show a success toast with “Switch organization” (no auto-switch).
  - In `ShareProjectDialog`, show a clear toast when an invite requires paid seat payment.

- **Dependencies**
  - Requires backend invite emails to include `?invite_org={id}`.

<sup>Written for commit 7f0cfeef8902fdd77efa9187ee020683bda7f3a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

