### PR TITLE
feat(evals): suite computer-environment picker + run-detail surfacing

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -418,13 +418,21 @@ export function RunDetailView({
   // friendly name best-effort; fall back to the snapshot's environmentId if the
   // environment was deleted since the run.
   const runComputerEnv = selectedRunDetails.configSnapshot?.computerEnvironment;
+  // Durable id keyed off the frozen pin, falling back to the snapshot's
+  // environment.computerEnvironmentId — so a run that recorded the id without
+  // the newer frozen object still shows an Environment row.
+  const runComputerEnvId =
+    runComputerEnv?.environmentId ??
+    selectedRunDetails.configSnapshot?.environment?.computerEnvironmentId ??
+    null;
   const runEnvironments = useEnvironments(
-    runComputerEnv ? selectedRunDetails.projectId ?? null : null
+    runComputerEnvId ? selectedRunDetails.projectId ?? null : null
   );
-  const runComputerEnvName = runComputerEnv
-    ? runEnvironments?.find(
-        (e) => e.environmentId === runComputerEnv.environmentId
-      )?.name ?? null
+  // Friendly name when resolvable; otherwise the RAW id (never truncated — it's
+  // the only durable identifier once the environment is deleted).
+  const runComputerEnvLabel = runComputerEnvId
+    ? runEnvironments?.find((e) => e.environmentId === runComputerEnvId)
+        ?.name ?? runComputerEnvId
     : null;
   const {
     result: goalCompletionResult,
@@ -699,23 +707,27 @@ export function RunDetailView({
         </div>
       ) : null}
 
-      {runComputerEnv ? (
+      {runComputerEnvId ? (
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <span className={runDetailMetaLabelClass}>Environment</span>
           <span
             className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs"
-            title={`Image ${runComputerEnv.e2bTemplateId}${
-              runComputerEnv.baseImageDigests[0]
-                ? ` · ${runComputerEnv.baseImageDigests[0]}`
-                : ""
-            } · ${runComputerEnv.provider}`}
+            title={
+              runComputerEnv
+                ? `Image ${runComputerEnv.e2bTemplateId}${
+                    runComputerEnv.baseImageDigests[0]
+                      ? ` · ${runComputerEnv.baseImageDigests[0]}`
+                      : ""
+                  } · ${runComputerEnv.provider}`
+                : undefined
+            }
           >
-            <span className="text-foreground">
-              {runComputerEnvName ?? formatRunId(runComputerEnv.environmentId)}
-            </span>
-            <span className="font-mono text-[10px] text-muted-foreground">
-              {runComputerEnv.provider}
-            </span>
+            <span className="text-foreground">{runComputerEnvLabel}</span>
+            {runComputerEnv ? (
+              <span className="font-mono text-[10px] text-muted-foreground">
+                {runComputerEnv.provider}
+              </span>
+            ) : null}
           </span>
         </div>
       ) : null}

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -48,6 +48,7 @@ import {
   type RunTrendPoint,
 } from "./run-insight-rail";
 import { runDetailMetaLabelClass } from "./run-detail-typography";
+import { useEnvironments } from "@/hooks/useComputerEnvironments";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -412,6 +413,19 @@ export function RunDetailView({
   const { availableModels } = useAvailableModels({
     projectId: selectedRunDetails.projectId ?? null,
   });
+
+  // The frozen reproducible-env pin this run launched from (if any). Resolve a
+  // friendly name best-effort; fall back to the snapshot's environmentId if the
+  // environment was deleted since the run.
+  const runComputerEnv = selectedRunDetails.configSnapshot?.computerEnvironment;
+  const runEnvironments = useEnvironments(
+    runComputerEnv ? selectedRunDetails.projectId ?? null : null
+  );
+  const runComputerEnvName = runComputerEnv
+    ? runEnvironments?.find(
+        (e) => e.environmentId === runComputerEnv.environmentId
+      )?.name ?? null
+    : null;
   const {
     result: goalCompletionResult,
     pending: goalCompletionPending,
@@ -682,6 +696,27 @@ export function RunDetailView({
         <div className="mb-4 flex flex-wrap items-center gap-2">
           <span className={runDetailMetaLabelClass}>Host</span>
           <HostChip name={runClient.displayName} hostId={runClient.hostId} />
+        </div>
+      ) : null}
+
+      {runComputerEnv ? (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <span className={runDetailMetaLabelClass}>Environment</span>
+          <span
+            className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-0.5 text-xs"
+            title={`Image ${runComputerEnv.e2bTemplateId}${
+              runComputerEnv.baseImageDigests[0]
+                ? ` · ${runComputerEnv.baseImageDigests[0]}`
+                : ""
+            } · ${runComputerEnv.provider}`}
+          >
+            <span className="text-foreground">
+              {runComputerEnvName ?? formatRunId(runComputerEnv.environmentId)}
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {runComputerEnv.provider}
+            </span>
+          </span>
         </div>
       ) : null}
 

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import { useMutation, useConvexAuth } from "convex/react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useHostList } from "@/hooks/useClients";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useEnvironments } from "@/hooks/useComputerEnvironments";
 import { toast } from "sonner";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { compareRunsBySequence } from "./helpers";
@@ -380,6 +382,12 @@ export function SuiteIterationsView({
 
   const updateSuite = useMutation("testSuites:updateTestSuite" as any);
   const { isAuthenticated } = useConvexAuth();
+  // Reproducible-evals env picker (gated by the computers feature flag). Only
+  // fetch the project's environments when the flag is on and we have a project.
+  const computersEnabled = useComputersEnabled();
+  const computerEnvironments = useEnvironments(
+    computersEnabled && projectId ? projectId : null
+  );
   // Hosts available to attach in the header's "+ Attach host" picker. The
   // query is owned here (not inside SuiteOverviewClientBar) so the bar stays
   // pure-props and renderable in test environments without a Convex provider.
@@ -1352,6 +1360,74 @@ export function SuiteIterationsView({
                   higher keeps its count; a per-run override still wins.
                 </p>
               </SettingsSection>
+
+              {/* ── Computer environment (reproducible evals) ──────────
+                  Gated behind the computers feature flag. Pins a built Docker
+                  environment so each eval iteration boots a fresh sandbox from
+                  the same image — comparable results across runs/edits. */}
+              {computersEnabled && projectId ? (
+                <SettingsSection
+                  label="Computer environment"
+                  layout="inline"
+                  inlineSlot={
+                    <select
+                      className="h-8 max-w-[16rem] rounded-md border border-input bg-background px-2 text-xs text-foreground"
+                      value={suite.environment?.computerEnvironmentId ?? ""}
+                      aria-label="Reproducible computer environment for eval runs"
+                      onChange={async (e) => {
+                        const next = e.target.value || undefined;
+                        try {
+                          await updateSuite({
+                            suiteId: suite._id,
+                            environment: {
+                              servers: suite.environment?.servers ?? [],
+                              serverBindings: suite.environment?.serverBindings,
+                              ...(next ? { computerEnvironmentId: next } : {}),
+                            },
+                          });
+                          toast.success(
+                            next
+                              ? "Computer environment set"
+                              : "Computer environment cleared"
+                          );
+                        } catch (error) {
+                          toast.error(
+                            getBillingErrorMessage(
+                              error,
+                              "Failed to update suite"
+                            )
+                          );
+                          console.error(
+                            "Failed to update computer environment:",
+                            error
+                          );
+                        }
+                      }}
+                    >
+                      <option value="">None (default image)</option>
+                      {(computerEnvironments ?? []).map((env) => {
+                        const ready = env.currentBuild?.status === "ready";
+                        return (
+                          <option
+                            key={env.environmentId}
+                            value={env.environmentId}
+                          >
+                            {env.name}
+                            {ready ? "" : " (not built)"}
+                          </option>
+                        );
+                      })}
+                    </select>
+                  }
+                >
+                  <p className="text-[11px] text-muted-foreground/60">
+                    Each eval iteration boots a fresh sandbox from this image
+                    and the agent gets a <span className="font-mono">bash</span>{" "}
+                    tool in it. Build the environment before running, or the run
+                    fails fast.
+                  </p>
+                </SettingsSection>
+              ) : null}
 
               {/* ── Tool calls ───────────────────────────────────────── */}
               <SettingsSection

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -114,6 +114,11 @@ export type EvalSuite = {
       serverName: string;
       projectServerId?: string;
     }>;
+    /**
+     * Reproducible-evals pin: the computer environment each eval iteration
+     * boots a fresh sandbox from. Set via the suite settings env-picker.
+     */
+    computerEnvironmentId?: string;
   };
   createdAt: number;
   updatedAt: number;
@@ -483,6 +488,20 @@ export type EvalSuiteRun = {
         serverName: string;
         projectServerId?: string;
       }>;
+      computerEnvironmentId?: string;
+    };
+    /**
+     * Frozen reproducible-env pin for this run: the exact built image each
+     * iteration's sandbox launched from. Surfaced in run-detail so users can
+     * see which environment a run used (and spot mismatches when comparing).
+     */
+    computerEnvironment?: {
+      environmentId: string;
+      environmentBuildId: string;
+      e2bTemplateId: string;
+      e2bBuildId?: string;
+      baseImageDigests: string[];
+      provider: "e2b" | "stub";
     };
     /**
      * Suite-level judge config snapshotted at run-create. The run-detail


### PR DESCRIPTION
## What

Restores the **reproducible-evals computer environment picker** that was built but never merged (lived only on a local branch). Lets a suite pin a built Docker environment so every eval iteration boots a fresh sandbox from the same image — comparable results across runs and edits — and surfaces which environment a completed run used.

## Changes (3 files, +142)

- **`suite-iterations-view.tsx`** — adds a **"Computer environment"** picker to suite settings, gated behind the `computers` feature flag (`useComputersEnabled()` + a project). Writes `environment.computerEnvironmentId` via `updateTestSuite`; lists the project's environments and marks unbuilt ones `(not built)`. Billing errors routed through `getBillingErrorMessage`.
- **`run-detail-view.tsx`** — surfaces an **Environment** row on the run detail. Resolves a friendly name best-effort; falls back to the raw (never-truncated) environment id when the environment was deleted since the run, so the durable identifier is always shown.
- **`types.ts`** — adds `computerEnvironmentId` to `EvalSuite.environment`, and a frozen `computerEnvironment` snapshot (`environmentId`, `environmentBuildId`, `e2bTemplateId`, digests, provider) to `EvalSuiteRun` so run detail can show the exact image a run launched from.

## Notes

- Fully **feature-flag gated** — no change for users without the `computers` flag.
- Dependencies (`useComputerEnvironments`, `useComputersEnabled`) already exist in main.
- Merges cleanly into current main (verified via `merge-tree`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pinning changes which sandbox image eval iterations use (when the runner honors the suite field), but the surface is computers-flag-gated and this PR is client/types only; clearing the picker may leave a stale id if the backend merge does not strip omitted fields.
> 
> **Overview**
> Adds **reproducible eval computer environments** to the inspector UI: suites can pin a built environment so iterations use a consistent sandbox image, and completed runs show which environment they used.
> 
> In **suite settings** (only when the computers feature flag is on and a project is set), a new **Computer environment** select loads project environments via `useEnvironments`, persists `environment.computerEnvironmentId` through `updateTestSuite`, and labels options that are not built yet. Choosing **None** omits the id on update (same pattern as other optional suite fields).
> 
> **Run detail** gains an **Environment** meta row beside Host when the run snapshot has a pin. It resolves a display name from live project data when possible, otherwise shows the full environment id (including after deletion). Tooltip includes frozen snapshot fields (template, digest, provider) when `configSnapshot.computerEnvironment` exists; older runs still show a row from `environment.computerEnvironmentId` alone.
> 
> **Types** document `computerEnvironmentId` on suite and run snapshot `environment`, plus optional frozen `configSnapshot.computerEnvironment` for the exact image/build used at launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab87b0f0e60812fe9c5c401644356fabc89726ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a suite “Computer environment” picker to pin a built Docker image for reproducible evals, and shows which environment a run used on the run detail page. Fully gated by the `computers` flag; no change for others.

- **New Features**
  - Suite settings: “Computer environment” select; persists `environment.computerEnvironmentId`, lists project environments, marks unbuilt ones as “(not built)”, and only fetches when the flag is on. Runs fail fast if the selected env isn’t built.
  - Run detail: new Environment row; resolves a friendly name when available, otherwise shows the raw `environmentId` for durability; tooltip includes image/digest/provider from the frozen snapshot.
  - Types: added `computerEnvironmentId` to `EvalSuite.environment` and a frozen `configSnapshot.computerEnvironment` on `EvalSuiteRun` to record the exact image used.

<sup>Written for commit ab87b0f0e60812fe9c5c401644356fabc89726ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

