### PR TITLE
[codex] harden progressive tool discovery

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -34,6 +34,11 @@ import type {
   EvalTraceSpanCategory,
 } from "@/shared/eval-trace";
 import { mcpErrorCodeLabel } from "@/shared/eval-trace";
+import {
+  META_TOOL_LOAD,
+  META_TOOL_SEARCH,
+  META_TOOL_SERVER_ID,
+} from "@/shared/progressive-tool-discovery";
 import { MemoizedMarkdown } from "@/components/chat-v2/thread/memomized-markdown";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
@@ -1310,7 +1315,14 @@ function deriveSpanLabel(
 
   if (span.category === "tool") {
     const name = (span.toolName ?? span.name).trim() || "tool";
-    const title = `Tool · ${name}`;
+    const isDiscoveryTool =
+      span.serverId === META_TOOL_SERVER_ID ||
+      name === META_TOOL_SEARCH ||
+      name === META_TOOL_LOAD;
+    const title = `${isDiscoveryTool ? "Discovery" : "Tool"} · ${name}`;
+    const serverHint = isDiscoveryTool
+      ? (span.serverName ?? "MCPJam")
+      : span.serverName;
     const toolSub = toolSubtitleFromTranscript(transcriptMessages, span);
     // Skip trivial subtitles like "{}" for empty tool inputs
     const isTrivialSub = !toolSub || toolSub === "{}" || toolSub === "None";
@@ -1340,12 +1352,14 @@ function deriveSpanLabel(
         title,
         subtitle: modelHint
           ? `${modelHint} · step ${span.stepIndex + 1}`
-          : `step ${span.stepIndex + 1}`,
+          : serverHint
+            ? `${serverHint} · step ${span.stepIndex + 1}`
+            : `step ${span.stepIndex + 1}`,
       };
     }
     return {
       title,
-      subtitle: modelHint,
+      subtitle: modelHint ?? serverHint,
     };
   }
 

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -34,11 +34,7 @@ import type {
   EvalTraceSpanCategory,
 } from "@/shared/eval-trace";
 import { mcpErrorCodeLabel } from "@/shared/eval-trace";
-import {
-  META_TOOL_LOAD,
-  META_TOOL_SEARCH,
-  META_TOOL_SERVER_ID,
-} from "@/shared/progressive-tool-discovery";
+import { META_TOOL_SERVER_ID } from "@/shared/progressive-tool-discovery";
 import { MemoizedMarkdown } from "@/components/chat-v2/thread/memomized-markdown";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
@@ -1315,10 +1311,7 @@ function deriveSpanLabel(
 
   if (span.category === "tool") {
     const name = (span.toolName ?? span.name).trim() || "tool";
-    const isDiscoveryTool =
-      span.serverId === META_TOOL_SERVER_ID ||
-      name === META_TOOL_SEARCH ||
-      name === META_TOOL_LOAD;
+    const isDiscoveryTool = span.serverId === META_TOOL_SERVER_ID;
     const title = `${isDiscoveryTool ? "Discovery" : "Tool"} · ${name}`;
     const serverHint = isDiscoveryTool
       ? (span.serverName ?? "MCPJam")

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/BehaviorTab.tsx
@@ -38,6 +38,11 @@ import { useAvailableModels } from "@/hooks/use-available-models";
 import { FieldRow, FocusBlock } from "./primitives";
 import { fieldsWithIssues } from "./useHostDraftValidation";
 import type { HostAttentionIssue } from "../types";
+import {
+  progressiveModeToValue,
+  progressiveValueToMode,
+  type ProgressiveToolsMode,
+} from "@/stores/ui-playground-store";
 
 // Tri-state UI ↔ persisted value. The backend treats `undefined` as
 // "auto" (orchestrator may still enable progressive mode above the
@@ -46,21 +51,9 @@ import type { HostAttentionIssue } from "../types";
 // actually fires. The three buttons map 1:1 to the three persisted
 // states; "Auto" preserves `undefined` so the backend dedupe hash
 // stays distinct from an explicit on/off override.
-type ProgressiveTriState = "auto" | "on" | "off";
-function progressiveValueToTri(
-  value: boolean | undefined
-): ProgressiveTriState {
-  if (value === true) return "on";
-  if (value === false) return "off";
-  return "auto";
-}
-function triToProgressiveValue(
-  value: ProgressiveTriState
-): boolean | undefined {
-  if (value === "on") return true;
-  if (value === "off") return false;
-  return undefined;
-}
+type ProgressiveTriState = ProgressiveToolsMode;
+const progressiveValueToTri = progressiveValueToMode;
+const triToProgressiveValue = progressiveModeToValue;
 
 function InfoHoverLabel({
   label,

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundCenterHeaderBar.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundCenterHeaderBar.tsx
@@ -39,6 +39,7 @@ interface Props {
    * user understands the toolbar only edits the lead column.
    */
   leadHostInMultiHost?: string | null;
+  progressiveToolsSessionId?: string | null;
 }
 
 export function PlaygroundCenterHeaderBar({
@@ -52,6 +53,7 @@ export function PlaygroundCenterHeaderBar({
   trailing,
   leading,
   leadHostInMultiHost,
+  progressiveToolsSessionId,
 }: Props) {
   const chromeRowClass = cn(
     "flex min-w-0 items-center gap-2 text-xs text-muted-foreground",
@@ -78,6 +80,7 @@ export function PlaygroundCenterHeaderBar({
             showThemeToggle
             className="w-max max-w-full"
             leadHostInMultiHost={leadHostInMultiHost}
+            progressiveToolsSessionId={progressiveToolsSessionId}
           />
         </div>
         {trailing ? (

--- a/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
@@ -65,6 +65,7 @@ import {
   CspPickerBody,
   DevicePickerBody,
   LocalePickerBody,
+  ProgressiveToolsPickerBody,
   TimezonePickerBody,
 } from "@/components/shared/client-context-picker-bodies";
 
@@ -140,6 +141,8 @@ export function ClientContextHeader({
   const [devicePopoverOpen, setDevicePopoverOpen] = useState(false);
   const [localePopoverOpen, setLocalePopoverOpen] = useState(false);
   const [cspPopoverOpen, setCspPopoverOpen] = useState(false);
+  const [progressiveToolsPopoverOpen, setProgressiveToolsPopoverOpen] =
+    useState(false);
   const [timezonePopoverOpen, setTimezonePopoverOpen] = useState(false);
   const [hostContextDialogOpen, setHostContextDialogOpen] = useState(false);
   const [hostCapsDialogOpen, setHostCapsDialogOpen] = useState(false);
@@ -169,6 +172,15 @@ export function ClientContextHeader({
   const mcpAppsCspMode = useUIPlaygroundStore((state) => state.mcpAppsCspMode);
   const setMcpAppsCspMode = useUIPlaygroundStore(
     (state) => state.setMcpAppsCspMode
+  );
+  const progressiveToolsMode = useUIPlaygroundStore(
+    (state) => state.progressiveToolsMode
+  );
+  const setProgressiveToolsMode = useUIPlaygroundStore(
+    (state) => state.setProgressiveToolsMode
+  );
+  const progressiveToolsStatus = useUIPlaygroundStore(
+    (state) => state.progressiveToolsStatus
   );
 
   const draftHostContext = useHostContextStore(
@@ -247,6 +259,15 @@ export function ClientContextHeader({
   const timeZone = extractHostTimeZone(draftHostContext, fallbackTimeZone);
   const capabilities = extractHostDeviceCapabilities(draftHostContext);
   const effectiveThemeMode = extractHostTheme(draftHostContext) ?? themeMode;
+  const progressiveToolsLabel =
+    progressiveToolsMode === "auto"
+      ? "Auto"
+      : progressiveToolsMode === "on"
+        ? "On"
+        : "Off";
+  const progressiveToolsStatusText = progressiveToolsStatus
+    ? `${progressiveToolsStatus.enabled ? "active" : "inactive"} · ${progressiveToolsStatus.toolCount} tools across ${progressiveToolsStatus.serverCount} servers`
+    : null;
 
   const handleCapabilityToggle = useCallback(
     (key: "hover" | "touch") => {
@@ -441,6 +462,62 @@ export function ClientContextHeader({
                 patchHostContext(patch);
               }}
               onSelectZone={() => setTimezonePopoverOpen(false)}
+            />
+          </PopoverContent>
+        </Popover>
+
+        <Popover
+          open={progressiveToolsPopoverOpen}
+          onOpenChange={(next) => {
+            if (next)
+              captureToolbar("host_toolbar_opened", {
+                control: "progressive_tools",
+                current: progressiveToolsMode,
+              });
+            setProgressiveToolsPopoverOpen(next);
+          }}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 shrink-0 gap-1.5 border bg-background px-2 text-xs shadow-xs"
+                  data-testid="progressive-tools-trigger"
+                >
+                  <Cpu className="h-3.5 w-3.5" />
+                  <span className="whitespace-nowrap @max-[760px]/playground-header:sr-only">
+                    {progressiveToolsLabel}
+                  </span>
+                </Button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
+              <HeaderTooltipBody
+                label="Progressive tools"
+                leadHostHint={leadHostInMultiHost}
+              />
+              {progressiveToolsStatusText ? (
+                <p className="text-xs font-light text-muted-foreground">
+                  {progressiveToolsStatusText}
+                </p>
+              ) : null}
+            </TooltipContent>
+          </Tooltip>
+          <PopoverContent className="w-44 p-2" align="start">
+            <ProgressiveToolsPickerBody
+              mode={progressiveToolsMode}
+              setMode={(next) => {
+                if (next !== progressiveToolsMode) {
+                  captureToolbar("host_toolbar_progressive_tools_changed", {
+                    from: progressiveToolsMode,
+                    to: next,
+                  });
+                }
+                setProgressiveToolsMode(next);
+              }}
+              onSelectMode={() => setProgressiveToolsPopoverOpen(false)}
             />
           </PopoverContent>
         </Popover>

--- a/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
@@ -128,6 +128,7 @@ export interface HostContextHeaderProps {
    * user understands the toolbar only affects the lead column.
    */
   leadHostInMultiHost?: string | null;
+  progressiveToolsSessionId?: string | null;
 }
 
 export function ClientContextHeader({
@@ -137,6 +138,7 @@ export function ClientContextHeader({
   showThemeToggle = false,
   className,
   leadHostInMultiHost,
+  progressiveToolsSessionId,
 }: HostContextHeaderProps) {
   const [devicePopoverOpen, setDevicePopoverOpen] = useState(false);
   const [localePopoverOpen, setLocalePopoverOpen] = useState(false);
@@ -182,6 +184,10 @@ export function ClientContextHeader({
   const progressiveToolsStatus = useUIPlaygroundStore(
     (state) => state.progressiveToolsStatus
   );
+  const visibleProgressiveToolsStatus =
+    progressiveToolsStatus?.sessionId === progressiveToolsSessionId
+      ? progressiveToolsStatus
+      : null;
 
   const draftHostContext = useHostContextStore(
     (state) => state.draftHostContext
@@ -265,8 +271,8 @@ export function ClientContextHeader({
       : progressiveToolsMode === "on"
         ? "On"
         : "Off";
-  const progressiveToolsStatusText = progressiveToolsStatus
-    ? `${progressiveToolsStatus.enabled ? "active" : "inactive"} · ${progressiveToolsStatus.toolCount} tools across ${progressiveToolsStatus.serverCount} servers`
+  const progressiveToolsStatusText = visibleProgressiveToolsStatus
+    ? `${visibleProgressiveToolsStatus.enabled ? "active" : "inactive"} · ${visibleProgressiveToolsStatus.toolCount} tools across ${visibleProgressiveToolsStatus.serverCount} servers`
     : null;
 
   const handleCapabilityToggle = useCallback(

--- a/mcpjam-inspector/client/src/components/shared/__tests__/ClientContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/ClientContextHeader.test.tsx
@@ -28,6 +28,11 @@ const {
     setCspMode: vi.fn(),
     mcpAppsCspMode: "widget-declared",
     setMcpAppsCspMode: vi.fn(),
+    progressiveToolsMode: "auto",
+    progressiveToolsModeTouched: false,
+    progressiveToolsStatus: null,
+    setProgressiveToolsMode: vi.fn(),
+    setProgressiveToolsStatus: vi.fn(),
   },
   mockHostContextState: {
     draftHostContext: {
@@ -201,6 +206,9 @@ describe("ClientContextHeader", () => {
     mockPreferencesState.hostStyle = "claude";
     mockUIPlaygroundStore.cspMode = "widget-declared";
     mockUIPlaygroundStore.mcpAppsCspMode = "widget-declared";
+    mockUIPlaygroundStore.progressiveToolsMode = "auto";
+    mockUIPlaygroundStore.progressiveToolsModeTouched = false;
+    mockUIPlaygroundStore.progressiveToolsStatus = null;
     mockHostContextState.draftHostContext = {
       locale: "en-US",
       timeZone: "UTC",
@@ -258,6 +266,16 @@ describe("ClientContextHeader", () => {
     expect(
       screen.queryByTestId("host-style-picker-trigger")
     ).not.toBeInTheDocument();
+  });
+
+  it("updates the session progressive tools override from the header pill", () => {
+    render(<ClientContextHeader activeProjectId="project-1" protocol={null} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "off" }));
+
+    expect(mockUIPlaygroundStore.setProgressiveToolsMode).toHaveBeenCalledWith(
+      "off"
+    );
   });
 
   it("opens the raw host context dialog when the host context button is clicked", () => {

--- a/mcpjam-inspector/client/src/components/shared/client-context-picker-bodies.tsx
+++ b/mcpjam-inspector/client/src/components/shared/client-context-picker-bodies.tsx
@@ -6,6 +6,10 @@ import { Maximize2, Settings2 } from "lucide-react";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@mcpjam/design-system/toggle-group";
+import {
   PRESET_DEVICE_CONFIGS,
   LOCALE_OPTIONS,
   TIMEZONE_OPTIONS,
@@ -15,6 +19,7 @@ import type {
   CustomViewport,
   CspMode,
   DeviceType,
+  ProgressiveToolsMode,
   PresetDeviceType,
 } from "@/stores/ui-playground-store";
 
@@ -250,6 +255,42 @@ export function CspPickerBody({
           </span>
         </button>
       ))}
+    </div>
+  );
+}
+
+export function ProgressiveToolsPickerBody({
+  mode,
+  setMode,
+  onSelectMode,
+}: {
+  mode: ProgressiveToolsMode;
+  setMode: (mode: ProgressiveToolsMode) => void;
+  onSelectMode?: () => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <ToggleGroup
+        type="single"
+        value={mode}
+        onValueChange={(value) => {
+          if (!value) return;
+          setMode(value as ProgressiveToolsMode);
+          onSelectMode?.();
+        }}
+        className="grid grid-cols-3 gap-1"
+      >
+        {(["auto", "on", "off"] as const).map((value) => (
+          <ToggleGroupItem
+            key={value}
+            value={value}
+            size="sm"
+            className="h-7 px-2 text-xs capitalize"
+          >
+            {value}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -73,6 +73,7 @@ import {
   revokeFileAttachmentUrls,
 } from "@/components/chat-v2/chat-input/attachments/file-utils";
 import {
+  progressiveModeToValue,
   useUIPlaygroundStore,
   type DeviceType,
   type DisplayMode,
@@ -715,11 +716,7 @@ export function PlaygroundMain({
     hostId: previewedHostId,
   });
   const resolvedProgressiveToolDiscovery = progressiveToolsModeTouched
-    ? progressiveToolsMode === "on"
-      ? true
-      : progressiveToolsMode === "off"
-        ? false
-        : undefined
+    ? progressiveModeToValue(progressiveToolsMode)
     : previewedHost?.config?.progressiveToolDiscovery;
   const effectiveMcpToolResultImageRendering = useMemo(
     () =>
@@ -3587,6 +3584,7 @@ export function PlaygroundMain({
             leadHostInMultiHost={
               isMultiHostMode ? leadHost?.name ?? null : null
             }
+            progressiveToolsSessionId={chatSessionId}
             // The standalone "Compare" host picker moved into the chat-input
             // run pill (see `hostCompare` in `sharedChatInputProps`). Single-host
             // switching still lives in the global `GlobalHostBar`.

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -590,6 +590,12 @@ export function PlaygroundMain({
   // Device config from store (managed by ClientContextHeader)
   const storeDeviceType = useUIPlaygroundStore((s) => s.deviceType);
   const customViewport = useUIPlaygroundStore((s) => s.customViewport);
+  const progressiveToolsMode = useUIPlaygroundStore(
+    (s) => s.progressiveToolsMode
+  );
+  const progressiveToolsModeTouched = useUIPlaygroundStore(
+    (s) => s.progressiveToolsModeTouched
+  );
   const hostContext = useHostContextStore((s) => s.draftHostContext);
   const patchHostContext = useHostContextStore((s) => s.patchHostContext);
 
@@ -612,7 +618,6 @@ export function PlaygroundMain({
     }
     return PRESET_DEVICE_CONFIGS[storeDeviceType];
   }, [storeDeviceType, customViewport]);
-
   const appState = useSharedAppState();
   const servers = appState.servers;
   const { isAuthenticated: isConvexAuthenticated } = useConvexAuth();
@@ -709,6 +714,13 @@ export function PlaygroundMain({
     isAuthenticated: isConvexAuthenticated,
     hostId: previewedHostId,
   });
+  const resolvedProgressiveToolDiscovery = progressiveToolsModeTouched
+    ? progressiveToolsMode === "on"
+      ? true
+      : progressiveToolsMode === "off"
+        ? false
+        : undefined
+    : previewedHost?.config?.progressiveToolDiscovery;
   const effectiveMcpToolResultImageRendering = useMemo(
     () =>
       gateMcpToolResultImageRenderingByModelVisibility(
@@ -794,7 +806,7 @@ export function PlaygroundMain({
     // Source the host-level toggle from the previewed host's resolved
     // DTO so flipping it in the host's Agent → Behavior tab takes
     // effect on the very next send without remounting the playground.
-    progressiveToolDiscovery: previewedHost?.config?.progressiveToolDiscovery,
+    progressiveToolDiscovery: resolvedProgressiveToolDiscovery,
     respectToolVisibility: previewedHost?.config?.respectToolVisibility,
     modelVisibleMcpToolResults:
       previewedHost?.config?.modelVisibleMcpToolResults,
@@ -3828,7 +3840,7 @@ export function PlaygroundMain({
                               temperature,
                               requireToolApproval,
                               progressiveToolDiscovery:
-                                previewedHost?.config?.progressiveToolDiscovery,
+                                resolvedProgressiveToolDiscovery,
                               respectToolVisibility:
                                 previewedHost?.config?.respectToolVisibility,
                               modelVisibleMcpToolResults:

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -64,6 +64,7 @@ import {
   type ChatboxHostStyle,
 } from "@/lib/chatbox-client-style";
 import {
+  progressiveModeToValue,
   useUIPlaygroundStore,
   type DeviceType,
   type DisplayMode,
@@ -312,11 +313,7 @@ export function MultiModelPlaygroundCard({
     (s) => s.progressiveToolsModeTouched
   );
   const resolvedProgressiveToolDiscovery = progressiveToolsModeTouched
-    ? progressiveToolsMode === "on"
-      ? true
-      : progressiveToolsMode === "off"
-        ? false
-        : undefined
+    ? progressiveModeToValue(progressiveToolsMode)
     : hostCapsResolver?.progressiveToolDiscovery;
 
   const {

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -63,7 +63,11 @@ import {
   getChatboxChatBackground,
   type ChatboxHostStyle,
 } from "@/lib/chatbox-client-style";
-import type { DeviceType, DisplayMode } from "@/stores/ui-playground-store";
+import {
+  useUIPlaygroundStore,
+  type DeviceType,
+  type DisplayMode,
+} from "@/stores/ui-playground-store";
 import type { BroadcastChatTurnRequest } from "@/components/chat-v2/multi-model-chat-card";
 import type { TraceViewMode } from "@/components/evals/trace-view-mode-tabs";
 import type { WidgetModelContextEntry } from "@/shared/chat-v2";
@@ -301,6 +305,19 @@ export function MultiModelPlaygroundCard({
       resolvedModelVisibleMcpToolResults,
     ]
   );
+  const progressiveToolsMode = useUIPlaygroundStore(
+    (s) => s.progressiveToolsMode
+  );
+  const progressiveToolsModeTouched = useUIPlaygroundStore(
+    (s) => s.progressiveToolsModeTouched
+  );
+  const resolvedProgressiveToolDiscovery = progressiveToolsModeTouched
+    ? progressiveToolsMode === "on"
+      ? true
+      : progressiveToolsMode === "off"
+        ? false
+        : undefined
+    : hostCapsResolver?.progressiveToolDiscovery;
 
   const {
     messages,
@@ -334,7 +351,7 @@ export function MultiModelPlaygroundCard({
     // or null when the column inherits from the tab-root scope; we let
     // `undefined` pass through to fall back to the orchestrator's auto
     // policy in that case.
-    progressiveToolDiscovery: hostCapsResolver?.progressiveToolDiscovery,
+    progressiveToolDiscovery: resolvedProgressiveToolDiscovery,
     respectToolVisibility: hostCapsResolver?.respectToolVisibility,
     modelVisibleMcpToolResults: resolvedModelVisibleMcpToolResults,
     onReset: () => {

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -78,6 +78,7 @@ import {
 } from "@/lib/mcpjam-limit";
 import { getGuestBearerToken } from "@/lib/guest-session";
 import { HOSTED_MODE } from "@/lib/config";
+import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 import {
   preserveHydratedMessageIds,
   transcriptToUIMessages,
@@ -1120,6 +1121,9 @@ export function useChatSession(
   // becomes undefined during host bootstrap, in which case fields fall back to
   // hook defaults rather than retaining the prior host's value.
   const isExecutionConfigControlled = "executionConfig" in options;
+  const setProgressiveToolsStatus = useUIPlaygroundStore(
+    (state) => state.setProgressiveToolsStatus
+  );
   const hostedProjectId = hostedContext?.projectId;
   const hostedSelectedServerIds = hostedContext?.selectedServerIds ?? [];
   const hostedEnsureServerIds = hostedContext?.ensureServerIds;
@@ -2735,6 +2739,36 @@ export function useChatSession(
 
     previousSelectedServersRef.current = currentNames;
   }, [selectedServers]);
+
+  useEffect(() => {
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const message = messages[index];
+      if (message.role !== "assistant" || !message.metadata) continue;
+      const metadata = message.metadata as {
+        progressiveToolDiscovery?: unknown;
+      };
+      const status = metadata.progressiveToolDiscovery;
+      if (!status || typeof status !== "object") continue;
+      const record = status as Record<string, unknown>;
+      if (
+        typeof record.enabled !== "boolean" ||
+        !Array.isArray(record.reasons) ||
+        typeof record.toolCount !== "number" ||
+        typeof record.serverCount !== "number"
+      ) {
+        continue;
+      }
+      setProgressiveToolsStatus({
+        enabled: record.enabled,
+        reasons: record.reasons.filter(
+          (reason): reason is string => typeof reason === "string"
+        ),
+        toolCount: record.toolCount,
+        serverCount: record.serverCount,
+      });
+      return;
+    }
+  }, [messages, setProgressiveToolsStatus]);
 
   // Token usage calculation
   const tokenUsage = useMemo<TokenUsage>(() => {

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -78,7 +78,10 @@ import {
 } from "@/lib/mcpjam-limit";
 import { getGuestBearerToken } from "@/lib/guest-session";
 import { HOSTED_MODE } from "@/lib/config";
-import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
+import {
+  useUIPlaygroundStore,
+  type ProgressiveToolsStatus,
+} from "@/stores/ui-playground-store";
 import {
   preserveHydratedMessageIds,
   transcriptToUIMessages,
@@ -1099,6 +1102,42 @@ function isAuthDeniedError(error: unknown): boolean {
   if (withStatus.status === 401 || withStatus.status === 403) return true;
   if (typeof withStatus.message !== "string") return false;
   return /\b(401|403)\b|unauthorized|forbidden/i.test(withStatus.message);
+}
+
+function readProgressiveToolsStatus(
+  messages: UIMessage[],
+  sessionId: string
+): ProgressiveToolsStatus | null {
+  const latestMessage = messages[messages.length - 1];
+  if (latestMessage?.role !== "assistant" || !latestMessage.metadata) {
+    return null;
+  }
+
+  const metadata = latestMessage.metadata as {
+    progressiveToolDiscovery?: unknown;
+  };
+  const status = metadata.progressiveToolDiscovery;
+  if (!status || typeof status !== "object") return null;
+
+  const record = status as Record<string, unknown>;
+  if (
+    typeof record.enabled !== "boolean" ||
+    !Array.isArray(record.reasons) ||
+    typeof record.toolCount !== "number" ||
+    typeof record.serverCount !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    sessionId,
+    enabled: record.enabled,
+    reasons: record.reasons.filter(
+      (reason): reason is string => typeof reason === "string"
+    ),
+    toolCount: record.toolCount,
+    serverCount: record.serverCount,
+  };
 }
 
 export function useChatSession(
@@ -2327,6 +2366,7 @@ export function useChatSession(
     clearPendingSessionHydration();
     resumedModelVisibleMcpToolResultsRef.current = undefined;
     resumedMcpToolResultImageRenderingRef.current = undefined;
+    setProgressiveToolsStatus(null);
     setChatSessionId(generateId());
     setMessages([]);
     setPersistedSnapshotToolCallIds([]);
@@ -2336,6 +2376,7 @@ export function useChatSession(
   }, [
     clearPendingSessionHydration,
     setMessages,
+    setProgressiveToolsStatus,
     syncResumedVersion,
     syncRestoredToolRenderOverrides,
   ]);
@@ -2741,34 +2782,10 @@ export function useChatSession(
   }, [selectedServers]);
 
   useEffect(() => {
-    for (let index = messages.length - 1; index >= 0; index--) {
-      const message = messages[index];
-      if (message.role !== "assistant" || !message.metadata) continue;
-      const metadata = message.metadata as {
-        progressiveToolDiscovery?: unknown;
-      };
-      const status = metadata.progressiveToolDiscovery;
-      if (!status || typeof status !== "object") continue;
-      const record = status as Record<string, unknown>;
-      if (
-        typeof record.enabled !== "boolean" ||
-        !Array.isArray(record.reasons) ||
-        typeof record.toolCount !== "number" ||
-        typeof record.serverCount !== "number"
-      ) {
-        continue;
-      }
-      setProgressiveToolsStatus({
-        enabled: record.enabled,
-        reasons: record.reasons.filter(
-          (reason): reason is string => typeof reason === "string"
-        ),
-        toolCount: record.toolCount,
-        serverCount: record.serverCount,
-      });
-      return;
-    }
-  }, [messages, setProgressiveToolsStatus]);
+    setProgressiveToolsStatus(
+      readProgressiveToolsStatus(messages, chatSessionId)
+    );
+  }, [chatSessionId, messages, setProgressiveToolsStatus]);
 
   // Token usage calculation
   const tokenUsage = useMemo<TokenUsage>(() => {

--- a/mcpjam-inspector/client/src/stores/ui-playground-store.ts
+++ b/mcpjam-inspector/client/src/stores/ui-playground-store.ts
@@ -32,6 +32,14 @@ export interface CustomViewport {
 }
 export type DisplayMode = "inline" | "pip" | "fullscreen";
 export type CspMode = "permissive" | "widget-declared";
+export type ProgressiveToolsMode = "auto" | "on" | "off";
+
+export interface ProgressiveToolsStatus {
+  enabled: boolean;
+  reasons: string[];
+  toolCount: number;
+  serverCount: number;
+}
 
 export interface DeviceCapabilities {
   hover: boolean;
@@ -125,6 +133,11 @@ interface UIPlaygroundState {
   // CSP enforcement mode for MCP Apps (SEP-1865)
   mcpAppsCspMode: CspMode;
 
+  // Progressive MCP tool discovery override for this playground session.
+  progressiveToolsMode: ProgressiveToolsMode;
+  progressiveToolsModeTouched: boolean;
+  progressiveToolsStatus: ProgressiveToolsStatus | null;
+
   // Device capabilities (hover/touch support)
   capabilities: DeviceCapabilities;
 
@@ -162,6 +175,8 @@ interface UIPlaygroundState {
   setPlaygroundActive: (active: boolean) => void;
   setCspMode: (mode: CspMode) => void;
   setMcpAppsCspMode: (mode: CspMode) => void;
+  setProgressiveToolsMode: (mode: ProgressiveToolsMode) => void;
+  setProgressiveToolsStatus: (status: ProgressiveToolsStatus | null) => void;
   setCapabilities: (capabilities: Partial<DeviceCapabilities>) => void;
   setSafeAreaPreset: (preset: SafeAreaPreset) => void;
   setSafeAreaInsets: (insets: Partial<SafeAreaInsets>) => void;
@@ -251,6 +266,9 @@ const initialState = {
   isSidebarVisible: getStoredVisibility(STORAGE_KEY_SIDEBAR, true),
   cspMode: "permissive" as CspMode,
   mcpAppsCspMode: "permissive" as CspMode,
+  progressiveToolsMode: "auto" as ProgressiveToolsMode,
+  progressiveToolsModeTouched: false,
+  progressiveToolsStatus: null,
   capabilities: getDefaultCapabilities(initialDeviceType),
   safeAreaPreset: "none" as SafeAreaPreset,
   safeAreaInsets: SAFE_AREA_PRESETS["none"],
@@ -362,6 +380,11 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
 
   setMcpAppsCspMode: (mode) => set({ mcpAppsCspMode: mode }),
 
+  setProgressiveToolsMode: (mode) =>
+    set({ progressiveToolsMode: mode, progressiveToolsModeTouched: true }),
+
+  setProgressiveToolsStatus: (status) => set({ progressiveToolsStatus: status }),
+
   setCapabilities: (newCapabilities) =>
     set((state) => ({
       capabilities: { ...state.capabilities, ...newCapabilities },
@@ -414,6 +437,10 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
         // Preserve CSP modes (may be set via CLI config before reset fires)
         cspMode: state.cspMode,
         mcpAppsCspMode: state.mcpAppsCspMode,
+        // Preserve session-level header overrides.
+        progressiveToolsMode: state.progressiveToolsMode,
+        progressiveToolsModeTouched: state.progressiveToolsModeTouched,
+        progressiveToolsStatus: state.progressiveToolsStatus,
       };
     }),
 }));

--- a/mcpjam-inspector/client/src/stores/ui-playground-store.ts
+++ b/mcpjam-inspector/client/src/stores/ui-playground-store.ts
@@ -35,10 +35,43 @@ export type CspMode = "permissive" | "widget-declared";
 export type ProgressiveToolsMode = "auto" | "on" | "off";
 
 export interface ProgressiveToolsStatus {
+  sessionId: string;
   enabled: boolean;
   reasons: string[];
   toolCount: number;
   serverCount: number;
+}
+
+export function progressiveModeToValue(
+  mode: ProgressiveToolsMode
+): boolean | undefined {
+  if (mode === "on") return true;
+  if (mode === "off") return false;
+  return undefined;
+}
+
+export function progressiveValueToMode(
+  value: boolean | undefined
+): ProgressiveToolsMode {
+  if (value === true) return "on";
+  if (value === false) return "off";
+  return "auto";
+}
+
+function areProgressiveToolsStatusesEqual(
+  left: ProgressiveToolsStatus | null,
+  right: ProgressiveToolsStatus | null
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.sessionId === right.sessionId &&
+    left.enabled === right.enabled &&
+    left.toolCount === right.toolCount &&
+    left.serverCount === right.serverCount &&
+    left.reasons.length === right.reasons.length &&
+    left.reasons.every((reason, index) => reason === right.reasons[index])
+  );
 }
 
 export interface DeviceCapabilities {
@@ -383,7 +416,12 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
   setProgressiveToolsMode: (mode) =>
     set({ progressiveToolsMode: mode, progressiveToolsModeTouched: true }),
 
-  setProgressiveToolsStatus: (status) => set({ progressiveToolsStatus: status }),
+  setProgressiveToolsStatus: (status) =>
+    set((state) =>
+      areProgressiveToolsStatusesEqual(state.progressiveToolsStatus, status)
+        ? state
+        : { progressiveToolsStatus: status }
+    ),
 
   setCapabilities: (newCapabilities) =>
     set((state) => ({
@@ -440,7 +478,6 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
         // Preserve session-level header overrides.
         progressiveToolsMode: state.progressiveToolsMode,
         progressiveToolsModeTouched: state.progressiveToolsModeTouched,
-        progressiveToolsStatus: state.progressiveToolsStatus,
       };
     }),
 }));

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -460,6 +460,7 @@ chatV2.post("/", async (c) => {
         manager,
         prepare: {
           selectedServerIds,
+          selectedServerNames,
           modelDefinition,
           systemPrompt,
           temperature,

--- a/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
+++ b/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
@@ -48,6 +48,7 @@ type StepSpanMeta = {
 type ToolSpanMeta = {
   toolCallId?: string;
   serverId?: string;
+  serverName?: string;
   messageStartIndex?: number;
   messageEndIndex?: number;
   status?: EvalTraceSpanStatus;
@@ -74,6 +75,7 @@ export type AiSdkEvalTraceContext = {
       stepNumber: number;
       startAt: number;
       serverId?: string;
+      serverName?: string;
       promptIndex: number;
     }
   >;
@@ -243,6 +245,10 @@ export function wrapToolSetForEvalTrace<T extends Record<string, unknown>>(
       typeof (raw as { _serverId?: unknown })._serverId === "string"
         ? ((raw as { _serverId?: string })._serverId ?? undefined)
         : undefined;
+    const serverName =
+      typeof (raw as { _serverName?: unknown })._serverName === "string"
+        ? ((raw as { _serverName?: string })._serverName ?? undefined)
+        : undefined;
     out[name] = {
       ...raw,
       execute: async (
@@ -270,6 +276,7 @@ export function wrapToolSetForEvalTrace<T extends Record<string, unknown>>(
           stepNumber,
           startAt: toolStartedAt,
           serverId,
+          serverName,
           promptIndex: resolvedPromptIndex,
         });
         let success = true;
@@ -297,6 +304,7 @@ export function wrapToolSetForEvalTrace<T extends Record<string, unknown>>(
             toolCallId,
             toolName: name,
             serverId,
+            serverName,
             status: success ? "ok" : "error",
             ...(mcpErrorCode !== undefined ? { mcpErrorCode } : {}),
             ...createOffsetInterval(
@@ -316,6 +324,7 @@ export function wrapToolSetForEvalTrace<T extends Record<string, unknown>>(
               toolCallId,
               toolName: name,
               serverId,
+              serverName,
               status: "error",
               ...(mcpErrorCode !== undefined ? { mcpErrorCode } : {}),
               ...createOffsetInterval(
@@ -515,6 +524,7 @@ export function finalizeAiSdkTraceOnFailure(
       toolCallId,
       toolName: t.toolName,
       serverId: t.serverId,
+      serverName: t.serverName,
       status: "error",
       ...createOffsetInterval(runStartedAt, t.startAt, failAt),
     });
@@ -528,6 +538,7 @@ export function finalizeAiSdkTraceOnFailure(
       toolCallId,
       toolName: t.toolName,
       serverId: t.serverId,
+      serverName: t.serverName,
       status: "error",
       ...createOffsetInterval(runStartedAt, t.startAt, failAt),
     });
@@ -762,6 +773,7 @@ export function wrapBackendToolsForTrace<T extends Record<string, unknown>>(
         },
       ) => unknown;
       _serverId?: string;
+      _serverName?: string;
     };
     if (!raw || typeof raw.execute !== "function") {
       continue;
@@ -810,6 +822,7 @@ export function wrapBackendToolsForTrace<T extends Record<string, unknown>>(
             toolCallId,
             toolName: name,
             serverId: raw._serverId,
+            serverName: raw._serverName,
             status: success ? "ok" : "error",
             ...(mcpErrorCode !== undefined ? { mcpErrorCode } : {}),
             ...createOffsetInterval(params.runStartedAt, startedAt, finishedAt),
@@ -828,6 +841,7 @@ export function wrapBackendToolsForTrace<T extends Record<string, unknown>>(
               toolCallId,
               toolName: name,
               serverId: raw._serverId,
+              serverName: raw._serverName,
               status: "error",
               ...(mcpErrorCode !== undefined ? { mcpErrorCode } : {}),
               ...createOffsetInterval(

--- a/mcpjam-inspector/server/utils/__tests__/progressive-tool-meta-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/progressive-tool-meta-tools.test.ts
@@ -12,6 +12,7 @@ import type { ToolSet } from "ai";
 function makeMcpTool(opts: {
   description?: string;
   serverId: string;
+  serverName?: string;
   fields?: Record<string, { type: string; required?: boolean }>;
 }) {
   const fields = opts.fields ?? {};
@@ -31,6 +32,7 @@ function makeMcpTool(opts: {
       },
     },
     _serverId: opts.serverId,
+    _serverName: opts.serverName,
     execute: async () => ({}),
   };
 }
@@ -40,11 +42,13 @@ function makeCatalog() {
     asana_create_task: makeMcpTool({
       description: "Create a task in Asana",
       serverId: "asana",
+      serverName: "Asana",
       fields: { name: { type: "string", required: true } },
     }),
     linear_create_issue: makeMcpTool({
       description: "Create an issue in Linear",
       serverId: "linear",
+      serverName: "Linear",
       fields: { title: { type: "string", required: true } },
     }),
   } as unknown as ToolSet;
@@ -85,9 +89,12 @@ describe("createProgressiveMetaTools", () => {
     });
     const res = (await execTool(tools, META_TOOL_SEARCH, {
       query: "task",
-    })) as { matches: { name: string; toolId: string }[] };
+    })) as {
+      matches: { name: string; toolId: string; serverName: string }[];
+    };
     expect(res.matches.length).toBeGreaterThan(0);
     expect(res.matches[0].name).toBe("asana_create_task");
+    expect(res.matches[0].serverName).toBe("Asana");
     // Verify the match object is intentionally narrow — no `inputSchema`.
     expect(res.matches[0]).not.toHaveProperty("inputSchema");
   });
@@ -215,10 +222,14 @@ describe("createProgressiveMetaTools", () => {
     });
     const res = (await execTool(tools, META_TOOL_LOAD, {
       toolIds: ["asana::asana_create_task", "nope::missing"],
-    })) as { loaded: { toolId: string }[]; notFound: string[] };
+    })) as {
+      loaded: { toolId: string; serverName: string | null }[];
+      notFound: string[];
+    };
     expect(res.loaded.map((l) => l.toolId)).toEqual([
       "asana::asana_create_task",
     ]);
+    expect(res.loaded[0].serverName).toBe("Asana");
     expect(res.notFound).toEqual(["nope::missing"]);
     expect([...state.newlyLoadedToolIds]).toEqual(["asana::asana_create_task"]);
   });

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -578,6 +578,7 @@ export function buildWidgetInteractionContextSystemPrompt(
 export interface PrepareChatV2Options {
   mcpClientManager: InstanceType<typeof MCPClientManager>;
   selectedServers?: string[];
+  selectedServerNames?: string[];
   modelDefinition: ModelDefinition;
   systemPrompt?: string;
   temperature?: number;
@@ -618,6 +619,37 @@ export interface PrepareChatV2Options {
    * Takes precedence over the local/HOSTED_MODE skill branches.
    */
   cloudSkills?: { authHeader: string; projectId: string };
+}
+
+function annotateToolsWithServerNames(
+  tools: ToolSet,
+  selectedServers: string[] | undefined,
+  selectedServerNames: string[] | undefined,
+): void {
+  if (!selectedServers || selectedServers.length === 0) return;
+  const namesById = new Map<string, string>();
+  selectedServers.forEach((serverId, index) => {
+    const serverName = selectedServerNames?.[index];
+    namesById.set(
+      serverId,
+      serverName && serverName.trim().length > 0 ? serverName : serverId,
+    );
+  });
+
+  for (const raw of Object.values(tools)) {
+    if (!raw || typeof raw !== "object") continue;
+    const toolEntry = raw as { _serverId?: unknown; _serverName?: unknown };
+    if (
+      typeof toolEntry._serverId !== "string" ||
+      toolEntry._serverId.length === 0 ||
+      (typeof toolEntry._serverName === "string" &&
+        toolEntry._serverName.length > 0)
+    ) {
+      continue;
+    }
+    toolEntry._serverName =
+      namesById.get(toolEntry._serverId) ?? toolEntry._serverId;
+  }
 }
 
 /**
@@ -760,6 +792,11 @@ export async function prepareChatV2(
   const mcpTools = await mcpClientManager.getToolsForAiSdk(
     knownSelectedServers,
     toolOptions
+  );
+  annotateToolsWithServerNames(
+    mcpTools,
+    selectedServers,
+    options.selectedServerNames,
   );
 
   // SEP-1865: tools whose `_meta.ui.visibility` is exactly `["app"]` are

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -440,7 +440,10 @@ export async function runHarnessTurn(
   // shows in the [harness][timing] phase log.
   let traceBaseMs = turnStartedAt;
   let stepStartedAt = turnStartedAt;
-  const toolSetForTrace: Record<string, { _serverId?: string }> = {};
+  const toolSetForTrace: Record<
+    string,
+    { _serverId?: string; _serverName?: string }
+  > = {};
   // The shared per-turn ritual (turn_start / onStepFinish / turn_finish /
   // PersistedTurnTrace / abort). Constructed at STREAM start once `traceBaseMs`
   // is finalized; read by `onFinishEngine` (a sibling closure) for the trace.
@@ -1299,7 +1302,9 @@ export async function runHarnessTurn(
             });
             // Stand-in ToolSet entry so emitTraceSnapshot's collectActualToolCalls
             // can resolve this tool's serverId (the harness has no `ai` ToolSet).
-            toolSetForTrace[toolName] = serverId ? { _serverId: serverId } : {};
+            toolSetForTrace[toolName] = serverId
+              ? { _serverId: serverId, _serverName: serverId }
+              : {};
             toolStartMs.set(toolCallId, Date.now());
             // providerExecuted:true — the harness runs ALL tools in-sandbox
             // (Claude Code executes them itself). Without it the client treats

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -1302,9 +1302,7 @@ export async function runHarnessTurn(
             });
             // Stand-in ToolSet entry so emitTraceSnapshot's collectActualToolCalls
             // can resolve this tool's serverId (the harness has no `ai` ToolSet).
-            toolSetForTrace[toolName] = serverId
-              ? { _serverId: serverId, _serverName: serverId }
-              : {};
+            toolSetForTrace[toolName] = serverId ? { _serverId: serverId } : {};
             toolStartMs.set(toolCallId, Date.now());
             // providerExecuted:true — the harness runs ALL tools in-sandbox
             // (Claude Code executes them itself). Without it the client treats

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -830,6 +830,7 @@ function createClientFinishChunk(
   finishChunk: UIMessageChunk | null,
   traceTurn: LiveTraceTurnContext | null,
   fallbackReason: "length" | "stop",
+  extraMessageMetadata?: Record<string, unknown>,
 ): UIMessageChunk {
   type FinishUIMessageChunk = Extract<UIMessageChunk, { type: "finish" }>;
   const source = finishChunk as Partial<FinishUIMessageChunk> | null;
@@ -842,18 +843,41 @@ function createClientFinishChunk(
       ? readUsageFromFinishChunk(finishChunk)
       : { inputTokens: 0, outputTokens: 0, totalTokens: 0 });
   const metadata = source?.messageMetadata;
+  const baseMessageMetadata =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? { ...metadata, ...(usage ?? {}) }
+      : (usage ?? metadata);
   const messageMetadata =
-    metadata &&
-    typeof metadata === "object" &&
-    !Array.isArray(metadata) &&
-    usage
-      ? { ...metadata, ...usage }
-      : (metadata ?? usage);
+    extraMessageMetadata &&
+    baseMessageMetadata &&
+    typeof baseMessageMetadata === "object" &&
+    !Array.isArray(baseMessageMetadata)
+      ? { ...baseMessageMetadata, ...extraMessageMetadata }
+      : (extraMessageMetadata ?? baseMessageMetadata);
 
   return buildFinishChunk({
     finishReason: source?.finishReason ?? fallbackReason,
     messageMetadata,
   });
+}
+
+function buildProgressiveToolDiscoveryMetadata(
+  plan: ProgressiveToolPlan | undefined,
+): Record<string, unknown> | undefined {
+  if (!plan) return undefined;
+  const serverKeys = new Set(
+    plan.catalog
+      .map((entry) => entry.serverId ?? entry.serverName)
+      .filter((value): value is string => typeof value === "string"),
+  );
+  return {
+    progressiveToolDiscovery: {
+      enabled: plan.enabled,
+      reasons: plan.reasons,
+      toolCount: plan.catalog.length,
+      serverCount: serverKeys.size,
+    },
+  };
 }
 
 function setStepSpanMessageRanges(
@@ -2334,7 +2358,14 @@ async function processOneStep(
       );
       emitTraceSnapshot(writer, messageHistory, tools, traceTurn);
       if (finishChunk) {
-        writer.write(createClientFinishChunk(finishChunk, traceTurn, "stop"));
+        writer.write(
+          createClientFinishChunk(
+            finishChunk,
+            traceTurn,
+            "stop",
+            buildProgressiveToolDiscoveryMetadata(progressivePlan),
+          ),
+        );
       }
       return { shouldContinue: false, didEmitFinish: !!finishChunk };
     }
@@ -2488,7 +2519,14 @@ async function processOneStep(
       // already been converted to error tool-results above.
       if (hasUnresolvedClientFulfilledToolCalls(messageHistory, tools)) {
         if (finishChunk) {
-          writer.write(createClientFinishChunk(finishChunk, traceTurn, "stop"));
+          writer.write(
+            createClientFinishChunk(
+              finishChunk,
+              traceTurn,
+              "stop",
+              buildProgressiveToolDiscoveryMetadata(progressivePlan),
+            ),
+          );
         }
         return { shouldContinue: false, didEmitFinish: !!finishChunk };
       }
@@ -2585,7 +2623,14 @@ async function processOneStep(
   // No more tool calls - emit finish and stop
   const didEmitFinish = !!finishChunk;
   if (finishChunk) {
-    writer.write(createClientFinishChunk(finishChunk, traceTurn, "stop"));
+    writer.write(
+      createClientFinishChunk(
+        finishChunk,
+        traceTurn,
+        "stop",
+        buildProgressiveToolDiscoveryMetadata(progressivePlan),
+      ),
+    );
   }
 
   // We're done with this conversation turn
@@ -2989,6 +3034,7 @@ export async function runChatEngineLoop(
             null,
             traceTurn,
             hitStepCap() ? "length" : "stop",
+            buildProgressiveToolDiscoveryMetadata(progressivePlan),
           ),
         );
         finishEmitted = true;

--- a/mcpjam-inspector/server/utils/progressive-tool-meta-tools.ts
+++ b/mcpjam-inspector/server/utils/progressive-tool-meta-tools.ts
@@ -13,6 +13,8 @@ import { tool, type ToolSet } from "ai";
 import { z } from "zod";
 import {
   META_TOOL_LOAD,
+  META_TOOL_SERVER_ID,
+  META_TOOL_SERVER_NAME,
   META_TOOL_SEARCH,
   formatToolSearchMatch,
   searchToolCatalog,
@@ -63,7 +65,12 @@ export interface SearchMcpToolsResult {
 }
 
 export interface LoadMcpToolsResult {
-  loaded: { toolId: string; name: string; serverId: string | null }[];
+  loaded: {
+    toolId: string;
+    name: string;
+    serverId: string | null;
+    serverName: string | null;
+  }[];
   notFound: string[];
 }
 
@@ -119,6 +126,10 @@ export function createProgressiveMetaTools(
       };
     },
   });
+  Object.assign(result[META_TOOL_SEARCH] as object, {
+    _serverId: META_TOOL_SERVER_ID,
+    _serverName: META_TOOL_SERVER_NAME,
+  });
   result[META_TOOL_LOAD] = tool({
     description: LOAD_DESCRIPTION,
     inputSchema: loadSchema,
@@ -141,10 +152,15 @@ export function createProgressiveMetaTools(
           toolId: entry.toolId,
           name: entry.modelName,
           serverId: entry.serverId,
+          serverName: entry.serverName,
         });
       }
       return { loaded, notFound };
     },
+  });
+  Object.assign(result[META_TOOL_LOAD] as object, {
+    _serverId: META_TOOL_SERVER_ID,
+    _serverName: META_TOOL_SERVER_NAME,
   });
   return result;
 }

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -151,6 +151,7 @@ export interface WebChatTurnPersistContext {
  */
 export interface WebChatTurnPrepareInputs {
   selectedServerIds: string[];
+  selectedServerNames?: string[];
   modelDefinition: ModelDefinition;
   systemPrompt?: string;
   temperature?: number;
@@ -238,6 +239,7 @@ export async function streamWebChatTurn(
     prepared = await prepareChatV2({
       mcpClientManager: manager,
       selectedServers: prepare.selectedServerIds,
+      selectedServerNames: prepare.selectedServerNames,
       modelDefinition: prepare.modelDefinition,
       systemPrompt: prepare.systemPrompt,
       temperature: prepare.temperature,

--- a/mcpjam-inspector/shared/__tests__/progressive-tool-discovery.test.ts
+++ b/mcpjam-inspector/shared/__tests__/progressive-tool-discovery.test.ts
@@ -26,6 +26,7 @@ import {
 function makeMcpTool(opts: {
   description?: string;
   serverId?: string;
+  serverName?: string;
   fields?: Record<string, { type: string; required?: boolean; desc?: string }>;
 }) {
   const fields = opts.fields ?? {};
@@ -47,6 +48,7 @@ function makeMcpTool(opts: {
     description: opts.description,
     parameters: { jsonSchema },
     _serverId: opts.serverId,
+    _serverName: opts.serverName,
     execute: async () => ({}),
   };
 }
@@ -80,10 +82,24 @@ describe("buildToolCatalog", () => {
     expect(catalog).toHaveLength(1);
     expect(catalog[0].toolId).toBe("asana::get_user");
     expect(catalog[0].serverId).toBe("asana");
+    expect(catalog[0].serverName).toBe("asana");
     expect(catalog[0].modelName).toBe("get_user");
     expect(catalog[0].fields).toEqual([
       { name: "userId", type: "string", required: true },
     ]);
+  });
+
+  it("reads human-readable server names into catalog and search results", () => {
+    const tools: ToolSet = {
+      create_task: makeMcpTool({
+        description: "Create a task",
+        serverId: "srv_asana",
+        serverName: "Asana",
+      }),
+    } as unknown as ToolSet;
+    const catalog = buildToolCatalog(tools);
+    expect(catalog[0].serverName).toBe("Asana");
+    expect(searchToolCatalog(catalog, "task")[0].serverName).toBe("Asana");
   });
 
   it("falls back to local:: prefix when no server id is attached", () => {

--- a/mcpjam-inspector/shared/eval-trace.ts
+++ b/mcpjam-inspector/shared/eval-trace.ts
@@ -23,6 +23,7 @@ export type EvalTraceSpan = {
   toolCallId?: string;
   toolName?: string;
   serverId?: string;
+  serverName?: string;
   modelId?: string;
   inputTokens?: number;
   outputTokens?: number;
@@ -505,6 +506,7 @@ export const evalTraceSpanZ = z.object({
   toolCallId: z.string().optional(),
   toolName: z.string().optional(),
   serverId: z.string().optional(),
+  serverName: z.string().optional(),
   modelId: z.string().optional(),
   inputTokens: z.number().optional(),
   outputTokens: z.number().optional(),

--- a/mcpjam-inspector/shared/http-tool-calls.ts
+++ b/mcpjam-inspector/shared/http-tool-calls.ts
@@ -30,6 +30,8 @@ function flattenToolsetsWithServerId(toolsets: Toolsets): ToolsMap {
         flattened[toolName] = {
           ...tool,
           _serverId: serverId,
+          _serverName:
+            typeof tool?._serverName === "string" ? tool._serverName : serverId,
         };
       }
     }

--- a/mcpjam-inspector/shared/progressive-tool-discovery.ts
+++ b/mcpjam-inspector/shared/progressive-tool-discovery.ts
@@ -24,6 +24,8 @@ export const META_TOOL_NAMES: readonly string[] = [
   META_TOOL_SEARCH,
   META_TOOL_LOAD,
 ] as const;
+export const META_TOOL_SERVER_ID = "mcpjam:discovery";
+export const META_TOOL_SERVER_NAME = "MCPJam";
 
 export interface ToolCatalogFieldSummary {
   name: string;
@@ -39,6 +41,8 @@ export interface ToolCatalogEntry {
   modelName: string;
   /** Underlying server/source identifier, or null for skill/local tools. */
   serverId: string | null;
+  /** Human-readable MCP server/source name when known. */
+  serverName: string | null;
   /** Original MCP tool name (before any inspector-side rename). */
   originalName: string;
   description?: string;
@@ -172,6 +176,7 @@ type AnyTool = {
   parameters?: unknown;
   inputSchema?: unknown;
   _serverId?: unknown;
+  _serverName?: unknown;
   _meta?: unknown;
   // Some MCP-adapter tools stash the original MCP name when the AI SDK name
   // was sanitized for provider naming rules.
@@ -242,6 +247,19 @@ function readServerId(tool: AnyTool): string | null {
   return null;
 }
 
+function readServerName(tool: AnyTool): string | null {
+  if (typeof tool._serverName === "string" && tool._serverName.length > 0) {
+    return tool._serverName;
+  }
+  if (tool._meta && typeof tool._meta === "object") {
+    const meta = tool._meta as Record<string, unknown>;
+    if (typeof meta._serverName === "string" && meta._serverName.length > 0) {
+      return meta._serverName;
+    }
+  }
+  return null;
+}
+
 function readOriginalName(tool: AnyTool, modelName: string): string {
   if (typeof tool._originalName === "string" && tool._originalName.length > 0) {
     return tool._originalName;
@@ -260,6 +278,7 @@ export function buildToolCatalog(tools: ToolSet): ToolCatalogEntry[] {
     if (META_TOOL_NAMES.includes(modelName)) continue;
     const tool = raw as AnyTool;
     const serverId = readServerId(tool);
+    const serverName = readServerName(tool) ?? serverId;
     const originalName = readOriginalName(tool, modelName);
     const inputSchema = readJsonSchema(tool.parameters ?? tool.inputSchema);
     const description =
@@ -277,6 +296,7 @@ export function buildToolCatalog(tools: ToolSet): ToolCatalogEntry[] {
       toolId,
       modelName,
       serverId,
+      serverName,
       originalName,
       description,
       fields,
@@ -483,6 +503,7 @@ export interface ToolSearchMatch {
   toolId: string;
   name: string;
   serverId: string | null;
+  serverName: string | null;
   description?: string;
   fields: { name: string; type: string; required: boolean }[];
 }
@@ -492,6 +513,7 @@ export function formatToolSearchMatch(entry: ToolCatalogEntry): ToolSearchMatch 
     toolId: entry.toolId,
     name: entry.modelName,
     serverId: entry.serverId,
+    serverName: entry.serverName,
     description: entry.description,
     fields: entry.fields.map((f) => ({
       name: f.name,


### PR DESCRIPTION
Summary:
- Backend: preserve server names through progressive discovery catalogs, meta-tool search/load responses, chat-v2 orchestration, HTTP tool flattening, harness traces, and hosted stream finish metadata.
- Eval tracing: persist serverName on tool spans and label discovery meta-tool rows clearly as MCPJam discovery activity.
- Frontend: add the header Auto/On/Off progressive-tools override and surface active discovery status from assistant message metadata.


Verification:
- npm run test --workspace @mcpjam/inspector -- shared/__tests__/progressive-tool-discovery.test.ts server/utils/__tests__/progressive-tool-meta-tools.test.ts client/src/components/shared/__tests__/ClientContextHeader.test.tsx client/src/components/evals/__tests__/trace-timeline.test.tsx
- npm run typecheck:client --workspace @mcpjam/inspector
- npm run sdk:build --workspace @mcpjam/inspector
- npm run build:server --workspace @mcpjam/inspector
- git diff --check