### PR TITLE
fix(hosts): explain why the Save host button is disabled

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -7,6 +7,11 @@ import { usePostHog } from "posthog-js/react";
 import { ReactFlowProvider } from "@xyflow/react";
 import { standardEventProps } from "@/lib/PosthogUtils";
 import { Button } from "@mcpjam/design-system/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
 import {
   ResizableHandle,
@@ -39,6 +44,7 @@ import { useComputerStatus } from "@/hooks/useProjectComputer";
 import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
 import {
   hasBlockingErrors,
+  saveDisabledReason as computeSaveDisabledReason,
   useHostDraftValidation,
 } from "./focus/useHostDraftValidation";
 import {
@@ -413,6 +419,17 @@ export function HostBuilderViewRedesigned({
   // non-positive timeout) and the write would only fail at the backend.
   const canSave = isDirty && !isSaving && !hasBlockingErrors(attention);
 
+  // Explain WHY the button is greyed out. A silently-disabled Save is what
+  // sent a Discord report chasing a phantom "you must pick a model" rule —
+  // the real gate is just "no unsaved changes" or a blocking validation
+  // error. Surface that verbatim on hover so the disabled state is never a
+  // guessing game. `null` ⇒ enabled (or actively saving) ⇒ no hint needed.
+  const saveDisabledReason = computeSaveDisabledReason({
+    isDirty,
+    isSaving,
+    issues: attention,
+  });
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
       <div className="relative shrink-0 border-b border-border/40 px-8 py-2.5">
@@ -426,24 +443,37 @@ export function HostBuilderViewRedesigned({
               if (next === "compare") navigate("/host-compare");
             }}
           />
-          <Button
-            size="sm"
-            onClick={() => void handleSave()}
-            disabled={!canSave}
-            variant={isDirty ? "default" : "ghost"}
-            className={
-              isDirty
-                ? "shrink-0"
-                : "shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-40"
-            }
-          >
-            {isSaving ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : (
-              <Save className="size-4" />
-            )}
-            {isDirty ? "Save host" : "Saved"}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* Span wrapper: a disabled <button> swallows pointer events,
+                  so the tooltip must hang off an always-interactive parent. */}
+              <span className="inline-flex shrink-0">
+                <Button
+                  size="sm"
+                  onClick={() => void handleSave()}
+                  disabled={!canSave}
+                  variant={isDirty ? "default" : "ghost"}
+                  className={
+                    isDirty
+                      ? "shrink-0"
+                      : "shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-40"
+                  }
+                >
+                  {isSaving ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Save className="size-4" />
+                  )}
+                  {isDirty ? "Save host" : "Saved"}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            {saveDisabledReason ? (
+              <TooltipContent side="bottom" variant="muted">
+                {saveDisabledReason}
+              </TooltipContent>
+            ) : null}
+          </Tooltip>
         </div>
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
           <div className="pointer-events-auto">

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/AppsExtensionTab.saveGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/AppsExtensionTab.saveGate.test.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  emptyHostConfigInputV2,
+  hostConfigInputsEqual,
+  type HostConfigInputV2,
+} from "@/lib/client-config-v2";
+
+vi.mock("@/components/ui/json-editor", () => ({
+  JsonEditor: ({
+    rawContent,
+    onRawChange,
+  }: {
+    rawContent: string;
+    onRawChange: (next: string) => void;
+  }) => (
+    <textarea
+      aria-label="json"
+      value={rawContent}
+      onChange={(e) => onRawChange(e.target.value)}
+    />
+  ),
+}));
+
+import { AppsExtensionTab } from "../AppsExtensionTab";
+
+function Harness({ initial }: { initial: HostConfigInputV2 }) {
+  const [draft, setDraft] = useState(initial);
+  const dirty = !hostConfigInputsEqual(draft, initial);
+  return (
+    <div>
+      <div data-testid="dirty">{dirty ? "dirty" : "clean"}</div>
+      <AppsExtensionTab
+        draft={draft}
+        onDraftChange={(updater) => setDraft((prev) => updater(prev))}
+        attention={[]}
+      />
+    </div>
+  );
+}
+
+function mcpjamHost(): HostConfigInputV2 {
+  return emptyHostConfigInputV2({
+    hostStyle: "mcpjam",
+    clientCapabilities: {
+      extensions: {
+        "io.modelcontextprotocol/ui": {
+          mimeTypes: ["text/html", "text/uri-list"],
+        },
+      },
+    },
+  } as Partial<HostConfigInputV2>);
+}
+
+describe("AppsExtensionTab arms the Save gate on edit", () => {
+  it("editing hostContext marks the draft dirty", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={mcpjamHost()} />);
+    expect(screen.getByTestId("dirty").textContent).toBe("clean");
+
+    const textarea = screen.getByLabelText("json") as HTMLTextAreaElement;
+    const current = JSON.parse(textarea.value);
+    current.hostContext = { locale: "en-US" };
+    await user.clear(textarea);
+    await user.paste(JSON.stringify(current, null, 2));
+
+    expect(screen.getByTestId("dirty").textContent).toBe("dirty");
+  });
+
+  it("editing an extension mimeType marks the draft dirty", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={mcpjamHost()} />);
+    expect(screen.getByTestId("dirty").textContent).toBe("clean");
+
+    const textarea = screen.getByLabelText("json") as HTMLTextAreaElement;
+    const current = JSON.parse(textarea.value);
+    current.extensions["io.modelcontextprotocol/ui"].mimeTypes = ["text/html"];
+    await user.clear(textarea);
+    await user.paste(JSON.stringify(current, null, 2));
+
+    expect(screen.getByTestId("dirty").textContent).toBe("dirty");
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.saveGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.saveGate.test.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  emptyHostConfigInputV2,
+  hostConfigInputsEqual,
+  type HostConfigInputV2,
+} from "@/lib/client-config-v2";
+import {
+  collectHostAttentionIssues,
+  hasBlockingErrors,
+} from "../useHostDraftValidation";
+
+// Regression guard for the Discord "Save host stays greyed after editing the
+// MCP Protocol config" report. Proves that a protocol-config edit alone arms
+// the exact production Save gate — no agent model required.
+//
+// Replace the heavy CodeMirror JSON editor with a plain textarea that
+// forwards edits through onRawChange — the exact contract ProtocolTab relies
+// on. This isolates the dirty-state logic from editor internals.
+vi.mock("@/components/ui/json-editor", () => ({
+  JsonEditor: ({
+    rawContent,
+    onRawChange,
+  }: {
+    rawContent: string;
+    onRawChange: (next: string) => void;
+  }) => (
+    <textarea
+      aria-label="json"
+      value={rawContent}
+      onChange={(e) => onRawChange(e.target.value)}
+    />
+  ),
+}));
+
+import { ProtocolTab } from "../ProtocolTab";
+
+// Mirror HostBuilderViewRedesigned's exact save gate:
+//   canSave = isDirty && !isSaving && !hasBlockingErrors(attention)
+// with a host that has NO model (modelId === "") — the reporter's case.
+function Harness({
+  initial,
+  hostName = "My host",
+}: {
+  initial: HostConfigInputV2;
+  hostName?: string;
+}) {
+  const [draft, setDraft] = useState(initial);
+  const dirty = !hostConfigInputsEqual(draft, initial);
+  const attention = collectHostAttentionIssues(draft, hostName);
+  const canSave = dirty && !hasBlockingErrors(attention);
+  return (
+    <div>
+      <div data-testid="dirty">{dirty ? "dirty" : "clean"}</div>
+      <div data-testid="cansave">{canSave ? "cansave" : "blocked"}</div>
+      <ProtocolTab
+        draft={draft}
+        onDraftChange={(updater) => setDraft((prev) => updater(prev))}
+        attention={attention}
+      />
+    </div>
+  );
+}
+
+// A realistic saved host: non-empty clientCapabilities.extensions plus a
+// populated mcpProfile — mirrors what a claude/mcpjam-style host persists.
+function realisticHost(): HostConfigInputV2 {
+  return emptyHostConfigInputV2({
+    clientCapabilities: {
+      extensions: {
+        "io.modelcontextprotocol/ui": { mimeTypes: ["text/html"] },
+      },
+    },
+    mcpProfile: {
+      profileVersion: 1,
+      apps: {
+        sandbox: {
+          csp: { restrictTo: { connectDomains: ["https://example.com"] } },
+        },
+      },
+    },
+  } as Partial<HostConfigInputV2>);
+}
+
+describe("ProtocolTab arms the Save gate on edit", () => {
+  it("editing capabilities in the JSON marks the draft dirty (empty host)", async () => {
+    const user = userEvent.setup();
+    const initial = emptyHostConfigInputV2();
+    render(<Harness initial={initial} />);
+
+    expect(screen.getByTestId("dirty").textContent).toBe("clean");
+
+    const textarea = screen.getByLabelText("json") as HTMLTextAreaElement;
+    const edited = JSON.stringify(
+      {
+        capabilities: { sampling: {} },
+        connectionDefaults: {
+          requestTimeout: initial.connectionDefaults.requestTimeout,
+        },
+      },
+      null,
+      2,
+    );
+    await user.clear(textarea);
+    await user.paste(edited);
+
+    expect(screen.getByTestId("dirty").textContent).toBe("dirty");
+  });
+
+  it("with NO model set, a protocol edit still enables Save (production gate)", async () => {
+    const user = userEvent.setup();
+    // modelId defaults to "" — the reporter's "no model" host.
+    const initial = emptyHostConfigInputV2();
+    expect(initial.modelId).toBe("");
+    render(<Harness initial={initial} />);
+
+    expect(screen.getByTestId("cansave").textContent).toBe("blocked");
+
+    const textarea = screen.getByLabelText("json") as HTMLTextAreaElement;
+    const current = JSON.parse(textarea.value);
+    current.capabilities = { ...(current.capabilities ?? {}), sampling: {} };
+    await user.clear(textarea);
+    await user.paste(JSON.stringify(current, null, 2));
+
+    // The reporter says Save stayed blocked until they set a model. If the
+    // production gate is sound, editing the protocol config alone must arm it.
+    expect(screen.getByTestId("cansave").textContent).toBe("cansave");
+  });
+
+  it("editing capabilities on a realistic seeded host marks dirty", async () => {
+    const user = userEvent.setup();
+    const initial = realisticHost();
+    render(<Harness initial={initial} />);
+
+    expect(screen.getByTestId("dirty").textContent).toBe("clean");
+
+    const textarea = screen.getByLabelText("json") as HTMLTextAreaElement;
+    const current = JSON.parse(textarea.value);
+    // Tweak a value inside the existing extensions capability.
+    current.capabilities.extensions["io.modelcontextprotocol/ui"].mimeTypes = [
+      "text/html",
+      "image/png",
+    ];
+    await user.clear(textarea);
+    await user.paste(JSON.stringify(current, null, 2));
+
+    expect(screen.getByTestId("dirty").textContent).toBe("dirty");
+  });
+
+  it("selecting the 2026 RC protocol version marks dirty", async () => {
+    const user = userEvent.setup();
+    const initial = realisticHost();
+    render(<Harness initial={initial} />);
+
+    expect(screen.getByTestId("dirty").textContent).toBe("clean");
+
+    // Radix Select: open then pick the RC option.
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByText(/2026 RC/i));
+
+    expect(screen.getByTestId("dirty").textContent).toBe("dirty");
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/saveDisabledReason.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/saveDisabledReason.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { saveDisabledReason } from "../useHostDraftValidation";
+import type { HostAttentionIssue } from "../../types";
+
+const err = (message: string): HostAttentionIssue => ({
+  level: "error",
+  tab: "behavior",
+  field: "hostDisplayName",
+  message,
+});
+const warn = (message: string): HostAttentionIssue => ({
+  level: "warning",
+  tab: "behavior",
+  field: "modelId",
+  message,
+});
+
+describe("saveDisabledReason", () => {
+  it("returns null while saving (spinner already communicates)", () => {
+    expect(
+      saveDisabledReason({ isDirty: true, isSaving: true, issues: [err("x")] }),
+    ).toBeNull();
+  });
+
+  it("returns null when the button is enabled (dirty, no blocking errors)", () => {
+    expect(
+      saveDisabledReason({ isDirty: true, isSaving: false, issues: [] }),
+    ).toBeNull();
+  });
+
+  it("explains that nothing has changed when the draft is clean", () => {
+    expect(
+      saveDisabledReason({ isDirty: false, isSaving: false, issues: [] }),
+    ).toMatch(/no unsaved changes/i);
+  });
+
+  it("does NOT claim a model is required — an unset model never gates Save", () => {
+    // The reporter's exact case: dirty draft with only the model warning.
+    // Save is enabled, so there is no disabled reason to show.
+    expect(
+      saveDisabledReason({
+        isDirty: true,
+        isSaving: false,
+        issues: [warn("Pick a model before chatting")],
+      }),
+    ).toBeNull();
+  });
+
+  it("surfaces blocking validation errors verbatim over the clean message", () => {
+    const reason = saveDisabledReason({
+      isDirty: false,
+      isSaving: false,
+      issues: [err("Client name is required"), warn("Empty system prompt")],
+    });
+    expect(reason).toBe("Client name is required");
+  });
+
+  it("joins multiple blocking errors", () => {
+    const reason = saveDisabledReason({
+      isDirty: true,
+      isSaving: false,
+      issues: [
+        err("Client name is required"),
+        err("Request timeout must be a positive number"),
+      ],
+    });
+    expect(reason).toBe(
+      "Client name is required · Request timeout must be a positive number",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/useHostDraftValidation.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/useHostDraftValidation.ts
@@ -176,6 +176,36 @@ export function hasBlockingErrors(
   return issues.some((issue) => issue.level === "error");
 }
 
+/**
+ * Human-readable explanation for why the "Save host" button is disabled, or
+ * `null` when it's enabled (or actively saving, where the spinner already
+ * speaks for itself).
+ *
+ * Motivation: a *silently* greyed Save button reads as an arbitrary rule.
+ * A Discord report chased a phantom "you must pick a model first" gate when
+ * the real reason was simply "nothing has changed yet" — model id is only a
+ * non-blocking warning and never gates Save. Surfacing the actual reason
+ * (no changes, or the specific blocking validation errors) on hover keeps
+ * the disabled state honest. Priority mirrors the `canSave` gate order:
+ * saving → blocking errors → not dirty.
+ */
+export function saveDisabledReason(args: {
+  isDirty: boolean;
+  isSaving: boolean;
+  issues: ReadonlyArray<HostAttentionIssue>;
+}): string | null {
+  const { isDirty, isSaving, issues } = args;
+  if (isSaving) return null;
+  const blocking = issues.filter((issue) => issue.level === "error");
+  if (blocking.length > 0) {
+    return blocking.map((issue) => issue.message).join(" · ");
+  }
+  if (!isDirty) {
+    return "No unsaved changes yet — edit any field to enable Save";
+  }
+  return null;
+}
+
 export function useHostDraftValidation(
   draft: HostConfigInputV2,
   hostDisplayName?: string,


### PR DESCRIPTION
## Problem

Reported by Andrew in Discord. On the Host page (`/hosts/:id`), after editing the host configuration — the MCP Protocol tab's config JSON (protocol version / capabilities / extensions) — the **Save host** button stayed greyed out. Clicking the Agent tab and selecting a model appeared to unblock it, suggesting either a required-model gate or that the dirty check ignored MCP Protocol edits.

## What's actually going on

Both hypotheses are **false against current code**, and I verified it with tests that exercise the real round-trip (`protocolToJson`/`appsToJson` → `applyJsonToDraft` → `hostConfigInputsEqual`):

- Editing the protocol/apps config **does** mark the draft dirty (capabilities, protocol-version dropdown, extensions, `hostContext`, …).
- An unset `modelId` is only a **non-blocking warning** — it never gates Save.
- A protocol edit **alone** flips the exact production gate `isDirty && !isSaving && !hasBlockingErrors(attention)` from blocked → enabled, even with no model set.

The real defect is the one the report names under **Expected**: Save is **silently** disabled. When it's greyed there's no signal whether it's because nothing changed (a no-op/invalid-JSON edit) or a blocking validation error — which is what makes it read as an arbitrary "you must pick a model first" rule.

## Fix

Make the disabled state self-explanatory. New pure helper `saveDisabledReason()` (beside `hasBlockingErrors`) returns, in gate-priority order:

- saving → `null` (spinner already communicates)
- blocking errors → the messages verbatim (e.g. _"Client name is required"_)
- not dirty → _"No unsaved changes yet — edit any field to enable Save"_

The Save button surfaces this on hover via a tooltip, wrapped in a `span` so it fires while the button is `disabled`. Model id stays a warning — it genuinely doesn't block saving, and the UI no longer implies otherwise.

## Tests

- `saveDisabledReason.test.ts` — 6 cases, incl. _"does NOT claim a model is required"_
- `ProtocolTab.saveGate.test.tsx` — a protocol edit arms the gate with no model set
- `AppsExtensionTab.saveGate.test.tsx` — extension / `hostContext` edits mark dirty
- Full `focus` suite: **109 passed**; no type errors in touched files.

Video:

https://github.com/user-attachments/assets/cdd68116-7e83-4806-bf94-f11aee2b0e10



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies why the "Save host" button is disabled on `/hosts/:id` and removes confusion about needing a model. A tooltip now explains the exact reason (blocking errors or no changes), and MCP Protocol/Apps edits correctly enable Save even without a model.

- **Bug Fixes**
  - Added `saveDisabledReason()` to return: null while saving/enabled, blocking error messages, or "No unsaved changes…" when clean; surfaced via a tooltip on the disabled button (span-wrapped trigger so it works when disabled).
  - Kept the production gate `isDirty && !isSaving && !hasBlockingErrors(...)`; `modelId` remains a warning and never blocks Save.
  - Added focused tests: `saveDisabledReason.test.ts`, `ProtocolTab.saveGate.test.tsx`, and `AppsExtensionTab.saveGate.test.tsx`.

<sup>Written for commit 08c33c7700fa59ac56cd5c36594fcfc23b647a04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

