### PR TITLE
feat(hosts): default Host Compare to Codex + Claude Code

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -23,6 +23,7 @@ import type {
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { HostCompareSelector } from "./HostCompareSelector";
 import {
+  DEFAULT_COMPARE_HOST_IDS,
   parseHostsParam,
   resolveInitialHostCompareSelection,
   toggleHostCompareSelection,
@@ -146,8 +147,10 @@ export function HostConfigCompareView({
   // becomes the source of truth and mirrors back into the URL.
   const urlConsumedRef = useRef(false);
 
-  // Real created hosts drive the default selection in the full app. Public
-  // preset-only compare defaults to presets so caniuse.dev renders without auth.
+  // Real created hosts only — the last-resort fallback inside
+  // `resolveInitialHostCompareSelection` if the ChatGPT/Claude presets
+  // are ever unavailable. The actual default selection is
+  // `DEFAULT_COMPARE_HOST_IDS` (see the ?hosts=-is-default suppression below).
   const liveHostIds = useMemo(
     () => liveHosts.map((host) => host.hostId),
     [liveHosts]
@@ -198,7 +201,7 @@ export function HostConfigCompareView({
   }, [presetOnly, projectId, selectionScopeId, selectedHostIds]);
 
   // Mirror selection → ?hosts=. Suppress when the selection is the default
-  // "all live hosts" (in original order) so shared links stay clean.
+  // (ChatGPT + Claude, in that order) so shared links stay clean.
   useEffect(() => {
     if (!presetOnly && !projectId) return;
     if (!urlConsumedRef.current) return;
@@ -209,12 +212,13 @@ export function HostConfigCompareView({
     // commit with `selectedHostIds` still empty. Treating that as "default"
     // would delete `?hosts=` before the queued state lands, clobbering the
     // deep link. After resolve, `selectedHostIds` is always ≥ 1 (resolver
-    // falls back to all live hosts; `toggleHostCompareSelection` keeps
-    // `minSelected=1`), so an empty selection means "not yet resolved."
+    // falls back to the ChatGPT/Claude presets, or live hosts if those
+    // are unavailable; `toggleHostCompareSelection` keeps `minSelected=1`),
+    // so an empty selection means "not yet resolved."
     if (selectedHostIds.length === 0) return;
     const isDefault =
-      selectedHostIds.length === defaultHostIds.length &&
-      selectedHostIds.every((id, i) => id === defaultHostIds[i]);
+      selectedHostIds.length === DEFAULT_COMPARE_HOST_IDS.length &&
+      selectedHostIds.every((id, i) => id === DEFAULT_COMPARE_HOST_IDS[i]);
     const current = searchParams.get(HOSTS_QUERY_PARAM);
     if (isDefault) {
       if (current === null) return;
@@ -230,7 +234,6 @@ export function HostConfigCompareView({
     setSearchParams(next, { replace: true });
   }, [
     selectedHostIds,
-    defaultHostIds,
     listLoading,
     presetOnly,
     projectId,

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-compare-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
+  DEFAULT_COMPARE_HOST_IDS,
   parseHostsParam,
   reconcileHostCompareSelection,
   resolveInitialHostCompareSelection,
@@ -36,7 +37,7 @@ describe("host-compare-selection", () => {
     ).toEqual(["b", "c"]);
   });
 
-  it("resolveInitialHostCompareSelection falls back to all live hosts", () => {
+  it("resolveInitialHostCompareSelection falls back to all live hosts when the default presets aren't known", () => {
     expect(
       resolveInitialHostCompareSelection({
         projectId: "proj_1",
@@ -109,14 +110,41 @@ describe("host-compare-selection", () => {
     ).toEqual(["preset:chatgpt"]);
   });
 
-  it("resolveInitialHostCompareSelection default stays real-hosts-only (presets opt-in)", () => {
+  it("resolveInitialHostCompareSelection falls back to live hosts when default presets are missing", () => {
     expect(
       resolveInitialHostCompareSelection({
         projectId: "proj_1",
         liveHostIds: ["a", "b"],
-        knownHostIds: ["a", "b", "preset:claude", "preset:chatgpt"],
+        knownHostIds: ["a", "b", "preset:codex", "preset:cursor"],
         previousSelection: [],
       }),
     ).toEqual(["a", "b"]);
+  });
+
+  it("resolveInitialHostCompareSelection defaults to ChatGPT + Claude over live hosts on a fresh visit", () => {
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: ["a", "b"],
+        knownHostIds: [
+          "a",
+          "b",
+          ...DEFAULT_COMPARE_HOST_IDS,
+          "preset:codex",
+        ],
+        previousSelection: [],
+      }),
+    ).toEqual([...DEFAULT_COMPARE_HOST_IDS]);
+  });
+
+  it("resolveInitialHostCompareSelection defaults to ChatGPT + Claude with zero live hosts", () => {
+    expect(
+      resolveInitialHostCompareSelection({
+        projectId: "proj_1",
+        liveHostIds: [],
+        knownHostIds: [...DEFAULT_COMPARE_HOST_IDS, "preset:codex"],
+        previousSelection: [],
+      }),
+    ).toEqual([...DEFAULT_COMPARE_HOST_IDS]);
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-compare-selection.ts
@@ -1,4 +1,17 @@
+import { PRESET_HOST_ID_PREFIX } from "./host-compare-presets";
+
 const STORAGE_PREFIX = "host-compare-selected:";
+
+/**
+ * Default compare columns when nothing else (URL param, stored preference,
+ * prior in-memory selection) picks a selection. ChatGPT and Claude give fresh
+ * Host Compare visits a useful baseline immediately instead of an empty
+ * "select a client" state.
+ */
+export const DEFAULT_COMPARE_HOST_IDS: readonly string[] = [
+  `${PRESET_HOST_ID_PREFIX}chatgpt`,
+  `${PRESET_HOST_ID_PREFIX}claude`,
+];
 
 export function readHostCompareSelection(projectId: string): string[] | null {
   if (typeof window === "undefined") return null;
@@ -66,9 +79,8 @@ export function resolveInitialHostCompareSelection(args: {
   /**
    * Every id the user is allowed to select — real live hosts plus synthetic
    * preset host ids. URL / stored / previous selections reconcile against this
-   * superset so a preset column survives a reload, while the default fallback
-   * stays real-hosts-only (presets are opt-in, never auto-selected). Defaults
-   * to `liveHostIds` when omitted (no presets in play).
+   * superset so a preset column survives a reload. Defaults to `liveHostIds`
+   * when omitted (no presets in play).
    */
   knownHostIds?: ReadonlyArray<string>;
 }): string[] {
@@ -90,6 +102,15 @@ export function resolveInitialHostCompareSelection(args: {
     known,
   );
   if (fromPrevious.length > 0) return fromPrevious;
+
+  // Fresh visit, nothing stored: default to ChatGPT + Claude rather than
+  // "all live hosts" — falls through to live hosts only if the catalog ever
+  // stops offering those two preset ids.
+  const fromDefaultPresets = reconcileHostCompareSelection(
+    DEFAULT_COMPARE_HOST_IDS,
+    known,
+  );
+  if (fromDefaultPresets.length > 0) return fromDefaultPresets;
 
   return [...args.liveHostIds];
 }


### PR DESCRIPTION
Host Compare (including the caniuse.dev landing) previously fell back to "all live hosts" when nothing else picked a selection, which is empty for anyone who hasn't created a host yet. Default to the Codex and Claude Code presets instead so a fresh visit shows a meaningful comparison immediately, with live hosts as the fallback if those presets are ever unavailable.
<img width="2552" height="1296" alt="image" src="https://github.com/user-attachments/assets/55e7c64c-7145-40ee-bb33-8a95fcbf81f5" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default Host Compare to the ChatGPT + Claude presets so first-time visits (including the caniuse.dev landing) show an immediate, meaningful comparison. If those presets aren’t available, fall back to live hosts.

- **New Features**
  - Added `DEFAULT_COMPARE_HOST_IDS` (`preset:chatgpt`, `preset:claude`) and used it for initial selection.
  - URL sync treats these presets as the default and suppresses `?hosts=` when selected in that order.
  - Tests cover zero-live-host cases and fallback when the default presets are missing.

<sup>Written for commit 7f953e2f872a21956d06dae8e467601dcb7d3360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

