### PR TITLE
fix(harness): provider-aware dispatch, fail-closed chatbox config, cloud-skills gate

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -194,6 +194,14 @@ vi.mock("../../../utils/guest-auth.js", () => ({
     .mockResolvedValue("Bearer guest-test-token"),
 }));
 
+// Chatbox turns must NEVER skip host-owned config resolution — the route
+// resolves a guest bearer for the fetch when the request carries none.
+const fetchChatboxRuntimeConfigMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../utils/chatbox-runtime-config.js", () => ({
+  fetchChatboxRuntimeConfig: (...args: unknown[]) =>
+    fetchChatboxRuntimeConfigMock(...args),
+}));
+
 // Mock http-tool-calls for testing unresolved tool calls scenario
 vi.mock("@/shared/http-tool-calls", () => ({
   hasUnresolvedToolCalls: vi.fn().mockReturnValue(false),
@@ -231,6 +239,60 @@ describe("POST /api/mcp/chat-v2", () => {
       getToolsForAiSdk: vi.fn().mockResolvedValue({}),
     });
     app = createTestApp(manager, "chat-v2");
+  });
+
+  describe("chatbox runtime-config gate", () => {
+    it("resolves the process guest bearer for a BEARER-LESS chatbox turn (config never skipped)", async () => {
+      fetchChatboxRuntimeConfigMock.mockResolvedValue({ ok: true, config: {} });
+
+      await postJson(app, "/api/mcp/chat-v2", {
+        chatboxId: "cbx_1",
+        messages: [{ role: "user", content: "hi" }],
+        model: { id: "gpt-4", provider: "openai" },
+      });
+
+      // The route mints a guest bearer later for MCPJam models, so "no
+      // incoming bearer" is not a hard stop — the config fetch must use the
+      // same process-cached guest bearer rather than being skipped.
+      expect(fetchChatboxRuntimeConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatboxId: "cbx_1",
+          bearer: "Bearer guest-test-token",
+        })
+      );
+    });
+
+    it("FAILS CLOSED (401) when a bearer-less chatbox turn can't resolve any bearer", async () => {
+      const { getProductionGuestAuthHeader } = await import(
+        "../../../utils/guest-auth.js"
+      );
+      vi.mocked(getProductionGuestAuthHeader).mockResolvedValueOnce(null);
+
+      const res = await postJson(app, "/api/mcp/chat-v2", {
+        chatboxId: "cbx_1",
+        messages: [{ role: "user", content: "hi" }],
+        model: { id: "gpt-4", provider: "openai" },
+      });
+
+      expect(res.status).toBe(401);
+      expect(fetchChatboxRuntimeConfigMock).not.toHaveBeenCalled();
+    });
+
+    it("fails closed when the chatbox config fetch itself fails", async () => {
+      fetchChatboxRuntimeConfigMock.mockResolvedValue({
+        ok: false,
+        status: 502,
+        error: "backend unreachable",
+      });
+
+      const res = await postAuthenticatedJson({
+        chatboxId: "cbx_1",
+        messages: [{ role: "user", content: "hi" }],
+        model: { id: "gpt-4", provider: "openai" },
+      });
+
+      expect(res.status).toBe(502);
+    });
   });
 
   describe("validation", () => {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -241,6 +241,26 @@ describe("POST /api/mcp/chat-v2", () => {
     app = createTestApp(manager, "chat-v2");
   });
 
+  describe("MCPJam model classification", () => {
+    it("classifies the model PROVIDER-AWARE (bare hosted ids must canonicalize)", async () => {
+      const { isMCPJamProvidedModel } = await import("@/shared/types");
+
+      await postAuthenticatedJson({
+        messages: [{ role: "user", content: "hi" }],
+        model: { id: "gpt-5-nano", provider: "openai" },
+      });
+
+      // The harness preflight is provider-aware; a provider-blind dispatch
+      // here would treat a bare hosted id as non-MCPJam and route it into
+      // org/BYOK after it passed preflight (same class of bug as the
+      // streamWebChatTurn dispatch).
+      expect(vi.mocked(isMCPJamProvidedModel)).toHaveBeenCalledWith(
+        "gpt-5-nano",
+        "openai"
+      );
+    });
+  });
+
   describe("chatbox runtime-config gate", () => {
     it("resolves the process guest bearer for a BEARER-LESS chatbox turn (config never skipped)", async () => {
       fetchChatboxRuntimeConfigMock.mockResolvedValue({ ok: true, config: {} });

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -316,8 +316,11 @@ chatV2.post("/", async (c) => {
     // Chatbox-bound turns re-resolve execution config from Convex so the
     // host's hostConfigs row is the source of truth (model / prompt /
     // temperature / requireToolApproval). Mirrors the web/chat-v2 path.
-    // Soft-fall-through on Convex blip — chat keeps running with body
-    // values, matching pre-rollout behavior.
+    // FAIL CLOSED on fetch failure — same rationale as the host-bound branch
+    // below: the fetched config is the only source of `harness`/`computer`
+    // and of every host-wins protection, so falling back to body values
+    // would silently downgrade a harness chatbox to the emulated engine and
+    // reopen the tampered-body window.
     //
     // PR 4c of the engine consolidation (`~/mcpjam-docs/unification.md`):
     // the field-by-field merge between body and `fetchChatboxRuntimeConfig`
@@ -348,12 +351,18 @@ chatV2.post("/", async (c) => {
           >;
         } else {
           logger.warn(
-            "[mcp/chat-v2] runtime-config fetch failed; using body values",
+            "[mcp/chat-v2] runtime-config fetch failed; failing closed",
             {
               chatboxId: bodyChatboxId,
               status: runtime.status,
               error: runtime.error,
             }
+          );
+          return c.json(
+            {
+              error: `Couldn't load this chatbox's settings, so the turn was stopped to avoid running with the wrong configuration. ${runtime.error}`,
+            },
+            runtime.status >= 500 ? 502 : (runtime.status as 400 | 401 | 403)
           );
         }
       }

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -556,14 +556,19 @@ chatV2.post("/", async (c) => {
     }
 
     const requestAuthHeader = c.req.header("authorization");
+    // Provider-aware, matching streamWebChatTurn's dispatch: bare hosted ids
+    // (`gpt-5-nano` + `openai`) only canonicalize to their prefixed MCPJam form
+    // with the provider — a provider-blind check here routes them into
+    // org/BYOK below even after they passed the harness preflight.
     const isMcpJamProvidedModel = Boolean(
-      modelDefinition.id && isMCPJamProvidedModel(modelDefinition.id)
+      modelDefinition.id &&
+        isMCPJamProvidedModel(modelDefinition.id, modelDefinition.provider)
     );
     if (
       isMcpJamProvidedModel &&
       modelDefinition.id &&
       !requestAuthHeader &&
-      !isMCPJamGuestAllowedModel(modelDefinition.id)
+      !isMCPJamGuestAllowedModel(modelDefinition.id, modelDefinition.provider)
     ) {
       return c.json(
         {

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -335,8 +335,30 @@ chatV2.post("/", async (c) => {
     let resolvedModelOverride: typeof model | null = null;
     let hostRuntimeConfig: Record<string, unknown> | null = null;
     if (isChatboxSession && bodyChatboxId) {
-      const bearer = c.req.header("authorization") ?? "";
-      if (bearer) {
+      // Chatbox config resolution must NEVER be skipped: the fetched config is
+      // the only source of host-owned harness/computer/executionScope and of
+      // every host-wins protection. A bearer-less request is NOT a hard stop on
+      // this route (the MCPJam-model path lazily mints a guest bearer below),
+      // so resolve the SAME process-cached production guest bearer here first —
+      // and fail closed if no bearer can be obtained at all.
+      let bearer = c.req.header("authorization") ?? "";
+      if (!bearer) {
+        try {
+          bearer = (await getProductionGuestAuthHeader()) ?? "";
+        } catch {
+          bearer = "";
+        }
+      }
+      if (!bearer) {
+        return c.json(
+          {
+            error:
+              "Couldn't authenticate this chatbox turn to load its settings — sign in (or retry) to continue.",
+          },
+          401,
+        );
+      }
+      {
         const runtime = await fetchChatboxRuntimeConfig({
           chatboxId: bodyChatboxId,
           bearer,

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -5,6 +5,7 @@ const {
   prepareChatV2Mock,
   handleMCPJamFreeChatModelMock,
   fetchHostRuntimeConfigMock,
+  fetchChatboxRuntimeConfigMock,
   persistChatSessionToConvexMock,
   disconnectAllServersMock,
   managerListToolsMock,
@@ -21,6 +22,7 @@ const {
   prepareChatV2Mock: vi.fn(),
   handleMCPJamFreeChatModelMock: vi.fn(),
   fetchHostRuntimeConfigMock: vi.fn(),
+  fetchChatboxRuntimeConfigMock: vi.fn(),
   persistChatSessionToConvexMock: vi.fn(),
   disconnectAllServersMock: vi.fn(),
   managerListToolsMock: vi.fn(),
@@ -127,6 +129,10 @@ vi.mock("../../../utils/host-runtime-config.js", () => ({
   fetchHostRuntimeConfig: fetchHostRuntimeConfigMock,
 }));
 
+vi.mock("../../../utils/chatbox-runtime-config.js", () => ({
+  fetchChatboxRuntimeConfig: fetchChatboxRuntimeConfigMock,
+}));
+
 vi.mock("../apps.js", () => ({
   default: new Hono(),
 }));
@@ -165,6 +171,13 @@ describe("web routes — chat-v2 hosted mode", () => {
     fetchHostRuntimeConfigMock.mockResolvedValue({
       ok: true,
       config: { selectedServerIds: ["server-1"] },
+    });
+    // Default: chatbox runtime-config resolves (empty = host has no
+    // overrides). Chatbox turns now FAIL CLOSED on a failed fetch, so the
+    // happy-path tests must resolve it rather than lean on the old fallback.
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {},
     });
 
     handleMCPJamFreeChatModelMock.mockImplementation(async (options: any) => {
@@ -329,6 +342,36 @@ describe("web routes — chat-v2 hosted mode", () => {
       token
     );
 
+    expect(response.status).not.toBe(200);
+    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+  });
+
+  it("FAILS CLOSED when the chatbox runtime-config fetch fails — never runs the engine", async () => {
+    const { app, token } = createWebTestApp();
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      error: "backend unreachable",
+    });
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        projectId: "project-1",
+        selectedServerIds: ["server-1"],
+        chatboxId: "cbx_1",
+        accessVersion: 1,
+        chatSessionId: "chat-cb-fail",
+        messages: [{ role: "user", content: "preview request" }],
+        model: { id: "openai/gpt-5-mini", provider: "openai", name: "GPT-5 Mini" },
+      },
+      token
+    );
+
+    // The fetched config is the only source of harness/computer and of the
+    // host-wins protections; falling back to body values would silently
+    // downgrade a harness chatbox and reopen the tampered-body window.
     expect(response.status).not.toBe(200);
     expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -372,7 +372,17 @@ describe("web routes — chat-v2 hosted mode", () => {
     // The fetched config is the only source of harness/computer and of the
     // host-wins protections; falling back to body values would silently
     // downgrade a harness chatbox and reopen the tampered-body window.
-    expect(response.status).not.toBe(200);
+    // Pin the full status/code/message mapping so it can't regress silently:
+    // upstream 5xx maps to 502 with the INTERNAL_ERROR envelope + the
+    // upstream error surfaced in the message.
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as {
+      code?: string;
+      message?: string;
+    };
+    expect(body.code).toBe("INTERNAL_ERROR");
+    expect(body.message).toContain("Couldn't load this chatbox's settings");
+    expect(body.message).toContain("backend unreachable");
     expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -136,18 +136,26 @@ chatV2.post("/", async (c) => {
           unknown
         >;
       } else {
-        // Don't fail the chat send on a transient Convex blip — fall
-        // through to client-supplied values and warn. The chat will run
-        // with potentially stale config, which is the current behavior;
-        // the host-side override is best-effort hardening, not a
-        // hard gate.
+        // FAIL CLOSED, matching the host-bound branch below. The fetched
+        // config is the ONLY source of `harness`/`computer` (deliberately
+        // excluded from ExecutionOverrides so the body can't set them) and of
+        // every host-wins protection. Falling back to body values would (a)
+        // silently run a harness-published chatbox on the emulated engine —
+        // misrepresenting the runtime — and (b) let client-supplied
+        // model/approval/server values govern a share-link-reachable turn,
+        // the exact tampered-body window this fetch exists to close.
         logger.warn(
-          "[chat-v2] runtime-config fetch failed; using body values",
+          "[chat-v2] runtime-config fetch failed; failing closed",
           {
             chatboxId,
             status: runtime.status,
             error: runtime.error,
           }
+        );
+        throw new WebRouteError(
+          runtime.status >= 500 ? 502 : runtime.status,
+          ErrorCode.INTERNAL_ERROR,
+          `Couldn't load this chatbox's settings, so the turn was stopped to avoid running with the wrong configuration. ${runtime.error}`
         );
       }
     } else if (!isChatboxSession && hostId) {
@@ -367,16 +375,21 @@ chatV2.post("/", async (c) => {
     // the emulated chat path wires the listSkills/loadSkill tools for any
     // signed-in member with a project. Gate only on:
     //   - not a guest (a share-link/chatbox guest gets no skill tools), and
-    //   - the turn will NOT run the real Claude Code harness — which delivers
-    //     skills via the adapter `skills` param instead, so advertising the tools
-    //     here would be a prompt/tool mismatch.
-    // The harness runs ONLY for harness:"claude-code" hosts on an MCPJam model; a
-    // BYOK model on such a host still runs emulated (web-chat-turn), so gate on
-    // the actual engine (model), not host config alone.
+    //   - the turn will NOT run a real harness runtime — Claude Code delivers
+    //     skills via the adapter `skills` param instead (Codex delivers none),
+    //     so advertising the tools here would be a prompt/tool mismatch.
+    // The harness runs only for harness hosts on an MCPJam model; a BYOK model
+    // on such a host is rejected by the availability preflight above, so gate
+    // on the actual engine (harness id + canonicalized model), not host config
+    // alone.
     const cloudSkillsEnabled = shouldEnableCloudSkillTools({
       isGuest: Boolean(c.get("guestId")),
       harness: resolvedExecution.harness,
       modelId: String(modelDefinition.id),
+      // Provider is required so bare hosted ids canonicalize — without it a
+      // bare-id harness turn would be mis-detected as emulated and get the
+      // emulated skill tools on top of adapter-delivered skills.
+      provider: modelDefinition.provider,
       hasProjectId: Boolean(hostedBody.projectId),
     });
 

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -362,15 +362,6 @@ chatV2.post("/", async (c) => {
       }
     );
 
-    // Cloud Skills: only when the (server-resolved) host actually has a
-    // computer — the SAME source the bash/computer built-in tool resolves from
-    // (`resolveHostTools` above), so skills wire wherever computer tools do.
-    // Today that's chatbox sessions (the only path that resolves
-    // hostRuntimeConfig); playground/direct host-config resolution lands later.
-    // Guests are excluded, mirroring the `isGuest` gate already applied to the
-    // computer-backed bash tool — a guest share-link/chatbox session must not
-    // be handed E2B skill tools. Loaded lazily so no wake unless a skill tool
-    // is called ("advertise == enforce").
     // Cloud skills are a Convex-backed PROJECT resource (no computer needed), so
     // the emulated chat path wires the listSkills/loadSkill tools for any
     // signed-in member with a project. Gate only on:

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -592,6 +592,7 @@ async function runOneSession(args: {
         isGuest: false,
         harness,
         modelId: String(modelDefinition.id),
+        provider: modelDefinition.provider,
         hasProjectId: Boolean(projectId),
       });
 

--- a/mcpjam-inspector/server/utils/__tests__/web-chat-turn-dispatch.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/web-chat-turn-dispatch.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Dispatch regression for `streamWebChatTurn`: the MCPJam-vs-org-BYOK branch
+ * must canonicalize the model id WITH the provider, exactly like the route's
+ * harness preflight does. Before the fix, a bare hosted id (`gpt-5-nano` +
+ * `openai`) passed the preflight (which supplies the provider) but the
+ * dispatch recomputed `isMCPJam` provider-blind — so the turn silently
+ * branched into org-BYOK handling and skipped `runHarnessTurn` even though
+ * `persist.harness` was set.
+ *
+ * The stream handlers are mocked; these are pure dispatch tests.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handlers = vi.hoisted(() => ({
+  mcpjamFree: vi.fn(async () => new Response("mcpjam")),
+  hostedOrg: vi.fn(async () => new Response("org-hosted")),
+  localOrg: vi.fn(async () => new Response("org-local")),
+}));
+
+vi.mock("../mcpjam-stream-handler.js", () => ({
+  handleMCPJamFreeChatModel: handlers.mcpjamFree,
+  warnIfChatAbortSignalMissing: vi.fn(),
+}));
+
+vi.mock("../org-model-stream-handler.js", () => ({
+  handleHostedOrgChatModel: handlers.hostedOrg,
+  handleLocalOrgChatModel: handlers.localOrg,
+}));
+
+vi.mock("../org-model-config.js", () => ({
+  deriveOrgProviderKey: vi.fn(() => ({ ok: true, key: "openai" })),
+  isLocalRuntimeEligible: vi.fn(() => false),
+  resolveOrgProviderRuntime: vi.fn(),
+}));
+
+vi.mock("../chat-v2-orchestration.js", () => ({
+  prepareChatV2: vi.fn(async () => ({
+    allTools: {},
+    enhancedSystemPrompt: "",
+    resolvedTemperature: undefined,
+    scrubMessages: (m: unknown[]) => m,
+    progressivePlan: undefined,
+    discoveryState: undefined,
+  })),
+  buildWidgetModelContextSystemPrompt: vi.fn(() => ""),
+}));
+
+vi.mock("../mcp-tool-result-model-output.js", () => ({
+  convertToMcpjamModelMessages: vi.fn(async () => []),
+}));
+
+vi.mock("../harness/harness-proxy-strategy.js", () => ({
+  resolveWebAuthorizedHarnessStrategy: vi.fn(() => ({
+    plane: "web-authorized",
+    mode: "direct",
+    publicBaseUrl: "https://inspector.example.com",
+  })),
+}));
+
+import { streamWebChatTurn } from "../web-chat-turn";
+
+function args(modelDefinition: {
+  id: string;
+  provider: string;
+  name?: string;
+}) {
+  const c = {
+    req: {
+      raw: { headers: new Headers(), signal: undefined },
+      header: () => undefined,
+    },
+  } as never;
+  return {
+    manager: {
+      disconnectAllServers: vi.fn(async () => {}),
+      hasServer: () => false,
+    } as never,
+    prepare: {
+      selectedServerIds: [],
+      modelDefinition: { name: "m", ...modelDefinition } as never,
+      uiMessages: [],
+    },
+    persist: {
+      chatSessionId: undefined,
+      projectId: "p1",
+      sourceType: "direct" as const,
+      origin: "playground" as const,
+      originalMessages: [],
+      selectedServerIds: [],
+      harness: "claude-code" as const,
+    },
+    runtime: {
+      authHeader: "Bearer t",
+      clientIp: null,
+      abortSignal: undefined,
+      c,
+    },
+  };
+}
+
+describe("streamWebChatTurn model dispatch", () => {
+  beforeEach(() => {
+    handlers.mcpjamFree.mockClear();
+    handlers.hostedOrg.mockClear();
+    handlers.localOrg.mockClear();
+    process.env.CONVEX_HTTP_URL = "https://convex.example.com";
+  });
+
+  it("routes a BARE MCPJam-hosted id + provider to the MCPJam path (harness runs)", async () => {
+    await streamWebChatTurn(
+      args({ id: "gpt-5-nano", provider: "openai" }) as never,
+    );
+    expect(handlers.mcpjamFree).toHaveBeenCalledTimes(1);
+    expect(handlers.hostedOrg).not.toHaveBeenCalled();
+    const opts = handlers.mcpjamFree.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(opts.harness).toBe("claude-code");
+  });
+
+  it("routes a prefixed MCPJam id to the MCPJam path (sanity)", async () => {
+    await streamWebChatTurn(
+      args({ id: "openai/gpt-5-nano", provider: "openai" }) as never,
+    );
+    expect(handlers.mcpjamFree).toHaveBeenCalledTimes(1);
+    expect(handlers.hostedOrg).not.toHaveBeenCalled();
+  });
+
+  it("routes a non-MCPJam model to the org-BYOK path", async () => {
+    await streamWebChatTurn(
+      args({ id: "gpt-4.1-mini-custom", provider: "openai" }) as never,
+    );
+    expect(handlers.hostedOrg).toHaveBeenCalledTimes(1);
+    expect(handlers.mcpjamFree).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/web-chat-turn-dispatch.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/web-chat-turn-dispatch.test.ts
@@ -9,7 +9,7 @@
  *
  * The stream handlers are mocked; these are pure dispatch tests.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const handlers = vi.hoisted(() => ({
   mcpjamFree: vi.fn(async () => new Response("mcpjam")),
@@ -103,7 +103,13 @@ describe("streamWebChatTurn model dispatch", () => {
     handlers.mcpjamFree.mockClear();
     handlers.hostedOrg.mockClear();
     handlers.localOrg.mockClear();
-    process.env.CONVEX_HTTP_URL = "https://convex.example.com";
+    // stubEnv (not a bare assignment) so the value is restored after each
+    // test and can't leak into suites that assert CONVEX_HTTP_URL is unset.
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.example.com");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("routes a BARE MCPJam-hosted id + provider to the MCPJam path (harness runs)", async () => {

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-skill-tools-gate.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 
 // Gate the engine signal: an MCPJam-provided model id reports true, BYOK false.
+// Mirrors the real helper's provider-aware canonicalization: a BARE id only
+// counts as MCPJam-provided when the provider is supplied (bare + provider →
+// prefixed hosted id).
 vi.mock("@/shared/types", () => ({
-  isMCPJamProvidedModel: (id: string) => id.startsWith("mcpjam/"),
+  isMCPJamProvidedModel: (id: string, provider?: string) =>
+    id.startsWith("mcpjam/") || (provider === "mcpjam" && !id.includes("/")),
 }));
 
 import { shouldEnableCloudSkillTools } from "../cloud-skill-tools";
@@ -56,5 +60,30 @@ describe("shouldEnableCloudSkillTools", () => {
         modelId: "openai/gpt-5",
       })
     ).toBe(true);
+  });
+
+  it("disables for a BARE MCPJam id + provider on a harness host (provider-aware)", () => {
+    // Regression: a provider-blind check mis-detected bare hosted ids as
+    // non-MCPJam and advertised the emulated skill tools into a harness turn.
+    expect(
+      shouldEnableCloudSkillTools({
+        ...base,
+        harness: "claude-code",
+        modelId: "bare-model",
+        provider: "mcpjam",
+      })
+    ).toBe(false);
+  });
+
+  it("disables for ANY harness id, not just claude-code (codex host)", () => {
+    // Codex runs a real harness too; emulated skill tools on that turn would
+    // be a prompt/tool mismatch even though Codex delivers no skills itself.
+    expect(
+      shouldEnableCloudSkillTools({
+        ...base,
+        harness: "codex",
+        modelId: "mcpjam/gpt-5",
+      })
+    ).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -25,21 +25,32 @@ const NAME_RE = /^[a-z0-9-]+$/;
  *
  * Cloud skills are a Convex-backed PROJECT resource (no computer required), so
  * any signed-in member with a project gets them — EXCEPT when the turn will run
- * the real Claude Code harness, which delivers skills via the adapter `skills`
- * param instead (advertising the tools there would be a prompt/tool mismatch).
+ * a real harness runtime, which delivers skills via the adapter `skills` param
+ * (or, for skills-incapable runtimes like Codex, not at all) — advertising the
+ * emulated tools there would be a prompt/tool mismatch.
  *
- * The harness runs ONLY for a `harness:"claude-code"` host on an MCPJam-provided
- * model; a BYOK model on that same host runs emulated — so gate on the actual
- * engine (model), not host config alone.
+ * Two footguns this check must not regress on:
+ *  - `provider` is REQUIRED for the model check: bare hosted ids
+ *    (`gpt-5-nano` + `openai`) only canonicalize to their prefixed form with
+ *    the provider, and a provider-blind check would advertise the emulated
+ *    tools into a real harness turn.
+ *  - Gate on ANY harness id, not the `claude-code` literal — a Codex host on
+ *    an MCPJam model runs the Codex harness, not the emulated engine.
+ *
+ * A BYOK model on a harness host does NOT reach the harness (the route
+ * preflight rejects non-eligible models), so `willRunHarness` false there is
+ * moot; keep the model check anyway so this helper stands alone.
  */
 export function shouldEnableCloudSkillTools(args: {
   isGuest: boolean;
   harness: string | undefined;
   modelId: string;
+  provider?: string;
   hasProjectId: boolean;
 }): boolean {
   const willRunHarness =
-    args.harness === "claude-code" && isMCPJamProvidedModel(args.modelId);
+    args.harness !== undefined &&
+    isMCPJamProvidedModel(args.modelId, args.provider);
   return !args.isGuest && !willRunHarness && args.hasProjectId;
 }
 

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -284,9 +284,17 @@ export async function streamWebChatTurn(
   };
 
   const isChatboxSession = persist.sourceType === "chatbox";
+  // Provider is REQUIRED here: bare hosted ids (`gpt-5-nano` + `openai`) only
+  // canonicalize to their prefixed form (`openai/gpt-5-nano`) when the provider
+  // is supplied. Without it, a bare id fails this check and the turn silently
+  // branches into org-BYOK — skipping runHarnessTurn even when the route's
+  // harness preflight (which does pass the provider) approved the turn.
   const isMCPJam =
     Boolean(prepare.modelDefinition.id) &&
-    isMCPJamProvidedModel(String(prepare.modelDefinition.id));
+    isMCPJamProvidedModel(
+      String(prepare.modelDefinition.id),
+      prepare.modelDefinition.provider,
+    );
 
   // Resolve the host config now that `resolvedTemperature` is known.
   // Legacy chat-v2 fed `resolvedTemperature` into `buildDirectHostConfig`;


### PR DESCRIPTION
Fixes for three findings from the #2991 review audit — all three **pre-exist on main** (the PR only widens their exposure to guest/chatbox surfaces), so they land here and #2991 inherits them on rebase.

## In plain English

1. **A bare hosted model id could silently skip the harness.** The route's harness preflight canonicalizes `gpt-5-nano` + `openai` → `openai/gpt-5-nano` (provider-aware), but the actual dispatch in `streamWebChatTurn` re-checked the model *without* the provider — so the same turn that passed the preflight branched into org-BYOK handling, never ran `runHarnessTurn`, and was attributed/billed as BYOK. One-line fix + a three-case dispatch regression (bare id routes to MCPJam, prefixed sanity, BYOK still routes to org).

2. **Chatbox turns now fail closed when the runtime-config fetch fails** (both `web/chat-v2` and `mcp/chat-v2`), matching the host-bound branch that already did. The fetched config is the *only* source of `harness`/`computer` (deliberately excluded from body overrides) and of every host-wins protection — the old fallback silently downgraded a harness chatbox to the emulated engine and let client-supplied model/approval/server values govern a share-link-reachable turn. Telling detail: the existing chatbox route tests only passed because their config fetch failed against the global fetch stub and the fallback swallowed it — they now mock a resolving config, and a new regression pins the fail-closed behavior.

3. **The cloud-skills gate had the same provider blindness plus a hardcoded `claude-code` literal.** After fix 1, a bare-id harness turn would have been mis-detected as emulated and had `listSkills`/`loadSkill` (plus the skills prompt preamble) injected on top of adapter-delivered skills; a Codex host slipped the gate entirely. Now provider-aware and gated on any harness id.

## Security

Fix 2 is the security-relevant one: it closes the window where a failed (or induced) Convex config fetch let request-body values steer a chatbox session — model selection, `requireToolApproval`, server set — on a surface reachable by share-link guests. Fixes 1 and 3 are correctness/attribution (engine misrouting and tool/prompt mismatch), not credential exposure.

## Verification

- New: 3-case dispatch regression, chatbox fail-closed route test, 2 new gate cases (bare id + provider, codex host).
- 111 files / 1311 tests green across the touched suites (`server/routes/web`, `server/routes/mcp`, `server/utils`, `server/services/sessionSimulation`, `server/utils/computers`).

Related: #2991 (guest harness enablement — its chatbox/executionScope paths get these guarantees on rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, chatbox config enforcement, and model/harness dispatch on share-link-reachable surfaces; misconfiguration could block turns or misroute billing/engine, but the intent is to close tampered-body and silent-fallback windows.
> 
> **Overview**
> Hardens chat routing so harness turns, host-owned chatbox settings, and emulated skill tools stay aligned.
> 
> **Provider-aware MCPJam detection** — `isMCPJamProvidedModel` (and guest-allow checks on `mcp/chat-v2`) now take `provider`, so bare hosted ids like `gpt-5-nano` + `openai` canonicalize the same way as harness preflight. `streamWebChatTurn` dispatch was the main bug: preflight could approve a harness turn while dispatch sent it to org/BYOK. Session simulation passes `provider` into the cloud-skills gate for the same reason.
> 
> **Chatbox runtime-config fails closed** — On `web/chat-v2` and `mcp/chat-v2`, a failed `fetchChatboxRuntimeConfig` no longer falls back to request-body model/approval/harness/computer. The MCP route always resolves config (process guest bearer when the request has no `Authorization`; **401** if no bearer can be obtained). Tests mock successful chatbox config on happy paths and pin fail-closed **502** / error envelopes.
> 
> **Cloud skill tools gate** — `shouldEnableCloudSkillTools` is provider-aware and treats **any** harness id (not only `claude-code`) as a real harness run, so emulated `listSkills`/`loadSkill` are not advertised on harness turns (including Codex).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e16ac94c13cf734d12e444beedba3e05a83f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens model dispatch and chatbox config to prevent misrouting and unsafe fallbacks. Dispatch and gates are provider-aware, chatbox config fetch always uses a resolved guest bearer and fails closed, and cloud-skill tools are disabled for any harness run.

- **Bug Fixes**
  - Provider-aware dispatch and checks: pass `provider` into model classification in both `streamWebChatTurn` and `/api/mcp/chat-v2` (including the guest-allowed check) so bare hosted ids route to the harness; BYOK still routes to org; dispatch regression added.
  - Chatbox runtime-config: in `web/chat-v2` and `mcp/chat-v2`, always fetch using the process guest bearer for bearer-less turns; return 401 if no bearer can be resolved; on fetch failure, fail closed (web maps upstream 5xx to 502 with `INTERNAL_ERROR`); tests updated and a fail-closed case pinned.
  - Cloud-skill tools gate: provider-aware and gated on any `harness` (not just `claude-code`), so emulated tools aren’t advertised during real harness runs (including Codex); tests added.

<sup>Written for commit a0e16ac94c13cf734d12e444beedba3e05a83f6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

