### PR TITLE
fix: stop autofill clobbering oauth scope fields

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -494,6 +494,11 @@ export function AuthenticationSection({
                     value={oauthScopesInput}
                     onChange={(e) => onOauthScopesChange(e.target.value)}
                     placeholder="Optional scopes separated by spaces"
+                    spellCheck={false}
+                    autoComplete="off"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-form-type="other"
                     className="h-10"
                   />
                 </div>
@@ -518,6 +523,11 @@ export function AuthenticationSection({
                             ? true
                             : undefined
                         }
+                        spellCheck={false}
+                        autoComplete="off"
+                        data-1p-ignore
+                        data-lpignore="true"
+                        data-form-type="other"
                         className={`h-10 ${clientIdError ? "border-red-500" : ""}`}
                       />
                       {clientIdError && (
@@ -602,6 +612,11 @@ export function AuthenticationSection({
                               }}
                               placeholder="Enter a new value to replace."
                               data-testid="revealed-client-secret"
+                              spellCheck={false}
+                              autoComplete="off"
+                              data-1p-ignore
+                              data-lpignore="true"
+                              data-form-type="other"
                               className={`h-10 pr-16 font-mono ${clientSecretError ? "border-red-500" : ""}`}
                             />
                             <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
@@ -667,6 +682,11 @@ export function AuthenticationSection({
                               ? "Enter a new value to replace."
                               : "Your OAuth Client Secret"
                           }
+                          spellCheck={false}
+                          autoComplete="off"
+                          data-1p-ignore
+                          data-lpignore="true"
+                          data-form-type="other"
                           className={`h-10 ${clientSecretError ? "border-red-500" : ""}`}
                         />
                       )}

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -396,6 +396,11 @@ export function OAuthProfileModal({
                         }
                         placeholder="openid profile email"
                         rows={1}
+                        spellCheck={false}
+                        autoComplete="off"
+                        data-1p-ignore
+                        data-lpignore="true"
+                        data-form-type="other"
                       />
                     </div>
 
@@ -419,6 +424,9 @@ export function OAuthProfileModal({
                           placeholder="Client ID"
                           spellCheck={false}
                           autoComplete="off"
+                          data-1p-ignore
+                          data-lpignore="true"
+                          data-form-type="other"
                         />
                         <Input
                           type="password"
@@ -431,6 +439,9 @@ export function OAuthProfileModal({
                           }
                           placeholder="Client Secret (optional)"
                           autoComplete="off"
+                          data-1p-ignore
+                          data-lpignore="true"
+                          data-form-type="other"
                         />
                       </div>
                     </div>


### PR DESCRIPTION
Fixes #3031

The "Configure Server to Test" dialog in the OAuth Debugger and the OAuth auth form on the Connect tab were allowing password managers like 1Password, LastPass, and browser autofill to inject saved credentials into their fields. The main issue was that a stored OAuth Client ID was being autofilled into the Scopes field, which overwrote it. This happened every time the dialog was opened or focused, and it was particularly confusing in CIMD mode. In that mode, the real client_id is a URL, but the leftover WorkOS-style client ID ended up in the Scopes field.

To fix this, this PR applies the same autofill suppression attributes we added to the XAA inputs in #2768. This includes `autoComplete="off"` along with `data-1p-ignore`, `data-lpignore="true"`, and `data-form-type="other"` to the scope, client-id, and client-secret inputs on both surfaces. This is just a presentational change. Didn't modify any logic, imports, labels, or test IDs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents password managers and browser autofill from overwriting OAuth scope, client ID, and client secret fields in the OAuth Debugger and Connect tab. Adds autofill-suppression so saved credentials no longer get injected.

- **Bug Fixes**
  - Applied autofill suppression to scope, client ID, and client secret inputs in `AuthenticationSection` and `OAuthProfileModal`.
  - Added autoComplete="off", data-1p-ignore, data-lpignore="true", data-form-type="other", and spellCheck={false}.
  - No logic, labels, imports, or test IDs changed.

<sup>Written for commit 3304b4e8b8e0221f02b584cd4ada22e4c20d370e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

