### PR TITLE
Seed host tool image policies

### DIFF
--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -33,11 +33,41 @@ import {
   GOOSE_PLATFORM,
 } from "./goose-style.js";
 import { SLACK_FONT_CSS, getSlackStyleVariables } from "./slack-style.js";
+import type {
+  McpToolResultImageRenderingPolicy,
+  ModelVisibleMcpToolResults,
+} from "../types.js";
 
 type HostThemeMode = "light" | "dark";
 
 /** Fallback when no appVersion is provided (only the mcpjam template reads it). */
 const DEFAULT_SEED_APP_VERSION = "0.0.0";
+
+function toolImageVisibilityPolicy(args: {
+  direct: boolean;
+  embedded: boolean;
+  linked: boolean;
+}): ModelVisibleMcpToolResults {
+  return {
+    directContent: { image: args.direct },
+    embeddedResources: { blob: { image: args.embedded } },
+    linkedResources: { blob: { image: args.linked } },
+  };
+}
+
+function toolImageRenderingPolicy(args: {
+  placement: "none" | "collapsed" | "inline";
+  direct: boolean;
+  embedded: boolean;
+  linked: boolean;
+}): McpToolResultImageRenderingPolicy {
+  return {
+    placement: args.placement,
+    directContent: { image: args.direct },
+    embeddedResources: { blob: { image: args.embedded } },
+    linkedResources: { blob: { image: args.linked } },
+  };
+}
 
 // Verbatim from a real claude.ai ui/initialize response. Kept out of the
 // template entry for readability. Updating these keeps the Claude template
@@ -516,6 +546,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 1.0,
         requireToolApproval: false,
       });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: true,
+        embedded: true,
+        linked: false,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "inline",
+        direct: true,
+        embedded: true,
+        linked: false,
+      });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // clientCapabilities: Real claude.ai publishes only the SDK-default
       // MCP UI extension (no `experimental` flag). emptyHostConfigInputV2
@@ -776,6 +817,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 0.7,
         requireToolApproval: false,
       });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: true,
+        embedded: true,
+        linked: true,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "inline",
+        direct: true,
+        embedded: true,
+        linked: true,
+      });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // Real ChatGPT advertises an `experimental.openai/visibility` flag on top
       // of the SDK-default MCP UI extension. Keep the default extension block
@@ -930,6 +982,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 0.7,
         requireToolApproval: false,
       });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: false,
+        embedded: false,
+        linked: false,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "none",
+        direct: false,
+        embedded: false,
+        linked: false,
+      });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
 
       // Le Chat's captured base MCP `initialize` reported:
@@ -1030,6 +1093,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         modelId: "openai/gpt-5-nano",
         temperature: 0.7,
         requireToolApproval: false,
+      });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: true,
+        embedded: false,
+        linked: false,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "collapsed",
+        direct: true,
+        embedded: false,
+        linked: false,
       });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
 
@@ -1263,6 +1337,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         // the spec-default `true` via emptyHostConfigInputV2.
         respectToolVisibility: false,
       });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: true,
+        embedded: true,
+        linked: true,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "none",
+        direct: false,
+        embedded: false,
+        linked: false,
+      });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // clientCapabilities: matches what real Cursor publishes during MCP
       // `initialize` — declares MCP UI support plus its own elicitation
@@ -1360,6 +1445,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         harness: "codex",
         computer: { kind: "personal" },
       });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: true,
+        embedded: true,
+        linked: true,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "collapsed",
+        direct: true,
+        embedded: false,
+        linked: false,
+      });
       // Codex CLI probe advertises only elicitation. It does NOT advertise
       // the MCP UI extension (no widget rendering), so we replace the SDK
       // default clientCapabilities entirely rather than spreading on top —
@@ -1410,6 +1506,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         modelId: "openai/gpt-5.3-chat",
         temperature: 0.7,
         requireToolApproval: false,
+      });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: true,
+        embedded: true,
+        linked: true,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "none",
+        direct: false,
+        embedded: false,
+        linked: false,
       });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // Copilot's MCP client identity is not publicly documented; declare
@@ -1562,6 +1669,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         // Code probe yet, so capability values are inherited from Cursor's.
         respectToolVisibility: false,
       });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: true,
+        embedded: true,
+        linked: true,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "inline",
+        direct: true,
+        embedded: true,
+        linked: true,
+      });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // VS Code is the editor Cursor forks (Cursor's own clientInfo.name is
       // "cursor-vscode"). Its MCP client declares the UI extension plus
@@ -1704,6 +1822,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 0.7,
         requireToolApproval: false,
       });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: false,
+        embedded: false,
+        linked: false,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "none",
+        direct: false,
+        embedded: false,
+        linked: false,
+      });
       // Captured from a real @n8n/n8n-nodes-langchain.mcpClientTool probe:
       // it sends an empty capabilities object and no MCP UI extension. Replace
       // the SDK default entirely so the template remains tools-only.
@@ -1738,6 +1867,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 0.7,
         requireToolApproval: false,
       });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: false,
+        embedded: false,
+        linked: false,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "none",
+        direct: false,
+        embedded: false,
+        linked: false,
+      });
       // Captured from the Perplexity host probe: protocol 2025-06-18,
       // clientInfo mcp@0.1.0, and an empty clientCapabilities object.
       base.clientCapabilities = {};
@@ -1766,6 +1906,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         modelId: "anthropic/claude-haiku-4.5",
         temperature: 1.0,
         requireToolApproval: false,
+      });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: true,
+        embedded: false,
+        linked: false,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "none",
+        direct: false,
+        embedded: false,
+        linked: false,
       });
       // Captured from the Cline 3.89.2 host probe: protocol 2025-11-25,
       // clientInfo Cline@3.89.2, and an empty clientCapabilities object.
@@ -1797,6 +1948,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         modelId: "anthropic/claude-haiku-4.5",
         temperature: 1.0,
         requireToolApproval: false,
+      });
+      base.modelVisibleMcpToolResults = toolImageVisibilityPolicy({
+        direct: false,
+        embedded: false,
+        linked: false,
+      });
+      base.mcpToolResultImageRendering = toolImageRenderingPolicy({
+        placement: "collapsed",
+        direct: true,
+        embedded: false,
+        linked: false,
       });
       // Bare client: advertises an empty capabilities object and negotiates no
       // MCP Apps/UI extension (no `mimeTypes`). Replace the SDK default

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -186,7 +186,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "placement": "inline",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -300,7 +331,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "placement": "inline",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -680,7 +742,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "inline",
+    },
     "modelId": "anthropic/claude-haiku-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -974,7 +1067,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "inline",
+    },
     "modelId": "anthropic/claude-haiku-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1009,7 +1133,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "anthropic/claude-haiku-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1044,7 +1199,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "anthropic/claude-haiku-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1084,7 +1270,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "collapsed",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1124,7 +1341,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "collapsed",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1226,7 +1474,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "openai/gpt-5.3-chat",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1328,7 +1607,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "openai/gpt-5.3-chat",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1416,7 +1726,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "anthropic/claude-sonnet-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1504,7 +1845,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "anthropic/claude-sonnet-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -1742,7 +2114,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "collapsed",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": true,
     "requireToolApproval": false,
@@ -1980,7 +2383,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "collapsed",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": true,
     "requireToolApproval": false,
@@ -2501,7 +2935,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "mistralai/mistral-large-2512",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -2652,7 +3117,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "mistralai/mistral-large-2512",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -2687,7 +3183,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -2722,7 +3249,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -2757,7 +3315,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "collapsed",
+    },
     "modelId": "anthropic/claude-haiku-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -2792,7 +3381,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "collapsed",
+    },
     "modelId": "anthropic/claude-haiku-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -2827,7 +3447,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -2862,7 +3513,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "placement": "none",
+    },
     "modelId": "openai/gpt-5-nano",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": false,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": false,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -3340,7 +4022,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "placement": "inline",
+    },
     "modelId": "anthropic/claude-sonnet-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,
@@ -3428,7 +4141,38 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "profileVersion": 1,
     },
+    "mcpToolResultImageRendering": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "placement": "inline",
+    },
     "modelId": "anthropic/claude-sonnet-4.5",
+    "modelVisibleMcpToolResults": {
+      "directContent": {
+        "image": true,
+      },
+      "embeddedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+      "linkedResources": {
+        "blob": {
+          "image": true,
+        },
+      },
+    },
     "optionalServerIds": [],
     "progressiveToolDiscovery": false,
     "requireToolApproval": false,

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -5,6 +5,7 @@ import {
   emptyHostConfigInputV2,
   type HostTemplateId,
 } from "../src/host-config/templates/index.js";
+import { extractHostExecutionPolicy } from "../src/host-config/host-policy.js";
 
 const ALL_IDS: HostTemplateId[] = [
   "mcpjam",
@@ -66,6 +67,100 @@ describe("seedHostTemplate", () => {
     expect(config.computer).toEqual({ kind: "personal" });
     // Codex (like Claude Code) can't pause for interactive approval.
     expect(config.requireToolApproval).toBe(false);
+  });
+
+  it("seeds MCP tool-result image policies from the observed client matrix", () => {
+    const expected: Partial<
+      Record<
+        HostTemplateId,
+        {
+          visible: [boolean, boolean, boolean];
+          render: ["none" | "collapsed" | "inline", boolean, boolean, boolean];
+        }
+      >
+    > = {
+      claude: {
+        visible: [true, true, false],
+        render: ["inline", true, true, false],
+      },
+      chatgpt: {
+        visible: [true, true, true],
+        render: ["inline", true, true, true],
+      },
+      notion: {
+        visible: [false, false, false],
+        render: ["collapsed", true, false, false],
+      },
+      goose: {
+        visible: [true, false, false],
+        render: ["collapsed", true, false, false],
+      },
+      codex: {
+        visible: [true, true, true],
+        render: ["collapsed", true, false, false],
+      },
+      cursor: {
+        visible: [true, true, true],
+        render: ["none", false, false, false],
+      },
+      vscode: {
+        visible: [true, true, true],
+        render: ["inline", true, true, true],
+      },
+      copilot: {
+        visible: [true, true, true],
+        render: ["none", false, false, false],
+      },
+      mistral: {
+        visible: [false, false, false],
+        render: ["none", false, false, false],
+      },
+      n8n: {
+        visible: [false, false, false],
+        render: ["none", false, false, false],
+      },
+      perplexity: {
+        visible: [false, false, false],
+        render: ["none", false, false, false],
+      },
+      cline: {
+        visible: [true, false, false],
+        render: ["none", false, false, false],
+      },
+    };
+
+    for (const [id, expectation] of Object.entries(expected) as Array<
+      [HostTemplateId, NonNullable<(typeof expected)[HostTemplateId]>]
+    >) {
+      const policy = extractHostExecutionPolicy(seedHostTemplate(id));
+      expect(
+        [
+          policy.modelVisibleMcpToolResults.directContent.image,
+          policy.modelVisibleMcpToolResults.embeddedResources.blob.image,
+          policy.modelVisibleMcpToolResults.linkedResources.blob.image,
+        ],
+        `${id} model-visible images`
+      ).toEqual(expectation.visible);
+      expect(
+        [
+          policy.mcpToolResultImageRendering.placement,
+          policy.mcpToolResultImageRendering.directContent.image,
+          policy.mcpToolResultImageRendering.embeddedResources.blob.image,
+          policy.mcpToolResultImageRendering.linkedResources.blob.image,
+        ],
+        `${id} rendered images`
+      ).toEqual(expectation.render);
+    }
+  });
+
+  it("renders VS Code tool images inline for every image shape", () => {
+    const policy = extractHostExecutionPolicy(seedHostTemplate("vscode"));
+    expect(policy.mcpToolResultImageRendering).toEqual({
+      placement: "inline",
+      directContent: { image: true },
+      embeddedResources: { blob: { image: true } },
+      linkedResources: { blob: { image: true } },
+    });
   });
 
   it("threads appVersion into the mcpjam template (and only it)", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Seeded per-host MCP tool-result image visibility and rendering policies into the seed host templates so each client shows images correctly. Adds tests to fix the matrix.

- **New Features**
  - Populate `modelVisibleMcpToolResults` and `mcpToolResultImageRendering` for all host templates based on the observed client matrix.
  - Add small helpers to build these policies and tests to lock expected behavior, including VS Code rendering images inline for direct, embedded, and linked shapes.

<sup>Written for commit 6e342eb86a45433aaf75c787fccdd710a23aec8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

