### PR TITLE
fix(harness): Claude Code turns 400 against the AI Gateway

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/stream-turn-driver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/stream-turn-driver.test.ts
@@ -25,6 +25,7 @@ function makeDriver(spans: EvalTraceSpan[] = [], onStepFinish?: any) {
     turnId: "turn-1",
     promptIndex: 0,
     modelId: "anthropic/claude",
+    engine: "emulated",
     traceBaseMs: 1000,
     spans,
     onStepFinish,
@@ -47,6 +48,30 @@ describe("StreamTurnDriver", () => {
         turnId: "turn-1",
         promptIndex: 0,
         startedAtMs: 1000,
+        engine: "emulated",
+      },
+    });
+  });
+
+  it("can annotate harness-backed turns", () => {
+    const { writer, chunks } = collectingWriter();
+    const d = new StreamTurnDriver({
+      turnId: "turn-1",
+      promptIndex: 0,
+      modelId: "anthropic/claude",
+      engine: "harness",
+      harness: "claude-code",
+      traceBaseMs: 1000,
+      spans: [],
+    });
+
+    d.emitTurnStart(writer);
+
+    expect(chunks[0]).toMatchObject({
+      data: {
+        type: "turn_start",
+        engine: "harness",
+        harness: "claude-code",
       },
     });
   });

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -161,6 +161,17 @@ const toUserMessage = (text) => ({
     expect(bridge?.content).toContain("modelOverrides");
     expect(bridge?.content).toContain("anthropic/claude-");
     expect(bridge?.content).toContain("claude-haiku-4-5-20251001");
+    // Fallback dedup only suppresses an EXACT repeat of the immediately prior
+    // fallback (e.g. msg.result echoing the last text block) — never a full
+    // history Set, which would drop legitimate non-adjacent repeats, and
+    // never a "first-emission-only" flag, which would silently swallow a
+    // distinct trailing msg.result (the real final answer) after any earlier
+    // fallback fired.
+    expect(bridge?.content).toContain("let lastEmittedFallbackText");
+    expect(bridge?.content).toContain(
+      "normalized === lastEmittedFallbackText"
+    );
+    expect(bridge?.content).not.toContain("emittedAssistantTextFallbacks");
     // Gateway compat: the CLI must omit output_config.effort (the gateway's
     // Anthropic-compat schema 400s on it).
     expect(bridge?.content).toContain(

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { HARNESS_IDS } from "@mcpjam/sdk/host-config/internal";
+import { createClaudeCode } from "@ai-sdk/harness-claude-code";
 import {
   getHarnessAdapter,
   isHarnessId,
+  patchClaudeCodeHarnessBootstrap,
   registeredHarnessIds,
+  toAnthropicGatewayBaseUrl,
+  toOpenAiCompatGatewayBaseUrl,
 } from "../registry";
 
 describe("harness registry", () => {
@@ -23,11 +27,21 @@ describe("harness registry", () => {
     expect(a.fileChangeToolName).toBe("fileChange");
   });
 
-  it("maps host model ids to Claude Code CLI-native aliases", () => {
+  it("maps Gateway Anthropic model ids to Claude Code selectable models", () => {
     const { toNativeModel } = getHarnessAdapter("claude-code");
     expect(toNativeModel?.("anthropic/claude-haiku-4.5")).toBe("haiku");
-    expect(toNativeModel?.("anthropic/claude-opus-4-6")).toBe("opus");
-    expect(toNativeModel?.("anthropic/claude-sonnet-4-6")).toBe("sonnet");
+    expect(toNativeModel?.("anthropic/claude-opus-4.7")).toBe(
+      "claude-opus-4-7"
+    );
+    expect(toNativeModel?.("anthropic/claude-opus-4-6")).toBe(
+      "claude-opus-4-6"
+    );
+    expect(toNativeModel?.("anthropic/claude-sonnet-4.6")).toBe(
+      "claude-sonnet-4-6"
+    );
+    expect(toNativeModel?.("anthropic/claude-sonnet-5")).toBe(
+      "claude-sonnet-5"
+    );
     expect(toNativeModel?.("openai/gpt-5")).toBeUndefined();
   });
 
@@ -41,6 +55,31 @@ describe("harness registry", () => {
     expect(toNativeModel?.("anthropic/claude-haiku-4.5")).toBeUndefined();
   });
 
+  it("normalizes the gateway base URL per wire protocol", () => {
+    // Claude Code's CLI joins `${ANTHROPIC_BASE_URL}/v1/messages` itself, so a
+    // /v1-suffixed base yields …/v1/v1/messages → live-gateway 404 on every
+    // model call. Its base must be the bare origin.
+    expect(toAnthropicGatewayBaseUrl("https://ai-gateway.vercel.sh/v1")).toBe(
+      "https://ai-gateway.vercel.sh"
+    );
+    expect(toAnthropicGatewayBaseUrl("https://ai-gateway.vercel.sh/v1/")).toBe(
+      "https://ai-gateway.vercel.sh"
+    );
+    expect(toAnthropicGatewayBaseUrl("https://ai-gateway.vercel.sh")).toBe(
+      "https://ai-gateway.vercel.sh"
+    );
+    // Codex's CLI treats OPENAI_BASE_URL as an OpenAI-compatible /v1 root.
+    expect(toOpenAiCompatGatewayBaseUrl("https://ai-gateway.vercel.sh")).toBe(
+      "https://ai-gateway.vercel.sh/v1"
+    );
+    expect(
+      toOpenAiCompatGatewayBaseUrl("https://ai-gateway.vercel.sh/v1")
+    ).toBe("https://ai-gateway.vercel.sh/v1");
+    expect(
+      toOpenAiCompatGatewayBaseUrl("https://ai-gateway.vercel.sh/v1/")
+    ).toBe("https://ai-gateway.vercel.sh/v1");
+  });
+
   it("supportsModel: Claude Code runs anything, Codex only gpt-5", () => {
     const cc = getHarnessAdapter("claude-code");
     const codex = getHarnessAdapter("codex");
@@ -52,20 +91,124 @@ describe("harness registry", () => {
     expect(codex.supportsModel("openai/o1")).toBe(false);
   });
 
+  it("patches the Claude Code bridge bootstrap compatibility gaps", async () => {
+    const harness = patchClaudeCodeHarnessBootstrap({
+      getBootstrap: async () => ({
+        harnessId: "claude-code",
+        bootstrapDir: "/tmp/harness/claude-code",
+        files: [
+          {
+            path: "/tmp/harness/claude-code/bridge.mjs",
+            content: `async function drive() {
+  let streamStarted = false;
+  const partialBlocks = new Map();
+  const permissionOptions = createPermissionOptions({
+    start,
+    turn,
+    emit,
+    nativeToolCallNames,
+    approvalRequestedToolUseIds
+  });
+  const q = claudeSdk.query({
+    options: {
+      ...start.model ? { model: start.model } : {},
+      ...start.maxTurns !== void 0 ? { maxTurns: start.maxTurns } : {},
+    }
+  });
+  for await (const msg of q) {
+    const type = msg.type;
+    if (type === "stream_event") {
+        handleStreamEvent(msg.event, partialBlocks, emit);
+        continue;
+      }
+    if (type === "assistant" && msg.message?.content) {
+      for (const block of msg.message.content) {
+          if (block.type === "tool_use" && typeof block.id === "string") {
+          emit({ type: "tool-call" });
+        }
+      }
+    }
+    if (type === "result") {
+      const emptyResult = !msg.result?.trim?.();
+          if (emptyResult && observedTerminalError) {
+        emitTerminalError(observedTerminalError);
+      }
+    }
+  }
+}
+const toUserMessage = (text) => ({
+  type: "user",
+    message: {
+      role: "user"
+    }
+});`,
+          },
+        ],
+        commands: [],
+      }),
+    } as any);
+
+    const bootstrap = await harness.getBootstrap?.();
+    const bridge = bootstrap?.files.find((file) =>
+      file.path.endsWith("/bridge.mjs")
+    );
+    expect(bridge?.content).toContain("parent_tool_use_id: null");
+    expect(bridge?.content).toContain("emitAssistantTextFallback");
+    expect(bridge?.content).toContain("streamedAssistantText = true");
+    expect(bridge?.content).toContain("emitAssistantTextFallback(block.text)");
+    expect(bridge?.content).toContain("emitAssistantTextFallback(msg.result)");
+    expect(bridge?.content).toContain("gatewayModelOverrideSettings");
+    expect(bridge?.content).toContain("modelOverrides");
+    expect(bridge?.content).toContain("anthropic/claude-");
+    expect(bridge?.content).toContain("claude-haiku-4-5-20251001");
+    // Gateway compat: the CLI must omit output_config.effort (the gateway's
+    // Anthropic-compat schema 400s on it).
+    expect(bridge?.content).toContain(
+      'process.env.CLAUDE_CODE_EFFORT_LEVEL ??= "unset"'
+    );
+  });
+
+  it("patches the installed Claude Code bridge bootstrap", async () => {
+    const harness = patchClaudeCodeHarnessBootstrap(
+      createClaudeCode({
+        model: "haiku",
+        auth: {
+          gateway: {
+            apiKey: "test",
+            baseUrl: "https://ai-gateway.vercel.sh/v1",
+          },
+        },
+      }) as any
+    );
+
+    const bootstrap = await harness.getBootstrap?.();
+    const bridge = bootstrap?.files.find((file) =>
+      file.path.endsWith("/bridge.mjs")
+    );
+    expect(bridge?.content).toContain("parent_tool_use_id: null");
+    expect(bridge?.content).toContain("emitAssistantTextFallback");
+    expect(bridge?.content).toContain("gatewayModelOverrideSettings");
+    expect(bridge?.content).toContain("modelOverrides");
+    expect(bridge?.content).toContain("claude-haiku-4-5-20251001");
+    expect(bridge?.content).toContain(
+      'process.env.CLAUDE_CODE_EFFORT_LEVEL ??= "unset"'
+    );
+  });
+
   it("Claude Code attributes mcp__ tool names; Codex passes them through", () => {
     const keyToServerId = { weather: "srv_123" };
     expect(
       getHarnessAdapter("claude-code").parseToolName(
         "mcp__weather__forecast",
-        keyToServerId,
-      ),
+        keyToServerId
+      )
     ).toEqual({ serverId: "srv_123", toolName: "forecast" });
     // Codex v1 has no MCP namespacing — names pass through as native tools.
     expect(
       getHarnessAdapter("codex").parseToolName(
         "mcp__weather__forecast",
-        keyToServerId,
-      ),
+        keyToServerId
+      )
     ).toEqual({ toolName: "mcp__weather__forecast" });
   });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -52,6 +52,12 @@ describe("harness registry", () => {
     expect(toNativeModel?.("anthropic/claude-sonnet-4-5-20250929")).toBe(
       "claude-sonnet-4-5"
     );
+    // Major-only dated snapshot (no minor version between major and date):
+    // the optional minor group's greedy digit match must not swallow the
+    // date as if it were a minor version.
+    expect(toNativeModel?.("anthropic/claude-opus-4-20250929")).toBe(
+      "claude-opus-4"
+    );
     // A bare substring match must NOT route a non-Anthropic/malformed id to
     // Claude Code's haiku alias (the regex-gated shortcut, not a loose
     // .includes check).

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -42,6 +42,20 @@ describe("harness registry", () => {
     expect(toNativeModel?.("anthropic/claude-sonnet-5")).toBe(
       "claude-sonnet-5"
     );
+    // Dated/pinned snapshot suffix (the exact shape Claude Code's own alias
+    // resolution can produce on the wire — see the bridge's modelOverrides
+    // keys) must still resolve to the haiku alias, not fall through to
+    // undefined (which would silently drop the model pin).
+    expect(toNativeModel?.("anthropic/claude-haiku-4-5-20251001")).toBe(
+      "haiku"
+    );
+    expect(toNativeModel?.("anthropic/claude-sonnet-4-5-20250929")).toBe(
+      "claude-sonnet-4-5"
+    );
+    // A bare substring match must NOT route a non-Anthropic/malformed id to
+    // Claude Code's haiku alias (the regex-gated shortcut, not a loose
+    // .includes check).
+    expect(toNativeModel?.("openai/my-haiku-experiment")).toBeUndefined();
     expect(toNativeModel?.("openai/gpt-5")).toBeUndefined();
   });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
@@ -158,4 +158,40 @@ describe("runHarnessTurn empty output projection", () => {
       content: [{ type: "text", text: "Created empty.txt" }],
     });
   });
+
+  it("treats a whitespace-only final text as non-visible and still falls back", async () => {
+    harnessState.streamParts = [{ type: "finish", finishReason: "stop" }];
+    harnessState.finalText = "   \n  ";
+
+    const result = await runHarnessTurn(baseOptions() as any, "none");
+
+    expect(result.messageHistory.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT }],
+    });
+  });
+
+  it("treats a whitespace-only streamed text-delta as non-visible and still falls back", async () => {
+    harnessState.streamParts = [
+      { type: "text-delta", delta: " \n " },
+      { type: "finish", finishReason: "stop" },
+    ];
+    harnessState.finalText = "";
+
+    const result = await runHarnessTurn(baseOptions() as any, "none");
+
+    const lastMessage = result.messageHistory.at(-1) as {
+      role: string;
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(lastMessage.role).toBe("assistant");
+    // The empty-output fallback appends onto the same open text part (it's
+    // what the harness actually said, plus the fallback notice) rather than
+    // being dropped for having "already produced text" — whitespace alone
+    // must not satisfy the "visible part" check.
+    expect(lastMessage.content[0]).toMatchObject({
+      type: "text",
+      text: " \n " + HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT,
+    });
+  });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelMessage } from "@ai-sdk/provider-utils";
+
+const harnessState = vi.hoisted(() => ({
+  streamParts: [] as Array<Record<string, unknown> & { type?: string }>,
+  finalText: "",
+  session: {
+    sessionId: "session-1",
+    stop: vi.fn(async () => ({})),
+    destroy: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("@ai-sdk/harness/agent", () => ({
+  HarnessAgent: class {
+    createSession = vi.fn(async () => harnessState.session);
+    stream = vi.fn(async () => ({
+      fullStream: (async function* () {
+        for (const part of harnessState.streamParts) {
+          yield part;
+        }
+      })(),
+      text: Promise.resolve(harnessState.finalText),
+    }));
+  },
+}));
+
+vi.mock("../registry.js", () => ({
+  buildBrokerDummyAuth: vi.fn(),
+  getHarnessAdapter: vi.fn(() => ({
+    id: "claude-code",
+    displayName: "Claude Code",
+    defaultPermissionMode: "allow-all",
+    supportsSkills: false,
+    supportsSelectedMcpServers: false,
+    supportsModel: vi.fn(() => true),
+    resolveAuth: vi.fn(async () => ({ gateway: { apiKey: "key" } })),
+    createHarness: vi.fn(() => ({ harnessId: "claude-code" })),
+    parseToolName: vi.fn((toolName: string) => ({ toolName })),
+  })),
+}));
+
+vi.mock("../resolve-sandbox.js", () => ({
+  resolveHarnessSandbox: vi.fn(async () => ({
+    computerId: "computer-1",
+    sandboxId: "sandbox-1",
+  })),
+}));
+
+vi.mock("../e2b-sandbox-provider.js", () => ({
+  createE2BHarnessSandboxProvider: vi.fn(() => ({
+    sandboxId: "sandbox-1",
+  })),
+}));
+
+vi.mock("../runtime-skills.js", () => ({
+  claudeCodeSafeSkills: vi.fn((skills) => skills),
+  fetchRuntimeSkills: vi.fn(async () => ({ ok: true, skills: [] })),
+  skillsFingerprint: vi.fn(() => "empty-skills"),
+}));
+
+vi.mock("../reconcile-skill-dirs.js", () => ({
+  reconcileSkillDirs: vi.fn(async () => {}),
+}));
+
+vi.mock("../harness-session-state.js", () => ({
+  claimHarnessSessionState: vi.fn(async () => ({
+    ok: true,
+    leaseId: "lease-1",
+    stateVersion: 1,
+    state: null,
+    fingerprintChanged: false,
+  })),
+  heartbeatHarnessSessionState: vi.fn(async () => "ok"),
+  releaseHarnessSessionState: vi.fn(async () => {}),
+}));
+
+vi.mock("../harness-model-broker.js", () => ({
+  revokeHarnessModelBroker: vi.fn(async () => {}),
+  startHarnessModelBroker: vi.fn(async () => ({
+    ok: true,
+    proxyBaseUrl: "https://broker.example",
+  })),
+}));
+
+vi.mock("../mcp-config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../mcp-config.js")>();
+  return {
+    ...actual,
+    buildHarnessMcpJson: vi.fn(() => ({ mcpServers: {} })),
+    harnessServerInputFromConfig: vi.fn(),
+    harnessServerKeyToName: vi.fn((key: string) => key),
+  };
+});
+
+import {
+  HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT,
+  runHarnessTurn,
+} from "../run-harness-turn";
+
+function baseOptions(overrides: Record<string, unknown> = {}) {
+  const messages: ModelMessage[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "create a file called empty.txt" }],
+    } as unknown as ModelMessage,
+  ];
+
+  return {
+    messages,
+    modelId: "anthropic/claude-sonnet-4-6",
+    provider: "anthropic",
+    systemPrompt: "You are Claude Code.",
+    authHeader: "Bearer test",
+    projectId: "project-1",
+    mcpClientManager: { getServerConfig: vi.fn() },
+    selectedServers: [],
+    requireToolApproval: false,
+    sourceType: "eval",
+    harness: "claude-code",
+    ...overrides,
+  };
+}
+
+describe("runHarnessTurn empty output projection", () => {
+  beforeEach(() => {
+    harnessState.streamParts = [];
+    harnessState.finalText = "";
+    harnessState.session.stop.mockClear();
+    harnessState.session.destroy.mockClear();
+  });
+
+  it("persists a visible assistant fallback when the harness finishes with no renderable parts", async () => {
+    harnessState.streamParts = [
+      {
+        type: "finish",
+        finishReason: "stop",
+        totalUsage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 },
+      },
+    ];
+
+    const result = await runHarnessTurn(baseOptions() as any, "none");
+
+    expect(result.messageHistory.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT }],
+    });
+  });
+
+  it("uses authoritative final text instead of the empty-output fallback", async () => {
+    harnessState.streamParts = [{ type: "finish", finishReason: "stop" }];
+    harnessState.finalText = "Created empty.txt";
+
+    const result = await runHarnessTurn(baseOptions() as any, "none");
+
+    expect(result.messageHistory.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Created empty.txt" }],
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -373,8 +373,13 @@ function toClaudeCodeModel(modelId: string): string | undefined {
   const withoutProvider = m.startsWith("anthropic/")
     ? m.slice("anthropic/".length)
     : m;
+  // Trailing (?:-\d+)? absorbs an optional dated/pinned snapshot suffix
+  // (e.g. "claude-haiku-4-5-20251001", the exact shape Claude Code's own
+  // internal alias resolution can produce on the wire — see the bridge's
+  // modelOverrides keys below) without being captured; the return value only
+  // ever depends on family/major/minor, same as the undated shape.
   const match = withoutProvider.match(
-    /^claude-(haiku|sonnet|opus)-(\d+)(?:[.-](\d+))?$/
+    /^claude-(haiku|sonnet|opus)-(\d+)(?:[.-](\d+))?(?:-\d+)?$/
   );
   if (match) {
     const [, family, major, minor] = match;

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -373,13 +373,18 @@ function toClaudeCodeModel(modelId: string): string | undefined {
   const withoutProvider = m.startsWith("anthropic/")
     ? m.slice("anthropic/".length)
     : m;
-  // Trailing (?:-\d+)? absorbs an optional dated/pinned snapshot suffix
+  // Trailing 8-digit date absorbs an optional dated/pinned snapshot suffix
   // (e.g. "claude-haiku-4-5-20251001", the exact shape Claude Code's own
   // internal alias resolution can produce on the wire — see the bridge's
   // modelOverrides keys below) without being captured; the return value only
-  // ever depends on family/major/minor, same as the undated shape.
+  // ever depends on family/major/minor, same as the undated shape. The
+  // alternation tries the bare "major + date, no minor" shape FIRST
+  // (-\d{8}) — a plain (?:-\d+)? suffix here is wrong: the earlier optional
+  // minor group's greedy \d+ swallows the date digits as if they were a
+  // minor version (e.g. "claude-opus-4-20250929" -> minor="20250929"),
+  // producing an invalid native model string instead of "claude-opus-4".
   const match = withoutProvider.match(
-    /^claude-(haiku|sonnet|opus)-(\d+)(?:[.-](\d+))?(?:-\d+)?$/
+    /^claude-(haiku|sonnet|opus)-(\d+)(?:-\d{8}|[.-](\d+)(?:-\d{8})?)?$/
   );
   if (match) {
     const [, family, major, minor] = match;

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -184,15 +184,15 @@ const CLAUDE_CODE_BRIDGE_TEXT_STATE_NEEDLE =
   "let streamStarted = false;\n  const partialBlocks";
 const CLAUDE_CODE_BRIDGE_TEXT_STATE_PATCH = `let streamStarted = false;
   let streamedAssistantText = false;
-  const emittedAssistantTextFallbacks = new Set();
+  let lastEmittedFallbackText;
   const emitAssistantTextFallback = (text) => {
     const normalized = typeof text === "string" ? text : "";
-    if (!normalized || streamedAssistantText || emittedAssistantTextFallbacks.has(normalized)) return;
+    if (!normalized || streamedAssistantText || normalized === lastEmittedFallbackText) return;
     const id = randomUUID();
     emit({ type: "text-start", id });
     emit({ type: "text-delta", id, delta: normalized });
     emit({ type: "text-end", id });
-    emittedAssistantTextFallbacks.add(normalized);
+    lastEmittedFallbackText = normalized;
   };
   const partialBlocks`;
 const CLAUDE_CODE_BRIDGE_STREAM_EVENT_NEEDLE = `if (type === "stream_event") {
@@ -373,12 +373,16 @@ function toClaudeCodeModel(modelId: string): string | undefined {
   const withoutProvider = m.startsWith("anthropic/")
     ? m.slice("anthropic/".length)
     : m;
-  if (withoutProvider.includes("haiku")) return "haiku";
   const match = withoutProvider.match(
     /^claude-(haiku|sonnet|opus)-(\d+)(?:[.-](\d+))?$/
   );
   if (match) {
     const [, family, major, minor] = match;
+    // Claude Code accepts "haiku" as a selectable main model but rejects the
+    // native shape ("claude-haiku-4-5") — only THIS shortcut needs the alias;
+    // gated on the regex match so it can't fire for a non-Anthropic or
+    // malformed id that merely contains "haiku" as a substring.
+    if (family === "haiku") return "haiku";
     return `claude-${family}-${major}${minor ? `-${minor}` : ""}`;
   }
   if (

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -177,18 +177,217 @@ export type HarnessRuntimeAdapter = {
   deliverMcpServers?(args: HarnessMcpDeliveryArgs): Promise<void>;
 };
 
-/** Map a host model id (gateway `creator/model`, e.g. `anthropic/claude-haiku-4.5`)
- *  to a Claude Code CLI-native alias. The CLI accepts `sonnet|opus|haiku` and
- *  resolves them to its current model; it does NOT understand the gateway
- *  `creator/model` form (passing it makes the CLI do zero inference). Unknown ⇒
- *  undefined (let the CLI use its default). */
-function toClaudeCodeModel(
-  modelId: string
-): "haiku" | "sonnet" | "opus" | undefined {
+const CLAUDE_CODE_BRIDGE_USER_MESSAGE_NEEDLE = 'type: "user",\n    message: {';
+const CLAUDE_CODE_BRIDGE_USER_MESSAGE_PATCH =
+  'type: "user",\n    parent_tool_use_id: null,\n    message: {';
+const CLAUDE_CODE_BRIDGE_TEXT_STATE_NEEDLE =
+  "let streamStarted = false;\n  const partialBlocks";
+const CLAUDE_CODE_BRIDGE_TEXT_STATE_PATCH = `let streamStarted = false;
+  let streamedAssistantText = false;
+  const emittedAssistantTextFallbacks = new Set();
+  const emitAssistantTextFallback = (text) => {
+    const normalized = typeof text === "string" ? text : "";
+    if (!normalized || streamedAssistantText || emittedAssistantTextFallbacks.has(normalized)) return;
+    const id = randomUUID();
+    emit({ type: "text-start", id });
+    emit({ type: "text-delta", id, delta: normalized });
+    emit({ type: "text-end", id });
+    emittedAssistantTextFallbacks.add(normalized);
+  };
+  const partialBlocks`;
+const CLAUDE_CODE_BRIDGE_STREAM_EVENT_NEEDLE = `if (type === "stream_event") {
+        handleStreamEvent(msg.event, partialBlocks, emit);
+        continue;
+      }`;
+const CLAUDE_CODE_BRIDGE_STREAM_EVENT_PATCH = `if (type === "stream_event") {
+        if (msg.event?.type === "content_block_delta" && msg.event?.delta?.type === "text_delta" && typeof msg.event?.delta?.text === "string" && msg.event.delta.text.length > 0) {
+          streamedAssistantText = true;
+        }
+        handleStreamEvent(msg.event, partialBlocks, emit);
+        continue;
+      }`;
+const CLAUDE_CODE_BRIDGE_ASSISTANT_TEXT_NEEDLE = `for (const block of msg.message.content) {
+          if (block.type === "tool_use"`;
+const CLAUDE_CODE_BRIDGE_ASSISTANT_TEXT_PATCH = `for (const block of msg.message.content) {
+          if (block.type === "text" && typeof block.text === "string") {
+            emitAssistantTextFallback(block.text);
+            continue;
+          }
+          if (block.type === "tool_use"`;
+const CLAUDE_CODE_BRIDGE_RESULT_TEXT_NEEDLE = `const emptyResult = !msg.result?.trim?.();
+          if (emptyResult && observedTerminalError) {`;
+const CLAUDE_CODE_BRIDGE_RESULT_TEXT_PATCH = `const emptyResult = !msg.result?.trim?.();
+          if (!emptyResult) {
+            emitAssistantTextFallback(msg.result);
+          }
+          if (emptyResult && observedTerminalError) {`;
+const CLAUDE_CODE_BRIDGE_MODEL_OVERRIDES_NEEDLE = `const permissionOptions = createPermissionOptions({
+    start,
+    turn,
+    emit,
+    nativeToolCallNames,
+    approvalRequestedToolUseIds
+  });`;
+const CLAUDE_CODE_BRIDGE_MODEL_OVERRIDES_PATCH = `const permissionOptions = createPermissionOptions({
+    start,
+    turn,
+    emit,
+    nativeToolCallNames,
+    approvalRequestedToolUseIds
+  });
+  const gatewayModelOverridesForClaudeModel = (model) => {
+    if (typeof model !== "string") return undefined;
+    if (model === "haiku") {
+      return {
+        haiku: "anthropic/claude-haiku-4.5",
+        "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
+        "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4.5"
+      };
+    }
+    if (!model.startsWith("claude-")) return undefined;
+    const match = model.match(/^claude-(haiku|sonnet|opus)-(\\d+)(?:-(\\d+))?$/);
+    if (!match) return undefined;
+    const [, family, major, minor] = match;
+    return {
+      [model]: \`anthropic/claude-\${family}-\${major}\${minor ? \`.\${minor}\` : ""}\`
+    };
+  };
+  const gatewayModelOverrides = gatewayModelOverridesForClaudeModel(start.model);
+  const gatewayModelOverrideSettings = gatewayModelOverrides
+    ? { modelOverrides: gatewayModelOverrides }
+    : undefined;
+  // AI Gateway's Anthropic-compat schema rejects the newer output_config.effort
+  // request field ("400 output_config.effort: Extra inputs are not permitted").
+  // "unset" makes the CLI omit the field entirely (verified in CLI 0.2.x-2.1.x:
+  // CLAUDE_CODE_EFFORT_LEVEL of "unset"/"auto" short-circuits effort resolution).
+  // The CLI runs as a child of this bridge process, so it inherits this env;
+  // ??= keeps any operator-provided override authoritative.
+  process.env.CLAUDE_CODE_EFFORT_LEVEL ??= "unset";`;
+const CLAUDE_CODE_BRIDGE_QUERY_OPTIONS_NEEDLE = `...start.model ? { model: start.model } : {},
+      ...start.maxTurns !== void 0 ? { maxTurns: start.maxTurns } : {},`;
+const CLAUDE_CODE_BRIDGE_QUERY_OPTIONS_PATCH = `...start.model ? { model: start.model } : {},
+      ...(gatewayModelOverrideSettings ? { settings: gatewayModelOverrideSettings } : {}),
+      ...start.maxTurns !== void 0 ? { maxTurns: start.maxTurns } : {},`;
+
+function patchClaudeCodeBridgeContent(content: string): string {
+  let patched = content;
+  if (!patched.includes("parent_tool_use_id")) {
+    if (!patched.includes(CLAUDE_CODE_BRIDGE_USER_MESSAGE_NEEDLE)) {
+      throw new Error(
+        "Unable to patch Claude Code bridge bootstrap: user-message shape changed"
+      );
+    }
+    patched = patched.replace(
+      CLAUDE_CODE_BRIDGE_USER_MESSAGE_NEEDLE,
+      CLAUDE_CODE_BRIDGE_USER_MESSAGE_PATCH
+    );
+  }
+
+  if (!patched.includes("emitAssistantTextFallback")) {
+    for (const [needle, replacement] of [
+      [
+        CLAUDE_CODE_BRIDGE_TEXT_STATE_NEEDLE,
+        CLAUDE_CODE_BRIDGE_TEXT_STATE_PATCH,
+      ],
+      [
+        CLAUDE_CODE_BRIDGE_STREAM_EVENT_NEEDLE,
+        CLAUDE_CODE_BRIDGE_STREAM_EVENT_PATCH,
+      ],
+      [
+        CLAUDE_CODE_BRIDGE_ASSISTANT_TEXT_NEEDLE,
+        CLAUDE_CODE_BRIDGE_ASSISTANT_TEXT_PATCH,
+      ],
+      [
+        CLAUDE_CODE_BRIDGE_RESULT_TEXT_NEEDLE,
+        CLAUDE_CODE_BRIDGE_RESULT_TEXT_PATCH,
+      ],
+    ] as const) {
+      if (!patched.includes(needle)) {
+        throw new Error(
+          "Unable to patch Claude Code bridge bootstrap: assistant text shape changed"
+        );
+      }
+      patched = patched.replace(needle, replacement);
+    }
+  }
+
+  if (!patched.includes("gatewayModelOverrideSettings")) {
+    for (const [needle, replacement] of [
+      [
+        CLAUDE_CODE_BRIDGE_MODEL_OVERRIDES_NEEDLE,
+        CLAUDE_CODE_BRIDGE_MODEL_OVERRIDES_PATCH,
+      ],
+      [
+        CLAUDE_CODE_BRIDGE_QUERY_OPTIONS_NEEDLE,
+        CLAUDE_CODE_BRIDGE_QUERY_OPTIONS_PATCH,
+      ],
+    ] as const) {
+      if (!patched.includes(needle)) {
+        throw new Error(
+          "Unable to patch Claude Code bridge bootstrap: model override shape changed"
+        );
+      }
+      patched = patched.replace(needle, replacement);
+    }
+  }
+
+  return patched;
+}
+
+export function patchClaudeCodeHarnessBootstrap(
+  harness: HarnessAgentAdapter
+): HarnessAgentAdapter {
+  const originalGetBootstrap = harness.getBootstrap?.bind(harness);
+  if (!originalGetBootstrap) return harness;
+
+  let cachedPatchedBootstrap:
+    | Awaited<ReturnType<NonNullable<typeof originalGetBootstrap>>>
+    | undefined;
+
+  return {
+    ...harness,
+    getBootstrap: async (...args) => {
+      if (cachedPatchedBootstrap) return cachedPatchedBootstrap;
+      const bootstrap = await originalGetBootstrap(...args);
+      cachedPatchedBootstrap = {
+        ...bootstrap,
+        files: bootstrap.files.map((file) =>
+          file.path.endsWith("/bridge.mjs")
+            ? { ...file, content: patchClaudeCodeBridgeContent(file.content) }
+            : file
+        ),
+      };
+      return cachedPatchedBootstrap;
+    },
+  };
+}
+
+/** Map a host model id (Gateway `creator/model`, e.g.
+ *  `anthropic/claude-opus-4.7`) to a Claude Code native model id. Haiku is the
+ *  exception: Claude Code accepts the `haiku` alias as a main model, but rejects
+ *  `claude-haiku-4-5` as a selectable main model. The patched bridge adds
+ *  `settings.modelOverrides` so aliases/native ids still talk to the Gateway
+ *  provider-specific id on the wire. */
+function toClaudeCodeModel(modelId: string): string | undefined {
   const m = modelId.toLowerCase();
-  if (m.includes("haiku")) return "haiku";
-  if (m.includes("opus")) return "opus";
-  if (m.includes("sonnet")) return "sonnet";
+  const withoutProvider = m.startsWith("anthropic/")
+    ? m.slice("anthropic/".length)
+    : m;
+  if (withoutProvider.includes("haiku")) return "haiku";
+  const match = withoutProvider.match(
+    /^claude-(haiku|sonnet|opus)-(\d+)(?:[.-](\d+))?$/
+  );
+  if (match) {
+    const [, family, major, minor] = match;
+    return `claude-${family}-${major}${minor ? `-${minor}` : ""}`;
+  }
+  if (
+    withoutProvider === "haiku" ||
+    withoutProvider === "sonnet" ||
+    withoutProvider === "opus"
+  ) {
+    return withoutProvider;
+  }
   return undefined;
 }
 
@@ -269,13 +468,18 @@ function memoizedBuiltinTools(
 /** Shared credential resolver — both harnesses fetch the same member-gated AI
  *  Gateway key from Convex and map it to `auth.gateway`. SECURITY: a `baseUrl`
  *  is always passed so the adapter never falls back to the host env for the
- *  gateway base URL (see `MCPJAM_GATEWAY_BASE_URL`). */
-async function resolveGatewayAuth(args: {
-  projectId: string;
-  modelId: string;
-  bearer: string;
-  signal?: AbortSignal;
-}): Promise<HarnessGatewayAuth> {
+ *  gateway base URL (see `MCPJAM_GATEWAY_BASE_URL`). Each adapter supplies a
+ *  `normalizeBaseUrl` because one Convex-issued URL can't serve both wire
+ *  protocols (see the normalizers below). */
+async function resolveGatewayAuth(
+  args: {
+    projectId: string;
+    modelId: string;
+    bearer: string;
+    signal?: AbortSignal;
+  },
+  normalizeBaseUrl: (baseUrl: string) => string
+): Promise<HarnessGatewayAuth> {
   const result = await fetchHarnessModelCredential({
     projectId: args.projectId,
     modelId: args.modelId,
@@ -291,14 +495,32 @@ async function resolveGatewayAuth(args: {
       // Always present: prefer the Convex-issued base URL, else the expected
       // Gateway default — never undefined (which would let the adapter read the
       // host env for the base URL).
-      baseUrl: result.credential.baseUrl ?? MCPJAM_GATEWAY_BASE_URL,
+      baseUrl: normalizeBaseUrl(
+        result.credential.baseUrl ?? MCPJAM_GATEWAY_BASE_URL
+      ),
     },
   };
 }
 
 /** The expected AI Gateway base URL. Used as the fail-safe default so an adapter
- *  can never resolve the gateway base URL from the host environment. */
+ *  can never resolve the gateway base URL from the host environment. Adapters
+ *  normalize it per wire protocol before use. */
 const MCPJAM_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1";
+
+/** Claude Code's CLI speaks the Anthropic protocol and joins
+ *  `${ANTHROPIC_BASE_URL}/v1/messages` itself, so its gateway base must be the
+ *  bare origin — a `/v1`-suffixed base yields `…/v1/v1/messages`, which the
+ *  live gateway 404s on every model call. */
+export function toAnthropicGatewayBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "").replace(/\/v1$/, "");
+}
+
+/** Codex's CLI treats `OPENAI_BASE_URL` as an OpenAI-compatible `/v1` root
+ *  (`/chat/completions` etc. live directly under it), so ensure the suffix. */
+export function toOpenAiCompatGatewayBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
+}
 
 const claudeCodeAdapter: HarnessRuntimeAdapter = {
   id: "claude-code",
@@ -313,10 +535,10 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
   // Claude Code does not emit file-change stream parts.
   fileChangeToolName: undefined,
   listBuiltinTools: memoizedBuiltinTools(() => createClaudeCode()),
-  resolveAuth: resolveGatewayAuth,
+  resolveAuth: (args) => resolveGatewayAuth(args, toAnthropicGatewayBaseUrl),
   toNativeModel: toClaudeCodeModel,
-  // The CLI runs any model it's pointed at (haiku/sonnet/opus map to aliases,
-  // others ride the gateway default); never block on model here.
+  // The CLI runs any Anthropic model we map into its native id shape; other
+  // providers are left to the runtime default rather than blocked in preflight.
   supportsModel: () => true,
   parseToolName: parseHarnessToolName,
   async deliverMcpServers({ writeTextFile, sessionWorkDir, mcpJson }) {
@@ -332,10 +554,17 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
     // Dual-`ai` boundary cast: createClaudeCode returns a HarnessV1 from its own
     // (nested) @ai-sdk/harness copy, nominally distinct from this server's copy
     // that HarnessAgent uses. Structurally identical; the drive reads loosely.
-    return createClaudeCode({
-      ...(nativeModel ? { model: nativeModel } : {}),
-      auth,
-    }) as unknown as HarnessAgentAdapter;
+    return patchClaudeCodeHarnessBootstrap(
+      createClaudeCode({
+        ...(nativeModel ? { model: nativeModel } : {}),
+        auth,
+        // Unset, Claude Code defaults to ADAPTIVE thinking, a first-party
+        // Anthropic API shape the AI Gateway's Anthropic-compat schema rejects
+        // (400: expected 'disabled' | 'enabled'). Pin thinking off until the
+        // gateway accepts adaptive.
+        thinking: "off",
+      }) as unknown as HarnessAgentAdapter
+    );
   },
 };
 
@@ -359,7 +588,7 @@ const codexAdapter: HarnessRuntimeAdapter = {
   // originate from a model-callable tool); we render them as this native tool.
   fileChangeToolName: "fileChange",
   listBuiltinTools: memoizedBuiltinTools(() => createCodex()),
-  resolveAuth: resolveGatewayAuth,
+  resolveAuth: (args) => resolveGatewayAuth(args, toOpenAiCompatGatewayBaseUrl),
   toNativeModel: toCodexModel,
   // Codex only runs the gpt-5 family it maps; anything else would silently fall
   // back to Codex's default model, so the preflight rejects it.

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -817,7 +817,13 @@ export async function runHarnessTurn(
           emitTextDelta(writer, finalTextId, text);
           emitTextEnd(writer, finalTextId);
           emittedAnyText = true;
-          emittedAnyVisiblePart = true;
+          // Whitespace-only text renders as a blank message to the user, so it
+          // must not count toward the "produced visible output" completeness
+          // check below (else a whitespace-only harness answer would silently
+          // skip the HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT fallback).
+          if (text.trim().length > 0) {
+            emittedAnyVisiblePart = true;
+          }
           onLiveTextDelta?.(text);
           const lastPart = assistantParts[assistantParts.length - 1];
           if (lastPart && lastPart.type === "text") {
@@ -984,7 +990,10 @@ export async function runHarnessTurn(
             }
             emitTextDelta(writer, textId, delta);
             emittedAnyText = true;
-            emittedAnyVisiblePart = true;
+            // See the whitespace-only note on projectAssistantText above.
+            if (delta.trim().length > 0) {
+              emittedAnyVisiblePart = true;
+            }
             onLiveTextDelta?.(delta);
           } else if (type === "tool-call" || type === "tool-input-available") {
             // A tool-call after tool results begins the next step.
@@ -1253,7 +1262,7 @@ export async function runHarnessTurn(
         if (
           !emittedAnyText &&
           typeof finalText === "string" &&
-          finalText.length > 0
+          finalText.trim().length > 0
         ) {
           // Final assistant text after tool results begins the next step — flush
           // the pending tool segment FIRST (mirrors the `text-delta` path),

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -100,7 +100,7 @@ import {
 type ChunkWriter = { write: (chunk: UIMessageChunk) => void };
 
 export const HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT =
-  "Claude Code completed the turn without returning a visible message.";
+  "The harness completed the turn without returning a visible message.";
 
 /**
  * Resolve the model credential the harness hands to the in-sandbox CLI — from

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -99,6 +99,9 @@ import {
  *  what the no-op (`streamSink: "none"`) path supplies. */
 type ChunkWriter = { write: (chunk: UIMessageChunk) => void };
 
+export const HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT =
+  "Claude Code completed the turn without returning a visible message.";
+
 /**
  * Resolve the model credential the harness hands to the in-sandbox CLI — from
  * Convex, like every other model key (keys live in Convex; the inspector holds
@@ -172,6 +175,10 @@ const HARNESS_INSTANCE_ID = crypto.randomUUID();
  *  run bound (we heartbeat well within it). */
 const HARNESS_LEASE_TTL_MS = 5 * 60_000;
 const HARNESS_HEARTBEAT_MS = 90_000;
+// v7: gateway base URL normalization (Anthropic-protocol origin without /v1) —
+// resumed sessions reconnect to a bridge process holding the OLD env, so force
+// fresh sessions to pick up the corrected ANTHROPIC_BASE_URL.
+const HARNESS_RUNTIME_COMPAT_VERSION = 7;
 
 /** Stable hash of the session-scoped runtime inputs. A change forces a fresh
  *  harness session (a resumed Claude Code thread keeps the model/tools it was
@@ -194,6 +201,7 @@ export function harnessRuntimeFingerprint(parts: {
   permissionMode: string;
 }): string {
   const s = [
+    String(HARNESS_RUNTIME_COMPAT_VERSION),
     (parts.selectedServers ?? []).slice().sort().join(","),
     parts.permissionMode,
   ].join("");
@@ -338,6 +346,8 @@ export async function runHarnessTurn(
     // parts, this stays false and we synthesize chunks from `res.text` below so
     // the Chat pane never renders a blank reply on a successful turn.
     let emittedAnyText = false;
+    let emittedAnyVisiblePart = false;
+    const seenHarnessPartTypes = new Set<string>();
 
     try {
       if (!projectId) {
@@ -801,6 +811,21 @@ export async function runHarnessTurn(
           output: unknown;
           isError: boolean;
         }> = [];
+        const projectAssistantText = (text: string) => {
+          const finalTextId = crypto.randomUUID();
+          emitTextStart(writer, finalTextId);
+          emitTextDelta(writer, finalTextId, text);
+          emitTextEnd(writer, finalTextId);
+          emittedAnyText = true;
+          emittedAnyVisiblePart = true;
+          onLiveTextDelta?.(text);
+          const lastPart = assistantParts[assistantParts.length - 1];
+          if (lastPart && lastPart.type === "text") {
+            lastPart.text += text;
+          } else {
+            assistantParts.push({ type: "text", text });
+          }
+        };
         const flushSegment = () => {
           if (assistantParts.length > 0) {
             const assistantMsgIndex = messageHistory.length;
@@ -915,6 +940,8 @@ export async function runHarnessTurn(
           turnId,
           promptIndex,
           modelId,
+          engine: "harness",
+          harness,
           traceBaseMs,
           spans: capturedSpans,
           onStepFinish,
@@ -930,6 +957,7 @@ export async function runHarnessTurn(
             break;
           }
           const type = part.type;
+          if (typeof type === "string") seenHarnessPartTypes.add(type);
           if (type === "text-delta" || type === "text") {
             const delta = String(
               (part as { text?: unknown; delta?: unknown }).delta ??
@@ -956,6 +984,7 @@ export async function runHarnessTurn(
             }
             emitTextDelta(writer, textId, delta);
             emittedAnyText = true;
+            emittedAnyVisiblePart = true;
             onLiveTextDelta?.(delta);
           } else if (type === "tool-call" || type === "tool-input-available") {
             // A tool-call after tool results begins the next step.
@@ -1009,6 +1038,7 @@ export async function runHarnessTurn(
               input,
               providerExecuted: true,
             });
+            emittedAnyVisiblePart = true;
             await onToolCall?.({
               toolCallId,
               toolName,
@@ -1119,6 +1149,7 @@ export async function runHarnessTurn(
                 input,
                 providerExecuted: true,
               });
+              emittedAnyVisiblePart = true;
               await onToolCall?.({
                 toolCallId,
                 toolName: fcName,
@@ -1234,18 +1265,18 @@ export async function runHarnessTurn(
             flushSegment();
             finishStep();
           }
-          const finalTextId = crypto.randomUUID();
-          emitTextStart(writer, finalTextId);
-          emitTextDelta(writer, finalTextId, finalText);
-          emitTextEnd(writer, finalTextId);
-          emittedAnyText = true;
-          onLiveTextDelta?.(finalText);
-          const lastPart = assistantParts[assistantParts.length - 1];
-          if (lastPart && lastPart.type === "text") {
-            lastPart.text += finalText;
-          } else {
-            assistantParts.push({ type: "text", text: finalText });
-          }
+          projectAssistantText(finalText);
+        }
+
+        if (!emittedAnyVisiblePart) {
+          const streamTypes =
+            [...seenHarnessPartTypes].sort().join(",") || "none";
+          const finalTextLength =
+            typeof finalText === "string" ? finalText.length : 0;
+          logger.warn(
+            `[harness] completed without visible chat parts; streamTypes=${streamTypes}; finalTextLength=${finalTextLength}`
+          );
+          projectAssistantText(HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT);
         }
 
         // Flush the final step's assistant message + its tool results. Earlier

--- a/mcpjam-inspector/server/utils/stream-turn-driver.ts
+++ b/mcpjam-inspector/server/utils/stream-turn-driver.ts
@@ -69,6 +69,8 @@ export interface StreamTurnDriverOptions {
   turnId: string;
   promptIndex: number;
   modelId: string;
+  engine?: "emulated" | "harness";
+  harness?: string;
   /** Span-offset zero point — set to STREAM start (after setup), so live and
    *  rehydrated traces align. Both engines clock spans from here. */
   traceBaseMs: number;
@@ -88,6 +90,8 @@ export class StreamTurnDriver {
   readonly turnId: string;
   readonly promptIndex: number;
   readonly modelId: string;
+  readonly engine?: "emulated" | "harness";
+  readonly harness?: string;
   readonly traceBaseMs: number;
   readonly spans: EvalTraceSpan[];
 
@@ -108,6 +112,8 @@ export class StreamTurnDriver {
     this.turnId = opts.turnId;
     this.promptIndex = opts.promptIndex;
     this.modelId = opts.modelId;
+    this.engine = opts.engine;
+    this.harness = opts.harness;
     this.traceBaseMs = opts.traceBaseMs;
     this.spans = opts.spans;
     this.onStepFinishCb = opts.onStepFinish;
@@ -129,6 +135,8 @@ export class StreamTurnDriver {
       turnId: this.turnId,
       promptIndex: this.promptIndex,
       startedAtMs: this.traceBaseMs,
+      ...(this.engine ? { engine: this.engine } : {}),
+      ...(this.harness ? { harness: this.harness } : {}),
     });
     this.started = true;
   }

--- a/mcpjam-inspector/shared/live-chat-trace.ts
+++ b/mcpjam-inspector/shared/live-chat-trace.ts
@@ -59,6 +59,8 @@ export type LiveChatTraceEvent =
       turnId: string;
       promptIndex: number;
       startedAtMs: number;
+      engine?: "emulated" | "harness";
+      harness?: string;
     }
   | {
       type: "text_delta";


### PR DESCRIPTION
## Summary
- Claude Code's CLI joins `${ANTHROPIC_BASE_URL}/v1/messages` itself, but the harness registry always suffixed the gateway base URL with `/v1` → every model call hit `.../v1/v1/messages` → 404. Normalize the base URL per adapter's wire protocol instead of one shared constant (Claude Code wants the bare origin; Codex's OpenAI-compat CLI wants a `/v1` root).
- With the URL fixed, the CLI's default request body still 400'd: it sends `thinking: {type: "adaptive"}` and `output_config.effort`, both newer Anthropic API fields the gateway's Anthropic-compat schema rejects. Pin `thinking: "off"` via the adapter's documented setting, and set `CLAUDE_CODE_EFFORT_LEVEL=unset` in the patched bridge bootstrap so `output_config.effort` is omitted from the request entirely (verified against the CLI's own effort-resolution logic).
- Bumped `HARNESS_RUNTIME_COMPAT_VERSION` so a resumed session (which would otherwise reconnect to a bridge process still holding the old `ANTHROPIC_BASE_URL`/effort env) is forced fresh and picks up the fix.

Diagnosed live end-to-end: 404 → thinking 400 → effort 400 → clean turn, each layer confirmed against real dev-deployment traffic and the vendored `@anthropic-ai/claude-agent-sdk` source.

## Test plan
- [x] `vitest run server/utils/harness/__tests__/ server/utils/__tests__/stream-turn-driver.test.ts` — 95/95 passing
- [x] `tsc --noEmit -p server/tsconfig.json` — no new errors vs. a clean `origin/main` baseline (4 pre-existing unrelated errors confirmed present on main itself)
- [x] Live verification against dev sandbox: Claude Code + Haiku 4.5 host, Playground chat, confirmed request reaches the gateway's real endpoint and passes schema validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes credential base URLs, in-sandbox bridge patching, and session resume fingerprinting on the harness model-call path; regressions would break Claude Code turns or strand resumed sessions until TTL.
> 
> **Overview**
> Fixes **Claude Code harness** calls against the AI Gateway by **normalizing gateway base URLs per adapter** (bare origin for Anthropic CLI vs `/v1` for Codex), **pinning gateway-incompatible request shapes** (`thinking: "off"`, bridge env to omit `output_config.effort`), and **patching the Claude Code bridge bootstrap** (user-message shape, assistant-text fallbacks, `settings.modelOverrides` for Gateway model ids).
> 
> **Model routing** moves from loose substring aliases to **regex mapping** for Gateway `anthropic/claude-*` ids (including dated snapshots), with **haiku** as the only short alias.
> 
> **Harness turns** now treat whitespace-only text as non-visible, prefer authoritative `res.text` when the stream had no text, and emit **`HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT`** when nothing visible was streamed. **`HARNESS_RUNTIME_COMPAT_VERSION` → 7** forces fresh sessions so resumed bridges pick up URL/env fixes.
> 
> **Tracing**: `turn_start` events can carry **`engine`** and **`harness`** (via `StreamTurnDriver` and shared trace types).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16657341c34426e5eb8a380009ffb20b3496dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude Code harness 400/404s against the AI Gateway by normalizing base URLs, pinning request shapes, and ensuring turns always produce a visible assistant message. Improves model routing and tracing so Anthropic IDs map correctly and traces tag the harness engine.

- **Bug Fixes**
  - Per-adapter Gateway base URL: Claude Code uses the bare origin (Anthropic), Codex uses `/v1` (OpenAI-compat).
  - Claude Code request shape: set `thinking: "off"`, set `CLAUDE_CODE_EFFORT_LEVEL=unset` to omit `output_config.effort`, add `parent_tool_use_id`, add assistant-text fallback with last-repeat dedup, treat whitespace-only text as non-visible, and add `settings.modelOverrides` so native/alias models route to `anthropic/claude-*`.
  - Model routing: regex mapping supports dated snapshots, including major-only dates (e.g., `anthropic/claude-opus-4-20250929` → `claude-opus-4`), maps `anthropic/claude-opus-4.7` → `claude-opus-4-7`, and only aliases `haiku` for valid Anthropic ids.
  - Turn projection and tracing: prefer authoritative `res.text` when present; emit a harness-agnostic empty-output fallback if nothing visible is streamed; tag `turn_start` with `engine: "harness"` and the `harness` id.

- **Migration**
  - Bumped `HARNESS_RUNTIME_COMPAT_VERSION` to 7 to force fresh sessions so the corrected env and base URL normalization take effect. Existing sessions will restart automatically.

<sup>Written for commit f16657341c34426e5eb8a380009ffb20b3496dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

