### PR TITLE
Feat/host compare default codex claude code

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -6,6 +6,7 @@ import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { HostCompareSelector } from "./HostCompareSelector";
 import {
+  DEFAULT_COMPARE_HOST_IDS,
   parseHostsParam,
   resolveInitialHostCompareSelection,
   toggleHostCompareSelection,
@@ -80,8 +81,10 @@ export function HostConfigCompareView({
   // becomes the source of truth and mirrors back into the URL.
   const urlConsumedRef = useRef(false);
 
-  // Real created hosts only — drives the default selection and the
-  // ?hosts=-is-default suppression. Presets are never part of the default.
+  // Real created hosts only — the last-resort fallback inside
+  // `resolveInitialHostCompareSelection` if the Codex/Claude Code presets
+  // are ever unavailable. The actual default selection is
+  // `DEFAULT_COMPARE_HOST_IDS` (see the ?hosts=-is-default suppression below).
   const liveHostIds = useMemo(
     () => liveHosts.map((host) => host.hostId),
     [liveHosts],
@@ -116,7 +119,7 @@ export function HostConfigCompareView({
   }, [projectId, selectedHostIds]);
 
   // Mirror selection → ?hosts=. Suppress when the selection is the default
-  // "all live hosts" (in original order) so shared links stay clean.
+  // (Codex + Claude Code, in that order) so shared links stay clean.
   useEffect(() => {
     if (!urlConsumedRef.current) return;
     if (listLoading) return;
@@ -126,12 +129,13 @@ export function HostConfigCompareView({
     // commit with `selectedHostIds` still empty. Treating that as "default"
     // would delete `?hosts=` before the queued state lands, clobbering the
     // deep link. After resolve, `selectedHostIds` is always ≥ 1 (resolver
-    // falls back to all live hosts; `toggleHostCompareSelection` keeps
-    // `minSelected=1`), so an empty selection means "not yet resolved."
+    // falls back to the Codex/Claude Code presets, or live hosts if those
+    // are unavailable; `toggleHostCompareSelection` keeps `minSelected=1`),
+    // so an empty selection means "not yet resolved."
     if (selectedHostIds.length === 0) return;
     const isDefault =
-      selectedHostIds.length === liveHostIds.length &&
-      selectedHostIds.every((id, i) => id === liveHostIds[i]);
+      selectedHostIds.length === DEFAULT_COMPARE_HOST_IDS.length &&
+      selectedHostIds.every((id, i) => id === DEFAULT_COMPARE_HOST_IDS[i]);
     const current = searchParams.get(HOSTS_QUERY_PARAM);
     if (isDefault) {
       if (current === null) return;
@@ -145,7 +149,7 @@ export function HostConfigCompareView({
     const next = new URLSearchParams(searchParams);
     next.set(HOSTS_QUERY_PARAM, desired);
     setSearchParams(next, { replace: true });
-  }, [selectedHostIds, liveHostIds, listLoading, searchParams, setSearchParams]);
+  }, [selectedHostIds, listLoading, searchParams, setSearchParams]);
 
   const reportSubject = useCallback(
     (hostId: string, subject: HostComparisonSubject) => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
+  DEFAULT_COMPARE_HOST_IDS,
   parseHostsParam,
   reconcileHostCompareSelection,
   resolveInitialHostCompareSelection,
@@ -36,7 +37,7 @@ describe("host-compare-selection", () => {
     ).toEqual(["b", "c"]);
   });
 
-  it("resolveInitialHostCompareSelection falls back to all live hosts", () => {
+  it("resolveInitialHostCompareSelection falls back to all live hosts when the default presets aren't known", () => {
     expect(
       resolveInitialHostCompareSelection({
         projectId: "proj_1",
@@ -109,7 +110,7 @@ describe("host-compare-selection", () => {
     ).toEqual(["preset:chatgpt"]);
   });
 
-  it("resolveInitialHostCompareSelection default stays real-hosts-only (presets opt-in)", () => {
+  it("resolveInitialHostCompareSelection ignores unrelated presets and falls back to live hosts", () => {
     expect(
       resolveInitialHostCompareSelection({
         projectId: "proj_1",
@@ -118,5 +119,32 @@ describe("host-compare-selection", () => {
         previousSelection: [],
       }),
     ).toEqual(["a", "b"]);
+  });
+
+  it("resolveInitialHostCompareSelection defaults to Codex + Claude Code over live hosts on a fresh visit", () => {
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: ["a", "b"],
+        knownHostIds: [
+          "a",
+          "b",
+          ...DEFAULT_COMPARE_HOST_IDS,
+          "preset:chatgpt",
+        ],
+        previousSelection: [],
+      }),
+    ).toEqual([...DEFAULT_COMPARE_HOST_IDS]);
+  });
+
+  it("resolveInitialHostCompareSelection defaults to Codex + Claude Code with zero live hosts", () => {
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: [],
+        knownHostIds: [...DEFAULT_COMPARE_HOST_IDS, "preset:chatgpt"],
+        previousSelection: [],
+      }),
+    ).toEqual([...DEFAULT_COMPARE_HOST_IDS]);
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
@@ -1,4 +1,19 @@
+import { PRESET_HOST_ID_PREFIX } from "./host-compare-presets";
+
 const STORAGE_PREFIX = "host-compare-selected:";
+
+/**
+ * Default compare columns when nothing else (URL param, stored preference,
+ * prior in-memory selection) picks a selection. Codex and Claude Code are the
+ * two most commonly compared coding-agent harnesses, and this default is what
+ * makes the caniuse.dev landing (and any other fresh visit to Host Compare)
+ * show a meaningful comparison immediately instead of an empty "select a
+ * client" state.
+ */
+export const DEFAULT_COMPARE_HOST_IDS: readonly string[] = [
+  `${PRESET_HOST_ID_PREFIX}codex`,
+  `${PRESET_HOST_ID_PREFIX}claude-code`,
+];
 
 export function readHostCompareSelection(projectId: string): string[] | null {
   if (typeof window === "undefined") return null;
@@ -90,6 +105,15 @@ export function resolveInitialHostCompareSelection(args: {
     known,
   );
   if (fromPrevious.length > 0) return fromPrevious;
+
+  // Fresh visit, nothing stored: default to Codex + Claude Code rather than
+  // "all live hosts" — falls through to live hosts only if the catalog ever
+  // stops offering those two preset ids.
+  const fromDefaultPresets = reconcileHostCompareSelection(
+    DEFAULT_COMPARE_HOST_IDS,
+    known,
+  );
+  if (fromDefaultPresets.length > 0) return fromDefaultPresets;
 
   return [...args.liveHostIds];
 }

--- a/mcpjam-inspector/server/utils/convex-guest-auth-sync.ts
+++ b/mcpjam-inspector/server/utils/convex-guest-auth-sync.ts
@@ -1,3 +1,5 @@
+import { createRequire } from "module";
+import { dirname, join } from "path";
 import {
   getGuestPrivateKeyPem,
   getGuestPublicKeyPem,
@@ -9,6 +11,23 @@ import { logger } from "./logger.js";
 
 let provisioningPromise: Promise<void> | null = null;
 let provisioningStarted = false;
+let cachedConvexCliEntry: string | null = null;
+
+// Resolve the Convex CLI's actual entry script instead of shelling out to
+// `npx`. On Windows, `npx` resolves to the `npx.cmd` shim, which CreateProcess
+// cannot execute without a shell — and routing through a shell to work around
+// that (`shell: true`) breaks here because the PEM values we pass as argv
+// contain embedded newlines, which cmd.exe splits into extra arguments.
+// Invoking `node <cli-entry>` directly avoids both problems: it's a real
+// executable, and Windows argv passing preserves embedded newlines in a
+// single argument untouched.
+function getConvexCliEntry(): string {
+  if (cachedConvexCliEntry) return cachedConvexCliEntry;
+  const require = createRequire(import.meta.url);
+  const pkgJsonPath = require.resolve("convex/package.json");
+  cachedConvexCliEntry = join(dirname(pkgJsonPath), "bin", "main.js");
+  return cachedConvexCliEntry;
+}
 
 function getConvexDeploymentForProvisioning(): string {
   if (process.env.CONVEX_DEPLOYMENT) {
@@ -42,13 +61,12 @@ async function execConvexEnvSet(
   name: string,
   value: string,
 ): Promise<void> {
-  const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
   const { execFile } = await import("child_process");
 
   await new Promise<void>((resolve, reject) => {
     execFile(
-      npxCommand,
-      ["convex", "env", "set", name, "--", value],
+      process.execPath,
+      [getConvexCliEntry(), "env", "set", name, "--", value],
       {
         env: convexEnv,
         timeout: 15_000,


### PR DESCRIPTION
# fix(server) + feat(hosts): Windows guest-auth fix, default Host Compare to Codex + Claude Code

Branch: `feat/host-compare-default-codex-claude-code` (2 commits on top of `main`)

## Summary
- Fix guest-auth Convex provisioning on Windows (spawn EINVAL / npx.cmd shim issue) by invoking the Convex CLI directly via `node`.
- Default Host Compare (`/clients/compare` and the `caniuse.dev` embed) to Codex + Claude Code instead of an empty "all live hosts" fallback.

## Why
- The Windows fix was blocking local dev entirely.
- The default was requested by Bernard (Slack, 2026-06-30) so caniuse.dev shows a meaningful comparison with no manual setup.

## Changes
- `convex-guest-auth-sync.ts` — resolve/invoke Convex CLI via `node`, not `npx`.
- `host-compare-selection.ts` — new `DEFAULT_COMPARE_HOST_IDS` fallback.
- `HostConfigCompareView.tsx` — URL-default check updated to match.
- `host-compare-selection.test.ts` — updated/added tests (13/13 passing).

<img width="2552" height="1296" alt="image" src="https://github.com/user-attachments/assets/89c0f96d-303e-4117-aed4-03061d731718" />

## Test plan
- [x] vitest 13/13 passing
- [x] tsc clean on touched files
- [x] Playwright manual repro of the loader fix


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows guest-auth provisioning by invoking the `convex` CLI via Node, and defaults Host Compare to Codex + Claude Code so fresh visits and embeds show a useful comparison.

- **New Features**
  - Default Host Compare (`/clients/compare` and the caniuse.dev embed) to Codex + Claude Code; falls back to live hosts if presets are unavailable.
  - Clean URLs by suppressing `?hosts=` when the selection matches the default order.

- **Bug Fixes**
  - Windows: provision guest auth by running `node <convex CLI entry>` instead of `npx` to avoid `spawn EINVAL` and newline-arg splitting, unblocking local dev.

<sup>Written for commit 06c2d3cbb94b074ba9b37af3dbcabdebdecb3652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

