### PR TITLE
ci(pr-preview): pin workos CLI to 0.17.1

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -97,7 +97,7 @@ jobs:
           echo "head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Install preview tooling
-        run: npm install -g @railway/cli@4.57.1 workos
+        run: npm install -g @railway/cli@4.57.1 workos@0.17.1
 
       - name: Resolve preview environment metadata
         id: meta
@@ -368,7 +368,7 @@ jobs:
           echo "head_sha=${{ github.event.client_payload.inspector_head_sha || '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Install preview tooling
-        run: npm install -g @railway/cli@4.57.1 workos
+        run: npm install -g @railway/cli@4.57.1 workos@0.17.1
 
       - name: Resolve preview environment metadata
         id: meta
@@ -726,7 +726,7 @@ jobs:
           echo "head_sha=${{ github.event.client_payload.inspector_head_sha || '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Install preview tooling
-        run: npm install -g @railway/cli@4.57.1 workos
+        run: npm install -g @railway/cli@4.57.1 workos@0.17.1
 
       - name: Resolve backend target
         id: backend_target


### PR DESCRIPTION
## Problem

Every PR preview job started failing today at the **Install preview tooling** step (`npm install -g @railway/cli@4.57.1 workos`) with exit 127 — e.g. [this run on #2991](https://github.com/MCPJam/inspector/actions/runs/28824814418/job/85485199748?pr=2991).

## Root cause

The Railway CLI is pinned but `workos` isn't, so runs install `workos@latest`. `workos@0.18.0` (published 2026-07-06 17:49 UTC, hours before the first failure) introduced this chain:

```
workos@0.18.0 → @workos/openapi-spec@0.14.0 → @workos/oagen@0.23.0
  → tree-sitter-kotlin (git+ssh://git@github.com/fwcd/tree-sitter-kotlin.git)
```

`tree-sitter-kotlin` is a raw git dependency, so npm builds it from source during install ("git dep preparation"), and its build script runs `node-gyp-build` — which isn't available in that temp build context on the runner:

```
npm error npm error command sh -c node-gyp-build
npm error npm error sh: 1: node-gyp-build: not found
```

## Fix

Pin `workos@0.17.1` (the previous release, June 8 — what every green run until today was using) in all three jobs that install the CLI: `upsert-preview`, `upsert-backend-pr-preview`, `sync-backend-preview`. Verified locally that 0.17.1 resolves a registry-only dependency tree (no git deps), while 0.18.0 reproduces the git clone. The workflow only calls `workos config redirect add` / `workos config cors add`, both present in 0.17.1.

Bump the pin deliberately once upstream drops the git dependency.

Note: since workflows run from each PR's merge ref, open PRs (like #2991) pick up the fix only after updating their branch from main once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only version pin with no application or auth logic changes; restores previously working preview tooling installs.
> 
> **Overview**
> Pins the global **`workos`** npm package to **`0.17.1`** on the **Install preview tooling** step in three `pr-preview.yml` jobs (`upsert-preview`, `upsert-backend-pr-preview`, `sync-backend-preview`), matching the already-pinned `@railway/cli@4.57.1`.
> 
> Unpinned installs were pulling **`workos@0.18.0`**, whose dependency tree builds a git-hosted `tree-sitter-kotlin` package and fails on GitHub runners with **`node-gyp-build: not found`**, breaking PR preview setup before WorkOS redirect/CORS registration runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6eae8ccd522ec5f20b3e8669f1c85e49860d0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the `workos` CLI to 0.17.1 in PR preview workflows to fix failing install steps. Restores preview jobs by avoiding a git-based dependency introduced in 0.18.0.

- **Bug Fixes**
  - Pin `workos@0.17.1` with `@railway/cli@4.57.1` in `upsert-preview`, `upsert-backend-pr-preview`, and `sync-backend-preview`.
  - Avoids the `@workos/openapi-spec` → `@workos/oagen` → `tree-sitter-kotlin` chain that triggers `node-gyp-build` and exit 127 on runners.
  - Our usage (`workos config redirect add` / `workos config cors add`) is supported in 0.17.1.

- **Migration**
  - Open PRs must merge or rebase from `main` to pick up the updated workflow.

<sup>Written for commit df6eae8ccd522ec5f20b3e8669f1c85e49860d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

