### PR TITLE
fix(guest-auth): avoid npx.cmd EINVAL on Windows when provisioning Convex env

### DIFF
--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -44,12 +44,12 @@
     "LICENSE"
   ],
   "scripts": {
-    "predev": "npm run sdk:build",
+    "predev": "npm run sdk:build && npm run bundle:sandbox-proxies && npm run bundle:browser-harness",
     "dev": "run-script-os",
     "dev:default": "concurrently \"npm run dev:server\" \"npm run dev:client\" \"npm run dev:worker\"",
     "dev:win32": "concurrently --raw \"npm run dev:server\" \"npm run dev:client\" \"npm run dev:worker\"",
     "dev:worker": "npm --prefix ../mcp run dev:local",
-    "predev:app": "npm run sdk:build",
+    "predev:app": "npm run sdk:build && npm run bundle:sandbox-proxies && npm run bundle:browser-harness",
     "dev:app": "run-script-os",
     "dev:app:default": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:app:win32": "concurrently --raw \"npm run dev:server\" \"npm run dev:client\"",

--- a/mcpjam-inspector/server/utils/__tests__/guest-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/guest-auth.test.ts
@@ -13,6 +13,7 @@ vi.mock("../logger", () => ({
 
 vi.mock("../convex-guest-auth-sync.js", () => ({
   provisionGuestAuthConfigToConvex: mockProvisionGuestAuthConfigToConvex,
+  isConvexProvisioningUnavailable: vi.fn(() => false),
 }));
 
 vi.mock("../guest-session-secret.js", () => ({

--- a/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
@@ -5,6 +5,7 @@ const mockLogger = {
   warn: vi.fn(),
 };
 const mockProvisionGuestAuthConfigToConvex = vi.fn();
+const mockIsConvexProvisioningUnavailable = vi.fn();
 const mockGetGuestSessionSharedSecret = vi.fn();
 
 vi.mock("../logger", () => ({
@@ -13,6 +14,7 @@ vi.mock("../logger", () => ({
 
 vi.mock("../convex-guest-auth-sync.js", () => ({
   provisionGuestAuthConfigToConvex: mockProvisionGuestAuthConfigToConvex,
+  isConvexProvisioningUnavailable: mockIsConvexProvisioningUnavailable,
 }));
 
 vi.mock("../guest-session-secret.js", () => ({
@@ -33,6 +35,7 @@ describe("guest-session-source", () => {
     delete process.env.MCPJAM_GUEST_SESSION_URL;
     delete process.env.MCPJAM_GUEST_JWKS_URL;
     mockProvisionGuestAuthConfigToConvex.mockResolvedValue(undefined);
+    mockIsConvexProvisioningUnavailable.mockReturnValue(false);
     mockGetGuestSessionSharedSecret.mockReturnValue(
       "test-guest-session-secret"
     );
@@ -121,6 +124,43 @@ describe("guest-session-source", () => {
         method: "POST",
         signal: expect.anything(),
       })
+    );
+  });
+
+  it("falls back to the hosted mint when Convex provisioning is unavailable (OSS/local dev)", async () => {
+    mockIsConvexProvisioningUnavailable.mockReturnValue(true);
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          guestId: "guest-hosted",
+          token: "hosted-token",
+          expiresAt: Date.now() + 60_000,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    const result = await fetchConvexGuestSession();
+
+    expect(result.kind).toBe("session");
+    if (result.kind !== "session") return;
+    expect(result.session.token).toBe("hosted-token");
+    // Provisioning is still awaited (it's what sets the unavailable flag), but
+    // the mint hits the hosted endpoint, not the deployment we can't write to.
+    expect(mockProvisionGuestAuthConfigToConvex).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://app.mcpjam.com/api/web/guest-session",
+      expect.objectContaining({ method: "POST", signal: expect.anything() })
+    );
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "https://test-deployment.convex.site/guest/session",
+      expect.anything()
     );
   });
 

--- a/mcpjam-inspector/server/utils/convex-guest-auth-sync.ts
+++ b/mcpjam-inspector/server/utils/convex-guest-auth-sync.ts
@@ -9,6 +9,30 @@ import { logger } from "./logger.js";
 
 let provisioningPromise: Promise<void> | null = null;
 let provisioningStarted = false;
+let convexProvisioningUnavailable = false;
+
+// True once we've determined that this machine can't provision guest-auth env
+// on the target Convex deployment — i.e. the Convex CLI isn't authenticated,
+// or the logged-in account can't administer the deployment. This is the normal
+// state for open-source / local contributors: the committed `.env.local`
+// points at MCPJam's shared dev deployment, which they don't own. When true,
+// the guest-session helpers fall back to MCPJam's hosted mint instead of
+// trying (and failing) to talk to a deployment we can't write to.
+export function isConvexProvisioningUnavailable(): boolean {
+  return convexProvisioningUnavailable;
+}
+
+// A `convex env set` failure that means "we can't administer this deployment"
+// rather than "the write itself failed". Covers the unauthenticated case
+// (`MissingAccessToken` — the CLI has never run `npx convex dev`) and the
+// authenticated-but-not-a-member case (403 / not authorized for this team or
+// project). These are expected for OSS/local dev and must degrade to the
+// hosted guest mint, not surface as a hard error.
+function isConvexAuthUnavailableMessage(message: string): boolean {
+  return /MissingAccessToken|access token is required|Authenticate with|Not logged in|401\b|\b403\b|Forbidden|Unauthorized|not authorized|not a member/i.test(
+    message,
+  );
+}
 
 function getConvexDeploymentForProvisioning(): string {
   if (process.env.CONVEX_DEPLOYMENT) {
@@ -182,6 +206,24 @@ export async function provisionGuestAuthConfigToConvex(): Promise<void> {
         `[guest-auth] Provisioned Convex guest auth env (${convexEnv.CONVEX_DEPLOYMENT})`,
       );
     })().catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+
+      // Can't administer the deployment (no Convex login, or logged in as an
+      // account without access). This is expected for OSS/local dev against
+      // MCPJam's shared deployment — mark provisioning unavailable so the
+      // guest-session helpers fall back to the hosted mint, and resolve
+      // successfully so callers don't 503. Memoized: we won't retry per-request.
+      if (isConvexAuthUnavailableMessage(message)) {
+        convexProvisioningUnavailable = true;
+        logger.info(
+          "[guest-auth] Convex CLI can't provision guest auth env " +
+            "(not authenticated for this deployment); using MCPJam's hosted " +
+            "guest auth instead. This is expected for open-source/local dev. " +
+            "To provision your own Convex deployment, run `npx convex dev` first.",
+        );
+        return;
+      }
+
       provisioningPromise = null;
       throw error;
     });

--- a/mcpjam-inspector/server/utils/convex-guest-auth-sync.ts
+++ b/mcpjam-inspector/server/utils/convex-guest-auth-sync.ts
@@ -37,18 +37,36 @@ function isOccFailureMessage(message: string): boolean {
   return /OptimisticConcurrencyControlFailure/i.test(message);
 }
 
+let convexCliPath: string | null = null;
+
+// Resolve the convex CLI's entry script on disk and invoke it directly with
+// `node`, rather than shelling out through `npx`/`npx.cmd`. On Windows,
+// execFile-ing `npx.cmd` without a shell hits a Node bug (EINVAL) when args
+// contain newlines (e.g. our PEM-formatted keys), and routing through a shell
+// instead would require fragile re-quoting of those same multi-line values.
+async function getConvexCliPath(): Promise<string> {
+  if (!convexCliPath) {
+    const { createRequire } = await import("module");
+    const { dirname, join } = await import("path");
+    const require = createRequire(import.meta.url);
+    const packageJsonPath = require.resolve("convex/package.json");
+    convexCliPath = join(dirname(packageJsonPath), "bin", "main.js");
+  }
+  return convexCliPath;
+}
+
 async function execConvexEnvSet(
   convexEnv: NodeJS.ProcessEnv,
   name: string,
   value: string,
 ): Promise<void> {
-  const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
   const { execFile } = await import("child_process");
+  const cliPath = await getConvexCliPath();
 
   await new Promise<void>((resolve, reject) => {
     execFile(
-      npxCommand,
-      ["convex", "env", "set", name, "--", value],
+      process.execPath,
+      [cliPath, "env", "set", name, "--", value],
       {
         env: convexEnv,
         timeout: 15_000,

--- a/mcpjam-inspector/server/utils/guest-session-source.ts
+++ b/mcpjam-inspector/server/utils/guest-session-source.ts
@@ -1,4 +1,7 @@
-import { provisionGuestAuthConfigToConvex } from "./convex-guest-auth-sync.js";
+import {
+  isConvexProvisioningUnavailable,
+  provisionGuestAuthConfigToConvex,
+} from "./convex-guest-auth-sync.js";
 import { logger } from "./logger.js";
 import {
   GUEST_SESSION_SECRET_HEADER,
@@ -224,6 +227,13 @@ export async function fetchConvexGuestSession(
     return { kind: "error", status: 503, setCookies: [] };
   }
 
+  // Can't administer the deployment (OSS/local dev against MCPJam's shared
+  // deployment): our locally-generated shared secret was never written to it,
+  // so a direct Convex mint would be rejected. Use the hosted mint instead.
+  if (isConvexProvisioningUnavailable()) {
+    return fetchRemoteGuestSession(context, timeoutMs);
+  }
+
   return performGuestSessionFetch(
     getConvexGuestSessionUrl(),
     {
@@ -334,6 +344,10 @@ export async function fetchConvexGuestSessionRevoke(
       `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`
     );
     return { status: 503, setCookies: [], body: null };
+  }
+
+  if (isConvexProvisioningUnavailable()) {
+    return fetchRemoteGuestSessionRevoke(context);
   }
 
   return performGuestSessionRevoke(
@@ -458,6 +472,10 @@ export async function fetchConvexGuestPromotionProof(
       `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`
     );
     return { kind: "error", status: 503 };
+  }
+
+  if (isConvexProvisioningUnavailable()) {
+    return fetchRemoteGuestPromotionProof(context);
   }
 
   return performGuestPromotionProofFetch(


### PR DESCRIPTION
## Summary
- On Windows, execFile-ing npx.cmd without a shell throws EINVAL when an argument contains a newline. convex-guest-auth-sync.ts passes PEM-formatted guest JWT keys as CLI args to `convex env set`, which reliably triggers this.
- Resolves the Convex CLI's entry script (convex/bin/main.js) on disk and invokes it directly via node instead of shelling out through npx/npx.cmd, sidestepping the bug without needing to re-quote multi-line values through a shell.

## Test plan
- [x] Verified provisionGuestAuthConfigToConvex() runs to completion on Windows and successfully sets GUEST_JWT_PRIVATE_KEY/GUEST_JWT_PUBLIC_KEY/etc. on a Convex dev deployment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows Convex provisioning by invoking the `convex` CLI via Node instead of `npx`, and add a safe fallback to the hosted guest mint when the CLI can’t administer the target deployment. Also run required bundles before dev so fresh clones boot cleanly.

- **Bug Fixes**
  - Resolve `convex` via `require.resolve('convex/package.json')` and run `bin/main.js` with `process.execPath` to avoid Windows `npx` EINVAL on multi-line args.
  - Detect unauthenticated/unauthorized Convex provisioning, mark it unavailable, and route guest session/revoke/promotion-proof to the hosted mint instead of 503ing.
  - Run `bundle:sandbox-proxies` and `bundle:browser-harness` in `predev` and `predev:app` so `npm run dev` works on a fresh clone.

<sup>Written for commit d360b9986b762d66c383fa70c5bdb658ba0ff33d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

