### PR TITLE
fix(sidebar): keep notifications popover open when opened from account menu

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useQuery } from "convex/react";
 import {
@@ -51,6 +51,10 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
   const { isMobile } = useSidebar();
   const [menuOpen, setMenuOpen] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
+  // Set when the Notifications item is selected so the dropdown's
+  // close-auto-focus handler knows to open the popover instead of returning
+  // focus to the shared trigger (which would immediately dismiss the popover).
+  const openNotificationsOnCloseRef = useRef(false);
   const { unreadCount } = useNotifications({ isAuthenticated });
   const appNavigate = useAppNavigate();
 
@@ -189,6 +193,18 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
               side={isMobile ? "bottom" : "right"}
               align="end"
               sideOffset={4}
+              onCloseAutoFocus={(event) => {
+                // When Notifications was selected, don't return focus to the
+                // trigger — that focus move lands outside the notifications
+                // popover and Radix would dismiss it as a focus-outside event.
+                // Instead, swallow the focus-return and open the popover here,
+                // once the menu has actually closed.
+                if (openNotificationsOnCloseRef.current) {
+                  openNotificationsOnCloseRef.current = false;
+                  event.preventDefault();
+                  setNotificationsOpen(true);
+                }
+              }}
             >
               <DropdownMenuLabel className="p-0 font-normal">
                 <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
@@ -228,7 +244,12 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
                 Settings
               </DropdownMenuItem>
               <DropdownMenuItem
-                onClick={() => setNotificationsOpen(true)}
+                onSelect={() => {
+                  // Flag the intent, then let the menu close normally; the
+                  // popover is opened from the dropdown's onCloseAutoFocus so
+                  // the focus-return doesn't dismiss it. See the handler above.
+                  openNotificationsOnCloseRef.current = true;
+                }}
                 className="cursor-pointer"
               >
                 <Bell className="size-4" />


### PR DESCRIPTION
## Problem

Opening **Notifications** from the account menu in the sidebar flashed the panel open and closed it immediately, so it could never be viewed.

## Root cause

The Notifications entry is a `DropdownMenuItem` inside the account `DropdownMenu`, and it opens a sibling `Popover`. Selecting the item closes the (modal) dropdown in the same event, and Radix's `onCloseAutoFocus` returns focus to the trigger. The trigger lives inside the notifications `PopoverAnchor` — i.e. *outside* the popover content — so that focus-return is seen by the just-opened popover as a focus-outside event and dismisses it instantly.

## Fix

- On `onSelect`, only flag the intent and let the dropdown close normally.
- In the dropdown's `onCloseAutoFocus`, when that flag is set, `preventDefault()` the focus-return to the trigger and open the popover there.

Focus never moves outside the popover, so it stays open.

## Testing

- `client/src/components/sidebar/__tests__/sidebar-user.test.tsx` (7 tests) pass.
- Manually verified the panel now stays open when clicking Notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxDVy5WRtRx5VySmmtwW98

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the instant close of the Notifications popover when opened from the account menu in the sidebar. Clicking Notifications now opens the popover and it stays open.

- **Bug Fixes**
  - On Notifications select, set a flag and let the dropdown close; in `onCloseAutoFocus`, prevent focus return to the trigger and open the popover.
  - Keeps focus inside the popover to avoid focus-outside dismissal.

<sup>Written for commit 9006ef45fc0d6fc4dac777506df8e61dd88eaabd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

