### PR TITLE
fix(playground): cloud skills use Convex project id, not client UUID

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -296,10 +296,10 @@ export function ChatInput({
   // so the popover's fetch effects don't re-run every render.
   const skillsSource = useMemo<SkillsSource | undefined>(
     () =>
-      HOSTED_MODE && clientSelector?.projectId
-        ? { kind: "cloud", projectId: clientSelector.projectId }
+      HOSTED_MODE && clientSelector?.cloudProjectId
+        ? { kind: "cloud", projectId: clientSelector.cloudProjectId }
         : undefined,
-    [clientSelector?.projectId],
+    [clientSelector?.cloudProjectId],
   );
   const chatboxHostStyle = useChatboxHostStyle();
   const chatboxHostTheme = useChatboxHostTheme();

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/client-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/client-selector.tsx
@@ -72,8 +72,10 @@ export interface ClientSelectorData {
   /** The project's CONVEX id (`sharedProjectId`), or null when the project has
    *  no Convex backing yet (e.g. the synthetic "Default" project). Cloud,
    *  Convex-scoped reads (cloud skills) MUST use this, never `projectId` — a
-   *  client-local UUID fails the `v.id("projects")` validator with a 500. */
-  cloudProjectId?: string | null;
+   *  client-local UUID fails the `v.id("projects")` validator with a 500.
+   *  Required (not optional) so every caller decides explicitly; pass `null`
+   *  when there's no Convex project rather than omitting it. */
+  cloudProjectId: string | null;
   /** Lead host id — the single active client / first compare column. */
   currentHostId: string | null;
   /** Persisted compare lineup (from `usePersistedHost`). */

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/client-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/client-selector.tsx
@@ -66,8 +66,14 @@ const QUICK_ADD_VISIBLE = 6;
  */
 export interface ClientSelectorData {
   hosts: HostListItem[];
-  /** Project the hosts belong to — required to create new hosts. */
+  /** Project the hosts belong to — required to create new hosts. May be a
+   *  client-local project id (UUID) before the project is synced to Convex. */
   projectId: string | null;
+  /** The project's CONVEX id (`sharedProjectId`), or null when the project has
+   *  no Convex backing yet (e.g. the synthetic "Default" project). Cloud,
+   *  Convex-scoped reads (cloud skills) MUST use this, never `projectId` — a
+   *  client-local UUID fails the `v.id("projects")` validator with a 500. */
+  cloudProjectId?: string | null;
   /** Lead host id — the single active client / first compare column. */
   currentHostId: string | null;
   /** Persisted compare lineup (from `usePersistedHost`). */

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -3170,6 +3170,10 @@ export function PlaygroundMain({
       : {
           hosts: hostList,
           projectId: multiHostProjectId,
+          // Cloud skills are Convex-scoped: use the real Convex project id
+          // (null for the synthetic "Default" project), never the UUID fallback
+          // baked into `multiHostProjectId`, which 500s the listSkills query.
+          cloudProjectId: convexProjectId,
           currentHostId: previewedHostId ?? null,
           selectedHostIds,
           multiHostEnabled,


### PR DESCRIPTION
## Problem

The Playground floods `/api/web/skills/list` with **500s**:

```
[CONVEX Q(projectSkills:listSkills)] ArgumentValidationError: Value does not match validator.
Path: .projectId
Value: "68127ec2-1b90-4ca5-972c-8c32785ed9ae"
Validator: v.id("projects")
```

The cloud-skills source was built from `clientSelector.projectId`, which in `PlaygroundMain` is `multiHostProjectId = convexProjectId ?? activeProjectId`. For the synthetic **"Default"** project (no `sharedProjectId`), that falls back to the **client-local UUID**, which the Convex `projectSkills:listSkills` query rejects (`v.id("projects")` throws *before* the handler) → 500 on every call.

## Fix

Thread the real Convex id through a new `ClientSelectorData.cloudProjectId` (= `convexProjectId`, `null` when the project has no Convex backing) and source the cloud-skills `SkillsSource` from it instead of the UUID-fallback `projectId`.

- A project without a Convex id now shows **no cloud skills** instead of spamming 500s.
- The `/` slash picker and prompts popover inherit the same fixed source.
- `SkillsTab` already used `convexProjectId` (App.tsx) and is unaffected.

## Testing
- `npm run typecheck:client` clean.
- Manual: open the Playground on the default project → no more `skills/list` 500s in the server log; cloud skills appear once the project has a Convex backing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow client-side ID wiring for cloud skills; no auth, persistence, or host-compare behavior changes beyond omitting cloud skills when `cloudProjectId` is null.
> 
> **Overview**
> Fixes repeated **500** errors on `/api/web/skills/list` when the Playground runs on a project without Convex backing (e.g. the synthetic **Default** project).
> 
> Hosted cloud skills were keyed off `clientSelector.projectId`, which in `PlaygroundMain` is `multiHostProjectId` (`convexProjectId ?? activeProjectId`). That fallback is a **client-local UUID**, which Convex rejects for `projectSkills:listSkills` (`v.id("projects")`).
> 
> The change adds **`cloudProjectId`** on `ClientSelectorData` (the real `sharedProjectId`, or `null`) and wires **`PlaygroundMain`** to pass `convexProjectId`. **`ChatInput`** builds the cloud `SkillsSource` from `cloudProjectId` instead of `projectId`, so the `/` picker and related popovers skip cloud listing when there is no Convex id instead of spamming the API. Host creation and compare still use `projectId` / `multiHostProjectId` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4433d704cb7e186b56452f42e2eeea769786677e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cloud skills lookups in the Playground by using the Convex project id instead of a client-local UUID. This removes the 500s and hides cloud skills until a project has Convex backing.

- **Bug Fixes**
  - Added required `cloudProjectId` to `ClientSelectorData` (avoids UUID fallback) and set it from `convexProjectId` in `PlaygroundMain`.
  - Built the cloud `SkillsSource` from `cloudProjectId` in `chat-input.tsx`.
  - Result: no more `/api/web/skills/list` 500s; cloud skills load once the project has a Convex id.

<sup>Written for commit 4433d704cb7e186b56452f42e2eeea769786677e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

