### PR TITLE
feat(sidebar): World Cup soccer ball next to the logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 .mcpjam/skills/
 **/.mcpjam/skills/
 .claude/
+docs/superpowers/
 mcpjam-inspector/server/routes/apps/**/*.bundled.ts
 mcpjam-inspector/server/utils/browser-harness/*.generated.ts
 cli/dist/

--- a/mcpjam-inspector/client/src/components/__tests__/world-cup-ball.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/world-cup-ball.test.tsx
@@ -1,0 +1,28 @@
+// ⚽ World Cup 2026 — remove after the tournament (see world-cup-ball.tsx)
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { WorldCupBall } from "@/components/world-cup-ball";
+
+describe("WorldCupBall", () => {
+  it("renders a soccer ball", () => {
+    render(<WorldCupBall />);
+    expect(screen.queryByRole("img", { name: /soccer ball/i })).not.toBeNull();
+  });
+
+  it("bounces on click without navigating (stops propagation)", () => {
+    const onParentClick = vi.fn();
+    render(
+      <button type="button" onClick={onParentClick}>
+        <WorldCupBall />
+      </button>
+    );
+
+    const ball = screen.getByRole("img", { name: /soccer ball/i });
+    fireEvent.click(ball);
+
+    // The ball lives inside the logo's nav button; clicking it must NOT bubble
+    // up and navigate — it should only trigger the kick animation.
+    expect(onParentClick).not.toHaveBeenCalled();
+    expect(ball.className).toContain("wc-ball--kick");
+  });
+});

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -50,6 +50,8 @@ import { SidebarUser } from "@/components/sidebar/sidebar-user";
 import { SidebarContextSwitcher } from "@/components/sidebar/sidebar-context-switcher";
 import { SidebarTrialCountdown } from "@/components/sidebar/sidebar-trial-countdown";
 import { ShareProjectDialog } from "@/components/project/ShareProjectDialog";
+// ⚽ World Cup 2026 — remove after the tournament (see world-cup-ball.tsx)
+import { WorldCupBall } from "@/components/world-cup-ball";
 import { useUpdateNotification } from "@/hooks/useUpdateNotification";
 import { Button } from "@mcpjam/design-system/button";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
@@ -712,6 +714,8 @@ export function MCPSidebar({
                   alt="MCP Jam"
                   className="h-4 w-auto"
                 />
+                {/* ⚽ World Cup 2026 — remove after the tournament */}
+                <WorldCupBall className="ml-1.5" />
               </button>
             ) : state === "expanded" ? (
               <div className="relative isolate w-full">
@@ -734,6 +738,8 @@ export function MCPSidebar({
                     alt="MCP Jam"
                     className="h-4 w-auto"
                   />
+                  {/* ⚽ World Cup 2026 — remove after the tournament */}
+                  <WorldCupBall className="ml-1.5" />
                 </button>
                 <SidebarTrigger
                   className={cn(

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -50,7 +50,7 @@ import { SidebarUser } from "@/components/sidebar/sidebar-user";
 import { SidebarContextSwitcher } from "@/components/sidebar/sidebar-context-switcher";
 import { SidebarTrialCountdown } from "@/components/sidebar/sidebar-trial-countdown";
 import { ShareProjectDialog } from "@/components/project/ShareProjectDialog";
-// ⚽ World Cup 2026 — remove after the tournament (see world-cup-ball.tsx)
+//World Cup 2026 TODO remove after the tournament (see world-cup-ball.tsx)
 import { WorldCupBall } from "@/components/world-cup-ball";
 import { useUpdateNotification } from "@/hooks/useUpdateNotification";
 import { Button } from "@mcpjam/design-system/button";
@@ -714,7 +714,7 @@ export function MCPSidebar({
                   alt="MCP Jam"
                   className="h-4 w-auto"
                 />
-                {/* ⚽ World Cup 2026 — remove after the tournament */}
+                {/*World Cup 2026, TODO remove after the tournament */}
                 <WorldCupBall className="ml-1.5" />
               </button>
             ) : state === "expanded" ? (
@@ -738,7 +738,7 @@ export function MCPSidebar({
                     alt="MCP Jam"
                     className="h-4 w-auto"
                   />
-                  {/* ⚽ World Cup 2026 — remove after the tournament */}
+                  {/*World Cup 2026, TODO remove after the tournament */}
                   <WorldCupBall className="ml-1.5" />
                 </button>
                 <SidebarTrigger

--- a/mcpjam-inspector/client/src/components/world-cup-ball.tsx
+++ b/mcpjam-inspector/client/src/components/world-cup-ball.tsx
@@ -1,0 +1,96 @@
+// ⚽ World Cup 2026 celebration — TEMPORARY.
+// To remove after the tournament: delete this file and the two <WorldCupBall />
+// usages in components/mcp-sidebar.tsx (search for "WorldCupBall").
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * A small soccer ball that sits next to the MCP Jam logo during the World Cup.
+ * Click it for a little "kick" bounce. It renders inside the logo's navigation
+ * button, so the click handler calls stopPropagation() to bounce without
+ * navigating. The animation respects prefers-reduced-motion.
+ */
+export function WorldCupBall({ className }: { className?: string }) {
+  const [kicking, setKicking] = useState(false);
+
+  return (
+    <span
+      role="img"
+      aria-label="Soccer ball"
+      title="Go World Cup! ⚽"
+      onClick={(e) => {
+        e.stopPropagation();
+        setKicking(true);
+      }}
+      onAnimationEnd={() => setKicking(false)}
+      className={cn(
+        "inline-flex cursor-pointer select-none",
+        kicking && "wc-ball--kick",
+        className
+      )}
+    >
+      <style>{`
+        @keyframes wc-ball-kick {
+          0%   { transform: translateY(0) rotate(0deg); }
+          30%  { transform: translateY(-6px) rotate(-25deg); }
+          60%  { transform: translateY(0) rotate(12deg); }
+          100% { transform: translateY(0) rotate(0deg); }
+        }
+        .wc-ball--kick { animation: wc-ball-kick 0.5s ease-out; }
+        @media (prefers-reduced-motion: reduce) {
+          .wc-ball--kick { animation: none; }
+        }
+      `}</style>
+      <svg
+        viewBox="0 0 64 64"
+        className="h-4 w-4"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <defs>
+          <clipPath id="wc-ball-clip">
+            <circle cx="32" cy="32" r="29" />
+          </clipPath>
+        </defs>
+        <circle
+          cx="32"
+          cy="32"
+          r="29"
+          fill="#ffffff"
+          stroke="#111827"
+          strokeWidth="2"
+        />
+        {/* Real soccer-ball pattern: a truncated icosahedron projected onto a
+            sphere — black pentagons + connected seams over the white hexagons.
+            Geometry was generated and visually verified (see the design doc). */}
+        <g clipPath="url(#wc-ball-clip)">
+          <polygon points="32.00,22.04 22.53,28.92 26.15,40.05 37.85,40.05 41.47,28.92" fill="#111827" />
+          <polygon points="20.30,58.06 26.15,56.16 20.30,48.11 10.83,45.03 10.83,51.18" fill="#111827" />
+          <polygon points="3.60,28.92 7.21,33.90 13.06,25.85 13.06,15.89 7.21,17.79" fill="#111827" />
+          <polygon points="56.79,17.79 50.94,15.89 50.94,25.85 56.79,33.90 60.40,28.92" fill="#111827" />
+          <polygon points="26.15,4.04 22.53,9.01 32.00,12.09 41.47,9.01 37.85,4.04" fill="#111827" />
+          <polygon points="53.17,51.18 53.17,45.03 43.70,48.11 37.85,56.16 43.70,58.06" fill="#111827" />
+          <g fill="none" stroke="#111827" strokeWidth="0.8" strokeLinejoin="round">
+            <polygon points="32.00,22.04 22.53,28.92 26.15,40.05 37.85,40.05 41.47,28.92" />
+            <polygon points="20.30,58.06 26.15,56.16 20.30,48.11 10.83,45.03 10.83,51.18" />
+            <polygon points="3.60,28.92 7.21,33.90 13.06,25.85 13.06,15.89 7.21,17.79" />
+            <polygon points="56.79,17.79 50.94,15.89 50.94,25.85 56.79,33.90 60.40,28.92" />
+            <polygon points="26.15,4.04 22.53,9.01 32.00,12.09 41.47,9.01 37.85,4.04" />
+            <polygon points="53.17,51.18 53.17,45.03 43.70,48.11 37.85,56.16 43.70,58.06" />
+            <polygon points="10.83,45.03 20.30,48.11 26.15,40.05 22.53,28.92 13.06,25.85 7.21,33.90" />
+            <polygon points="43.70,48.11 37.85,40.05 26.15,40.05 20.30,48.11 26.15,56.16 37.85,56.16" />
+            <polygon points="13.06,15.89 13.06,25.85 22.53,28.92 32.00,22.04 32.00,12.09 22.53,9.01" />
+            <polygon points="32.00,12.09 32.00,22.04 41.47,28.92 50.94,25.85 50.94,15.89 41.47,9.01" />
+            <polygon points="56.79,33.90 50.94,25.85 41.47,28.92 37.85,40.05 43.70,48.11 53.17,45.03" />
+            <polygon points="7.21,46.21 10.83,51.18 10.83,45.03 7.21,33.90 3.60,28.92 3.60,35.08" />
+            <polygon points="37.85,56.16 26.15,56.16 20.30,58.06 26.15,59.96 37.85,59.96 43.70,58.06" />
+            <polygon points="20.30,5.94 10.83,12.82 7.21,17.79 13.06,15.89 22.53,9.01 26.15,4.04" />
+            <polygon points="37.85,4.04 41.47,9.01 50.94,15.89 56.79,17.79 53.17,12.82 43.70,5.94" />
+            <polygon points="60.40,35.08 60.40,28.92 56.79,33.90 53.17,45.03 53.17,51.18 56.79,46.21" />
+          </g>
+        </g>
+      </svg>
+    </span>
+  );
+}

--- a/mcpjam-inspector/client/src/components/world-cup-ball.tsx
+++ b/mcpjam-inspector/client/src/components/world-cup-ball.tsx
@@ -18,7 +18,7 @@ export function WorldCupBall({ className }: { className?: string }) {
     <span
       role="img"
       aria-label="Soccer ball"
-      title="Go World Cup! ⚽"
+      title="Go World Cup 2026!"
       onClick={(e) => {
         e.stopPropagation();
         setKicking(true);


### PR DESCRIPTION
## What
Adds a small soccer ball next to the MCP Jam logo to celebrate the World Cup (like Claude Desktop's seasonal touches). Click it for a little "kick" bounce.
Closes #2879

## Details
- New self-contained component `WorldCupBall`,  inline SVG of a real truncated-icosahedron soccer ball, CSS kick animation on click, respects `prefers-reduced-motion`.
- Shown next to the logo in the expanded sidebar and on mobile. Uses `stopPropagation` so clicking bounces without navigating.
- Easy to remove after the tournament: delete `world-cup-ball.tsx` and the two `<WorldCupBall />` usages in `mcp-sidebar.tsx`.


## Screenshots
<img width="1148" height="541" alt="image" src="https://github.com/user-attachments/assets/73509aa6-a19e-40b6-8128-c6824c80d07c" />
<img width="2548" height="732" alt="image" src="https://github.com/user-attachments/assets/ac90afec-b4bc-43e7-a07d-b9d12bf846d6" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small World Cup soccer ball next to the MCP Jam logo in the sidebar and on mobile. Clicking it triggers a quick bounce without navigation (closes #2879).

- **New Features**
  - Adds `WorldCupBall` (inline SVG) with a click “kick” animation; respects `prefers-reduced-motion`.
  - Renders beside the logo in the expanded sidebar and on mobile; uses `stopPropagation()` to avoid nav.
  - Includes tests for rendering and non-bubbling click; easy to remove later by deleting `world-cup-ball.tsx` and its two uses in `mcp-sidebar.tsx`.

<sup>Written for commit b6e15c8a7ae2b1d216f6553f0fe4271f732b7ed4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

