### PR TITLE
duplicate servers in incorrect orgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 worktrees/
+.worktrees/
 .cursor/
 node_modules/
 .mcpjam/skills/

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -999,6 +999,7 @@ export function AuthRoute() {
 export function OAuthFlowRoute() {
   const {
     appState,
+    displayServerConfigs,
     setSelectedServer,
     saveServerConfigWithoutConnecting,
     handleConnectWithTokensFromOAuthFlow,
@@ -1053,7 +1054,7 @@ export function OAuthFlowRoute() {
       }}
     >
       <OAuthFlowTab
-        serverConfigs={appState.servers}
+        serverConfigs={displayServerConfigs}
         selectedServerName={appState.selectedServer}
         onSelectServer={setSelectedServer}
         onSaveServerConfig={saveServerConfigWithoutConnecting}

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -76,6 +76,7 @@ const {
     isLoadingRemoteProjects: false,
     areServersHydrated: true,
     projectServers: {},
+    displayServerConfigs: {},
     connectedOrConnectingServerConfigs: {},
     selectedMCPConfig: null,
     handleConnect: vi.fn(),
@@ -128,6 +129,7 @@ const {
     mockOAuthFlowTabState: {
       shouldThrow: false,
       error: new Error("OAuth debugger failed"),
+      lastProps: undefined as unknown,
     },
     mockOrganizationsTab: vi.fn(() => <div />),
     mockPosthogCapture: vi.fn(),
@@ -359,7 +361,8 @@ vi.mock("../components/AuthTab", () => ({
   AuthTab: () => <div />,
 }));
 vi.mock("../components/OAuthFlowTab", () => ({
-  OAuthFlowTab: () => {
+  OAuthFlowTab: (props: unknown) => {
+    mockOAuthFlowTabState.lastProps = props;
     if (mockOAuthFlowTabState.shouldThrow) {
       throw mockOAuthFlowTabState.error;
     }
@@ -518,6 +521,7 @@ describe("App hosted OAuth callback handling", () => {
     mockMCPSidebar.mockImplementation(() => <div data-testid="mcp-sidebar" />);
     mockOAuthFlowTabState.shouldThrow = false;
     mockOAuthFlowTabState.error = new Error("OAuth debugger failed");
+    mockOAuthFlowTabState.lastProps = undefined;
     mockPosthogCapture.mockReset();
     mockPlaygroundTabMounts.mockReset();
     mockPlaygroundTabProps.mockReset();
@@ -2885,6 +2889,7 @@ describe("App hosted OAuth callback handling", () => {
       },
     };
     appStateMock.projectServers = currentProjectServers;
+    appStateMock.displayServerConfigs = currentProjectServers;
     appStateMock.appState.servers = {
       ...currentProjectServers,
       "other-project-oauth": {
@@ -2918,6 +2923,10 @@ describe("App hosted OAuth callback handling", () => {
     expect(latestProps.activeServerSelectorProps?.serverConfigs).toBe(
       currentProjectServers
     );
+    expect(
+      (mockOAuthFlowTabState.lastProps as { serverConfigs?: unknown })
+        .serverConfigs
+    ).toBe(currentProjectServers);
   });
 
   it("leaves the header server selector unfiltered outside the OAuth Debugger tab", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.hosted.test.tsx
@@ -289,6 +289,34 @@ describe("useAppState pending OAuth marker org preference", () => {
     expect(result.current.activeOrganizationId).toBe("org-from-marker");
   });
 
+  it("prefers the marker org over a valid stored org during the callback", async () => {
+    localStorage.setItem("active-organization-id:user-1", "org-stored");
+    writePendingMarker("org-from-marker");
+
+    const { result } = renderHook(() =>
+      useAppState({
+        currentUserId: "user-1",
+        routeOrganizationId: undefined,
+        hasOrganizations: true,
+        isLoadingOrganizations: false,
+        validOrganizations: [
+          { _id: "org-stored", myRole: "owner" },
+          { _id: "org-from-marker", myRole: "owner" },
+        ],
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.activeOrganizationId).toBe("org-from-marker");
+    });
+
+    await waitFor(() => {
+      expect(localStorage.getItem("active-organization-id:user-1")).toBe(
+        "org-from-marker"
+      );
+    });
+  });
+
   it("ignores the marker when the URL has no callback params (post-finalize / connection-failure path, #2)", async () => {
     // Simulate the post-callback state: URL has been cleaned by
     // finalizeHostedOAuth, even if the marker somehow survived.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -19,6 +19,7 @@ const {
   deleteProjectMock,
   projectQueryState,
   projectServersState,
+  useProjectServersMock,
   projectsBulkServersState,
   emitEmbeddedBlobReadMock,
   sentryCaptureMessageMock,
@@ -40,6 +41,7 @@ const {
     servers: undefined as any,
     isLoading: false as boolean,
   },
+  useProjectServersMock: vi.fn(),
   projectsBulkServersState: {
     serversByProject: {} as Record<string, any[]>,
     isLoading: false as boolean,
@@ -78,7 +80,7 @@ vi.mock("../useProjects", () => ({
     patchProjectDefaultConnection: patchProjectDefaultConnectionMock,
     deleteProject: deleteProjectMock,
   }),
-  useProjectServers: () => projectServersState,
+  useProjectServers: (...args: unknown[]) => useProjectServersMock(...args),
   useProjectsBulkServers: () => projectsBulkServersState,
 }));
 
@@ -238,6 +240,7 @@ describe("useProjectState automatic project creation", () => {
     patchProjectDefaultConnectionMock.mockResolvedValue(undefined);
     updateProjectMock.mockResolvedValue("remote-project-id");
     deleteProjectMock.mockResolvedValue(undefined);
+    useProjectServersMock.mockImplementation(() => projectServersState);
     projectQueryState.allProjects = [];
     projectQueryState.projects = [];
     projectQueryState.isLoading = false;
@@ -320,6 +323,53 @@ describe("useProjectState automatic project creation", () => {
 
     expect(ensureDefaultProjectMock).toHaveBeenLastCalledWith({
       organizationId: "org-c",
+    });
+  });
+
+  it("queries flat servers for the current org project when stored active project belongs to another org", () => {
+    localStorage.setItem(
+      "convex-active-project-id:test-actor",
+      "project-org-a",
+    );
+    projectQueryState.allProjects = [
+      {
+        _id: "project-org-a",
+        name: "Org A project",
+        servers: {},
+        ownerId: "user-1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        _id: "project-org-b",
+        name: "Org B project",
+        servers: {},
+        ownerId: "user-1",
+        organizationId: "org-b",
+        createdAt: 2,
+        updatedAt: 2,
+      },
+    ];
+    projectQueryState.projects = [projectQueryState.allProjects[1]];
+    projectServersState.servers = [];
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+    });
+    const { result } = renderUseProjectState({
+      appState,
+      activeOrganizationId: "org-b",
+      validOrganizationIds: ["org-a", "org-b"],
+    });
+
+    expect(result.current.effectiveActiveProjectId).toBe("project-org-b");
+    expect(result.current.activeProjectServersFlatProjectId).toBe(
+      "project-org-b",
+    );
+    expect(useProjectServersMock).toHaveBeenLastCalledWith({
+      projectId: "project-org-b",
+      isAuthenticated: true,
     });
   });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -245,6 +245,8 @@ function renderUseServerState(
     isAuthenticated?: boolean;
     isUserReady?: boolean;
     useLocalFallback?: boolean;
+    activeOrganizationId?: string;
+    restoreActiveOrganizationId?: (organizationId: string) => void;
     effectiveProjects?: AppState["projects"];
     effectiveActiveProjectId?: string;
     activeProjectServersFlat?: any;
@@ -267,6 +269,8 @@ function renderUseServerState(
       isAuthLoading: false,
       isLoadingProjects: false,
       useLocalFallback: options?.useLocalFallback ?? true,
+      activeOrganizationId: options?.activeOrganizationId,
+      restoreActiveOrganizationId: options?.restoreActiveOrganizationId,
       effectiveProjects: options?.effectiveProjects ?? appState.projects,
       effectiveActiveProjectId:
         options?.effectiveActiveProjectId ?? appState.activeProjectId,
@@ -667,6 +671,14 @@ describe("useServerState effective server projection", () => {
       }),
     });
     expect(result.current.projectServers).not.toHaveProperty(
+      "runtime-connected"
+    );
+    expect(result.current.displayServerConfigs).toEqual({
+      "persisted-server": expect.objectContaining({
+        name: "persisted-server",
+      }),
+    });
+    expect(result.current.displayServerConfigs).not.toHaveProperty(
       "runtime-connected"
     );
     expect(result.current.selectedMCPConfig).toBeUndefined();
@@ -1157,6 +1169,172 @@ describe("useServerState OAuth callback failures", () => {
     expect(window.location.pathname).toBe("/servers");
     expect(window.location.search).toBe("");
     expect(window.location.hash).toBe("");
+  });
+
+  it("syncs the hosted OAuth profile against the marker-pinned project, not the ambient active project", async () => {
+    // Regression: an OAuth server added in org A duplicated into the user's
+    // owned org because the post-callback sync resolved by name against the
+    // ambient active project (which had flipped to the fallback org's default
+    // project during the redirect remount) instead of the pinned target.
+    mockHostedMode.mockReturnValue(true);
+    localStorage.setItem(
+      "mcp-hosted-oauth-pending",
+      JSON.stringify({
+        surface: "project",
+        organizationId: "org_pinned",
+        projectId: "project_pinned",
+        serverId: "srv_pinned",
+        serverName: "bart",
+        serverUrl: "https://bart.example.com/mcp",
+        accessScope: "project_member",
+        returnPath: "/servers",
+        startedAt: Date.now(),
+      })
+    );
+    completeHostedOAuthCallbackMock.mockResolvedValue({
+      success: true,
+      serverName: "bart",
+      serverConfig: {
+        type: "http",
+        url: "https://bart.example.com/mcp",
+      },
+    });
+    mockConvexQuery.mockResolvedValue([
+      {
+        _id: "srv_pinned",
+        projectId: "project_pinned",
+        name: "bart",
+      },
+    ]);
+    mockUpdateServer.mockResolvedValue("srv_pinned");
+    window.history.replaceState({}, "", "/oauth/callback?code=test-code");
+
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_ambient";
+    const dispatch = vi.fn();
+    const restoreActiveOrganizationId = vi.fn();
+    renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      isUserReady: true,
+      useLocalFallback: false,
+      activeOrganizationId: "org_fallback",
+      restoreActiveOrganizationId,
+      effectiveProjects: appState.projects,
+      effectiveActiveProjectId: "project_ambient",
+      activeProjectServersFlat: [],
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateServer).toHaveBeenCalled();
+    });
+
+    // Existence was decided against the pinned project and the pinned row
+    // was updated in place — no create in the ambient project.
+    expect(mockConvexQuery).toHaveBeenCalledWith("servers:getProjectServers", {
+      projectId: "project_pinned",
+    });
+    expect(mockUpdateServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: "srv_pinned",
+        name: "bart",
+      })
+    );
+    expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
+    expect(mockCreateServer).not.toHaveBeenCalled();
+    expect(mockCreateServerWithClientSecret).not.toHaveBeenCalled();
+
+    // The callback URL is only restored once completion settles, the org
+    // selection is restored from the marker, and the return path is the
+    // marker's returnPath.
+    await waitFor(() => {
+      expect(window.location.search).toBe("");
+    });
+    expect(restoreActiveOrganizationId).toHaveBeenCalledWith("org_pinned");
+    expect(window.location.pathname).toBe("/servers");
+  });
+
+  it("pins the post-callback sync in local (non-hosted) mode too", async () => {
+    // Regression: local dev runs with HOSTED_MODE=false, where completion
+    // goes through the legacy client-side token exchange. The pending marker
+    // is still written before the redirect, and the Convex sync after the
+    // callback must honor it — this was the path that kept duplicating the
+    // server into the fallback org after the hosted-only fix.
+    localStorage.setItem("mcp-oauth-pending", "bart");
+    localStorage.setItem(
+      "mcp-hosted-oauth-pending",
+      JSON.stringify({
+        surface: "project",
+        organizationId: "org_pinned",
+        projectId: "project_pinned",
+        serverId: "srv_pinned",
+        serverName: "bart",
+        serverUrl: "https://bart.example.com/mcp",
+        accessScope: "project_member",
+        returnPath: "/servers",
+        startedAt: Date.now(),
+      })
+    );
+    handleOAuthCallbackMock.mockResolvedValue({
+      success: true,
+      serverName: "bart",
+      serverConfig: {
+        type: "http",
+        url: "https://bart.example.com/mcp",
+      },
+    });
+    mockConvexQuery.mockResolvedValue([
+      {
+        _id: "srv_pinned",
+        projectId: "project_pinned",
+        name: "bart",
+      },
+    ]);
+    mockUpdateServer.mockResolvedValue("srv_pinned");
+    window.history.replaceState({}, "", "/oauth/callback?code=test-code");
+
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_ambient";
+    const dispatch = vi.fn();
+    const restoreActiveOrganizationId = vi.fn();
+    renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      isUserReady: true,
+      useLocalFallback: false,
+      activeOrganizationId: "org_fallback",
+      restoreActiveOrganizationId,
+      effectiveProjects: appState.projects,
+      effectiveActiveProjectId: "project_ambient",
+      activeProjectServersFlat: [],
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateServer).toHaveBeenCalled();
+    });
+
+    expect(completeHostedOAuthCallbackMock).not.toHaveBeenCalled();
+    expect(handleOAuthCallbackMock).toHaveBeenCalled();
+    expect(mockConvexQuery).toHaveBeenCalledWith("servers:getProjectServers", {
+      projectId: "project_pinned",
+    });
+    expect(mockUpdateServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: "srv_pinned",
+        name: "bart",
+      })
+    );
+    expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
+    expect(mockCreateServer).not.toHaveBeenCalled();
+    expect(mockCreateServerWithClientSecret).not.toHaveBeenCalled();
+    // Marker cleanup applies to the legacy completion path as well.
+    await waitFor(() => {
+      expect(localStorage.getItem("mcp-hosted-oauth-pending")).toBeNull();
+    });
+    // The org the flow started in is restored as the explicit selection.
+    await waitFor(() => {
+      expect(restoreActiveOrganizationId).toHaveBeenCalledWith("org_pinned");
+    });
   });
 
   it("preserves existing HTTP config without keeping the callback bearer token", async () => {
@@ -2458,6 +2636,116 @@ describe("syncServerToConvex name-collision recovery", () => {
     );
     expect(mockCreateServer).not.toHaveBeenCalled();
     expect(mockConvexQuery).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale snapshot rows from another project when saving", async () => {
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_default";
+    const dispatch = vi.fn();
+
+    mockCreateServerIfMissing.mockResolvedValue("srv_current_project");
+
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+      effectiveProjects: appState.projects,
+      activeProjectServersFlat: [
+        {
+          _id: "srv_other_project",
+          projectId: "other-project",
+          name: "Excalidraw (App)",
+        },
+      ],
+    });
+
+    await act(async () => {
+      await result.current.saveServerConfigWithoutConnecting({
+        name: "Excalidraw (App)",
+        type: "http",
+        url: "https://mcp.excalidraw.com/mcp",
+      });
+    });
+
+    expect(mockUpdateServer).not.toHaveBeenCalled();
+    expect(mockCreateServerIfMissing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "default",
+        name: "Excalidraw (App)",
+      })
+    );
+    expect(mockConvexQuery).not.toHaveBeenCalled();
+  });
+
+  it("refuses to save when the active project belongs to another organization", async () => {
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_default";
+    appState.projects.default.organizationId = "org_a";
+    const dispatch = vi.fn();
+
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+      activeOrganizationId: "org_b",
+      effectiveProjects: appState.projects,
+      activeProjectServersFlat: [],
+    });
+
+    await act(async () => {
+      await result.current.saveServerConfigWithoutConnecting({
+        name: "Cross Org Server",
+        type: "http",
+        url: "https://example.com/mcp",
+      });
+    });
+
+    expect(mockUpdateServer).not.toHaveBeenCalled();
+    expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
+    expect(mockCreateServerWithClientSecret).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "UPSERT_SERVER" })
+    );
+    expect(toastError.mock.calls[0]?.[0]).toEqual(
+      expect.stringContaining("selected project is not in the active organization")
+    );
+  });
+
+  it("does not start a hosted runtime connection when scoped Convex save is refused", async () => {
+    mockHostedMode.mockReturnValue(true);
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_default";
+    appState.projects.default.organizationId = "org_a";
+    const dispatch = vi.fn();
+
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+      activeOrganizationId: "org_b",
+      effectiveProjects: appState.projects,
+      activeProjectServersFlat: [],
+    });
+
+    await act(async () => {
+      await result.current.handleConnect({
+        name: "Cross Org Server",
+        type: "http",
+        url: "https://example.com/mcp",
+      });
+    });
+
+    expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
+    expect(testConnectionMock).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "CONNECT_FAILURE",
+        name: "Cross Org Server",
+        error: expect.stringContaining(
+          "selected project is not in the active organization"
+        ),
+      })
+    );
   });
 
   it("syncs bearer-token metadata when saving header secrets", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -239,10 +239,10 @@ export function useAppState({
     validOrganizations.some(
       (organization) => organization._id === pendingOAuthMarkerOrgId
     );
-  const activeOrganizationId = isStoredActiveOrganizationValid
-    ? storedActiveOrganizationId
-    : isPendingOAuthMarkerOrgValid
+  const activeOrganizationId = isPendingOAuthMarkerOrgValid
     ? pendingOAuthMarkerOrgId
+    : isStoredActiveOrganizationValid
+    ? storedActiveOrganizationId
     : fallbackActiveOrganizationId;
   const setActiveOrganizationId = useCallback(
     (organizationId: string | undefined) => {
@@ -517,6 +517,8 @@ export function useAppState({
     isAuthLoading,
     isLoadingProjects: projectState.isLoadingProjects,
     useLocalFallback: projectState.useLocalFallback,
+    activeOrganizationId,
+    restoreActiveOrganizationId: setActiveOrganizationId,
     effectiveProjects: projectState.effectiveProjects,
     effectiveActiveProjectId: projectState.effectiveActiveProjectId,
     activeProjectServersFlat: projectState.activeProjectServersFlat,

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -285,20 +285,64 @@ export function useProjectState({
   // reference `shouldUseLocalFallback` collapse cleanly without renames.
   const shouldUseLocalFallback = false as const;
 
+  const scopedLocalProjects = useMemo((): Record<string, Project> => {
+    if (!shouldScopeLocalFallbackByOrganization) {
+      return appState.projects;
+    }
+
+    return Object.fromEntries(
+      Object.entries(appState.projects).filter(
+        ([, project]) => project.organizationId === projectOrganizationId,
+      ),
+    );
+  }, [
+    appState.projects,
+    shouldScopeLocalFallbackByOrganization,
+    projectOrganizationId,
+  ]);
+
+  const activeScopedLocalProject = useMemo(
+    () => scopedLocalProjects[appState.activeProjectId],
+    [scopedLocalProjects, appState.activeProjectId],
+  );
+
+  const activeScopedRemoteProjectId =
+    activeScopedLocalProject?.sharedProjectId ?? null;
+
   const clearConvexActiveProjectSelection = useCallback(() => {
     setConvexActiveProjectId(null);
     writeStoredActiveProjectId(activeProjectActorKeyRef.current, null);
   }, []);
 
-  // Project id that the flat-server query should target. We can't wait for
-  // the auto-set effect to copy convexActiveProjectId from remoteProjects[0]
-  // — the consumer renders one frame earlier with effectiveActiveProjectId
-  // resolving to the same fallback, so the flat query has to fire on that
-  // same frame or the project briefly renders as "no servers". Falling back
-  // to remoteProjects[0] mirrors what the auto-set effect would land on.
-  const resolvedActiveProjectIdForServers = shouldTreatRemoteProjectsAsEmpty
-    ? null
-    : (convexActiveProjectId ?? remoteProjects?.[0]?._id ?? null);
+  // Project id that the flat-server query should target. The stored active
+  // project id is per actor, while the visible project list is org-scoped. Only
+  // let the flat server query use a stored id after the current scoped project
+  // list proves it belongs to this org; otherwise stale server snapshots from a
+  // different org can drive existing-server detection in the add/connect flow.
+  const resolvedActiveProjectIdForServers = useMemo(() => {
+    if (shouldTreatRemoteProjectsAsEmpty) return null;
+    if (isAuthenticated && !shouldUseLocalFallback) {
+      if (remoteProjects === undefined) return null;
+      const hasProject = (projectId: string | null | undefined) =>
+        !!projectId &&
+        remoteProjects.some((project) => project._id === projectId);
+      if (hasProject(activeScopedRemoteProjectId)) {
+        return activeScopedRemoteProjectId;
+      }
+      if (hasProject(convexActiveProjectId)) {
+        return convexActiveProjectId;
+      }
+      return remoteProjects[0]?._id ?? null;
+    }
+    return convexActiveProjectId ?? remoteProjects?.[0]?._id ?? null;
+  }, [
+    activeScopedRemoteProjectId,
+    convexActiveProjectId,
+    isAuthenticated,
+    remoteProjects,
+    shouldTreatRemoteProjectsAsEmpty,
+    shouldUseLocalFallback,
+  ]);
 
   const { servers: activeProjectServersFlat, isLoading: isLoadingServers } =
     useProjectServers({
@@ -500,18 +544,6 @@ export function useProjectState({
     }
   }, [clearPendingClientConfigSync, convexProjects]);
 
-  const scopedLocalProjects = useMemo((): Record<string, Project> => {
-    if (!shouldScopeLocalFallbackByOrganization) {
-      return appState.projects;
-    }
-
-    return Object.fromEntries(
-      Object.entries(appState.projects).filter(
-        ([, project]) => project.organizationId === projectOrganizationId,
-      ),
-    );
-  }, [appState.projects, shouldScopeLocalFallbackByOrganization, projectOrganizationId]);
-
   // Legacy fallback memo. Convex is the only source of truth post-unification;
   // `useLocalFallback` is permanently false. Kept as a stable empty/identity
   // reference so the dead-code branches below collapse without renames.
@@ -523,14 +555,6 @@ export function useProjectState({
     // below, but they must not render after actor or organization changes.
     return convexProjects;
   }, [convexProjects]);
-
-  const activeScopedLocalProject = useMemo(
-    () => scopedLocalProjects[appState.activeProjectId],
-    [scopedLocalProjects, appState.activeProjectId],
-  );
-
-  const activeScopedRemoteProjectId =
-    activeScopedLocalProject?.sharedProjectId ?? null;
 
   // Authenticated users never keep local-fallback projects in the rendered
   // project list. Their canonical project set lives in Convex; local rows are

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -42,6 +42,7 @@ import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 import {
   clearHostedOAuthPendingState,
   getHostedOAuthCallbackContext,
+  resolveHostedOAuthReturnPath,
   writeHostedOAuthPendingMarker,
 } from "@/lib/hosted-oauth-callback";
 import { HOSTED_MODE } from "@/lib/config";
@@ -596,6 +597,14 @@ interface UseServerStateParams {
   isAuthLoading: boolean;
   isLoadingProjects: boolean;
   useLocalFallback: boolean;
+  activeOrganizationId?: string;
+  /**
+   * Re-applies an organization as the user's explicit selection. Called when
+   * an OAuth callback settles, with the organization the flow was pinned to,
+   * so the post-callback UI returns to the org the user connected from
+   * (routes like /servers carry no org of their own).
+   */
+  restoreActiveOrganizationId?: (organizationId: string) => void;
   effectiveProjects: Record<string, Project>;
   effectiveActiveProjectId: string;
   activeProjectServersFlat: RemoteServer[] | undefined;
@@ -632,6 +641,17 @@ const PROJECT_SERVERS_SNAPSHOT_WAIT_MS = 10_000;
 /** Must stay below Vitest's default 30s test timeout so callers can finish after a full wait + margin. */
 const PROJECT_SERVER_ECHO_WAIT_MS = 25_000;
 const PROJECT_SERVERS_POLL_MS = 100;
+const SERVER_PROJECT_ORG_MISMATCH_ERROR_MESSAGE =
+  "Cannot save server: the selected project is not in the active organization. Refresh and try again.";
+
+function remoteServerBelongsToProject(
+  server: RemoteServer,
+  projectId: string | null | undefined
+): boolean {
+  if (!projectId) return false;
+  const rowProjectId = (server as { projectId?: string }).projectId;
+  return !rowProjectId || rowProjectId === projectId;
+}
 
 export interface ServerUpdateResult {
   ok: boolean;
@@ -672,6 +692,8 @@ export function useServerState({
   isAuthLoading,
   isLoadingProjects,
   useLocalFallback,
+  activeOrganizationId,
+  restoreActiveOrganizationId,
   effectiveProjects,
   effectiveActiveProjectId,
   activeProjectServersFlat,
@@ -704,6 +726,10 @@ export function useServerState({
   useLocalFallbackRef.current = useLocalFallback;
   const effectiveActiveProjectIdRef = useRef(effectiveActiveProjectId);
   effectiveActiveProjectIdRef.current = effectiveActiveProjectId;
+  const activeOrganizationIdRef = useRef(activeOrganizationId);
+  activeOrganizationIdRef.current = activeOrganizationId;
+  const effectiveProjectsRef = useRef(effectiveProjects);
+  effectiveProjectsRef.current = effectiveProjects;
   const appStateServersRef = useRef(appState.servers);
   appStateServersRef.current = appState.servers;
   const activeProjectServersFlatRef = useRef(activeProjectServersFlat);
@@ -756,6 +782,13 @@ export function useServerState({
   const isStaleOp = (name: string, token: number) =>
     (opTokenRef.current.get(name) ?? 0) !== token;
 
+  // Pins the org/project/server the OAuth flow starts from so the callback
+  // can write back to the same rows. Written in BOTH hosted and local modes:
+  // local-mode completion runs client-side, but the post-callback Convex sync
+  // is identical, and without the pin it targets whatever project is active
+  // after the redirect remount (the fallback org's default project).
+  // Hosted-only behavior (the backend session) stays gated inside
+  // createHostedOAuthSessionIfNeeded, which checks HOSTED_MODE itself.
   const prepareHostedProjectOAuthRedirect = useCallback(
     (params: {
       serverId?: string | null;
@@ -763,7 +796,6 @@ export function useServerState({
       serverUrl?: string | null;
     }): boolean => {
       if (
-        !HOSTED_MODE ||
         !isAuthenticated ||
         !effectiveActiveProjectId ||
         !params.serverId ||
@@ -867,16 +899,16 @@ export function useServerState({
   );
 
   // What chat-input's "Servers" popover (and any other "show me everything
-  // we can talk to" surface) should iterate: the project catalog PLUS any
-  // runtime-connected/connecting servers that aren't in it yet. The catalog
-  // (effectiveServers) is the Convex `project_servers` query in hosted mode
-  // and can lag mcpjam-backend's `MCPClientManager` — a server is genuinely
-  // connected (Tools pane and tool calls work against it) but its catalog
-  // row hasn't synced, so the popover used to hide it. We only merge
-  // runtime entries that are currently connected/connecting; disconnected
-  // runtime leftovers from a previous session/project never surface here.
+  // we can talk to" surface) should iterate. In Convex-backed projects this
+  // must be the project catalog only: runtime-only entries are global app
+  // state and can otherwise bleed across organization/project switches.
+  // Local/fallback mode still merges connected/connecting runtime entries
+  // because there is no scoped Convex project-server catalog to wait for.
   const displayServerConfigs = useMemo(() => {
     const result: Record<string, ServerWithName> = { ...effectiveServers };
+    if (isAuthenticated && !useLocalFallback) {
+      return result;
+    }
     for (const [name, runtime] of Object.entries(appState.servers)) {
       if (result[name]) continue;
       if (
@@ -888,7 +920,7 @@ export function useServerState({
       result[name] = runtime;
     }
     return result;
-  }, [effectiveServers, appState.servers]);
+  }, [effectiveServers, appState.servers, isAuthenticated, useLocalFallback]);
 
   const latestEffectiveServersRef = useRef(effectiveServers);
 
@@ -1226,11 +1258,19 @@ export function useServerState({
         clearClientSecret?: boolean;
         env?: Record<string, string>;
         headers?: Record<string, string>;
-      }
+      },
+      // Explicit write target for flows that pinned their project/server
+      // before a redirect (hosted OAuth). The ambient active project can
+      // legitimately change while such a flow is in flight — post-callback
+      // remounts resolve the fallback organization until hydration settles —
+      // so a pinned target must win over the refs or the write lands in
+      // whatever project happens to be active.
+      target?: { projectId: string; serverId?: string | null }
     ): Promise<string | undefined> => {
       const latestUseLocalFallback = useLocalFallbackRef.current;
       const latestIsAuthenticated = isAuthenticatedRef.current;
-      const latestProjectId = effectiveActiveProjectIdRef.current;
+      const latestProjectId =
+        target?.projectId ?? effectiveActiveProjectIdRef.current;
       if (
         latestUseLocalFallback ||
         !latestIsAuthenticated ||
@@ -1238,6 +1278,27 @@ export function useServerState({
         latestProjectId === "none"
       ) {
         return undefined;
+      }
+
+      // The ambient org/project coherence guard only applies to ambient
+      // writes: a pinned target is allowed to differ from the active
+      // organization (that is the point of pinning).
+      const latestActiveOrganizationId = activeOrganizationIdRef.current;
+      if (!target && latestActiveOrganizationId) {
+        const latestProject = effectiveProjectsRef.current[latestProjectId];
+        const latestProjectOrganizationId = latestProject?.organizationId;
+        if (latestProjectOrganizationId !== latestActiveOrganizationId) {
+          logger.warn(
+            "Refusing to sync server because active project does not belong to active organization",
+            {
+              serverName,
+              projectId: latestProjectId,
+              projectOrganizationId: latestProjectOrganizationId ?? null,
+              activeOrganizationId: latestActiveOrganizationId,
+            }
+          );
+          throw new Error(SERVER_PROJECT_ORG_MISMATCH_ERROR_MESSAGE);
+        }
       }
 
       const flatSnapshot =
@@ -1278,9 +1339,22 @@ export function useServerState({
         snapshot: RemoteServer[] | undefined,
         options?: { queryWhenLoaded?: boolean }
       ): Promise<RemoteServer | undefined> => {
-        const local = snapshot?.find((s) => s.name === serverName);
+        // A pinned serverId is authoritative: the row was created before the
+        // OAuth redirect and the hosted session validated it. Match by id
+        // first; fall back to name-within-pinned-project in case the row was
+        // deleted and recreated mid-flow.
+        const matches = (s: RemoteServer) =>
+          target?.serverId
+            ? s._id === target.serverId
+            : s.name === serverName &&
+              remoteServerBelongsToProject(s, latestProjectId);
+        const local = snapshot?.find(matches);
         if (local) return local;
-        if (snapshot !== undefined && options?.queryWhenLoaded !== true) {
+        // The snapshot tracks the ambient active project. For a pinned
+        // target it can describe a different project entirely, so a miss
+        // there proves nothing — always fall through to the one-shot query
+        // against the pinned project.
+        if (!target && snapshot !== undefined && options?.queryWhenLoaded !== true) {
           return undefined;
         }
         if (!isUserReadyRef.current) {
@@ -1291,7 +1365,12 @@ export function useServerState({
             "servers:getProjectServers" as any,
             { projectId: latestProjectId } as any
           )) as RemoteServer[] | undefined;
-          return fresh?.find((s) => s.name === serverName);
+          return (
+            fresh?.find(matches) ??
+            (target?.serverId
+              ? fresh?.find((s) => s.name === serverName)
+              : undefined)
+          );
         } catch {
           return undefined;
         }
@@ -1592,7 +1671,12 @@ export function useServerState({
         }
         runtime = liveRuntime;
 
-        if (flatAfterWait.some((s) => s.name === serverName)) {
+        if (
+          flatAfterWait.some(
+            (s) =>
+              s.name === serverName && remoteServerBelongsToProject(s, projectId)
+          )
+        ) {
           logger.warn(
             "persistRuntimeServerToProjectIfNeeded: runtime server not persisted because a saved server with the same name already exists",
             { serverName, projectId }
@@ -1638,7 +1722,13 @@ export function useServerState({
         let echoed = false;
         while (Date.now() - echoStarted < PROJECT_SERVER_ECHO_WAIT_MS) {
           const flatEcho = activeProjectServersFlatRef.current;
-          if (flatEcho?.some((s) => s.name === serverName)) {
+          if (
+            flatEcho?.some(
+              (s) =>
+                s.name === serverName &&
+                remoteServerBelongsToProject(s, projectId)
+            )
+          ) {
             echoed = true;
             break;
           }
@@ -2058,7 +2148,10 @@ export function useServerState({
             });
 
         localStorage.removeItem("mcp-oauth-return-hash");
-        if (isHostedProjectCallback) {
+        if (hostedCallbackContext) {
+          // The pending marker is written for local-mode project flows too —
+          // clear it whenever a marker-backed callback settles, not only on
+          // the hosted completion path.
           clearHostedOAuthPendingState();
         }
         if (result.success) {
@@ -2117,7 +2210,26 @@ export function useServerState({
           if (!isAuthenticated || useLocalFallback) {
             persistServerToLocalProject(serverName, oauthServerEntry);
           } else {
-            syncServerToConvex(serverName, oauthServerEntry).catch((error) =>
+            // Sync against the project/server the OAuth flow was pinned to
+            // when the redirect started, not the ambient active project. The
+            // active organization can resolve to the fallback org (first
+            // owned org) during the post-callback remount, and syncing by
+            // name against that org's project used to create an
+            // unauthenticated duplicate of the server there. The pin applies
+            // to hosted AND legacy (local-mode) completions — both funnel
+            // into this same Convex sync.
+            const pinnedTarget = hostedCallbackContext?.projectId
+              ? {
+                  projectId: hostedCallbackContext.projectId,
+                  serverId: hostedCallbackContext.serverId ?? null,
+                }
+              : undefined;
+            syncServerToConvex(
+              serverName,
+              oauthServerEntry,
+              undefined,
+              pinnedTarget
+            ).catch((error) =>
               logger.warn("Failed to sync OAuth profile to Convex", {
                 serverName,
                 error,
@@ -2266,9 +2378,11 @@ export function useServerState({
     const error = urlParams.get("error");
     const errorDescription = urlParams.get("error_description");
     const electronCallbackUrl = buildElectronMcpCallbackUrl();
-    const hostedOAuthCallbackContext = HOSTED_MODE
-      ? getHostedOAuthCallbackContext()
-      : null;
+    // Read in local mode too: the pending marker pins the org/project/server
+    // the flow started from, and the post-callback sync needs that pin
+    // regardless of whether completion runs hosted (backend session) or
+    // legacy (client-side token exchange).
+    const hostedOAuthCallbackContext = getHostedOAuthCallbackContext();
     if (electronCallbackUrl) {
       return;
     }
@@ -2303,18 +2417,39 @@ export function useServerState({
         }
       }
 
+      // Captured before completion: handleOAuthCallbackComplete clears the
+      // return-hash key as part of its cleanup.
       const savedHash = localStorage.getItem("mcp-oauth-return-hash") || "";
-      window.history.replaceState(
-        {},
-        document.title,
-        restorePathAfterOAuthCallback(window.location.pathname, savedHash)
-      );
+      const restoreCallbackUrl = () => {
+        // The pending marker pinned the organization the flow started in.
+        // Re-apply it as the explicit selection before navigating: most
+        // routes (e.g. /servers) carry no org, so restoring the path alone
+        // would render it under whatever org the fallback resolution picks
+        // once the marker is cleared.
+        const markerOrganizationId = hostedOAuthCallbackContext?.organizationId;
+        if (markerOrganizationId) {
+          restoreActiveOrganizationId?.(markerOrganizationId);
+        }
+        // Navigate through the app router, not raw history.replaceState —
+        // the router never observes replaceState, so route-derived state
+        // (org-scoped routes, active tab) would go stale. The marker's
+        // returnPath is the exact location the user connected from.
+        const returnTarget = hostedOAuthCallbackContext?.returnPath
+          ? resolveHostedOAuthReturnPath(hostedOAuthCallbackContext)
+          : restorePathAfterOAuthCallback(window.location.pathname, savedHash);
+        navigateApp(returnTarget, { replace: true });
+      };
 
-      handleOAuthCallbackComplete(
+      // Strip the ?code from the URL only after completion settles. The
+      // pending-marker org pin (use-app-state) is scoped to "callback params
+      // present in the URL"; stripping eagerly killed the pin mid-completion,
+      // so the active org/project flipped to the fallback organization while
+      // the token exchange was still in flight.
+      void handleOAuthCallbackComplete(
         code,
         state,
         isHostedProjectCallback ? hostedOAuthCallbackContext : null
-      );
+      ).finally(restoreCallbackUrl);
     } else if (error) {
       if (hostedOAuthCallbackContext && !isHostedProjectCallback) {
         return; // Handled by App.tsx hosted OAuth interception
@@ -2332,11 +2467,16 @@ export function useServerState({
         errorDescription,
       });
       oauthCallbackHandledRef.current = true;
-      window.history.replaceState(
-        {},
-        document.title,
-        restorePathAfterOAuthCallback(window.location.pathname, savedHash)
-      );
+      // Denied/failed authorizations return the user to where they started
+      // too: same org restore + router-aware navigation as the success path.
+      const markerOrganizationId = hostedOAuthCallbackContext?.organizationId;
+      if (markerOrganizationId) {
+        restoreActiveOrganizationId?.(markerOrganizationId);
+      }
+      const returnTarget = hostedOAuthCallbackContext?.returnPath
+        ? resolveHostedOAuthReturnPath(hostedOAuthCallbackContext)
+        : restorePathAfterOAuthCallback(window.location.pathname, savedHash);
+      navigateApp(returnTarget, { replace: true });
     }
   }, [
     isLoading,
@@ -2347,6 +2487,7 @@ export function useServerState({
     effectiveActiveProjectId,
     failPendingOAuthConnection,
     handleOAuthCallbackComplete,
+    restoreActiveOrganizationId,
     logger,
   ]);
 
@@ -2458,15 +2599,20 @@ export function useServerState({
           err,
         });
       }
-      if (HOSTED_MODE && formData.useOAuth && !hostedServerId) {
-        // OAuth in hosted mode requires a Convex serverId to bind credentials
-        // to; without it the OAuth dance would complete without a durable
-        // credential. Local-mode OAuth is guarded later when tokens are
-        // imported into backend storage instead of being saved locally.
+      if (
+        HOSTED_MODE &&
+        isAuthenticated &&
+        !useLocalFallback &&
+        (syncErr || !hostedServerId)
+      ) {
+        // Hosted project connects require a Convex server row before any
+        // runtime connection starts. Continuing after a cloud save failure
+        // creates an unscoped runtime-only server that can appear under another
+        // organization while remaining unauthenticated.
         const errorMessage =
           syncErr instanceof Error
-            ? `Could not save the hosted server before starting OAuth: ${syncErr.message}`
-            : "Could not save the hosted server before starting OAuth. Please try again.";
+            ? syncErr.message
+            : "Could not save the hosted server before connecting. Please try again.";
         dispatch({
           type: "CONNECT_FAILURE",
           name: formData.name,
@@ -2849,14 +2995,6 @@ export function useServerState({
         clearOAuthData(serverName);
       }
 
-      dispatch({
-        type: "UPSERT_SERVER",
-        name: serverName,
-        server: serverEntry,
-      });
-
-      saveOAuthConfigToLocalStorage(formData);
-
       if (
         isAuthenticated &&
         !useLocalFallback &&
@@ -2864,26 +3002,51 @@ export function useServerState({
         effectiveActiveProjectId !== "none"
       ) {
         try {
-          await syncServerToConvex(serverName, serverEntry, {
-            ...(formData.clientSecret
-              ? { clientSecret: formData.clientSecret }
-              : {}),
-            ...(formData.clearClientSecret ? { clearClientSecret: true } : {}),
-            ...(formData.secretPatch?.env !== undefined
-              ? { env: formData.secretPatch.env }
-              : {}),
-            ...(formData.secretPatch?.headers !== undefined
-              ? { headers: formData.secretPatch.headers }
-              : {}),
-          });
+          const syncedServerId = await syncServerToConvex(
+            serverName,
+            serverEntry,
+            {
+              ...(formData.clientSecret
+                ? { clientSecret: formData.clientSecret }
+                : {}),
+              ...(formData.clearClientSecret ? { clearClientSecret: true } : {}),
+              ...(formData.secretPatch?.env !== undefined
+                ? { env: formData.secretPatch.env }
+                : {}),
+              ...(formData.secretPatch?.headers !== undefined
+                ? { headers: formData.secretPatch.headers }
+                : {}),
+            }
+          );
+          if (!syncedServerId) {
+            logger.error("Failed to sync server to Convex", {
+              error: "Server sync returned no server id",
+            });
+            toast.error("Could not save the server. Please try again.");
+            return;
+          }
         } catch (error) {
           logger.error("Failed to sync server to Convex", {
             error: error instanceof Error ? error.message : "Unknown error",
           });
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Could not save the server. Please try again."
+          );
+          return;
         }
       } else {
         persistServerToLocalProject(serverName, serverEntry);
       }
+
+      dispatch({
+        type: "UPSERT_SERVER",
+        name: serverName,
+        server: serverEntry,
+      });
+
+      saveOAuthConfigToLocalStorage(formData);
 
       logger.info("Saved server configuration without connecting", {
         serverName,

--- a/mcpjam-inspector/server/utils/__tests__/__snapshots__/mcpjam-stream-handler-snapshot.test.ts.snap
+++ b/mcpjam-inspector/server/utils/__tests__/__snapshots__/mcpjam-stream-handler-snapshot.test.ts.snap
@@ -4,6 +4,7 @@ exports[`handleMCPJamFreeChatModel SSE byte-equivalence snapshot > emits a stabl
 [
   {
     "data": {
+      "engine": "emulated",
       "promptIndex": 0,
       "startedAtMs": "<timestamp>",
       "turnId": "<id>",
@@ -304,6 +305,7 @@ exports[`handleMCPJamFreeChatModel SSE byte-equivalence snapshot > emits a stabl
 [
   {
     "data": {
+      "engine": "emulated",
       "promptIndex": 0,
       "startedAtMs": "<timestamp>",
       "turnId": "<id>",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes servers being duplicated into the wrong organization by pinning OAuth flows to their starting org/project, scoping saves/queries to the active org, and showing only the current project’s catalog when authenticated.

- Pins hosted and local OAuth flows to the starting org/project, restores that org after callback, and syncs the server to the pinned project (no more ambient‑org writes).
- Defers URL cleanup until OAuth completion settles, restores the starting org via app state (marker org preferred over stored), clears the pending marker in both modes, and uses app‑router navigation on return paths.
- Validates that the active project belongs to the active org before saving/connecting; blocks hosted connections if the cloud save fails and shows a clear error.
- Filters server lists to the Convex project catalog when authenticated; runtime‑only entries are shown only in local fallback. `OAuthFlowTab` now receives `displayServerConfigs`.
- Scopes flat server queries to the current org’s project and ignores stale snapshot rows from other projects when checking for existing servers.
- CI: ignores `.worktrees/` and removes an accidental worktree gitlink to fix CI checkout noise.
- Tests: updates stream handler snapshots to include the engine field ("emulated").

<sup>Written for commit b5ac3c8049d99b0c9c6492cd06983019caeea078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

