### PR TITLE
changesets

### DIFF
--- a/.changeset/oauth-xaa-debugger-fixes.md
+++ b/.changeset/oauth-xaa-debugger-fixes.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Persist OAuth debugger registration settings through project serialization and surface actionable XAA issuer-mismatch errors.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Patch for `@mcpjam/inspector` that persists OAuth debugger registration settings across project save/load and shows actionable XAA issuer‑mismatch errors.

<sup>Written for commit 513e2f1dd1d62c012cf4a4ebdc4e6d86b7474b6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

