### PR TITLE
feat(harness): route harness MCP through MCPJam (proxy, both planes) — port to main

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1671,6 +1671,7 @@ export default function App() {
     handleReconnect,
     reconnectServerForClientSwitch,
     ensureServersReady,
+    ensureHostedServerIdsForNames,
     syncAgentStatus,
     handleUpdate,
     handleRemoveServer,
@@ -3322,6 +3323,7 @@ export default function App() {
         <ServerActionsProvider
           actions={{
             ensureServersReady,
+            ensureHostedServerIdsForNames,
             runtimeDisconnectServer: handleRuntimeDisconnect,
             reconnectServer: reconnectServerForClientSwitch,
             setSelectedServerNames: setSelectedMCPConfigs,

--- a/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
@@ -9,10 +9,18 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { Button } from "@mcpjam/design-system/button";
-import { Copy, Eraser, Loader2, RotateCcw, TerminalSquare } from "lucide-react";
+import {
+  Copy,
+  Eraser,
+  Loader2,
+  RotateCcw,
+  TerminalSquare,
+  Upload,
+} from "lucide-react";
 import { toast } from "sonner";
 import {
   openTerminalConnection,
+  uploadFilesToComputer,
   type TerminalConnection,
 } from "@/lib/computer-terminal-connection";
 
@@ -115,6 +123,7 @@ export function ComputerTerminal({
   themeMode,
   className,
   baseUrl,
+  cwd,
 }: {
   mintToken: () => Promise<string>;
   themeMode: "light" | "dark";
@@ -125,6 +134,12 @@ export function ComputerTerminal({
    * (see useComputersDataPlaneConfig).
    */
   baseUrl?: string;
+  /**
+   * Starting working directory for the PTY (e.g. a harness session workdir).
+   * Applied at (re)connect; the server falls back to home if it can't `cd` there.
+   * To re-target an already-open terminal, remount with a new `key`.
+   */
+  cwd?: string;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -142,6 +157,11 @@ export function ComputerTerminal({
   const [state, setState] = useState<TerminalState>("connecting");
   const [detail, setDetail] = useState<string>("");
   const [hasSelection, setHasSelection] = useState(false);
+  // Drag-and-drop file upload into the box. dragDepth counts nested
+  // dragenter/leave so the overlay doesn't flicker over child elements.
+  const [dragActive, setDragActive] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const dragDepthRef = useRef(0);
 
   const termBg = themeMode === "dark" ? "#1a1916" : "#f5f0e8";
   const toolbarBg = themeMode === "dark" ? "#222019" : "#ede7d8";
@@ -188,6 +208,7 @@ export function ComputerTerminal({
       cols: term.cols,
       rows: term.rows,
       ...(baseUrl ? { baseUrl } : {}),
+      ...(cwd ? { cwd } : {}),
       onOutput: (bytes) => {
         if (isStale()) return;
         term.write(bytes);
@@ -218,7 +239,7 @@ export function ComputerTerminal({
       if (isStale()) return;
       conn.ping();
     }, PING_INTERVAL_MS);
-  }, [mintToken, teardownConnection, baseUrl]);
+  }, [mintToken, teardownConnection, baseUrl, cwd]);
 
   const handleCopy = useCallback(() => {
     const sel = termRef.current?.getSelection();
@@ -232,6 +253,78 @@ export function ComputerTerminal({
     termRef.current?.clear();
     termRef.current?.focus();
   }, []);
+
+  const hasDraggedFiles = (e: React.DragEvent) =>
+    Array.from(e.dataTransfer?.types ?? []).includes("Files");
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (!hasDraggedFiles(e)) return;
+    e.preventDefault();
+    dragDepthRef.current += 1;
+    setDragActive(true);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (!hasDraggedFiles(e)) return;
+    // Required for the drop event to fire.
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (!hasDraggedFiles(e)) return;
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setDragActive(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault();
+      dragDepthRef.current = 0;
+      setDragActive(false);
+      const files = Array.from(e.dataTransfer?.files ?? []);
+      if (files.length === 0) return;
+      if (state !== "connected") {
+        toast.error("Connect the terminal first, then drop files.");
+        return;
+      }
+      setUploading(true);
+      try {
+        const token = await mintToken();
+        const written = await uploadFilesToComputer({
+          token,
+          files,
+          // Land files in the Shell's cwd (the harness workdir) when known, so
+          // they appear right where the user is working; else the server bucket.
+          ...(baseUrl ? { baseUrl } : {}),
+          ...(cwd ? { dir: cwd } : {}),
+        });
+        // The destination dir of the first written file (server-resolved; may be
+        // the fallback bucket if cwd was absent/rejected).
+        const destDir =
+          written[0]?.path.slice(0, written[0].path.lastIndexOf("/")) || "~";
+        const single = written.length === 1 ? written[0] : undefined;
+        // Copy the path so the user can paste it straight into chat ("read <path>").
+        if (single) void navigator.clipboard?.writeText(single.path).catch(() => {});
+        toast.success(
+          single
+            ? `Uploaded to ${single.path} (path copied)`
+            : `Uploaded ${written.length} files to ${destDir}`,
+          { duration: 4000 }
+        );
+        // Surface the result in the user's real shell. Ctrl-U (\x15) clears any
+        // half-typed input first so this can't interleave with their command.
+        connRef.current?.sendInput(
+          new TextEncoder().encode(`\x15ls -la ${destDir}/\n`)
+        );
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Upload failed.");
+      } finally {
+        setUploading(false);
+      }
+    },
+    [state, mintToken, baseUrl, cwd]
+  );
 
   // Create the xterm instance once; wire input + resize; auto-connect.
   useEffect(() => {
@@ -363,8 +456,33 @@ export function ComputerTerminal({
         </div>
 
         {/* Terminal canvas + overlay */}
-        <div className="relative min-h-0 flex-1">
+        <div
+          className="relative min-h-0 flex-1"
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
           <div ref={containerRef} className="absolute inset-0 p-1" onClick={() => termRef.current?.focus()} />
+          {dragActive || uploading ? (
+            <div className="pointer-events-none absolute inset-2 z-10 flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-primary/60 bg-background/85 text-sm">
+              {uploading ? (
+                <span className="inline-flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Uploading…
+                </span>
+              ) : (
+                <>
+                  <Upload className="h-5 w-5 text-primary" />
+                  <span className="text-foreground">
+                    {cwd
+                      ? "Drop files to upload to this directory"
+                      : "Drop files to upload to your computer"}
+                  </span>
+                </>
+              )}
+            </div>
+          ) : null}
           {showOverlay ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background/80 text-sm">
               {state === "connecting" ? (

--- a/mcpjam-inspector/client/src/components/computer/ComputerTerminalPane.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTerminalPane.tsx
@@ -14,9 +14,12 @@ import type { ComputerTerminalController } from "./useComputerTerminal";
 export function ComputerTerminalPane({
   controller,
   className,
+  cwd,
 }: {
   controller: ComputerTerminalController;
   className?: string;
+  /** Starting directory for the terminal (harness workdir); home if unset. */
+  cwd?: string;
 }) {
   const {
     status,
@@ -76,6 +79,7 @@ export function ComputerTerminalPane({
           themeMode={terminalTheme}
           className="h-full"
           {...(terminalBaseUrl ? { baseUrl: terminalBaseUrl } : {})}
+          {...(cwd ? { cwd } : {})}
         />
       );
     }

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import {
   FileText,
+  FolderTree,
   Loader2,
   PanelRightClose,
   TerminalSquare,
@@ -14,6 +15,7 @@ import { ComputerStatusChip } from "@/components/computer/ComputerStatusChip";
 import { ComputerTerminalPane } from "@/components/computer/ComputerTerminalPane";
 import { useComputerTerminal } from "@/components/computer/useComputerTerminal";
 import { useComputersEnabledState } from "@/hooks/useComputersEnabled";
+import { useHarnessWorkdir } from "@/stores/harness-workdir-store";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 
 /**
@@ -26,11 +28,16 @@ import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 export function PlaygroundRightRail({
   onClose,
   hostConfig,
+  hostId,
   projectId,
   isAuthenticated,
 }: {
   onClose: () => void;
   hostConfig: HostConfigDtoV2 | null;
+  /** Convex host document id (previewedHostId) — the SAME id the chat stream
+   *  keys the harness workdir cache by. NOT hostConfig.id (a content-addressed
+   *  config id), which would never match the write side. */
+  hostId: string | null;
   projectId: string | null;
   isAuthenticated: boolean;
 }) {
@@ -45,6 +52,8 @@ export function PlaygroundRightRail({
       onClose={onClose}
       projectId={projectId}
       isAuthenticated={isAuthenticated}
+      hostConfig={hostConfig}
+      hostId={hostId}
     />
   );
 }
@@ -55,22 +64,30 @@ function RightRailTabbed({
   onClose,
   projectId,
   isAuthenticated,
+  hostConfig,
+  hostId,
 }: {
   onClose: () => void;
   projectId: string | null;
   isAuthenticated: boolean;
+  hostConfig: HostConfigDtoV2 | null;
+  hostId: string | null;
 }) {
   const [activeTab, setActiveTab] = useState<RightRailTab>("logs");
+  // Bumped to remount (and thus reconnect) the terminal into the latest harness
+  // workdir on demand — cwd only applies at connect time.
+  const [reloadKey, setReloadKey] = useState(0);
   const posthog = usePostHog();
   // One controller for the rail so the terminal session survives Logs ⇄ Shell
   // toggles (both bodies stay mounted; we only show/hide).
   const ct = useComputerTerminal({ projectId, isAuthenticated });
-  // The Shell opens in the computer's default directory. Opening it in the
-  // harness session workdir (cd into the agent's cwd) is a FOLLOW-UP: it needs
-  // both a producer (the chat stream emitting `sessionWorkDir`) and cwd
-  // threading through the terminal WebSocket, neither of which is in this
-  // restore (they depend on the harness-session/create-pty changes that
-  // conflict with main's newer commits).
+  // Open the terminal in the harness session workdir — but only for harness
+  // hosts (plain computer hosts have no such dir → home).
+  const isHarnessHost = !!hostConfig?.harness;
+  // Read with the SAME key the chat stream writes (previewedHostId), not
+  // hostConfig.id — those are different identifiers and would never match.
+  const streamedWorkdir = useHarnessWorkdir(projectId, hostId);
+  const harnessCwd = isHarnessHost ? streamedWorkdir : undefined;
   // Only offer "Open terminal" once the data-plane config has resolved to a
   // usable plane — opening while it's still loading mounts the terminal at the
   // page origin; opening with no plane reserves a computer it can't reach.
@@ -148,9 +165,30 @@ function RightRailTabbed({
               )}
               Open terminal
             </Button>
+          ) : ct.terminalOpen && harnessCwd ? (
+            // cwd is applied at connect time; remount to reconnect into the
+            // latest harness workdir (e.g. after a new turn ran).
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setReloadKey((k) => k + 1)}
+              title={`Reconnect in ${harnessCwd}`}
+            >
+              <FolderTree className="mr-1.5 h-3.5 w-3.5" />
+              Reload in harness dir
+            </Button>
           ) : null}
         </div>
-        <ComputerTerminalPane controller={ct} className="px-3 pb-3" />
+        {/* Key on reloadKey ONLY (explicit reconnect) — NOT on cwd, so a newer
+            harness workdir streaming in mid-session doesn't yank the user's open
+            terminal. Reopening the terminal already picks up the latest cwd
+            (ComputerTerminal remounts when terminalOpen flips). */}
+        <ComputerTerminalPane
+          key={reloadKey}
+          controller={ct}
+          className="px-3 pb-3"
+          {...(harnessCwd ? { cwd: harnessCwd } : {})}
+        />
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -343,6 +343,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
                               <PlaygroundRightRail
                                 onClose={() => setIsRightRailVisible(false)}
                                 hostConfig={effectiveHostConfig}
+                                hostId={previewedHostId ?? null}
                                 projectId={
                                   props.sharedProjectId ??
                                   props.activeProjectId ??

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -111,6 +111,7 @@ import { usePersistedHost } from "@/hooks/use-persisted-host";
 import { usePlaygroundHostSlots } from "@/hooks/use-playground-host-slots";
 import { replaceLeadHostId } from "@/lib/selected-host-storage";
 import { useProjectServers } from "@/hooks/useViews";
+import { useServerActionsOptional } from "@/state/server-actions-context";
 import { useProjectMembers } from "@/hooks/useProjects";
 import { buildProjectOwnerProfileByUserId } from "@/components/chat-v2/history/project-thread-owner-avatar";
 import { buildSenderAvatarResolver } from "@/components/chat-v2/shared/sender-avatar";
@@ -664,6 +665,9 @@ export function PlaygroundMain({
     isAuthenticated: isConvexAuthenticated,
     projectId: convexProjectId,
   });
+  // Optional: present app-wide, absent in isolated embeds. Drives the hosted
+  // harness preflight (resolve/persist selected server names → Convex ids).
+  const playgroundServerActions = useServerActionsOptional();
   const hostedSelectedServerIds = useMemo(
     () =>
       selectedServers
@@ -761,6 +765,16 @@ export function PlaygroundMain({
       projectId: convexProjectId,
       selectedServerIds: hostedSelectedServerIds,
       oauthTokens: hostedOAuthTokens,
+      // Resolve/persist selected server names → Convex ids before a hosted
+      // harness send (ad-hoc/App servers included), so the proxy never sees a
+      // display name. Absent in isolated embeds → falls back to the
+      // pre-resolved selection above.
+      ...(playgroundServerActions?.ensureHostedServerIdsForNames
+        ? {
+            ensureServerIds:
+              playgroundServerActions.ensureHostedServerIdsForNames,
+          }
+        : {}),
       // Forward the previewed host id so the server re-resolves its
       // authoritative runtime config (harness/computer) for this direct
       // session, and so switching hosts forks the chat session.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -318,6 +318,61 @@ beforeEach(() => {
   });
 });
 
+describe("ensureHostedServerIdsForNames (hosted harness preflight)", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+    mockCreateServer.mockReset();
+    mockCreateServerIfMissing.mockReset();
+    mockConvexQuery.mockReset();
+    getStoredTokensMock.mockReturnValue(null);
+    readStoredOAuthConfigMock.mockReturnValue({});
+    testConnectionMock.mockResolvedValue({ success: true, initInfo: null });
+  });
+
+  it("returns existing Convex ids without persisting when names already resolve", async () => {
+    tryResolveProjectServerMock.mockReturnValue({
+      projectId: "default",
+      serverId: "srv_existing",
+    });
+    const appState = createAppState();
+    const { result } = renderUseServerState(vi.fn(), appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+    });
+
+    let resolved: Array<{ serverName: string; serverId: string }> = [];
+    await act(async () => {
+      resolved =
+        await result.current.ensureHostedServerIdsForNames(["demo-server"]);
+    });
+
+    expect(resolved).toEqual([
+      { serverName: "demo-server", serverId: "srv_existing" },
+    ]);
+    // Already resolved → no persistence side effect.
+    expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
+    expect(mockCreateServer).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (throws) when a selected name is neither mapped nor connected", async () => {
+    tryResolveProjectServerMock.mockReturnValue(null);
+    const appState = createAppState(); // top-level servers has only "demo-server"
+    const { result } = renderUseServerState(vi.fn(), appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+    });
+
+    await expect(
+      result.current.ensureHostedServerIdsForNames(["ghost-server"])
+    ).rejects.toThrow(/ghost-server/);
+  });
+});
+
 describe("useServerState CLI config import", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -848,6 +848,7 @@ export function useAppState({
       serverState.handleRefreshTokensFromOAuthFlow,
     persistRuntimeServerToProjectIfNeeded:
       serverState.persistRuntimeServerToProjectIfNeeded,
+    ensureHostedServerIdsForNames: serverState.ensureHostedServerIdsForNames,
 
     handleSwitchProject,
     handleCreateProject: projectState.handleCreateProject,

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -22,6 +22,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { useChat, type UIMessage } from "@ai-sdk/react";
+import { toast } from "sonner";
 import {
   convertToModelMessages,
   type ChatTransport,
@@ -111,6 +112,12 @@ import {
   pickTranscriptForLiveTracePreview,
 } from "@/shared/live-chat-trace-preview";
 import { isHostedRpcLogDataPart } from "@/shared/hosted-rpc-log";
+import {
+  isHarnessSessionDataPart,
+  isHarnessResetDataPart,
+  type HarnessResetReason,
+} from "@/shared/harness-session";
+import { useHarnessWorkdirStore } from "@/stores/harness-workdir-store";
 import { ingestHostedRpcLogsFromResponse } from "@/lib/apis/web/rpc-logs";
 import type { ExecutionConfig } from "@/lib/chat-execution-config";
 import type { HostedRuntimeContext } from "@/lib/hosted-runtime-context";
@@ -119,6 +126,17 @@ import {
   getApiContextRevision,
   subscribeApiContext,
 } from "@/lib/apis/web/context";
+
+// User-facing copy for a harness session reset, keyed by reason. Only hard
+// resets are shown; `legacy-cold-resume` is a server-side log (resume is still
+// attempted) and intentionally maps to no toast.
+const HARNESS_RESET_MESSAGES: Record<HarnessResetReason, string | null> = {
+  "sandbox-replaced":
+    "Started a new session — the project computer was reset, so earlier context isn't available.",
+  "resume-failed":
+    "Started a new session — couldn't resume the previous one, so earlier context isn't available.",
+  "legacy-cold-resume": null,
+};
 
 // SEP-1865 App-Provided Tools: opaque alias shape minted by
 // `useAppToolsRegistry`. Mirrors the regex in `app-tools-registry.ts`,
@@ -1092,6 +1110,7 @@ export function useChatSession(
   const isExecutionConfigControlled = "executionConfig" in options;
   const hostedProjectId = hostedContext?.projectId;
   const hostedSelectedServerIds = hostedContext?.selectedServerIds ?? [];
+  const hostedEnsureServerIds = hostedContext?.ensureServerIds;
   const hostedOAuthTokens = hostedContext?.oauthTokens;
   const hostedChatboxId = hostedContext?.chatboxId;
   const hostedHostId = hostedContext?.hostId;
@@ -1264,16 +1283,35 @@ export function useChatSession(
     liveTraceState.activeTurnHasSnapshot,
     liveTraceState.events,
   ]);
-  const handleStreamDataPart = useCallback((part: unknown) => {
-    if (!isTraceEventDataPart(part)) {
-      if (isHostedRpcLogDataPart(part)) {
-        ingestHostedRpcLogs([part.data]);
+  const handleStreamDataPart = useCallback(
+    (part: unknown) => {
+      if (!isTraceEventDataPart(part)) {
+        if (isHostedRpcLogDataPart(part)) {
+          ingestHostedRpcLogs([part.data]);
+        } else if (isHarnessSessionDataPart(part)) {
+          // Cache the harness workdir so the Playground Shell can open a
+          // terminal there. Keyed by project + host (both known here).
+          useHarnessWorkdirStore
+            .getState()
+            .setWorkdir(
+              hostedProjectId ?? null,
+              hostedHostId ?? null,
+              part.data.workdir,
+            );
+        } else if (isHarnessResetDataPart(part)) {
+          // The harness couldn't warm-resume the prior in-box session and
+          // started a fresh one. Surface it so a lost conversation reads as an
+          // explained reset, not the model silently "forgetting".
+          const message = HARNESS_RESET_MESSAGES[part.data.reason];
+          if (message) toast.info(message);
+        }
+        return;
       }
-      return;
-    }
 
-    setLiveTraceState((current) => applyLiveTraceEvent(current, part.data));
-  }, []);
+      setLiveTraceState((current) => applyLiveTraceEvent(current, part.data));
+    },
+    [hostedProjectId, hostedHostId],
+  );
 
   const syncResumedVersion = useCallback((version: number | null) => {
     resumedVersionRef.current = version;
@@ -1454,6 +1492,10 @@ export function useChatSession(
   const pendingWidgetModelContextRef = useRef<
     WidgetModelContextEntry[] | undefined
   >(undefined);
+  // Convex server ids resolved by the hosted preflight (`hostedEnsureServerIds`)
+  // in `sendMessage`, consumed once by the (synchronous) transport body so the
+  // hosted send carries real ids for ad-hoc/App servers, not display names.
+  const resolvedHostedServerIdsRef = useRef<string[] | null>(null);
 
   const transport = useMemo(() => {
     const shouldUseOrgAwareChatApi =
@@ -1496,9 +1538,14 @@ export function useChatSession(
         throw new Error("Hosted chat context is not ready: missing projectId.");
       }
       const isHostedDirectChat = !hostedChatboxId;
+      // Prefer ids resolved by the `sendMessage` preflight (ad-hoc/App servers
+      // persisted to real Convex ids); consume once. Fall back to the
+      // pre-resolved selection for surfaces without a preflight (e.g. chatbox).
+      const preflightServerIds = resolvedHostedServerIdsRef.current;
+      resolvedHostedServerIdsRef.current = null;
       const hostedServerBatch = buildResolvedServerBatchRequest({
         projectId: hostedProjectId,
-        serverIds: hostedSelectedServerIds,
+        serverIds: preflightServerIds ?? hostedSelectedServerIds,
         serverNames: selectedServers,
         accessScope: "chat_v2",
         ...(isHostedDirectChat &&
@@ -2157,19 +2204,55 @@ export function useChatSession(
         widgetModelContext && widgetModelContext.length > 0
           ? widgetModelContext
           : undefined;
-      try {
-        if (files && files.length > 0) {
-          // AI SDK accepts FileUIPart[] with data URLs
-          baseSendMessage({ text, files, ...extra });
-        } else {
-          baseSendMessage({ text, ...extra });
+      return (async () => {
+        // Hosted preflight: resolve selected runtime server NAMES → persisted
+        // Convex ids (persisting ad-hoc/App servers) BEFORE the synchronous
+        // transport body builds, so the hosted send never carries a display
+        // name. Only on the web-engine path, and only when the surface provided
+        // a resolver (Playground). On failure, fail the send CLOSED with a
+        // visible toast (callers fire-and-forget, so don't reject).
+        const usesWebEngine =
+          HOSTED_MODE || selectedModelUsesOrgRuntime || hostedRequiresWebChatApi;
+        if (
+          usesWebEngine &&
+          hostedEnsureServerIds &&
+          selectedServers.length > 0
+        ) {
+          try {
+            const resolved = await hostedEnsureServerIds(selectedServers);
+            resolvedHostedServerIdsRef.current = resolved.map((r) => r.serverId);
+          } catch (error) {
+            pendingWidgetModelContextRef.current = undefined;
+            resolvedHostedServerIdsRef.current = null;
+            toast.error(
+              error instanceof Error
+                ? error.message
+                : "Couldn't prepare the selected servers for this run."
+            );
+            return; // fail closed — do not send with unresolved servers
+          }
         }
-      } catch (error) {
-        pendingWidgetModelContextRef.current = undefined;
-        throw error;
-      }
+        try {
+          if (files && files.length > 0) {
+            // AI SDK accepts FileUIPart[] with data URLs
+            baseSendMessage({ text, files, ...extra });
+          } else {
+            baseSendMessage({ text, ...extra });
+          }
+        } catch (error) {
+          pendingWidgetModelContextRef.current = undefined;
+          resolvedHostedServerIdsRef.current = null;
+          throw error;
+        }
+      })();
     },
-    [baseSendMessage]
+    [
+      baseSendMessage,
+      hostedEnsureServerIds,
+      selectedServers,
+      selectedModelUsesOrgRuntime,
+      hostedRequiresWebChatApi,
+    ]
   );
 
   // Reset chat

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1673,6 +1673,47 @@ export function useServerState({
     [effectiveActiveProjectId, syncServerToConvex, logger]
   );
 
+  /**
+   * Resolve selected runtime server names → persisted Convex server ids for a
+   * HOSTED send, persisting any ad-hoc/App server that isn't saved yet. The
+   * hosted harness proxy + `authorize-batch` operate on real `Id<'servers'>`, so
+   * a display name like "Excalidraw (App)" must become a Convex id before the
+   * send (otherwise the mint endpoint 422s and the turn fails closed). Mirrors
+   * the manual-connect persist path (`syncServerToConvex` → inject mapping).
+   * THROWS if a name can't be resolved/persisted — the caller must fail the send
+   * closed rather than send a name.
+   */
+  const ensureHostedServerIdsForNames = useCallback(
+    async (
+      serverNames: string[]
+    ): Promise<Array<{ serverName: string; serverId: string }>> => {
+      const out: Array<{ serverName: string; serverId: string }> = [];
+      for (const serverName of serverNames) {
+        const resolved = tryResolveProjectServer(serverName);
+        if (resolved?.serverId) {
+          out.push({ serverName, serverId: resolved.serverId });
+          continue;
+        }
+        const entry = appStateServersRef.current[serverName];
+        if (!entry) {
+          throw new Error(
+            `Cannot start: server "${serverName}" is not connected, so it can't be saved to the project.`
+          );
+        }
+        const serverId = await syncServerToConvex(serverName, entry);
+        if (!serverId) {
+          throw new Error(
+            `Cannot start: failed to save server "${serverName}" to the project.`
+          );
+        }
+        injectHostedServerMapping(serverName, serverId);
+        out.push({ serverName, serverId });
+      }
+      return out;
+    },
+    [syncServerToConvex]
+  );
+
   const removeServerFromConvex = useCallback(
     async (serverName: string) => {
       if (useLocalFallback || !isAuthenticated || !effectiveActiveProjectId) {
@@ -4440,5 +4481,6 @@ export function useServerState({
     handleConnectWithTokensFromOAuthFlow,
     handleRefreshTokensFromOAuthFlow,
     persistRuntimeServerToProjectIfNeeded,
+    ensureHostedServerIdsForNames,
   };
 }

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildComputerUploadUrl,
   buildTerminalWsUrl,
   openTerminalConnection,
   toTerminalWsBase,
+  uploadFilesToComputer,
   type TerminalEvent,
 } from "../computer-terminal-connection";
 
@@ -76,6 +78,27 @@ describe("buildTerminalWsUrl", () => {
       "wss://host.test/api/web/computers/terminal?token=abc&cols=100&rows=30"
     );
   });
+
+  it("appends an encoded cwd when provided", () => {
+    const url = buildTerminalWsUrl({
+      token: "abc",
+      cols: 80,
+      rows: 24,
+      baseUrl: "wss://host.test",
+      cwd: "/home/user/claude-code-XyZ",
+    });
+    expect(url).toContain("&cwd=%2Fhome%2Fuser%2Fclaude-code-XyZ");
+  });
+
+  it("omits cwd when absent", () => {
+    const url = buildTerminalWsUrl({
+      token: "abc",
+      cols: 80,
+      rows: 24,
+      baseUrl: "wss://host.test",
+    });
+    expect(url).not.toContain("cwd=");
+  });
 });
 
 describe("openTerminalConnection", () => {
@@ -140,6 +163,91 @@ describe("openTerminalConnection", () => {
       ws.onmessage?.({ data: "not json {{{" } as MessageEvent)
     ).not.toThrow();
     expect(events).toHaveLength(0);
+  });
+});
+
+describe("buildComputerUploadUrl", () => {
+  it("converts a wss base to https and appends the upload path", () => {
+    expect(buildComputerUploadUrl({ baseUrl: "wss://host.test" })).toBe(
+      "https://host.test/api/web/computers/upload"
+    );
+    expect(buildComputerUploadUrl({ baseUrl: "ws://localhost:3500" })).toBe(
+      "http://localhost:3500/api/web/computers/upload"
+    );
+  });
+
+  it("returns a relative path when no base is given (page origin)", () => {
+    expect(buildComputerUploadUrl()).toBe("/api/web/computers/upload");
+    expect(buildComputerUploadUrl({})).toBe("/api/web/computers/upload");
+  });
+});
+
+describe("uploadFilesToComputer", () => {
+  function fakeFile(name: string): File {
+    return new File([new Uint8Array([1, 2, 3])], name, { type: "text/plain" });
+  }
+
+  it("POSTs a FormData with the token in the query and returns written files", async () => {
+    let calledUrl = "";
+    let calledInit: RequestInit | undefined;
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      calledUrl = String(url);
+      calledInit = init;
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          files: [{ name: "x", path: "/home/user/uploads/x", bytes: 3 }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+
+    const files = await uploadFilesToComputer({
+      token: "tok-9",
+      files: [fakeFile("a.txt")],
+      baseUrl: "wss://host.test",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(calledUrl).toBe(
+      "https://host.test/api/web/computers/upload?token=tok-9"
+    );
+    expect(calledInit?.method).toBe("POST");
+    expect(calledInit?.body).toBeInstanceOf(FormData);
+    expect((calledInit?.body as FormData).getAll("files")).toHaveLength(1);
+    expect(files).toEqual([
+      { name: "x", path: "/home/user/uploads/x", bytes: 3 },
+    ]);
+  });
+
+  it("throws with the server-supplied message on a non-2xx response", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: false, error: "computer asleep" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        })
+    );
+    await expect(
+      uploadFilesToComputer({
+        token: "t",
+        files: [fakeFile("a.txt")],
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      })
+    ).rejects.toThrow("computer asleep");
+  });
+
+  it("throws a status fallback when the body isn't JSON", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("<html>502</html>", { status: 502 })
+    );
+    await expect(
+      uploadFilesToComputer({
+        token: "t",
+        files: [fakeFile("a.txt")],
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      })
+    ).rejects.toThrow("502");
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/computer-terminal-connection.ts
+++ b/mcpjam-inspector/client/src/lib/computer-terminal-connection.ts
@@ -36,6 +36,9 @@ export interface OpenTerminalOptions {
   onClose: (code: number, reason: string) => void;
   /** Origin override (defaults to the current page origin); mainly for tests. */
   baseUrl?: string;
+  /** Starting working directory for the PTY (e.g. the harness session workdir).
+   *  Applied server-side at PTY creation; falls back to home if it can't be set. */
+  cwd?: string;
   /** WebSocket factory override for tests. */
   wsFactory?: (url: string) => WebSocket;
 }
@@ -58,12 +61,72 @@ export function toTerminalWsBase(httpOrigin: string): string | undefined {
   }
 }
 
+/**
+ * Build the `http(s)://…/api/web/computers/upload` URL. The upload MUST hit the
+ * same data plane as the terminal WebSocket (the sandbox lives there), so when a
+ * remote `ws(s)://` base is set we convert it back to `http(s)://`; otherwise we
+ * return a page-origin-relative path.
+ */
+export function buildComputerUploadUrl(args?: { baseUrl?: string }): string {
+  const path = "/api/web/computers/upload";
+  const base = args?.baseUrl;
+  if (!base) return path;
+  // `baseUrl` is the ws(s):// terminal base; swap the scheme for fetch.
+  const origin = base
+    .replace(/^wss:\/\//i, "https://")
+    .replace(/^ws:\/\//i, "http://");
+  return `${origin}${path}`;
+}
+
+export interface UploadedComputerFile {
+  name: string;
+  path: string;
+  bytes: number;
+}
+
+/**
+ * POST files to the user's project computer (drag-and-drop from the Shell). The
+ * `token` is a fresh Convex-minted terminal token (the same one the WS uses);
+ * auth is the token in the query string. `dir` targets a destination directory
+ * (the Shell's cwd — i.e. the harness workdir) so uploads land where the user is
+ * working; the server confines it under the box home and falls back to a default
+ * bucket when absent/invalid. Resolves to the written files (with their absolute
+ * sandbox paths) or throws with a server-supplied message.
+ */
+export async function uploadFilesToComputer(args: {
+  token: string;
+  files: File[];
+  baseUrl?: string;
+  dir?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<UploadedComputerFile[]> {
+  const params = new URLSearchParams({ token: args.token });
+  if (args.dir) params.set("dir", args.dir);
+  const url = `${buildComputerUploadUrl({ baseUrl: args.baseUrl })}?${params.toString()}`;
+  const form = new FormData();
+  for (const file of args.files) form.append("files", file);
+
+  const doFetch = args.fetchImpl ?? fetch;
+  const res = await doFetch(url, { method: "POST", body: form });
+  let body: { ok?: boolean; files?: UploadedComputerFile[]; error?: string } = {};
+  try {
+    body = (await res.json()) as typeof body;
+  } catch {
+    // non-JSON (e.g. a proxy error page) — fall through to the status check.
+  }
+  if (!res.ok || !body.ok) {
+    throw new Error(body.error || `Upload failed (${res.status}).`);
+  }
+  return body.files ?? [];
+}
+
 /** Build the `ws(s)://…/api/web/computers/terminal?…` URL from page origin. */
 export function buildTerminalWsUrl(args: {
   token: string;
   cols: number;
   rows: number;
   baseUrl?: string;
+  cwd?: string;
 }): string {
   const origin =
     args.baseUrl ??
@@ -75,6 +138,7 @@ export function buildTerminalWsUrl(args: {
     cols: String(args.cols),
     rows: String(args.rows),
   });
+  if (args.cwd) params.set("cwd", args.cwd);
   return `${origin}/api/web/computers/terminal?${params.toString()}`;
 }
 

--- a/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
@@ -35,4 +35,17 @@ export type HostedRuntimeContext = {
    * reuse the builder's locally-connected servers.
    */
   requiresWebChatApi?: boolean;
+  /**
+   * Preflight that resolves selected runtime server NAMES → persisted Convex
+   * server ids (persisting ad-hoc/App servers that aren't saved yet), awaited
+   * before a hosted harness send so the proxy/authorize-batch never receive a
+   * display name. Provided by Playground-class surfaces from
+   * `useServerActions().ensureHostedServerIdsForNames`; absent for surfaces
+   * whose servers are already Convex-resolved (e.g. chatbox), which keep the
+   * existing pre-resolved `selectedServerIds` path. Throws on an unresolvable
+   * name so the caller fails the send closed.
+   */
+  ensureServerIds?: (
+    serverNames: string[],
+  ) => Promise<Array<{ serverName: string; serverId: string }>>;
 };

--- a/mcpjam-inspector/client/src/state/server-actions-context.tsx
+++ b/mcpjam-inspector/client/src/state/server-actions-context.tsx
@@ -33,6 +33,16 @@ export interface ServerActions {
    * flip each toggle by hand after every switch.
    */
   setSelectedServerNames: (names: string[]) => void;
+  /**
+   * Resolve selected runtime server names → persisted Convex server ids for a
+   * hosted send (persisting ad-hoc/App servers that aren't saved yet). Throws if
+   * a name can't be resolved/persisted. Surfaces use this as a preflight before a
+   * hosted harness turn so the proxy/authorize-batch never receive a display
+   * name. Re-exposed from `useServerState().ensureHostedServerIdsForNames`.
+   */
+  ensureHostedServerIdsForNames: (
+    serverNames: string[],
+  ) => Promise<Array<{ serverName: string; serverId: string }>>;
 }
 
 const ServerActionsContext = createContext<ServerActions | null>(null);
@@ -59,4 +69,13 @@ export function useServerActions(): ServerActions {
     );
   }
   return ctx;
+}
+
+/**
+ * Non-throwing variant: returns `null` when rendered outside a provider (e.g. a
+ * PlaygroundMain embedded in an isolated context). Callers must treat the
+ * actions as optional.
+ */
+export function useServerActionsOptional(): ServerActions | null {
+  return useContext(ServerActionsContext);
 }

--- a/mcpjam-inspector/client/src/stores/harness-workdir-store.ts
+++ b/mcpjam-inspector/client/src/stores/harness-workdir-store.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+
+/**
+ * Caches the latest harness working directory streamed from the server, keyed by
+ * project + host. The Playground Shell reads it to open a terminal in the harness
+ * workdir (`/home/user/claude-code-<id>`) instead of the box's home.
+ *
+ * "Latest per (project, host)" is the intended scope: the user inspects the run
+ * they just did. Project+host keying avoids a stale cwd when switching between two
+ * harness hosts in the same project.
+ */
+// The host id (previewedHostId — a globally-unique Convex doc id) is the primary
+// key: the write side (chat stream) and read side (rail) both derive it from
+// `usePreviewedHostId`, so it always matches. We key by it ALONE when present so
+// the result is immune to the two sides resolving `projectId` from slightly
+// different sources. projectId is only the fallback when there's no host id.
+function workdirKey(projectId: string | null, hostId: string | null): string {
+  return hostId ? `h:${hostId}` : `p:${projectId ?? ""}`;
+}
+
+interface HarnessWorkdirState {
+  byKey: Record<string, string>;
+  setWorkdir: (
+    projectId: string | null,
+    hostId: string | null,
+    workdir: string,
+  ) => void;
+}
+
+export const useHarnessWorkdirStore = create<HarnessWorkdirState>((set) => ({
+  byKey: {},
+  setWorkdir: (projectId, hostId, workdir) =>
+    set((state) => {
+      const key = workdirKey(projectId, hostId);
+      if (state.byKey[key] === workdir) return state;
+      return { byKey: { ...state.byKey, [key]: workdir } };
+    }),
+}));
+
+/** Selector: the cached harness workdir for a (project, host), or undefined. */
+export function useHarnessWorkdir(
+  projectId: string | null,
+  hostId: string | null,
+): string | undefined {
+  const key = workdirKey(projectId, hostId);
+  return useHarnessWorkdirStore((s) => s.byKey[key]);
+}

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -50,6 +50,7 @@ import { getSystemLogger } from "./utils/request-logger";
 import { requestLogContextMiddleware } from "./middleware/request-log-context";
 import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url";
 import { createComputerTerminalWsHandler } from "./routes/web/computer-terminal";
+import { createComputerUploadHandler } from "./routes/web/computer-upload";
 import { registerSelfFetch } from "./utils/self-app";
 
 const sysLogger = getSystemLogger("process");
@@ -337,8 +338,9 @@ app.use(
   })
 );
 
-// 1MB JSON cap for /api/web/*, with a multipart carve-out for the cloud-skills
-// folder upload (bounded by the service caps instead). See `webBodyLimit`.
+// 1MB JSON cap for /api/web/*, with a carve-out for the computer file-upload
+// route (multipart blobs; it applies its own higher bodyLimit at the mount
+// site below). See `webBodyLimit`.
 app.use("/api/web/*", webBodyLimit());
 
 // Typed event logging context (matches app.ts)
@@ -372,6 +374,21 @@ app.route("/api/web", webRoutes);
 app.get(
   "/api/web/computers/terminal",
   createComputerTerminalWsHandler(upgradeWebSocket)
+);
+// Computer file upload (drag-and-drop from the Shell panel). Same terminal-token
+// auth as the WS above; its own 30MB bodyLimit (the global /api/web/* 1MB cap
+// excludes this path). See routes/web/computer-upload.
+app.post(
+  "/api/web/computers/upload",
+  bodyLimit({
+    maxSize: 30 * 1024 * 1024,
+    onError: (c) =>
+      c.json(
+        { ok: false, error: "Upload exceeds the 30MB request limit." },
+        413
+      ),
+  }),
+  createComputerUploadHandler()
 );
 
 // Hosted public API (v1). Same 1MB JSON cap as /api/web; routes wrap the same

--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -61,13 +61,15 @@ const UNPROTECTED_PREFIXES = [
 
 /**
  * Scrub sensitive tokens from URLs for safe logging.
- * Replaces _token (session token) and k (tunnel bearer secret) query
- * parameter values with [REDACTED].
+ * Replaces _token (session token), k (tunnel bearer secret), and t (the
+ * retired harness `?t=` proxy-token fallback — still scrubbed in case a stale
+ * URL carries one) query parameter values with [REDACTED].
  */
 export function scrubTokenFromUrl(url: string): string {
   return url
     .replace(/([?&])_token=[^&]*/g, "$1_token=[REDACTED]")
-    .replace(/([?&])k=[^&]*/g, "$1k=[REDACTED]");
+    .replace(/([?&])k=[^&]*/g, "$1k=[REDACTED]")
+    .replace(/([?&])t=[^&]*/g, "$1t=[REDACTED]");
 }
 
 // Routes that typically use query param auth (SSE endpoints)

--- a/mcpjam-inspector/server/middleware/web-body-limit.ts
+++ b/mcpjam-inspector/server/middleware/web-body-limit.ts
@@ -3,6 +3,9 @@
  * and cloud-skill creates carry only a small inline SKILL.md body well under
  * the cap). Mount once with `app.use("/api/web/*", webBodyLimit())`.
  *
+ * Carve-out: the computer file-upload route carries multipart blobs and
+ * applies its own (higher) bodyLimit at its mount site, so it is exempt here.
+ *
  * (An earlier multipart carve-out for skill *folder* uploads was removed when
  * skills moved to a Convex source of truth — there's no large multipart upload
  * on this surface in v1.)
@@ -13,8 +16,9 @@ import type { Context, Next } from "hono";
 export const DEFAULT_WEB_BODY_LIMIT = 1024 * 1024; // 1MB
 
 export function webBodyLimit() {
-  return (c: Context, next: Next) =>
-    bodyLimit({
+  return (c: Context, next: Next) => {
+    if (c.req.path === "/api/web/computers/upload") return next();
+    return bodyLimit({
       maxSize: DEFAULT_WEB_BODY_LIMIT,
       onError: (ctx) =>
         ctx.json(
@@ -22,4 +26,5 @@ export function webBodyLimit() {
           400,
         ),
     })(c, next);
+  };
 }

--- a/mcpjam-inspector/server/routes/mcp/__tests__/harness-proxy.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/harness-proxy.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Harness proxy-token on `adapter-http` (LOCAL plane, validate-when-present).
+ *
+ * The relay edge binds every tunnel to `/api/mcp/adapter-http/{serverId}`, so
+ * the local-desktop harness reuses that route. Its `X-MCPJam-Proxy-Token`
+ * (header-only) — minted by Convex, verified here — is checked only WHEN
+ * PRESENT: the harness always sends it; external MCP clients send none and are
+ * unaffected.
+ */
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import type { Hono } from "hono";
+import {
+  createMockMcpClientManager,
+  createTestApp,
+  expectJson,
+  type MockMCPClientManager,
+} from "./helpers/index.js";
+import { signTestProxyToken } from "../../../utils/harness/__tests__/sign-test-token.js";
+
+const mintLocal = (serverId: string) => signTestProxyToken({ serverId });
+
+describe("adapter-http harness proxy-token (validate-when-present)", () => {
+  let manager: MockMCPClientManager;
+  let app: Hono;
+
+  beforeAll(() => {
+    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "test-harness-proxy-secret-32-chars";
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = createMockMcpClientManager({
+      listServers: vi.fn().mockReturnValue(["test-server"]),
+      getManagedClient: vi
+        .fn()
+        .mockImplementation((id: string) =>
+          id === "test-server" ? {} : undefined,
+        ),
+      hasServer: vi.fn().mockImplementation((id: string) => id === "test-server"),
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: "echo" }] }),
+    });
+    app = createTestApp(manager, ["adapter-http"]);
+  });
+
+  const toolsList = (headers: Record<string, string> = {}, query = "") =>
+    app.request(`/api/mcp/adapter-http/test-server${query}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ id: 1, method: "tools/list", params: {} }),
+    });
+
+  it("200s for external clients (no token) — unaffected", async () => {
+    const res = await toolsList();
+    const { status, data } = await expectJson(res);
+    expect(status).toBe(200);
+    expect(data.result.tools).toEqual([{ name: "echo" }]);
+  });
+
+  it("401s when a token is supplied but invalid", async () => {
+    const res = await toolsList({ "X-MCPJam-Proxy-Token": "nope" });
+    expect(res.status).toBe(401);
+  });
+
+  it("200s with a valid token (header)", async () => {
+    const res = await toolsList({ "X-MCPJam-Proxy-Token": mintLocal("test-server") });
+    expect(res.status).toBe(200);
+  });
+
+  it("IGNORES a `?t=` query token (header-only, Phase 4) — treated as no token", async () => {
+    // A bogus `?t=` would 401 if honored; header-only means it's ignored, so
+    // the request is unauthenticated-but-present-free → passes through (200).
+    const res = await toolsList({}, `?t=bogus`);
+    expect(res.status).toBe(200);
+  });
+
+  it("401s a token minted for another server (server-scoped)", async () => {
+    const res = await toolsList({ "X-MCPJam-Proxy-Token": mintLocal("other-server") });
+    expect(res.status).toBe(401);
+  });
+
+  it("401s the GET (SSE) stream when an invalid token is supplied (header)", async () => {
+    const res = await app.request("/api/mcp/adapter-http/test-server", {
+      method: "GET",
+      headers: { "X-MCPJam-Proxy-Token": "bogus" },
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/__tests__/http-adapters.streamable-http.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/http-adapters.streamable-http.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Phase 0 transport-gate spike (STATIC half) — "Keep MCPJam being MCPJam" plan.
+ *
+ * The harness writes `.mcp.json` entries as `type:"http"`, i.e. Claude Code's
+ * in-sandbox MCP client speaks modern **Streamable HTTP** (single endpoint:
+ * POST a JSON-RPC message → server replies with `application/json` OR an SSE
+ * stream; optional standalone GET for server→client messages; `Mcp-Session-Id`
+ * for session continuity).
+ *
+ * The reuse candidate `adapter-http` is the LEGACY HTTP+SSE transport (GET emits
+ * an `endpoint` handshake to a separate `/messages` channel). This test pins,
+ * in-process, exactly how much of a Streamable-HTTP client's contract the route
+ * already satisfies — so the live E2B spike only has to confirm the genuinely
+ * unknowable bits (does Claude Code's client tolerate them) rather than the
+ * whole thing.
+ *
+ * VERDICT codified below:
+ *  - Request/response path (initialize → tools/list → tools/call via POST):
+ *    SATISFIED. POST returns a single `application/json` JSON-RPC response,
+ *    which is a legal *stateless* Streamable-HTTP server reply.
+ *  - Session continuity: the route returns NO `Mcp-Session-Id` header → a
+ *    Streamable-HTTP client must treat it as stateless. Live unknown: does
+ *    Claude Code's client accept a stateless server?
+ *  - Server→client notifications (e.g. tools/list_changed): NOT delivered on
+ *    the POST. They only flow on the legacy GET `endpoint`/`message` stream,
+ *    which a Streamable-HTTP client won't drive. This caps the plan's
+ *    "dynamic" tier at the transport layer (gate #3), independent of client
+ *    behavior.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Hono } from "hono";
+import {
+  createMockMcpClientManager,
+  createTestApp,
+  expectJson,
+  type MockMCPClientManager,
+} from "./helpers/index.js";
+
+// Headers a Streamable-HTTP client sends on every request. No Origin → in-process
+// (tunneled) client, which the route serves without a session token.
+const STREAMABLE_HTTP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+};
+
+describe("Phase 0 transport gate: adapter-http vs a Streamable-HTTP client", () => {
+  let manager: MockMCPClientManager;
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = createMockMcpClientManager({
+      listServers: vi.fn().mockReturnValue(["test-server"]),
+      getManagedClient: vi
+        .fn()
+        .mockImplementation((id: string) =>
+          id === "test-server" ? {} : undefined,
+        ),
+      hasServer: vi.fn().mockImplementation((id: string) => id === "test-server"),
+      getInitializationInfo: vi.fn().mockReturnValue({
+        protocolVersion: "2025-06-18",
+        transport: "http",
+        serverCapabilities: { tools: { listChanged: true } },
+        serverVersion: { name: "real-server", version: "1.2.3" },
+        clientCapabilities: {},
+      }),
+      listTools: vi
+        .fn()
+        .mockResolvedValue({ tools: [{ name: "echo", inputSchema: {} }] }),
+      executeTool: vi
+        .fn()
+        .mockResolvedValue({ content: [{ type: "text", text: "ok" }] }),
+    });
+    app = createTestApp(manager, ["adapter-http"], { withSecurity: true });
+  });
+
+  const post = (body: unknown) =>
+    app.request("/api/mcp/adapter-http/test-server", {
+      method: "POST",
+      headers: STREAMABLE_HTTP_HEADERS,
+      body: JSON.stringify(body),
+    });
+
+  it("SATISFIES the core request/response flow (initialize → tools/list → tools/call)", async () => {
+    // initialize
+    const initRes = await post({
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    });
+    expect(initRes.status).toBe(200);
+    // A Streamable-HTTP client accepts a single JSON reply to its POST.
+    expect(initRes.headers.get("Content-Type")).toContain("application/json");
+    {
+      const { data } = await expectJson(initRes);
+      expect(data.jsonrpc).toBe("2.0");
+      expect(data.result.protocolVersion).toBe("2025-06-18");
+      expect(data.result.serverInfo.name).toBe("real-server");
+    }
+
+    // tools/list
+    const listRes = await post({ id: 2, method: "tools/list", params: {} });
+    {
+      const { status, data } = await expectJson(listRes);
+      expect(status).toBe(200);
+      expect(data.result.tools).toEqual([{ name: "echo", inputSchema: {} }]);
+    }
+
+    // tools/call
+    const callRes = await post({
+      id: 3,
+      method: "tools/call",
+      params: { name: "echo", arguments: { text: "hi" } },
+    });
+    {
+      const { status, data } = await expectJson(callRes);
+      expect(status).toBe(200);
+      expect(data.result.content).toEqual([{ type: "text", text: "ok" }]);
+    }
+  });
+
+  it("returns NO Mcp-Session-Id header → a Streamable-HTTP client must treat the server as stateless (LIVE-SPIKE UNKNOWN: does Claude Code accept that?)", async () => {
+    const res = await post({
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    });
+    expect(res.status).toBe(200);
+    // Documents the gap: the route is stateless-only. If a future change adds
+    // session continuity, flip this assertion and echo the header on POSTs.
+    expect(res.headers.get("Mcp-Session-Id")).toBeNull();
+  });
+
+  it("GET is the LEGACY endpoint-handshake, not a Streamable-HTTP server stream → server→client notifications won't reach the harness this way (caps the dynamic tier, gate #3)", async () => {
+    const res = await app.request("/api/mcp/adapter-http/test-server", {
+      method: "GET",
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+
+    // Drain the handshake: legacy transport advertises a separate POST channel
+    // via an `endpoint` event. A Streamable-HTTP client does NOT consume this;
+    // it expects this GET to be a raw stream of server JSON-RPC messages.
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    for (let i = 0; i < 12; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      // The `data:` line carrying the URL arrives a chunk after its
+      // `event: endpoint` line, so wait for the URL itself.
+      if (buf.includes("/messages")) break;
+    }
+    await reader.cancel();
+    expect(buf).toContain("event: endpoint");
+    expect(buf).toContain("/messages");
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -755,7 +755,23 @@ chatV2.post("/", async (c) => {
         selectedServers,
         requireToolApproval,
         ...(resolvedExecution.harness
-          ? { harness: resolvedExecution.harness }
+          ? {
+              harness: resolvedExecution.harness,
+              // LOCAL-MCP plane: this is an /api/mcp request (desktop), so the
+              // harness reaches the private inspector via a tunnel landing on
+              // adapter-http (the persistent singleton manager).
+              harnessMcpProxy: { plane: "local-mcp" as const },
+              // Multi-turn continuity: runHarnessTurn claims the harnessSessions
+              // lane from the chat OWNER (chatSessionId + sourceType). The web
+              // route threads these via streamWebChatTurn's persist; this route
+              // calls the handler directly, so without them the continuity gate
+              // is skipped and every harness turn starts a fresh (amnesiac)
+              // Claude Code session. Scoped to the harness branch — the emulated
+              // path persists via onConversationComplete and doesn't read these.
+              ...(chatSessionId ? { chatSessionId } : {}),
+              sourceType: chatSessionSourceType,
+              ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
+            }
           : {}),
         // Server-executed built-ins forwarded separately so the harness path
         // can hand them to HarnessAgent (MCP-server tools arrive via .mcp.json).
@@ -763,13 +779,18 @@ chatV2.post("/", async (c) => {
         projectId: body.projectId,
         abortSignal: inboundAbortSignalMcp,
         onConversationComplete: chatSessionId
-          ? async (fullHistory, turnTrace) => {
+          ? async (fullHistory, turnTrace, harnessSessionCommit) => {
               await persistChatSessionToConvex({
                 chatSessionId,
                 modelId: String(modelDefinition.id),
                 modelSource: "mcpjam",
                 sourceType: chatSessionSourceType,
                 origin: chatSessionOrigin,
+                // Harness multi-turn continuity: ride the resume-state commit on
+                // /ingest-chat ATOMICALLY with the transcript (this releases the
+                // claimed lease). Without forwarding this 3rd arg, the lease is
+                // never released and the next turn fails `harness_turn_in_progress`.
+                ...(harnessSessionCommit ? { harnessSessionCommit } : {}),
                 ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
                 ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
                 ...(bodyChatboxId && Number.isFinite(bodyAccessVersion)

--- a/mcpjam-inspector/server/routes/mcp/http-adapters.ts
+++ b/mcpjam-inspector/server/routes/mcp/http-adapters.ts
@@ -7,6 +7,7 @@ import {
 } from "../../services/tunnel-registry";
 import { recordTunnelRequest } from "../../services/tunnel-request-log";
 import { getRequestLogger } from "../../utils/request-logger";
+import { verifyHarnessProxyToken } from "../../utils/harness/harness-proxy-token";
 
 // In-memory SSE session store per serverId:sessionId
 type Session = {
@@ -154,9 +155,19 @@ function normalizeServerId(clientManager: any, serverId: string): string {
   return match ?? serverId;
 }
 
-// Unified HTTP adapter that handles both adapter-http and manager-http routes
-// with the same robust implementation but different JSON-RPC response modes
+// Per-turn harness-proxy token (`X-MCPJam-Proxy-Token`, HEADER-ONLY). The relay
+// edge binds every adapter tunnel to `/api/mcp/adapter-http/{serverId}`
+// (backend `tunnelPolicy.ts`), so the harness reuses THIS route rather than a
+// dedicated one. The token is VALIDATE-WHEN-PRESENT: the harness always sends
+// it (per-turn expiry/revocation on top of the tunnel's per-server `?k=`
+// bearer), while external MCP clients send none and are unaffected. The old
+// `?t=` query fallback is removed — tokens in URLs leak into edge/access logs.
+function readProxyToken(c: any): string | undefined {
+  return c.req.header("x-mcpjam-proxy-token") || undefined;
+}
 
+// Unified HTTP adapter for adapter-http + manager-http (same robust
+// implementation, different JSON-RPC response modes).
 function createHttpHandler(mode: BridgeMode, routePrefix: string) {
   const router = new Hono();
 
@@ -174,6 +185,14 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
     // A per-server tunnel must not reach any other server's adapter.
     if (tunnelScopeViolation(c, serverId)) {
       return c.json({ error: "Not found" }, 404);
+    }
+
+    // Harness proxy token: when supplied it MUST be valid + scoped to this
+    // serverId (covers GET/POST/HEAD before any stream opens or RPC runs).
+    // Absent ⇒ external client ⇒ unaffected.
+    const proxyTok = readProxyToken(c);
+    if (proxyTok && !verifyHarnessProxyToken(proxyTok, serverId)) {
+      return c.json({ error: "Unauthorized" }, 401);
     }
 
     // SSE endpoint for clients that probe/subscribe via GET; HEAD advertises event-stream
@@ -337,6 +356,11 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
       return c.json({ error: "Not found" }, 404);
     }
 
+    const proxyTok = readProxyToken(c);
+    if (proxyTok && !verifyHarnessProxyToken(proxyTok, serverId)) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
     const url = new URL(c.req.url);
     const sessionId = url.searchParams.get("sessionId") || "";
     const key = `${serverId}:${sessionId}`;
@@ -398,7 +422,9 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
   return router;
 }
 
-// Create both adapters with their respective modes
+// Create both adapters with their respective modes. The Claude Code harness
+// connects through `adapter-http` (the edge-bound tunnel path), carrying its
+// per-turn `X-MCPJam-Proxy-Token` which is validated-when-present above.
 export const adapterHttp = createHttpHandler("adapter", "adapter-http");
 export const managerHttp = createHttpHandler("manager", "manager-http");
 

--- a/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import {
+  createComputerUploadHandler,
+  type UploadSandbox,
+} from "../computer-upload";
+
+// Route-level tests for POST /api/web/computers/upload. The control plane
+// (`/computers/sandbox-info`) is a fetch stub; the E2B sandbox is an injected
+// fake that records makeDir/write calls. Terminal tokens are signed locally
+// with the shared HS256 secret, mirroring computers-terminal-token.test.ts.
+
+const SECRET = "test-terminal-secret-0123456789";
+const ISSUER = "https://api.mcpjam.com/computer-terminal";
+const CONVEX_URL = "https://convex.example";
+
+function b64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+async function signToken(
+  claims: Record<string, unknown> = {},
+  secret = SECRET
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const full = {
+    iss: ISSUER,
+    purpose: "computer-terminal",
+    sub: "users_123",
+    computerId: "computers_456",
+    projectId: "projects_789",
+    iat: now,
+    exp: now + 60,
+    ...claims,
+  };
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const header = b64url(
+    new TextEncoder().encode(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+  );
+  const payload = b64url(new TextEncoder().encode(JSON.stringify(full)));
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${header}.${payload}`)
+  );
+  return `${header}.${payload}.${b64url(new Uint8Array(sig))}`;
+}
+
+function fakeSandbox() {
+  const writes: { path: string; bytes: number }[] = [];
+  let madeDir = 0;
+  const sandbox: UploadSandbox = {
+    files: {
+      makeDir: async () => {
+        madeDir += 1;
+        return true;
+      },
+      write: async (path, data) => {
+        writes.push({ path, bytes: data.byteLength });
+      },
+    },
+  };
+  return {
+    sandbox,
+    writes,
+    get madeDirCount() {
+      return madeDir;
+    },
+  };
+}
+
+function installSandboxInfoStub(
+  override?: (path: string) => { status: number; json: unknown } | undefined
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL) => {
+      const path = new URL(String(url)).pathname;
+      const custom = override?.(path);
+      if (custom) {
+        return new Response(JSON.stringify(custom.json), {
+          status: custom.status,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (path === "/computers/sandbox-info") {
+        return new Response(
+          JSON.stringify({
+            computerId: "computers_456",
+            providerComputerId: "sbx_42",
+            provider: "e2b",
+            status: "ready",
+            projectId: "projects_789",
+            ownerUserId: "users_123",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+      throw new Error(`unexpected path ${path}`);
+    })
+  );
+}
+
+function stubConfiguredEnv() {
+  vi.stubEnv("CONVEX_HTTP_URL", CONVEX_URL);
+  vi.stubEnv("COMPUTERS_DATA_PLANE_SECRET", "test-secret");
+  vi.stubEnv("E2B_API_KEY", "e2b_test");
+  vi.stubEnv("COMPUTERS_TERMINAL_TOKEN_SECRET", SECRET);
+}
+
+function createApp(connectSandbox: (id: string) => Promise<UploadSandbox>) {
+  const app = new Hono();
+  app.post(
+    "/api/web/computers/upload",
+    createComputerUploadHandler({ connectSandbox })
+  );
+  return app;
+}
+
+async function uploadRequest(
+  app: Hono,
+  token: string | null,
+  files: File[],
+  dir?: string
+): Promise<Response> {
+  const form = new FormData();
+  for (const f of files) form.append("files", f);
+  const params = new URLSearchParams();
+  if (token) params.set("token", token);
+  if (dir) params.set("dir", dir);
+  const qs = params.toString();
+  return await app.request(
+    `/api/web/computers/upload${qs ? `?${qs}` : ""}`,
+    { method: "POST", body: form }
+  );
+}
+
+beforeEach(() => {
+  installSandboxInfoStub();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/web/computers/upload", () => {
+  it("503s when the data plane is unconfigured", async () => {
+    // No env stubbed → isComputersDataPlaneConfigured() is false.
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1, 2, 3])], "a.txt"),
+    ]);
+    expect(res.status).toBe(503);
+    expect(fake.writes).toHaveLength(0);
+  });
+
+  it("401s on an invalid token", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, "not.a.token", [
+      new File([new Uint8Array([1])], "a.txt"),
+    ]);
+    expect(res.status).toBe(401);
+    expect(fake.writes).toHaveLength(0);
+  });
+
+  it("400s when no files are attached", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), []);
+    expect(res.status).toBe(400);
+  });
+
+  it("413s when too many files are attached", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const files = Array.from(
+      { length: 21 },
+      (_, i) => new File([new Uint8Array([i])], `f${i}.txt`)
+    );
+    const res = await uploadRequest(app, await signToken(), files);
+    expect(res.status).toBe(413);
+    expect(fake.writes).toHaveLength(0);
+  });
+
+  it("413s when a file exceeds the per-file size cap", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const big = new File([new Uint8Array(25 * 1024 * 1024 + 1)], "big.bin");
+    const res = await uploadRequest(app, await signToken(), [big]);
+    expect(res.status).toBe(413);
+    expect(fake.writes).toHaveLength(0);
+  });
+
+  it("sanitizes a path-traversal filename to a basename under the upload root", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1, 2])], "../../etc/passwd"),
+    ]);
+    expect(res.status).toBe(200);
+    expect(fake.writes).toHaveLength(1);
+    const writtenPath = fake.writes[0].path;
+    expect(writtenPath.startsWith("/home/user/uploads/")).toBe(true);
+    expect(writtenPath).not.toContain("..");
+    // basename preserved (after the random prefix), no directory components.
+    expect(writtenPath).toMatch(/\/home\/user\/uploads\/[0-9a-f]{8}-passwd$/);
+  });
+
+  it("writes each file and returns absolute paths on the happy path", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1, 2, 3])], "one.png"),
+      new File([new Uint8Array([4, 5])], "two.txt"),
+    ]);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      files: { name: string; path: string; bytes: number }[];
+    };
+    expect(body.ok).toBe(true);
+    expect(body.files).toHaveLength(2);
+    expect(fake.madeDirCount).toBe(1);
+    expect(fake.writes).toHaveLength(2);
+    expect(body.files[0].bytes).toBe(3);
+    expect(body.files[1].bytes).toBe(2);
+    for (const f of body.files) {
+      expect(f.path.startsWith("/home/user/uploads/")).toBe(true);
+    }
+  });
+
+  it("writes into a valid requested dir under the box home (harness workdir)", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(
+      app,
+      await signToken(),
+      [new File([new Uint8Array([1])], "shot.png")],
+      "/home/user/claude-code-XyZ"
+    );
+    expect(res.status).toBe(200);
+    expect(fake.writes).toHaveLength(1);
+    expect(fake.writes[0].path).toMatch(
+      /^\/home\/user\/claude-code-XyZ\/[0-9a-f]{8}-shot\.png$/
+    );
+  });
+
+  it("falls back to the upload bucket for a dir outside the box home", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(
+      app,
+      await signToken(),
+      [new File([new Uint8Array([1])], "x.txt")],
+      "/etc"
+    );
+    expect(res.status).toBe(200);
+    expect(fake.writes[0].path.startsWith("/home/user/uploads/")).toBe(true);
+  });
+
+  it("falls back to the upload bucket for a traversal dir", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(
+      app,
+      await signToken(),
+      [new File([new Uint8Array([1])], "x.txt")],
+      "/home/user/../../etc"
+    );
+    expect(res.status).toBe(200);
+    expect(fake.writes[0].path.startsWith("/home/user/uploads/")).toBe(true);
+  });
+
+  it("503s when the sandbox is asleep (connect throws)", async () => {
+    stubConfiguredEnv();
+    const app = createApp(async () => {
+      throw new Error("sandbox not found");
+    });
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1])], "a.txt"),
+    ]);
+    expect(res.status).toBe(503);
+  });
+
+  it("503s when the computer is still provisioning (no providerComputerId)", async () => {
+    stubConfiguredEnv();
+    installSandboxInfoStub((path) =>
+      path === "/computers/sandbox-info"
+        ? {
+            status: 200,
+            json: {
+              computerId: "computers_456",
+              providerComputerId: null,
+              provider: "e2b",
+              status: "provisioning",
+              projectId: "projects_789",
+              ownerUserId: "users_123",
+            },
+          }
+        : undefined
+    );
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, await signToken(), [
+      new File([new Uint8Array([1])], "a.txt"),
+    ]);
+    expect(res.status).toBe(503);
+    expect(fake.writes).toHaveLength(0);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/harness-mcp.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/harness-mcp.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Hosted-plane `/api/web/harness-mcp/:serverId` route.
+ *
+ * Mocks `./auth` (createAuthorizedManager + withManager) so the route doesn't
+ * hit Convex; uses a REAL signed token and the REAL JSON-RPC bridge over a mock
+ * authorized manager. Verifies the token gate (REQUIRED + identity + serverId
+ * scope) and that a valid web token forwards through the bridge.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { Hono } from "hono";
+
+// vi.hoisted so the mock manager exists when the hoisted vi.mock factory runs.
+const { mockManager } = vi.hoisted(() => ({
+  mockManager: {
+    listTools: vi.fn().mockResolvedValue({ tools: [{ name: "echo" }] }),
+    getInitializationInfo: () => ({
+      protocolVersion: "2025-06-18",
+      serverCapabilities: { tools: { listChanged: true } },
+      serverVersion: { name: "real-server", version: "1.0.0" },
+      clientCapabilities: {},
+    }),
+    disconnectAllServers: vi.fn(),
+  },
+}));
+
+vi.mock("../auth", () => ({
+  createAuthorizedManager: vi.fn().mockResolvedValue({ manager: mockManager }),
+  withManager: async (
+    mp: Promise<any>,
+    fn: (m: any) => Promise<any>,
+  ): Promise<any> => {
+    const r = await mp;
+    return fn(r.manager ?? r);
+  },
+}));
+
+import { harnessMcp } from "../harness-mcp.js";
+import { signTestProxyToken } from "../../../utils/harness/__tests__/sign-test-token.js";
+
+beforeAll(() => {
+  process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "test-harness-proxy-secret-32-chars";
+});
+
+const app = new Hono();
+app.route("/api/web/harness-mcp", harnessMcp);
+
+const webToken = (serverId: string) =>
+  signTestProxyToken({
+    serverId,
+    projectId: "p1",
+    externalId: "user_ext_1",
+    orgId: "org_1",
+  });
+
+const post = (serverId: string, headers: Record<string, string> = {}) =>
+  app.request(`/api/web/harness-mcp/${serverId}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify({ id: 1, method: "tools/list", params: {} }),
+  });
+
+describe("/api/web/harness-mcp", () => {
+  it("401s without a token (token IS the auth here)", async () => {
+    expect((await post("srv-a")).status).toBe(401);
+  });
+
+  it("401s a token missing the delegated identity (externalId)", async () => {
+    const noIdentity = signTestProxyToken({ serverId: "srv-a", externalId: "" });
+    const res = await post("srv-a", { "X-MCPJam-Proxy-Token": noIdentity });
+    expect(res.status).toBe(401);
+  });
+
+  it("401s a token minted for a different server", async () => {
+    const res = await post("srv-a", { "X-MCPJam-Proxy-Token": webToken("srv-b") });
+    expect(res.status).toBe(401);
+  });
+
+  it("200s and forwards tools/list through the bridge with a valid web token", async () => {
+    const res = await post("srv-a", { "X-MCPJam-Proxy-Token": webToken("srv-a") });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.jsonrpc).toBe("2.0");
+    expect(data.result.tools).toEqual([{ name: "echo" }]);
+    expect(mockManager.listTools).toHaveBeenCalledWith("srv-a");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/computer-terminal.ts
@@ -35,6 +35,10 @@ import type { MiddlewareHandler } from "hono";
 import { Sandbox, type CommandHandle } from "e2b";
 import { verifyComputerTerminalToken } from "../../utils/computers/terminal-token.js";
 import {
+  createPtyWithCwd,
+  sanitizeTerminalCwd,
+} from "../../utils/computers/create-pty.js";
+import {
   getComputerSandboxInfo,
   isComputersDataPlaneConfigured,
   recordTerminalSession,
@@ -81,6 +85,9 @@ export function createComputerTerminalWsHandler(
     const token = c.req.query("token") ?? "";
     const cols = clampDimension(c.req.query("cols"), DEFAULT_COLS, 500);
     const rows = clampDimension(c.req.query("rows"), DEFAULT_ROWS, 300);
+    // Optional starting directory (e.g. the harness session workdir). Best
+    // effort: a stale/invalid path falls back to home (createPtyWithCwd).
+    const cwd = sanitizeTerminalCwd(c.req.query("cwd"));
     // Captured at upgrade time; the WS callbacks below outlive the request
     // but keep its log context (requestId, route) for typed events.
     const requestLogger = getRequestLogger(c, "routes.web.computer-terminal");
@@ -142,23 +149,27 @@ export function createComputerTerminalWsHandler(
         void (async () => {
           try {
             sandbox = await Sandbox.connect(sandboxId);
-            pty = await sandbox.pty.create({
-              cols,
-              rows,
-              timeoutMs: PTY_TIMEOUT_MS,
-              onData: (data) => {
-                if (closed) return;
-                // Copy into a standalone ArrayBuffer: WSContext.send is typed
-                // for Uint8Array<ArrayBuffer>, while the SDK hands us a view
-                // over ArrayBufferLike.
-                ws.send(
-                  data.buffer.slice(
-                    data.byteOffset,
-                    data.byteOffset + data.byteLength
-                  ) as ArrayBuffer
-                );
+            pty = await createPtyWithCwd(
+              sandbox,
+              {
+                cols,
+                rows,
+                timeoutMs: PTY_TIMEOUT_MS,
+                onData: (data) => {
+                  if (closed) return;
+                  // Copy into a standalone ArrayBuffer: WSContext.send is typed
+                  // for Uint8Array<ArrayBuffer>, while the SDK hands us a view
+                  // over ArrayBufferLike.
+                  ws.send(
+                    data.buffer.slice(
+                      data.byteOffset,
+                      data.byteOffset + data.byteLength
+                    ) as ArrayBuffer
+                  );
+                },
               },
-            });
+              cwd
+            );
             await recordTerminalSession({
               sessionId,
               action: "open",

--- a/mcpjam-inspector/server/routes/web/computer-upload.ts
+++ b/mcpjam-inspector/server/routes/web/computer-upload.ts
@@ -1,0 +1,225 @@
+/**
+ * Computer file upload (`POST /api/web/computers/upload`).
+ *
+ * Drag-and-drop files from the browser Shell panel straight into the user's
+ * project computer (E2B). The files land under a stable absolute root
+ * (`/home/user/uploads`); the user then references that path in chat so the
+ * Claude Code harness's native `Read` tool can open them (the harness prompt
+ * channel is text-only and can't carry image/file parts — see
+ * server/utils/harness/run-harness-turn.ts).
+ *
+ * Auth mirrors the terminal WebSocket (routes/web/computer-terminal.ts):
+ *   - The browser mints a ~60s Convex terminal token and sends `?token=<jwt>`.
+ *   - We verify it LOCALLY (shared HS256 secret) → `computerId`, then exchange
+ *     it for the vendor sandbox id via the secret-gated `/computers/sandbox-info`
+ *     control-plane route. The browser never sees vendor ids or credentials.
+ *
+ * An upload is strictly WEAKER than the Shell it sits next to: anyone holding a
+ * terminal token can already run arbitrary commands in the box (`cat > file`).
+ * So the only gate that matters for tenant isolation is reusing that
+ * computer-scoped token; the rest is hygiene — path confinement (no traversal
+ * out of the upload root), size/count caps (no disk-fill), and a friendly
+ * failure when the box is asleep.
+ *
+ * The 30 MB body cap is applied by a route-specific `bodyLimit` at the mount
+ * site (server/index.ts); the global `/api/web/*` 1 MB cap excludes this path.
+ */
+import { randomUUID } from "node:crypto";
+import { posix } from "node:path";
+import type { Context } from "hono";
+import { Sandbox } from "e2b";
+import { verifyComputerTerminalToken } from "../../utils/computers/terminal-token.js";
+import {
+  getComputerSandboxInfo,
+  isComputersDataPlaneConfigured,
+} from "../../utils/computers/control-plane-client.js";
+import { logger } from "../../utils/logger.js";
+import { classifyError } from "../../utils/error-classify.js";
+
+/** The box home. The client may request a specific destination dir (the Shell's
+ *  cwd — e.g. the harness session workdir `/home/user/claude-code-<id>`); we
+ *  confine any requested dir under this root and fall back to `UPLOAD_ROOT`. */
+const HOME_ROOT = "/home/user";
+/** Fallback destination when the client provides no (or an invalid) target dir
+ *  — e.g. a plain computer host, or the Shell opened before any harness turn. */
+const UPLOAD_ROOT = "/home/user/uploads";
+const MAX_DIR_LEN = 1024;
+const MAX_FILES = 20;
+const MAX_FILE_BYTES = 25 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 30 * 1024 * 1024;
+
+/** Narrow structural view of the E2B sandbox — only the file ops we need, so
+ *  tests can inject a fake without the full SDK surface. `Sandbox` satisfies it. */
+export interface UploadSandbox {
+  files: {
+    makeDir(path: string): Promise<boolean>;
+    write(path: string, data: ArrayBuffer): Promise<unknown>;
+  };
+}
+
+export interface ComputerUploadDeps {
+  /** Connect to a live sandbox by vendor id. Defaults to E2B `Sandbox.connect`
+   *  (which auto-resumes a paused box, like the terminal route). */
+  connectSandbox?: (sandboxId: string) => Promise<UploadSandbox>;
+}
+
+/** Resolve the destination directory. The client passes the Shell's cwd (the
+ *  harness workdir) so uploads land where the user is actually working, not in a
+ *  detached bucket. We confine it under the box home and reject traversal; any
+ *  missing/invalid value falls back to `UPLOAD_ROOT`. This is hygiene, not a
+ *  trust boundary — the terminal token already grants full shell write access —
+ *  but it keeps the endpoint from being a write-anywhere primitive and avoids
+ *  footguns like a stray dir landing files in `/etc`. */
+function resolveUploadDir(requested: string | undefined): string {
+  if (!requested || requested.length > MAX_DIR_LEN) return UPLOAD_ROOT;
+  if (!requested.startsWith("/")) return UPLOAD_ROOT;
+  const normalized = posix.normalize(requested).replace(/\/+$/, "");
+  if (normalized !== HOME_ROOT && !normalized.startsWith(`${HOME_ROOT}/`)) {
+    return UPLOAD_ROOT;
+  }
+  if (normalized.split("/").includes("..")) return UPLOAD_ROOT;
+  return normalized;
+}
+
+/** Turn a user-supplied filename into a safe, collision-free basename. Strips
+ *  any path, neutralizes odd characters, and prefixes a short random id — the
+ *  prefix is what guarantees a drop into a shared harness workdir can't clobber
+ *  a file the model just wrote. Never returns `.`/`..` or an empty name. */
+function safeUploadName(rawName: string): string {
+  const base = posix.basename(rawName || "");
+  const cleaned = base.replace(/[^\w.\- ]/g, "_").trim();
+  const safe = cleaned && cleaned !== "." && cleaned !== ".." ? cleaned : "file";
+  return `${randomUUID().slice(0, 8)}-${safe}`;
+}
+
+export function createComputerUploadHandler(deps: ComputerUploadDeps = {}) {
+  const connectSandbox =
+    deps.connectSandbox ??
+    ((id: string) => Sandbox.connect(id) as unknown as Promise<UploadSandbox>);
+
+  return async (c: Context): Promise<Response> => {
+    if (!isComputersDataPlaneConfigured()) {
+      return c.json(
+        { ok: false, error: "Computers are not configured on this server." },
+        503
+      );
+    }
+
+    // ── auth: terminal token → computerId → vendor sandbox id ──────────────
+    const token = c.req.query("token") ?? "";
+    const claims = await verifyComputerTerminalToken(token);
+    if (!claims) {
+      return c.json(
+        { ok: false, error: "Invalid or expired terminal token." },
+        401
+      );
+    }
+    const info = await getComputerSandboxInfo({ computerId: claims.computerId });
+    if (!info.ok) {
+      return c.json(
+        { ok: false, error: `Computer unavailable: ${info.error}` },
+        503
+      );
+    }
+    if (!info.value.providerComputerId) {
+      return c.json({ ok: false, error: "Computer is still provisioning." }, 503);
+    }
+    const sandboxId = info.value.providerComputerId;
+
+    // ── body: multipart files, with count/size caps ───────────────────────
+    let formData: FormData;
+    try {
+      formData = await c.req.formData();
+    } catch {
+      return c.json({ ok: false, error: "Expected multipart/form-data." }, 400);
+    }
+    const files = formData
+      .getAll("files")
+      .filter((f): f is File => f instanceof File);
+    if (files.length === 0) {
+      return c.json({ ok: false, error: "No files uploaded." }, 400);
+    }
+    if (files.length > MAX_FILES) {
+      return c.json(
+        { ok: false, error: `Too many files (max ${MAX_FILES}).` },
+        413
+      );
+    }
+    let totalBytes = 0;
+    for (const f of files) {
+      if (f.size > MAX_FILE_BYTES) {
+        return c.json(
+          {
+            ok: false,
+            error: `File "${f.name}" exceeds the ${MAX_FILE_BYTES / 1024 / 1024} MB per-file limit.`,
+          },
+          413
+        );
+      }
+      totalBytes += f.size;
+    }
+    if (totalBytes > MAX_TOTAL_BYTES) {
+      return c.json(
+        { ok: false, error: "Upload exceeds the total size limit." },
+        413
+      );
+    }
+
+    const targetDir = resolveUploadDir(c.req.query("dir"));
+    const planned = files.map((f) => {
+      const name = safeUploadName(f.name);
+      return { file: f, name, path: `${targetDir}/${name}` };
+    });
+
+    // ── write into the box ─────────────────────────────────────────────────
+    let sandbox: UploadSandbox;
+    try {
+      sandbox = await connectSandbox(sandboxId);
+    } catch (err) {
+      logger.warn("[computer-upload] sandbox connect failed", {
+        computerId: claims.computerId,
+        errorCode: classifyError(err),
+      });
+      return c.json(
+        {
+          ok: false,
+          error:
+            "Your computer is asleep — send a message in chat to wake it, then try again.",
+        },
+        503
+      );
+    }
+
+    try {
+      // Idempotent; makeDir on an existing path is a no-op/false, not an error.
+      await sandbox.files.makeDir(targetDir);
+    } catch {
+      // Best-effort: the write below surfaces a genuine permissions problem.
+    }
+
+    const written: { name: string; path: string; bytes: number }[] = [];
+    try {
+      for (const p of planned) {
+        const buf = await p.file.arrayBuffer();
+        await sandbox.files.write(p.path, buf);
+        written.push({ name: p.name, path: p.path, bytes: p.file.size });
+      }
+    } catch (err) {
+      logger.warn("[computer-upload] write failed", {
+        computerId: claims.computerId,
+        errorCode: classifyError(err),
+      });
+      return c.json(
+        { ok: false, error: "Failed to write files to your computer." },
+        502
+      );
+    }
+
+    logger.info("[computer-upload] uploaded", {
+      computerId: claims.computerId,
+      count: written.length,
+      totalBytes,
+    });
+    return c.json({ ok: true, files: written });
+  };
+}

--- a/mcpjam-inspector/server/routes/web/harness-mcp.ts
+++ b/mcpjam-inspector/server/routes/web/harness-mcp.ts
@@ -1,0 +1,181 @@
+/**
+ * Hosted-plane harness MCP proxy: `POST /api/web/harness-mcp/:serverId`.
+ *
+ * The Claude Code harness (in a cloud sandbox) speaks MCP JSON-RPC to THIS
+ * route, which forwards to the user's real MCP server through MCPJam — so the
+ * harness's MCP runs through the playground even in the horizontally-scaled
+ * hosted plane. Auth is the **signed proxy token** (NOT a browser bearer): it
+ * carries the acting user's delegated identity, which we hand to the existing
+ * `workos_api_key` acting-as path so the per-request `createAuthorizedManager`
+ * rebuilds the user's authorized connection server-side. Stateless — any
+ * instance serves it.
+ *
+ * Mounted WITHOUT `bearerAuthMiddleware` (the token is the auth);
+ * `sessionAuthMiddleware` already bypasses `/api/web/*`.
+ *
+ * Transport: mirrors `adapter-http`'s raw-spec shape that the Phase-0 spike
+ * proved Claude Code's `type:"http"` client speaks — POST → single
+ * `application/json`; the optional GET returns a minimal server-stream the
+ * client probes then closes; no `Mcp-Session-Id` (stateless).
+ */
+import { Hono } from "hono";
+import "../../types/hono";
+import { handleJsonRpc } from "../../services/mcp-http-bridge";
+import {
+  createAuthorizedManager,
+  withManager,
+  type ManagerCallerContext,
+} from "./auth";
+import { verifyHarnessProxyToken } from "../../utils/harness/harness-proxy-token";
+import { logger } from "../../utils/logger";
+
+const harnessMcp = new Hono();
+
+/** Per-request connect timeout for the authorized manager. */
+const HARNESS_MCP_TIMEOUT_MS = 30_000;
+/** Hard cap on the probe GET event-stream so a forgotten stream can't leak. */
+const HARNESS_MCP_STREAM_MAX_MS = 10 * 60_000;
+/** Lightweight fixed-window rate limit per (user, server). */
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX_PER_WINDOW = 600;
+const rateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function rateLimited(key: string): boolean {
+  const now = Date.now();
+  const bucket = rateBuckets.get(key);
+  if (!bucket || now >= bucket.resetAt) {
+    // Opportunistic prune so the map can't grow unbounded.
+    if (rateBuckets.size > 5000) {
+      for (const [k, b] of rateBuckets) if (now >= b.resetAt) rateBuckets.delete(k);
+    }
+    rateBuckets.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return false;
+  }
+  bucket.count += 1;
+  return bucket.count > RATE_MAX_PER_WINDOW;
+}
+
+/**
+ * HEADER-ONLY (Phase 4 hardening): the token must arrive as
+ * `X-MCPJam-Proxy-Token`. The old `?t=` query fallback is removed — tokens in
+ * URLs leak into relay/edge/access logs. (The tunnel's own `?k=` secret is a
+ * separate, edge-consumed credential and is untouched.)
+ */
+function readProxyToken(c: any): string | undefined {
+  return c.req.header("x-mcpjam-proxy-token") || undefined;
+}
+
+async function handle(c: any) {
+  const serverId = c.req.param("serverId");
+
+  // Token is REQUIRED here (unlike adapter-http's validate-when-present) — it
+  // is the only auth on this route, and carries the delegated identity.
+  const claims = verifyHarnessProxyToken(readProxyToken(c), serverId);
+  if (!claims || !claims.externalId || !claims.orgId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  if (rateLimited(`${claims.userId}:${serverId}`)) {
+    return c.json({ error: "Rate limited" }, 429);
+  }
+
+  const method = c.req.method;
+
+  // Optional GET server-stream: Claude Code opens it then (per Phase 0) closes
+  // it. We have no persistent connection to relay from in this stateless route,
+  // so return a minimal keep-alive event-stream and clean up on disconnect.
+  if (method === "GET" || method === "HEAD") {
+    if (method === "HEAD") {
+      return c.body(null, 200, { "Content-Type": "text/event-stream" });
+    }
+    const encoder = new TextEncoder();
+    let timer: ReturnType<typeof setInterval> | undefined;
+    let killAt: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = () => {
+      if (timer) clearInterval(timer);
+      if (killAt) clearTimeout(killAt);
+    };
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(`: ok\n\n`));
+        timer = setInterval(() => {
+          try {
+            controller.enqueue(encoder.encode(`: keepalive\n\n`));
+          } catch {}
+        }, 15000);
+        // Hard cap: never hold the stream open indefinitely.
+        killAt = setTimeout(() => {
+          cleanup();
+          try {
+            controller.close();
+          } catch {}
+        }, HARNESS_MCP_STREAM_MAX_MS);
+      },
+      cancel() {
+        cleanup();
+      },
+    });
+    return c.body(stream as any, 200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    });
+  }
+
+  if (method !== "POST") {
+    return c.json({ error: "Unsupported request" }, 400);
+  }
+
+  let body: any;
+  try {
+    body = await c.req.json();
+  } catch {
+    body = undefined;
+  }
+
+  // Rebuild the user's authorized connection server-side via the acting-as
+  // service-token exchange (no browser bearer in the sandbox). Convex baked the
+  // verified identity into the token; Convex also access-checked the server at
+  // mint time, so membership authorization here is the project-ownership path.
+  const caller: ManagerCallerContext = {
+    authMethod: "workos_api_key",
+    workosUserId: claims.externalId,
+    mcpjamOrganizationId: claims.orgId,
+  };
+
+  try {
+    const response = await withManager(
+      createAuthorizedManager(
+        caller,
+        "", // bearer ignored on the workos_api_key path
+        claims.projectId,
+        [serverId],
+        HARNESS_MCP_TIMEOUT_MS,
+      ),
+      (manager) => handleJsonRpc(serverId, body, manager, "adapter"),
+    );
+    // Notification (no id) → 202 Accepted, no body.
+    if (!response) return c.body("Accepted", 202);
+    return c.json(response);
+  } catch (e: any) {
+    // Log the real cause server-side, but NEVER leak internal exception text to
+    // the sandbox — return a generic JSON-RPC error so the client can recover.
+    logger.error(
+      `[harness-mcp] proxy error serverId=${serverId}: ${e?.message ?? e}`,
+    );
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        id: body?.id ?? null,
+        error: { code: -32000, message: "harness proxy error" },
+      },
+      200,
+    );
+  }
+}
+
+harnessMcp.all("/:serverId", handle);
+harnessMcp.all("/:serverId/*", handle);
+
+export { harnessMcp };

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -10,6 +10,7 @@ import chatV2 from "./chat-v2.js";
 import mcpjamAgent from "./mcpjam-agent.js";
 import chatboxes from "./chatboxes.js";
 import chatboxSessions from "./chatbox-sessions.js";
+import { harnessMcp } from "./harness-mcp.js";
 import apps from "./apps.js";
 import evals from "./evals.js";
 import oauthWeb from "./oauth.js";
@@ -68,6 +69,10 @@ web.route("/chatboxes", chatboxSessions);
 web.route("/evals", evals);
 web.route("/export", exporter);
 web.route("/chat-v2", chatV2);
+// Token-only (signed proxy token IS the auth) — NO bearerAuthMiddleware, like
+// /guest-token. `sessionAuthMiddleware` already bypasses /api/web/*. The Claude
+// Code harness (in a cloud sandbox) connects its MCP through here.
+web.route("/harness-mcp", harnessMcp);
 web.route("/mcpjam-agent", mcpjamAgent);
 web.route("/apps", apps);
 web.route("/oauth", oauthWeb);

--- a/mcpjam-inspector/server/services/ensure-server-tunnel.ts
+++ b/mcpjam-inspector/server/services/ensure-server-tunnel.ts
@@ -1,0 +1,72 @@
+/**
+ * Ensure a per-server relay tunnel is live and return its public bearer URL
+ * (`https://{slug}.tunnels.mcpjam.com/api/mcp/adapter-http/{serverId}?k=…`).
+ *
+ * Extracted from `routes/mcp/tunnels.ts` so the harness turn (always-proxy)
+ * and the web tunnel route share one idempotent code path: existing tunnel →
+ * return as-is; otherwise mint a Convex relay grant and open the relay socket.
+ * Serialized per server via the same tunnel lock the route uses, so concurrent
+ * callers (a chat turn + the UI) don't race the edge's view of the live grant.
+ */
+import { tunnelManager } from "./tunnel-manager";
+import { withTunnelLock } from "./tunnel-locks";
+import { fetchRelayGrant } from "./tunnel-grants";
+import { LOCAL_SERVER_ADDR } from "../config";
+
+export async function ensureServerTunnel(
+  serverId: string,
+  authHeader?: string,
+): Promise<string> {
+  return withTunnelLock(serverId, async () => {
+    const existing = tunnelManager.getServerTunnelUrl(serverId);
+    if (existing) return existing;
+
+    const grant = await fetchRelayGrant(serverId, authHeader);
+    await tunnelManager.createTunnel(serverId, {
+      localAddr: LOCAL_SERVER_ADDR,
+      slug: grant.slug,
+      relayWsUrl: grant.relayWsUrl,
+      connectToken: grant.connectToken,
+      publicUrl: grant.url,
+      secretVersion: grant.secretVersion,
+    });
+    // Prefer the live entry; fall back to the grant URL if a permanent edge
+    // close raced in right after createTunnel (mirrors routes/mcp/tunnels.ts).
+    return tunnelManager.getServerTunnelUrl(serverId) ?? grant.url;
+  });
+}
+
+/**
+ * Like `ensureServerTunnel`, but for the `harness-web` scope: returns a bearer
+ * URL bound to `/api/web/harness-mcp/{serverId}` instead of the adapter path.
+ * Used by the hosted harness proxy strategy when the inspector is private (local
+ * dev / self-hosted) and can't be reached directly by the cloud sandbox. The
+ * tunnel coexists with any adapter-http tunnel for the same server (independent
+ * slug/secret/lock).
+ */
+export async function ensureHarnessWebTunnel(
+  serverId: string,
+  authHeader?: string,
+): Promise<string> {
+  return withTunnelLock(`harness-web ${serverId}`, async () => {
+    const existing = tunnelManager.getServerTunnelUrl(serverId, "harness-web");
+    if (existing) return existing;
+
+    const grant = await fetchRelayGrant(serverId, authHeader, "harness-web");
+    await tunnelManager.createTunnel(
+      serverId,
+      {
+        localAddr: LOCAL_SERVER_ADDR,
+        slug: grant.slug,
+        relayWsUrl: grant.relayWsUrl,
+        connectToken: grant.connectToken,
+        publicUrl: grant.url,
+        secretVersion: grant.secretVersion,
+      },
+      "harness-web",
+    );
+    return (
+      tunnelManager.getServerTunnelUrl(serverId, "harness-web") ?? grant.url
+    );
+  });
+}

--- a/mcpjam-inspector/server/services/tunnel-grants.ts
+++ b/mcpjam-inspector/server/services/tunnel-grants.ts
@@ -107,14 +107,16 @@ export function validateGrant(
 // bearer secret AND disconnects/denies the previous grant at the edge.
 export async function fetchRelayGrant(
   serverId: string,
-  authHeader?: string
+  authHeader?: string,
+  scope: "adapter-http" | "harness-web" = "adapter-http"
 ): Promise<RelayGrant> {
   const convexUrl = requireConvexHttpUrl();
 
+  const scopeParam = scope === "harness-web" ? "&scope=harness-web" : "";
   const response = await convexFetch(
     `${convexUrl}/tunnels/token?serverId=${encodeURIComponent(
       serverId
-    )}&transport=relay`,
+    )}&transport=relay${scopeParam}`,
     {
       method: "GET",
       headers: convexHeaders(authHeader),

--- a/mcpjam-inspector/server/services/tunnel-manager.ts
+++ b/mcpjam-inspector/server/services/tunnel-manager.ts
@@ -5,6 +5,18 @@ import {
   unregisterTunnelDomain,
 } from "./tunnel-registry";
 
+/**
+ * A tunnel is bound to one path scope. `adapter-http` (default) fronts the
+ * desktop MCP adapter; `harness-web` fronts the hosted harness proxy route.
+ * Both can be live for the same server simultaneously, so the manager keys
+ * entries by `(scope, serverId)`.
+ */
+export type TunnelScope = "adapter-http" | "harness-web";
+
+function entryKey(scope: TunnelScope, serverId: string): string {
+  return `${scope}\x1f${serverId}`;
+}
+
 interface TunnelEntry {
   connection: RelayConnection;
   /** Public host ({slug}.tunnels.mcpjam.com) registered for isolation checks. */
@@ -36,9 +48,11 @@ class TunnelManager {
    */
   async createTunnel(
     serverId: string,
-    options: CreateTunnelOptions
+    options: CreateTunnelOptions,
+    scope: TunnelScope = "adapter-http"
   ): Promise<string> {
-    const existingTunnel = this.tunnels.get(serverId);
+    const key = entryKey(scope, serverId);
+    const existingTunnel = this.tunnels.get(key);
     if (existingTunnel) {
       return existingTunnel.baseUrl;
     }
@@ -61,15 +75,23 @@ class TunnelManager {
           earlyPermanentFailure = { reason, code };
           return;
         }
-        this.dropEntry(serverId, reason, code);
+        this.dropEntry(key, serverId, reason, code);
       },
     } satisfies RelayConnectionOptions);
 
     try {
       await connection.connect();
-      if (earlyPermanentFailure || connection.permanentFailure) {
+      // Snapshot with an `as` cast: the closure-assigned `let` is otherwise
+      // flow-narrowed to its `null` initializer (the assignment is invisible to
+      // TS), which makes the `||` truthy-branch collapse to `never`. The cast
+      // restores the real declared type.
+      const early = earlyPermanentFailure as {
+        reason: string;
+        code: number;
+      } | null;
+      if (early || connection.permanentFailure) {
         throw new Error(
-          earlyPermanentFailure?.reason ??
+          early?.reason ??
             connection.permanentFailure ??
             "Tunnel relay closed permanently before registration"
         );
@@ -98,7 +120,7 @@ class TunnelManager {
     }
 
     const baseUrl = `https://${host}`;
-    this.tunnels.set(serverId, {
+    this.tunnels.set(key, {
       connection,
       host,
       baseUrl,
@@ -107,10 +129,12 @@ class TunnelManager {
       secretVersion: options.secretVersion,
     });
     registered = true;
+    // Register the host for tunnel isolation + the session-token-leak guard
+    // (which must deny the session token on harness-web tunnel hosts too).
     registerTunnelDomain(host, serverId);
 
     logger.info(
-      `✓ Created tunnel (${serverId}): ${baseUrl} -> ${options.localAddr}`
+      `✓ Created tunnel [${scope}] (${serverId}): ${baseUrl} -> ${options.localAddr}`
     );
     return baseUrl;
   }
@@ -124,30 +148,41 @@ class TunnelManager {
    */
   async rotateTunnel(
     serverId: string,
-    options: CreateTunnelOptions
+    options: CreateTunnelOptions,
+    scope: TunnelScope = "adapter-http"
   ): Promise<string> {
-    await this.closeTunnel(serverId);
-    return this.createTunnel(serverId, options);
+    await this.closeTunnel(serverId, scope);
+    return this.createTunnel(serverId, options, scope);
   }
 
-  async closeTunnel(serverId: string): Promise<void> {
-    const entry = this.tunnels.get(serverId);
+  async closeTunnel(
+    serverId: string,
+    scope: TunnelScope = "adapter-http"
+  ): Promise<void> {
+    const key = entryKey(scope, serverId);
+    const entry = this.tunnels.get(key);
     if (!entry) {
       return;
     }
 
     entry.connection.close();
-    this.tunnels.delete(serverId);
+    this.tunnels.delete(key);
     unregisterTunnelDomain(entry.host);
-    logger.info(`✓ Closed tunnel (${serverId})`);
+    logger.info(`✓ Closed tunnel [${scope}] (${serverId})`);
   }
 
-  getServerTunnelUrl(serverId: string): string | null {
-    return this.tunnels.get(serverId)?.publicUrl ?? null;
+  getServerTunnelUrl(
+    serverId: string,
+    scope: TunnelScope = "adapter-http"
+  ): string | null {
+    return this.tunnels.get(entryKey(scope, serverId))?.publicUrl ?? null;
   }
 
-  getServerTunnelSlug(serverId: string): string | null {
-    return this.tunnels.get(serverId)?.slug ?? null;
+  getServerTunnelSlug(
+    serverId: string,
+    scope: TunnelScope = "adapter-http"
+  ): string | null {
+    return this.tunnels.get(entryKey(scope, serverId))?.slug ?? null;
   }
 
   hasTunnel(): boolean {
@@ -155,16 +190,23 @@ class TunnelManager {
   }
 
   async closeAll(): Promise<void> {
-    const serverIds = [...this.tunnels.keys()];
-    for (const serverId of serverIds) {
-      await this.closeTunnel(serverId);
+    const entries = [...this.tunnels.values()];
+    this.tunnels.clear();
+    for (const entry of entries) {
+      entry.connection.close();
+      unregisterTunnelDomain(entry.host);
     }
   }
 
-  private dropEntry(serverId: string, reason: string, code: number): void {
-    const entry = this.tunnels.get(serverId);
+  private dropEntry(
+    key: string,
+    serverId: string,
+    reason: string,
+    code: number
+  ): void {
+    const entry = this.tunnels.get(key);
     if (!entry) return;
-    this.tunnels.delete(serverId);
+    this.tunnels.delete(key);
     unregisterTunnelDomain(entry.host);
     logger.warn(`Tunnel (${serverId}) ended by relay [${code}]: ${reason}`);
   }

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -175,9 +175,10 @@ interface PersistChatSessionOptions {
   expectedVersion?: number;
   turnTrace?: PersistedTurnTrace;
   /**
-   * §3: chat-backed Claude Code harness resume-state commit. Applied ATOMICALLY
-   * with the transcript inside the ingest mutation (a failed sidecar commit
-   * rolls back the transcript write). Opaque pass-through.
+   * §3: chat-backed harness resume-state commit. Applied ATOMICALLY with the
+   * transcript inside the ingest mutation (a failed sidecar commit rolls back
+   * the transcript write). Opaque pass-through. `harnessId` is a lane-key
+   * dimension (the backend keys per-harness), so it carries the full union.
    */
   harnessSessionCommit?: {
     ownerType: "direct-chat" | "chatbox-chat";
@@ -185,7 +186,7 @@ interface PersistChatSessionOptions {
     chatboxId?: string;
     leaseId: string;
     expectedStateVersion: number;
-    harnessId: "claude-code";
+    harnessId: "claude-code" | "codex";
     harnessSessionId: string;
     resumeState: unknown;
     computerId: string;

--- a/mcpjam-inspector/server/utils/computers/__tests__/create-pty.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/create-pty.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPtyWithCwd,
+  sanitizeTerminalCwd,
+  type PtyBaseOpts,
+} from "../create-pty.js";
+
+const baseOpts: PtyBaseOpts = {
+  cols: 80,
+  rows: 24,
+  timeoutMs: 1000,
+  onData: () => {},
+};
+
+function fakeSandbox(create: (opts: PtyBaseOpts & { cwd?: string }) => Promise<string>) {
+  return { pty: { create: vi.fn(create) } };
+}
+
+describe("createPtyWithCwd", () => {
+  it("creates the PTY with the cwd when provided", async () => {
+    const sandbox = fakeSandbox(async () => "handle");
+    const handle = await createPtyWithCwd(sandbox, baseOpts, "/home/user/wd");
+    expect(handle).toBe("handle");
+    expect(sandbox.pty.create).toHaveBeenCalledTimes(1);
+    expect(sandbox.pty.create).toHaveBeenCalledWith({
+      ...baseOpts,
+      cwd: "/home/user/wd",
+    });
+  });
+
+  it("creates without cwd when none is given", async () => {
+    const sandbox = fakeSandbox(async () => "handle");
+    await createPtyWithCwd(sandbox, baseOpts, undefined);
+    expect(sandbox.pty.create).toHaveBeenCalledTimes(1);
+    expect(sandbox.pty.create).toHaveBeenCalledWith(baseOpts);
+  });
+
+  it("retries once WITHOUT cwd when the cwd attempt rejects", async () => {
+    let call = 0;
+    const sandbox = fakeSandbox(async (opts) => {
+      call += 1;
+      if (call === 1) {
+        expect(opts.cwd).toBe("/stale/dir");
+        throw new Error("chdir failed");
+      }
+      expect(opts.cwd).toBeUndefined();
+      return "fallback-handle";
+    });
+    const handle = await createPtyWithCwd(sandbox, baseOpts, "/stale/dir");
+    expect(handle).toBe("fallback-handle");
+    expect(sandbox.pty.create).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("sanitizeTerminalCwd", () => {
+  it("accepts an absolute, bounded path", () => {
+    expect(sanitizeTerminalCwd("/home/user/claude-code-1")).toBe(
+      "/home/user/claude-code-1",
+    );
+  });
+
+  it("rejects relative, empty, or over-long paths", () => {
+    expect(sanitizeTerminalCwd(undefined)).toBeUndefined();
+    expect(sanitizeTerminalCwd("")).toBeUndefined();
+    expect(sanitizeTerminalCwd("relative/path")).toBeUndefined();
+    expect(sanitizeTerminalCwd("/" + "a".repeat(2000))).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/create-pty.ts
+++ b/mcpjam-inspector/server/utils/computers/create-pty.ts
@@ -1,0 +1,47 @@
+/**
+ * Create a PTY, optionally in a starting working directory, with a fallback.
+ *
+ * The Playground Shell can ask to open in the harness session workdir
+ * (`/home/user/claude-code-<id>`). That dir normally exists, but it could be
+ * stale/gone (computer recycled, session cleaned up). A missing `cwd` must never
+ * brick the terminal — so if `pty.create` rejects *with* a cwd, we retry once
+ * *without* it (lands in home). Extracted from the WS route so the retry has a
+ * unit test (the route itself isn't unit-testable — it holds a live socket).
+ */
+
+/** The subset of E2B's `pty.create` options we set. */
+export interface PtyBaseOpts {
+  cols: number;
+  rows: number;
+  timeoutMs: number;
+  onData: (data: Uint8Array) => void;
+}
+
+/** Minimal shape of the E2B sandbox we depend on (keeps this unit-testable). */
+export interface PtyCreator<Handle> {
+  pty: {
+    create: (opts: PtyBaseOpts & { cwd?: string }) => Promise<Handle>;
+  };
+}
+
+export async function createPtyWithCwd<Handle>(
+  sandbox: PtyCreator<Handle>,
+  baseOpts: PtyBaseOpts,
+  cwd: string | undefined,
+): Promise<Handle> {
+  if (!cwd) {
+    return sandbox.pty.create(baseOpts);
+  }
+  try {
+    return await sandbox.pty.create({ ...baseOpts, cwd });
+  } catch {
+    // Stale/invalid workdir — fall back to home rather than failing the open.
+    return sandbox.pty.create(baseOpts);
+  }
+}
+
+/** Accept only an absolute, length-bounded path as a cwd; reject anything else. */
+export function sanitizeTerminalCwd(raw: string | undefined): string | undefined {
+  if (!raw || !raw.startsWith("/") || raw.length > 1024) return undefined;
+  return raw;
+}

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -78,9 +78,26 @@ describe("checkHarnessRuntimeAvailable", () => {
     if (!r.ok) expect(r.reason).toMatch(/computers data plane/);
   });
 
-  it("fails when the host requires interactive tool approval", () => {
+  it("allows an approval host on Claude Code (WS3: native tool approval)", () => {
     setFullyAvailable();
     const r = checkHarnessRuntimeAvailable(args({ requireToolApproval: true }));
+    expect(r.ok).toBe(true);
+  });
+
+  it("still blocks an approval host WITH selected MCP servers (no MCP approval knob)", () => {
+    setFullyAvailable();
+    const r = checkHarnessRuntimeAvailable(
+      args({ requireToolApproval: true, hasSelectedMcpServers: true }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/MCP-server tools/);
+  });
+
+  it("still blocks an approval host on Codex (no native approval)", () => {
+    setFullyAvailable();
+    const r = checkHarnessRuntimeAvailable(
+      args({ harnessId: "codex", requireToolApproval: true }),
+    );
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toMatch(/tool approval/);
   });

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-strategy.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-strategy.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isPubliclyReachableUrl } from "../../localhost-check.js";
+import { resolveWebAuthorizedHarnessStrategy } from "../harness-proxy-strategy.js";
+
+describe("isPubliclyReachableUrl", () => {
+  it("accepts genuinely public origins", () => {
+    expect(isPubliclyReachableUrl("https://app.mcpjam.com")).toBe(true);
+    expect(isPubliclyReachableUrl("https://x.tunnels.mcpjam.com")).toBe(true);
+    expect(isPubliclyReachableUrl("http://8.8.8.8:6274")).toBe(true);
+  });
+
+  it("rejects every non-routable host (not just loopback)", () => {
+    for (const url of [
+      "http://localhost:6274",
+      "http://127.0.0.1:6274",
+      "http://[::1]:6274",
+      "http://0.0.0.0:6274",
+      "http://192.168.1.20:6274", // RFC1918
+      "http://10.0.0.5:6274", // RFC1918
+      "http://172.16.4.4:6274", // RFC1918
+      "http://172.31.255.1", // RFC1918 upper bound
+      "http://169.254.1.1", // link-local
+      "http://100.64.0.1", // CGNAT 100.64/10
+      "http://100.127.255.1", // CGNAT upper bound
+      "http://198.18.0.1", // benchmarking 198.18/15
+      "http://224.0.0.1", // multicast
+      "http://240.0.0.1", // reserved
+      "http://203.0.113.7", // TEST-NET-3 (documentation)
+      "http://192.0.2.5", // TEST-NET-1
+      "http://my-box.local", // mDNS
+      "not a url",
+    ]) {
+      expect(isPubliclyReachableUrl(url), url).toBe(false);
+    }
+  });
+
+  it("does not treat 172.15/172.32 as private (outside 172.16/12)", () => {
+    expect(isPubliclyReachableUrl("http://172.15.0.1")).toBe(true);
+    expect(isPubliclyReachableUrl("http://172.32.0.1")).toBe(true);
+  });
+});
+
+describe("resolveWebAuthorizedHarnessStrategy", () => {
+  const ENV_KEYS = ["MCPJAM_INSPECTOR_PUBLIC_URL", "BASE_URL"] as const;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("DIRECT when a publicly-reachable URL is configured", () => {
+    process.env.MCPJAM_INSPECTOR_PUBLIC_URL = "https://app.mcpjam.com";
+    expect(resolveWebAuthorizedHarnessStrategy()).toEqual({
+      plane: "web-authorized",
+      mode: "direct",
+      publicBaseUrl: "https://app.mcpjam.com",
+    });
+  });
+
+  it("RELAY when no URL is configured (private inspector, e.g. dev:hosted)", () => {
+    expect(resolveWebAuthorizedHarnessStrategy()).toEqual({
+      plane: "web-authorized",
+      mode: "relay",
+    });
+  });
+
+  it("RELAY when the configured URL is loopback (would be unreachable direct)", () => {
+    process.env.BASE_URL = "http://localhost:6274";
+    expect(resolveWebAuthorizedHarnessStrategy()).toEqual({
+      plane: "web-authorized",
+      mode: "relay",
+    });
+  });
+
+  it("RELAY when BASE_URL is a private/RFC1918 address (never wrongly direct)", () => {
+    process.env.BASE_URL = "http://192.168.1.50:6274";
+    expect(resolveWebAuthorizedHarnessStrategy()).toEqual({
+      plane: "web-authorized",
+      mode: "relay",
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-token.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-token.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { verifyHarnessProxyToken } from "../harness-proxy-token.js";
+import { signTestProxyToken } from "./sign-test-token.js";
+
+const SECRET = "test-harness-proxy-secret-32-chars-min";
+
+beforeAll(() => {
+  process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = SECRET;
+});
+
+describe("verifyHarnessProxyToken (verifies Convex-minted HS256 tokens)", () => {
+  it("returns claims for a valid token, scoped to its serverId", () => {
+    const token = signTestProxyToken({
+      serverId: "srv-a",
+      userId: "u_convex",
+      externalId: "u_ext",
+      orgId: "o1",
+      projectId: "p1",
+    });
+    expect(verifyHarnessProxyToken(token, "srv-a")).toEqual({
+      userId: "u_convex",
+      externalId: "u_ext",
+      orgId: "o1",
+      projectId: "p1",
+      serverId: "srv-a",
+    });
+    // Wrong server → rejected.
+    expect(verifyHarnessProxyToken(token, "srv-b")).toBeNull();
+  });
+
+  it("fails closed for missing / garbage tokens", () => {
+    expect(verifyHarnessProxyToken(undefined, "srv-a")).toBeNull();
+    expect(verifyHarnessProxyToken("", "srv-a")).toBeNull();
+    expect(verifyHarnessProxyToken("not.a.jwt", "srv-a")).toBeNull();
+    expect(verifyHarnessProxyToken("a.b.c.d", "srv-a")).toBeNull();
+  });
+
+  it("rejects a missing required identity claim", () => {
+    const noExt = signTestProxyToken({ serverId: "srv-a", externalId: "" });
+    expect(verifyHarnessProxyToken(noExt, "srv-a")).toBeNull();
+  });
+
+  it("rejects an expired token", () => {
+    const token = signTestProxyToken(
+      { serverId: "srv-a" },
+      { nowS: 1000, expS: 2000 },
+    );
+    expect(verifyHarnessProxyToken(token, "srv-a", { nowMs: 2_001_000 })).toBeNull();
+    expect(
+      verifyHarnessProxyToken(token, "srv-a", { nowMs: 1_500_000 }),
+    ).not.toBeNull();
+  });
+
+  it("rejects a tampered signature", () => {
+    const token = signTestProxyToken({ serverId: "srv-a" });
+    const [h, p] = token.split(".");
+    expect(verifyHarnessProxyToken(`${h}.${p}.deadbeef`, "srv-a")).toBeNull();
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const token = signTestProxyToken({ serverId: "srv-a" });
+    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "a-different-secret-1234567890";
+    expect(verifyHarnessProxyToken(token, "srv-a")).toBeNull();
+    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = SECRET; // restore
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-runtime-fingerprint.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-runtime-fingerprint.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { harnessRuntimeFingerprint } from "../run-harness-turn";
+import { harnessRuntimeFingerprint, toToolResultOutput } from "../run-harness-turn";
 
 // Regression: the fingerprint must be STABLE across turns of one chat so the
 // session resumes. App/widget chats mutate the system prompt every turn (live
@@ -59,5 +59,51 @@ describe("harnessRuntimeFingerprint", () => {
       systemPrompt: "a wildly different per-turn widget prompt",
     });
     expect(withStray).toBe(harnessRuntimeFingerprint(base));
+  });
+});
+
+// Regression: the harness `tool-result` `.output` (`event.result`) must be
+// persisted single-wrapped — matching the emulated engine — not re-wrapped in a
+// second `{type:"json",value:...}` envelope. The bug produced the double-nested
+// `{type:json,value:{type:json,value:{}}}` seen in broken transcripts.
+describe("toToolResultOutput", () => {
+  it("wraps a raw structured result once as json", () => {
+    expect(toToolResultOutput({ stdout: "ok" }, false)).toEqual({
+      type: "json",
+      value: { stdout: "ok" },
+    });
+  });
+
+  it("passes an already-typed json output through (no double-nest)", () => {
+    expect(toToolResultOutput({ type: "json", value: { ok: true } }, false)).toEqual({
+      type: "json",
+      value: { ok: true },
+    });
+  });
+
+  it("passes an already-typed content output through (computer-use/image)", () => {
+    const content = {
+      type: "content",
+      value: [{ type: "media", data: "…", mediaType: "image/png" }],
+    };
+    expect(toToolResultOutput(content, false)).toBe(content);
+  });
+
+  it("renders an error as error-text", () => {
+    expect(toToolResultOutput("boom", true)).toEqual({
+      type: "error-text",
+      value: "boom",
+    });
+    expect(toToolResultOutput({ msg: "boom" }, true)).toEqual({
+      type: "error-text",
+      value: JSON.stringify({ msg: "boom" }),
+    });
+  });
+
+  it("does not treat a bare {type} (no value) as already-typed", () => {
+    expect(toToolResultOutput({ type: "json" }, false)).toEqual({
+      type: "json",
+      value: { type: "json" },
+    });
   });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-session-state.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-session-state.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   claimHarnessSessionState,
   commitHarnessSessionState,
+  getHarnessResumeEligibility,
   heartbeatHarnessSessionState,
   type HarnessOwnerRef,
+  type HarnessResumePayload,
 } from "../harness-session-state";
 
 const ORIGINAL_FETCH = globalThis.fetch;
@@ -132,6 +134,64 @@ describe("heartbeatHarnessSessionState — tri-state liveness", () => {
       throw new Error("ECONNRESET");
     }) as unknown as typeof fetch;
     expect(await heartbeatHarnessSessionState(args)).toBe("retryable");
+  });
+});
+
+describe("getHarnessResumeEligibility", () => {
+  const warmState = (sandboxId: string): HarnessResumePayload => ({
+    harnessSessionId: "h1",
+    computerId: "comp",
+    resumeState: {
+      type: "resume-session",
+      data: { bridge: { port: 9, token: "t", sandboxId } },
+    },
+  });
+
+  it("no prior state → fresh, no reason (normal first turn)", () => {
+    expect(
+      getHarnessResumeEligibility({ state: null, computerId: "comp", sandboxId: "sb" }),
+    ).toEqual({ resume: false });
+  });
+
+  it("computerId moved → sandbox-replaced (no resume)", () => {
+    expect(
+      getHarnessResumeEligibility({
+        state: warmState("sb"),
+        computerId: "OTHER",
+        sandboxId: "sb",
+      }),
+    ).toEqual({ resume: false, reason: "sandbox-replaced" });
+  });
+
+  it("bridge sandboxId differs → sandbox-replaced (box swapped under same computer)", () => {
+    expect(
+      getHarnessResumeEligibility({
+        state: warmState("OLD-SANDBOX"),
+        computerId: "comp",
+        sandboxId: "NEW-SANDBOX",
+      }),
+    ).toEqual({ resume: false, reason: "sandbox-replaced" });
+  });
+
+  it("matching computer + sandbox → resume, no reason", () => {
+    expect(
+      getHarnessResumeEligibility({
+        state: warmState("sb"),
+        computerId: "comp",
+        sandboxId: "sb",
+      }),
+    ).toEqual({ resume: true });
+  });
+
+  it("legacy stop()-created sidecar (no bridge coords) → cold resume, flagged", () => {
+    const legacy: HarnessResumePayload = {
+      harnessSessionId: "h1",
+      computerId: "comp",
+      resumeState: { type: "resume-session", data: {} },
+    };
+    expect(
+      getHarnessResumeEligibility({ state: legacy, computerId: "comp", sandboxId: "sb" }),
+    ).toEqual({ resume: true, reason: "legacy-cold-resume" });
   });
 });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/mcp-config.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/mcp-config.test.ts
@@ -1,160 +1,85 @@
 import { describe, it, expect } from "vitest";
-import type { MCPServerConfig } from "@mcpjam/sdk";
 import {
-  buildHarnessMcpJson,
-  harnessServerInputFromConfig,
+  buildHarnessProxyMcpJson,
   harnessServerKeyToName,
   parseHarnessToolName,
   serializeHarnessMcpJson,
-  HarnessMcpConfigError,
+  type HarnessProxyServerInput,
 } from "../mcp-config.js";
 
-describe("buildHarnessMcpJson", () => {
-  it("maps a remote http server to a direct http entry", () => {
-    const out = buildHarnessMcpJson([
-      {
-        name: "weather",
-        transport: "http",
-        url: "https://api.example.com/mcp",
-        headers: { Authorization: "Bearer t" },
-      },
+const srv = (
+  name: string,
+  proxyUrl: string,
+  proxyToken = "tok",
+): HarnessProxyServerInput => ({ name, proxyUrl, proxyToken });
+
+describe("buildHarnessProxyMcpJson", () => {
+  it("points every entry at its proxy URL with ONLY the proxy token (no upstream headers)", () => {
+    const out = buildHarnessProxyMcpJson([
+      srv("notion", "https://abc.tunnels.mcpjam.com/api/mcp/adapter-http/notion?k=s1", "t1"),
     ]);
-    expect(out.mcpServers.weather).toEqual({
+    expect(out.mcpServers.notion).toEqual({
       type: "http",
-      url: "https://api.example.com/mcp",
-      headers: { Authorization: "Bearer t" },
+      url: "https://abc.tunnels.mcpjam.com/api/mcp/adapter-http/notion?k=s1",
+      headers: { "X-MCPJam-Proxy-Token": "t1" },
     });
+    // The win: no upstream Authorization ever reaches the sandbox file.
+    expect(
+      JSON.stringify(out).toLowerCase().includes("authorization"),
+    ).toBe(false);
   });
 
-  it("maps a local stdio server to its tunnel url as an http entry", () => {
-    const tunnelUrl =
-      "https://slug.tunnels.mcpjam.com/api/mcp/adapter-http/srv?k=secret";
-    const out = buildHarnessMcpJson([
-      { name: "files", transport: "stdio", tunnelUrl },
-    ]);
-    expect(out.mcpServers.files).toEqual({ type: "http", url: tunnelUrl });
-  });
-
-  it("omits empty headers", () => {
-    const out = buildHarnessMcpJson([
-      { name: "x", transport: "http", url: "https://x", headers: {} },
-    ]);
-    expect(out.mcpServers.x.headers).toBeUndefined();
-  });
-
-  it("sanitizes names and de-duplicates collisions", () => {
-    const out = buildHarnessMcpJson([
-      { name: "My Server!", transport: "http", url: "https://a" },
-      { name: "My/Server?", transport: "http", url: "https://b" },
+  it("sanitizes and de-duplicates colliding server names into distinct keys", () => {
+    const out = buildHarnessProxyMcpJson([
+      srv("My Server", "https://t/api/mcp/adapter-http/a?k=1"),
+      srv("My/Server", "https://t/api/mcp/adapter-http/b?k=2"),
     ]);
     const keys = Object.keys(out.mcpServers);
-    expect(keys).toContain("My_Server");
-    expect(keys).toContain("My_Server_2");
     expect(keys).toHaveLength(2);
+    expect(new Set(keys).size).toBe(2); // no collision
+    expect(keys.every((k) => /^[A-Za-z0-9_-]+$/.test(k))).toBe(true);
   });
 
-  it("falls back to 'server' for an all-symbol name", () => {
-    const out = buildHarnessMcpJson([
-      { name: "!!!", transport: "http", url: "https://a" },
+  it("returns an empty object for no servers", () => {
+    expect(buildHarnessProxyMcpJson([])).toEqual({ mcpServers: {} });
+  });
+
+  it("omits the proxy-token header when no token is supplied (local plane)", () => {
+    const out = buildHarnessProxyMcpJson([
+      { name: "local", proxyUrl: "https://t/api/mcp/adapter-http/local?k=1" },
     ]);
-    expect(Object.keys(out.mcpServers)).toEqual(["server"]);
-  });
-
-  it("returns an empty mcpServers map for no servers", () => {
-    expect(buildHarnessMcpJson([])).toEqual({ mcpServers: {} });
-  });
-});
-
-describe("harnessServerInputFromConfig", () => {
-  it("normalizes an http config (url + headers)", () => {
-    const cfg = {
-      url: "https://api/mcp",
-      requestInit: { headers: { "X-Foo": "bar" } },
-    } as unknown as MCPServerConfig;
-    expect(harnessServerInputFromConfig("remote", cfg)).toEqual({
-      name: "remote",
-      transport: "http",
-      url: "https://api/mcp",
-      headers: { "X-Foo": "bar" },
+    expect(out.mcpServers.local).toEqual({
+      type: "http",
+      url: "https://t/api/mcp/adapter-http/local?k=1",
     });
-  });
-
-  it("adds Authorization from a bare accessToken", () => {
-    const cfg = {
-      url: "https://api/mcp",
-      accessToken: "tok",
-    } as unknown as MCPServerConfig;
-    const input = harnessServerInputFromConfig("remote", cfg);
-    expect(input.transport).toBe("http");
-    expect(input.headers).toEqual({ Authorization: "Bearer tok" });
-  });
-
-  it("does not clobber an existing Authorization header", () => {
-    const cfg = {
-      url: "https://api/mcp",
-      accessToken: "tok",
-      requestInit: { headers: { Authorization: "Bearer existing" } },
-    } as unknown as MCPServerConfig;
-    const input = harnessServerInputFromConfig("remote", cfg);
-    expect(input.headers).toEqual({ Authorization: "Bearer existing" });
-  });
-
-  it("treats Authorization header keys case-insensitively", () => {
-    const cfg = {
-      url: "https://api/mcp",
-      accessToken: "tok",
-      requestInit: { headers: { AUTHORIZATION: "Bearer existing" } },
-    } as unknown as MCPServerConfig;
-    const input = harnessServerInputFromConfig("remote", cfg);
-    expect(input.headers).toEqual({ AUTHORIZATION: "Bearer existing" });
-  });
-
-  it("normalizes a stdio config to its tunnel url", () => {
-    const cfg = {
-      command: "node",
-      args: ["x.js"],
-    } as unknown as MCPServerConfig;
-    expect(
-      harnessServerInputFromConfig("local", cfg, { tunnelUrl: "https://t/u?k=s" }),
-    ).toEqual({ name: "local", transport: "stdio", tunnelUrl: "https://t/u?k=s" });
-  });
-
-  it("throws for a stdio config without a tunnel url", () => {
-    const cfg = { command: "node" } as unknown as MCPServerConfig;
-    expect(() => harnessServerInputFromConfig("local", cfg)).toThrow(
-      HarnessMcpConfigError,
-    );
+    expect(out.mcpServers.local.headers).toBeUndefined();
   });
 });
 
 describe("serializeHarnessMcpJson", () => {
-  it("produces parseable JSON round-tripping the object", () => {
-    const json = buildHarnessMcpJson([
-      { name: "w", transport: "http", url: "https://x" },
+  it("pretty-prints the .mcp.json", () => {
+    const json = buildHarnessProxyMcpJson([
+      srv("a", "https://t/api/mcp/adapter-http/a?k=1", "t1"),
     ]);
-    expect(JSON.parse(serializeHarnessMcpJson(json))).toEqual(json);
+    const text = serializeHarnessMcpJson(json);
+    expect(text).toContain('"mcpServers"');
+    expect(text).toContain('"X-MCPJam-Proxy-Token": "t1"');
+    expect(text).toBe(JSON.stringify(json, null, 2));
   });
 });
 
 describe("harnessServerKeyToName", () => {
-  it("maps sanitized keys back to original input names (deduped)", () => {
-    const map = harnessServerKeyToName([
-      { name: "My Server!", transport: "http", url: "https://a" },
-      { name: "My/Server?", transport: "http", url: "https://b" },
-    ]);
-    expect(map).toEqual({
-      My_Server: "My Server!",
-      My_Server_2: "My/Server?",
-    });
-  });
-
-  it("uses the same keys buildHarnessMcpJson produces", () => {
+  it("maps the SAME keys buildHarnessProxyMcpJson produces back to serverIds", () => {
     const servers = [
-      { name: "alpha", transport: "http" as const, url: "https://a" },
-      { name: "beta", transport: "http" as const, url: "https://b" },
+      srv("weather", "https://t/api/mcp/adapter-http/weather?k=1"),
+      srv("My Server 2", "https://t/api/mcp/adapter-http/srv2?k=2"),
     ];
-    expect(Object.keys(harnessServerKeyToName(servers)).sort()).toEqual(
-      Object.keys(buildHarnessMcpJson(servers).mcpServers).sort(),
+    const keyToName = harnessServerKeyToName(servers);
+    expect(Object.keys(keyToName).sort()).toEqual(
+      Object.keys(buildHarnessProxyMcpJson(servers).mcpServers).sort(),
+    );
+    expect(Object.values(keyToName).sort()).toEqual(
+      ["My Server 2", "weather"].sort(),
     );
   });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
@@ -23,6 +23,8 @@ vi.mock("@ai-sdk/harness/agent", () => ({
       text: Promise.resolve(harnessState.finalText),
     }));
   },
+  // WS3: no trailing tool-approval-response parts in these prompts.
+  collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
 }));
 
 vi.mock("../registry.js", () => ({
@@ -63,17 +65,23 @@ vi.mock("../reconcile-skill-dirs.js", () => ({
   reconcileSkillDirs: vi.fn(async () => {}),
 }));
 
-vi.mock("../harness-session-state.js", () => ({
-  claimHarnessSessionState: vi.fn(async () => ({
-    ok: true,
-    leaseId: "lease-1",
-    stateVersion: 1,
-    state: null,
-    fingerprintChanged: false,
-  })),
-  heartbeatHarnessSessionState: vi.fn(async () => "ok"),
-  releaseHarnessSessionState: vi.fn(async () => {}),
-}));
+vi.mock("../harness-session-state.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../harness-session-state.js")>();
+  return {
+    ...actual,
+    claimHarnessSessionState: vi.fn(async () => ({
+      ok: true,
+      leaseId: "lease-1",
+      stateVersion: 1,
+      state: null,
+      fingerprintChanged: false,
+    })),
+    commitHarnessSessionState: vi.fn(async () => true),
+    heartbeatHarnessSessionState: vi.fn(async () => "ok"),
+    releaseHarnessSessionState: vi.fn(async () => {}),
+  };
+});
 
 vi.mock("../harness-model-broker.js", () => ({
   revokeHarnessModelBroker: vi.fn(async () => {}),

--- a/mcpjam-inspector/server/utils/harness/__tests__/sign-test-token.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/sign-test-token.ts
@@ -1,0 +1,39 @@
+/**
+ * Test-only signer that mints a harness MCP proxy token exactly as Convex does
+ * (`mcpjam-backend/convex/lib/harnessMcpProxyToken.ts`), so tests can exercise
+ * the inspector's verifier without a live backend. NOT a *.test.ts file → not
+ * run as a suite; imported by the route/token tests. Requires
+ * `COMPUTERS_TERMINAL_TOKEN_SECRET` to be set.
+ */
+import { createHmac } from "node:crypto";
+
+export function signTestProxyToken(
+  claims: {
+    serverId: string;
+    userId?: string;
+    externalId?: string;
+    orgId?: string;
+    projectId?: string;
+  },
+  opts: { nowS?: number; expS?: number } = {},
+): string {
+  const secret = process.env.COMPUTERS_TERMINAL_TOKEN_SECRET;
+  if (!secret) throw new Error("set COMPUTERS_TERMINAL_TOKEN_SECRET in the test");
+  const now = opts.nowS ?? Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: "https://api.mcpjam.com/harness-mcp-proxy",
+    purpose: "harness-mcp-proxy",
+    sub: claims.userId ?? "user_convex_1",
+    ext: claims.externalId ?? "user_ext_1",
+    org: claims.orgId ?? "org_1",
+    projectId: claims.projectId ?? "proj_1",
+    serverId: claims.serverId,
+    iat: now,
+    exp: opts.expS ?? now + 3600,
+  };
+  const b64 = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  const input = `${b64({ alg: "HS256", typ: "JWT" })}.${b64(payload)}`;
+  const sig = createHmac("sha256", secret).update(input).digest("base64url");
+  return `${input}.${sig}`;
+}

--- a/mcpjam-inspector/server/utils/harness/harness-proxy-strategy.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-proxy-strategy.ts
@@ -1,0 +1,79 @@
+/**
+ * Harness MCP proxy *plane strategy* — selected by the CALLER ROUTE, never by a
+ * global env. `/api/web/chat-v2` is a hosted-plane request even in local dev
+ * (it builds an ephemeral authorized manager), so reading `HOSTED_MODE` inside
+ * the turn would route the sandbox to the wrong manager. The route passes this
+ * strategy through `MCPJamHandlerOptions.harnessMcpProxy`; the turn asks it only
+ * for the per-server URL (the token is minted by Convex — see
+ * `harness-proxy-token-client.ts` — so no identity rides the strategy).
+ *
+ * - `local-mcp`            → sandbox reaches the private inspector via a
+ *                            per-server tunnel, landing on
+ *                            `/api/mcp/adapter-http/{id}`.
+ * - `web-authorized direct`→ sandbox reaches a PUBLIC inspector directly at
+ *                            `{publicBaseUrl}/api/web/harness-mcp/{id}`.
+ * - `web-authorized relay` → inspector is PRIVATE (local dev / self-hosted) and
+ *                            unreachable from the cloud sandbox, so it's exposed
+ *                            via a scoped `harness-web` tunnel whose edge only
+ *                            permits `/api/web/harness-mcp/{id}`.
+ */
+import {
+  ensureServerTunnel,
+  ensureHarnessWebTunnel,
+} from "../../services/ensure-server-tunnel.js";
+import { isPubliclyReachableUrl } from "../localhost-check.js";
+
+export type HarnessMcpProxyStrategy =
+  | { plane: "local-mcp" }
+  | {
+      plane: "web-authorized";
+      mode: "direct";
+      /** Server-authoritative PUBLIC origin of the inspector's `/api/web`. */
+      publicBaseUrl: string;
+    }
+  | { plane: "web-authorized"; mode: "relay" };
+
+/**
+ * Decide how the cloud sandbox reaches THIS inspector's `/api/web/harness-mcp`
+ * for a hosted (`/api/web`) harness turn — a single **deploy-topology** call,
+ * no extra env knob: is the inspector publicly reachable?
+ *  - a publicly-reachable `MCPJAM_INSPECTOR_PUBLIC_URL`/`BASE_URL` → **direct**
+ *    (cloud prod; a configured public self-host);
+ *  - otherwise (no URL, loopback, or RFC1918/private) the inspector is private
+ *    — local dev (`dev:hosted`) or self-hosted-behind-a-firewall — so the cloud
+ *    sandbox reaches it through the scoped **harness-web relay**.
+ * Still fail-closed where it matters: if relay infra isn't configured,
+ * `ensureHarnessWebTunnel` throws at tunnel-creation with a concrete error.
+ */
+export function resolveWebAuthorizedHarnessStrategy(): HarnessMcpProxyStrategy {
+  const publicUrl =
+    process.env.MCPJAM_INSPECTOR_PUBLIC_URL?.trim() ||
+    process.env.BASE_URL?.trim();
+  if (publicUrl && isPubliclyReachableUrl(publicUrl)) {
+    return { plane: "web-authorized", mode: "direct", publicBaseUrl: publicUrl };
+  }
+  return { plane: "web-authorized", mode: "relay" };
+}
+
+/**
+ * Resolve the `.mcp.json` URL for one server. `local-mcp` ensures the
+ * adapter-http tunnel; `web-authorized` either points at the public route
+ * directly or ensures a scoped `harness-web` tunnel (whose bearer URL already
+ * carries the `/api/web/harness-mcp/{id}` path + `?k=`).
+ */
+export async function resolveHarnessProxyUrl(args: {
+  strategy: HarnessMcpProxyStrategy;
+  serverId: string;
+  authHeader: string;
+}): Promise<string> {
+  const { strategy, serverId, authHeader } = args;
+  if (strategy.plane === "web-authorized") {
+    if (strategy.mode === "direct") {
+      const base = strategy.publicBaseUrl.replace(/\/+$/, "");
+      return `${base}/api/web/harness-mcp/${encodeURIComponent(serverId)}`;
+    }
+    return ensureHarnessWebTunnel(serverId, authHeader);
+  }
+  // local-mcp: reach the private inspector through the per-server adapter tunnel.
+  return ensureServerTunnel(serverId, authHeader);
+}

--- a/mcpjam-inspector/server/utils/harness/harness-proxy-token-client.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-proxy-token-client.ts
@@ -1,0 +1,86 @@
+/**
+ * Fetch per-server harness MCP proxy tokens from Convex — the same bearer-authed
+ * channel the harness already uses for `model-credential` and `session-state`.
+ *
+ * Convex MINTS the tokens (it knows the authenticated user, so identity is
+ * authoritative and baked in) and checks per-server access; the inspector only
+ * verifies + forwards. Mirrors `harness-model-credential.ts`.
+ *
+ * Backed by `convex/http.ts:/web/harness/mcp-proxy-token`.
+ */
+import { logger } from "../logger.js";
+
+export type HarnessProxyTokensResult =
+  | { ok: true; tokens: Record<string, string> }
+  | { ok: false; status: number; error: string };
+
+function getConvexHttpUrl(): string {
+  const convexHttpUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexHttpUrl) {
+    throw new Error("CONVEX_HTTP_URL is required for harness proxy tokens");
+  }
+  return convexHttpUrl;
+}
+
+/**
+ * Mint a token per server. Convex returns only servers the caller can access
+ * (others are silently omitted — the inspector just won't attach them).
+ */
+export async function fetchHarnessProxyTokens(args: {
+  projectId: string;
+  serverIds: string[];
+  bearer: string;
+  signal?: AbortSignal;
+}): Promise<HarnessProxyTokensResult> {
+  const url = new URL(
+    "/web/harness/mcp-proxy-token",
+    getConvexHttpUrl(),
+  ).toString();
+  const authorization = args.bearer.startsWith("Bearer ")
+    ? args.bearer
+    : `Bearer ${args.bearer}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization },
+      body: JSON.stringify({
+        projectId: args.projectId,
+        serverIds: args.serverIds,
+      }),
+      ...(args.signal ? { signal: args.signal } : {}),
+    });
+  } catch (err) {
+    logger.error("[harness-proxy-token] network error", err);
+    return {
+      ok: false,
+      status: 502,
+      error: "Failed to reach harness mcp-proxy-token endpoint",
+    };
+  }
+
+  let payload: any = null;
+  try {
+    payload = await response.json();
+  } catch {
+    return {
+      ok: false,
+      status: response.ok ? 502 : response.status,
+      error: `Harness mcp-proxy-token returned ${response.status} with non-JSON body`,
+    };
+  }
+
+  if (!response.ok || payload?.ok !== true || typeof payload?.tokens !== "object") {
+    return {
+      ok: false,
+      status: response.ok ? 502 : response.status,
+      error:
+        typeof payload?.error === "string"
+          ? payload.error
+          : `Harness mcp-proxy-token failed (${response.status})`,
+    };
+  }
+
+  return { ok: true, tokens: payload.tokens as Record<string, string> };
+}

--- a/mcpjam-inspector/server/utils/harness/harness-proxy-token.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-proxy-token.ts
@@ -1,0 +1,107 @@
+/**
+ * Harness MCP proxy token — VERIFY side (inspector / data plane).
+ *
+ * The token is MINTED by Convex (`/web/harness/mcp-proxy-token`, bearer-authed —
+ * Convex knows the user, so the identity is authoritative and baked in), exactly
+ * like computers mint terminal tokens. The inspector only VERIFIES it here,
+ * REUSING the existing shared `COMPUTERS_TERMINAL_TOKEN_SECRET` (the distinct
+ * `purpose` claim isolates it from terminal tokens — no new deployment secret).
+ * HS256, fail-closed.
+ *
+ * HAND-MIRRORED CONTRACT: this verifier must agree byte-for-byte with the Convex
+ * signer (`mcpjam-backend/convex/lib/harnessMcpProxyToken.ts`) — same claim
+ * shape, issuer, purpose, and base64url(JWT) encoding — or it will reject
+ * legitimate tokens. (Node `createHmac` and Convex `crypto.subtle` produce the
+ * identical HMAC-SHA256 bytes for the same secret + signing input.)
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const ISSUER = "https://api.mcpjam.com/harness-mcp-proxy";
+const PURPOSE = "harness-mcp-proxy";
+const MIN_SECRET_LENGTH = 16;
+
+/** Claims a route gets back from a verified token. `externalId` + `orgId` drive
+ *  the hosted route's acting-as authorize; the local route ignores them. */
+export interface HarnessMcpProxyClaims {
+  userId: string;
+  externalId: string;
+  orgId: string;
+  projectId: string;
+  serverId: string;
+}
+
+function getSecret(): string {
+  // Reuse the computer-terminal token secret (already on both sides); the
+  // purpose claim isolates harness-mcp tokens from terminal tokens.
+  const secret = process.env.COMPUTERS_TERMINAL_TOKEN_SECRET?.trim();
+  if (!secret) {
+    throw new Error(
+      "harness-proxy-token: COMPUTERS_TERMINAL_TOKEN_SECRET is not set on this deployment",
+    );
+  }
+  if (secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `harness-proxy-token: COMPUTERS_TERMINAL_TOKEN_SECRET must be at least ${MIN_SECRET_LENGTH} characters`,
+    );
+  }
+  return secret;
+}
+
+/**
+ * Verify a Convex-minted token and that it was minted for exactly `serverId`.
+ * Returns the claims, or `null` for anything wrong (missing/weak secret,
+ * malformed, tampered signature, wrong issuer/purpose, wrong serverId, expired).
+ * Never throws.
+ */
+export function verifyHarnessProxyToken(
+  token: string | undefined | null,
+  serverId: string,
+  opts: { nowMs?: number } = {},
+): HarnessMcpProxyClaims | null {
+  if (!token) return null;
+  let secret: string;
+  try {
+    secret = getSecret();
+  } catch {
+    return null;
+  }
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [h, p, s] = parts;
+  if (!h || !p || !s) return null;
+
+  const expected = createHmac("sha256", secret).update(`${h}.${p}`).digest();
+  let given: Buffer;
+  try {
+    given = Buffer.from(s, "base64url");
+  } catch {
+    return null;
+  }
+  if (expected.length !== given.length || !timingSafeEqual(expected, given)) {
+    return null;
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(Buffer.from(p, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (payload.iss !== ISSUER || payload.purpose !== PURPOSE) return null;
+  for (const k of ["sub", "ext", "org", "projectId", "serverId"] as const) {
+    if (typeof payload[k] !== "string" || (payload[k] as string).length === 0) {
+      return null;
+    }
+  }
+  if (payload.serverId !== serverId) return null;
+  if (typeof payload.exp !== "number") return null;
+  if (Math.floor((opts.nowMs ?? Date.now()) / 1000) > payload.exp) return null;
+
+  return {
+    userId: payload.sub as string,
+    externalId: payload.ext as string,
+    orgId: payload.org as string,
+    projectId: payload.projectId as string,
+    serverId: payload.serverId as string,
+  };
+}

--- a/mcpjam-inspector/server/utils/harness/harness-session-state.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-session-state.ts
@@ -9,6 +9,7 @@
  */
 import { type Harness } from "@mcpjam/sdk/host-config/internal";
 import { logger } from "../logger.js";
+import type { HarnessResetReason } from "@/shared/harness-session";
 
 export type HarnessOwnerType =
   | "direct-chat"
@@ -33,6 +34,10 @@ export type HarnessResumePayload = {
   harnessSessionId: string;
   resumeState: unknown;
   computerId: string;
+  /** WS3: when true, `resumeState` is a `continue-turn` payload (the turn paused
+   *  for a tool approval) — resume with `createSession({ continueFrom })` +
+   *  `continueStream`, not `resumeFrom` + `stream`. */
+  awaitingApproval?: boolean;
 };
 
 /**
@@ -55,6 +60,9 @@ export type HarnessSessionCommitPayload = {
   runtimeFingerprint: string;
   /** Omit on a failed/skipped skills fetch so the stored hash is preserved. */
   skillsHash?: string;
+  /** WS3: the committed state is a paused-for-approval continuation (see
+   *  HarnessResumePayload.awaitingApproval). */
+  awaitingApproval?: boolean;
 };
 
 export type HarnessClaimResult =
@@ -65,6 +73,54 @@ export type HarnessClaimResult =
       fingerprintChanged: boolean;
     }
   | { ok: false; status: number; error: string };
+
+export type HarnessResumeEligibility = {
+  resume: boolean;
+  reason?: HarnessResetReason;
+};
+
+/**
+ * Decide whether a claimed harness session sidecar can warm-resume on THIS
+ * computer/sandbox, and if not, why. Pure + side-effect-free so the resume
+ * policy is unit-testable without a live harness runner.
+ *
+ *  - no prior state                      → fresh, no reason (normal first turn).
+ *  - computerId moved                    → `sandbox-replaced` (control-plane reprovision).
+ *  - prior bridge sandboxId ≠ current    → `sandbox-replaced` (box swapped under the same computer).
+ *  - prior sidecar has no bridge sandbox → `legacy-cold-resume` (pre-`detach()` state; still
+ *                                          attempt the disk/cold resume, but don't claim warm continuity).
+ *  - otherwise                           → resume.
+ *
+ * The bridge sandbox id is read defensively from the opaque `resumeState`
+ * (`detach()` embeds it at `data.bridge.sandboxId`); an unexpected shape
+ * degrades to the legacy path rather than throwing. This only detects a
+ * REPROVISIONED box — it cannot tell whether a bridge died inside the SAME
+ * sandbox (that path is swallowed inside the adapter and falls back fresh on
+ * its own).
+ */
+export function getHarnessResumeEligibility(args: {
+  state: HarnessResumePayload | null | undefined;
+  computerId: string;
+  sandboxId: string;
+}): HarnessResumeEligibility {
+  const { state, computerId, sandboxId } = args;
+  if (!state) return { resume: false };
+  if (state.computerId !== computerId) {
+    return { resume: false, reason: "sandbox-replaced" };
+  }
+  const priorSandboxId = (
+    state.resumeState as
+      | { data?: { bridge?: { sandboxId?: unknown } } }
+      | null
+      | undefined
+  )?.data?.bridge?.sandboxId;
+  if (typeof priorSandboxId === "string" && priorSandboxId.length > 0) {
+    return priorSandboxId === sandboxId
+      ? { resume: true }
+      : { resume: false, reason: "sandbox-replaced" };
+  }
+  return { resume: true, reason: "legacy-cold-resume" };
+}
 
 function getConvexHttpUrl(): string {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
@@ -217,6 +273,7 @@ export async function commitHarnessSessionState(args: {
   runtimeFingerprint: string;
   /** Omit on a failed/skipped skills fetch so the stored hash is preserved. */
   skillsHash?: string;
+  awaitingApproval?: boolean;
   bearer: string;
 }): Promise<boolean> {
   const res = await postSessionState("commit", args.bearer, {
@@ -228,6 +285,7 @@ export async function commitHarnessSessionState(args: {
     computerId: args.computerId,
     runtimeFingerprint: args.runtimeFingerprint,
     ...(args.skillsHash !== undefined ? { skillsHash: args.skillsHash } : {}),
+    ...(args.awaitingApproval ? { awaitingApproval: true } : {}),
   });
   if (!res.ok) {
     logger.warn("[harness-session-state] commit failed", { error: res.error });

--- a/mcpjam-inspector/server/utils/harness/mcp-config.ts
+++ b/mcpjam-inspector/server/utils/harness/mcp-config.ts
@@ -1,23 +1,22 @@
 /**
- * Build a Claude Code `.mcp.json` from a host's selected MCP servers.
+ * Build a Claude Code `.mcp.json` from a host's selected MCP servers — the
+ * "Keep MCPJam being MCPJam" Phase 1 shape.
  *
- * Claude Code runs INSIDE the E2B sandbox and connects to each server itself,
- * so EVERY entry is an `http` entry — the sandbox can neither spawn our stdio
- * subprocesses nor reach private addresses:
- *   - remote http/sse servers → their public url + headers directly (sandbox
- *     egress reaches the public internet);
- *   - local/stdio servers → the inspector's tunnel relay url, which bridges an
- *     external https request back to the local stdio process. Claude Code never
- *     spawns a stdio server itself.
+ * Every entry points the harness at MCPJam's OWN per-server tunnel
+ * (`…/api/mcp/adapter-http/{serverId}?k=…`), NOT at the upstream server. MCPJam
+ * forwards to the real server via the live `MCPClientManager`, so:
+ *   - the harness's MCP traffic flows through MCPJam (observation, the shared
+ *     authorized connection, host-knob enforcement — the whole playground);
+ *   - **no upstream credentials land in the sandbox** — the only secrets in
+ *     `.mcp.json` are the tunnel's per-server `?k=` bearer and a per-turn,
+ *     server-scoped `X-MCPJam-Proxy-Token` (validated-when-present by
+ *     `adapter-http`; see `harness-proxy-token.ts`).
  *
- * This is the pure generator. Resolving each server's effective config (and the
- * tunnel url for local ones) is the caller's job — see Phase 4's
- * `runHarnessTurn`, which has the live MCPClientManager + tunnelManager.
+ * This is the pure generator. Resolving each server's tunnel URL + minting its
+ * token is the caller's job — see `run-harness-turn`.
  */
-import { isHttpServerConfig } from "@mcpjam/sdk";
-import type { MCPServerConfig } from "@mcpjam/sdk";
 
-/** Failure building the harness MCP config (e.g. a local server with no tunnel). */
+/** Failure building the harness MCP config (e.g. a server with no tunnel). */
 export class HarnessMcpConfigError extends Error {
   constructor(message: string) {
     super(message);
@@ -25,25 +24,21 @@ export class HarnessMcpConfigError extends Error {
   }
 }
 
-/**
- * A selected MCP server, normalized for the harness. Both variants resolve to
- * an http entry; the variant only records where the url came from.
- */
-export type HarnessMcpServerInput =
-  | {
-      name: string;
-      transport: "http";
-      /** Public URL the sandbox reaches directly. */
-      url: string;
-      headers?: Record<string, string>;
-    }
-  | {
-      name: string;
-      transport: "stdio";
-      /** Tunnel relay URL bridging the local stdio server over https. */
-      tunnelUrl: string;
-      headers?: Record<string, string>;
-    };
+/** One server, resolved to its MCPJam proxy endpoint + per-turn token. */
+export interface HarnessProxyServerInput {
+  /** The MCPJam serverId (used as the key→name source for tool mapping). */
+  name: string;
+  /** Per-server tunnel URL that lands at `adapter-http/{serverId}` (carries `?k=`). */
+  proxyUrl: string;
+  /**
+   * Convex-minted, server-scoped identity token sent as `X-MCPJam-Proxy-Token`.
+   * Present on the HOSTED (web-authorized) plane, where the route uses it for
+   * acting-as. OMITTED on the local-mcp plane: local servers have no Convex row
+   * to authorize, the persistent manager already holds the connection, and the
+   * tunnel's `?k=` secret is the auth (`adapter-http` is validate-when-present).
+   */
+  proxyToken?: string;
+}
 
 /** A single Claude Code `.mcp.json` server entry (http transport). */
 export interface HarnessMcpHttpEntry {
@@ -67,76 +62,14 @@ function sanitizeServerName(name: string): string {
   return cleaned || "server";
 }
 
-/** Normalize a transport `headers` value (Headers | tuples | record) to a plain
- *  record; returns undefined when there's nothing to send. */
-function coerceHeaders(h: unknown): Record<string, string> | undefined {
-  if (!h) return undefined;
-  let entries: Array<[string, string]> = [];
-  if (typeof Headers !== "undefined" && h instanceof Headers) {
-    entries = [...h.entries()];
-  } else if (Array.isArray(h)) {
-    entries = h
-      .filter((p): p is [unknown, unknown] => Array.isArray(p) && p.length >= 2)
-      .map(([k, v]) => [String(k), String(v)]);
-  } else if (typeof h === "object") {
-    entries = Object.entries(h as Record<string, unknown>).map(([k, v]) => [
-      k,
-      String(v),
-    ]);
-  }
-  const out: Record<string, string> = {};
-  for (const [k, v] of entries) out[k] = v;
-  return Object.keys(out).length ? out : undefined;
-}
-
-/**
- * Normalize one resolved `MCPServerConfig` (the shape `createAuthorizedManager`
- * produces) into a harness input.
- *  - http/sse → its url + headers directly.
- *  - stdio    → requires `tunnelUrl` (the local process isn't reachable from
- *               the sandbox); throws `HarnessMcpConfigError` if it's missing.
- */
-export function harnessServerInputFromConfig(
-  name: string,
-  config: MCPServerConfig,
-  opts: { tunnelUrl?: string | null } = {},
-): HarnessMcpServerInput {
-  if (isHttpServerConfig(config)) {
-    const headers = coerceHeaders(config.requestInit?.headers) ?? {};
-    // createAuthorizedManager already overlays OAuth into headers, but honor a
-    // bare accessToken too (any existing Authorization header wins, regardless
-    // of casing — header names are case-insensitive).
-    const hasAuthorizationHeader = Object.keys(headers).some(
-      (key) => key.toLowerCase() === "authorization",
-    );
-    if (config.accessToken && !hasAuthorizationHeader) {
-      headers.Authorization = `Bearer ${config.accessToken}`;
-    }
-    return {
-      name,
-      transport: "http",
-      url: config.url,
-      headers: Object.keys(headers).length ? headers : undefined,
-    };
-  }
-  // stdio — not reachable from the sandbox without a tunnel.
-  if (!opts.tunnelUrl) {
-    throw new HarnessMcpConfigError(
-      `local (stdio) server "${name}" needs a tunnel URL to be reachable from ` +
-        `the sandbox — open a tunnel for it before starting the harness turn`,
-    );
-  }
-  return { name, transport: "stdio", tunnelUrl: opts.tunnelUrl };
-}
-
 /** Assign each server its sanitized, de-duplicated `.mcp.json` key, preserving
- *  input order. Shared by buildHarnessMcpJson and harnessServerKeyToName so the
- *  keys — and thus Claude Code's `mcp__<key>__<tool>` names — can't drift. */
-function assignServerKeys(
-  servers: HarnessMcpServerInput[],
-): Array<{ key: string; server: HarnessMcpServerInput }> {
+ *  input order. Shared by the json builder and the key→name map so the keys —
+ *  and thus Claude Code's `mcp__<key>__<tool>` names — can't drift. */
+function assignServerKeys<T extends { name: string }>(
+  servers: T[],
+): Array<{ key: string; server: T }> {
   const used = new Set<string>();
-  const out: Array<{ key: string; server: HarnessMcpServerInput }> = [];
+  const out: Array<{ key: string; server: T }> = [];
   for (const server of servers) {
     let key = sanitizeServerName(server.name);
     if (used.has(key)) {
@@ -150,29 +83,35 @@ function assignServerKeys(
   return out;
 }
 
-/** Build the `.mcp.json` object from normalized inputs. Names are sanitized and
- *  de-duplicated so distinct servers never collide on a key. */
-export function buildHarnessMcpJson(
-  servers: HarnessMcpServerInput[],
+/**
+ * Build the `.mcp.json` object — every entry is an `http` entry pointing at the
+ * server's MCPJam proxy URL, carrying ONLY the per-turn proxy token (no upstream
+ * auth). Names are sanitized + de-duplicated so distinct servers never collide.
+ */
+export function buildHarnessProxyMcpJson(
+  servers: HarnessProxyServerInput[],
 ): HarnessMcpJson {
   const mcpServers: Record<string, HarnessMcpHttpEntry> = {};
-  for (const { key, server: s } of assignServerKeys(servers)) {
-    const url = s.transport === "http" ? s.url : s.tunnelUrl;
-    const entry: HarnessMcpHttpEntry = { type: "http", url };
-    if (s.headers && Object.keys(s.headers).length > 0) {
-      entry.headers = { ...s.headers };
-    }
-    mcpServers[key] = entry;
+  for (const { key, server } of assignServerKeys(servers)) {
+    mcpServers[key] = {
+      type: "http",
+      url: server.proxyUrl,
+      // Header only when a token was minted (hosted plane); the local plane is
+      // gated by the tunnel `?k=` and sends none.
+      ...(server.proxyToken
+        ? { headers: { "X-MCPJam-Proxy-Token": server.proxyToken } }
+        : {}),
+    };
   }
   return { mcpServers };
 }
 
 /** Map each sanitized `.mcp.json` key → the input's original name (the MCPJam
- *  serverId), using the SAME sanitize+dedup as buildHarnessMcpJson. Lets the
- *  turn runner map Claude Code's `mcp__<key>__<tool>` tool names back to the
+ *  serverId), using the SAME sanitize+dedup as `buildHarnessProxyMcpJson`. Lets
+ *  the turn runner map Claude Code's `mcp__<key>__<tool>` tool names back to the
  *  originating serverId (eval tool matching, trace spans, MCP App rendering). */
 export function harnessServerKeyToName(
-  servers: HarnessMcpServerInput[],
+  servers: Array<{ name: string }>,
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const { key, server } of assignServerKeys(servers)) {

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -122,8 +122,14 @@ export type HarnessRuntimeAdapter = {
    *  today is "allow-all"; modeled per-adapter so it isn't a hardcoded constant. */
   defaultPermissionMode: HarnessV1PermissionMode;
   /** Can the runtime PAUSE for interactive approval of its NATIVE built-in tools
-   *  (Bash/Read/…)? Both current adapters: false (the CLI runs them itself). */
+   *  (Bash/Edit/Write/…)? Claude Code: yes (WS3) — the turn pauses on a
+   *  `tool-approval-request` and resumes with the decision. Codex v1: false. */
   supportsNativeToolApproval: boolean;
+  /** Permission mode used when the host requires tool approval (WS3). Gates
+   *  side-effecting built-ins behind approval while reads stay free — the
+   *  closest faithful mapping to the emulated engine, which gates tool CALLS,
+   *  never reads. Only honored when `supportsNativeToolApproval` is true. */
+  approvalPermissionMode: HarnessV1PermissionMode;
   /** Can the runtime pause for approval of MCP-server tools it calls in-sandbox?
    *  Both current adapters: false. */
   supportsMcpToolApproval: boolean;
@@ -541,9 +547,15 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
   displayName: "Claude Code",
   requiresComputer: true,
   defaultPermissionMode: "allow-all",
-  supportsNativeToolApproval: false,
+  // WS3: the CLI pauses on a tool-approval-request for side-effecting
+  // built-ins under "allow-edits"; the turn suspends and resumes with the
+  // user's decision (see run-harness-turn's approval-continuation path).
+  supportsNativeToolApproval: true,
+  approvalPermissionMode: "allow-edits",
   supportsMcpToolApproval: false,
-  supportsHostExecutedToolApproval: false,
+  // WS3 wires host-executed tools through `toolApproval` (the agent pauses on
+  // tool-approval-request and resumes with the decision), same path as native.
+  supportsHostExecutedToolApproval: true,
   supportsSelectedMcpServers: true,
   supportsSkills: true,
   // Claude Code does not emit file-change stream parts.
@@ -589,6 +601,9 @@ const codexAdapter: HarnessRuntimeAdapter = {
   // Codex doesn't support built-in tool approval requests — use allow-all.
   defaultPermissionMode: "allow-all",
   supportsNativeToolApproval: false,
+  // Never honored while supportsNativeToolApproval is false; keep it the
+  // same as the default mode so a future flip is an explicit decision.
+  approvalPermissionMode: "allow-all",
   supportsMcpToolApproval: false,
   // Codex docs say host-executed AI SDK approvals can work, but it's not wired/
   // tested in MCPJam yet — keep false for v1; flip without code churn later.

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -31,7 +31,10 @@ import {
   type ToolSet,
   type UIMessageChunk,
 } from "ai";
-import { HarnessAgent } from "@ai-sdk/harness/agent";
+import {
+  HarnessAgent,
+  collectHarnessAgentToolApprovalContinuations,
+} from "@ai-sdk/harness/agent";
 import {
   emitTraceSnapshot,
   getPromptIndex,
@@ -43,6 +46,7 @@ import {
   buildBrokerDummyAuth,
   type HarnessAuth,
 } from "./registry.js";
+import type { HarnessV1PermissionMode } from "@ai-sdk/harness";
 import {
   startHarnessModelBroker,
   revokeHarnessModelBroker,
@@ -57,13 +61,16 @@ function harnessBrokerDeliveryEnabled(): boolean {
 import {
   emitError,
   emitFinish,
+  emitReasoningDelta,
+  emitReasoningEnd,
+  emitReasoningStart,
   emitTextDelta,
   emitTextEnd,
   emitTextStart,
+  emitToolApprovalRequest,
   emitToolInput,
   emitToolOutput,
 } from "../chat-stream-chunks.js";
-import { tunnelManager } from "../../services/tunnel-manager.js";
 import { logger } from "../logger.js";
 import type {
   ChatEngineLoopResult,
@@ -83,17 +90,24 @@ import {
 import { reconcileSkillDirs } from "./reconcile-skill-dirs.js";
 import {
   claimHarnessSessionState,
+  commitHarnessSessionState,
+  getHarnessResumeEligibility,
   heartbeatHarnessSessionState,
   releaseHarnessSessionState,
   type HarnessOwnerRef,
   type HarnessSessionCommitPayload,
 } from "./harness-session-state.js";
+import type { HarnessResetReason } from "@/shared/harness-session";
 import {
-  buildHarnessMcpJson,
-  harnessServerInputFromConfig,
+  buildHarnessProxyMcpJson,
   harnessServerKeyToName,
-  type HarnessMcpServerInput,
+  type HarnessProxyServerInput,
 } from "./mcp-config.js";
+import {
+  resolveHarnessProxyUrl,
+  type HarnessMcpProxyStrategy,
+} from "./harness-proxy-strategy.js";
+import { fetchHarnessProxyTokens } from "./harness-proxy-token-client.js";
 
 /** A minimal writer matching what `createUIMessageStream` hands `execute` and
  *  what the no-op (`streamSink: "none"`) path supplies. */
@@ -122,29 +136,73 @@ export const HARNESS_EMPTY_VISIBLE_OUTPUT_TEXT =
  * a box.
  */
 /**
- * Build the harness `.mcp.json` from the selected servers' live configs.
- * Resolves each id via `mcpClientManager.getServerConfig` and, for stdio
- * servers, the inspector's already-open tunnel (local processes aren't
- * reachable from the sandbox). A selected id with no config is skipped.
+ * Build the harness `.mcp.json` — "always-proxy". Every selected, registered
+ * server points at MCPJam's own proxy (carrying a signed `X-MCPJam-Proxy-Token`
+ * and NO upstream credentials); MCPJam forwards to the real server, so the
+ * harness's MCP runs through the playground. The `harnessMcpProxy` strategy
+ * (set by the caller route, NOT a global env) decides the URL per plane —
+ * tunnel + adapter-http (local) or direct `/api/web/harness-mcp` (hosted). A
+ * selected id with no live config is skipped.
  */
-function buildMcpJsonFromManager(
-  manager: MCPJamHandlerOptions["mcpClientManager"],
-  selectedServerIds: string[]
-) {
-  const inputs: HarnessMcpServerInput[] = [];
-  for (const id of selectedServerIds) {
-    const config = manager.getServerConfig(id);
-    if (!config) {
-      logger.warn("[harness] selected server has no live config; skipping", {
-        serverId: id,
-      });
-      continue;
+async function buildHarnessProxyMcpJsonFromManager(args: {
+  manager: MCPJamHandlerOptions["mcpClientManager"];
+  selectedServerIds: string[];
+  authHeader: string;
+  projectId: string;
+  strategy: HarnessMcpProxyStrategy;
+}) {
+  const { manager, selectedServerIds, authHeader, projectId, strategy } = args;
+  const configured = selectedServerIds.filter((id) => {
+    if (manager.getServerConfig(id)) return true;
+    logger.warn(
+      `[harness] selected server has no live config; skipping serverId=${id}`,
+    );
+    return false;
+  });
+
+  const inputs: HarnessProxyServerInput[] = [];
+  if (configured.length > 0 && strategy.plane === "web-authorized") {
+    // HOSTED plane: servers are persisted Convex rows, and the harness-mcp route
+    // rebuilds the connection per-request via acting-as. Convex mints a signed
+    // identity token per server (bearer-authed + access-checked). Fail closed:
+    // no tokens ⇒ the harness can't proxy.
+    const minted = await fetchHarnessProxyTokens({
+      projectId,
+      serverIds: configured,
+      bearer: authHeader,
+    });
+    if (!minted.ok) {
+      throw new Error(
+        `Couldn't mint harness MCP proxy tokens (${minted.status}): ${minted.error}`,
+      );
     }
-    const tunnelUrl = tunnelManager.getServerTunnelUrl(id);
-    inputs.push(harnessServerInputFromConfig(id, config, { tunnelUrl }));
+    // Hard-fail, never skip: the harness must run with every selected server or
+    // none — a silently-dropped server means the agent runs with missing MCP
+    // tools, which is far worse to debug than a clear up-front failure. (The
+    // mint endpoint is already all-or-nothing — 422 on any malformed/unauthorized
+    // id — so this guards an unexpected partial response.)
+    for (const id of configured) {
+      const token = minted.tokens[id];
+      if (!token) {
+        throw new Error(
+          `Harness MCP proxy: no token minted for selected serverId=${id} — refusing to run with missing MCP tools`,
+        );
+      }
+      const url = await resolveHarnessProxyUrl({ strategy, serverId: id, authHeader });
+      inputs.push({ name: id, proxyUrl: url, proxyToken: token });
+    }
+  } else if (configured.length > 0) {
+    // LOCAL plane: servers live in the persistent manager (often just local
+    // names with no Convex row), reached through the per-server adapter tunnel.
+    // The tunnel's `?k=` secret is the auth (adapter-http validate-when-present)
+    // — no Convex identity token to mint.
+    for (const id of configured) {
+      const url = await resolveHarnessProxyUrl({ strategy, serverId: id, authHeader });
+      inputs.push({ name: id, proxyUrl: url });
+    }
   }
   return {
-    mcpJson: buildHarnessMcpJson(inputs),
+    mcpJson: buildHarnessProxyMcpJson(inputs),
     // Sanitized .mcp.json key → serverId, so Claude Code's mcp__<key>__<tool>
     // tool names map back to a serverId for eval matching / spans / MCP App
     // rendering (which all key off serverId + the un-namespaced tool name).
@@ -166,6 +224,47 @@ function coerceToolInput(raw: unknown): unknown {
   } catch {
     return raw;
   }
+}
+
+/** AI-SDK `ToolResultPart.output` discriminators we must NOT re-wrap. */
+const TYPED_TOOL_OUTPUT_TYPES: ReadonlySet<string> = new Set([
+  "json",
+  "text",
+  "error-text",
+  "content",
+]);
+
+/** Build the persisted `tool-result` `output` for a harness tool result, matching
+ *  the emulated engine's canonical single-wrap shape (shared/http-tool-calls.ts).
+ *
+ *  The harness `tool-result` part's `.output` (`event.result`) is the RAW result
+ *  for most tools, but some tools — and computer-use / image results — already
+ *  hand back an already-typed `{type, value}` output. Blindly wrapping that as
+ *  `{type:"json", value: rawOutput}` produced the double-nested
+ *  `{type:json,value:{type:json,value:…}}` seen in persisted transcripts. So:
+ *  errors → `error-text`; an already-typed output passes through unchanged;
+ *  anything else is wrapped once as `{type:"json", value}`. */
+export function toToolResultOutput(
+  rawOutput: unknown,
+  isError: boolean,
+): { type: string; value: unknown } {
+  if (isError) {
+    return {
+      type: "error-text",
+      value:
+        typeof rawOutput === "string" ? rawOutput : JSON.stringify(rawOutput),
+    };
+  }
+  if (
+    rawOutput !== null &&
+    typeof rawOutput === "object" &&
+    typeof (rawOutput as { type?: unknown }).type === "string" &&
+    TYPED_TOOL_OUTPUT_TYPES.has((rawOutput as { type: string }).type) &&
+    "value" in (rawOutput as object)
+  ) {
+    return rawOutput as { type: string; value: unknown };
+  }
+  return { type: "json", value: rawOutput };
 }
 
 /** Per-process id for lease attribution (logs/debugging). */
@@ -240,6 +339,7 @@ export async function runHarnessTurn(
     chatboxId,
     sourceType,
     harness,
+    harnessMcpProxy,
     builtInTools,
   } = options;
   // Canonicalize the model id up front (bare hosted ids like `gpt-5-nano` →
@@ -273,6 +373,11 @@ export async function runHarnessTurn(
   const promptIndex = getPromptIndex(messages);
   let aborted = false;
   let runSucceeded = false;
+  // WS3: the turn paused awaiting a tool approval (a third terminal alongside
+  // success/abort). Treated like a clean end that happens to await input — the
+  // continuation is committed with `awaitingApproval` and the next request
+  // resumes it. Hoisted so the finally + onFinishEngine see it.
+  let pausedForApproval = false;
   // Internal liveness abort: the heartbeat fires this when the lease is
   // DEFINITIVELY lost (stolen/expired) or when transient heartbeat failures
   // span the lease TTL. Combined with the caller's abortSignal so either tears
@@ -286,10 +391,10 @@ export async function runHarnessTurn(
     | undefined;
   let turnFinishReason: FinishReason = "stop";
   let capturedTurnTrace: PersistedTurnTrace | undefined;
-  // §3 atomic commit: built in executeEngine's finally (after session.stop()),
+  // §3 atomic commit: built in executeEngine's finally (after session.detach()),
   // consumed by onFinishEngine's onConversationComplete so the resume state
   // rides /ingest-chat with the transcript. `releaseHarnessLease` lets either
-  // closure free the lane if the commit can't happen (stop/persist failure).
+  // closure free the lane if the commit can't happen (detach/persist failure).
   let capturedHarnessCommit: HarnessSessionCommitPayload | undefined;
   let releaseHarnessLease: (() => Promise<void>) | undefined;
   // Broker-delivery run identity, set after the lease is installed into E2B's
@@ -348,6 +453,15 @@ export async function runHarnessTurn(
     let emittedAnyText = false;
     let emittedAnyVisiblePart = false;
     const seenHarnessPartTypes = new Set<string>();
+    // Open reasoning block id (separate UI part from text). The harness emits
+    // reasoning-* as a distinct block; we close it before any text/tool/finish.
+    let reasoningId: string | undefined;
+    const closeReasoning = () => {
+      if (reasoningId !== undefined) {
+        emitReasoningEnd(writer, reasoningId);
+        reasoningId = undefined;
+      }
+    };
 
     try {
       if (!projectId) {
@@ -360,28 +474,21 @@ export async function runHarnessTurn(
           "harness turn requires an auth bearer to resolve the computer"
         );
       }
-      // Interactive tool approval isn't bridged into the harness yet (no
-      // tool-approval-request continuation handling), and the harness runs
-      // allow-all — it can neither pause for approval nor selectively deny one
-      // call. So fail closed when the host actually wants approval gating:
-      // requireToolApproval. Every harness-reachable caller threads the host's
-      // real requireToolApproval through (chat/playground directly; eval +
-      // synthetic forward resolvedExecution.requireToolApproval), so this is the
-      // authoritative signal.
-      //
-      // approvalMode "auto-deny" alone is NOT rejected: it's the headless
-      // "no human in the loop" default eval/synthetic always set. With a
-      // non-approval host nothing needs denying, so allow-all is faithful; an
-      // approval host is already caught by requireToolApproval above. To run a
-      // Claude Code harness host that requires approval, use the emulated engine
-      // until approval continuations land.
-      if (requireToolApproval) {
-        throw new Error(
-          "harness (Claude Code) turns don't support interactive tool approval " +
-            "yet — turn off requireToolApproval on this host, or use the " +
-            "emulated engine, until approval continuation handling lands"
-        );
-      }
+      // WS3: requireToolApproval is now SUPPORTED via the harness's native
+      // permissionMode (built-ins) + toolApproval (host tools) — the turn pauses
+      // on a `tool-approval-request`, we surface MCPJam's approval chunk, then
+      // resume with the decision. NOTE: this gates built-in + host-executed
+      // tools only; MCP-server tools (via .mcp.json) have no harness approval
+      // knob, so harness approval is weaker than emulated — the availability
+      // preflight still rejects approval hosts WITH selected MCP servers
+      // (adapter.supportsMcpToolApproval stays false).
+      // Detect an approval-response resume up front (the inbound messages carry
+      // the user's decision as trailing tool-approval-response parts); a resume
+      // continues the paused turn rather than starting a new prompt.
+      const approvalContinuations = collectHarnessAgentToolApprovalContinuations(
+        { messages: messages as never },
+      );
+      const isApprovalResume = approvalContinuations.length > 0;
 
       // Phase timing — log where a turn spends its wall-clock (credential /
       // claim / box wake / session connect / model stream / finalize) so "takes
@@ -432,10 +539,10 @@ export async function runHarnessTurn(
           });
       tAuth = Date.now();
 
-      // 2. Build the .mcp.json from the selected servers. Pure + fail-fast —
-      // harnessServerInputFromConfig throws e.g. for a local stdio server with
-      // no tunnel — so build it BEFORE waking the computer: a bad MCP config
-      // shouldn't wake/provision the box (or bump its activity) only to fail.
+      // 2. Build the .mcp.json — always-proxy: ensure a per-server tunnel and
+      // point every entry at MCPJam's own adapter-http (no upstream creds in the
+      // box). Done BEFORE waking the computer so a tunnel/grant failure doesn't
+      // provision (or bump activity on) the box only to fail.
       //
       // Progressive tool discovery (progressivePlan / discoveryState) is
       // intentionally NOT applied here. It is an EMULATED-engine mechanism:
@@ -449,9 +556,22 @@ export async function runHarnessTurn(
       // .mcp.json has no knob to inject MCPJam meta-tools into the real loop.
       // Only adapters that deliver MCP servers (Claude Code) build the config;
       // the undeliverable-servers case already failed closed in step 0(b) above.
+      // Fail closed: with MCP servers selected but no plane strategy, the
+      // harness would silently get zero MCP tools (the exact failure we hit).
+      if ((selectedServers?.length ?? 0) > 0 && !harnessMcpProxy) {
+        throw new Error(
+          "harness turn has MCP servers but no harnessMcpProxy strategy — the caller route must set options.harnessMcpProxy",
+        );
+      }
       const { mcpJson, keyToServerId } =
         harnessAdapter.supportsSelectedMcpServers
-          ? buildMcpJsonFromManager(mcpClientManager, selectedServers ?? [])
+          ? await buildHarnessProxyMcpJsonFromManager({
+              manager: mcpClientManager,
+              selectedServerIds: selectedServers ?? [],
+              authHeader,
+              projectId,
+              strategy: harnessMcpProxy ?? { plane: "local-mcp" },
+            })
           : { mcpJson: { mcpServers: {} }, keyToServerId: {} };
 
       // 2b. Claim the harness session lane (multi-turn continuity). Done BEFORE
@@ -475,11 +595,23 @@ export async function runHarnessTurn(
       const skillsHash =
         runtimeSkills !== null ? skillsFingerprint(runtimeSkills) : undefined;
 
+      // WS3: gate side-effecting built-ins (Bash/Edit/Write) behind approval
+      // when the host requires it, via the adapter's declared approval mode
+      // (Claude Code: allow-edits — reads stay free, the closest faithful
+      // mapping to the emulated engine, which gates tool CALLS, never reads).
+      // The adapter's default otherwise. Computed BEFORE the fingerprint:
+      // flipping approval mode must fork the session (a resumed thread keeps
+      // the mode it was created with).
+      const permissionMode: HarnessV1PermissionMode =
+        requireToolApproval && harnessAdapter.supportsNativeToolApproval
+          ? harnessAdapter.approvalPermissionMode
+          : harnessAdapter.defaultPermissionMode;
+
       const runtimeFingerprint = harnessRuntimeFingerprint({
         harnessId: harnessAdapter.id,
         modelId,
         selectedServers: selectedServers ?? [],
-        permissionMode: harnessAdapter.defaultPermissionMode,
+        permissionMode,
       });
       const ownerType: HarnessOwnerRef["ownerType"] | undefined =
         sourceType === "chatbox"
@@ -496,6 +628,7 @@ export async function runHarnessTurn(
               harnessSessionId: string;
               resumeState: unknown;
               computerId: string;
+              awaitingApproval?: boolean;
             } | null;
           }
         | undefined;
@@ -610,10 +743,7 @@ export async function runHarnessTurn(
 
       // 4. Assemble the harness over the host's E2B computer.
       const sandbox = createE2BHarnessSandboxProvider({ sandboxId });
-      // Approval-required turns are refused at the availability preflight (the
-      // adapter declares it can't pause for native/MCP tool approval), so the
-      // remaining turns run with the adapter's declared mode (allow-all today).
-      const permissionMode = harnessAdapter.defaultPermissionMode;
+      // (permissionMode was computed above, before the runtime fingerprint.)
 
       // The adapter maps the host modelId to the harness's native model and
       // constructs it (for Claude Code: the gateway `creator/model` id becomes a
@@ -654,6 +784,20 @@ export async function runHarnessTurn(
             }
           : {}),
         permissionMode,
+        // WS3: gate host-executed tools (web_search, …) behind approval too —
+        // permissionMode only covers the harness's native built-ins. Honors the
+        // adapter's declared capability (advertise = enforce).
+        ...(requireToolApproval &&
+        harnessAdapter.supportsHostExecutedToolApproval &&
+        Object.keys(hostExecutedTools).length
+          ? {
+              toolApproval: Object.fromEntries(
+                Object.keys(hostExecutedTools).map((n) => [n, "user-approval"]),
+              ) as NonNullable<
+                ConstructorParameters<typeof HarnessAgent>[0]["toolApproval"]
+              >,
+            }
+          : {}),
         onSandboxSession: async ({ session, sessionWorkDir }) => {
           // Deliver the host's MCP servers into the session before the runtime
           // starts, via the adapter's own strategy (Claude Code writes a
@@ -692,6 +836,15 @@ export async function runHarnessTurn(
               ...(abortSignal ? { signal: abortSignal } : {}),
             }).catch(() => {});
           }
+          // Stream the workdir to the client (transient) so the Playground Shell
+          // can open a terminal here instead of the box's home. The client keys
+          // the cached path by project + host (it knows both); we only need the
+          // path. Fires every turn (fresh or resumed) — always the current dir.
+          writer.write({
+            type: "data-harness-session",
+            data: { workdir: sessionWorkDir },
+            transient: true,
+          } as unknown as UIMessageChunk);
         },
       });
 
@@ -705,14 +858,45 @@ export async function runHarnessTurn(
       //
       // Resume-or-fresh: if the claimed lane has resume state captured on THIS
       // computer (the workdir lives there), reattach the Claude Code thread so
-      // prior turns carry over. Any resume failure falls back fresh (lossy,
-      // logged). A computer mismatch (reset/reprovision) ⇒ fresh.
-      const resumable =
-        continuity?.state && continuity.state.computerId === computerId
-          ? continuity.state
-          : undefined;
+      // prior turns carry over. getHarnessResumeEligibility decides whether the
+      // sidecar can warm-resume on this computer AND sandbox — a reprovisioned
+      // box (sandbox-replaced) can't, so we go fresh and SURFACE a visible reset
+      // (below) instead of the adapter silently spawning a blank session. A
+      // legacy pre-detach sidecar is cold-resumed (logged, not surfaced).
+      const eligibility = getHarnessResumeEligibility({
+        state: continuity?.state ?? null,
+        computerId,
+        sandboxId,
+      });
+      const resumable = eligibility.resume
+        ? (continuity?.state ?? undefined)
+        : undefined;
+      // Categorical reason to surface to the client (never a raw sandbox id).
+      // Only hard resets are shown; legacy-cold-resume is a logged attempt.
+      let resetReason: HarnessResetReason | undefined =
+        eligibility.reason === "sandbox-replaced" ? "sandbox-replaced" : undefined;
+      if (eligibility.reason === "legacy-cold-resume") {
+        logger.warn(
+          "[harness] resuming a pre-detach sidecar (cold/disk resume; continuity not guaranteed)",
+          { harnessSessionId: continuity?.state?.harnessSessionId },
+        );
+      }
+      // WS3: resuming a turn the user just approved/denied. The committed state
+      // is a `continue-turn` payload (awaitingApproval), reattached via
+      // continueFrom (NOT resumeFrom) and continued with continueStream below.
+      const resumeFromApproval =
+        isApprovalResume && resumable?.awaitingApproval === true;
       let session: Awaited<ReturnType<typeof agent.createSession>>;
-      if (resumable) {
+      if (resumeFromApproval && resumable) {
+        // No fresh fallback here: if the paused continuation is stale (computer
+        // moved / schema drift) the decision can't be applied — fail closed via
+        // the throw so the user retries rather than silently losing the call.
+        session = await agent.createSession({
+          sessionId: resumable.harnessSessionId,
+          continueFrom: resumable.resumeState,
+        } as unknown as Parameters<typeof agent.createSession>[0]);
+        resumedSession = true;
+      } else if (resumable) {
         try {
           session = await agent.createSession({
             sessionId: resumable.harnessSessionId,
@@ -723,10 +907,23 @@ export async function runHarnessTurn(
           logger.warn("[harness] resume failed; starting fresh", {
             error: resumeErr instanceof Error ? resumeErr.message : resumeErr,
           });
+          // Reattach threw — fall back fresh, but make it VISIBLE (the adapter
+          // swallows its own reattach failures; this catch is our last signal).
+          resetReason = "resume-failed";
           session = await agent.createSession();
         }
       } else {
         session = await agent.createSession();
+      }
+      // Surface a visible reset (transient, never persisted) so a lost session
+      // reads as an explained "new session" rather than the model forgetting.
+      // Carries only the categorical reason — NEVER a raw E2B sandbox id.
+      if (resetReason) {
+        writer.write({
+          type: "data-harness-reset",
+          data: { reason: resetReason },
+          transient: true,
+        } as unknown as UIMessageChunk);
       }
       tConnect = Date.now();
       // Session is up: the finalizer + heartbeat now own the continuity lane, so
@@ -780,14 +977,22 @@ export async function runHarnessTurn(
         // _startTurn (session.promptTurn); omitting it throws "Cannot read
         // properties of undefined (reading 'promptTurn')". `_resolveTurnInput`
         // accepts `messages` and uses the last role:"user" entry as the prompt.
-        const res = await agent.stream({
-          session,
-          messages,
-          // Hand the harness the combined abort signal so a user cancel OR a
-          // lost-lease liveness abort propagates into the in-sandbox run rather
-          // than only stopping our forwarding.
-          abortSignal: effectiveAbortSignal,
-        } as unknown as Parameters<typeof agent.stream>[0]);
+        // WS3: a resume carries no new user prompt — feed the approval decision
+        // into the in-flight turn via continueStream (the adapter collapses
+        // `messages` to the last user message, so stream() would re-prompt).
+        const res = resumeFromApproval
+          ? await agent.continueStream({
+              session,
+              toolApprovalContinuations: approvalContinuations,
+              abortSignal: effectiveAbortSignal,
+            } as unknown as Parameters<typeof agent.continueStream>[0])
+          : await agent.stream({
+              session,
+              messages,
+              // Hand the harness the combined abort signal so a user cancel OR a
+              // lost-lease liveness abort propagates into the in-sandbox run.
+              abortSignal: effectiveAbortSignal,
+            } as unknown as Parameters<typeof agent.stream>[0]);
 
         // Read the harness fullStream LOOSELY and hand-build ai@6 UI chunks.
         // Reconstruct the transcript INCREMENTALLY so persisted history keeps
@@ -886,17 +1091,9 @@ export async function runHarnessTurn(
                   type: "tool-result",
                   toolCallId: tr.toolCallId,
                   toolName: tr.toolName ?? "tool",
-                  // Failures use error-text (matches the emulated engine) so
-                  // eval/trace consumers distinguish errors from success.
-                  output: tr.isError
-                    ? {
-                        type: "error-text",
-                        value:
-                          typeof tr.output === "string"
-                            ? tr.output
-                            : JSON.stringify(tr.output),
-                      }
-                    : { type: "json", value: tr.output },
+                  // Single-wrap, matching the emulated engine: errors → error-text;
+                  // already-typed outputs pass through (no double-nest); else json.
+                  output: toToolResultOutput(tr.output, tr.isError),
                 },
               ],
             } as unknown as ModelMessage);
@@ -964,7 +1161,33 @@ export async function runHarnessTurn(
           }
           const type = part.type;
           if (typeof type === "string") seenHarnessPartTypes.add(type);
-          if (type === "text-delta" || type === "text") {
+          if (
+            type === "reasoning-start" ||
+            type === "reasoning-delta" ||
+            type === "reasoning-end"
+          ) {
+            // Surface the harness's reasoning as a live UI reasoning part (the
+            // emulated engine forwards the identical chunks from Convex).
+            if (type === "reasoning-end") {
+              closeReasoning();
+            } else {
+              if (reasoningId === undefined) {
+                reasoningId = String(
+                  (part as { id?: unknown }).id ?? crypto.randomUUID(),
+                );
+                emitReasoningStart(writer, reasoningId);
+              }
+              if (type === "reasoning-delta") {
+                const rDelta = String(
+                  (part as { text?: unknown; delta?: unknown }).text ??
+                    (part as { delta?: unknown }).delta ??
+                    "",
+                );
+                if (rDelta) emitReasoningDelta(writer, reasoningId, rDelta);
+              }
+            }
+          } else if (type === "text-delta" || type === "text") {
+            closeReasoning();
             const delta = String(
               (part as { text?: unknown; delta?: unknown }).delta ??
                 (part as { text?: unknown }).text ??
@@ -996,6 +1219,7 @@ export async function runHarnessTurn(
             }
             onLiveTextDelta?.(delta);
           } else if (type === "tool-call" || type === "tool-input-available") {
+            closeReasoning();
             // A tool-call after tool results begins the next step.
             if (pendingResults.length > 0) {
               flushSegment();
@@ -1208,6 +1432,29 @@ export async function runHarnessTurn(
                 isError: false,
               });
             }
+          } else if (type === "tool-approval-request") {
+            // WS3: the turn paused awaiting a tool approval. Surface MCPJam's
+            // approval chunk (the SAME one the emulated engine emits → zero
+            // client changes), close open blocks, and break — the finally
+            // suspends the turn and commits the continuation (awaitingApproval).
+            // NOTE: how the pause surfaces (this stream part vs turnState/
+            // stream-end for built-in permissionMode tools) needs live
+            // confirmation; host-tool `toolApproval` reliably emits this part.
+            const approvalId = String(
+              (part as { approvalId?: unknown }).approvalId ??
+                crypto.randomUUID(),
+            );
+            const toolCallId = String(
+              (part as { toolCallId?: unknown }).toolCallId ?? "",
+            );
+            closeReasoning();
+            if (textId !== undefined) {
+              emitTextEnd(writer, textId);
+              textId = undefined;
+            }
+            emitToolApprovalRequest(writer, { approvalId, toolCallId });
+            pausedForApproval = true;
+            break;
           } else if (type === "finish") {
             const fr = (part as { finishReason?: unknown }).finishReason;
             if (typeof fr === "string" && fr)
@@ -1233,18 +1480,41 @@ export async function runHarnessTurn(
         }
         // Close any open text block first so BOTH the cancelled and normal
         // paths leave a balanced UI stream.
-        if (textId !== undefined) emitTextEnd(writer, textId);
+        closeReasoning();
+      if (textId !== undefined) emitTextEnd(writer, textId);
 
         // Cancelled mid-stream: do NOT drain res.text (it would block until the
         // full harness run finishes). The finally below destroys the harness
         // session, stopping the in-sandbox Claude Code run.
         if (aborted) return;
 
+        // WS3: paused awaiting approval. Do NOT `await res.text` — the turn
+        // hasn't finished (it's suspended), so awaiting it would hang. Close
+        // open blocks, emit a finish (tool-calls = "ended awaiting tool
+        // resolution"), and let the finally suspend + commit the continuation.
+        // runSucceeded stays false so onFinishEngine skips transcript persist
+        // (the partial turn isn't a completed conversation).
+        if (pausedForApproval) {
+          closeReasoning();
+          flushSegment();
+          finishStep();
+          emitFinish(writer, {
+            finishReason: "tool-calls" as FinishReason,
+            messageMetadata: usage,
+          });
+          // turn_finish WITHOUT driver.finishTurn — that would set succeeded
+          // and gate-open persistence for a mid-flight (suspended) turn.
+          activeDriver.usage = usage;
+          activeDriver.emitErrorTurnFinish(writer);
+          return;
+        }
+
         // The AI SDK terminal result is authoritative for the final assistant
         // answer + usage. `res.text` settles the complete answer even when the
         // bridge delivered it as a final result rather than streamed
         // `text-delta` parts. Drain it before building the persisted transcript.
         const finalText = await res.text;
+        closeReasoning();
 
         // Settle cumulative usage + finish reason on the driver NOW — usage is
         // known from the finish part. Set before the completeness fallback below
@@ -1316,15 +1586,33 @@ export async function runHarnessTurn(
       } finally {
         if (heartbeatTimer) clearInterval(heartbeatTimer);
         try {
-          // On a clean turn with continuity: STOP (not destroy) to get the
-          // resume payload, then BUILD the commit (don't send it here). The
-          // commit rides /ingest-chat atomically with the transcript in
-          // onFinishEngine so transcript + sidecar advance together. stop()
-          // exits the in-sandbox bridge; MCPJam's E2B provider stop() is a no-op
-          // so the computer (and the workdir holding the Claude Code thread)
-          // stays alive. On abort/error: destroy + release the lease.
-          if (runSucceeded && !aborted && continuity) {
-            const resumeState = await session.stop();
+          // On a clean turn with continuity: detach to park the live bridge and
+          // get a warm resume payload, then BUILD the commit (don't send it
+          // here). The commit rides /ingest-chat atomically with the transcript
+          // in onFinishEngine so transcript + sidecar advance together. On
+          // abort/error: destroy + release the lease.
+          if (pausedForApproval && continuity && !aborted) {
+            // WS3: keep the runtime/sandbox alive (suspendTurn, NOT stop) and
+            // standalone-commit the continuation with awaitingApproval. The
+            // commit releases the MCPJam lease (don't hold it across the human
+            // decision — it would TTL-expire); the next request re-claims the
+            // lane and resumes via continueFrom. No transcript here — the turn
+            // is mid-flight (committed via the standalone endpoint, not ingest).
+            const continueState = await session.suspendTurn();
+            const ok = await commitHarnessSessionState({
+              owner: continuity.owner,
+              leaseId: continuity.leaseId,
+              expectedStateVersion: continuity.stateVersion,
+              harnessSessionId: session.sessionId,
+              resumeState: continueState,
+              computerId,
+              runtimeFingerprint,
+              awaitingApproval: true,
+              bearer: authHeader,
+            });
+            if (!ok) await releaseHarnessLease?.();
+          } else if (runSucceeded && !aborted && continuity) {
+            const resumeState = await session.detach();
             capturedHarnessCommit = {
               ownerType: continuity.owner.ownerType as
                 | "direct-chat"
@@ -1367,6 +1655,7 @@ export async function runHarnessTurn(
       const errorText = err instanceof Error ? err.message : String(err);
       logger.error("[harness] turn failed", err);
       // Close any open text block so the UI stream stays balanced.
+      closeReasoning();
       if (textId !== undefined) emitTextEnd(writer, textId);
       emitError(writer, errorText);
       // A mid-stream failure still gets a final snapshot + turn_finish so the

--- a/mcpjam-inspector/server/utils/localhost-check.ts
+++ b/mcpjam-inspector/server/utils/localhost-check.ts
@@ -23,6 +23,48 @@
  * @param hostHeader - The Host header value from the request
  * @returns true if the request is from localhost, false otherwise
  */
+/**
+ * Whether a configured base URL is reachable from a CLOUD sandbox (i.e. truly
+ * public). Rejects every non-routable host, not just loopback — a private
+ * `BASE_URL` like `http://192.168.x.x` must NOT be treated as direct-reachable.
+ * Used by the hosted harness URL strategy to choose direct vs relay.
+ */
+export function isPubliclyReachableUrl(raw: string): boolean {
+  let host: string;
+  try {
+    host = new URL(raw).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host === "localhost" || host.endsWith(".local")) return false;
+  // Unwrap IPv6 brackets.
+  const h = host.replace(/^\[/, "").replace(/\]$/, "");
+  if (h === "::1" || h === "0.0.0.0" || h === "::") return false;
+  if (h.startsWith("fe80:") || h.startsWith("fc") || h.startsWith("fd")) {
+    return false; // IPv6 link-local / unique-local
+  }
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    const c = Number(m[3]);
+    if (a === 0 || a === 127) return false; // this-host / loopback
+    if (a === 10) return false; // 10.0.0.0/8 private
+    if (a === 192 && b === 168) return false; // 192.168.0.0/16 private
+    if (a === 172 && b >= 16 && b <= 31) return false; // 172.16.0.0/12 private
+    if (a === 169 && b === 254) return false; // 169.254.0.0/16 link-local
+    if (a === 100 && b >= 64 && b <= 127) return false; // 100.64.0.0/10 CGNAT
+    if (a === 198 && (b === 18 || b === 19)) return false; // 198.18.0.0/15 benchmarking
+    if (a >= 224) return false; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
+    // Documentation / protocol-assignment ranges (not routable on the internet).
+    if (a === 192 && b === 0 && c === 0) return false; // 192.0.0.0/24
+    if (a === 192 && b === 0 && c === 2) return false; // 192.0.2.0/24 TEST-NET-1
+    if (a === 198 && b === 51 && c === 100) return false; // 198.51.100.0/24 TEST-NET-2
+    if (a === 203 && b === 0 && c === 113) return false; // 203.0.113.0/24 TEST-NET-3
+  }
+  return true;
+}
+
 export function isLocalhostRequest(hostHeader: string | undefined): boolean {
   if (!hostHeader) {
     return false;

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -27,6 +27,7 @@ import { zodSchema } from "@ai-sdk/provider-utils";
 import type { MCPClientManager, Harness } from "@mcpjam/sdk";
 import { runHarnessTurn } from "./harness/run-harness-turn.js";
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
+import type { HarnessMcpProxyStrategy } from "./harness/harness-proxy-strategy.js";
 import {
   buildFinishChunk,
   emitError,
@@ -312,6 +313,12 @@ export interface MCPJamHandlerOptions {
    * browser-fulfilled) and skills (the harness has its own).
    */
   builtInTools?: ToolSet;
+  /**
+   * WS5 foundation: reusable instruction bundles for the harness runtime,
+   * forwarded to `new HarnessAgent({ skills })`. Harness-only (emulated ignores).
+   * Empty/unset today — hosted-mode skills authoring is a separate workstream.
+   */
+  skills?: unknown[];
   authHeader?: string;
   chatboxId?: string;
   accessVersion?: number;
@@ -323,6 +330,11 @@ export interface MCPJamHandlerOptions {
   /** Real agent harness for this turn (absent ⇒ MCPJam's emulated engine).
    *  When "claude-code", handleMCPJamFreeChatModel routes to runHarnessTurn. */
   harness?: Harness;
+  /** Which MCP-proxy plane the harness uses to route its MCP through MCPJam —
+   *  set by the CALLER ROUTE (local `/api/mcp/*` vs hosted `/api/web/*`), not a
+   *  global env. Absent ⇒ harness runs without proxied MCP. See
+   *  `harness-proxy-strategy.ts`. */
+  harnessMcpProxy?: HarnessMcpProxyStrategy;
   requireToolApproval?: boolean;
   /**
    * Approval-pause policy. `"prompt"` (default) is the real-chat path:

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -66,6 +66,10 @@ import {
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
 import type { CustomProviderConfig } from "./chat-helpers.js";
 import { getClientIp } from "./client-ip.js";
+import {
+  resolveWebAuthorizedHarnessStrategy,
+  type HarnessMcpProxyStrategy,
+} from "./harness/harness-proxy-strategy.js";
 
 type RpcCollector = ReturnType<typeof createHostedRpcLogCollector>;
 
@@ -455,6 +459,16 @@ export async function streamWebChatTurn(
   );
   warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
 
+  // Harness MCP proxy — WEB-AUTHORIZED plane: this is an /api/web request, so
+  // the harness reaches MCPJam either directly (public inspector) or via a
+  // scoped harness-web relay (private/dev inspector), decided purely by whether
+  // the inspector is publicly reachable. The token (with the user's identity) is
+  // minted by Convex from the same bearer. If relay infra is needed but absent,
+  // the turn fails closed later, at tunnel creation.
+  const harnessMcpProxy: HarnessMcpProxyStrategy | undefined = persist.harness
+    ? resolveWebAuthorizedHarnessStrategy()
+    : undefined;
+
   return handleMCPJamFreeChatModel({
     messages: modelMessages,
     modelId: mcpjamModelId,
@@ -475,6 +489,7 @@ export async function streamWebChatTurn(
     selectedServers: persist.selectedServerIds,
     requireToolApproval: persist.requireToolApproval,
     ...(persist.harness ? { harness: persist.harness } : {}),
+    ...(harnessMcpProxy ? { harnessMcpProxy } : {}),
     // Forwarded SEPARATELY (also merged into `tools` for the emulated engine)
     // so the harness path can hand MCPJam's server-executed built-ins
     // (web_search) to HarnessAgent without the MCP-server tools, which the

--- a/mcpjam-inspector/shared/harness-session.ts
+++ b/mcpjam-inspector/shared/harness-session.ts
@@ -1,0 +1,93 @@
+/**
+ * Transient SSE data part carrying the harness's working directory for a turn.
+ *
+ * A Claude Code harness runs each turn inside `/home/user/claude-code-<sessionId>`
+ * on the project computer. The server knows this path during the turn; it streams
+ * it to the client so the Playground Shell can open a terminal there instead of in
+ * the box's home. Transient (not persisted): the client caches the latest path and
+ * passes it as the terminal `cwd`.
+ */
+export interface HarnessSessionInfo {
+  /** Absolute path of the harness session workdir on the computer. */
+  workdir: string;
+}
+
+export interface HarnessSessionDataPart {
+  type: "data-harness-session";
+  data: HarnessSessionInfo;
+}
+
+export function isHarnessSessionDataPart(
+  value: unknown,
+): value is HarnessSessionDataPart {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.type !== "data-harness-session") {
+    return false;
+  }
+  const data = candidate.data;
+  return (
+    !!data &&
+    typeof data === "object" &&
+    typeof (data as Record<string, unknown>).workdir === "string" &&
+    (data as Record<string, unknown>).workdir !== ""
+  );
+}
+
+/**
+ * Why a harness turn could NOT warm-resume the prior in-box session and started
+ * a fresh one. Surfaced to the client so a silent reset (the user's earlier
+ * context is gone) becomes a visible, explainable notice instead of the model
+ * appearing to "forget" everything.
+ *
+ *  - `sandbox-replaced`   — the project computer was reprovisioned between turns
+ *                           (new sandbox / fresh disk); the saved session is
+ *                           unrecoverable.
+ *  - `legacy-cold-resume` — the saved sidecar predates warm-detach (no bridge
+ *                           coordinates); resume is still attempted from disk but
+ *                           continuity isn't guaranteed. (Logged, not necessarily
+ *                           shown — it's an attempt, not a hard reset.)
+ *  - `resume-failed`      — reattaching to the saved session threw; fell back fresh.
+ *
+ * NEVER carries raw E2B sandbox ids — only the categorical reason.
+ */
+export type HarnessResetReason =
+  | "sandbox-replaced"
+  | "legacy-cold-resume"
+  | "resume-failed";
+
+export interface HarnessResetInfo {
+  reason: HarnessResetReason;
+}
+
+export interface HarnessResetDataPart {
+  type: "data-harness-reset";
+  data: HarnessResetInfo;
+}
+
+const HARNESS_RESET_REASONS: ReadonlySet<string> = new Set([
+  "sandbox-replaced",
+  "legacy-cold-resume",
+  "resume-failed",
+]);
+
+export function isHarnessResetDataPart(
+  value: unknown,
+): value is HarnessResetDataPart {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.type !== "data-harness-reset") {
+    return false;
+  }
+  const data = candidate.data;
+  return (
+    !!data &&
+    typeof data === "object" &&
+    typeof (data as Record<string, unknown>).reason === "string" &&
+    HARNESS_RESET_REASONS.has((data as Record<string, unknown>).reason as string)
+  );
+}


### PR DESCRIPTION
## What this is

The harness MCP-proxy work from `feat/claude-code-harness-host` was never opened as a follow-up PR — the rest of that branch shipped in evolved form via #2931/#2965/#2975/#2977/#2992/#2993, but its top five commits (the proxy, WS3 approvals, workdir Shell, drag-drop upload, claim continuity) stayed stranded. This ports them onto today's main, re-woven into the registry-driven two-harness architecture. The Convex side (`/web/harness/mcp-proxy-token`, `awaitingApproval` session state, scoped `harness-web` tunnels) already shipped on mcpjam-backend main — this is the inspector half.

## In plain English

Today a Claude Code harness in the cloud sandbox talks to the user's MCP servers **directly** — MCPJam can't observe the traffic, host-page knobs don't apply, and server credentials would have to ride into the sandbox. After this PR, every MCP server in the harness's `.mcp.json` points back at **MCPJam's own proxy**, and MCPJam forwards to the real server:

- **Local plane** (`/api/mcp/chat-v2`, desktop): sandbox → per-server tunnel → `adapter-http/{serverId}` → the live client manager.
- **Hosted plane** (`/api/web/chat-v2`): sandbox → new stateless `POST /api/web/harness-mcp/:serverId` → per-request acting-as authorized manager. If the inspector is private (local dev / firewalled self-host), a scoped `harness-web` relay tunnel is created; if public, the sandbox hits it directly.

Also in the port (it's one interleaved delta):
- **WS3 tool approvals**: an approval-requiring host can now run the real harness — the turn pauses on a `tool-approval-request`, surfaces MCPJam's normal approval chunk, commits an `awaitingApproval` continuation, and the next request resumes it. Approval hosts **with** selected MCP servers are still rejected (the harness has no MCP approval knob — advertise = enforce).
- **Session continuity/UX**: `detach()` warm resumes, sandbox-aware resume eligibility, and a visible "started a new session" toast (categorical reason only) instead of the model silently forgetting.
- **Reasoning stream parts** forwarded as live UI reasoning blocks; tool results single-wrapped (no more double-nested `{type:json,value:{type:json,…}}`).
- **Playground Shell**: opens the terminal in the harness session workdir (streamed per turn as a transient data part) with an explicit "Reload in harness dir"; drag-and-drop file upload into the sandbox (30MB, own body limit).

## Security

- **No upstream credentials in the sandbox.** The only secrets in `.mcp.json` are the tunnel's per-server `?k=` bearer and a per-turn, server-scoped proxy token.
- **The proxy token is minted by Convex** (bearer-authed, per-server access-checked, identity baked in) and only **verified** by the inspector — HS256 over the existing `COMPUTERS_TERMINAL_TOKEN_SECRET` with a distinct `purpose` claim, constant-time compare, expiry, fail-closed on any mismatch. Header-only (`X-MCPJam-Proxy-Token`); the `?t=` query fallback was removed so tokens can't leak into edge/access logs (and `t=` is scrubbed defensively from logged URLs anyway).
- **`/api/web/harness-mcp` requires the token** (it's the only auth on that route) and rebuilds the user's authorized connection server-side via the existing acting-as path — any instance serves it, no session state. Rate-limited per (user, server); internal errors are logged server-side and returned as a generic JSON-RPC error so exception text never reaches the sandbox.
- **`adapter-http` validates the token when present** — external MCP clients that send none are unaffected; a *bad* token is rejected even though the tunnel `?k=` was right (per-turn revocation on top of the per-server secret).
- **Fail-closed everywhere it matters**: MCP servers selected but no plane strategy → throw before waking the box; missing minted token for any selected server → refuse the turn (never run with silently-missing tools); relay infra absent → tunnel creation throws.
- Upload route uses the same Convex-minted terminal-token auth as the terminal WS, with its own 30MB cap carved out of the global 1MB `/api/web` JSON cap.

## What was deliberately NOT ported

- The branch's `ComputerView` migration onto the shared pane/hook — it predates the Environments UI (#2935) and would have deleted it. `ComputerView` is untouched.
- The branch's older `openTerminal` (no data-plane guard) — main's guarded version is kept.
- The branch's WS5 `skills` handler option — superseded by Cloud Skills (`fetchRuntimeSkills`).

Two drive-by fixes that fell out of the weave: `chat-ingestion`'s `harnessSessionCommit.harnessId` widened to the harness union (pre-existing type error for Codex commits on main), and the local `/api/mcp` chat route now threads `chatSessionId`/`sourceType`/`chatboxId` + forwards the harness commit — without which every local harness turn was amnesiac and the continuity lease was never released.

## Verification

- `npm run typecheck:client` green; server `tsc` error set is byte-identical to main's baseline (minus the Codex type error this fixes).
- Full `vitest run`: **7327 passed**; the only failures are the two `mcpjam-stream-handler-snapshot` snapshots that already fail on pristine main (stale snapshot from #2993's `engine` tag — pre-existing, left out of scope).
- Availability tests updated for the WS3 capability flip (approval hosts allowed on Claude Code, still blocked with MCP servers, still blocked on Codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change to harness auth (proxy tokens, new public MCP route, tunnel scopes) and hosted send preflight; mistakes could break turns, leak credentials into sandboxes, or bypass server authorization.
> 
> **Overview**
> **Harness MCP no longer talks to user servers directly.** `.mcp.json` is rebuilt so every entry hits MCPJam: local turns use per-server tunnels to `adapter-http/{serverId}` with optional **header-only** `X-MCPJam-Proxy-Token` validation; hosted turns add **`POST /api/web/harness-mcp/:serverId`** (acting-as authorized manager, rate-limited) with **direct vs `harness-web` relay** based on whether the inspector URL is publicly reachable. Convex-minted proxy tokens are verified on the inspector; upstream OAuth never lands in the sandbox.
> 
> **Playground and chat UX:** streamed harness **workdir** is cached and passed into the Shell terminal (`cwd` on the WS + optional remount via “Reload in harness dir”); **drag-and-drop upload** to the project computer uses the same terminal token and a new **30MB** upload route. Hosted sends run **`ensureHostedServerIdsForNames`** preflight so ad-hoc/App server names become Convex ids before the web chat body is built.
> 
> **Continuity and approvals (Claude Code):** local `/api/mcp/chat-v2` now threads session owner fields and forwards harness commits; resume eligibility distinguishes sandbox replacement vs legacy cold resume with user toasts on hard resets. Availability rules change so approval hosts work on Claude Code (still blocked with selected MCP servers or on Codex).
> 
> **Supporting fixes:** tunnel manager scopes **`harness-web`** alongside adapter-http; tool-result output avoids double JSON wrapping; terminal PTY creation accepts `cwd` with home fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4196b168927b9edf198159d84b93bcb94583154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all Claude Code harness MCP traffic through MCPJam on both local and hosted planes so the sandbox never connects to servers directly. Also adds approvals, better session continuity, and a Shell that opens in the harness workdir with drag‑and‑drop uploads.

- **New Features**
  - MCP proxy for every selected server:
    - Local: tunnel to `/api/mcp/adapter-http/:serverId`. Hosted: new `POST /api/web/harness-mcp/:serverId` (direct if public, or via `harness-web` relay).
    - Per‑turn `X-MCPJam-Proxy-Token` minted by Convex; `adapter-http` validates when present. Removed `?t=`; tokens scrubbed from logs.
    - Always‑proxy `.mcp.json`; no upstream creds reach the sandbox. Hosted sends preflight server‑name→id via `ensureHostedServerIdsForNames`.
  - WS3 tool approvals (Claude Code): pause on `tool-approval-request`, emit approval chunk, resume on next request. Approval hosts with selected MCP servers still blocked; Codex unchanged.
  - Session continuity and output: warm resume via `detach()`, sandbox‑aware resume gate with reset toast; reasoning stream parts rendered live; fixed double‑wrapped tool results.
  - Playground Shell: terminal opens in the harness workdir with “Reload in harness dir”; drag‑and‑drop upload to `POST /api/web/computers/upload` (terminal‑token auth, 30MB cap).

- **Bug Fixes**
  - Local `/api/mcp/chat-v2` now threads `chatSessionId`/`sourceType`/`chatboxId` and forwards the harness commit to fix amnesiac turns and lease release.
  - Widened `harnessSessionCommit.harnessId` to include `codex` to resolve a pre‑existing type error.

<sup>Written for commit d4196b168927b9edf198159d84b93bcb94583154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

