### PR TITLE
eval iterations bar

### DIFF
--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -227,27 +227,37 @@ export function CreditBalanceCard({
                   )}`
                 : undefined
             }
+            // "remaining / allowed": bar drains as iterations are used —
+            // matches the monthly team credits row.
             rightText={
               isEvalIterationQuotaLoading ||
               !evalIterationQuota ||
               evalIterationQuota.allowed === null
                 ? null
-                : `${evalIterationQuota.used.toLocaleString()} / ${evalIterationQuota.allowed.toLocaleString()}`
+                : `${Math.max(
+                    0,
+                    evalIterationQuota.allowed - evalIterationQuota.used
+                  ).toLocaleString()} / ${evalIterationQuota.allowed.toLocaleString()}`
             }
             fillPercent={
               isEvalIterationQuotaLoading ||
               !evalIterationQuota ||
               !evalIterationQuota.allowed
                 ? 0
-                : Math.min(
-                    100,
-                    (evalIterationQuota.used / evalIterationQuota.allowed) * 100
+                : Math.max(
+                    0,
+                    ((evalIterationQuota.allowed - evalIterationQuota.used) /
+                      evalIterationQuota.allowed) *
+                      100
                   )
             }
-            ariaLabel={`${evalIterationLabel} used`}
+            ariaLabel={`${evalIterationLabel} remaining`}
             ariaValueText={
               evalIterationQuota && evalIterationQuota.allowed !== null
-                ? `${evalIterationQuota.used.toLocaleString()} of ${evalIterationQuota.allowed.toLocaleString()} eval iterations used`
+                ? `${Math.max(
+                    0,
+                    evalIterationQuota.allowed - evalIterationQuota.used
+                  ).toLocaleString()} of ${evalIterationQuota.allowed.toLocaleString()} eval iterations remaining`
                 : undefined
             }
             isLoading={isEvalIterationQuotaLoading}

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -203,7 +203,8 @@ describe("CreditBalanceCard", () => {
 
     const evalRow = screen.getByTestId("usage-eval-iterations");
     expect(evalRow).toHaveTextContent(/Monthly eval iterations/);
-    expect(evalRow).toHaveTextContent(/7,580 \/ 10,000/);
+    // Remaining / allowed — 10,000 allowed minus 7,580 used.
+    expect(evalRow).toHaveTextContent(/2,420 \/ 10,000/);
     expect(evalRow).not.toHaveTextContent(/Resets/);
   });
 


### PR DESCRIPTION
<img width="965" height="205" alt="Screenshot 2026-07-04 at 11 33 02 AM" src="https://github.com/user-attachments/assets/4d196070-df9b-4cd3-b3ba-5deb328b3cf1" />
- make eval iterations bar go right to left as it confused some of our customers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the eval iterations bar to show remaining quota (remaining / allowed) and drain as iterations are used, matching the monthly team credits row to reduce confusion.
Updated the fill percent, visible label, and ARIA text to use “remaining,” and adjusted the unit test to expect remaining (e.g., 2,420 / 10,000).

<sup>Written for commit 3ee40ab952dc0abcd7973d12e692e9c608a14550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

