### PR TITLE
proxy api key creation to hsoted mcpjam

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createWebTestApp, expectJson } from "./helpers/test-app.js";
+import type { Hono } from "hono";
 
 // The session bearer is verified in-route (resolveSessionContext); stub it to
 // a fixed WorkOS user so tests exercise the WorkOS REST flow, not JWT crypto.
@@ -44,6 +44,25 @@ function keyRecord(id: string) {
   };
 }
 
+async function createApiKeysTestApp(hostedMode: boolean): Promise<Hono> {
+  vi.resetModules();
+  vi.doMock("../../../config.js", async (importOriginal) => {
+    const actual = await importOriginal<object>();
+    return { ...actual, HOSTED_MODE: hostedMode };
+  });
+  const { createWebTestApp } = await import("./helpers/test-app.js");
+  return createWebTestApp().app;
+}
+
+async function expectJson<T = unknown>(
+  response: Response,
+): Promise<{ status: number; data: T }> {
+  return {
+    status: response.status,
+    data: (await response.json()) as T,
+  };
+}
+
 /**
  * Stub WorkOS: serve the user-scoped key list from `pages` (each entry is one
  * page; `list_metadata.after` chains them) and accept the admin DELETE.
@@ -76,7 +95,7 @@ function stubWorkOS(pages: Array<{ data: unknown[]; after?: string | null }>) {
   return { fetchMock, deleted };
 }
 
-async function deleteKey(app: ReturnType<typeof createWebTestApp>["app"], id: string) {
+async function deleteKey(app: Hono, id: string) {
   return app.request(`/api/web/api-keys/${id}`, {
     method: "DELETE",
     headers: { Authorization: "Bearer session-jwt" },
@@ -84,15 +103,17 @@ async function deleteKey(app: ReturnType<typeof createWebTestApp>["app"], id: st
 }
 
 describe("web routes — API key revoke ownership", () => {
-  const { app } = createWebTestApp();
+  let app: Hono;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    app = await createApiKeysTestApp(true);
     vi.stubEnv("WORKOS_API_KEY", "sk_test_admin");
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
+    vi.doUnmock("../../../config.js");
   });
 
   it("revokes a key that appears in the session user's list", async () => {
@@ -156,5 +177,128 @@ describe("web routes — API key revoke ownership", () => {
       message: "Could not verify API key ownership",
     });
     expect(deleted).toEqual([]);
+  });
+});
+
+// Local mode forwards the whole sub-router to the hosted app — see the proxy
+// middleware in api-keys.ts. WORKOS_API_KEY is deliberately SET here: an MCP
+// developer's own WorkOS key in the shell env must not flip the inspector into
+// local minting against their WorkOS account.
+describe("web routes — API key local-mode proxy to hosted", () => {
+  let app: Hono;
+  const REMOTE_BASE = "https://hosted.example/api/web/api-keys";
+
+  beforeEach(async () => {
+    app = await createApiKeysTestApp(false);
+    vi.stubEnv("WORKOS_API_KEY", "sk_users_own_key");
+    vi.stubEnv("MCPJAM_REMOTE_API_KEYS_URL", REMOTE_BASE);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.doUnmock("../../../config.js");
+  });
+
+  function stubHosted(response: Response) {
+    const fetchMock = vi.fn(async () => response);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("forwards create requests verbatim and passes the response through", async () => {
+    const created = { id: "api_key_new", name: "ci", value: "sk_secret" };
+    const fetchMock = stubHosted(workosJson(created));
+
+    const response = await app.request("/api/web/api-keys", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer session-jwt",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: "ci", organizationId: "org_1" }),
+    });
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual(created);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [target, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(target).toBe(REMOTE_BASE);
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+      "Bearer session-jwt",
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      name: "ci",
+      organizationId: "org_1",
+    });
+  });
+
+  it("forwards the key id path segment on revoke", async () => {
+    const fetchMock = stubHosted(workosJson({ ok: true }));
+
+    const { status, data } = await expectJson(
+      await deleteKey(app, "api_key_remote_1"),
+    );
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ ok: true });
+    const [target, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(target).toBe(`${REMOTE_BASE}/api_key_remote_1`);
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("passes hosted error responses through untouched", async () => {
+    stubHosted(
+      workosJson({ code: "UNAUTHORIZED", message: "Invalid session" }, 401),
+    );
+
+    const response = await app.request("/api/web/api-keys", {
+      method: "GET",
+      headers: { Authorization: "Bearer session-jwt" },
+    });
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(401);
+    expect(data).toEqual({ code: "UNAUTHORIZED", message: "Invalid session" });
+  });
+
+  it("maps an unreachable hosted app to 502 SERVER_UNREACHABLE", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("connect ECONNREFUSED");
+      }),
+    );
+
+    const response = await app.request("/api/web/api-keys", {
+      method: "GET",
+      headers: { Authorization: "Bearer session-jwt" },
+    });
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(502);
+    expect(data).toMatchObject({ code: "SERVER_UNREACHABLE" });
+  });
+
+  it("still rejects sk_ bearers locally without calling hosted", async () => {
+    const fetchMock = stubHosted(workosJson({}));
+
+    const response = await app.request("/api/web/api-keys", {
+      method: "GET",
+      headers: { Authorization: "Bearer sk_live_123" },
+    });
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(403);
+    expect(data).toMatchObject({ code: "FORBIDDEN" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -21,6 +21,7 @@ import {
   verifyAuthKitToken,
   AuthKitConfigError,
 } from "../../services/authkit-jwt.js";
+import { HOSTED_MODE } from "../../config.js";
 
 /**
  * `/api/web/api-keys/*` — WorkOS API Key management.
@@ -30,6 +31,10 @@ import {
  * we need for v1 are documented REST routes). MCPJam never stores the raw
  * key value — `value` is in WorkOS's create response only, returned to the
  * browser once, and never persisted or logged.
+ *
+ * Local mode (npx) has neither `WORKOS_API_KEY` nor the backend service
+ * token, so these routes can never be served locally — requests are proxied
+ * verbatim to the hosted app instead (see the proxy middleware below).
  *
  * Security notes for future contributors:
  * - A user can only mint a key as powerful as their own session: the
@@ -65,6 +70,72 @@ apiKeys.use("*", async (c, next) => {
     );
   }
   return next();
+});
+
+// ---------------------------------------------------------------------------
+// Local-mode proxy: npx installs can never serve key management themselves,
+// so forward the request verbatim to the hosted app — it re-verifies the
+// session bearer and applies all validation, and the response shapes are
+// identical, so the client is none the wiser. Same local→hosted pattern as
+// the remote guest-session source (guest-session-source.ts).
+//
+// Hosted mode never proxies: a missing WORKOS_API_KEY there is a deployment
+// fault that must surface as the existing 500, not loop back into itself.
+const DEFAULT_REMOTE_API_KEYS_URL = "https://app.mcpjam.com/api/web/api-keys";
+const REMOTE_PROXY_TIMEOUT_MS = 30_000;
+
+function getRemoteApiKeysUrl(): string {
+  return process.env.MCPJAM_REMOTE_API_KEYS_URL || DEFAULT_REMOTE_API_KEYS_URL;
+}
+
+apiKeys.use("*", async (c, next) => {
+  if (HOSTED_MODE) {
+    return next();
+  }
+
+  const url = new URL(c.req.url);
+  const mountIndex = url.pathname.indexOf("/api-keys");
+  const suffix =
+    mountIndex >= 0 ? url.pathname.slice(mountIndex + "/api-keys".length) : "";
+  const target = `${getRemoteApiKeysUrl()}${suffix}${url.search}`;
+
+  const headers: Record<string, string> = {};
+  const authorization = c.req.header("authorization");
+  if (authorization) headers["Authorization"] = authorization;
+  const contentType = c.req.header("content-type");
+  if (contentType) headers["Content-Type"] = contentType;
+
+  const method = c.req.method;
+  const body =
+    method === "GET" || method === "HEAD" ? undefined : await c.req.text();
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method,
+      headers,
+      body,
+      signal: AbortSignal.timeout(REMOTE_PROXY_TIMEOUT_MS),
+    });
+  } catch (error) {
+    logger.error("API key proxy to hosted app failed", {
+      target,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "Could not reach the hosted MCPJam service to manage API keys",
+    );
+  }
+
+  return new Response(await upstream.text(), {
+    status: upstream.status,
+    headers: {
+      "Content-Type":
+        upstream.headers.get("content-type") ?? "application/json",
+    },
+  });
 });
 
 // `sessionAuthMiddleware` bypasses `/api/web/*` entirely (session-auth.ts:103),


### PR DESCRIPTION
## Summary
Local/npx API key requests now proxy to the hosted MCPJam app.
## Why
Local users should not need WORKOS_API_KEY. Hosted prod owns that secret and creates the sk_... keys safely.
## Follow-up
Add a proper dev-only API key flow later, including WorkOS org setup/auto-assignment for dev users.
## Tests
Focused API key route tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxies local `/api/web/api-keys` requests to the hosted MCPJam service so devs don’t need `WORKOS_API_KEY` when running via npx. Hosted handles key creation securely; local behaves as a thin pass-through.

- New Features
  - In non-`HOSTED_MODE`, forward all API key routes to `https://app.mcpjam.com/api/web/api-keys` (override with `MCPJAM_REMOTE_API_KEYS_URL`).
  - Preserve method, path, query, body, and `Authorization` header; return hosted response as-is.
  - 30s timeout; unreachable hosted service returns 502 with code `SERVER_UNREACHABLE`.
  - Hosted mode never proxies; local still rejects `sk_` bearer tokens without contacting hosted.

<sup>Written for commit 09a6a2bd37784f0c3358543c2674a702288643e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

