### PR TITLE
fix(security): harden harness proxy + computer upload (4 findings from #2996 review)

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
@@ -187,7 +187,7 @@ describe("uploadFilesToComputer", () => {
     return new File([new Uint8Array([1, 2, 3])], name, { type: "text/plain" });
   }
 
-  it("POSTs a FormData with the token in the query and returns written files", async () => {
+  it("POSTs a FormData with the token in the Authorization header (never the URL)", async () => {
     let calledUrl = "";
     let calledInit: RequestInit | undefined;
     const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
@@ -209,15 +209,40 @@ describe("uploadFilesToComputer", () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    expect(calledUrl).toBe(
-      "https://host.test/api/web/computers/upload?token=tok-9"
-    );
+    // Token rides the header, not the URL — URLs land in access/proxy logs.
+    expect(calledUrl).toBe("https://host.test/api/web/computers/upload");
+    expect(calledInit?.headers).toEqual({ Authorization: "Bearer tok-9" });
     expect(calledInit?.method).toBe("POST");
     expect(calledInit?.body).toBeInstanceOf(FormData);
     expect((calledInit?.body as FormData).getAll("files")).toHaveLength(1);
     expect(files).toEqual([
       { name: "x", path: "/home/user/uploads/x", bytes: 3 },
     ]);
+  });
+
+  it("keeps dir in the query while the token stays in the header", async () => {
+    let calledUrl = "";
+    let calledInit: RequestInit | undefined;
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      calledUrl = String(url);
+      calledInit = init;
+      return new Response(JSON.stringify({ ok: true, files: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    await uploadFilesToComputer({
+      token: "tok-9",
+      files: [fakeFile("a.txt")],
+      dir: "/home/user/claude-code-1",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(calledUrl).toBe(
+      "/api/web/computers/upload?dir=%2Fhome%2Fuser%2Fclaude-code-1"
+    );
+    expect(calledInit?.headers).toEqual({ Authorization: "Bearer tok-9" });
   });
 
   it("throws with the server-supplied message on a non-2xx response", async () => {

--- a/mcpjam-inspector/client/src/lib/computer-terminal-connection.ts
+++ b/mcpjam-inspector/client/src/lib/computer-terminal-connection.ts
@@ -87,11 +87,12 @@ export interface UploadedComputerFile {
 /**
  * POST files to the user's project computer (drag-and-drop from the Shell). The
  * `token` is a fresh Convex-minted terminal token (the same one the WS uses);
- * auth is the token in the query string. `dir` targets a destination directory
- * (the Shell's cwd — i.e. the harness workdir) so uploads land where the user is
- * working; the server confines it under the box home and falls back to a default
- * bucket when absent/invalid. Resolves to the written files (with their absolute
- * sandbox paths) or throws with a server-supplied message.
+ * auth is `Authorization: Bearer <token>` — headers stay out of access/proxy
+ * logs, query strings don't. `dir` targets a destination directory (the
+ * Shell's cwd — i.e. the harness workdir) so uploads land where the user is
+ * working; the server confines it under the box home and falls back to a
+ * default bucket when absent/invalid. Resolves to the written files (with
+ * their absolute sandbox paths) or throws with a server-supplied message.
  */
 export async function uploadFilesToComputer(args: {
   token: string;
@@ -100,14 +101,19 @@ export async function uploadFilesToComputer(args: {
   dir?: string;
   fetchImpl?: typeof fetch;
 }): Promise<UploadedComputerFile[]> {
-  const params = new URLSearchParams({ token: args.token });
+  const params = new URLSearchParams();
   if (args.dir) params.set("dir", args.dir);
-  const url = `${buildComputerUploadUrl({ baseUrl: args.baseUrl })}?${params.toString()}`;
+  const query = params.size > 0 ? `?${params.toString()}` : "";
+  const url = `${buildComputerUploadUrl({ baseUrl: args.baseUrl })}${query}`;
   const form = new FormData();
   for (const file of args.files) form.append("files", file);
 
   const doFetch = args.fetchImpl ?? fetch;
-  const res = await doFetch(url, { method: "POST", body: form });
+  const res = await doFetch(url, {
+    method: "POST",
+    body: form,
+    headers: { Authorization: `Bearer ${args.token}` },
+  });
   let body: { ok?: boolean; files?: UploadedComputerFile[]; error?: string } = {};
   try {
     body = (await res.json()) as typeof body;

--- a/mcpjam-inspector/server/middleware/__tests__/web-body-limit.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/web-body-limit.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { webBodyLimit, DEFAULT_WEB_BODY_LIMIT } from "../web-body-limit";
+
+function buildApp() {
+  const app = new Hono();
+  app.use("/api/web/*", webBodyLimit());
+  // Handlers consume the body — hono's bodyLimit counts bytes as the stream
+  // is read, so a handler that never reads would never trip the cap. (The
+  // upload route's own 30MB cap is out of scope; we only assert which
+  // requests the blanket middleware lets through.)
+  const readBody = async (c: any) => {
+    await c.req.text();
+    return c.json({ ok: true });
+  };
+  app.post("/api/web/computers/upload", readBody);
+  app.put("/api/web/computers/upload", readBody);
+  app.post("/api/web/other", readBody);
+  return app;
+}
+
+const OVERSIZED = "x".repeat(DEFAULT_WEB_BODY_LIMIT + 1);
+
+describe("webBodyLimit", () => {
+  it("caps ordinary /api/web routes at 1MB", async () => {
+    const res = await buildApp().request("/api/web/other", {
+      method: "POST",
+      body: OVERSIZED,
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("lets small bodies through", async () => {
+    const res = await buildApp().request("/api/web/other", {
+      method: "POST",
+      body: JSON.stringify({ small: true }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("exempts POST to the computer upload route (it mounts its own cap)", async () => {
+    const res = await buildApp().request("/api/web/computers/upload", {
+      method: "POST",
+      body: OVERSIZED,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("does NOT exempt non-POST methods on the upload path", async () => {
+    const res = await buildApp().request("/api/web/computers/upload", {
+      method: "PUT",
+      body: OVERSIZED,
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+});

--- a/mcpjam-inspector/server/middleware/web-body-limit.ts
+++ b/mcpjam-inspector/server/middleware/web-body-limit.ts
@@ -3,8 +3,10 @@
  * and cloud-skill creates carry only a small inline SKILL.md body well under
  * the cap). Mount once with `app.use("/api/web/*", webBodyLimit())`.
  *
- * Carve-out: the computer file-upload route carries multipart blobs and
- * applies its own (higher) bodyLimit at its mount site, so it is exempt here.
+ * Carve-out: POST to the computer file-upload route carries multipart blobs
+ * and applies its own (higher) bodyLimit at its mount site, so it is exempt
+ * here. POST-only: the route's own cap is mounted on POST, so exempting other
+ * methods on the path would leave them with no cap at all.
  *
  * (An earlier multipart carve-out for skill *folder* uploads was removed when
  * skills moved to a Convex source of truth — there's no large multipart upload
@@ -17,7 +19,12 @@ export const DEFAULT_WEB_BODY_LIMIT = 1024 * 1024; // 1MB
 
 export function webBodyLimit() {
   return (c: Context, next: Next) => {
-    if (c.req.path === "/api/web/computers/upload") return next();
+    if (
+      c.req.method === "POST" &&
+      c.req.path === "/api/web/computers/upload"
+    ) {
+      return next();
+    }
     return bodyLimit({
       maxSize: DEFAULT_WEB_BODY_LIMIT,
       onError: (ctx) =>

--- a/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computer-upload.test.ts
@@ -136,13 +136,13 @@ async function uploadRequest(
   const form = new FormData();
   for (const f of files) form.append("files", f);
   const params = new URLSearchParams();
-  if (token) params.set("token", token);
   if (dir) params.set("dir", dir);
   const qs = params.toString();
-  return await app.request(
-    `/api/web/computers/upload${qs ? `?${qs}` : ""}`,
-    { method: "POST", body: form }
-  );
+  return await app.request(`/api/web/computers/upload${qs ? `?${qs}` : ""}`, {
+    method: "POST",
+    body: form,
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
 }
 
 beforeEach(() => {
@@ -176,6 +176,31 @@ describe("POST /api/web/computers/upload", () => {
     ]);
     expect(res.status).toBe(401);
     expect(fake.writes).toHaveLength(0);
+  });
+
+  it("401s when no credentials are provided at all", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const res = await uploadRequest(app, null, [
+      new File([new Uint8Array([1])], "a.txt"),
+    ]);
+    expect(res.status).toBe(401);
+    expect(fake.writes).toHaveLength(0);
+  });
+
+  it("still accepts the legacy ?token= query (stale tabs across a deploy)", async () => {
+    stubConfiguredEnv();
+    const fake = fakeSandbox();
+    const app = createApp(async () => fake.sandbox);
+    const form = new FormData();
+    form.append("files", new File([new Uint8Array([1, 2])], "a.txt"));
+    const res = await app.request(
+      `/api/web/computers/upload?token=${encodeURIComponent(await signToken())}`,
+      { method: "POST", body: form }
+    );
+    expect(res.status).toBe(200);
+    expect(fake.writes).toHaveLength(1);
   });
 
   it("400s when no files are attached", async () => {

--- a/mcpjam-inspector/server/routes/web/computer-upload.ts
+++ b/mcpjam-inspector/server/routes/web/computer-upload.ts
@@ -9,7 +9,10 @@
  * server/utils/harness/run-harness-turn.ts).
  *
  * Auth mirrors the terminal WebSocket (routes/web/computer-terminal.ts):
- *   - The browser mints a ~60s Convex terminal token and sends `?token=<jwt>`.
+ *   - The browser mints a ~60s Convex terminal token and sends it as
+ *     `Authorization: Bearer <jwt>` (a `?token=` query fallback is kept one
+ *     release for stale tabs open across a deploy — headers stay out of
+ *     access/proxy logs, query strings don't).
  *   - We verify it LOCALLY (shared HS256 secret) → `computerId`, then exchange
  *     it for the vendor sandbox id via the secret-gated `/computers/sandbox-info`
  *     control-plane route. The browser never sees vendor ids or credentials.
@@ -106,7 +109,12 @@ export function createComputerUploadHandler(deps: ComputerUploadDeps = {}) {
     }
 
     // ── auth: terminal token → computerId → vendor sandbox id ──────────────
-    const token = c.req.query("token") ?? "";
+    const authHeader = c.req.header("authorization") ?? "";
+    const bearer = /^bearer\s+/i.test(authHeader)
+      ? authHeader.replace(/^bearer\s+/i, "").trim()
+      : "";
+    // `?token=` fallback: remove after one release (see header comment).
+    const token = bearer || c.req.query("token") || "";
     const claims = await verifyComputerTerminalToken(token);
     if (!claims) {
       return c.json(

--- a/mcpjam-inspector/server/utils/__tests__/computers-terminal-token.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computers-terminal-token.test.ts
@@ -76,6 +76,12 @@ describe("verifyComputerTerminalToken", () => {
     expect(await verifyComputerTerminalToken(await sign(claims))).toBeNull();
   });
 
+  it("rejects a token AT its exp second (JWT NumericDate: expired at exp, not after)", async () => {
+    const claims = baseClaims();
+    claims.exp = Math.floor(Date.now() / 1000);
+    expect(await verifyComputerTerminalToken(await sign(claims))).toBeNull();
+  });
+
   it("rejects a missing/foreign purpose claim (other JWT populations)", async () => {
     const noPurpose = { ...baseClaims() };
     delete (noPurpose as { purpose?: unknown }).purpose;

--- a/mcpjam-inspector/server/utils/computers/terminal-token.ts
+++ b/mcpjam-inspector/server/utils/computers/terminal-token.ts
@@ -98,7 +98,8 @@ export async function verifyComputerTerminalToken(
     return null;
   }
   if (typeof payload.exp !== "number") return null;
-  if (Math.floor(Date.now() / 1000) > payload.exp) return null;
+  // JWT NumericDate semantics: the token is expired AT `exp`, not after it.
+  if (Math.floor(Date.now() / 1000) >= payload.exp) return null;
 
   return {
     userId: payload.sub,

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-strategy.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-strategy.test.ts
@@ -89,4 +89,20 @@ describe("resolveWebAuthorizedHarnessStrategy", () => {
       mode: "relay",
     });
   });
+
+  it("RELAY when the public URL is plain http (proxy token must never ride cleartext)", () => {
+    process.env.MCPJAM_INSPECTOR_PUBLIC_URL = "http://inspector.example.com";
+    expect(resolveWebAuthorizedHarnessStrategy()).toEqual({
+      plane: "web-authorized",
+      mode: "relay",
+    });
+  });
+
+  it("RELAY when the public URL is a plain-http public IP", () => {
+    process.env.BASE_URL = "http://8.8.8.8:6274";
+    expect(resolveWebAuthorizedHarnessStrategy()).toEqual({
+      plane: "web-authorized",
+      mode: "relay",
+    });
+  });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-token.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-token.test.ts
@@ -51,6 +51,18 @@ describe("verifyHarnessProxyToken (verifies Convex-minted HS256 tokens)", () => 
     ).not.toBeNull();
   });
 
+  it("rejects a token AT its exp second (JWT NumericDate: expired at exp, not after)", () => {
+    const token = signTestProxyToken(
+      { serverId: "srv-a" },
+      { nowS: 1000, expS: 2000 },
+    );
+    expect(verifyHarnessProxyToken(token, "srv-a", { nowMs: 2_000_000 })).toBeNull();
+    // The final second BEFORE exp is still valid.
+    expect(
+      verifyHarnessProxyToken(token, "srv-a", { nowMs: 1_999_999 }),
+    ).not.toBeNull();
+  });
+
   it("rejects a tampered signature", () => {
     const token = signTestProxyToken({ serverId: "srv-a" });
     const [h, p] = token.split(".");

--- a/mcpjam-inspector/server/utils/harness/harness-proxy-strategy.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-proxy-strategy.ts
@@ -37,11 +37,14 @@ export type HarnessMcpProxyStrategy =
  * Decide how the cloud sandbox reaches THIS inspector's `/api/web/harness-mcp`
  * for a hosted (`/api/web`) harness turn — a single **deploy-topology** call,
  * no extra env knob: is the inspector publicly reachable?
- *  - a publicly-reachable `MCPJAM_INSPECTOR_PUBLIC_URL`/`BASE_URL` → **direct**
- *    (cloud prod; a configured public self-host);
- *  - otherwise (no URL, loopback, or RFC1918/private) the inspector is private
- *    — local dev (`dev:hosted`) or self-hosted-behind-a-firewall — so the cloud
- *    sandbox reaches it through the scoped **harness-web relay**.
+ *  - a publicly-reachable HTTPS `MCPJAM_INSPECTOR_PUBLIC_URL`/`BASE_URL` →
+ *    **direct** (cloud prod; a configured public self-host);
+ *  - otherwise (no URL, plain-http, loopback, or RFC1918/private) the inspector
+ *    is private — local dev (`dev:hosted`) or self-hosted-behind-a-firewall —
+ *    so the cloud sandbox reaches it through the scoped **harness-web relay**.
+ * Direct mode requires `https:`: every hosted `.mcp.json` entry carries an
+ * `X-MCPJam-Proxy-Token`, so a public plain-http URL would send that token in
+ * cleartext across the internet; such a topology degrades to relay instead.
  * Still fail-closed where it matters: if relay infra isn't configured,
  * `ensureHarnessWebTunnel` throws at tunnel-creation with a concrete error.
  */
@@ -49,10 +52,18 @@ export function resolveWebAuthorizedHarnessStrategy(): HarnessMcpProxyStrategy {
   const publicUrl =
     process.env.MCPJAM_INSPECTOR_PUBLIC_URL?.trim() ||
     process.env.BASE_URL?.trim();
-  if (publicUrl && isPubliclyReachableUrl(publicUrl)) {
+  if (publicUrl && isHttpsUrl(publicUrl) && isPubliclyReachableUrl(publicUrl)) {
     return { plane: "web-authorized", mode: "direct", publicBaseUrl: publicUrl };
   }
   return { plane: "web-authorized", mode: "relay" };
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/mcpjam-inspector/server/utils/harness/harness-proxy-token.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-proxy-token.ts
@@ -95,7 +95,8 @@ export function verifyHarnessProxyToken(
   }
   if (payload.serverId !== serverId) return null;
   if (typeof payload.exp !== "number") return null;
-  if (Math.floor((opts.nowMs ?? Date.now()) / 1000) > payload.exp) return null;
+  // JWT NumericDate semantics: the token is expired AT `exp`, not after it.
+  if (Math.floor((opts.nowMs ?? Date.now()) / 1000) >= payload.exp) return null;
 
   return {
     userId: payload.sub as string,


### PR DESCRIPTION
## What

Fixes the four security findings from cubic's review of #2996 (all verified against the merged code before fixing):

1. **Require `https:` before direct harness proxy mode** — a public plain-http `MCPJAM_INSPECTOR_PUBLIC_URL`/`BASE_URL` previously selected direct mode, sending `X-MCPJam-Proxy-Token` cleartext across the internet. Now degrades to the harness-web relay (fail-closed). Latent in cloud prod (URLs are https); active only for a plain-http self-host.
2. **JWT expiry off-by-one** — both local HS256 verifiers (`harness-proxy-token.ts`, `computers/terminal-token.ts`) accepted tokens during their entire `exp` second (`>` instead of `>=`). The terminal-token twin was found by auditing sibling verifiers, not flagged by the review.
3. **Body-limit carve-out narrowed to POST** — the upload exemption was path-only, so non-POST methods on `/api/web/computers/upload` escaped every body cap. Theoretical today (no other handler reads those bodies), closed before it isn't.
4. **Upload token moved from `?token=` query to `Authorization: Bearer`** — query strings land in access/proxy logs. Server keeps the query fallback for one release (stale tabs across the deploy), then it can be removed. CORS is unaffected: hono's `cors()` reflects requested headers.

Cache-freshness `expiresAt >` comparisons elsewhere were audited and deliberately left alone — they're internal caches, not security verifiers.

## Tests

- Strategy: public http URL / plain-http public IP → relay (plus existing direct/relay matrix).
- Both verifiers: token AT its exp second rejected, final second before exp accepted.
- New `web-body-limit.test.ts`: 1MB cap on ordinary routes, POST upload exempt, PUT upload capped.
- Upload: header auth end-to-end, no-credentials → 401, legacy `?token=` still accepted; client asserts token never appears in the URL.

248 tests green across the touched suites; `typecheck:client` clean; server tsc error count unchanged from main (111 pre-existing, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth and token verification paths for computer upload and harness MCP proxy; behavior shifts for plain-http deploys (relay) and tokens at the exact `exp` second, mitigated by legacy query fallback and broad test coverage.
> 
> **Overview**
> Security hardening across harness proxy routing, computer file upload, JWT verification, and `/api/web` body limits.
> 
> **Harness direct mode** now requires a publicly reachable **HTTPS** public URL; plain-http configs fall back to relay so `X-MCPJam-Proxy-Token` is not sent in cleartext.
> 
> **Computer upload** auth moves from `?token=` to `Authorization: Bearer` on the client and server (with a temporary `?token=` fallback for stale tabs). **`webBodyLimit`** only skips the 1MB cap for **POST** on the upload path so other methods stay capped.
> 
> **JWT expiry** in the terminal and harness proxy verifiers uses `>= exp` (NumericDate: invalid at `exp`), with tests for the boundary second.
> 
> Tests cover relay vs direct for http URLs, upload header auth and legacy query, body-limit POST vs PUT, and client upload never putting the token in the URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c26fc780afa33de2dcbc1e7d263b8df59459b28e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened harness proxy and computer upload to close four security gaps: enforce HTTPS for direct mode, fix JWT expiry checks, tighten body-size limits, and move upload auth to headers.

- **Bug Fixes**
  - Harness proxy: direct mode now requires an HTTPS `MCPJAM_INSPECTOR_PUBLIC_URL`/`BASE_URL`; plain HTTP falls back to the harness-web relay.
  - JWT verifiers: reject tokens at their `exp` second in both `harness-proxy-token` and `computers/terminal-token`.
  - Body limit: the 1MB cap applies to all `/api/web/*` routes; only POST `/api/web/computers/upload` is exempt (non-POST on that path is capped).
  - Upload auth: client sends `Authorization: Bearer <token>`; server keeps a `?token=` query fallback for one release. CORS remains unchanged.

<sup>Written for commit c26fc780afa33de2dcbc1e7d263b8df59459b28e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/2998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

