### PR TITLE
fix(xaa): make the issuer-mismatch abort visible and actionable

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa-server-target.test.ts
@@ -301,6 +301,58 @@ describe("server-target /proxy/token", () => {
     expect(discoveryUrl).not.toContain("stored-server.example.com");
   });
 
+  it("fail-closes with a 409 naming both issuers when the metadata advertises a different issuer", async () => {
+    // The stored issuer and the metadata's advertised issuer diverge — the
+    // secret must never be posted, and the error must carry both values so
+    // the user can fix the config. The status must stay out of the 502/504
+    // family: CDN edges replace those bodies with a branded error page.
+    const resolver = vi.fn(async () => ({
+      clientSecret: "stored-secret",
+      clientId: "stored-client-id",
+      serverUrl: "https://stored-server.example.com",
+      xaaAuthzIssuer: "https://stored-issuer.example.com",
+    }));
+    const app = buildApp(resolver);
+
+    let tokenPosted = false;
+    // stubDiscoveryAndToken serves metadata advertising
+    // https://stored-server.example.com — not the stored issuer above.
+    stubDiscoveryAndToken({
+      onTokenPost: () => {
+        tokenPosted = true;
+      },
+    });
+
+    const response = await app.request("/api/web/xaa/proxy/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer user-token",
+      },
+      body: JSON.stringify({
+        serverId: "srv_1",
+        projectId: "proj_1",
+        assertion: "aaa.bbb.ccc",
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as {
+      code?: string;
+      message?: string;
+      details?: Record<string, unknown>;
+    };
+    expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body.message).toContain("https://stored-issuer.example.com");
+    expect(body.message).toContain("https://stored-server.example.com");
+    expect(body.details).toMatchObject({
+      requestedIssuer: "https://stored-issuer.example.com",
+      advertisedIssuer: "https://stored-server.example.com",
+      schemeOnly: false,
+    });
+    expect(tokenPosted).toBe(false);
+  });
+
   it("returns 404 when no authorization server can be discovered", async () => {
     const resolver = vi.fn(async () => ({
       clientSecret: "stored-secret",

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -610,6 +610,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         return toJsonError(error.message, {
           status: error.status,
           code: error.code,
+          details: error.details,
         });
       }
 
@@ -839,6 +840,7 @@ export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
         return toJsonError(error.message, {
           status: error.status,
           code: error.code,
+          details: error.details,
         });
       }
       throw error;

--- a/mcpjam-inspector/server/services/xaa-mint.ts
+++ b/mcpjam-inspector/server/services/xaa-mint.ts
@@ -124,12 +124,24 @@ export async function discoverServerTargetTokenEndpoint(
       });
       // Fail closed on an issuer mismatch: the metadata's advertised issuer
       // differs from the one we asked for, so its token endpoint can't be
-      // trusted with the stored confidential client secret.
+      // trusted with the stored confidential client secret. This deliberate
+      // abort must NOT wear a 502/504 — CDN edges (Cloudflare in hosted)
+      // replace origin 502/504 bodies with their own branded error page, which
+      // would hide this message from the user entirely.
       if (verdict.issuerMismatch) {
+        const { requested, advertised, schemeOnly } = verdict.issuerMismatch;
         throw new WebRouteError(
-          502,
-          ErrorCode.SERVER_UNREACHABLE,
-          "Authorization server metadata issuer does not match the requested issuer"
+          409,
+          ErrorCode.VALIDATION_ERROR,
+          `Authorization server issuer mismatch: the stored config expects "${requested}" but the server's metadata advertises "${advertised}". ` +
+            (schemeOnly
+              ? "Only the scheme differs — the authorization server is likely behind a TLS-terminating proxy but advertises an http:// issuer."
+              : "Set the server's Authorization Server issuer to the advertised value (or fix the server URL)."),
+          {
+            requestedIssuer: requested,
+            advertisedIssuer: advertised,
+            schemeOnly,
+          }
         );
       }
       // The AS explicitly declares it doesn't support the jwt-bearer grant —


### PR DESCRIPTION
## What

When a server-backed XAA run (stored client secret) re-discovers the authorization server, a mismatch between the stored issuer and the metadata's advertised issuer triggers a deliberate fail-closed abort — the secret is never posted. Two DX bugs made that abort indistinguishable from an outage:

1. **It returned 502.** Cloudflare (in front of app.mcpjam.com) replaces origin 502/504 bodies with its branded Bad Gateway HTML page, so the diagnostic JSON never reached the user. A dev reported exactly this in the field: "this endpoint is returning 502 (a cloudflare 502 bad gateway html)" — with WAF/LB logs open, he still couldn't tell it was a config mismatch on his side.
2. **The message named neither issuer.** The guard computes `requested` vs `advertised` (including the scheme-only http-behind-https-proxy case) and threw both away.

## Changes

- The issuer-mismatch abort is now `409 VALIDATION_ERROR` instead of `502 SERVER_UNREACHABLE` — a 4xx passes through CDN edges untouched, and this is a config conflict, not an unreachable upstream (genuine unreachable/timeout errors keep their 502/504).
- The message now names both issuers and tells the user what to do: set the server's Authorization Server issuer to the advertised value; the scheme-only case gets the TLS-proxy hint instead.
- `requestedIssuer` / `advertisedIssuer` / `schemeOnly` ride in `details`, and the `/proxy/token` + `/negative-tests` WebRouteError handlers now forward `details` onto the JSON response.

## Security

No change to the fail-closed behavior itself: the secret is still never posted on mismatch (regression test asserts no token POST occurs). The advertised issuer included in the error comes from metadata the caller could already fetch themselves — no new information exposure. Connect-path consumers of the same guard log-and-rethrow without status branching, so the 409 is safe there too.

## Tests

- New regression test: mismatch → 409 `VALIDATION_ERROR`, message contains both issuers, `details` carries the structured values, and the stored secret is never posted.
- All 50 XAA suite tests pass (`xaa-server-target`, `xaa`, `xaa-mint`, `xaa-discovery`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f1a7bff83b2b3632aa0bdad9ed681ec4954030eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make issuer-mismatch errors in server-backed XAA discovery visible and actionable by returning 409 and including both issuers, so users see a clear config conflict instead of a Cloudflare 502 page. The secret is still never posted on mismatch.

- **Bug Fixes**
  - Return 409 `VALIDATION_ERROR` for issuer mismatch; real upstream outages keep 502/504.
  - Error message names the requested and advertised issuers and adds a TLS-proxy hint when only the scheme differs.
  - Add structured `details` (`requestedIssuer`, `advertisedIssuer`, `schemeOnly`) and forward them in `/proxy/token` and `/negative-tests`; regression test asserts 409, message contents, details, and no token POST.

<sup>Written for commit f1a7bff83b2b3632aa0bdad9ed681ec4954030eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

