### PR TITLE
feat(harness): surface harness MCP traffic in the Playground Logs panel

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/harness-mcp.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/harness-mcp.test.ts
@@ -83,4 +83,34 @@ describe("/api/web/harness-mcp", () => {
     expect(data.result.tools).toEqual([{ name: "echo" }]);
     expect(mockManager.listTools).toHaveBeenCalledWith("srv-a");
   });
+
+  it("wires an rpcLogger that publishes the sandbox's MCP traffic to the rpc-log bus", async () => {
+    const { createAuthorizedManager } = await import("../auth");
+    const { rpcLogBus } = await import("../../../services/rpc-log-bus.js");
+    (createAuthorizedManager as ReturnType<typeof vi.fn>).mockClear();
+
+    const res = await post("srv-a", { "X-MCPJam-Proxy-Token": webToken("srv-a") });
+    expect(res.status).toBe(200);
+
+    // 8th arg = options; the route must hand the manager a logger that lands
+    // on the shared bus (the live harness turn bridges the bus into its
+    // collector — see bridgeHarnessRpcLogsToCollector).
+    const options = (createAuthorizedManager as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[7] as { rpcLogger?: (e: unknown) => void } | undefined;
+    expect(typeof options?.rpcLogger).toBe("function");
+
+    const seen: unknown[] = [];
+    const stop = rpcLogBus.subscribe(["srv-a"], (e) => seen.push(e));
+    try {
+      options!.rpcLogger!({
+        direction: "send",
+        serverId: "srv-a",
+        message: { jsonrpc: "2.0", id: 9, method: "tools/call" },
+      });
+    } finally {
+      stop();
+    }
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ serverId: "srv-a", direction: "send" });
+  });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/rpc-logs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/rpc-logs.test.ts
@@ -304,3 +304,78 @@ describe("web hosted rpc logs", () => {
     expect(data._rpcLogs).toBeUndefined();
   });
 });
+
+// ── Harness bridge: rpcLogBus → a live turn's collector ─────────────────────
+// The harness's MCP traffic arrives as separate /api/web/harness-mcp requests
+// that publish to the in-process bus; the chat turn bridges those entries into
+// its collector so the Logs panel fills like an emulated turn.
+import {
+  bridgeHarnessRpcLogsToCollector,
+  createHostedRpcLogCollector,
+} from "../hosted-rpc-logs.js";
+import { rpcLogBus } from "../../../services/rpc-log-bus.js";
+
+describe("bridgeHarnessRpcLogsToCollector", () => {
+  it("forwards bus events for the turn's servers into the collector (with name resolution)", () => {
+    const collector = createHostedRpcLogCollector({
+      selectedServerIds: ["srv-1"],
+      selectedServerNames: ["My Server"],
+    });
+    const stop = bridgeHarnessRpcLogsToCollector(["srv-1"], collector);
+    try {
+      rpcLogBus.publish({
+        serverId: "srv-1",
+        direction: "send",
+        timestamp: new Date().toISOString(),
+        message: { jsonrpc: "2.0", id: 1, method: "tools/call" },
+      });
+      rpcLogBus.publish({
+        serverId: "other-srv",
+        direction: "send",
+        timestamp: new Date().toISOString(),
+        message: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      });
+    } finally {
+      stop();
+    }
+
+    const logs = collector.getLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      serverId: "srv-1",
+      serverName: "My Server",
+      direction: "send",
+    });
+  });
+
+  it("stops forwarding after unsubscribe", () => {
+    const collector = createHostedRpcLogCollector({
+      selectedServerIds: ["srv-1"],
+    });
+    const stop = bridgeHarnessRpcLogsToCollector(["srv-1"], collector);
+    stop();
+    rpcLogBus.publish({
+      serverId: "srv-1",
+      direction: "receive",
+      timestamp: new Date().toISOString(),
+      message: {},
+    });
+    expect(collector.hasLogs()).toBe(false);
+  });
+
+  it("subscribes to NOTHING for an empty server list (bus treats empty filter as all)", () => {
+    const collector = createHostedRpcLogCollector({});
+    const stop = bridgeHarnessRpcLogsToCollector([], collector);
+    try {
+      rpcLogBus.publish({
+        serverId: "any-srv",
+        direction: "send",
+        timestamp: new Date().toISOString(),
+        message: {},
+      });
+    } finally {
+      stop();
+    }
+    expect(collector.hasLogs()).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/harness-mcp.ts
+++ b/mcpjam-inspector/server/routes/web/harness-mcp.ts
@@ -160,15 +160,25 @@ async function handle(c: any) {
           // so a live harness turn ON THIS INSTANCE can forward it into the
           // Playground Logs panel (see bridgeHarnessRpcLogsToCollector), and
           // the local-mode Logs SSE/buffer sees it too. Observation-only —
-          // never affects the proxy result. Cross-instance hosted delivery
+          // never affects the proxy result: the bus isolates subscribers, and
+          // this guard is the belt-and-suspenders so no logging failure can
+          // reach the RPC try/catch below. Cross-instance hosted delivery
           // needs a shared sink (follow-up issue).
           rpcLogger: ({ direction, message, serverId: sid }) => {
-            rpcLogBus.publish({
-              serverId: sid,
-              direction,
-              timestamp: new Date().toISOString(),
-              message,
-            });
+            try {
+              rpcLogBus.publish({
+                serverId: sid,
+                direction,
+                timestamp: new Date().toISOString(),
+                message,
+              });
+            } catch (error) {
+              logger.warn(
+                `[harness-mcp] rpc log publish failed serverId=${sid}: ${
+                  error instanceof Error ? error.message : error
+                }`,
+              );
+            }
           },
         },
       ),

--- a/mcpjam-inspector/server/routes/web/harness-mcp.ts
+++ b/mcpjam-inspector/server/routes/web/harness-mcp.ts
@@ -27,6 +27,7 @@ import {
   type ManagerCallerContext,
 } from "./auth";
 import { verifyHarnessProxyToken } from "../../utils/harness/harness-proxy-token";
+import { rpcLogBus } from "../../services/rpc-log-bus";
 import { logger } from "../../utils/logger";
 
 const harnessMcp = new Hono();
@@ -152,6 +153,24 @@ async function handle(c: any) {
         claims.projectId,
         [serverId],
         HARNESS_MCP_TIMEOUT_MS,
+        undefined,
+        undefined,
+        {
+          // Publish the sandbox's MCP traffic into the in-process rpc-log bus
+          // so a live harness turn ON THIS INSTANCE can forward it into the
+          // Playground Logs panel (see bridgeHarnessRpcLogsToCollector), and
+          // the local-mode Logs SSE/buffer sees it too. Observation-only —
+          // never affects the proxy result. Cross-instance hosted delivery
+          // needs a shared sink (follow-up issue).
+          rpcLogger: ({ direction, message, serverId: sid }) => {
+            rpcLogBus.publish({
+              serverId: sid,
+              direction,
+              timestamp: new Date().toISOString(),
+              message,
+            });
+          },
+        },
       ),
       (manager) => handleJsonRpc(serverId, body, manager, "adapter"),
     );

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -1,5 +1,6 @@
 import type { UIMessageChunk } from "ai";
 import type { RpcLogger } from "@mcpjam/sdk";
+import { rpcLogBus } from "../../services/rpc-log-bus.js";
 import { logger } from "../../utils/logger.js";
 import type {
   HostedRpcLogEvent,
@@ -150,6 +151,45 @@ export function createHostedRpcLogCollector(
   body: Record<string, unknown> | null | undefined,
 ): HostedRpcLogCollector {
   return new HostedRpcLogCollector(extractServerNamesById(body));
+}
+
+/**
+ * Bridge sandbox-originated harness MCP traffic into a live turn's collector.
+ *
+ * A harness turn's MCP calls don't flow through the chat request's manager —
+ * they arrive as separate `/api/web/harness-mcp/:serverId` requests, whose
+ * per-request manager publishes into the in-process `rpcLogBus` (the same bus
+ * the local singleton manager feeds). Subscribing the turn's collector to the
+ * bus for its selected servers routes those entries into the SAME delivery the
+ * emulated engine uses (`data-rpc-log` stream parts / response envelope), so
+ * the Playground Logs panel fills for harness turns with zero client changes.
+ *
+ * SINGLE-INSTANCE by design: the bus is per-process, so this covers local dev
+ * and self-hosted. In the horizontally-scaled hosted plane a harness-mcp
+ * request may land on another instance and its entries won't reach this turn —
+ * cross-instance fan-in needs a shared sink (tracked as a follow-up issue).
+ *
+ * Scoped by serverId only (the proxy token carries no turn id), so a
+ * concurrent turn against the same server on this instance would also see the
+ * entries — same per-server semantics as the local-mode Logs SSE.
+ *
+ * Returns the unsubscribe; callers MUST run it on stream completion or the
+ * collector (and its closed writer) leak on the bus for the process lifetime.
+ */
+export function bridgeHarnessRpcLogsToCollector(
+  serverIds: string[],
+  collector: HostedRpcLogCollector,
+): () => void {
+  // An empty filter would subscribe to EVERY server's traffic (bus semantics);
+  // a harness turn with no MCP servers has nothing to bridge.
+  if (serverIds.length === 0) return () => {};
+  return rpcLogBus.subscribe(serverIds, (event) => {
+    collector.rpcLogger({
+      direction: event.direction,
+      message: event.message,
+      serverId: event.serverId,
+    });
+  });
 }
 
 export function attachHostedRpcLogs<T>(

--- a/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { rpcLogBus, type RpcLogEvent } from "../rpc-log-bus";
+
+function event(serverId: string, id: number): RpcLogEvent {
+  return {
+    serverId,
+    direction: "send",
+    timestamp: new Date().toISOString(),
+    message: { jsonrpc: "2.0", id, method: "tools/call" },
+  };
+}
+
+describe("rpcLogBus", () => {
+  it("caps the per-server replay buffer on write (oldest evicted)", () => {
+    const serverId = `cap-test-${crypto.randomUUID()}`;
+    for (let i = 0; i < 620; i++) rpcLogBus.publish(event(serverId, i));
+
+    const all = rpcLogBus.getBuffer([serverId], -1);
+    expect(all).toHaveLength(500);
+    // Oldest entries were evicted; the newest survive.
+    expect((all[0].message as { id: number }).id).toBe(120);
+    expect((all[all.length - 1].message as { id: number }).id).toBe(619);
+  });
+
+  it("isolates a throwing subscriber: publish never throws and later subscribers still fire", () => {
+    const serverId = `throw-test-${crypto.randomUUID()}`;
+    const seen: RpcLogEvent[] = [];
+    const stopThrowing = rpcLogBus.subscribe([serverId], () => {
+      throw new Error("subscriber bug");
+    });
+    const stopHealthy = rpcLogBus.subscribe([serverId], (e) => seen.push(e));
+    try {
+      expect(() => rpcLogBus.publish(event(serverId, 1))).not.toThrow();
+    } finally {
+      stopThrowing();
+      stopHealthy();
+    }
+    // The healthy subscriber (registered AFTER the throwing one) still got it.
+    expect(seen).toHaveLength(1);
+  });
+
+  it("unsubscribe stops delivery", () => {
+    const serverId = `unsub-test-${crypto.randomUUID()}`;
+    const listener = vi.fn();
+    const stop = rpcLogBus.subscribe([serverId], listener);
+    stop();
+    rpcLogBus.publish(event(serverId, 1));
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/services/rpc-log-bus.ts
+++ b/mcpjam-inspector/server/services/rpc-log-bus.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { logger } from "../utils/logger";
 
 export type RpcLogEvent = {
   serverId: string;
@@ -7,6 +8,12 @@ export type RpcLogEvent = {
   message: unknown;
 };
 
+/** Per-server replay-buffer cap, enforced on WRITE. The buffer exists only to
+ *  seed the Logs SSE with recent history (`getBuffer`); without a cap a
+ *  long-lived process publishing steadily (e.g. hosted harness-mcp traffic)
+ *  retains every payload for the process lifetime. */
+const MAX_BUFFERED_EVENTS_PER_SERVER = 500;
+
 class RpcLogBus {
   private readonly emitter = new EventEmitter();
   private readonly bufferByServer = new Map<string, RpcLogEvent[]>();
@@ -14,6 +21,9 @@ class RpcLogBus {
   publish(event: RpcLogEvent): void {
     const buffer = this.bufferByServer.get(event.serverId) ?? [];
     buffer.push(event);
+    if (buffer.length > MAX_BUFFERED_EVENTS_PER_SERVER) {
+      buffer.splice(0, buffer.length - MAX_BUFFERED_EVENTS_PER_SERVER);
+    }
     this.bufferByServer.set(event.serverId, buffer);
     this.emitter.emit("event", event);
   }
@@ -24,7 +34,20 @@ class RpcLogBus {
   ): () => void {
     const filter = new Set(serverIds);
     const handler = (event: RpcLogEvent) => {
-      if (filter.size === 0 || filter.has(event.serverId)) listener(event);
+      if (filter.size === 0 || filter.has(event.serverId)) {
+        // Isolate subscribers: EventEmitter.emit re-throws synchronously, so
+        // an unguarded listener would propagate into the PRODUCER — turning a
+        // logging side-effect into an RPC failure (e.g. failing a harness-mcp
+        // proxy call) and starving later subscribers of the same event.
+        try {
+          listener(event);
+        } catch (error) {
+          logger.warn("[rpc-log-bus] subscriber threw; event dropped for it", {
+            serverId: event.serverId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
     };
     this.emitter.on("event", handler);
     return () => this.emitter.off("event", handler);

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -65,6 +65,7 @@ import type { HarnessSessionCommitPayload } from "./harness/harness-session-stat
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import type { createHostedRpcLogCollector } from "./../routes/web/hosted-rpc-logs.js";
+import { bridgeHarnessRpcLogsToCollector } from "./../routes/web/hosted-rpc-logs.js";
 import type { CustomProviderConfig } from "./chat-helpers.js";
 import { getClientIp } from "./client-ip.js";
 import { convertToMcpjamModelMessages } from "./mcp-tool-result-model-output.js";
@@ -492,6 +493,14 @@ export async function streamWebChatTurn(
     ? resolveWebAuthorizedHarnessStrategy()
     : undefined;
 
+  // Harness observation: the turn's MCP traffic arrives as separate
+  // `/api/web/harness-mcp` requests (not through THIS request's manager), so
+  // bridge the in-process rpc-log bus into this turn's collector while the
+  // stream is live — the Logs panel then fills exactly like an emulated turn.
+  // Subscribed at stream start (not before — a pre-stream failure must not
+  // leave a live subscription) and torn down with the stream.
+  let stopHarnessRpcLogBridge: (() => void) | undefined;
+
   return handleMCPJamFreeChatModel({
     messages: modelMessages,
     modelId: mcpjamModelId,
@@ -521,8 +530,19 @@ export async function streamWebChatTurn(
     ...(prepare.builtInTools ? { builtInTools: prepare.builtInTools } : {}),
     abortSignal: runtime.abortSignal,
     onConversationComplete,
-    onStreamComplete: cleanupStream,
-    onStreamWriterReady: (writer) =>
-      runtime.rpcCollector?.attachStreamWriter(writer),
+    onStreamComplete: async () => {
+      stopHarnessRpcLogBridge?.();
+      stopHarnessRpcLogBridge = undefined;
+      await cleanupStream();
+    },
+    onStreamWriterReady: (writer) => {
+      runtime.rpcCollector?.attachStreamWriter(writer);
+      if (persist.harness && runtime.rpcCollector && !stopHarnessRpcLogBridge) {
+        stopHarnessRpcLogBridge = bridgeHarnessRpcLogsToCollector(
+          persist.selectedServerIds,
+          runtime.rpcCollector
+        );
+      }
+    },
   });
 }


### PR DESCRIPTION
## What

On a harness turn the Playground Logs panel stayed empty ("No logs yet") even though tool calls succeeded. Reason: the panel is fed by RPC logs collected inside the browser's own chat request, but a harness turn's MCP traffic arrives as **separate sandbox-originated** `/api/web/harness-mcp/:serverId` requests — the chat request's manager makes zero MCP calls, and the proxy route's ephemeral manager had no logger and no path back to the browser.

## How

Two small seams, reusing everything that already exists:

1. **Producer** — `harness-mcp` hands its per-request manager an `rpcLogger` that publishes into the in-process `rpcLogBus` (the same bus the local singleton manager already feeds for the local-mode Logs SSE). Observation-only; never affects the proxy result.
2. **Consumer** — a hosted harness turn bridges the bus into its own `HostedRpcLogCollector` for its selected servers while the stream is live (`bridgeHarnessRpcLogsToCollector`). Entries then ride the existing `data-rpc-log` stream parts, so the Logs panel fills exactly like an emulated turn — zero client changes. Subscribed at stream start (a pre-stream failure never leaves a live subscription), torn down with the stream.

The local plane (`/api/mcp` desktop) needed nothing: adapter-http runs on the singleton manager, which already publishes to the bus.

## Limits (by design, documented in code)

- **Single-instance:** the bus is per-process — covers dev and self-hosted. Cross-instance fan-in for the scaled hosted plane needs a shared sink; tracked in the follow-up issue.
- **Per-server scoping:** the proxy token carries no turn id, so a concurrent turn against the same server on the same instance sees the same entries — matching local-mode Logs SSE semantics.

## Security

No new surface: the logger only publishes to the in-process bus; delivery to the browser goes through the turn's existing collector on the already-authenticated chat stream. No token material appears in the logged JSON-RPC frames (they're the MCP payloads, same as emulated turns).

## Verification

- 4 new tests: bridge forward/name-resolution, unsubscribe stops delivery, empty-server-list subscribes to nothing (bus treats an empty filter as "all"), and the route wires a bus-publishing `rpcLogger`.
- Full affected suites green: 67 files / 868 tests; `typecheck:client` green; no new server `tsc` errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the harness MCP proxy and chat streaming path; logging is isolated so RPC results should not fail, but concurrent turns on the same server can share log entries and multi-instance hosted deploys still miss cross-node traffic.
> 
> **Overview**
> **Harness turns** can now populate the Playground **Logs** panel even though MCP JSON-RPC runs on separate `/api/web/harness-mcp` requests instead of the chat stream’s manager.
> 
> The **harness-mcp** route passes an **`rpcLogger`** into `createAuthorizedManager` that **publishes** sandbox MCP send/receive frames to the in-process **`rpcLogBus`** (observation-only; publish failures are logged and do not fail the proxy). **`bridgeHarnessRpcLogsToCollector`** subscribes the live turn’s **`HostedRpcLogCollector`** to that bus for the turn’s selected server IDs, so entries reuse existing **`data-rpc-log`** delivery with no client changes. **`web-chat-turn`** starts that bridge when the stream writer is ready for harness MCPJam-free turns and **unsubscribes** on stream complete.
> 
> **`rpcLogBus`** is hardened with a **500-event per-server replay cap**, **try/catch around subscribers** so a bad listener cannot break publishers or other subscribers, plus tests for the bridge, route wiring, and bus behavior. Cross-instance hosted fan-in remains out of scope (per-process bus).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ea440fda3eb15320c5009482f2e60b24283a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->