### PR TITLE
fix(oauth-debugger): persist registration strategy + protocol version through Convex

### DIFF
--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1421,6 +1421,11 @@ export function useServerState({
         oauthResourceUrl:
           serverEntry.oauthFlowProfile?.resourceUrl ||
           storedOAuthConfig.resourceUrl,
+        // Persist the debugger test-profile choices so the catalog
+        // round-trip doesn't silently reset them to DCR / 2025-11-25.
+        oauthProtocolVersion: serverEntry.oauthFlowProfile?.protocolVersion,
+        oauthRegistrationStrategy:
+          serverEntry.oauthFlowProfile?.registrationStrategy,
         ...(serverEntry.xaaAuthzIssuer !== undefined
           ? { xaaAuthzIssuer: serverEntry.xaaAuthzIssuer }
           : {}),

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -44,6 +44,8 @@ export interface RemoteServer {
   useOAuth?: boolean;
   oauthScopes?: string[];
   clientId?: string;
+  oauthProtocolVersion?: string;
+  oauthRegistrationStrategy?: string;
   hasClientSecret?: boolean;
   hasEnv?: boolean;
   hasHeaders?: boolean;

--- a/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
@@ -302,3 +302,76 @@ describe("project-serialization xaaAuthzIssuer round-trip", () => {
     ).toBe(true);
   });
 });
+
+describe("OAuth test-profile round-trip (protocol version + registration strategy)", () => {
+  it("restores persisted strategy and protocol version from flat Convex columns", () => {
+    const servers = deserializeServersFromConvex([
+      {
+        name: "prereg",
+        enabled: true,
+        useOAuth: true,
+        url: "https://example.test/mcp",
+        clientId: "client_abc",
+        oauthScopes: ["openid", "email"],
+        oauthProtocolVersion: "2025-06-18",
+        oauthRegistrationStrategy: "preregistered",
+      },
+    ]);
+
+    const profile = servers.prereg.oauthFlowProfile!;
+    expect(profile.registrationStrategy).toBe("preregistered");
+    expect(profile.protocolVersion).toBe("2025-06-18");
+    expect(profile.clientId).toBe("client_abc");
+  });
+
+  it("builds a profile even when only the strategy columns are present", () => {
+    const servers = deserializeServersFromConvex([
+      {
+        name: "cimd-only",
+        enabled: true,
+        useOAuth: true,
+        url: "https://example.test/mcp",
+        oauthRegistrationStrategy: "cimd",
+      },
+    ]);
+
+    expect(servers["cimd-only"].oauthFlowProfile?.registrationStrategy).toBe(
+      "cimd",
+    );
+  });
+
+  it("ignores unknown wire values so the reader-side defaults apply", () => {
+    const servers = deserializeServersFromConvex([
+      {
+        name: "future",
+        enabled: true,
+        useOAuth: true,
+        url: "https://example.test/mcp",
+        clientId: "client_abc",
+        oauthProtocolVersion: "2099-01-01",
+        oauthRegistrationStrategy: "quantum",
+      },
+    ]);
+
+    const profile = servers.future.oauthFlowProfile as any;
+    expect(profile.registrationStrategy).toBeUndefined();
+    expect(profile.protocolVersion).toBeUndefined();
+    expect(profile.clientId).toBe("client_abc");
+  });
+
+  it("legacy rows without the columns keep no strategy on the profile", () => {
+    const servers = deserializeServersFromConvex([
+      {
+        name: "legacy",
+        enabled: true,
+        useOAuth: true,
+        url: "https://example.test/mcp",
+        clientId: "client_abc",
+      },
+    ]);
+
+    const profile = servers.legacy.oauthFlowProfile as any;
+    expect(profile.registrationStrategy).toBeUndefined();
+    expect(profile.protocolVersion).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/profile.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/profile.ts
@@ -31,3 +31,33 @@ export const EMPTY_OAUTH_TEST_PROFILE: OAuthTestProfile = {
   protocolVersion: "2025-11-25",
   registrationStrategy: "dcr",
 };
+
+const OAUTH_PROTOCOL_VERSIONS: readonly OAuthProtocolVersion[] = [
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+];
+
+const OAUTH_REGISTRATION_STRATEGIES: readonly OAuthRegistrationStrategy[] = [
+  "cimd",
+  "dcr",
+  "preregistered",
+];
+
+/**
+ * The Convex `servers` columns backing these are plain strings (so an older
+ * or newer client never fails the whole server save over an unknown value) —
+ * narrow them back to the closed unions here; anything unrecognized reads as
+ * absent and falls to the profile defaults.
+ */
+export function normalizeOAuthProtocolVersion(
+  value: unknown,
+): OAuthProtocolVersion | undefined {
+  return OAUTH_PROTOCOL_VERSIONS.find((known) => known === value);
+}
+
+export function normalizeOAuthRegistrationStrategy(
+  value: unknown,
+): OAuthRegistrationStrategy | undefined {
+  return OAUTH_REGISTRATION_STRATEGIES.find((known) => known === value);
+}

--- a/mcpjam-inspector/client/src/lib/project-serialization.ts
+++ b/mcpjam-inspector/client/src/lib/project-serialization.ts
@@ -1,4 +1,8 @@
 import type { ServerWithName, ConnectionStatus } from "@/state/app-types";
+import {
+  normalizeOAuthProtocolVersion,
+  normalizeOAuthRegistrationStrategy,
+} from "@/lib/oauth/profile";
 
 type SerializeOptions = {
   /**
@@ -259,13 +263,21 @@ export function deserializeServersFromConvex(
       server.oauthFlowProfile = serverData.oauthFlowProfile;
     }
 
-    // NEW: Handle flat oauthScopes/clientId from servers table
+    // NEW: Handle flat OAuth profile fields from the servers table
     // Convert oauthScopes array to comma-separated string for OAuthTestProfile.scopes
+    const flatProtocolVersion = normalizeOAuthProtocolVersion(
+      serverData.oauthProtocolVersion,
+    );
+    const flatRegistrationStrategy = normalizeOAuthRegistrationStrategy(
+      serverData.oauthRegistrationStrategy,
+    );
     if (
       serverData.oauthScopes ||
       serverData.clientId ||
       serverData.hasClientSecret ||
-      serverData.oauthResourceUrl
+      serverData.oauthResourceUrl ||
+      flatProtocolVersion ||
+      flatRegistrationStrategy
     ) {
       const existingProfile = (server.oauthFlowProfile as any) || {};
       server.oauthFlowProfile = {
@@ -277,6 +289,15 @@ export function deserializeServersFromConvex(
         clientSecret: "",
         resourceUrl:
           serverData.oauthResourceUrl || existingProfile.resourceUrl || "",
+        // Persisted debugger test-profile choices. Absent (legacy rows or an
+        // unknown wire value) keeps the legacy-nested value when present and
+        // otherwise falls to the reader-side defaults (DCR / 2025-11-25).
+        ...(flatProtocolVersion
+          ? { protocolVersion: flatProtocolVersion }
+          : {}),
+        ...(flatRegistrationStrategy
+          ? { registrationStrategy: flatRegistrationStrategy }
+          : {}),
       } as typeof server.oauthFlowProfile;
     }
 

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/lib/oauth/mcp-oauth", () => ({
 }));
 
 import { ensureAuthorizedForReconnect } from "../oauth-orchestrator";
+import { deserializeServersFromConvex } from "@/lib/project-serialization";
 
 describe("ensureAuthorizedForReconnect", () => {
   const createServer = (
@@ -171,6 +172,44 @@ describe("ensureAuthorizedForReconnect", () => {
     );
     expect(clearOAuthDataMock.mock.invocationCallOrder[0]).toBeLessThan(
       initiateOAuthMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("reconnects with the registration strategy persisted on the Convex catalog entry", async () => {
+    initiateOAuthMock.mockResolvedValue({ success: true });
+
+    // Simulate the real hosted pipeline: the server the reconnect handler
+    // receives is the project-catalog entry deserialized from the flat
+    // Convex servers row — not the in-memory entry from the original save.
+    const [server] = Object.values(
+      deserializeServersFromConvex([
+        {
+          name: "asana",
+          enabled: true,
+          transportType: "http",
+          url: "https://mcp.asana.com/sse",
+          useOAuth: true,
+          oauthScopes: ["default", "profile"],
+          clientId: "prereg-client",
+          oauthProtocolVersion: "2025-06-18",
+          oauthRegistrationStrategy: "preregistered",
+        },
+      ]),
+    );
+
+    await ensureAuthorizedForReconnect(
+      { ...server, oauthTokens: { access_token: "t" } } as ServerWithName,
+      { allowInteractiveOAuthFlow: true },
+    );
+
+    expect(initiateOAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "prereg-client",
+        protocolMode: "2025-06-18",
+        protocolVersion: "2025-06-18",
+        registrationMode: "preregistered",
+        registrationStrategy: "preregistered",
+      }),
     );
   });
 


### PR DESCRIPTION
Inspector half of the OAuth Debugger persistence fix. **Depends on MCPJam/mcpjam-backend#658 — the backend must deploy first** (Convex mutations reject unexpected args, so sending the new fields against the old deployment would break server saves).

## Problem

In authenticated projects, saving "Pre-registered" (or CIMD, or an older protocol version) in the debugger's "Configure Server to Test" modal silently reverts to Dynamic (DCR) / 2025-11-25:

1. The save is correct in memory, but the Convex sync payload only carried `oauthScopes` / `clientId` / `oauthResourceUrl` — the rest of the test profile had nowhere to go (no columns).
2. The Convex live query then rebuilds `activeProject.servers` from the flat row, reconstructing `oauthFlowProfile` without a strategy → defaults back to DCR.
3. The localStorage fallback (`mcp-oauth-config-*`) is explicitly disabled in hosted mode on both write and read, so nothing backstops it.

This also meant **reconnect** ran the wrong flow: `ensureAuthorizedForReconnect` prefers `server.oauthFlowProfile.registrationStrategy`, but that field never survived the catalog round-trip.

## Change

- **Sync payload** (`use-server-state.ts`): sends `oauthProtocolVersion` + `oauthRegistrationStrategy` from the profile.
- **Deserialization** (`project-serialization.ts`): restores both into the rebuilt profile. The backend columns are plain strings by design (so an old/new client never fails a whole server save over an unknown value); the client narrows them back to the closed unions via new `normalizeOAuthProtocolVersion` / `normalizeOAuthRegistrationStrategy` in `lib/oauth/profile.ts` — unknown wire values read as absent and fall to the reader-side defaults.
- **Reconnect**: no code change needed — the orchestrator already prefers the profile; it just never received it. A new test drives the real pipeline end-to-end: flat Convex row → `deserializeServersFromConvex` → `ensureAuthorizedForReconnect` → `initiateOAuth` called with `registrationStrategy: "preregistered"` / `protocolVersion: "2025-06-18"`.
- `RemoteServer` type gains the two optional fields.

## Tests

- Deserialization: persisted values restored, strategy-only rows still build a profile, unknown wire values (`"quantum"`, `"2099-01-01"`) normalize to absent, legacy rows unchanged.
- Reconnect integration test as above.
- Full lib + state + OAuthFlowTab suites: 1161 passed; client typecheck clean.

## Rollout

1. Merge + deploy mcpjam-backend#658.
2. Merge this. Legacy rows (no columns) behave exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth reconnect and Convex server save payloads; rollout depends on the backend schema/mutations accepting the new fields first.
> 
> **Overview**
> Fixes hosted OAuth debugger settings **silently reverting** to Dynamic (DCR) and protocol **2025-11-25** after save when the Convex catalog rebuilds `oauthFlowProfile` from flat server rows.
> 
> **Convex sync** (`use-server-state.ts`) now includes `oauthProtocolVersion` and `oauthRegistrationStrategy` from the in-memory test profile. **`RemoteServer`** types those fields.
> 
> **Deserialize** (`project-serialization.ts`) maps the flat columns back onto `oauthFlowProfile`, with **`normalizeOAuthProtocolVersion` / `normalizeOAuthRegistrationStrategy`** in `lib/oauth/profile.ts` so unknown wire strings are dropped instead of breaking saves.
> 
> **Reconnect** needs no orchestrator change: once the profile survives the round-trip, `ensureAuthorizedForReconnect` passes the saved strategy/version into `initiateOAuth` (new integration test via `deserializeServersFromConvex`).
> 
> Tests cover full round-trip, strategy-only rows, unknown values, and legacy rows without columns. **Requires backend #658 deployed first** so Convex accepts the new mutation fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9fcfc511ab7ae943bbfa96d2251fd82dd9021a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the OAuth Debugger’s registration strategy and protocol version through Convex so saved profiles don’t reset to DCR/2025-11-25, and reconnect uses the right flow.

- **Bug Fixes**
  - Include `oauthProtocolVersion` and `oauthRegistrationStrategy` in the sync payload.
  - Restore and normalize both fields into `oauthFlowProfile` on read; unknown values fall back to defaults, legacy rows unchanged.
  - Extend `RemoteServer` with optional fields and add round‑trip + reconnect tests.

- **Dependencies**
  - Requires `MCPJam/mcpjam-backend#658` to be deployed first.

<sup>Written for commit 9d9fcfc511ab7ae943bbfa96d2251fd82dd9021a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

