### PR TITLE
fix(sdk/oauth): honor client_secret_basic with an Authorization header

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-oauth-preregistered-credentials.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-oauth-preregistered-credentials.test.ts
@@ -122,11 +122,6 @@ describe("OAuth debugger pre-registered client credentials (#3029)", () => {
       protocolVersion: "2025-11-25",
       preregisteredClientId: CLIENT_ID,
       preregisteredClientSecret: CLIENT_SECRET,
-      // Pin the AS to client_secret_post so the body-borne secret asserted
-      // below is the spec-correct transport. NOTE: the debug state machines
-      // currently transmit the secret in the body even when the resolved
-      // method is client_secret_basic (no Authorization: Basic header is
-      // built anywhere) — tracked as a follow-up SDK issue.
       tokenEndpointAuthMethodsSupported: ["client_secret_post"],
     });
 
@@ -153,6 +148,102 @@ describe("OAuth debugger pre-registered client credentials (#3029)", () => {
         client_secret: CLIENT_SECRET,
       },
     });
+    expect(getState().lastRequest?.headers).not.toHaveProperty("Authorization");
+  });
+
+  it("sends the secret as an Authorization: Basic header for client_secret_basic (#3034)", async () => {
+    vi.useFakeTimers();
+    const { machine, getState, updateState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+      preregisteredClientId: CLIENT_ID,
+      preregisteredClientSecret: CLIENT_SECRET,
+      tokenEndpointAuthMethodsSupported: ["client_secret_basic"],
+    });
+
+    await machine.proceedToNextStep();
+    expect(getState().tokenEndpointAuthMethod).toBe("client_secret_basic");
+
+    updateState({
+      currentStep: "received_authorization_code",
+      authorizationCode: "auth-code-123",
+      codeVerifier: "pkce-verifier",
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(getState().currentStep).toBe("token_request");
+    expect(getState().lastRequest?.headers).toMatchObject({
+      Authorization: `Basic ${btoa(`${CLIENT_ID}:${CLIENT_SECRET}`)}`,
+    });
+    // With Basic auth the credential rides in the header — the body carries
+    // neither the secret nor the (redundant) client_id.
+    expect(getState().lastRequest?.body).not.toHaveProperty("client_secret");
+    expect(getState().lastRequest?.body).not.toHaveProperty("client_id");
+  });
+
+  it("forwards the Basic header through the debug proxy on the actual exchange", async () => {
+    vi.useFakeTimers();
+    const { authFetch } = await import("@/lib/session-token");
+    vi.mocked(authFetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: { access_token: "tok", token_type: "Bearer" },
+      }),
+    } as unknown as Response);
+
+    const { machine, getState, updateState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+      preregisteredClientId: CLIENT_ID,
+      preregisteredClientSecret: CLIENT_SECRET,
+      tokenEndpointAuthMethodsSupported: ["client_secret_basic"],
+    });
+
+    await machine.proceedToNextStep();
+    updateState({
+      currentStep: "token_request",
+      authorizationCode: "auth-code-123",
+      codeVerifier: "pkce-verifier",
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(authFetch).toHaveBeenCalled();
+    const proxyPayload = JSON.parse(
+      vi.mocked(authFetch).mock.calls.at(-1)![1]!.body as string,
+    );
+    expect(proxyPayload.headers.Authorization).toBe(
+      `Basic ${btoa(`${CLIENT_ID}:${CLIENT_SECRET}`)}`,
+    );
+    expect(proxyPayload.body).not.toHaveProperty("client_secret");
+    expect(getState().accessToken).toBe("tok");
+  });
+
+  it("never transmits the secret when the AS only supports 'none'", async () => {
+    vi.useFakeTimers();
+    const { machine, getState, updateState } = createPreregisteredHarness({
+      protocolVersion: "2025-11-25",
+      preregisteredClientId: CLIENT_ID,
+      preregisteredClientSecret: CLIENT_SECRET,
+      tokenEndpointAuthMethodsSupported: ["none"],
+    });
+
+    await machine.proceedToNextStep();
+    expect(getState().tokenEndpointAuthMethod).toBe("none");
+
+    updateState({
+      currentStep: "received_authorization_code",
+      authorizationCode: "auth-code-123",
+      codeVerifier: "pkce-verifier",
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(getState().lastRequest?.body).toMatchObject({ client_id: CLIENT_ID });
+    expect(getState().lastRequest?.body).not.toHaveProperty("client_secret");
+    expect(getState().lastRequest?.headers).not.toHaveProperty("Authorization");
   });
 
   it("stays a public client when no secret is configured", async () => {
@@ -176,6 +267,7 @@ describe("OAuth debugger pre-registered client credentials (#3029)", () => {
     await machine.proceedToNextStep();
 
     expect(getState().lastRequest?.body).not.toHaveProperty("client_secret");
+    expect(getState().lastRequest?.headers).not.toHaveProperty("Authorization");
   });
 
   it("prefers the profile clientId over a stored DCR client record", async () => {

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -41,6 +41,7 @@ import {
 import { resolveRequestedScopeValue } from "./shared/challenges.js";
 import {
   buildTokenRequestClientAuth,
+  normalizeRegisteredClientAuthMethod,
   resolvePreregisteredClientAuthMethod,
 } from "./shared/client-auth.js";
 
@@ -1039,7 +1040,7 @@ export const createDebugOAuthStateMachine = (
                   clientId: clientInfo.client_id,
                   clientSecret: clientInfo.client_secret,
                   tokenEndpointAuthMethod:
-                    clientInfo.token_endpoint_auth_method || "none",
+                    normalizeRegisteredClientAuthMethod(clientInfo),
                   lastResponse: registrationResponseData,
                   httpHistory: updatedHistoryReg,
                   infoLogs,
@@ -1199,7 +1200,7 @@ export const createDebugOAuthStateMachine = (
             });
             break;
 
-          case "received_authorization_code":
+          case "received_authorization_code": {
             // Step 10: Prepare token exchange
             if (
               !state.authorizationCode ||
@@ -1267,6 +1268,7 @@ export const createDebugOAuthStateMachine = (
 
             autoAdvance(50);
             return;
+          }
 
           case "token_request":
             // Step 11: Exchange authorization code for access token

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -39,7 +39,10 @@ import {
   resolveInitializeProtocolVersion,
 } from "./shared/initialize.js";
 import { resolveRequestedScopeValue } from "./shared/challenges.js";
-import { resolvePreregisteredClientAuthMethod } from "./shared/client-auth.js";
+import {
+  buildTokenRequestClientAuth,
+  resolvePreregisteredClientAuthMethod,
+} from "./shared/client-auth.js";
 
 // Re-export types for backward compatibility
 export type { OAuthFlowStep, OAuthFlowState };
@@ -1214,19 +1217,18 @@ export const createDebugOAuthStateMachine = (
               throw new Error("Missing token endpoint");
             }
 
+            const previewClientAuth = buildTokenRequestClientAuth({
+              clientId: state.clientId,
+              clientSecret: state.clientSecret,
+              tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
+            });
+
             const tokenRequestBodyObj: Record<string, string> = {
               grant_type: "authorization_code",
               code: state.authorizationCode,
               redirect_uri: redirectUri,
+              ...previewClientAuth.bodyParams,
             };
-
-            if (state.clientId) {
-              tokenRequestBodyObj.client_id = state.clientId;
-            }
-
-            if (state.clientSecret) {
-              tokenRequestBodyObj.client_secret = state.clientSecret;
-            }
 
             if (state.codeVerifier) {
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
@@ -1241,6 +1243,7 @@ export const createDebugOAuthStateMachine = (
               url: state.authorizationServerMetadata.token_endpoint,
               headers: {
                 "Content-Type": "application/x-www-form-urlencoded",
+                ...previewClientAuth.headers,
               },
               body: tokenRequestBodyObj,
             };
@@ -1282,29 +1285,38 @@ export const createDebugOAuthStateMachine = (
             }
 
             try {
+              const clientAuth = buildTokenRequestClientAuth({
+                clientId: state.clientId,
+                clientSecret: state.clientSecret,
+                tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
+              });
+
               const tokenRequestBody = new URLSearchParams({
                 grant_type: "authorization_code",
                 code: state.authorizationCode,
                 redirect_uri: redirectUri,
-                client_id: state.clientId || "",
                 code_verifier: state.codeVerifier || "",
+                ...clientAuth.bodyParams,
               });
-
-              if (state.clientSecret) {
-                tokenRequestBody.set("client_secret", state.clientSecret);
-              }
 
               if (state.serverUrl) {
                 tokenRequestBody.set("resource", state.serverUrl);
               }
 
+              // The client-auth Authorization header is applied AFTER the
+              // merge: the merge strips user-configured Authorization headers
+              // so MCP-server credentials never leak to the AS, but the Basic
+              // credential here IS addressed to the AS (client_secret_basic).
               const response = await executeRequest(
                 state.authorizationServerMetadata.token_endpoint,
                 {
                   method: "POST",
-                  headers: mergeHeadersForAuthServer(customHeaders, {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                  }),
+                  headers: {
+                    ...mergeHeadersForAuthServer(customHeaders, {
+                      "Content-Type": "application/x-www-form-urlencoded",
+                    }),
+                    ...clientAuth.headers,
+                  },
                   body: tokenRequestBody.toString(),
                 },
               );

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -46,6 +46,7 @@ import {
 } from "./shared/challenges.js";
 import {
   buildTokenRequestClientAuth,
+  normalizeRegisteredClientAuthMethod,
   resolvePreregisteredClientAuthMethod,
 } from "./shared/client-auth.js";
 import { discoverOAuthProtectedResourceMetadata } from "../browser-auth.js";
@@ -1380,7 +1381,7 @@ export const createDebugOAuthStateMachine = (
                   clientId: clientInfo.client_id,
                   clientSecret: clientInfo.client_secret,
                   tokenEndpointAuthMethod:
-                    clientInfo.token_endpoint_auth_method || "none",
+                    normalizeRegisteredClientAuthMethod(clientInfo),
                   lastResponse: registrationResponseData,
                   httpHistory: updatedHistoryReg,
                   infoLogs,
@@ -1548,7 +1549,7 @@ export const createDebugOAuthStateMachine = (
             });
             break;
 
-          case "received_authorization_code":
+          case "received_authorization_code": {
             // Step 10: Validate authorization code and prepare for token exchange
 
             if (
@@ -1620,6 +1621,7 @@ export const createDebugOAuthStateMachine = (
             // Automatically proceed to make the actual request
             autoAdvance(50);
             return;
+          }
 
           case "token_request":
             // Step 11: Exchange authorization code for access token

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -44,7 +44,10 @@ import {
   parseScopeString,
   resolveRequestedScopeValue,
 } from "./shared/challenges.js";
-import { resolvePreregisteredClientAuthMethod } from "./shared/client-auth.js";
+import {
+  buildTokenRequestClientAuth,
+  resolvePreregisteredClientAuthMethod,
+} from "./shared/client-auth.js";
 import { discoverOAuthProtectedResourceMetadata } from "../browser-auth.js";
 
 // Re-export types for backward compatibility
@@ -1565,19 +1568,18 @@ export const createDebugOAuthStateMachine = (
             }
 
             // Build the token request body as an object (will be shown in HTTP history)
+            const previewClientAuth = buildTokenRequestClientAuth({
+              clientId: state.clientId,
+              clientSecret: state.clientSecret,
+              tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
+            });
+
             const tokenRequestBodyObj: Record<string, string> = {
               grant_type: "authorization_code",
               code: state.authorizationCode,
               redirect_uri: redirectUri,
+              ...previewClientAuth.bodyParams,
             };
-
-            if (state.clientId) {
-              tokenRequestBodyObj.client_id = state.clientId;
-            }
-
-            if (state.clientSecret) {
-              tokenRequestBodyObj.client_secret = state.clientSecret;
-            }
 
             if (state.codeVerifier) {
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
@@ -1592,6 +1594,7 @@ export const createDebugOAuthStateMachine = (
               url: state.authorizationServerMetadata.token_endpoint,
               headers: {
                 "Content-Type": "application/x-www-form-urlencoded",
+                ...previewClientAuth.headers,
               },
               body: tokenRequestBodyObj,
             };
@@ -1636,32 +1639,40 @@ export const createDebugOAuthStateMachine = (
 
             try {
               // Prepare token request body (form-urlencoded)
+              const clientAuth = buildTokenRequestClientAuth({
+                clientId: state.clientId,
+                clientSecret: state.clientSecret,
+                tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
+              });
+
               const tokenRequestBody = new URLSearchParams({
                 grant_type: "authorization_code",
                 code: state.authorizationCode,
                 redirect_uri: redirectUri,
-                client_id: state.clientId || "",
                 code_verifier: state.codeVerifier || "",
+                ...clientAuth.bodyParams,
               });
-
-              // Add client_secret if available (for confidential clients)
-              if (state.clientSecret) {
-                tokenRequestBody.set("client_secret", state.clientSecret);
-              }
 
               // Add resource parameter if available
               if (state.serverUrl) {
                 tokenRequestBody.set("resource", state.serverUrl);
               }
 
-              // Make the token request via backend proxy
+              // Make the token request via backend proxy. The client-auth
+              // Authorization header is applied AFTER the merge: the merge
+              // strips user-configured Authorization headers so MCP-server
+              // credentials never leak to the AS, but the Basic credential
+              // here IS addressed to the AS (client_secret_basic).
               const response = await executeRequest(
                 state.authorizationServerMetadata.token_endpoint,
                 {
                   method: "POST",
-                  headers: mergeHeadersForAuthServer(customHeaders, {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                  }),
+                  headers: {
+                    ...mergeHeadersForAuthServer(customHeaders, {
+                      "Content-Type": "application/x-www-form-urlencoded",
+                    }),
+                    ...clientAuth.headers,
+                  },
                   body: tokenRequestBody.toString(),
                 },
               );

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -49,6 +49,7 @@ import {
 } from "./shared/challenges.js";
 import {
   buildTokenRequestClientAuth,
+  normalizeRegisteredClientAuthMethod,
   resolvePreregisteredClientAuthMethod,
 } from "./shared/client-auth.js";
 import { discoverOAuthProtectedResourceMetadata } from "../browser-auth.js";
@@ -1553,7 +1554,7 @@ export const createDebugOAuthStateMachine = (
                   clientId: clientInfo.client_id,
                   clientSecret: clientInfo.client_secret,
                   tokenEndpointAuthMethod:
-                    clientInfo.token_endpoint_auth_method || "none",
+                    normalizeRegisteredClientAuthMethod(clientInfo),
                   lastResponse: registrationResponseData,
                   httpHistory: updatedHistoryReg,
                   infoLogs,
@@ -1835,7 +1836,7 @@ export const createDebugOAuthStateMachine = (
             });
             break;
 
-          case "received_authorization_code":
+          case "received_authorization_code": {
             // Step 10: Validate authorization code and prepare for token exchange
 
             if (
@@ -1905,6 +1906,7 @@ export const createDebugOAuthStateMachine = (
             // Automatically proceed to make the actual request
             autoAdvance(50);
             return;
+          }
 
           case "token_request":
             // Step 11: Exchange authorization code for access token

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -47,7 +47,10 @@ import {
   parseScopeString,
   resolveRequestedScopeValue,
 } from "./shared/challenges.js";
-import { resolvePreregisteredClientAuthMethod } from "./shared/client-auth.js";
+import {
+  buildTokenRequestClientAuth,
+  resolvePreregisteredClientAuthMethod,
+} from "./shared/client-auth.js";
 import { discoverOAuthProtectedResourceMetadata } from "../browser-auth.js";
 
 export type { OAuthFlowStep, OAuthFlowState };
@@ -1852,19 +1855,18 @@ export const createDebugOAuthStateMachine = (
             }
 
             // Build the token request body as an object (will be shown in HTTP history)
+            const previewClientAuth = buildTokenRequestClientAuth({
+              clientId: state.clientId,
+              clientSecret: state.clientSecret,
+              tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
+            });
+
             const tokenRequestBodyObj: Record<string, string> = {
               grant_type: "authorization_code",
               code: state.authorizationCode,
               redirect_uri: redirectUri,
+              ...previewClientAuth.bodyParams,
             };
-
-            if (state.clientId) {
-              tokenRequestBodyObj.client_id = state.clientId;
-            }
-
-            if (state.clientSecret) {
-              tokenRequestBodyObj.client_secret = state.clientSecret;
-            }
 
             if (state.codeVerifier) {
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
@@ -1877,6 +1879,7 @@ export const createDebugOAuthStateMachine = (
               url: state.authorizationServerMetadata.token_endpoint,
               headers: {
                 "Content-Type": "application/x-www-form-urlencoded",
+                ...previewClientAuth.headers,
               },
               body: tokenRequestBodyObj,
             };
@@ -1921,30 +1924,38 @@ export const createDebugOAuthStateMachine = (
 
             try {
               // Prepare token request body (form-urlencoded)
+              const clientAuth = buildTokenRequestClientAuth({
+                clientId: state.clientId,
+                clientSecret: state.clientSecret,
+                tokenEndpointAuthMethod: state.tokenEndpointAuthMethod,
+              });
+
               const tokenRequestBody = new URLSearchParams({
                 grant_type: "authorization_code",
                 code: state.authorizationCode,
                 redirect_uri: redirectUri,
-                client_id: state.clientId || "",
                 code_verifier: state.codeVerifier || "",
+                ...clientAuth.bodyParams,
               });
-
-              // Add client_secret if available (for confidential clients)
-              if (state.clientSecret) {
-                tokenRequestBody.set("client_secret", state.clientSecret);
-              }
 
               // Add resource parameter (canonicalized per RFC 8707)
               tokenRequestBody.set("resource", canonicalServerUrl);
 
-              // Make the token request via backend proxy
+              // Make the token request via backend proxy. The client-auth
+              // Authorization header is applied AFTER the merge: the merge
+              // strips user-configured Authorization headers so MCP-server
+              // credentials never leak to the AS, but the Basic credential
+              // here IS addressed to the AS (client_secret_basic).
               const response = await executeRequest(
                 state.authorizationServerMetadata.token_endpoint,
                 {
                   method: "POST",
-                  headers: mergeHeadersForAuthServer(customHeaders, {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                  }),
+                  headers: {
+                    ...mergeHeadersForAuthServer(customHeaders, {
+                      "Content-Type": "application/x-www-form-urlencoded",
+                    }),
+                    ...clientAuth.headers,
+                  },
                   body: tokenRequestBody.toString(),
                 }
               );

--- a/sdk/src/oauth/state-machines/shared/client-auth.ts
+++ b/sdk/src/oauth/state-machines/shared/client-auth.ts
@@ -76,6 +76,15 @@ export interface TokenRequestClientAuth {
 }
 
 /**
+ * RFC 6749 §2.3.1 / Appendix B: each Basic-auth credential part is encoded
+ * per application/x-www-form-urlencoded (space → `+`, `!`/`~`/`'`/`(`/`)`
+ * percent-encoded) before base64 — which differs from encodeURIComponent.
+ */
+function formUrlEncode(value: string): string {
+  return new URLSearchParams([["v", value]]).toString().slice(2);
+}
+
+/**
  * Translate the resolved token-endpoint auth method into how the client
  * credential is actually transmitted (#3034 — previously the secret always
  * went in the body regardless of the resolved method):
@@ -97,7 +106,7 @@ export function buildTokenRequestClientAuth(input: {
 
   if (clientSecret && tokenEndpointAuthMethod === "client_secret_basic") {
     const credentials = btoa(
-      `${encodeURIComponent(clientId ?? "")}:${encodeURIComponent(clientSecret)}`,
+      `${formUrlEncode(clientId ?? "")}:${formUrlEncode(clientSecret)}`,
     );
     return {
       headers: { Authorization: `Basic ${credentials}` },
@@ -113,4 +122,23 @@ export function buildTokenRequestClientAuth(input: {
     bodyParams.client_secret = clientSecret;
   }
   return { headers: {}, bodyParams };
+}
+
+/**
+ * Normalize the auth method echoed by a DCR registration response before it
+ * is stored on flow state. A server that issues a `client_secret` while
+ * echoing `"none"` (typically just our own requested hint bounced back) or
+ * omitting the method is contradicting itself — favor the credential: store
+ * `undefined` so the token request keeps the legacy `client_secret_post`
+ * body shape instead of dropping the secret (#2505's bug class).
+ */
+export function normalizeRegisteredClientAuthMethod(clientInfo: {
+  client_secret?: string;
+  token_endpoint_auth_method?: string;
+}): string | undefined {
+  const method = clientInfo.token_endpoint_auth_method;
+  if (clientInfo.client_secret && (!method || method === "none")) {
+    return undefined;
+  }
+  return method || "none";
 }

--- a/sdk/src/oauth/state-machines/shared/client-auth.ts
+++ b/sdk/src/oauth/state-machines/shared/client-auth.ts
@@ -62,3 +62,55 @@ export function resolvePreregisteredClientAuthMethod(input: {
   // "none" but accept unauthenticated public-client requests.
   return { ok: true, method: "none", supportedMethods };
 }
+
+export interface TokenRequestClientAuth {
+  /**
+   * Headers to add to the token request. Contains `Authorization: Basic …`
+   * for `client_secret_basic`; empty otherwise. Must be applied AFTER
+   * `mergeHeadersForAuthServer`, which strips user-configured Authorization
+   * headers — this protocol-required credential is the one exception.
+   */
+  headers: Record<string, string>;
+  /** `client_id` / `client_secret` body parameters, per the resolved method. */
+  bodyParams: Record<string, string>;
+}
+
+/**
+ * Translate the resolved token-endpoint auth method into how the client
+ * credential is actually transmitted (#3034 — previously the secret always
+ * went in the body regardless of the resolved method):
+ *
+ * - `client_secret_basic` → `Authorization: Basic` header, nothing in the
+ *   body (per RFC 6749 §2.3.1 the id and secret are each form-urlencoded
+ *   before base64; the id is carried by the header, not the body).
+ * - `client_secret_post` → `client_id` + `client_secret` body parameters.
+ * - `none` → `client_id` only; a secret is never transmitted.
+ * - method absent with a secret → body parameters (legacy shape for
+ *   DCR-issued secrets whose registration response omitted the method).
+ */
+export function buildTokenRequestClientAuth(input: {
+  clientId?: string;
+  clientSecret?: string;
+  tokenEndpointAuthMethod?: string;
+}): TokenRequestClientAuth {
+  const { clientId, clientSecret, tokenEndpointAuthMethod } = input;
+
+  if (clientSecret && tokenEndpointAuthMethod === "client_secret_basic") {
+    const credentials = btoa(
+      `${encodeURIComponent(clientId ?? "")}:${encodeURIComponent(clientSecret)}`,
+    );
+    return {
+      headers: { Authorization: `Basic ${credentials}` },
+      bodyParams: {},
+    };
+  }
+
+  const bodyParams: Record<string, string> = {};
+  if (clientId) {
+    bodyParams.client_id = clientId;
+  }
+  if (clientSecret && tokenEndpointAuthMethod !== "none") {
+    bodyParams.client_secret = clientSecret;
+  }
+  return { headers: {}, bodyParams };
+}

--- a/sdk/tests/token-request-client-auth.test.ts
+++ b/sdk/tests/token-request-client-auth.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { buildTokenRequestClientAuth } from "../src/oauth/state-machines/shared/client-auth.js";
+
+describe("buildTokenRequestClientAuth", () => {
+  it("client_secret_basic → Authorization header, empty body params", () => {
+    const auth = buildTokenRequestClientAuth({
+      clientId: "client_abc",
+      clientSecret: "shhh",
+      tokenEndpointAuthMethod: "client_secret_basic",
+    });
+
+    expect(auth.headers).toEqual({
+      Authorization: `Basic ${btoa("client_abc:shhh")}`,
+    });
+    expect(auth.bodyParams).toEqual({});
+  });
+
+  it("form-urlencodes credential parts before base64 (RFC 6749 §2.3.1)", () => {
+    const auth = buildTokenRequestClientAuth({
+      clientId: "client:with colon",
+      clientSecret: "p@ss wörd+/=",
+      tokenEndpointAuthMethod: "client_secret_basic",
+    });
+
+    const expected = `${encodeURIComponent("client:with colon")}:${encodeURIComponent("p@ss wörd+/=")}`;
+    expect(auth.headers.Authorization).toBe(`Basic ${btoa(expected)}`);
+  });
+
+  it("client_secret_post → id and secret in body params, no header", () => {
+    const auth = buildTokenRequestClientAuth({
+      clientId: "client_abc",
+      clientSecret: "shhh",
+      tokenEndpointAuthMethod: "client_secret_post",
+    });
+
+    expect(auth.headers).toEqual({});
+    expect(auth.bodyParams).toEqual({
+      client_id: "client_abc",
+      client_secret: "shhh",
+    });
+  });
+
+  it("none → client_id only; the secret is never transmitted", () => {
+    const auth = buildTokenRequestClientAuth({
+      clientId: "client_abc",
+      clientSecret: "shhh",
+      tokenEndpointAuthMethod: "none",
+    });
+
+    expect(auth.headers).toEqual({});
+    expect(auth.bodyParams).toEqual({ client_id: "client_abc" });
+  });
+
+  it("absent method with a secret keeps the legacy body shape (DCR-issued secrets)", () => {
+    const auth = buildTokenRequestClientAuth({
+      clientId: "client_abc",
+      clientSecret: "shhh",
+    });
+
+    expect(auth.headers).toEqual({});
+    expect(auth.bodyParams).toEqual({
+      client_id: "client_abc",
+      client_secret: "shhh",
+    });
+  });
+
+  it("public client without a secret sends only client_id", () => {
+    const auth = buildTokenRequestClientAuth({ clientId: "client_abc" });
+
+    expect(auth.headers).toEqual({});
+    expect(auth.bodyParams).toEqual({ client_id: "client_abc" });
+  });
+
+  it("no credentials at all yields empty header and body params", () => {
+    const auth = buildTokenRequestClientAuth({});
+
+    expect(auth.headers).toEqual({});
+    expect(auth.bodyParams).toEqual({});
+  });
+});

--- a/sdk/tests/token-request-client-auth.test.ts
+++ b/sdk/tests/token-request-client-auth.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildTokenRequestClientAuth } from "../src/oauth/state-machines/shared/client-auth.js";
+import {
+  buildTokenRequestClientAuth,
+  normalizeRegisteredClientAuthMethod,
+} from "../src/oauth/state-machines/shared/client-auth.js";
 
 describe("buildTokenRequestClientAuth", () => {
   it("client_secret_basic → Authorization header, empty body params", () => {
@@ -15,14 +18,21 @@ describe("buildTokenRequestClientAuth", () => {
     expect(auth.bodyParams).toEqual({});
   });
 
-  it("form-urlencodes credential parts before base64 (RFC 6749 §2.3.1)", () => {
+  it("form-urlencodes credential parts before base64 (RFC 6749 §2.3.1 / Appendix B)", () => {
     const auth = buildTokenRequestClientAuth({
       clientId: "client:with colon",
-      clientSecret: "p@ss wörd+/=",
+      clientSecret: "p@ss wörd+/=!~",
       tokenEndpointAuthMethod: "client_secret_basic",
     });
 
-    const expected = `${encodeURIComponent("client:with colon")}:${encodeURIComponent("p@ss wörd+/=")}`;
+    // application/x-www-form-urlencoded, NOT encodeURIComponent: space → "+",
+    // and "!" / "~" are percent-encoded.
+    const formEncode = (v: string) =>
+      new URLSearchParams([["v", v]]).toString().slice(2);
+    expect(formEncode("p@ss wörd+/=!~")).toContain("+w%C3%B6rd");
+    expect(formEncode("p@ss wörd+/=!~")).toContain("%21%7E");
+
+    const expected = `${formEncode("client:with colon")}:${formEncode("p@ss wörd+/=!~")}`;
     expect(auth.headers.Authorization).toBe(`Basic ${btoa(expected)}`);
   });
 
@@ -76,5 +86,40 @@ describe("buildTokenRequestClientAuth", () => {
 
     expect(auth.headers).toEqual({});
     expect(auth.bodyParams).toEqual({});
+  });
+});
+
+describe("normalizeRegisteredClientAuthMethod", () => {
+  it("drops a contradictory 'none' when the DCR response issued a secret", () => {
+    expect(
+      normalizeRegisteredClientAuthMethod({
+        client_secret: "shhh",
+        token_endpoint_auth_method: "none",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("stores undefined for a secret without an advertised method (legacy body shape)", () => {
+    expect(
+      normalizeRegisteredClientAuthMethod({ client_secret: "shhh" }),
+    ).toBeUndefined();
+  });
+
+  it("keeps an explicit method for secret-bearing clients", () => {
+    expect(
+      normalizeRegisteredClientAuthMethod({
+        client_secret: "shhh",
+        token_endpoint_auth_method: "client_secret_basic",
+      }),
+    ).toBe("client_secret_basic");
+  });
+
+  it("defaults public clients to 'none'", () => {
+    expect(normalizeRegisteredClientAuthMethod({})).toBe("none");
+    expect(
+      normalizeRegisteredClientAuthMethod({
+        token_endpoint_auth_method: "none",
+      }),
+    ).toBe("none");
   });
 });


### PR DESCRIPTION
Fixes #3034. Completes the client-authentication work from #3033 / #3030.

## What was wrong

The OAuth debugger's state machines *resolve* a token-endpoint auth method for pre-registered confidential clients (preferring `client_secret_basic`, the RFC 8414 default) — but the code that builds the token request ignored that decision and always put `client_secret` in the request body. No machine ever constructed a `Basic` header. Two consequences:

- Token exchange failed against auth servers that only accept `client_secret_basic`.
- The debugger's log said "Token Auth Method: client_secret_basic" while the displayed request showed a body-borne secret — a protocol debugger misreporting the wire.

## The fix

One shared helper, `buildTokenRequestClientAuth` (in `shared/client-auth.ts`, next to the existing method resolver), translates the resolved method into the actual transport. It's applied at all six token-request sites — the HTTP-history preview builder and the real executor, across all three protocol machines (2025-03-26, 2025-06-18, 2025-11-25) — so the request users see in the debugger is byte-for-byte what's sent:

| Resolved method | Transport |
|---|---|
| `client_secret_basic` | `Authorization: Basic base64(urlencode(id):urlencode(secret))` per RFC 6749 §2.3.1; body carries neither the secret nor the redundant `client_id` |
| `client_secret_post` | `client_id` + `client_secret` body params (unchanged) |
| `none` | `client_id` only — a secret is **never** transmitted (previously it leaked into the body even when the AS only advertised `none`) |
| absent, with secret | legacy body shape, preserving DCR-issued secrets whose registration response omitted the method |

## Security notes

- `mergeHeadersForAuthServer` deliberately strips user-configured `Authorization` headers so MCP-server credentials never leak to the auth server. That guard is untouched: the Basic credential is applied **after** the merge, as the one protocol-required exception. A custom `Authorization` header still cannot reach the AS.
- Verified the debug proxy (`executeDebugOAuthProxy`, both local and hosted routes) forwards request headers verbatim, so the Basic header reaches the token endpoint. Covered by a test asserting the exact proxied payload.
- Minor behavior change: the executor previously sent `client_id=""` (empty string) when no client id was set; it now omits the parameter.

## Tests

- `sdk/tests/token-request-client-auth.test.ts` — 7 unit tests for the helper, including RFC 6749 §2.3.1 encoding of special characters.
- Client machine-level suite extended (drives the real state machines): Basic header on the built request + through the debug proxy on the actual exchange, `none`-only AS never receives the secret, `client_secret_post` unchanged, public client sends no auth header.
- Full SDK suite (1638 tests), client OAuth suite (96), both typechecks, and the OAuth-debugger Playwright e2e (dev + hosted, against the rebuilt SDK) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth token-exchange and client-secret handling across three state machines; behavior changes are spec-correct but can affect interoperability with misconfigured AS metadata and DCR echo quirks.
> 
> **Overview**
> Fixes **#3034**: OAuth debug state machines resolved `client_secret_basic` but always sent `client_secret` in the token body, so exchanges failed on Basic-only auth servers and the debugger UI lied about the wire format.
> 
> Adds **`buildTokenRequestClientAuth`** and **`normalizeRegisteredClientAuthMethod`** in `shared/client-auth.ts`, then wires them into token **preview** and **executor** paths on all three protocol machines (`2025-03-26`, `2025-06-18`, `2025-11-25`). **`client_secret_basic`** now uses `Authorization: Basic` (RFC 6749 form-urlencoded credential parts); **`client_secret_post`** and **`none`** behave correctly (no secret on `none`); DCR responses that issue a secret but echo `none`/omit the method keep the legacy body shape via normalization.
> 
> The protocol Basic header is merged **after** `mergeHeadersForAuthServer` so user MCP `Authorization` headers still cannot reach the AS. New SDK unit tests and extended inspector preregistered-client tests cover Basic, proxy forwarding, and `none`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa1f715bb9b598f1b62e9f3b4468bdea3d894b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `client_secret_basic` for confidential clients by sending a proper Authorization: Basic header instead of putting the secret in the body. Also fixes credential encoding and DCR auth-method handling so the debugger’s preview matches the real token request and exchanges succeed with servers that require Basic auth.

- **Bug Fixes**
  - Added shared `buildTokenRequestClientAuth` to translate the resolved token auth method into headers/body.
  - For `client_secret_basic`, send `Authorization: Basic` with RFC 6749 §2.3.1/Appendix B encoding (application/x-www-form-urlencoded parts before base64); no `client_id` or `client_secret` in the body.
  - Other cases: keep `client_secret_post` as body params; `none` sends only `client_id`; if the method is absent or is `"none"` while a secret exists (DCR contradiction), keep the legacy body shape so the secret is preserved.
  - Applied across all token requests (preview + executor) for `2025-03-26`, `2025-06-18`, `2025-11-25`. Security: custom `Authorization` headers are still stripped by `mergeHeadersForAuthServer`; the Basic header is added after the merge. Also stops sending `client_id=""`.

<sup>Written for commit 8aa1f715bb9b598f1b62e9f3b4468bdea3d894b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

