### PR TITLE
fix release smoke inspector shutdown

### DIFF
--- a/.changeset/release-smoke-inspector-shutdown.md
+++ b/.changeset/release-smoke-inspector-shutdown.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only fix for the packed Inspector startup smoke test shutdown path; no package release required.

--- a/.github/scripts/smoke-packed-npm-packages.mjs
+++ b/.github/scripts/smoke-packed-npm-packages.mjs
@@ -201,8 +201,17 @@ function collectDependencyVersions(node, packageName, versions = []) {
 
 async function smokeInspectorStartup(installDir) {
   const port = String(62000 + Math.floor(Math.random() * 1000));
-  const child = spawn("npx", ["--no-install", "inspector", "--port", port], {
+  const inspectorBin = path.join(
+    installDir,
+    "node_modules",
+    "@mcpjam",
+    "inspector",
+    "bin",
+    "start.js",
+  );
+  const child = spawn(process.execPath, [inspectorBin, "--port", port], {
     cwd: installDir,
+    detached: process.platform !== "win32",
     env: {
       ...process.env,
       MCPJAM_INSPECTOR_DISABLE_ORPHAN_CHECK: "1",
@@ -225,8 +234,7 @@ async function smokeInspectorStartup(installDir) {
     throw new Error(`Inspector smoke exited early with code ${earlyExit.code}:\n${output}`);
   }
 
-  child.kill("SIGTERM");
-  await waitForExit(child, 5000);
+  await terminateChildProcess(child, 5000);
   console.log("Inspector startup smoke stayed alive long enough to pass.");
 }
 
@@ -251,19 +259,55 @@ function waitForEarlyExit(child, ms) {
 function waitForExit(child, ms) {
   return new Promise((resolve) => {
     if (child.exitCode !== null) {
-      resolve();
+      resolve(true);
       return;
     }
 
     const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-      resolve();
+      cleanup();
+      resolve(false);
     }, ms);
-    child.once("exit", () => {
+    const onExit = () => {
+      cleanup();
+      resolve(true);
+    };
+    const cleanup = () => {
       clearTimeout(timer);
-      resolve();
-    });
+      child.off("exit", onExit);
+    };
+    child.once("exit", onExit);
   });
+}
+
+async function terminateChildProcess(child, gracefulMs) {
+  sendSignal(child, "SIGTERM");
+
+  if (!await waitForExit(child, gracefulMs)) {
+    sendSignal(child, "SIGKILL");
+    await waitForExit(child, 2000);
+  }
+
+  child.stdout?.destroy();
+  child.stderr?.destroy();
+  child.stdin?.destroy();
+}
+
+function sendSignal(child, signal) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  try {
+    if (process.platform !== "win32" && child.pid) {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch (error) {
+    if (error?.code !== "ESRCH") {
+      throw error;
+    }
+  }
 }
 
 function run(command, args, options = {}) {

--- a/.github/scripts/smoke-packed-npm-packages.mjs
+++ b/.github/scripts/smoke-packed-npm-packages.mjs
@@ -258,7 +258,7 @@ function waitForEarlyExit(child, ms) {
 
 function waitForExit(child, ms) {
   return new Promise((resolve) => {
-    if (child.exitCode !== null) {
+    if (child.exitCode !== null || child.signalCode !== null) {
       resolve(true);
       return;
     }


### PR DESCRIPTION
release test file in publish packages step got stuck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release smoke test hang by starting the inspector directly and shutting it down reliably, so the “publish packages” step doesn’t get stuck. CI-only change; no package release.

- **Bug Fixes**
  - Launch inspector with Node using `@mcpjam/inspector/bin/start.js` instead of `npx`; run detached on non‑Windows.
  - Add terminateChildProcess and sendSignal: SIGTERM then SIGKILL via process group; ignore ESRCH; close stdio to avoid orphans.
  - Update waitForExit to return a boolean, detect exits via code or signal, and handle timeouts cleanly; use the new shutdown in the smoke test.

<sup>Written for commit 746e71d1fba9c07ca28291b6a5c68fb0df9e7815. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

