### PR TITLE
fix(oauth-debugger): send configured client_secret in token exchange

### DIFF
--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -281,12 +281,16 @@ export const OAuthFlowTab = ({
       customScopes: profile.scopes.trim() || undefined,
       customHeaders,
       registrationStrategy,
+      preregisteredClientId: profile.clientId.trim() || undefined,
+      preregisteredClientSecret: profile.clientSecret.trim() || undefined,
     });
   }, [
     hasProfile,
     protocolVersion,
     profile.serverUrl,
     profile.scopes,
+    profile.clientId,
+    profile.clientSecret,
     serverIdentifier,
     customHeaders,
     registrationStrategy,

--- a/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
@@ -150,4 +150,46 @@ describe("OAuthFlowTab", () => {
       "https://example.com/mcp",
     );
   });
+
+  it("passes the profile's pre-registered credentials to the state machine (#3029)", async () => {
+    const { createInspectorOAuthStateMachine } = await import(
+      "@/lib/oauth/debug-state-machine-adapter"
+    );
+    vi.mocked(createInspectorOAuthStateMachine).mockClear();
+
+    const serverConfigs = {
+      "prereg-server": createServer({
+        name: "prereg-server",
+        useOAuth: true,
+        config: {
+          url: "https://example.com/mcp",
+        },
+        oauthFlowProfile: {
+          serverUrl: "https://example.com/mcp",
+          clientId: "client_prereg",
+          clientSecret: "prereg-secret",
+          scopes: "openid profile email",
+          customHeaders: [],
+          protocolVersion: "2025-11-25",
+          registrationStrategy: "preregistered",
+        } as ServerWithName["oauthFlowProfile"],
+      }),
+    };
+
+    render(
+      <OAuthFlowTab
+        serverConfigs={serverConfigs}
+        selectedServerName="prereg-server"
+        onSelectServer={vi.fn()}
+      />,
+    );
+
+    expect(createInspectorOAuthStateMachine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registrationStrategy: "preregistered",
+        preregisteredClientId: "client_prereg",
+        preregisteredClientSecret: "prereg-secret",
+      }),
+    );
+  });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-oauth-preregistered-credentials.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-oauth-preregistered-credentials.test.ts
@@ -116,16 +116,23 @@ describe("OAuth debugger pre-registered client credentials (#3029)", () => {
     expect(getState().clientSecret).toBe(CLIENT_SECRET);
   });
 
-  it("includes the client_secret in the token request body", async () => {
+  it("includes the client_secret in the token request body (client_secret_post)", async () => {
     vi.useFakeTimers();
     const { machine, getState, updateState } = createPreregisteredHarness({
       protocolVersion: "2025-11-25",
       preregisteredClientId: CLIENT_ID,
       preregisteredClientSecret: CLIENT_SECRET,
+      // Pin the AS to client_secret_post so the body-borne secret asserted
+      // below is the spec-correct transport. NOTE: the debug state machines
+      // currently transmit the secret in the body even when the resolved
+      // method is client_secret_basic (no Authorization: Basic header is
+      // built anywhere) — tracked as a follow-up SDK issue.
+      tokenEndpointAuthMethodsSupported: ["client_secret_post"],
     });
 
     await machine.proceedToNextStep();
     expect(getState().currentStep).toBe("received_client_credentials");
+    expect(getState().tokenEndpointAuthMethod).toBe("client_secret_post");
 
     updateState({
       currentStep: "received_authorization_code",
@@ -189,7 +196,7 @@ describe("OAuth debugger pre-registered client credentials (#3029)", () => {
     expect(getState().clientSecret).toBe(CLIENT_SECRET);
   });
 
-  it("falls back to the stored client record when no profile clientId is configured", async () => {
+  it("falls back to the stored client record when the profile has no credentials", async () => {
     localStorage.setItem(
       `mcp-client-${SERVER_NAME}`,
       JSON.stringify({ client_id: "stored_client" }),
@@ -202,5 +209,25 @@ describe("OAuth debugger pre-registered client credentials (#3029)", () => {
     await machine.proceedToNextStep();
 
     expect(getState().clientId).toBe("stored_client");
+  });
+
+  it("does not pair a profile secret with a stored client id", async () => {
+    localStorage.setItem(
+      `mcp-client-${SERVER_NAME}`,
+      JSON.stringify({ client_id: "stale_dcr_client" }),
+    );
+
+    const { machine, getState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+      preregisteredClientSecret: CLIENT_SECRET,
+    });
+
+    await machine.proceedToNextStep();
+
+    // A secret belongs to a specific client id. Adopting the stored (possibly
+    // stale DCR) id would authenticate as the wrong client, so the machine
+    // fails fast and asks for the missing client id instead.
+    expect(getState().clientId).toBeUndefined();
+    expect(getState().error).toMatch(/client ID is required/i);
   });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-oauth-preregistered-credentials.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-oauth-preregistered-credentials.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EMPTY_OAUTH_FLOW_STATE,
+  type OAuthFlowState,
+} from "@mcpjam/sdk/browser";
+import { createInspectorOAuthStateMachine } from "../debug-state-machine-adapter";
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: false,
+}));
+
+const SERVER_NAME = "Test Server";
+const CLIENT_ID = "client_from_profile";
+const CLIENT_SECRET = "s3cr3t-from-profile";
+
+type ProtocolVersion = "2025-03-26" | "2025-06-18" | "2025-11-25";
+
+function createPreregisteredHarness(options: {
+  protocolVersion: ProtocolVersion;
+  preregisteredClientId?: string;
+  preregisteredClientSecret?: string;
+  tokenEndpointAuthMethodsSupported?: string[];
+}) {
+  const authorizationServerMetadata = {
+    issuer: "https://auth.example.com",
+    authorization_endpoint: "https://auth.example.com/authorize",
+    token_endpoint: "https://auth.example.com/token",
+    response_types_supported: ["code"],
+    ...(options.tokenEndpointAuthMethodsSupported
+      ? {
+          token_endpoint_auth_methods_supported:
+            options.tokenEndpointAuthMethodsSupported,
+        }
+      : {}),
+  } as OAuthFlowState["authorizationServerMetadata"];
+
+  let state: OAuthFlowState = {
+    ...EMPTY_OAUTH_FLOW_STATE,
+    currentStep: "received_authorization_server_metadata",
+    authorizationServerMetadata,
+    httpHistory: [],
+    infoLogs: [],
+  };
+
+  const updateState = (updates: Partial<OAuthFlowState>) => {
+    state = { ...state, ...updates };
+  };
+
+  const machine = createInspectorOAuthStateMachine({
+    protocolVersion: options.protocolVersion,
+    state,
+    getState: () => state,
+    updateState,
+    serverUrl: "https://mcp.example.com",
+    serverName: SERVER_NAME,
+    registrationStrategy: "preregistered",
+    preregisteredClientId: options.preregisteredClientId,
+    preregisteredClientSecret: options.preregisteredClientSecret,
+  });
+
+  return {
+    machine,
+    getState: () => state,
+    updateState,
+  };
+}
+
+describe("OAuth debugger pre-registered client credentials (#3029)", () => {
+  afterEach(() => {
+    localStorage.clear();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it.each<{ protocolVersion: ProtocolVersion }>([
+    { protocolVersion: "2025-03-26" },
+    { protocolVersion: "2025-06-18" },
+    { protocolVersion: "2025-11-25" },
+  ])(
+    "$protocolVersion resolves a confidential client from the configured profile credentials",
+    async ({ protocolVersion }) => {
+      const { machine, getState } = createPreregisteredHarness({
+        protocolVersion,
+        preregisteredClientId: CLIENT_ID,
+        preregisteredClientSecret: CLIENT_SECRET,
+      });
+
+      await machine.proceedToNextStep();
+
+      expect(getState().currentStep).toBe("received_client_credentials");
+      expect(getState().clientId).toBe(CLIENT_ID);
+      expect(getState().clientSecret).toBe(CLIENT_SECRET);
+      expect(getState().tokenEndpointAuthMethod).toBe("client_secret_basic");
+    },
+  );
+
+  it("does not fall back to 'none' when the AS also advertises it (WorkOS-style metadata)", async () => {
+    const { machine, getState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+      preregisteredClientId: CLIENT_ID,
+      preregisteredClientSecret: CLIENT_SECRET,
+      tokenEndpointAuthMethodsSupported: [
+        "none",
+        "client_secret_post",
+        "client_secret_basic",
+      ],
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(getState().tokenEndpointAuthMethod).toBe("client_secret_basic");
+    expect(getState().clientSecret).toBe(CLIENT_SECRET);
+  });
+
+  it("includes the client_secret in the token request body", async () => {
+    vi.useFakeTimers();
+    const { machine, getState, updateState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+      preregisteredClientId: CLIENT_ID,
+      preregisteredClientSecret: CLIENT_SECRET,
+    });
+
+    await machine.proceedToNextStep();
+    expect(getState().currentStep).toBe("received_client_credentials");
+
+    updateState({
+      currentStep: "received_authorization_code",
+      authorizationCode: "auth-code-123",
+      codeVerifier: "pkce-verifier",
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(getState().currentStep).toBe("token_request");
+    expect(getState().lastRequest).toMatchObject({
+      method: "POST",
+      url: "https://auth.example.com/token",
+      body: {
+        grant_type: "authorization_code",
+        code: "auth-code-123",
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+      },
+    });
+  });
+
+  it("stays a public client when no secret is configured", async () => {
+    vi.useFakeTimers();
+    const { machine, getState, updateState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+      preregisteredClientId: CLIENT_ID,
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(getState().tokenEndpointAuthMethod).toBe("none");
+    expect(getState().clientSecret).toBeUndefined();
+
+    updateState({
+      currentStep: "received_authorization_code",
+      authorizationCode: "auth-code-123",
+      codeVerifier: "pkce-verifier",
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(getState().lastRequest?.body).not.toHaveProperty("client_secret");
+  });
+
+  it("prefers the profile clientId over a stored DCR client record", async () => {
+    localStorage.setItem(
+      `mcp-client-${SERVER_NAME}`,
+      JSON.stringify({ client_id: "stale_dcr_client" }),
+    );
+
+    const { machine, getState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+      preregisteredClientId: CLIENT_ID,
+      preregisteredClientSecret: CLIENT_SECRET,
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(getState().clientId).toBe(CLIENT_ID);
+    expect(getState().clientSecret).toBe(CLIENT_SECRET);
+  });
+
+  it("falls back to the stored client record when no profile clientId is configured", async () => {
+    localStorage.setItem(
+      `mcp-client-${SERVER_NAME}`,
+      JSON.stringify({ client_id: "stored_client" }),
+    );
+
+    const { machine, getState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(getState().clientId).toBe("stored_client");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -27,6 +27,14 @@ export interface InspectorOAuthStateMachineConfig {
   serverName: string;
   customScopes?: string;
   customHeaders?: Record<string, string>;
+  /**
+   * Credentials the user configured on the OAuth test profile ("Configure
+   * Server to Test" → Client credentials). Secrets are never written to
+   * localStorage, so they can only reach the state machine through here —
+   * the stored `mcp-client-*` record is a clientId-only fallback.
+   */
+  preregisteredClientId?: string;
+  preregisteredClientSecret?: string;
 }
 
 function normalizeResponseHeaders(
@@ -144,14 +152,26 @@ export function loadDebugPreregisteredCredentials({
 export function createInspectorOAuthStateMachine(
   config: InspectorOAuthStateMachineConfig,
 ) {
+  const { preregisteredClientId, preregisteredClientSecret, ...machineConfig } =
+    config;
   return createOAuthStateMachine({
-    ...config,
+    ...machineConfig,
     redirectUrl: getDebugRedirectUrl(),
     requestExecutor: createDebugRequestExecutor(),
     scheduleAutoAdvance: (fn, delayMs) => {
       window.setTimeout(fn, delayMs);
     },
-    loadPreregisteredCredentials: loadDebugPreregisteredCredentials,
+    // Profile credentials win over the localStorage record: the stored
+    // `mcp-client-*` entry can hold a stale DCR-registered client id, and it
+    // never holds a secret. Without the explicit secret the machine resolves
+    // the token auth method as "none" and the exchange 401s (#3029).
+    loadPreregisteredCredentials: (input) => {
+      const stored = loadDebugPreregisteredCredentials(input);
+      return {
+        clientId: preregisteredClientId || stored.clientId,
+        clientSecret: preregisteredClientSecret || undefined,
+      };
+    },
     dynamicRegistration: getBrowserDebugDynamicRegistrationMetadata(
       config.protocolVersion,
     ),

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -161,16 +161,21 @@ export function createInspectorOAuthStateMachine(
     scheduleAutoAdvance: (fn, delayMs) => {
       window.setTimeout(fn, delayMs);
     },
-    // Profile credentials win over the localStorage record: the stored
-    // `mcp-client-*` entry can hold a stale DCR-registered client id, and it
-    // never holds a secret. Without the explicit secret the machine resolves
-    // the token auth method as "none" and the exchange 401s (#3029).
+    // Profile credentials are authoritative when configured: the stored
+    // `mcp-client-*` record can hold a stale DCR-registered client id, and it
+    // never holds a secret — without the explicit secret the machine resolves
+    // the token auth method as "none" and the exchange 401s (#3029). Pairing
+    // a profile secret with a stored client id would authenticate as the
+    // wrong client, so the stored record is only consulted when the profile
+    // has no credentials at all.
     loadPreregisteredCredentials: (input) => {
-      const stored = loadDebugPreregisteredCredentials(input);
-      return {
-        clientId: preregisteredClientId || stored.clientId,
-        clientSecret: preregisteredClientSecret || undefined,
-      };
+      if (preregisteredClientId || preregisteredClientSecret) {
+        return {
+          clientId: preregisteredClientId,
+          clientSecret: preregisteredClientSecret || undefined,
+        };
+      }
+      return loadDebugPreregisteredCredentials(input);
     },
     dynamicRegistration: getBrowserDebugDynamicRegistrationMetadata(
       config.protocolVersion,


### PR DESCRIPTION
Fixes #3029

## What was happening

The OAuth Debugger's token exchange returned `401 Unauthorized` for **Pre-registered** clients configured with a Client Secret. The token request contained no `client_secret` and no `Authorization` header, even though a secret was saved in "Configure Server to Test" → Client credentials.

## Root cause

The debugger runs on the SDK OAuth state machine, which fully supports confidential clients — its `loadPreregisteredCredentials` hook accepts `{ clientId, clientSecret }` and puts the secret in the token request body (the conformance runner already uses it this way). But the inspector side never supplied the secret:

- `OAuthFlowTab` created the machine without the profile's client credentials.
- The adapter's `loadDebugPreregisteredCredentials` only reads the `mcp-client-<server>` localStorage record, which holds **clientId only** — secrets are deliberately never written to localStorage (and are actively scrubbed from it).

So the machine resolved `hasClientSecret: false` → token auth method `"none"` → no secret sent → the AS correctly rejected the exchange. This is a separate path from the Connect tab flow that #2505 fixed (`mcp-oauth.ts`), which is why that fix didn't cover the debugger.

## The fix

- `debug-state-machine-adapter.ts`: `InspectorOAuthStateMachineConfig` gains `preregisteredClientId` / `preregisteredClientSecret`; the credential loader prefers them over the stored record (which can also hold a stale DCR client id) and finally forwards the secret.
- `OAuthFlowTab.tsx`: passes the OAuth test profile's trimmed clientId/clientSecret into the adapter.

The fix is at the adapter level, so it covers all three protocol versions (2025-03-26, 2025-06-18, 2025-11-25).

## Tests

- New `debug-oauth-preregistered-credentials.test.ts` (8 tests): confidential-client resolution across all three protocol versions, WorkOS-style metadata (`none` + `client_secret_post` + `client_secret_basic` advertised — the exact #3029 scenario) not falling back to `none`, `client_secret` present in the token request body, public-client behavior unchanged when no secret is configured, and profile-vs-stored clientId precedence.
- New `OAuthFlowTab` component test asserting the profile credentials reach the state machine.
- Full OAuth test surface green (83 tests), client typecheck clean, and the OAuth debugger Playwright e2e suite passes (dev + hosted projects).

## Security notes

- The secret continues to never touch localStorage; it flows in memory from the saved profile into the state machine, and the token request goes through the existing debug proxy as before.
- The debugger's HTTP history will now show the `client_secret` in the displayed token request body — same as it already does for DCR-issued secrets, and arguably desired in a debugging tool, but flagging it for reviewer awareness.

## Follow-up (out of scope)

In hosted mode, a secret synced to Convex (`server.hasClientSecret` with no local plaintext) still won't reach the debugger — that needs a fetch via the hosted client-secret API and its own scoping. The reported scenario (local/npx, secret in the profile) is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth token-exchange credential resolution (security-sensitive), but secrets stay in memory and behavior is narrowed to fixing missing profile wiring with added regression tests.
> 
> **Overview**
> Fixes **401 Unauthorized** on token exchange for pre-registered confidential clients in the OAuth Debugger (#3029) by wiring the OAuth test profile’s **client ID and client secret** into the debug state machine instead of relying only on the `mcp-client-*` localStorage record (client ID only).
> 
> **`OAuthFlowTab`** passes trimmed `profile.clientId` / `profile.clientSecret` into **`createInspectorOAuthStateMachine`**. The **debug adapter** adds `preregisteredClientId` / `preregisteredClientSecret` and overrides `loadPreregisteredCredentials` so profile credentials win over stored DCR IDs; if only a secret is set without a profile client ID, the machine fails fast rather than pairing the secret with a stale stored ID. Public clients (no secret) behave unchanged.
> 
> New tests cover all three protocol versions, WorkOS-style auth-method metadata, token body `client_secret`, and profile vs localStorage precedence; **`OAuthFlowTab`** asserts credentials reach the adapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8c399167a60ebc2cdf9591e84b12e6a4db70342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 401s in the OAuth Debugger for pre-registered confidential clients by sending the configured client_secret during the token exchange and treating profile credentials as authoritative. The state machine now uses the profile’s clientId/clientSecret instead of (or in preference to) the clientId-only localStorage record. Fixes #3029.

- **Bug Fixes**
  - `OAuthFlowTab` passes the profile `clientId`/`clientSecret` to the debug state machine.
  - Adapter prefers profile credentials over `mcp-client-*` localStorage; if either is set, the stored record is ignored. A secret without a clientId now fails fast instead of pairing with a stored (possibly stale) id.
  - `client_secret` is forwarded in the token request; public-client behavior unchanged. Tests pin body assertions to `client_secret_post`. Applies to 2025-03-26, 2025-06-18, and 2025-11-25; secrets never stored in localStorage, and the HTTP history shows `client_secret` for debugging.

<sup>Written for commit c8c399167a60ebc2cdf9591e84b12e6a4db70342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

