### PR TITLE
Gate Cross-App Access (XAA) auth option behind the xaa flag

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
@@ -1,11 +1,18 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { AuthenticationSection } from "../shared/AuthenticationSection";
 import { fetchOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-api";
 
 vi.mock("@/lib/apis/hosted-oauth-client-secret-api", () => ({
   fetchOAuthClientSecret: vi.fn(),
+}));
+
+let xaaFlagValue: boolean | undefined = undefined;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: (flag: string) =>
+    flag === "xaa" ? xaaFlagValue : undefined,
 }));
 
 const fetchOAuthClientSecretMock = vi.mocked(fetchOAuthClientSecret);
@@ -37,6 +44,104 @@ const hostedSecretProps = {
 };
 
 describe("AuthenticationSection", () => {
+  beforeEach(() => {
+    xaaFlagValue = undefined;
+  });
+
+  it("hides the Cross-App Access (XAA) option when the xaa flag is off", async () => {
+    xaaFlagValue = false;
+    render(
+      <AuthenticationSection
+        serverUrl="https://example.com/mcp"
+        authType="none"
+        onAuthTypeChange={vi.fn()}
+        showAuthSettings={false}
+        bearerToken=""
+        onBearerTokenChange={vi.fn()}
+        oauthScopesInput=""
+        onOauthScopesChange={vi.fn()}
+        oauthProtocolMode="2025-11-25"
+        onOauthProtocolModeChange={vi.fn()}
+        oauthRegistrationMode="auto"
+        onOauthRegistrationModeChange={vi.fn()}
+        useCustomClientId={false}
+        onUseCustomClientIdChange={vi.fn()}
+        clientId=""
+        onClientIdChange={vi.fn()}
+        clientSecret=""
+        onClientSecretChange={vi.fn()}
+        clientIdError={null}
+        clientSecretError={null}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("combobox"));
+    expect(
+      screen.queryByText("Cross-App Access (XAA)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Cross-App Access (XAA) option when the xaa flag is enabled", async () => {
+    xaaFlagValue = true;
+    render(
+      <AuthenticationSection
+        serverUrl="https://example.com/mcp"
+        authType="none"
+        onAuthTypeChange={vi.fn()}
+        showAuthSettings={false}
+        bearerToken=""
+        onBearerTokenChange={vi.fn()}
+        oauthScopesInput=""
+        onOauthScopesChange={vi.fn()}
+        oauthProtocolMode="2025-11-25"
+        onOauthProtocolModeChange={vi.fn()}
+        oauthRegistrationMode="auto"
+        onOauthRegistrationModeChange={vi.fn()}
+        useCustomClientId={false}
+        onUseCustomClientIdChange={vi.fn()}
+        clientId=""
+        onClientIdChange={vi.fn()}
+        clientSecret=""
+        onClientSecretChange={vi.fn()}
+        clientIdError={null}
+        clientSecretError={null}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("combobox"));
+    expect(screen.getByText("Cross-App Access (XAA)")).toBeInTheDocument();
+  });
+
+  it("keeps the Cross-App Access (XAA) option visible for a server already using it, even when the flag is off", async () => {
+    xaaFlagValue = false;
+    render(
+      <AuthenticationSection
+        serverUrl="https://example.com/mcp"
+        authType="xaa"
+        onAuthTypeChange={vi.fn()}
+        showAuthSettings={true}
+        bearerToken=""
+        onBearerTokenChange={vi.fn()}
+        oauthScopesInput=""
+        onOauthScopesChange={vi.fn()}
+        oauthProtocolMode="2025-11-25"
+        onOauthProtocolModeChange={vi.fn()}
+        oauthRegistrationMode="auto"
+        onOauthRegistrationModeChange={vi.fn()}
+        useCustomClientId={false}
+        onUseCustomClientIdChange={vi.fn()}
+        clientId=""
+        onClientIdChange={vi.fn()}
+        clientSecret=""
+        onClientSecretChange={vi.fn()}
+        clientIdError={null}
+        clientSecretError={null}
+      />,
+    );
+
+    expect(screen.getByText("Cross-App Access (XAA)")).toBeInTheDocument();
+  });
+
   it("does not show the OAuth plan explainer for a typical automatic OAuth setup", () => {
     render(
       <AuthenticationSection

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import {
@@ -147,6 +148,11 @@ export function AuthenticationSection({
   // itself if they clear it back to empty).
   const [isReplacingSecret, setIsReplacingSecret] = useState(false);
   const [isBearerTokenVisible, setIsBearerTokenVisible] = useState(false);
+
+  const xaaFlagEnabled = useFeatureFlagEnabled("xaa");
+  // Keep the option visible if a server is already configured with XAA, even
+  // when the flag is off, so the trigger doesn't render blank for it.
+  const showXaaOption = xaaFlagEnabled === true || authType === "xaa";
 
   const canRevealClientSecret =
     hasStoredClientSecret &&
@@ -312,7 +318,9 @@ export function AuthenticationSection({
               <SelectItem value="none">No Authentication</SelectItem>
               <SelectItem value="bearer">Bearer Token</SelectItem>
               <SelectItem value="oauth">OAuth</SelectItem>
-              <SelectItem value="xaa">Cross-App Access (XAA)</SelectItem>
+              {showXaaOption && (
+                <SelectItem value="xaa">Cross-App Access (XAA)</SelectItem>
+              )}
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Summary
- The Add/Edit Server auth type dropdown always listed "Cross-App Access (XAA)" regardless of the `xaa` PostHog flag, unlike the dedicated XAA flow tab which is already flag-gated.
- `AuthenticationSection` now hides the option unless `useFeatureFlagEnabled("xaa")` is true, but keeps it visible when a server is already configured with `authType: "xaa"` so its dropdown trigger doesn't render blank for existing configs.

## Test plan
- [x] `npm run typecheck:client -w @mcpjam/inspector` passes
- [x] `AuthenticationSection.test.tsx` (13 tests, 3 new) covers: hidden when flag off, shown when flag on, preserved for pre-existing xaa config
- [x] Full `client/src/components/connection` suite (164 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only feature-flag gating in the connection form; existing XAA servers remain editable with no auth or backend behavior changes.
> 
> **Overview**
> The Add/Edit Server **Authentication** dropdown no longer always shows **Cross-App Access (XAA)**. `AuthenticationSection` now reads `useFeatureFlagEnabled("xaa")` and only renders that auth type when the flag is **on**, aligning with other XAA UI that is already flag-gated.
> 
> If a server is already saved with `authType: "xaa"`, the option stays visible when the flag is off so the select trigger still shows a label instead of going blank.
> 
> Tests mock PostHog and cover flag off (hidden), flag on (shown), and existing XAA config (still shown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71ece487144348f74224a797f6a44d50394d3e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->