### PR TITLE
feat(telemetry): track stateless MCP protocol connects

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
@@ -24,6 +24,7 @@ const {
   getStoredTokensMock,
   getInitializationInfoMock,
   mockUseDbUserReady,
+  posthogCaptureMock,
 } = vi.hoisted(() => ({
   reconnectServerMock: vi.fn(),
   tryResolveProjectServerMock: vi.fn<
@@ -32,6 +33,7 @@ const {
   getStoredTokensMock: vi.fn(),
   getInitializationInfoMock: vi.fn(),
   mockUseDbUserReady: vi.fn(() => true),
+  posthogCaptureMock: vi.fn(),
 }));
 
 vi.mock("sonner", () => ({
@@ -44,6 +46,10 @@ vi.mock("convex/react", () => ({
 
 vi.mock("@/contexts/db-user-ready-context", () => ({
   useDbUserReady: mockUseDbUserReady,
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: posthogCaptureMock }),
 }));
 
 vi.mock("@/state/mcp-api", () => ({
@@ -160,7 +166,7 @@ function buildHostConfig(overrides?: HostOverrides): any {
 
 function renderRevalidationHook(
   dispatch: (action: AppAction) => void,
-  initial: { profile: Profile; hostConfig: any },
+  initial: { profile: Profile; hostConfig: any }
 ) {
   const appState = buildConnectedAppState();
   const state = { ...initial };
@@ -186,7 +192,7 @@ function renderRevalidationHook(
       activeMcpProfile: state.profile as any,
       activeHostConfig: state.hostConfig,
       logger,
-    }),
+    })
   );
   return {
     ...hook,
@@ -224,6 +230,7 @@ beforeEach(() => {
     initInfo: null,
   });
   mockUseDbUserReady.mockReturnValue(true);
+  posthogCaptureMock.mockReset();
 });
 
 describe("useServerState mcpProtocolVersion re-validation", () => {
@@ -237,10 +244,10 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
     await flushAsyncWork(10);
     expect(reconnectServerMock).not.toHaveBeenCalled();
     expect(dispatch).not.toHaveBeenCalledWith(
-      expect.objectContaining({ type: "CONNECT_FAILURE" }),
+      expect.objectContaining({ type: "CONNECT_FAILURE" })
     );
     expect(dispatch).not.toHaveBeenCalledWith(
-      expect.objectContaining({ type: "CONNECT_SUCCESS" }),
+      expect.objectContaining({ type: "CONNECT_SUCCESS" })
     );
   });
 
@@ -274,7 +281,7 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
           type: "CONNECT_FAILURE",
           name: "demo-server",
           error: expect.stringContaining("UnsupportedProtocolVersionError"),
-        }),
+        })
       );
     });
   });
@@ -307,13 +314,65 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
         expect.objectContaining({
           type: "CONNECT_SUCCESS",
           name: "demo-server",
-        }),
+        })
       );
     });
 
     expect(dispatch).not.toHaveBeenCalledWith(
-      expect.objectContaining({ type: "CONNECT_FAILURE" }),
+      expect.objectContaining({ type: "CONNECT_FAILURE" })
     );
+  });
+
+  it("captures stateless protocol connect metadata after a successful reconnect", async () => {
+    reconnectServerMock.mockResolvedValue({
+      success: true,
+      initInfo: { serverCapabilities: {} },
+    });
+
+    const dispatch = vi.fn();
+    const { rerender } = renderRevalidationHook(dispatch, {
+      profile: undefined,
+      hostConfig: buildHostConfig(),
+    });
+
+    await flushAsyncWork(5);
+
+    rerender({
+      profile: { mcpProtocolVersion: "2026-07-28" },
+      hostConfig: buildHostConfig(),
+    });
+
+    await waitFor(() => {
+      expect(posthogCaptureMock).toHaveBeenCalledWith(
+        "stateless_protocol_connect",
+        expect.objectContaining({
+          mcp_protocol_version: "2026-07-28",
+          protocol_pin_source: "host_default",
+          connection_transport: "http",
+          auth_mode: "none",
+          hosted_mode: false,
+          has_project_context: true,
+          has_host_config: true,
+          has_mcp_profile: true,
+          has_timeout_ms: true,
+          connection_defaults_header_count: 0,
+          client_capability_count: 0,
+          has_client_info: false,
+          supported_protocol_version_count: 0,
+          reconnect_attempt: "protocol_revalidation",
+          reconnect_attempt_index: 1,
+          reconnect_select: true,
+          reconnect_suppressed_errors: false,
+          allow_interactive_oauth_flow: false,
+          had_synced_oauth_retry: false,
+        })
+      );
+    });
+
+    expect(posthogCaptureMock.mock.calls[0]?.[1]).not.toHaveProperty(
+      "serverName"
+    );
+    expect(posthogCaptureMock.mock.calls[0]?.[1]).not.toHaveProperty("url");
   });
 
   it("re-tests when a per-server override moves while the host default stays", async () => {
@@ -377,5 +436,4 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
     await flushAsyncWork(10);
     expect(reconnectServerMock).not.toHaveBeenCalled();
   });
-
 });

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -6,7 +6,10 @@ import type {
   MCPServerConfig,
   NormalizedError,
 } from "@mcpjam/sdk/browser";
-import { isKnownProtocolVersion } from "@mcpjam/sdk/browser";
+import {
+  isKnownProtocolVersion,
+  isStatelessProtocolVersion,
+} from "@mcpjam/sdk/browser";
 import type {
   AppAction,
   AppState,
@@ -80,6 +83,9 @@ import {
 } from "@/lib/client-config-v2";
 import { resolveServerConnectionSettings } from "@/lib/client-connection-resolve";
 import { useDbUserReady } from "@/contexts/db-user-ready-context";
+import { standardEventProps } from "@/lib/PosthogUtils";
+import { usePostHog } from "posthog-js/react";
+import type { ConnectionDefaults } from "@/shared/connection-defaults";
 
 /** Skip noisy connect toast while first-run App Builder onboarding is in progress. */
 function shouldSuppressExcalidrawConnectToastForOnboarding(
@@ -676,6 +682,63 @@ interface ReconnectServerInternalOptions {
   suppressErrors?: boolean;
 }
 
+type StatelessProtocolConnectAttempt =
+  | "direct"
+  | "forced_oauth"
+  | "synced_oauth_credentials"
+  | "authorized_reconnect"
+  | "protocol_revalidation";
+
+type StatelessProtocolConnectMetadata = ReturnType<
+  typeof standardEventProps
+> & {
+  mcp_protocol_version: McpProtocolVersion;
+  protocol_pin_source: "server_override" | "host_default" | "unknown";
+  connection_transport: string;
+  auth_mode: "oauth" | "bearer" | "none" | "unknown";
+  hosted_mode: boolean;
+  has_project_context: boolean;
+  has_host_config: boolean;
+  has_mcp_profile: boolean;
+  has_timeout_ms: boolean;
+  connection_defaults_header_count: number;
+  client_capability_count: number;
+  has_client_info: boolean;
+  supported_protocol_version_count: number;
+  reconnect_attempt: StatelessProtocolConnectAttempt;
+  reconnect_attempt_index: number;
+  reconnect_select: boolean;
+  reconnect_suppressed_errors: boolean;
+  allow_interactive_oauth_flow: boolean;
+  had_synced_oauth_retry: boolean;
+};
+
+type StatelessProtocolConnectTelemetry = {
+  attempt?: StatelessProtocolConnectAttempt;
+  attemptIndex?: number;
+  select?: boolean;
+  suppressErrors?: boolean;
+  allowInteractiveOAuthFlow?: boolean;
+  hadSyncedOAuthRetry?: boolean;
+  capture?: (metadata: StatelessProtocolConnectMetadata) => void;
+};
+
+function getConnectionTransport(serverConfig: MCPServerConfig): string {
+  const configuredType = (serverConfig as { type?: unknown }).type;
+  if (typeof configuredType === "string" && configuredType.trim() !== "") {
+    return configuredType;
+  }
+  if ("url" in serverConfig) return "http";
+  if ("command" in serverConfig) return "stdio";
+  return "unknown";
+}
+
+function countRecordKeys(value: unknown): number {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? Object.keys(value).length
+    : 0;
+}
+
 export interface EnsureServersReadyResult {
   readyServerNames: string[];
   missingServerNames: string[];
@@ -704,6 +767,7 @@ export function useServerState({
 }: UseServerStateParams) {
   const isUserReady = useDbUserReady();
   const convex = useConvex();
+  const posthog = usePostHog();
   const {
     createServerIfMissing: convexCreateServerIfMissing,
     updateServer: convexUpdateServer,
@@ -1099,17 +1163,7 @@ export function useServerState({
       // bug PR #2257 review flagged).
       serverId?: string
     ) => {
-      const defaults: {
-        headers?: Record<string, string>;
-        timeoutMs?: number;
-        clientCapabilities?: Record<string, unknown>;
-        clientInfo?: { name?: string; version?: string } & Record<
-          string,
-          unknown
-        >;
-        supportedProtocolVersions?: string[];
-        mcpProtocolVersion?: import("@mcpjam/sdk/browser").McpProtocolVersion;
-      } = {};
+      const defaults: ConnectionDefaults = {};
       if ("url" in serverConfig) {
         const headers = omitAuthorizationHeader(
           extractRequestHeaders(serverConfig.requestInit)
@@ -1175,6 +1229,72 @@ export function useServerState({
     [activeHostConfig]
   );
 
+  const buildStatelessProtocolConnectMetadata = useCallback(
+    (
+      serverName: string,
+      serverConfig: MCPServerConfig,
+      serverId: string,
+      connectionDefaults: ConnectionDefaults | undefined,
+      effectiveProtocolVersion: McpProtocolVersion,
+      telemetry?: StatelessProtocolConnectTelemetry
+    ): StatelessProtocolConnectMetadata => {
+      const server =
+        latestEffectiveServersRef.current[serverName] ??
+        appStateServersRef.current[serverName];
+      const usesOAuth = server?.useOAuth === true;
+      const hasBearerToken = getServerBearerTokenState(server) === true;
+      const rawServerOverride =
+        activeHostConfig?.serverConnectionOverrides?.[serverId]
+          ?.mcpProtocolVersionOverride;
+      const serverOverride =
+        typeof rawServerOverride === "string" &&
+        isKnownProtocolVersion(rawServerOverride)
+          ? rawServerOverride
+          : undefined;
+      const rawHostPin = activeMcpProfile?.mcpProtocolVersion;
+      const hostPin =
+        typeof rawHostPin === "string" && isKnownProtocolVersion(rawHostPin)
+          ? rawHostPin
+          : undefined;
+      const protocolPinSource =
+        serverOverride === effectiveProtocolVersion
+          ? "server_override"
+          : hostPin === effectiveProtocolVersion
+          ? "host_default"
+          : "unknown";
+
+      return {
+        ...standardEventProps("use_server_state"),
+        mcp_protocol_version: effectiveProtocolVersion,
+        protocol_pin_source: protocolPinSource,
+        connection_transport: getConnectionTransport(serverConfig),
+        auth_mode: usesOAuth ? "oauth" : hasBearerToken ? "bearer" : "none",
+        hosted_mode: HOSTED_MODE,
+        has_project_context: true,
+        has_host_config: Boolean(activeHostConfig),
+        has_mcp_profile: Boolean(activeMcpProfile),
+        has_timeout_ms: typeof connectionDefaults?.timeoutMs === "number",
+        connection_defaults_header_count: countRecordKeys(
+          connectionDefaults?.headers
+        ),
+        client_capability_count: countRecordKeys(
+          connectionDefaults?.clientCapabilities
+        ),
+        has_client_info: Boolean(connectionDefaults?.clientInfo),
+        supported_protocol_version_count:
+          connectionDefaults?.supportedProtocolVersions?.length ?? 0,
+        reconnect_attempt: telemetry?.attempt ?? "direct",
+        reconnect_attempt_index: telemetry?.attemptIndex ?? 1,
+        reconnect_select: telemetry?.select ?? true,
+        reconnect_suppressed_errors: telemetry?.suppressErrors ?? false,
+        allow_interactive_oauth_flow:
+          telemetry?.allowInteractiveOAuthFlow ?? false,
+        had_synced_oauth_retry: telemetry?.hadSyncedOAuthRetry ?? false,
+      };
+    },
+    [activeHostConfig, activeMcpProfile]
+  );
+
   const guardedTestConnection = useCallback(
     async (serverConfig: MCPServerConfig, serverName: string) => {
       assertClientConfigSynced();
@@ -1209,7 +1329,11 @@ export function useServerState({
   );
 
   const guardedReconnectServer = useCallback(
-    async (serverName: string, serverConfig: MCPServerConfig) => {
+    async (
+      serverName: string,
+      serverConfig: MCPServerConfig,
+      telemetry?: StatelessProtocolConnectTelemetry
+    ) => {
       assertClientConfigSynced();
       const resolved = tryResolveProjectServer(serverName);
       if (resolved) {
@@ -1217,15 +1341,41 @@ export function useServerState({
           serverConfig,
           resolved.serverId
         );
-        return reconnectServer(resolved.serverId, configWithDefaults, {
-          projectId: resolved.projectId,
-          serverName,
-          connectionDefaults: buildResolverConnectionDefaults(
+        const connectionDefaults = buildResolverConnectionDefaults(
+          configWithDefaults,
+          activeMcpProfile,
+          resolved.serverId
+        );
+        const effectiveProtocolVersion = connectionDefaults?.mcpProtocolVersion;
+        const result = await reconnectServer(
+          resolved.serverId,
+          configWithDefaults,
+          {
+            projectId: resolved.projectId,
+            serverName,
+            connectionDefaults,
+          }
+        );
+        if (
+          result?.success &&
+          effectiveProtocolVersion &&
+          isStatelessProtocolVersion(effectiveProtocolVersion)
+        ) {
+          const metadata = buildStatelessProtocolConnectMetadata(
+            serverName,
             configWithDefaults,
-            activeMcpProfile,
-            resolved.serverId
-          ),
-        });
+            resolved.serverId,
+            connectionDefaults,
+            effectiveProtocolVersion,
+            telemetry
+          );
+          if (telemetry?.capture) {
+            telemetry.capture(metadata);
+          } else {
+            posthog?.capture("stateless_protocol_connect", metadata);
+          }
+        }
+        return result;
       }
       throw new Error(PROJECT_NOT_PROVISIONED_ERROR_MESSAGE);
     },
@@ -1234,6 +1384,8 @@ export function useServerState({
       buildResolverConnectionDefaults,
       activeMcpProfile,
       withProjectConnectionDefaults,
+      buildStatelessProtocolConnectMetadata,
+      posthog,
     ]
   );
 
@@ -2002,7 +2154,9 @@ export function useServerState({
       const token = nextOpToken(name);
       void (async () => {
         try {
-          const result = await guardedReconnectServer(name, serverConfig);
+          const result = await guardedReconnectServer(name, serverConfig, {
+            attempt: "protocol_revalidation",
+          });
           if (isStaleOp(name, token)) return;
           if (result?.success) {
             dispatch({
@@ -3759,6 +3913,29 @@ export function useServerState({
       const hostedProjectServerId = activeProjectServersFlat?.find(
         (remoteServer) => remoteServer.name === serverName
       )?._id;
+      let statelessProtocolConnectCaptured = false;
+      let reconnectAttemptIndex = 0;
+      let hadSyncedOAuthRetry = false;
+      const captureStatelessProtocolConnect = (
+        metadata: StatelessProtocolConnectMetadata
+      ) => {
+        if (statelessProtocolConnectCaptured) {
+          return;
+        }
+        statelessProtocolConnectCaptured = true;
+        posthog?.capture("stateless_protocol_connect", metadata);
+      };
+      const buildStatelessTelemetry = (
+        attempt: StatelessProtocolConnectAttempt
+      ): StatelessProtocolConnectTelemetry => ({
+        attempt,
+        attemptIndex: (reconnectAttemptIndex += 1),
+        select,
+        suppressErrors,
+        allowInteractiveOAuthFlow: options?.allowInteractiveOAuthFlow ?? false,
+        hadSyncedOAuthRetry,
+        capture: captureStatelessProtocolConnect,
+      });
 
       if (options?.forceOAuthFlow) {
         const serverUrl = (server.config as any)?.url?.toString?.();
@@ -3909,7 +4086,8 @@ export function useServerState({
         );
         const result = await guardedReconnectServer(
           serverName,
-          withProjectConnectionDefaults(oauthServerConfig)
+          withProjectConnectionDefaults(oauthServerConfig),
+          buildStatelessTelemetry("forced_oauth")
         );
         if (isStaleOp(serverName, token)) {
           return {
@@ -3955,7 +4133,8 @@ export function useServerState({
         try {
           const result = await guardedReconnectServer(
             serverName,
-            syncedReconnectConfig
+            syncedReconnectConfig,
+            buildStatelessTelemetry("synced_oauth_credentials")
           );
           if (isStaleOp(serverName, token)) {
             return {
@@ -4000,6 +4179,7 @@ export function useServerState({
             "Reconnect requires a fresh OAuth flow after synced credential lookup",
             { serverName, error: result.error }
           );
+          hadSyncedOAuthRetry = true;
         } catch (error) {
           if (isStaleOp(serverName, token)) {
             return {
@@ -4032,6 +4212,7 @@ export function useServerState({
             "Reconnect requires a fresh OAuth flow after synced credential lookup",
             { serverName, error: errorMessage }
           );
+          hadSyncedOAuthRetry = true;
         }
       }
 
@@ -4102,7 +4283,8 @@ export function useServerState({
             : authResult.serverConfig;
         const result = await guardedReconnectServer(
           serverName,
-          withProjectConnectionDefaults(authServerConfig)
+          withProjectConnectionDefaults(authServerConfig),
+          buildStatelessTelemetry("authorized_reconnect")
         );
         if (isStaleOp(serverName, token)) {
           return {
@@ -4180,6 +4362,7 @@ export function useServerState({
       mergeWithProjectHeaders,
       updateServerOAuthTrace,
       withProjectConnectionDefaults,
+      posthog,
     ]
   );
 


### PR DESCRIPTION
usePostHog for telemetry on stateless mcp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track and enrich stateless MCP protocol connect telemetry via PostHog. Emits one `stateless_protocol_connect` event per successful connect when the effective protocol pin is a stateless version.

- **New Features**
  - Emit with `standardEventProps("use_server_state")` and rich metadata: `mcp_protocol_version`, `protocol_pin_source`, `connection_transport`, `auth_mode`, attempt type (`direct|forced_oauth|synced_oauth_credentials|authorized_reconnect|protocol_revalidation`), and lightweight counts (headers/capabilities/versions).
  - Capture at the reconnect chokepoint across all flows, de-dup per reconnect, and gate on `isStatelessProtocolVersion(effectiveProtocolVersion)`; safe no-op when `usePostHog` is unavailable.
  - Add tests to confirm event shape and that sensitive fields like `serverName` and `url` are not included.

<sup>Written for commit 7079b5c048e12599219d227888875572af423538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

