### PR TITLE
canniuse.dev pollish

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -657,6 +657,7 @@ export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
     <HostConfigCompareView
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
+      presetOnly={bare}
     />
   );
 
@@ -3290,25 +3291,27 @@ export default function App() {
   // Still nested inside every provider in the return below, so auth, project,
   // and the guest session resolve exactly as on the normal route.
   const bareCompareContent = (
-    <div className="flex h-screen w-screen flex-col overflow-hidden bg-background">
-      {/* Subtle branding + entry point back to the full product. */}
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-2">
-        <a
-          href={MAIN_PRODUCT_URL}
-          className="text-[15px] font-semibold tracking-tight text-foreground"
-          aria-label="MCPJam home"
-        >
-          MCP<span className="text-primary">Jam</span>
-        </a>
-        <a
-          href={MAIN_PRODUCT_URL}
-          className="inline-flex items-center gap-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Open the full app
-          <span aria-hidden>↗</span>
-        </a>
+    <div className="flex h-[100dvh] min-w-0 max-w-full flex-col overflow-hidden bg-background">
+      <div className="shrink-0 px-4 pb-4 pt-5 text-center md:pb-5 md:pt-6">
+        <div className="text-[30px] font-bold leading-none tracking-tight text-foreground">
+          Can I use…
+        </div>
+        <div className="mt-2 flex min-w-0 items-center justify-center gap-2 text-[13px] leading-none text-muted-foreground">
+          <span className="shrink-0">Brought to you by</span>
+          <a
+            href={MAIN_PRODUCT_URL}
+            className="inline-flex min-w-0 items-center transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            aria-label="Open MCPJam"
+          >
+            <img
+              src="/mcp_jam_light.png"
+              alt="MCPJam"
+              className="h-5 w-auto"
+            />
+          </a>
+        </div>
       </div>
-      <div className="min-h-0 flex-1">
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
         <AppRouteReactContext.Provider value={routeContext}>
           {locationContext ? (
             <Outlet context={routeContext} />

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -645,9 +645,6 @@ export function HostsRoute() {
   );
 }
 
-/** Where the embed (caniuse.dev) entry point sends people for the full product. */
-const MAIN_PRODUCT_URL = "https://app.mcpjam.com";
-
 export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
   const { convexProjectId, isAuthenticated } = useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
@@ -3292,25 +3289,6 @@ export default function App() {
   // and the guest session resolve exactly as on the normal route.
   const bareCompareContent = (
     <div className="flex h-[100dvh] min-w-0 max-w-full flex-col overflow-hidden bg-background">
-      <div className="shrink-0 px-4 pb-4 pt-5 text-center md:pb-5 md:pt-6">
-        <div className="text-[30px] font-bold leading-none tracking-tight text-foreground">
-          Can I use…
-        </div>
-        <div className="mt-2 flex min-w-0 items-center justify-center gap-2 text-[13px] leading-none text-muted-foreground">
-          <span className="shrink-0">Brought to you by</span>
-          <a
-            href={MAIN_PRODUCT_URL}
-            className="inline-flex min-w-0 items-center transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-            aria-label="Open MCPJam"
-          >
-            <img
-              src="/mcp_jam_light.png"
-              alt="MCPJam"
-              className="h-5 w-auto"
-            />
-          </a>
-        </div>
-      </div>
       <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
         <AppRouteReactContext.Provider value={routeContext}>
           {locationContext ? (

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCapabilityListView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCapabilityListView.tsx
@@ -22,6 +22,7 @@ interface HostCapabilityListViewProps {
   supportFilter?: SupportFilterMode;
   searchQuery?: string;
   themeMode?: HostThemeMode;
+  mobileOptimized?: boolean;
 }
 
 /**
@@ -42,6 +43,7 @@ export function HostCapabilityListView({
   supportFilter = "all",
   searchQuery = "",
   themeMode = "light",
+  mobileOptimized = false,
 }: HostCapabilityListViewProps) {
   const configs = useMemo(() => subjects.map((s) => s.config), [subjects]);
   const visibleFieldIds = useMemo(
@@ -52,7 +54,7 @@ export function HostCapabilityListView({
         supportFilter,
         searchQuery,
       }),
-    [configs, divergingOnly, supportFilter, searchQuery],
+    [configs, divergingOnly, supportFilter, searchQuery]
   );
 
   // Support-shaped, currently-visible fields in registry order. Support-shape
@@ -60,8 +62,11 @@ export function HostCapabilityListView({
   // reading `configs[0]` while subjects are still hydrating (subjects can be
   // empty here even when hosts are selected).
   const fields = useMemo(
-    () => HOST_CONFIG_FIELDS.filter((f) => visibleFieldIds.has(f.id) && isSupportField(f)),
-    [visibleFieldIds],
+    () =>
+      HOST_CONFIG_FIELDS.filter(
+        (f) => visibleFieldIds.has(f.id) && isSupportField(f)
+      ),
+    [visibleFieldIds]
   );
 
   if (subjects.length === 0) {
@@ -95,6 +100,7 @@ export function HostCapabilityListView({
           subject={subject}
           fields={fields}
           themeMode={themeMode}
+          mobileOptimized={mobileOptimized}
         />
       ))}
     </div>
@@ -105,15 +111,17 @@ function HostListColumn({
   subject,
   fields,
   themeMode,
+  mobileOptimized,
 }: {
   subject: HostComparisonSubject;
   fields: ReadonlyArray<(typeof HOST_CONFIG_FIELDS)[number]>;
   themeMode: HostThemeMode;
+  mobileOptimized: boolean;
 }) {
   const logoSrc = getChatboxHostLogo(
     subject.hostStyle,
     subject.config.chatUiOverride,
-    themeMode,
+    themeMode
   );
 
   // Bucket every visible support-shaped field by its level for this host.
@@ -136,11 +144,17 @@ function HostListColumn({
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
-      className="flex flex-col gap-4 rounded-xl border border-border bg-card p-4"
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-border bg-card p-4",
+        mobileOptimized && "min-w-0 overflow-hidden"
+      )}
     >
       <div className="flex items-center gap-2 border-b border-border pb-3">
         <img src={logoSrc} alt="" className="size-4 shrink-0 object-contain" />
-        <span className="truncate text-[14px] font-medium" title={subject.hostName}>
+        <span
+          className="truncate text-[14px] font-medium"
+          title={subject.hostName}
+        >
           {subject.hostName}
         </span>
       </div>
@@ -164,7 +178,11 @@ function HostListColumn({
                   key={label}
                   level={level}
                   label={label}
-                  className={cn(level === "neutral" && "opacity-90")}
+                  className={cn(
+                    mobileOptimized && "max-w-full",
+                    level === "neutral" && "opacity-90"
+                  )}
+                  truncateLabel={mobileOptimized}
                 />
               ))}
             </div>

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCapabilityListView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCapabilityListView.tsx
@@ -178,10 +178,7 @@ function HostListColumn({
                   key={label}
                   level={level}
                   label={label}
-                  className={cn(
-                    mobileOptimized && "max-w-full",
-                    level === "neutral" && "opacity-90"
-                  )}
+                  className={cn(level === "neutral" && "opacity-90")}
                   truncateLabel={mobileOptimized}
                 />
               ))}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
@@ -57,8 +57,10 @@ interface HostCompareSelectorProps {
   onSupportFilterChange: (mode: SupportFilterMode) => void;
   showDescriptions: boolean;
   onShowDescriptionsChange: (enabled: boolean) => void;
+  descriptionsDisabled?: boolean;
   disabled?: boolean;
   themeMode?: HostThemeMode;
+  mobileOptimized?: boolean;
 }
 
 export function HostCompareSelector({
@@ -72,15 +74,22 @@ export function HostCompareSelector({
   onSupportFilterChange,
   showDescriptions,
   onShowDescriptionsChange,
+  descriptionsDisabled = false,
   disabled = false,
   themeMode = "light",
+  mobileOptimized = false,
 }: HostCompareSelectorProps) {
   const selectedSet = new Set(selectedHostIds);
   const inlineHosts = hosts.slice(0, INLINE_CHIP_LIMIT);
   const overflowHosts = hosts.slice(INLINE_CHIP_LIMIT);
 
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-2">
+    <div
+      className={cn(
+        "mb-4 flex flex-wrap items-center gap-2",
+        mobileOptimized && "min-w-0"
+      )}
+    >
       {inlineHosts.map((host) => (
         <HostCompareChip
           key={host.hostId}
@@ -104,11 +113,21 @@ export function HostCompareSelector({
         />
       ) : null}
 
-      <div className="ml-auto flex items-center gap-4">
+      <div
+        className={cn(
+          "ml-auto flex items-center gap-4",
+          mobileOptimized &&
+            "ml-0 min-w-0 w-full flex-wrap gap-2 sm:ml-auto sm:w-auto sm:flex-nowrap sm:gap-4"
+        )}
+      >
         <div
           role="group"
           aria-label="Filter by support level"
-          className="flex items-center gap-0.5 rounded-full border border-border p-0.5"
+          className={cn(
+            "flex items-center gap-0.5 rounded-full border border-border p-0.5",
+            mobileOptimized &&
+              "max-w-full overflow-x-auto [-webkit-overflow-scrolling:touch]"
+          )}
         >
           {SUPPORT_FILTERS.map((f) => {
             const active = supportFilter === f.value;
@@ -123,11 +142,12 @@ export function HostCompareSelector({
                 onClick={() => onSupportFilterChange(f.value)}
                 className={cn(
                   "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
+                  mobileOptimized && "shrink-0",
                   "disabled:cursor-not-allowed disabled:opacity-50",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
                   active
                     ? "bg-primary/10 text-foreground"
-                    : "text-muted-foreground hover:text-foreground",
+                    : "text-muted-foreground hover:text-foreground"
                 )}
               >
                 {f.label}
@@ -135,15 +155,32 @@ export function HostCompareSelector({
             );
           })}
         </div>
-        <label className="flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground">
+        <label
+          className={cn(
+            "flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground",
+            descriptionsDisabled && "cursor-not-allowed opacity-40",
+            mobileOptimized && "shrink-0"
+          )}
+          title={
+            descriptionsDisabled
+              ? "Descriptions are available in table view"
+              : undefined
+          }
+        >
           <Switch
             checked={showDescriptions}
+            disabled={disabled || descriptionsDisabled}
             onCheckedChange={onShowDescriptionsChange}
             aria-label="Show field descriptions"
           />
           <span>Descriptions</span>
         </label>
-        <label className="flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground">
+        <label
+          className={cn(
+            "flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground",
+            mobileOptimized && "shrink-0"
+          )}
+        >
           <Switch
             checked={divergingOnly}
             onCheckedChange={onDivergingOnlyChange}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
@@ -51,6 +51,12 @@ interface HostCompareSelectorProps {
   selectedHostIds: ReadonlyArray<string>;
   subjectsByHost: Readonly<Record<string, HostComparisonSubject>>;
   onToggleHost: (hostId: string) => void;
+  matchCount?: number;
+  totalCount?: number;
+  showCount?: boolean;
+  viewMode?: "table" | "list";
+  onViewModeChange?: (mode: "table" | "list") => void;
+  disableListView?: boolean;
   divergingOnly: boolean;
   onDivergingOnlyChange: (enabled: boolean) => void;
   supportFilter: SupportFilterMode;
@@ -68,6 +74,12 @@ export function HostCompareSelector({
   selectedHostIds,
   subjectsByHost,
   onToggleHost,
+  matchCount,
+  totalCount,
+  showCount = false,
+  viewMode,
+  onViewModeChange,
+  disableListView = false,
   divergingOnly,
   onDivergingOnlyChange,
   supportFilter,
@@ -82,6 +94,8 @@ export function HostCompareSelector({
   const selectedSet = new Set(selectedHostIds);
   const inlineHosts = hosts.slice(0, INLINE_CHIP_LIMIT);
   const overflowHosts = hosts.slice(INLINE_CHIP_LIMIT);
+  const showMobileViewMode =
+    mobileOptimized && viewMode !== undefined && onViewModeChange !== undefined;
 
   return (
     <div
@@ -111,6 +125,56 @@ export function HostCompareSelector({
           disabled={disabled}
           themeMode={themeMode}
         />
+      ) : null}
+
+      {showMobileViewMode ? (
+        <>
+          {showCount && matchCount !== undefined && totalCount !== undefined ? (
+            <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+              {matchCount} / {totalCount} fields
+            </span>
+          ) : null}
+          <div
+            role="group"
+            aria-label="View mode"
+            className="flex shrink-0 items-center gap-0.5 rounded-full border border-border p-0.5"
+          >
+            {(
+              [
+                { value: "table", label: "Tables" },
+                { value: "list", label: "List" },
+              ] as const
+            ).map((v) => {
+              const active = viewMode === v.value;
+              const disabled = v.value === "list" && disableListView;
+              return (
+                <button
+                  key={v.value}
+                  type="button"
+                  aria-pressed={active}
+                  disabled={disabled}
+                  title={
+                    disabled
+                      ? "Turn descriptions off before switching to list view"
+                      : undefined
+                  }
+                  data-testid={`compare-view-${v.value}`}
+                  onClick={() => onViewModeChange(v.value)}
+                  className={cn(
+                    "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
+                    "disabled:cursor-not-allowed disabled:opacity-40",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                    active
+                      ? "bg-primary/10 text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  {v.label}
+                </button>
+              );
+            })}
+          </div>
+        </>
       ) : null}
 
       <div
@@ -178,11 +242,13 @@ export function HostCompareSelector({
         <label
           className={cn(
             "flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground",
+            disabled && "cursor-not-allowed opacity-40",
             mobileOptimized && "shrink-0"
           )}
         >
           <Switch
             checked={divergingOnly}
+            disabled={disabled}
             onCheckedChange={onDivergingOnlyChange}
             aria-label="Show only diverging fields"
           />

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostCompareSelector.tsx
@@ -146,15 +146,16 @@ export function HostCompareSelector({
               ] as const
             ).map((v) => {
               const active = viewMode === v.value;
-              const disabled = v.value === "list" && disableListView;
+              const viewModeDisabled =
+                disabled || (v.value === "list" && disableListView);
               return (
                 <button
                   key={v.value}
                   type="button"
                   aria-pressed={active}
-                  disabled={disabled}
+                  disabled={viewModeDisabled}
                   title={
-                    disabled
+                    viewModeDisabled
                       ? "Turn descriptions off before switching to list view"
                       : undefined
                   }
@@ -222,7 +223,8 @@ export function HostCompareSelector({
         <label
           className={cn(
             "flex cursor-pointer items-center gap-2 text-[12px] text-muted-foreground",
-            descriptionsDisabled && "cursor-not-allowed opacity-40",
+            (disabled || descriptionsDisabled) &&
+              "cursor-not-allowed opacity-40",
             mobileOptimized && "shrink-0"
           )}
           title={

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -116,15 +116,10 @@ export function HostConfigCompareView({
   }, [claudeCodeEnabled]);
   const presets = useMemo(
     () =>
-      buildPresetCompareEntries(
-        themeMode,
-        presetOnly
-          ? {
-              excludedTemplateIds: excludedPresetTemplateIds,
-            }
-          : undefined
-      ),
-    [themeMode, presetOnly, excludedPresetTemplateIds]
+      buildPresetCompareEntries(themeMode, {
+        excludedTemplateIds: excludedPresetTemplateIds,
+      }),
+    [themeMode, excludedPresetTemplateIds]
   );
 
   // Real created hosts first, then presets — what the selector chips iterate.
@@ -569,6 +564,9 @@ function CompareSearchBar({
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const searchAnchorRef = useRef<HTMLDivElement | null>(null);
+  const themeMode = usePreferencesStore((s) => s.themeMode);
+  const mcpJamLogoSrc =
+    themeMode === "dark" ? "/mcp_jam_dark.png" : "/mcp_jam_light.png";
   const fieldGroups = useMemo(
     () =>
       groupHostConfigFields(
@@ -717,9 +715,10 @@ function CompareSearchBar({
       {mobileOptimized && (
         <span className="inline-flex shrink-0 items-center gap-2">
           <span
-            aria-hidden
+            aria-label="Search MCP client capabilities across default clients"
+            tabIndex={0}
             title="Search MCP client capabilities across default clients"
-            className="text-[24px] font-semibold leading-none text-foreground"
+            className="text-[24px] font-semibold leading-none text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
           >
             ?
           </span>
@@ -747,7 +746,7 @@ function CompareSearchBar({
           >
             <span>Brought to you by</span>
             <img
-              src="/mcp_jam_light.png"
+              src={mcpJamLogoSrc}
               alt="MCPJam"
               className="h-3.5 w-auto"
             />

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -48,6 +48,7 @@ import { cn } from "@/lib/utils";
 type CompareViewMode = "table" | "list";
 
 const HOSTS_QUERY_PARAM = "hosts";
+const MAIN_PRODUCT_URL = "https://app.mcpjam.com";
 const MOBILE_COMPARE_MEDIA_QUERY = "(max-width: 640px)";
 const SEARCH_PICKER_HIDDEN_FIELD_IDS = new Set([
   "modelId",
@@ -445,6 +446,12 @@ export function HostConfigCompareView({
               selectedHostIds={selectedHostIds}
               subjectsByHost={allSubjects}
               onToggleHost={handleToggleHost}
+              matchCount={matchCount}
+              totalCount={totalFieldCount}
+              showCount={orderedSubjects.length > 0}
+              viewMode={viewMode}
+              onViewModeChange={handleViewModeChange}
+              disableListView={showDescriptions}
               divergingOnly={divergingOnly}
               onDivergingOnlyChange={setDivergingOnly}
               supportFilter={supportFilter}
@@ -607,14 +614,13 @@ function CompareSearchBar({
     []
   );
 
-  return (
-    <div
-      className={cn(
-        "mb-4 flex flex-wrap items-center gap-3",
-        mobileOptimized && "min-w-0 items-stretch"
-      )}
-    >
-      {!mobileOptimized && (
+  const searchRow = (
+    <>
+      {mobileOptimized ? (
+        <span className="shrink-0 text-[24px] font-semibold leading-none tracking-normal text-foreground">
+          Can I use…
+        </span>
+      ) : (
         <span className="shrink-0 text-[15px] font-medium tracking-tight text-foreground">
           Can I use…
         </span>
@@ -625,21 +631,38 @@ function CompareSearchBar({
             ref={searchAnchorRef}
             className={cn(
               mobileOptimized
-                ? "order-first min-w-0 flex-[1_1_100%]"
+                ? "min-w-0 max-w-full flex-1"
                 : "order-last w-full sm:order-none sm:w-auto sm:min-w-[240px] sm:flex-1"
             )}
           >
-            <SearchInput
-              value={query}
-              onValueChange={(next) => {
-                onQueryChange(next);
-                setPickerOpen(true);
-              }}
-              onFocus={() => setPickerOpen(true)}
-              placeholder="Search capabilities, fields, descriptions…"
-              aria-label="Search host config fields"
-              className="w-full"
-            />
+            {mobileOptimized ? (
+              <input
+                value={query}
+                onChange={(event) => {
+                  onQueryChange(event.target.value);
+                  setPickerOpen(true);
+                }}
+                onFocus={() => setPickerOpen(true)}
+                placeholder="Search capabilities, fields, descriptions…"
+                aria-label="Search host config fields"
+                type="search"
+                autoComplete="off"
+                spellCheck={false}
+                className="h-10 w-full border-0 border-b border-dotted border-muted-foreground/60 bg-transparent px-0 text-center text-sm text-foreground outline-none placeholder:text-center placeholder:text-muted-foreground/60 focus:border-foreground focus:ring-0 [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden"
+              />
+            ) : (
+              <SearchInput
+                value={query}
+                onValueChange={(next) => {
+                  onQueryChange(next);
+                  setPickerOpen(true);
+                }}
+                onFocus={() => setPickerOpen(true)}
+                placeholder="Search capabilities, fields, descriptions…"
+                aria-label="Search host config fields"
+                className="w-full"
+              />
+            )}
           </div>
         </PopoverAnchor>
         <PopoverContent
@@ -691,51 +714,95 @@ function CompareSearchBar({
           </Command>
         </PopoverContent>
       </Popover>
-      {showCount && (
+      {mobileOptimized && (
+        <span className="inline-flex shrink-0 items-center gap-2">
+          <span
+            aria-hidden
+            title="Search MCP client capabilities across default clients"
+            className="text-[24px] font-semibold leading-none text-foreground"
+          >
+            ?
+          </span>
+        </span>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      className={cn(
+        "mb-4 flex flex-wrap items-center gap-3",
+        mobileOptimized && "min-w-0 items-center gap-2"
+      )}
+    >
+      {mobileOptimized ? (
+        <div className="flex basis-full flex-col items-center gap-1 pb-2 pt-1 sm:grid sm:grid-cols-[minmax(0,1fr)_minmax(0,720px)_minmax(0,1fr)] sm:items-center sm:gap-2">
+          <div className="flex w-full min-w-0 flex-nowrap items-center justify-center gap-2 sm:col-start-2">
+            {searchRow}
+          </div>
+          <a
+            href={MAIN_PRODUCT_URL}
+            className="inline-flex min-w-0 shrink-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:col-start-3 sm:justify-self-end"
+            aria-label="Open MCPJam"
+          >
+            <span>Brought to you by</span>
+            <img
+              src="/mcp_jam_light.png"
+              alt="MCPJam"
+              className="h-3.5 w-auto"
+            />
+          </a>
+        </div>
+      ) : (
+        searchRow
+      )}
+      {showCount && !mobileOptimized && (
         <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
           {matchCount} / {totalCount} fields
         </span>
       )}
-      <div
-        role="group"
-        aria-label="View mode"
-        className="flex shrink-0 items-center gap-0.5 rounded-full border border-border p-0.5"
-      >
-        {(
-          [
-            { value: "table", label: "Tables" },
-            { value: "list", label: "List" },
-          ] as const
-        ).map((v) => {
-          const active = viewMode === v.value;
-          const disabled = v.value === "list" && disableListView;
-          return (
-            <button
-              key={v.value}
-              type="button"
-              aria-pressed={active}
-              disabled={disabled}
-              title={
-                disabled
-                  ? "Turn descriptions off before switching to list view"
-                  : undefined
-              }
-              data-testid={`compare-view-${v.value}`}
-              onClick={() => onViewModeChange(v.value)}
-              className={cn(
-                "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
-                "disabled:cursor-not-allowed disabled:opacity-40",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                active
-                  ? "bg-primary/10 text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              {v.label}
-            </button>
-          );
-        })}
-      </div>
+      {!mobileOptimized && (
+        <div
+          role="group"
+          aria-label="View mode"
+          className="flex shrink-0 items-center gap-0.5 rounded-full border border-border p-0.5"
+        >
+          {(
+            [
+              { value: "table", label: "Tables" },
+              { value: "list", label: "List" },
+            ] as const
+          ).map((v) => {
+            const active = viewMode === v.value;
+            const disabled = v.value === "list" && disableListView;
+            return (
+              <button
+                key={v.value}
+                type="button"
+                aria-pressed={active}
+                disabled={disabled}
+                title={
+                  disabled
+                    ? "Turn descriptions off before switching to list view"
+                    : undefined
+                }
+                data-testid={`compare-view-${v.value}`}
+                onClick={() => onViewModeChange(v.value)}
+                className={cn(
+                  "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
+                  "disabled:cursor-not-allowed disabled:opacity-40",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                  active
+                    ? "bg-primary/10 text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {v.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -1,8 +1,25 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@mcpjam/design-system/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@mcpjam/design-system/command";
 import { useSearchParams } from "react-router";
 import { useHost, useHostList } from "@/hooks/useClients";
-import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
+import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
+import type {
+  HostComparisonSubject,
+  HostConfigFieldDef,
+} from "@/lib/host-config-field-schema";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { HostCompareSelector } from "./HostCompareSelector";
 import {
@@ -16,10 +33,12 @@ import { HostConfigComparisonMatrix } from "./host-config-comparison-matrix";
 import { HostCapabilityListView } from "./HostCapabilityListView";
 import {
   computeVisibleFieldIds,
+  fieldMatchesQuery,
   isSupportField,
   type SupportFilterMode,
 } from "./support-level";
 import {
+  groupHostConfigFields,
   HOST_CONFIG_FIELDS,
   hostConfigField,
 } from "@/lib/host-config-field-schema";
@@ -29,10 +48,37 @@ import { cn } from "@/lib/utils";
 type CompareViewMode = "table" | "list";
 
 const HOSTS_QUERY_PARAM = "hosts";
+const MOBILE_COMPARE_MEDIA_QUERY = "(max-width: 640px)";
+const SEARCH_PICKER_HIDDEN_FIELD_IDS = new Set([
+  "modelId",
+  "systemPrompt",
+  "temperature",
+]);
+
+function getInitialCompareViewMode(): CompareViewMode {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return "table";
+  }
+  return window.matchMedia(MOBILE_COMPARE_MEDIA_QUERY).matches
+    ? "list"
+    : "table";
+}
+
+function sameStringArray(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
 
 interface HostConfigCompareViewProps {
   projectId: string | null;
   isAuthenticated: boolean;
+  /**
+   * Public caniuse.dev embed mode: compare only static preset host profiles.
+   * The full MCPJam app keeps live project hosts available.
+   */
+  presetOnly?: boolean;
 }
 
 /**
@@ -43,26 +89,47 @@ interface HostConfigCompareViewProps {
 export function HostConfigCompareView({
   projectId,
   isAuthenticated,
+  presetOnly = false,
 }: HostConfigCompareViewProps) {
-  const { hosts: liveHosts, isLoading: listLoading } = useHostList({
-    isAuthenticated,
-    projectId,
-  });
+  const canQueryLiveHosts =
+    !presetOnly && isAuthenticated && shouldQueryProjectId(projectId);
+  const { hosts: queriedLiveHosts, isLoading: queriedListLoading } =
+    useHostList({
+      isAuthenticated: canQueryLiveHosts,
+      projectId,
+    });
+  const liveHosts = canQueryLiveHosts ? queriedLiveHosts : [];
+  const listLoading = canQueryLiveHosts ? queriedListLoading : false;
+  const selectionScopeId = presetOnly ? "public" : projectId ?? "";
 
   // Static host profiles (Claude, ChatGPT, Cursor, …) offered as opt-in
   // comparison columns even when the user hasn't created them — the same
   // best-effort profiles the server detail modal's Hosts tab renders. Threaded
   // with the current theme so preset configs match the rest of the app.
   const themeMode = usePreferencesStore((s) => s.themeMode);
+  const claudeCodeEnabled = useClaudeCodeHostEnabled();
+  const excludedPresetTemplateIds = useMemo(() => {
+    const excluded = new Set<"claude-code">();
+    if (!claudeCodeEnabled) excluded.add("claude-code");
+    return excluded;
+  }, [claudeCodeEnabled]);
   const presets = useMemo(
-    () => buildPresetCompareEntries(themeMode),
-    [themeMode],
+    () =>
+      buildPresetCompareEntries(
+        themeMode,
+        presetOnly
+          ? {
+              excludedTemplateIds: excludedPresetTemplateIds,
+            }
+          : undefined
+      ),
+    [themeMode, presetOnly, excludedPresetTemplateIds]
   );
 
   // Real created hosts first, then presets — what the selector chips iterate.
   const hosts = useMemo(
-    () => [...liveHosts, ...presets.hosts],
-    [liveHosts, presets.hosts],
+    () => (presetOnly ? presets.hosts : [...liveHosts, ...presets.hosts]),
+    [liveHosts, presetOnly, presets.hosts]
   );
 
   const [subjectsByHost, setSubjectsByHost] = useState<
@@ -72,52 +139,72 @@ export function HostConfigCompareView({
   const [divergingOnly, setDivergingOnly] = useState(false);
   const [supportFilter, setSupportFilter] = useState<SupportFilterMode>("all");
   const [fieldSearchQuery, setFieldSearchQuery] = useState("");
-  const [viewMode, setViewMode] = useState<CompareViewMode>("table");
+  const [viewMode, setViewMode] = useState<CompareViewMode>(() =>
+    getInitialCompareViewMode()
+  );
   const [showDescriptions, setShowDescriptions] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
+  const viewModeUserSetRef = useRef(false);
   // Tracks whether the initial URL-driven selection has been applied.
   // After the first resolve, subsequent URL changes are ignored — Compare
   // becomes the source of truth and mirrors back into the URL.
   const urlConsumedRef = useRef(false);
 
-  // Real created hosts only — drives the default selection and the
-  // ?hosts=-is-default suppression. Presets are never part of the default.
+  // Real created hosts drive the default selection in the full app. Public
+  // preset-only compare defaults to presets so caniuse.dev renders without auth.
   const liveHostIds = useMemo(
     () => liveHosts.map((host) => host.hostId),
-    [liveHosts],
+    [liveHosts]
+  );
+  const presetHostIds = useMemo(
+    () => presets.hosts.map((host) => host.hostId),
+    [presets.hosts]
+  );
+  const defaultHostIds = useMemo(
+    () => (presetOnly ? presetHostIds : liveHostIds),
+    [liveHostIds, presetHostIds, presetOnly]
   );
   // Every selectable id (real + preset). URL / stored selections reconcile
   // against this so a chosen preset column survives a reload.
-  const knownHostIds = useMemo(
-    () => hosts.map((host) => host.hostId),
-    [hosts],
-  );
+  const knownHostIds = useMemo(() => hosts.map((host) => host.hostId), [hosts]);
 
   useEffect(() => {
+    if (!presetOnly && !projectId) return;
     if (listLoading) return;
     const urlSelection = urlConsumedRef.current
       ? null
       : parseHostsParam(searchParams.get(HOSTS_QUERY_PARAM));
     urlConsumedRef.current = true;
-    setSelectedHostIds((previous) =>
-      resolveInitialHostCompareSelection({
-        projectId: projectId ?? "",
-        liveHostIds,
+    setSelectedHostIds((previous) => {
+      const next = resolveInitialHostCompareSelection({
+        projectId: selectionScopeId,
+        liveHostIds: defaultHostIds,
         knownHostIds,
         previousSelection: previous,
         urlSelection,
-      }),
-    );
-  }, [listLoading, liveHostIds, knownHostIds, projectId, searchParams]);
+      });
+      return sameStringArray(previous, next) ? previous : next;
+    });
+  }, [
+    defaultHostIds,
+    knownHostIds,
+    listLoading,
+    presetOnly,
+    projectId,
+    searchParams,
+    selectionScopeId,
+  ]);
 
   useEffect(() => {
-    if (!projectId || selectedHostIds.length === 0) return;
-    writeHostCompareSelection(projectId, selectedHostIds);
-  }, [projectId, selectedHostIds]);
+    if (!presetOnly && !projectId) return;
+    if (selectedHostIds.length === 0) return;
+    writeHostCompareSelection(selectionScopeId, selectedHostIds);
+  }, [presetOnly, projectId, selectionScopeId, selectedHostIds]);
 
   // Mirror selection → ?hosts=. Suppress when the selection is the default
   // "all live hosts" (in original order) so shared links stay clean.
   useEffect(() => {
+    if (!presetOnly && !projectId) return;
     if (!urlConsumedRef.current) return;
     if (listLoading) return;
     // Skip while the selection hasn't been resolved yet. The selection
@@ -130,8 +217,8 @@ export function HostConfigCompareView({
     // `minSelected=1`), so an empty selection means "not yet resolved."
     if (selectedHostIds.length === 0) return;
     const isDefault =
-      selectedHostIds.length === liveHostIds.length &&
-      selectedHostIds.every((id, i) => id === liveHostIds[i]);
+      selectedHostIds.length === defaultHostIds.length &&
+      selectedHostIds.every((id, i) => id === defaultHostIds[i]);
     const current = searchParams.get(HOSTS_QUERY_PARAM);
     if (isDefault) {
       if (current === null) return;
@@ -145,7 +232,15 @@ export function HostConfigCompareView({
     const next = new URLSearchParams(searchParams);
     next.set(HOSTS_QUERY_PARAM, desired);
     setSearchParams(next, { replace: true });
-  }, [selectedHostIds, liveHostIds, listLoading, searchParams, setSearchParams]);
+  }, [
+    selectedHostIds,
+    defaultHostIds,
+    listLoading,
+    presetOnly,
+    projectId,
+    searchParams,
+    setSearchParams,
+  ]);
 
   const reportSubject = useCallback(
     (hostId: string, subject: HostComparisonSubject) => {
@@ -161,7 +256,7 @@ export function HostConfigCompareView({
         return { ...prev, [hostId]: subject };
       });
     },
-    [],
+    []
   );
 
   useEffect(() => {
@@ -180,20 +275,22 @@ export function HostConfigCompareView({
 
   const selectedHostIdSet = useMemo(
     () => new Set(selectedHostIds),
-    [selectedHostIds],
+    [selectedHostIds]
   );
 
   // Preset subjects are static and available immediately; fetched real-host
   // subjects (keyed by Convex id, no prefix collision) layer on top.
   const allSubjects = useMemo(
     () => ({ ...presets.subjects, ...subjectsByHost }),
-    [presets.subjects, subjectsByHost],
+    [presets.subjects, subjectsByHost]
   );
 
   const orderedSubjects = useMemo(() => {
     return selectedHostIds
       .map((hostId) => allSubjects[hostId])
-      .filter((subject): subject is HostComparisonSubject => subject !== undefined);
+      .filter(
+        (subject): subject is HostComparisonSubject => subject !== undefined
+      );
   }, [selectedHostIds, allSubjects]);
 
   const loadedSelectedCount = orderedSubjects.length;
@@ -201,10 +298,51 @@ export function HostConfigCompareView({
   const allSelectedLoaded =
     !listLoading && loadedSelectedCount === totalSelectedCount;
 
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+
+    const media = window.matchMedia(MOBILE_COMPARE_MEDIA_QUERY);
+    const syncModeToViewport = () => {
+      if (viewModeUserSetRef.current) return;
+      setViewMode(media.matches ? "list" : "table");
+    };
+
+    syncModeToViewport();
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", syncModeToViewport);
+      return () => media.removeEventListener("change", syncModeToViewport);
+    }
+
+    media.addListener(syncModeToViewport);
+    return () => media.removeListener(syncModeToViewport);
+  }, []);
+
   const handleToggleHost = useCallback((hostId: string) => {
     setSelectedHostIds((previous) =>
-      toggleHostCompareSelection(previous, hostId),
+      toggleHostCompareSelection(previous, hostId)
     );
+  }, []);
+
+  const handleViewModeChange = useCallback(
+    (mode: CompareViewMode) => {
+      if (mode === "list" && showDescriptions) return;
+      viewModeUserSetRef.current = true;
+      setViewMode(mode);
+    },
+    [showDescriptions]
+  );
+
+  const handleShowDescriptionsChange = useCallback((enabled: boolean) => {
+    setShowDescriptions(enabled);
+    if (enabled) {
+      viewModeUserSetRef.current = true;
+      setViewMode("table");
+    }
   }, []);
 
   // "N / M fields" count for the search header — same predicate the matrix and
@@ -223,17 +361,23 @@ export function HostConfigCompareView({
       if (isSupportField(hostConfigField(id))) n += 1;
     }
     return n;
-  }, [orderedSubjects, divergingOnly, supportFilter, fieldSearchQuery, viewMode]);
+  }, [
+    orderedSubjects,
+    divergingOnly,
+    supportFilter,
+    fieldSearchQuery,
+    viewMode,
+  ]);
 
   const totalFieldCount = useMemo(
     () =>
       viewMode === "list"
         ? HOST_CONFIG_FIELDS.filter(isSupportField).length
         : HOST_CONFIG_FIELDS.length,
-    [viewMode],
+    [viewMode]
   );
 
-  if (!projectId) {
+  if (!presetOnly && !projectId) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
         Sign in to compare your hosts.
@@ -242,7 +386,12 @@ export function HostConfigCompareView({
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background">
+    <div
+      className={cn(
+        "flex h-full min-h-0 flex-col bg-background",
+        presetOnly && "min-w-0 overflow-hidden"
+      )}
+    >
       {selectedHostIds.map((hostId) => {
         // Only real hosts hydrate over the wire — preset subjects are already
         // in `presets.subjects`, so a preset id finds no `liveHosts` row and
@@ -261,7 +410,13 @@ export function HostConfigCompareView({
         );
       })}
 
-      <div className="flex-1 min-h-0 overflow-auto p-4 md:p-8">
+      <div
+        className={cn(
+          presetOnly
+            ? "min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-3 pt-1 sm:px-4 sm:pb-4 sm:pt-2 md:px-6 md:pb-6 md:pt-2"
+            : "min-h-0 flex-1 overflow-auto p-4 md:p-8"
+        )}
+      >
         {listLoading ? (
           <LoadingState label="Loading hosts…" />
         ) : hosts.length === 0 ? (
@@ -280,7 +435,9 @@ export function HostConfigCompareView({
               totalCount={totalFieldCount}
               showCount={orderedSubjects.length > 0}
               viewMode={viewMode}
-              onViewModeChange={setViewMode}
+              onViewModeChange={handleViewModeChange}
+              disableListView={showDescriptions}
+              mobileOptimized={presetOnly}
             />
 
             <HostCompareSelector
@@ -293,9 +450,11 @@ export function HostConfigCompareView({
               supportFilter={supportFilter}
               onSupportFilterChange={setSupportFilter}
               showDescriptions={showDescriptions}
-              onShowDescriptionsChange={setShowDescriptions}
+              onShowDescriptionsChange={handleShowDescriptionsChange}
+              descriptionsDisabled={viewMode === "list"}
               disabled={listLoading}
               themeMode={themeMode}
+              mobileOptimized={presetOnly}
             />
 
             {totalSelectedCount === 0 ? (
@@ -321,6 +480,7 @@ export function HostConfigCompareView({
                     searchQuery={fieldSearchQuery}
                     showDescriptions={showDescriptions}
                     themeMode={themeMode}
+                    mobileOptimized={presetOnly}
                     onRemoveHost={
                       selectedHostIdSet.size > 1 ? handleToggleHost : undefined
                     }
@@ -332,6 +492,7 @@ export function HostConfigCompareView({
                     supportFilter={supportFilter}
                     searchQuery={fieldSearchQuery}
                     themeMode={themeMode}
+                    mobileOptimized={presetOnly}
                   />
                 )}
               </>
@@ -385,6 +546,8 @@ function CompareSearchBar({
   showCount,
   viewMode,
   onViewModeChange,
+  disableListView = false,
+  mobileOptimized = false,
 }: {
   query: string;
   onQueryChange: (q: string) => void;
@@ -394,19 +557,140 @@ function CompareSearchBar({
   showCount: boolean;
   viewMode: CompareViewMode;
   onViewModeChange: (mode: CompareViewMode) => void;
+  disableListView?: boolean;
+  mobileOptimized?: boolean;
 }) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const searchAnchorRef = useRef<HTMLDivElement | null>(null);
+  const fieldGroups = useMemo(
+    () =>
+      groupHostConfigFields(
+        HOST_CONFIG_FIELDS.filter(
+          (field) => !SEARCH_PICKER_HIDDEN_FIELD_IDS.has(field.id)
+        )
+      ),
+    []
+  );
+  const filteredFieldGroups = useMemo(() => {
+    const loweredQuery = query.trim().toLowerCase();
+    return fieldGroups
+      .map((group) => ({
+        ...group,
+        subsections: group.subsections
+          .map((subsection) => ({
+            ...subsection,
+            fields: subsection.fields.filter((field) =>
+              fieldMatchesQuery(field, loweredQuery)
+            ),
+          }))
+          .filter((subsection) => subsection.fields.length > 0),
+      }))
+      .filter((group) => group.subsections.length > 0);
+  }, [fieldGroups, query]);
+
+  const handleSelectField = useCallback(
+    (field: HostConfigFieldDef) => {
+      onQueryChange(field.label);
+      setPickerOpen(false);
+    },
+    [onQueryChange]
+  );
+
+  const keepPickerOpenForSearchAnchor = useCallback(
+    (event: CustomEvent<{ originalEvent?: Event }>) => {
+      const target = (event.detail.originalEvent?.target ??
+        event.target) as Node | null;
+      if (target && searchAnchorRef.current?.contains(target)) {
+        event.preventDefault();
+      }
+    },
+    []
+  );
+
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-3">
-      <span className="shrink-0 text-[15px] font-medium tracking-tight text-foreground">
-        Can I use…
-      </span>
-      <SearchInput
-        value={query}
-        onValueChange={onQueryChange}
-        placeholder="Search capabilities, fields, descriptions…"
-        aria-label="Search host config fields"
-        className="order-last w-full sm:order-none sm:w-auto sm:min-w-[240px] sm:flex-1"
-      />
+    <div
+      className={cn(
+        "mb-4 flex flex-wrap items-center gap-3",
+        mobileOptimized && "min-w-0 items-stretch"
+      )}
+    >
+      {!mobileOptimized && (
+        <span className="shrink-0 text-[15px] font-medium tracking-tight text-foreground">
+          Can I use…
+        </span>
+      )}
+      <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+        <PopoverAnchor asChild>
+          <div
+            ref={searchAnchorRef}
+            className={cn(
+              mobileOptimized
+                ? "order-first min-w-0 flex-[1_1_100%]"
+                : "order-last w-full sm:order-none sm:w-auto sm:min-w-[240px] sm:flex-1"
+            )}
+          >
+            <SearchInput
+              value={query}
+              onValueChange={(next) => {
+                onQueryChange(next);
+                setPickerOpen(true);
+              }}
+              onFocus={() => setPickerOpen(true)}
+              placeholder="Search capabilities, fields, descriptions…"
+              aria-label="Search host config fields"
+              className="w-full"
+            />
+          </div>
+        </PopoverAnchor>
+        <PopoverContent
+          align="start"
+          className="w-[min(420px,calc(100vw-2rem))] p-0"
+          onFocusOutside={keepPickerOpenForSearchAnchor}
+          onInteractOutside={keepPickerOpenForSearchAnchor}
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <Command shouldFilter={false}>
+            <CommandList className="max-h-[320px]">
+              <CommandEmpty>No matching fields.</CommandEmpty>
+              {filteredFieldGroups.map((group) => (
+                <CommandGroup
+                  key={group.section.id}
+                  heading={group.section.label}
+                >
+                  {group.subsections.map((subsection) =>
+                    subsection.fields.map((field) => (
+                      <CommandItem
+                        key={field.id}
+                        value={`${field.label} ${field.id} ${field.path} ${
+                          field.subsection
+                        } ${field.description ?? ""}`}
+                        onSelect={() => handleSelectField(field)}
+                        className="items-start py-2"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className="truncate text-[13px] font-medium">
+                              {field.label}
+                            </span>
+                            <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                              {subsection.label}
+                            </span>
+                          </div>
+                          {field.description ? (
+                            <p className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-muted-foreground">
+                              {field.description}
+                            </p>
+                          ) : null}
+                        </div>
+                      </CommandItem>
+                    ))
+                  )}
+                </CommandGroup>
+              ))}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
       {showCount && (
         <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
           {matchCount} / {totalCount} fields
@@ -424,19 +708,27 @@ function CompareSearchBar({
           ] as const
         ).map((v) => {
           const active = viewMode === v.value;
+          const disabled = v.value === "list" && disableListView;
           return (
             <button
               key={v.value}
               type="button"
               aria-pressed={active}
+              disabled={disabled}
+              title={
+                disabled
+                  ? "Turn descriptions off before switching to list view"
+                  : undefined
+              }
               data-testid={`compare-view-${v.value}`}
               onClick={() => onViewModeChange(v.value)}
               className={cn(
                 "rounded-full px-2.5 py-0.5 text-[11px] transition-colors",
+                "disabled:cursor-not-allowed disabled:opacity-40",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
                 active
                   ? "bg-primary/10 text-foreground"
-                  : "text-muted-foreground hover:text-foreground",
+                  : "text-muted-foreground hover:text-foreground"
               )}
             >
               {v.label}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCapabilityListView.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCapabilityListView.test.tsx
@@ -7,7 +7,7 @@ import { HostCapabilityListView } from "../HostCapabilityListView";
 function makeSubject(
   hostId: string,
   hostName: string,
-  overrides: Partial<HostConfigDtoV2> = {},
+  overrides: Partial<HostConfigDtoV2> = {}
 ): HostComparisonSubject {
   return {
     hostId,
@@ -36,11 +36,11 @@ function makeSubject(
 describe("HostCapabilityListView", () => {
   it("renders a column per host with grouped support walls", () => {
     render(
-      <HostCapabilityListView subjects={[makeSubject("h_a", "Claude Code")]} />,
+      <HostCapabilityListView subjects={[makeSubject("h_a", "Claude Code")]} />
     );
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
     // At least one group heading appears, and capability chips render in walls.
-    const groups = screen.queryAllByText(/Supported|Not advertised|Partial/);
+    const groups = screen.queryAllByText(/Supported|Not supported|Partial/);
     expect(groups.length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("openLinks").length).toBeGreaterThanOrEqual(1);
   });
@@ -57,7 +57,7 @@ describe("HostCapabilityListView", () => {
       <HostCapabilityListView
         subjects={[makeSubject("h_a", "Claude Code")]}
         searchQuery="zzz-no-such-capability"
-      />,
+      />
     );
     expect(screen.getByText(/No capabilities match/i)).toBeInTheDocument();
   });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostCompareSelector.test.tsx
@@ -100,4 +100,24 @@ describe("HostCompareSelector", () => {
     await user.click(screen.getByTestId("support-filter-missing"));
     expect(onSupportFilterChange).toHaveBeenCalledWith("missing");
   });
+
+  it("disables the diverging toggle when the selector is disabled", () => {
+    render(
+      <HostCompareSelector
+        hosts={[makeHost("h_a", "Claude")]}
+        selectedHostIds={["h_a"]}
+        subjectsByHost={{}}
+        onToggleHost={vi.fn()}
+        divergingOnly={false}
+        onDivergingOnlyChange={vi.fn()}
+        supportFilter="all"
+        onSupportFilterChange={vi.fn()}
+        showDescriptions={false}
+        onShowDescriptionsChange={vi.fn()}
+        disabled
+      />
+    );
+
+    expect(screen.getByLabelText("Show only diverging fields")).toBeDisabled();
+  });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -15,6 +15,11 @@ vi.mock("@/hooks/useClients", () => ({
   useHost: () => ({ host: null, isLoading: false }),
 }));
 
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => false,
+  usePostHog: () => ({ capture: () => undefined }),
+}));
+
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: () => "light",
 }));

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -74,7 +74,7 @@ describe("HostConfigCompareView public mode", () => {
     expect(
       screen.getByLabelText("Search host config fields")
     ).toBeInTheDocument();
-    expect(screen.queryByText("Can I use…")).not.toBeInTheDocument();
+    expect(screen.getByText("Can I use…")).toBeInTheDocument();
     expect(
       screen.getByTestId("host-compare-chip-preset:claude")
     ).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HostConfigCompareView } from "../HostConfigCompareView";
+
+const mockHostListState = vi.hoisted(() => ({
+  hosts: [] as any[],
+}));
+
+const originalMatchMedia = window.matchMedia;
+
+vi.mock("@/hooks/useClients", () => ({
+  useHostList: () => ({ hosts: mockHostListState.hosts, isLoading: false }),
+  useHost: () => ({ host: null, isLoading: false }),
+}));
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: () => "light",
+}));
+
+function makeHost(hostId: string, name: string) {
+  return {
+    hostId,
+    name,
+    hostConfigId: `hc_${hostId}`,
+    modelId: "claude-sonnet-4-6",
+    serverCount: 0,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function mockMobileViewport() {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(max-width: 640px)",
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe("HostConfigCompareView public mode", () => {
+  beforeEach(() => {
+    mockHostListState.hosts = [];
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it("renders preset compare content without requiring sign-in or a project", async () => {
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/Sign in to compare/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Search host config fields")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Can I use…")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("host-compare-chip-preset:claude")
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Select at least one client/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the full app no-project state behind sign-in", () => {
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView projectId={null} isAuthenticated={false} />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText(/Sign in to compare your hosts/i)
+    ).toBeInTheDocument();
+  });
+
+  it("prevents list mode and descriptions from being active together", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByLabelText("Show field descriptions"));
+    expect(screen.getByTestId("compare-view-list")).toBeDisabled();
+
+    await user.click(screen.getByLabelText("Show field descriptions"));
+    await user.click(screen.getByTestId("compare-view-list"));
+    expect(screen.getByLabelText("Show field descriptions")).toBeDisabled();
+  });
+
+  it("defaults the full MCPJam compare page to list view on phone", () => {
+    mockMobileViewport();
+    mockHostListState.hosts = [makeHost("h_claude", "Claude")];
+
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView projectId="abc123" isAuthenticated />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId("compare-view-list")).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-presets.test.ts
@@ -30,4 +30,16 @@ describe("host-compare-presets", () => {
     expect(hosts.every((h) => isPresetHostId(h.hostId))).toBe(true);
     expect(isPresetHostId("k1234567890abcdef")).toBe(false);
   });
+
+  it("omits excluded gated templates", () => {
+    const { hosts, subjects } = buildPresetCompareEntries("light", {
+      excludedTemplateIds: new Set(["claude-code"]),
+    });
+
+    const hostIds = hosts.map((h) => h.hostId);
+    expect(hostIds).not.toContain(`${PRESET_HOST_ID_PREFIX}claude-code`);
+    expect(hostIds).toContain(`${PRESET_HOST_ID_PREFIX}codex`);
+    expect(subjects[`${PRESET_HOST_ID_PREFIX}claude-code`]).toBeUndefined();
+    expect(subjects[`${PRESET_HOST_ID_PREFIX}codex`]).toBeDefined();
+  });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
@@ -28,7 +28,7 @@ function makeSubject(
   hostId: string,
   hostName: string,
   overrides: Partial<HostConfigDtoV2> = {},
-  configHashShort?: string,
+  configHashShort?: string
 ): HostComparisonSubject {
   return {
     hostId,
@@ -42,22 +42,19 @@ function makeSubject(
 describe("HostConfigComparisonMatrix", () => {
   it("renders the empty-state hint when no subjects are passed", () => {
     render(<HostConfigComparisonMatrix subjects={[]} />);
-    expect(
-      screen.getByText(/No hosts to compare/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No hosts to compare/i)).toBeInTheDocument();
   });
 
   it("renders the three section bands in the canonical order", () => {
     render(
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a3f9d2_claude", "Claude Code")]}
-      />,
+      />
     );
-    const sections = screen.getAllByRole("columnheader", { hidden: true })
+    const sections = screen
+      .getAllByRole("columnheader", { hidden: true })
       .map((el) => el.textContent ?? "")
-      .filter((text) =>
-        /^Agent|^MCP Protocol|^Apps/.test(text.trim()),
-      );
+      .filter((text) => /^Agent|^MCP Protocol|^Apps/.test(text.trim()));
     // The first three matching headers should be Agent → MCP Protocol → Apps.
     expect(sections.length).toBeGreaterThanOrEqual(3);
     expect(sections[0]).toMatch(/^Agent/);
@@ -70,9 +67,14 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[
           makeSubject("h_claude_001", "Claude Code", {}, "a3f9d2"),
-          makeSubject("h_cursor_002", "Cursor", { hostStyle: "cursor" }, "1b8e44"),
+          makeSubject(
+            "h_cursor_002",
+            "Cursor",
+            { hostStyle: "cursor" },
+            "1b8e44"
+          ),
         ]}
-      />,
+      />
     );
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
     expect(screen.getByText("Cursor")).toBeInTheDocument();
@@ -85,7 +87,7 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_goose_001", "Goose", { hostStyle: "goose" }, "goose1"),
         ]}
         themeMode="dark"
-      />,
+      />
     );
 
     const header = screen.getByText("Goose").closest("th");
@@ -100,22 +102,21 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_a", "A", { temperature: 0.2 }),
           makeSubject("h_b", "B", { temperature: 0.7 }),
         ]}
-      />,
+      />
     );
-    expect(screen.getByTestId("diverge-gutter-temperature")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("diverge-gutter-temperature")
+    ).toBeInTheDocument();
   });
 
   it("omits the diverge gutter on rows that agree", () => {
     render(
       <HostConfigComparisonMatrix
-        subjects={[
-          makeSubject("h_a", "A"),
-          makeSubject("h_b", "B"),
-        ]}
-      />,
+        subjects={[makeSubject("h_a", "A"), makeSubject("h_b", "B")]}
+      />
     );
     expect(
-      screen.queryByTestId("diverge-gutter-temperature"),
+      screen.queryByTestId("diverge-gutter-temperature")
     ).not.toBeInTheDocument();
   });
 
@@ -127,10 +128,12 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_b", "B", { temperature: 0.7 }),
         ]}
         divergingOnly
-      />,
+      />
     );
     // temperature differs → still visible
-    expect(screen.getByTestId("diverge-gutter-temperature")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("diverge-gutter-temperature")
+    ).toBeInTheDocument();
     // modelId is identical across both → row hidden
     expect(screen.queryByText("modelId")).not.toBeInTheDocument();
   });
@@ -142,35 +145,31 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_a", "A", { requireToolApproval: true }),
           makeSubject("h_b", "B", { requireToolApproval: false }),
         ]}
-      />,
+      />
     );
     expect(screen.getAllByText("Yes").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("No").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders progressiveToolDiscovery=undefined as Auto (tri-state)", () => {
-    render(
-      <HostConfigComparisonMatrix
-        subjects={[makeSubject("h_a", "A")]}
-      />,
-    );
+    render(<HostConfigComparisonMatrix subjects={[makeSubject("h_a", "A")]} />);
     expect(screen.getAllByText("Auto").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders client capabilities as Advertised / Not advertised chips", () => {
+  it("renders client capabilities as Supported / Not supported chips", () => {
     render(
       <HostConfigComparisonMatrix
         subjects={[
           makeSubject("h_a", "A", { clientCapabilities: { sampling: {} } }),
         ]}
-      />,
+      />
     );
-    // sampling present → Advertised
-    expect(screen.getAllByText("Advertised").length).toBeGreaterThanOrEqual(1);
-    // roots/elicitation/experimental absent → Not advertised
-    expect(
-      screen.getAllByText("Not advertised").length,
-    ).toBeGreaterThanOrEqual(1);
+    // sampling present → Supported
+    expect(screen.getAllByText("Supported").length).toBeGreaterThanOrEqual(1);
+    // roots/elicitation/experimental absent → Not supported
+    expect(screen.getAllByText("Not supported").length).toBeGreaterThanOrEqual(
+      1
+    );
   });
 
   it("shows a per-row coverage stat for capability rows", () => {
@@ -180,12 +179,12 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_a", "A", { clientCapabilities: { sampling: {} } }),
           makeSubject("h_b", "B", { clientCapabilities: {} }),
         ]}
-      />,
+      />
     );
     // sampling supported by 1 of 2 hosts
-    expect(screen.getByTestId("coverage-capabilities.sampling")).toHaveTextContent(
-      "1/2",
-    );
+    expect(
+      screen.getByTestId("coverage-capabilities.sampling")
+    ).toHaveTextContent("1/2");
     // scalar rows get no coverage stat
     expect(screen.queryByTestId("coverage-modelId")).not.toBeInTheDocument();
   });
@@ -194,7 +193,7 @@ describe("HostConfigComparisonMatrix", () => {
     render(
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a", "A", { hostStyle: "claude" })]}
-      />,
+      />
     );
     // Effective MCP Apps + OpenAI shim dimensions render as their own rows…
     expect(screen.getByText("openLinks")).toBeInTheDocument();
@@ -203,7 +202,9 @@ describe("HostConfigComparisonMatrix", () => {
     expect(screen.getByText("camera")).toBeInTheDocument();
     // …and the old opaque override rows are gone.
     expect(screen.queryByText("Spec-bridge overrides")).not.toBeInTheDocument();
-    expect(screen.queryByText("Permissions allow-list")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Permissions allow-list")
+    ).not.toBeInTheDocument();
   });
 
   it("filters rows live by search query", () => {
@@ -211,7 +212,7 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a", "A")]}
         searchQuery="temperature"
-      />,
+      />
     );
     expect(screen.getByText("Temperature")).toBeInTheDocument();
     expect(screen.queryByText("Model")).not.toBeInTheDocument();
@@ -222,7 +223,7 @@ describe("HostConfigComparisonMatrix", () => {
       <HostConfigComparisonMatrix
         subjects={[makeSubject("h_a", "A")]}
         searchQuery="zzz-no-such-field"
-      />,
+      />
     );
     expect(screen.getByText(/No fields match/i)).toBeInTheDocument();
   });
@@ -235,7 +236,7 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_b", "B", { clientCapabilities: { sampling: {} } }),
         ]}
         supportFilter="missing"
-      />,
+      />
     );
     // sampling supported by all → hidden
     expect(screen.queryByText("Sampling")).not.toBeInTheDocument();
@@ -251,12 +252,9 @@ describe("HostConfigComparisonMatrix", () => {
 
     render(
       <HostConfigComparisonMatrix
-        subjects={[
-          makeSubject("h_a", "A"),
-          makeSubject("h_b", "B"),
-        ]}
+        subjects={[makeSubject("h_a", "A"), makeSubject("h_b", "B")]}
         onRemoveHost={onRemoveHost}
-      />,
+      />
     );
 
     await user.click(screen.getByTestId("host-compare-remove-h_b"));

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/support-level.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/support-level.test.ts
@@ -223,6 +223,12 @@ describe("fieldMatchesQuery / computeVisibleFieldIds", () => {
     expect(fieldMatchesQuery(hostConfigField("temperature"), "zzz")).toBe(false);
   });
 
+  it("matches fields by subsection name", () => {
+    expect(
+      fieldMatchesQuery(hostConfigField("capabilities.roots"), "supported"),
+    ).toBe(true);
+  });
+
   it("narrows visible ids by search query", () => {
     const all = computeVisibleFieldIds({
       configs: [makeConfig()],

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-presets.ts
@@ -2,7 +2,7 @@ import type { HostThemeMode } from "@/lib/client-styles/types";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 import type { HostListItem } from "@/hooks/useClients";
 import type { HostComparisonSubject } from "@/lib/host-config-field-schema";
-import { HOST_TEMPLATES } from "@/lib/client-templates";
+import { HOST_TEMPLATES, type HostTemplateId } from "@/lib/client-templates";
 
 /**
  * Static host profiles surfaced in Host Compare so a user can compare against
@@ -28,6 +28,10 @@ export interface PresetCompareEntries {
   subjects: Record<string, HostComparisonSubject>;
 }
 
+interface PresetCompareOptions {
+  excludedTemplateIds?: ReadonlySet<HostTemplateId>;
+}
+
 /**
  * Build the preset selector chips + their comparison subjects from the host
  * template catalog. A template `seed()` returns a `HostConfigInputV2`, which is
@@ -40,11 +44,14 @@ export interface PresetCompareEntries {
  */
 export function buildPresetCompareEntries(
   theme: HostThemeMode,
+  options: PresetCompareOptions = {},
 ): PresetCompareEntries {
   const hosts: HostListItem[] = [];
   const subjects: Record<string, HostComparisonSubject> = {};
 
   for (const template of HOST_TEMPLATES) {
+    if (options.excludedTemplateIds?.has(template.id)) continue;
+
     const hostId = `${PRESET_HOST_ID_PREFIX}${template.id}`;
     const input = template.seed({ theme });
     const config: HostConfigDtoV2 = {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -48,6 +48,7 @@ interface HostConfigComparisonMatrixProps {
   /** Remove a column; omitted when only one host remains. */
   onRemoveHost?: (hostId: string) => void;
   themeMode?: HostThemeMode;
+  mobileOptimized?: boolean;
 }
 
 /**
@@ -66,6 +67,7 @@ export function HostConfigComparisonMatrix({
   showDescriptions = false,
   onRemoveHost,
   themeMode = "light",
+  mobileOptimized = false,
 }: HostConfigComparisonMatrixProps) {
   const groups = useMemo(() => groupHostConfigFields(HOST_CONFIG_FIELDS), []);
   const configs = useMemo(() => subjects.map((s) => s.config), [subjects]);
@@ -89,7 +91,7 @@ export function HostConfigComparisonMatrix({
         supportFilter,
         searchQuery,
       }),
-    [configs, divergingOnly, supportFilter, searchQuery],
+    [configs, divergingOnly, supportFilter, searchQuery]
   );
 
   if (subjects.length === 0) {
@@ -113,65 +115,91 @@ export function HostConfigComparisonMatrix({
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-      className="overflow-hidden rounded-xl border border-border bg-card shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_30px_-18px_rgba(0,0,0,0.18)]"
+      className={cn(
+        "overflow-hidden rounded-xl border border-border bg-card shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_30px_-18px_rgba(0,0,0,0.18)]",
+        mobileOptimized && "min-w-0 max-w-full"
+      )}
     >
-      {/* Legend sits outside the horizontal scroll so it never slides off-screen on mobile. */}
-      <SupportLegend />
       {/* Only the table scrolls horizontally; field column stays sticky. */}
-      <div className="overflow-auto">
-      <table className="w-full border-collapse text-[13px]">
-        <colgroup>
-          <col className="w-[168px] sm:w-[300px]" />
-          {subjects.map((s) => (
-            <col key={s.hostId} className="w-[148px] sm:w-[220px]" />
-          ))}
-        </colgroup>
-
-        <thead>
-          <tr>
-            <th className="sticky left-0 top-0 z-30 bg-card border-b border-r border-border px-3 py-3 sm:px-5 sm:py-4 text-left">
-              <span className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                Field
-              </span>
-            </th>
+      <div
+        className={
+          mobileOptimized
+            ? "max-w-full overflow-x-auto overflow-y-visible [-webkit-overflow-scrolling:touch]"
+            : "overflow-auto"
+        }
+      >
+        <table
+          className={cn(
+            "border-collapse text-[13px]",
+            mobileOptimized ? "w-max min-w-full" : "w-full"
+          )}
+        >
+          <colgroup>
+            <col
+              className={
+                mobileOptimized
+                  ? "w-[140px] sm:w-[300px]"
+                  : "w-[168px] sm:w-[300px]"
+              }
+            />
             {subjects.map((s) => (
-              <HostColumnHeader
+              <col
                 key={s.hostId}
-                subject={s}
-                onRemove={onRemoveHost}
-                themeMode={themeMode}
+                className={
+                  mobileOptimized
+                    ? "w-[132px] sm:w-[220px]"
+                    : "w-[148px] sm:w-[220px]"
+                }
               />
             ))}
-          </tr>
-        </thead>
+          </colgroup>
 
-        <tbody>
-          {groups.map((group, groupIndex) => {
-            const visibleFieldsInGroup = group.subsections
-              .flatMap((sub) => sub.fields)
-              .filter((f) => visibleFieldIds.has(f.id));
-            if (visibleFieldsInGroup.length === 0) return null;
+          <thead>
+            <tr>
+              <th className="sticky left-0 top-0 z-30 bg-card border-b border-r border-border px-3 py-3 sm:px-5 sm:py-4 text-left">
+                <span className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                  Field
+                </span>
+              </th>
+              {subjects.map((s) => (
+                <HostColumnHeader
+                  key={s.hostId}
+                  subject={s}
+                  onRemove={onRemoveHost}
+                  themeMode={themeMode}
+                />
+              ))}
+            </tr>
+          </thead>
 
-            const groupDivergeCount = group.subsections
-              .flatMap((sub) => sub.fields)
-              .filter((f) => divergingIds.has(f.id)).length;
+          <tbody>
+            {groups.map((group, groupIndex) => {
+              const visibleFieldsInGroup = group.subsections
+                .flatMap((sub) => sub.fields)
+                .filter((f) => visibleFieldIds.has(f.id));
+              if (visibleFieldsInGroup.length === 0) return null;
 
-            return (
-              <SectionRows
-                key={group.section.id}
-                index={groupIndex}
-                sectionLabel={group.section.label}
-                divergeCount={groupDivergeCount}
-                subsections={group.subsections}
-                subjects={subjects}
-                divergingIds={divergingIds}
-                visibleFieldIds={visibleFieldIds}
-                showDescriptions={showDescriptions}
-              />
-            );
-          })}
-        </tbody>
-      </table>
+              const groupDivergeCount = group.subsections
+                .flatMap((sub) => sub.fields)
+                .filter((f) => divergingIds.has(f.id)).length;
+
+              return (
+                <SectionRows
+                  key={group.section.id}
+                  index={groupIndex}
+                  sectionLabel={group.section.label}
+                  divergeCount={groupDivergeCount}
+                  subsections={group.subsections}
+                  subjects={subjects}
+                  divergingIds={divergingIds}
+                  visibleFieldIds={visibleFieldIds}
+                  showDescriptions={showDescriptions}
+                  mobileOptimized={mobileOptimized}
+                />
+              );
+            })}
+          </tbody>
+        </table>
       </div>
     </motion.div>
   );
@@ -189,6 +217,7 @@ interface SectionRowsProps {
   divergingIds: ReadonlySet<string>;
   visibleFieldIds: ReadonlySet<string>;
   showDescriptions: boolean;
+  mobileOptimized: boolean;
 }
 
 function SectionRows({
@@ -200,6 +229,7 @@ function SectionRows({
   divergingIds,
   visibleFieldIds,
   showDescriptions,
+  mobileOptimized,
 }: SectionRowsProps) {
   const colSpan = subjects.length + 1;
   return (
@@ -229,7 +259,12 @@ function SectionRows({
                 className="inline-block size-1.5 rounded-full bg-primary/70"
                 initial={{ scale: 0 }}
                 animate={{ scale: 1 }}
-                transition={{ delay: 0.2 + index * 0.07, type: "spring", stiffness: 600, damping: 18 }}
+                transition={{
+                  delay: 0.2 + index * 0.07,
+                  type: "spring",
+                  stiffness: 600,
+                  damping: 18,
+                }}
               />
             )}
             <span className="ml-auto text-[10.5px] text-muted-foreground tabular-nums">
@@ -251,6 +286,7 @@ function SectionRows({
             divergingIds={divergingIds}
             colSpan={colSpan}
             showDescriptions={showDescriptions}
+            mobileOptimized={mobileOptimized}
           />
         );
       })}
@@ -265,6 +301,7 @@ function SubsectionRows({
   divergingIds,
   colSpan,
   showDescriptions,
+  mobileOptimized,
 }: {
   label: string;
   fields: ReadonlyArray<HostConfigFieldDef>;
@@ -272,6 +309,7 @@ function SubsectionRows({
   divergingIds: ReadonlySet<string>;
   colSpan: number;
   showDescriptions: boolean;
+  mobileOptimized: boolean;
 }) {
   return (
     <>
@@ -290,6 +328,7 @@ function SubsectionRows({
           subjects={subjects}
           diverges={divergingIds.has(field.id)}
           showDescriptions={showDescriptions}
+          mobileOptimized={mobileOptimized}
         />
       ))}
     </>
@@ -301,23 +340,28 @@ function FieldRow({
   subjects,
   diverges,
   showDescriptions,
+  mobileOptimized,
 }: {
   field: HostConfigFieldDef;
   subjects: ReadonlyArray<HostComparisonSubject>;
   diverges: boolean;
   showDescriptions: boolean;
+  mobileOptimized: boolean;
 }) {
   // caniuse "global support" equivalent — only meaningful when comparing ≥2 hosts.
   const coverage =
     subjects.length >= 2
-      ? rowCoverage(field, subjects.map((s) => s.config))
+      ? rowCoverage(
+          field,
+          subjects.map((s) => s.config)
+        )
       : null;
   return (
     <tr className="border-b border-border last:border-b-0">
       <td
         className={cn(
           "sticky left-0 z-10 bg-card border-r border-border px-3 sm:px-5 py-2.5",
-          "relative",
+          "relative"
         )}
       >
         {diverges && (
@@ -333,8 +377,18 @@ function FieldRow({
             }}
           />
         )}
-        <div className="flex items-center gap-1.5">
-          <span className="text-[13px] font-medium text-foreground leading-tight">
+        <div
+          className={cn(
+            "flex items-center gap-1.5",
+            mobileOptimized && "min-w-0"
+          )}
+        >
+          <span
+            className={cn(
+              "text-[13px] font-medium leading-tight text-foreground",
+              mobileOptimized && "min-w-0 break-words"
+            )}
+          >
             {field.label}
           </span>
           {coverage && (
@@ -378,7 +432,11 @@ function FieldRow({
           key={s.hostId}
           className="border-l border-border px-3 sm:px-4 py-2.5 align-top"
         >
-          <FieldCell field={field} subject={s} />
+          <FieldCell
+            field={field}
+            subject={s}
+            mobileOptimized={mobileOptimized}
+          />
         </td>
       ))}
     </tr>
@@ -388,9 +446,11 @@ function FieldRow({
 function FieldCell({
   field,
   subject,
+  mobileOptimized,
 }: {
   field: HostConfigFieldDef;
   subject: HostComparisonSubject;
+  mobileOptimized: boolean;
 }) {
   const value = field.read(subject.config);
   const kind = field.kind;
@@ -409,7 +469,9 @@ function FieldCell({
   switch (kind.kind) {
     case "boolean": {
       const level: SupportLevel = value === true ? "supported" : "neutral";
-      return <SupportChip level={level} label={value === true ? "Yes" : "No"} />;
+      return (
+        <SupportChip level={level} label={value === true ? "Yes" : "No"} />
+      );
     }
 
     case "tri-state": {
@@ -422,7 +484,7 @@ function FieldCell({
     case "capability": {
       const level = getSupportLevel(field, subject.config) ?? "neutral";
       if (value === undefined || value === null) {
-        return <SupportChip level={level} label="Not advertised" />;
+        return <SupportChip level={level} label="Not supported" />;
       }
       const caveats = getCapabilityCaveats(field, subject.config);
       const keys =
@@ -431,16 +493,11 @@ function FieldCell({
           : [];
       return (
         <span className="inline-flex items-center gap-2">
-          <SupportChip level={level} label="Advertised" caveats={caveats} />
-          {keys.length > 0 && (
-            <ExpandablePreview
-              label={`${keys.length} key${keys.length === 1 ? "" : "s"} ›`}
-            >
-              <pre className="whitespace-pre-wrap text-[11.5px] leading-snug font-mono max-w-[480px] max-h-[320px] overflow-auto">
-                {JSON.stringify(value, null, 2)}
-              </pre>
-            </ExpandablePreview>
-          )}
+          <SupportChip level={level} label="Supported" />
+          <CapabilityInfoTooltip
+            caveats={caveats}
+            value={keys.length > 0 ? value : undefined}
+          />
         </span>
       );
     }
@@ -469,7 +526,16 @@ function FieldCell({
         const level = getSupportLevel(field, subject.config) ?? "neutral";
         return <SupportChip level={level} label={String(value)} />;
       }
-      return <span className="text-[13px] text-foreground">{String(value)}</span>;
+      return (
+        <span
+          className={cn(
+            "text-[13px] text-foreground",
+            mobileOptimized && "break-words"
+          )}
+        >
+          {String(value)}
+        </span>
+      );
     }
 
     case "mode-set": {
@@ -501,10 +567,15 @@ function FieldCell({
       return (
         <div className="flex flex-col gap-0.5">
           <div className="text-[12px] truncate max-w-[200px]">
-            {firstLine || <span className="italic text-muted-foreground">empty</span>}
+            {firstLine || (
+              <span className="italic text-muted-foreground">empty</span>
+            )}
           </div>
           {s.length > 0 && (
-            <ExpandablePreview label={`view ${s.length.toLocaleString()} chars`}>
+            <ExpandablePreview
+              label={`view ${s.length.toLocaleString()} chars`}
+              mobileOptimized={mobileOptimized}
+            >
               <pre className="whitespace-pre-wrap text-[11.5px] leading-snug font-mono max-w-[480px] max-h-[320px] overflow-auto">
                 {s}
               </pre>
@@ -515,12 +586,20 @@ function FieldCell({
     }
 
     case "string-array": {
-      if (!Array.isArray(value)) return <span className="text-[12px] text-muted-foreground/60">—</span>;
+      if (!Array.isArray(value))
+        return <span className="text-[12px] text-muted-foreground/60">—</span>;
       if (value.length === 0) {
-        return <span className="text-[12px] text-muted-foreground/60">[] empty</span>;
+        return (
+          <span className="text-[12px] text-muted-foreground/60">[] empty</span>
+        );
       }
       return (
-        <span className="text-[13px] text-foreground leading-snug">
+        <span
+          className={cn(
+            "text-[13px] leading-snug text-foreground",
+            mobileOptimized && "break-words"
+          )}
+        >
           {value.join(", ")}
         </span>
       );
@@ -545,7 +624,10 @@ function FieldCell({
         const noun = kind.itemNoun ?? "key";
         return (
           <ExpandablePreview
-            label={`${entries.length} ${noun}${entries.length === 1 ? "" : "s"} ›`}
+            label={`${entries.length} ${noun}${
+              entries.length === 1 ? "" : "s"
+            } ›`}
+            mobileOptimized={mobileOptimized}
           >
             <pre className="whitespace-pre-wrap text-[11.5px] leading-snug font-mono max-w-[480px] max-h-[320px] overflow-auto">
               {JSON.stringify(value, null, 2)}
@@ -567,22 +649,49 @@ function FieldCell({
   }
 }
 
-/**
- * Decodes the chip colors. Labels are kind-agnostic because the same colors are
- * shared by booleans (Yes/No), tri-state (On/Off/Auto), and capabilities
- * (Advertised/Not advertised) — `neutral` covers all the "off / absent" states.
- * Red `unsupported` is omitted until a field maps to it.
- */
-function SupportLegend() {
+function CapabilityInfoTooltip({
+  caveats,
+  value,
+}: {
+  caveats: ReadonlyArray<string>;
+  value?: unknown;
+}) {
+  const hasCaveats = caveats.length > 0;
+  const hasValue = value !== undefined;
+  if (!hasCaveats && !hasValue) return null;
+
   return (
-    <div className="flex flex-wrap items-center justify-end gap-2.5 border-b border-border px-4 py-2">
-      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-        Support
-      </span>
-      <SupportChip level="supported" label="Supported" />
-      <SupportChip level="partial" label="Partial" />
-      <SupportChip level="neutral" label="Off / absent" />
-    </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label="Capability details"
+          className="inline-flex size-4 shrink-0 items-center justify-center rounded-full text-muted-foreground/70 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          <Info className="size-3" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        variant="muted"
+        className="max-w-[min(360px,calc(100vw-24px))] text-left [text-wrap:normal]"
+      >
+        <div className="space-y-2">
+          {hasCaveats ? (
+            <ul className="space-y-1">
+              {caveats.map((caveat) => (
+                <li key={caveat}>{caveat}</li>
+              ))}
+            </ul>
+          ) : null}
+          {hasValue ? (
+            <pre className="max-h-[240px] overflow-auto whitespace-pre-wrap font-mono text-[11px] leading-snug">
+              {JSON.stringify(value, null, 2)}
+            </pre>
+          ) : null}
+        </div>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -598,7 +707,7 @@ function HostColumnHeader({
   const logoSrc = getChatboxHostLogo(
     subject.hostStyle,
     subject.config.chatUiOverride,
-    themeMode,
+    themeMode
   );
   const reduceMotion = useReducedMotion();
 
@@ -630,7 +739,10 @@ function HostColumnHeader({
           alt=""
           className="mt-0.5 size-4 shrink-0 object-contain"
         />
-        <div className="min-w-0 font-medium text-[14px] truncate leading-tight" title={subject.hostName}>
+        <div
+          className="min-w-0 font-medium text-[14px] truncate leading-tight"
+          title={subject.hostName}
+        >
           {subject.hostName}
         </div>
       </motion.div>
@@ -648,9 +760,11 @@ function formatObjectValue(v: unknown): string {
 function ExpandablePreview({
   label,
   children,
+  mobileOptimized = false,
 }: {
   label: string;
   children: React.ReactNode;
+  mobileOptimized?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   return (
@@ -663,7 +777,14 @@ function ExpandablePreview({
           {label}
         </button>
       </PopoverTrigger>
-      <PopoverContent className="max-w-[520px] max-h-[400px] overflow-auto p-3">
+      <PopoverContent
+        className={cn(
+          "max-h-[400px] overflow-auto p-3",
+          mobileOptimized
+            ? "max-w-[calc(100vw-24px)] sm:max-w-[520px]"
+            : "max-w-[520px]"
+        )}
+      >
         {children}
       </PopoverContent>
     </Popover>

--- a/mcpjam-inspector/client/src/components/hosts/comparison/support-chip.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/support-chip.tsx
@@ -1,16 +1,10 @@
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@mcpjam/design-system/popover";
 import { cn } from "@/lib/utils";
 import type { SupportLevel } from "./support-level";
 
 /**
  * caniuse-style support pill: a colored dot + label. Tinted surface (`/40–/50`)
  * with a full-token dot and `text-foreground`, per the surface-vs-foreground
- * opacity convention. When `caveats` are present the chip grows a superscript
- * count and a popover footnote ("yes, with caveats").
+ * opacity convention.
  */
 
 const LEVEL_SURFACE: Record<SupportLevel, string> = {
@@ -30,61 +24,34 @@ const LEVEL_DOT: Record<SupportLevel, string> = {
 export function SupportChip({
   level,
   label,
-  caveats,
   className,
+  truncateLabel = false,
 }: {
   level: SupportLevel;
   label: string;
-  caveats?: ReadonlyArray<string>;
   className?: string;
+  truncateLabel?: boolean;
 }) {
-  const hasCaveats = !!caveats && caveats.length > 0;
-
-  const chip = (
+  return (
     <span
       data-support-level={level}
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5",
+        truncateLabel && "max-w-full",
         "text-[11px] font-medium leading-none whitespace-nowrap",
         LEVEL_SURFACE[level],
-        className,
+        className
       )}
     >
-      <span aria-hidden className={cn("size-1.5 rounded-full", LEVEL_DOT[level])} />
-      {label}
-      {hasCaveats && (
-        <sup className="ml-0.5 text-[9px] font-semibold tabular-nums">
-          {caveats!.length}
-        </sup>
+      <span
+        aria-hidden
+        className={cn("size-1.5 rounded-full", LEVEL_DOT[level])}
+      />
+      {truncateLabel ? (
+        <span className="min-w-0 truncate">{label}</span>
+      ) : (
+        label
       )}
     </span>
-  );
-
-  if (!hasCaveats) return chip;
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          aria-label={`${label} — ${caveats!.length} caveat${caveats!.length === 1 ? "" : "s"}`}
-          className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-        >
-          {chip}
-        </button>
-      </PopoverTrigger>
-      <PopoverContent className="max-w-[280px] p-3 text-[11.5px] leading-snug">
-        <ul className="space-y-1.5">
-          {caveats!.map((c, i) => (
-            <li key={i} className="flex gap-1.5">
-              <span className="shrink-0 text-muted-foreground tabular-nums">
-                {i + 1}.
-              </span>
-              <span>{c}</span>
-            </li>
-          ))}
-        </ul>
-      </PopoverContent>
-    </Popover>
   );
 }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
@@ -156,7 +156,7 @@ function normalizeFieldSearchText(value: string): string {
     .trim();
 }
 
-/** Free-text match against a field's label / description / id / path. */
+/** Free-text match against a field's label / subsection / description / id / path. */
 export function fieldMatchesQuery(
   field: HostConfigFieldDef,
   loweredQuery: string
@@ -167,7 +167,13 @@ export function fieldMatchesQuery(
   if (queryTokens.length === 0) return true;
 
   const haystackTokens = normalizeFieldSearchText(
-    [field.id, field.label, field.path, field.description ?? ""].join(" ")
+    [
+      field.id,
+      field.label,
+      field.subsection,
+      field.path,
+      field.description ?? "",
+    ].join(" ")
   )
     .split(/\s+/)
     .filter(Boolean);

--- a/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
@@ -45,7 +45,7 @@ export function isSupportField(field: HostConfigFieldDef): boolean {
  */
 export function getSupportLevel(
   field: HostConfigFieldDef,
-  cfg: HostConfigDtoV2,
+  cfg: HostConfigDtoV2
 ): SupportLevel | null {
   const value = field.read(cfg);
   switch (field.kind.kind) {
@@ -102,7 +102,7 @@ export function getSupportLevel(
 /** Support levels across every host for one row (support-shaped fields only). */
 export function rowSupportLevels(
   field: HostConfigFieldDef,
-  configs: ReadonlyArray<HostConfigDtoV2>,
+  configs: ReadonlyArray<HostConfigDtoV2>
 ): SupportLevel[] {
   return configs
     .map((c) => getSupportLevel(field, c))
@@ -115,7 +115,7 @@ export function rowSupportLevels(
  */
 export function rowCoverage(
   field: HostConfigFieldDef,
-  configs: ReadonlyArray<HostConfigDtoV2>,
+  configs: ReadonlyArray<HostConfigDtoV2>
 ): { supported: number; total: number } | null {
   if (!isSupportField(field)) return null;
   const levels = rowSupportLevels(field, configs);
@@ -132,7 +132,7 @@ export type SupportFilterMode = "all" | "missing" | "partial" | "supported";
 export function rowPassesSupportFilter(
   field: HostConfigFieldDef,
   configs: ReadonlyArray<HostConfigDtoV2>,
-  mode: SupportFilterMode,
+  mode: SupportFilterMode
 ): boolean {
   if (mode === "all") return true;
   if (!isSupportField(field)) return false;
@@ -148,16 +148,31 @@ export function rowPassesSupportFilter(
   }
 }
 
-/** Free-text match against a field's label / description / subsection. */
+function normalizeFieldSearchText(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/** Free-text match against a field's label / description / id / path. */
 export function fieldMatchesQuery(
   field: HostConfigFieldDef,
-  loweredQuery: string,
+  loweredQuery: string
 ): boolean {
-  if (!loweredQuery) return true;
-  return (
-    field.label.toLowerCase().includes(loweredQuery) ||
-    (field.description?.toLowerCase().includes(loweredQuery) ?? false) ||
-    field.subsection.toLowerCase().includes(loweredQuery)
+  const queryTokens = normalizeFieldSearchText(loweredQuery)
+    .split(/\s+/)
+    .filter(Boolean);
+  if (queryTokens.length === 0) return true;
+
+  const haystackTokens = normalizeFieldSearchText(
+    [field.id, field.label, field.path, field.description ?? ""].join(" ")
+  )
+    .split(/\s+/)
+    .filter(Boolean);
+  return queryTokens.every((part) =>
+    haystackTokens.some((token) => token.startsWith(part))
   );
 }
 
@@ -176,7 +191,8 @@ export function computeVisibleFieldIds(args: {
   const set = new Set<string>();
   for (const field of HOST_CONFIG_FIELDS) {
     if (args.divergingOnly && !fieldDiverges(field, args.configs)) continue;
-    if (!rowPassesSupportFilter(field, args.configs, args.supportFilter)) continue;
+    if (!rowPassesSupportFilter(field, args.configs, args.supportFilter))
+      continue;
     if (!fieldMatchesQuery(field, q)) continue;
     set.add(field.id);
   }
@@ -190,7 +206,7 @@ export function computeVisibleFieldIds(args: {
  */
 export function getCapabilityCaveats(
   field: HostConfigFieldDef,
-  cfg: HostConfigDtoV2,
+  cfg: HostConfigDtoV2
 ): string[] {
   const caveats: string[] = [];
   if (field.kind.kind !== "capability") return caveats;
@@ -199,15 +215,12 @@ export function getCapabilityCaveats(
   const rec = value as Record<string, unknown>;
 
   if (rec.listChanged === false) {
-    caveats.push("Advertised without list-changed notifications.");
+    caveats.push("Supported without list-changed notifications.");
   }
   if (field.id === "capabilities.sampling" && "tools" in rec) {
     caveats.push("Supports tool use in sampling (SEP-1577).");
   }
-  if (
-    field.id === "capabilities.experimental" &&
-    Object.keys(rec).length > 0
-  ) {
+  if (field.id === "capabilities.experimental" && Object.keys(rec).length > 0) {
     caveats.push("Vendor / experimental — outside the core capability set.");
   }
   return caveats;

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -472,7 +472,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
     subsection: "Version",
     label: "Supported protocol versions",
     path: "mcpProfile.initialize.supportedProtocolVersions",
-    description: "Accept-list advertised in the initialize handshake.",
+    description: "Accept-list supported in the initialize handshake.",
     kind: { kind: "string-array" },
     read: (cfg) => mcpProfile(cfg)?.initialize?.supportedProtocolVersions,
   },
@@ -508,12 +508,12 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   },
 
   // ============================================================
-  // Protocol · Client capabilities advertised
+  // Protocol · Client capabilities supported
   // ============================================================
   {
     id: "capabilities.roots",
     section: "protocol",
-    subsection: "Client capabilities advertised",
+    subsection: "Client capabilities supported",
     label: "Roots",
     path: "clientCapabilities.roots",
     description: "Filesystem roots exposed to the server.",
@@ -523,7 +523,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "capabilities.sampling",
     section: "protocol",
-    subsection: "Client capabilities advertised",
+    subsection: "Client capabilities supported",
     label: "Sampling",
     path: "clientCapabilities.sampling",
     description: "Server-initiated LLM calls.",
@@ -533,7 +533,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "capabilities.elicitation",
     section: "protocol",
-    subsection: "Client capabilities advertised",
+    subsection: "Client capabilities supported",
     label: "Elicitation",
     path: "clientCapabilities.elicitation",
     description: "Mid-call structured prompts back to the user.",
@@ -543,7 +543,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "capabilities.experimental",
     section: "protocol",
-    subsection: "Client capabilities advertised",
+    subsection: "Client capabilities supported",
     label: "Experimental",
     path: "clientCapabilities.experimental",
     description: "Vendor-extension capabilities.",
@@ -594,7 +594,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
     subsection: "MCP Apps spec bridge",
     label: "ui/initialize hostInfo",
     path: "mcpProfile.apps.uiInitialize.hostInfo",
-    description: "Override the `hostInfo` advertised in `ui/initialize`.",
+    description: "Override the `hostInfo` sent in `ui/initialize`.",
     kind: { kind: "object", itemNoun: "field" },
     read: (cfg) => mcpProfile(cfg)?.apps?.uiInitialize?.hostInfo,
   },


### PR DESCRIPTION
## Summary

This PR updates the shared Host Compare page so it can cleanly power **caniuse.dev** without making caniuse behave like the normal MCPJam app.

Important distinction:

- **caniuse.dev** uses the same compare UI code, but in `presetOnly` mode.
- **MCPJam Host Compare** keeps using normal project hosts + presets.

## What is caniuse-only

- Adds `presetOnly={bare}` so the shared compare view knows when it is rendering caniuse.dev.
- Removes the sign-in requirement on caniuse.dev.
- Shows only preset/default client templates on caniuse.dev, not saved MCPJam project hosts.
- Selecting clients on caniuse.dev does not change selections in MCPJam Host Compare.- Applies caniuse-specific mobile overflow fixes.
- Uses caniuse-specific top branding:
  - centered `Can I use…`
  - `Brought to you by MCPJam`
  - MCPJam logo links to the full app
- Hides the lower `Can I use…` search label on caniuse.dev and makes the search input full-width.
- Hides Claude Code from caniuse.dev when the existing `claude-code-host-enabled` flag is off.

## What is shared with MCPJam Host Compare

- `Advertised` copy is now `Supported`.
- Removed the support legend.
- Replaced the ugly `1 key`/click behavior with an info tooltip.
- List view and descriptions now disable each other.
- Search picker behavior.
- Model, System Prompt, and Temperature are hidden from the search picker.
- Phone view defaults to List mode for both caniuse.dev and normal MCPJam Host Compare.